### PR TITLE
feat(tts): add Fish Audio S2 provider and managed references

### DIFF
--- a/Docs/STT-TTS/TTS-SETUP-GUIDE.md
+++ b/Docs/STT-TTS/TTS-SETUP-GUIDE.md
@@ -22,6 +22,54 @@ OPENAI_API_KEY=your-api-key-here
 ELEVENLABS_API_KEY=your-api-key-here
 ```
 
+### Fish Audio S2
+
+Fish Audio S2 is currently supported through the upstream Fish HTTP server.
+The tldw provider key is `fish_s2`, and v1 expects the `native_http` backend.
+
+#### Upstream Server
+
+Start Fish Speech's API server separately and expose its `/v1/tts` and
+`/v1/references/*` routes. A typical local deployment uses:
+
+```bash
+python tools/api_server.py --host 127.0.0.1 --port 8080
+```
+
+#### Configuration (YAML)
+
+Enable `fish_s2` in `tldw_Server_API/Config_Files/tts_providers_config.yaml`:
+
+```yaml
+providers:
+  fish_s2:
+    enabled: true
+    backend: "native_http"
+    base_url: "http://127.0.0.1:8080"
+    api_key: null
+    timeout: 120
+    model: "s2-pro"
+    sample_rate: 24000
+    max_text_length: 5000
+    extra_params:
+      default_chunk_length: 200
+      default_normalize: true
+      default_use_memory_cache: "off"
+```
+
+#### Request Notes
+
+- Model aliases include `fish_s2`, `fish-s2-pro`, `s2-pro`, and `fishaudio/s2-pro`.
+- Streaming is WAV-only for the native Fish server path.
+- Managed references are user-scoped through:
+  - `POST /api/v1/audio/providers/fish_s2/references`
+  - `GET /api/v1/audio/providers/fish_s2/references`
+  - `DELETE /api/v1/audio/providers/fish_s2/references/{reference_id}`
+- `extra_params.reference_id` uses the local stored `voice_id`, not the backend
+  Fish reference ID.
+- `voice=custom:<voice_id>` reuses existing Fish metadata when present and falls
+  back to an inline reference payload built from the stored voice sample.
+
 ## Local Model Providers
 
 ### One-Command Installers (Recommended)

--- a/tldw_Server_API/Config_Files/tts_providers_config.yaml
+++ b/tldw_Server_API/Config_Files/tts_providers_config.yaml
@@ -17,6 +17,7 @@ provider_priority:
   - higgs       # Advanced multi-lingual
   - index_tts   # IndexTTS2 (local, expressive zero-shot)
   - qwen3_tts   # Qwen3-TTS (local, multilingual; disabled by default)
+  - fish_s2     # Fish Audio S2 via upstream HTTP server (disabled by default)
 
 # Provider-specific configurations
 providers:
@@ -320,6 +321,22 @@ providers:
       warmup_on_startup: false
       idle_shutdown_seconds: 900
       resident_mode: false
+
+  # Fish Audio S2 Configuration (remote Fish HTTP server)
+  fish_s2:
+    enabled: false
+    backend: "native_http"
+    base_url: "http://127.0.0.1:8080"
+    api_key: null
+    timeout: 120
+    verify_api_key_on_init: false
+    model: "s2-pro"
+    sample_rate: 24000
+    max_text_length: 5000
+    extra_params:
+      default_chunk_length: 200
+      default_normalize: true
+      default_use_memory_cache: "off"
 
 # Voice mappings for cross-provider compatibility
 # NOTE: Providers like index_tts rely on uploaded reference audio; the

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio.py
@@ -5,8 +5,9 @@ import importlib
 import os
 from typing import Any, Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from loguru import logger
+from starlette import status
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import get_usage_event_logger
@@ -26,11 +27,9 @@ from tldw_Server_API.app.core.Metrics.metrics_manager import (
 from . import (
     audio_health,
     audio_history,
-    audio_presets,
     audio_tokenizer,
     audio_transcriptions,
     audio_tts,
-    audio_voice_conversion,
     audio_voices,
 )
 
@@ -46,12 +45,10 @@ router = APIRouter(
 # Include HTTP routers
 router.include_router(audio_tts.router)
 router.include_router(audio_history.router)
-router.include_router(audio_presets.router)
 router.include_router(audio_tokenizer.router)
 router.include_router(audio_transcriptions.router)
 router.include_router(audio_health.router)
 router.include_router(audio_voices.router)
-router.include_router(audio_voice_conversion.router)
 
 _AUDIO_STREAMING_MODULE = f"{__package__}.audio_streaming"
 
@@ -69,8 +66,8 @@ def _mount_streaming_routes() -> APIRouter:
         streaming_module = _load_audio_streaming()
         router.include_router(streaming_module.router)
         return streaming_module.ws_router
-    except Exception:
-        logger.warning("Audio streaming routes unavailable; skipping import")
+    except Exception as exc:
+        logger.warning(f"Audio streaming routes unavailable; skipping import: {exc}")
         return APIRouter()
 
 
@@ -83,8 +80,6 @@ create_speech_metadata = audio_tts.create_speech_metadata
 list_tts_providers = audio_tts.list_tts_providers
 list_tts_voices = audio_tts.list_tts_voices
 reset_tts_metrics = audio_tts.reset_tts_metrics
-get_tts_provider_model_info = audio_tts.get_tts_provider_model_info
-unload_tts_provider = audio_tts.unload_tts_provider
 encode_audio_tokenizer = audio_tokenizer.encode_audio_tokenizer
 decode_audio_tokenizer = audio_tokenizer.decode_audio_tokenizer
 create_transcription = audio_transcriptions.create_transcription
@@ -98,13 +93,23 @@ list_voices = audio_voices.list_voices
 get_voice_details = audio_voices.get_voice_details
 delete_voice = audio_voices.delete_voice
 preview_voice = audio_voices.preview_voice
-create_voice_conversion = audio_voice_conversion.create_voice_conversion
+create_fish_s2_reference = audio_voices.create_fish_s2_reference
+list_fish_s2_references = audio_voices.list_fish_s2_references
+delete_fish_s2_reference = audio_voices.delete_fish_s2_reference
 
 # Dependency helpers (for FastAPI overrides in tests)
 get_tts_service = audio_tts.get_tts_service
 get_usage_event_logger = get_usage_event_logger
 check_rate_limit = check_rate_limit
 
+# Shared helper re-exports used in tests
+from tldw_Server_API.app.core.Audio.tts_service import (
+    _tts_fallback_resolver,
+)
+from tldw_Server_API.app.core.AuthNZ.byok_runtime import (
+    record_byok_missing_credentials,
+    resolve_byok_credentials,
+)
 from tldw_Server_API.app.core.config import load_comprehensive_config as _load_comprehensive_config
 
 # Re-export config loader for tests to monkeypatch
@@ -119,14 +124,51 @@ async def _resolve_tts_byok(
     force_oauth_refresh: bool = False,
 ):
     """Wrapper to preserve audio.py patch points for BYOK resolution."""
-    from tldw_Server_API.app.core.Audio import tts_service as core_tts_service
+    user_id_int = None
+    try:
+        user_id_int = getattr(current_user, "id_int", None)
+        if user_id_int is None:
+            raw_id = getattr(current_user, "id", None)
+            if raw_id is not None:
+                user_id_int = int(raw_id)
+    except (AttributeError, TypeError, ValueError) as exc:
+        logger.debug(f"Failed to extract user_id from current_user: {exc}")
+        user_id_int = None
 
-    return await core_tts_service._resolve_tts_byok(
-        provider_hint=provider_hint,
-        current_user=current_user,
-        request=request,
-        force_oauth_refresh=force_oauth_refresh,
-    )
+    tts_overrides = None
+    byok_tts_resolution = None
+    if provider_hint:
+        resolver = resolve_byok_credentials
+        try:
+            from tldw_Server_API.app.api.v1.endpoints import audio as _audio_pkg
+
+            resolver = getattr(_audio_pkg, "resolve_byok_credentials", resolve_byok_credentials)
+        except Exception:
+            resolver = resolve_byok_credentials
+        byok_tts_resolution = await resolver(
+            provider_hint,
+            user_id=user_id_int,
+            request=request,
+            fallback_resolver=_tts_fallback_resolver,
+            force_oauth_refresh=force_oauth_refresh,
+        )
+        if byok_tts_resolution.uses_byok:
+            tts_overrides = {"api_key": byok_tts_resolution.api_key}
+            base_url = byok_tts_resolution.credential_fields.get("base_url")
+            if isinstance(base_url, str) and base_url.strip():
+                tts_overrides["base_url"] = base_url.strip()
+        elif not byok_tts_resolution.api_key:
+            if provider_hint in {"openai", "elevenlabs"}:
+                record_byok_missing_credentials(provider_hint, operation="audio_tts")
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail={
+                        "error_code": "missing_provider_credentials",
+                        "message": f"TTS provider '{provider_hint}' requires an API key.",
+                    },
+                )
+
+    return user_id_int, tts_overrides, byok_tts_resolution
 
 
 def _get_failopen_cap_minutes() -> float:
@@ -144,8 +186,8 @@ def _get_failopen_cap_minutes() -> float:
             f = float(v)
             if f > 0:
                 return f
-        except (ValueError, TypeError):
-            logger.debug("AUDIO_FAILOPEN_CAP_MINUTES parse failed")
+        except (ValueError, TypeError) as exc:
+            logger.debug(f"AUDIO_FAILOPEN_CAP_MINUTES parse failed: {exc}")
     try:
         try:
             from tldw_Server_API.app.api.v1.endpoints import audio as _audio_pkg
@@ -160,17 +202,17 @@ def _get_failopen_cap_minutes() -> float:
                     f = float(cfg.get("Audio-Quota", "failopen_cap_minutes", fallback=""))
                     if f > 0:
                         return f
-                except (ValueError, TypeError):
-                    logger.debug("[Audio-Quota].failopen_cap_minutes parse failed")
+                except (ValueError, TypeError) as exc:
+                    logger.debug(f"[Audio-Quota].failopen_cap_minutes parse failed: {exc}")
             if cfg.has_section("Audio"):
                 try:
                     f = float(cfg.get("Audio", "failopen_cap_minutes", fallback=""))
                     if f > 0:
                         return f
-                except (ValueError, TypeError):
-                    logger.debug("[Audio].failopen_cap_minutes parse failed")
-    except Exception:
-        logger.debug("Config read for failopen cap failed")
+                except (ValueError, TypeError) as exc:
+                    logger.debug(f"[Audio].failopen_cap_minutes parse failed: {exc}")
+    except Exception as exc:
+        logger.debug(f"Config read for failopen cap failed: {exc}")
     return 5.0
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
@@ -354,3 +354,151 @@ async def preview_voice(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to generate voice preview"
         ) from e
+
+
+@router.post(
+    "/providers/fish_s2/references",
+    summary="Create or sync a managed Fish S2 reference",
+    dependencies=[
+        Depends(check_rate_limit),
+        Depends(
+            require_token_scope(
+                "any",
+                require_if_present=True,
+                endpoint_id=VOICE_SCOPE_UPLOAD,
+                count_as=VOICE_COUNTER_TYPE,
+            )
+        ),
+    ],
+)
+async def create_fish_s2_reference(
+    request: Request,
+    voice_id: Optional[str] = Form(default=None, description="Existing stored voice ID to sync"),
+    reference_text: Optional[str] = Form(default=None, description="Transcript of the reference audio"),
+    name: Optional[str] = Form(default=None, description="Name when creating from a new upload"),
+    description: Optional[str] = Form(default=None, description="Description when creating from a new upload"),
+    force: bool = Form(default=False, description="Recreate the remote Fish reference even if already cached"),
+    file: Optional[UploadFile] = File(default=None, description="Optional audio upload when creating a new managed reference"),
+    current_user: User = Depends(get_request_user),
+    tts_service: TTSServiceV2 = Depends(get_tts_service),
+):
+    """Create a managed Fish S2 reference from an existing stored voice or a new upload."""
+    request_id = ensure_request_id(request)
+    if voice_id:
+        if file is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=_http_error_detail("Provide either voice_id or file, not both", request_id),
+            )
+        file_content = None
+        filename = None
+    else:
+        if file is None or not name or not reference_text:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=_http_error_detail(
+                    "file, name, and reference_text are required when voice_id is not provided",
+                    request_id,
+                ),
+            )
+        file_content = await file.read()
+        filename = file.filename
+
+    try:
+        return await tts_service.create_fish_s2_reference(
+            user_id=current_user.id,
+            voice_id=voice_id,
+            file_content=file_content,
+            filename=filename,
+            name=name,
+            description=description,
+            reference_text=reference_text,
+            force=force,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        if e.__class__.__name__ == "VoiceProcessingError":
+            logger.warning(f"Fish S2 reference creation failed: {e}", exc_info=True)
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=_http_error_detail("Fish S2 reference creation failed", request_id, exc=e),
+            ) from e
+        logger.error(f"Fish S2 reference creation error: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create Fish S2 reference",
+        ) from e
+
+
+@router.get(
+    "/providers/fish_s2/references",
+    summary="List managed Fish S2 references for the current user",
+    dependencies=[
+        Depends(check_rate_limit),
+        Depends(
+            require_token_scope(
+                "any",
+                require_if_present=True,
+                endpoint_id=VOICE_SCOPE_LIST,
+                count_as=VOICE_COUNTER_TYPE,
+            )
+        ),
+    ],
+)
+async def list_fish_s2_references(
+    current_user: User = Depends(get_request_user),
+    tts_service: TTSServiceV2 = Depends(get_tts_service),
+):
+    """List Fish S2 managed references from local user-scoped metadata."""
+    try:
+        references = await tts_service.list_fish_s2_references(user_id=current_user.id)
+        return {"references": references, "count": len(references)}
+    except Exception as e:
+        logger.error(f"Fish S2 reference listing error: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list Fish S2 references",
+        ) from e
+
+
+@router.delete(
+    "/providers/fish_s2/references/{reference_id}",
+    summary="Delete a managed Fish S2 reference",
+    dependencies=[
+        Depends(check_rate_limit),
+        Depends(
+            require_token_scope(
+                "any",
+                require_if_present=True,
+                endpoint_id=VOICE_SCOPE_DELETE,
+                count_as=VOICE_COUNTER_TYPE,
+            )
+        ),
+    ],
+)
+async def delete_fish_s2_reference(
+    request: Request,
+    reference_id: str = Path(..., description="Local Fish S2 reference ID"),
+    current_user: User = Depends(get_request_user),
+    tts_service: TTSServiceV2 = Depends(get_tts_service),
+):
+    """Delete the remote Fish S2 reference while preserving the local voice asset."""
+    request_id = ensure_request_id(request)
+    try:
+        return await tts_service.delete_fish_s2_reference(
+            user_id=current_user.id,
+            reference_id=reference_id,
+        )
+    except Exception as e:
+        if e.__class__.__name__ == "VoiceProcessingError":
+            logger.warning(f"Fish S2 reference deletion failed: {e}", exc_info=True)
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=_http_error_detail("Fish S2 reference not found", request_id, exc=e),
+            ) from e
+        logger.error(f"Fish S2 reference deletion error: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to delete Fish S2 reference",
+        ) from e

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
@@ -6,7 +6,13 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Path, Request
 from fastapi.responses import StreamingResponse
 from loguru import logger
 from starlette import status
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_request_user, TokenScopeGuard, User
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    TokenScopeGuard,
+    User,
+    check_rate_limit,
+    get_request_user,
+    require_token_scope,
+)
 
 from tldw_Server_API.app.api.v1.endpoints.audio.audio_tts import get_tts_service
 from tldw_Server_API.app.api.v1.schemas.audio_schemas import (

--- a/tldw_Server_API/app/core/TTS/TTS-README.md
+++ b/tldw_Server_API/app/core/TTS/TTS-README.md
@@ -9,9 +9,9 @@ Developer-oriented details (architecture, provider matrix, configuration, and te
 ## Features
 
 ### Core Capabilities
-- **Multi-Provider Support**: OpenAI, ElevenLabs, and local adapters (Kokoro, KittenTTS, PocketTTS, LuxTTS, Higgs, Chatterbox, Dia, VibeVoice, VibeVoice Realtime, Qwen3-TTS, IndexTTS2, NeuTTS, Supertonic, Supertonic2, EchoTTS) with a mock adapter for testing.
+- **Multi-Provider Support**: OpenAI, ElevenLabs, Fish Audio S2, and local adapters (Kokoro, KittenTTS, PocketTTS, LuxTTS, Higgs, Chatterbox, Dia, VibeVoice, VibeVoice Realtime, Qwen3-TTS, IndexTTS2, NeuTTS, Supertonic, Supertonic2, EchoTTS) with a mock adapter for testing.
 - **Managed Sidecars**: OmniVoice runs behind a dedicated loopback sidecar runtime instead of sharing the main server interpreter.
-- **Voice Cloning**: Voice reference audio accepted by PocketTTS, LuxTTS, Higgs, Chatterbox, Dia, VibeVoice, Qwen3-TTS, NeuTTS, IndexTTS2, and EchoTTS (ElevenLabs supports user voices via API).
+- **Voice Cloning**: Voice reference audio accepted by Fish Audio S2, PocketTTS, LuxTTS, Higgs, Chatterbox, Dia, VibeVoice, Qwen3-TTS, NeuTTS, IndexTTS2, and EchoTTS (ElevenLabs supports user voices via API).
 - **Streaming Audio**: Real-time chunked streaming across adapters; NeuTTS enables streaming when a quantized (GGUF) backbone is loaded; VibeVoice Realtime uses a WS backend.
 - **Format Support**: Adapter-specific coverage spanning MP3, WAV, OPUS, FLAC, PCM, AAC, and OGG via the shared `AudioFormat` enum.
 - **OpenAI Compatibility**: Drop-in replacement for OpenAI TTS API
@@ -26,6 +26,7 @@ Developer-oriented details (architecture, provider matrix, configuration, and te
 |----------|------|-----------|---------------|--------------|
 | **OpenAI** | Commercial API | EN* | ❌ | Industry standard, HD quality |
 | **ElevenLabs** | Commercial API | 29 | ✅ (Pro/user voices) | Premium quality, emotion control |
+| **Fish Audio S2** | Remote HTTP server | Multi | ✅ (managed refs) | S2 Pro via upstream Fish server, user-scoped reference routing |
 | **Kokoro** | Local ONNX | EN (US/GB) | ❌ | Lightweight, CPU-friendly, offline |
 | **KittenTTS** | Local ONNX | EN | ❌ | Small local ONNX voices, first-use download, pinned HF revisions |
 | **PocketTTS** | Local ONNX | EN | ✅ (reference) | Zero-shot cloning, streaming ONNX |

--- a/tldw_Server_API/app/core/TTS/adapter_registry.py
+++ b/tldw_Server_API/app/core/TTS/adapter_registry.py
@@ -82,6 +82,7 @@ class TTSProvider(Enum):
     OMNIVOICE = "omnivoice"
     LUX_TTS = "lux_tts"
     KITTEN_TTS = "kitten_tts"
+    FISH_S2 = "fish_s2"
     # Additional providers
     ALLTALK = "alltalk"  # TODO: Implement AllTalk adapter
     MOCK = "mock"  # Mock provider for testing
@@ -118,6 +119,9 @@ def _build_tts_provider_aliases() -> dict[str, TTSProvider]:
         "echotts": TTSProvider.ECHO_TTS,
         "kittentts": TTSProvider.KITTEN_TTS,
         "vibevoice-asr": TTSProvider.VIBEVOICE,
+        "fish-s2-pro": TTSProvider.FISH_S2,
+        "s2-pro": TTSProvider.FISH_S2,
+        "fishaudio/s2-pro": TTSProvider.FISH_S2,
     }
     for alias, provider in explicit_aliases.items():
         for token in _provider_alias_tokens(alias):
@@ -294,6 +298,7 @@ class TTSAdapterRegistry:
         TTSProvider.OMNIVOICE: "tldw_Server_API.app.core.TTS.adapters.omnivoice_adapter.OmniVoiceAdapter",
         TTSProvider.LUX_TTS: "tldw_Server_API.app.core.TTS.adapters.luxtts_adapter.LuxTTSAdapter",
         TTSProvider.KITTEN_TTS: "tldw_Server_API.app.core.TTS.adapters.kitten_tts_adapter.KittenTTSAdapter",
+        TTSProvider.FISH_S2: "tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter.FishS2Adapter",
     }
 
     @classmethod
@@ -1204,6 +1209,13 @@ class TTSAdapterFactory:
         "kittenml/kitten-tts-nano-0.8": TTSProvider.KITTEN_TTS,
         "kittenml/kitten-tts-nano-0.8-fp32": TTSProvider.KITTEN_TTS,
         "kittenml/kitten-tts-nano-0.8-int8": TTSProvider.KITTEN_TTS,
+
+        # Fish Audio S2 models
+        "fish_s2": TTSProvider.FISH_S2,
+        "fish-s2": TTSProvider.FISH_S2,
+        "fish-s2-pro": TTSProvider.FISH_S2,
+        "s2-pro": TTSProvider.FISH_S2,
+        "fishaudio/s2-pro": TTSProvider.FISH_S2,
     }
 
     def __init__(self, config: Optional[dict[str, Any]] = None):

--- a/tldw_Server_API/app/core/TTS/adapters/fish_s2_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/fish_s2_adapter.py
@@ -194,6 +194,42 @@ class FishS2Adapter(TTSAdapter):
             model=normalized_request.model,
         )
 
+    async def add_reference(
+        self,
+        *,
+        reference_id: str,
+        audio_b64: str,
+        reference_text: str,
+    ) -> dict[str, Any]:
+        if not await self.ensure_initialized():
+            raise TTSProviderNotConfiguredError(
+                "Fish S2 adapter not initialized",
+                provider=self.PROVIDER_KEY,
+            )
+        if self._backend is None:
+            raise TTSProviderInitializationError(
+                "Fish S2 backend is not available",
+                provider=self.PROVIDER_KEY,
+            )
+        return await self._backend.add_reference(
+            reference_id=reference_id,
+            audio_b64=audio_b64,
+            reference_text=reference_text,
+        )
+
+    async def delete_reference(self, *, reference_id: str) -> bool:
+        if not await self.ensure_initialized():
+            raise TTSProviderNotConfiguredError(
+                "Fish S2 adapter not initialized",
+                provider=self.PROVIDER_KEY,
+            )
+        if self._backend is None:
+            raise TTSProviderInitializationError(
+                "Fish S2 backend is not available",
+                provider=self.PROVIDER_KEY,
+            )
+        return await self._backend.delete_reference(reference_id=reference_id)
+
     def _normalize_request(self, request: TTSRequest) -> TTSRequest:
         extras = dict(request.extra_params or {})
         voice = request.voice

--- a/tldw_Server_API/app/core/TTS/adapters/fish_s2_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/fish_s2_adapter.py
@@ -1,0 +1,247 @@
+"""Fish Audio S2 provider adapter."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import replace
+from typing import Any, Optional
+
+from loguru import logger
+
+from ..backends.fish_s2_base import FishS2Backend
+from ..backends.fish_s2_native_http import FishS2NativeHttpBackend
+from ..tts_exceptions import (
+    TTSProviderInitializationError,
+    TTSProviderNotConfiguredError,
+)
+from ..tts_validation import validate_tts_request
+from .base import (
+    AudioFormat,
+    ProviderStatus,
+    TTSAdapter,
+    TTSCapabilities,
+    TTSRequest,
+    TTSResponse,
+)
+
+
+_SUPPORTED_LANGUAGES = {
+    "ar",
+    "auto",
+    "cs",
+    "da",
+    "de",
+    "el",
+    "en",
+    "es",
+    "fi",
+    "fr",
+    "he",
+    "hi",
+    "hu",
+    "id",
+    "it",
+    "ja",
+    "ko",
+    "ms",
+    "nl",
+    "no",
+    "pl",
+    "pt",
+    "ro",
+    "ru",
+    "sv",
+    "th",
+    "tr",
+    "uk",
+    "vi",
+    "zh",
+}
+
+
+def _build_backend(config: dict[str, Any]) -> FishS2Backend:
+    backend_name = str(config.get("backend", "native_http")).strip().lower()
+    if backend_name == "native_http":
+        return FishS2NativeHttpBackend(config)
+    if backend_name == "local_runtime":
+        raise TTSProviderInitializationError(
+            "Fish S2 local_runtime backend is not implemented yet",
+            provider="fish_s2",
+        )
+    raise TTSProviderInitializationError(
+        f"Unknown Fish S2 backend '{backend_name}'",
+        provider="fish_s2",
+        details={"backend": backend_name},
+    )
+
+
+class FishS2Adapter(TTSAdapter):
+    """Registry-facing adapter for Fish Audio S2."""
+
+    PROVIDER_KEY = "fish_s2"
+    SUPPORTED_FORMATS = {AudioFormat.WAV, AudioFormat.MP3, AudioFormat.PCM}
+
+    def __init__(self, config: Optional[dict[str, Any]] = None):
+        super().__init__(config)
+        cfg = config or {}
+        extras = cfg.get("extra_params", {}) or {}
+
+        self.backend_name = str(cfg.get("backend", "native_http")).strip().lower()
+        self.sample_rate = int(cfg.get("sample_rate", 24000))
+        self.max_text_length = int(cfg.get("max_text_length", 5000))
+        self.default_chunk_length = extras.get("default_chunk_length")
+        self.default_normalize = extras.get("default_normalize")
+        self.default_use_memory_cache = extras.get("default_use_memory_cache")
+        self._backend: FishS2Backend | None = None
+
+    async def ensure_initialized(self) -> bool:
+        """Propagate initialization errors for clearer operator feedback."""
+        if self._initialized:
+            return True
+
+        async with self._init_lock:
+            if self._initialized:
+                return True
+
+            self._status = ProviderStatus.INITIALIZING
+            success = await self.initialize()
+            if success:
+                self._capabilities = await self.get_capabilities()
+                self._status = ProviderStatus.AVAILABLE
+                self._initialized = True
+            else:
+                self._status = ProviderStatus.ERROR
+            return success
+
+    async def initialize(self) -> bool:
+        self._backend = _build_backend(self.config)
+
+        is_healthy = await self._backend.health_check()
+        if not is_healthy:
+            raise TTSProviderInitializationError(
+                "Fish S2 backend health check failed",
+                provider=self.PROVIDER_KEY,
+            )
+
+        logger.info("Fish S2 adapter initialized with backend={}", self.backend_name)
+        return True
+
+    async def get_capabilities(self) -> TTSCapabilities:
+        return TTSCapabilities(
+            provider_name="Fish Audio S2",
+            supported_languages=_SUPPORTED_LANGUAGES,
+            supported_voices=[],
+            supported_formats=self.SUPPORTED_FORMATS,
+            max_text_length=self.max_text_length,
+            supports_streaming=True,
+            supports_voice_cloning=True,
+            supports_emotion_control=False,
+            supports_speech_rate=False,
+            supports_pitch_control=False,
+            supports_volume_control=False,
+            supports_ssml=False,
+            supports_phonemes=False,
+            supports_multi_speaker=False,
+            supports_background_audio=False,
+            latency_ms=250,
+            sample_rate=self.sample_rate,
+            default_format=AudioFormat.WAV,
+        )
+
+    async def generate(self, request: TTSRequest) -> TTSResponse:
+        if not await self.ensure_initialized():
+            raise TTSProviderNotConfiguredError(
+                "Fish S2 adapter not initialized",
+                provider=self.PROVIDER_KEY,
+            )
+        if self._backend is None:
+            raise TTSProviderInitializationError(
+                "Fish S2 backend is not available",
+                provider=self.PROVIDER_KEY,
+            )
+
+        normalized_request = self._normalize_request(request)
+        validate_tts_request(normalized_request, provider=self.provider_key)
+
+        reference_id = self._resolve_reference_id(normalized_request)
+        backend_extra_params = self._build_backend_extra_params(normalized_request.extra_params)
+        result = await self._backend.synthesize(
+            text=self.preprocess_text(normalized_request.text),
+            response_format=normalized_request.format.value,
+            streaming=normalized_request.stream,
+            reference_id=reference_id,
+            extra_params=backend_extra_params or None,
+        )
+
+        if normalized_request.stream:
+            return TTSResponse(
+                audio_stream=result,  # type: ignore[arg-type]
+                format=normalized_request.format,
+                sample_rate=self.sample_rate,
+                channels=1,
+                voice_used=reference_id or normalized_request.voice,
+                provider=self.PROVIDER_KEY,
+                model=normalized_request.model,
+            )
+
+        return TTSResponse(
+            audio_data=result,  # type: ignore[arg-type]
+            format=normalized_request.format,
+            sample_rate=self.sample_rate,
+            channels=1,
+            voice_used=reference_id or normalized_request.voice,
+            provider=self.PROVIDER_KEY,
+            model=normalized_request.model,
+        )
+
+    def _normalize_request(self, request: TTSRequest) -> TTSRequest:
+        extras = dict(request.extra_params or {})
+        voice = request.voice
+
+        if isinstance(voice, str) and voice.startswith("fishref:"):
+            logical_id = voice.split("fishref:", 1)[-1].strip()
+            if logical_id and "reference_id" not in extras:
+                extras["reference_id"] = logical_id
+            voice = None
+
+        return replace(request, voice=voice, extra_params=extras)
+
+    def _resolve_reference_id(self, request: TTSRequest) -> str | None:
+        extras = request.extra_params if isinstance(request.extra_params, dict) else {}
+        explicit_reference_id = extras.get("reference_id")
+        if explicit_reference_id:
+            return str(explicit_reference_id)
+
+        voice = request.voice or ""
+        if isinstance(voice, str) and voice.startswith("fishref:"):
+            logical_id = voice.split("fishref:", 1)[-1].strip()
+            return logical_id or None
+        return None
+
+    def _build_backend_extra_params(self, extra_params: dict[str, Any] | None) -> dict[str, Any]:
+        extras = dict(extra_params or {})
+        extras.pop("reference_id", None)
+
+        backend_extra_params: dict[str, Any] = {}
+        if self.default_chunk_length is not None and "chunk_length" not in extras:
+            backend_extra_params["chunk_length"] = self.default_chunk_length
+        if self.default_normalize is not None and "normalize" not in extras:
+            backend_extra_params["normalize"] = self.default_normalize
+        if self.default_use_memory_cache is not None and "use_memory_cache" not in extras:
+            backend_extra_params["use_memory_cache"] = self.default_use_memory_cache
+
+        for key in (
+            "chunk_length",
+            "normalize",
+            "seed",
+            "top_p",
+            "temperature",
+            "repetition_penalty",
+            "use_memory_cache",
+            "references",
+        ):
+            value = extras.get(key)
+            if value is not None:
+                backend_extra_params[key] = value
+
+        return backend_extra_params

--- a/tldw_Server_API/app/core/TTS/backends/__init__.py
+++ b/tldw_Server_API/app/core/TTS/backends/__init__.py
@@ -1,0 +1,6 @@
+"""Backend implementations for TTS providers that need transport indirection."""
+
+from .fish_s2_base import FishS2Backend
+from .fish_s2_native_http import FishS2NativeHttpBackend
+
+__all__ = ["FishS2Backend", "FishS2NativeHttpBackend"]

--- a/tldw_Server_API/app/core/TTS/backends/fish_s2_base.py
+++ b/tldw_Server_API/app/core/TTS/backends/fish_s2_base.py
@@ -1,0 +1,28 @@
+"""Shared interfaces for Fish S2 backend implementations."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any, Protocol, runtime_checkable
+
+
+FishS2SynthesisResult = bytes | AsyncIterator[bytes]
+
+
+@runtime_checkable
+class FishS2Backend(Protocol):
+    """Transport/backend contract for the Fish S2 provider."""
+
+    async def health_check(self) -> bool:
+        """Return whether the backend appears reachable/usable."""
+
+    async def synthesize(
+        self,
+        *,
+        text: str,
+        response_format: str,
+        streaming: bool,
+        reference_id: str | None,
+        extra_params: dict[str, Any] | None,
+    ) -> FishS2SynthesisResult:
+        """Generate speech or return a byte stream for a request."""

--- a/tldw_Server_API/app/core/TTS/backends/fish_s2_base.py
+++ b/tldw_Server_API/app/core/TTS/backends/fish_s2_base.py
@@ -26,3 +26,15 @@ class FishS2Backend(Protocol):
         extra_params: dict[str, Any] | None,
     ) -> FishS2SynthesisResult:
         """Generate speech or return a byte stream for a request."""
+
+    async def add_reference(
+        self,
+        *,
+        reference_id: str,
+        audio_b64: str,
+        reference_text: str,
+    ) -> dict[str, Any]:
+        """Create or update a managed Fish reference."""
+
+    async def delete_reference(self, *, reference_id: str) -> bool:
+        """Delete a managed Fish reference."""

--- a/tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py
+++ b/tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py
@@ -86,6 +86,50 @@ class FishS2NativeHttpBackend(FishS2Backend):
         self._raise_for_response_error(response)
         return getattr(response, "content", b"") or b""
 
+    async def add_reference(
+        self,
+        *,
+        reference_id: str,
+        audio_b64: str,
+        reference_text: str,
+    ) -> dict[str, Any]:
+        payload = {
+            "reference_id": reference_id,
+            "audio_b64": audio_b64,
+            "text": reference_text,
+        }
+        try:
+            response = await afetch(
+                method="POST",
+                url=f"{self.base_url}/v1/references/add",
+                headers=self._headers(),
+                json=payload,
+                timeout=self.timeout,
+            )
+        except Exception as exc:
+            self._raise_transport_error(exc)
+
+        self._raise_for_response_error(response)
+        data = self._response_json(response)
+        if isinstance(data, dict):
+            return data
+        return {"reference_id": reference_id}
+
+    async def delete_reference(self, *, reference_id: str) -> bool:
+        try:
+            response = await afetch(
+                method="DELETE",
+                url=f"{self.base_url}/v1/references/delete",
+                headers=self._headers(),
+                json={"reference_id": reference_id},
+                timeout=self.timeout,
+            )
+        except Exception as exc:
+            self._raise_transport_error(exc)
+
+        self._raise_for_response_error(response)
+        return True
+
     @property
     def _tts_url(self) -> str:
         return f"{self.base_url}/v1/tts"
@@ -189,6 +233,16 @@ class FishS2NativeHttpBackend(FishS2Backend):
         if self._is_timeout_error(exc):
             raise timeout_error(self.PROVIDER_KEY, timeout_seconds=self.timeout) from exc
         raise network_error(self.PROVIDER_KEY, exc) from exc
+
+    @staticmethod
+    def _response_json(response: Any) -> Any:
+        try:
+            json_fn = getattr(response, "json", None)
+            if callable(json_fn):
+                return json_fn()
+        except Exception:
+            return None
+        return None
 
     @staticmethod
     def _normalize_api_key(value: Any) -> str | None:

--- a/tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py
+++ b/tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -93,17 +95,29 @@ class FishS2NativeHttpBackend(FishS2Backend):
         audio_b64: str,
         reference_text: str,
     ) -> dict[str, Any]:
-        payload = {
-            "reference_id": reference_id,
-            "audio_b64": audio_b64,
+        try:
+            audio_bytes = base64.b64decode(audio_b64, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise TTSValidationError(
+                "Fish S2 reference audio must be valid base64",
+                provider=self.PROVIDER_KEY,
+                details={"reference_id": reference_id},
+            ) from exc
+
+        form_data = {
+            "id": reference_id,
             "text": reference_text,
+        }
+        files = {
+            "audio": ("reference.wav", audio_bytes, "audio/wav"),
         }
         try:
             response = await afetch(
                 method="POST",
                 url=f"{self.base_url}/v1/references/add",
                 headers=self._headers(),
-                json=payload,
+                data=form_data,
+                files=files,
                 timeout=self.timeout,
             )
         except Exception as exc:

--- a/tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py
+++ b/tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py
@@ -1,0 +1,212 @@
+"""Native Fish Audio HTTP backend for the Fish S2 provider."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.http_client import afetch, astream_bytes
+
+from ..tts_exceptions import (
+    TTSAuthenticationError,
+    TTSNetworkError,
+    TTSProviderError,
+    TTSRateLimitError,
+    TTSTimeoutError,
+    TTSValidationError,
+    auth_error,
+    network_error,
+    provider_error,
+    rate_limit_error,
+    timeout_error,
+)
+from .fish_s2_base import FishS2Backend, FishS2SynthesisResult
+
+
+_PASSTHROUGH_PARAMS = {
+    "chunk_length",
+    "normalize",
+    "seed",
+    "top_p",
+    "temperature",
+    "repetition_penalty",
+    "use_memory_cache",
+    "references",
+}
+
+
+class FishS2NativeHttpBackend(FishS2Backend):
+    """HTTP transport wrapper for Fish Speech's `/v1/tts` API."""
+
+    PROVIDER_KEY = "fish_s2"
+
+    def __init__(self, config: dict[str, Any] | None = None):
+        self.config = config or {}
+        self.base_url = str(self.config.get("base_url", "")).rstrip("/")
+        self.api_key = self._normalize_api_key(self.config.get("api_key"))
+        self.timeout = self.config.get("timeout", 60)
+
+    async def health_check(self) -> bool:
+        return bool(self.base_url)
+
+    async def synthesize(
+        self,
+        *,
+        text: str,
+        response_format: str,
+        streaming: bool,
+        reference_id: str | None,
+        extra_params: dict[str, Any] | None,
+    ) -> FishS2SynthesisResult:
+        payload = self._build_tts_payload(
+            text=text,
+            response_format=response_format,
+            streaming=streaming,
+            reference_id=reference_id,
+            extra_params=extra_params,
+        )
+
+        if streaming:
+            return self._stream_audio(payload)
+
+        try:
+            response = await afetch(
+                method="POST",
+                url=self._tts_url,
+                headers=self._headers(),
+                json=payload,
+                timeout=self.timeout,
+            )
+        except Exception as exc:
+            self._raise_transport_error(exc)
+
+        self._raise_for_response_error(response)
+        return getattr(response, "content", b"") or b""
+
+    @property
+    def _tts_url(self) -> str:
+        return f"{self.base_url}/v1/tts"
+
+    def _headers(self) -> dict[str, str]:
+        if not self.api_key:
+            return {}
+        return {"Authorization": f"Bearer {self.api_key}"}
+
+    def _build_tts_payload(
+        self,
+        *,
+        text: str,
+        response_format: str,
+        streaming: bool,
+        reference_id: str | None,
+        extra_params: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "text": text,
+            "format": self._normalize_format(response_format),
+            "streaming": streaming,
+        }
+        if reference_id:
+            payload["reference_id"] = reference_id
+        if extra_params:
+            for key, value in extra_params.items():
+                if key in _PASSTHROUGH_PARAMS and value is not None:
+                    payload[key] = value
+        return payload
+
+    async def _stream_audio(self, payload: dict[str, Any]) -> AsyncIterator[bytes]:
+        try:
+            async for chunk in astream_bytes(
+                method="POST",
+                url=self._tts_url,
+                headers=self._headers(),
+                json=payload,
+                timeout=self.timeout,
+            ):
+                if chunk:
+                    yield chunk
+        except Exception as exc:
+            self._raise_transport_error(exc)
+
+    def _raise_for_response_error(self, response: Any) -> None:
+        status_code = getattr(response, "status_code", None)
+        if status_code is None or status_code < 400:
+            return
+
+        body = getattr(response, "text", "") or ""
+        headers = getattr(response, "headers", {}) or {}
+
+        logger.error(
+            "%s upstream returned %s: %s",
+            self.PROVIDER_KEY,
+            status_code,
+            body,
+        )
+        self._raise_status_error(status_code=status_code, body=body, headers=headers)
+
+    def _raise_status_error(
+        self,
+        *,
+        status_code: int,
+        body: str,
+        headers: dict[str, Any],
+    ) -> None:
+        if status_code in (401, 403):
+            raise auth_error(self.PROVIDER_KEY, "Fish S2 authentication failed")
+        if status_code == 429:
+            retry_after = headers.get("retry-after") if isinstance(headers, dict) else None
+            raise rate_limit_error(
+                self.PROVIDER_KEY,
+                retry_after=int(retry_after) if retry_after else None,
+            )
+        if status_code in (400, 404):
+            raise TTSValidationError(
+                f"Fish S2 request failed ({status_code})",
+                provider=self.PROVIDER_KEY,
+                details={"status": status_code, "body": body},
+            )
+        if status_code in (408, 504):
+            raise timeout_error(self.PROVIDER_KEY, timeout_seconds=self.timeout)
+        if 500 <= status_code < 600:
+            raise provider_error(
+                "Fish S2 upstream error",
+                provider=self.PROVIDER_KEY,
+                error_code=str(status_code),
+                details={"status": status_code, "body": body},
+            )
+        raise TTSProviderError(
+            f"Fish S2 request failed ({status_code})",
+            provider=self.PROVIDER_KEY,
+            details={"status": status_code, "body": body},
+        )
+
+    def _raise_transport_error(self, exc: Exception) -> None:
+        if isinstance(exc, (TTSAuthenticationError, TTSRateLimitError, TTSTimeoutError, TTSValidationError, TTSProviderError)):
+            raise exc
+        if self._is_timeout_error(exc):
+            raise timeout_error(self.PROVIDER_KEY, timeout_seconds=self.timeout) from exc
+        raise network_error(self.PROVIDER_KEY, exc) from exc
+
+    @staticmethod
+    def _normalize_api_key(value: Any) -> str | None:
+        if value is None:
+            return None
+        raw = str(value).strip()
+        if not raw or raw.lower() in {"none", "null"}:
+            return None
+        return raw
+
+    @staticmethod
+    def _normalize_format(response_format: Any) -> str:
+        value = getattr(response_format, "value", response_format)
+        return str(value).lower()
+
+    @staticmethod
+    def _is_timeout_error(exc: Exception) -> bool:
+        if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
+            return True
+        exc_name = exc.__class__.__name__.lower()
+        return "timeout" in exc_name or "timeout" in str(exc).lower()

--- a/tldw_Server_API/app/core/TTS/tts_service_v2.py
+++ b/tldw_Server_API/app/core/TTS/tts_service_v2.py
@@ -2767,6 +2767,156 @@ class TTSServiceV2:
                 exc,
             )
 
+    async def create_fish_s2_reference(
+        self,
+        *,
+        user_id: int,
+        voice_id: Optional[str] = None,
+        file_content: Optional[bytes] = None,
+        filename: Optional[str] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        reference_text: Optional[str] = None,
+        force: bool = False,
+    ) -> dict[str, Any]:
+        """Create or reuse a managed Fish S2 reference backed by local voice metadata."""
+        from tldw_Server_API.app.core.TTS.voice_manager import (
+            VoiceProcessingError,
+            VoiceReferenceMetadata,
+            VoiceUploadRequest,
+            get_voice_manager,
+        )
+
+        voice_manager = get_voice_manager()
+
+        resolved_voice_id = voice_id
+        if not resolved_voice_id:
+            if not file_content or not filename or not name or not reference_text:
+                raise VoiceProcessingError(
+                    "file, filename, name, and reference_text are required when voice_id is not provided"
+                )
+            upload_request = VoiceUploadRequest(
+                name=name,
+                description=description,
+                provider="fish_s2",
+                reference_text=reference_text,
+            )
+            upload_result = await voice_manager.upload_voice(
+                user_id=user_id,
+                file_content=file_content,
+                filename=filename,
+                request=upload_request,
+            )
+            resolved_voice_id = upload_result.voice_id
+
+        metadata = await voice_manager.load_reference_metadata(user_id, resolved_voice_id)
+        if metadata is None:
+            metadata = VoiceReferenceMetadata(voice_id=resolved_voice_id)
+        if reference_text:
+            metadata.reference_text = reference_text.strip() or None
+
+        fish_artifacts = metadata.provider_artifacts.get("fish_s2") or {}
+        existing_remote_reference_id = fish_artifacts.get("remote_reference_id")
+        if existing_remote_reference_id and not force:
+            return {
+                "reference_id": resolved_voice_id,
+                "voice_id": resolved_voice_id,
+                "remote_reference_id": existing_remote_reference_id,
+                "reference_text": fish_artifacts.get("reference_text") or metadata.reference_text,
+                "cached": True,
+            }
+
+        voice_bytes = await voice_manager.load_voice_reference_audio(user_id, resolved_voice_id)
+        resolved_reference_text = metadata.reference_text
+        if not resolved_reference_text:
+            raise VoiceProcessingError("reference_text is required for Fish S2 references")
+
+        adapter = await self._get_adapter("fish_s2", provider="fish_s2")
+        if adapter is None or not hasattr(adapter, "add_reference"):
+            raise TTSProviderNotConfiguredError("Fish S2 adapter is not available", provider="fish_s2")
+
+        remote_reference_id = self._build_fish_s2_remote_reference_id(user_id, resolved_voice_id)
+        if force and existing_remote_reference_id and hasattr(adapter, "delete_reference"):
+            with suppress(_TTS_NONCRITICAL_EXCEPTIONS):
+                await adapter.delete_reference(reference_id=str(existing_remote_reference_id))
+
+        await adapter.add_reference(
+            reference_id=remote_reference_id,
+            audio_b64=base64.b64encode(voice_bytes).decode("ascii"),
+            reference_text=resolved_reference_text,
+        )
+
+        metadata.provider_artifacts["fish_s2"] = {
+            "remote_reference_id": remote_reference_id,
+            "reference_text": resolved_reference_text,
+        }
+        await voice_manager.save_reference_metadata(user_id, metadata)
+        return {
+            "reference_id": resolved_voice_id,
+            "voice_id": resolved_voice_id,
+            "remote_reference_id": remote_reference_id,
+            "reference_text": resolved_reference_text,
+            "cached": False,
+        }
+
+    async def list_fish_s2_references(self, *, user_id: int) -> list[dict[str, Any]]:
+        """List Fish S2 managed references from local voice metadata."""
+        from tldw_Server_API.app.core.TTS.voice_manager import get_voice_manager
+
+        voice_manager = get_voice_manager()
+        voices = await voice_manager.list_user_voices(user_id, refresh=True)
+        references: list[dict[str, Any]] = []
+
+        for voice in voices:
+            voice_id = getattr(voice, "voice_id", None)
+            if not voice_id:
+                continue
+            metadata = await voice_manager.load_reference_metadata(user_id, voice_id)
+            if metadata is None:
+                continue
+            fish_artifacts = metadata.provider_artifacts.get("fish_s2") or {}
+            remote_reference_id = fish_artifacts.get("remote_reference_id")
+            if not remote_reference_id:
+                continue
+            references.append(
+                {
+                    "reference_id": voice_id,
+                    "voice_id": voice_id,
+                    "name": getattr(voice, "name", voice_id),
+                    "reference_text": fish_artifacts.get("reference_text") or metadata.reference_text,
+                    "remote_reference_id": remote_reference_id,
+                }
+            )
+
+        return references
+
+    async def delete_fish_s2_reference(self, *, user_id: int, reference_id: str) -> dict[str, Any]:
+        """Delete a Fish S2 managed reference while preserving the local voice record."""
+        from tldw_Server_API.app.core.TTS.voice_manager import VoiceProcessingError, get_voice_manager
+
+        voice_manager = get_voice_manager()
+        metadata = await voice_manager.load_reference_metadata(user_id, reference_id)
+        if metadata is None:
+            raise VoiceProcessingError(f"Fish S2 reference not found: {reference_id}")
+
+        fish_artifacts = metadata.provider_artifacts.get("fish_s2") or {}
+        remote_reference_id = fish_artifacts.get("remote_reference_id")
+        if not remote_reference_id:
+            raise VoiceProcessingError(f"Fish S2 reference not found: {reference_id}")
+
+        adapter = await self._get_adapter("fish_s2", provider="fish_s2")
+        if adapter is None or not hasattr(adapter, "delete_reference"):
+            raise TTSProviderNotConfiguredError("Fish S2 adapter is not available", provider="fish_s2")
+
+        await adapter.delete_reference(reference_id=str(remote_reference_id))
+        metadata.provider_artifacts.pop("fish_s2", None)
+        await voice_manager.save_reference_metadata(user_id, metadata)
+        return {"reference_id": reference_id, "deleted": True}
+
+    @staticmethod
+    def _build_fish_s2_remote_reference_id(user_id: int, voice_id: str) -> str:
+        return f"tldw_u{user_id}_{voice_id}"
+
     async def _get_adapter(
         self,
         model: str,

--- a/tldw_Server_API/app/core/TTS/tts_service_v2.py
+++ b/tldw_Server_API/app/core/TTS/tts_service_v2.py
@@ -466,6 +466,7 @@ class TTSServiceV2:
                 config=self._get_validation_config(),
             )
             await self._apply_custom_voice_reference(tts_request, user_id, provider_hint)
+            await self._apply_fish_s2_reference_context(tts_request, user_id, provider_hint)
 
             adapter = await self._get_adapter(request.model, provider, overrides=provider_overrides)
             if not adapter and fallback:
@@ -2682,6 +2683,86 @@ class TTSServiceV2:
             logger.debug(
                 "Failed to persist Qwen3 voice_clone_prompt for {} (request_id={}): {}",
                 raw_id,
+                request_id or "unknown",
+                exc,
+            )
+
+    async def _apply_fish_s2_reference_context(
+        self,
+        request: TTSRequest,
+        user_id: Optional[int],
+        provider_hint: Optional[str],
+    ) -> None:
+        """Resolve Fish S2 logical references into backend-ready request fields."""
+        if not user_id or (provider_hint or "").lower() != "fish_s2":
+            return
+
+        extras = request.extra_params or {}
+        if not isinstance(extras, dict):
+            extras = {}
+
+        explicit_reference_id = extras.get("reference_id")
+        local_voice_id: Optional[str] = None
+        if isinstance(explicit_reference_id, str) and explicit_reference_id.strip():
+            local_voice_id = explicit_reference_id.strip()
+        elif isinstance(request.voice, str) and request.voice.startswith("custom:"):
+            local_voice_id = request.voice.split("custom:", 1)[-1].strip() or None
+
+        if not local_voice_id:
+            request.extra_params = extras
+            return
+
+        try:
+            from tldw_Server_API.app.core.TTS.voice_manager import VoiceProcessingError, get_voice_manager
+
+            voice_manager = get_voice_manager()
+            metadata = await voice_manager.load_reference_metadata(user_id, local_voice_id)
+
+            fish_artifacts = {}
+            if metadata and isinstance(metadata.provider_artifacts, dict):
+                fish_artifacts = metadata.provider_artifacts.get("fish_s2") or {}
+
+            remote_reference_id = None
+            if isinstance(fish_artifacts, dict):
+                remote_reference_id = fish_artifacts.get("remote_reference_id") or fish_artifacts.get("reference_id")
+
+            if remote_reference_id:
+                extras["reference_id"] = str(remote_reference_id)
+                extras.pop("references", None)
+                request.extra_params = extras
+                return
+
+            reference_text = (
+                extras.get("reference_text")
+                or extras.get("ref_text")
+                or extras.get("voice_reference_text")
+                or (fish_artifacts.get("reference_text") if isinstance(fish_artifacts, dict) else None)
+                or (metadata.reference_text if metadata else None)
+            )
+
+            voice_bytes = request.voice_reference
+            if voice_bytes is None:
+                try:
+                    voice_bytes = await voice_manager.load_voice_reference_audio(user_id, local_voice_id)
+                    request.voice_reference = voice_bytes
+                except VoiceProcessingError:
+                    voice_bytes = None
+
+            if isinstance(voice_bytes, (bytes, bytearray)) and reference_text:
+                extras.pop("reference_id", None)
+                extras["references"] = [
+                    {
+                        "audio_b64": base64.b64encode(bytes(voice_bytes)).decode("ascii"),
+                        "text": str(reference_text),
+                    }
+                ]
+
+            request.extra_params = extras
+        except _TTS_NONCRITICAL_EXCEPTIONS as exc:
+            request_id, _ = self._get_tts_request_observability(request)
+            logger.debug(
+                "Fish S2 reference resolution failed for {} (request_id={}): {}",
+                local_voice_id,
                 request_id or "unknown",
                 exc,
             )

--- a/tldw_Server_API/app/core/TTS/tts_validation.py
+++ b/tldw_Server_API/app/core/TTS/tts_validation.py
@@ -194,6 +194,10 @@ class ProviderLimits:
             "max_text_length": 5000,
             "languages": ["en"],
             "valid_formats": {"mp3", "opus", "aac", "flac", "wav", "pcm"},
+        },
+        "fish_s2": {
+            "max_text_length": 5000,
+            "valid_formats": {"wav", "mp3", "opus", "pcm"},
             "min_speed": 0.25,
             "max_speed": 4.0,
         }
@@ -300,6 +304,7 @@ class TTSInputValidator:
         "lux_tts": 5000,
         "qwen3_tts": 5000,
         "omnivoice": 5000,
+        "fish_s2": 5000,
         "default": 5000,
     }
 
@@ -357,6 +362,7 @@ class TTSInputValidator:
         "lux_tts": {AudioFormat.MP3, AudioFormat.WAV, AudioFormat.FLAC, AudioFormat.OPUS, AudioFormat.AAC, AudioFormat.PCM},
         "qwen3_tts": {AudioFormat.MP3, AudioFormat.OPUS, AudioFormat.AAC, AudioFormat.WAV, AudioFormat.PCM},
         "omnivoice": {AudioFormat.MP3, AudioFormat.OPUS, AudioFormat.AAC, AudioFormat.FLAC, AudioFormat.WAV, AudioFormat.PCM},
+        "fish_s2": {AudioFormat.WAV, AudioFormat.MP3, AudioFormat.OPUS, AudioFormat.PCM},
     }
 
     # Voice reference file validation
@@ -601,6 +607,16 @@ class TTSInputValidator:
             # Validate format
             if request.format:
                 self._validate_format(request.format, provider)
+
+            if provider == "fish_s2" and request.stream and request.format != AudioFormat.WAV:
+                raise TTSUnsupportedFormatError(
+                    "Fish S2 streaming only supports WAV format",
+                    provider=provider,
+                    details={
+                        "requested_format": request.format.value,
+                        "supported_streaming_formats": [AudioFormat.WAV.value],
+                    },
+                )
 
             # Validate language (allow extra_params.language override)
             language = request.language

--- a/tldw_Server_API/app/core/TTS/voice_manager.py
+++ b/tldw_Server_API/app/core/TTS/voice_manager.py
@@ -111,6 +111,13 @@ PROVIDER_REQUIREMENTS = {
         "duration": {"min": 3, "max": 30},
         "sample_rate": 24000,
         "convert_to": "wav",
+    },
+    "fish_s2": {
+        "formats": [".wav", ".mp3", ".flac", ".ogg", ".m4a", ".opus"],
+        "max_size_mb": 50,
+        "duration": {"min": 3, "max": 60},
+        "sample_rate": 24000,
+        "convert_to": "wav"
     }
 }
 

--- a/tldw_Server_API/tests/TTS_NEW/integration/test_fish_s2_reference_endpoints.py
+++ b/tldw_Server_API/tests/TTS_NEW/integration/test_fish_s2_reference_endpoints.py
@@ -1,0 +1,123 @@
+import os
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.endpoints.audio import audio_voices
+from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("TEST_MODE", "true")
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("SINGLE_USER_API_KEY", "test-api-key-1234567890")
+    monkeypatch.setenv("SINGLE_USER_FIXED_ID", "1")
+    reset_settings()
+    app = FastAPI()
+    app.include_router(audio_voices.router, prefix="/api/v1/audio")
+    with TestClient(app) as c:
+        yield c, app
+
+
+def test_create_fish_s2_reference_from_existing_voice(client):
+    client_obj, app = client
+    called = {}
+
+    class _FakeTTSService:
+        async def create_fish_s2_reference(self, **kwargs):
+            called.update(kwargs)
+            return {
+                "reference_id": kwargs["voice_id"],
+                "voice_id": kwargs["voice_id"],
+                "remote_reference_id": "tldw_u1_voice-1",
+                "reference_text": kwargs["reference_text"],
+                "cached": False,
+            }
+
+    app.dependency_overrides[audio_voices.get_tts_service] = lambda: _FakeTTSService()
+    try:
+        response = client_obj.post(
+            "/api/v1/audio/providers/fish_s2/references",
+            data={"voice_id": "voice-1", "reference_text": "stored text"},
+            headers={"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]},
+        )
+    finally:
+        app.dependency_overrides.pop(audio_voices.get_tts_service, None)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["reference_id"] == "voice-1"
+    assert body["remote_reference_id"] == "tldw_u1_voice-1"
+    assert str(called["user_id"]) == "1"
+    assert called["voice_id"] == "voice-1"
+
+
+def test_create_fish_s2_reference_requires_upload_fields_when_voice_missing(client):
+    client_obj, app = client
+    app.dependency_overrides[audio_voices.get_tts_service] = lambda: object()
+    try:
+        response = client_obj.post(
+            "/api/v1/audio/providers/fish_s2/references",
+            data={},
+            headers={"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]},
+        )
+    finally:
+        app.dependency_overrides.pop(audio_voices.get_tts_service, None)
+
+    assert response.status_code == 400
+
+
+def test_list_fish_s2_references(client):
+    client_obj, app = client
+
+    class _FakeTTSService:
+        async def list_fish_s2_references(self, **kwargs):
+            return [
+                {
+                    "reference_id": "voice-1",
+                    "voice_id": "voice-1",
+                    "name": "Voice One",
+                    "reference_text": "stored text",
+                    "remote_reference_id": "tldw_u1_voice-1",
+                }
+            ]
+
+    app.dependency_overrides[audio_voices.get_tts_service] = lambda: _FakeTTSService()
+    try:
+        response = client_obj.get(
+            "/api/v1/audio/providers/fish_s2/references",
+            headers={"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]},
+        )
+    finally:
+        app.dependency_overrides.pop(audio_voices.get_tts_service, None)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["count"] == 1
+    assert body["references"][0]["reference_id"] == "voice-1"
+
+
+def test_delete_fish_s2_reference(client):
+    client_obj, app = client
+    called = {}
+
+    class _FakeTTSService:
+        async def delete_fish_s2_reference(self, **kwargs):
+            called.update(kwargs)
+            return {"reference_id": kwargs["reference_id"], "deleted": True}
+
+    app.dependency_overrides[audio_voices.get_tts_service] = lambda: _FakeTTSService()
+    try:
+        response = client_obj.delete(
+            "/api/v1/audio/providers/fish_s2/references/voice-1",
+            headers={"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]},
+        )
+    finally:
+        app.dependency_overrides.pop(audio_voices.get_tts_service, None)
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"reference_id": "voice-1", "deleted": True}
+    assert str(called["user_id"]) == "1"
+    assert called["reference_id"] == "voice-1"

--- a/tldw_Server_API/tests/TTS_NEW/integration/test_voice_routes_rate_limit.py
+++ b/tldw_Server_API/tests/TTS_NEW/integration/test_voice_routes_rate_limit.py
@@ -3,7 +3,6 @@ from fastapi import FastAPI, HTTPException
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 
-from tldw_Server_API.app.api.v1.endpoints.audio.audio import router as audio_router
 from tldw_Server_API.app.api.v1.endpoints.audio import audio_voices
 from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
 
@@ -16,7 +15,7 @@ def client(monkeypatch):
     monkeypatch.setenv("SINGLE_USER_FIXED_ID", "1")
     reset_settings()
     app = FastAPI()
-    app.include_router(audio_router, prefix="/api/v1/audio")
+    app.include_router(audio_voices.router, prefix="/api/v1/audio")
 
     async def _deny_rate_limit():
         raise HTTPException(status_code=429, detail="rate limited in test")
@@ -54,7 +53,7 @@ def _extract_token_scope_dependency(route: APIRoute):
 
 def test_voice_routes_use_granular_endpoint_ids_and_voice_counter():
     app = FastAPI()
-    app.include_router(audio_router, prefix="/api/v1/audio")
+    app.include_router(audio_voices.router, prefix="/api/v1/audio")
 
     expectations = [
         ("POST", "/api/v1/audio/voices/upload", "audio.voices.upload"),
@@ -63,6 +62,9 @@ def test_voice_routes_use_granular_endpoint_ids_and_voice_counter():
         ("GET", "/api/v1/audio/voices/{voice_id}", "audio.voices.get"),
         ("DELETE", "/api/v1/audio/voices/{voice_id}", "audio.voices.delete"),
         ("POST", "/api/v1/audio/voices/{voice_id}/preview", "audio.voices.preview"),
+        ("POST", "/api/v1/audio/providers/fish_s2/references", "audio.voices.upload"),
+        ("GET", "/api/v1/audio/providers/fish_s2/references", "audio.voices.list"),
+        ("DELETE", "/api/v1/audio/providers/fish_s2/references/{reference_id}", "audio.voices.delete"),
     ]
 
     for method, path, endpoint_id in expectations:

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_adapter.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_adapter.py
@@ -151,3 +151,55 @@ async def test_adapter_returns_streaming_response(monkeypatch):
     assert response.audio_stream is not None
     chunks = [chunk async for chunk in response.audio_stream]
     assert chunks == [b"a", b"b", b"c"]
+
+
+@pytest.mark.asyncio
+async def test_adapter_add_and_delete_reference_delegate_to_backend(monkeypatch):
+    from tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter import FishS2Adapter
+
+    class _BackendWithRefs(_FakeBackend):
+        def __init__(self):
+            super().__init__()
+            self.add_calls = []
+            self.delete_calls = []
+
+        async def add_reference(self, *, reference_id, audio_b64, reference_text):
+            self.add_calls.append(
+                {
+                    "reference_id": reference_id,
+                    "audio_b64": audio_b64,
+                    "reference_text": reference_text,
+                }
+            )
+            return {"reference_id": reference_id}
+
+        async def delete_reference(self, *, reference_id):
+            self.delete_calls.append(reference_id)
+            return True
+
+    backend = _BackendWithRefs()
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter._build_backend",
+        lambda config: backend,
+    )
+
+    adapter = FishS2Adapter({"backend": "native_http", "base_url": "http://fish.local"})
+    await adapter.ensure_initialized()
+
+    created = await adapter.add_reference(
+        reference_id="tldw_u1_voice-1",
+        audio_b64="QUJD",
+        reference_text="hello there",
+    )
+    deleted = await adapter.delete_reference(reference_id="tldw_u1_voice-1")
+
+    assert created == {"reference_id": "tldw_u1_voice-1"}
+    assert deleted is True
+    assert backend.add_calls == [
+        {
+            "reference_id": "tldw_u1_voice-1",
+            "audio_b64": "QUJD",
+            "reference_text": "hello there",
+        }
+    ]
+    assert backend.delete_calls == ["tldw_u1_voice-1"]

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_adapter.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_adapter.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSProviderInitializationError
+
+
+class _FakeBackend:
+    def __init__(self, *, response: bytes = b"audio", stream_chunks: list[bytes] | None = None) -> None:
+        self.calls: list[dict[str, object]] = []
+        self._response = response
+        self._stream_chunks = stream_chunks or [b"chunk1", b"chunk2"]
+
+    async def health_check(self) -> bool:
+        return True
+
+    async def synthesize(
+        self,
+        *,
+        text: str,
+        response_format: str,
+        streaming: bool,
+        reference_id: str | None,
+        extra_params: dict[str, object] | None,
+    ) -> bytes | AsyncIterator[bytes]:
+        self.calls.append(
+            {
+                "text": text,
+                "response_format": response_format,
+                "streaming": streaming,
+                "reference_id": reference_id,
+                "extra_params": extra_params,
+            }
+        )
+        if streaming:
+            async def _gen() -> AsyncIterator[bytes]:
+                for chunk in self._stream_chunks:
+                    yield chunk
+
+            return _gen()
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_adapter_initializes_native_http_backend(monkeypatch):
+    from tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter import FishS2Adapter
+
+    backend = _FakeBackend()
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter._build_backend",
+        lambda config: backend,
+    )
+
+    adapter = FishS2Adapter({"backend": "native_http", "base_url": "http://fish.local"})
+
+    assert await adapter.ensure_initialized() is True
+    assert adapter.capabilities is not None
+    assert adapter.capabilities.provider_name == "Fish Audio S2"
+    assert adapter.capabilities.supports_streaming is True
+    assert adapter.capabilities.supports_voice_cloning is True
+    assert adapter.capabilities.supports_multi_speaker is False
+
+
+@pytest.mark.asyncio
+async def test_adapter_rejects_unimplemented_local_runtime():
+    from tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter import FishS2Adapter
+
+    adapter = FishS2Adapter({"backend": "local_runtime"})
+
+    with pytest.raises(TTSProviderInitializationError):
+        await adapter.ensure_initialized()
+
+
+@pytest.mark.asyncio
+async def test_adapter_maps_request_and_merges_defaults(monkeypatch):
+    from tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter import FishS2Adapter
+
+    backend = _FakeBackend(response=b"fish-audio")
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter._build_backend",
+        lambda config: backend,
+    )
+
+    adapter = FishS2Adapter(
+        {
+            "backend": "native_http",
+            "base_url": "http://fish.local",
+            "sample_rate": 24000,
+            "extra_params": {
+                "default_chunk_length": 180,
+                "default_normalize": False,
+            },
+        }
+    )
+    await adapter.ensure_initialized()
+
+    response = await adapter.generate(
+        TTSRequest(
+            text="hello",
+            voice="fishref:voice-from-voice",
+            format=AudioFormat.WAV,
+            stream=False,
+            extra_params={
+                "reference_id": "voice-explicit",
+                "seed": 7,
+            },
+        )
+    )
+
+    assert response.audio_content == b"fish-audio"
+    assert response.format == AudioFormat.WAV
+    assert response.sample_rate == 24000
+    assert backend.calls[-1] == {
+        "text": "hello",
+        "response_format": "wav",
+        "streaming": False,
+        "reference_id": "voice-explicit",
+        "extra_params": {
+            "chunk_length": 180,
+            "normalize": False,
+            "seed": 7,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_adapter_returns_streaming_response(monkeypatch):
+    from tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter import FishS2Adapter
+
+    backend = _FakeBackend(stream_chunks=[b"a", b"b", b"c"])
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.fish_s2_adapter._build_backend",
+        lambda config: backend,
+    )
+
+    adapter = FishS2Adapter({"backend": "native_http", "base_url": "http://fish.local"})
+    await adapter.ensure_initialized()
+
+    response = await adapter.generate(
+        TTSRequest(
+            text="hello",
+            format=AudioFormat.WAV,
+            stream=True,
+            extra_params={"reference_id": "voice-123"},
+        )
+    )
+
+    assert response.audio_stream is not None
+    chunks = [chunk async for chunk in response.audio_stream]
+    assert chunks == [b"a", b"b", b"c"]

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_native_http_backend.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_native_http_backend.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSAuthenticationError
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int = 200, content: bytes = b"audio", text: str = "ok"):
+        self.status_code = status_code
+        self.content = content
+        self.text = text
+
+
+@pytest.mark.asyncio
+async def test_backend_builds_tts_payload_from_request(monkeypatch):
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_native_http import FishS2NativeHttpBackend
+
+    backend = FishS2NativeHttpBackend(
+        {"base_url": "http://fish.local", "api_key": "secret", "timeout": 30}
+    )
+
+    captured: dict[str, object] = {}
+
+    async def fake_fetch(*, method, url, json=None, headers=None, timeout=None, **_kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return _FakeResponse()
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.backends.fish_s2_native_http.afetch",
+        fake_fetch,
+    )
+
+    audio = await backend.synthesize(
+        text="hello",
+        response_format="wav",
+        streaming=False,
+        reference_id="tldw_u1_vabc",
+        extra_params={"chunk_length": 200, "normalize": True},
+    )
+
+    assert audio == b"audio"
+    assert captured["method"] == "POST"
+    assert captured["url"] == "http://fish.local/v1/tts"
+    assert captured["json"] == {
+        "text": "hello",
+        "format": "wav",
+        "streaming": False,
+        "reference_id": "tldw_u1_vabc",
+        "chunk_length": 200,
+        "normalize": True,
+    }
+    assert captured["headers"] == {"Authorization": "Bearer secret"}
+    assert captured["timeout"] == 30
+
+
+@pytest.mark.asyncio
+async def test_backend_uses_streaming_helper_for_streaming_requests(monkeypatch):
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_native_http import FishS2NativeHttpBackend
+
+    backend = FishS2NativeHttpBackend({"base_url": "http://fish.local"})
+
+    async def fake_stream(*, method, url, json=None, headers=None, timeout=None, **_kwargs):
+        yield b"chunk1"
+        yield b"chunk2"
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.backends.fish_s2_native_http.astream_bytes",
+        fake_stream,
+    )
+
+    stream = await backend.synthesize(
+        text="hello",
+        response_format="wav",
+        streaming=True,
+        reference_id=None,
+        extra_params=None,
+    )
+
+    chunks = [chunk async for chunk in stream]
+    assert chunks == [b"chunk1", b"chunk2"]
+
+
+@pytest.mark.asyncio
+async def test_backend_maps_401_to_authentication_error(monkeypatch):
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_native_http import FishS2NativeHttpBackend
+
+    backend = FishS2NativeHttpBackend({"base_url": "http://fish.local", "api_key": "secret"})
+
+    async def fake_fetch(**_kwargs):
+        return _FakeResponse(status_code=401, text="invalid token")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.backends.fish_s2_native_http.afetch",
+        fake_fetch,
+    )
+
+    with pytest.raises(TTSAuthenticationError):
+        await backend.synthesize(
+            text="hello",
+            response_format="wav",
+            streaming=False,
+            reference_id=None,
+            extra_params=None,
+        )

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_native_http_backend.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_native_http_backend.py
@@ -121,10 +121,12 @@ async def test_backend_add_reference_posts_expected_payload(monkeypatch):
 
     captured = {}
 
-    async def fake_fetch(*, method, url, json=None, headers=None, timeout=None, **_kwargs):
+    async def fake_fetch(*, method, url, json=None, data=None, files=None, headers=None, timeout=None, **_kwargs):
         captured["method"] = method
         captured["url"] = url
         captured["json"] = json
+        captured["data"] = data
+        captured["files"] = files
         captured["headers"] = headers
         captured["timeout"] = timeout
         return _FakeResponse(json_data={"reference_id": "tldw_u1_voice-1"})
@@ -143,11 +145,16 @@ async def test_backend_add_reference_posts_expected_payload(monkeypatch):
     assert result == {"reference_id": "tldw_u1_voice-1"}
     assert captured["method"] == "POST"
     assert captured["url"] == "http://fish.local/v1/references/add"
-    assert captured["json"] == {
-        "reference_id": "tldw_u1_voice-1",
-        "audio_b64": "QUJD",
+    assert captured["json"] is None
+    assert captured["data"] == {
+        "id": "tldw_u1_voice-1",
         "text": "hello there",
     }
+    assert captured["files"] == {
+        "audio": ("reference.wav", b"ABC", "audio/wav"),
+    }
+    assert captured["headers"] == {"Authorization": "Bearer secret"}
+    assert captured["timeout"] == backend.timeout
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_native_http_backend.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_native_http_backend.py
@@ -6,10 +6,14 @@ from tldw_Server_API.app.core.TTS.tts_exceptions import TTSAuthenticationError
 
 
 class _FakeResponse:
-    def __init__(self, status_code: int = 200, content: bytes = b"audio", text: str = "ok"):
+    def __init__(self, status_code: int = 200, content: bytes = b"audio", text: str = "ok", json_data=None):
         self.status_code = status_code
         self.content = content
         self.text = text
+        self._json_data = json_data
+
+    def json(self):
+        return self._json_data
 
 
 @pytest.mark.asyncio
@@ -107,3 +111,67 @@ async def test_backend_maps_401_to_authentication_error(monkeypatch):
             reference_id=None,
             extra_params=None,
         )
+
+
+@pytest.mark.asyncio
+async def test_backend_add_reference_posts_expected_payload(monkeypatch):
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_native_http import FishS2NativeHttpBackend
+
+    backend = FishS2NativeHttpBackend({"base_url": "http://fish.local", "api_key": "secret"})
+
+    captured = {}
+
+    async def fake_fetch(*, method, url, json=None, headers=None, timeout=None, **_kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return _FakeResponse(json_data={"reference_id": "tldw_u1_voice-1"})
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.backends.fish_s2_native_http.afetch",
+        fake_fetch,
+    )
+
+    result = await backend.add_reference(
+        reference_id="tldw_u1_voice-1",
+        audio_b64="QUJD",
+        reference_text="hello there",
+    )
+
+    assert result == {"reference_id": "tldw_u1_voice-1"}
+    assert captured["method"] == "POST"
+    assert captured["url"] == "http://fish.local/v1/references/add"
+    assert captured["json"] == {
+        "reference_id": "tldw_u1_voice-1",
+        "audio_b64": "QUJD",
+        "text": "hello there",
+    }
+
+
+@pytest.mark.asyncio
+async def test_backend_delete_reference_posts_expected_payload(monkeypatch):
+    from tldw_Server_API.app.core.TTS.backends.fish_s2_native_http import FishS2NativeHttpBackend
+
+    backend = FishS2NativeHttpBackend({"base_url": "http://fish.local"})
+
+    captured = {}
+
+    async def fake_fetch(*, method, url, json=None, **_kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["json"] = json
+        return _FakeResponse(status_code=204)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.backends.fish_s2_native_http.afetch",
+        fake_fetch,
+    )
+
+    deleted = await backend.delete_reference(reference_id="tldw_u1_voice-1")
+
+    assert deleted is True
+    assert captured["method"] == "DELETE"
+    assert captured["url"] == "http://fish.local/v1/references/delete"
+    assert captured["json"] == {"reference_id": "tldw_u1_voice-1"}

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_fish_s2_registry.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_fish_s2_registry.py
@@ -1,0 +1,13 @@
+import pytest
+
+from tldw_Server_API.app.core.TTS.adapter_registry import TTSAdapterFactory, TTSProvider
+
+
+@pytest.mark.unit
+def test_fish_s2_aliases_resolve_to_provider():
+    factory = TTSAdapterFactory(config={"providers": {"fish_s2": {"enabled": True}}})
+
+    assert factory.get_provider_for_model("fish_s2") == TTSProvider.FISH_S2
+    assert factory.get_provider_for_model("fish-s2-pro") == TTSProvider.FISH_S2
+    assert factory.get_provider_for_model("s2-pro") == TTSProvider.FISH_S2
+    assert factory.get_provider_for_model("fishaudio/s2-pro") == TTSProvider.FISH_S2

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_service.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_service.py
@@ -5,6 +5,7 @@ Tests the main service logic, adapter selection, and request processing
 with mocked dependencies.
 """
 
+import base64
 import pytest
 from unittest.mock import Mock, AsyncMock, patch, MagicMock
 import asyncio
@@ -805,6 +806,124 @@ async def test_custom_voice_stores_qwen3_prompt_metadata(tts_service, monkeypatc
     assert metadata is not None
     assert metadata.voice_clone_prompt_b64 == "PROMPTDATA"
     assert metadata.voice_clone_prompt_format == "qwen3_tts_prompt_v1"
+
+
+@pytest.mark.unit
+async def test_fish_custom_voice_reuses_remote_reference_metadata(tts_service, monkeypatch):
+    class _FakeVoiceManager:
+        async def load_voice_reference_audio(self, user_id, voice_id):
+            return b"audio-bytes"
+
+        async def load_reference_metadata(self, user_id, voice_id):
+            return VoiceReferenceMetadata(
+                voice_id=voice_id,
+                reference_text="stored text",
+                provider_artifacts={
+                    "fish_s2": {
+                        "remote_reference_id": "tldw_u1_voice-1",
+                        "reference_text": "stored text",
+                    }
+                },
+            )
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _FakeVoiceManager(),
+        raising=True,
+    )
+
+    req = OpenAISpeechRequest(
+        model="fish_s2",
+        input="hello",
+        voice="custom:voice-1",
+        response_format="wav",
+        stream=False,
+    )
+    tts_request = tts_service._convert_request(req)
+
+    await tts_service._apply_custom_voice_reference(tts_request, user_id=1, provider_hint="fish_s2")
+    await tts_service._apply_fish_s2_reference_context(tts_request, user_id=1, provider_hint="fish_s2")
+
+    assert tts_request.extra_params.get("reference_id") == "tldw_u1_voice-1"
+    assert "references" not in tts_request.extra_params
+
+
+@pytest.mark.unit
+async def test_fish_custom_voice_falls_back_to_inline_reference(tts_service, monkeypatch):
+    class _FakeVoiceManager:
+        async def load_voice_reference_audio(self, user_id, voice_id):
+            return b"audio-bytes"
+
+        async def load_reference_metadata(self, user_id, voice_id):
+            return VoiceReferenceMetadata(
+                voice_id=voice_id,
+                reference_text="stored text",
+                provider_artifacts={},
+            )
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _FakeVoiceManager(),
+        raising=True,
+    )
+
+    req = OpenAISpeechRequest(
+        model="fish_s2",
+        input="hello",
+        voice="custom:voice-1",
+        response_format="wav",
+        stream=False,
+    )
+    tts_request = tts_service._convert_request(req)
+
+    await tts_service._apply_custom_voice_reference(tts_request, user_id=1, provider_hint="fish_s2")
+    await tts_service._apply_fish_s2_reference_context(tts_request, user_id=1, provider_hint="fish_s2")
+
+    assert tts_request.extra_params.get("reference_id") is None
+    assert tts_request.extra_params.get("references") == [
+        {
+            "audio_b64": base64.b64encode(b"audio-bytes").decode("ascii"),
+            "text": "stored text",
+        }
+    ]
+
+
+@pytest.mark.unit
+async def test_fish_reference_id_resolves_local_voice_id(tts_service, monkeypatch):
+    class _FakeVoiceManager:
+        async def load_voice_reference_audio(self, user_id, voice_id):
+            return b"audio-bytes"
+
+        async def load_reference_metadata(self, user_id, voice_id):
+            return VoiceReferenceMetadata(
+                voice_id=voice_id,
+                reference_text="stored text",
+                provider_artifacts={
+                    "fish_s2": {
+                        "remote_reference_id": "tldw_u1_voice-1",
+                    }
+                },
+            )
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _FakeVoiceManager(),
+        raising=True,
+    )
+
+    req = OpenAISpeechRequest(
+        model="fish_s2",
+        input="hello",
+        voice="alloy",
+        response_format="wav",
+        stream=False,
+        extra_params={"reference_id": "voice-1"},
+    )
+    tts_request = tts_service._convert_request(req)
+
+    await tts_service._apply_fish_s2_reference_context(tts_request, user_id=1, provider_hint="fish_s2")
+
+    assert tts_request.extra_params.get("reference_id") == "tldw_u1_voice-1"
 
 # ========================================================================
 # Caching Tests

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_service.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_service.py
@@ -925,6 +925,164 @@ async def test_fish_reference_id_resolves_local_voice_id(tts_service, monkeypatc
 
     assert tts_request.extra_params.get("reference_id") == "tldw_u1_voice-1"
 
+
+@pytest.mark.unit
+async def test_create_fish_s2_reference_persists_remote_mapping(tts_service, monkeypatch):
+    saved = {}
+
+    class _FakeVoiceManager:
+        async def load_reference_metadata(self, user_id, voice_id):
+            return VoiceReferenceMetadata(voice_id=voice_id, reference_text="stored text")
+
+        async def load_voice_reference_audio(self, user_id, voice_id):
+            return b"audio-bytes"
+
+        async def save_reference_metadata(self, user_id, metadata):
+            saved["metadata"] = metadata
+
+    class _FakeAdapter:
+        async def add_reference(self, *, reference_id, audio_b64, reference_text):
+            return {"reference_id": reference_id}
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _FakeVoiceManager(),
+        raising=True,
+    )
+    monkeypatch.setattr(tts_service, "_get_adapter", AsyncMock(return_value=_FakeAdapter()))
+
+    result = await tts_service.create_fish_s2_reference(
+        user_id=1,
+        voice_id="voice-1",
+        reference_text="stored text",
+    )
+
+    assert result["reference_id"] == "voice-1"
+    assert result["remote_reference_id"] == "tldw_u1_voice-1"
+    metadata = saved["metadata"]
+    assert metadata.provider_artifacts["fish_s2"]["remote_reference_id"] == "tldw_u1_voice-1"
+    assert metadata.provider_artifacts["fish_s2"]["reference_text"] == "stored text"
+
+
+@pytest.mark.unit
+async def test_create_fish_s2_reference_returns_cached_mapping(tts_service, monkeypatch):
+    class _FakeVoiceManager:
+        async def load_reference_metadata(self, user_id, voice_id):
+            return VoiceReferenceMetadata(
+                voice_id=voice_id,
+                reference_text="stored text",
+                provider_artifacts={
+                    "fish_s2": {
+                        "remote_reference_id": "tldw_u1_voice-1",
+                        "reference_text": "stored text",
+                    }
+                },
+            )
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _FakeVoiceManager(),
+        raising=True,
+    )
+    get_adapter = AsyncMock()
+    monkeypatch.setattr(tts_service, "_get_adapter", get_adapter)
+
+    result = await tts_service.create_fish_s2_reference(
+        user_id=1,
+        voice_id="voice-1",
+    )
+
+    assert result["cached"] is True
+    assert result["remote_reference_id"] == "tldw_u1_voice-1"
+    get_adapter.assert_not_called()
+
+
+@pytest.mark.unit
+async def test_delete_fish_s2_reference_clears_remote_mapping(tts_service, monkeypatch):
+    saved = {}
+
+    class _FakeVoiceManager:
+        async def load_reference_metadata(self, user_id, voice_id):
+            return VoiceReferenceMetadata(
+                voice_id=voice_id,
+                reference_text="stored text",
+                provider_artifacts={
+                    "fish_s2": {
+                        "remote_reference_id": "tldw_u1_voice-1",
+                        "reference_text": "stored text",
+                    }
+                },
+            )
+
+        async def save_reference_metadata(self, user_id, metadata):
+            saved["metadata"] = metadata
+
+    class _FakeAdapter:
+        def __init__(self):
+            self.calls = []
+
+        async def delete_reference(self, *, reference_id):
+            self.calls.append(reference_id)
+            return True
+
+    adapter = _FakeAdapter()
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _FakeVoiceManager(),
+        raising=True,
+    )
+    monkeypatch.setattr(tts_service, "_get_adapter", AsyncMock(return_value=adapter))
+
+    result = await tts_service.delete_fish_s2_reference(user_id=1, reference_id="voice-1")
+
+    assert result["deleted"] is True
+    assert adapter.calls == ["tldw_u1_voice-1"]
+    assert saved["metadata"].provider_artifacts == {}
+
+
+@pytest.mark.unit
+async def test_list_fish_s2_references_reads_local_metadata(tts_service, monkeypatch):
+    class _Voice:
+        def __init__(self, voice_id, name):
+            self.voice_id = voice_id
+            self.name = name
+
+    class _FakeVoiceManager:
+        async def list_user_voices(self, user_id, refresh=False):
+            return [_Voice("voice-1", "Voice One"), _Voice("voice-2", "Voice Two")]
+
+        async def load_reference_metadata(self, user_id, voice_id):
+            if voice_id == "voice-1":
+                return VoiceReferenceMetadata(
+                    voice_id=voice_id,
+                    reference_text="stored text",
+                    provider_artifacts={
+                        "fish_s2": {
+                            "remote_reference_id": "tldw_u1_voice-1",
+                            "reference_text": "stored text",
+                        }
+                    },
+                )
+            return VoiceReferenceMetadata(voice_id=voice_id, reference_text="other text")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _FakeVoiceManager(),
+        raising=True,
+    )
+
+    result = await tts_service.list_fish_s2_references(user_id=1)
+
+    assert result == [
+        {
+            "reference_id": "voice-1",
+            "voice_id": "voice-1",
+            "name": "Voice One",
+            "reference_text": "stored text",
+            "remote_reference_id": "tldw_u1_voice-1",
+        }
+    ]
+
 # ========================================================================
 # Caching Tests
 # ========================================================================

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_fish_s2.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_fish_s2.py
@@ -1,0 +1,21 @@
+import pytest
+
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSValidationError
+from tldw_Server_API.app.core.TTS.tts_validation import validate_tts_request
+
+
+@pytest.mark.unit
+def test_fish_s2_streaming_requires_wav():
+    request = TTSRequest(
+        text="hello",
+        provider="fish_s2",
+        format=AudioFormat.MP3,
+        stream=True,
+        extra_params={"reference_id": "voice-123"},
+    )
+
+    with pytest.raises(TTSValidationError) as exc:
+        validate_tts_request(request, provider="fish_s2")
+
+    assert "wav" in str(exc.value).lower()


### PR DESCRIPTION
## Summary

- add a canonical `fish_s2` TTS provider with registry/config wiring and a native HTTP backend for upstream Fish `s2-pro`
- add Fish-managed reference support across the service and new provider routes for add/list/delete
- document setup, align the reference upload client to the current upstream multipart contract, and fix the small `dev` rebase integration drift in `audio_voices.py`

## Test Plan

- [x] `source .venv/bin/activate && python -m pytest -q tldw_Server_API/tests/TTS_NEW/unit/test_tts_service.py -k "fish_" tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_native_http_backend.py tldw_Server_API/tests/TTS_NEW/unit/adapters/test_fish_s2_adapter.py tldw_Server_API/tests/TTS_NEW/integration/test_fish_s2_reference_endpoints.py`
- [x] `source .venv/bin/activate && python -m bandit -f json -o /tmp/bandit_fish_s2_rebased_dev_postfix.json tldw_Server_API/app/api/v1/endpoints/audio/audio.py tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py tldw_Server_API/app/core/TTS/adapters/fish_s2_adapter.py tldw_Server_API/app/core/TTS/backends/fish_s2_base.py tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py tldw_Server_API/app/core/TTS/tts_service_v2.py`

## Notes

- This branch is rebased onto the latest `origin/dev`.
- Live remote validation against a running Fish server is still pending and is tracked in #1339.
