### PR TITLE
FIX FOR GRADIO NOT LAUNCHING

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ pydub~=0.25.1
 pymupdf~=1.24.13
 pymupdf4llm~=0.0.17
 docling~=2.4.0
+pydantic==2.10.6 # I didn't think I could hate Gradio more than I already did.
 #PyAudioWPatch # For windows system recording
 pypandoc~=1.13
 pypandoc_binary


### PR DESCRIPTION
Gradio now launches. 
'Fix' was `pydantic==2.10.6`; 

Seems there's an issue with Gradio somewhere, and some update in the past few months caused this issue.

yea. idk.