### PR TITLE
Improve Skills beginner empty state

### DIFF
--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import {
+  Alert,
   Button,
   Form,
   Input,
@@ -61,7 +62,13 @@ export const SkillsManager: React.FC = () => {
 
   const offset = (page - 1) * pageSize
 
-  const { data, isLoading } = useQuery<SkillsListResponse>({
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    refetch
+  } = useQuery<SkillsListResponse>({
     queryKey: ["skills", page, pageSize],
     queryFn: () => tldwClient.listSkills({ limit: pageSize, offset })
   })
@@ -77,13 +84,34 @@ export const SkillsManager: React.FC = () => {
       )
   }, [data?.skills, search])
 
+  const hasLoadedSkills = data != null && !isError
   const totalSkills = data?.total ?? 0
   const hasSearch = search.trim().length > 0
-  const isLibraryEmpty = !isLoading && totalSkills === 0 && !hasSearch
-  const skillCountLabel = t("option:skills.countSummary", {
-    defaultValue: `${totalSkills} ${totalSkills === 1 ? "skill" : "skills"}`,
-    count: totalSkills
-  })
+  const isLibraryEmpty =
+    hasLoadedSkills && !isLoading && totalSkills === 0 && !hasSearch
+  const skillCountLabel = isError
+    ? t("option:skills.countUnavailable", {
+        defaultValue: "Count unavailable"
+      })
+    : t("option:skills.countSummary", {
+        defaultValue: `${totalSkills} ${totalSkills === 1 ? "skill" : "skills"}`,
+        count: totalSkills
+      })
+  const listErrorDescription =
+    error instanceof Error && error.message
+      ? error.message
+      : t("option:skills.loadListErrorDescription", {
+          defaultValue: "Check your server connection and try again."
+        })
+
+  React.useEffect(() => {
+    if (!hasLoadedSkills) return
+
+    const lastPage = Math.max(1, Math.ceil(totalSkills / pageSize))
+    if (page > lastPage) {
+      setPage(lastPage)
+    }
+  }, [hasLoadedSkills, page, pageSize, totalSkills])
 
   const deleteMutation = useMutation({
     mutationFn: (name: string) => tldwClient.deleteSkill(name),
@@ -401,11 +429,35 @@ export const SkillsManager: React.FC = () => {
           })}
         </Button>
         <Button icon={<UploadIcon size={14} />} onClick={openImportTextModal}>
-          {t("option:skills.import", { defaultValue: "Import" })}
+          {t("option:skills.emptyImportText", {
+            defaultValue: "Import from text"
+          })}
         </Button>
       </div>
     </div>
   )
+
+  let tableEmptyText: React.ReactNode = beginnerEmptyState
+  if (!isLibraryEmpty) {
+    let emptyText = t("option:skills.emptyTable", {
+      defaultValue: "No skills yet."
+    })
+    if (isError) {
+      emptyText = t("option:skills.emptyTableError", {
+        defaultValue: "Unable to load skills."
+      })
+    } else if (hasSearch) {
+      emptyText = t("option:skills.noMatches", {
+        defaultValue: "No skills match this search."
+      })
+    } else if (totalSkills > 0) {
+      emptyText = t("option:skills.emptyCurrentPage", {
+        defaultValue: "No skills on this page."
+      })
+    }
+
+    tableEmptyText = emptyText
+  }
 
   return (
     <div className="flex flex-col gap-4">
@@ -464,6 +516,22 @@ export const SkillsManager: React.FC = () => {
         </div>
       </div>
 
+      {isError && (
+        <Alert
+          type="error"
+          showIcon
+          title={t("option:skills.loadListError", {
+            defaultValue: "Failed to load skills"
+          })}
+          description={listErrorDescription}
+          action={
+            <Button size="small" onClick={() => void refetch()}>
+              {t("common:tryAgain", { defaultValue: "Try again" })}
+            </Button>
+          }
+        />
+      )}
+
       <Table
         dataSource={filteredSkills}
         columns={columns}
@@ -472,13 +540,7 @@ export const SkillsManager: React.FC = () => {
         pagination={false}
         size="middle"
         locale={{
-          emptyText: isLibraryEmpty
-            ? beginnerEmptyState
-            : t("option:skills.noMatches", {
-                defaultValue: hasSearch
-                  ? "No skills match this search."
-                  : "No skills yet."
-              })
+          emptyText: tableEmptyText
         }}
       />
 

--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -74,8 +74,16 @@ export const SkillsManager: React.FC = () => {
       (s) =>
         s.name.toLowerCase().includes(q) ||
         (s.description && s.description.toLowerCase().includes(q))
-    )
+      )
   }, [data?.skills, search])
+
+  const totalSkills = data?.total ?? 0
+  const hasSearch = search.trim().length > 0
+  const isLibraryEmpty = !isLoading && totalSkills === 0 && !hasSearch
+  const skillCountLabel = t("option:skills.countSummary", {
+    defaultValue: `${totalSkills} ${totalSkills === 1 ? "skill" : "skills"}`,
+    count: totalSkills
+  })
 
   const deleteMutation = useMutation({
     mutationFn: (name: string) => tldwClient.deleteSkill(name),
@@ -358,9 +366,75 @@ export const SkillsManager: React.FC = () => {
     }
   ]
 
+  const beginnerEmptyState = (
+    <div
+      className="mx-auto flex max-w-xl flex-col items-center gap-3 py-8 text-center"
+      data-testid="skills-empty-state"
+    >
+      <div className="space-y-1">
+        <h2 className="text-base font-semibold text-text">
+          {t("option:skills.emptyTitle", {
+            defaultValue: "Start with a reusable skill"
+          })}
+        </h2>
+        <p className="m-0 text-sm text-text-muted">
+          {t("option:skills.emptyDescription", {
+            defaultValue:
+              "Skills are reusable instructions that can be tested here and used from chat."
+          })}
+        </p>
+      </div>
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <Button
+          type="primary"
+          icon={<Database size={14} />}
+          loading={seedBuiltinsMutation.isPending}
+          onClick={() => seedBuiltinsMutation.mutate(false)}
+        >
+          {t("option:skills.emptySeedBuiltins", {
+            defaultValue: "Seed built-ins"
+          })}
+        </Button>
+        <Button icon={<Plus size={14} />} onClick={handleNew}>
+          {t("option:skills.emptyCreateFromTemplate", {
+            defaultValue: "Create from template"
+          })}
+        </Button>
+        <Button icon={<UploadIcon size={14} />} onClick={openImportTextModal}>
+          {t("option:skills.import", { defaultValue: "Import" })}
+        </Button>
+      </div>
+    </div>
+  )
+
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between gap-3">
+      <section
+        aria-labelledby="skills-manager-title"
+        className="flex flex-col gap-1"
+      >
+        <div className="flex flex-col gap-1 md:flex-row md:items-start md:justify-between">
+          <div>
+            <h1
+              id="skills-manager-title"
+              className="m-0 text-xl font-semibold text-text"
+            >
+              {t("option:skills.title", { defaultValue: "Skills" })}
+            </h1>
+            <p className="m-0 max-w-2xl text-sm text-text-muted">
+              {t("option:skills.description", {
+                defaultValue:
+                  "Discover, test, create, import, and manage reusable instructions."
+              })}
+            </p>
+          </div>
+          <p className="m-0 text-sm font-medium text-text-muted">
+            {skillCountLabel}
+          </p>
+        </div>
+      </section>
+
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <Input.Search
           placeholder={t("option:skills.searchPlaceholder", {
             defaultValue: "Search skills..."
@@ -368,9 +442,9 @@ export const SkillsManager: React.FC = () => {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           allowClear
-          style={{ maxWidth: 300 }}
+          style={{ maxWidth: 360 }}
         />
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <Dropdown menu={{ items: importMenuItems }} trigger={["click"]}>
             <Button icon={<UploadIcon size={14} />}>
               {t("option:skills.import", { defaultValue: "Import" })}
@@ -397,14 +471,23 @@ export const SkillsManager: React.FC = () => {
         loading={isLoading}
         pagination={false}
         size="middle"
+        locale={{
+          emptyText: isLibraryEmpty
+            ? beginnerEmptyState
+            : t("option:skills.noMatches", {
+                defaultValue: hasSearch
+                  ? "No skills match this search."
+                  : "No skills yet."
+              })
+        }}
       />
 
-      {(data?.total ?? 0) > pageSize && (
+      {totalSkills > pageSize && (
         <div className="flex justify-end">
           <Pagination
             current={page}
             pageSize={pageSize}
-            total={data?.total ?? 0}
+            total={totalSkills}
             onChange={(p, ps) => {
               setPage(p)
               setPageSize(ps)

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -19,6 +19,8 @@ const notificationMock = vi.hoisted(() => ({
   error: vi.fn()
 }))
 
+const skillDrawerMock = vi.hoisted(() => vi.fn())
+
 vi.mock("@/services/tldw/TldwApiClient", () => ({
   tldwClient: tldwClientMock
 }))
@@ -43,7 +45,10 @@ vi.mock("react-i18next", () => ({
 }))
 
 vi.mock("../SkillDrawer", () => ({
-  SkillDrawer: () => null
+  SkillDrawer: (props: { open: boolean }) => {
+    skillDrawerMock(props)
+    return props.open ? <div data-testid="skill-drawer-open">Skill drawer open</div> : null
+  }
 }))
 
 vi.mock("../SkillPreview", () => ({
@@ -112,6 +117,73 @@ describe("SkillsManager imports", () => {
         <SkillsManager />
       </QueryClientProvider>
     )
+
+  it("orients users with a page summary and library count", async () => {
+    tldwClientMock.listSkills.mockResolvedValueOnce({
+      skills: [
+        {
+          name: "summarize",
+          description: "Summarize source material",
+          context: "inline",
+          source: "builtin",
+          path: "skills/summarize/SKILL.md"
+        },
+        {
+          name: "code-review",
+          description: "Review code changes",
+          context: "fork",
+          source: "builtin",
+          path: "skills/code-review/SKILL.md"
+        }
+      ],
+      count: 2,
+      total: 2,
+      limit: 10,
+      offset: 0
+    })
+
+    renderManager()
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Skills"
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("Discover, test, create, import, and manage reusable instructions.")
+    ).toBeInTheDocument()
+    expect(await screen.findByText("2 skills")).toBeInTheDocument()
+  })
+
+  it("shows a Skills-specific beginner empty state with first actions", async () => {
+    renderManager()
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Start with a reusable skill"
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("Skills are reusable instructions that can be tested here and used from chat.")
+    ).toBeInTheDocument()
+
+    const emptyState = screen.getByTestId("skills-empty-state")
+    fireEvent.click(within(emptyState).getByRole("button", { name: "Seed built-ins" }))
+
+    await waitFor(() => {
+      expect(tldwClientMock.seedSkills).toHaveBeenCalledWith({ overwrite: false })
+    })
+
+    fireEvent.click(within(emptyState).getByRole("button", { name: "Create from template" }))
+    expect(await screen.findByTestId("skill-drawer-open")).toBeInTheDocument()
+
+    fireEvent.click(within(emptyState).getByRole("button", { name: "Import" }))
+    expect(
+      await screen.findByRole("dialog", {
+        name: "Import Skill from Text"
+      })
+    ).toBeInTheDocument()
+  })
 
   it("imports a skill from text via importSkill", async () => {
     renderManager()

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -55,6 +55,15 @@ vi.mock("../SkillPreview", () => ({
   SkillPreview: () => null
 }))
 
+const makeSkill = (index: number) => ({
+  name: `skill-${index}`,
+  description: `Skill ${index}`,
+  argument_hint: null,
+  user_invocable: true,
+  disable_model_invocation: false,
+  context: "inline" as const
+})
+
 describe("SkillsManager imports", () => {
   let queryClient: QueryClient
 
@@ -177,12 +186,90 @@ describe("SkillsManager imports", () => {
     fireEvent.click(within(emptyState).getByRole("button", { name: "Create from template" }))
     expect(await screen.findByTestId("skill-drawer-open")).toBeInTheDocument()
 
-    fireEvent.click(within(emptyState).getByRole("button", { name: "Import" }))
+    expect(within(emptyState).queryByRole("button", { name: "Import" })).not.toBeInTheDocument()
+    fireEvent.click(within(emptyState).getByRole("button", { name: "Import from text" }))
     expect(
       await screen.findByRole("dialog", {
         name: "Import Skill from Text"
       })
     ).toBeInTheDocument()
+  })
+
+  it("shows an explicit load error instead of the beginner empty state", async () => {
+    tldwClientMock.listSkills.mockRejectedValueOnce(new Error("backend down"))
+
+    renderManager()
+
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent("Failed to load skills")
+    expect(alert).toHaveTextContent("backend down")
+    expect(screen.queryByTestId("skills-empty-state")).not.toBeInTheDocument()
+
+    fireEvent.click(within(alert).getByRole("button", { name: "Try again" }))
+
+    await waitFor(() => {
+      expect(tldwClientMock.listSkills).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it("clamps stale pagination when totals shrink", async () => {
+    const firstPageBeforeShrink = Array.from({ length: 10 }, (_, index) => makeSkill(index + 1))
+    const firstPageAfterShrink = Array.from({ length: 5 }, (_, index) => makeSkill(index + 1))
+    let firstPageCalls = 0
+
+    tldwClientMock.listSkills.mockImplementation(({ offset }: { offset: number }) => {
+      if (offset === 10) {
+        return Promise.resolve({
+          skills: [],
+          count: 0,
+          total: 5,
+          limit: 10,
+          offset: 10
+        })
+      }
+
+      firstPageCalls += 1
+      return Promise.resolve({
+        skills: firstPageCalls === 1 ? firstPageBeforeShrink : firstPageAfterShrink,
+        count: firstPageCalls === 1 ? 10 : 5,
+        total: firstPageCalls === 1 ? 11 : 5,
+        limit: 10,
+        offset: 0
+      })
+    })
+
+    renderManager()
+
+    expect(await screen.findByText("11 skills")).toBeInTheDocument()
+
+    const secondPageItem = await screen.findByTitle("2")
+    fireEvent.click(within(secondPageItem).getByText("2"))
+
+    await waitFor(() => {
+      expect(tldwClientMock.listSkills).toHaveBeenCalledWith({ limit: 10, offset: 10 })
+    })
+    await waitFor(() => {
+      expect(tldwClientMock.listSkills).toHaveBeenLastCalledWith({ limit: 10, offset: 0 })
+    })
+    expect(await screen.findByText("5 skills")).toBeInTheDocument()
+    expect(screen.queryByText("No skills yet.")).not.toBeInTheDocument()
+  })
+
+  it("distinguishes a non-empty library with an empty current page", async () => {
+    tldwClientMock.listSkills.mockResolvedValueOnce({
+      skills: [],
+      count: 0,
+      total: 5,
+      limit: 10,
+      offset: 10
+    })
+
+    renderManager()
+
+    expect(await screen.findByText("5 skills")).toBeInTheDocument()
+    expect(screen.getByText("No skills on this page.")).toBeInTheDocument()
+    expect(screen.queryByText("No skills yet.")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("skills-empty-state")).not.toBeInTheDocument()
   })
 
   it("imports a skill from text via importSkill", async () => {

--- a/backlog/tasks/task-530.1 - Implement-Skills-beginner-activation-empty-state.md
+++ b/backlog/tasks/task-530.1 - Implement-Skills-beginner-activation-empty-state.md
@@ -1,0 +1,59 @@
+---
+id: TASK-530.1
+title: Implement Skills beginner activation empty state
+status: Done
+labels:
+- skills
+- webui
+- ux
+priority: medium
+parent_task_id: TASK-530
+modified_files:
+- apps/packages/ui/src/components/Option/Skills/Manager.tsx
+- apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next scoped Skills UX slice from TASK-530: add a restrained /skills page summary with count and replace the zero-skill generic table state with a Skills-specific beginner activation state. Keep scope limited to Manager UI/tests unless a tiny support change is required.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-08-skills-beginner-activation-and-guided-authoring.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the next scoped Skills UX slice: the active /skills manager now shows a visible Skills heading, a short workflow summary, and the current total count above the toolbar. The zero-skill table state now explains what Skills are and gives first actions to seed built-ins, open skill creation, or import text, while searched-empty states stay as simple no-match feedback.
+
+Verification:
+- `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --maxWorkers=1` passed 6 tests after red/green.
+- `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx src/components/Option/Skills/__tests__/SkillsWorkspace.test.tsx --maxWorkers=1` passed 12 tests.
+- `git diff --check` exited 0.
+- Browser smoke on `http://127.0.0.1:18002/skills` confirmed the Skills heading, workflow summary, `0 skills` count, and beginner empty-state actions in the accessibility snapshot. The global backend reachability modal appeared because no tldw server was running.
+- Bandit skipped: frontend-only TypeScript/TSX slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-530.1 - Implement-Skills-beginner-activation-empty-state.md
+++ b/backlog/tasks/task-530.1 - Implement-Skills-beginner-activation-empty-state.md
@@ -32,28 +32,21 @@ Docs/superpowers/plans/2026-06-08-skills-beginner-activation-and-guided-authorin
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+['Rebased codex/skills-beginner-empty-state on latest origin/dev.', 'Addressed PR #2319 review feedback: load failures now render an explicit Alert with retry instead of the beginner empty state; stale pagination clamps to the last valid page after totals shrink; non-empty libraries with empty current pages show a distinct table empty message; beginner empty-state import action now says Import from text to avoid duplicate Import labels.', 'Added regression coverage for load-error handling, stale pagination clamping, empty-current-page messaging, and duplicate Import label avoidance.', 'Verification: bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --maxWorkers=1 passed 9 tests; bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx src/components/Option/Skills/__tests__/SkillsWorkspace.test.tsx --maxWorkers=1 passed 15 tests; git diff --check passed; Bandit via repo .venv against apps/packages/ui/src/components/Option/Skills produced 0 findings / 0 LOC because touched scope is TypeScript.']
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the next scoped Skills UX slice: the active /skills manager now shows a visible Skills heading, a short workflow summary, and the current total count above the toolbar. The zero-skill table state now explains what Skills are and gives first actions to seed built-ins, open skill creation, or import text, while searched-empty states stay as simple no-match feedback.
-
-Verification:
-- `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --maxWorkers=1` passed 6 tests after red/green.
-- `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx src/components/Option/Skills/__tests__/SkillsWorkspace.test.tsx --maxWorkers=1` passed 12 tests.
-- `git diff --check` exited 0.
-- Browser smoke on `http://127.0.0.1:18002/skills` confirmed the Skills heading, workflow summary, `0 skills` count, and beginner empty-state actions in the accessibility snapshot. The global backend reachability modal appeared because no tldw server was running.
-- Bandit skipped: frontend-only TypeScript/TSX slice.
+Rebased PR #2319 on latest dev and addressed review feedback. The Skills manager now shows an explicit load-error alert with retry instead of the beginner empty state, clamps stale pagination when totals shrink, distinguishes empty current pages from empty libraries, and gives the beginner import action a unique accessible label. Added regression tests for each review item and verified the focused Skills suites, diff check, and Bandit touched-scope report.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Skills: add page summary and beginner empty-state actions
<code>✨ Enhancement</code> <code>🧪 Tests</code> <code>📝 Documentation</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Scope
- Add a restrained Skills page heading, workflow summary, and total count above the existing toolbar.
- Replace the generic empty table state with a Skills-specific first-run state when the library is empty and no search is active.
- Wire first-run actions to seed built-ins, open the existing new-skill entry point, and open import text.
- Keep search-empty state as simple no-match feedback.

## Verification
- `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx --maxWorkers=1` passed 6 tests after red/green.
- `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx src/components/Option/Skills/__tests__/SkillsWorkspace.test.tsx --maxWorkers=1` passed 12 tests.
- `git diff --check HEAD~1..HEAD` exited 0.
- Browser smoke on `http://127.0.0.1:18002/skills` confirmed the Skills heading, summary, `0 skills` count, and beginner empty-state actions in the accessibility snapshot. The global backend reachability modal appeared because no tldw server was running.
- Bandit skipped: frontend-only TypeScript/TSX slice.

## Human Change Summary Gate
Per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`, merge still requires the human requester to add or own the final Change summary explaining what changed and why.

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Add Skills heading, workflow summary, and total-count indicator above the toolbar.
• Replace zero-skill table empty state with a Skills-specific first-run experience and actions.
• Add test coverage for the new summary/count and beginner empty-state interactions.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  B["SkillsManager"] --> C["Skills table"] --> E["Empty text renderer"]
  E -->|"Seed built-ins"| I{{"tldw API"}}
  E -->|"Create template"| G["SkillDrawer"]
  E -->|"Import text"| H("Import text modal")
  B -->|"List skills"| I

  subgraph Legend
    direction LR
    _cmp["UI component"] ~~~ _modal("Modal") ~~~ _api{{"API"}}
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

Using the table&#x27;s `locale.emptyText` to host the first-run experience is a good fit: it keeps the empty-state behavior colocated with the listing UI while preserving a simpler no-match message during search. Alternatives like extracting a dedicated EmptyState component or moving the empty state outside the table were considered but aren&#x27;t necessary at this scope.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>Manager.tsx</strong> <code>Add Skills page header, count summary, and first-run empty state actions</code> <code>+89/-6</code></summary>

<br/>

>Add Skills page header, count summary, and first-run empty state actions
>
><pre>
>• Introduces a page-level heading and workflow summary plus a total skills count. Replaces the generic table empty state with a Skills-specific beginner experience when the library is empty and no search is active, including actions to seed built-ins, open creation, and open import-from-text. Keeps search-empty feedback as a simple no-match message and reuses the computed total for pagination.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2319/files#diff-9e402bd6cb1c23737bd77d4314b743be8f20d336524f7b9f4a007086ba00fb9f'>apps/packages/ui/src/components/Option/Skills/Manager.tsx</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>Manager.test.tsx</strong> <code>Test Skills page summary/count and beginner empty state flows</code> <code>+73/-1</code></summary>

<br/>

>Test Skills page summary/count and beginner empty state flows
>
><pre>
>• Expands the SkillDrawer mock to assert that the creation entry point opens when triggered. Adds tests verifying the new page header/summary/count and the beginner empty-state actions (seed built-ins, create from template, import text) and their wiring to API calls and dialogs.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2319/files#diff-f95e954b79f553961e59e1bb2eb532808ab0731af3fcf82f4f4af1944ad5e726'>apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Documentation</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>task-530.1 - Implement-Skills-beginner-activation-empty-state.md</strong> <code>Document TASK-530.1: Skills beginner empty-state implementation and verification</code> <code>+59/-0</code></summary>

<br/>

>Document TASK-530.1: Skills beginner empty-state implementation and verification
>
><pre>
>• Adds a completed backlog task record describing the UX scope, modified files, final summary, and verification commands/results for this slice.
></pre>
>
><a href='https://github.com/rmusser01/tldw_server/pull/2319/files#diff-67334d637a144bec526a4fe61a625227972f989ed14ae46f704fb4aa0d73e488'>backlog/tasks/task-530.1 - Implement-Skills-beginner-activation-empty-state.md</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>