### PR TITLE
Add Workspace Assistant Defaults V1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -792,6 +792,7 @@ jobs:
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_assistant_defaults_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_sub_resources_db.py
+              tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py
               tldw_Server_API/tests/ChaChaNotesDB/test_writing_playground_db.py
           - name: db-privileges
             paths: >-
@@ -2186,6 +2187,7 @@ jobs:
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_assistant_defaults_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_sub_resources_db.py
+              tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py
               tldw_Server_API/tests/ChaChaNotesDB/test_writing_playground_db.py
           - name: db-privileges
             paths: >-
@@ -3453,6 +3455,7 @@ jobs:
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_assistant_defaults_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_sub_resources_db.py
+              tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py
               tldw_Server_API/tests/ChaChaNotesDB/test_writing_playground_db.py
           - name: db-privileges
             paths: >-
@@ -4644,6 +4647,7 @@ jobs:
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_assistant_defaults_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_sub_resources_db.py
+              tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py
               tldw_Server_API/tests/ChaChaNotesDB/test_writing_playground_db.py
           - name: db-privileges
             paths: >-
@@ -5836,6 +5840,7 @@ jobs:
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_assistant_defaults_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py
               tldw_Server_API/tests/ChaChaNotesDB/test_workspace_sub_resources_db.py
+              tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py
               tldw_Server_API/tests/ChaChaNotesDB/test_writing_playground_db.py
           - name: db-privileges
             paths: >-

--- a/Docs/Product/Workspace_Persona_Defaults_PRD.md
+++ b/Docs/Product/Workspace_Persona_Defaults_PRD.md
@@ -1,6 +1,6 @@
 # Workspace Assistant Defaults PRD
 
-Status: Draft
+Status: V1 implemented for Workspace schema/API, Workspace settings, and Chat Workspace startup. Later Workspace-bound surfaces remain future adoption stages.
 
 Owner: Persona module / Workspaces integration
 

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspaceConsole.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspaceConsole.tsx
@@ -1,10 +1,14 @@
-import type { WorkspaceSource } from "@/types/workspace"
+import type {
+  EffectiveWorkspaceAssistantDefault,
+  WorkspaceSource
+} from "@/types/workspace"
 
 import { InspectorRail } from "./InspectorRail"
 import { WorkspaceChatPanel } from "./WorkspaceChatPanel"
 import { WorkspaceRail } from "./WorkspaceRail"
 import { WorkspaceStatusStrip } from "./WorkspaceStatusStrip"
 import type {
+  ChatWorkspaceAssistantSource,
   ChatWorkspaceRuntimeState,
   StagedWorkspaceSource
 } from "./types"
@@ -18,6 +22,11 @@ export type ChatWorkspaceConsoleProps = {
   stagedSources: StagedWorkspaceSource[]
   selectedModelLabel: string
   selectedPersonaLabel: string | null
+  assistantSource: ChatWorkspaceAssistantSource
+  workspaceAssistantDegradedReason?: ChatWorkspaceRuntimeState[
+    "workspaceAssistantDegradedReason"
+  ]
+  effectiveAssistantDefault?: EffectiveWorkspaceAssistantDefault | null
   backendAvailable: boolean
   chatBackendAvailable: boolean
   streaming: boolean
@@ -35,6 +44,9 @@ export const ChatWorkspaceConsole = ({
   stagedSources,
   selectedModelLabel,
   selectedPersonaLabel,
+  assistantSource,
+  workspaceAssistantDegradedReason,
+  effectiveAssistantDefault,
   backendAvailable,
   chatBackendAvailable,
   streaming,
@@ -76,6 +88,7 @@ export const ChatWorkspaceConsole = ({
               stagedSources={stagedSources}
               onClearStagedSources={onClearStagedSources}
               backendAvailable={chatBackendAvailable}
+              effectiveAssistantDefault={effectiveAssistantDefault}
               onRuntimeStateChange={onRuntimeStateChange}
             />
           </div>
@@ -93,6 +106,8 @@ export const ChatWorkspaceConsole = ({
             stagedSources={inspectorSources}
             selectedModelLabel={selectedModelLabel}
             selectedPersonaLabel={selectedPersonaLabel}
+            assistantSource={assistantSource}
+            workspaceAssistantDegradedReason={workspaceAssistantDegradedReason}
             backendAvailable={backendAvailable}
             streaming={streaming}
           />

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspacePage.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspacePage.tsx
@@ -12,6 +12,7 @@ import type {
   StagedWorkspaceSource
 } from "./types"
 import { normalizeWorkspaceId } from "./workspaceIdentity"
+import type { EffectiveWorkspaceAssistantDefault } from "@/types/workspace"
 
 type WorkspaceContextState = {
   workspaceId: string | null
@@ -20,18 +21,28 @@ type WorkspaceContextState = {
 }
 
 const createInitialRuntimeState = (
-  backendAvailable: boolean
+  backendAvailable: boolean,
+  effectiveAssistantDefault?: EffectiveWorkspaceAssistantDefault | null
 ): ChatWorkspaceRuntimeState => ({
   backendAvailable,
   streaming: false,
   selectedModelLabel: "No model selected",
-  selectedPersonaLabel: null
+  selectedPersonaLabel: null,
+  assistantSource:
+    effectiveAssistantDefault?.status === "unavailable" ? "unavailable" : "none",
+  workspaceAssistantDegradedReason:
+    effectiveAssistantDefault?.status === "unavailable"
+      ? effectiveAssistantDefault.degradedReason
+      : null
 })
 
 export const ChatWorkspacePage = () => {
   const rawWorkspaceId = useWorkspaceStore((state) => state.workspaceId)
   const workspaceName = useWorkspaceStore((state) => state.workspaceName)
   const sources = useWorkspaceStore((state) => state.sources)
+  const effectiveAssistantDefault = useWorkspaceStore(
+    (state) => state.effectiveAssistantDefault
+  )
   const setRouteContext = useChatSurfaceCoordinatorStore(
     (state) => state.setRouteContext
   )
@@ -53,7 +64,7 @@ export const ChatWorkspacePage = () => {
     }))
   const [runtimeState, setRuntimeState] =
     React.useState<ChatWorkspaceRuntimeState>(() =>
-      createInitialRuntimeState(backendAvailable)
+      createInitialRuntimeState(backendAvailable, effectiveAssistantDefault)
     )
 
   const scopeLabel = workspaceName || "Workspace"
@@ -140,6 +151,11 @@ export const ChatWorkspacePage = () => {
         stagedSources={stagedSources}
         selectedModelLabel={runtimeState.selectedModelLabel}
         selectedPersonaLabel={runtimeState.selectedPersonaLabel}
+        assistantSource={runtimeState.assistantSource}
+        workspaceAssistantDegradedReason={
+          runtimeState.workspaceAssistantDegradedReason
+        }
+        effectiveAssistantDefault={effectiveAssistantDefault}
         backendAvailable={backendAvailable}
         chatBackendAvailable={backendAvailable && workspaceReady}
         streaming={runtimeState.streaming}

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/InspectorRail.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/InspectorRail.tsx
@@ -1,4 +1,6 @@
 import { getDesignSystemState } from "@/design-system"
+import type { WorkspaceAssistantDefaultDegradedReason } from "@/types/workspace"
+import type { ChatWorkspaceAssistantSource } from "./types"
 
 export type InspectorRailStagedSource = {
   sourceId: string
@@ -11,6 +13,8 @@ export type InspectorRailProps = {
   stagedSources: InspectorRailStagedSource[]
   selectedModelLabel: string
   selectedPersonaLabel: string | null
+  assistantSource: ChatWorkspaceAssistantSource
+  workspaceAssistantDegradedReason?: WorkspaceAssistantDefaultDegradedReason | null
   backendAvailable: boolean
   streaming: boolean
 }
@@ -29,16 +33,42 @@ const getRuntimeLabel = (backendAvailable: boolean, streaming: boolean) => {
   return streaming ? "Streaming" : READY_STATE_LABEL
 }
 
+const degradedReasonLabels: Record<
+  WorkspaceAssistantDefaultDegradedReason,
+  string
+> = {
+  invalid_default: "Invalid default",
+  permission_denied: "Permission denied",
+  persona_deleted: "Persona deleted",
+  persona_feature_disabled: "Persona feature disabled",
+  persona_unavailable: "Persona unavailable",
+  unsupported_assistant_kind: "Unsupported assistant kind"
+}
+
+const getAssistantSourceLabel = (
+  assistantSource: ChatWorkspaceAssistantSource
+) => {
+  if (assistantSource === "workspace") return "Inherited from workspace"
+  if (assistantSource === "explicit") return "Explicit persona"
+  return null
+}
+
 export const InspectorRail = ({
   scopeLabel,
   stagedSourceCount,
   stagedSources,
   selectedModelLabel,
   selectedPersonaLabel,
+  assistantSource,
+  workspaceAssistantDegradedReason,
   backendAvailable,
   streaming
 }: InspectorRailProps) => {
   const runtimeLabel = getRuntimeLabel(backendAvailable, streaming)
+  const assistantSourceLabel = getAssistantSourceLabel(assistantSource)
+  const degradedReasonLabel = workspaceAssistantDegradedReason
+    ? degradedReasonLabels[workspaceAssistantDegradedReason]
+    : null
 
   return (
     <aside
@@ -74,7 +104,23 @@ export const InspectorRail = ({
       <section className={panelClass}>
         <h2 className={headingClass}>Model / Persona</h2>
         <p className={valueClass}>{selectedModelLabel}</p>
-        <p className={mutedClass}>{selectedPersonaLabel ?? "No persona selected"}</p>
+        {assistantSource === "unavailable" ? (
+          <>
+            <p className={mutedClass}>Workspace default unavailable</p>
+            {degradedReasonLabel ? (
+              <p className={mutedClass}>{degradedReasonLabel}</p>
+            ) : null}
+          </>
+        ) : (
+          <>
+            <p className={mutedClass}>
+              {selectedPersonaLabel ?? "No persona selected"}
+            </p>
+            {assistantSourceLabel ? (
+              <p className={mutedClass}>{assistantSourceLabel}</p>
+            ) : null}
+          </>
+        )}
       </section>
 
       <section className={panelClass}>

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceChatPanel.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceChatPanel.tsx
@@ -162,9 +162,15 @@ export const WorkspaceChatPanel = ({
     selectedAssistant?.kind === "persona" &&
     inheritedAssistant?.kind === "persona" &&
     selectedAssistant.id === inheritedAssistant.id
+  const restoredWorkspaceAssistant =
+    !selectedAssistant &&
+    inheritedAssistant?.kind === "persona" &&
+    serverChatAssistantKind === "persona" &&
+    serverChatAssistantId === inheritedAssistant.id
   const usingWorkspaceAssistant =
     Boolean(inheritedAssistant) &&
     (selectedMatchesWorkspaceAssistant ||
+      restoredWorkspaceAssistant ||
       (selectedAssistantSource === "workspace" &&
         !selectedAssistant &&
         messages.length === 0))
@@ -177,7 +183,7 @@ export const WorkspaceChatPanel = ({
         : "none"
   const runtimeSelectedPersonaLabel =
     assistantSource === "workspace"
-      ? selectedAssistant?.name ?? inheritedAssistant?.name ?? null
+      ? inheritedAssistant?.name ?? selectedAssistant?.name ?? null
       : selectedAssistant?.name ??
         (assistantSource === "explicit" && serverChatAssistantKind === "persona"
           ? "Persona"

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceChatPanel.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceChatPanel.tsx
@@ -8,7 +8,12 @@ import {
 } from "@/hooks/chat/chat-action-utils"
 import type { Message } from "@/store/option"
 import { useMessageOption } from "@/hooks/useMessageOption"
+import type { AssistantSelection } from "@/types/assistant-selection"
 import type { ChatScope } from "@/types/chat-scope"
+import type {
+  EffectiveWorkspaceAssistantDefault,
+  WorkspacePersonaMemoryMode
+} from "@/types/workspace"
 
 import { ContextStagingCard } from "./ContextStagingCard"
 import {
@@ -16,6 +21,7 @@ import {
   getReadyStagedMediaIds
 } from "./staging"
 import type {
+  ChatWorkspaceAssistantSource,
   ChatWorkspaceRuntimeState,
   StagedWorkspaceSource
 } from "./types"
@@ -27,6 +33,7 @@ export type WorkspaceChatPanelProps = {
   stagedSources: StagedWorkspaceSource[]
   onClearStagedSources: () => void
   backendAvailable: boolean
+  effectiveAssistantDefault?: EffectiveWorkspaceAssistantDefault | null
   onRuntimeStateChange?: (state: ChatWorkspaceRuntimeState) => void
 }
 
@@ -51,12 +58,51 @@ const getMessageRole = (message: WorkspacePanelMessage): "user" | "assistant" | 
   return "assistant"
 }
 
+type InheritedWorkspacePersonaAssistant = AssistantSelection & { kind: "persona" }
+
+const normalizePersonaMemoryMode = (
+  value: WorkspacePersonaMemoryMode | null | undefined
+): WorkspacePersonaMemoryMode => {
+  return value === "read_write" ? "read_write" : "read_only"
+}
+
+const buildInheritedWorkspaceAssistant = (
+  effectiveAssistantDefault: EffectiveWorkspaceAssistantDefault | null | undefined,
+  workspaceReady: boolean
+): InheritedWorkspacePersonaAssistant | null => {
+  if (!workspaceReady || effectiveAssistantDefault?.status !== "available") {
+    return null
+  }
+  if (
+    effectiveAssistantDefault.assistantKind !== "persona" ||
+    !effectiveAssistantDefault.assistantId
+  ) {
+    return null
+  }
+
+  const personaMemoryMode = normalizePersonaMemoryMode(
+    effectiveAssistantDefault.personaMemoryMode
+  )
+
+  return {
+    kind: "persona",
+    id: effectiveAssistantDefault.assistantId,
+    name: effectiveAssistantDefault.label ?? "Workspace Persona",
+    metadata: {
+      selectionMode: "tracked",
+      source: "workspace",
+      personaMemoryMode
+    }
+  }
+}
+
 export const WorkspaceChatPanel = ({
   workspaceId,
   workspaceName,
   stagedSources,
   onClearStagedSources,
   backendAvailable,
+  effectiveAssistantDefault,
   onRuntimeStateChange
 }: WorkspaceChatPanelProps) => {
   const [draft, setDraft] = React.useState("")
@@ -75,6 +121,26 @@ export const WorkspaceChatPanel = ({
         : { type: "global" },
     [normalizedWorkspaceId]
   )
+  const inheritedAssistant = React.useMemo(
+    () => buildInheritedWorkspaceAssistant(effectiveAssistantDefault, workspaceReady),
+    [effectiveAssistantDefault, workspaceReady]
+  )
+  const inheritedPersonaMemoryMode = inheritedAssistant
+    ? normalizePersonaMemoryMode(
+        effectiveAssistantDefault?.personaMemoryMode ?? null
+      )
+    : null
+  const messageOptionArgs = React.useMemo(
+    () =>
+      inheritedAssistant
+        ? {
+            scope,
+            inheritedAssistant,
+            inheritedPersonaMemoryMode
+          }
+        : { scope },
+    [inheritedAssistant, inheritedPersonaMemoryMode, scope]
+  )
 
   const {
     messages,
@@ -84,8 +150,37 @@ export const WorkspaceChatPanel = ({
     isProcessing,
     stopStreamingRequest,
     selectedModel,
-    selectedAssistant
-  } = useMessageOption({ scope })
+    selectedAssistant,
+    selectedAssistantSource,
+    serverChatId,
+    serverChatAssistantKind,
+    serverChatAssistantId
+  } = useMessageOption(messageOptionArgs)
+
+  const hasExistingChatSession = Boolean(serverChatId)
+  const hasExistingAssistantMetadata = Boolean(
+    serverChatAssistantKind || serverChatAssistantId
+  )
+  const usingWorkspaceAssistant =
+    Boolean(inheritedAssistant) &&
+    !hasExistingChatSession &&
+    !hasExistingAssistantMetadata &&
+    (selectedAssistantSource === "workspace" ||
+      (!selectedAssistant && messages.length === 0))
+  const assistantSource: ChatWorkspaceAssistantSource = usingWorkspaceAssistant
+    ? "workspace"
+    : selectedAssistant || hasExistingAssistantMetadata
+      ? "explicit"
+      : effectiveAssistantDefault?.status === "unavailable"
+        ? "unavailable"
+        : "none"
+  const runtimeSelectedPersonaLabel =
+    assistantSource === "workspace"
+      ? inheritedAssistant?.name ?? selectedAssistant?.name ?? null
+      : selectedAssistant?.name ??
+        (assistantSource === "explicit" && serverChatAssistantKind === "persona"
+          ? "Persona"
+          : null)
 
   React.useEffect(() => {
     setDraft("")
@@ -97,12 +192,19 @@ export const WorkspaceChatPanel = ({
       backendAvailable: chatBackendAvailable,
       streaming,
       selectedModelLabel: selectedModel || "No model selected",
-      selectedPersonaLabel: selectedAssistant?.name ?? null
+      selectedPersonaLabel: runtimeSelectedPersonaLabel,
+      assistantSource,
+      workspaceAssistantDegradedReason:
+        assistantSource === "unavailable"
+          ? effectiveAssistantDefault?.degradedReason ?? null
+          : null
     })
   }, [
+    assistantSource,
     chatBackendAvailable,
+    effectiveAssistantDefault?.degradedReason,
     onRuntimeStateChange,
-    selectedAssistant?.name,
+    runtimeSelectedPersonaLabel,
     selectedModel,
     streaming
   ])
@@ -159,7 +261,14 @@ export const WorkspaceChatPanel = ({
           requestOverrides: {
             ragMediaIds: readyMediaIds,
             fileRetrievalEnabled: hasReadyMedia,
-            chatMode: hasReadyMedia ? "rag" : "normal"
+            chatMode: hasReadyMedia ? "rag" : "normal",
+            ...(usingWorkspaceAssistant && inheritedAssistant
+              ? {
+                  assistant_kind: "persona",
+                  assistant_id: inheritedAssistant.id,
+                  persona_memory_mode: inheritedPersonaMemoryMode ?? "read_only"
+                }
+              : {})
           }
         })) as ChatSubmitResult | undefined
       )
@@ -182,12 +291,15 @@ export const WorkspaceChatPanel = ({
     chatBackendAvailable,
     hasReadyMedia,
     hasUncarriedStagedContext,
+    inheritedAssistant,
+    inheritedPersonaMemoryMode,
     onClearStagedSources,
     onSubmit,
     readyMediaIds,
     sendDisabled,
     stagedSources,
-    trimmedDraft
+    trimmedDraft,
+    usingWorkspaceAssistant
   ])
 
   const handleSubmit = React.useCallback(

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceChatPanel.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceChatPanel.tsx
@@ -157,26 +157,27 @@ export const WorkspaceChatPanel = ({
     serverChatAssistantId
   } = useMessageOption(messageOptionArgs)
 
-  const hasExistingChatSession = Boolean(serverChatId)
-  const hasExistingAssistantMetadata = Boolean(
-    serverChatAssistantKind || serverChatAssistantId
-  )
+  const selectedMatchesWorkspaceAssistant =
+    selectedAssistantSource === "workspace" &&
+    selectedAssistant?.kind === "persona" &&
+    inheritedAssistant?.kind === "persona" &&
+    selectedAssistant.id === inheritedAssistant.id
   const usingWorkspaceAssistant =
     Boolean(inheritedAssistant) &&
-    !hasExistingChatSession &&
-    !hasExistingAssistantMetadata &&
-    (selectedAssistantSource === "workspace" ||
-      (!selectedAssistant && messages.length === 0))
+    (selectedMatchesWorkspaceAssistant ||
+      (selectedAssistantSource === "workspace" &&
+        !selectedAssistant &&
+        messages.length === 0))
   const assistantSource: ChatWorkspaceAssistantSource = usingWorkspaceAssistant
     ? "workspace"
-    : selectedAssistant || hasExistingAssistantMetadata
+    : selectedAssistant || serverChatAssistantKind || serverChatAssistantId
       ? "explicit"
       : effectiveAssistantDefault?.status === "unavailable"
         ? "unavailable"
         : "none"
   const runtimeSelectedPersonaLabel =
     assistantSource === "workspace"
-      ? inheritedAssistant?.name ?? selectedAssistant?.name ?? null
+      ? selectedAssistant?.name ?? inheritedAssistant?.name ?? null
       : selectedAssistant?.name ??
         (assistantSource === "explicit" && serverChatAssistantKind === "persona"
           ? "Persona"

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/ChatWorkspacePage.test.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/ChatWorkspacePage.test.tsx
@@ -8,7 +8,7 @@ const setRouteContext = vi.fn()
 const chatPanelRuntimeState = vi.hoisted(() => ({
   backendAvailable: true
 }))
-const workspaceState = vi.hoisted(() => ({
+const workspaceState = vi.hoisted((): { value: any } => ({
   value: {
     workspaceId: "workspace-1",
     workspaceName: "Default workspace",
@@ -21,7 +21,16 @@ const workspaceState = vi.hoisted(() => ({
         status: "ready",
         addedAt: new Date("2026-05-03T00:00:00Z")
       }
-    ]
+    ],
+    effectiveAssistantDefault: {
+      status: "available",
+      source: "workspace",
+      assistantKind: "persona",
+      assistantId: "workspace-persona",
+      label: "Workspace Analyst",
+      personaMemoryMode: "read_only",
+      degradedReason: null
+    }
   }
 }))
 const connectionState = vi.hoisted(() => ({
@@ -55,12 +64,14 @@ vi.mock("../WorkspaceChatPanel", () => ({
     workspaceId,
     onClearStagedSources,
     backendAvailable,
+    effectiveAssistantDefault,
     onRuntimeStateChange
   }: {
     stagedSources: unknown[]
     workspaceId?: string | null
     onClearStagedSources: () => void
     backendAvailable: boolean
+    effectiveAssistantDefault?: { assistantId?: string | null } | null
     onRuntimeStateChange?: (state: unknown) => void
   }) => {
     const [mountedWorkspaceId] = React.useState(workspaceId)
@@ -74,7 +85,8 @@ vi.mock("../WorkspaceChatPanel", () => ({
         backendAvailable: chatPanelRuntimeState.backendAvailable,
         streaming: true,
         selectedModelLabel: "gpt-test",
-        selectedPersonaLabel: "Analyst"
+        selectedPersonaLabel: "Analyst",
+        assistantSource: "explicit"
       })
     }, [onRuntimeStateChange])
 
@@ -83,6 +95,7 @@ vi.mock("../WorkspaceChatPanel", () => ({
         data-testid="workspace-chat-panel"
         data-workspace-id={workspaceId ?? "null"}
         data-backend-available={String(backendAvailable)}
+        data-effective-assistant-id={effectiveAssistantDefault?.assistantId ?? "null"}
       >
         staged:{stagedSources.length}; workspace:{workspaceId}; mounted:
         {mountedWorkspaceId}; backend:{String(backendAvailable)}
@@ -107,7 +120,16 @@ describe("ChatWorkspacePage", () => {
           status: "ready",
           addedAt: new Date("2026-05-03T00:00:00Z")
         }
-      ]
+      ],
+      effectiveAssistantDefault: {
+        status: "available",
+        source: "workspace",
+        assistantKind: "persona",
+        assistantId: "workspace-persona",
+        label: "Workspace Analyst",
+        personaMemoryMode: "read_only",
+        degradedReason: null
+      }
     }
     connectionState.value = {
       phase: "connected",
@@ -150,6 +172,10 @@ describe("ChatWorkspacePage", () => {
 
     expect(screen.getByTestId("workspace-chat-panel")).toHaveTextContent(
       "workspace:workspace-1"
+    )
+    expect(screen.getByTestId("workspace-chat-panel")).toHaveAttribute(
+      "data-effective-assistant-id",
+      "workspace-persona"
     )
     expect(await screen.findByText("gpt-test")).toBeInTheDocument()
     expect(screen.getByText("Analyst")).toBeInTheDocument()

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/InspectorRail.test.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/InspectorRail.test.tsx
@@ -34,6 +34,7 @@ describe("InspectorRail", () => {
         ]}
         selectedModelLabel="gpt-test"
         selectedPersonaLabel="Analyst"
+        assistantSource="explicit"
         backendAvailable
         streaming={false}
       />
@@ -43,6 +44,7 @@ describe("InspectorRail", () => {
     expect(screen.getByText("Operator Notes")).toBeInTheDocument()
     expect(screen.getByText("gpt-test")).toBeInTheDocument()
     expect(screen.getByText("Analyst")).toBeInTheDocument()
+    expect(screen.getByText("Explicit persona")).toBeInTheDocument()
     expect(screen.getByText("Ready via registry")).toBeInTheDocument()
   })
 
@@ -54,6 +56,7 @@ describe("InspectorRail", () => {
         stagedSources={[]}
         selectedModelLabel="No model selected"
         selectedPersonaLabel={null}
+        assistantSource="none"
         backendAvailable={false}
         streaming={false}
       />
@@ -75,6 +78,7 @@ describe("InspectorRail", () => {
         ]}
         selectedModelLabel="gpt-test"
         selectedPersonaLabel={null}
+        assistantSource="none"
         backendAvailable
         streaming={false}
       />
@@ -87,5 +91,43 @@ describe("InspectorRail", () => {
     const source = readFileSync(resolve(__dirname, "../InspectorRail.tsx"), "utf8")
 
     expect(source).not.toContain("stagedSourceTitles")
+  })
+
+  it("labels an inherited workspace persona separately from explicit selection", () => {
+    render(
+      <InspectorRail
+        scopeLabel="Default workspace"
+        stagedSourceCount={0}
+        stagedSources={[]}
+        selectedModelLabel="gpt-test"
+        selectedPersonaLabel="Workspace Analyst"
+        assistantSource="workspace"
+        backendAvailable
+        streaming={false}
+      />
+    )
+
+    expect(screen.getByText("Workspace Analyst")).toBeInTheDocument()
+    expect(screen.getByText("Inherited from workspace")).toBeInTheDocument()
+  })
+
+  it("shows unavailable workspace defaults without duplicating persona content", () => {
+    render(
+      <InspectorRail
+        scopeLabel="Default workspace"
+        stagedSourceCount={0}
+        stagedSources={[]}
+        selectedModelLabel="gpt-test"
+        selectedPersonaLabel={null}
+        assistantSource="unavailable"
+        workspaceAssistantDegradedReason="persona_deleted"
+        backendAvailable
+        streaming={false}
+      />
+    )
+
+    expect(screen.getByText("Workspace default unavailable")).toBeInTheDocument()
+    expect(screen.getByText("Persona deleted")).toBeInTheDocument()
+    expect(screen.queryByText("No persona selected")).not.toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/WorkspaceChatPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/WorkspaceChatPanel.test.tsx
@@ -640,6 +640,33 @@ describe("WorkspaceChatPanel", () => {
     )
   })
 
+  it("keeps workspace provenance when reopening an inherited persona chat", () => {
+    chatHookState.value.selectedAssistant = null
+    chatHookState.value.selectedAssistantSource = "none"
+    chatHookState.value.serverChatId = "workspace-persona-chat"
+    chatHookState.value.serverChatAssistantKind = "persona"
+    chatHookState.value.serverChatAssistantId = "workspace-persona"
+    const onRuntimeStateChange = vi.fn()
+
+    render(
+      <WorkspaceChatPanel
+        stagedSources={[]}
+        onClearStagedSources={vi.fn()}
+        backendAvailable
+        workspaceId="workspace-1"
+        effectiveAssistantDefault={availableWorkspaceDefault}
+        onRuntimeStateChange={onRuntimeStateChange}
+      />
+    )
+
+    expect(onRuntimeStateChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedPersonaLabel: "Workspace Analyst",
+        assistantSource: "workspace"
+      })
+    )
+  })
+
   it("keeps an explicit selected persona ahead of the workspace default", async () => {
     chatHookState.value.selectedAssistant = {
       kind: "persona",

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/WorkspaceChatPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/WorkspaceChatPanel.test.tsx
@@ -23,6 +23,8 @@ const chatHookState = vi.hoisted(() => {
     stopStreamingRequest,
     selectedModel: "gpt-test",
     selectedAssistant: { kind: "persona", id: "p1", name: "Analyst" },
+    selectedAssistantSource: "explicit",
+    serverChatId: null,
     serverChatAssistantKind: null,
     serverChatAssistantId: null,
     serverChatMetaLoaded: false
@@ -122,6 +124,8 @@ describe("WorkspaceChatPanel", () => {
       id: "p1",
       name: "Analyst"
     }
+    chatHookState.value.selectedAssistantSource = "explicit"
+    chatHookState.value.serverChatId = null
     chatHookState.value.serverChatAssistantKind = null
     chatHookState.value.serverChatAssistantId = null
     chatHookState.value.serverChatMetaLoaded = false
@@ -549,7 +553,12 @@ describe("WorkspaceChatPanel", () => {
   })
 
   it("inherits the available workspace persona default on first submit", async () => {
-    chatHookState.value.selectedAssistant = null
+    chatHookState.value.selectedAssistant = {
+      kind: "persona",
+      id: "workspace-persona",
+      name: "Workspace Analyst"
+    }
+    chatHookState.value.selectedAssistantSource = "workspace"
     const onRuntimeStateChange = vi.fn()
 
     render(
@@ -600,6 +609,37 @@ describe("WorkspaceChatPanel", () => {
     })
   })
 
+  it("keeps workspace provenance after the inherited persona chat is created", () => {
+    chatHookState.value.selectedAssistant = {
+      kind: "persona",
+      id: "workspace-persona",
+      name: "Workspace Analyst"
+    }
+    chatHookState.value.selectedAssistantSource = "workspace"
+    chatHookState.value.serverChatId = "workspace-persona-chat"
+    chatHookState.value.serverChatAssistantKind = "persona"
+    chatHookState.value.serverChatAssistantId = "workspace-persona"
+    const onRuntimeStateChange = vi.fn()
+
+    render(
+      <WorkspaceChatPanel
+        stagedSources={[]}
+        onClearStagedSources={vi.fn()}
+        backendAvailable
+        workspaceId="workspace-1"
+        effectiveAssistantDefault={availableWorkspaceDefault}
+        onRuntimeStateChange={onRuntimeStateChange}
+      />
+    )
+
+    expect(onRuntimeStateChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedPersonaLabel: "Workspace Analyst",
+        assistantSource: "workspace"
+      })
+    )
+  })
+
   it("keeps an explicit selected persona ahead of the workspace default", async () => {
     chatHookState.value.selectedAssistant = {
       kind: "persona",
@@ -633,6 +673,7 @@ describe("WorkspaceChatPanel", () => {
 
   it("does not inherit an unavailable workspace default", async () => {
     chatHookState.value.selectedAssistant = null
+    chatHookState.value.selectedAssistantSource = "none"
     const onRuntimeStateChange = vi.fn()
 
     render(
@@ -668,6 +709,7 @@ describe("WorkspaceChatPanel", () => {
 
   it("does not mutate existing chat assistant metadata when the workspace default changes", async () => {
     chatHookState.value.selectedAssistant = null
+    chatHookState.value.selectedAssistantSource = "none"
     chatHookState.value.serverChatAssistantKind = "persona"
     chatHookState.value.serverChatAssistantId = "session-persona"
     chatHookState.value.serverChatMetaLoaded = true

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/WorkspaceChatPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/WorkspaceChatPanel.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { useMessageOption as useMessageOptionHook } from "@/hooks/useMessageOption"
 import { WorkspaceChatPanel } from "../WorkspaceChatPanel"
 import type { StagedWorkspaceSource } from "../types"
+import type { EffectiveWorkspaceAssistantDefault } from "@/types/workspace"
 
 type UseMessageOptionHook = typeof useMessageOptionHook
 type UseMessageOptionState = ReturnType<UseMessageOptionHook>
@@ -21,7 +22,10 @@ const chatHookState = vi.hoisted(() => {
     isProcessing: false,
     stopStreamingRequest,
     selectedModel: "gpt-test",
-    selectedAssistant: { kind: "persona", id: "p1", name: "Analyst" }
+    selectedAssistant: { kind: "persona", id: "p1", name: "Analyst" },
+    serverChatAssistantKind: null,
+    serverChatAssistantId: null,
+    serverChatMetaLoaded: false
   } as unknown as UseMessageOptionState
   const useMessageOption = vi.fn<UseMessageOptionHook>(() => value)
 
@@ -86,6 +90,26 @@ const getSubmitPayload = (): SubmitPayload => {
   return payload
 }
 
+const availableWorkspaceDefault: EffectiveWorkspaceAssistantDefault = {
+  status: "available",
+  source: "workspace",
+  assistantKind: "persona",
+  assistantId: "workspace-persona",
+  label: "Workspace Analyst",
+  personaMemoryMode: "read_write",
+  degradedReason: null
+}
+
+const unavailableWorkspaceDefault: EffectiveWorkspaceAssistantDefault = {
+  status: "unavailable",
+  source: "workspace",
+  assistantKind: "persona",
+  assistantId: "workspace-persona",
+  label: "Workspace Analyst",
+  personaMemoryMode: "read_write",
+  degradedReason: "persona_deleted"
+}
+
 describe("WorkspaceChatPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -93,6 +117,14 @@ describe("WorkspaceChatPanel", () => {
     chatHookState.value.streaming = false
     chatHookState.value.isLoading = false
     chatHookState.value.isProcessing = false
+    chatHookState.value.selectedAssistant = {
+      kind: "persona",
+      id: "p1",
+      name: "Analyst"
+    }
+    chatHookState.value.serverChatAssistantKind = null
+    chatHookState.value.serverChatAssistantId = null
+    chatHookState.value.serverChatMetaLoaded = false
     chatHookState.onSubmit.mockResolvedValue({ status: "submitted" })
   })
 
@@ -501,15 +533,163 @@ describe("WorkspaceChatPanel", () => {
       />
     )
 
-    expect(chatHookState.useMessageOption).toHaveBeenCalledWith({
-      scope: { type: "workspace", workspaceId: "workspace-1" }
-    })
+    expect(chatHookState.useMessageOption).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: { type: "workspace", workspaceId: "workspace-1" }
+      })
+    )
     expect(onRuntimeStateChange).toHaveBeenCalledWith(
       expect.objectContaining({
         streaming: false,
         selectedModelLabel: "gpt-test",
-        selectedPersonaLabel: "Analyst"
+        selectedPersonaLabel: "Analyst",
+        assistantSource: "explicit"
       })
     )
+  })
+
+  it("inherits the available workspace persona default on first submit", async () => {
+    chatHookState.value.selectedAssistant = null
+    const onRuntimeStateChange = vi.fn()
+
+    render(
+      <WorkspaceChatPanel
+        stagedSources={[]}
+        onClearStagedSources={vi.fn()}
+        backendAvailable
+        workspaceId="workspace-1"
+        effectiveAssistantDefault={availableWorkspaceDefault}
+        onRuntimeStateChange={onRuntimeStateChange}
+      />
+    )
+
+    expect(chatHookState.useMessageOption).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: { type: "workspace", workspaceId: "workspace-1" },
+        inheritedAssistant: expect.objectContaining({
+          kind: "persona",
+          id: "workspace-persona",
+          name: "Workspace Analyst",
+          metadata: expect.objectContaining({
+            selectionMode: "tracked",
+            source: "workspace",
+            personaMemoryMode: "read_write"
+          })
+        })
+      })
+    )
+    expect(onRuntimeStateChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedPersonaLabel: "Workspace Analyst",
+        assistantSource: "workspace"
+      })
+    )
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Chat workspace message" }), {
+      target: { value: "Use the default persona" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }))
+
+    await waitFor(() => expect(chatHookState.onSubmit).toHaveBeenCalledTimes(1))
+    expect(getSubmitPayload()).toMatchObject({
+      requestOverrides: expect.objectContaining({
+        assistant_kind: "persona",
+        assistant_id: "workspace-persona",
+        persona_memory_mode: "read_write"
+      })
+    })
+  })
+
+  it("keeps an explicit selected persona ahead of the workspace default", async () => {
+    chatHookState.value.selectedAssistant = {
+      kind: "persona",
+      id: "explicit-persona",
+      name: "Explicit Analyst",
+      metadata: {
+        selectionMode: "tracked"
+      }
+    }
+
+    render(
+      <WorkspaceChatPanel
+        stagedSources={[]}
+        onClearStagedSources={vi.fn()}
+        backendAvailable
+        workspaceId="workspace-1"
+        effectiveAssistantDefault={availableWorkspaceDefault}
+      />
+    )
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Chat workspace message" }), {
+      target: { value: "Use explicit persona" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }))
+
+    await waitFor(() => expect(chatHookState.onSubmit).toHaveBeenCalledTimes(1))
+    expect(getSubmitPayload().requestOverrides).not.toMatchObject({
+      assistant_id: "workspace-persona"
+    })
+  })
+
+  it("does not inherit an unavailable workspace default", async () => {
+    chatHookState.value.selectedAssistant = null
+    const onRuntimeStateChange = vi.fn()
+
+    render(
+      <WorkspaceChatPanel
+        stagedSources={[]}
+        onClearStagedSources={vi.fn()}
+        backendAvailable
+        workspaceId="workspace-1"
+        effectiveAssistantDefault={unavailableWorkspaceDefault}
+        onRuntimeStateChange={onRuntimeStateChange}
+      />
+    )
+
+    expect(onRuntimeStateChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedPersonaLabel: null,
+        assistantSource: "unavailable",
+        workspaceAssistantDegradedReason: "persona_deleted"
+      })
+    )
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Chat workspace message" }), {
+      target: { value: "No default persona" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }))
+
+    await waitFor(() => expect(chatHookState.onSubmit).toHaveBeenCalledTimes(1))
+    expect(getSubmitPayload().requestOverrides).not.toMatchObject({
+      assistant_kind: "persona",
+      assistant_id: "workspace-persona"
+    })
+  })
+
+  it("does not mutate existing chat assistant metadata when the workspace default changes", async () => {
+    chatHookState.value.selectedAssistant = null
+    chatHookState.value.serverChatAssistantKind = "persona"
+    chatHookState.value.serverChatAssistantId = "session-persona"
+    chatHookState.value.serverChatMetaLoaded = true
+
+    render(
+      <WorkspaceChatPanel
+        stagedSources={[]}
+        onClearStagedSources={vi.fn()}
+        backendAvailable
+        workspaceId="workspace-1"
+        effectiveAssistantDefault={availableWorkspaceDefault}
+      />
+    )
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Chat workspace message" }), {
+      target: { value: "Continue existing chat" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }))
+
+    await waitFor(() => expect(chatHookState.onSubmit).toHaveBeenCalledTimes(1))
+    expect(getSubmitPayload().requestOverrides).not.toMatchObject({
+      assistant_id: "workspace-persona"
+    })
   })
 })

--- a/apps/packages/ui/src/components/Option/ChatWorkspace/types.ts
+++ b/apps/packages/ui/src/components/Option/ChatWorkspace/types.ts
@@ -1,4 +1,7 @@
-import type { WorkspaceSourceType } from "@/types/workspace"
+import type {
+  WorkspaceAssistantDefaultDegradedReason,
+  WorkspaceSourceType
+} from "@/types/workspace"
 
 export type StagedSourceAvailability =
   | "ready"
@@ -16,9 +19,17 @@ export type StagedWorkspaceSource = {
   statusMessage?: string
 }
 
+export type ChatWorkspaceAssistantSource =
+  | "explicit"
+  | "workspace"
+  | "none"
+  | "unavailable"
+
 export type ChatWorkspaceRuntimeState = {
   backendAvailable: boolean
   streaming: boolean
   selectedModelLabel: string
   selectedPersonaLabel: string | null
+  assistantSource: ChatWorkspaceAssistantSource
+  workspaceAssistantDegradedReason?: WorkspaceAssistantDefaultDegradedReason | null
 }

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/KnowledgeQAProvider.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/KnowledgeQAProvider.tsx
@@ -1804,9 +1804,6 @@ export function KnowledgeQAProvider({ children }: { children: ReactNode }) {
       const cleanupRemoteIfSkipped = options?.cleanupRemoteIfSkipped ?? false
       try {
         const characterId = await resolveDefaultCharacterId()
-        if (!characterId) {
-          throw new Error("Default character unavailable")
-        }
 
         const resolvedTitle = title?.trim()
           ? title.trim()
@@ -1814,7 +1811,7 @@ export function KnowledgeQAProvider({ children }: { children: ReactNode }) {
 
         // Create a new conversation via API
         const response = await tldwClient.createChat({
-          character_id: characterId,
+          ...(characterId != null ? { character_id: characterId } : {}),
           title: resolvedTitle,
           state: "in-progress",
           source: "knowledge_qa",

--- a/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQAProvider.persistence.test.tsx
+++ b/apps/packages/ui/src/components/Option/KnowledgeQA/__tests__/KnowledgeQAProvider.persistence.test.tsx
@@ -93,6 +93,8 @@ describe("KnowledgeQAProvider persistence safeguards", () => {
   })
 
   it("switches into local-only mode when thread creation falls back to local ids", async () => {
+    createChatMock.mockRejectedValueOnce(new Error("create failed"))
+
     render(
       <KnowledgeQAProvider>
         <ContextProbe />
@@ -113,6 +115,30 @@ describe("KnowledgeQAProvider persistence safeguards", () => {
       expect(latestContext!.currentThreadId).toMatch(/^local-/)
       expect(latestContext!.isLocalOnlyThread).toBe(true)
     })
+  })
+
+  it("creates a remote Knowledge QA thread when no default character is available", async () => {
+    render(
+      <KnowledgeQAProvider>
+        <ContextProbe />
+      </KnowledgeQAProvider>
+    )
+
+    await waitFor(() => expect(latestContext).not.toBeNull())
+
+    await act(async () => {
+      await expect(latestContext!.createNewThread("No character thread")).resolves.toBe(
+        "thread-1"
+      )
+    })
+
+    expect(searchCharactersMock).toHaveBeenCalled()
+    expect(listCharactersMock).toHaveBeenCalled()
+    expect(createChatMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({ character_id: expect.anything() })
+    )
+    expect(latestContext!.currentThreadId).toBe("thread-1")
+    expect(latestContext!.isLocalOnlyThread).toBe(false)
   })
 
   it("shows persistence warning only on first chat message save failure", async () => {

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx
@@ -40,10 +40,18 @@ import {
   Search
 } from "lucide-react"
 import type {
+  EffectiveWorkspaceAssistantDefault,
   SavedWorkspace,
+  WorkspaceAssistantDefaults,
   WorkspaceBannerImage,
-  WorkspaceCollection
+  WorkspaceCollection,
+  WorkspacePersonaMemoryMode
 } from "@/types/workspace"
+import {
+  tldwClient,
+  type PersonaProfileSummary
+} from "@/services/tldw/TldwApiClient"
+import type { WorkspaceApiResponse } from "@/services/tldw/domains/workspace-api"
 import { useWorkspaceStore } from "@/store/workspace"
 import { useConnectionStore } from "@/store/connection"
 import { DESIGN_SYSTEM_STATES, getDesignSystemState } from "@/design-system"
@@ -222,6 +230,21 @@ const getServerWorkspaceContextStatusCopy = (
   }
 }
 
+const DEFAULT_ASSISTANT_DEGRADED_REASON_LABELS: Record<string, string> = {
+  persona_deleted: "Persona deleted",
+  persona_unavailable: "Persona unavailable",
+  persona_feature_disabled: "Persona feature disabled",
+  permission_denied: "Permission denied",
+  invalid_default: "Invalid default",
+  unsupported_assistant_kind: "Unsupported assistant kind"
+}
+
+const formatDefaultAssistantDegradedReason = (reason: string | null | undefined) =>
+  reason ? DEFAULT_ASSISTANT_DEGRADED_REASON_LABELS[reason] ?? "Unavailable" : "Unavailable"
+
+const getPersonaProfileLabel = (profile: PersonaProfileSummary) =>
+  profile.name?.trim() || profile.id
+
 export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
   leftPaneOpen,
   rightPaneOpen,
@@ -316,6 +339,25 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
   const [bannerModalError, setBannerModalError] = React.useState<string | null>(
     null
   )
+  const [defaultAssistantModalOpen, setDefaultAssistantModalOpen] =
+    React.useState(false)
+  const [defaultAssistantLoading, setDefaultAssistantLoading] =
+    React.useState(false)
+  const [defaultAssistantSaving, setDefaultAssistantSaving] =
+    React.useState(false)
+  const [defaultAssistantError, setDefaultAssistantError] =
+    React.useState<string | null>(null)
+  const [defaultAssistantWorkspace, setDefaultAssistantWorkspace] =
+    React.useState<WorkspaceApiResponse | null>(null)
+  const [personaProfiles, setPersonaProfiles] = React.useState<
+    PersonaProfileSummary[]
+  >([])
+  const [defaultAssistantPersonaId, setDefaultAssistantPersonaId] =
+    React.useState("")
+  const [defaultAssistantMemoryMode, setDefaultAssistantMemoryMode] =
+    React.useState<WorkspacePersonaMemoryMode>("read_only")
+  const [defaultAssistantConfirmReadWrite, setDefaultAssistantConfirmReadWrite] =
+    React.useState(false)
   const lastConnectivityStatusRef = React.useRef<string | null>(null)
   const importFileInputRef = React.useRef<HTMLInputElement | null>(null)
   const bannerFileInputRef = React.useRef<HTMLInputElement | null>(null)
@@ -636,6 +678,151 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
 
   const handleCloseAcpHistoryModal = () => {
     setAcpHistoryModalOpen(false)
+  }
+
+  const applyDefaultAssistantWorkspaceState = (
+    workspace: WorkspaceApiResponse
+  ) => {
+    setDefaultAssistantWorkspace(workspace)
+    setDefaultAssistantPersonaId(workspace.assistantDefaults?.assistantId ?? "")
+    setDefaultAssistantMemoryMode(
+      workspace.assistantDefaults?.personaMemoryMode ?? "read_only"
+    )
+    setDefaultAssistantConfirmReadWrite(false)
+  }
+
+  const handleOpenDefaultAssistantModal = async () => {
+    if (!workspaceId) return
+
+    setDefaultAssistantModalOpen(true)
+    setDefaultAssistantLoading(true)
+    setDefaultAssistantError(null)
+    try {
+      const [workspace, personas] = await Promise.all([
+        tldwClient.getWorkspace(workspaceId),
+        tldwClient.listPersonaProfiles()
+      ])
+      applyDefaultAssistantWorkspaceState(workspace)
+      setPersonaProfiles(personas)
+    } catch {
+      setDefaultAssistantError(
+        t(
+          "playground:workspace.defaultAssistantLoadError",
+          "Could not load default assistant settings."
+        )
+      )
+    } finally {
+      setDefaultAssistantLoading(false)
+    }
+  }
+
+  const handleCloseDefaultAssistantModal = () => {
+    setDefaultAssistantModalOpen(false)
+    setDefaultAssistantError(null)
+    setDefaultAssistantSaving(false)
+  }
+
+  const handleDefaultAssistantMemoryModeChange = (
+    event: React.ChangeEvent<HTMLSelectElement>
+  ) => {
+    const nextMode = event.target.value as WorkspacePersonaMemoryMode
+    setDefaultAssistantMemoryMode(nextMode)
+    if (nextMode !== "read_write") {
+      setDefaultAssistantConfirmReadWrite(false)
+    }
+  }
+
+  const buildDefaultAssistantPayload = (): WorkspaceAssistantDefaults => ({
+    assistantKind: "persona",
+    assistantId: defaultAssistantPersonaId.trim(),
+    personaMemoryMode: defaultAssistantMemoryMode,
+    voice: null,
+    style: null,
+    toolPolicyProfileId: null
+  })
+
+  const handleSaveDefaultAssistant = async () => {
+    if (!workspaceId || !defaultAssistantWorkspace) return
+    if (!defaultAssistantPersonaId.trim()) {
+      setDefaultAssistantError(
+        t(
+          "playground:workspace.defaultAssistantSelectRequired",
+          "Select a Persona before saving."
+        )
+      )
+      return
+    }
+    if (
+      defaultAssistantMemoryMode === "read_write" &&
+      !defaultAssistantConfirmReadWrite
+    ) {
+      setDefaultAssistantError(
+        t(
+          "playground:workspace.defaultAssistantReadWriteConfirmRequired",
+          "Confirm read-write memory access before saving."
+        )
+      )
+      return
+    }
+
+    setDefaultAssistantSaving(true)
+    setDefaultAssistantError(null)
+    try {
+      const updatedWorkspace = await tldwClient.patchWorkspace(workspaceId, {
+        version: defaultAssistantWorkspace.version,
+        assistantDefaults: buildDefaultAssistantPayload(),
+        ...(defaultAssistantMemoryMode === "read_write"
+          ? { confirmReadWriteAssistantDefault: true }
+          : {})
+      })
+      applyDefaultAssistantWorkspaceState(updatedWorkspace)
+      setDefaultAssistantModalOpen(false)
+      messageApi.success(
+        t(
+          "playground:workspace.defaultAssistantSaved",
+          "Default assistant updated"
+        )
+      )
+    } catch {
+      setDefaultAssistantError(
+        t(
+          "playground:workspace.defaultAssistantSaveError",
+          "Could not save default assistant settings."
+        )
+      )
+    } finally {
+      setDefaultAssistantSaving(false)
+    }
+  }
+
+  const handleClearDefaultAssistant = async () => {
+    if (!workspaceId || !defaultAssistantWorkspace) return
+
+    setDefaultAssistantSaving(true)
+    setDefaultAssistantError(null)
+    try {
+      const updatedWorkspace = await tldwClient.patchWorkspace(workspaceId, {
+        version: defaultAssistantWorkspace.version,
+        assistantDefaults: null
+      })
+      applyDefaultAssistantWorkspaceState(updatedWorkspace)
+      setDefaultAssistantModalOpen(false)
+      messageApi.success(
+        t(
+          "playground:workspace.defaultAssistantCleared",
+          "Default assistant cleared"
+        )
+      )
+    } catch {
+      setDefaultAssistantError(
+        t(
+          "playground:workspace.defaultAssistantClearError",
+          "Could not clear default assistant settings."
+        )
+      )
+    } finally {
+      setDefaultAssistantSaving(false)
+    }
   }
 
   const handleOpenAgentTasksPage = () => {
@@ -1734,6 +1921,17 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
             onClick: () => setSandboxDiagnosticsOpen(true)
           },
           {
+            key: "default-assistant",
+            icon: <Bot className="h-4 w-4" />,
+            label: t(
+              "playground:workspace.defaultAssistant",
+              "Default assistant"
+            ),
+            onClick: () => {
+              void handleOpenDefaultAssistantModal()
+            }
+          },
+          {
             key: "duplicate-current",
             icon: <Copy className="h-4 w-4" />,
             label: t(
@@ -1847,6 +2045,65 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
       onClick: handleGoToSimpleChat
     }
   ]
+
+  const effectiveDefaultAssistant: EffectiveWorkspaceAssistantDefault | null =
+    defaultAssistantWorkspace?.effectiveAssistantDefault ?? null
+  const storedDefaultAssistant = defaultAssistantWorkspace?.assistantDefaults ?? null
+  const redactedDefaultAssistantId =
+    effectiveDefaultAssistant?.status === "unavailable"
+      ? storedDefaultAssistant?.assistantId ?? null
+      : null
+  const selectedDefaultAssistantIsRedacted =
+    Boolean(redactedDefaultAssistantId) &&
+    redactedDefaultAssistantId === defaultAssistantPersonaId
+  const personaProfileOptions = redactedDefaultAssistantId
+    ? personaProfiles.filter((profile) => profile.id !== redactedDefaultAssistantId)
+    : personaProfiles
+  const selectedDefaultAssistantProfile = personaProfiles.find(
+    (profile) =>
+      !selectedDefaultAssistantIsRedacted &&
+      profile.id === defaultAssistantPersonaId
+  )
+  const selectedDefaultAssistantAvailable =
+    !defaultAssistantPersonaId || Boolean(selectedDefaultAssistantProfile)
+  const defaultAssistantStatusTitle =
+    effectiveDefaultAssistant?.status === "available"
+      ? effectiveDefaultAssistant.label ||
+        selectedDefaultAssistantProfile?.name ||
+        t(
+          "playground:workspace.defaultAssistantPersonaDefault",
+          "Persona default"
+        )
+      : effectiveDefaultAssistant?.status === "unavailable"
+        ? t(
+            "playground:workspace.defaultAssistantUnavailable",
+            "Default unavailable"
+          )
+        : t(
+            "playground:workspace.defaultAssistantNone",
+            "No default assistant"
+          )
+  const defaultAssistantStatusDetail =
+    effectiveDefaultAssistant?.status === "available"
+      ? t(
+          "playground:workspace.defaultAssistantAvailableDetail",
+          "New workspace chats can inherit this Persona when no assistant is selected."
+        )
+      : effectiveDefaultAssistant?.status === "unavailable"
+        ? formatDefaultAssistantDegradedReason(
+            effectiveDefaultAssistant.degradedReason
+          )
+        : t(
+            "playground:workspace.defaultAssistantNoneDetail",
+            "New workspace chats start without a default Persona."
+          )
+  const defaultAssistantSaveDisabled =
+    defaultAssistantLoading ||
+    defaultAssistantSaving ||
+    !defaultAssistantPersonaId.trim() ||
+    !selectedDefaultAssistantAvailable ||
+    (defaultAssistantMemoryMode === "read_write" &&
+      !defaultAssistantConfirmReadWrite)
 
   return (
     <header
@@ -2137,6 +2394,165 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
             )}
           </p>
         )}
+      </Modal>
+
+      <Modal
+        title={t(
+          "playground:workspace.defaultAssistantTitle",
+          "Default assistant"
+        )}
+        open={defaultAssistantModalOpen}
+        onCancel={handleCloseDefaultAssistantModal}
+        width={620}
+        destroyOnHidden
+        footer={[
+          <Button
+            key="clear-default-assistant"
+            danger
+            disabled={
+              defaultAssistantLoading ||
+              defaultAssistantSaving ||
+              !storedDefaultAssistant
+            }
+            onClick={() => void handleClearDefaultAssistant()}
+          >
+            {t(
+              "playground:workspace.defaultAssistantClear",
+              "Clear default"
+            )}
+          </Button>,
+          <Button
+            key="cancel-default-assistant"
+            onClick={handleCloseDefaultAssistantModal}
+          >
+            {t("common:cancel", "Cancel")}
+          </Button>,
+          <Button
+            key="save-default-assistant"
+            type="primary"
+            loading={defaultAssistantSaving}
+            disabled={defaultAssistantSaveDisabled}
+            onClick={() => void handleSaveDefaultAssistant()}
+          >
+            {t("playground:workspace.defaultAssistantSave", "Save default")}
+          </Button>
+        ]}
+      >
+        <div
+          data-testid="workspace-default-assistant-modal"
+          className="space-y-4"
+        >
+          <div className="rounded-lg border border-border bg-surface2 px-3 py-2">
+            <p className="text-xs font-semibold uppercase text-text-muted">
+              {t(
+                "playground:workspace.defaultAssistantCurrent",
+                "Current default"
+              )}
+            </p>
+            <p className="mt-1 text-sm font-medium text-text">
+              {defaultAssistantStatusTitle}
+            </p>
+            <p className="mt-1 text-xs text-text-muted">
+              {defaultAssistantLoading
+                ? t(
+                    "playground:workspace.defaultAssistantLoading",
+                    "Loading default assistant settings..."
+                  )
+                : defaultAssistantStatusDetail}
+            </p>
+          </div>
+
+          <label className="block space-y-1 text-sm text-text">
+            <span className="font-medium">
+              {t("playground:workspace.defaultAssistantPersona", "Persona")}
+            </span>
+            <select
+              data-testid="workspace-default-assistant-select"
+              value={defaultAssistantPersonaId}
+              disabled={defaultAssistantLoading || defaultAssistantSaving}
+              onChange={(event) =>
+                setDefaultAssistantPersonaId(event.target.value)
+              }
+              className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text"
+            >
+              <option value="">
+                {t(
+                  "playground:workspace.defaultAssistantSelectPersona",
+                  "Select a Persona"
+                )}
+              </option>
+              {defaultAssistantPersonaId && !selectedDefaultAssistantAvailable && (
+                <option value={defaultAssistantPersonaId}>
+                  {t(
+                    "playground:workspace.defaultAssistantUnavailablePersona",
+                    "Unavailable Persona"
+                  )}
+                </option>
+              )}
+              {personaProfileOptions.map((profile) => (
+                <option key={profile.id} value={profile.id}>
+                  {getPersonaProfileLabel(profile)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block space-y-1 text-sm text-text">
+            <span className="font-medium">
+              {t(
+                "playground:workspace.defaultAssistantMemoryMode",
+                "Memory access"
+              )}
+            </span>
+            <select
+              data-testid="workspace-default-assistant-memory-mode"
+              value={defaultAssistantMemoryMode}
+              disabled={defaultAssistantLoading || defaultAssistantSaving}
+              onChange={handleDefaultAssistantMemoryModeChange}
+              className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text"
+            >
+              <option value="read_only">
+                {t(
+                  "playground:workspace.defaultAssistantReadOnly",
+                  "Read only"
+                )}
+              </option>
+              <option value="read_write">
+                {t(
+                  "playground:workspace.defaultAssistantReadWrite",
+                  "Read and write"
+                )}
+              </option>
+            </select>
+          </label>
+
+          {defaultAssistantMemoryMode === "read_write" && (
+            <label className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-text">
+              <input
+                data-testid="workspace-default-assistant-read-write-confirm"
+                type="checkbox"
+                checked={defaultAssistantConfirmReadWrite}
+                disabled={defaultAssistantSaving}
+                onChange={(event) =>
+                  setDefaultAssistantConfirmReadWrite(event.target.checked)
+                }
+                className="mt-0.5"
+              />
+              <span>
+                {t(
+                  "playground:workspace.defaultAssistantReadWriteConfirm",
+                  "Allow this Persona default to write memory in this workspace."
+                )}
+              </span>
+            </label>
+          )}
+
+          {defaultAssistantError && (
+            <p className="rounded border border-error/40 bg-error/10 px-3 py-2 text-sm text-error">
+              {defaultAssistantError}
+            </p>
+          )}
+        </div>
       </Modal>
 
       <input

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx
@@ -230,17 +230,47 @@ const getServerWorkspaceContextStatusCopy = (
   }
 }
 
-const DEFAULT_ASSISTANT_DEGRADED_REASON_LABELS: Record<string, string> = {
-  persona_deleted: "Persona deleted",
-  persona_unavailable: "Persona unavailable",
-  persona_feature_disabled: "Persona feature disabled",
-  permission_denied: "Permission denied",
-  invalid_default: "Invalid default",
-  unsupported_assistant_kind: "Unsupported assistant kind"
+const getDefaultAssistantDegradedReasonCopy = (
+  reason: string | null | undefined
+) => {
+  switch (reason) {
+    case "persona_deleted":
+      return {
+        key: "playground:workspace.defaultAssistantDegraded.personaDeleted",
+        fallback: "Persona deleted"
+      }
+    case "persona_unavailable":
+      return {
+        key: "playground:workspace.defaultAssistantDegraded.personaUnavailable",
+        fallback: "Persona unavailable"
+      }
+    case "persona_feature_disabled":
+      return {
+        key: "playground:workspace.defaultAssistantDegraded.personaFeatureDisabled",
+        fallback: "Persona feature disabled"
+      }
+    case "permission_denied":
+      return {
+        key: "playground:workspace.defaultAssistantDegraded.permissionDenied",
+        fallback: "Permission denied"
+      }
+    case "invalid_default":
+      return {
+        key: "playground:workspace.defaultAssistantDegraded.invalidDefault",
+        fallback: "Invalid default"
+      }
+    case "unsupported_assistant_kind":
+      return {
+        key: "playground:workspace.defaultAssistantDegraded.unsupportedAssistantKind",
+        fallback: "Unsupported assistant kind"
+      }
+    default:
+      return {
+        key: "playground:workspace.defaultAssistantDegraded.unavailable",
+        fallback: "Unavailable"
+      }
+  }
 }
-
-const formatDefaultAssistantDegradedReason = (reason: string | null | undefined) =>
-  reason ? DEFAULT_ASSISTANT_DEGRADED_REASON_LABELS[reason] ?? "Unavailable" : "Unavailable"
 
 const getPersonaProfileLabel = (profile: PersonaProfileSummary) =>
   profile.name?.trim() || profile.id
@@ -778,7 +808,9 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
   })
 
   const handleSaveDefaultAssistant = async () => {
-    if (!workspaceId || !defaultAssistantWorkspace) return
+    if (!defaultAssistantWorkspace) return
+    const loadedWorkspaceId = defaultAssistantWorkspace.id?.trim()
+    if (!loadedWorkspaceId) return
     if (!defaultAssistantPersonaId.trim()) {
       setDefaultAssistantError(
         t(
@@ -804,7 +836,7 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
     setDefaultAssistantSaving(true)
     setDefaultAssistantError(null)
     try {
-      const updatedWorkspace = await tldwClient.patchWorkspace(workspaceId, {
+      const updatedWorkspace = await tldwClient.patchWorkspace(loadedWorkspaceId, {
         version: defaultAssistantWorkspace.version,
         assistantDefaults: buildDefaultAssistantPayload(),
         ...(defaultAssistantMemoryMode === "read_write"
@@ -833,12 +865,14 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
   }
 
   const handleClearDefaultAssistant = async () => {
-    if (!workspaceId || !defaultAssistantWorkspace) return
+    if (!defaultAssistantWorkspace) return
+    const loadedWorkspaceId = defaultAssistantWorkspace.id?.trim()
+    if (!loadedWorkspaceId) return
 
     setDefaultAssistantSaving(true)
     setDefaultAssistantError(null)
     try {
-      const updatedWorkspace = await tldwClient.patchWorkspace(workspaceId, {
+      const updatedWorkspace = await tldwClient.patchWorkspace(loadedWorkspaceId, {
         version: defaultAssistantWorkspace.version,
         assistantDefaults: null
       })
@@ -2121,6 +2155,10 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
             "playground:workspace.defaultAssistantNone",
             "No default assistant"
           )
+  const defaultAssistantDegradedReasonCopy =
+    getDefaultAssistantDegradedReasonCopy(
+      effectiveDefaultAssistant?.degradedReason
+    )
   const defaultAssistantStatusDetail =
     effectiveDefaultAssistant?.status === "available"
       ? t(
@@ -2128,8 +2166,9 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
           "New workspace chats can inherit this Persona when no assistant is selected."
         )
       : effectiveDefaultAssistant?.status === "unavailable"
-        ? formatDefaultAssistantDegradedReason(
-            effectiveDefaultAssistant.degradedReason
+        ? t(
+            defaultAssistantDegradedReasonCopy.key,
+            defaultAssistantDegradedReasonCopy.fallback
           )
         : t(
             "playground:workspace.defaultAssistantNoneDetail",

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx
@@ -358,6 +358,7 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
     React.useState<WorkspacePersonaMemoryMode>("read_only")
   const [defaultAssistantConfirmReadWrite, setDefaultAssistantConfirmReadWrite] =
     React.useState(false)
+  const defaultAssistantRequestIdRef = React.useRef(0)
   const lastConnectivityStatusRef = React.useRef<string | null>(null)
   const importFileInputRef = React.useRef<HTMLInputElement | null>(null)
   const bannerFileInputRef = React.useRef<HTMLInputElement | null>(null)
@@ -691,20 +692,50 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
     setDefaultAssistantConfirmReadWrite(false)
   }
 
+  const resetDefaultAssistantModalState = () => {
+    setDefaultAssistantWorkspace(null)
+    setPersonaProfiles([])
+    setDefaultAssistantPersonaId("")
+    setDefaultAssistantMemoryMode("read_only")
+    setDefaultAssistantConfirmReadWrite(false)
+  }
+
+  const syncDefaultAssistantWorkspaceState = (
+    workspace: WorkspaceApiResponse
+  ) => {
+    useWorkspaceStore.setState((state) => {
+      if (state.workspaceId !== workspace.id) return {}
+      return {
+        assistantDefaults: workspace.assistantDefaults ?? null,
+        effectiveAssistantDefault: workspace.effectiveAssistantDefault ?? null
+      }
+    })
+
+    const currentState = useWorkspaceStore.getState()
+    if (currentState.workspaceId === workspace.id) {
+      currentState.saveCurrentWorkspace()
+    }
+  }
+
   const handleOpenDefaultAssistantModal = async () => {
     if (!workspaceId) return
+    const requestId = ++defaultAssistantRequestIdRef.current
 
     setDefaultAssistantModalOpen(true)
     setDefaultAssistantLoading(true)
     setDefaultAssistantError(null)
+    resetDefaultAssistantModalState()
     try {
       const [workspace, personas] = await Promise.all([
         tldwClient.getWorkspace(workspaceId),
         tldwClient.listPersonaProfiles()
       ])
+      if (requestId !== defaultAssistantRequestIdRef.current) return
       applyDefaultAssistantWorkspaceState(workspace)
       setPersonaProfiles(personas)
     } catch {
+      if (requestId !== defaultAssistantRequestIdRef.current) return
+      resetDefaultAssistantModalState()
       setDefaultAssistantError(
         t(
           "playground:workspace.defaultAssistantLoadError",
@@ -712,14 +743,18 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
         )
       )
     } finally {
+      if (requestId !== defaultAssistantRequestIdRef.current) return
       setDefaultAssistantLoading(false)
     }
   }
 
   const handleCloseDefaultAssistantModal = () => {
+    defaultAssistantRequestIdRef.current += 1
     setDefaultAssistantModalOpen(false)
+    setDefaultAssistantLoading(false)
     setDefaultAssistantError(null)
     setDefaultAssistantSaving(false)
+    resetDefaultAssistantModalState()
   }
 
   const handleDefaultAssistantMemoryModeChange = (
@@ -776,6 +811,7 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
           : {})
       })
       applyDefaultAssistantWorkspaceState(updatedWorkspace)
+      syncDefaultAssistantWorkspaceState(updatedWorkspace)
       setDefaultAssistantModalOpen(false)
       messageApi.success(
         t(
@@ -806,6 +842,7 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
         assistantDefaults: null
       })
       applyDefaultAssistantWorkspaceState(updatedWorkspace)
+      syncDefaultAssistantWorkspaceState(updatedWorkspace)
       setDefaultAssistantModalOpen(false)
       messageApi.success(
         t(
@@ -2100,6 +2137,7 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
   const defaultAssistantSaveDisabled =
     defaultAssistantLoading ||
     defaultAssistantSaving ||
+    !defaultAssistantWorkspace ||
     !defaultAssistantPersonaId.trim() ||
     !selectedDefaultAssistantAvailable ||
     (defaultAssistantMemoryMode === "read_write" &&
@@ -2412,6 +2450,7 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
             disabled={
               defaultAssistantLoading ||
               defaultAssistantSaving ||
+              !defaultAssistantWorkspace ||
               !storedDefaultAssistant
             }
             onClick={() => void handleClearDefaultAssistant()}

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx
@@ -743,8 +743,9 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
         )
       )
     } finally {
-      if (requestId !== defaultAssistantRequestIdRef.current) return
-      setDefaultAssistantLoading(false)
+      if (requestId === defaultAssistantRequestIdRef.current) {
+        setDefaultAssistantLoading(false)
+      }
     }
   }
 

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
@@ -339,11 +339,28 @@ vi.mock("antd", async () => {
   }
 })
 
-vi.mock("@/store/workspace", () => ({
-  useWorkspaceStore: (
+vi.mock("@/store/workspace", () => {
+  const useWorkspaceStore = ((
     selector: (state: typeof mockStoreState) => unknown
-  ) => selector(mockStoreState)
-}))
+  ) => selector(mockStoreState)) as ((
+    selector: (state: typeof mockStoreState) => unknown
+  ) => unknown) & {
+    getState: () => typeof mockStoreState
+    setState: (
+      update:
+        | Partial<typeof mockStoreState>
+        | ((state: typeof mockStoreState) => Partial<typeof mockStoreState>)
+    ) => void
+  }
+
+  useWorkspaceStore.getState = () => mockStoreState
+  useWorkspaceStore.setState = (update) => {
+    const next = typeof update === "function" ? update(mockStoreState) : update
+    Object.assign(mockStoreState, next)
+  }
+
+  return { useWorkspaceStore }
+})
 
 vi.mock("@/store/tutorials", () => ({
   useTutorialStore: (
@@ -1178,6 +1195,86 @@ describe("WorkspaceHeader workspace browser modal", () => {
         })
       )
     })
+    await waitFor(() => {
+      expect(mockStoreState.assistantDefaults).toEqual(
+        expect.objectContaining({
+          assistantKind: "persona",
+          assistantId: "persona-lit-reviewer",
+          personaMemoryMode: "read_only"
+        })
+      )
+      expect(mockSaveCurrentWorkspace).toHaveBeenCalled()
+    })
+  })
+
+  it("clears default assistant modal state before failed reloads can reuse stale values", async () => {
+    mockGetWorkspace.mockResolvedValueOnce(
+      createWorkspaceApiResponse({
+        version: 11,
+        assistantDefaults: {
+          assistantKind: "persona",
+          assistantId: "persona-lit-reviewer",
+          personaMemoryMode: "read_only",
+          voice: null,
+          style: null,
+          toolPolicyProfileId: null
+        },
+        effectiveAssistantDefault: {
+          status: "available",
+          source: "workspace",
+          assistantKind: "persona",
+          assistantId: "persona-lit-reviewer",
+          label: "Literature Reviewer",
+          personaMemoryMode: "read_only",
+          degradedReason: null
+        }
+      })
+    )
+    mockGetWorkspace.mockRejectedValueOnce(new Error("temporary failure"))
+
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
+    fireEvent.click(await screen.findByText("Default assistant"))
+
+    const modal = await screen.findByTestId("workspace-default-assistant-modal")
+    await waitFor(() => {
+      expect(
+        within(modal).getByTestId("workspace-default-assistant-select")
+      ).toHaveValue("persona-lit-reviewer")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }))
+    fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
+    const defaultAssistantItems = await screen.findAllByText("Default assistant")
+    const reopenedDefaultAssistantItem =
+      defaultAssistantItems.find((item) =>
+        item.closest(".ant-dropdown-menu")
+      ) ?? defaultAssistantItems[0]
+    fireEvent.click(reopenedDefaultAssistantItem)
+
+    const reopenedModal = await screen.findByTestId(
+      "workspace-default-assistant-modal"
+    )
+    await waitFor(() => {
+      expect(
+        within(reopenedModal).getByText(
+          "Could not load default assistant settings."
+        )
+      ).toBeInTheDocument()
+    })
+    expect(
+      within(reopenedModal).getByTestId("workspace-default-assistant-select")
+    ).toHaveValue("")
+    expect(screen.getByRole("button", { name: "Save default" })).toBeDisabled()
+    expect(mockPatchWorkspace).not.toHaveBeenCalled()
   })
 
   it("requires confirmation before saving a read-write Persona default", async () => {
@@ -1194,6 +1291,11 @@ describe("WorkspaceHeader workspace browser modal", () => {
     fireEvent.click(await screen.findByText("Default assistant"))
 
     const modal = await screen.findByTestId("workspace-default-assistant-modal")
+    await waitFor(() => {
+      expect(
+        within(modal).getByTestId("workspace-default-assistant-select")
+      ).toBeEnabled()
+    })
     fireEvent.change(
       within(modal).getByTestId("workspace-default-assistant-select"),
       { target: { value: "persona-methods" } }
@@ -1211,7 +1313,9 @@ describe("WorkspaceHeader workspace browser modal", () => {
     fireEvent.click(
       within(modal).getByTestId("workspace-default-assistant-read-write-confirm")
     )
-    expect(screen.getByRole("button", { name: "Save default" })).toBeEnabled()
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save default" })).toBeEnabled()
+    })
 
     fireEvent.click(screen.getByRole("button", { name: "Save default" }))
 
@@ -1275,6 +1379,10 @@ describe("WorkspaceHeader workspace browser modal", () => {
         version: 11,
         assistantDefaults: null
       })
+    })
+    await waitFor(() => {
+      expect(mockStoreState.assistantDefaults).toBeNull()
+      expect(mockSaveCurrentWorkspace).toHaveBeenCalled()
     })
   })
 

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
@@ -511,6 +511,9 @@ describe("WorkspaceHeader workspace browser modal", () => {
     clearWorkspaceUndoActionsForTests()
     registryStateOverrides.missingDegraded = false
     registryStateOverrides.degradedLabel = "Degraded"
+    mockStoreState.workspaceId = "workspace-alpha"
+    mockStoreState.workspaceName = "Alpha Research"
+    mockStoreState.workspaceTag = "workspace:alpha-research"
     mockStoreState.assistantDefaults = null
     mockStoreState.effectiveAssistantDefault = null
     connectionConfigState.loading = false
@@ -1207,6 +1210,49 @@ describe("WorkspaceHeader workspace browser modal", () => {
     })
   })
 
+  it("saves default assistant settings against the workspace loaded into the modal", async () => {
+    const header = (
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+    const { rerender } = render(header)
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
+    fireEvent.click(await screen.findByText("Default assistant"))
+    const modal = await screen.findByTestId("workspace-default-assistant-modal")
+
+    mockStoreState.workspaceId = "workspace-beta"
+    mockStoreState.workspaceName = "Beta Deep Dive"
+    mockStoreState.workspaceTag = "workspace:beta-deep-dive"
+    rerender(header)
+
+    fireEvent.change(
+      within(modal).getByTestId("workspace-default-assistant-select"),
+      { target: { value: "persona-lit-reviewer" } }
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Save default" }))
+
+    await waitFor(() => {
+      expect(mockPatchWorkspace).toHaveBeenCalledWith(
+        "workspace-alpha",
+        expect.objectContaining({
+          version: 7,
+          assistantDefaults: expect.objectContaining({
+            assistantId: "persona-lit-reviewer"
+          })
+        })
+      )
+    })
+    expect(mockPatchWorkspace).not.toHaveBeenCalledWith(
+      "workspace-beta",
+      expect.anything()
+    )
+  })
+
   it("clears default assistant modal state before failed reloads can reuse stale values", async () => {
     mockGetWorkspace.mockResolvedValueOnce(
       createWorkspaceApiResponse({
@@ -1434,6 +1480,9 @@ describe("WorkspaceHeader workspace browser modal", () => {
     const modal = await screen.findByTestId("workspace-default-assistant-modal")
     expect(within(modal).getByText("Default unavailable")).toBeInTheDocument()
     expect(within(modal).getByText("Permission denied")).toBeInTheDocument()
+    expect(translationMock.keys).toContain(
+      "playground:workspace.defaultAssistantDegraded.permissionDenied"
+    )
     expect(within(modal).queryByText("Hidden Persona")).not.toBeInTheDocument()
 
     fireEvent.change(

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
@@ -47,7 +47,13 @@ const workspaceContextMocks = vi.hoisted(() => ({
 const translationMock = vi.hoisted(() => ({
   keys: [] as string[]
 }))
-const { mockStartTutorial, mockMessageApi } = vi.hoisted(() => ({
+const {
+  mockStartTutorial,
+  mockMessageApi,
+  mockListPersonaProfiles,
+  mockGetWorkspace,
+  mockPatchWorkspace
+} = vi.hoisted(() => ({
   mockStartTutorial: vi.fn(),
   mockMessageApi: {
     success: vi.fn(),
@@ -56,7 +62,10 @@ const { mockStartTutorial, mockMessageApi } = vi.hoisted(() => ({
     warning: vi.fn(),
     open: vi.fn(),
     destroy: vi.fn()
-  }
+  },
+  mockListPersonaProfiles: vi.fn(),
+  mockGetWorkspace: vi.fn(),
+  mockPatchWorkspace: vi.fn()
 }))
 
 const now = new Date("2026-02-18T12:00:00.000Z")
@@ -87,6 +96,8 @@ const mockStoreState = {
       url: "https://example.com/alpha-whitepaper"
     }
   ],
+  assistantDefaults: null,
+  effectiveAssistantDefault: null,
   setWorkspaceName: mockSetWorkspaceName,
   setWorkspaceBanner: mockSetWorkspaceBanner,
   clearWorkspaceBannerImage: mockClearWorkspaceBannerImage,
@@ -237,6 +248,38 @@ const makeActiveWorkspaceContext = (
     message: "Workspace action is available.",
     nextStepLabel: null,
     nextStepHref: null
+  },
+  ...overrides
+})
+
+const createWorkspaceApiResponse = (
+  overrides: Record<string, unknown> = {}
+) => ({
+  id: "workspace-alpha",
+  name: "Alpha Research",
+  archived: false,
+  studyMaterialsPolicy: "workspace",
+  workspaceProfile: "research",
+  deleted: false,
+  bannerTitle: "Alpha Banner",
+  bannerSubtitle: "Alpha subtitle",
+  bannerColor: null,
+  audioProvider: null,
+  audioModel: null,
+  audioVoice: null,
+  audioSpeed: null,
+  createdAt: "2026-02-10T10:00:00.000Z",
+  lastModified: "2026-02-18T12:00:00.000Z",
+  version: 7,
+  assistantDefaults: null,
+  effectiveAssistantDefault: {
+    status: "none",
+    source: "none",
+    assistantKind: null,
+    assistantId: null,
+    label: null,
+    personaMemoryMode: null,
+    degradedReason: null
   },
   ...overrides
 })
@@ -398,6 +441,14 @@ vi.mock("@/utils/research-workspace-telemetry", async () => {
   }
 })
 
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    listPersonaProfiles: (...args: unknown[]) => mockListPersonaProfiles(...args),
+    getWorkspace: (...args: unknown[]) => mockGetWorkspace(...args),
+    patchWorkspace: (...args: unknown[]) => mockPatchWorkspace(...args)
+  }
+}))
+
 if (!(globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver) {
   ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
     observe() {}
@@ -443,6 +494,8 @@ describe("WorkspaceHeader workspace browser modal", () => {
     clearWorkspaceUndoActionsForTests()
     registryStateOverrides.missingDegraded = false
     registryStateOverrides.degradedLabel = "Degraded"
+    mockStoreState.assistantDefaults = null
+    mockStoreState.effectiveAssistantDefault = null
     connectionConfigState.loading = false
     connectionConfigState.config = {
       serverUrl: "http://127.0.0.1:8000",
@@ -632,6 +685,33 @@ describe("WorkspaceHeader workspace browser modal", () => {
       bytes: 16000,
       updatedAt: new Date("2026-02-25T10:00:00.000Z")
     })
+    mockListPersonaProfiles.mockResolvedValue([
+      {
+        id: "persona-lit-reviewer",
+        name: "Literature Reviewer",
+        character_card_id: null,
+        origin_character_id: null,
+        buddy_summary: null,
+        metadata: null
+      },
+      {
+        id: "persona-methods",
+        name: "Methods Auditor",
+        character_card_id: null,
+        origin_character_id: null,
+        buddy_summary: null,
+        metadata: null
+      }
+    ])
+    mockGetWorkspace.mockResolvedValue(createWorkspaceApiResponse())
+    mockPatchWorkspace.mockImplementation(
+      async (_workspaceId: string, payload: Record<string, unknown>) =>
+        createWorkspaceApiResponse({
+          version: 8,
+          assistantDefaults:
+            "assistantDefaults" in payload ? payload.assistantDefaults : null
+        })
+    )
     connectionConfigState.config = {
       serverUrl: "http://127.0.0.1:8000",
       authMode: "single-user",
@@ -1056,6 +1136,203 @@ describe("WorkspaceHeader workspace browser modal", () => {
 
     expect(mockSaveCurrentWorkspace).toHaveBeenCalledTimes(1)
     expect(mockNavigate).toHaveBeenCalledWith("/workspaces")
+  })
+
+  it("opens default assistant settings and saves a read-only Persona default", async () => {
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
+    fireEvent.click(await screen.findByText("Default assistant"))
+
+    const modal = await screen.findByTestId("workspace-default-assistant-modal")
+    expect(within(modal).getByText("No default assistant")).toBeInTheDocument()
+    expect(mockGetWorkspace).toHaveBeenCalledWith("workspace-alpha")
+    expect(mockListPersonaProfiles).toHaveBeenCalledTimes(1)
+
+    fireEvent.change(
+      within(modal).getByTestId("workspace-default-assistant-select"),
+      { target: { value: "persona-lit-reviewer" } }
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Save default" }))
+
+    await waitFor(() => {
+      expect(mockPatchWorkspace).toHaveBeenCalledWith(
+        "workspace-alpha",
+        expect.objectContaining({
+          version: 7,
+          assistantDefaults: {
+            assistantKind: "persona",
+            assistantId: "persona-lit-reviewer",
+            personaMemoryMode: "read_only",
+            voice: null,
+            style: null,
+            toolPolicyProfileId: null
+          }
+        })
+      )
+    })
+  })
+
+  it("requires confirmation before saving a read-write Persona default", async () => {
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
+    fireEvent.click(await screen.findByText("Default assistant"))
+
+    const modal = await screen.findByTestId("workspace-default-assistant-modal")
+    fireEvent.change(
+      within(modal).getByTestId("workspace-default-assistant-select"),
+      { target: { value: "persona-methods" } }
+    )
+    fireEvent.change(
+      within(modal).getByTestId("workspace-default-assistant-memory-mode"),
+      { target: { value: "read_write" } }
+    )
+
+    expect(
+      within(modal).getByTestId("workspace-default-assistant-read-write-confirm")
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Save default" })).toBeDisabled()
+
+    fireEvent.click(
+      within(modal).getByTestId("workspace-default-assistant-read-write-confirm")
+    )
+    expect(screen.getByRole("button", { name: "Save default" })).toBeEnabled()
+
+    fireEvent.click(screen.getByRole("button", { name: "Save default" }))
+
+    await waitFor(() => {
+      expect(mockPatchWorkspace).toHaveBeenCalledWith(
+        "workspace-alpha",
+        expect.objectContaining({
+          version: 7,
+          assistantDefaults: expect.objectContaining({
+            assistantKind: "persona",
+            assistantId: "persona-methods",
+            personaMemoryMode: "read_write"
+          }),
+          confirmReadWriteAssistantDefault: true
+        })
+      )
+    })
+  })
+
+  it("clears the Workspace default assistant", async () => {
+    mockGetWorkspace.mockResolvedValueOnce(
+      createWorkspaceApiResponse({
+        version: 11,
+        assistantDefaults: {
+          assistantKind: "persona",
+          assistantId: "persona-lit-reviewer",
+          personaMemoryMode: "read_only",
+          voice: null,
+          style: null,
+          toolPolicyProfileId: null
+        },
+        effectiveAssistantDefault: {
+          status: "available",
+          source: "workspace",
+          assistantKind: "persona",
+          assistantId: "persona-lit-reviewer",
+          label: "Literature Reviewer",
+          personaMemoryMode: "read_only",
+          degradedReason: null
+        }
+      })
+    )
+
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
+    fireEvent.click(await screen.findByText("Default assistant"))
+
+    await screen.findByTestId("workspace-default-assistant-modal")
+    fireEvent.click(screen.getByRole("button", { name: "Clear default" }))
+
+    await waitFor(() => {
+      expect(mockPatchWorkspace).toHaveBeenCalledWith("workspace-alpha", {
+        version: 11,
+        assistantDefaults: null
+      })
+    })
+  })
+
+  it("redacts unavailable default assistant labels", async () => {
+    mockListPersonaProfiles.mockResolvedValueOnce([
+      {
+        id: "persona-hidden",
+        name: "Hidden Persona",
+        character_card_id: null,
+        origin_character_id: null,
+        buddy_summary: null,
+        metadata: null
+      }
+    ])
+    mockGetWorkspace.mockResolvedValueOnce(
+      createWorkspaceApiResponse({
+        assistantDefaults: {
+          assistantKind: "persona",
+          assistantId: "persona-hidden",
+          personaMemoryMode: "read_only",
+          voice: null,
+          style: null,
+          toolPolicyProfileId: null
+        },
+        effectiveAssistantDefault: {
+          status: "unavailable",
+          source: "workspace",
+          assistantKind: "persona",
+          assistantId: "persona-hidden",
+          label: null,
+          personaMemoryMode: "read_only",
+          degradedReason: "permission_denied"
+        }
+      })
+    )
+
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspace settings" }))
+    fireEvent.click(await screen.findByText("Default assistant"))
+
+    const modal = await screen.findByTestId("workspace-default-assistant-modal")
+    expect(within(modal).getByText("Default unavailable")).toBeInTheDocument()
+    expect(within(modal).getByText("Permission denied")).toBeInTheDocument()
+    expect(within(modal).queryByText("Hidden Persona")).not.toBeInTheDocument()
+
+    fireEvent.change(
+      within(modal).getByTestId("workspace-default-assistant-select"),
+      { target: { value: "" } }
+    )
+    expect(within(modal).queryByText("Hidden Persona")).not.toBeInTheDocument()
   })
 
   it("raises split workspace intent from the settings menu", async () => {

--- a/apps/packages/ui/src/hooks/__tests__/useMessageOption.assistant-overlay.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/useMessageOption.assistant-overlay.test.tsx
@@ -350,6 +350,7 @@ describe("useMessageOption assistant overlay changes", () => {
     chatBaseState.setHistory.mockReset()
     chatBaseState.setHistoryId.mockReset()
     storeState.setServerChatId.mockReset()
+    lastUseChatActionsArgs.value = null
   })
 
   it("does not clear the loaded conversation when the overlay selection changes", () => {
@@ -376,5 +377,75 @@ describe("useMessageOption assistant overlay changes", () => {
     expect(chatBaseState.setMessages).not.toHaveBeenCalledWith([])
     expect(chatBaseState.setHistory).not.toHaveBeenCalledWith([])
     expect(chatBaseState.setHistoryId).not.toHaveBeenCalledWith(null)
+  })
+
+  it("preserves workspace assistant provenance after server chat metadata arrives", () => {
+    selectedAssistantState.current = null
+    chatSettingsState.current = null
+    storeState.serverChatId = null
+    storeState.serverChatAssistantKind = null
+    storeState.serverChatAssistantId = null
+    storeState.serverChatPersonaMemoryMode = null
+    chatBaseState.messages = []
+    chatBaseState.history = []
+    chatBaseState.historyId = null
+    const inheritedAssistant = {
+      kind: "persona" as const,
+      id: "workspace-helper",
+      name: "Workspace Helper",
+      metadata: {
+        selectionMode: "tracked",
+        source: "workspace",
+        personaMemoryMode: "read_write"
+      }
+    }
+
+    const { result, rerender } = renderHook(() =>
+      useMessageOption({
+        inheritedAssistant,
+        inheritedPersonaMemoryMode: "read_write"
+      })
+    )
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        selectedAssistant: expect.objectContaining({
+          id: "workspace-helper",
+          name: "Workspace Helper"
+        }),
+        selectedAssistantSource: "workspace"
+      })
+    )
+
+    storeState.serverChatId = "workspace-chat-1"
+    storeState.serverChatAssistantKind = "persona"
+    storeState.serverChatAssistantId = "workspace-helper"
+    storeState.serverChatPersonaMemoryMode = "read_write"
+    chatBaseState.messages = [
+      {
+        id: "msg-1",
+        role: "user",
+        message: "Use workspace persona",
+        isBot: false,
+        sources: []
+      }
+    ]
+    chatBaseState.history = [
+      {
+        role: "user",
+        content: "Use workspace persona"
+      }
+    ]
+    rerender()
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        selectedAssistant: expect.objectContaining({
+          id: "workspace-helper",
+          name: "Workspace Helper"
+        }),
+        selectedAssistantSource: "workspace"
+      })
+    )
   })
 })

--- a/apps/packages/ui/src/hooks/chat/__tests__/personaServerChat.test.ts
+++ b/apps/packages/ui/src/hooks/chat/__tests__/personaServerChat.test.ts
@@ -439,7 +439,7 @@ describe("ensurePersonaServerChat", () => {
     expect(result).toEqual({
       chatId: "restored-chat",
       historyId: "history-restored",
-      personaMemoryMode: "read_only"
+      personaMemoryMode: "read_write"
     })
   })
 })

--- a/apps/packages/ui/src/hooks/chat/__tests__/personaServerChat.test.ts
+++ b/apps/packages/ui/src/hooks/chat/__tests__/personaServerChat.test.ts
@@ -131,6 +131,56 @@ describe("ensurePersonaServerChat", () => {
     )
   })
 
+  it("uses the requested persona memory mode when creating a new persona-backed chat", async () => {
+    const setters = createSetterBundle()
+    const createChat = vi.fn().mockResolvedValue({
+      id: "persona-chat-memory",
+      title: "Memory persona chat",
+      assistant_kind: "persona",
+      assistant_id: "garden-helper",
+      persona_memory_mode: "read_write"
+    })
+
+    const result = await ensurePersonaServerChat({
+      assistant: {
+        kind: "persona",
+        id: "garden-helper",
+        name: "Garden Helper"
+      },
+      requestedPersonaMemoryMode: "read_write",
+      serverChatId: null,
+      serverChatTitle: null,
+      serverChatAssistantKind: null,
+      serverChatAssistantId: null,
+      serverChatPersonaMemoryMode: null,
+      serverChatMetaLoaded: false,
+      serverChatState: "in-progress",
+      serverChatTopic: null,
+      serverChatClusterId: null,
+      serverChatSource: null,
+      serverChatExternalRef: null,
+      historyId: null,
+      temporaryChat: false,
+      createChat,
+      ensureServerChatHistoryId: vi.fn().mockResolvedValue("history-memory"),
+      invalidateServerChatHistory: vi.fn(),
+      ...setters
+    })
+
+    expect(createChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assistant_kind: "persona",
+        assistant_id: "garden-helper",
+        persona_memory_mode: "read_write"
+      }),
+      undefined
+    )
+    expect(setters.setServerChatPersonaMemoryMode).toHaveBeenCalledWith(
+      "read_write"
+    )
+    expect(result.personaMemoryMode).toBe("read_write")
+  })
+
   it("starts a brand new persona chat with fresh metadata even when stale state remains in the store", async () => {
     const setters = createSetterBundle()
     const createChat = vi.fn().mockResolvedValue({

--- a/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx
@@ -343,19 +343,20 @@ describe("useChatActions persona integration", () => {
   })
 
   it("routes an inherited workspace persona default when no explicit assistant is selected", async () => {
+    const inheritedWorkspaceAssistant = {
+      kind: "persona" as const,
+      id: "workspace-helper",
+      name: "Workspace Helper",
+      metadata: {
+        selectionMode: "tracked",
+        source: "workspace",
+        personaMemoryMode: "read_write"
+      }
+    }
     const options = {
       ...createHookOptions(),
-      selectedAssistant: null,
-      inheritedAssistant: {
-        kind: "persona" as const,
-        id: "workspace-helper",
-        name: "Workspace Helper",
-        metadata: {
-          selectionMode: "tracked",
-          source: "workspace",
-          personaMemoryMode: "read_write"
-        }
-      },
+      selectedAssistant: inheritedWorkspaceAssistant,
+      inheritedAssistant: inheritedWorkspaceAssistant,
       inheritedPersonaMemoryMode: "read_write" as const
     }
     createChatMock.mockResolvedValueOnce({

--- a/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx
@@ -342,6 +342,78 @@ describe("useChatActions persona integration", () => {
     )
   })
 
+  it("routes an inherited workspace persona default when no explicit assistant is selected", async () => {
+    const options = {
+      ...createHookOptions(),
+      selectedAssistant: null,
+      inheritedAssistant: {
+        kind: "persona" as const,
+        id: "workspace-helper",
+        name: "Workspace Helper",
+        metadata: {
+          selectionMode: "tracked",
+          source: "workspace",
+          personaMemoryMode: "read_write"
+        }
+      },
+      inheritedPersonaMemoryMode: "read_write" as const
+    }
+    createChatMock.mockResolvedValueOnce({
+      id: "workspace-persona-chat",
+      title: "Workspace persona chat",
+      assistant_kind: "persona",
+      assistant_id: "workspace-helper",
+      persona_memory_mode: "read_write"
+    })
+    const { result } = renderHook(() => useChatActions(options as any))
+
+    await act(async () => {
+      await result.current.onSubmit({
+        message: "Use workspace persona",
+        image: ""
+      })
+    })
+
+    expect(createChatMock).toHaveBeenCalledWith({
+      assistant_kind: "persona",
+      assistant_id: "workspace-helper",
+      persona_memory_mode: "read_write",
+      state: "in-progress",
+      topic_label: undefined,
+      cluster_id: undefined,
+      source: undefined,
+      external_ref: undefined
+    })
+    expect(options.setServerChatAssistantKind).toHaveBeenCalledWith("persona")
+    expect(options.setServerChatAssistantId).toHaveBeenCalledWith(
+      "workspace-helper"
+    )
+    expect(savePlaygroundSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverChatId: "workspace-persona-chat",
+        trackedAssistantKind: "persona",
+        trackedAssistantId: "workspace-helper",
+        trackedAssistantDisplayName: "Workspace Helper",
+        serverChatPersonaMemoryMode: "read_write"
+      })
+    )
+    expect(normalChatModeMock).toHaveBeenCalledWith(
+      "Use workspace persona",
+      "",
+      false,
+      [],
+      [],
+      expect.any(AbortSignal),
+      expect.objectContaining({
+        assistantIdentity: {
+          name: "Workspace Helper",
+          avatarUrl: undefined
+        },
+        serverChatId: "workspace-persona-chat"
+      })
+    )
+  })
+
   it("does not forward stale character state into the first persona send", async () => {
     const options = {
       ...createHookOptions(),

--- a/apps/packages/ui/src/hooks/chat/personaServerChat.ts
+++ b/apps/packages/ui/src/hooks/chat/personaServerChat.ts
@@ -5,10 +5,15 @@ import { normalizeConversationState } from "@/utils/conversation-state"
 export const DEFAULT_PERSONA_MEMORY_MODE = "read_only" as const
 
 type PersonaAssistant = AssistantSelection & { kind: "persona" }
+type PersonaMemoryMode = "read_only" | "read_write"
+
+const normalizePersonaMemoryMode = (value: unknown): PersonaMemoryMode | null =>
+  value === "read_only" || value === "read_write" ? value : null
 
 type EnsurePersonaServerChatArgs = {
   assistant: PersonaAssistant
   serverChatIdOverride?: string | null
+  requestedPersonaMemoryMode?: PersonaMemoryMode | null
   serverChatId: string | null
   serverChatTitle: string | null
   serverChatAssistantKind: "character" | "persona" | null
@@ -97,6 +102,7 @@ export const resetAssistantServerChatState = ({
 export const ensurePersonaServerChat = async ({
   assistant,
   serverChatIdOverride,
+  requestedPersonaMemoryMode,
   serverChatId,
   serverChatTitle,
   serverChatAssistantKind,
@@ -139,6 +145,9 @@ export const ensurePersonaServerChat = async ({
       : null
   const resolvedServerChatId = overrideChatId || serverChatId
   const assistantId = String(assistant.id)
+  const newChatPersonaMemoryMode =
+    normalizePersonaMemoryMode(requestedPersonaMemoryMode) ??
+    DEFAULT_PERSONA_MEMORY_MODE
   const isMatchingPersonaChat =
     Boolean(resolvedServerChatId) &&
     serverChatMetaLoaded &&
@@ -146,8 +155,8 @@ export const ensurePersonaServerChat = async ({
     Boolean(serverChatAssistantId) &&
     String(serverChatAssistantId) === assistantId
   const personaMemoryMode = isMatchingPersonaChat
-    ? serverChatPersonaMemoryMode ?? DEFAULT_PERSONA_MEMORY_MODE
-    : DEFAULT_PERSONA_MEMORY_MODE
+    ? serverChatPersonaMemoryMode ?? newChatPersonaMemoryMode
+    : newChatPersonaMemoryMode
   const shouldResetServerChat =
     Boolean(resolvedServerChatId) &&
     serverChatMetaLoaded &&

--- a/apps/packages/ui/src/hooks/chat/personaServerChat.ts
+++ b/apps/packages/ui/src/hooks/chat/personaServerChat.ts
@@ -148,15 +148,19 @@ export const ensurePersonaServerChat = async ({
   const newChatPersonaMemoryMode =
     normalizePersonaMemoryMode(requestedPersonaMemoryMode) ??
     DEFAULT_PERSONA_MEMORY_MODE
+  const isReusingUnhydratedChat =
+    Boolean(resolvedServerChatId) && !serverChatMetaLoaded
   const isMatchingPersonaChat =
     Boolean(resolvedServerChatId) &&
     serverChatMetaLoaded &&
     serverChatAssistantKind === "persona" &&
     Boolean(serverChatAssistantId) &&
     String(serverChatAssistantId) === assistantId
-  const personaMemoryMode = isMatchingPersonaChat
-    ? serverChatPersonaMemoryMode ?? newChatPersonaMemoryMode
-    : newChatPersonaMemoryMode
+  const personaMemoryMode =
+    isMatchingPersonaChat || isReusingUnhydratedChat
+      ? normalizePersonaMemoryMode(serverChatPersonaMemoryMode) ??
+        newChatPersonaMemoryMode
+      : newChatPersonaMemoryMode
   const shouldResetServerChat =
     Boolean(resolvedServerChatId) &&
     serverChatMetaLoaded &&

--- a/apps/packages/ui/src/hooks/chat/useChatActions.ts
+++ b/apps/packages/ui/src/hooks/chat/useChatActions.ts
@@ -168,9 +168,14 @@ type ChatModeOverrides = {
   selectedKnowledge?: Knowledge | null
 } & Record<string, unknown>
 
+type PersonaMemoryMode = "read_only" | "read_write"
+
 const loadActorSettings = () => import("@/services/actor-settings")
 const STREAMING_UPDATE_INTERVAL_MS = 80
 const toChatSubmitResult = normalizeChatSubmitResult
+
+const normalizePersonaMemoryMode = (value: unknown): PersonaMemoryMode | null =>
+  value === "read_only" || value === "read_write" ? value : null
 
 const persistTrackedPersonaPlaygroundSession = async ({
   chatId,
@@ -383,6 +388,8 @@ type UseChatActionsOptions = {
   invalidateServerChatHistory: () => void
   selectedCharacter: Character | null
   selectedAssistant: AssistantSelection | null
+  inheritedAssistant?: AssistantSelection | null
+  inheritedPersonaMemoryMode?: PersonaMemoryMode | null
   messageSteeringMode: MessageSteeringMode
   messageSteeringForceNarrate: boolean
   clearMessageSteering: () => void
@@ -431,6 +438,7 @@ export const useChatActions = ({
   serverChatClusterId,
   serverChatSource,
   serverChatExternalRef,
+  scope,
   setServerChatId,
   setServerChatTitle,
   setServerChatCharacterId,
@@ -463,6 +471,8 @@ export const useChatActions = ({
   invalidateServerChatHistory,
   selectedCharacter,
   selectedAssistant,
+  inheritedAssistant,
+  inheritedPersonaMemoryMode,
   messageSteeringMode,
   messageSteeringForceNarrate,
   clearMessageSteering
@@ -529,9 +539,41 @@ export const useChatActions = ({
       serverChatCharacterId
     ]
   )
+  const inheritedTrackedAssistant = React.useMemo<AssistantSelection | null>(() => {
+    if (
+      effectiveAssistantState.mode !== "plain" ||
+      selectedAssistant ||
+      serverChatId ||
+      serverChatAssistantKind ||
+      serverChatAssistantId ||
+      serverChatCharacterId ||
+      messages.length > 0 ||
+      history.length > 0
+    ) {
+      return null
+    }
+    if (
+      !isPersonaAssistantSelection(inheritedAssistant) ||
+      getAssistantSelectionMode(inheritedAssistant) !== "tracked"
+    ) {
+      return null
+    }
+
+    return inheritedAssistant
+  }, [
+    effectiveAssistantState.mode,
+    history.length,
+    inheritedAssistant,
+    messages.length,
+    selectedAssistant,
+    serverChatAssistantId,
+    serverChatAssistantKind,
+    serverChatCharacterId,
+    serverChatId
+  ])
   const effectiveSelectedAssistant = React.useMemo<AssistantSelection | null>(() => {
     if (effectiveAssistantState.mode === "plain") {
-      return selectedAssistant
+      return inheritedTrackedAssistant ?? selectedAssistant
     }
 
     const matchesDraftSelection =
@@ -554,7 +596,28 @@ export const useChatActions = ({
         draftMetadata?.system_prompt ??
         null
     }
-  }, [effectiveAssistantState, selectedAssistant])
+  }, [effectiveAssistantState, inheritedTrackedAssistant, selectedAssistant])
+  const routingSelectedAssistant = inheritedTrackedAssistant ?? selectedAssistant
+  const selectedPersonaMemoryMode = React.useMemo(() => {
+    if (!isPersonaAssistantSelection(routingSelectedAssistant)) return null
+
+    const inheritedMatchesSelectedPersona =
+      isPersonaAssistantSelection(inheritedAssistant) &&
+      String(inheritedAssistant.id) === String(routingSelectedAssistant.id)
+
+    return (
+      (inheritedMatchesSelectedPersona
+        ? normalizePersonaMemoryMode(inheritedPersonaMemoryMode)
+        : null) ??
+      normalizePersonaMemoryMode(
+        routingSelectedAssistant.metadata?.personaMemoryMode
+      )
+    )
+  }, [
+    inheritedAssistant,
+    inheritedPersonaMemoryMode,
+    routingSelectedAssistant
+  ])
   const greetingEnabled = chatSettings?.greetingEnabled ?? true
   const greetingSelectionId =
     typeof chatSettings?.greetingSelectionId === "string"
@@ -1132,10 +1195,12 @@ export const useChatActions = ({
   const ensurePersonaServerChatWithState = React.useCallback(
     async ({
       assistant,
-      serverChatIdOverride
+      serverChatIdOverride,
+      requestedPersonaMemoryMode
     }: {
       assistant: AssistantSelection & { kind: "persona" }
       serverChatIdOverride?: string | null
+      requestedPersonaMemoryMode?: PersonaMemoryMode | null
     }): Promise<{
       chatId: string
       historyId: string | null
@@ -1144,6 +1209,7 @@ export const useChatActions = ({
       ensurePersonaServerChat({
         assistant,
         serverChatIdOverride,
+        requestedPersonaMemoryMode,
         serverChatId,
         serverChatTitle,
         serverChatAssistantKind,
@@ -1157,7 +1223,11 @@ export const useChatActions = ({
         serverChatExternalRef,
         historyId,
         temporaryChat,
-        createChat: (payload) => tldwClient.createChat(payload),
+        scope,
+        createChat: (payload, options) =>
+          options
+            ? tldwClient.createChat(payload, options)
+            : tldwClient.createChat(payload),
         ensureServerChatHistoryId,
         invalidateServerChatHistory,
         setServerChatId,
@@ -1189,6 +1259,7 @@ export const useChatActions = ({
       serverChatState,
       serverChatTitle,
       serverChatTopic,
+      scope,
       setServerChatAssistantId,
       setServerChatAssistantKind,
       setServerChatCharacterId,
@@ -2773,24 +2844,24 @@ export const useChatActions = ({
           hasEffectiveAssistant: Boolean(
             effectiveSelectedAssistant?.kind && effectiveSelectedAssistant?.id
           ),
-          draftAssistantKind: selectedAssistant?.kind ?? null,
+          draftAssistantKind: routingSelectedAssistant?.kind ?? null,
           draftAssistantSelectionMode: getAssistantSelectionMode(
-            selectedAssistant
+            routingSelectedAssistant
           )
         })
         const resolvedSendMode =
-          getAssistantSelectionMode(selectedAssistant) === "tracked" &&
-          selectedAssistant?.kind === "persona"
+          getAssistantSelectionMode(routingSelectedAssistant) === "tracked" &&
+          routingSelectedAssistant?.kind === "persona"
             ? "tracked_persona"
-            : getAssistantSelectionMode(selectedAssistant) === "tracked" &&
-                selectedAssistant?.kind === "character"
+            : getAssistantSelectionMode(routingSelectedAssistant) === "tracked" &&
+                routingSelectedAssistant?.kind === "character"
               ? "tracked_character"
               : sendMode
         const trackedPersonaAssistantForSend =
           resolvedSendMode === "tracked_persona"
-            ? isPersonaAssistantSelection(selectedAssistant) &&
-              getAssistantSelectionMode(selectedAssistant) === "tracked"
-              ? selectedAssistant
+            ? isPersonaAssistantSelection(routingSelectedAssistant) &&
+              getAssistantSelectionMode(routingSelectedAssistant) === "tracked"
+              ? routingSelectedAssistant
               : isPersonaAssistantSelection(effectiveSelectedAssistant)
                 ? effectiveSelectedAssistant
                 : null
@@ -2812,7 +2883,8 @@ export const useChatActions = ({
 
             const personaServerChat = await ensurePersonaServerChatWithState({
               assistant: trackedPersonaAssistantForSend,
-              serverChatIdOverride
+              serverChatIdOverride,
+              requestedPersonaMemoryMode: selectedPersonaMemoryMode
             })
             await persistTrackedPersonaPlaygroundSession({
               chatId: personaServerChat.chatId,
@@ -2856,10 +2928,10 @@ export const useChatActions = ({
               : null
           const draftTrackedCharacter =
             resolvedSendMode === "tracked_character" &&
-            selectedAssistant?.kind === "character" &&
-            getAssistantSelectionMode(selectedAssistant) === "tracked"
+            routingSelectedAssistant?.kind === "character" &&
+            getAssistantSelectionMode(routingSelectedAssistant) === "tracked"
               ? assistantSelectionToCharacter<Character & Record<string, unknown>>(
-                  selectedAssistant
+                  routingSelectedAssistant
                 )
               : null
           const resolvedSelectedCharacter =

--- a/apps/packages/ui/src/hooks/useMessageOption.tsx
+++ b/apps/packages/ui/src/hooks/useMessageOption.tsx
@@ -252,6 +252,26 @@ export const useMessageOption = (
     historyId,
     serverChatId,
   });
+  const inheritedAssistantRef = React.useRef<AssistantSelection | null>(null);
+  const canCaptureInheritedAssistant =
+    !selectedAssistant &&
+    opts.inheritedAssistant?.kind === "persona" &&
+    opts.inheritedAssistant.id != null &&
+    !serverChatId &&
+    !serverChatAssistantKind &&
+    !serverChatAssistantId &&
+    !serverChatCharacterId &&
+    messages.length === 0 &&
+    history.length === 0;
+
+  if (selectedAssistant) {
+    inheritedAssistantRef.current = null;
+  } else if (canCaptureInheritedAssistant) {
+    inheritedAssistantRef.current = opts.inheritedAssistant;
+  }
+
+  const assistantDraftSelection =
+    selectedAssistant ?? inheritedAssistantRef.current;
   const effectiveAssistantState = React.useMemo(
     () =>
       resolveEffectiveAssistantState({
@@ -261,11 +281,11 @@ export const useMessageOption = (
           characterId: serverChatCharacterId,
         },
         settings: chatSettings ?? null,
-        draftSelection: selectedAssistant,
+        draftSelection: assistantDraftSelection,
       }),
     [
+      assistantDraftSelection,
       chatSettings,
-      selectedAssistant,
       serverChatAssistantId,
       serverChatAssistantKind,
       serverChatCharacterId,
@@ -282,38 +302,12 @@ export const useMessageOption = (
       opts.inheritedPersonaMemoryMode,
     ],
   );
-  const inheritedAssistant = React.useMemo<AssistantSelection | null>(() => {
-    if (
-      effectiveAssistantState.mode !== "plain" ||
-      selectedAssistant ||
-      serverChatId ||
-      serverChatAssistantKind ||
-      serverChatAssistantId ||
-      serverChatCharacterId ||
-      messages.length > 0 ||
-      history.length > 0
-    ) {
-      return null;
-    }
-    if (
-      opts.inheritedAssistant?.kind !== "persona" ||
-      opts.inheritedAssistant.id == null
-    ) {
-      return null;
-    }
-
-    return opts.inheritedAssistant;
-  }, [
-    effectiveAssistantState.mode,
-    history.length,
-    messages.length,
-    opts.inheritedAssistant,
-    selectedAssistant,
-    serverChatAssistantId,
-    serverChatAssistantKind,
-    serverChatCharacterId,
-    serverChatId,
-  ]);
+  const inheritedAssistant =
+    !selectedAssistant &&
+    inheritedAssistantRef.current?.kind === "persona" &&
+    inheritedAssistantRef.current.id != null
+      ? inheritedAssistantRef.current
+      : null;
   const effectiveSelectedAssistant = React.useMemo<AssistantSelection | null>(() => {
     if (effectiveAssistantState.mode === "plain") {
       return inheritedAssistant ?? selectedAssistant;
@@ -339,11 +333,14 @@ export const useMessageOption = (
         null,
     };
   }, [effectiveAssistantState, inheritedAssistant, selectedAssistant]);
-  const selectedAssistantSource = inheritedAssistant
-    ? "workspace"
-    : effectiveSelectedAssistant
-      ? "explicit"
-      : "none";
+  const selectedAssistantSource =
+    inheritedAssistant &&
+    effectiveSelectedAssistant?.kind === inheritedAssistant.kind &&
+    effectiveSelectedAssistant.id === inheritedAssistant.id
+      ? "workspace"
+      : effectiveSelectedAssistant
+        ? "explicit"
+        : "none";
 
   React.useEffect(() => {
     if (!serverChatId || temporaryChat) return;

--- a/apps/packages/ui/src/hooks/useMessageOption.tsx
+++ b/apps/packages/ui/src/hooks/useMessageOption.tsx
@@ -51,6 +51,24 @@ const normalizePersonaMemoryMode = (
   return value === "read_only" || value === "read_write" ? value : null;
 };
 
+const assistantSelectionsMatch = (
+  left: AssistantSelection | null,
+  right: AssistantSelection | null,
+): boolean => {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return (
+    left.kind === right.kind &&
+    left.id === right.id &&
+    left.name === right.name &&
+    (left.avatar_url ?? null) === (right.avatar_url ?? null) &&
+    (left.system_prompt ?? null) === (right.system_prompt ?? null) &&
+    left.metadata?.selectionMode === right.metadata?.selectionMode &&
+    left.metadata?.source === right.metadata?.source &&
+    left.metadata?.personaMemoryMode === right.metadata?.personaMemoryMode
+  );
+};
+
 export const useMessageOption = (
   opts: UseMessageOptionOptions = {},
 ) => {
@@ -252,7 +270,10 @@ export const useMessageOption = (
     historyId,
     serverChatId,
   });
-  const inheritedAssistantRef = React.useRef<AssistantSelection | null>(null);
+  const [
+    inheritedAssistantSnapshot,
+    setInheritedAssistantSnapshot,
+  ] = React.useState<AssistantSelection | null>(null);
   const canCaptureInheritedAssistant =
     !selectedAssistant &&
     opts.inheritedAssistant?.kind === "persona" &&
@@ -264,14 +285,26 @@ export const useMessageOption = (
     messages.length === 0 &&
     history.length === 0;
 
-  if (selectedAssistant) {
-    inheritedAssistantRef.current = null;
-  } else if (canCaptureInheritedAssistant) {
-    inheritedAssistantRef.current = opts.inheritedAssistant;
-  }
+  const inheritedAssistantCandidate =
+    canCaptureInheritedAssistant && opts.inheritedAssistant?.kind === "persona"
+      ? opts.inheritedAssistant
+      : null;
+
+  React.useEffect(() => {
+    if (selectedAssistant) {
+      setInheritedAssistantSnapshot((current) => (current === null ? current : null));
+      return;
+    }
+    if (!inheritedAssistantCandidate) return;
+    setInheritedAssistantSnapshot((current) =>
+      assistantSelectionsMatch(current, inheritedAssistantCandidate)
+        ? current
+        : inheritedAssistantCandidate,
+    );
+  }, [inheritedAssistantCandidate, selectedAssistant]);
 
   const assistantDraftSelection =
-    selectedAssistant ?? inheritedAssistantRef.current;
+    selectedAssistant ?? inheritedAssistantSnapshot ?? inheritedAssistantCandidate;
   const effectiveAssistantState = React.useMemo(
     () =>
       resolveEffectiveAssistantState({
@@ -304,9 +337,9 @@ export const useMessageOption = (
   );
   const inheritedAssistant =
     !selectedAssistant &&
-    inheritedAssistantRef.current?.kind === "persona" &&
-    inheritedAssistantRef.current.id != null
-      ? inheritedAssistantRef.current
+    (inheritedAssistantSnapshot ?? inheritedAssistantCandidate)?.kind === "persona" &&
+    (inheritedAssistantSnapshot ?? inheritedAssistantCandidate)?.id != null
+      ? inheritedAssistantSnapshot ?? inheritedAssistantCandidate
       : null;
   const effectiveSelectedAssistant = React.useMemo<AssistantSelection | null>(() => {
     if (effectiveAssistantState.mode === "plain") {

--- a/apps/packages/ui/src/hooks/useMessageOption.tsx
+++ b/apps/packages/ui/src/hooks/useMessageOption.tsx
@@ -36,8 +36,23 @@ import { useChatLoopState } from "@/services/chat-loop/hooks";
 import { subscribeChatLoopEvents } from "@/services/chat-loop/bridge";
 import type { ChatScope } from "@/types/chat-scope";
 
+type PersonaMemoryMode = "read_only" | "read_write";
+
+type UseMessageOptionOptions = {
+  forceCompareEnabled?: boolean;
+  scope?: ChatScope;
+  inheritedAssistant?: AssistantSelection | null;
+  inheritedPersonaMemoryMode?: PersonaMemoryMode | null;
+};
+
+const normalizePersonaMemoryMode = (
+  value: unknown,
+): PersonaMemoryMode | null => {
+  return value === "read_only" || value === "read_write" ? value : null;
+};
+
 export const useMessageOption = (
-  opts: { forceCompareEnabled?: boolean; scope?: ChatScope } = {},
+  opts: UseMessageOptionOptions = {},
 ) => {
   // Controllers come from Context (for aborting streaming requests)
   const { controller: abortController, setController: setAbortController } =
@@ -256,9 +271,52 @@ export const useMessageOption = (
       serverChatCharacterId,
     ],
   );
+  const inheritedPersonaMemoryMode = React.useMemo(
+    () =>
+      normalizePersonaMemoryMode(opts.inheritedPersonaMemoryMode) ??
+      normalizePersonaMemoryMode(
+        opts.inheritedAssistant?.metadata?.personaMemoryMode,
+      ),
+    [
+      opts.inheritedAssistant?.metadata?.personaMemoryMode,
+      opts.inheritedPersonaMemoryMode,
+    ],
+  );
+  const inheritedAssistant = React.useMemo<AssistantSelection | null>(() => {
+    if (
+      effectiveAssistantState.mode !== "plain" ||
+      selectedAssistant ||
+      serverChatId ||
+      serverChatAssistantKind ||
+      serverChatAssistantId ||
+      serverChatCharacterId ||
+      messages.length > 0 ||
+      history.length > 0
+    ) {
+      return null;
+    }
+    if (
+      opts.inheritedAssistant?.kind !== "persona" ||
+      opts.inheritedAssistant.id == null
+    ) {
+      return null;
+    }
+
+    return opts.inheritedAssistant;
+  }, [
+    effectiveAssistantState.mode,
+    history.length,
+    messages.length,
+    opts.inheritedAssistant,
+    selectedAssistant,
+    serverChatAssistantId,
+    serverChatAssistantKind,
+    serverChatCharacterId,
+    serverChatId,
+  ]);
   const effectiveSelectedAssistant = React.useMemo<AssistantSelection | null>(() => {
     if (effectiveAssistantState.mode === "plain") {
-      return selectedAssistant;
+      return inheritedAssistant ?? selectedAssistant;
     }
 
     const matchesDraftSelection =
@@ -280,7 +338,12 @@ export const useMessageOption = (
         draftMetadata?.system_prompt ??
         null,
     };
-  }, [effectiveAssistantState, selectedAssistant]);
+  }, [effectiveAssistantState, inheritedAssistant, selectedAssistant]);
+  const selectedAssistantSource = inheritedAssistant
+    ? "workspace"
+    : effectiveSelectedAssistant
+      ? "explicit"
+      : "none";
 
   React.useEffect(() => {
     if (!serverChatId || temporaryChat) return;
@@ -415,6 +478,8 @@ export const useMessageOption = (
     invalidateServerChatHistory,
     selectedCharacter,
     selectedAssistant: effectiveSelectedAssistant,
+    inheritedAssistant,
+    inheritedPersonaMemoryMode,
     scope: opts.scope,
   });
   const onSubmit = React.useCallback(
@@ -566,6 +631,7 @@ export const useMessageOption = (
     selectedCharacter,
     setSelectedCharacter,
     selectedAssistant: effectiveSelectedAssistant,
+    selectedAssistantSource,
     setSelectedAssistant,
     replyTarget,
     clearReplyTarget,

--- a/apps/packages/ui/src/services/__tests__/tldw-api-client.connection-sync.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-api-client.connection-sync.test.ts
@@ -115,6 +115,75 @@ describe("TldwApiClient connection storage sync", () => {
     })
   })
 
+  it("uses the in-memory WebUI config for chat creation", async () => {
+    const client = new TldwApiClient()
+    await client.updateConfig({
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: "test-api-key"
+    })
+    mocks.tldwRequest.mockResolvedValue({
+      ok: true,
+      status: 201,
+      data: { id: "thread-1", title: "Knowledge thread" }
+    })
+
+    await expect(
+      client.createChat({ title: "Knowledge thread", source: "knowledge_qa" })
+    ).resolves.toMatchObject({ id: "thread-1", title: "Knowledge thread" })
+
+    expect(mocks.bgRequest).not.toHaveBeenCalled()
+    expect(mocks.tldwRequest).toHaveBeenCalledTimes(1)
+    const [request, runtime] = mocks.tldwRequest.mock.calls[0]
+    expect(request).toMatchObject({
+      path: "/api/v1/chats/",
+      method: "POST",
+      body: { title: "Knowledge thread", source: "knowledge_qa" }
+    })
+    await expect(runtime.getConfig()).resolves.toMatchObject({
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: "test-api-key"
+    })
+  })
+
+  it("uses the in-memory WebUI config for RAG search", async () => {
+    const client = new TldwApiClient()
+    await client.updateConfig({
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: "test-api-key"
+    })
+    mocks.tldwRequest.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: {
+        results: [],
+        generated_answer: "No relevant sources found."
+      }
+    })
+
+    await expect(
+      client.ragSearch("What changed?", { sources: ["media_db"] })
+    ).resolves.toMatchObject({
+      generated_answer: "No relevant sources found."
+    })
+
+    expect(mocks.bgRequest).not.toHaveBeenCalled()
+    expect(mocks.tldwRequest).toHaveBeenCalledTimes(1)
+    const [request, runtime] = mocks.tldwRequest.mock.calls[0]
+    expect(request).toMatchObject({
+      path: "/api/v1/rag/search",
+      method: "POST",
+      body: { query: "What changed?", sources: ["media_db"] }
+    })
+    await expect(runtime.getConfig()).resolves.toMatchObject({
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: "test-api-key"
+    })
+  })
+
   it("uses the in-memory WebUI config for OpenAPI discovery", async () => {
     const client = new TldwApiClient()
     await client.updateConfig({

--- a/apps/packages/ui/src/services/__tests__/tldw-api-client.workspace-api.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-api-client.workspace-api.test.ts
@@ -600,6 +600,24 @@ describe("workspace API domain contract", () => {
     )
   })
 
+  it("rejects malformed assistant defaults patch payloads before sending", async () => {
+    await expect(
+      workspaceApiMethods.patchWorkspace("ws-1", {
+        version: 2,
+        assistantDefaults: {
+          assistantKind: "persona",
+          assistantId: "   ",
+          personaMemoryMode: "read_only",
+          voice: null,
+          style: null,
+          toolPolicyProfileId: null
+        } as any
+      })
+    ).rejects.toThrow(/assistant_defaults/)
+
+    expect(mocks.bgRequest).not.toHaveBeenCalled()
+  })
+
   it("exposes raw workspace delete API support without manager semantics", async () => {
     mocks.bgRequest.mockResolvedValue(undefined)
 

--- a/apps/packages/ui/src/services/__tests__/tldw-api-client.workspace-api.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-api-client.workspace-api.test.ts
@@ -43,6 +43,27 @@ const workspaceResponse = {
   version: 2
 }
 
+const workspaceAssistantDefaultsResponse = {
+  ...workspaceResponse,
+  assistant_defaults: {
+    assistant_kind: "persona",
+    assistant_id: "persona-1",
+    persona_memory_mode: "read_only",
+    voice: null,
+    style: null,
+    tool_policy_profile_id: null
+  },
+  effective_assistant_default: {
+    status: "available",
+    source: "workspace",
+    assistant_kind: "persona",
+    assistant_id: "persona-1",
+    label: "Literature Review Assistant",
+    persona_memory_mode: "read_only",
+    degraded_reason: null
+  }
+}
+
 const rootsResponse = {
   workspace_id: "ws-1",
   workspace_profile: "project",
@@ -520,6 +541,60 @@ describe("workspace API domain contract", () => {
           archived: true,
           workspace_profile: "project",
           version: 1
+        }
+      })
+    )
+  })
+
+  it("maps workspace assistant defaults response fields and serializes patch payloads", async () => {
+    mocks.bgRequest.mockResolvedValue(workspaceAssistantDefaultsResponse)
+
+    const response = await workspaceApiMethods.patchWorkspace("ws-1", {
+      version: 2,
+      assistantDefaults: {
+        assistantKind: "persona",
+        assistantId: "persona-2",
+        personaMemoryMode: "read_write",
+        voice: null,
+        style: null,
+        toolPolicyProfileId: null
+      },
+      confirmReadWriteAssistantDefault: true
+    })
+
+    expect(response.assistantDefaults).toEqual({
+      assistantKind: "persona",
+      assistantId: "persona-1",
+      personaMemoryMode: "read_only",
+      voice: null,
+      style: null,
+      toolPolicyProfileId: null
+    })
+    expect(response.effectiveAssistantDefault).toEqual({
+      status: "available",
+      source: "workspace",
+      assistantKind: "persona",
+      assistantId: "persona-1",
+      label: "Literature Review Assistant",
+      personaMemoryMode: "read_only",
+      degradedReason: null
+    })
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/workspaces/ws-1",
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: {
+          version: 2,
+          assistant_defaults: {
+            assistant_kind: "persona",
+            assistant_id: "persona-2",
+            persona_memory_mode: "read_write",
+            voice: null,
+            style: null,
+            tool_policy_profile_id: null
+          },
+          confirm_read_write_assistant_default: true
         }
       })
     )

--- a/apps/packages/ui/src/services/tldw/TldwApiClient.ts
+++ b/apps/packages/ui/src/services/tldw/TldwApiClient.ts
@@ -2653,7 +2653,7 @@ export class TldwApiClientBase {
     const { timeoutMs, signal, ...rest } = options || {}
     const normalizedQuery = this.normalizeRagQuery(query)
     try {
-      return await bgRequest<any>({
+      return await this.requestWithCurrentConfig<any>({
         path: '/api/v1/rag/search',
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -2685,7 +2685,7 @@ export class TldwApiClientBase {
         '[tldw:rag] /api/v1/rag/search failed; retrying once without reranking',
         { status, message }
       )
-      return await bgRequest<any>({
+      return await this.requestWithCurrentConfig<any>({
         path: '/api/v1/rag/search',
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -4892,7 +4892,7 @@ export class TldwApiClientBase {
   }
 
   async createChat(payload: Record<string, any>, options?: { scope?: ChatScope }): Promise<ServerChatSummary> {
-    const res = await bgRequest<any>({
+    const res = await this.requestWithCurrentConfig<any>({
       path: "/api/v1/chats/",
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/apps/packages/ui/src/services/tldw/domains/chat-rag.ts
+++ b/apps/packages/ui/src/services/tldw/domains/chat-rag.ts
@@ -289,7 +289,7 @@ export const chatRagMethods = {
     const { timeoutMs, signal, ...rest } = options || {}
     const normalizedQuery = this.normalizeRagQuery(query)
     try {
-      return await bgRequest<any>({
+      return await this.requestWithCurrentConfig<any>({
         path: '/api/v1/rag/search',
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -322,7 +322,7 @@ export const chatRagMethods = {
         { status }
       )
       try {
-        return await bgRequest<any>({
+        return await this.requestWithCurrentConfig<any>({
           path: '/api/v1/rag/search',
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -510,7 +510,7 @@ export const chatRagMethods = {
   },
 
   async createChat(this: TldwApiClientCore, payload: Record<string, any>, options?: { scope?: ChatScope }): Promise<ServerChatSummary> {
-    const res = await bgRequest<any>({
+    const res = await this.requestWithCurrentConfig<any>({
       path: "/api/v1/chats/",
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
+++ b/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
@@ -877,12 +877,26 @@ export const normalizeWorkspaceAssistantDefaults = (
   }
 }
 
+const describeWorkspaceAssistantDefaultsPayload = (value: unknown): string => {
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return Object.prototype.toString.call(value)
+  }
+}
+
 export const serializeWorkspaceAssistantDefaults = (
   value: WorkspaceAssistantDefaults | WorkspaceAssistantDefaultsApiPayload | null
 ): WorkspaceAssistantDefaultsApiPayload | null => {
   if (value === null) return null
   const normalized = normalizeWorkspaceAssistantDefaults(value)
-  if (!normalized) return null
+  if (!normalized) {
+    throw new Error(
+      `Invalid assistant_defaults payload: expected persona assistant_kind and non-empty assistant_id; received ${describeWorkspaceAssistantDefaultsPayload(
+        value
+      )}.`
+    )
+  }
   return {
     assistant_kind: normalized.assistantKind,
     assistant_id: normalized.assistantId,

--- a/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
+++ b/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
@@ -11,6 +11,15 @@ import type {
   SkillsListParams,
   SkillsListResponse
 } from "@/types/skill"
+import type {
+  EffectiveWorkspaceAssistantDefault,
+  EffectiveWorkspaceAssistantDefaultSource,
+  EffectiveWorkspaceAssistantDefaultStatus,
+  WorkspaceAssistantDefaultDegradedReason,
+  WorkspaceAssistantDefaults,
+  WorkspaceAssistantKind,
+  WorkspacePersonaMemoryMode
+} from "@/types/workspace"
 
 /**
  * Minimal interface for the TldwApiClient methods referenced via `this`.
@@ -64,6 +73,25 @@ export type WorkspaceProjectRootState =
 
 export type WorkspaceResolutionStatus = "complete" | "partial" | "failed"
 
+export interface WorkspaceAssistantDefaultsApiPayload {
+  assistant_kind: WorkspaceAssistantKind
+  assistant_id: string
+  persona_memory_mode?: WorkspacePersonaMemoryMode
+  voice?: null
+  style?: null
+  tool_policy_profile_id?: null
+}
+
+export interface WorkspaceEffectiveAssistantDefaultApiPayload {
+  status: EffectiveWorkspaceAssistantDefaultStatus
+  source: EffectiveWorkspaceAssistantDefaultSource
+  assistant_kind?: WorkspaceAssistantKind | null
+  assistant_id?: string | null
+  label?: string | null
+  persona_memory_mode?: WorkspacePersonaMemoryMode | null
+  degraded_reason?: WorkspaceAssistantDefaultDegradedReason | null
+}
+
 export interface WorkspaceApiResponse {
   id: string
   name: string | null
@@ -81,6 +109,10 @@ export interface WorkspaceApiResponse {
   created_at: string
   last_modified: string
   version: number
+  assistant_defaults?: WorkspaceAssistantDefaultsApiPayload | null
+  effective_assistant_default?: WorkspaceEffectiveAssistantDefaultApiPayload | null
+  assistantDefaults?: WorkspaceAssistantDefaults | null
+  effectiveAssistantDefault?: EffectiveWorkspaceAssistantDefault
 }
 
 export interface WorkspaceListApiResponse {
@@ -460,6 +492,10 @@ export interface WorkspacePatchRequest {
   audio_model?: string | null
   audio_voice?: string | null
   audio_speed?: number | null
+  assistant_defaults?: WorkspaceAssistantDefaultsApiPayload | null
+  assistantDefaults?: WorkspaceAssistantDefaults | null
+  confirm_read_write_assistant_default?: boolean | null
+  confirmReadWriteAssistantDefault?: boolean | null
   version: number
 }
 
@@ -797,6 +833,168 @@ const resolveSkillExportFilename = (
     : fallbackFilename
 }
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value)
+
+const WORKSPACE_ASSISTANT_DEFAULT_DEGRADED_REASONS = new Set<string>([
+  "persona_deleted",
+  "persona_unavailable",
+  "persona_feature_disabled",
+  "permission_denied",
+  "invalid_default",
+  "unsupported_assistant_kind"
+])
+
+export const normalizeWorkspaceAssistantDefaults = (
+  value: unknown
+): WorkspaceAssistantDefaults | null => {
+  if (!isRecord(value)) return null
+  if (value.assistant_kind !== "persona" && value.assistantKind !== "persona") {
+    return null
+  }
+
+  const assistantId =
+    typeof value.assistant_id === "string"
+      ? value.assistant_id.trim()
+      : typeof value.assistantId === "string"
+        ? value.assistantId.trim()
+        : ""
+  if (!assistantId) return null
+
+  const memoryMode =
+    value.persona_memory_mode === "read_write" ||
+    value.personaMemoryMode === "read_write"
+      ? "read_write"
+      : "read_only"
+
+  return {
+    assistantKind: "persona",
+    assistantId,
+    personaMemoryMode: memoryMode,
+    voice: null,
+    style: null,
+    toolPolicyProfileId: null
+  }
+}
+
+export const serializeWorkspaceAssistantDefaults = (
+  value: WorkspaceAssistantDefaults | WorkspaceAssistantDefaultsApiPayload | null
+): WorkspaceAssistantDefaultsApiPayload | null => {
+  if (value === null) return null
+  const normalized = normalizeWorkspaceAssistantDefaults(value)
+  if (!normalized) return null
+  return {
+    assistant_kind: normalized.assistantKind,
+    assistant_id: normalized.assistantId,
+    persona_memory_mode: normalized.personaMemoryMode,
+    voice: null,
+    style: null,
+    tool_policy_profile_id: null
+  }
+}
+
+const normalizeEffectiveWorkspaceAssistantDefault = (
+  value: unknown
+): EffectiveWorkspaceAssistantDefault => {
+  if (!isRecord(value)) {
+    return {
+      status: "none",
+      source: "none",
+      assistantKind: null,
+      assistantId: null,
+      label: null,
+      personaMemoryMode: null,
+      degradedReason: null
+    }
+  }
+
+  const status =
+    value.status === "available" || value.status === "unavailable"
+      ? value.status
+      : "none"
+  const source = value.source === "workspace" ? "workspace" : "none"
+  const assistantKind =
+    value.assistant_kind === "persona" || value.assistantKind === "persona"
+      ? "persona"
+      : null
+  const assistantId =
+    typeof value.assistant_id === "string"
+      ? value.assistant_id
+      : typeof value.assistantId === "string"
+        ? value.assistantId
+        : null
+  const personaMemoryMode =
+    value.persona_memory_mode === "read_write" ||
+    value.personaMemoryMode === "read_write"
+      ? "read_write"
+      : value.persona_memory_mode === "read_only" ||
+          value.personaMemoryMode === "read_only"
+        ? "read_only"
+        : null
+  const degradedReason =
+    typeof value.degraded_reason === "string"
+      ? value.degraded_reason
+      : typeof value.degradedReason === "string"
+        ? value.degradedReason
+        : null
+  const normalizedDegradedReason =
+    degradedReason &&
+    WORKSPACE_ASSISTANT_DEFAULT_DEGRADED_REASONS.has(degradedReason)
+      ? degradedReason
+      : null
+
+  return {
+    status,
+    source,
+    assistantKind,
+    assistantId,
+    label: typeof value.label === "string" ? value.label : null,
+    personaMemoryMode,
+    degradedReason:
+      normalizedDegradedReason as WorkspaceAssistantDefaultDegradedReason | null
+  }
+}
+
+export const normalizeWorkspaceApiResponse = (
+  workspace: WorkspaceApiResponse
+): WorkspaceApiResponse => ({
+  ...workspace,
+  assistantDefaults: normalizeWorkspaceAssistantDefaults(
+    workspace.assistant_defaults ?? workspace.assistantDefaults ?? null
+  ),
+  effectiveAssistantDefault: normalizeEffectiveWorkspaceAssistantDefault(
+    workspace.effective_assistant_default ??
+      workspace.effectiveAssistantDefault ??
+      null
+  )
+})
+
+const serializeWorkspacePatchRequest = (
+  data: WorkspacePatchRequest
+): WorkspacePatchRequest => {
+  const body: WorkspacePatchRequest = { ...data }
+
+  if ("assistantDefaults" in body) {
+    body.assistant_defaults =
+      body.assistantDefaults === undefined
+        ? undefined
+        : serializeWorkspaceAssistantDefaults(body.assistantDefaults)
+    delete body.assistantDefaults
+  } else if ("assistant_defaults" in body && body.assistant_defaults !== undefined) {
+    body.assistant_defaults = serializeWorkspaceAssistantDefaults(
+      body.assistant_defaults
+    )
+  }
+
+  if ("confirmReadWriteAssistantDefault" in body) {
+    body.confirm_read_write_assistant_default =
+      body.confirmReadWriteAssistantDefault ?? null
+    delete body.confirmReadWriteAssistantDefault
+  }
+
+  return body
+}
+
 export const workspaceApiMethods = {
   // ── Skills API ──
 
@@ -1095,41 +1293,48 @@ export const workspaceApiMethods = {
   // ── Workspace sub-resource methods ──
 
   async listWorkspaces(): Promise<WorkspaceListApiResponse> {
-    return await bgRequest<WorkspaceListApiResponse>({
+    const response = await bgRequest<WorkspaceListApiResponse>({
       path: "/api/v1/workspaces",
       method: "GET"
     })
+    return {
+      ...response,
+      items: response.items.map(normalizeWorkspaceApiResponse)
+    }
   },
 
   async upsertWorkspace(
     workspaceId: string,
     data: WorkspaceUpsertRequest
   ): Promise<WorkspaceApiResponse> {
-    return await bgRequest<WorkspaceApiResponse>({
+    const response = await bgRequest<WorkspaceApiResponse>({
       path: workspacePath(workspaceId),
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: data
     })
+    return normalizeWorkspaceApiResponse(response)
   },
 
   async getWorkspace(workspaceId: string): Promise<WorkspaceApiResponse> {
-    return await bgRequest<WorkspaceApiResponse>({
+    const response = await bgRequest<WorkspaceApiResponse>({
       path: workspacePath(workspaceId),
       method: "GET"
     })
+    return normalizeWorkspaceApiResponse(response)
   },
 
   async patchWorkspace(
     workspaceId: string,
     data: WorkspacePatchRequest
   ): Promise<WorkspaceApiResponse> {
-    return await bgRequest<WorkspaceApiResponse>({
+    const response = await bgRequest<WorkspaceApiResponse>({
       path: workspacePath(workspaceId),
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: data
+      body: serializeWorkspacePatchRequest(data)
     })
+    return normalizeWorkspaceApiResponse(response)
   },
 
   async deleteWorkspace(workspaceId: string): Promise<void> {

--- a/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
+++ b/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
@@ -20,6 +20,10 @@ import type {
   WorkspaceAssistantKind,
   WorkspacePersonaMemoryMode
 } from "@/types/workspace"
+import {
+  normalizeEffectiveWorkspaceAssistantDefault,
+  normalizeWorkspaceAssistantDefaults
+} from "@/types/workspace-assistant-defaults"
 
 /**
  * Minimal interface for the TldwApiClient methods referenced via `this`.
@@ -833,50 +837,6 @@ const resolveSkillExportFilename = (
     : fallbackFilename
 }
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  value !== null && typeof value === "object" && !Array.isArray(value)
-
-const WORKSPACE_ASSISTANT_DEFAULT_DEGRADED_REASONS = new Set<string>([
-  "persona_deleted",
-  "persona_unavailable",
-  "persona_feature_disabled",
-  "permission_denied",
-  "invalid_default",
-  "unsupported_assistant_kind"
-])
-
-export const normalizeWorkspaceAssistantDefaults = (
-  value: unknown
-): WorkspaceAssistantDefaults | null => {
-  if (!isRecord(value)) return null
-  if (value.assistant_kind !== "persona" && value.assistantKind !== "persona") {
-    return null
-  }
-
-  const assistantId =
-    typeof value.assistant_id === "string"
-      ? value.assistant_id.trim()
-      : typeof value.assistantId === "string"
-        ? value.assistantId.trim()
-        : ""
-  if (!assistantId) return null
-
-  const memoryMode =
-    value.persona_memory_mode === "read_write" ||
-    value.personaMemoryMode === "read_write"
-      ? "read_write"
-      : "read_only"
-
-  return {
-    assistantKind: "persona",
-    assistantId,
-    personaMemoryMode: memoryMode,
-    voice: null,
-    style: null,
-    toolPolicyProfileId: null
-  }
-}
-
 const describeWorkspaceAssistantDefaultsPayload = (value: unknown): string => {
   try {
     return JSON.stringify(value)
@@ -904,68 +864,6 @@ export const serializeWorkspaceAssistantDefaults = (
     voice: null,
     style: null,
     tool_policy_profile_id: null
-  }
-}
-
-const normalizeEffectiveWorkspaceAssistantDefault = (
-  value: unknown
-): EffectiveWorkspaceAssistantDefault => {
-  if (!isRecord(value)) {
-    return {
-      status: "none",
-      source: "none",
-      assistantKind: null,
-      assistantId: null,
-      label: null,
-      personaMemoryMode: null,
-      degradedReason: null
-    }
-  }
-
-  const status =
-    value.status === "available" || value.status === "unavailable"
-      ? value.status
-      : "none"
-  const source = value.source === "workspace" ? "workspace" : "none"
-  const assistantKind =
-    value.assistant_kind === "persona" || value.assistantKind === "persona"
-      ? "persona"
-      : null
-  const assistantId =
-    typeof value.assistant_id === "string"
-      ? value.assistant_id
-      : typeof value.assistantId === "string"
-        ? value.assistantId
-        : null
-  const personaMemoryMode =
-    value.persona_memory_mode === "read_write" ||
-    value.personaMemoryMode === "read_write"
-      ? "read_write"
-      : value.persona_memory_mode === "read_only" ||
-          value.personaMemoryMode === "read_only"
-        ? "read_only"
-        : null
-  const degradedReason =
-    typeof value.degraded_reason === "string"
-      ? value.degraded_reason
-      : typeof value.degradedReason === "string"
-        ? value.degradedReason
-        : null
-  const normalizedDegradedReason =
-    degradedReason &&
-    WORKSPACE_ASSISTANT_DEFAULT_DEGRADED_REASONS.has(degradedReason)
-      ? degradedReason
-      : null
-
-  return {
-    status,
-    source,
-    assistantKind,
-    assistantId,
-    label: typeof value.label === "string" ? value.label : null,
-    personaMemoryMode,
-    degradedReason:
-      normalizedDegradedReason as WorkspaceAssistantDefaultDegradedReason | null
   }
 }
 

--- a/apps/packages/ui/src/store/__tests__/workspace.test.ts
+++ b/apps/packages/ui/src/store/__tests__/workspace.test.ts
@@ -78,6 +78,8 @@ const resetWorkspaceStore = () => {
     workspaceTag: "",
     workspaceCreatedAt: null,
     workspaceChatReferenceId: "",
+    assistantDefaults: null,
+    effectiveAssistantDefault: null,
     sources: [],
     selectedSourceIds: [],
     sourceFolders: [],
@@ -321,6 +323,50 @@ describe("workspace store snapshot persistence", () => {
         workspaceTag: "workspace:renamed-research"
       })
     )
+  })
+
+  it("persists workspace assistant defaults without resolved effective labels", async () => {
+    useWorkspaceStore.getState().initializeWorkspace("Assistant Workspace")
+    const workspaceId = useWorkspaceStore.getState().workspaceId
+
+    useWorkspaceStore.setState({
+      assistantDefaults: {
+        assistantKind: "persona",
+        assistantId: "persona-1",
+        personaMemoryMode: "read_only",
+        voice: null,
+        style: null,
+        toolPolicyProfileId: null
+      },
+      effectiveAssistantDefault: {
+        status: "available",
+        source: "workspace",
+        assistantKind: "persona",
+        assistantId: "persona-1",
+        label: "Resolved Persona Label",
+        personaMemoryMode: "read_only",
+        degradedReason: null
+      }
+    })
+    useWorkspaceStore.getState().saveCurrentWorkspace()
+
+    await Promise.resolve()
+
+    const persistedRaw = localStorage.getItem(STORAGE_KEY)
+    expect(persistedRaw).toBeTruthy()
+    const persisted = persistedRaw ? JSON.parse(persistedRaw) : null
+    const snapshot = persisted?.state?.workspaceSnapshots?.[workspaceId]
+
+    expect(snapshot?.assistantDefaults).toEqual({
+      assistantKind: "persona",
+      assistantId: "persona-1",
+      personaMemoryMode: "read_only",
+      voice: null,
+      style: null,
+      toolPolicyProfileId: null
+    })
+    expect(snapshot?.effectiveAssistantDefault).toBeUndefined()
+    expect(JSON.stringify(snapshot)).not.toContain("Resolved Persona Label")
   })
 
   it("creates isolated snapshots for new workspaces", () => {

--- a/apps/packages/ui/src/store/workspace-slices/workspace-list-slice.ts
+++ b/apps/packages/ui/src/store/workspace-slices/workspace-list-slice.ts
@@ -51,6 +51,7 @@ import {
   reviveSavedWorkspace,
   reviveWorkspaceCollections,
   reviveWorkspaceSnapshot,
+  coerceWorkspaceAssistantDefaultsForRehydrate,
   coerceWorkspaceBannerForRehydrate,
   createFallbackWorkspaceSnapshot,
   duplicateWorkspaceSnapshot,
@@ -1150,6 +1151,10 @@ export const createWorkspaceListSlice: WorkspaceSlice<WorkspaceListSliceActions>
       workspaceName: clonedSnapshot.workspaceName,
       workspaceTag: clonedSnapshot.workspaceTag,
       studyMaterialsPolicy: clonedSnapshot.studyMaterialsPolicy ?? null,
+      assistantDefaults: coerceWorkspaceAssistantDefaultsForRehydrate(
+        clonedSnapshot.assistantDefaults
+      ),
+      effectiveAssistantDefault: clonedSnapshot.effectiveAssistantDefault ?? null,
       workspaceCreatedAt: reviveDateOrNull(clonedSnapshot.workspaceCreatedAt),
       workspaceChatReferenceId:
         clonedSnapshot.workspaceChatReferenceId ||

--- a/apps/packages/ui/src/store/workspace.ts
+++ b/apps/packages/ui/src/store/workspace.ts
@@ -38,9 +38,11 @@ import type {
   ArtifactType,
   AudioGenerationSettings,
   AudioTtsProvider,
+  EffectiveWorkspaceAssistantDefault,
   GeneratedArtifact,
   StudyMaterialsPolicy,
   SavedWorkspace,
+  WorkspaceAssistantDefaults,
   WorkspaceBanner,
   WorkspaceBannerImage,
   WorkspaceBannerImageMimeType,
@@ -2007,6 +2009,8 @@ interface WorkspaceIdentityState {
   workspaceName: string
   workspaceTag: string // Format: "workspace:<slug>"
   studyMaterialsPolicy: StudyMaterialsPolicy | null
+  assistantDefaults: WorkspaceAssistantDefaults | null
+  effectiveAssistantDefault: EffectiveWorkspaceAssistantDefault | null
   workspaceCreatedAt: Date | null
   workspaceChatReferenceId: string
 }
@@ -2060,6 +2064,7 @@ interface WorkspaceSnapshot {
   workspaceName: string
   workspaceTag: string
   studyMaterialsPolicy: StudyMaterialsPolicy | null
+  assistantDefaults: WorkspaceAssistantDefaults | null
   workspaceCreatedAt: Date | null
   workspaceChatReferenceId: string
   sources: WorkspaceSource[]
@@ -2105,6 +2110,8 @@ export interface WorkspaceUndoSnapshot {
   workspaceName: string
   workspaceTag: string
   studyMaterialsPolicy: StudyMaterialsPolicy | null
+  assistantDefaults: WorkspaceAssistantDefaults | null
+  effectiveAssistantDefault: EffectiveWorkspaceAssistantDefault | null
   workspaceCreatedAt: Date | null
   workspaceChatReferenceId: string
   sources: WorkspaceSource[]
@@ -2387,6 +2394,8 @@ const initialIdentityState: WorkspaceIdentityState = {
   workspaceName: "",
   workspaceTag: "",
   studyMaterialsPolicy: null,
+  assistantDefaults: null,
+  effectiveAssistantDefault: null,
   workspaceCreatedAt: null,
   workspaceChatReferenceId: ""
 }
@@ -2921,6 +2930,38 @@ export const reviveSavedWorkspace = (workspace: SavedWorkspace): SavedWorkspace 
   lastAccessedAt: reviveDateOrNull(workspace.lastAccessedAt) || new Date()
 })
 
+export const coerceWorkspaceAssistantDefaultsForRehydrate = (
+  candidate: unknown
+): WorkspaceAssistantDefaults | null => {
+  if (!isRecord(candidate)) return null
+  const assistantKind =
+    candidate.assistantKind === "persona" || candidate.assistant_kind === "persona"
+      ? "persona"
+      : null
+  if (!assistantKind) return null
+
+  const assistantId =
+    typeof candidate.assistantId === "string"
+      ? candidate.assistantId.trim()
+      : typeof candidate.assistant_id === "string"
+        ? candidate.assistant_id.trim()
+        : ""
+  if (!assistantId) return null
+
+  return {
+    assistantKind,
+    assistantId,
+    personaMemoryMode:
+      candidate.personaMemoryMode === "read_write" ||
+      candidate.persona_memory_mode === "read_write"
+        ? "read_write"
+        : "read_only",
+    voice: null,
+    style: null,
+    toolPolicyProfileId: null
+  }
+}
+
 export const reviveWorkspaceSnapshot = (
   workspaceId: string,
   snapshot: WorkspaceSnapshot
@@ -2948,6 +2989,9 @@ export const reviveWorkspaceSnapshot = (
     ...snapshot,
     workspaceId: snapshot.workspaceId || workspaceId,
     studyMaterialsPolicy: resolvedStudyMaterialsPolicy,
+    assistantDefaults: coerceWorkspaceAssistantDefaultsForRehydrate(
+      snapshot.assistantDefaults
+    ),
     workspaceCreatedAt: createdAt,
     workspaceChatReferenceId:
       snapshot.workspaceChatReferenceId ||
@@ -3294,6 +3338,9 @@ const buildLegacyTopLevelSnapshotForMigration = (
     workspaceName: resolvedWorkspaceName,
     workspaceTag: resolvedWorkspaceTag,
     studyMaterialsPolicy: resolvedStudyMaterialsPolicy,
+    assistantDefaults: coerceWorkspaceAssistantDefaultsForRehydrate(
+      persisted.assistantDefaults
+    ),
     workspaceCreatedAt: reviveDateOrNull(
       persisted.workspaceCreatedAt as Date | string | null | undefined
     ),
@@ -3377,18 +3424,21 @@ export const createEmptyWorkspaceSnapshot = ({
   name,
   tag,
   createdAt,
-  studyMaterialsPolicy = null
+  studyMaterialsPolicy = null,
+  assistantDefaults = null
 }: {
   id: string
   name: string
   tag: string
   createdAt: Date
   studyMaterialsPolicy?: StudyMaterialsPolicy | null
+  assistantDefaults?: WorkspaceAssistantDefaults | null
 }): WorkspaceSnapshot => ({
   workspaceId: id,
   workspaceName: name,
   workspaceTag: tag,
   studyMaterialsPolicy: studyMaterialsPolicy ?? null,
+  assistantDefaults: assistantDefaults ?? null,
   workspaceCreatedAt: createdAt,
   workspaceChatReferenceId: id,
   sources: [],
@@ -3414,6 +3464,8 @@ export const applyWorkspaceSnapshot = (
   | "workspaceName"
   | "workspaceTag"
   | "studyMaterialsPolicy"
+  | "assistantDefaults"
+  | "effectiveAssistantDefault"
   | "workspaceCreatedAt"
   | "workspaceChatReferenceId"
   | "sources"
@@ -3434,6 +3486,8 @@ export const applyWorkspaceSnapshot = (
   workspaceName: snapshot.workspaceName,
   workspaceTag: snapshot.workspaceTag,
   studyMaterialsPolicy: snapshot.studyMaterialsPolicy ?? null,
+  assistantDefaults: snapshot.assistantDefaults ?? null,
+  effectiveAssistantDefault: null,
   workspaceCreatedAt: snapshot.workspaceCreatedAt,
   workspaceChatReferenceId: snapshot.workspaceChatReferenceId,
   sources: snapshot.sources.map((source) => ({ ...source })),
@@ -3460,6 +3514,7 @@ export const buildWorkspaceSnapshot = (state: WorkspaceState): WorkspaceSnapshot
   workspaceName: state.workspaceName || "Untitled Workspace",
   workspaceTag: state.workspaceTag,
   studyMaterialsPolicy: state.studyMaterialsPolicy ?? null,
+  assistantDefaults: state.assistantDefaults ?? null,
   workspaceCreatedAt: state.workspaceCreatedAt,
   workspaceChatReferenceId: state.workspaceChatReferenceId || state.workspaceId,
   sources: state.sources.map((source) => ({ ...source })),
@@ -3551,6 +3606,7 @@ export const hydrateWorkspaceBundleSnapshot = (
     workspaceName,
     workspaceTag,
     studyMaterialsPolicy: snapshot.studyMaterialsPolicy ?? null,
+    assistantDefaults: null,
     workspaceCreatedAt: new Date(),
     workspaceChatReferenceId: workspaceId,
     sources: revivedSources,
@@ -3589,6 +3645,8 @@ export const buildWorkspaceUndoSnapshot = (
     workspaceName: state.workspaceName,
     workspaceTag: state.workspaceTag,
     studyMaterialsPolicy: state.studyMaterialsPolicy ?? null,
+    assistantDefaults: state.assistantDefaults ?? null,
+    effectiveAssistantDefault: state.effectiveAssistantDefault ?? null,
     workspaceCreatedAt: state.workspaceCreatedAt,
     workspaceChatReferenceId:
       state.workspaceChatReferenceId || state.workspaceId,
@@ -3784,6 +3842,9 @@ export const duplicateWorkspaceSnapshot = (
     workspaceName: duplicateName,
     workspaceTag: duplicateTag,
     studyMaterialsPolicy: snapshot.studyMaterialsPolicy ?? null,
+    assistantDefaults: coerceWorkspaceAssistantDefaultsForRehydrate(
+      snapshot.assistantDefaults
+    ),
     workspaceCreatedAt: new Date(),
     workspaceChatReferenceId: duplicateId,
     sources: duplicatedSources,

--- a/apps/packages/ui/src/store/workspace.ts
+++ b/apps/packages/ui/src/store/workspace.ts
@@ -66,6 +66,7 @@ import {
   DEFAULT_WORKSPACE_BANNER,
   DEFAULT_WORKSPACE_NOTE
 } from "@/types/workspace"
+import { normalizeWorkspaceAssistantDefaults } from "@/types/workspace-assistant-defaults"
 import {
   collectDescendantFolderIds,
   createWorkspaceOrganizationIndex,
@@ -2930,37 +2931,8 @@ export const reviveSavedWorkspace = (workspace: SavedWorkspace): SavedWorkspace 
   lastAccessedAt: reviveDateOrNull(workspace.lastAccessedAt) || new Date()
 })
 
-export const coerceWorkspaceAssistantDefaultsForRehydrate = (
-  candidate: unknown
-): WorkspaceAssistantDefaults | null => {
-  if (!isRecord(candidate)) return null
-  const assistantKind =
-    candidate.assistantKind === "persona" || candidate.assistant_kind === "persona"
-      ? "persona"
-      : null
-  if (!assistantKind) return null
-
-  const assistantId =
-    typeof candidate.assistantId === "string"
-      ? candidate.assistantId.trim()
-      : typeof candidate.assistant_id === "string"
-        ? candidate.assistant_id.trim()
-        : ""
-  if (!assistantId) return null
-
-  return {
-    assistantKind,
-    assistantId,
-    personaMemoryMode:
-      candidate.personaMemoryMode === "read_write" ||
-      candidate.persona_memory_mode === "read_write"
-        ? "read_write"
-        : "read_only",
-    voice: null,
-    style: null,
-    toolPolicyProfileId: null
-  }
-}
+export const coerceWorkspaceAssistantDefaultsForRehydrate =
+  normalizeWorkspaceAssistantDefaults
 
 export const reviveWorkspaceSnapshot = (
   workspaceId: string,

--- a/apps/packages/ui/src/types/workspace-assistant-defaults.ts
+++ b/apps/packages/ui/src/types/workspace-assistant-defaults.ts
@@ -1,0 +1,111 @@
+import type {
+  EffectiveWorkspaceAssistantDefault,
+  WorkspaceAssistantDefaultDegradedReason,
+  WorkspaceAssistantDefaults
+} from "@/types/workspace"
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value)
+
+export const WORKSPACE_ASSISTANT_DEFAULT_DEGRADED_REASONS = new Set<string>([
+  "persona_deleted",
+  "persona_unavailable",
+  "persona_feature_disabled",
+  "permission_denied",
+  "invalid_default",
+  "unsupported_assistant_kind"
+])
+
+export const normalizeWorkspaceAssistantDefaults = (
+  value: unknown
+): WorkspaceAssistantDefaults | null => {
+  if (!isRecord(value)) return null
+  if (value.assistant_kind !== "persona" && value.assistantKind !== "persona") {
+    return null
+  }
+
+  const assistantId =
+    typeof value.assistant_id === "string"
+      ? value.assistant_id.trim()
+      : typeof value.assistantId === "string"
+        ? value.assistantId.trim()
+        : ""
+  if (!assistantId) return null
+
+  const personaMemoryMode =
+    value.persona_memory_mode === "read_write" ||
+    value.personaMemoryMode === "read_write"
+      ? "read_write"
+      : "read_only"
+
+  return {
+    assistantKind: "persona",
+    assistantId,
+    personaMemoryMode,
+    voice: null,
+    style: null,
+    toolPolicyProfileId: null
+  }
+}
+
+export const normalizeEffectiveWorkspaceAssistantDefault = (
+  value: unknown
+): EffectiveWorkspaceAssistantDefault => {
+  if (!isRecord(value)) {
+    return {
+      status: "none",
+      source: "none",
+      assistantKind: null,
+      assistantId: null,
+      label: null,
+      personaMemoryMode: null,
+      degradedReason: null
+    }
+  }
+
+  const status =
+    value.status === "available" || value.status === "unavailable"
+      ? value.status
+      : "none"
+  const source = value.source === "workspace" ? "workspace" : "none"
+  const assistantKind =
+    value.assistant_kind === "persona" || value.assistantKind === "persona"
+      ? "persona"
+      : null
+  const assistantId =
+    typeof value.assistant_id === "string"
+      ? value.assistant_id
+      : typeof value.assistantId === "string"
+        ? value.assistantId
+        : null
+  const personaMemoryMode =
+    value.persona_memory_mode === "read_write" ||
+    value.personaMemoryMode === "read_write"
+      ? "read_write"
+      : value.persona_memory_mode === "read_only" ||
+          value.personaMemoryMode === "read_only"
+        ? "read_only"
+        : null
+  const degradedReason =
+    typeof value.degraded_reason === "string"
+      ? value.degraded_reason
+      : typeof value.degradedReason === "string"
+        ? value.degradedReason
+        : null
+  const normalizedDegradedReason =
+    degradedReason &&
+    WORKSPACE_ASSISTANT_DEFAULT_DEGRADED_REASONS.has(degradedReason)
+      ? degradedReason
+      : null
+
+  return {
+    status,
+    source,
+    assistantKind,
+    assistantId,
+    label: typeof value.label === "string" ? value.label : null,
+    personaMemoryMode,
+    degradedReason:
+      normalizedDegradedReason as WorkspaceAssistantDefaultDegradedReason | null
+  }
+}

--- a/apps/packages/ui/src/types/workspace.ts
+++ b/apps/packages/ui/src/types/workspace.ts
@@ -299,6 +299,40 @@ export interface TraceableArtifactRedaction {
 
 export type StudyMaterialsPolicy = "general" | "workspace"
 
+export type WorkspaceAssistantKind = "persona"
+export type WorkspacePersonaMemoryMode = "read_only" | "read_write"
+export type EffectiveWorkspaceAssistantDefaultStatus =
+  | "available"
+  | "unavailable"
+  | "none"
+export type EffectiveWorkspaceAssistantDefaultSource = "workspace" | "none"
+export type WorkspaceAssistantDefaultDegradedReason =
+  | "persona_deleted"
+  | "persona_unavailable"
+  | "persona_feature_disabled"
+  | "permission_denied"
+  | "invalid_default"
+  | "unsupported_assistant_kind"
+
+export interface WorkspaceAssistantDefaults {
+  assistantKind: WorkspaceAssistantKind
+  assistantId: string
+  personaMemoryMode: WorkspacePersonaMemoryMode
+  voice: null
+  style: null
+  toolPolicyProfileId: null
+}
+
+export interface EffectiveWorkspaceAssistantDefault {
+  status: EffectiveWorkspaceAssistantDefaultStatus
+  source: EffectiveWorkspaceAssistantDefaultSource
+  assistantKind: WorkspaceAssistantKind | null
+  assistantId: string | null
+  label: string | null
+  personaMemoryMode: WorkspacePersonaMemoryMode | null
+  degradedReason: WorkspaceAssistantDefaultDegradedReason | null
+}
+
 export type WorkspaceStudyArtifactSource = {
   source_type: string
   source_id: string

--- a/apps/tldw-frontend/__tests__/extension/runtime-bootstrap.test.ts
+++ b/apps/tldw-frontend/__tests__/extension/runtime-bootstrap.test.ts
@@ -288,6 +288,33 @@ describe("runtime-bootstrap chrome shim", () => {
     })
   })
 
+  it("uses an existing stored single-user key as a runtime override before scrubbing it", async () => {
+    process.env.NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE = "advanced"
+    process.env.NEXT_PUBLIC_API_URL = "http://127.0.0.1:8000"
+    delete process.env.NEXT_PUBLIC_X_API_KEY
+    localStorage.setItem(
+      "tldwConfig",
+      JSON.stringify({
+        authMode: "single-user",
+        apiKey: "manual-user-key",
+        serverUrl: "http://127.0.0.1:8000"
+      })
+    )
+
+    await importAndAwaitBootstrap()
+    const { getRuntimeSingleUserApiKeyOverride } = await import(
+      "@/services/tldw/runtime-auth-override"
+    )
+
+    expect(getRuntimeSingleUserApiKeyOverride()).toBe("manual-user-key")
+    await vi.waitFor(() => {
+      const nextConfig = readStoredValue("tldwConfig") as Record<string, unknown>
+      expect(nextConfig.serverUrl).toBe("http://127.0.0.1:8000")
+      expect(nextConfig.apiKey).toBeUndefined()
+      expect(localStorage.getItem("tldwConfig")).not.toContain("manual-user-key")
+    })
+  })
+
   it("repairs a stale env LAN host to the current browser host during bootstrap", async () => {
     process.env.NEXT_PUBLIC_API_URL = "http://192.168.5.184:8000"
 

--- a/apps/tldw-frontend/extension/shims/runtime-bootstrap.ts
+++ b/apps/tldw-frontend/extension/shims/runtime-bootstrap.ts
@@ -513,6 +513,21 @@ const seedTldwConfigFromEnv = async (): Promise<void> => {
     const existing = (await storage.get<TldwConfig>("tldwConfig").catch(() => null)) || null
     const storedServerUrl =
       (await storage.get<string>("tldwServerUrl").catch(() => null)) || null
+    const existingSingleUserKey =
+      existing?.authMode === "single-user" && typeof existing.apiKey === "string"
+        ? normalizeApiKey(existing.apiKey)
+        : null
+    if (
+      !envAuthOptedOut &&
+      !apiKey &&
+      !apiBearer &&
+      existingSingleUserKey &&
+      !isPlaceholderApiKey(existingSingleUserKey) &&
+      !getRuntimeSingleUserApiKeyOverride()
+    ) {
+      setRuntimeApiKey(existingSingleUserKey)
+      setRuntimeSingleUserApiKeyOverride(existingSingleUserKey)
+    }
     const quickstartWebUiServerUrl = getQuickstartWebUiServerUrl()
     const effectiveExplicitWebHost =
       !quickstartWebUiServerUrl && isCurrentBrowserOrigin(repairedExplicitWebHost)

--- a/backlog/tasks/task-12115 - Rebase-PR-2316-on-latest-dev-and-fix-CI-failures.md
+++ b/backlog/tasks/task-12115 - Rebase-PR-2316-on-latest-dev-and-fix-CI-failures.md
@@ -1,0 +1,39 @@
+---
+id: TASK-12115
+title: Rebase PR 2316 on latest dev and fix CI failures
+status: Done
+references:
+- https://github.com/rmusser01/tldw_server/pull/2316
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase GitHub PR #2316 onto the latest dev branch, investigate failed GitHub Actions checks, determine whether failures are already addressed on dev, and apply targeted fixes if needed.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+['Rebased PR #2316 branch onto origin/dev at 6eb33300f2c5cba62b5c9d31904e860f385941bd; merge-base now equals origin/dev.', 'Backend CI failures inspected from Actions logs were addressed by dev/rebase; targeted persona aliasing, chatbook manifest/integration, and Fish S2 tests pass locally.', 'Remaining UX Smoke failure reproduced locally as a Next runtime overlay in Knowledge QA. Fixed by allowing Knowledge QA chat creation without a default character, routing createChat/ragSearch through current WebUI config, and preserving stored single-user keys as runtime overrides before bootstrap scrubbing.', 'Onboarding E2E first-source desktop/mobile focused spec passes locally after rebase/fixes.']
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR #2316 branch onto latest origin/dev, resolved the tracked-character conflict, committed frontend fixes, and force-pushed with lease. Backend CI failures reviewed from the previous run were already addressed on dev and targeted backend tests passed locally. Remaining local UX Smoke failure was fixed by allowing Knowledge QA to create plain chats without a default character, routing createChat/ragSearch through the current WebUI config, and preserving stored single-user auth as an in-memory runtime override before scrubbing persisted config. Local targeted Vitest, Playwright smoke/onboarding gates, diff check, and Bandit frontend touched-scope check pass. Post-push GitHub checks were queued/pending with no failures when last checked.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2278 - Implement-Workspace-Assistant-Defaults-backend-storage.md
+++ b/backlog/tasks/task-2278 - Implement-Workspace-Assistant-Defaults-backend-storage.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-2278
 title: Implement Workspace Assistant Defaults backend storage
-status: In Progress
+status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-08 00:37'
+updated_date: '2026-06-08 05:57'
 labels: []
 dependencies: []
 ---

--- a/backlog/tasks/task-2318 - Plan-Workspace-Assistant-Defaults-implementation.md
+++ b/backlog/tasks/task-2318 - Plan-Workspace-Assistant-Defaults-implementation.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-2276
+id: TASK-2318
 title: Plan Workspace Assistant Defaults implementation
 status: Done
 labels:

--- a/backlog/tasks/task-2318.1 - Map-Workspace-Assistant-Defaults-in-WebUI-client-and-store.md
+++ b/backlog/tasks/task-2318.1 - Map-Workspace-Assistant-Defaults-in-WebUI-client-and-store.md
@@ -1,0 +1,64 @@
+---
+id: TASK-2318.1
+title: Map Workspace Assistant Defaults in WebUI client and store
+status: Done
+labels:
+- workspaces
+- webui
+- assistant-defaults
+- persona
+priority: high
+parent_task_id: TASK-2318
+references:
+- https://github.com/rmusser01/tldw_server/issues/1911
+- Docs/Product/Workspace_Persona_Defaults_PRD.md
+documentation:
+- Docs/superpowers/plans/2026-06-07-workspace-assistant-defaults-implementation-plan.md
+modified_files:
+- apps/packages/ui/src/types/workspace.ts
+- apps/packages/ui/src/services/tldw/domains/workspace-api.ts
+- apps/packages/ui/src/services/__tests__/tldw-api-client.workspace-api.test.ts
+- apps/packages/ui/src/store/workspace.ts
+- apps/packages/ui/src/store/workspace-slices/workspace-list-slice.ts
+- apps/packages/ui/src/store/__tests__/workspace.test.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the frontend API/types/store mapping slice from the Workspace Assistant Defaults V1 plan. Normalize stored assistant defaults and effective assistant default response fields from Workspace API responses, serialize patch payloads back to the backend contract, and keep resolved effective labels out of persisted Workspace snapshots.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 WebUI Workspace types include stored assistantDefaults and runtime effectiveAssistantDefault shapes using camelCase fields.
+- [x] #2 Workspace API/client normalization preserves assistantDefaults and effectiveAssistantDefault from server responses and serializes assistantDefaults patch payloads to the backend snake_case contract.
+- [x] #3 Workspace store/state can carry active Workspace assistant default metadata while persisting only reference-backed stored defaults and never resolved effective labels.
+- [x] #4 Focused Vitest coverage proves response normalization, patch serialization, and no effective label persistence.
+- [x] #5 Implementation does not apply defaults to Chat Workspace or add settings UI; those remain later plan slices.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added camelCase Workspace Assistant Defaults and effective default types for the WebUI.
+- Normalized Workspace API responses from backend snake_case fields into frontend camelCase fields and serialized PATCH payloads back to snake_case.
+- Extended workspace state snapshots to persist stored assistant default references while keeping resolved effective default labels out of local storage.
+- Left Chat Workspace default application and settings UI untouched for later planned slices.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Mapped Workspace Assistant Defaults through the frontend API client and workspace store. Focused coverage verifies response normalization, patch serialization, and that effective assistant labels are not persisted. Verification: ./node_modules/.bin/vitest run src/services/__tests__/tldw-api-client.workspace-api.test.ts src/store/__tests__/workspace.test.ts --maxWorkers=1 --no-file-parallelism (68 passed); git diff --check passed. Bandit not run because this task only touched TypeScript/WebUI and Backlog files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2318.2 - Expose-Workspace-Assistant-Defaults-API-validation-and-effective-state.md
+++ b/backlog/tasks/task-2318.2 - Expose-Workspace-Assistant-Defaults-API-validation-and-effective-state.md
@@ -1,0 +1,63 @@
+---
+id: TASK-2318.2
+title: Expose Workspace Assistant Defaults API validation and effective state
+status: Done
+labels:
+- workspaces
+- api
+- assistant-defaults
+- persona
+priority: high
+parent_task_id: TASK-2318
+references:
+- https://github.com/rmusser01/tldw_server/issues/1911
+- Docs/Product/Workspace_Persona_Defaults_PRD.md
+documentation:
+- Docs/superpowers/plans/2026-06-07-workspace-assistant-defaults-implementation-plan.md
+modified_files:
+- tldw_Server_API/app/api/v1/endpoints/workspaces.py
+- tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+- tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py
+- tldw_Server_API/tests/Workspaces/test_workspaces_api.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the Workspace Assistant Defaults V1 API slice from the implementation plan. Validate Persona-backed assistant_defaults updates, enforce read_write confirmation, and expose permission-safe effective_assistant_default values on Workspace get/list/patch responses.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 `PATCH /api/v1/workspaces/{workspace_id}` accepts valid Persona `assistant_defaults`, stores the reference-backed value, and returns stored plus effective default shapes.
+- [x] #2 `persona_memory_mode: read_write` requires `confirm_read_write_assistant_default: true` and returns a validation error without it.
+- [x] #3 Unsupported assistant kinds/deferred fields remain rejected by request validation.
+- [x] #4 Missing, deleted, or inaccessible Persona defaults do not leak labels in effective responses and return an unavailable degraded state for stored drift.
+- [x] #5 Workspace get/list/patch responses include `effective_assistant_default`.
+- [x] #6 Focused API tests and touched-scope Bandit/diff verification are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added endpoint helpers to parse stored assistant defaults, resolve permission-safe effective Persona defaults, and reject invalid Persona references before Workspace writes.
+- Workspace get/list/put/patch/context response paths now use the same response helper and always include `effective_assistant_default`.
+- Updated existing assistant-default API tests to create real Persona profiles instead of relying on dangling IDs.
+- Added focused API tests covering available defaults, list/get projection, missing Persona rejection, and deleted-Persona drift redaction.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Workspace Assistant Defaults API validation and effective state projection. Workspace get/list/patch/context responses now emit a required effective_assistant_default, patch writes reject missing/deleted/inactive Persona references, and stored drift is returned as an unavailable redacted state. Verification: py_compile passed for touched app files; focused pytest passed 82 tests across test_workspace_assistant_defaults_api.py and test_workspaces_api.py; git diff --check passed; Bandit on touched app files reported 0 findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2318.3 - Add-Workspace-default-assistant-settings-UI.md
+++ b/backlog/tasks/task-2318.3 - Add-Workspace-default-assistant-settings-UI.md
@@ -1,0 +1,68 @@
+---
+id: TASK-2318.3
+title: Add Workspace default assistant settings UI
+status: Done
+labels:
+- workspaces
+- webui
+- assistant-defaults
+- persona
+priority: high
+parent_task_id: TASK-2318
+references:
+- https://github.com/rmusser01/tldw_server/issues/1911
+- Docs/Product/Workspace_Persona_Defaults_PRD.md
+documentation:
+- Docs/superpowers/plans/2026-06-07-workspace-assistant-defaults-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the Workspace Assistant Defaults V1 settings UI slice. Add a Research Workspace header settings flow for selecting, confirming read-write, saving, and clearing a Persona-backed default assistant while showing redacted effective/default state.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Workspace header settings exposes a “Default assistant” entry that opens a focused settings surface.
+- [x] #2 The settings surface lists Persona choices, shows current effective state, and displays unavailable defaults without leaking Persona labels.
+- [x] #3 Saving a `read_only` Persona default sends the Workspace PATCH `assistant_defaults` payload using the current Workspace version.
+- [x] #4 Saving a `read_write` Persona default requires a visible confirmation checkbox before save is enabled.
+- [x] #5 Clearing the default sends `assistant_defaults: null`.
+- [x] #6 Focused WorkspaceHeader Vitest coverage and diff/security applicability are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added a Research Workspace settings menu entry and focused modal for Workspace default assistant management. The modal loads the current Workspace record and Persona catalog from the existing `tldwClient`, uses the fetched Workspace `version` for PATCH optimistic locking, sends reference-only Persona defaults, requires explicit read-write confirmation before enabling save, and clears with `assistantDefaults: null`.
+
+The effective-state display treats `unavailable` defaults as redacted: it shows generic unavailable copy plus the degraded reason label and does not fall back to Persona profile labels or IDs.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the Workspace default assistant settings UI in `WorkspaceHeader` with focused Vitest coverage for opening the settings surface, saving read-only defaults, requiring read-write confirmation, clearing defaults, and redacting unavailable defaults.
+
+Verification:
+- RED: `./node_modules/.bin/vitest run src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx --maxWorkers=1 --no-file-parallelism` failed 4 new tests because `Default assistant` was missing.
+- RED follow-up: `./node_modules/.bin/vitest run src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx -t "redacts unavailable default assistant labels" --maxWorkers=1 --no-file-parallelism` failed when an unavailable Persona ID was also present in the Persona catalog, including after changing the select away from the stored value, proving the select leaked the Persona label before the redaction fix.
+- GREEN: same focused Vitest command passed 47 tests.
+- GREEN follow-up: the unavailable-label targeted Vitest command passed after filtering the selected unavailable Persona out of visible options.
+- `git diff --check` passed.
+- `env NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc --noEmit --project tsconfig.json --pretty false` passed from `apps/packages/ui`.
+- Bandit skipped: touched implementation is frontend TSX/tests plus Backlog metadata only; no Python code changed.
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2318.4 - Apply-Workspace-Persona-defaults-to-Chat-Workspace-startup.md
+++ b/backlog/tasks/task-2318.4 - Apply-Workspace-Persona-defaults-to-Chat-Workspace-startup.md
@@ -1,0 +1,64 @@
+---
+id: TASK-2318.4
+title: Apply Workspace Persona defaults to Chat Workspace startup
+status: Done
+labels:
+- workspaces
+- webui
+- assistant-defaults
+- chat-workspace
+- persona
+priority: high
+parent_task_id: TASK-2318
+references:
+- https://github.com/rmusser01/tldw_server/issues/1911
+- Docs/Product/Workspace_Persona_Defaults_PRD.md
+documentation:
+- Docs/superpowers/plans/2026-06-07-workspace-assistant-defaults-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the Workspace Assistant Defaults V1 Chat Workspace startup slice. Apply available effective Workspace Persona defaults only to new Workspace-scoped chats when no explicit assistant is selected, keep existing session metadata authoritative after creation, and expose inherited/explicit/unavailable source state in the Chat Workspace inspector.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Available effective Workspace Persona default is sent on first submit when no explicit assistant is selected.
+- [x] #2 Explicit selected assistant overrides the Workspace default.
+- [x] #3 Unavailable effective default does not auto-apply.
+- [x] #4 Changing Workspace default after a session exists does not mutate persisted chat assistant metadata.
+- [x] #5 Inspector distinguishes inherited Workspace default, explicit assistant, no assistant, and unavailable default states without duplicating Persona content.
+- [x] #6 Focused Chat Workspace Vitest coverage and diff/security applicability are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented workspace persona default inheritance for Chat Workspace startup. The effective workspace default now flows from the workspace store through ChatWorkspacePage/Console into WorkspaceChatPanel and useMessageOption/useChatActions. Workspace defaults are treated as inherited tracked personas only for fresh chats with no explicit assistant and no existing server chat/session assistant metadata; explicit selected assistants and existing chat metadata remain authoritative. The inspector now distinguishes explicit persona, inherited workspace default, no persona, and unavailable workspace default states. Persona server-chat creation now accepts requested persona memory mode and preserves workspace-scoped createChat options.
+
+Verification recorded:
+- ./node_modules/.bin/vitest run src/components/Option/ChatWorkspace/__tests__/WorkspaceChatPanel.test.tsx src/components/Option/ChatWorkspace/__tests__/InspectorRail.test.tsx src/components/Option/ChatWorkspace/__tests__/ChatWorkspacePage.test.tsx src/hooks/chat/__tests__/personaServerChat.test.ts src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx --maxWorkers=1 --no-file-parallelism (pass: 47 tests)
+- ./node_modules/.bin/vitest run src/hooks/__tests__/useMessageOption.assistant-overlay.test.tsx src/hooks/__tests__/useMessageOption.selected-model-sync.test.tsx src/hooks/chat/__tests__/useChatActions.character.integration.test.tsx src/hooks/chat/__tests__/useChatActions.overlay.integration.test.tsx src/hooks/__tests__/useMessage.assistant-overlay.guard.test.ts --maxWorkers=1 --no-file-parallelism (pass: 9 tests)
+- git diff --check (pass)
+- env NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc --noEmit --project tsconfig.json --pretty false (pass)
+- Bandit not run: frontend-only TypeScript/UI changes.
+Finalization note: no separate product documentation update was needed for this implementation slice because the behavior is covered by the existing Workspace Persona Defaults PRD and implementation plan references. Known security skip is limited to Bandit being non-applicable for frontend TypeScript/UI changes.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Applied effective Workspace Persona defaults to Chat Workspace startup without changing the global selected assistant. Available workspace defaults are inherited only for fresh workspace chats with no explicit assistant and no existing server chat/session assistant metadata; explicit selections and existing metadata remain authoritative. The inspector now labels explicit, inherited, unavailable, and no-persona states, and persona chat creation carries the requested memory mode plus workspace scope. Verification passed for focused Chat Workspace tests, adjacent chat hook regressions, diff whitespace, and UI TypeScript. Bandit was not applicable because the touched implementation is frontend TypeScript/UI code.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2318.5 - Close-out-Workspace-Assistant-Defaults-V1-verification.md
+++ b/backlog/tasks/task-2318.5 - Close-out-Workspace-Assistant-Defaults-V1-verification.md
@@ -1,0 +1,70 @@
+---
+id: TASK-2318.5
+title: Close out Workspace Assistant Defaults V1 verification
+status: Done
+labels:
+- workspaces
+- assistant-defaults
+- persona
+- verification
+- docs
+priority: high
+parent_task_id: TASK-2318
+references:
+- https://github.com/rmusser01/tldw_server/issues/1911
+- Docs/Product/Workspace_Persona_Defaults_PRD.md
+documentation:
+- Docs/superpowers/plans/2026-06-07-workspace-assistant-defaults-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Run Workspace Assistant Defaults V1 closeout verification across backend storage/API and frontend Workspace settings/Chat Workspace surfaces, record the implemented V1 PRD status without claiming deferred surfaces, and capture final evidence in Backlog.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Backend Workspace assistant default storage/API regression tests pass or any pre-existing unrelated failures are documented.
+- [x] #2 Frontend Workspace Assistant Defaults client/settings/Chat Workspace regression tests pass or any pre-existing unrelated failures are documented.
+- [x] #3 Touched backend Bandit scope passes or findings are resolved/documented.
+- [x] #4 Workspace Persona Defaults PRD status is updated to reflect V1 implementation for schema/API, Workspace settings, and Chat Workspace startup only.
+- [x] #5 Backlog closeout records exact verification commands, skips, blockers, and final summary.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Closeout verification completed for Workspace Assistant Defaults V1.
+
+Backend verification:
+- Initial repo-standard command using local `.venv` failed in this isolated worktree because `.venv/bin/activate` was not present. Reran through the shared main checkout virtualenv at `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv`.
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py tldw_Server_API/tests/Chat/unit/test_chat_conversations_api.py -q` passed: 22 tests, 8 warnings.
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_workspace_assistant_defaults_db.py tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py tldw_Server_API/tests/Workspaces/test_workspaces_api.py tldw_Server_API/tests/ChaChaNotesDB/test_workspace_sub_resources_db.py -q` passed: 115 tests, 7 warnings.
+
+Frontend verification:
+- `./node_modules/.bin/vitest run src/services/__tests__/tldw-api-client.workspace-api.test.ts src/services/__tests__/tldw-api-client.assistant-identity.test.ts src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx src/components/Option/ChatWorkspace/__tests__/WorkspaceChatPanel.test.tsx src/components/Option/ChatWorkspace/__tests__/InspectorRail.test.tsx src/components/Option/ChatWorkspace/__tests__/ChatWorkspacePage.test.tsx src/hooks/chat/__tests__/personaServerChat.test.ts src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx src/hooks/__tests__/useMessageOption.assistant-overlay.test.tsx src/hooks/__tests__/useMessageOption.selected-model-sync.test.tsx --maxWorkers=1 --no-file-parallelism` passed: 120 tests.
+
+Security/diff verification:
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/schemas/workspace_schemas.py tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py -f json -o /tmp/bandit_workspace_assistant_defaults.json` passed. JSON summary: 0 results, 0 severity findings, 78 skipped tests from existing nosec annotations in ChaChaNotes_DB.py.
+- `git diff --check` passed after the PRD status update.
+
+Docs update:
+- Updated `Docs/Product/Workspace_Persona_Defaults_PRD.md` status from Draft to: `V1 implemented for Workspace schema/API, Workspace settings, and Chat Workspace startup. Later Workspace-bound surfaces remain future adoption stages.`
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Closed out Workspace Assistant Defaults V1 with backend storage/API regression, frontend client/settings/Chat Workspace regression, touched backend Bandit, and PRD status update. All closeout verification passed. The PRD now records V1 implementation only for Workspace schema/API, Workspace settings, and Chat Workspace startup, leaving Research Workspace, Prompt Studio, writing, audio overview, and agent/tool adoption as future stages.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2318.6 - Address-Workspace-Assistant-Defaults-PR-review-feedback.md
+++ b/backlog/tasks/task-2318.6 - Address-Workspace-Assistant-Defaults-PR-review-feedback.md
@@ -4,7 +4,7 @@ title: Address Workspace Assistant Defaults PR review feedback
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-07-01 14:27'
+updated_date: '2026-07-01 14:38'
 labels:
   - workspaces
   - review
@@ -39,6 +39,8 @@ Resolve PR #2316 review feedback after rebasing on latest dev: modal stale state
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Cubic follow-up review pass: address modal save/clear workspace-id targeting, localize default-assistant degraded reason copy, and consolidate assistant-default normalization logic.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -49,6 +51,8 @@ Resolved PR #2316 review feedback after rebasing onto latest dev. Added modal st
 Follow-up PR #2316 review pass addressed the remaining open CodeRabbit findings: preserved workspace assistant provenance for reopened inherited persona chats, removed the unsafe return from the default-assistant modal finally block, moved inherited assistant snapshot capture out of render-time ref mutation, and mapped Persona lookup failures through map_db_error_to_http. Added focused regressions for reopened workspace provenance and Persona lookup error mapping. Verification: Workspace Assistant Defaults backend/chat API focused pytest 25 passed; focused frontend Vitest suite 103 passed; git diff --check passed; Bandit on tldw_Server_API/app/api/v1/endpoints/workspaces.py reported zero findings.
 
 CI follow-up: added tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py to each chacha-content-persona shard in .github/workflows/ci.yml after the shard coverage guard reported it as newly unassigned. Verification: python Helper_Scripts/ci/check_shard_coverage.py --ci-file .github/workflows/ci.yml now reports new_uncovered=0; git diff --check passed.
+
+Cubic follow-up addressed the remaining PR #2316 review threads: save and clear now patch the workspace loaded into the default-assistant modal, degraded default-assistant reason labels route through i18n keys with fallbacks, and assistant-default normalization is shared between API mapping and store rehydrate. Verification: Vitest WorkspaceHeader/workspace store/workspace API tests passed (135 tests), git diff --check passed, and Bandit reported zero findings for tldw_Server_API/app/api/v1/endpoints/workspaces.py.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2318.6 - Address-Workspace-Assistant-Defaults-PR-review-feedback.md
+++ b/backlog/tasks/task-2318.6 - Address-Workspace-Assistant-Defaults-PR-review-feedback.md
@@ -2,28 +2,17 @@
 id: TASK-2318.6
 title: Address Workspace Assistant Defaults PR review feedback
 status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-07-01 06:46'
 labels:
-- workspaces
-- review
-- frontend
-- backend
-priority: High
+  - workspaces
+  - review
+  - frontend
+  - backend
+dependencies: []
 parent_task_id: TASK-2318
-modified_files:
-- apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx
-- apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
-- apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceChatPanel.tsx
-- apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/WorkspaceChatPanel.test.tsx
-- apps/packages/ui/src/hooks/useMessageOption.tsx
-- apps/packages/ui/src/hooks/__tests__/useMessageOption.assistant-overlay.test.tsx
-- apps/packages/ui/src/hooks/chat/personaServerChat.ts
-- apps/packages/ui/src/hooks/chat/__tests__/personaServerChat.test.ts
-- apps/packages/ui/src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx
-- apps/packages/ui/src/services/tldw/domains/workspace-api.ts
-- apps/packages/ui/src/services/__tests__/tldw-api-client.workspace-api.test.ts
-- tldw_Server_API/app/api/v1/endpoints/workspaces.py
-- tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py
-- tldw_Server_API/tests/Workspaces/test_workspaces_api.py
+priority: high
 ---
 
 ## Description
@@ -46,14 +35,18 @@ Resolve PR #2316 review feedback after rebasing on latest dev: modal stale state
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Resolved PR #2316 review feedback after rebasing onto latest dev. Added modal state invalidation/request guards and shared store sync for assistant default save/clear; preserved workspace-inherited assistant provenance and display labels after server chat creation; preserved restored persona memory mode while metadata hydrates; made invalid assistantDefaults patch payloads throw before request serialization; added backend contextual logging, readable degraded reason assignment, and request-scoped persona profile cache for workspace list effective-default resolution; normalized test helper shape and documented backend helper. Verification: focused frontend review-fix suite 101 passed; broader Workspace Assistant Defaults frontend suite 125 passed; backend Workspace regression suite 116 passed; git diff --check passed; Bandit production endpoint scope passed with zero findings. Attempted Bandit including test files returned existing B101 assert findings; attempted full UI tsc with 8GB heap is blocked by unrelated Notes test prop errors (onCreateNote/listError/ServerCapabilities/onSyncFolder).
+
+Follow-up PR #2316 review pass addressed the remaining open CodeRabbit findings: preserved workspace assistant provenance for reopened inherited persona chats, removed the unsafe return from the default-assistant modal finally block, moved inherited assistant snapshot capture out of render-time ref mutation, and mapped Persona lookup failures through map_db_error_to_http. Added focused regressions for reopened workspace provenance and Persona lookup error mapping. Verification: Workspace Assistant Defaults backend/chat API focused pytest 25 passed; focused frontend Vitest suite 103 passed; git diff --check passed; Bandit on tldw_Server_API/app/api/v1/endpoints/workspaces.py reported zero findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2318.6 - Address-Workspace-Assistant-Defaults-PR-review-feedback.md
+++ b/backlog/tasks/task-2318.6 - Address-Workspace-Assistant-Defaults-PR-review-feedback.md
@@ -1,0 +1,67 @@
+---
+id: TASK-2318.6
+title: Address Workspace Assistant Defaults PR review feedback
+status: Done
+labels:
+- workspaces
+- review
+- frontend
+- backend
+priority: High
+parent_task_id: TASK-2318
+modified_files:
+- apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx
+- apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
+- apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceChatPanel.tsx
+- apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/WorkspaceChatPanel.test.tsx
+- apps/packages/ui/src/hooks/useMessageOption.tsx
+- apps/packages/ui/src/hooks/__tests__/useMessageOption.assistant-overlay.test.tsx
+- apps/packages/ui/src/hooks/chat/personaServerChat.ts
+- apps/packages/ui/src/hooks/chat/__tests__/personaServerChat.test.ts
+- apps/packages/ui/src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx
+- apps/packages/ui/src/services/tldw/domains/workspace-api.ts
+- apps/packages/ui/src/services/__tests__/tldw-api-client.workspace-api.test.ts
+- tldw_Server_API/app/api/v1/endpoints/workspaces.py
+- tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py
+- tldw_Server_API/tests/Workspaces/test_workspaces_api.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve PR #2316 review feedback after rebasing on latest dev: modal stale state/store sync, inherited assistant provenance, client validation, backend logging/style/list resolution performance, and test helper cleanup.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PR #2316 branch is rebased onto latest dev and pushed.
+- [x] #2 All actionable PR review comments are either fixed or explicitly evaluated with a technical reason for no code change.
+- [x] #3 Workspace default assistant modal cannot reuse stale workspace/persona/version state after failed or out-of-order loads.
+- [x] #4 Saving or clearing workspace assistant defaults updates the shared workspace store for other workspace views.
+- [x] #5 Workspace-inherited assistant provenance and label remain stable after first server chat creation.
+- [x] #6 Malformed non-null assistantDefaults client payloads fail fast instead of serializing to assistant_defaults: null.
+- [x] #7 Backend assistant default effective-state resolution includes contextual warning logs, readable formatting, and avoids repeated persona lookups within workspace list responses.
+- [x] #8 Focused backend/frontend tests, typecheck, diff check, and Bandit are run after fixes.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Resolved PR #2316 review feedback after rebasing onto latest dev. Added modal state invalidation/request guards and shared store sync for assistant default save/clear; preserved workspace-inherited assistant provenance and display labels after server chat creation; preserved restored persona memory mode while metadata hydrates; made invalid assistantDefaults patch payloads throw before request serialization; added backend contextual logging, readable degraded reason assignment, and request-scoped persona profile cache for workspace list effective-default resolution; normalized test helper shape and documented backend helper. Verification: focused frontend review-fix suite 101 passed; broader Workspace Assistant Defaults frontend suite 125 passed; backend Workspace regression suite 116 passed; git diff --check passed; Bandit production endpoint scope passed with zero findings. Attempted Bandit including test files returned existing B101 assert findings; attempted full UI tsc with 8GB heap is blocked by unrelated Notes test prop errors (onCreateNote/listError/ServerCapabilities/onSyncFolder).
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2318.6 - Address-Workspace-Assistant-Defaults-PR-review-feedback.md
+++ b/backlog/tasks/task-2318.6 - Address-Workspace-Assistant-Defaults-PR-review-feedback.md
@@ -4,7 +4,7 @@ title: Address Workspace Assistant Defaults PR review feedback
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-07-01 06:46'
+updated_date: '2026-07-01 14:27'
 labels:
   - workspaces
   - review
@@ -47,6 +47,8 @@ Resolve PR #2316 review feedback after rebasing on latest dev: modal stale state
 Resolved PR #2316 review feedback after rebasing onto latest dev. Added modal state invalidation/request guards and shared store sync for assistant default save/clear; preserved workspace-inherited assistant provenance and display labels after server chat creation; preserved restored persona memory mode while metadata hydrates; made invalid assistantDefaults patch payloads throw before request serialization; added backend contextual logging, readable degraded reason assignment, and request-scoped persona profile cache for workspace list effective-default resolution; normalized test helper shape and documented backend helper. Verification: focused frontend review-fix suite 101 passed; broader Workspace Assistant Defaults frontend suite 125 passed; backend Workspace regression suite 116 passed; git diff --check passed; Bandit production endpoint scope passed with zero findings. Attempted Bandit including test files returned existing B101 assert findings; attempted full UI tsc with 8GB heap is blocked by unrelated Notes test prop errors (onCreateNote/listError/ServerCapabilities/onSyncFolder).
 
 Follow-up PR #2316 review pass addressed the remaining open CodeRabbit findings: preserved workspace assistant provenance for reopened inherited persona chats, removed the unsafe return from the default-assistant modal finally block, moved inherited assistant snapshot capture out of render-time ref mutation, and mapped Persona lookup failures through map_db_error_to_http. Added focused regressions for reopened workspace provenance and Persona lookup error mapping. Verification: Workspace Assistant Defaults backend/chat API focused pytest 25 passed; focused frontend Vitest suite 103 passed; git diff --check passed; Bandit on tldw_Server_API/app/api/v1/endpoints/workspaces.py reported zero findings.
+
+CI follow-up: added tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py to each chacha-content-persona shard in .github/workflows/ci.yml after the shard coverage guard reported it as newly unassigned. Verification: python Helper_Scripts/ci/check_shard_coverage.py --ci-file .github/workflows/ci.yml now reports new_uncovered=0; git diff --check passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/endpoints/workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspaces.py
@@ -149,15 +149,52 @@ def _user_id_for_workspace_scope(current_user: User) -> str:
 
 def _parse_workspace_assistant_defaults(
     raw: Any,
+    *,
+    workspace_id: str | None = None,
 ) -> tuple[WorkspaceAssistantDefaults | None, bool]:
     """Parse stored Workspace Assistant Defaults without leaking invalid storage drift."""
     if raw is None:
         return None, False
     try:
         return WorkspaceAssistantDefaults.model_validate(raw), False
-    except ValueError:
-        logger.warning("Ignoring invalid stored workspace assistant defaults.")
+    except ValueError as exc:
+        payload_keys = sorted(raw.keys()) if isinstance(raw, dict) else None
+        logger.warning(
+            "Ignoring invalid stored workspace assistant defaults "
+            "for workspace_id={workspace_id}: error={error}; "
+            "payload_type={payload_type}; payload_keys={payload_keys}",
+            workspace_id=workspace_id or "<unknown>",
+            error=str(exc),
+            payload_type=type(raw).__name__,
+            payload_keys=payload_keys,
+        )
         return None, True
+
+
+WorkspacePersonaProfileCache = dict[tuple[str, str, bool], dict[str, Any] | None]
+
+
+def _get_workspace_persona_profile(
+    *,
+    db: CharactersRAGDB,
+    assistant_id: str,
+    user_id: str,
+    include_deleted: bool,
+    cache: WorkspacePersonaProfileCache | None = None,
+) -> dict[str, Any] | None:
+    """Return a persona profile with optional request-scoped lookup caching."""
+    cache_key = (user_id, assistant_id, include_deleted)
+    if cache is not None and cache_key in cache:
+        return cache[cache_key]
+
+    profile = db.get_persona_profile(
+        assistant_id,
+        user_id=user_id,
+        include_deleted=include_deleted,
+    )
+    if cache is not None:
+        cache[cache_key] = profile
+    return profile
 
 
 def _effective_workspace_assistant_default(
@@ -166,6 +203,7 @@ def _effective_workspace_assistant_default(
     stored: WorkspaceAssistantDefaults | None,
     user_id: str,
     invalid_stored_default: bool = False,
+    persona_profile_cache: WorkspacePersonaProfileCache | None = None,
 ) -> WorkspaceEffectiveAssistantDefault:
     """Resolve a Workspace assistant default into a permission-safe client projection."""
     if invalid_stored_default:
@@ -184,10 +222,12 @@ def _effective_workspace_assistant_default(
             degraded_reason="unsupported_assistant_kind",
         )
 
-    profile = db.get_persona_profile(
-        stored.assistant_id,
+    profile = _get_workspace_persona_profile(
+        db=db,
+        assistant_id=stored.assistant_id,
         user_id=user_id,
         include_deleted=False,
+        cache=persona_profile_cache,
     )
     if profile is not None:
         if not bool(profile.get("is_active", True)):
@@ -208,12 +248,18 @@ def _effective_workspace_assistant_default(
             persona_memory_mode=stored.persona_memory_mode,
         )
 
-    deleted_profile = db.get_persona_profile(
-        stored.assistant_id,
+    deleted_profile = _get_workspace_persona_profile(
+        db=db,
+        assistant_id=stored.assistant_id,
         user_id=user_id,
         include_deleted=True,
+        cache=persona_profile_cache,
     )
-    degraded_reason = "persona_deleted" if deleted_profile is not None else "permission_denied"
+    degraded_reason = (
+        "persona_deleted"
+        if deleted_profile is not None
+        else "permission_denied"
+    )
     return WorkspaceEffectiveAssistantDefault(
         status="unavailable",
         source="workspace",
@@ -253,10 +299,12 @@ def _ws_to_response(
     *,
     db: CharactersRAGDB,
     current_user: User,
+    persona_profile_cache: WorkspacePersonaProfileCache | None = None,
 ) -> WorkspaceResponse:
     """Convert a workspace DB row dict to a WorkspaceResponse schema."""
     assistant_defaults, invalid_stored_default = _parse_workspace_assistant_defaults(
-        ws.get("assistant_defaults_json")
+        ws.get("assistant_defaults_json"),
+        workspace_id=str(ws.get("id") or ""),
     )
     return WorkspaceResponse(
         id=ws["id"],
@@ -278,6 +326,7 @@ def _ws_to_response(
             stored=assistant_defaults,
             user_id=_user_id_for_workspace_scope(current_user),
             invalid_stored_default=invalid_stored_default,
+            persona_profile_cache=persona_profile_cache,
         ),
         created_at=str(ws.get("created_at", "")),
         last_modified=str(ws.get("last_modified", "")),
@@ -1210,8 +1259,17 @@ async def list_workspaces(
         items = db.list_workspaces()
     except (ConflictError, InputError, CharactersRAGDBError) as exc:
         raise map_db_error_to_http(exc, default_detail="Failed to fetch workspaces") from exc
+    persona_profile_cache: WorkspacePersonaProfileCache = {}
     return WorkspaceListResponse(
-        items=[_ws_to_response(w, db=db, current_user=current_user) for w in items],
+        items=[
+            _ws_to_response(
+                w,
+                db=db,
+                current_user=current_user,
+                persona_profile_cache=persona_profile_cache,
+            )
+            for w in items
+        ],
         total=len(items),
     )
 

--- a/tldw_Server_API/app/api/v1/endpoints/workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspaces.py
@@ -187,11 +187,17 @@ def _get_workspace_persona_profile(
     if cache is not None and cache_key in cache:
         return cache[cache_key]
 
-    profile = db.get_persona_profile(
-        assistant_id,
-        user_id=user_id,
-        include_deleted=include_deleted,
-    )
+    try:
+        profile = db.get_persona_profile(
+            assistant_id,
+            user_id=user_id,
+            include_deleted=include_deleted,
+        )
+    except (ConflictError, InputError, CharactersRAGDBError) as exc:
+        raise map_db_error_to_http(
+            exc,
+            default_detail="Failed to resolve workspace assistant default",
+        ) from exc
     if cache is not None:
         cache[cache_key] = profile
     return profile
@@ -282,8 +288,9 @@ def _validate_workspace_assistant_default_reference(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="assistant_defaults.assistant_kind is not supported",
         )
-    profile = db.get_persona_profile(
-        stored.assistant_id,
+    profile = _get_workspace_persona_profile(
+        db=db,
+        assistant_id=stored.assistant_id,
         user_id=user_id,
         include_deleted=False,
     )

--- a/tldw_Server_API/app/api/v1/endpoints/workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspaces.py
@@ -31,7 +31,9 @@ from tldw_Server_API.app.api.v1.schemas.workspace_schemas import (
     WorkspaceArtifactExportResponse,
     WorkspaceArtifactResponse,
     WorkspaceArtifactUpdateRequest,
+    WorkspaceAssistantDefaults,
     WorkspaceContextResponse,
+    WorkspaceEffectiveAssistantDefault,
     WorkspaceFileInventoryEntryKind,
     WorkspaceFileInventoryItemsResponse,
     WorkspaceFileInventoryScanRequest,
@@ -140,8 +142,122 @@ def get_workspace_sandbox_volume_service() -> SandboxWorkspaceVolumeService:
     return SandboxWorkspaceVolumeService(store=get_sandbox_store())
 
 
-def _ws_to_response(ws: dict) -> WorkspaceResponse:
+def _user_id_for_workspace_scope(current_user: User) -> str:
+    """Return the canonical string user id used by Workspace-scoped Persona APIs."""
+    return str(current_user.id)
+
+
+def _parse_workspace_assistant_defaults(
+    raw: Any,
+) -> tuple[WorkspaceAssistantDefaults | None, bool]:
+    """Parse stored Workspace Assistant Defaults without leaking invalid storage drift."""
+    if raw is None:
+        return None, False
+    try:
+        return WorkspaceAssistantDefaults.model_validate(raw), False
+    except ValueError:
+        logger.warning("Ignoring invalid stored workspace assistant defaults.")
+        return None, True
+
+
+def _effective_workspace_assistant_default(
+    *,
+    db: CharactersRAGDB,
+    stored: WorkspaceAssistantDefaults | None,
+    user_id: str,
+    invalid_stored_default: bool = False,
+) -> WorkspaceEffectiveAssistantDefault:
+    """Resolve a Workspace assistant default into a permission-safe client projection."""
+    if invalid_stored_default:
+        return WorkspaceEffectiveAssistantDefault(
+            status="unavailable",
+            source="workspace",
+            degraded_reason="invalid_default",
+        )
+    if stored is None:
+        return WorkspaceEffectiveAssistantDefault(status="none", source="none")
+
+    if stored.assistant_kind != "persona":
+        return WorkspaceEffectiveAssistantDefault(
+            status="unavailable",
+            source="workspace",
+            degraded_reason="unsupported_assistant_kind",
+        )
+
+    profile = db.get_persona_profile(
+        stored.assistant_id,
+        user_id=user_id,
+        include_deleted=False,
+    )
+    if profile is not None:
+        if not bool(profile.get("is_active", True)):
+            return WorkspaceEffectiveAssistantDefault(
+                status="unavailable",
+                source="workspace",
+                assistant_kind="persona",
+                assistant_id=stored.assistant_id,
+                persona_memory_mode=stored.persona_memory_mode,
+                degraded_reason="persona_unavailable",
+            )
+        return WorkspaceEffectiveAssistantDefault(
+            status="available",
+            source="workspace",
+            assistant_kind="persona",
+            assistant_id=stored.assistant_id,
+            label=str(profile.get("name") or stored.assistant_id),
+            persona_memory_mode=stored.persona_memory_mode,
+        )
+
+    deleted_profile = db.get_persona_profile(
+        stored.assistant_id,
+        user_id=user_id,
+        include_deleted=True,
+    )
+    degraded_reason = "persona_deleted" if deleted_profile is not None else "permission_denied"
+    return WorkspaceEffectiveAssistantDefault(
+        status="unavailable",
+        source="workspace",
+        assistant_kind="persona",
+        assistant_id=stored.assistant_id,
+        persona_memory_mode=stored.persona_memory_mode,
+        degraded_reason=degraded_reason,
+    )
+
+
+def _validate_workspace_assistant_default_reference(
+    *,
+    db: CharactersRAGDB,
+    stored: WorkspaceAssistantDefaults,
+    user_id: str,
+) -> None:
+    """Reject writes that would store an unusable Persona default reference."""
+    if stored.assistant_kind != "persona":
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="assistant_defaults.assistant_kind is not supported",
+        )
+    profile = db.get_persona_profile(
+        stored.assistant_id,
+        user_id=user_id,
+        include_deleted=False,
+    )
+    if profile is None or not bool(profile.get("is_active", True)):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="assistant_defaults.assistant_id must reference an active Persona available to the current user",
+        )
+
+
+def _ws_to_response(
+    ws: dict,
+    *,
+    db: CharactersRAGDB,
+    current_user: User,
+) -> WorkspaceResponse:
     """Convert a workspace DB row dict to a WorkspaceResponse schema."""
+    assistant_defaults, invalid_stored_default = _parse_workspace_assistant_defaults(
+        ws.get("assistant_defaults_json")
+    )
     return WorkspaceResponse(
         id=ws["id"],
         name=ws.get("name"),
@@ -156,7 +272,13 @@ def _ws_to_response(ws: dict) -> WorkspaceResponse:
         audio_model=ws.get("audio_model"),
         audio_voice=ws.get("audio_voice"),
         audio_speed=ws.get("audio_speed"),
-        assistant_defaults=ws.get("assistant_defaults_json"),
+        assistant_defaults=assistant_defaults,
+        effective_assistant_default=_effective_workspace_assistant_default(
+            db=db,
+            stored=assistant_defaults,
+            user_id=_user_id_for_workspace_scope(current_user),
+            invalid_stored_default=invalid_stored_default,
+        ),
         created_at=str(ws.get("created_at", "")),
         last_modified=str(ws.get("last_modified", "")),
         version=ws.get("version", 1),
@@ -1089,7 +1211,7 @@ async def list_workspaces(
     except (ConflictError, InputError, CharactersRAGDBError) as exc:
         raise map_db_error_to_http(exc, default_detail="Failed to fetch workspaces") from exc
     return WorkspaceListResponse(
-        items=[_ws_to_response(w) for w in items],
+        items=[_ws_to_response(w, db=db, current_user=current_user) for w in items],
         total=len(items),
     )
 
@@ -1110,7 +1232,7 @@ async def get_workspace(
         ws = _require_workspace(db, workspace_id)
     except (ConflictError, InputError, CharactersRAGDBError) as exc:
         raise map_db_error_to_http(exc, default_detail="Failed to fetch workspace") from exc
-    return _ws_to_response(ws)
+    return _ws_to_response(ws, db=db, current_user=current_user)
 
 
 @router.put(
@@ -1140,7 +1262,7 @@ async def upsert_workspace(
         )
     except (ConflictError, InputError, CharactersRAGDBError) as exc:
         raise map_db_error_to_http(exc, default_detail="Failed to create or update workspace") from exc
-    return _ws_to_response(ws)
+    return _ws_to_response(ws, db=db, current_user=current_user)
 
 
 @router.patch(
@@ -1158,6 +1280,12 @@ async def patch_workspace(
     """Update workspace fields with optimistic locking."""
     updates = body.model_dump(exclude_unset=True, exclude={"version"})
     if "assistant_defaults" in updates:
+        if body.assistant_defaults is not None:
+            _validate_workspace_assistant_default_reference(
+                db=db,
+                stored=body.assistant_defaults,
+                user_id=_user_id_for_workspace_scope(current_user),
+            )
         updates["assistant_defaults_json"] = updates.pop("assistant_defaults")
     updates.pop("confirm_read_write_assistant_default", None)
     if not updates:
@@ -1169,7 +1297,7 @@ async def patch_workspace(
         ws = db.update_workspace(workspace_id, updates, body.version)
     except (ConflictError, InputError, CharactersRAGDBError) as exc:
         raise map_db_error_to_http(exc, default_detail="Failed to update workspace") from exc
-    return _ws_to_response(ws)
+    return _ws_to_response(ws, db=db, current_user=current_user)
 
 
 @router.delete(
@@ -1747,7 +1875,7 @@ async def get_workspace_context(
         workspace_kind=str(capability_payload.get("workspace_kind") or "research_workspace"),
         schema_version=2,
         generated_at=_utc_now_iso(),
-        workspace=_ws_to_response(workspace),
+        workspace=_ws_to_response(workspace, db=db, current_user=current_user),
         attention_state=str(core_context_payload.get("attention_state") or "needs_attention"),
         resolution=capability_payload.get("resolution") or {},
         project_root=capability_payload.get("project_root") or {},

--- a/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
@@ -226,7 +226,7 @@ class WorkspaceResponse(BaseModel):
     audio_voice: str | None = None
     audio_speed: float | None = None
     assistant_defaults: WorkspaceAssistantDefaults | None = None
-    effective_assistant_default: WorkspaceEffectiveAssistantDefault | None = None
+    effective_assistant_default: WorkspaceEffectiveAssistantDefault
     created_at: str
     last_modified: str
     version: int

--- a/tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py
@@ -18,7 +18,11 @@ from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import (
     WORKSPACES_WRITE_RATE_LIMIT,
 )
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import get_request_user
-from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    CharactersRAGDBError,
+    InputError,
+)
 
 
 @pytest.fixture
@@ -215,6 +219,68 @@ def test_list_workspaces_caches_repeated_persona_default_lookups(
         "ws-assistant-b",
     }
     assert profile_lookup_count == 1
+
+
+@pytest.mark.integration
+def test_get_workspace_maps_persona_lookup_database_errors(
+    workspace_app: FastAPI,
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = db.upsert_workspace("ws-assistant", "Assistant Defaults")
+    db.update_workspace(
+        "ws-assistant",
+        {"assistant_defaults_json": _assistant_defaults_payload("persona-1")},
+        expected_version=int(workspace["version"]),
+    )
+
+    def _raise_get_persona_profile(*args: Any, **kwargs: Any) -> Any:
+        raise CharactersRAGDBError("lookup failed")
+
+    monkeypatch.setattr(db, "get_persona_profile", _raise_get_persona_profile)
+    _install_workspace_overrides(workspace_app, db)
+
+    try:
+        with TestClient(workspace_app, raise_server_exceptions=False) as client:
+            response = client.get("/api/v1/workspaces/ws-assistant")
+    finally:
+        _clear_workspace_overrides(workspace_app)
+
+    assert response.status_code == 500, response.text
+    assert response.json() == {
+        "detail": "Failed to resolve workspace assistant default"
+    }
+
+
+@pytest.mark.integration
+def test_patch_workspace_maps_persona_lookup_input_errors(
+    workspace_app: FastAPI,
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = db.upsert_workspace("ws-assistant", "Assistant Defaults")
+
+    def _raise_get_persona_profile(*args: Any, **kwargs: Any) -> Any:
+        raise InputError("invalid persona lookup")
+
+    monkeypatch.setattr(db, "get_persona_profile", _raise_get_persona_profile)
+    _install_workspace_overrides(workspace_app, db, write=True)
+
+    try:
+        with TestClient(workspace_app, raise_server_exceptions=False) as client:
+            response = client.patch(
+                "/api/v1/workspaces/ws-assistant",
+                json={
+                    "version": workspace["version"],
+                    "assistant_defaults": _assistant_defaults_payload("persona-1"),
+                },
+            )
+    finally:
+        _clear_workspace_overrides(workspace_app)
+
+    assert response.status_code == 400, response.text
+    assert response.json() == {"detail": "invalid persona lookup"}
+    assert db.get_workspace("ws-assistant")["assistant_defaults_json"] is None
 
 
 @pytest.mark.integration

--- a/tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py
@@ -176,6 +176,48 @@ def test_get_and_list_workspaces_include_effective_default(
 
 
 @pytest.mark.integration
+def test_list_workspaces_caches_repeated_persona_default_lookups(
+    workspace_app: FastAPI,
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    persona_id = _create_persona(db)
+    first_workspace = db.upsert_workspace("ws-assistant-a", "Assistant A")
+    second_workspace = db.upsert_workspace("ws-assistant-b", "Assistant B")
+    for workspace in (first_workspace, second_workspace):
+        db.update_workspace(
+            workspace["id"],
+            {"assistant_defaults_json": _assistant_defaults_payload(persona_id)},
+            expected_version=int(workspace["version"]),
+        )
+
+    original_get_persona_profile = db.get_persona_profile
+    profile_lookup_count = 0
+
+    def _counting_get_persona_profile(*args: Any, **kwargs: Any) -> Any:
+        nonlocal profile_lookup_count
+        profile_lookup_count += 1
+        return original_get_persona_profile(*args, **kwargs)
+
+    monkeypatch.setattr(db, "get_persona_profile", _counting_get_persona_profile)
+    _install_workspace_overrides(workspace_app, db)
+
+    try:
+        with TestClient(workspace_app, raise_server_exceptions=False) as client:
+            response = client.get("/api/v1/workspaces/")
+    finally:
+        _clear_workspace_overrides(workspace_app)
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert {item["id"] for item in payload["items"]} == {
+        "ws-assistant-a",
+        "ws-assistant-b",
+    }
+    assert profile_lookup_count == 1
+
+
+@pytest.mark.integration
 def test_patch_workspace_rejects_missing_persona_default(
     workspace_app: FastAPI,
     db: CharactersRAGDB,

--- a/tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py
@@ -1,0 +1,241 @@
+"""API coverage for Workspace Assistant Defaults effective state."""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import (
+    get_chacha_db_for_user,
+)
+from tldw_Server_API.app.api.v1.endpoints import workspaces as workspaces_endpoint
+from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import (
+    WORKSPACES_READ_RATE_LIMIT,
+    WORKSPACES_WRITE_RATE_LIMIT,
+)
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import get_request_user
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> CharactersRAGDB:
+    database = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="1")
+    database.add_character_card(
+        {
+            "name": "Workspace Persona Source",
+            "description": "Source character for workspace persona default tests",
+            "personality": "Focused",
+            "scenario": "Research",
+            "system_prompt": "You support workspace research.",
+            "first_message": "Ready.",
+            "creator_notes": "Test fixture",
+        }
+    )
+    return database
+
+
+@pytest.fixture
+def workspace_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(workspaces_endpoint.router, prefix="/api/v1/workspaces")
+    return app
+
+
+def _allow_rate_limit() -> None:
+    return None
+
+
+def _install_workspace_overrides(
+    app: FastAPI,
+    db: CharactersRAGDB,
+    *,
+    user_id: int = 1,
+    write: bool = False,
+) -> None:
+    app.dependency_overrides[get_request_user] = lambda: SimpleNamespace(id=user_id)
+    app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    app.dependency_overrides[WORKSPACES_READ_RATE_LIMIT] = _allow_rate_limit
+    if write:
+        app.dependency_overrides[WORKSPACES_WRITE_RATE_LIMIT] = _allow_rate_limit
+
+
+def _clear_workspace_overrides(app: FastAPI) -> None:
+    app.dependency_overrides.pop(get_request_user, None)
+    app.dependency_overrides.pop(get_chacha_db_for_user, None)
+    app.dependency_overrides.pop(WORKSPACES_READ_RATE_LIMIT, None)
+    app.dependency_overrides.pop(WORKSPACES_WRITE_RATE_LIMIT, None)
+
+
+def _create_persona(
+    db: CharactersRAGDB,
+    *,
+    persona_id: str = "persona-1",
+    user_id: str = "1",
+    name: str = "Literature Review Assistant",
+) -> str:
+    character = db.get_character_card_by_name("Workspace Persona Source")
+    assert character is not None  # nosec B101
+    return db.create_persona_profile(
+        {
+            "id": persona_id,
+            "user_id": user_id,
+            "name": name,
+            "character_card_id": int(character["id"]),
+            "mode": "session_scoped",
+            "system_prompt": "You support literature review workflows.",
+            "is_active": True,
+        }
+    )
+
+
+def _assistant_defaults_payload(
+    persona_id: str = "persona-1",
+    memory_mode: str = "read_only",
+) -> dict[str, Any]:
+    return {
+        "assistant_kind": "persona",
+        "assistant_id": persona_id,
+        "persona_memory_mode": memory_mode,
+    }
+
+
+@pytest.mark.integration
+def test_patch_workspace_returns_effective_default_for_existing_persona(
+    workspace_app: FastAPI,
+    db: CharactersRAGDB,
+) -> None:
+    workspace = db.upsert_workspace("ws-assistant", "Assistant Defaults")
+    persona_id = _create_persona(db)
+    _install_workspace_overrides(workspace_app, db, write=True)
+
+    try:
+        with TestClient(workspace_app, raise_server_exceptions=False) as client:
+            response = client.patch(
+                "/api/v1/workspaces/ws-assistant",
+                json={
+                    "version": workspace["version"],
+                    "assistant_defaults": _assistant_defaults_payload(persona_id),
+                },
+            )
+    finally:
+        _clear_workspace_overrides(workspace_app)
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["assistant_defaults"] == {
+        "assistant_kind": "persona",
+        "assistant_id": persona_id,
+        "persona_memory_mode": "read_only",
+        "voice": None,
+        "style": None,
+        "tool_policy_profile_id": None,
+    }
+    assert payload["effective_assistant_default"] == {
+        "status": "available",
+        "source": "workspace",
+        "assistant_kind": "persona",
+        "assistant_id": persona_id,
+        "label": "Literature Review Assistant",
+        "persona_memory_mode": "read_only",
+        "degraded_reason": None,
+    }
+
+
+@pytest.mark.integration
+def test_get_and_list_workspaces_include_effective_default(
+    workspace_app: FastAPI,
+    db: CharactersRAGDB,
+) -> None:
+    workspace = db.upsert_workspace("ws-assistant", "Assistant Defaults")
+    persona_id = _create_persona(db)
+    db.update_workspace(
+        "ws-assistant",
+        {"assistant_defaults_json": _assistant_defaults_payload(persona_id)},
+        expected_version=int(workspace["version"]),
+    )
+    _install_workspace_overrides(workspace_app, db)
+
+    try:
+        with TestClient(workspace_app, raise_server_exceptions=False) as client:
+            get_response = client.get("/api/v1/workspaces/ws-assistant")
+            list_response = client.get("/api/v1/workspaces/")
+    finally:
+        _clear_workspace_overrides(workspace_app)
+
+    assert get_response.status_code == 200, get_response.text
+    assert list_response.status_code == 200, list_response.text
+    assert get_response.json()["effective_assistant_default"]["status"] == "available"
+    [listed] = list_response.json()["items"]
+    assert listed["id"] == "ws-assistant"
+    assert listed["effective_assistant_default"]["assistant_id"] == persona_id
+    assert listed["effective_assistant_default"]["label"] == "Literature Review Assistant"
+
+
+@pytest.mark.integration
+def test_patch_workspace_rejects_missing_persona_default(
+    workspace_app: FastAPI,
+    db: CharactersRAGDB,
+) -> None:
+    workspace = db.upsert_workspace("ws-assistant", "Assistant Defaults")
+    _install_workspace_overrides(workspace_app, db, write=True)
+
+    try:
+        with TestClient(workspace_app, raise_server_exceptions=False) as client:
+            response = client.patch(
+                "/api/v1/workspaces/ws-assistant",
+                json={
+                    "version": workspace["version"],
+                    "assistant_defaults": _assistant_defaults_payload("missing-persona"),
+                },
+            )
+    finally:
+        _clear_workspace_overrides(workspace_app)
+
+    assert response.status_code == 422, response.text
+    assert "assistant_defaults.assistant_id" in response.text
+    assert db.get_workspace("ws-assistant")["assistant_defaults_json"] is None
+
+
+@pytest.mark.integration
+def test_effective_default_redacts_deleted_persona_drift(
+    workspace_app: FastAPI,
+    db: CharactersRAGDB,
+) -> None:
+    workspace = db.upsert_workspace("ws-assistant", "Assistant Defaults")
+    persona_id = _create_persona(db)
+    db.update_workspace(
+        "ws-assistant",
+        {"assistant_defaults_json": _assistant_defaults_payload(persona_id)},
+        expected_version=int(workspace["version"]),
+    )
+    profile = db.get_persona_profile(persona_id, user_id="1")
+    assert profile is not None  # nosec B101
+    assert db.soft_delete_persona_profile(
+        persona_id=persona_id,
+        user_id="1",
+        expected_version=int(profile["version"]),
+    )
+    _install_workspace_overrides(workspace_app, db)
+
+    try:
+        with TestClient(workspace_app, raise_server_exceptions=False) as client:
+            response = client.get("/api/v1/workspaces/ws-assistant")
+    finally:
+        _clear_workspace_overrides(workspace_app)
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["assistant_defaults"]["assistant_id"] == persona_id
+    assert payload["effective_assistant_default"] == {
+        "status": "unavailable",
+        "source": "workspace",
+        "assistant_kind": "persona",
+        "assistant_id": persona_id,
+        "label": None,
+        "persona_memory_mode": "read_only",
+        "degraded_reason": "persona_deleted",
+    }

--- a/tldw_Server_API/tests/Workspaces/test_workspaces_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspaces_api.py
@@ -74,6 +74,21 @@ def _create_workspace_test_persona(
     user_id: str = "1",
     name: str = "Workspace Persona",
 ) -> str:
+    """Create a test Persona profile for workspace endpoint tests.
+
+    Args:
+        db: CharactersRAGDB test database that already contains "Test Char".
+        persona_id: Stable Persona id to write into the profile row.
+        user_id: Owner user id for permission-scoped Persona lookups.
+        name: Display name to store on the Persona profile.
+
+    Returns:
+        The Persona id returned by ``db.create_persona_profile``.
+
+    Side Effects:
+        Asserts that the "Test Char" character card exists, then creates a
+        session-scoped Persona profile linked to that character.
+    """
     character = db.get_character_card_by_name("Test Char")
     assert character is not None  # nosec B101
     return db.create_persona_profile(

--- a/tldw_Server_API/tests/Workspaces/test_workspaces_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspaces_api.py
@@ -67,6 +67,28 @@ def workspace_fastapi_app() -> FastAPI:
     return app
 
 
+def _create_workspace_test_persona(
+    db: CharactersRAGDB,
+    *,
+    persona_id: str = "persona-1",
+    user_id: str = "1",
+    name: str = "Workspace Persona",
+) -> str:
+    character = db.get_character_card_by_name("Test Char")
+    assert character is not None  # nosec B101
+    return db.create_persona_profile(
+        {
+            "id": persona_id,
+            "user_id": user_id,
+            "name": name,
+            "character_card_id": int(character["id"]),
+            "mode": "session_scoped",
+            "system_prompt": "You support workspace tests.",
+            "is_active": True,
+        }
+    )
+
+
 def _get_workspace_roots_response(
     workspace_fastapi_app: FastAPI,
     db_like: Any,
@@ -463,6 +485,7 @@ def test_workspace_api_patches_assistant_defaults(workspace_fastapi_app, db):
         )
 
     workspace = db.upsert_workspace("ws-assistant", "Assistant Defaults")
+    _create_workspace_test_persona(db)
     workspace_fastapi_app.dependency_overrides[get_request_user] = _user
     workspace_fastapi_app.dependency_overrides[get_chacha_db_for_user] = lambda: db
     workspace_fastapi_app.dependency_overrides[WORKSPACES_WRITE_RATE_LIMIT] = _allow_rate_limit
@@ -518,6 +541,7 @@ def test_workspace_api_requires_confirmation_for_read_write_assistant_default(wo
         )
 
     workspace = db.upsert_workspace("ws-assistant", "Assistant Defaults")
+    _create_workspace_test_persona(db)
     workspace_fastapi_app.dependency_overrides[get_request_user] = _user
     workspace_fastapi_app.dependency_overrides[get_chacha_db_for_user] = lambda: db
     workspace_fastapi_app.dependency_overrides[WORKSPACES_WRITE_RATE_LIMIT] = _allow_rate_limit


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Add Workspace Assistant Defaults V1
<code>✨ Enhancement</code> <code>🧪 Tests</code> <code>🕐 40+ Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Summary
- Adds Workspace Assistant Defaults V1 across backend effective-state API, WebUI client/store mapping, and Research Workspace settings.
- Applies available Workspace Persona defaults to fresh Chat Workspace startup while preserving explicit assistant selections and existing chat assistant metadata.
- Adds inspector/status copy for explicit, inherited, unavailable, and unset assistant states.
- Closes out the Workspace Assistant Defaults backlog task chain and PRD V1 status.

## Change summary
Maintainer note: this PR is materially AI-authored. Please replace or supplement this section with the required human-owned change summary before merge.

## Verification
- `python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py tldw_Server_API/tests/Chat/unit/test_chat_conversations_api.py -q` -> 22 passed.
- `python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_workspace_assistant_defaults_db.py tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py tldw_Server_API/tests/Workspaces/test_workspaces_api.py tldw_Server_API/tests/ChaChaNotesDB/test_workspace_sub_resources_db.py -q` -> 115 passed.
- `vitest run` focused Workspace Assistant Defaults frontend suite -> 120 passed.
- `tsc --noEmit` in `apps/packages/ui` -> passed.
- `git diff --check` -> passed.
- `bandit` on touched backend workspace schema/endpoint/DB scope -> no findings.

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Adds <b><i>WorkspaceAssistantDefaults</i></b> and <b><i>EffectiveWorkspaceAssistantDefault</i></b> types, API
  normalization/serialization, and workspace store state to carry and persist Persona default
  references without leaking resolved labels.
• Exposes <b><i>effective_assistant_default</i></b> on all Workspace API responses (get/list/patch/context);
  validates Persona references on PATCH and rejects missing/deleted/inactive Personas with a 422.
• Applies available Workspace Persona defaults to fresh Chat Workspace startup via
  <b><i>useMessageOption</i></b>/<b><i>useChatActions</i></b>, preserving explicit assistant selections and existing chat
  session metadata.
• Adds a &quot;Default assistant&quot; settings modal in <b><i>WorkspaceHeader</i></b> for selecting, configuring memory
  mode (read-only/read-write with confirmation), saving, and clearing the Workspace Persona default.
• Adds inspector/status copy in <b><i>InspectorRail</i></b> distinguishing explicit, inherited-from-workspace,
  unavailable, and no-persona states.
• Closes out the Workspace Assistant Defaults backlog task chain (TASK-2318.1–2318.5) and updates
  the PRD status to V1.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
    subgraph Backend["Backend (Python)"]
        WS_EP["workspaces.py\nEndpoint"] --> WS_SCH["workspace_schemas.py\nSchemas"]
        WS_EP --> DB[("CharactersRAGDB")]
    end

    subgraph APIClient["API Client (TS)"]
        WS_API["workspace-api.ts\nNormalize / Serialize"]
    end

    subgraph Store["Workspace Store"]
        WS_STORE["workspace.ts\nState + Snapshots"]
        WS_LIST["workspace-list-slice.ts"]
    end

    subgraph ChatWorkspace["Chat Workspace UI"]
        CWP["ChatWorkspacePage"] --> CWC["ChatWorkspaceConsole"]
        CWC --> WCP["WorkspaceChatPanel"]
        CWC --> IR["InspectorRail"]
        WCP --> UMO["useMessageOption"]
        UMO --> UCA["useChatActions"]
        UCA --> PSC["personaServerChat"]
    end

    subgraph ResearchWorkspace["Research Workspace UI"]
        WH["WorkspaceHeader\nDefault Assistant Modal"]
    end

    DB -- "effective_assistant_default" --> WS_EP
    WS_EP -- "WorkspaceResponse" --> WS_API
    WS_API -- "normalized response" --> WS_STORE
    WS_STORE -- "effectiveAssistantDefault" --> CWP
    WS_STORE -- "assistantDefaults" --> WH
    WH -- "PATCH assistantDefaults" --> WS_API

    subgraph Legend
        direction LR
        _db[("Database")] ~~~ _svc["Service/Hook"] ~~~ _ui(["UI Component"])
    end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. React context for effectiveAssistantDefault</b></summary>

- ➕ Eliminates prop-drilling through ChatWorkspaceConsole
- ➕ Easier to consume in deeply nested components without prop threading
- ➖ Inconsistent with existing workspace prop-threading pattern
- ➖ Adds a new context boundary that may complicate testing

</details>

**Recommendation:** The PR&#x27;s approach — threading `effectiveAssistantDefault` from the store through props into `WorkspaceChatPanel` and `useMessageOption` — is sound and keeps the inheritance logic close to the chat submission path. One alternative worth considering is a dedicated React context for workspace assistant defaults rather than prop-drilling through Console → Panel, which would reduce the prop surface area. However, the current approach is consistent with how other workspace state (e.g., `backendAvailable`, `stagedSources`) is already threaded, so deviating would be inconsistent. The decision to exclude `effectiveAssistantDefault` from persisted snapshots (only persisting `assistantDefaults`) is correct and avoids stale resolved labels in localStorage.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (14)</summary>

<blockquote>
<details>
<summary><strong>workspace.ts</strong> <code>Add Workspace Assistant Defaults type definitions</code> <code>+34/-0</code></summary>

<br/>

>Add Workspace Assistant Defaults type definitions
>
><pre>
>• Adds &#x27;WorkspaceAssistantKind&#x27;, &#x27;WorkspacePersonaMemoryMode&#x27;, &#x27;WorkspaceAssistantDefaults&#x27;, &#x27;EffectiveWorkspaceAssistantDefault&#x27;, and related status/source/degraded-reason union types to the shared workspace type module.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-ea742cc0dcf71634b6848f569a5fbbd3516372639d4bfe54c229be007ceeab06'>apps/packages/ui/src/types/workspace.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>workspace-api.ts</strong> <code>Normalize and serialize Workspace Assistant Defaults in API client</code> <code>+210/-5</code></summary>

<br/>

>Normalize and serialize Workspace Assistant Defaults in API client
>
><pre>
>• Adds &#x27;normalizeWorkspaceAssistantDefaults&#x27;, &#x27;normalizeEffectiveWorkspaceAssistantDefault&#x27;, &#x27;normalizeWorkspaceApiResponse&#x27;, and &#x27;serializeWorkspacePatchRequest&#x27; helpers. All workspace API methods (list, get, upsert, patch) now run responses through &#x27;normalizeWorkspaceApiResponse&#x27; and patch payloads through &#x27;serializeWorkspacePatchRequest&#x27; to translate between snake_case backend and camelCase frontend.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-7af72f15cc8a11790b79449d5332aa1a4bde9c2e268a1fffcb70a19b7907ac35'>apps/packages/ui/src/services/tldw/domains/workspace-api.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>workspace.ts</strong> <code>Add assistantDefaults and effectiveAssistantDefault to workspace store</code> <code>+62/-1</code></summary>

<br/>

>Add assistantDefaults and effectiveAssistantDefault to workspace store
>
><pre>
>• Extends &#x27;WorkspaceIdentityState&#x27;, &#x27;WorkspaceSnapshot&#x27;, and &#x27;WorkspaceUndoSnapshot&#x27; with &#x27;assistantDefaults&#x27; and &#x27;effectiveAssistantDefault&#x27; fields. Adds &#x27;coerceWorkspaceAssistantDefaultsForRehydrate&#x27; for safe deserialization from localStorage. Snapshot build/apply/revive/duplicate paths all carry &#x27;assistantDefaults&#x27;; &#x27;effectiveAssistantDefault&#x27; is intentionally excluded from persisted snapshots.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-a0e5b711fe2b890d434ccf27223e40ce0739a3eeb1d6778bd1253489a1ef5f8e'>apps/packages/ui/src/store/workspace.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>workspace-list-slice.ts</strong> <code>Rehydrate assistantDefaults when switching workspaces</code> <code>+5/-0</code></summary>

<br/>

>Rehydrate assistantDefaults when switching workspaces
>
><pre>
>• Calls &#x27;coerceWorkspaceAssistantDefaultsForRehydrate&#x27; when applying a cloned workspace snapshot so that assistant defaults are safely coerced on workspace switch.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-926bc19a2e8319b52b621a779ffb5d9ad82f74d91b041927cef2f928c37e308c'>apps/packages/ui/src/store/workspace-slices/workspace-list-slice.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>useMessageOption.tsx</strong> <code>Accept inheritedAssistant/inheritedPersonaMemoryMode options and expose selectedAssistantSource</code> <code>+69/-3</code></summary>

<br/>

>Accept inheritedAssistant/inheritedPersonaMemoryMode options and expose selectedAssistantSource
>
><pre>
>• Adds &#x27;UseMessageOptionOptions&#x27; type with &#x27;inheritedAssistant&#x27; and &#x27;inheritedPersonaMemoryMode&#x27; fields. Computes an &#x27;inheritedAssistant&#x27; memo that activates only for fresh plain-mode chats with no existing session or explicit selection. Exposes &#x27;selectedAssistantSource&#x27; (&#x27;workspace&#x27; | &#x27;explicit&#x27; | &#x27;none&#x27;) and passes inherited assistant/memory-mode through to &#x27;useChatActions&#x27;.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-718e10a413dd924e77940c2ab1b222deec437a0f1fe2c3b7eb0cf2f79105371d'>apps/packages/ui/src/hooks/useMessageOption.tsx</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>useChatActions.ts</strong> <code>Route inherited workspace persona default through chat send path</code> <code>+89/-17</code></summary>

<br/>

>Route inherited workspace persona default through chat send path
>
><pre>
>• Adds &#x27;inheritedAssistant&#x27; and &#x27;inheritedPersonaMemoryMode&#x27; options. Computes &#x27;inheritedTrackedAssistant&#x27; (active only for fresh chats with no existing session/character/history) and &#x27;selectedPersonaMemoryMode&#x27;. Replaces &#x27;selectedAssistant&#x27; with &#x27;routingSelectedAssistant&#x27; throughout send-mode resolution and persona server-chat creation. Passes &#x27;requestedPersonaMemoryMode&#x27; to &#x27;ensurePersonaServerChatWithState&#x27;.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-2f9253e4555022fdda5725d8e622ed3450b9934a70dd0ba9a1096a5b2dd0b4f2'>apps/packages/ui/src/hooks/chat/useChatActions.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>personaServerChat.ts</strong> <code>Accept requestedPersonaMemoryMode when creating persona server chats</code> <code>+11/-2</code></summary>

<br/>

>Accept requestedPersonaMemoryMode when creating persona server chats
>
><pre>
>• Adds &#x27;requestedPersonaMemoryMode&#x27; parameter to &#x27;EnsurePersonaServerChatArgs&#x27; and &#x27;ensurePersonaServerChat&#x27;. New chats use the requested mode (defaulting to &#x27;read_only&#x27;) instead of always defaulting; existing matching chats preserve their stored mode.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-d91c16268c49d8ed2587afa4ef3e1a7bcb50fc6321f578cab0789268422c9563'>apps/packages/ui/src/hooks/chat/personaServerChat.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>types.ts</strong> <code>Add ChatWorkspaceAssistantSource type and extend runtime state</code> <code>+12/-1</code></summary>

<br/>

>Add ChatWorkspaceAssistantSource type and extend runtime state
>
><pre>
>• Defines &#x27;ChatWorkspaceAssistantSource&#x27; union (&#x27;explicit&#x27; | &#x27;workspace&#x27; | &#x27;none&#x27; | &#x27;unavailable&#x27;) and adds &#x27;assistantSource&#x27; and &#x27;workspaceAssistantDegradedReason&#x27; fields to &#x27;ChatWorkspaceRuntimeState&#x27;.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-b38586464efa56e8b7d8931fbe2c50b5b6121750ff1348ab152f0ac5776cf291'>apps/packages/ui/src/components/Option/ChatWorkspace/types.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>WorkspaceChatPanel.tsx</strong> <code>Apply workspace persona default on first submit and report assistant source</code> <code>+118/-6</code></summary>

<br/>

>Apply workspace persona default on first submit and report assistant source
>
><pre>
>• Accepts &#x27;effectiveAssistantDefault&#x27; prop and builds an &#x27;inheritedAssistant&#x27; from it when the workspace is ready and no explicit assistant or existing session exists. Computes &#x27;assistantSource&#x27; and &#x27;runtimeSelectedPersonaLabel&#x27; for the inspector. Injects &#x27;assistant_kind&#x27;, &#x27;assistant_id&#x27;, and &#x27;persona_memory_mode&#x27; into the submit payload when using the workspace default.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-ab254aa00e9ae123b2784ab4a314ebbfbf1fbcfa99bdfade000858520a9189af'>apps/packages/ui/src/components/Option/ChatWorkspace/WorkspaceChatPanel.tsx</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>ChatWorkspacePage.tsx</strong> <code>Thread effectiveAssistantDefault from store into ChatWorkspaceConsole</code> <code>+19/-3</code></summary>

<br/>

>Thread effectiveAssistantDefault from store into ChatWorkspaceConsole
>
><pre>
>• Reads &#x27;effectiveAssistantDefault&#x27; from the workspace store and passes it to &#x27;createInitialRuntimeState&#x27; (setting initial &#x27;assistantSource&#x27; to &#x27;unavailable&#x27; when appropriate) and down to &#x27;ChatWorkspaceConsole&#x27;.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-0bd55d3adf820105b18420670a07cc58371ddfac56f32663c536d2044a1f25e8'>apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspacePage.tsx</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>ChatWorkspaceConsole.tsx</strong> <code>Forward assistantSource and effectiveAssistantDefault to child panels</code> <code>+16/-1</code></summary>

<br/>

>Forward assistantSource and effectiveAssistantDefault to child panels
>
><pre>
>• Adds &#x27;assistantSource&#x27;, &#x27;workspaceAssistantDegradedReason&#x27;, and &#x27;effectiveAssistantDefault&#x27; props and threads them to &#x27;InspectorRail&#x27; and &#x27;WorkspaceChatPanel&#x27; respectively.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-9fea925e4e9980f1cee660a4e5e995f3548ebdc0de50a90aa0939151666a22dd'>apps/packages/ui/src/components/Option/ChatWorkspace/ChatWorkspaceConsole.tsx</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>InspectorRail.tsx</strong> <code>Show assistant source and degraded-reason labels in the inspector</code> <code>+47/-1</code></summary>

<br/>

>Show assistant source and degraded-reason labels in the inspector
>
><pre>
>• Adds &#x27;assistantSource&#x27; and &#x27;workspaceAssistantDegradedReason&#x27; props. Renders &#x27;Inherited from workspace&#x27;, &#x27;Explicit persona&#x27;, &#x27;Workspace default unavailable&#x27;, or a degraded-reason label depending on the source state, replacing the previous single persona-name line.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-1ed53d9fba9b827a2e0a39414f439110172a377b34ebed54fd1a6ee47439a57f'>apps/packages/ui/src/components/Option/ChatWorkspace/InspectorRail.tsx</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>workspaces.py</strong> <code>Validate Persona references and emit effective_assistant_default on all workspace responses</code> <code>+135/-7</code></summary>

<br/>

>Validate Persona references and emit effective_assistant_default on all workspace responses
>
><pre>
>• Adds &#x27;_parse_workspace_assistant_defaults&#x27;, &#x27;_effective_workspace_assistant_default&#x27;, and &#x27;_validate_workspace_assistant_default_reference&#x27; helpers. Updates &#x27;_ws_to_response&#x27; to accept &#x27;db&#x27; and &#x27;current_user&#x27;, resolve the effective default, and include it in every response. PATCH now validates that the referenced Persona is active and accessible before writing.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-7ff1c5d9ca65a24209fb08d4779d347efe50dccbe06d4b473c31469a7725e3a7'>tldw_Server_API/app/api/v1/endpoints/workspaces.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>workspace_schemas.py</strong> <code>Make effective_assistant_default a required field on WorkspaceResponse</code> <code>+1/-1</code></summary>

<br/>

>Make effective_assistant_default a required field on WorkspaceResponse
>
><pre>
>• Changes &#x27;effective_assistant_default&#x27; from &#x27;Optional&#x27; to a required non-nullable field on &#x27;WorkspaceResponse&#x27;, enforcing that all response paths always include the effective default.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-c48fdc8cb71a65fdcbcaa6a5b69a85c590fb4f9ca64c98b45527647747f868af'>tldw_Server_API/app/api/v1/schemas/workspace_schemas.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>task-2318 - Plan-Workspace-Assistant-Defaults-implementation.md</strong> <code>Fix task ID typo in planning task</code> <code>+1/-1</code></summary>

<br/>

>Fix task ID typo in planning task
>
><pre>
>• Corrects the task &#x27;id&#x27; field from TASK-2276 to TASK-2318.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-15780b3bcbb09fe7a3b33dbe04ca9fab712070855db309eb44cf9153b88b1d5c'>backlog/tasks/task-2318 - Plan-Workspace-Assistant-Defaults-implementation.md</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (10)</summary>

<blockquote>
<details>
<summary><strong>test_workspace_assistant_defaults_api.py</strong> <code>New API integration tests for Workspace Assistant Defaults effective state</code> <code>+241/-0</code></summary>

<br/>

>New API integration tests for Workspace Assistant Defaults effective state
>
><pre>
>• Adds four integration tests covering: PATCH returning available effective default for an existing Persona, GET/LIST including effective default, PATCH rejecting a missing Persona reference, and GET redacting a deleted Persona as &#x27;persona_deleted&#x27; drift.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-313a2033849d97c764b194d8a3f3566fb4860a0e2c9de396f41f8ba29ebff09c'>tldw_Server_API/tests/Workspaces/test_workspace_assistant_defaults_api.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>test_workspaces_api.py</strong> <code>Create real Persona profiles in existing workspace assistant default tests</code> <code>+24/-0</code></summary>

<br/>

>Create real Persona profiles in existing workspace assistant default tests
>
><pre>
>• Adds &#x27;_create_workspace_test_persona&#x27; helper and calls it in existing assistant-defaults test cases so they reference real Persona records instead of dangling IDs.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-d506343be37460773d28d2d1279448e755716bc99cea50b813b0d345822f9b84'>tldw_Server_API/tests/Workspaces/test_workspaces_api.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>tldw-api-client.workspace-api.test.ts</strong> <code>Test workspace assistant defaults response mapping and patch serialization</code> <code>+75/-0</code></summary>

<br/>

>Test workspace assistant defaults response mapping and patch serialization
>
><pre>
>• Adds a test verifying that &#x27;patchWorkspace&#x27; correctly maps &#x27;assistant_defaults&#x27; and &#x27;effective_assistant_default&#x27; response fields to camelCase and serializes the patch payload body to snake_case including &#x27;confirm_read_write_assistant_default&#x27;.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-52af2b20af6d7750044de09b7ac4c7d9af979f6ccda0ada291840fdc275d3806'>apps/packages/ui/src/services/__tests__/tldw-api-client.workspace-api.test.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>workspace.test.ts</strong> <code>Test that effective assistant labels are not persisted in workspace snapshots</code> <code>+46/-0</code></summary>

<br/>

>Test that effective assistant labels are not persisted in workspace snapshots
>
><pre>
>• Adds a test confirming that &#x27;assistantDefaults&#x27; is persisted in workspace snapshots while &#x27;effectiveAssistantDefault&#x27; (including resolved labels) is excluded from localStorage.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-e6ba092f20abf54b6b9f5af5d8a2ee27aba548d13733d0424510c34d813f6a2f'>apps/packages/ui/src/store/__tests__/workspace.test.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>WorkspaceChatPanel.test.tsx</strong> <code>Add tests for workspace persona default inheritance and override logic</code> <code>+185/-5</code></summary>

<br/>

>Add tests for workspace persona default inheritance and override logic
>
><pre>
>• Adds four new test cases: inheriting an available workspace default on first submit, explicit persona overriding the workspace default, not inheriting an unavailable default, and not mutating existing chat assistant metadata when the workspace default changes.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-18eab67c649afe8e28d90adb0d76c11ca3e38cffb8c4c19e63a0b579964f2658'>apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/WorkspaceChatPanel.test.tsx</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>InspectorRail.test.tsx</strong> <code>Add tests for inherited workspace and unavailable assistant source labels</code> <code>+42/-0</code></summary>

<br/>

>Add tests for inherited workspace and unavailable assistant source labels
>
><pre>
>• Adds tests verifying &#x27;Inherited from workspace&#x27; label for workspace-sourced persona, &#x27;Explicit persona&#x27; label for explicit selection, and &#x27;Workspace default unavailable&#x27; + degraded reason for unavailable state without duplicating persona content.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-f36e063cf24307d9ef941760fdea04a1cbc7b34dee522b7de3e42059502769e5'>apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/InspectorRail.test.tsx</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>ChatWorkspacePage.test.tsx</strong> <code>Update ChatWorkspacePage tests with effectiveAssistantDefault fixture data</code> <code>+30/-4</code></summary>

<br/>

>Update ChatWorkspacePage tests with effectiveAssistantDefault fixture data
>
><pre>
>• Adds &#x27;effectiveAssistantDefault&#x27; to workspace state fixtures and verifies that the effective assistant ID is forwarded to the chat panel via a data attribute.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-b4816e7857d70d24551a85b2cb63e5b6cc5ec1ad8cc7fa3c485d4f5ac648bbc6'>apps/packages/ui/src/components/Option/ChatWorkspace/__tests__/ChatWorkspacePage.test.tsx</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>WorkspaceHeader.test.tsx</strong> <code>Add WorkspaceHeader tests for default assistant settings modal</code> <code>+271/-0</code></summary>

<br/>

>Add WorkspaceHeader tests for default assistant settings modal
>
><pre>
>• Adds four integration tests covering: opening the modal and saving a read-only Persona default, requiring confirmation before saving read-write, clearing the default, and redacting unavailable default assistant labels in the modal.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-9ba6d003de8b8c9891e2883cbdd610fe674386b8b19d2af3c6715795c3b7cd66'>apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>personaServerChat.test.ts</strong> <code>Test requestedPersonaMemoryMode propagation in persona server chat creation</code> <code>+50/-0</code></summary>

<br/>

>Test requestedPersonaMemoryMode propagation in persona server chat creation
>
><pre>
>• Adds a test verifying that &#x27;ensurePersonaServerChat&#x27; uses the &#x27;requestedPersonaMemoryMode&#x27; (&#x27;read_write&#x27;) when creating a new persona-backed chat and sets the store state accordingly.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-6660a2080211a968b9998417e774e5029e1f798e069f357fd4ea22e60c2de275'>apps/packages/ui/src/hooks/chat/__tests__/personaServerChat.test.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>useChatActions.persona.integration.test.tsx</strong> <code>Test inherited workspace persona default routing through useChatActions</code> <code>+72/-0</code></summary>

<br/>

>Test inherited workspace persona default routing through useChatActions
>
><pre>
>• Adds an integration test verifying that an inherited workspace persona default (with no explicit assistant selected) is routed through &#x27;createChat&#x27; with the correct &#x27;assistant_kind&#x27;, &#x27;assistant_id&#x27;, and &#x27;persona_memory_mode&#x27;, and that the playground session is persisted with the workspace persona metadata.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-93adaa51f9fa07f9e1b1c4d0d48bfa26434acfc419626847cd405db27eb1ab20'>apps/packages/ui/src/hooks/chat/__tests__/useChatActions.persona.integration.test.tsx</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Documentation</strong> (7)</summary>

<blockquote>
<details>
<summary><strong>Workspace_Persona_Defaults_PRD.md</strong> <code>Update PRD status to V1 implemented</code> <code>+1/-1</code></summary>

<br/>

>Update PRD status to V1 implemented
>
><pre>
>• Changes the PRD status from &#x27;Draft&#x27; to &#x27;V1 implemented for Workspace schema/API, Workspace settings, and Chat Workspace startup. Later Workspace-bound surfaces remain future adoption stages.&#x27;
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-26f0f93a6246b01edd9ee62f61fa317bdc84aabad8caecc208dd192bfca5725b'>Docs/Product/Workspace_Persona_Defaults_PRD.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>task-2318.1 - Map-Workspace-Assistant-Defaults-in-WebUI-client-and-store.md</strong> <code>Add completed backlog task for WebUI client/store mapping</code> <code>+64/-0</code></summary>

<br/>

>Add completed backlog task for WebUI client/store mapping
>
><pre>
>• New backlog task document (TASK-2318.1) recording acceptance criteria, implementation notes, and final summary for the WebUI client and store mapping slice.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-40849a9fe20a58ff4160f7ab29047fdf3087af9ec1150edbf585b484074fea55'>backlog/tasks/task-2318.1 - Map-Workspace-Assistant-Defaults-in-WebUI-client-and-store.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>task-2318.2 - Expose-Workspace-Assistant-Defaults-API-validation-and-effective-state.md</strong> <code>Add completed backlog task for backend API validation and effective state</code> <code>+63/-0</code></summary>

<br/>

>Add completed backlog task for backend API validation and effective state
>
><pre>
>• New backlog task document (TASK-2318.2) recording acceptance criteria, implementation notes, and final summary for the backend API slice.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-5d14998bf9822fa340192acc131e841dc977d2f874552355509088ed65998c68'>backlog/tasks/task-2318.2 - Expose-Workspace-Assistant-Defaults-API-validation-and-effective-state.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>task-2318.3 - Add-Workspace-default-assistant-settings-UI.md</strong> <code>Add completed backlog task for default assistant settings UI</code> <code>+68/-0</code></summary>

<br/>

>Add completed backlog task for default assistant settings UI
>
><pre>
>• New backlog task document (TASK-2318.3) recording acceptance criteria, implementation notes, and final summary for the settings UI slice.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-e5ec5da4c4b1325db3e33f8997c2549ef00d4915df67d42165d97c52231e36f0'>backlog/tasks/task-2318.3 - Add-Workspace-default-assistant-settings-UI.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>task-2318.4 - Apply-Workspace-Persona-defaults-to-Chat-Workspace-startup.md</strong> <code>Add completed backlog task for Chat Workspace startup defaults</code> <code>+64/-0</code></summary>

<br/>

>Add completed backlog task for Chat Workspace startup defaults
>
><pre>
>• New backlog task document (TASK-2318.4) recording acceptance criteria, implementation notes, and final summary for the Chat Workspace startup slice.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-51cdb2137c6e0725cbf321cd7cf77e1aa40bff6aef60708f9c382ad0bfeb52ea'>backlog/tasks/task-2318.4 - Apply-Workspace-Persona-defaults-to-Chat-Workspace-startup.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>task-2318.5 - Close-out-Workspace-Assistant-Defaults-V1-verification.md</strong> <code>Add completed backlog task for V1 closeout verification</code> <code>+70/-0</code></summary>

<br/>

>Add completed backlog task for V1 closeout verification
>
><pre>
>• New backlog task document (TASK-2318.5) recording closeout verification commands, results, and final summary for the full V1 implementation.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-60981edec3e220dedf176dce10f400f944f534ef084d679f66b6b093a7272eb1'>backlog/tasks/task-2318.5 - Close-out-Workspace-Assistant-Defaults-V1-verification.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>task-2278 - Implement-Workspace-Assistant-Defaults-backend-storage.md</strong> <code>Mark backend storage task as Done</code> <code>+2/-2</code></summary>

<br/>

>Mark backend storage task as Done
>
><pre>
>• Updates TASK-2278 status from &#x27;In Progress&#x27; to &#x27;Done&#x27; and updates the modification timestamp.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-cb1b4c91bbb9afc97d3942cd7ff7c3c885b736d38089a3c725d9a8cc2dea933e'>backlog/tasks/task-2278 - Implement-Workspace-Assistant-Defaults-backend-storage.md</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>WorkspaceHeader.tsx</strong> <code>Add Default Assistant settings modal to workspace header</code> <code>+417/-1</code></summary>

<br/>

>Add Default Assistant settings modal to workspace header
>
><pre>
>• Adds a &#x27;Default assistant&#x27; entry to the workspace settings menu that opens a modal for selecting a Persona, configuring memory mode (read-only/read-write with explicit confirmation checkbox), saving, and clearing the workspace default. Handles loading, saving, error, and redacted-unavailable states. Calls &#x27;tldwClient.getWorkspace&#x27;, &#x27;listPersonaProfiles&#x27;, and &#x27;patchWorkspace&#x27;.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2316/files#diff-87d1c798e535e486c84450b357a48fa5d88937cc1f8780d6cb4650e661fdef85'>apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>