### PR TITLE
TASK-530.5 add Skills table density controls

### DIFF
--- a/Docs/Plans/IMPLEMENTATION_PLAN_skills_density_columns_TASK_530_5.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_skills_density_columns_TASK_530_5.md
@@ -25,7 +25,8 @@
 **Status**: Complete
 
 ## Verification Notes
-- PASS: `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx` (21 tests).
+- PR #2339 review follow-up addressed hidden context sort state, AntD-class-coupled test selection, and render-phase preference initialization feedback.
+- PASS: `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx` (22 tests).
 - PASS: `bunx vitest run src/services/__tests__/tldw-api-client.boundary-slices.test.ts` (8 tests).
 - PASS: `git diff --check`.
 - TYPECHECK CAVEAT: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json --pretty false` still fails on inherited baseline errors in Notes tests, `src/entries/background.ts`, and `src/services/tldw/voice-cloning.ts`; no `src/components/Option/Skills/Manager.tsx` errors remain.

--- a/Docs/Plans/IMPLEMENTATION_PLAN_skills_density_columns_TASK_530_5.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_skills_density_columns_TASK_530_5.md
@@ -1,0 +1,32 @@
+# Skills Density And Column Controls Implementation Plan
+
+## Stage 1: Preference Contract And Regression Tests
+**Goal**: Define the focused frontend behavior for Skills table density and optional columns.
+**Success Criteria**: Tests fail before implementation for density toggling, column visibility, and restored preferences.
+**Tests**: Add focused cases to `apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx`.
+**Status**: Complete
+
+## Stage 2: Local Preference Helpers
+**Goal**: Add small, component-local helpers for loading and saving Skills table preferences safely.
+**Success Criteria**: Missing, malformed, or partial localStorage values fall back to defaults without breaking render.
+**Tests**: Covered through Skills manager render/remount tests.
+**Status**: Complete
+
+## Stage 3: Dense View And Column Controls
+**Goal**: Add keyboard-accessible controls that let users switch table density and show/hide optional secondary columns.
+**Success Criteria**: Name and actions remain mandatory; optional description, mode, argument hint, visibility, and model invocation columns can be toggled.
+**Tests**: Focused Skills manager tests verify visible columns, persisted choices, and unchanged server-backed query behavior.
+**Status**: Complete
+
+## Stage 4: Verification And Task Closeout
+**Goal**: Verify the focused UI slice, update task notes, and keep unrelated work out of the branch.
+**Success Criteria**: Focused Vitest passes, `git diff --check` passes, Bandit is documented as not applicable for frontend-only TypeScript, and `TASK-530.5` records verification.
+**Tests**: `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx`; `git diff --check`.
+**Status**: Complete
+
+## Verification Notes
+- PASS: `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx` (21 tests).
+- PASS: `bunx vitest run src/services/__tests__/tldw-api-client.boundary-slices.test.ts` (8 tests).
+- PASS: `git diff --check`.
+- TYPECHECK CAVEAT: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json --pretty false` still fails on inherited baseline errors in Notes tests, `src/entries/background.ts`, and `src/services/tldw/voice-cloning.ts`; no `src/components/Option/Skills/Manager.tsx` errors remain.
+- Bandit is not applicable for this frontend-only TypeScript/docs/test task.

--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -190,7 +190,6 @@ export const SkillsManager: React.FC = () => {
   const { t } = useTranslation(["option", "common"])
   const queryClient = useQueryClient()
   const notification = useAntdNotification()
-  const initialTablePreferences = React.useMemo(loadSkillsTablePreferences, [])
 
   const [page, setPage] = React.useState(1)
   const [pageSize, setPageSize] = React.useState(DEFAULT_PAGE_SIZE)
@@ -204,10 +203,10 @@ export const SkillsManager: React.FC = () => {
   const [modelFilter, setModelFilter] = React.useState("")
   const [debouncedModelFilter, setDebouncedModelFilter] = React.useState("")
   const [tableDensity, setTableDensity] =
-    React.useState<SkillTableDensity>(initialTablePreferences.density)
+    React.useState<SkillTableDensity>(() => loadSkillsTablePreferences().density)
   const [visibleOptionalColumns, setVisibleOptionalColumns] = React.useState<
     SkillOptionalColumnKey[]
-  >(initialTablePreferences.visibleColumns)
+  >(() => loadSkillsTablePreferences().visibleColumns)
   const [sortState, setSortState] = React.useState<SkillSortState>({})
   const [drawerOpen, setDrawerOpen] = React.useState(false)
   const [importTextOpen, setImportTextOpen] = React.useState(false)
@@ -354,6 +353,15 @@ export const SkillsManager: React.FC = () => {
 
   const handleColumnVisibilityToggle = (columnKey: string) => {
     if (!isSkillOptionalColumnKey(columnKey)) return
+
+    if (
+      visibleOptionalColumns.includes(columnKey)
+      && isSkillTableSortField(columnKey)
+      && sortState.field === columnKey
+    ) {
+      setSortState({})
+      setPage(1)
+    }
 
     setVisibleOptionalColumns((current) => {
       return current.includes(columnKey)

--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -12,7 +12,9 @@ import {
   Modal,
   Switch
 } from "antd"
+import type { MenuProps } from "antd"
 import type { ColumnsType, TableProps } from "antd/es/table"
+import type { SortOrder } from "antd/es/table/interface"
 import React from "react"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 import {
@@ -25,7 +27,9 @@ import {
   FileDown,
   FileText,
   Database,
-  Copy
+  Copy,
+  Columns3,
+  Rows3
 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { useAntdNotification } from "@/hooks/useAntdNotification"
@@ -44,6 +48,8 @@ import type {
 const DEFAULT_PAGE_SIZE = 10
 const SKILLS_SEARCH_DEBOUNCE_MS = 300
 const SKILL_NAME_REGEX = /^[a-z][a-z0-9-]{0,63}$/
+const SKILLS_TABLE_PREFERENCES_STORAGE_KEY = "tldw:skills-manager:table-preferences:v1"
+const SKILL_TABLE_SORT_DIRECTIONS: SortOrder[] = ["ascend", "descend"]
 
 interface ImportTextFormValues {
   name?: string
@@ -67,11 +73,36 @@ interface SeedSkillsResult {
 type SkillContextFilter = "all" | SkillContext
 type SkillVisibilityFilter = "visible" | "hidden" | "all"
 type SkillToolsFilter = "any" | "with-tools" | "without-tools"
+type SkillTableDensity = "comfortable" | "compact"
+type SkillOptionalColumnKey =
+  | "description"
+  | "context"
+  | "argument_hint"
+  | "user_invocable"
+  | "model_invocation"
 
 interface SkillSortState {
   field?: SkillListSort
   order?: SkillListOrder
 }
+
+interface SkillsTablePreferences {
+  density: SkillTableDensity
+  visibleColumns: SkillOptionalColumnKey[]
+}
+
+const DEFAULT_SKILLS_TABLE_PREFERENCES: SkillsTablePreferences = {
+  density: "comfortable",
+  visibleColumns: ["description", "context"]
+}
+
+const SKILL_OPTIONAL_COLUMN_KEYS: SkillOptionalColumnKey[] = [
+  "description",
+  "context",
+  "argument_hint",
+  "user_invocable",
+  "model_invocation"
+]
 
 const getResponseSkillName = (result: unknown): string | undefined => {
   if (!result || typeof result !== "object") return undefined
@@ -92,10 +123,74 @@ const buildSkillInvocation = (skillName: string) => `/skill ${skillName}`
 const isSkillTableSortField = (value: React.Key | undefined): value is SkillListSort =>
   value === "name" || value === "context"
 
+const getSkillTableSortOrder = (
+  sortState: SkillSortState,
+  field: SkillListSort
+): SortOrder => {
+  if (sortState.field !== field) return null
+  return sortState.order === "asc" ? "ascend" : "descend"
+}
+
+const isSkillTableDensity = (value: unknown): value is SkillTableDensity =>
+  value === "comfortable" || value === "compact"
+
+const isSkillOptionalColumnKey = (value: unknown): value is SkillOptionalColumnKey =>
+  typeof value === "string"
+  && SKILL_OPTIONAL_COLUMN_KEYS.includes(value as SkillOptionalColumnKey)
+
+const normalizeSkillsTablePreferences = (value: unknown): SkillsTablePreferences => {
+  if (!value || typeof value !== "object") return DEFAULT_SKILLS_TABLE_PREFERENCES
+
+  const raw = value as {
+    density?: unknown
+    visibleColumns?: unknown
+  }
+  const density = isSkillTableDensity(raw.density)
+    ? raw.density
+    : DEFAULT_SKILLS_TABLE_PREFERENCES.density
+  const visibleColumnValues = Array.isArray(raw.visibleColumns)
+    ? raw.visibleColumns
+    : undefined
+  const visibleColumns = visibleColumnValues
+    ? SKILL_OPTIONAL_COLUMN_KEYS.filter((key) => visibleColumnValues.includes(key))
+    : DEFAULT_SKILLS_TABLE_PREFERENCES.visibleColumns
+
+  return {
+    density,
+    visibleColumns
+  }
+}
+
+const loadSkillsTablePreferences = (): SkillsTablePreferences => {
+  if (typeof window === "undefined") return DEFAULT_SKILLS_TABLE_PREFERENCES
+
+  try {
+    const raw = window.localStorage.getItem(SKILLS_TABLE_PREFERENCES_STORAGE_KEY)
+    if (!raw) return DEFAULT_SKILLS_TABLE_PREFERENCES
+    return normalizeSkillsTablePreferences(JSON.parse(raw))
+  } catch {
+    return DEFAULT_SKILLS_TABLE_PREFERENCES
+  }
+}
+
+const saveSkillsTablePreferences = (preferences: SkillsTablePreferences) => {
+  if (typeof window === "undefined") return
+
+  try {
+    window.localStorage.setItem(
+      SKILLS_TABLE_PREFERENCES_STORAGE_KEY,
+      JSON.stringify(preferences)
+    )
+  } catch {
+    // Preference persistence is best-effort; rendering must not depend on storage.
+  }
+}
+
 export const SkillsManager: React.FC = () => {
   const { t } = useTranslation(["option", "common"])
   const queryClient = useQueryClient()
   const notification = useAntdNotification()
+  const initialTablePreferences = React.useMemo(loadSkillsTablePreferences, [])
 
   const [page, setPage] = React.useState(1)
   const [pageSize, setPageSize] = React.useState(DEFAULT_PAGE_SIZE)
@@ -108,6 +203,11 @@ export const SkillsManager: React.FC = () => {
   const [toolsFilter, setToolsFilter] = React.useState<SkillToolsFilter>("any")
   const [modelFilter, setModelFilter] = React.useState("")
   const [debouncedModelFilter, setDebouncedModelFilter] = React.useState("")
+  const [tableDensity, setTableDensity] =
+    React.useState<SkillTableDensity>(initialTablePreferences.density)
+  const [visibleOptionalColumns, setVisibleOptionalColumns] = React.useState<
+    SkillOptionalColumnKey[]
+  >(initialTablePreferences.visibleColumns)
   const [sortState, setSortState] = React.useState<SkillSortState>({})
   const [drawerOpen, setDrawerOpen] = React.useState(false)
   const [importTextOpen, setImportTextOpen] = React.useState(false)
@@ -157,6 +257,13 @@ export const SkillsManager: React.FC = () => {
 
     return () => window.clearTimeout(timer)
   }, [debouncedModelFilter, modelFilter])
+
+  React.useEffect(() => {
+    saveSkillsTablePreferences({
+      density: tableDensity,
+      visibleColumns: visibleOptionalColumns
+    })
+  }, [tableDensity, visibleOptionalColumns])
 
   const {
     data,
@@ -239,6 +346,20 @@ export const SkillsManager: React.FC = () => {
 
   const handleModelFilterChange = (nextValue: string) => {
     setModelFilter(nextValue)
+  }
+
+  const handleDensityChange = (nextDensity: SkillTableDensity) => {
+    setTableDensity(nextDensity)
+  }
+
+  const handleColumnVisibilityToggle = (columnKey: string) => {
+    if (!isSkillOptionalColumnKey(columnKey)) return
+
+    setVisibleOptionalColumns((current) => {
+      return current.includes(columnKey)
+        ? current.filter((key) => key !== columnKey)
+        : SKILL_OPTIONAL_COLUMN_KEYS.filter((key) => current.includes(key) || key === columnKey)
+    })
   }
 
   const handleTableChange: TableProps<SkillSummary>["onChange"] = (
@@ -514,45 +635,103 @@ export const SkillsManager: React.FC = () => {
     }
   }
 
+  const isOptionalColumnVisible = (columnKey: SkillOptionalColumnKey) =>
+    visibleOptionalColumns.includes(columnKey)
+
+  const optionalColumnLabels: Record<SkillOptionalColumnKey, string> = {
+    description: t("option:skills.colDescription", { defaultValue: "Description" }),
+    context: t("option:skills.colContext", { defaultValue: "Mode" }),
+    argument_hint: t("option:skills.colArgumentHint", { defaultValue: "Argument hint" }),
+    user_invocable: t("option:skills.colVisibility", { defaultValue: "Visibility" }),
+    model_invocation: t("option:skills.colModelUse", { defaultValue: "Model use" })
+  }
+
+  const columnVisibilityMenuItems: MenuProps["items"] = SKILL_OPTIONAL_COLUMN_KEYS.map(
+    (key) => ({
+      key,
+      label: optionalColumnLabels[key]
+    })
+  )
+
   const columns: ColumnsType<SkillSummary> = [
     {
       title: t("option:skills.colName", { defaultValue: "Name" }),
       dataIndex: "name",
       key: "name",
       sorter: true,
-      sortDirections: ["ascend", "descend"],
-      sortOrder:
-        sortState.field === "name"
-          ? sortState.order === "asc" ? "ascend" : "descend"
-          : null,
+      sortDirections: SKILL_TABLE_SORT_DIRECTIONS,
+      sortOrder: getSkillTableSortOrder(sortState, "name"),
       render: (name: string) => (
         <span className="font-mono text-sm">{name}</span>
       )
     },
-    {
-      title: t("option:skills.colDescription", { defaultValue: "Description" }),
-      dataIndex: "description",
-      key: "description",
-      ellipsis: true,
-      render: (desc: string | null) => desc || "-"
-    },
-    {
-      title: t("option:skills.colContext", { defaultValue: "Mode" }),
-      dataIndex: "context",
-      key: "context",
-      width: 100,
-      sorter: true,
-      sortDirections: ["ascend", "descend"],
-      sortOrder:
-        sortState.field === "context"
-          ? sortState.order === "asc" ? "ascend" : "descend"
-          : null,
-      render: (ctx: string) => (
-        <Tag color={ctx === "fork" ? "blue" : "green"}>
-          {ctx}
-        </Tag>
-      )
-    },
+    ...(isOptionalColumnVisible("description")
+      ? [{
+          title: optionalColumnLabels.description,
+          dataIndex: "description",
+          key: "description",
+          ellipsis: true,
+          render: (desc: string | null) => desc || "-"
+        }]
+      : []),
+    ...(isOptionalColumnVisible("context")
+      ? [{
+          title: optionalColumnLabels.context,
+          dataIndex: "context",
+          key: "context",
+          width: 100,
+          sorter: true,
+          sortDirections: SKILL_TABLE_SORT_DIRECTIONS,
+          sortOrder: getSkillTableSortOrder(sortState, "context"),
+          render: (ctx: string) => (
+            <Tag color={ctx === "fork" ? "blue" : "green"}>
+              {ctx}
+            </Tag>
+          )
+        }]
+      : []),
+    ...(isOptionalColumnVisible("argument_hint")
+      ? [{
+          title: optionalColumnLabels.argument_hint,
+          dataIndex: "argument_hint",
+          key: "argument_hint",
+          width: 160,
+          ellipsis: true,
+          render: (hint: string | null) => hint ? (
+            <span className="font-mono text-sm">{hint}</span>
+          ) : "-"
+        }]
+      : []),
+    ...(isOptionalColumnVisible("user_invocable")
+      ? [{
+          title: optionalColumnLabels.user_invocable,
+          dataIndex: "user_invocable",
+          key: "user_invocable",
+          width: 110,
+          render: (userInvocable: boolean) => (
+            <Tag color={userInvocable ? "green" : "default"}>
+              {userInvocable
+                ? t("option:skills.visibleState", { defaultValue: "Visible" })
+                : t("option:skills.hiddenState", { defaultValue: "Hidden" })}
+            </Tag>
+          )
+        }]
+      : []),
+    ...(isOptionalColumnVisible("model_invocation")
+      ? [{
+          title: optionalColumnLabels.model_invocation,
+          dataIndex: "disable_model_invocation",
+          key: "model_invocation",
+          width: 130,
+          render: (disableModelInvocation: boolean) => (
+            <Tag color={disableModelInvocation ? "orange" : "green"}>
+              {disableModelInvocation
+                ? t("option:skills.modelDisabled", { defaultValue: "Model disabled" })
+                : t("option:skills.modelAllowed", { defaultValue: "Model allowed" })}
+            </Tag>
+          )
+        }]
+      : []),
     {
       title: t("option:skills.colActions", { defaultValue: "Actions" }),
       key: "actions",
@@ -727,6 +906,8 @@ export const SkillsManager: React.FC = () => {
     tableEmptyText = emptyText
   }
 
+  const tableSize = tableDensity === "compact" ? "small" : "middle"
+
   return (
     <div className="flex flex-col gap-4">
       <section
@@ -894,6 +1075,58 @@ export const SkillsManager: React.FC = () => {
           size="small"
           style={{ width: 160 }}
         />
+        <div
+          role="group"
+          aria-label={t("option:skills.tableDensity", {
+            defaultValue: "Table density"
+          })}
+          className="flex flex-wrap items-center gap-1"
+        >
+          <Button
+            size="small"
+            type={tableDensity === "comfortable" ? "primary" : "default"}
+            aria-label={t("option:skills.comfortableDensity", {
+              defaultValue: "Comfortable density"
+            })}
+            aria-pressed={tableDensity === "comfortable"}
+            icon={<Rows3 size={14} />}
+            onClick={() => handleDensityChange("comfortable")}
+          >
+            {t("option:skills.densityComfortable", { defaultValue: "Comfortable" })}
+          </Button>
+          <Button
+            size="small"
+            type={tableDensity === "compact" ? "primary" : "default"}
+            aria-label={t("option:skills.compactDensity", {
+              defaultValue: "Compact density"
+            })}
+            aria-pressed={tableDensity === "compact"}
+            icon={<Rows3 size={14} />}
+            onClick={() => handleDensityChange("compact")}
+          >
+            {t("option:skills.densityCompact", { defaultValue: "Compact" })}
+          </Button>
+        </div>
+        <Dropdown
+          menu={{
+            items: columnVisibilityMenuItems,
+            selectable: true,
+            multiple: true,
+            selectedKeys: visibleOptionalColumns,
+            onClick: ({ key }) => handleColumnVisibilityToggle(key)
+          }}
+          trigger={["click"]}
+        >
+          <Button
+            size="small"
+            aria-label={t("option:skills.columnVisibility", {
+              defaultValue: "Column visibility"
+            })}
+            icon={<Columns3 size={14} />}
+          >
+            {t("option:skills.columns", { defaultValue: "Columns" })}
+          </Button>
+        </Dropdown>
       </div>
 
       {isError && (
@@ -960,13 +1193,15 @@ export const SkillsManager: React.FC = () => {
       )}
 
       <Table
+        data-testid="skills-table"
+        data-density={tableDensity}
         dataSource={data?.skills ?? []}
         columns={columns}
         rowKey="name"
         loading={isLoading}
         onChange={handleTableChange}
         pagination={false}
-        size="middle"
+        size={tableSize}
         locale={{
           emptyText: tableEmptyText
         }}

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -157,6 +157,14 @@ describe("SkillsManager imports", () => {
       </QueryClientProvider>
     )
 
+  const openColumnVisibilityMenu = async () => {
+    fireEvent.click(screen.getByRole("button", { name: "Column visibility" }))
+    return screen.findByRole("menu")
+  }
+
+  const getColumnVisibilityOption = async (name: string) =>
+    within(await openColumnVisibilityMenu()).findByRole("menuitem", { name })
+
   it("orients users with a page summary and library count", async () => {
     tldwClientMock.listSkills.mockResolvedValueOnce({
       skills: [
@@ -579,6 +587,53 @@ describe("SkillsManager imports", () => {
     })
   })
 
+  it("clears server-backed mode sorting when the mode column is hidden", async () => {
+    tldwClientMock.listSkills.mockResolvedValue({
+      skills: [
+        {
+          name: "mode-sorted",
+          description: "Mode sorted skill",
+          argument_hint: null,
+          user_invocable: true,
+          disable_model_invocation: false,
+          context: "inline" as const
+        }
+      ],
+      count: 1,
+      total: 1,
+      limit: 10,
+      offset: 0
+    })
+
+    renderManager()
+
+    expect(await screen.findByText("1 skill")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("columnheader", { name: /Mode/ }))
+
+    await waitFor(() => {
+      expect(tldwClientMock.listSkills).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          sort: "context",
+          order: "asc",
+          limit: 10,
+          offset: 0
+        })
+      )
+    })
+
+    fireEvent.click(await getColumnVisibilityOption("Mode"))
+
+    await waitFor(() => {
+      expect(tldwClientMock.listSkills).toHaveBeenLastCalledWith(
+        expect.not.objectContaining({
+          sort: "context",
+          order: "asc"
+        })
+      )
+    })
+    expect(screen.queryByRole("columnheader", { name: /Mode/ })).not.toBeInTheDocument()
+  })
+
   it("resets pagination when server-backed filters change", async () => {
     const pageOneSkills = Array.from({ length: 10 }, (_, index) => makeSkill(index + 1))
     const pageTwoSkills = [makeSkill(11), makeSkill(12)]
@@ -747,18 +802,12 @@ describe("SkillsManager imports", () => {
     expect(screen.queryByRole("columnheader", { name: "Argument hint" })).not.toBeInTheDocument()
     expect(screen.getByRole("columnheader", { name: /Mode/ })).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole("button", { name: "Column visibility" }))
-    fireEvent.click(await screen.findByText("Argument hint"))
+    fireEvent.click(await getColumnVisibilityOption("Argument hint"))
 
     expect(await screen.findByRole("columnheader", { name: "Argument hint" })).toBeInTheDocument()
     expect(screen.getByText("topic")).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole("button", { name: "Column visibility" }))
-    const modeMenuItem = screen
-      .getAllByText("Mode")
-      .find((element) => element.closest(".ant-dropdown-menu"))
-    expect(modeMenuItem).toBeTruthy()
-    fireEvent.click(modeMenuItem!)
+    fireEvent.click(await getColumnVisibilityOption("Mode"))
 
     expect(screen.queryByRole("columnheader", { name: /Mode/ })).not.toBeInTheDocument()
     expect(window.localStorage.getItem("tldw:skills-manager:table-preferences:v1")).toContain(

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -90,6 +90,7 @@ describe("SkillsManager imports", () => {
       }
     })
     vi.clearAllMocks()
+    window.localStorage.clear()
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: {
@@ -697,6 +698,105 @@ describe("SkillsManager imports", () => {
       )
     })
     expect(await screen.findByText("model-specific")).toBeInTheDocument()
+  })
+
+  it("lets power users switch to compact table density", async () => {
+    tldwClientMock.listSkills.mockResolvedValue({
+      skills: [makeSkill(1)],
+      count: 1,
+      total: 1,
+      limit: 10,
+      offset: 0
+    })
+
+    renderManager()
+
+    expect(await screen.findByText("1 skill")).toBeInTheDocument()
+    const table = screen.getByTestId("skills-table")
+    expect(table).toHaveAttribute("data-density", "comfortable")
+
+    fireEvent.click(screen.getByRole("button", { name: "Compact density" }))
+
+    expect(table).toHaveAttribute("data-density", "compact")
+    expect(window.localStorage.getItem("tldw:skills-manager:table-preferences:v1")).toContain(
+      "\"density\":\"compact\""
+    )
+  })
+
+  it("lets power users show and hide optional table columns", async () => {
+    tldwClientMock.listSkills.mockResolvedValue({
+      skills: [
+        {
+          name: "argument-skill",
+          description: "Uses a topic",
+          argument_hint: "topic",
+          user_invocable: false,
+          disable_model_invocation: true,
+          context: "fork" as const
+        }
+      ],
+      count: 1,
+      total: 1,
+      limit: 10,
+      offset: 0
+    })
+
+    renderManager()
+
+    expect(await screen.findByText("argument-skill")).toBeInTheDocument()
+    expect(screen.queryByRole("columnheader", { name: "Argument hint" })).not.toBeInTheDocument()
+    expect(screen.getByRole("columnheader", { name: /Mode/ })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Column visibility" }))
+    fireEvent.click(await screen.findByText("Argument hint"))
+
+    expect(await screen.findByRole("columnheader", { name: "Argument hint" })).toBeInTheDocument()
+    expect(screen.getByText("topic")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Column visibility" }))
+    const modeMenuItem = screen
+      .getAllByText("Mode")
+      .find((element) => element.closest(".ant-dropdown-menu"))
+    expect(modeMenuItem).toBeTruthy()
+    fireEvent.click(modeMenuItem!)
+
+    expect(screen.queryByRole("columnheader", { name: /Mode/ })).not.toBeInTheDocument()
+    expect(window.localStorage.getItem("tldw:skills-manager:table-preferences:v1")).toContain(
+      "argument_hint"
+    )
+  }, 10000)
+
+  it("restores persisted density and column visibility preferences", async () => {
+    window.localStorage.setItem(
+      "tldw:skills-manager:table-preferences:v1",
+      JSON.stringify({
+        density: "compact",
+        visibleColumns: ["description", "argument_hint"]
+      })
+    )
+    tldwClientMock.listSkills.mockResolvedValue({
+      skills: [
+        {
+          name: "restored-skill",
+          description: "Restored description",
+          argument_hint: "subject",
+          user_invocable: true,
+          disable_model_invocation: false,
+          context: "inline" as const
+        }
+      ],
+      count: 1,
+      total: 1,
+      limit: 10,
+      offset: 0
+    })
+
+    renderManager()
+
+    expect(await screen.findByText("restored-skill")).toBeInTheDocument()
+    expect(screen.getByTestId("skills-table")).toHaveAttribute("data-density", "compact")
+    expect(screen.getByRole("columnheader", { name: "Argument hint" })).toBeInTheDocument()
+    expect(screen.queryByRole("columnheader", { name: /Mode/ })).not.toBeInTheDocument()
   })
 
   it("imports a skill from text via importSkill", async () => {

--- a/backlog/tasks/task-530.5 - Implement-Skills-dense-view-and-column-controls.md
+++ b/backlog/tasks/task-530.5 - Implement-Skills-dense-view-and-column-controls.md
@@ -1,0 +1,77 @@
+---
+id: TASK-530.5
+title: Implement Skills dense view and column controls
+status: Done
+labels:
+- skills
+- webui
+- ux
+- power-user
+priority: high
+parent_task_id: TASK-530
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue TASK-530 power-user Skills remediation after TASK-530.4. Add a focused frontend slice for faster scanning and predictable table personalization on /skills.
+
+Scope:
+- Add a compact/dense table view toggle for power users.
+- Add column visibility controls for secondary Skills metadata columns that already exist in list rows.
+- Persist the user's density and column visibility choices locally.
+- Preserve existing server-backed search, filters, sorting, pagination, and beginner empty-state behavior.
+
+Out of scope:
+- Bulk actions/export.
+- Backend schema/API changes.
+- Import review, delete/version semantics, and safe execution workflows.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The Skills manager exposes a keyboard-accessible view density toggle that switches the table between normal and compact scanning density.
+- [x] #2 The Skills manager exposes a keyboard-accessible column visibility control for optional secondary columns without hiding required name/actions columns.
+- [x] #3 Density and visible-column preferences persist locally and are restored on remount.
+- [x] #4 Existing server-backed search, filters, sorting, pagination, and beginner empty states continue to work.
+- [x] #5 Focused Skills manager tests cover density toggling, column visibility, persistence, and regression coverage for existing list behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/Plans/IMPLEMENTATION_PLAN_skills_density_columns_TASK_530_5.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added component-local Skills table preference loading/saving under localStorage key `tldw:skills-manager:table-preferences:v1`, with malformed/partial values normalized to safe defaults.
+- Added a table density control with accessible pressed state; compact mode maps the Skills table to Ant Design `size="small"` and records `data-density="compact"` for regression coverage.
+- Added a column visibility dropdown for optional list-row metadata columns: description, mode/context, argument hint, user visibility, and model invocation. Name and actions remain mandatory.
+- Existing server-backed search, filters, sorting, pagination, import, seed, preview, and create flows remain covered by the expanded Skills manager suite.
+- Bandit is not applicable: touched implementation files are frontend TypeScript/React plus tests/docs; no Python code changed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented TASK-530.5 power-user table scanning controls for `/skills`: compact/comfortable density, optional metadata column visibility, and local persistence of both preferences. Regression tests cover density toggling, optional column visibility, preference restoration, and the existing Skills manager behavior.
+
+Verification:
+- PASS: `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx` (21 tests)
+- PASS: `bunx vitest run src/services/__tests__/tldw-api-client.boundary-slices.test.ts` (8 tests)
+- PASS: `git diff --check`
+- TYPECHECK CAVEAT: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json --pretty false` still fails on inherited baseline errors in Notes tests, `src/entries/background.ts`, and `src/services/tldw/voice-cloning.ts`; no `src/components/Option/Skills/Manager.tsx` errors remain after the touched-file fixes.
+- COMBINED VITEST CAVEAT: running the Skills manager suite and service boundary slice in one Vitest command passed the service slice but timed out once on an existing filter-control test under load; the same manager suite and service slice pass separately.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-530.5 - Implement-Skills-dense-view-and-column-controls.md
+++ b/backlog/tasks/task-530.5 - Implement-Skills-dense-view-and-column-controls.md
@@ -51,6 +51,9 @@ Docs/Plans/IMPLEMENTATION_PLAN_skills_density_columns_TASK_530_5.md
 - Added a column visibility dropdown for optional list-row metadata columns: description, mode/context, argument hint, user visibility, and model invocation. Name and actions remain mandatory.
 - Existing server-backed search, filters, sorting, pagination, import, seed, preview, and create flows remain covered by the expanded Skills manager suite.
 - Bandit is not applicable: touched implementation files are frontend TypeScript/React plus tests/docs; no Python code changed.
+- PR #2339 review follow-up: replaced the column-visibility test's Ant Design class traversal with accessible menu/menuitem queries.
+- PR #2339 review follow-up: hiding the Mode/context column now clears an active `sort=context` state and resets to page 1 so backend query state cannot remain sorted by a hidden column.
+- PR #2339 review follow-up: table preference state now uses React lazy initializers instead of a render-phase `useMemo` read.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -59,7 +62,7 @@ Docs/Plans/IMPLEMENTATION_PLAN_skills_density_columns_TASK_530_5.md
 Implemented TASK-530.5 power-user table scanning controls for `/skills`: compact/comfortable density, optional metadata column visibility, and local persistence of both preferences. Regression tests cover density toggling, optional column visibility, preference restoration, and the existing Skills manager behavior.
 
 Verification:
-- PASS: `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx` (21 tests)
+- PASS: `bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx` (22 tests after PR review follow-up)
 - PASS: `bunx vitest run src/services/__tests__/tldw-api-client.boundary-slices.test.ts` (8 tests)
 - PASS: `git diff --check`
 - TYPECHECK CAVEAT: `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json --pretty false` still fails on inherited baseline errors in Notes tests, `src/entries/background.ts`, and `src/services/tldw/voice-cloning.ts`; no `src/components/Option/Skills/Manager.tsx` errors remain after the touched-file fixes.


### PR DESCRIPTION
## Change summary
Adds power-user table personalization to the /skills manager without changing the Skills API. The table now supports comfortable/compact density, optional metadata column visibility, and local persistence of those preferences. Name and actions remain mandatory so users cannot hide the primary identifier or controls.

This is intentionally component-local because the behavior is a user preference for scanning the current UI, not server-backed skill data. Preferences are normalized on load so malformed localStorage values fall back safely.

## Verification
- PASS: bunx vitest run src/components/Option/Skills/__tests__/Manager.test.tsx (21 tests)
- PASS: bunx vitest run src/services/__tests__/tldw-api-client.boundary-slices.test.ts (8 tests)
- PASS: git diff --cached --check
- TYPECHECK CAVEAT: NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json --pretty false still fails on inherited baseline errors in Notes tests, src/entries/background.ts, and src/services/tldw/voice-cloning.ts; no src/components/Option/Skills/Manager.tsx errors remain.
- Bandit: not applicable for this frontend-only TypeScript/docs/test task.

## Scope notes
- No backend/API changes.
- No bulk actions/export/import review/delete semantics included.
- Excludes dependency-install symlink noise from bun install.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds power‑user table controls to the `/skills` manager: a density toggle (comfortable/compact) and a column visibility menu with preferences saved and restored locally; implements TASK-530.5. No backend changes; search, filters, sorting, and pagination behave as before.

- **New Features**
  - Density toggle persists per user and restores on load.
  - Column visibility for optional columns: description, mode, argument hint, visibility, and model use; name and actions stay mandatory.

- **Bug Fixes**
  - Hiding a sorted optional column (e.g., Mode) now clears the active sort and resets to page 1 to keep queries consistent.

<sup>Written for commit bd522539df866500898bb44a5943c28d05fb9bbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

