### PR TITLE
Harden Persona backend chat session metadata contract

### DIFF
--- a/backlog/tasks/task-2264 - Harden-Persona-backend-chat-session-metadata-contract.md
+++ b/backlog/tasks/task-2264 - Harden-Persona-backend-chat-session-metadata-contract.md
@@ -1,0 +1,65 @@
+---
+id: TASK-2264
+title: Harden Persona backend chat session metadata contract
+status: Done
+labels:
+- persona
+- chat
+- backend
+- tests
+priority: Medium
+references:
+- https://github.com/rmusser01/tldw_server/issues/1908
+- Docs/superpowers/plans/2026-05-22-persona-backed-chat-startup-hardening.md
+- https://github.com/rmusser01/tldw_server/pull/1941
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the backend session metadata slice from the Persona-backed Chat Startup plan: verify Persona chat session creation requires assistant_id, preserves explicit read_only/read_write modes, rejects invalid modes, and rejects persona memory mode on Character chats.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Backend tests verify Persona chat creation requires assistant_id.
+- [x] #2 Backend tests verify explicit read_only/read_write persona_memory_mode values are accepted and preserved where applicable.
+- [x] #3 Backend tests verify persona_memory_mode is rejected for Character chats and invalid Persona memory modes are rejected.
+- [x] #4 Verification commands and Bandit applicability are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implementation notes:
+- Extended ChatSessionCreate schema contract coverage in tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_session_create_schema.py.
+- Existing test already verifies Persona chat creation requires assistant_id.
+- Added coverage for explicit read_only/read_write preservation.
+- Added rejection coverage for persona_memory_mode on Character chats and invalid Persona memory modes.
+
+Verification:
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_session_create_schema.py -q
+- git diff --check
+
+Bandit:
+- Skipped: this slice changes tests and Backlog metadata only; no executable application code was changed.
+
+Final summary:
+- Persona backend chat session schema contract coverage now covers the remaining tracked memory-mode boundaries for the current startup hardening slice.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Persona backend chat session schema contract coverage now covers the remaining tracked memory-mode boundaries for the current startup hardening slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_session_create_schema.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_session_create_schema.py
@@ -30,7 +30,7 @@ def test_chat_session_create_requires_assistant_id_for_tracked_persona_chat():
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("memory_mode", ["read_only", "read_write"])
+@pytest.mark.parametrize("memory_mode", [None, "read_only", "read_write"])
 def test_chat_session_create_preserves_explicit_persona_memory_mode(memory_mode):
     chat = ChatSessionCreate(
         assistant_kind="persona",

--- a/tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_session_create_schema.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_session_create_schema.py
@@ -52,10 +52,11 @@ def test_chat_session_create_rejects_persona_memory_mode_for_character_chat():
 
 
 @pytest.mark.unit
-def test_chat_session_create_rejects_invalid_persona_memory_mode():
+@pytest.mark.parametrize("invalid_mode", ["session", "", 123])
+def test_chat_session_create_rejects_invalid_persona_memory_mode(invalid_mode):
     with pytest.raises(ValidationError, match="persona_memory_mode"):
         ChatSessionCreate(
             assistant_kind="persona",
             assistant_id="garden-helper",
-            persona_memory_mode="session",
+            persona_memory_mode=invalid_mode,
         )

--- a/tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_session_create_schema.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_session_create_schema.py
@@ -46,9 +46,10 @@ def test_chat_session_create_preserves_explicit_persona_memory_mode(memory_mode)
 
 
 @pytest.mark.unit
-def test_chat_session_create_rejects_persona_memory_mode_for_character_chat():
+@pytest.mark.parametrize("memory_mode", ["read_only", "read_write"])
+def test_chat_session_create_rejects_persona_memory_mode_for_character_chat(memory_mode):
     with pytest.raises(ValidationError, match="persona_memory_mode is only valid for persona chats"):
-        ChatSessionCreate(character_id=7, persona_memory_mode="read_only")
+        ChatSessionCreate(character_id=7, persona_memory_mode=memory_mode)
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_session_create_schema.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_session_create_schema.py
@@ -27,3 +27,35 @@ def test_chat_session_create_normalizes_tracked_character_identity():
 def test_chat_session_create_requires_assistant_id_for_tracked_persona_chat():
     with pytest.raises(ValidationError, match="Persona chats require assistant_id"):
         ChatSessionCreate(assistant_kind="persona", title="Tracked persona chat")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("memory_mode", ["read_only", "read_write"])
+def test_chat_session_create_preserves_explicit_persona_memory_mode(memory_mode):
+    chat = ChatSessionCreate(
+        assistant_kind="persona",
+        assistant_id="garden-helper",
+        persona_memory_mode=memory_mode,
+        title="Tracked persona chat",
+    )
+
+    assert chat.character_id is None
+    assert chat.assistant_kind == "persona"
+    assert chat.assistant_id == "garden-helper"
+    assert chat.persona_memory_mode == memory_mode
+
+
+@pytest.mark.unit
+def test_chat_session_create_rejects_persona_memory_mode_for_character_chat():
+    with pytest.raises(ValidationError, match="persona_memory_mode is only valid for persona chats"):
+        ChatSessionCreate(character_id=7, persona_memory_mode="read_only")
+
+
+@pytest.mark.unit
+def test_chat_session_create_rejects_invalid_persona_memory_mode():
+    with pytest.raises(ValidationError, match="persona_memory_mode"):
+        ChatSessionCreate(
+            assistant_kind="persona",
+            assistant_id="garden-helper",
+            persona_memory_mode="session",
+        )


### PR DESCRIPTION
## Summary
- Adds schema contract coverage for Persona chat session metadata creation.
- Verifies explicit read_only/read_write Persona memory modes are preserved.
- Verifies Persona memory mode is rejected on Character chats and invalid Persona memory modes are rejected.

## Tracking
- Part of #1908
- Backlog: TASK-2264

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_session_create_schema.py -q
- git diff --check
- git diff --cached --check
- Bandit skipped: tests/backlog only; no executable application code changed.

## Change Summary
Human-authored change summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Harden Persona chat session metadata with unit tests that require assistant_id for persona chats, preserve persona_memory_mode (None, read_only, read_write), and reject invalid modes or any persona_memory_mode on character chats. Adds TASK-2264 backlog doc and aligns with #1908.

<sup>Written for commit 5815d693d89c125b43af45e5f15b4a2b4945045f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

