### PR TITLE
docs: design MCP default profile tooling presets

### DIFF
--- a/Docs/superpowers/plans/2026-06-03-mcp-default-profile-tooling-presets-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-03-mcp-default-profile-tooling-presets-implementation-plan.md
@@ -1,0 +1,951 @@
+# MCP Default Profile Tooling Presets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the first reviewable slice of MCP role profile tooling presets: rich preset metadata, a patchable recommendation catalog, profile-scoped tool discovery/ranking, gateway bridge tools, and package docs.
+
+**Architecture:** Keep executable authority in `MCPProfile.policy_document` and grants. Put display/setup guidance in `profile.metadata["tooling"]` and a separate recommendation catalog helper. Add pure catalog/ranking helpers before wiring them into `ProfileAwareGatewayRuntime`, so policy behavior can be tested without a transport.
+
+**Tech Stack:** Python 3.10+, Pydantic v2, FastAPI/JSON-RPC gateway contracts, pytest, pytest-asyncio, Bandit.
+
+---
+
+## Scope
+
+This plan implements the metadata and discovery surface needed by the spec. It does not implement the native browser, git, safe test runner, LSP, issue tracker, or web-search tools themselves.
+
+Follow-up plans should cover:
+
+- Native CDP browser inspection tools.
+- Safe test runner command registry and execution approval flow.
+- Git inspect/conflict-read tools.
+- Native file search/edit helpers.
+- External MCP install/update templates beyond the initial CDP exact target.
+
+## Source Spec
+
+- `Docs/superpowers/specs/2026-06-03-mcp-default-profile-tooling-presets-design.md`
+
+## File Structure
+
+- Modify: `mcp_unified/profiles/presets.py`
+  - Bump preset release metadata.
+  - Populate `metadata["tooling"]` for built-in role presets.
+  - Extend safety validation for the new reviewed risk classes.
+- Create: `mcp_unified/profiles/tooling.py`
+  - Define role tooling metadata helpers, recommendation catalog defaults, progressive-disclosure defaults, and patchable recommendation merge helpers.
+- Create: `mcp_unified/gateway/tool_discovery.py`
+  - Build profile-scoped direct/deferred tool catalogs from profile metadata, backend tools, and installed external binding state.
+  - Implement deterministic filter-first/BM25 ranking.
+  - Resolve bridge `tool_id` values to underlying callable backend tool names.
+- Modify: `mcp_unified/gateway/profile_runtime.py`
+  - Expose bridge tools when the active profile has deferred categories.
+  - Intercept `tool_categories.list`, `profile.tools.list`, `tool_search`, `tool_describe`, and `tool_call`.
+  - Keep backend policy checks authoritative for actual execution.
+- Modify: `mcp_unified/gateway/cli.py`
+  - Include compact tooling summary fields in `list-presets` output while preserving `show-preset` full output.
+- Modify: `mcp_unified/USER_GUIDE.md`
+  - Document mode presets, direct vs recommended tools, CDP exact target, and recommendation catalog patching semantics.
+- Modify: `mcp_unified/README.md`
+  - Add a short pointer to role presets and progressive disclosure.
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py`
+  - Extend existing preset tests for metadata, safety, version, recommendation authority, and exact CDP target.
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py`
+  - Unit-test pure discovery, ranking, and bridge resolution.
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+  - Add runtime/JSON-RPC integration tests for bridge tools.
+- Modify if needed: `mcp_unified/__init__.py`, `mcp_unified/profiles/__init__.py`, `mcp_unified/gateway/__init__.py`
+  - Export new helpers only when they are intended as package-local API.
+
+---
+
+### Task 1: Preset Tooling Metadata Tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py`
+- Modify: `mcp_unified/profiles/presets.py`
+- Create: `mcp_unified/profiles/tooling.py`
+
+- [ ] **Step 1: Write failing tests for required tooling metadata**
+
+Add tests that assert every default mode preset has a `metadata["tooling"]` object with direct tools, capabilities, recommendations, external server categories, and progressive disclosure:
+
+```python
+def test_role_presets_include_tooling_metadata() -> None:
+    role_ids = {
+        "product-owner",
+        "architect",
+        "merge-conflict-resolver",
+        "documentation-writer",
+        "project-researcher",
+        "code-reviewer",
+        "devops-engineer",
+        "backend-engineer",
+        "frontend-engineer",
+        "qa-engineer",
+        "sdet",
+    }
+    presets_by_id = {preset.id: preset for preset in presets.list_builtin_presets()}
+
+    for preset_id in role_ids:
+        tooling = presets_by_id[preset_id].profile.metadata["tooling"]
+        assert tooling["enabled_tools"]
+        assert tooling["enabled_capabilities"]
+        assert "recommended_tools" in tooling
+        assert "recommended_servers" in tooling
+        assert tooling["recommendation_catalog_patchable"] is True
+        assert tooling["progressive_disclosure"]["max_direct_tools"] <= 24
+```
+
+Add targeted tests:
+
+```python
+def test_web_search_is_recommended_unavailable_not_enabled() -> None:
+    product_owner = presets.get_builtin_preset("product-owner")
+    assert product_owner is not None
+    tooling = product_owner.profile.metadata["tooling"]
+    assert "web.search" not in product_owner.profile.policy_document.allowed_tools
+    assert any(
+        item["category"] == "web_search"
+        and item["required"] is False
+        for item in tooling["recommended_servers"]
+    )
+
+
+def test_cdp_browser_exact_target_is_documented() -> None:
+    frontend = presets.get_builtin_preset("frontend-engineer")
+    assert frontend is not None
+    browser_servers = [
+        server
+        for server in frontend.profile.metadata["tooling"]["recommended_servers"]
+        if server["category"] == "browser"
+    ]
+    assert browser_servers
+    assert any(
+        option["id"] == "chrome-devtools-mcp"
+        and option["install_target"] == "ChromeDevTools/chrome-devtools-mcp"
+        and option["maturity"] == "exact_target"
+        for server in browser_servers
+        for option in server["binding_options"]
+    )
+
+
+def test_recommendation_catalog_patch_does_not_grant_authority() -> None:
+    from mcp_unified.profiles.tooling import merge_tooling_recommendations
+
+    product_owner = presets.get_builtin_preset("product-owner")
+    assert product_owner is not None
+    patched_tooling = merge_tooling_recommendations(
+        product_owner.profile.metadata["tooling"],
+        {
+            "recommended_tools": [
+                {
+                    "id": "shell.run",
+                    "category": "shell",
+                    "activation": "requires_operator_enablement",
+                }
+            ]
+        },
+    )
+
+    assert any(item["id"] == "shell.run" for item in patched_tooling["recommended_tools"])
+    assert "shell.run" not in product_owner.profile.policy_document.allowed_tools
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py -q
+```
+
+Expected: FAIL because `metadata["tooling"]` and the exact CDP binding target do not exist yet.
+
+- [ ] **Step 3: Create `mcp_unified/profiles/tooling.py`**
+
+Implement package-local helpers with dict outputs, not executable policy side effects:
+
+```python
+"""Default profile tooling metadata and recommendation catalog helpers."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+DEFAULT_MAX_DIRECT_TOOLS = 24
+
+CHROME_DEVTOOLS_MCP_OPTION: dict[str, Any] = {
+    "id": "chrome-devtools-mcp",
+    "category": "browser",
+    "kind": "external_mcp",
+    "install_target": "ChromeDevTools/chrome-devtools-mcp",
+    "credential_slots": [],
+    "required_scopes": [],
+    "risk_classes": ["external_network"],
+    "maturity": "exact_target",
+    "setup_url": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
+}
+
+
+def tooling_metadata(
+    *,
+    enabled_tools: list[str],
+    enabled_capabilities: list[str],
+    direct_categories: list[str],
+    deferred_categories: list[str],
+    recommended_tools: list[dict[str, Any]] | None = None,
+    recommended_servers: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Return caller-owned tooling metadata for a role preset."""
+    return {
+        "enabled_tools": list(enabled_tools),
+        "enabled_capabilities": list(enabled_capabilities),
+        "recommended_tools": deepcopy(recommended_tools or []),
+        "recommended_servers": deepcopy(recommended_servers or []),
+        "recommendation_catalog_patchable": True,
+        "progressive_disclosure": {
+            "direct_categories": list(direct_categories),
+            "deferred_categories": list(deferred_categories),
+            "max_direct_tools": DEFAULT_MAX_DIRECT_TOOLS,
+        },
+        "tool_search": {
+            "ranking": ["profile_grants", "installation_status", "category", "bm25"],
+            "semantic_search": False,
+        },
+    }
+```
+
+Add small builders for common recommendation server entries:
+
+```python
+def browser_server_recommendation() -> dict[str, Any]:
+    """Return the browser/CDP recommendation category."""
+    return {
+        "category": "browser",
+        "required": False,
+        "binding_options": [deepcopy(CHROME_DEVTOOLS_MCP_OPTION)],
+    }
+
+
+def web_search_server_recommendation() -> dict[str, Any]:
+    """Return vendor-neutral web-search recommendation metadata."""
+    return {
+        "category": "web_search",
+        "required": False,
+        "binding_options": [
+            {
+                "id": "configured-web-search",
+                "category": "web_search",
+                "kind": "external_mcp",
+                "install_target": None,
+                "credential_slots": [],
+                "required_scopes": ["search:read"],
+                "risk_classes": ["external_network"],
+                "maturity": "category_placeholder",
+                "activation": "requires_configured_provider",
+            }
+        ],
+    }
+
+
+def issue_tracker_server_recommendation() -> dict[str, Any]:
+    """Return vendor-neutral issue-tracker recommendation metadata."""
+    return {
+        "category": "issue_tracker",
+        "required": False,
+        "binding_options": [
+            {
+                "id": "jira",
+                "category": "issue_tracker",
+                "kind": "external_mcp",
+                "install_target": None,
+                "credential_slots": ["jira_api_token"],
+                "required_scopes": ["issues:read", "issues:write"],
+                "risk_classes": ["external_network", "mutating"],
+                "maturity": "category_placeholder",
+            },
+            {
+                "id": "linear",
+                "category": "issue_tracker",
+                "kind": "external_mcp",
+                "install_target": None,
+                "credential_slots": ["linear_api_key"],
+                "required_scopes": ["issues:read", "issues:write"],
+                "risk_classes": ["external_network", "mutating"],
+                "maturity": "category_placeholder",
+            },
+        ],
+    }
+
+
+def merge_tooling_recommendations(
+    tooling: dict[str, Any],
+    patch: dict[str, Any],
+) -> dict[str, Any]:
+    """Return patched recommendation metadata without changing policy."""
+    merged = deepcopy(tooling)
+    for key in ("recommended_tools", "recommended_servers"):
+        additions = patch.get(key)
+        if isinstance(additions, list):
+            merged.setdefault(key, [])
+            merged[key].extend(deepcopy(additions))
+    return merged
+```
+
+Keep helpers simple and data-oriented. Do not import from `tldw_Server_API`.
+
+- [ ] **Step 4: Populate preset metadata in `mcp_unified/profiles/presets.py`**
+
+Update imports:
+
+```python
+from .tooling import (
+    browser_server_recommendation,
+    tooling_metadata,
+    web_search_server_recommendation,
+)
+```
+
+Update `_profile()` to accept `tooling_metadata_document: dict[str, Any] | None = None` and merge it under `metadata`:
+
+```python
+metadata = {
+    "agent_metadata": {
+        "ui_label": name,
+        **(agent_metadata or {}),
+    }
+}
+if tooling_metadata_document is not None:
+    metadata["tooling"] = tooling_metadata_document
+```
+
+Update `_preset()` to pass the new metadata. Populate at least the eleven requested role presets from the spec. Example for Product Owner:
+
+```python
+tooling_metadata_document=tooling_metadata(
+    enabled_tools=[
+        "tool_categories.list",
+        "tool_search",
+        "tool_describe",
+        "profile.tools.list",
+        "fs.list",
+        "fs.read_text",
+        "fs.write_text",
+        "kanban.cards.create",
+        "memory.recall",
+    ],
+    enabled_capabilities=[
+        "filesystem.read",
+        "filesystem.write_scoped",
+        "issues.plan",
+        "stories.write",
+        "memory.read",
+    ],
+    direct_categories=["files", "tool_discovery", "issues", "memory"],
+    deferred_categories=["issue_tracker", "web_search", "docs_search", "browser"],
+    recommended_servers=[
+        web_search_server_recommendation(),
+        browser_server_recommendation(),
+        issue_tracker_server_recommendation(),
+    ],
+),
+```
+
+Do not grant `web.search`, browser interaction, shell, SSH, deployment mutation, arbitrary process execution, or memory writes by default.
+
+- [ ] **Step 5: Run preset tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_unified/profiles/tooling.py mcp_unified/profiles/presets.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+git commit -m "feat: add mcp profile tooling metadata"
+```
+
+---
+
+### Task 2: Risk-Class Safety Validation
+
+**Files:**
+- Modify: `mcp_unified/profiles/presets.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py`
+
+- [ ] **Step 1: Write failing safety tests for reviewed risk classes**
+
+Add tests for the new reviewed risk classes:
+
+```python
+def test_safety_validation_accepts_reviewed_high_risk_classes_with_approval_and_provenance() -> None:
+    profile = MCPProfile(
+        id="safe-browser",
+        name="Safe Browser",
+        policy_document={
+            "risk_classes": ["browser_mutation", "git_mutation", "deployment_mutation", "memory_mutation", "test_execution"],
+        },
+        approval_policy={"required_for": ["browser_mutation", "git_mutation", "deployment_mutation", "memory_mutation", "test_execution"]},
+        provenance={
+            "high_risk": {
+                "browser_mutation": "reviewed",
+                "git_mutation": "reviewed",
+                "deployment_mutation": "reviewed",
+                "memory_mutation": "reviewed",
+                "test_execution": "reviewed",
+            }
+        },
+    )
+    preset = presets.ProfilePreset(id="safe-browser", version="test", profile=profile)
+    assert presets.validate_preset_safety(preset) == []
+```
+
+Add a negative test:
+
+```python
+def test_safety_validation_rejects_reviewed_high_risk_class_without_approval() -> None:
+    profile = MCPProfile(
+        id="unsafe-browser",
+        name="Unsafe Browser",
+        policy_document={"risk_classes": ["browser_mutation"]},
+        provenance={"high_risk": {"browser_mutation": "reviewed"}},
+    )
+    preset = presets.ProfilePreset(id="unsafe-browser", version="test", profile=profile)
+    assert "browser_mutation_requires_approval" in presets.validate_preset_safety(preset)
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py -q
+```
+
+Expected: FAIL because the validator treats these as unknown high-risk classes or does not require approval/provenance.
+
+- [ ] **Step 3: Extend safety validator**
+
+In `mcp_unified/profiles/presets.py`, add reviewed classes:
+
+```python
+_APPROVAL_REQUIRED_RISK_CLASSES = {
+    "browser_mutation",
+    "deployment_mutation",
+    "git_mutation",
+    "memory_mutation",
+    "test_execution",
+}
+
+_HIGH_RISK_RISK_CLASSES = {
+    "credential_use",
+    "destructive_filesystem",
+    "external_network",
+    "process_execution",
+    *_APPROVAL_REQUIRED_RISK_CLASSES,
+}
+```
+
+Then add a loop in `validate_preset_safety()`:
+
+```python
+for risk_class in sorted(risk_classes & _APPROVAL_REQUIRED_RISK_CLASSES):
+    if not _approval_required_for(profile, risk_class):
+        violations.append(f"{risk_class}_requires_approval")
+    if not _has_high_risk_provenance(profile, risk_class):
+        violations.append("high_risk_capability_requires_provenance")
+```
+
+Keep unknown risk classes failing review.
+
+- [ ] **Step 4: Run safety tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_unified/profiles/presets.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+git commit -m "test: cover mcp profile risk class validation"
+```
+
+---
+
+### Task 3: Profile-Scoped Tool Discovery And Ranking
+
+**Files:**
+- Create: `mcp_unified/gateway/tool_discovery.py`
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py`
+
+- [ ] **Step 1: Write failing tests for filtering and ranking**
+
+Create tests with backend tools and a profile:
+
+```python
+from mcp_unified.gateway.tool_discovery import search_profile_tools
+from mcp_unified.profiles.models import MCPProfile, ProfilePolicy
+
+
+def test_tool_search_filters_by_profile_before_bm25() -> None:
+    profile = MCPProfile(
+        id="reviewer",
+        name="Reviewer",
+        policy_document=ProfilePolicy(capabilities=["code_search"]),
+    )
+    tools = [
+        {"name": "code.search", "description": "Search code", "metadata": {"capability": "code_search", "category": "code"}},
+        {"name": "shell.run", "description": "Run shell commands", "metadata": {"capability": "process.execute", "category": "shell"}},
+    ]
+
+    results = search_profile_tools(profile, tools, query="run search")
+
+    assert [item["tool_id"] for item in results] == ["code.search"]
+```
+
+Add ranking test:
+
+```python
+def test_tool_search_orders_installed_before_unavailable_then_bm25() -> None:
+    profile = MCPProfile(
+        id="frontend",
+        name="Frontend",
+        policy_document=ProfilePolicy(capabilities=["browser.inspect"]),
+        metadata={
+            "tooling": {
+                "recommended_tools": [
+                    {
+                        "id": "browser.trace",
+                        "category": "browser",
+                        "description": "Browser trace capture",
+                        "activation": "requires_browser_runtime",
+                    }
+                ],
+                "progressive_disclosure": {"direct_categories": [], "deferred_categories": ["browser"], "max_direct_tools": 24},
+            }
+        },
+    )
+    installed = [
+        {"name": "browser.snapshot", "description": "Browser DOM snapshot", "metadata": {"capability": "browser.inspect", "category": "browser"}}
+    ]
+
+    results = search_profile_tools(profile, installed, query="browser", category="browser")
+
+    assert [item["tool_id"] for item in results] == ["browser.snapshot", "browser.trace"]
+    assert results[0]["installation_status"] == "installed"
+    assert results[1]["installation_status"] == "recommended_unavailable"
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py -q
+```
+
+Expected: FAIL because `mcp_unified.gateway.tool_discovery` does not exist.
+
+- [ ] **Step 3: Implement catalog and ranking helpers**
+
+Implement these functions:
+
+```python
+def list_profile_tools(profile: MCPProfile, backend_tools: list[dict[str, Any]]) -> dict[str, Any]:
+    """Return profile-scoped direct, deferred, and recommended tool catalog data."""
+
+
+def search_profile_tools(
+    profile: MCPProfile,
+    backend_tools: list[dict[str, Any]],
+    *,
+    query: str = "",
+    category: str | None = None,
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    """Return ranked tool-search results scoped to profile policy."""
+
+
+def describe_profile_tool(profile: MCPProfile, backend_tools: list[dict[str, Any]], tool_id: str) -> dict[str, Any] | None:
+    """Return one visible tool descriptor by profile-scoped tool id."""
+
+
+def resolve_profile_tool_call(profile: MCPProfile, backend_tools: list[dict[str, Any]], tool_id: str) -> dict[str, Any]:
+    """Resolve a bridge tool id to an installed backend tool or an unavailable reason."""
+```
+
+Use `build_effective_policy_result()` for profile grants, not ad hoc allow logic.
+
+Implement small local BM25 helpers with standard library only:
+
+```python
+def _tokenize(text: str) -> list[str]:
+    return re.findall(r"[a-z0-9_./:-]+", text.lower())
+```
+
+No semantic-search dependency is allowed in this first implementation.
+
+- [ ] **Step 4: Run discovery tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_unified/gateway/tool_discovery.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py
+git commit -m "feat: add profile scoped tool discovery"
+```
+
+---
+
+### Task 4: Gateway Bridge Tool Integration
+
+**Files:**
+- Modify: `mcp_unified/gateway/profile_runtime.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
+
+- [ ] **Step 1: Write failing runtime tests for bridge visibility**
+
+Add tests using existing fake runtimes in `test_gateway_fastapi_package.py` or a new small runtime double:
+
+```python
+@pytest.mark.asyncio
+async def test_profile_runtime_exposes_discovery_bridge_tools_for_deferred_categories() -> None:
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    profile = MCPProfile(
+        id="frontend",
+        name="Frontend",
+        policy_document=ProfilePolicy(capabilities=["browser.inspect"]),
+        metadata={
+            "tooling": {
+                "progressive_disclosure": {
+                    "direct_categories": ["tool_discovery"],
+                    "deferred_categories": ["browser"],
+                    "max_direct_tools": 24,
+                },
+                "recommended_tools": [],
+                "recommended_servers": [],
+            }
+        },
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        _MultiToolGatewayRuntime(),
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="frontend",
+    )
+
+    tools = await runtime.list_tools(GatewayRequestContext(request_id="req"))
+
+    assert any(tool["name"] == "tool_search" for tool in tools)
+    assert any(tool["name"] == "tool_describe" for tool in tools)
+    assert any(tool["name"] == "tool_call" for tool in tools)
+```
+
+Add tests for `tool_search`, `tool_describe`, and `tool_call`:
+
+```python
+@pytest.mark.asyncio
+async def test_tool_call_rejects_recommended_unavailable_tool() -> None:
+    result = await runtime.call_tool(
+        "tool_call",
+        {"tool_id": "browser.trace", "arguments": {}},
+        GatewayRequestContext(request_id="req"),
+    )
+    assert result["error"]["reason_code"] == "tool_not_enabled"
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q
+```
+
+Expected: FAIL because bridge tools are not exposed or intercepted yet.
+
+- [ ] **Step 3: Add bridge tool descriptors**
+
+In `mcp_unified/gateway/profile_runtime.py`, add constants for direct bridge descriptors:
+
+```python
+_DISCOVERY_BRIDGE_TOOLS: tuple[dict[str, Any], ...] = (
+    {
+        "name": "tool_categories.list",
+        "description": "List profile-visible tool categories.",
+        "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+        "metadata": {"category": "tool_discovery", "capability": "tool_discovery.read"},
+    },
+    ...
+)
+```
+
+Only append `tool_call` when `metadata["tooling"]["progressive_disclosure"]["deferred_categories"]` is non-empty.
+
+- [ ] **Step 4: Intercept bridge calls**
+
+In `ProfileAwareGatewayRuntime.call_tool()`:
+
+1. Resolve profile first.
+2. If `name` is one of the discovery bridge tools, call helper methods.
+3. For `tool_call`, validate schema manually:
+
+```python
+if set(arguments) - {"tool_id", "arguments"}:
+    raise GatewayPolicyDenied(... reason_code="invalid_tool_call_arguments")
+if not isinstance(arguments.get("tool_id"), str) or not isinstance(arguments.get("arguments"), dict):
+    raise GatewayPolicyDenied(... reason_code="invalid_tool_call_arguments")
+```
+
+4. Resolve the underlying installed tool with `resolve_profile_tool_call()`.
+5. If unavailable, return a structured non-executing payload:
+
+```python
+return {
+    "error": {
+        "reason_code": "tool_not_enabled",
+        "tool_id": requested_tool_id,
+    }
+}
+```
+
+6. If installed, run the existing policy path against the real backend tool name and call the backend.
+
+- [ ] **Step 5: Run bridge integration tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_unified/gateway/profile_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+git commit -m "feat: expose profile scoped tool discovery bridge"
+```
+
+---
+
+### Task 5: CLI And Documentation
+
+**Files:**
+- Modify: `mcp_unified/gateway/cli.py`
+- Modify: `mcp_unified/README.md`
+- Modify: `mcp_unified/USER_GUIDE.md`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py`
+
+- [ ] **Step 1: Write failing CLI test for preset tooling summaries**
+
+In `test_gateway_cli_package.py`, add or extend a CLI test:
+
+```python
+def test_list_presets_includes_tooling_summary() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "mcp_unified.gateway.cli", "list-presets"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+    product_owner = next(item for item in payload["presets"] if item["id"] == "product-owner")
+    assert product_owner["tooling"]["direct_categories"]
+    assert product_owner["tooling"]["deferred_categories"]
+    assert product_owner["tooling"]["recommendation_catalog_patchable"] is True
+```
+
+- [ ] **Step 2: Run CLI test and verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -q
+```
+
+Expected: FAIL because `list-presets` only emits id/name/description/version.
+
+- [ ] **Step 3: Add compact CLI summary**
+
+Update `_handle_list_presets()` to include a compact tooling summary:
+
+```python
+def _preset_tooling_summary(preset: ProfilePreset) -> dict[str, Any]:
+    tooling = preset.profile.metadata.get("tooling")
+    if not isinstance(tooling, dict):
+        return {}
+    progressive = tooling.get("progressive_disclosure")
+    if not isinstance(progressive, dict):
+        progressive = {}
+    return {
+        "direct_categories": list(progressive.get("direct_categories") or []),
+        "deferred_categories": list(progressive.get("deferred_categories") or []),
+        "recommended_server_categories": [
+            server.get("category")
+            for server in tooling.get("recommended_servers", [])
+            if isinstance(server, dict) and isinstance(server.get("category"), str)
+        ],
+        "recommendation_catalog_patchable": tooling.get("recommendation_catalog_patchable") is True,
+    }
+```
+
+Keep `show-preset` unchanged so users can inspect the full metadata.
+
+- [ ] **Step 4: Update package docs**
+
+In `mcp_unified/USER_GUIDE.md`, add a section after "Work With Profiles":
+
+- Explain direct tools vs recommended unavailable tools.
+- Explain progressive disclosure bridge tools.
+- Document that recommendation catalog patches do not grant execution authority.
+- Document CDP first and the `ChromeDevTools/chrome-devtools-mcp` exact target.
+
+In `mcp_unified/README.md`, add a short bullet under "What Is Included" for role presets and progressive disclosure.
+
+- [ ] **Step 5: Run CLI/docs-adjacent tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_unified/gateway/cli.py mcp_unified/README.md mcp_unified/USER_GUIDE.md tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+git commit -m "docs: document mcp profile tooling discovery"
+```
+
+---
+
+### Task 6: Final Verification And PR Update
+
+**Files:**
+- Modify: existing branch/PR only
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run package artifact gate**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  -c mcp_unified/pytest-artifact-gate.ini \
+  .github/tests/test_mcp_unified_artifact_gate.py::test_mcp_unified_standalone_distribution_metadata_matches_extras \
+  .github/tests/test_mcp_unified_artifact_gate.py::test_mcp_unified_standalone_sdist_contains_only_package_boundary \
+  .github/tests/test_mcp_unified_artifact_gate.py::test_mcp_unified_standalone_artifacts_include_typed_marker \
+  .github/tests/test_mcp_unified_artifact_gate.py::test_mcp_unified_standalone_artifacts_include_package_docs \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run Bandit on touched package scope**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r mcp_unified/profiles mcp_unified/gateway -f json -o /tmp/bandit_mcp_profile_tooling.json
+```
+
+Expected: exit 0 or only known non-touched baseline issues. Fix any new findings in touched code before continuing.
+
+- [ ] **Step 4: Run whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit 0.
+
+- [ ] **Step 5: Update the draft PR**
+
+Run:
+
+```bash
+git status --short
+git push
+gh pr view 2251 --repo rmusser01/tldw_server --json url,isDraft,state,headRefName,baseRefName
+```
+
+Expected: working tree clean, branch pushed, PR #2251 remains open and draft until active MCP/ACP reconciliation is complete.
+
+- [ ] **Step 6: Final commit if verification notes changed**
+
+Only commit additional documentation/task-record changes if needed:
+
+```bash
+git add <changed-files>
+git commit -m "docs: record mcp profile tooling verification"
+```
+
+---
+
+## Implementation Notes
+
+- Use @superpowers:test-driven-development for each task that changes code.
+- Use @superpowers:verification-before-completion before claiming each task is complete.
+- Keep recommendation metadata non-authoritative. Runtime execution must still go through profile policy, external-server grants, credential grants, approval policy, and audit.
+- Do not add semantic search dependencies in this slice.
+- Do not enable shell, SSH, browser mutation, deploy mutation, CI mutation, arbitrary process execution, or memory writes by default.
+- Keep package boundary clean: files under `mcp_unified/` must not import `tldw_Server_API`.

--- a/Docs/superpowers/specs/2026-06-03-mcp-default-profile-tooling-presets-design.md
+++ b/Docs/superpowers/specs/2026-06-03-mcp-default-profile-tooling-presets-design.md
@@ -1,8 +1,8 @@
 # MCP Default Profile Tooling Presets Design
 
 Date: 2026-06-03
-Status: Spec review approved; awaiting user approval for implementation planning
-Backlog: TASK-2232
+Status: Spec review approved; draft PR placeholder pending active-work reconciliation
+Backlog: TASK-2232, TASK-2233
 
 ## Summary
 
@@ -24,6 +24,28 @@ The design also adds progressive disclosure as a first-class profile contract.
 Small, high-frequency tools are exposed directly. Large native, external, or
 plugin catalogs are hidden behind profile-scoped category/search/describe/call
 bridge tools so frontends and agents do not receive an unbounded tool list.
+
+## Placeholder PR Scope
+
+This spec is ready to serve as a draft PR anchor, but it is intentionally not
+the final implementation contract yet. Active MCP/ACP gateway work may still
+change runtime names, admin surfaces, permission-routing details, or external
+server lifecycle APIs. The draft PR should keep this design visible for review
+while those dependencies settle.
+
+Before implementation planning begins, the owner should do a reconciliation
+pass and update this spec if any of these inputs changed:
+
+- Profile preset model fields or validation rules.
+- Gateway tool catalog, discovery, or progressive-disclosure APIs.
+- External server registry, install/update, runtime lifecycle, or credential
+  grant surfaces.
+- ACP workspace binding, approval callback, or permission-routing contracts.
+- Browser inspection, safe test runner, git inspection, or LSP native tool
+  implementation choices.
+- Supported risk classes, approval policy semantics, or audit-event schema.
+- Concrete external MCP install targets that graduate from category
+  placeholders to exact package targets.
 
 ## Context
 
@@ -155,6 +177,39 @@ Sources:
    browsing only expose tools visible to the active profile/session.
 7. **Workspace binding is required for scoped writes and test execution.**
 8. **Audit covers denies, approval requests, approval decisions, and execution.**
+
+## Decision Status
+
+The following decisions are settled enough for the placeholder PR:
+
+- Use hybrid profile metadata: abstract capabilities for policy plus
+  vendor-neutral concrete binding recommendations for setup guidance.
+- Keep packaged defaults conservative. Writes, browser interaction, process
+  execution, credential use, deployment mutation, memory writes, and git
+  mutation require explicit enablement and approval.
+- Treat recommended tools and servers as non-authoritative display/setup
+  metadata until an operator installs, grants, and enables them.
+- Use progressive disclosure through profile-scoped category, search, describe,
+  and bridge-call tools.
+- Prefer native/default-included tools for mature tldw_server workspace
+  primitives and external bindings for vendor-specific systems.
+- Keep web search/fetch recommended unavailable in packaged defaults until a
+  configured provider or external binding supplies grants and provenance.
+- Represent issue/story output through native Kanban/cards and markdown first,
+  with Jira/Linear/GitHub/GitLab as optional external bindings.
+
+The following decisions remain provisional and must be rechecked before code
+implementation:
+
+- Exact public schemas and names for discovery, category, and bridge-call
+  tools.
+- Native browser-inspection backend choice: Playwright, CDP, or host adapter.
+- Safe test runner command-definition source and workspace trust boundary.
+- Whether recommendation catalog metadata is immutable built-in data or
+  operator-patchable configuration.
+- Ranking implementation for profile-scoped tool search.
+- Which external MCP options are stable exact install targets instead of
+  category placeholders.
 
 ## Default Tool Substrate
 
@@ -577,6 +632,11 @@ The implementation plan should include these test groups:
   `exact_target` rather than `category_placeholder`?
 
 ## Recommended Next Plan
+
+Before writing the implementation plan, reconcile this placeholder spec against
+the active MCP/ACP work listed in "Placeholder PR Scope". If the active work
+changes a settled assumption above, update the spec and keep the PR in draft
+until the mismatch is resolved.
 
 The next implementation plan should split this work into small reviewable
 slices:

--- a/Docs/superpowers/specs/2026-06-03-mcp-default-profile-tooling-presets-design.md
+++ b/Docs/superpowers/specs/2026-06-03-mcp-default-profile-tooling-presets-design.md
@@ -123,17 +123,20 @@ Sources:
 ## Goals
 
 - Define default role profile presets for:
+  - Orchestrator
   - Product Owner
   - Architect
   - Merge Conflict Resolver
   - Documentation Writer
   - Project Researcher
+  - Deep Researcher
   - Code Reviewer
   - DevOps Engineer
   - Backend Engineer
   - Frontend Engineer
   - QA Engineer
   - Software Development Engineer in Test
+  - Memory Keeper
 - Keep defaults vendor-neutral while surfacing recommended concrete bindings.
 - Split immediately enabled tools from recommended inactive tools/servers.
 - Add progressive-disclosure metadata for category browsing and profile-scoped
@@ -143,6 +146,10 @@ Sources:
 - Preserve the existing `MCPProfile` model shape where possible by placing
   richer setup metadata under `profile.metadata["tooling"]`.
 - Maintain conservative approvals and auditability for all risky behavior.
+
+This scope covers the existing built-in role-like presets in
+`mcp_unified/profiles/presets.py`; none of `Orchestrator`, `Deep Researcher`,
+or `Memory Keeper` are deprecated or intentionally excluded.
 
 ## Non-Goals
 
@@ -284,6 +291,12 @@ Profiles should expose tools in layers.
    Approvals, path scope, credential grants, external-server grants, and audit
    run against the resolved underlying tool, not against the generic bridge
    name.
+   `tool_not_enabled` and `tool_not_found` are normal bridge tool results with
+   `ok: false`, top-level `status`, `reason_code`, and `tool_id` fields, plus an
+   `error` object carrying the same structured values and any setup details such
+   as `installation_status`, `activation`, or `unavailable_reason`. Malformed
+   bridge arguments and profile/policy denials remain transport-level gateway
+   policy errors.
 
 ### Tool Search Ranking
 
@@ -309,7 +322,7 @@ The existing `MCPProfile` and `ProfilePolicy` fields should remain the
 enforcement source of truth. Rich tooling setup metadata should live under
 `profile.metadata["tooling"]`.
 
-Example:
+Example of the `profile.metadata["tooling"]` structure:
 
 ```json
 {
@@ -332,13 +345,17 @@ Example:
           "id": "jira",
           "kind": "external_mcp",
           "install_target": null,
-          "credential_slots": ["jira_api_token"]
+          "credential_slots": ["jira_api_token"],
+          "required_scopes": ["read", "write"],
+          "maturity": "documented_candidate"
         },
         {
           "id": "linear",
           "kind": "external_mcp",
           "install_target": null,
-          "credential_slots": ["linear_api_key"]
+          "credential_slots": ["linear_api_key"],
+          "required_scopes": ["read", "write"],
+          "maturity": "documented_candidate"
         }
       ]
     }
@@ -374,17 +391,20 @@ setup metadata until converted into real profile policy/grants by an operator.
 
 | Profile | Enabled by default | Recommended inactive | External binding categories |
 | --- | --- | --- | --- |
+| Orchestrator | Tool discovery, profile-aware delegation, planning/subtask helpers, memory recall, file read/search | Subagent launch, workflow mutation, workspace writes | `subagents`, `workflow`, `repo_host` |
 | Product Owner | File read/search/write markdown, native Kanban/cards, docs search, memory recall, tool discovery | Browser inspect, web fetch/search, issue tracker create/update | `issue_tracker`, `web_search`, `docs_search`, `browser` |
 | Architect | File read/search, CodeGraph read/context, docs search, git inspect, memory recall, tool discovery, subtask planning | LSP full graph, diagram generation, web research | `repo_host`, `docs_search`, `diagram`, `web_search` |
 | Merge Conflict Resolver | File read, git status/diff/conflict inspect, CodeGraph read, scoped file patch/edit, checkpoint | Git add/commit/rebase/merge, test runner | `repo_host`, `git_provider`, `test_runner` |
 | Documentation Writer | File read/search/write markdown, docs search, memory recall, tool discovery | Browser inspect, web fetch/search, diagram generation, docs publishing | `docs_search`, `web_search`, `browser`, `diagram`, `cms_docs_publisher` |
 | Project Researcher | File read/search, CodeGraph read/context, knowledge/media/notes/prompts/chats search, docs search, memory recall | Browser inspect, web fetch/search, deep research/citation tools | `web_search`, `docs_search`, `browser`, `citation_manager` |
+| Deep Researcher | Web research/fetch when explicitly granted, citation/source management, knowledge search, memory recall, tool discovery | Browser inspect, external research databases, long-running research jobs | `web_search`, `browser`, `citation_manager`, `research_database` |
 | Code Reviewer | File read/search, CodeGraph read/context, git diff/log/blame inspect, test result read, memory recall, tool discovery | PR review/comment tools, LSP diagnostics, CI read | `repo_host`, `pr_review`, `ci_cd`, `lsp` |
 | DevOps Engineer | Config file read, git inspect, native logs/service/runtime status, memory recall, tool discovery | CI/CD read, deploy/restart/rollback, cloud resource mutation, SSH, shell | `ci_cd`, `cloud_provider`, `ssh`, `secrets_manager`, `observability` |
 | Backend Engineer | File read/search/write scoped, CodeGraph read/index, LSP diagnostics, git inspect, safe test runner, checkpoint, memory recall | Git mutate, shell, debugger, DB migration runner | `repo_host`, `test_runner`, `debugger`, `database`, `api_docs` |
 | Frontend Engineer | File read/search/write scoped, browser inspect/screenshots/console read, LSP diagnostics, git inspect, safe test runner, checkpoint | Browser interact, visual regression, shell, design asset tools | `browser`, `visual_regression`, `design_assets`, `test_runner` |
 | QA Engineer | Browser inspect/screenshots/console/network read, app state read, logs read, safe test runner, file read/search, memory recall | Browser interact, bug filing, trace/video capture | `browser`, `issue_tracker`, `observability`, `test_runner` |
 | SDET | File read/search/write test files, safe test runner, CodeGraph read, LSP diagnostics, git inspect, checkpoint, memory recall | CI mutation, browser interact, shell, debugger | `test_runner`, `browser`, `ci_cd`, `debugger`, `repo_host` |
+| Memory Keeper | Memory/context recall, knowledge graph read, profile/tool discovery | Long-term memory writes/reflections with approval | `memory_graph`, `knowledge_graph` |
 
 ## Approval And Risk Defaults
 
@@ -409,6 +429,7 @@ Default presets should use conservative approval rules.
 Suggested risk classes:
 
 - `mutating`
+- `destructive_filesystem`
 - `external_network`
 - `process_execution`
 - `credential_use`
@@ -428,6 +449,7 @@ not as accidental unknowns, and each must map to approval and provenance rules.
 | Risk class | Default enablement | Required approval/provenance behavior | Validator change |
 | --- | --- | --- | --- |
 | `mutating` | Allowed by scoped-write roles | Approval required for writes/mutations. | Existing behavior remains valid. |
+| `destructive_filesystem` | Not enabled by default | Approval and high-risk provenance required for deletes, unscoped writes, recursive edits, or irreversible filesystem mutations. Use `mutating` for routine scoped writes and `destructive_filesystem` for destructive or unscoped filesystem authority. | Existing behavior remains valid. |
 | `external_network` | Not enabled in packaged defaults unless configured | Requires provenance explaining provider/binding and external-server grant; credential grant when secrets are needed. | Existing behavior remains valid, but web-search presets must not claim enabled access without grants. |
 | `process_execution` | Not enabled by default | Approval and high-risk provenance required. | Existing behavior remains valid. |
 | `credential_use` | Not enabled by default | High-risk provenance and credential-grant metadata required; never stores secret values. | Existing behavior remains valid. |

--- a/Docs/superpowers/specs/2026-06-03-mcp-default-profile-tooling-presets-design.md
+++ b/Docs/superpowers/specs/2026-06-03-mcp-default-profile-tooling-presets-design.md
@@ -2,7 +2,7 @@
 
 Date: 2026-06-03
 Status: Spec review approved; draft PR placeholder pending active-work reconciliation
-Backlog: TASK-2232, TASK-2233
+Backlog: TASK-2232, TASK-2233, TASK-2234
 
 ## Summary
 
@@ -110,7 +110,7 @@ The progressive-disclosure references add a second important lesson:
 - Matthew Kruczek's progressive-disclosure MCP article compares two-stage
   tool use, category/Strata-style disclosure, semantic search, tree browsing,
   and skills. For tldw_server, the best fit is hybrid category navigation plus
-  semantic/BM25 search.
+  grant-aware BM25 search.
 
 Sources:
 
@@ -197,19 +197,22 @@ The following decisions are settled enough for the placeholder PR:
   configured provider or external binding supplies grants and provenance.
 - Represent issue/story output through native Kanban/cards and markdown first,
   with Jira/Linear/GitHub/GitLab as optional external bindings.
+- Use CDP as the first browser-inspection path.
+- Rank tool-search results without semantic search in the first version:
+  profile grants filter first, then installation status, then category filters,
+  then BM25 matching.
+- Manage profile recommendation catalog metadata separately from executable
+  policy so operators can patch recommendations without granting authority.
+- Treat `ChromeDevTools/chrome-devtools-mcp` as the first known exact external
+  MCP install target for the browser/CDP category.
 
 The following decisions remain provisional and must be rechecked before code
 implementation:
 
 - Exact public schemas and names for discovery, category, and bridge-call
   tools.
-- Native browser-inspection backend choice: Playwright, CDP, or host adapter.
 - Safe test runner command-definition source and workspace trust boundary.
-- Whether recommendation catalog metadata is immutable built-in data or
-  operator-patchable configuration.
-- Ranking implementation for profile-scoped tool search.
-- Which external MCP options are stable exact install targets instead of
-  category placeholders.
+- Exact external MCP install targets outside the browser/CDP category.
 
 ## Default Tool Substrate
 
@@ -225,7 +228,7 @@ listed below.
 | Git mutate | Recommended inactive | Add, commit, merge, rebase, conflict write require enablement and approval. |
 | Native Kanban/tasks | Enabled for Product Owner | Out-of-box issue/story surface. |
 | Markdown/doc write | Enabled by PO/docs/engineering roles | Workspace-scoped and approval-gated. |
-| Browser inspect | Enabled for QA/Frontend where available | Screenshots, DOM snapshot, console/network read. |
+| Browser inspect | Enabled for QA/Frontend where CDP is available | Start with CDP for screenshots, DOM snapshot, console/network read. |
 | Browser interact | Approval-gated | Navigation, click, type, select, and state mutation. |
 | Safe test runner | Enabled for Backend/Frontend/QA/SDET | Project-configured commands only, approval required. |
 | Shell/process | Not enabled by default | Recommended inactive for engineering/devops only. |
@@ -281,6 +284,24 @@ Profiles should expose tools in layers.
    Approvals, path scope, credential grants, external-server grants, and audit
    run against the resolved underlying tool, not against the generic bridge
    name.
+
+### Tool Search Ranking
+
+The first implementation should not use semantic search for tool discovery.
+Ranking must be deterministic and policy-first:
+
+1. Filter to tools visible under the active profile grants and workspace
+   assignment.
+2. Partition by installation status so installed/enabled tools rank ahead of
+   recommended-but-unavailable tools.
+3. Apply category filters when supplied.
+4. Run BM25 text matching over tool id, display name, category, description,
+   capability labels, and unavailable reason metadata.
+5. Return stable tie-breaks by category priority and tool id.
+
+This order keeps authorization and setup state ahead of text relevance. BM25
+improves findability inside the already-allowed result set; it must not expose
+tools outside the active profile's discovery scope.
 
 ## Profile Metadata Schema
 
@@ -458,7 +479,7 @@ and ACP workspaces.
 | Git scoped mutate | `git.apply_patch`, `git.conflicts.resolve_file`, `git.add`, `git.commit` as inactive/approval-gated |
 | Tool discovery | `tool_search`, `tool_describe`, `tool_call`, `tool_categories.list`, `profile.tools.list` |
 | Safe test runner | `tests.list_commands`, `tests.run_configured`, `tests.results.read` |
-| Browser inspect | `browser.snapshot`, `browser.screenshot`, `browser.console`, `browser.network`, `browser.page_state` |
+| Browser inspect | `browser.snapshot`, `browser.screenshot`, `browser.console`, `browser.network`, `browser.page_state`; CDP first |
 | Browser interact | `browser.navigate`, `browser.click`, `browser.type`, `browser.select`, all approval-gated |
 | LSP/code intel | `lsp.diagnostics`, `lsp.symbols`, `lsp.references`, `lsp.definition`, `lsp.code_actions` |
 | Review helpers | `review.findings.create`, `review.findings.list`, `review.summary.write` |
@@ -491,7 +512,7 @@ grouped by category with concrete options where known.
 | `repo_host` | GitHub, GitLab, Bitbucket, Forgejo/Gitea |
 | `pr_review` | GitHub PRs, GitLab merge requests, Bitbucket PRs |
 | `ci_cd` | GitHub Actions, GitLab CI, Buildkite, Jenkins, CircleCI |
-| `browser` | Playwright MCP, Chrome DevTools/CDP MCP |
+| `browser` | Chrome DevTools/CDP MCP, Playwright MCP |
 | `web_search` | Brave Search, Tavily, Exa, Kagi, SearxNG |
 | `docs_search` | Context7-style docs search, vendor docs MCP, local docs index |
 | `diagram` | Mermaid renderer, draw.io/Excalidraw integration |
@@ -517,6 +538,12 @@ Each option should carry:
 - `maturity` such as `exact_target`, `category_placeholder`, or
   `documented_candidate`
 - `setup_url` or package docs when known
+
+Initial exact target:
+
+| Category | Binding option | Maturity | Setup |
+| --- | --- | --- | --- |
+| `browser` | `ChromeDevTools/chrome-devtools-mcp` | `exact_target` | https://github.com/ChromeDevTools/chrome-devtools-mcp |
 
 ## Runtime Flow
 
@@ -602,6 +629,10 @@ The implementation plan should include these test groups:
   unavailable unless a configured provider/binding and required grants exist.
 - Progressive disclosure tests: direct tool list stays below threshold;
   deferred tools are found through `tool_search`; discovery is profile-scoped.
+- Tool-search ranking tests: profile grants filter results before ranking,
+  installed/enabled tools sort ahead of unavailable recommendations, category
+  filters apply before BM25 scoring, and the first implementation does not
+  require semantic-search infrastructure.
 - Runtime policy tests: `tool_call` dispatch checks the real underlying tool,
   path scope, risk, approval, external grants, credential grants, and audit.
 - Bridge-schema tests: `tool_call` requires `tool_id` and `arguments`, rejects
@@ -619,17 +650,18 @@ The implementation plan should include these test groups:
 - Docs tests: package-local user guide documents mode presets, categories, and
   setup-dependent bindings.
 
-## Open Implementation Questions
+## Resolved Implementation Decisions
 
-- Which native browser inspection path should be first: Playwright, CDP, or a
-  host-provided browser adapter?
-- How should tool-search ranking combine semantic search, BM25, category
-  filters, profile grants, and installation status?
-- Should profile recommendations be managed as immutable built-in metadata, or
-  should operators be able to patch the recommendation catalog separately from
-  executable policy?
-- Which exact external MCP install targets are stable enough to include as
-  `exact_target` rather than `category_placeholder`?
+- First browser inspection path: CDP.
+- Tool-search ranking: do not use semantic search initially. Filter first by
+  profile grants and workspace assignment, rank installed/enabled tools ahead
+  of unavailable recommendations, apply category filters, then use BM25 over
+  the filtered catalog.
+- Recommendation catalog mutability: operators can patch recommendation
+  metadata separately from executable policy. Patchable recommendations still
+  do not grant runtime authority.
+- Initial exact external MCP target: `ChromeDevTools/chrome-devtools-mcp` for
+  the browser/CDP category.
 
 ## Recommended Next Plan
 

--- a/Docs/superpowers/specs/2026-06-03-mcp-default-profile-tooling-presets-design.md
+++ b/Docs/superpowers/specs/2026-06-03-mcp-default-profile-tooling-presets-design.md
@@ -1,0 +1,591 @@
+# MCP Default Profile Tooling Presets Design
+
+Date: 2026-06-03
+Status: Spec review approved; awaiting user approval for implementation planning
+Backlog: TASK-2232
+
+## Summary
+
+The standalone MCP gateway and tldw_server MCP/ACP workspace flows should ship
+with role-oriented default profile presets that describe both immediate tool
+authority and setup-dependent recommended tools. The presets should use a
+hybrid model: stable abstract capabilities plus a vendor-neutral catalog of
+recommended concrete tool and MCP-server bindings.
+
+The default posture is conservative. Read, search, inspect, and discovery tools
+can be enabled per role. Mutating work, credentialed calls, browser
+interaction, test execution, deployment changes, memory writes, and any process
+execution require explicit approval and workspace binding. Arbitrary shell,
+SSH, debugger control, REPL kernels, CI mutation, and deployment mutation are
+not enabled by default; they appear as recommended inactive capabilities where a
+role needs them.
+
+The design also adds progressive disclosure as a first-class profile contract.
+Small, high-frequency tools are exposed directly. Large native, external, or
+plugin catalogs are hidden behind profile-scoped category/search/describe/call
+bridge tools so frontends and agents do not receive an unbounded tool list.
+
+## Context
+
+The `mcp_unified` package already has:
+
+- `MCPProfile` and `ProfilePolicy` models.
+- Built-in role-like profile presets in `mcp_unified/profiles/presets.py`.
+- Profile resolution and profile-aware runtime enforcement.
+- Profile, assignment, external-server, credential-grant, snapshot, and audit
+  stores.
+- External MCP server registry/lifecycle/admin surfaces.
+- Package-local documentation and CLI commands for listing and duplicating
+  presets.
+
+The current presets mostly define capability strings and broad risk classes.
+They do not yet describe the concrete tool families, external binding
+categories, progressive disclosure behavior, or default-included native tools
+needed for serious agentic workspace operation.
+
+The tldw_server host already has a useful native foundation:
+
+- Filesystem module with `fs.list`, `fs.read_text`, `fs.write_text`.
+- CodeGraph module with status, indexing, symbol search, graph traversal, and
+  context tools.
+- Knowledge, media, notes, chats, prompts, and characters search/get tools.
+- Kanban/workflow tools that can act as a native issue/story surface.
+- External federation through `external.servers.list`,
+  `external.tools.refresh`, and `ext.<server>.<tool>`.
+- Gateway admin surfaces for external servers, credential grants, snapshots,
+  and runtime lifecycle.
+
+The next design step is to decide what tool substrate profiles draw from, what
+is enabled by default for each role, what is recommended but inactive, and how
+frontends expose those choices safely.
+
+## Prior-Art Review
+
+The reviewed agent harnesses point to the same conclusion: effective coding
+agents need a workspace operating surface, not only a handful of generic MCP
+tools.
+
+- `SafeRL-Lab/cheetahclaws` exposes tool modules for browser, diagnostics,
+  files/filesystem, interaction, notebook, research, security, shell, and web.
+  Its repository also has memory, checkpoint, jobs, monitor, multi-agent,
+  plugin, research, skill, task, bridge, and MCP areas.
+- `can1357/oh-my-pi` has source areas for edit, eval, exec, DAP/debug, LSP,
+  MCP, memories, memory backends, modes, plan mode, secrets, session, SSH,
+  task, tool discovery, web, and workspace-tree behavior.
+- `tanbiralam/claude-code` exposes a broad tool directory including Bash,
+  PowerShell, file read/write/edit, glob, grep, LSP, MCP resource access,
+  browser, web fetch/search, task/todo/team tools, plan/worktree tools, REPL,
+  cron/remote triggers, monitoring, notifications, skills, and workflow tools.
+
+These references support a full agent-harness catalog, but they do not imply
+that all tools should be enabled for all roles. The catalog should be broad;
+profiles should be narrow.
+
+The progressive-disclosure references add a second important lesson:
+
+- Hermes Tool Search keeps core tools direct and defers large MCP/plugin tool
+  catalogs behind a search flow when the visible tool count crosses a threshold.
+- Matthew Kruczek's progressive-disclosure MCP article compares two-stage
+  tool use, category/Strata-style disclosure, semantic search, tree browsing,
+  and skills. For tldw_server, the best fit is hybrid category navigation plus
+  semantic/BM25 search.
+
+Sources:
+
+- https://github.com/SafeRL-Lab/cheetahclaws
+- https://github.com/can1357/oh-my-pi
+- https://github.com/tanbiralam/claude-code
+- https://hermes-agent.nousresearch.com/docs/user-guide/features/tool-search
+- https://matthewkruczek.ai/blog/progressive-disclosure-mcp-servers.html
+
+## Goals
+
+- Define default role profile presets for:
+  - Product Owner
+  - Architect
+  - Merge Conflict Resolver
+  - Documentation Writer
+  - Project Researcher
+  - Code Reviewer
+  - DevOps Engineer
+  - Backend Engineer
+  - Frontend Engineer
+  - QA Engineer
+  - Software Development Engineer in Test
+- Keep defaults vendor-neutral while surfacing recommended concrete bindings.
+- Split immediately enabled tools from recommended inactive tools/servers.
+- Add progressive-disclosure metadata for category browsing and profile-scoped
+  tool search.
+- Identify native/default-included tool additions needed for tldw_server MCP
+  and ACP workspaces.
+- Preserve the existing `MCPProfile` model shape where possible by placing
+  richer setup metadata under `profile.metadata["tooling"]`.
+- Maintain conservative approvals and auditability for all risky behavior.
+
+## Non-Goals
+
+- Do not implement the tool modules in this spec.
+- Do not choose a single vendor baseline for issues, repo hosting, CI/CD,
+  browser automation, cloud, or docs publishing.
+- Do not grant arbitrary shell/process access through default profiles.
+- Do not make recommended inactive tools callable.
+- Do not embed credential secret values in profiles, grants, snapshots, or
+  recommendations.
+- Do not redesign ACP itself; ACP sessions should receive the same
+  profile-filtered catalog and route execution through ACP permission flows
+  where applicable.
+
+## Design Principles
+
+1. **Broad catalog, narrow profiles.** tldw_server can know about many tools,
+   but each role sees only the enabled and recommended subset allowed by policy.
+2. **Native where mature, external where vendor-specific.** Existing nearby
+   tldw_server modules should become native tools when practical. Jira, Linear,
+   GitHub, GitLab, cloud providers, CI systems, and specialized browsers should
+   be external bindings.
+3. **Recommended does not mean authorized.** Recommended tools and servers are
+   setup guidance until an operator installs, binds, grants, and enables them.
+4. **Execution is constrained by abstraction.** Tests, git, browser, CI, and
+   deploy tools must not tunnel into arbitrary shell.
+5. **External network is a risk even when read-only.** Web search/fetch is
+   useful for several roles, but packaged defaults should expose it as
+   recommended unavailable until a native configured provider or external
+   binding supplies explicit provenance and grants.
+6. **Progressive disclosure is policy-scoped.** Tool search and category
+   browsing only expose tools visible to the active profile/session.
+7. **Workspace binding is required for scoped writes and test execution.**
+8. **Audit covers denies, approval requests, approval decisions, and execution.**
+
+## Default Tool Substrate
+
+The default catalog should be a full agent-harness catalog with explicit
+activation state and maturity labels. The initial native/default candidates are
+listed below.
+
+| Tool family | Default posture | Notes |
+| --- | --- | --- |
+| Filesystem read/list/write | Enabled by role | Existing `fs.list`, `fs.read_text`, `fs.write_text`; add edit/search helpers. |
+| Code search/intelligence | Enabled by role | Existing CodeGraph; add LSP tools later. |
+| Git inspect | Enabled for engineering/review roles | Status, diff, log, blame, branches, conflicts. |
+| Git mutate | Recommended inactive | Add, commit, merge, rebase, conflict write require enablement and approval. |
+| Native Kanban/tasks | Enabled for Product Owner | Out-of-box issue/story surface. |
+| Markdown/doc write | Enabled by PO/docs/engineering roles | Workspace-scoped and approval-gated. |
+| Browser inspect | Enabled for QA/Frontend where available | Screenshots, DOM snapshot, console/network read. |
+| Browser interact | Approval-gated | Navigation, click, type, select, and state mutation. |
+| Safe test runner | Enabled for Backend/Frontend/QA/SDET | Project-configured commands only, approval required. |
+| Shell/process | Not enabled by default | Recommended inactive for engineering/devops only. |
+| Web search/fetch | Recommended unavailable unless configured | No vendor baseline. A configured native/provider binding can enable read-only access with `external_network` provenance and grants. |
+| Issue tracker integrations | Recommended external | Jira, Linear, GitHub Issues, GitLab Issues, etc. |
+| CI/CD/deploy/cloud | Recommended external | DevOps inspect can be enabled when bound; mutations require approval. |
+| Memory recall | Enabled read-only | All roles can read memory/context. |
+| Memory write | Recommended inactive | Memory Keeper or approved reflection only. |
+| Checkpoint/rewind | Enabled for mutating engineering roles | Session safety surface. |
+| Subagents/tasks/plans | Enabled by orchestrating roles | Bounded by profile and approval. |
+| Debug/DAP/REPL/SSH | Recommended inactive | High risk; explicit enablement required. |
+
+## Progressive Disclosure Contract
+
+Profiles should expose tools in layers.
+
+1. Core direct tools stay visible for most profiles:
+   `tool_categories.list`, `tool_search`, `tool_describe`, `profile.tools.list`,
+   file read/list, ask-user, todo, and memory recall.
+2. Role-enabled direct tools remain visible while the direct tool count stays
+   below the profile threshold.
+3. Large catalogs move behind bridge tools:
+   - `tool_search(query, category?, limit?)`
+   - `tool_describe(tool_id)`
+   - `tool_call(tool_id, arguments)`
+4. Frontends browse category groups such as Files, Code Search, Git, Browser,
+   Issues, CI/CD, Memory, Tests, Docs, External Servers, and DevOps.
+5. Discovery is profile-scoped. A Product Owner cannot discover SSH, debugger,
+   deploy, or shell tools because they exist globally.
+6. Search and describe are read-only. They must not execute actions, consume
+   credentials, call external APIs for side effects, or bypass approval.
+7. `tool_call` is a public MCP bridge tool, but only for profiles that have
+   deferred categories. It is exposed directly with the other discovery tools
+   when `progressive_disclosure.deferred_categories` is non-empty; otherwise it
+   may be omitted from the direct catalog.
+8. `tool_call` has a small fixed schema with `additionalProperties: false`. It
+   accepts only a `tool_id` string returned by `tool_search` or `tool_describe`
+   plus an `arguments` object:
+
+   ```json
+   {
+     "tool_id": "ext.issue_tracker.jira.issue.create",
+     "arguments": {"title": "Example"}
+   }
+   ```
+
+   `tool_id` and `arguments` are required. The bridge never trusts the caller's
+   category label. It resolves `tool_id` to the underlying tool name,
+   capability set, server binding, activation status, and risk metadata before
+   dispatch.
+9. `tool_call` must return `tool_not_enabled` for recommended inactive tools and
+   `tool_not_found` for tools outside the active profile's discovery scope.
+   Approvals, path scope, credential grants, external-server grants, and audit
+   run against the resolved underlying tool, not against the generic bridge
+   name.
+
+## Profile Metadata Schema
+
+The existing `MCPProfile` and `ProfilePolicy` fields should remain the
+enforcement source of truth. Rich tooling setup metadata should live under
+`profile.metadata["tooling"]`.
+
+Example:
+
+```json
+{
+  "enabled_tools": ["fs.list", "fs.read_text", "codegraph.search"],
+  "enabled_capabilities": ["filesystem.read", "codegraph.read"],
+  "recommended_tools": [
+    {
+      "id": "browser.inspect",
+      "category": "browser",
+      "status": "native_candidate",
+      "activation": "requires_browser_runtime"
+    }
+  ],
+  "recommended_servers": [
+    {
+      "category": "issue_tracker",
+      "required": false,
+      "binding_options": [
+        {
+          "id": "jira",
+          "kind": "external_mcp",
+          "install_target": null,
+          "credential_slots": ["jira_api_token"]
+        },
+        {
+          "id": "linear",
+          "kind": "external_mcp",
+          "install_target": null,
+          "credential_slots": ["linear_api_key"]
+        }
+      ]
+    }
+  ],
+  "progressive_disclosure": {
+    "direct_categories": ["files", "tool_discovery", "memory"],
+    "deferred_categories": ["issue_tracker", "ci_cd", "browser"],
+    "max_direct_tools": 24
+  }
+}
+```
+
+Field meanings:
+
+- `policy_document.allowed_tools`: immediately callable native tools.
+- `policy_document.capabilities`: enforceable capability grants.
+- `policy_document.risk_classes`: risk labels used by policy and approval.
+- `metadata.tooling.enabled_tools`: frontend-friendly mirror of direct tools.
+- `metadata.tooling.recommended_tools`: setup-dependent native candidates or
+  externally supplied tools.
+- `metadata.tooling.recommended_servers`: vendor-neutral binding categories
+  with concrete options.
+- `external_server_grants`: actual executable external-server grants after a
+  binding is installed.
+- `credential_grants`: broker metadata only; never secret values.
+- `approval_policy`: required approvals for writes, execution, credentials,
+  browser mutation, deployment mutation, and similar risks.
+
+Recommended tools and servers must not grant authority. They are display and
+setup metadata until converted into real profile policy/grants by an operator.
+
+## Role Preset Matrix
+
+| Profile | Enabled by default | Recommended inactive | External binding categories |
+| --- | --- | --- | --- |
+| Product Owner | File read/search/write markdown, native Kanban/cards, docs search, memory recall, tool discovery | Browser inspect, web fetch/search, issue tracker create/update | `issue_tracker`, `web_search`, `docs_search`, `browser` |
+| Architect | File read/search, CodeGraph read/context, docs search, git inspect, memory recall, tool discovery, subtask planning | LSP full graph, diagram generation, web research | `repo_host`, `docs_search`, `diagram`, `web_search` |
+| Merge Conflict Resolver | File read, git status/diff/conflict inspect, CodeGraph read, scoped file patch/edit, checkpoint | Git add/commit/rebase/merge, test runner | `repo_host`, `git_provider`, `test_runner` |
+| Documentation Writer | File read/search/write markdown, docs search, memory recall, tool discovery | Browser inspect, web fetch/search, diagram generation, docs publishing | `docs_search`, `web_search`, `browser`, `diagram`, `cms_docs_publisher` |
+| Project Researcher | File read/search, CodeGraph read/context, knowledge/media/notes/prompts/chats search, docs search, memory recall | Browser inspect, web fetch/search, deep research/citation tools | `web_search`, `docs_search`, `browser`, `citation_manager` |
+| Code Reviewer | File read/search, CodeGraph read/context, git diff/log/blame inspect, test result read, memory recall, tool discovery | PR review/comment tools, LSP diagnostics, CI read | `repo_host`, `pr_review`, `ci_cd`, `lsp` |
+| DevOps Engineer | Config file read, git inspect, native logs/service/runtime status, memory recall, tool discovery | CI/CD read, deploy/restart/rollback, cloud resource mutation, SSH, shell | `ci_cd`, `cloud_provider`, `ssh`, `secrets_manager`, `observability` |
+| Backend Engineer | File read/search/write scoped, CodeGraph read/index, LSP diagnostics, git inspect, safe test runner, checkpoint, memory recall | Git mutate, shell, debugger, DB migration runner | `repo_host`, `test_runner`, `debugger`, `database`, `api_docs` |
+| Frontend Engineer | File read/search/write scoped, browser inspect/screenshots/console read, LSP diagnostics, git inspect, safe test runner, checkpoint | Browser interact, visual regression, shell, design asset tools | `browser`, `visual_regression`, `design_assets`, `test_runner` |
+| QA Engineer | Browser inspect/screenshots/console/network read, app state read, logs read, safe test runner, file read/search, memory recall | Browser interact, bug filing, trace/video capture | `browser`, `issue_tracker`, `observability`, `test_runner` |
+| SDET | File read/search/write test files, safe test runner, CodeGraph read, LSP diagnostics, git inspect, checkpoint, memory recall | CI mutation, browser interact, shell, debugger | `test_runner`, `browser`, `ci_cd`, `debugger`, `repo_host` |
+
+## Approval And Risk Defaults
+
+Default presets should use conservative approval rules.
+
+- Markdown writes, native Kanban/card creation, file edits, and test execution
+  require approval.
+- Browser inspect is read-only; browser interaction requires approval.
+- Shell, SSH, debugger, deploy, CI mutation, REPL, and arbitrary process
+  execution are not enabled by default.
+- Web search/fetch is recommended unavailable in packaged defaults unless a
+  native configured provider or external MCP binding exists. Once enabled, it is
+  read-only, records `external_network` provenance, and requires the relevant
+  external-server and credential grant metadata when the provider needs secrets.
+- Memory recall is enabled; memory writes are not enabled for these role
+  presets by default.
+- Git mutate is recommended inactive unless explicitly enabled by an operator.
+- Credentialed external calls require credential grant metadata and approval
+  policy evaluation.
+- Workspace binding is required for all scoped writes and test execution.
+
+Suggested risk classes:
+
+- `mutating`
+- `external_network`
+- `process_execution`
+- `credential_use`
+- `browser_mutation`
+- `git_mutation`
+- `deployment_mutation`
+- `memory_mutation`
+- `test_execution`
+
+### Risk-Class Compatibility
+
+The implementation plan must update preset safety validation before introducing
+new risk classes. `validate_preset_safety()` currently recognizes only a narrow
+high-risk set. These proposed classes must be treated as known reviewed risks,
+not as accidental unknowns, and each must map to approval and provenance rules.
+
+| Risk class | Default enablement | Required approval/provenance behavior | Validator change |
+| --- | --- | --- | --- |
+| `mutating` | Allowed by scoped-write roles | Approval required for writes/mutations. | Existing behavior remains valid. |
+| `external_network` | Not enabled in packaged defaults unless configured | Requires provenance explaining provider/binding and external-server grant; credential grant when secrets are needed. | Existing behavior remains valid, but web-search presets must not claim enabled access without grants. |
+| `process_execution` | Not enabled by default | Approval and high-risk provenance required. | Existing behavior remains valid. |
+| `credential_use` | Not enabled by default | High-risk provenance and credential-grant metadata required; never stores secret values. | Existing behavior remains valid. |
+| `browser_mutation` | Recommended inactive | Approval required for navigation, click, type, select, or page-state mutation. Browser inspect stays read-only. | Add as known high-risk class requiring approval/provenance. |
+| `git_mutation` | Recommended inactive | Approval required for add, commit, merge, rebase, conflict writes, or ref changes. | Add as known high-risk class requiring approval/provenance. |
+| `deployment_mutation` | Recommended inactive | Approval and provenance required for deploy, restart, rollback, cloud mutation, or CI mutation. | Add as known high-risk class requiring approval/provenance. |
+| `memory_mutation` | Recommended inactive | Approval required for long-term memory writes/reflections outside Memory Keeper flows. | Add as known high-risk class requiring approval/provenance. |
+| `test_execution` | Enabled only through safe runner roles | Approval required and audited as resolved configured command identity. | Add as known execution-adjacent class requiring approval/provenance but not arbitrary shell authority. |
+
+Unknown risk classes should continue to fail safety validation or require
+explicit spec review. New profile presets must not introduce new risk strings
+without extending this compatibility table and the validator tests.
+
+### Safe Test Runner Contract
+
+The safe test runner is a constrained process abstraction, not a shell escape.
+It may be enabled for Backend Engineer, Frontend Engineer, QA Engineer, and
+SDET only when the workspace has immutable test command definitions from a
+trusted project configuration source.
+
+Required constraints:
+
+- Agents call `tests.run_configured` with a stable command id, not a free-form
+  shell command string.
+- Command definitions are workspace-bound and resolved server-side from trusted
+  config, not from request arguments.
+- Allowed arguments must be declared per command id. Callers may only provide
+  typed fields from that definition, such as test target, marker, file path, or
+  reporter.
+- `cwd`, environment, executable, and base argv are fixed by the command
+  definition or selected from an allowlist. Callers cannot provide arbitrary
+  env vars, shell fragments, redirections, pipes, command separators, or
+  executable paths.
+- Execution always requires approval, records `test_execution` provenance, and
+  audits the resolved command id, target, workspace, approval decision, and
+  result summary.
+- Test-result reads through `tests.results.read` are read-only and do not imply
+  authority to rerun tests.
+
+## Native Tool Backlog
+
+The design implies these native/default-included additions for tldw_server MCP
+and ACP workspaces.
+
+| Category | Tools |
+| --- | --- |
+| File operations | `fs.edit`, `fs.patch`, `fs.glob`, `fs.grep`, `fs.stat` |
+| Git inspect | `git.status`, `git.diff`, `git.log`, `git.blame`, `git.branches`, `git.conflicts.list` |
+| Git scoped mutate | `git.apply_patch`, `git.conflicts.resolve_file`, `git.add`, `git.commit` as inactive/approval-gated |
+| Tool discovery | `tool_search`, `tool_describe`, `tool_call`, `tool_categories.list`, `profile.tools.list` |
+| Safe test runner | `tests.list_commands`, `tests.run_configured`, `tests.results.read` |
+| Browser inspect | `browser.snapshot`, `browser.screenshot`, `browser.console`, `browser.network`, `browser.page_state` |
+| Browser interact | `browser.navigate`, `browser.click`, `browser.type`, `browser.select`, all approval-gated |
+| LSP/code intel | `lsp.diagnostics`, `lsp.symbols`, `lsp.references`, `lsp.definition`, `lsp.code_actions` |
+| Review helpers | `review.findings.create`, `review.findings.list`, `review.summary.write` |
+| Checkpoint/session | `checkpoint.create`, `checkpoint.list`, `checkpoint.diff`, `checkpoint.restore` gated |
+| Memory | `memory.recall`, `memory.search`, `memory.write_reflection` gated |
+| Ask/user coordination | `ask_user`, `todo.write`, `plan.enter`, `plan.update` |
+| Issue abstraction | Native Kanban now; external `issue.create`, `issue.update`, `issue.search` through bindings |
+| CI/CD inspect | `ci.runs.list`, `ci.logs.read`, `ci.artifacts.list` through external bindings first |
+| DevOps inspect | `logs.search`, `service.status`, `env.inspect` through native or external bindings |
+| Debug/REPL/SSH | Catalog-only initially; inactive until explicitly enabled |
+
+These are not all same-priority. The first implementation slices should favor
+the tools closest to existing modules:
+
+1. File search/edit helpers and profile-scoped tool discovery.
+2. Git inspect and conflict-read tools.
+3. Safe test runner abstraction.
+4. Browser inspect read tools.
+5. LSP/code-intelligence read tools.
+6. External binding catalog and setup status surfaces.
+
+## External Server Categories
+
+Presets should remain vendor-neutral. Recommended external bindings should be
+grouped by category with concrete options where known.
+
+| Category | Example binding options |
+| --- | --- |
+| `issue_tracker` | Jira, Linear, GitHub Issues, GitLab Issues |
+| `repo_host` | GitHub, GitLab, Bitbucket, Forgejo/Gitea |
+| `pr_review` | GitHub PRs, GitLab merge requests, Bitbucket PRs |
+| `ci_cd` | GitHub Actions, GitLab CI, Buildkite, Jenkins, CircleCI |
+| `browser` | Playwright MCP, Chrome DevTools/CDP MCP |
+| `web_search` | Brave Search, Tavily, Exa, Kagi, SearxNG |
+| `docs_search` | Context7-style docs search, vendor docs MCP, local docs index |
+| `diagram` | Mermaid renderer, draw.io/Excalidraw integration |
+| `citation_manager` | Zotero, reference manager, scholarly search |
+| `cloud_provider` | AWS, Azure, GCP, Kubernetes |
+| `observability` | Datadog, Grafana, Sentry, OpenTelemetry/Prometheus |
+| `secrets_manager` | 1Password, Vault, cloud secret managers |
+| `debugger` | DAP server adapters |
+| `database` | Postgres, SQLite admin, migration tool adapters |
+| `visual_regression` | Playwright traces, Percy, Chromatic |
+| `design_assets` | Figma, image generation, asset catalog |
+| `cms_docs_publisher` | Git-backed docs, Confluence, Notion, ReadMe |
+
+Each option should carry:
+
+- `id`
+- `category`
+- `kind` such as `external_mcp`, `native_candidate`, or `host_adapter`
+- `install_target` when known
+- `credential_slots`
+- `required_scopes`
+- `risk_classes`
+- `maturity` such as `exact_target`, `category_placeholder`, or
+  `documented_candidate`
+- `setup_url` or package docs when known
+
+## Runtime Flow
+
+Catalog flow:
+
+1. Frontend or ACP session starts with `profile_id` and workspace binding.
+2. Gateway resolves profile and assignment.
+3. Gateway builds effective policy:
+   - enabled tools/capabilities
+   - path scopes
+   - risk classes
+   - approval policy
+   - credential/external-server grants
+   - progressive disclosure settings
+4. Frontend requests direct tools, categories, and unavailable recommended
+   bindings.
+5. Gateway returns directly exposed schemas, deferred categories, missing
+   recommended servers, and unavailable reason codes.
+
+Execution flow:
+
+1. Agent calls a direct tool or public `tool_call(tool_id, args)` bridge.
+2. Gateway resolves the real tool, activation status, required capability, and
+   risk metadata. `tool_call` can only resolve ids previously visible to this
+   profile through search/describe.
+3. Policy checks profile allow/deny, workspace/path scope, external-server
+   grant, credential grant, risk class, and approval policy.
+4. If approval is required, return structured `approval_required` with risk,
+   target, and human-readable reason.
+5. On approval, execute through native module, ACP host, or external MCP
+   runtime.
+6. Append audit event with profile, workspace, tool, risk, approval status, and
+   target.
+
+Safety invariants:
+
+- Recommended tools do not grant authority.
+- Search/describe never execute or consume credentials.
+- Shell/process cannot be reached through test runner, git, browser, CI, or
+  deploy abstractions. Each abstraction resolves a server-owned configured
+  operation identity before policy checks.
+- Credential grants never contain secret values.
+- Workspace binding is required for scoped writes and tests.
+- Audit runs for denial, approval request, approval grant/deny, and execution.
+
+## ACP Workspace Implications
+
+ACP-hosted agents should not receive a different conceptual tool set. They
+should receive the same profile-filtered catalog as native MCP clients, but
+execution may route through ACP/editor permission flows for filesystem,
+terminal, or browser actions.
+
+An ACP session should bind:
+
+- workspace root
+- path scopes
+- profile id
+- allowed categories
+- approval callback channel
+- audit stream
+- checkpoint/session boundary
+
+ACP permission prompts should preserve the same risk classification and
+underlying tool identity used by MCP runtime policy. A frontend can display
+profile recommendations and unavailable categories the same way for direct MCP
+clients and ACP-routed agents.
+
+## Testing Requirements
+
+The implementation plan should include these test groups:
+
+- Preset schema tests: every role preset has stable ids, display metadata,
+  enabled tools, recommended tools/servers, risk classes, and progressive
+  disclosure config.
+- Safety tests: no profile enables shell, SSH, debugger, deploy, CI mutation,
+  memory write, REPL, arbitrary process execution, or browser interaction by
+  default.
+- Role coverage tests: each requested profile has enough enabled/default tools
+  for its purpose.
+- Recommendation tests: setup-dependent tools are visible as recommended but
+  not callable until explicitly enabled.
+- Web-search tests: packaged defaults list web search/fetch as recommended
+  unavailable unless a configured provider/binding and required grants exist.
+- Progressive disclosure tests: direct tool list stays below threshold;
+  deferred tools are found through `tool_search`; discovery is profile-scoped.
+- Runtime policy tests: `tool_call` dispatch checks the real underlying tool,
+  path scope, risk, approval, external grants, credential grants, and audit.
+- Bridge-schema tests: `tool_call` requires `tool_id` and `arguments`, rejects
+  unknown fields, rejects ids outside profile-scoped discovery, and returns
+  `tool_not_enabled` for recommended inactive tools.
+- Risk-validator tests: every proposed risk class is known, maps to approval
+  and provenance requirements, and unknown future risk classes still fail.
+- Safe-runner tests: `tests.run_configured` accepts only configured command
+  ids, rejects free-form commands, constrains args/env/cwd, requires approval,
+  and audits the resolved command identity.
+- ACP tests: workspace binding and approval callbacks are enforced consistently
+  for ACP-routed calls.
+- Snapshot/import tests: profile recommendations and binding metadata survive
+  export/import without embedding secrets.
+- Docs tests: package-local user guide documents mode presets, categories, and
+  setup-dependent bindings.
+
+## Open Implementation Questions
+
+- Which native browser inspection path should be first: Playwright, CDP, or a
+  host-provided browser adapter?
+- How should tool-search ranking combine semantic search, BM25, category
+  filters, profile grants, and installation status?
+- Should profile recommendations be managed as immutable built-in metadata, or
+  should operators be able to patch the recommendation catalog separately from
+  executable policy?
+- Which exact external MCP install targets are stable enough to include as
+  `exact_target` rather than `category_placeholder`?
+
+## Recommended Next Plan
+
+The next implementation plan should split this work into small reviewable
+slices:
+
+1. Add schema tests and `metadata.tooling` fixtures for role presets.
+2. Add native file search/edit helpers and profile-scoped tool discovery.
+3. Add vendor-neutral external binding catalog metadata.
+4. Add progressive disclosure runtime responses.
+5. Add git inspect/conflict-read tools.
+6. Add safe test runner abstraction.
+7. Add browser inspect read tools.
+8. Update package-local user guide and admin docs.

--- a/backlog/tasks/task-2232 - Design-MCP-default-profile-tooling-presets.md
+++ b/backlog/tasks/task-2232 - Design-MCP-default-profile-tooling-presets.md
@@ -1,0 +1,54 @@
+---
+id: TASK-2232
+title: Design MCP default profile tooling presets
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-06-03 07:43
+labels:
+- mcp-unified
+- design
+- profiles
+- tools
+dependencies: []
+priority: medium
+modified_files:
+- Docs/superpowers/specs/2026-06-03-mcp-default-profile-tooling-presets-design.md
+- backlog/tasks/task-2232 - Design-MCP-default-profile-tooling-presets.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write the approved design spec for default MCP role profile tooling, progressive disclosure, external binding categories, and native tool backlog for tldw_server MCP/ACP workspaces.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Drafted the approved brainstorming design into the repo's superpowers spec format. The spec covers researched agent-harness prior art, the default tool substrate, progressive disclosure, role preset matrix, metadata.tooling schema, native tool backlog, external binding categories, runtime enforcement, ACP implications, and testing requirements.
+
+Spec review pass 1 found four issues: unresolved public/internal tool_call semantics, web-search default conflict with vendor-neutral/external-network policy, missing risk-class validator compatibility details, and underspecified safe test-runner command-source constraints. Revised the spec to make tool_call a public profile-scoped bridge with fixed schema and authorization path; make web search recommended-unavailable until configured with grants/provenance; add a risk-class compatibility table and validator requirements; and define safe test runner command identity, args/env/cwd, approval, and audit constraints.
+
+Spec review pass 2 returned APPROVED.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed and spec-review-approved the MCP default profile tooling presets design. Verification: git diff --check passed; spec review pass 2 returned APPROVED. Bandit skipped because this is documentation-only design work.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2232 - Design-MCP-default-profile-tooling-presets.md
+++ b/backlog/tasks/task-2232 - Design-MCP-default-profile-tooling-presets.md
@@ -3,7 +3,7 @@ id: TASK-2232
 title: Design MCP default profile tooling presets
 status: Done
 assignee: []
-created_date: ''
+created_date: 2026-06-03T07:43:00Z
 updated_date: 2026-06-03 07:43
 labels:
 - mcp-unified
@@ -25,17 +25,23 @@ Write the approved design spec for default MCP role profile tooling, progressive
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- MCP default profile tooling preset scope is documented, including role coverage,
+  progressive disclosure, native/default tool candidates, external binding
+  categories, and approval/risk defaults.
+- The spec records review outcomes and validation evidence for the design pass.
+- Documentation-only security validation is explicitly recorded with the Bandit
+  skip rationale.
 <!-- AC:END -->
 
 ## Implementation Notes
 
-<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Drafted the approved brainstorming design into the repo's superpowers spec format. The spec covers researched agent-harness prior art, the default tool substrate, progressive disclosure, role preset matrix, metadata.tooling schema, native tool backlog, external binding categories, runtime enforcement, ACP implications, and testing requirements.
 
 Spec review pass 1 found four issues: unresolved public/internal tool_call semantics, web-search default conflict with vendor-neutral/external-network policy, missing risk-class validator compatibility details, and underspecified safe test-runner command-source constraints. Revised the spec to make tool_call a public profile-scoped bridge with fixed schema and authorization path; make web search recommended-unavailable until configured with grants/provenance; add a risk-class compatibility table and validator requirements; and define safe test runner command identity, args/env/cwd, approval, and audit constraints.
 
 Spec review pass 2 returned APPROVED.
-<!-- SECTION:NOTES:END -->
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 

--- a/backlog/tasks/task-2233 - Prepare-MCP-tooling-presets-spec-placeholder-PR.md
+++ b/backlog/tasks/task-2233 - Prepare-MCP-tooling-presets-spec-placeholder-PR.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2233
 title: Prepare MCP tooling presets spec placeholder PR
-status: In Progress
+status: Done
 labels:
 - mcp-unified
 - design
@@ -35,20 +35,27 @@ dependency revision triggers were implicit.
 Updated the spec with a Placeholder PR Scope section, a Decision Status
 section, and a pre-implementation reconciliation reminder in Recommended Next
 Plan.
+
+Opened draft placeholder PR: https://github.com/rmusser01/tldw_server/pull/2251
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Reviewed and improved the spec for placeholder-PR readiness. Added explicit
+draft placeholder scope, active-work revision triggers, settled/provisional
+decision status, and a pre-implementation reconciliation requirement. Draft PR:
+https://github.com/rmusser01/tldw_server/pull/2251. Verification: git diff
+--check passed; rg confirmed the new placeholder/reconciliation sections.
+Bandit skipped because this is documentation-only work.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2233 - Prepare-MCP-tooling-presets-spec-placeholder-PR.md
+++ b/backlog/tasks/task-2233 - Prepare-MCP-tooling-presets-spec-placeholder-PR.md
@@ -1,0 +1,54 @@
+---
+id: TASK-2233
+title: Prepare MCP tooling presets spec placeholder PR
+status: In Progress
+labels:
+- mcp-unified
+- design
+- profiles
+- tools
+- pr
+priority: medium
+modified_files:
+- Docs/superpowers/specs/2026-06-03-mcp-default-profile-tooling-presets-design.md
+- backlog/tasks/task-2233 - Prepare-MCP-tooling-presets-spec-placeholder-PR.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Review the MCP default profile tooling presets spec for placeholder-PR readiness, address concrete spec issues or improvements, validate the documentation-only change, and open a draft PR while active dependent work settles.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Reviewed the approved spec for placeholder-PR readiness. Identified three
+doc-level gaps: the status did not communicate provisional draft-PR scope,
+settled vs provisional decisions were not separated, and active MCP/ACP
+dependency revision triggers were implicit.
+
+Updated the spec with a Placeholder PR Scope section, a Decision Status
+section, and a pre-implementation reconciliation reminder in Recommended Next
+Plan.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2233 - Prepare-MCP-tooling-presets-spec-placeholder-PR.md
+++ b/backlog/tasks/task-2233 - Prepare-MCP-tooling-presets-spec-placeholder-PR.md
@@ -22,6 +22,12 @@ Review the MCP default profile tooling presets spec for placeholder-PR readiness
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- Placeholder PR scope is explicit and communicates that active MCP/ACP work may
+  require later reconciliation before implementation.
+- Settled and provisional design decisions are separated so reviewers can
+  identify which choices are ready to implement.
+- Draft PR creation and documentation-only validation evidence are recorded in
+  the task summary.
 <!-- AC:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-2234 - Resolve-MCP-tooling-preset-spec-open-questions.md
+++ b/backlog/tasks/task-2234 - Resolve-MCP-tooling-preset-spec-open-questions.md
@@ -1,0 +1,62 @@
+---
+id: TASK-2234
+title: Resolve MCP tooling preset spec open questions
+status: Done
+labels:
+- mcp-unified
+- design
+- profiles
+- tools
+- pr
+priority: medium
+modified_files:
+- Docs/superpowers/specs/2026-06-03-mcp-default-profile-tooling-presets-design.md
+- backlog/tasks/task-2234 - Resolve-MCP-tooling-preset-spec-open-questions.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Update the MCP default profile tooling presets draft spec with user decisions for browser inspection path, tool-search ranking, recommendation catalog mutability, and exact external MCP install targets.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Updated the draft spec with the user decisions:
+
+- CDP is the first browser inspection path.
+- Tool search does not use semantic search initially; it filters by profile
+  grants and workspace assignment, partitions by installation status, applies
+  category filters, then BM25 scores the allowed catalog.
+- Operators can patch recommendation catalog metadata separately from
+  executable policy; recommendation patches do not grant authority.
+- `ChromeDevTools/chrome-devtools-mcp` is the initial `exact_target` external
+  MCP binding for the browser/CDP category.
+
+Also moved these items out of open questions into resolved implementation
+decisions and added a test requirement for the tool-search ranking behavior.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved the spec's browser path, tool-search ranking, recommendation catalog
+mutability, and initial exact external MCP target decisions. Verification: git
+diff --check passed; rg confirmed the resolved-decision and ranking-test
+sections. Bandit skipped because this is documentation-only work.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2235 - Plan-MCP-default-profile-tooling-preset-implementation.md
+++ b/backlog/tasks/task-2235 - Plan-MCP-default-profile-tooling-preset-implementation.md
@@ -1,0 +1,60 @@
+---
+id: TASK-2235
+title: Plan MCP default profile tooling preset implementation
+status: Done
+labels:
+- mcp-unified
+- design
+- profiles
+- tools
+- planning
+priority: medium
+modified_files:
+- Docs/superpowers/plans/2026-06-03-mcp-default-profile-tooling-presets-implementation-plan.md
+- backlog/tasks/task-2235 - Plan-MCP-default-profile-tooling-preset-implementation.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create the implementation plan for adding default MCP role profile tooling metadata, profile-scoped discovery/ranking, and related documentation/tests based on the approved spec.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Created the implementation plan for the first reviewable MCP default profile
+tooling slice. The plan covers preset metadata, recommendation catalog helpers,
+profile-scoped tool discovery/ranking, gateway bridge tools, CLI/docs updates,
+and verification.
+
+Used the writing-plans skill. The normal plan reviewer subagent step was not
+run because the available subagent tool is restricted to explicit delegation
+requests; performed a local review instead and patched found issues before
+finalizing.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Plan saved at
+Docs/superpowers/plans/2026-06-03-mcp-default-profile-tooling-presets-implementation-plan.md.
+Verification: git diff --check passed; local review fixed stale helper/test
+references and added concrete recommendation-catalog patch helper coverage.
+Bandit skipped because this is documentation-only planning work.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2236 - Implement-MCP-profile-tooling-metadata-slice.md
+++ b/backlog/tasks/task-2236 - Implement-MCP-profile-tooling-metadata-slice.md
@@ -33,7 +33,7 @@ Execute Task 1 from the MCP default profile tooling implementation plan: add pre
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented Task 1 preset tooling metadata slice. Added package-local tooling metadata helpers, wired tooling metadata into the eleven requested built-in role presets, and added preset tests for required metadata shape, Product Owner web-search recommendation-only behavior, Frontend Engineer Chrome DevTools exact target metadata, and recommendation patching not granting executable authority. Verification: RED run failed as expected with missing metadata/helper module; final focused pytest passed 15 tests; git diff --check passed. Bandit runtime scan for touched mcp_unified profile modules had 0 findings; full touched-scope Bandit reported only B101 pytest assert warnings in the test file.
+Review follow-up completed: Product Owner web search now appears only as a non-required recommended server category. Strengthened the Product Owner preset test to assert web search is absent from executable allowed tools, enabled tools, enabled capabilities, recommended tools, and progressive disclosure categories while still present in recommended_servers with required False. Verification: RED run failed on web_search in deferred_categories; final focused pytest passed 15 tests; git diff --check passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2236 - Implement-MCP-profile-tooling-metadata-slice.md
+++ b/backlog/tasks/task-2236 - Implement-MCP-profile-tooling-metadata-slice.md
@@ -1,0 +1,47 @@
+---
+id: TASK-2236
+title: Implement MCP profile tooling metadata slice
+status: Done
+labels:
+- mcp-unified
+- profiles
+- tools
+- implementation
+priority: medium
+modified_files:
+- mcp_unified/profiles/tooling.py
+- mcp_unified/profiles/presets.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute Task 1 from the MCP default profile tooling implementation plan: add preset tooling metadata helpers, populate role preset metadata, and extend preset tests for recommendations, CDP exact target, and non-authoritative recommendation patching.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Task 1 preset tooling metadata slice. Added package-local tooling metadata helpers, wired tooling metadata into the eleven requested built-in role presets, and added preset tests for required metadata shape, Product Owner web-search recommendation-only behavior, Frontend Engineer Chrome DevTools exact target metadata, and recommendation patching not granting executable authority. Verification: RED run failed as expected with missing metadata/helper module; final focused pytest passed 15 tests; git diff --check passed. Bandit runtime scan for touched mcp_unified profile modules had 0 findings; full touched-scope Bandit reported only B101 pytest assert warnings in the test file.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2236 - Implement-MCP-profile-tooling-metadata-slice.md
+++ b/backlog/tasks/task-2236 - Implement-MCP-profile-tooling-metadata-slice.md
@@ -33,7 +33,7 @@ Execute Task 1 from the MCP default profile tooling implementation plan: add pre
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Review follow-up completed: Product Owner web search now appears only as a non-required recommended server category. Strengthened the Product Owner preset test to assert web search is absent from executable allowed tools, enabled tools, enabled capabilities, recommended tools, and progressive disclosure categories while still present in recommended_servers with required False. Verification: RED run failed on web_search in deferred_categories; final focused pytest passed 15 tests; git diff --check passed.
+Second review follow-up completed: strengthened the role tooling metadata test to require non-empty recommended_tools and recommended_servers for all eleven requested presets, and to assert recommended tool IDs are not executable allowed_tools. Added recommendation-only tool metadata for each requested preset without changing policy grants. Product Owner web search remains absent from recommended_tools/direct/deferred categories and appears only as a non-required recommended server. RED evidence: focused pytest failed on empty recommended_tools. Final verification: focused pytest passed 15 tests; git diff --check passed; runtime Bandit on touched mcp_unified profile files had 0 findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2236 - Implement-MCP-profile-tooling-metadata-slice.md
+++ b/backlog/tasks/task-2236 - Implement-MCP-profile-tooling-metadata-slice.md
@@ -38,10 +38,10 @@ Second review follow-up completed: strengthened the role tooling metadata test t
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2237 - Implement-MCP-preset-reviewed-risk-class-validation.md
+++ b/backlog/tasks/task-2237 - Implement-MCP-preset-reviewed-risk-class-validation.md
@@ -1,0 +1,53 @@
+---
+id: TASK-2237
+title: Implement MCP preset reviewed risk-class validation
+status: Done
+labels:
+- mcp-unified
+- profiles
+- risk
+- implementation
+priority: medium
+modified_files:
+- mcp_unified/profiles/presets.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute Task 2 from the MCP default profile tooling implementation plan: add tests and validator support for reviewed high-risk classes including browser_mutation, deployment_mutation, git_mutation, memory_mutation, and test_execution.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] Reviewed risk classes are accepted when each has explicit approval and high-risk provenance.
+- [x] `browser_mutation` without approval returns `browser_mutation_requires_approval`.
+- [x] Unknown future risk classes still return `unknown_high_risk_requires_review`.
+- [x] Existing safety behavior remains covered by the preset safety test file.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added TDD coverage for `browser_mutation`, `deployment_mutation`, `git_mutation`, `memory_mutation`, and `test_execution`.
+- RED evidence: the first targeted pytest run failed with `unknown_high_risk_requires_review` for the reviewed classes and no `browser_mutation_requires_approval` violation.
+- Added an extra regression asserting generic `mutating`/`write` approval does not satisfy reviewed high-risk approval; that test failed before tightening `_approval_required_for()`.
+- Final verification evidence: targeted pytest passed, `git diff --check` passed, and Bandit reported zero findings for `mcp_unified/profiles/presets.py`.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Extended preset safety validation so reviewed high-risk classes are known, require exact approval_policy.required_for entries, and require high-risk provenance. Verified with targeted pytest, git diff --check, and Bandit on mcp_unified/profiles/presets.py.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2238 - Implement-MCP-profile-scoped-tool-discovery.md
+++ b/backlog/tasks/task-2238 - Implement-MCP-profile-scoped-tool-discovery.md
@@ -1,0 +1,60 @@
+---
+id: TASK-2238
+title: Implement MCP profile-scoped tool discovery
+status: Done
+labels:
+- mcp-unified
+- gateway
+- profiles
+- tools
+- implementation
+priority: medium
+modified_files:
+- mcp_unified/gateway/tool_discovery.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute Task 3 from the MCP default profile tooling implementation plan: add profile-scoped tool discovery helpers, deterministic filter-first/BM25 ranking, visible tool description, and bridge tool resolution primitives.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Documentation changes are not required for this pure helper/test slice; bridge
+  runtime documentation remains part of the follow-up runtime integration task.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented profile-scoped gateway tool discovery helpers in mcp_unified/gateway/tool_discovery.py and focused coverage in tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py.
+
+Summary:
+- Added installed backend tool discovery filtered through build_effective_policy_result().
+- Added recommendation-only profile metadata visibility for recommended unavailable tools while keeping bridge resolution non-callable with tool_not_enabled.
+- Added deterministic category filtering, installed-before-unavailable ordering, standard-library BM25 scoring metadata, category/id tie-breaks, describe, list, and resolve helpers.
+- Added tests for policy-before-ranking filtering, installed/recommended ranking, describe visibility, bridge resolution, invalid descriptor handling, no semantic-search dependency metadata, and package-boundary cleanliness.
+
+Verification:
+- RED: source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py -q failed at collection with ImportError because mcp_unified.gateway.tool_discovery was missing.
+- GREEN: source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py -q passed: 7 passed, 5 warnings.
+- git diff --check passed with no output.
+- source .venv/bin/activate && python -m bandit -r mcp_unified/gateway/tool_discovery.py -f json -o /tmp/bandit_mcp_tool_discovery.json passed with 0 findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2238 - Implement-MCP-profile-scoped-tool-discovery.md
+++ b/backlog/tasks/task-2238 - Implement-MCP-profile-scoped-tool-discovery.md
@@ -40,11 +40,14 @@ Summary:
 - Added installed backend tool discovery filtered through build_effective_policy_result().
 - Added recommendation-only profile metadata visibility for recommended unavailable tools while keeping bridge resolution non-callable with tool_not_enabled.
 - Added deterministic category filtering, installed-before-unavailable ordering, standard-library BM25 scoring metadata, category/id tie-breaks, describe, list, and resolve helpers.
-- Added tests for policy-before-ranking filtering, installed/recommended ranking, describe visibility, bridge resolution, invalid descriptor handling, no semantic-search dependency metadata, and package-boundary cleanliness.
+- Addressed spec-compliance review feedback by requiring recommended tools to resolve through effective profile policy before search/describe/resolve visibility.
+- Preserved explicit allowed_tools semantics for recommendations: no-capability recommendations are visible only when explicitly allowed by id, and capability recommendations require build_effective_policy_result(profile, tool_name=tool_id, capability=capability) to resolve.
+- Added regression tests proving ungranted recommendations are not searchable/describable/resolvable, while granted recommendations remain visible and resolve as tool_not_enabled.
 
 Verification:
-- RED: source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py -q failed at collection with ImportError because mcp_unified.gateway.tool_discovery was missing.
-- GREEN: source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py -q passed: 7 passed, 5 warnings.
+- Initial RED: source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py -q failed at collection with ImportError because mcp_unified.gateway.tool_discovery was missing.
+- Review-fix RED: source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py -q failed with test_ungranted_recommended_tools_are_not_discoverable and test_recommended_tools_preserve_explicit_allowed_tools_semantics because ungranted recommendations were visible.
+- GREEN: source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py -q passed: 9 passed, 5 warnings.
 - git diff --check passed with no output.
 - source .venv/bin/activate && python -m bandit -r mcp_unified/gateway/tool_discovery.py -f json -o /tmp/bandit_mcp_tool_discovery.json passed with 0 findings.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-2239 - Implement-MCP-profile-discovery-bridge-runtime-integration.md
+++ b/backlog/tasks/task-2239 - Implement-MCP-profile-discovery-bridge-runtime-integration.md
@@ -37,6 +37,7 @@ Execute Task 4 from the MCP default profile tooling implementation plan: expose 
 - Integrated Task 3 discovery helpers without modifying `mcp_unified/gateway/tool_discovery.py`.
 - Added strict runtime validation for `tool_call` arguments with `invalid_tool_call_arguments` denials for missing fields, unknown fields, non-string `tool_id`, and non-object delegated arguments.
 - Updated profile runtime tests to account for synthetic discovery helpers while preserving ordinary backend profile filtering assertions.
+- Review fix: backend tools whose names collide with bridge-reserved names now win when profile policy allows them; mixed-type unknown argument keys no longer crash validation; profile-runtime list assertions now check exact visible tool-name sets.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -47,6 +48,12 @@ Implemented profile-scoped MCP discovery bridge integration in ProfileAwareGatew
 Verification:
 - RED: source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q failed with 23 expected bridge-related failures before implementation.
 - Focused: source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q passed: 174 passed, 6 warnings.
+- git diff --check passed.
+- Bandit: source .venv/bin/activate && python -m bandit -r mcp_unified/gateway/profile_runtime.py -f json -o /tmp/bandit_mcp_profile_runtime_bridge.json passed with 0 findings.
+
+Review follow-up verification:
+- RED: source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q failed with 2 expected failures: bridge-name collision returned the synthetic descriptor, and mixed-type unknown keys raised TypeError.
+- Focused: source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q passed: 176 passed, 6 warnings.
 - git diff --check passed.
 - Bandit: source .venv/bin/activate && python -m bandit -r mcp_unified/gateway/profile_runtime.py -f json -o /tmp/bandit_mcp_profile_runtime_bridge.json passed with 0 findings.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-2239 - Implement-MCP-profile-discovery-bridge-runtime-integration.md
+++ b/backlog/tasks/task-2239 - Implement-MCP-profile-discovery-bridge-runtime-integration.md
@@ -1,0 +1,62 @@
+---
+id: TASK-2239
+title: Implement MCP profile discovery bridge runtime integration
+status: Done
+labels:
+- mcp-unified
+- gateway
+- profiles
+- tools
+- implementation
+priority: medium
+modified_files:
+- mcp_unified/gateway/profile_runtime.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute Task 4 from the MCP default profile tooling implementation plan: expose profile-scoped discovery bridge tools in ProfileAwareGatewayRuntime and intercept tool_categories.list, profile.tools.list, tool_search, tool_describe, and tool_call.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] Resolved profiles expose read-only discovery bridge tools.
+- [x] `tool_call` is exposed only for profiles with deferred categories.
+- [x] Bridge calls are intercepted before ordinary backend execution.
+- [x] Installed `tool_call` delegates to the resolved backend tool through policy.
+- [x] Recommended-unavailable and denied tools are not made executable.
+- [x] Non-list backend tool discovery does not crash bridge catalog behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added synthetic tool descriptors in `mcp_unified/gateway/profile_runtime.py` with `metadata.category == "tool_discovery"` and fixed small input schemas.
+- Integrated Task 3 discovery helpers without modifying `mcp_unified/gateway/tool_discovery.py`.
+- Added strict runtime validation for `tool_call` arguments with `invalid_tool_call_arguments` denials for missing fields, unknown fields, non-string `tool_id`, and non-object delegated arguments.
+- Updated profile runtime tests to account for synthetic discovery helpers while preserving ordinary backend profile filtering assertions.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented profile-scoped MCP discovery bridge integration in ProfileAwareGatewayRuntime. list_tools now appends synthetic discovery descriptors for resolved profiles, including tool_call only when deferred categories are configured. call_tool now intercepts tool_categories.list, profile.tools.list, tool_search, tool_describe, and tool_call before backend execution. Installed tool_call requests resolve to the real backend tool and reuse the existing profile policy path; recommended-only or hidden tools return structured normal result payloads instead of executing. Added runtime tests for bridge exposure, profile-scoped search/catalog results, denied descriptions, recommended-unavailable rejection, installed delegation, and strict invalid tool_call argument handling.
+
+Verification:
+- RED: source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q failed with 23 expected bridge-related failures before implementation.
+- Focused: source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q passed: 174 passed, 6 warnings.
+- git diff --check passed.
+- Bandit: source .venv/bin/activate && python -m bandit -r mcp_unified/gateway/profile_runtime.py -f json -o /tmp/bandit_mcp_profile_runtime_bridge.json passed with 0 findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2239 - Implement-MCP-profile-discovery-bridge-runtime-integration.md
+++ b/backlog/tasks/task-2239 - Implement-MCP-profile-discovery-bridge-runtime-integration.md
@@ -38,6 +38,7 @@ Execute Task 4 from the MCP default profile tooling implementation plan: expose 
 - Added strict runtime validation for `tool_call` arguments with `invalid_tool_call_arguments` denials for missing fields, unknown fields, non-string `tool_id`, and non-object delegated arguments.
 - Updated profile runtime tests to account for synthetic discovery helpers while preserving ordinary backend profile filtering assertions.
 - Review fix: backend tools whose names collide with bridge-reserved names now win when profile policy allows them; mixed-type unknown argument keys no longer crash validation; profile-runtime list assertions now check exact visible tool-name sets.
+- Re-review fix: when backend discovery fails for bridge-reserved names, malformed synthetic bridge arguments are validated before surfacing the backend discovery exception.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -54,6 +55,12 @@ Verification:
 Review follow-up verification:
 - RED: source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q failed with 2 expected failures: bridge-name collision returned the synthetic descriptor, and mixed-type unknown keys raised TypeError.
 - Focused: source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q passed: 176 passed, 6 warnings.
+- git diff --check passed.
+- Bandit: source .venv/bin/activate && python -m bandit -r mcp_unified/gateway/profile_runtime.py -f json -o /tmp/bandit_mcp_profile_runtime_bridge.json passed with 0 findings.
+
+Re-review follow-up verification:
+- RED: source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q failed with the new regression raising the backend RuntimeBackendError before invalid bridge argument validation.
+- Focused: source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q passed: 177 passed, 6 warnings.
 - git diff --check passed.
 - Bandit: source .venv/bin/activate && python -m bandit -r mcp_unified/gateway/profile_runtime.py -f json -o /tmp/bandit_mcp_profile_runtime_bridge.json passed with 0 findings.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-2240 - Implement-MCP-profile-tooling-CLI-and-docs.md
+++ b/backlog/tasks/task-2240 - Implement-MCP-profile-tooling-CLI-and-docs.md
@@ -1,0 +1,54 @@
+---
+id: TASK-2240
+title: Implement MCP profile tooling CLI and docs
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-03 21:41'
+labels:
+  - mcp-unified
+  - gateway
+  - profiles
+  - docs
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Task 5 from Docs/superpowers/plans/2026-06-03-mcp-default-profile-tooling-presets-implementation-plan.md. Add a compact tooling summary to the gateway CLI list-presets output, document profile tooling discovery/progressive disclosure, and validate CLI/package-boundary behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-03-mcp-default-profile-tooling-presets-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RED: extended the gateway CLI list-presets package test to run `python -m mcp_unified.gateway.cli list-presets`; focused pytest failed for the intended reason with `KeyError: 'tooling'`. GREEN: added compact preset tooling summary in `mcp_unified/gateway/cli.py` and documented profile tooling discovery/progressive disclosure in package docs.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Task 5. Added a subprocess-based CLI regression test for `python -m mcp_unified.gateway.cli list-presets` that asserts compact tooling metadata for the `product-owner` preset. Updated `list-presets` output to include direct/deferred tooling categories, recommended server categories, and recommendation catalog patchability while leaving `show-preset` as the full metadata inspection command. Updated package README and user guide documentation for role preset tooling discovery, progressive disclosure bridge tools, recommendation catalog authority limits, and the CDP-first browser inspection target `ChromeDevTools/chrome-devtools-mcp`.
+
+Verification recorded: RED focused CLI test failed with `KeyError: 'tooling'`; focused GREEN test passed; required pytest command passed with 103 tests; Bandit on `mcp_unified/gateway/cli.py` exited 0 and wrote `/tmp/bandit_mcp_profile_tooling_cli.json`; `git diff --check` passed. Known skips or blockers: none.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2240 - Implement-MCP-profile-tooling-CLI-and-docs.md
+++ b/backlog/tasks/task-2240 - Implement-MCP-profile-tooling-CLI-and-docs.md
@@ -38,9 +38,11 @@ RED: extended the gateway CLI list-presets package test to run `python -m mcp_un
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented Task 5. Added a subprocess-based CLI regression test for `python -m mcp_unified.gateway.cli list-presets` that asserts compact tooling metadata for the `product-owner` preset. Updated `list-presets` output to include direct/deferred tooling categories, recommended server categories, and recommendation catalog patchability while leaving `show-preset` as the full metadata inspection command. Updated package README and user guide documentation for role preset tooling discovery, progressive disclosure bridge tools, recommendation catalog authority limits, and the CDP-first browser inspection target `ChromeDevTools/chrome-devtools-mcp`.
+Implemented Task 5 and follow-up review hardening. Added a subprocess-based CLI regression test for `python -m mcp_unified.gateway.cli list-presets` that asserts compact tooling metadata for the `product-owner` preset. Updated `list-presets` output to include direct/deferred tooling categories, recommended server categories, and recommendation catalog patchability while leaving `show-preset` as the full metadata inspection command. Updated package README and user guide documentation for role preset tooling discovery, progressive disclosure bridge tools, recommendation catalog authority limits, and the CDP-first browser inspection target `ChromeDevTools/chrome-devtools-mcp`.
 
-Verification recorded: RED focused CLI test failed with `KeyError: 'tooling'`; focused GREEN test passed; required pytest command passed with 103 tests; Bandit on `mcp_unified/gateway/cli.py` exited 0 and wrote `/tmp/bandit_mcp_profile_tooling_cli.json`; `git diff --check` passed. Known skips or blockers: none.
+Follow-up review fix: added a focused helper regression test for malformed tooling metadata and hardened `_preset_tooling_summary()` so category values are accepted only from list/tuple sources, only strings are emitted, and `recommended_servers` is ignored unless it is list/tuple metadata.
+
+Verification recorded: original RED focused CLI test failed with `KeyError: 'tooling'`; review RED focused helper test failed with `TypeError: 'NoneType' object is not iterable`; focused GREEN tests passed; required pytest, Bandit, and `git diff --check` verification run for the review fix. Known skips or blockers: none.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2241 - Fix-MCP-recommendation-discovery-visibility.md
+++ b/backlog/tasks/task-2241 - Fix-MCP-recommendation-discovery-visibility.md
@@ -1,0 +1,59 @@
+---
+id: TASK-2241
+title: Fix MCP recommendation discovery visibility
+status: Done
+labels:
+- mcp-unified
+- gateway
+- profiles
+- review-fix
+modified_files:
+- mcp_unified/gateway/tool_discovery.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Final review fix for PR 2251: recommended setup-dependent tools from profile metadata must be visible as recommended_unavailable in profile discovery/search/describe while remaining non-callable through tool_call. Current discovery filters recommendations through executable policy and hides bundled recommendations without explicit grants.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-03-mcp-default-profile-tooling-presets-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+TDD RED: added/updated gateway discovery coverage so recommendations without executable grants, including bundled/default descriptors with no capability, must be discoverable as recommended_unavailable and resolve as unavailable/tool_not_enabled. Initial focused pytest failed as intended because search returned [] under the old _recommendation_visible() executable-policy gate.
+
+Implementation: removed the recommendation executable-policy visibility gate from _recommended_entry(); recommendations still require a valid normalized id, remain non-callable without an installed backend entry, and installed backend tools still use _installed_tool_allowed()/build_effective_policy_result().
+Verification:
+- source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py::test_recommendations_without_executable_grants_are_discoverable_not_callable -q -> RED before production change: failed because results were [] instead of the expected recommendation ids; GREEN after fix: 1 passed.
+- source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py -q -> 9 passed.
+- source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py -q -> 196 passed.
+- source .venv/bin/activate && python -m bandit -r mcp_unified/gateway/tool_discovery.py -f json -o /tmp/bandit_mcp_recommendation_visibility.json -> exit 0, JSON report written.
+- git diff --check -> exit 0.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Exposed profile recommendation metadata in discovery/search/describe without requiring executable policy grants. Recommendation descriptors still require a valid id, normalize safely, show as recommended_unavailable, and resolve/call as unavailable with tool_not_enabled unless an installed backend tool is actually policy-granted. Installed backend tool visibility remains filtered by build_effective_policy_result(), preserving denial behavior and existing BM25 filter-first ranking.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2242 - Address-PR-2251-review-feedback.md
+++ b/backlog/tasks/task-2242 - Address-PR-2251-review-feedback.md
@@ -40,6 +40,14 @@ still-valid comments with doc/task-record-only edits:
   changed the task-2232 implementation notes markers to
   `SECTION:IMPLEMENTATION_NOTES`.
 
+Second Qodo pass after push raised two additional valid items. Addressed both:
+
+- Reflowed long schema/constant/helper lines in `profile_runtime.py`,
+  `tool_discovery.py`, and `presets.py`.
+- Fixed category summary aggregation to normalize category keys consistently with
+  category filtering, and added a regression test covering mixed-case category
+  metadata.
+
 No unresolved review item was skipped as stale.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
@@ -47,10 +55,11 @@ No unresolved review item was skipped as stale.
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Rebased PR #2251 onto latest `origin/dev`, addressed all still-valid review
-threads with minimal documentation/task-record updates, and validated the
-rebased branch. Verification: focused MCP pytest suite passed
-(`273 passed, 6 warnings`); `git diff --check` passed; Bandit on changed MCP
-implementation modules reported zero findings in
+threads with minimal documentation/task-record and MCP discovery fixes, and
+validated the rebased branch. Verification: added regression test failed before
+the category normalization fix and passed after; focused MCP pytest suite passed
+(`274 passed, 6 warnings`); Ruff touched-file check passed; `git diff --check`
+passed; Bandit on changed MCP implementation modules reported zero findings in
 `/tmp/bandit_pr2251_profile_tooling.json`. PR merge is performed after pushing
 this branch update and confirming remote checks.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-2242 - Address-PR-2251-review-feedback.md
+++ b/backlog/tasks/task-2242 - Address-PR-2251-review-feedback.md
@@ -1,0 +1,66 @@
+---
+id: TASK-2242
+title: Address PR 2251 review feedback
+status: Done
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase PR #2251 onto latest dev, verify and address still-valid review comments, validate, push, and merge before returning to the current PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- PR #2251 is rebased onto the latest `origin/dev`.
+- Every unresolved review thread is verified against current code and either
+  addressed with minimal changes or skipped with a brief reason.
+- Focused validation, diff checks, and the documentation-only Bandit decision are
+  recorded.
+- The branch is pushed and PR #2251 is merged before returning to the current PR.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Rebased `codex/mcp-default-profile-tooling-design` onto `origin/dev` cleanly.
+
+Verified all unresolved review threads against the rebased branch. Addressed the
+still-valid comments with doc/task-record-only edits:
+
+- Added `Orchestrator`, `Deep Researcher`, and `Memory Keeper` to the design
+  goals and role matrix, with an explicit note that existing built-in presets
+  are not deprecated.
+- Clarified the example as `profile.metadata["tooling"]`, added
+  `required_scopes` and `maturity` to binding options, and documented the
+  normal bridge error payload for `tool_not_found`/`tool_not_enabled`.
+- Added `destructive_filesystem` to the suggested risk classes and compatibility
+  table, aligned with current preset safety validation.
+- Populated missing acceptance criteria, fixed the empty `created_date`, and
+  changed the task-2232 implementation notes markers to
+  `SECTION:IMPLEMENTATION_NOTES`.
+
+No unresolved review item was skipped as stale.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR #2251 onto latest `origin/dev`, addressed all still-valid review
+threads with minimal documentation/task-record updates, and validated the
+rebased branch. Verification: focused MCP pytest suite passed
+(`273 passed, 6 warnings`); `git diff --check` passed; Bandit on changed MCP
+implementation modules reported zero findings in
+`/tmp/bandit_pr2251_profile_tooling.json`. PR merge is performed after pushing
+this branch update and confirming remote checks.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/README.md
+++ b/mcp_unified/README.md
@@ -12,6 +12,8 @@ surface for early standalone gateway work.
 
 - JSON-RPC gateway runtime primitives for HTTP, WebSocket, and stdio entrypoints.
 - Profile presets, profile resolution, and policy result models.
+- Role presets with compact tooling discovery metadata and progressive
+  disclosure categories for suggested next-step tools.
 - Gateway-local profile, assignment, external-server, credential-grant, and
   audit storage interfaces.
 - Optional SQLite-backed stores for standalone gateway configuration.
@@ -124,4 +126,3 @@ python -m pytest \
   .github/tests/test_mcp_unified_artifact_gate.py::test_mcp_unified_standalone_artifacts_include_package_docs \
   -q
 ```
-

--- a/mcp_unified/USER_GUIDE.md
+++ b/mcp_unified/USER_GUIDE.md
@@ -96,6 +96,29 @@ mcp-unified-gateway get-default-profile \
   --config ./gateway.json
 ```
 
+### Profile Tooling Discovery
+
+`list-presets` includes compact tooling discovery metadata for role presets.
+Direct categories describe tools the profile can expose immediately, subject to
+the profile policy and any assignment constraints. Deferred categories describe
+recommended unavailable tools or server-backed capabilities that may be useful
+for the role but are not executable until explicitly registered, granted, and
+allowed by policy.
+
+Profiles can expose progressive disclosure bridge tools such as
+`tool_categories.list`, `tool_search`, `tool_describe`, and
+`profile.tools.list`. These help clients inspect available direct tools first,
+then discover recommended next-step tools without expanding the executable tool
+surface by default.
+
+Recommendation catalog patches only change discovery metadata. They do not grant
+execution authority, start external servers, create credential grants, or bypass
+profile policy and approval requirements.
+
+For native browser inspection, prefer the Chrome DevTools Protocol path first.
+The stable exact target for that path is
+`ChromeDevTools/chrome-devtools-mcp`.
+
 ## 4. Register External Servers
 
 External servers describe upstream MCP servers that the gateway can manage and
@@ -275,4 +298,3 @@ Secrets appear in a config file
 
 : Remove them. Store only broker ids, credential slot names, scopes, and binding
   metadata in gateway configuration.
-

--- a/mcp_unified/gateway/cli.py
+++ b/mcp_unified/gateway/cli.py
@@ -13,6 +13,7 @@ from typing import Any, NoReturn, TextIO
 
 from mcp_unified.package_metadata import package_metadata_summary
 from mcp_unified.profiles.presets import (
+    ProfilePreset,
     duplicate_builtin_preset,
     get_builtin_preset,
     list_builtin_presets,
@@ -1516,6 +1517,32 @@ def _load_json_argument_file(path: Path, *, label: str) -> dict[str, Any]:
     return payload
 
 
+def _preset_tooling_summary(preset: ProfilePreset) -> dict[str, Any]:
+    """Build compact tooling discovery metadata for preset list output."""
+
+    tooling = preset.profile.metadata.get("tooling")
+    if not isinstance(tooling, dict):
+        return {}
+
+    progressive = tooling.get("progressive_disclosure")
+    if not isinstance(progressive, dict):
+        progressive = {}
+
+    return {
+        "direct_categories": list(progressive.get("direct_categories") or []),
+        "deferred_categories": list(progressive.get("deferred_categories") or []),
+        "recommended_server_categories": [
+            server.get("category")
+            for server in tooling.get("recommended_servers", [])
+            if isinstance(server, dict) and isinstance(server.get("category"), str)
+        ],
+        "recommendation_catalog_patchable": tooling.get(
+            "recommendation_catalog_patchable"
+        )
+        is True,
+    }
+
+
 def _handle_list_presets(_args: argparse.Namespace) -> int:
     """Emit bundled profile preset summaries as deterministic JSON."""
 
@@ -1527,6 +1554,7 @@ def _handle_list_presets(_args: argparse.Namespace) -> int:
                     "description": preset.profile.description,
                     "id": preset.id,
                     "name": preset.profile.name,
+                    "tooling": _preset_tooling_summary(preset),
                     "version": preset.version,
                 }
                 for preset in presets

--- a/mcp_unified/gateway/cli.py
+++ b/mcp_unified/gateway/cli.py
@@ -1528,12 +1528,16 @@ def _preset_tooling_summary(preset: ProfilePreset) -> dict[str, Any]:
     if not isinstance(progressive, dict):
         progressive = {}
 
+    recommended_servers = tooling.get("recommended_servers")
+    if not isinstance(recommended_servers, (list, tuple)):
+        recommended_servers = []
+
     return {
-        "direct_categories": list(progressive.get("direct_categories") or []),
-        "deferred_categories": list(progressive.get("deferred_categories") or []),
+        "direct_categories": _string_list(progressive.get("direct_categories")),
+        "deferred_categories": _string_list(progressive.get("deferred_categories")),
         "recommended_server_categories": [
             server.get("category")
-            for server in tooling.get("recommended_servers", [])
+            for server in recommended_servers
             if isinstance(server, dict) and isinstance(server.get("category"), str)
         ],
         "recommendation_catalog_patchable": tooling.get(
@@ -1541,6 +1545,14 @@ def _preset_tooling_summary(preset: ProfilePreset) -> dict[str, Any]:
         )
         is True,
     }
+
+
+def _string_list(value: Any) -> list[str]:
+    """Return only string items from list-like metadata values."""
+
+    if not isinstance(value, (list, tuple)):
+        return []
+    return [item for item in value if isinstance(item, str)]
 
 
 def _handle_list_presets(_args: argparse.Namespace) -> int:

--- a/mcp_unified/gateway/profile_runtime.py
+++ b/mcp_unified/gateway/profile_runtime.py
@@ -183,22 +183,26 @@ class ProfileAwareGatewayRuntime:
 
         tools = await self._safe_backend_tools(context)
         allowed_tools: list[dict[str, Any]] = []
+        allowed_tool_names: set[str] = set()
         for tool in tools:
             if not isinstance(tool, dict):
                 continue
             name = _tool_name(tool)
             if (
                 name is not None
-                and not _is_bridge_tool_name(name)
                 and _tool_allowed_by_profile(
                     profile_result.profile,
                     tool,
                 )
             ):
+                allowed_tool_names.add(name)
                 allowed_tools.append(deepcopy(tool))
         return [
             *allowed_tools,
-            *_profile_bridge_tool_descriptors(profile_result.profile),
+            *_profile_bridge_tool_descriptors(
+                profile_result.profile,
+                suppressed_names=allowed_tool_names,
+            ),
         ]
 
     async def call_tool(
@@ -211,7 +215,23 @@ class ProfileAwareGatewayRuntime:
 
         profile = await self._require_profile(context)
         if _is_bridge_tool_name(name):
-            return await self._call_bridge_tool(profile, name, arguments, context)
+            backend_tools = await self._safe_backend_tools(context)
+            collision_tool = _allowed_backend_tool_by_name(profile, backend_tools, name)
+            if collision_tool is not None:
+                return await self._call_backend_tool_through_policy(
+                    profile,
+                    name,
+                    arguments,
+                    context,
+                    tool=collision_tool,
+                )
+            return await self._call_bridge_tool(
+                profile,
+                name,
+                arguments,
+                context,
+                backend_tools=backend_tools,
+            )
         return await self._call_backend_tool_through_policy(
             profile,
             name,
@@ -312,6 +332,8 @@ class ProfileAwareGatewayRuntime:
         name: str,
         arguments: dict[str, Any],
         context: GatewayRequestContext,
+        *,
+        backend_tools: list[Any],
     ) -> dict[str, Any]:
         """Execute one synthetic profile-scoped tool discovery helper."""
 
@@ -322,7 +344,6 @@ class ProfileAwareGatewayRuntime:
                 _EMPTY_ARGUMENT_KEYS,
                 reason_code="invalid_tool_categories_arguments",
             )
-            backend_tools = await self._safe_backend_tools(context)
             catalog = list_profile_tools(profile, backend_tools)
             return {
                 "profile_id": catalog["profile_id"],
@@ -336,11 +357,9 @@ class ProfileAwareGatewayRuntime:
                 _EMPTY_ARGUMENT_KEYS,
                 reason_code="invalid_profile_tools_list_arguments",
             )
-            backend_tools = await self._safe_backend_tools(context)
             return list_profile_tools(profile, backend_tools)
         if name == _TOOL_SEARCH:
             query, category, limit = _validated_tool_search_arguments(arguments)
-            backend_tools = await self._safe_backend_tools(context)
             return {
                 "tools": search_profile_tools(
                     profile,
@@ -352,7 +371,6 @@ class ProfileAwareGatewayRuntime:
             }
         if name == _TOOL_DESCRIBE:
             tool_id = _validated_tool_describe_arguments(arguments)
-            backend_tools = await self._safe_backend_tools(context)
             description = describe_profile_tool(profile, backend_tools, tool_id)
             if description is None:
                 return _bridge_tool_error_payload(
@@ -369,7 +387,6 @@ class ProfileAwareGatewayRuntime:
                     reason_code="tool_not_allowed",
                     provenance={"profile_id": profile.id, "tool_name": name},
                 )
-            backend_tools = await self._safe_backend_tools(context)
             resolution = resolve_profile_tool_call(profile, backend_tools, tool_id)
             if resolution.get("status") == "not_found":
                 return _bridge_tool_error_payload(
@@ -450,7 +467,28 @@ def _is_bridge_tool_name(name: str) -> bool:
     return name in _BRIDGE_TOOL_NAMES
 
 
-def _profile_bridge_tool_descriptors(profile: MCPProfile) -> list[dict[str, Any]]:
+def _allowed_backend_tool_by_name(
+    profile: MCPProfile,
+    backend_tools: list[Any],
+    name: str,
+) -> dict[str, Any] | None:
+    """Return an allowed backend descriptor matching a bridge-reserved name."""
+
+    for tool in backend_tools:
+        if (
+            isinstance(tool, dict)
+            and _tool_name(tool) == name
+            and _tool_allowed_by_profile(profile, tool)
+        ):
+            return tool
+    return None
+
+
+def _profile_bridge_tool_descriptors(
+    profile: MCPProfile,
+    *,
+    suppressed_names: set[str],
+) -> list[dict[str, Any]]:
     """Return caller-owned synthetic discovery tool descriptors for a profile."""
 
     names = [
@@ -461,7 +499,11 @@ def _profile_bridge_tool_descriptors(profile: MCPProfile) -> list[dict[str, Any]
     ]
     if _profile_has_deferred_categories(profile):
         names.append(_TOOL_CALL)
-    return [deepcopy(_BRIDGE_TOOL_DESCRIPTORS[name]) for name in names]
+    return [
+        deepcopy(_BRIDGE_TOOL_DESCRIPTORS[name])
+        for name in names
+        if name not in suppressed_names
+    ]
 
 
 def _profile_has_deferred_categories(profile: MCPProfile) -> bool:
@@ -569,9 +611,12 @@ def _validate_bridge_argument_keys(
 
     if not isinstance(arguments, dict):
         raise _invalid_bridge_arguments(tool_name, reason_code=reason_code)
-    keys = set(arguments)
-    missing = sorted(required_keys - keys)
-    unknown = sorted(keys - allowed_keys)
+    missing = sorted(key for key in required_keys if key not in arguments)
+    unknown = [
+        _bridge_argument_key_label(key)
+        for key in arguments
+        if key not in allowed_keys
+    ]
     if missing or unknown:
         raise _invalid_bridge_arguments(
             tool_name,
@@ -579,6 +624,12 @@ def _validate_bridge_argument_keys(
             missing=missing,
             unknown=unknown,
         )
+
+
+def _bridge_argument_key_label(key: Any) -> str:
+    """Return a stable validation label for arbitrary mapping keys."""
+
+    return key if isinstance(key, str) else repr(key)
 
 
 def _required_bridge_tool_id(

--- a/mcp_unified/gateway/profile_runtime.py
+++ b/mcp_unified/gateway/profile_runtime.py
@@ -80,7 +80,12 @@ _BRIDGE_TOOL_DESCRIPTORS: dict[str, dict[str, Any]] = {
             "properties": {
                 "query": {"type": "string", "default": ""},
                 "category": {"type": ["string", "null"], "default": None},
-                "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 20},
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 20,
+                },
             },
             "additionalProperties": False,
         },

--- a/mcp_unified/gateway/profile_runtime.py
+++ b/mcp_unified/gateway/profile_runtime.py
@@ -215,7 +215,11 @@ class ProfileAwareGatewayRuntime:
 
         profile = await self._require_profile(context)
         if _is_bridge_tool_name(name):
-            backend_tools = await self._safe_backend_tools(context)
+            try:
+                backend_tools = await self._safe_backend_tools(context)
+            except Exception:
+                _validate_synthetic_bridge_arguments(name, arguments)
+                raise
             collision_tool = _allowed_backend_tool_by_name(profile, backend_tools, name)
             if collision_tool is not None:
                 return await self._call_backend_tool_through_policy(
@@ -459,6 +463,36 @@ class ProfileAwareGatewayRuntime:
             arguments,
             _context_with_effective_policy(context, policy_result.policy),
         )
+
+
+def _validate_synthetic_bridge_arguments(name: str, arguments: Any) -> None:
+    """Validate bridge arguments without requiring backend discovery."""
+
+    if name == _TOOL_CATEGORIES_LIST:
+        _validate_bridge_argument_keys(
+            name,
+            arguments,
+            _EMPTY_ARGUMENT_KEYS,
+            reason_code="invalid_tool_categories_arguments",
+        )
+        return
+    if name == _PROFILE_TOOLS_LIST:
+        _validate_bridge_argument_keys(
+            name,
+            arguments,
+            _EMPTY_ARGUMENT_KEYS,
+            reason_code="invalid_profile_tools_list_arguments",
+        )
+        return
+    if name == _TOOL_SEARCH:
+        _validated_tool_search_arguments(arguments)
+        return
+    if name == _TOOL_DESCRIBE:
+        _validated_tool_describe_arguments(arguments)
+        return
+    if name == _TOOL_CALL:
+        _validated_tool_call_arguments(arguments)
+        return
 
 
 def _is_bridge_tool_name(name: str) -> bool:

--- a/mcp_unified/gateway/profile_runtime.py
+++ b/mcp_unified/gateway/profile_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from copy import deepcopy
 from typing import Any, Protocol
 
 from mcp_unified.interfaces.storage import ProfileStore
@@ -15,8 +16,116 @@ from mcp_unified.profiles.resolution import (
 from mcp_unified.profiles.resolver import StoreBackedProfileResolver
 
 from .runtime import GatewayPolicyDenied, GatewayRequestContext, GatewayRuntime
+from .tool_discovery import (
+    describe_profile_tool,
+    list_profile_tools,
+    resolve_profile_tool_call,
+    search_profile_tools,
+)
 
 EFFECTIVE_POLICY_METADATA_KEY = "_gateway_effective_policy"
+_TOOL_DISCOVERY_CATEGORY = "tool_discovery"
+_TOOL_DISCOVERY_READ_CAPABILITY = "tool_discovery.read"
+_TOOL_DISCOVERY_CALL_CAPABILITY = "tool_discovery.call"
+_TOOL_CATEGORIES_LIST = "tool_categories.list"
+_PROFILE_TOOLS_LIST = "profile.tools.list"
+_TOOL_SEARCH = "tool_search"
+_TOOL_DESCRIBE = "tool_describe"
+_TOOL_CALL = "tool_call"
+_READ_ONLY_BRIDGE_TOOL_NAMES = frozenset(
+    {
+        _TOOL_CATEGORIES_LIST,
+        _PROFILE_TOOLS_LIST,
+        _TOOL_SEARCH,
+        _TOOL_DESCRIBE,
+    }
+)
+_BRIDGE_TOOL_NAMES = frozenset({*_READ_ONLY_BRIDGE_TOOL_NAMES, _TOOL_CALL})
+_TOOL_CALL_ARGUMENT_KEYS = frozenset({"tool_id", "arguments"})
+_TOOL_SEARCH_ARGUMENT_KEYS = frozenset({"query", "category", "limit"})
+_TOOL_DESCRIBE_ARGUMENT_KEYS = frozenset({"tool_id"})
+_EMPTY_ARGUMENT_KEYS = frozenset()
+_BRIDGE_TOOL_DESCRIPTORS: dict[str, dict[str, Any]] = {
+    _TOOL_CATEGORIES_LIST: {
+        "name": _TOOL_CATEGORIES_LIST,
+        "description": "List tool categories visible to the active profile.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+        "metadata": {
+            "category": _TOOL_DISCOVERY_CATEGORY,
+            "capabilities": [_TOOL_DISCOVERY_READ_CAPABILITY],
+        },
+    },
+    _PROFILE_TOOLS_LIST: {
+        "name": _PROFILE_TOOLS_LIST,
+        "description": "List the tool catalog visible to the active profile.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+        "metadata": {
+            "category": _TOOL_DISCOVERY_CATEGORY,
+            "capabilities": [_TOOL_DISCOVERY_READ_CAPABILITY],
+        },
+    },
+    _TOOL_SEARCH: {
+        "name": _TOOL_SEARCH,
+        "description": "Search tools visible to the active profile.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "default": ""},
+                "category": {"type": ["string", "null"], "default": None},
+                "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 20},
+            },
+            "additionalProperties": False,
+        },
+        "metadata": {
+            "category": _TOOL_DISCOVERY_CATEGORY,
+            "capabilities": [_TOOL_DISCOVERY_READ_CAPABILITY],
+        },
+    },
+    _TOOL_DESCRIBE: {
+        "name": _TOOL_DESCRIBE,
+        "description": "Describe one tool visible to the active profile.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "tool_id": {"type": "string"},
+            },
+            "required": ["tool_id"],
+            "additionalProperties": False,
+        },
+        "metadata": {
+            "category": _TOOL_DISCOVERY_CATEGORY,
+            "capabilities": [_TOOL_DISCOVERY_READ_CAPABILITY],
+        },
+    },
+    _TOOL_CALL: {
+        "name": _TOOL_CALL,
+        "description": "Call an installed tool by profile-scoped tool id.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "tool_id": {"type": "string"},
+                "arguments": {"type": "object"},
+            },
+            "required": ["tool_id", "arguments"],
+            "additionalProperties": False,
+        },
+        "metadata": {
+            "category": _TOOL_DISCOVERY_CATEGORY,
+            "capabilities": [
+                _TOOL_DISCOVERY_READ_CAPABILITY,
+                _TOOL_DISCOVERY_CALL_CAPABILITY,
+            ],
+        },
+    },
+}
 
 
 class GatewayProfileResolver(Protocol):
@@ -72,20 +181,25 @@ class ProfileAwareGatewayRuntime:
         if profile_result.status != "resolved" or profile_result.profile is None:
             return []
 
-        tools = await self._backend.list_tools(context)
-        if not isinstance(tools, list):
-            return []
-
+        tools = await self._safe_backend_tools(context)
         allowed_tools: list[dict[str, Any]] = []
         for tool in tools:
             if not isinstance(tool, dict):
                 continue
-            if _tool_name(tool) is not None and _tool_allowed_by_profile(
-                profile_result.profile,
-                tool,
+            name = _tool_name(tool)
+            if (
+                name is not None
+                and not _is_bridge_tool_name(name)
+                and _tool_allowed_by_profile(
+                    profile_result.profile,
+                    tool,
+                )
             ):
-                allowed_tools.append(tool)
-        return allowed_tools
+                allowed_tools.append(deepcopy(tool))
+        return [
+            *allowed_tools,
+            *_profile_bridge_tool_descriptors(profile_result.profile),
+        ]
 
     async def call_tool(
         self,
@@ -96,29 +210,13 @@ class ProfileAwareGatewayRuntime:
         """Execute an allowed backend tool or raise a structured policy denial."""
 
         profile = await self._require_profile(context)
-        policy_result = _allowed_policy_result_for_tool(profile, name, None)
-        if _policy_needs_backend_tool_metadata(profile, policy_result):
-            try:
-                tool = await self._find_backend_tool(name, context)
-            except Exception as exc:
-                raise GatewayPolicyDenied(
-                    "Gateway profile could not inspect backend tool metadata",
-                    reason_code="tool_metadata_unavailable",
-                    provenance={
-                        "tool_name": name,
-                        "backend_error": type(exc).__name__,
-                    },
-                ) from exc
-            policy_result = _allowed_policy_result_for_tool(profile, name, tool)
-        if policy_result.status != "resolved":
-            raise _policy_denied(
-                policy_result,
-                message=f"Gateway profile denied tool execution: {policy_result.reason_code}",
-            )
-        return await self._backend.call_tool(
+        if _is_bridge_tool_name(name):
+            return await self._call_bridge_tool(profile, name, arguments, context)
+        return await self._call_backend_tool_through_policy(
+            profile,
             name,
             arguments,
-            _context_with_effective_policy(context, policy_result.policy),
+            context,
         )
 
     async def list_resources(self, context: GatewayRequestContext) -> list[dict[str, Any]]:
@@ -198,6 +296,356 @@ class ProfileAwareGatewayRuntime:
             ),
             None,
         )
+
+    async def _safe_backend_tools(
+        self,
+        context: GatewayRequestContext,
+    ) -> list[Any]:
+        """Return backend discovery data for bridge catalog operations."""
+
+        tools = await self._backend.list_tools(context)
+        return tools if isinstance(tools, list) else []
+
+    async def _call_bridge_tool(
+        self,
+        profile: MCPProfile,
+        name: str,
+        arguments: dict[str, Any],
+        context: GatewayRequestContext,
+    ) -> dict[str, Any]:
+        """Execute one synthetic profile-scoped tool discovery helper."""
+
+        if name == _TOOL_CATEGORIES_LIST:
+            _validate_bridge_argument_keys(
+                name,
+                arguments,
+                _EMPTY_ARGUMENT_KEYS,
+                reason_code="invalid_tool_categories_arguments",
+            )
+            backend_tools = await self._safe_backend_tools(context)
+            catalog = list_profile_tools(profile, backend_tools)
+            return {
+                "profile_id": catalog["profile_id"],
+                "categories": catalog["categories"],
+                "progressive_disclosure": catalog["progressive_disclosure"],
+            }
+        if name == _PROFILE_TOOLS_LIST:
+            _validate_bridge_argument_keys(
+                name,
+                arguments,
+                _EMPTY_ARGUMENT_KEYS,
+                reason_code="invalid_profile_tools_list_arguments",
+            )
+            backend_tools = await self._safe_backend_tools(context)
+            return list_profile_tools(profile, backend_tools)
+        if name == _TOOL_SEARCH:
+            query, category, limit = _validated_tool_search_arguments(arguments)
+            backend_tools = await self._safe_backend_tools(context)
+            return {
+                "tools": search_profile_tools(
+                    profile,
+                    backend_tools,
+                    query=query,
+                    category=category,
+                    limit=limit,
+                )
+            }
+        if name == _TOOL_DESCRIBE:
+            tool_id = _validated_tool_describe_arguments(arguments)
+            backend_tools = await self._safe_backend_tools(context)
+            description = describe_profile_tool(profile, backend_tools, tool_id)
+            if description is None:
+                return _bridge_tool_error_payload(
+                    "tool_not_found",
+                    status="not_found",
+                    tool_id=tool_id,
+                )
+            return description
+        if name == _TOOL_CALL:
+            tool_id, delegated_arguments = _validated_tool_call_arguments(arguments)
+            if not _profile_has_deferred_categories(profile):
+                raise GatewayPolicyDenied(
+                    "Gateway profile denied tool execution: tool_not_allowed",
+                    reason_code="tool_not_allowed",
+                    provenance={"profile_id": profile.id, "tool_name": name},
+                )
+            backend_tools = await self._safe_backend_tools(context)
+            resolution = resolve_profile_tool_call(profile, backend_tools, tool_id)
+            if resolution.get("status") == "not_found":
+                return _bridge_tool_error_payload(
+                    "tool_not_found",
+                    status="not_found",
+                    tool_id=str(resolution.get("tool_id", tool_id)),
+                )
+            if resolution.get("status") == "unavailable":
+                return _bridge_tool_error_payload(
+                    "tool_not_enabled",
+                    status="unavailable",
+                    tool_id=str(resolution.get("tool_id", tool_id)),
+                    installation_status=resolution.get("installation_status"),
+                    activation=resolution.get("activation"),
+                    unavailable_reason=resolution.get("unavailable_reason"),
+                )
+            resolved_name = resolution.get("tool_name")
+            if not isinstance(resolved_name, str) or not resolved_name.strip():
+                return _bridge_tool_error_payload(
+                    "tool_not_found",
+                    status="not_found",
+                    tool_id=tool_id,
+                )
+            return await self._call_backend_tool_through_policy(
+                profile,
+                resolved_name.strip(),
+                delegated_arguments,
+                context,
+                tool=resolution.get("tool"),
+            )
+
+        raise GatewayPolicyDenied(
+            "Gateway profile denied tool execution: tool_not_allowed",
+            reason_code="tool_not_allowed",
+            provenance={"profile_id": profile.id, "tool_name": name},
+        )
+
+    async def _call_backend_tool_through_policy(
+        self,
+        profile: MCPProfile,
+        name: str,
+        arguments: dict[str, Any],
+        context: GatewayRequestContext,
+        *,
+        tool: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Run profile policy for a real backend tool before delegation."""
+
+        policy_result = _allowed_policy_result_for_tool(profile, name, tool)
+        if tool is None and _policy_needs_backend_tool_metadata(profile, policy_result):
+            try:
+                tool = await self._find_backend_tool(name, context)
+            except Exception as exc:
+                raise GatewayPolicyDenied(
+                    "Gateway profile could not inspect backend tool metadata",
+                    reason_code="tool_metadata_unavailable",
+                    provenance={
+                        "tool_name": name,
+                        "backend_error": type(exc).__name__,
+                    },
+                ) from exc
+            policy_result = _allowed_policy_result_for_tool(profile, name, tool)
+        if policy_result.status != "resolved":
+            raise _policy_denied(
+                policy_result,
+                message=f"Gateway profile denied tool execution: {policy_result.reason_code}",
+            )
+        return await self._backend.call_tool(
+            name,
+            arguments,
+            _context_with_effective_policy(context, policy_result.policy),
+        )
+
+
+def _is_bridge_tool_name(name: str) -> bool:
+    """Return whether a tool name is reserved for profile discovery bridging."""
+
+    return name in _BRIDGE_TOOL_NAMES
+
+
+def _profile_bridge_tool_descriptors(profile: MCPProfile) -> list[dict[str, Any]]:
+    """Return caller-owned synthetic discovery tool descriptors for a profile."""
+
+    names = [
+        _TOOL_CATEGORIES_LIST,
+        _PROFILE_TOOLS_LIST,
+        _TOOL_SEARCH,
+        _TOOL_DESCRIBE,
+    ]
+    if _profile_has_deferred_categories(profile):
+        names.append(_TOOL_CALL)
+    return [deepcopy(_BRIDGE_TOOL_DESCRIPTORS[name]) for name in names]
+
+
+def _profile_has_deferred_categories(profile: MCPProfile) -> bool:
+    """Return whether profile tooling metadata defers any categories."""
+
+    metadata = profile.metadata if isinstance(profile.metadata, dict) else {}
+    tooling = metadata.get("tooling")
+    if not isinstance(tooling, dict):
+        return False
+    progressive = tooling.get("progressive_disclosure")
+    if not isinstance(progressive, dict):
+        return False
+    return any(
+        isinstance(category, str) and bool(category.strip())
+        for category in _as_sequence(progressive.get("deferred_categories"))
+    )
+
+
+def _validated_tool_search_arguments(
+    arguments: Any,
+) -> tuple[str, str | None, int]:
+    """Return normalized tool search arguments or raise policy-denied validation."""
+
+    _validate_bridge_argument_keys(
+        _TOOL_SEARCH,
+        arguments,
+        _TOOL_SEARCH_ARGUMENT_KEYS,
+        reason_code="invalid_tool_search_arguments",
+    )
+    query = arguments.get("query", "")
+    if not isinstance(query, str):
+        raise _invalid_bridge_arguments(
+            _TOOL_SEARCH,
+            reason_code="invalid_tool_search_arguments",
+            field="query",
+        )
+    category = arguments.get("category")
+    if category is not None and not isinstance(category, str):
+        raise _invalid_bridge_arguments(
+            _TOOL_SEARCH,
+            reason_code="invalid_tool_search_arguments",
+            field="category",
+        )
+    limit = arguments.get("limit", 20)
+    if isinstance(limit, bool) or not isinstance(limit, int) or limit < 1 or limit > 100:
+        raise _invalid_bridge_arguments(
+            _TOOL_SEARCH,
+            reason_code="invalid_tool_search_arguments",
+            field="limit",
+        )
+    return query, category, limit
+
+
+def _validated_tool_describe_arguments(arguments: Any) -> str:
+    """Return a normalized tool id for tool_describe."""
+
+    _validate_bridge_argument_keys(
+        _TOOL_DESCRIBE,
+        arguments,
+        _TOOL_DESCRIBE_ARGUMENT_KEYS,
+        reason_code="invalid_tool_describe_arguments",
+        required_keys=_TOOL_DESCRIBE_ARGUMENT_KEYS,
+    )
+    return _required_bridge_tool_id(
+        _TOOL_DESCRIBE,
+        arguments.get("tool_id"),
+        reason_code="invalid_tool_describe_arguments",
+    )
+
+
+def _validated_tool_call_arguments(arguments: Any) -> tuple[str, dict[str, Any]]:
+    """Return normalized installed-tool call arguments."""
+
+    _validate_bridge_argument_keys(
+        _TOOL_CALL,
+        arguments,
+        _TOOL_CALL_ARGUMENT_KEYS,
+        reason_code="invalid_tool_call_arguments",
+        required_keys=_TOOL_CALL_ARGUMENT_KEYS,
+    )
+    tool_id = _required_bridge_tool_id(
+        _TOOL_CALL,
+        arguments.get("tool_id"),
+        reason_code="invalid_tool_call_arguments",
+    )
+    delegated_arguments = arguments.get("arguments")
+    if not isinstance(delegated_arguments, dict):
+        raise _invalid_bridge_arguments(
+            _TOOL_CALL,
+            reason_code="invalid_tool_call_arguments",
+            field="arguments",
+        )
+    return tool_id, deepcopy(delegated_arguments)
+
+
+def _validate_bridge_argument_keys(
+    tool_name: str,
+    arguments: Any,
+    allowed_keys: frozenset[str],
+    *,
+    reason_code: str,
+    required_keys: frozenset[str] = frozenset(),
+) -> None:
+    """Validate bridge argument object shape and reject unknown fields."""
+
+    if not isinstance(arguments, dict):
+        raise _invalid_bridge_arguments(tool_name, reason_code=reason_code)
+    keys = set(arguments)
+    missing = sorted(required_keys - keys)
+    unknown = sorted(keys - allowed_keys)
+    if missing or unknown:
+        raise _invalid_bridge_arguments(
+            tool_name,
+            reason_code=reason_code,
+            missing=missing,
+            unknown=unknown,
+        )
+
+
+def _required_bridge_tool_id(
+    tool_name: str,
+    value: Any,
+    *,
+    reason_code: str,
+) -> str:
+    """Return a non-empty tool id string for a bridge helper."""
+
+    if not isinstance(value, str) or not value.strip():
+        raise _invalid_bridge_arguments(
+            tool_name,
+            reason_code=reason_code,
+            field="tool_id",
+        )
+    return value.strip()
+
+
+def _invalid_bridge_arguments(
+    tool_name: str,
+    *,
+    reason_code: str,
+    field: str | None = None,
+    missing: list[str] | None = None,
+    unknown: list[str] | None = None,
+) -> GatewayPolicyDenied:
+    """Build a structured policy denial for invalid synthetic tool arguments."""
+
+    provenance: dict[str, Any] = {"tool_name": tool_name}
+    if field is not None:
+        provenance["field"] = field
+    if missing:
+        provenance["missing_fields"] = missing
+    if unknown:
+        provenance["unknown_fields"] = unknown
+    return GatewayPolicyDenied(
+        f"Invalid arguments for profile discovery bridge tool: {tool_name}",
+        reason_code=reason_code,
+        provenance=provenance,
+    )
+
+
+def _bridge_tool_error_payload(
+    reason_code: str,
+    *,
+    status: str,
+    tool_id: str,
+    **details: Any,
+) -> dict[str, Any]:
+    """Return a normal tool result payload for profile bridge lookup failures."""
+
+    error = {
+        "status": status,
+        "reason_code": reason_code,
+        "tool_id": tool_id,
+    }
+    for key, value in details.items():
+        if value is not None:
+            error[key] = value
+    return {
+        "ok": False,
+        "status": status,
+        "reason_code": reason_code,
+        "tool_id": tool_id,
+        "error": error,
+    }
 
 
 def _context_profile_id(context: GatewayRequestContext) -> str | None:

--- a/mcp_unified/gateway/tool_discovery.py
+++ b/mcp_unified/gateway/tool_discovery.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
+import re
 from collections import Counter
 from collections.abc import Sequence
 from copy import deepcopy
 from dataclasses import dataclass
 from math import log
-import re
 from typing import Any
 
 from mcp_unified.profiles.models import MCPProfile
@@ -196,7 +196,11 @@ def _installed_entry(profile: MCPProfile, tool: Any) -> _ToolEntry | None:
         or _first_text(tool, "display_name", "displayName", "title")
         or tool_id
     )
-    description = _first_text(tool, "description") or _first_text(metadata, "description") or ""
+    description = (
+        _first_text(tool, "description")
+        or _first_text(metadata, "description")
+        or ""
+    )
     capabilities = tuple(_tool_capabilities(tool))
     activation = _first_text(metadata, "activation") or _first_text(tool, "activation")
     unavailable_reason = (
@@ -450,8 +454,9 @@ def _category_payload(
     fallback_priority = len(category_priorities)
     categories: dict[str, Counter[str]] = {}
     for entry in entries:
-        categories.setdefault(entry.category, Counter())
-        categories[entry.category][entry.installation_status] += 1
+        category = _normalize_category(entry.category) or _DEFAULT_CATEGORY
+        categories.setdefault(category, Counter())
+        categories[category][entry.installation_status] += 1
 
     return [
         {

--- a/mcp_unified/gateway/tool_discovery.py
+++ b/mcp_unified/gateway/tool_discovery.py
@@ -328,23 +328,18 @@ def _recommendation_visible(
 ) -> bool:
     """Return whether recommendation metadata is visible for this profile."""
 
-    tool_result = build_effective_policy_result(profile, tool_name=tool_id)
-    if tool_result.reason_code == "tool_denied":
-        return False
-    if tool_result.reason_code == "workspace_scope_required":
-        return False
+    if build_effective_policy_result(profile, tool_name=tool_id).status == "resolved":
+        return True
 
     for capability in _recommendation_capabilities(recommendation):
         capability_result = build_effective_policy_result(
             profile,
+            tool_name=tool_id,
             capability=capability,
         )
-        if capability_result.reason_code in {
-            "capability_denied",
-            "workspace_scope_required",
-        }:
-            return False
-    return True
+        if capability_result.status == "resolved":
+            return True
+    return False
 
 
 def _tool_name(tool: dict[str, Any]) -> str | None:

--- a/mcp_unified/gateway/tool_discovery.py
+++ b/mcp_unified/gateway/tool_discovery.py
@@ -239,7 +239,7 @@ def _recommended_entry(
         return None
 
     tool_id = _first_text(recommendation, "id", "tool_id", "name")
-    if tool_id is None or not _recommendation_visible(profile, recommendation, tool_id):
+    if tool_id is None:
         return None
 
     metadata = (
@@ -314,27 +314,6 @@ def _installed_tool_allowed(profile: MCPProfile, tool: dict[str, Any]) -> bool:
         capability_result = build_effective_policy_result(
             profile,
             tool_name=tool_name,
-            capability=capability,
-        )
-        if capability_result.status == "resolved":
-            return True
-    return False
-
-
-def _recommendation_visible(
-    profile: MCPProfile,
-    recommendation: dict[str, Any],
-    tool_id: str,
-) -> bool:
-    """Return whether recommendation metadata is visible for this profile."""
-
-    if build_effective_policy_result(profile, tool_name=tool_id).status == "resolved":
-        return True
-
-    for capability in _recommendation_capabilities(recommendation):
-        capability_result = build_effective_policy_result(
-            profile,
-            tool_name=tool_id,
             capability=capability,
         )
         if capability_result.status == "resolved":

--- a/mcp_unified/gateway/tool_discovery.py
+++ b/mcp_unified/gateway/tool_discovery.py
@@ -1,0 +1,656 @@
+"""Profile-scoped MCP gateway tool discovery and ranking helpers."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Sequence
+from copy import deepcopy
+from dataclasses import dataclass
+from math import log
+import re
+from typing import Any
+
+from mcp_unified.profiles.models import MCPProfile
+from mcp_unified.profiles.resolution import build_effective_policy_result
+
+_TOKEN_PATTERN = re.compile(r"[A-Za-z0-9]+")
+_DEFAULT_CATEGORY = "uncategorized"
+_INSTALLED = "installed"
+_RECOMMENDED_UNAVAILABLE = "recommended_unavailable"
+_RANKING_METADATA: dict[str, Any] = {
+    "semantic_search": False,
+    "scoring": "bm25_standard_library",
+    "order": [
+        "profile_grants",
+        "installation_status",
+        "category_filter",
+        "bm25",
+        "category_priority",
+        "tool_id",
+    ],
+}
+
+
+@dataclass(frozen=True, slots=True)
+class _ToolEntry:
+    """Normalized internal representation for one visible discovery item."""
+
+    tool_id: str
+    tool_name: str | None
+    display_name: str
+    description: str
+    category: str
+    capabilities: tuple[str, ...]
+    installation_status: str
+    source: str
+    text: str
+    backend_tool: dict[str, Any] | None = None
+    activation: str | None = None
+    unavailable_reason: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+def list_profile_tools(profile: MCPProfile, backend_tools: Any) -> dict[str, Any]:
+    """Return all tools visible to a profile with deterministic category metadata."""
+
+    entries = _visible_entries(profile, backend_tools)
+    ordered = _sort_entries(profile, entries, scores={})
+    return {
+        "profile_id": profile.id,
+        "tools": [_entry_payload(entry, score=0.0) for entry in ordered],
+        "categories": _category_payload(profile, ordered),
+        "progressive_disclosure": _progressive_disclosure(profile),
+        "ranking": _ranking_metadata(),
+    }
+
+
+def search_profile_tools(
+    profile: MCPProfile,
+    backend_tools: Any,
+    *,
+    query: str = "",
+    category: str | None = None,
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    """Search profile-visible tools using filter-first, standard-library BM25 ranking."""
+
+    if limit <= 0:
+        return []
+
+    entries = _visible_entries(profile, backend_tools)
+    filtered = _filter_by_category(entries, category)
+    scores = _bm25_scores(filtered, query)
+    ordered = _sort_entries(profile, filtered, scores=scores)
+    return [
+        _entry_payload(entry, score=scores.get(entry.tool_id, 0.0))
+        for entry in ordered[:limit]
+    ]
+
+
+def describe_profile_tool(
+    profile: MCPProfile,
+    backend_tools: Any,
+    tool_id: str,
+) -> dict[str, Any] | None:
+    """Return a profile-visible tool description by id, or None when out of scope."""
+
+    normalized_tool_id = _clean_text(tool_id)
+    if normalized_tool_id is None:
+        return None
+    for entry in _visible_entries(profile, backend_tools):
+        if entry.tool_id == normalized_tool_id:
+            return _entry_payload(entry, score=0.0)
+    return None
+
+
+def resolve_profile_tool_call(
+    profile: MCPProfile,
+    backend_tools: Any,
+    tool_id: str,
+) -> dict[str, Any]:
+    """Resolve a profile-visible bridge tool id to a callable backend tool or denial."""
+
+    normalized_tool_id = _clean_text(tool_id)
+    if normalized_tool_id is None:
+        return {
+            "status": "not_found",
+            "reason_code": "tool_not_found",
+            "tool_id": tool_id,
+        }
+
+    for entry in _visible_entries(profile, backend_tools):
+        if entry.tool_id != normalized_tool_id:
+            continue
+        if entry.installation_status == _INSTALLED and entry.backend_tool is not None:
+            return {
+                "status": "resolved",
+                "tool_id": entry.tool_id,
+                "tool_name": entry.tool_name or entry.tool_id,
+                "tool": entry.backend_tool,
+            }
+        return {
+            "status": "unavailable",
+            "reason_code": "tool_not_enabled",
+            "tool_id": entry.tool_id,
+            "installation_status": entry.installation_status,
+            "activation": entry.activation,
+            "unavailable_reason": entry.unavailable_reason,
+        }
+
+    return {
+        "status": "not_found",
+        "reason_code": "tool_not_found",
+        "tool_id": normalized_tool_id,
+    }
+
+
+def _visible_entries(profile: MCPProfile, backend_tools: Any) -> list[_ToolEntry]:
+    """Return installed and recommendation-only tools visible for a profile."""
+
+    if not getattr(profile, "enabled", False):
+        return []
+    if build_effective_policy_result(profile).status != "resolved":
+        return []
+
+    installed: list[_ToolEntry] = []
+    seen_installed: set[str] = set()
+    for tool in _backend_tool_sequence(backend_tools):
+        entry = _installed_entry(profile, tool)
+        if entry is None or entry.tool_id in seen_installed:
+            continue
+        installed.append(entry)
+        seen_installed.add(entry.tool_id)
+
+    entries = list(installed)
+    seen_recommendations = set(seen_installed)
+    for recommendation in _recommended_tool_sequence(profile):
+        entry = _recommended_entry(profile, recommendation)
+        if entry is None or entry.tool_id in seen_recommendations:
+            continue
+        entries.append(entry)
+        seen_recommendations.add(entry.tool_id)
+    return entries
+
+
+def _backend_tool_sequence(backend_tools: Any) -> Sequence[Any]:
+    """Return a safe sequence of backend tool descriptors."""
+
+    return backend_tools if isinstance(backend_tools, list) else ()
+
+
+def _installed_entry(profile: MCPProfile, tool: Any) -> _ToolEntry | None:
+    """Normalize one installed backend descriptor when profile policy grants it."""
+
+    if not isinstance(tool, dict) or not _installed_tool_allowed(profile, tool):
+        return None
+
+    tool_id = _tool_name(tool)
+    if tool_id is None:
+        return None
+
+    metadata = tool.get("metadata") if isinstance(tool.get("metadata"), dict) else {}
+    category = _first_text(metadata, "category") or _first_text(tool, "category")
+    category = category or _DEFAULT_CATEGORY
+    display_name = (
+        _first_text(metadata, "display_name", "displayName", "title", "name")
+        or _first_text(tool, "display_name", "displayName", "title")
+        or tool_id
+    )
+    description = _first_text(tool, "description") or _first_text(metadata, "description") or ""
+    capabilities = tuple(_tool_capabilities(tool))
+    activation = _first_text(metadata, "activation") or _first_text(tool, "activation")
+    unavailable_reason = (
+        _first_text(metadata, "unavailable_reason", "reason", "reason_code")
+        or _first_text(tool, "unavailable_reason", "reason", "reason_code")
+    )
+    text = _search_text(
+        tool_id,
+        display_name,
+        category,
+        description,
+        *capabilities,
+        activation,
+        unavailable_reason,
+    )
+    return _ToolEntry(
+        tool_id=tool_id,
+        tool_name=tool_id,
+        display_name=display_name,
+        description=description,
+        category=category,
+        capabilities=capabilities,
+        installation_status=_INSTALLED,
+        source="backend",
+        text=text,
+        backend_tool=tool,
+        activation=activation,
+        unavailable_reason=unavailable_reason,
+        metadata=deepcopy(metadata),
+    )
+
+
+def _recommended_entry(
+    profile: MCPProfile,
+    recommendation: Any,
+) -> _ToolEntry | None:
+    """Normalize one profile recommendation as visible but not callable."""
+
+    if not isinstance(recommendation, dict):
+        return None
+
+    tool_id = _first_text(recommendation, "id", "tool_id", "name")
+    if tool_id is None or not _recommendation_visible(profile, recommendation, tool_id):
+        return None
+
+    metadata = (
+        recommendation.get("metadata")
+        if isinstance(recommendation.get("metadata"), dict)
+        else {}
+    )
+    category = (
+        _first_text(recommendation, "category")
+        or _first_text(metadata, "category")
+        or _DEFAULT_CATEGORY
+    )
+    display_name = (
+        _first_text(recommendation, "display_name", "displayName", "title", "name")
+        or _first_text(metadata, "display_name", "displayName", "title", "name")
+        or tool_id
+    )
+    description = (
+        _first_text(recommendation, "description")
+        or _first_text(metadata, "description")
+        or ""
+    )
+    capabilities = tuple(_recommendation_capabilities(recommendation))
+    activation = _first_text(recommendation, "activation") or _first_text(
+        metadata,
+        "activation",
+    )
+    unavailable_reason = (
+        _first_text(recommendation, "unavailable_reason", "reason", "reason_code")
+        or _first_text(metadata, "unavailable_reason", "reason", "reason_code")
+        or activation
+    )
+    text = _search_text(
+        tool_id,
+        display_name,
+        category,
+        description,
+        *capabilities,
+        activation,
+        unavailable_reason,
+    )
+    return _ToolEntry(
+        tool_id=tool_id,
+        tool_name=None,
+        display_name=display_name,
+        description=description,
+        category=category,
+        capabilities=capabilities,
+        installation_status=_RECOMMENDED_UNAVAILABLE,
+        source="profile_recommendation",
+        text=text,
+        activation=activation,
+        unavailable_reason=unavailable_reason,
+        metadata=deepcopy(recommendation),
+    )
+
+
+def _installed_tool_allowed(profile: MCPProfile, tool: dict[str, Any]) -> bool:
+    """Return whether effective profile policy grants an installed backend tool."""
+
+    tool_name = _tool_name(tool)
+    if tool_name is None:
+        return False
+
+    name_result = build_effective_policy_result(profile, tool_name=tool_name)
+    if name_result.status == "resolved":
+        return True
+    if name_result.reason_code != "tool_not_allowed":
+        return False
+
+    for capability in _tool_capabilities(tool):
+        capability_result = build_effective_policy_result(
+            profile,
+            tool_name=tool_name,
+            capability=capability,
+        )
+        if capability_result.status == "resolved":
+            return True
+    return False
+
+
+def _recommendation_visible(
+    profile: MCPProfile,
+    recommendation: dict[str, Any],
+    tool_id: str,
+) -> bool:
+    """Return whether recommendation metadata is visible for this profile."""
+
+    tool_result = build_effective_policy_result(profile, tool_name=tool_id)
+    if tool_result.reason_code == "tool_denied":
+        return False
+    if tool_result.reason_code == "workspace_scope_required":
+        return False
+
+    for capability in _recommendation_capabilities(recommendation):
+        capability_result = build_effective_policy_result(
+            profile,
+            capability=capability,
+        )
+        if capability_result.reason_code in {
+            "capability_denied",
+            "workspace_scope_required",
+        }:
+            return False
+    return True
+
+
+def _tool_name(tool: dict[str, Any]) -> str | None:
+    """Return a valid backend tool name."""
+
+    return _first_text(tool, "name")
+
+
+def _tool_capabilities(tool: dict[str, Any]) -> list[str]:
+    """Return recognized capability labels from a backend tool descriptor."""
+
+    metadata = tool.get("metadata")
+    capability_values: list[Any] = []
+    if isinstance(metadata, dict):
+        capability_values.extend(_as_sequence(metadata.get("capabilities")))
+        capability_values.extend(_as_sequence(metadata.get("capability")))
+    capability_values.extend(_as_sequence(tool.get("capabilities")))
+    return _unique_texts(capability_values)
+
+
+def _recommendation_capabilities(recommendation: dict[str, Any]) -> list[str]:
+    """Return recognized capability labels from a recommendation descriptor."""
+
+    metadata = recommendation.get("metadata")
+    capability_values: list[Any] = []
+    capability_values.extend(_as_sequence(recommendation.get("capabilities")))
+    capability_values.extend(_as_sequence(recommendation.get("capability")))
+    if isinstance(metadata, dict):
+        capability_values.extend(_as_sequence(metadata.get("capabilities")))
+        capability_values.extend(_as_sequence(metadata.get("capability")))
+    return _unique_texts(capability_values)
+
+
+def _recommended_tool_sequence(profile: MCPProfile) -> Sequence[Any]:
+    """Return recommendation entries from profile metadata."""
+
+    tooling = _tooling_metadata(profile)
+    recommended_tools = tooling.get("recommended_tools")
+    return recommended_tools if isinstance(recommended_tools, list) else ()
+
+
+def _tooling_metadata(profile: MCPProfile) -> dict[str, Any]:
+    """Return profile tooling metadata when present."""
+
+    metadata = profile.metadata if isinstance(profile.metadata, dict) else {}
+    tooling = metadata.get("tooling")
+    return tooling if isinstance(tooling, dict) else {}
+
+
+def _progressive_disclosure(profile: MCPProfile) -> dict[str, Any]:
+    """Return normalized progressive-disclosure metadata."""
+
+    progressive = _tooling_metadata(profile).get("progressive_disclosure")
+    if not isinstance(progressive, dict):
+        progressive = {}
+    return {
+        "direct_categories": _unique_texts(
+            _as_sequence(progressive.get("direct_categories")),
+        ),
+        "deferred_categories": _unique_texts(
+            _as_sequence(progressive.get("deferred_categories")),
+        ),
+        "max_direct_tools": progressive.get("max_direct_tools", 20),
+    }
+
+
+def _category_priority(profile: MCPProfile) -> dict[str, int]:
+    """Return category priority from profile progressive-disclosure order."""
+
+    progressive = _progressive_disclosure(profile)
+    ordered_categories = [
+        *progressive["direct_categories"],
+        *progressive["deferred_categories"],
+    ]
+    return {
+        _normalize_category(category): index
+        for index, category in enumerate(ordered_categories)
+    }
+
+
+def _filter_by_category(
+    entries: list[_ToolEntry],
+    category: str | None,
+) -> list[_ToolEntry]:
+    """Apply an optional category filter before scoring."""
+
+    normalized = _normalize_category(category)
+    if normalized is None:
+        return entries
+    return [
+        entry
+        for entry in entries
+        if _normalize_category(entry.category) == normalized
+    ]
+
+
+def _sort_entries(
+    profile: MCPProfile,
+    entries: list[_ToolEntry],
+    *,
+    scores: dict[str, float],
+) -> list[_ToolEntry]:
+    """Sort entries by installation state, BM25 score, category priority, and id."""
+
+    category_priorities = _category_priority(profile)
+    fallback_priority = len(category_priorities)
+    return sorted(
+        entries,
+        key=lambda entry: (
+            0 if entry.installation_status == _INSTALLED else 1,
+            -scores.get(entry.tool_id, 0.0),
+            category_priorities.get(
+                _normalize_category(entry.category) or "",
+                fallback_priority,
+            ),
+            _normalize_sort_text(entry.category),
+            _normalize_sort_text(entry.tool_id),
+        ),
+    )
+
+
+def _category_payload(
+    profile: MCPProfile,
+    entries: list[_ToolEntry],
+) -> list[dict[str, Any]]:
+    """Return deterministic category counts for the visible catalog."""
+
+    category_priorities = _category_priority(profile)
+    fallback_priority = len(category_priorities)
+    categories: dict[str, Counter[str]] = {}
+    for entry in entries:
+        categories.setdefault(entry.category, Counter())
+        categories[entry.category][entry.installation_status] += 1
+
+    return [
+        {
+            "category": category,
+            "count": sum(counts.values()),
+            "installed_count": counts.get(_INSTALLED, 0),
+            "recommended_unavailable_count": counts.get(
+                _RECOMMENDED_UNAVAILABLE,
+                0,
+            ),
+        }
+        for category, counts in sorted(
+            categories.items(),
+            key=lambda item: (
+                category_priorities.get(
+                    _normalize_category(item[0]) or "",
+                    fallback_priority,
+                ),
+                _normalize_sort_text(item[0]),
+            ),
+        )
+    ]
+
+
+def _entry_payload(entry: _ToolEntry, *, score: float) -> dict[str, Any]:
+    """Return a JSON-safe public payload for one discovery entry."""
+
+    payload: dict[str, Any] = {
+        "tool_id": entry.tool_id,
+        "display_name": entry.display_name,
+        "description": entry.description,
+        "category": entry.category,
+        "capabilities": list(entry.capabilities),
+        "installation_status": entry.installation_status,
+        "source": entry.source,
+        "ranking": _ranking_metadata(score),
+    }
+    if entry.tool_name is not None:
+        payload["tool_name"] = entry.tool_name
+    if entry.activation is not None:
+        payload["activation"] = entry.activation
+    if entry.unavailable_reason is not None:
+        payload["unavailable_reason"] = entry.unavailable_reason
+    if entry.metadata:
+        payload["metadata"] = deepcopy(entry.metadata)
+    return payload
+
+
+def _ranking_metadata(score: float | None = None) -> dict[str, Any]:
+    """Return ranking metadata that documents the non-semantic scorer."""
+
+    metadata = deepcopy(_RANKING_METADATA)
+    if score is not None:
+        metadata["bm25_score"] = round(score, 6)
+    return metadata
+
+
+def _bm25_scores(entries: list[_ToolEntry], query: str) -> dict[str, float]:
+    """Return BM25 scores for entries using only standard-library primitives."""
+
+    query_terms = _tokenize(query)
+    if not query_terms or not entries:
+        return {entry.tool_id: 0.0 for entry in entries}
+
+    documents = [_tokenize(entry.text) for entry in entries]
+    doc_count = len(documents)
+    average_length = sum(len(document) for document in documents) / doc_count
+    average_length = average_length or 1.0
+
+    document_frequencies: Counter[str] = Counter()
+    for document in documents:
+        document_frequencies.update(set(document))
+
+    k1 = 1.5
+    b = 0.75
+    scores: dict[str, float] = {}
+    for entry, document in zip(entries, documents):
+        frequencies = Counter(document)
+        document_length = len(document) or 1
+        score = 0.0
+        for term in query_terms:
+            frequency = frequencies.get(term, 0)
+            if frequency == 0:
+                continue
+            idf = log(
+                1
+                + (doc_count - document_frequencies[term] + 0.5)
+                / (document_frequencies[term] + 0.5),
+            )
+            denominator = frequency + k1 * (
+                1 - b + b * document_length / average_length
+            )
+            score += idf * (frequency * (k1 + 1)) / denominator
+        scores[entry.tool_id] = score
+    return scores
+
+
+def _search_text(*values: Any) -> str:
+    """Join text-bearing fields used by the BM25 scorer."""
+
+    return " ".join(value for value in _unique_texts(values))
+
+
+def _tokenize(value: Any) -> list[str]:
+    """Tokenize search text into lowercase alphanumeric terms."""
+
+    if not isinstance(value, str):
+        return []
+    return [match.group(0).lower() for match in _TOKEN_PATTERN.finditer(value)]
+
+
+def _first_text(mapping: dict[str, Any], *keys: str) -> str | None:
+    """Return the first non-empty string value for the supplied keys."""
+
+    for key in keys:
+        value = mapping.get(key)
+        cleaned = _clean_text(value)
+        if cleaned is not None:
+            return cleaned
+    return None
+
+
+def _clean_text(value: Any) -> str | None:
+    """Return stripped text for non-empty strings."""
+
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _unique_texts(values: Sequence[Any]) -> list[str]:
+    """Return stripped string values without duplicates, preserving order."""
+
+    texts: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        cleaned = _clean_text(value)
+        if cleaned is None or cleaned in seen:
+            continue
+        texts.append(cleaned)
+        seen.add(cleaned)
+    return texts
+
+
+def _as_sequence(value: Any) -> Sequence[Any]:
+    """Normalize scalar-or-sequence metadata into a sequence."""
+
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, Sequence):
+        return value
+    return ()
+
+
+def _normalize_category(category: str | None) -> str | None:
+    """Normalize category labels for filtering and priority lookup."""
+
+    cleaned = _clean_text(category)
+    return cleaned.lower() if cleaned is not None else None
+
+
+def _normalize_sort_text(value: str) -> str:
+    """Normalize text for stable lexical tie-breaks."""
+
+    return value.casefold()
+
+
+__all__ = [
+    "describe_profile_tool",
+    "list_profile_tools",
+    "resolve_profile_tool_call",
+    "search_profile_tools",
+]

--- a/mcp_unified/profiles/presets.py
+++ b/mcp_unified/profiles/presets.py
@@ -39,11 +39,19 @@ _DESTRUCTIVE_FILESYSTEM_CAPABILITIES = {
 _EXTERNAL_NETWORK_CAPABILITIES = {
     "external.network",
 }
+_APPROVAL_REQUIRED_RISK_CLASSES = {
+    "browser_mutation",
+    "deployment_mutation",
+    "git_mutation",
+    "memory_mutation",
+    "test_execution",
+}
 _HIGH_RISK_RISK_CLASSES = {
     "credential_use",
     "destructive_filesystem",
     "external_network",
     "process_execution",
+    *_APPROVAL_REQUIRED_RISK_CLASSES,
 }
 
 
@@ -775,6 +783,12 @@ def validate_preset_safety(preset: ProfilePreset) -> list[str]:
         if not _has_high_risk_provenance(profile, "external_network"):
             violations.append("high_risk_capability_requires_provenance")
 
+    for risk_class in sorted(risk_classes & _APPROVAL_REQUIRED_RISK_CLASSES):
+        if not _approval_required_for(profile, risk_class):
+            violations.append(f"{risk_class}_requires_approval")
+        if not _has_high_risk_provenance(profile, risk_class):
+            violations.append("high_risk_capability_requires_provenance")
+
     unknown_high_risk = risk_classes - _HIGH_RISK_RISK_CLASSES - {"mutating"}
     if unknown_high_risk:
         violations.append("unknown_high_risk_requires_review")
@@ -798,8 +812,8 @@ def _approval_required_for(profile: MCPProfile, risk_class: str) -> bool:
     else:
         required_for = []
 
-    if risk_class == "process_execution":
-        return "process_execution" in required_for
+    if risk_class == "process_execution" or risk_class in _APPROVAL_REQUIRED_RISK_CLASSES:
+        return risk_class in required_for
 
     return risk_class in required_for or "mutating" in required_for or "write" in required_for
 

--- a/mcp_unified/profiles/presets.py
+++ b/mcp_unified/profiles/presets.py
@@ -12,6 +12,7 @@ from .models import MCPProfile, ProfilePolicy
 from .tooling import (
     browser_server_recommendation,
     issue_tracker_server_recommendation,
+    recommended_tool,
     tooling_metadata,
     web_search_server_recommendation,
 )
@@ -226,6 +227,18 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
                 "docs_search",
                 "browser",
             ],
+            recommended_tools=[
+                recommended_tool(
+                    "stories.acceptance_criteria.draft",
+                    category="issues",
+                    description="Draft acceptance criteria from scoped product notes.",
+                ),
+                recommended_tool(
+                    "requirements.traceability.map",
+                    category="docs",
+                    description="Prepare a requirements-to-story traceability map.",
+                ),
+            ],
             recommended_servers=[
                 web_search_server_recommendation(),
                 browser_server_recommendation(),
@@ -253,6 +266,18 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
             ],
             direct_categories=["files", "tool_discovery", "code", "docs"],
             deferred_categories=["web_search", "browser", "diagramming"],
+            recommended_tools=[
+                recommended_tool(
+                    "architecture.decision_record.draft",
+                    category="docs",
+                    description="Draft architecture decision records from scoped context.",
+                ),
+                recommended_tool(
+                    "architecture.dependency_map.preview",
+                    category="code",
+                    description="Preview package and module dependency relationships.",
+                ),
+            ],
             recommended_servers=[
                 web_search_server_recommendation(),
                 browser_server_recommendation(),
@@ -284,6 +309,18 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
             ],
             direct_categories=["git", "files", "tool_discovery"],
             deferred_categories=["safe_test_runner", "issue_tracker", "browser"],
+            recommended_tools=[
+                recommended_tool(
+                    "git.conflict_resolution.plan",
+                    category="git",
+                    description="Summarize conflict hunks and propose a resolution plan.",
+                ),
+                recommended_tool(
+                    "tests.impact.read",
+                    category="tests",
+                    description="Identify tests likely affected by conflict resolution.",
+                ),
+            ],
             recommended_servers=[
                 browser_server_recommendation(),
                 issue_tracker_server_recommendation(),
@@ -314,6 +351,18 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
             ],
             direct_categories=["files", "docs", "tool_discovery", "memory"],
             deferred_categories=["web_search", "browser", "issue_tracker"],
+            recommended_tools=[
+                recommended_tool(
+                    "docs.link_check.request",
+                    category="docs",
+                    description="Request a scoped documentation link-check report.",
+                ),
+                recommended_tool(
+                    "docs.style_review.prepare",
+                    category="docs",
+                    description="Prepare style and consistency review notes.",
+                ),
+            ],
             recommended_servers=[
                 web_search_server_recommendation(),
                 browser_server_recommendation(),
@@ -336,6 +385,18 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
             enabled_capabilities=["code_search", "filesystem.read", "docs.read"],
             direct_categories=["files", "code", "docs", "tool_discovery"],
             deferred_categories=["web_search", "browser", "citations"],
+            recommended_tools=[
+                recommended_tool(
+                    "project.map.generate",
+                    category="code",
+                    description="Generate a read-only project structure map.",
+                ),
+                recommended_tool(
+                    "citations.collect",
+                    category="citations",
+                    description="Collect citation candidates for later review.",
+                ),
+            ],
             recommended_servers=[
                 web_search_server_recommendation(),
                 browser_server_recommendation(),
@@ -384,6 +445,18 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
             ],
             direct_categories=["files", "code", "git", "tests", "tool_discovery"],
             deferred_categories=["browser", "issue_tracker", "safe_test_runner"],
+            recommended_tools=[
+                recommended_tool(
+                    "review.findings.draft",
+                    category="code",
+                    description="Draft review findings from scoped diffs and files.",
+                ),
+                recommended_tool(
+                    "tests.failure_summarize",
+                    category="tests",
+                    description="Summarize existing test failure output.",
+                ),
+            ],
             recommended_servers=[
                 browser_server_recommendation(),
                 issue_tracker_server_recommendation(),
@@ -412,6 +485,18 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
             enabled_capabilities=["deploy.inspect", "logs.read", "infra.read"],
             direct_categories=["deployments", "logs", "infra", "tool_discovery"],
             deferred_categories=["issue_tracker", "safe_test_runner", "browser"],
+            recommended_tools=[
+                recommended_tool(
+                    "deploy.plan.preview",
+                    category="deployments",
+                    description="Preview deployment plans without applying changes.",
+                ),
+                recommended_tool(
+                    "logs.incident_timeline.prepare",
+                    category="logs",
+                    description="Prepare an incident timeline from read-only logs.",
+                ),
+            ],
             recommended_servers=[
                 browser_server_recommendation(),
                 issue_tracker_server_recommendation(),
@@ -452,6 +537,18 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
                 "issue_tracker",
                 "browser",
                 "web_search",
+            ],
+            recommended_tools=[
+                recommended_tool(
+                    "api.contract.diff",
+                    category="backend",
+                    description="Compare API contract snapshots for review.",
+                ),
+                recommended_tool(
+                    "database.schema.inspect",
+                    category="backend",
+                    description="Inspect database schema metadata without mutation.",
+                ),
             ],
             recommended_servers=[
                 browser_server_recommendation(),
@@ -495,6 +592,18 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
                 "issue_tracker",
                 "web_search",
             ],
+            recommended_tools=[
+                recommended_tool(
+                    "ui.accessibility.audit_request",
+                    category="frontend",
+                    description="Request accessibility audit guidance for scoped UI changes.",
+                ),
+                recommended_tool(
+                    "design.tokens.inspect",
+                    category="frontend",
+                    description="Inspect design token usage across scoped frontend files.",
+                ),
+            ],
             recommended_servers=[
                 browser_server_recommendation(),
                 issue_tracker_server_recommendation(),
@@ -518,6 +627,18 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
             enabled_capabilities=["logs.read", "screenshots.capture", "app_state.read"],
             direct_categories=["logs", "screenshots", "app_state", "tool_discovery"],
             deferred_categories=["browser", "safe_test_runner", "issue_tracker"],
+            recommended_tools=[
+                recommended_tool(
+                    "test_cases.generate",
+                    category="tests",
+                    description="Generate manual test case drafts from scoped requirements.",
+                ),
+                recommended_tool(
+                    "bug_report.draft",
+                    category="issues",
+                    description="Draft bug reports from logs and screenshots.",
+                ),
+            ],
             recommended_servers=[
                 browser_server_recommendation(),
                 issue_tracker_server_recommendation(),
@@ -548,6 +669,18 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
             ],
             direct_categories=["files", "code", "tests", "tool_discovery"],
             deferred_categories=["safe_test_runner", "browser", "issue_tracker"],
+            recommended_tools=[
+                recommended_tool(
+                    "tests.plan.generate",
+                    category="tests",
+                    description="Generate test plan drafts for scoped code changes.",
+                ),
+                recommended_tool(
+                    "coverage.report.read",
+                    category="tests",
+                    description="Read and summarize coverage reports.",
+                ),
+            ],
             recommended_servers=[
                 browser_server_recommendation(),
                 issue_tracker_server_recommendation(),

--- a/mcp_unified/profiles/presets.py
+++ b/mcp_unified/profiles/presets.py
@@ -223,7 +223,6 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
             direct_categories=["files", "tool_discovery", "issues", "memory"],
             deferred_categories=[
                 "issue_tracker",
-                "web_search",
                 "docs_search",
                 "browser",
             ],

--- a/mcp_unified/profiles/presets.py
+++ b/mcp_unified/profiles/presets.py
@@ -9,6 +9,12 @@ from uuid import uuid4
 from pydantic import BaseModel, ConfigDict
 
 from .models import MCPProfile, ProfilePolicy
+from .tooling import (
+    browser_server_recommendation,
+    issue_tracker_server_recommendation,
+    tooling_metadata,
+    web_search_server_recommendation,
+)
 
 PRESET_RELEASE_DATE = date(2026, 5, 27)
 PRESET_VERSION = PRESET_RELEASE_DATE.strftime("%Y.%m.%d")
@@ -83,14 +89,18 @@ def _profile(
     requires_workspace_binding: bool = False,
     provenance: dict[str, Any] | None = None,
     agent_metadata: dict[str, Any] | None = None,
+    tooling_metadata_document: dict[str, Any] | None = None,
 ) -> MCPProfile:
     """Build an MCP profile template with preset provenance metadata."""
-    metadata = {
+    metadata: dict[str, Any] = {
         "agent_metadata": {
             "ui_label": name,
             **(agent_metadata or {}),
         }
     }
+    if tooling_metadata_document is not None:
+        metadata["tooling"] = tooling_metadata_document
+
     return MCPProfile(
         id=preset_id,
         name=name,
@@ -134,6 +144,7 @@ def _preset(
     requires_workspace_binding: bool = False,
     provenance: dict[str, Any] | None = None,
     agent_metadata: dict[str, Any] | None = None,
+    tooling_metadata_document: dict[str, Any] | None = None,
 ) -> ProfilePreset:
     """Build an immutable preset wrapper for a bundled MCP profile template."""
     return ProfilePreset(
@@ -150,6 +161,7 @@ def _preset(
             requires_workspace_binding=requires_workspace_binding,
             provenance=provenance,
             agent_metadata=agent_metadata,
+            tooling_metadata_document=tooling_metadata_document,
         ),
     )
 
@@ -158,6 +170,21 @@ _WRITE_APPROVAL_POLICY: dict[str, Any] = {
     "required_for": ["write", "mutating"],
     "reason": "Preset includes scoped write-oriented capabilities.",
 }
+
+_TOOL_DISCOVERY_TOOLS = [
+    "tool_categories.list",
+    "tool_search",
+    "tool_describe",
+    "profile.tools.list",
+]
+_FILES_READ_TOOLS = ["fs.list", "fs.read_text"]
+_FILES_WRITE_TOOLS = [*_FILES_READ_TOOLS, "fs.write_text"]
+_CODE_READ_TOOLS = ["code.search", "code.symbols", "code.references"]
+_DOCS_READ_TOOLS = ["docs.search", "docs.read"]
+_DOCS_WRITE_TOOLS = [*_DOCS_READ_TOOLS, "docs.write"]
+_GIT_READ_TOOLS = ["git.status", "git.diff", "git.conflicts.list", "git.conflicts.read"]
+_TEST_READ_TOOLS = ["tests.results.read", "tests.logs.read"]
+_TEST_REQUEST_TOOLS = [*_TEST_READ_TOOLS, "tests.request"]
 
 _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
     _preset(
@@ -177,12 +204,61 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
         risk_classes=["mutating"],
         approval_policy=_WRITE_APPROVAL_POLICY,
         requires_workspace_binding=True,
+        tooling_metadata_document=tooling_metadata(
+            enabled_tools=[
+                *_TOOL_DISCOVERY_TOOLS,
+                "fs.list",
+                "fs.read_text",
+                "fs.write_text",
+                "kanban.cards.create",
+                "memory.recall",
+            ],
+            enabled_capabilities=[
+                "filesystem.read",
+                "filesystem.write_scoped",
+                "issues.plan",
+                "stories.write",
+                "memory.read",
+            ],
+            direct_categories=["files", "tool_discovery", "issues", "memory"],
+            deferred_categories=[
+                "issue_tracker",
+                "web_search",
+                "docs_search",
+                "browser",
+            ],
+            recommended_servers=[
+                web_search_server_recommendation(),
+                browser_server_recommendation(),
+                issue_tracker_server_recommendation(),
+            ],
+        ),
     ),
     _preset(
         preset_id="architect",
         name="Architect",
         description="Reviews architecture with code search, documentation, and read-only filesystem access.",
         capabilities=["code_search", "docs.read", "filesystem.read"],
+        tooling_metadata_document=tooling_metadata(
+            enabled_tools=[
+                *_TOOL_DISCOVERY_TOOLS,
+                *_FILES_READ_TOOLS,
+                *_CODE_READ_TOOLS,
+                *_DOCS_READ_TOOLS,
+            ],
+            enabled_capabilities=[
+                "code_search",
+                "docs.read",
+                "filesystem.read",
+                "architecture.review",
+            ],
+            direct_categories=["files", "tool_discovery", "code", "docs"],
+            deferred_categories=["web_search", "browser", "diagramming"],
+            recommended_servers=[
+                web_search_server_recommendation(),
+                browser_server_recommendation(),
+            ],
+        ),
     ),
     _preset(
         preset_id="merge-conflict-resolver",
@@ -195,6 +271,25 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
             "reason": "Conflict resolution writes are repo-scoped and mutating.",
         },
         requires_workspace_binding=True,
+        tooling_metadata_document=tooling_metadata(
+            enabled_tools=[
+                *_TOOL_DISCOVERY_TOOLS,
+                *_GIT_READ_TOOLS,
+                *_FILES_WRITE_TOOLS,
+            ],
+            enabled_capabilities=[
+                "git.status",
+                "git.diff",
+                "filesystem.read",
+                "repo.write_scoped",
+            ],
+            direct_categories=["git", "files", "tool_discovery"],
+            deferred_categories=["safe_test_runner", "issue_tracker", "browser"],
+            recommended_servers=[
+                browser_server_recommendation(),
+                issue_tracker_server_recommendation(),
+            ],
+        ),
     ),
     _preset(
         preset_id="documentation-writer",
@@ -204,12 +299,49 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
         risk_classes=["mutating"],
         approval_policy=_WRITE_APPROVAL_POLICY,
         requires_workspace_binding=True,
+        tooling_metadata_document=tooling_metadata(
+            enabled_tools=[
+                *_TOOL_DISCOVERY_TOOLS,
+                *_FILES_WRITE_TOOLS,
+                *_DOCS_WRITE_TOOLS,
+                "memory.recall",
+            ],
+            enabled_capabilities=[
+                "docs.read",
+                "docs.write_scoped",
+                "filesystem.read",
+                "filesystem.write_scoped",
+                "memory.read",
+            ],
+            direct_categories=["files", "docs", "tool_discovery", "memory"],
+            deferred_categories=["web_search", "browser", "issue_tracker"],
+            recommended_servers=[
+                web_search_server_recommendation(),
+                browser_server_recommendation(),
+                issue_tracker_server_recommendation(),
+            ],
+        ),
     ),
     _preset(
         preset_id="project-researcher",
         name="Project Researcher",
         description="Searches and reads the codebase without write or execution capabilities.",
         capabilities=["code_search", "filesystem.read", "docs.read"],
+        tooling_metadata_document=tooling_metadata(
+            enabled_tools=[
+                *_TOOL_DISCOVERY_TOOLS,
+                *_FILES_READ_TOOLS,
+                *_CODE_READ_TOOLS,
+                *_DOCS_READ_TOOLS,
+            ],
+            enabled_capabilities=["code_search", "filesystem.read", "docs.read"],
+            direct_categories=["files", "code", "docs", "tool_discovery"],
+            deferred_categories=["web_search", "browser", "citations"],
+            recommended_servers=[
+                web_search_server_recommendation(),
+                browser_server_recommendation(),
+            ],
+        ),
     ),
     _preset(
         preset_id="deep-researcher",
@@ -237,6 +369,27 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
         name="Code Reviewer",
         description="Reviews diffs, code, and test results without write access.",
         capabilities=["code_search", "diff.read", "tests.read", "filesystem.read"],
+        tooling_metadata_document=tooling_metadata(
+            enabled_tools=[
+                *_TOOL_DISCOVERY_TOOLS,
+                *_FILES_READ_TOOLS,
+                *_CODE_READ_TOOLS,
+                *_GIT_READ_TOOLS,
+                *_TEST_READ_TOOLS,
+            ],
+            enabled_capabilities=[
+                "code_search",
+                "diff.read",
+                "tests.read",
+                "filesystem.read",
+            ],
+            direct_categories=["files", "code", "git", "tests", "tool_discovery"],
+            deferred_categories=["browser", "issue_tracker", "safe_test_runner"],
+            recommended_servers=[
+                browser_server_recommendation(),
+                issue_tracker_server_recommendation(),
+            ],
+        ),
     ),
     _preset(
         preset_id="devops-engineer",
@@ -249,6 +402,22 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
             "reason": "Infrastructure changes require explicit approval.",
         },
         requires_workspace_binding=True,
+        tooling_metadata_document=tooling_metadata(
+            enabled_tools=[
+                *_TOOL_DISCOVERY_TOOLS,
+                "deploy.status",
+                "deploy.logs.read",
+                "infra.inspect",
+                "logs.search",
+            ],
+            enabled_capabilities=["deploy.inspect", "logs.read", "infra.read"],
+            direct_categories=["deployments", "logs", "infra", "tool_discovery"],
+            deferred_categories=["issue_tracker", "safe_test_runner", "browser"],
+            recommended_servers=[
+                browser_server_recommendation(),
+                issue_tracker_server_recommendation(),
+            ],
+        ),
     ),
     _preset(
         preset_id="backend-engineer",
@@ -258,6 +427,39 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
         risk_classes=["mutating"],
         approval_policy=_WRITE_APPROVAL_POLICY,
         requires_workspace_binding=True,
+        tooling_metadata_document=tooling_metadata(
+            enabled_tools=[
+                *_TOOL_DISCOVERY_TOOLS,
+                *_FILES_WRITE_TOOLS,
+                *_CODE_READ_TOOLS,
+                *_TEST_REQUEST_TOOLS,
+                "api.schema.inspect",
+            ],
+            enabled_capabilities=[
+                "source.write_scoped",
+                "code_search",
+                "tests.request",
+                "backend.inspect",
+            ],
+            direct_categories=[
+                "files",
+                "code",
+                "tests",
+                "backend",
+                "tool_discovery",
+            ],
+            deferred_categories=[
+                "safe_test_runner",
+                "issue_tracker",
+                "browser",
+                "web_search",
+            ],
+            recommended_servers=[
+                browser_server_recommendation(),
+                issue_tracker_server_recommendation(),
+                web_search_server_recommendation(),
+            ],
+        ),
     ),
     _preset(
         preset_id="frontend-engineer",
@@ -267,12 +469,61 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
         risk_classes=["mutating"],
         approval_policy=_WRITE_APPROVAL_POLICY,
         requires_workspace_binding=True,
+        tooling_metadata_document=tooling_metadata(
+            enabled_tools=[
+                *_TOOL_DISCOVERY_TOOLS,
+                *_FILES_WRITE_TOOLS,
+                *_CODE_READ_TOOLS,
+                *_TEST_REQUEST_TOOLS,
+                "ui.components.inspect",
+            ],
+            enabled_capabilities=[
+                "source.write_scoped",
+                "frontend.inspect",
+                "tests.request",
+                "code_search",
+            ],
+            direct_categories=[
+                "files",
+                "code",
+                "tests",
+                "frontend",
+                "tool_discovery",
+            ],
+            deferred_categories=[
+                "browser",
+                "safe_test_runner",
+                "issue_tracker",
+                "web_search",
+            ],
+            recommended_servers=[
+                browser_server_recommendation(),
+                issue_tracker_server_recommendation(),
+                web_search_server_recommendation(),
+            ],
+        ),
     ),
     _preset(
         preset_id="qa-engineer",
         name="QA Engineer",
         description="Debugs running applications with browser, logs, screenshots, and read-only app state.",
         capabilities=["browser.debug", "logs.read", "screenshots.capture", "app_state.read"],
+        tooling_metadata_document=tooling_metadata(
+            enabled_tools=[
+                *_TOOL_DISCOVERY_TOOLS,
+                "logs.search",
+                "screenshots.list",
+                "app_state.read",
+                "test_cases.read",
+            ],
+            enabled_capabilities=["logs.read", "screenshots.capture", "app_state.read"],
+            direct_categories=["logs", "screenshots", "app_state", "tool_discovery"],
+            deferred_categories=["browser", "safe_test_runner", "issue_tracker"],
+            recommended_servers=[
+                browser_server_recommendation(),
+                issue_tracker_server_recommendation(),
+            ],
+        ),
     ),
     _preset(
         preset_id="sdet",
@@ -282,6 +533,27 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
         risk_classes=["mutating"],
         approval_policy=_WRITE_APPROVAL_POLICY,
         requires_workspace_binding=True,
+        tooling_metadata_document=tooling_metadata(
+            enabled_tools=[
+                *_TOOL_DISCOVERY_TOOLS,
+                *_FILES_WRITE_TOOLS,
+                *_CODE_READ_TOOLS,
+                *_TEST_REQUEST_TOOLS,
+            ],
+            enabled_capabilities=[
+                "tests.write_scoped",
+                "tests.request",
+                "code_search",
+                "filesystem.read",
+                "filesystem.write_scoped",
+            ],
+            direct_categories=["files", "code", "tests", "tool_discovery"],
+            deferred_categories=["safe_test_runner", "browser", "issue_tracker"],
+            recommended_servers=[
+                browser_server_recommendation(),
+                issue_tracker_server_recommendation(),
+            ],
+        ),
     ),
     _preset(
         preset_id="memory-keeper",

--- a/mcp_unified/profiles/presets.py
+++ b/mcp_unified/profiles/presets.py
@@ -191,7 +191,12 @@ _FILES_WRITE_TOOLS = [*_FILES_READ_TOOLS, "fs.write_text"]
 _CODE_READ_TOOLS = ["code.search", "code.symbols", "code.references"]
 _DOCS_READ_TOOLS = ["docs.search", "docs.read"]
 _DOCS_WRITE_TOOLS = [*_DOCS_READ_TOOLS, "docs.write"]
-_GIT_READ_TOOLS = ["git.status", "git.diff", "git.conflicts.list", "git.conflicts.read"]
+_GIT_READ_TOOLS = [
+    "git.status",
+    "git.diff",
+    "git.conflicts.list",
+    "git.conflicts.read",
+]
 _TEST_READ_TOOLS = ["tests.results.read", "tests.logs.read"]
 _TEST_REQUEST_TOOLS = [*_TEST_READ_TOOLS, "tests.request"]
 

--- a/mcp_unified/profiles/tooling.py
+++ b/mcp_unified/profiles/tooling.py
@@ -1,0 +1,122 @@
+"""Default profile tooling metadata and recommendation catalog helpers."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+DEFAULT_MAX_DIRECT_TOOLS = 24
+
+CHROME_DEVTOOLS_MCP_OPTION: dict[str, Any] = {
+    "id": "chrome-devtools-mcp",
+    "category": "browser",
+    "kind": "external_mcp",
+    "install_target": "ChromeDevTools/chrome-devtools-mcp",
+    "credential_slots": [],
+    "required_scopes": [],
+    "risk_classes": ["external_network"],
+    "maturity": "exact_target",
+    "setup_url": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
+}
+
+
+def tooling_metadata(
+    *,
+    enabled_tools: list[str],
+    enabled_capabilities: list[str],
+    direct_categories: list[str],
+    deferred_categories: list[str],
+    recommended_tools: list[dict[str, Any]] | None = None,
+    recommended_servers: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Return caller-owned tooling metadata for a role preset."""
+    return {
+        "enabled_tools": list(enabled_tools),
+        "enabled_capabilities": list(enabled_capabilities),
+        "recommended_tools": deepcopy(recommended_tools or []),
+        "recommended_servers": deepcopy(recommended_servers or []),
+        "recommendation_catalog_patchable": True,
+        "progressive_disclosure": {
+            "direct_categories": list(direct_categories),
+            "deferred_categories": list(deferred_categories),
+            "max_direct_tools": DEFAULT_MAX_DIRECT_TOOLS,
+        },
+        "tool_search": {
+            "ranking": ["profile_grants", "installation_status", "category", "bm25"],
+            "semantic_search": False,
+        },
+    }
+
+
+def browser_server_recommendation() -> dict[str, Any]:
+    """Return the browser/CDP recommendation category."""
+    return {
+        "category": "browser",
+        "required": False,
+        "binding_options": [deepcopy(CHROME_DEVTOOLS_MCP_OPTION)],
+    }
+
+
+def web_search_server_recommendation() -> dict[str, Any]:
+    """Return vendor-neutral web-search recommendation metadata."""
+    return {
+        "category": "web_search",
+        "required": False,
+        "binding_options": [
+            {
+                "id": "configured-web-search",
+                "category": "web_search",
+                "kind": "external_mcp",
+                "install_target": None,
+                "credential_slots": [],
+                "required_scopes": ["search:read"],
+                "risk_classes": ["external_network"],
+                "maturity": "category_placeholder",
+                "activation": "requires_configured_provider",
+            }
+        ],
+    }
+
+
+def issue_tracker_server_recommendation() -> dict[str, Any]:
+    """Return vendor-neutral issue-tracker recommendation metadata."""
+    return {
+        "category": "issue_tracker",
+        "required": False,
+        "binding_options": [
+            {
+                "id": "jira",
+                "category": "issue_tracker",
+                "kind": "external_mcp",
+                "install_target": None,
+                "credential_slots": ["jira_api_token"],
+                "required_scopes": ["issues:read", "issues:write"],
+                "risk_classes": ["external_network", "mutating"],
+                "maturity": "category_placeholder",
+            },
+            {
+                "id": "linear",
+                "category": "issue_tracker",
+                "kind": "external_mcp",
+                "install_target": None,
+                "credential_slots": ["linear_api_key"],
+                "required_scopes": ["issues:read", "issues:write"],
+                "risk_classes": ["external_network", "mutating"],
+                "maturity": "category_placeholder",
+            },
+        ],
+    }
+
+
+def merge_tooling_recommendations(
+    tooling: dict[str, Any],
+    patch: dict[str, Any],
+) -> dict[str, Any]:
+    """Return patched recommendation metadata without changing policy."""
+    merged = deepcopy(tooling)
+    for key in ("recommended_tools", "recommended_servers"):
+        additions = patch.get(key)
+        if isinstance(additions, list):
+            merged.setdefault(key, [])
+            merged[key].extend(deepcopy(additions))
+    return merged

--- a/mcp_unified/profiles/tooling.py
+++ b/mcp_unified/profiles/tooling.py
@@ -48,6 +48,24 @@ def tooling_metadata(
     }
 
 
+def recommended_tool(
+    tool_id: str,
+    *,
+    category: str,
+    description: str,
+    activation: str = "requires_operator_enablement",
+) -> dict[str, Any]:
+    """Return recommendation-only metadata for an optional tool."""
+    return {
+        "id": tool_id,
+        "category": category,
+        "description": description,
+        "activation": activation,
+        "required": False,
+        "authority": "recommendation_only",
+    }
+
+
 def browser_server_recommendation() -> dict[str, Any]:
     """Return the browser/CDP recommendation category."""
     return {

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import os
+import subprocess
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -222,22 +225,33 @@ def test_gateway_cli_argument_errors_are_json(
 
 
 def test_gateway_cli_list_presets_reports_builtin_summary(
-    capsys: pytest.CaptureFixture[str],
 ) -> None:
     """List bundled presets as a small JSON summary for front-end discovery."""
 
-    exit_code = gateway_cli.main(["list-presets"])
+    result = subprocess.run(
+        [sys.executable, "-m", "mcp_unified.gateway.cli", "list-presets"],
+        check=False,
+        cwd=_repo_root(),
+        env={**os.environ, "PYTHONWARNINGS": "ignore"},
+        text=True,
+        capture_output=True,
+    )
 
-    captured = capsys.readouterr()
-    payload = json.loads(captured.out)
+    payload = json.loads(result.stdout)
     preset_ids = {preset["id"] for preset in payload["presets"]}
-    assert exit_code == 0
-    assert captured.err == ""
+    product_owner = next(
+        preset for preset in payload["presets"] if preset["id"] == "product-owner"
+    )
+    assert result.returncode == 0
+    assert result.stderr == ""
     assert "project-researcher" in preset_ids
     assert all(
         {"description", "id", "name", "version"} <= set(preset)
         for preset in payload["presets"]
     )
+    assert product_owner["tooling"]["direct_categories"]
+    assert product_owner["tooling"]["deferred_categories"]
+    assert product_owner["tooling"]["recommendation_catalog_patchable"] is True
 
 
 def test_gateway_cli_show_preset_reports_full_builtin_profile(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -22,6 +22,7 @@ from mcp_unified.gateway.config import (
 from mcp_unified.gateway.profiles import GatewayProfileManager
 from mcp_unified.gateway.snapshots import GatewayConfigSnapshotManagementError
 from mcp_unified.profiles.models import MCPProfile
+from mcp_unified.profiles.presets import ProfilePreset
 from mcp_unified.storage.models import (
     CredentialGrant,
     ExternalServerDefinition,
@@ -252,6 +253,72 @@ def test_gateway_cli_list_presets_reports_builtin_summary(
     assert product_owner["tooling"]["direct_categories"]
     assert product_owner["tooling"]["deferred_categories"]
     assert product_owner["tooling"]["recommendation_catalog_patchable"] is True
+
+
+def test_gateway_cli_preset_tooling_summary_ignores_malformed_metadata() -> None:
+    """Malformed tooling metadata does not leak invalid category values."""
+
+    preset_with_missing_servers = ProfilePreset(
+        id="malformed",
+        version="test",
+        profile=MCPProfile(
+            id="malformed",
+            name="Malformed",
+            metadata={
+                "tooling": {
+                    "progressive_disclosure": {
+                        "direct_categories": "files",
+                        "deferred_categories": ("browser", 42, None),
+                    },
+                    "recommended_servers": None,
+                    "recommendation_catalog_patchable": True,
+                }
+            },
+        ),
+    )
+    preset_with_mixed_servers = preset_with_missing_servers.model_copy(
+        update={
+            "profile": preset_with_missing_servers.profile.model_copy(
+                update={
+                    "metadata": {
+                        "tooling": {
+                            "progressive_disclosure": {
+                                "direct_categories": ("files", 42),
+                                "deferred_categories": ["browser", None],
+                            },
+                            "recommended_servers": [
+                                {"category": "browser"},
+                                {"category": 7},
+                                object(),
+                                {"category": "search"},
+                            ],
+                            "recommendation_catalog_patchable": True,
+                        }
+                    }
+                }
+            )
+        }
+    )
+
+    missing_servers_summary = gateway_cli._preset_tooling_summary(
+        preset_with_missing_servers
+    )
+    mixed_servers_summary = gateway_cli._preset_tooling_summary(
+        preset_with_mixed_servers
+    )
+
+    assert missing_servers_summary == {
+        "direct_categories": [],
+        "deferred_categories": ["browser"],
+        "recommended_server_categories": [],
+        "recommendation_catalog_patchable": True,
+    }
+    assert mixed_servers_summary == {
+        "direct_categories": ["files"],
+        "deferred_categories": ["browser"],
+        "recommended_server_categories": ["browser", "search"],
+        "recommendation_catalog_patchable": True,
+    }
 
 
 def test_gateway_cli_show_preset_reports_full_builtin_profile(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -23,6 +23,13 @@ from mcp_unified.storage.models import ExternalServerDefinition
 
 REPO_ROOT = Path(__file__).resolve().parents[5]
 GATEWAY_ROOT = REPO_ROOT / "mcp_unified" / "gateway"
+PROFILE_DISCOVERY_READ_TOOL_NAMES = {
+    "tool_categories.list",
+    "profile.tools.list",
+    "tool_search",
+    "tool_describe",
+}
+PROFILE_DISCOVERY_CALL_TOOL_NAME = "tool_call"
 
 
 def _import_sources(path: Path) -> list[str]:
@@ -223,6 +230,30 @@ def _assert_jsonrpc_error(
     assert "message" in body["error"]
 
 
+def _listed_tool_names(tools: list[dict[str, Any]]) -> list[str]:
+    """Return tool names from JSON-RPC tool descriptors."""
+
+    return [tool["name"] for tool in tools]
+
+
+def _assert_profile_runtime_tool_names(
+    tools: list[dict[str, Any]],
+    *,
+    backend_tools: list[str],
+    includes_tool_call: bool = False,
+) -> None:
+    """Assert ordinary profile tools plus synthetic discovery helpers are exposed."""
+
+    names = set(_listed_tool_names(tools))
+    for tool_name in backend_tools:
+        assert tool_name in names
+    assert PROFILE_DISCOVERY_READ_TOOL_NAMES <= names
+    if includes_tool_call:
+        assert PROFILE_DISCOVERY_CALL_TOOL_NAME in names
+    else:
+        assert PROFILE_DISCOVERY_CALL_TOOL_NAME not in names
+
+
 def _profile_with_allowed_tools(profile_id: str, allowed_tools: list[str]) -> Any:
     """Build a profile that allows only the supplied explicit tool names."""
 
@@ -244,6 +275,41 @@ def _profile_with_capabilities(profile_id: str, capabilities: list[str]) -> Any:
         id=profile_id,
         name=f"Profile {profile_id}",
         policy_document=ProfilePolicy(capabilities=capabilities),
+    )
+
+
+def _profile_with_tooling_metadata(
+    profile_id: str,
+    *,
+    capabilities: list[str] | None = None,
+    allowed_tools: list[str] | None = None,
+    denied_tools: list[str] | None = None,
+    recommended_tools: list[dict[str, Any]] | None = None,
+    direct_categories: list[str] | None = None,
+    deferred_categories: list[str] | None = None,
+) -> Any:
+    """Build a profile with default-profile tooling metadata."""
+
+    from mcp_unified.profiles.models import MCPProfile, ProfilePolicy
+
+    return MCPProfile(
+        id=profile_id,
+        name=f"Profile {profile_id}",
+        policy_document=ProfilePolicy(
+            allowed_tools=allowed_tools or [],
+            denied_tools=denied_tools or [],
+            capabilities=capabilities or [],
+        ),
+        metadata={
+            "tooling": {
+                "recommended_tools": recommended_tools or [],
+                "progressive_disclosure": {
+                    "direct_categories": direct_categories or [],
+                    "deferred_categories": deferred_categories or [],
+                    "max_direct_tools": 24,
+                },
+            }
+        },
     )
 
 
@@ -2415,7 +2481,10 @@ def test_gateway_profile_runtime_filters_and_allows_default_profile_tools() -> N
             },
         )
 
-    assert [tool["name"] for tool in listed.json()["result"]["tools"]] == ["echo.search"]
+    _assert_profile_runtime_tool_names(
+        listed.json()["result"]["tools"],
+        backend_tools=["echo.search"],
+    )
     assert allowed.json()["result"]["content"][0]["text"] == "echo.search:hello"
     assert backend.call_requests[-1][0] == "echo.search"
     denied_body = denied.json()
@@ -2514,7 +2583,7 @@ def test_gateway_profile_runtime_ignores_invalid_backend_tool_descriptors() -> N
 
     tools = asyncio.run(runtime.list_tools(GatewayRequestContext(request_id="invalid-tools")))
 
-    assert [tool["name"] for tool in tools] == ["echo.search"]
+    _assert_profile_runtime_tool_names(tools, backend_tools=["echo.search"])
 
 
 def test_gateway_profile_runtime_treats_non_list_backend_tools_as_empty() -> None:
@@ -2530,7 +2599,289 @@ def test_gateway_profile_runtime_treats_non_list_backend_tools_as_empty() -> Non
         default_profile_id="reviewer",
     )
 
-    assert asyncio.run(runtime.list_tools(GatewayRequestContext(request_id="non-list-tools"))) == []
+    tools = asyncio.run(runtime.list_tools(GatewayRequestContext(request_id="non-list-tools")))
+
+    _assert_profile_runtime_tool_names(tools, backend_tools=[])
+
+
+def test_profile_runtime_exposes_discovery_bridge_tools_for_deferred_categories() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.gateway.runtime import GatewayRequestContext
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime(
+        [
+            {
+                "name": "browser.snapshot",
+                "description": "Inspect browser DOM.",
+                "metadata": {
+                    "capability": "browser.inspect",
+                    "category": "browser",
+                },
+            }
+        ]
+    )
+    profile = _profile_with_tooling_metadata(
+        "frontend",
+        capabilities=["browser.inspect"],
+        deferred_categories=["browser"],
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="frontend",
+    )
+
+    tools = asyncio.run(runtime.list_tools(GatewayRequestContext(request_id="bridge-list")))
+    descriptors = {tool["name"]: tool for tool in tools}
+
+    _assert_profile_runtime_tool_names(
+        tools,
+        backend_tools=["browser.snapshot"],
+        includes_tool_call=True,
+    )
+    for name in (
+        *PROFILE_DISCOVERY_READ_TOOL_NAMES,
+        PROFILE_DISCOVERY_CALL_TOOL_NAME,
+    ):
+        descriptor = descriptors[name]
+        assert descriptor["metadata"]["category"] == "tool_discovery"
+        assert "tool_discovery.read" in descriptor["metadata"]["capabilities"]
+        assert descriptor["inputSchema"]["type"] == "object"
+    assert descriptors["tool_call"]["inputSchema"]["required"] == [
+        "tool_id",
+        "arguments",
+    ]
+    assert descriptors["tool_call"]["inputSchema"]["additionalProperties"] is False
+
+
+def test_profile_runtime_omits_tool_call_without_deferred_categories() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.gateway.runtime import GatewayRequestContext
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _MultiToolGatewayRuntime()
+    profile = _profile_with_tooling_metadata(
+        "researcher",
+        capabilities=["code_search"],
+        direct_categories=["test"],
+        deferred_categories=[],
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="researcher",
+    )
+
+    tools = asyncio.run(runtime.list_tools(GatewayRequestContext(request_id="bridge-read-only")))
+
+    _assert_profile_runtime_tool_names(tools, backend_tools=["echo.search"])
+
+
+def test_profile_runtime_tool_search_bridge_returns_profile_scoped_results() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.gateway.runtime import GatewayRequestContext
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime(
+        [
+            {
+                "name": "browser.snapshot",
+                "description": "Browser DOM snapshot.",
+                "metadata": {
+                    "capability": "browser.inspect",
+                    "category": "browser",
+                },
+            },
+            {
+                "name": "shell.run",
+                "description": "Run shell commands.",
+                "metadata": {
+                    "capability": "process.execute",
+                    "category": "shell",
+                },
+            },
+        ]
+    )
+    profile = _profile_with_tooling_metadata(
+        "frontend",
+        capabilities=["browser.inspect"],
+        recommended_tools=[
+            {
+                "id": "browser.trace",
+                "category": "browser",
+                "description": "Browser trace capture.",
+                "capability": "browser.inspect",
+                "activation": "requires_browser_runtime",
+            }
+        ],
+        deferred_categories=["browser"],
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="frontend",
+    )
+    context = GatewayRequestContext(request_id="bridge-search")
+
+    categories = asyncio.run(runtime.call_tool("tool_categories.list", {}, context))
+    catalog = asyncio.run(runtime.call_tool("profile.tools.list", {}, context))
+    results = asyncio.run(
+        runtime.call_tool(
+            "tool_search",
+            {"query": "browser", "category": "browser", "limit": 10},
+            context,
+        )
+    )
+
+    assert [category["category"] for category in categories["categories"]] == ["browser"]
+    assert [tool["tool_id"] for tool in catalog["tools"]] == [
+        "browser.snapshot",
+        "browser.trace",
+    ]
+    assert [tool["tool_id"] for tool in results["tools"]] == [
+        "browser.snapshot",
+        "browser.trace",
+    ]
+    assert results["tools"][0]["installation_status"] == "installed"
+    assert results["tools"][1]["installation_status"] == "recommended_unavailable"
+    assert backend.call_requests == []
+
+
+def test_profile_runtime_tool_describe_bridge_hides_denied_tools() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.gateway.runtime import GatewayRequestContext
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _MultiToolGatewayRuntime()
+    profile = _profile_with_capabilities("researcher", ["code_search"])
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="researcher",
+    )
+
+    payload = asyncio.run(
+        runtime.call_tool(
+            "tool_describe",
+            {"tool_id": "admin.delete"},
+            GatewayRequestContext(request_id="bridge-describe-denied"),
+        )
+    )
+
+    assert payload["error"]["reason_code"] == "tool_not_found"
+    assert payload["tool_id"] == "admin.delete"
+    assert backend.call_requests == []
+
+
+def test_profile_runtime_tool_call_rejects_recommended_unavailable_tool() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.gateway.runtime import GatewayRequestContext
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime([])
+    profile = _profile_with_tooling_metadata(
+        "frontend",
+        allowed_tools=["browser.trace"],
+        recommended_tools=[
+            {
+                "id": "browser.trace",
+                "category": "browser",
+                "description": "Browser trace capture.",
+                "activation": "requires_browser_runtime",
+            }
+        ],
+        deferred_categories=["browser"],
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="frontend",
+    )
+
+    payload = asyncio.run(
+        runtime.call_tool(
+            "tool_call",
+            {"tool_id": "browser.trace", "arguments": {}},
+            GatewayRequestContext(request_id="bridge-call-unavailable"),
+        )
+    )
+
+    assert payload["error"]["reason_code"] == "tool_not_enabled"
+    assert payload["tool_id"] == "browser.trace"
+    assert backend.call_requests == []
+
+
+def test_profile_runtime_tool_call_delegates_installed_tool_through_policy() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.gateway.runtime import GatewayRequestContext
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _MultiToolGatewayRuntime()
+    profile = _profile_with_tooling_metadata(
+        "researcher",
+        capabilities=["code_search"],
+        deferred_categories=["test"],
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="researcher",
+    )
+
+    payload = asyncio.run(
+        runtime.call_tool(
+            "tool_call",
+            {"tool_id": "echo.search", "arguments": {"query": "bridge"}},
+            GatewayRequestContext(request_id="bridge-call-installed"),
+        )
+    )
+
+    assert payload["content"][0]["text"] == "echo.search:bridge"
+    assert backend.call_requests[-1][0] == "echo.search"
+    assert backend.call_requests[-1][1] == {"query": "bridge"}
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {"arguments": {}},
+        {"tool_id": "echo.search"},
+        {"tool_id": 123, "arguments": {}},
+        {"tool_id": "echo.search", "arguments": []},
+        {"tool_id": "echo.search", "arguments": {}, "extra": True},
+    ],
+)
+def test_profile_runtime_tool_call_rejects_invalid_arguments(
+    arguments: Any,
+) -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.gateway.runtime import GatewayPolicyDenied, GatewayRequestContext
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _MultiToolGatewayRuntime()
+    profile = _profile_with_tooling_metadata(
+        "researcher",
+        capabilities=["code_search"],
+        deferred_categories=["test"],
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="researcher",
+    )
+
+    with pytest.raises(GatewayPolicyDenied) as exc_info:
+        asyncio.run(
+            runtime.call_tool(
+                "tool_call",
+                arguments,
+                GatewayRequestContext(request_id="bridge-call-invalid"),
+            )
+        )
+
+    assert exc_info.value.reason_code == "invalid_tool_call_arguments"
+    assert backend.call_requests == []
 
 
 def test_gateway_profile_bootstrap_seeds_default_builtin_preset_profile() -> None:
@@ -2572,7 +2923,11 @@ def test_gateway_profile_bootstrap_seeds_default_builtin_preset_profile() -> Non
         "kind": "memory",
         "persistent": False,
     }
-    assert [tool["name"] for tool in listed.json()["result"]["tools"]] == ["echo.search"]
+    _assert_profile_runtime_tool_names(
+        listed.json()["result"]["tools"],
+        backend_tools=["echo.search"],
+        includes_tool_call=True,
+    )
     assert allowed.json()["result"]["content"][0]["text"] == "echo.search:bootstrap"
 
 
@@ -2601,7 +2956,10 @@ def test_gateway_profile_bootstrap_uses_caller_profiles_as_default() -> None:
     assert bootstrap.default_profile_id == "reviewer"
     assert bootstrap.seeded_profile_ids == ()
     assert [profile.id for profile in stored_profiles] == ["reviewer"]
-    assert [tool["name"] for tool in listed.json()["result"]["tools"]] == ["echo.search"]
+    _assert_profile_runtime_tool_names(
+        listed.json()["result"]["tools"],
+        backend_tools=["echo.search"],
+    )
 
 
 def test_gateway_profile_bootstrap_keeps_explicit_default_when_seeding_preset() -> None:
@@ -2630,7 +2988,10 @@ def test_gateway_profile_bootstrap_keeps_explicit_default_when_seeding_preset() 
     assert bootstrap.default_profile_id == "reviewer"
     assert bootstrap.seeded_profile_ids == ("project-researcher",)
     assert {profile.id for profile in stored_profiles} == {"reviewer", "project-researcher"}
-    assert [tool["name"] for tool in listed.json()["result"]["tools"]] == ["admin.delete"]
+    _assert_profile_runtime_tool_names(
+        listed.json()["result"]["tools"],
+        backend_tools=["admin.delete"],
+    )
 
 
 def test_gateway_profile_bootstrap_manager_default_changes_runtime_without_restart() -> None:
@@ -2668,9 +3029,18 @@ def test_gateway_profile_bootstrap_manager_default_changes_runtime_without_resta
             json={"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": "tools-explicit"},
         )
 
-    assert [tool["name"] for tool in first.json()["result"]["tools"]] == ["echo.search"]
-    assert [tool["name"] for tool in second.json()["result"]["tools"]] == ["admin.delete"]
-    assert [tool["name"] for tool in explicit.json()["result"]["tools"]] == ["echo.search"]
+    _assert_profile_runtime_tool_names(
+        first.json()["result"]["tools"],
+        backend_tools=["echo.search"],
+    )
+    _assert_profile_runtime_tool_names(
+        second.json()["result"]["tools"],
+        backend_tools=["admin.delete"],
+    )
+    _assert_profile_runtime_tool_names(
+        explicit.json()["result"]["tools"],
+        backend_tools=["echo.search"],
+    )
 
 
 def test_gateway_profile_management_http_default_changes_runtime_without_restart() -> None:
@@ -2713,10 +3083,16 @@ def test_gateway_profile_management_http_default_changes_runtime_without_restart
 
     assert first_default.status_code == 200
     assert first_default.json()["default"]["profile_id"] == "reviewer"
-    assert [tool["name"] for tool in first_tools.json()["result"]["tools"]] == ["echo.search"]
+    _assert_profile_runtime_tool_names(
+        first_tools.json()["result"]["tools"],
+        backend_tools=["echo.search"],
+    )
     assert second_default.status_code == 200
     assert second_default.json()["default"]["profile_id"] == "architect"
-    assert [tool["name"] for tool in second_tools.json()["result"]["tools"]] == ["admin.delete"]
+    _assert_profile_runtime_tool_names(
+        second_tools.json()["result"]["tools"],
+        backend_tools=["admin.delete"],
+    )
 
 
 def test_gateway_profile_bootstrap_rejects_existing_preset_profile_collision() -> None:
@@ -2770,7 +3146,11 @@ def test_gateway_config_bootstrap_uses_memory_store_default_preset() -> None:
 
     assert bootstrap.default_profile_id == "project-researcher"
     assert bootstrap.seeded_profile_ids == ("project-researcher",)
-    assert [tool["name"] for tool in listed.json()["result"]["tools"]] == ["echo.search"]
+    _assert_profile_runtime_tool_names(
+        listed.json()["result"]["tools"],
+        backend_tools=["echo.search"],
+        includes_tool_call=True,
+    )
 
 
 def test_gateway_config_bootstrap_uses_sqlite_profile_store(tmp_path: Path) -> None:
@@ -3357,7 +3737,10 @@ def test_gateway_config_bootstrap_preserves_injected_profile_store(tmp_path: Pat
         )
 
     assert bootstrap.profile_store is injected_store
-    assert [tool["name"] for tool in listed.json()["result"]["tools"]] == ["admin.delete"]
+    _assert_profile_runtime_tool_names(
+        listed.json()["result"]["tools"],
+        backend_tools=["admin.delete"],
+    )
 
 
 def test_gateway_config_storage_reuses_injected_sqlite_store_capabilities(tmp_path: Path) -> None:
@@ -3667,7 +4050,10 @@ def test_gateway_config_bootstrap_copies_profile_mapping_inputs() -> None:
             json={"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": "tools-config-copy"},
         )
 
-    assert [tool["name"] for tool in listed.json()["result"]["tools"]] == ["echo.search"]
+    _assert_profile_runtime_tool_names(
+        listed.json()["result"]["tools"],
+        backend_tools=["echo.search"],
+    )
 
 
 def test_gateway_config_loader_reads_json_and_bootstraps_default_preset(tmp_path: Path) -> None:
@@ -3700,7 +4086,11 @@ def test_gateway_config_loader_reads_json_and_bootstraps_default_preset(tmp_path
         )
 
     assert bootstrap.default_profile_id == "project-researcher"
-    assert [tool["name"] for tool in listed.json()["result"]["tools"]] == ["echo.search"]
+    _assert_profile_runtime_tool_names(
+        listed.json()["result"]["tools"],
+        backend_tools=["echo.search"],
+        includes_tool_call=True,
+    )
 
 
 def test_gateway_config_loader_reads_toml_store_config(tmp_path: Path) -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -2938,6 +2938,36 @@ def test_profile_runtime_tool_call_rejects_invalid_arguments(
     assert backend.call_requests == []
 
 
+def test_profile_runtime_tool_call_validates_invalid_arguments_before_backend_failure() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.gateway.runtime import GatewayPolicyDenied, GatewayRequestContext
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomExplodingGatewayRuntime()
+    profile = _profile_with_tooling_metadata(
+        "researcher",
+        capabilities=["code_search"],
+        deferred_categories=["test"],
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="researcher",
+    )
+
+    with pytest.raises(GatewayPolicyDenied) as exc_info:
+        asyncio.run(
+            runtime.call_tool(
+                "tool_call",
+                {"extra": True, 1: True},
+                GatewayRequestContext(request_id="bridge-call-invalid-before-backend"),
+            )
+        )
+
+    assert exc_info.value.reason_code == "invalid_tool_call_arguments"
+    assert backend.call_requests == []
+
+
 def test_gateway_profile_bootstrap_seeds_default_builtin_preset_profile() -> None:
     from mcp_unified.gateway.bootstrap import bootstrap_profile_gateway
     from mcp_unified.gateway.profiles import GatewayProfileManager

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -244,14 +244,17 @@ def _assert_profile_runtime_tool_names(
 ) -> None:
     """Assert ordinary profile tools plus synthetic discovery helpers are exposed."""
 
-    names = set(_listed_tool_names(tools))
-    for tool_name in backend_tools:
-        assert tool_name in names
-    assert PROFILE_DISCOVERY_READ_TOOL_NAMES <= names
+    expected_names = {
+        *backend_tools,
+        *PROFILE_DISCOVERY_READ_TOOL_NAMES,
+    }
     if includes_tool_call:
-        assert PROFILE_DISCOVERY_CALL_TOOL_NAME in names
+        expected_names.add(PROFILE_DISCOVERY_CALL_TOOL_NAME)
     else:
-        assert PROFILE_DISCOVERY_CALL_TOOL_NAME not in names
+        expected_names.discard(PROFILE_DISCOVERY_CALL_TOOL_NAME)
+    listed_names = _listed_tool_names(tools)
+    assert len(listed_names) == len(set(listed_names))
+    assert set(listed_names) == expected_names
 
 
 def _profile_with_allowed_tools(profile_id: str, allowed_tools: list[str]) -> Any:
@@ -2842,6 +2845,56 @@ def test_profile_runtime_tool_call_delegates_installed_tool_through_policy() -> 
     assert backend.call_requests[-1][1] == {"query": "bridge"}
 
 
+def test_profile_runtime_backend_tool_with_bridge_name_wins_collision() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.gateway.runtime import GatewayRequestContext
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime(
+        [
+            {
+                "name": "tool_search",
+                "description": "Backend search tool.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+                "metadata": {"category": "test"},
+            },
+            {
+                "name": "admin.delete",
+                "description": "Denied admin tool.",
+                "metadata": {"category": "admin"},
+            },
+        ]
+    )
+    profile = _profile_with_allowed_tools("collision", ["tool_search"])
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="collision",
+    )
+    context = GatewayRequestContext(request_id="bridge-name-collision")
+
+    tools = asyncio.run(runtime.list_tools(context))
+    descriptors = {tool["name"]: tool for tool in tools}
+    payload = asyncio.run(
+        runtime.call_tool(
+            "tool_search",
+            {"query": "backend"},
+            context,
+        )
+    )
+
+    _assert_profile_runtime_tool_names(tools, backend_tools=["tool_search"])
+    assert descriptors["tool_search"]["description"] == "Backend search tool."
+    assert descriptors["tool_search"]["metadata"]["category"] == "test"
+    assert payload["content"][0]["text"] == "tool_search:backend"
+    assert backend.call_requests[-1][0] == "tool_search"
+    assert all(tool["name"] != "admin.delete" for tool in tools)
+
+
 @pytest.mark.parametrize(
     "arguments",
     [
@@ -2850,6 +2903,7 @@ def test_profile_runtime_tool_call_delegates_installed_tool_through_policy() -> 
         {"tool_id": 123, "arguments": {}},
         {"tool_id": "echo.search", "arguments": []},
         {"tool_id": "echo.search", "arguments": {}, "extra": True},
+        {"tool_id": "echo.search", "arguments": {}, "extra": True, 1: True},
     ],
 )
 def test_profile_runtime_tool_call_rejects_invalid_arguments(

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py
@@ -15,7 +15,6 @@ from mcp_unified.gateway.tool_discovery import (
 )
 from mcp_unified.profiles.models import MCPProfile, ProfilePolicy
 
-
 REPO_ROOT = Path(__file__).resolve().parents[5]
 TOOL_DISCOVERY_PATH = REPO_ROOT / "mcp_unified" / "gateway" / "tool_discovery.py"
 
@@ -70,6 +69,35 @@ def test_tool_search_filters_by_profile_before_bm25() -> None:
     results = search_profile_tools(profile, tools, query="run search")
 
     assert [item["tool_id"] for item in results] == ["code.search"]
+
+
+def test_list_profile_tools_consolidates_category_counts_by_normalized_name() -> None:
+    profile = _profile(capabilities=["code_search"])
+    tools = [
+        {
+            "name": "code.search",
+            "description": "Search code",
+            "metadata": {"capability": "code_search", "category": "Code"},
+        },
+        {
+            "name": "code.symbols",
+            "description": "Find symbols",
+            "metadata": {"capability": "code_search", "category": "code"},
+        },
+    ]
+
+    payload = list_profile_tools(profile, tools)
+    results = search_profile_tools(profile, tools, query="", category="CODE")
+
+    assert payload["categories"] == [
+        {
+            "category": "code",
+            "count": 2,
+            "installed_count": 2,
+            "recommended_unavailable_count": 0,
+        }
+    ]
+    assert {item["tool_id"] for item in results} == {"code.search", "code.symbols"}
 
 
 def test_tool_search_orders_installed_before_unavailable_then_bm25() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py
@@ -84,6 +84,7 @@ def test_tool_search_orders_installed_before_unavailable_then_bm25() -> None:
                         "id": "browser.trace",
                         "category": "browser",
                         "description": "Browser trace capture",
+                        "capability": "browser.inspect",
                         "activation": "requires_browser_runtime",
                     }
                 ],
@@ -129,6 +130,7 @@ def test_describe_profile_tool_returns_visible_installed_and_recommended_only() 
                 "id": "code.index",
                 "category": "code",
                 "description": "Build a code index after setup",
+                "capability": "code_search",
                 "activation": "requires_index_runtime",
             }
         ],
@@ -173,6 +175,7 @@ def test_resolve_profile_tool_call_resolves_installed_and_rejects_recommended() 
                 "id": "browser.trace",
                 "category": "browser",
                 "description": "Browser trace capture",
+                "capability": "browser.inspect",
                 "activation": "requires_browser_runtime",
             }
         ],
@@ -210,6 +213,81 @@ def test_resolve_profile_tool_call_resolves_installed_and_rejects_recommended() 
         "reason_code": "tool_not_found",
         "tool_id": "shell.run",
     }
+
+
+def test_ungranted_recommended_tools_are_not_discoverable() -> None:
+    profile = _profile(
+        capabilities=["code_search"],
+        recommended_tools=[
+            {
+                "id": "code.index",
+                "category": "code",
+                "description": "No capability recommendation",
+                "activation": "requires_index_runtime",
+            },
+            {
+                "id": "shell.run",
+                "category": "shell",
+                "description": "Run shell commands",
+                "capability": "process.execute",
+                "activation": "requires_operator_enablement",
+            },
+        ],
+    )
+
+    results = search_profile_tools(profile, [], query="index shell")
+    no_capability_description = describe_profile_tool(profile, [], "code.index")
+    denied_capability_description = describe_profile_tool(profile, [], "shell.run")
+    no_capability_resolution = resolve_profile_tool_call(profile, [], "code.index")
+    denied_capability_resolution = resolve_profile_tool_call(profile, [], "shell.run")
+
+    assert results == []
+    assert no_capability_description is None
+    assert denied_capability_description is None
+    assert no_capability_resolution == {
+        "status": "not_found",
+        "reason_code": "tool_not_found",
+        "tool_id": "code.index",
+    }
+    assert denied_capability_resolution == {
+        "status": "not_found",
+        "reason_code": "tool_not_found",
+        "tool_id": "shell.run",
+    }
+
+
+def test_recommended_tools_preserve_explicit_allowed_tools_semantics() -> None:
+    profile = _profile(
+        allowed_tools=["browser.trace"],
+        recommended_tools=[
+            {
+                "id": "browser.trace",
+                "category": "browser",
+                "description": "Browser trace capture",
+                "activation": "requires_browser_runtime",
+            },
+            {
+                "id": "code.index",
+                "category": "code",
+                "description": "Code index setup",
+                "capability": "code_search",
+                "activation": "requires_index_runtime",
+            },
+        ],
+    )
+
+    results = search_profile_tools(profile, [], query="browser code")
+    allowed = describe_profile_tool(profile, [], "browser.trace")
+    denied = describe_profile_tool(profile, [], "code.index")
+    resolved = resolve_profile_tool_call(profile, [], "browser.trace")
+
+    assert [item["tool_id"] for item in results] == ["browser.trace"]
+    assert allowed is not None
+    assert allowed["installation_status"] == "recommended_unavailable"
+    assert denied is None
+    assert resolved["status"] == "unavailable"
+    assert resolved["reason_code"] == "tool_not_enabled"
+    assert resolved["tool_id"] == "browser.trace"
 
 
 def test_unknown_backend_descriptors_do_not_crash_or_leak() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py
@@ -215,7 +215,7 @@ def test_resolve_profile_tool_call_resolves_installed_and_rejects_recommended() 
     }
 
 
-def test_ungranted_recommended_tools_are_not_discoverable() -> None:
+def test_recommendations_without_executable_grants_are_discoverable_not_callable() -> None:
     profile = _profile(
         capabilities=["code_search"],
         recommended_tools=[
@@ -237,23 +237,23 @@ def test_ungranted_recommended_tools_are_not_discoverable() -> None:
 
     results = search_profile_tools(profile, [], query="index shell")
     no_capability_description = describe_profile_tool(profile, [], "code.index")
-    denied_capability_description = describe_profile_tool(profile, [], "shell.run")
+    ungranted_capability_description = describe_profile_tool(profile, [], "shell.run")
     no_capability_resolution = resolve_profile_tool_call(profile, [], "code.index")
-    denied_capability_resolution = resolve_profile_tool_call(profile, [], "shell.run")
+    ungranted_capability_resolution = resolve_profile_tool_call(profile, [], "shell.run")
 
-    assert results == []
-    assert no_capability_description is None
-    assert denied_capability_description is None
-    assert no_capability_resolution == {
-        "status": "not_found",
-        "reason_code": "tool_not_found",
-        "tool_id": "code.index",
-    }
-    assert denied_capability_resolution == {
-        "status": "not_found",
-        "reason_code": "tool_not_found",
-        "tool_id": "shell.run",
-    }
+    assert {item["tool_id"] for item in results} == {"code.index", "shell.run"}
+    assert no_capability_description is not None
+    assert no_capability_description["installation_status"] == "recommended_unavailable"
+    assert no_capability_description["capabilities"] == []
+    assert ungranted_capability_description is not None
+    assert ungranted_capability_description["installation_status"] == "recommended_unavailable"
+    assert ungranted_capability_description["capabilities"] == ["process.execute"]
+    assert no_capability_resolution["status"] == "unavailable"
+    assert no_capability_resolution["reason_code"] == "tool_not_enabled"
+    assert no_capability_resolution["tool_id"] == "code.index"
+    assert ungranted_capability_resolution["status"] == "unavailable"
+    assert ungranted_capability_resolution["reason_code"] == "tool_not_enabled"
+    assert ungranted_capability_resolution["tool_id"] == "shell.run"
 
 
 def test_recommended_tools_preserve_explicit_allowed_tools_semantics() -> None:
@@ -278,16 +278,21 @@ def test_recommended_tools_preserve_explicit_allowed_tools_semantics() -> None:
 
     results = search_profile_tools(profile, [], query="browser code")
     allowed = describe_profile_tool(profile, [], "browser.trace")
-    denied = describe_profile_tool(profile, [], "code.index")
+    recommended = describe_profile_tool(profile, [], "code.index")
     resolved = resolve_profile_tool_call(profile, [], "browser.trace")
+    inactive = resolve_profile_tool_call(profile, [], "code.index")
 
-    assert [item["tool_id"] for item in results] == ["browser.trace"]
+    assert [item["tool_id"] for item in results] == ["browser.trace", "code.index"]
     assert allowed is not None
     assert allowed["installation_status"] == "recommended_unavailable"
-    assert denied is None
+    assert recommended is not None
+    assert recommended["installation_status"] == "recommended_unavailable"
     assert resolved["status"] == "unavailable"
     assert resolved["reason_code"] == "tool_not_enabled"
     assert resolved["tool_id"] == "browser.trace"
+    assert inactive["status"] == "unavailable"
+    assert inactive["reason_code"] == "tool_not_enabled"
+    assert inactive["tool_id"] == "code.index"
 
 
 def test_unknown_backend_descriptors_do_not_crash_or_leak() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py
@@ -1,0 +1,272 @@
+"""Tests for profile-scoped MCP gateway tool discovery helpers."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+from mcp_unified.gateway import tool_discovery
+from mcp_unified.gateway.tool_discovery import (
+    describe_profile_tool,
+    list_profile_tools,
+    resolve_profile_tool_call,
+    search_profile_tools,
+)
+from mcp_unified.profiles.models import MCPProfile, ProfilePolicy
+
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+TOOL_DISCOVERY_PATH = REPO_ROOT / "mcp_unified" / "gateway" / "tool_discovery.py"
+
+
+def _profile(
+    *,
+    capabilities: list[str] | None = None,
+    allowed_tools: list[str] | None = None,
+    denied_tools: list[str] | None = None,
+    recommended_tools: list[dict[str, Any]] | None = None,
+) -> MCPProfile:
+    return MCPProfile(
+        id="profile",
+        name="Profile",
+        policy_document=ProfilePolicy(
+            allowed_tools=allowed_tools or [],
+            denied_tools=denied_tools or [],
+            capabilities=capabilities or [],
+        ),
+        metadata={
+            "tooling": {
+                "recommended_tools": recommended_tools or [],
+                "progressive_disclosure": {
+                    "direct_categories": [],
+                    "deferred_categories": ["browser", "code"],
+                    "max_direct_tools": 24,
+                },
+            }
+        },
+    )
+
+
+def test_tool_search_filters_by_profile_before_bm25() -> None:
+    profile = MCPProfile(
+        id="reviewer",
+        name="Reviewer",
+        policy_document=ProfilePolicy(capabilities=["code_search"]),
+    )
+    tools = [
+        {
+            "name": "code.search",
+            "description": "Search code",
+            "metadata": {"capability": "code_search", "category": "code"},
+        },
+        {
+            "name": "shell.run",
+            "description": "Run shell commands",
+            "metadata": {"capability": "process.execute", "category": "shell"},
+        },
+    ]
+
+    results = search_profile_tools(profile, tools, query="run search")
+
+    assert [item["tool_id"] for item in results] == ["code.search"]
+
+
+def test_tool_search_orders_installed_before_unavailable_then_bm25() -> None:
+    profile = MCPProfile(
+        id="frontend",
+        name="Frontend",
+        policy_document=ProfilePolicy(capabilities=["browser.inspect"]),
+        metadata={
+            "tooling": {
+                "recommended_tools": [
+                    {
+                        "id": "browser.trace",
+                        "category": "browser",
+                        "description": "Browser trace capture",
+                        "activation": "requires_browser_runtime",
+                    }
+                ],
+                "progressive_disclosure": {
+                    "direct_categories": [],
+                    "deferred_categories": ["browser"],
+                    "max_direct_tools": 24,
+                },
+            }
+        },
+    )
+    installed = [
+        {
+            "name": "browser.snapshot",
+            "description": "Browser DOM snapshot",
+            "metadata": {
+                "capability": "browser.inspect",
+                "category": "browser",
+            },
+        }
+    ]
+
+    results = search_profile_tools(
+        profile,
+        installed,
+        query="browser",
+        category="browser",
+    )
+
+    assert [item["tool_id"] for item in results] == [
+        "browser.snapshot",
+        "browser.trace",
+    ]
+    assert results[0]["installation_status"] == "installed"
+    assert results[1]["installation_status"] == "recommended_unavailable"
+
+
+def test_describe_profile_tool_returns_visible_installed_and_recommended_only() -> None:
+    profile = _profile(
+        capabilities=["code_search"],
+        recommended_tools=[
+            {
+                "id": "code.index",
+                "category": "code",
+                "description": "Build a code index after setup",
+                "activation": "requires_index_runtime",
+            }
+        ],
+    )
+    tools = [
+        {
+            "name": "code.search",
+            "description": "Search code",
+            "metadata": {
+                "capability": "code_search",
+                "category": "code",
+                "display_name": "Code Search",
+            },
+        },
+        {
+            "name": "shell.run",
+            "description": "Run shell commands",
+            "metadata": {"capability": "process.execute", "category": "shell"},
+        },
+    ]
+
+    installed = describe_profile_tool(profile, tools, "code.search")
+    recommended = describe_profile_tool(profile, tools, "code.index")
+    denied = describe_profile_tool(profile, tools, "shell.run")
+
+    assert installed is not None
+    assert installed["tool_id"] == "code.search"
+    assert installed["installation_status"] == "installed"
+    assert installed["display_name"] == "Code Search"
+    assert recommended is not None
+    assert recommended["tool_id"] == "code.index"
+    assert recommended["installation_status"] == "recommended_unavailable"
+    assert recommended["activation"] == "requires_index_runtime"
+    assert denied is None
+
+
+def test_resolve_profile_tool_call_resolves_installed_and_rejects_recommended() -> None:
+    profile = _profile(
+        capabilities=["browser.inspect"],
+        recommended_tools=[
+            {
+                "id": "browser.trace",
+                "category": "browser",
+                "description": "Browser trace capture",
+                "activation": "requires_browser_runtime",
+            }
+        ],
+    )
+    backend_tool = {
+        "name": "browser.snapshot",
+        "description": "Browser DOM snapshot",
+        "metadata": {"capability": "browser.inspect", "category": "browser"},
+    }
+    tools = [
+        backend_tool,
+        {
+            "name": "shell.run",
+            "description": "Run shell commands",
+            "metadata": {"capability": "process.execute", "category": "shell"},
+        },
+    ]
+
+    resolved = resolve_profile_tool_call(profile, tools, "browser.snapshot")
+    unavailable = resolve_profile_tool_call(profile, tools, "browser.trace")
+    denied = resolve_profile_tool_call(profile, tools, "shell.run")
+
+    assert resolved == {
+        "status": "resolved",
+        "tool_id": "browser.snapshot",
+        "tool_name": "browser.snapshot",
+        "tool": backend_tool,
+    }
+    assert unavailable["status"] == "unavailable"
+    assert unavailable["reason_code"] == "tool_not_enabled"
+    assert unavailable["tool_id"] == "browser.trace"
+    assert unavailable["installation_status"] == "recommended_unavailable"
+    assert denied == {
+        "status": "not_found",
+        "reason_code": "tool_not_found",
+        "tool_id": "shell.run",
+    }
+
+
+def test_unknown_backend_descriptors_do_not_crash_or_leak() -> None:
+    profile = _profile(capabilities=["code_search"])
+    tools: list[Any] = [
+        None,
+        "code.search",
+        {"description": "missing name", "metadata": {"capability": "code_search"}},
+        {"name": "   ", "metadata": {"capability": "code_search"}},
+        {
+            "name": "future.tool",
+            "description": "Future descriptor shape",
+            "metadata": {"category": "code"},
+            "unexpected": {"capability": "code_search"},
+        },
+        {
+            "name": "code.search",
+            "description": "Search code",
+            "metadata": {"capability": "code_search", "category": "code"},
+        },
+    ]
+
+    results = search_profile_tools(profile, tools, query="future search")
+    listed = list_profile_tools(profile, tools)
+
+    assert [item["tool_id"] for item in results] == ["code.search"]
+    assert [item["tool_id"] for item in listed["tools"]] == ["code.search"]
+
+
+def test_tool_search_uses_standard_library_bm25_metadata() -> None:
+    profile = _profile(capabilities=["code_search"])
+    tools = [
+        {
+            "name": "code.search",
+            "description": "Search code",
+            "metadata": {"capability": "code_search", "category": "code"},
+        }
+    ]
+
+    payload = list_profile_tools(profile, tools)
+    results = search_profile_tools(profile, tools, query="code")
+
+    assert payload["ranking"]["semantic_search"] is False
+    assert payload["ranking"]["scoring"] == "bm25_standard_library"
+    assert results[0]["ranking"]["semantic_search"] is False
+    assert results[0]["ranking"]["scoring"] == "bm25_standard_library"
+
+
+def test_tool_discovery_module_keeps_package_boundary_clean() -> None:
+    tree = ast.parse(TOOL_DISCOVERY_PATH.read_text(encoding="utf-8"))
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.append(node.module)
+
+    assert "tldw_Server_API" not in imports
+    assert all(not item.startswith("tldw_Server_API.") for item in imports)
+    assert tool_discovery.__name__ == "mcp_unified.gateway.tool_discovery"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
@@ -120,12 +120,17 @@ def test_role_presets_include_tooling_metadata() -> None:
     bundled_by_id = {preset.id: preset for preset in presets.list_builtin_presets()}
 
     for preset_id in TOOLING_PRESET_IDS:
-        tooling = bundled_by_id[preset_id].profile.metadata["tooling"]
+        preset = bundled_by_id[preset_id]
+        tooling = preset.profile.metadata["tooling"]
 
         assert tooling["enabled_tools"]
         assert tooling["enabled_capabilities"]
-        assert "recommended_tools" in tooling
-        assert "recommended_servers" in tooling
+        assert tooling["recommended_tools"]
+        assert tooling["recommended_servers"]
+        assert all(
+            item["id"] not in preset.profile.policy_document.allowed_tools
+            for item in tooling["recommended_tools"]
+        )
         assert tooling["recommendation_catalog_patchable"] is True
         assert tooling["progressive_disclosure"]["max_direct_tools"] <= 24
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
@@ -135,12 +135,26 @@ def test_web_search_is_recommended_unavailable_not_enabled() -> None:
     assert product_owner is not None
 
     tooling = product_owner.profile.metadata["tooling"]
+    progressive_disclosure = tooling["progressive_disclosure"]
+    web_search_markers = {"web.search", "web_search"}
+    web_search_recommendations = [
+        item
+        for item in tooling["recommended_servers"]
+        if item["category"] == "web_search"
+    ]
 
     assert "web.search" not in product_owner.profile.policy_document.allowed_tools
-    assert any(
-        item["category"] == "web_search" and item["required"] is False
-        for item in tooling["recommended_servers"]
+    assert web_search_markers.isdisjoint(tooling["enabled_tools"])
+    assert web_search_markers.isdisjoint(tooling["enabled_capabilities"])
+    assert all(
+        item.get("id") not in web_search_markers
+        and item.get("category") not in web_search_markers
+        for item in tooling["recommended_tools"]
     )
+    assert "web_search" not in progressive_disclosure["direct_categories"]
+    assert "web_search" not in progressive_disclosure["deferred_categories"]
+    assert web_search_recommendations
+    assert all(item["required"] is False for item in web_search_recommendations)
 
 
 def test_cdp_browser_exact_target_is_documented() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
@@ -299,6 +299,97 @@ def test_safety_validation_rejects_unsafe_unapproved_process_capability() -> Non
     assert "high_risk_capability_requires_provenance" in violations
 
 
+def test_safety_validation_accepts_reviewed_high_risk_classes_with_approval_and_provenance() -> None:
+    profile = MCPProfile(
+        id="safe-reviewed-risk",
+        name="Safe Reviewed Risk",
+        policy_document={
+            "risk_classes": [
+                "browser_mutation",
+                "git_mutation",
+                "deployment_mutation",
+                "memory_mutation",
+                "test_execution",
+            ],
+        },
+        approval_policy={
+            "required_for": [
+                "browser_mutation",
+                "git_mutation",
+                "deployment_mutation",
+                "memory_mutation",
+                "test_execution",
+            ],
+        },
+        provenance={
+            "high_risk": {
+                "browser_mutation": "reviewed",
+                "git_mutation": "reviewed",
+                "deployment_mutation": "reviewed",
+                "memory_mutation": "reviewed",
+                "test_execution": "reviewed",
+            },
+        },
+    )
+    preset = presets.ProfilePreset(
+        id="safe-reviewed-risk",
+        version="test",
+        profile=profile,
+    )
+
+    assert presets.validate_preset_safety(preset) == []
+
+
+def test_safety_validation_rejects_reviewed_high_risk_class_without_approval() -> None:
+    profile = MCPProfile(
+        id="unsafe-browser",
+        name="Unsafe Browser",
+        policy_document={"risk_classes": ["browser_mutation"]},
+        provenance={"high_risk": {"browser_mutation": "reviewed"}},
+    )
+    preset = presets.ProfilePreset(
+        id="unsafe-browser",
+        version="test",
+        profile=profile,
+    )
+
+    assert "browser_mutation_requires_approval" in presets.validate_preset_safety(preset)
+
+
+def test_safety_validation_requires_explicit_reviewed_high_risk_approval() -> None:
+    profile = MCPProfile(
+        id="unsafe-generic-browser",
+        name="Unsafe Generic Browser",
+        policy_document={"risk_classes": ["browser_mutation"]},
+        approval_policy={"required_for": ["mutating", "write"]},
+        provenance={"high_risk": {"browser_mutation": "reviewed"}},
+    )
+    preset = presets.ProfilePreset(
+        id="unsafe-generic-browser",
+        version="test",
+        profile=profile,
+    )
+
+    assert "browser_mutation_requires_approval" in presets.validate_preset_safety(preset)
+
+
+def test_safety_validation_rejects_unknown_future_risk_classes() -> None:
+    profile = MCPProfile(
+        id="unsafe-future-risk",
+        name="Unsafe Future Risk",
+        policy_document={"risk_classes": ["future_mutation"]},
+        approval_policy={"required_for": ["future_mutation"]},
+        provenance={"high_risk": {"future_mutation": "reviewed"}},
+    )
+    preset = presets.ProfilePreset(
+        id="unsafe-future-risk",
+        version="test",
+        profile=profile,
+    )
+
+    assert "unknown_high_risk_requires_review" in presets.validate_preset_safety(preset)
+
+
 def test_safety_validation_requires_explicit_process_execution_approval() -> None:
     unsafe_profile = MCPProfile(
         id="unsafe-process",

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
@@ -39,6 +39,20 @@ WORKSPACE_BOUND_PRESET_IDS = {
     "memory-keeper",
 }
 
+TOOLING_PRESET_IDS = {
+    "product-owner",
+    "architect",
+    "merge-conflict-resolver",
+    "documentation-writer",
+    "project-researcher",
+    "code-reviewer",
+    "devops-engineer",
+    "backend-engineer",
+    "frontend-engineer",
+    "qa-engineer",
+    "sdet",
+}
+
 
 def _tldw_imports_for(path: Path) -> list[str]:
     """Return imports from a Python file that cross into the host package."""
@@ -100,6 +114,76 @@ def test_write_capable_presets_advertise_workspace_binding_requirement() -> None
 
     assert workspace_bound == WORKSPACE_BOUND_PRESET_IDS
     assert assignment_bound == WORKSPACE_BOUND_PRESET_IDS
+
+
+def test_role_presets_include_tooling_metadata() -> None:
+    bundled_by_id = {preset.id: preset for preset in presets.list_builtin_presets()}
+
+    for preset_id in TOOLING_PRESET_IDS:
+        tooling = bundled_by_id[preset_id].profile.metadata["tooling"]
+
+        assert tooling["enabled_tools"]
+        assert tooling["enabled_capabilities"]
+        assert "recommended_tools" in tooling
+        assert "recommended_servers" in tooling
+        assert tooling["recommendation_catalog_patchable"] is True
+        assert tooling["progressive_disclosure"]["max_direct_tools"] <= 24
+
+
+def test_web_search_is_recommended_unavailable_not_enabled() -> None:
+    product_owner = presets.get_builtin_preset("product-owner")
+    assert product_owner is not None
+
+    tooling = product_owner.profile.metadata["tooling"]
+
+    assert "web.search" not in product_owner.profile.policy_document.allowed_tools
+    assert any(
+        item["category"] == "web_search" and item["required"] is False
+        for item in tooling["recommended_servers"]
+    )
+
+
+def test_cdp_browser_exact_target_is_documented() -> None:
+    frontend = presets.get_builtin_preset("frontend-engineer")
+    assert frontend is not None
+
+    browser_servers = [
+        server
+        for server in frontend.profile.metadata["tooling"]["recommended_servers"]
+        if server["category"] == "browser"
+    ]
+
+    assert browser_servers
+    assert any(
+        option["id"] == "chrome-devtools-mcp"
+        and option["install_target"] == "ChromeDevTools/chrome-devtools-mcp"
+        and option["maturity"] == "exact_target"
+        for server in browser_servers
+        for option in server["binding_options"]
+    )
+
+
+def test_recommendation_catalog_patch_does_not_grant_authority() -> None:
+    from mcp_unified.profiles.tooling import merge_tooling_recommendations
+
+    product_owner = presets.get_builtin_preset("product-owner")
+    assert product_owner is not None
+
+    patched_tooling = merge_tooling_recommendations(
+        product_owner.profile.metadata["tooling"],
+        {
+            "recommended_tools": [
+                {
+                    "id": "shell.run",
+                    "category": "shell",
+                    "activation": "requires_operator_enablement",
+                }
+            ]
+        },
+    )
+
+    assert any(item["id"] == "shell.run" for item in patched_tooling["recommended_tools"])
+    assert "shell.run" not in product_owner.profile.policy_document.allowed_tools
 
 
 def test_get_builtin_preset_returns_stable_profile_template() -> None:


### PR DESCRIPTION
## What Changed

Adds the MCP default profile tooling preset design and the first implementation
slice for profile-scoped tool discovery:

- Built-in role preset tooling metadata with enabled tools, capabilities,
  progressive disclosure categories, and recommended tools/servers.
- Profile-scoped discovery helpers for listing, searching, describing, and
  resolving tools, with filter-first BM25 ranking and recommendation visibility.
- Gateway bridge tools for `tool_categories.list`, `profile.tools.list`,
  `tool_search`, `tool_describe`, and gated `tool_call`.
- CLI/user-guide updates for preset tooling summaries and progressive disclosure.
- Review follow-ups for task-record consistency, risk-class vocabulary,
  tool-call error semantics, category normalization, and code readability.

## Why

The MCP standalone gateway needs default role profiles that front-ends can use to
expose a narrow, policy-scoped tool surface while still giving users setup
guidance for unavailable/recommended tools. This keeps recommendations separate
from executable authority and gives operators a path to patch recommendation
metadata without granting tools.

## Validation

- [x] `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py`
  - Result: `274 passed, 6 warnings`
- [x] `python -m ruff check mcp_unified/gateway/profile_runtime.py mcp_unified/gateway/tool_discovery.py mcp_unified/profiles/presets.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_tool_discovery.py`
  - Result: all checks passed
- [x] `python -m bandit mcp_unified/gateway/cli.py mcp_unified/gateway/profile_runtime.py mcp_unified/gateway/tool_discovery.py mcp_unified/profiles/presets.py mcp_unified/profiles/tooling.py -f json -o /tmp/bandit_pr2251_profile_tooling.json`
  - Result: zero findings, no errors
- [x] `git diff --check`
  - Result: passed

## UX Audit Checklist

- [x] No user-facing WebUI layout, styling, or interaction changes.
- [x] CLI output is covered by focused tests.
- [x] Progressive disclosure behavior is documented for front-end consumers.

## Watchlists Checklist

- [x] Not applicable. This PR does not change Watchlists behavior, storage, or UI.

## Risk And Rollback

Risk level: Medium.

Main risks are profile discovery policy regressions or confusing recommendation
metadata. The implementation keeps executable policy as the enforcement source
of truth and treats recommendations as non-callable setup metadata.

Rollback plan: revert the PR to remove the preset tooling metadata, discovery
helpers, gateway bridge additions, and related docs/task records. Existing
non-tooling MCP profile behavior should return to the previous state because the
new discovery bridge is additive and profile-scoped.
