### PR TITLE
Scheduled Tasks Phase 4B API foundation

### DIFF
--- a/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
@@ -1,0 +1,1422 @@
+# Scheduled Tasks Phase 4B Backend API Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the Phase 4B Scheduled Tasks API foundation for durable Recurring Question and Agent Task definitions, durable previews, lifecycle management, audit, normalized control-plane projection, and reference-client WebUI wiring without executing scheduled work.
+
+**Architecture:** Add Scheduled Tasks-owned definition resources under the existing `/api/v1/scheduled-tasks` namespace. Keep persistence behind a focused repository backed first by per-user SQLite, layer business rules in a service, expose resource-oriented endpoints, and project definitions into the existing scheduled-tasks control-plane list as a new `automation_definition` primitive. The WebUI should act as an API client that can preview, create, inspect, edit, pause/resume, archive, and duplicate definitions while clearly showing execution is unavailable.
+
+**Tech Stack:** FastAPI, Pydantic, SQLite, pytest, Loguru, Next.js package UI, TypeScript, React, Ant Design, Vitest, Testing Library, existing scheduled-tasks control-plane client and components.
+
+---
+
+## Source Inputs
+
+- Approved spec: `Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-design.md`
+- Prior Phase 4 API contract spec: `Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase4-recurring-question-agent-task-api-contract-design.md`
+- Prior Phase 4A shell plan: `Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4a-api-first-planned-shell-implementation-plan.md`
+- Scheduler vs Jobs ADR: `Docs/ADR/003-jobs-vs-scheduler-default.md`
+- Backlog: `TASK-2350`
+
+## Scope Check
+
+This plan is one backend/API foundation slice with a reference WebUI client. It intentionally does not implement execution.
+
+In scope:
+
+- capability discovery for `recurring_question` and `agent_task`;
+- durable preview records for create/update;
+- persisted definitions;
+- lifecycle mutations: create, update, pause, resume, archive, duplicate;
+- per-definition audit;
+- optional idempotency support for mutating endpoints;
+- normalized `automation_definition` rows in `/api/v1/scheduled-tasks`;
+- WebUI preview/create/edit/lifecycle/detail wiring over the API.
+
+Out of scope:
+
+- scheduled execution, manual run, Jobs enqueueing, Scheduler integration;
+- RAG query execution;
+- ACP/API agent dispatch;
+- approval queue mutations;
+- notification delivery;
+- fake run rows, fake results, fake Home cards;
+- migration or replacement of Watchlists or `/acp/schedules`.
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `tldw_Server_API/app/api/v1/schemas/scheduled_tasks_automation_schemas.py` | New Pydantic contract for capabilities, previews, definitions, schedules, visibility, lifecycle, audit, and errors. |
+| `tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py` | Per-user SQLite repository for previews, definitions, audit events, and idempotency records. |
+| `tldw_Server_API/app/services/scheduled_task_automation_service.py` | Business rules: capabilities, validation, preview consumption, lifecycle transitions, duplicate semantics, audit, idempotency, and projection helpers. |
+| `tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py` | Add static child routes before `/{task_id}` and connect them to the automation service. Preserve existing reminder endpoints. |
+| `tldw_Server_API/app/api/v1/schemas/scheduled_tasks_control_plane_schemas.py` | Extend `ScheduledTaskPrimitive` with `automation_definition`. |
+| `tldw_Server_API/app/services/scheduled_tasks_control_plane_service.py` | Compose automation definitions into the existing list/detail read model without changing reminders or Watchlists behavior. |
+| `tldw_Server_API/tests/Notifications/test_scheduled_task_automation_db.py` | Repository unit tests. |
+| `tldw_Server_API/tests/Notifications/test_scheduled_task_automation_service.py` | Service/business-rule unit tests. |
+| `tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py` | Endpoint integration tests for capabilities, previews, definitions, lifecycle, audit, idempotency, route ordering, and permissions. |
+| `tldw_Server_API/tests/Notifications/test_scheduled_tasks_control_plane.py` | Extend existing projection compatibility tests for `automation_definition`. |
+| `apps/packages/ui/src/services/scheduled-tasks-control-plane.ts` | Add API client types and methods for capabilities, previews, definitions, lifecycle, and audit. |
+| `apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-automation-status.ts` | Pure helper for `automation_definition` family/type/status/lifecycle copy. |
+| `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskAutomationDefinitionEditor.tsx` | Preview-backed create/edit form for Recurring Question and Agent Task definitions. |
+| `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx` | Replace planned-only state with API-driven create affordances when capabilities allow definition management. |
+| `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskTable.tsx` | Add `automation_definition` filter/type/status handling and lifecycle actions. |
+| `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskDetailDrawer.tsx` | Show definition detail, execution-unavailable copy, preview history, audit events, and lifecycle actions. |
+| `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx` | Wire API client flows, optimistic refresh, and error messages. |
+| `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-automation-status.test.ts` | Pure helper tests for status/type copy. |
+| `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskAutomationDefinitionEditor.test.tsx` | Editor preview/save tests. |
+| `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx` | Integration tests for create/manage/detail flows and no fake results. |
+| `backlog/tasks/task-2350 - Plan-Scheduled-Tasks-Phase-4B-backend-API-foundation-implementation.md` | Planning task notes and verification record. |
+
+## Guardrails
+
+- Do not enqueue Jobs, register Scheduler tasks, or run RAG/agent work.
+- Do not create run history, results, notifications, or Home cards for 4B definitions.
+- Do not collapse Watchlists into Scheduled Tasks. Watchlists remains an external management workspace.
+- Do not store raw Agent Task message text inline in definition, preview, or audit rows.
+- Keep all new list endpoints paginated and filterable.
+- Register static `/scheduled-tasks/capabilities`, `/scheduled-tasks/previews`, and `/scheduled-tasks/definitions` routes before `/{task_id}`.
+- Treat `owner_id` as part of the logical key for definitions, previews, audit reads, and idempotency records.
+- Use `TASKS_READ` for read endpoints and `TASKS_CONTROL` for preview/create/update/lifecycle mutations.
+- Use `archive`, not hard delete.
+
+## Task 1: Backend Schema Contracts And Route Skeleton
+
+**Files:**
+- Create: `tldw_Server_API/app/api/v1/schemas/scheduled_tasks_automation_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/scheduled_tasks_control_plane_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py`
+- Create: `tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py`
+
+- [ ] **Step 1: Write failing route and schema tests**
+
+Add tests that prove static child routes are not captured by `/{task_id}` and that capabilities return explicit unavailable execution actions.
+
+The existing `scheduled_tasks_client` fixture currently lives inside `test_scheduled_tasks_control_plane.py`, so it is not visible to a new test module. In `test_scheduled_task_automation_api.py`, either move the shared fixture helpers into `tldw_Server_API/tests/Notifications/conftest.py` or duplicate a small local fixture block with `_make_principal`, `_override_auth`, and `scheduled_tasks_client`. Do not import fixtures from another test module.
+
+```python
+def test_scheduled_task_static_child_routes_do_not_resolve_as_task_ids(scheduled_tasks_client, auth_headers):
+    for path in (
+        "/api/v1/scheduled-tasks/capabilities",
+        "/api/v1/scheduled-tasks/previews",
+        "/api/v1/scheduled-tasks/definitions",
+    ):
+        response = scheduled_tasks_client.get(path, headers=auth_headers)
+        assert response.status_code != 404, response.text
+        assert response.text != "scheduled_task_not_found"
+
+
+def test_capabilities_report_definition_actions_but_no_execution(scheduled_tasks_client, auth_headers):
+    response = scheduled_tasks_client.get("/api/v1/scheduled-tasks/capabilities", headers=auth_headers)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    families = {item["family"]: item for item in body["items"]}
+    assert {"recurring_question", "agent_task"} <= set(families)
+    for family in ("recurring_question", "agent_task"):
+        actions = families[family]["actions"]
+        assert actions["preview"]["status"] == "available"
+        assert actions["create_definition"]["status"] == "available"
+        assert actions["execute"]["status"] == "unavailable"
+        assert actions["execute"]["reason"] == "execution_not_implemented"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py -q
+```
+
+Expected: FAIL because schemas/routes do not exist or static routes are shadowed.
+
+- [ ] **Step 3: Add schema types**
+
+Create `scheduled_tasks_automation_schemas.py` with Pydantic models and literal aliases. Include at minimum:
+
+```python
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+ScheduledTaskAutomationFamily = Literal["recurring_question", "agent_task"]
+ScheduledTaskAutomationActionStatus = Literal["available", "unavailable", "planned", "disabled"]
+ScheduledTaskAutomationFamilyAvailability = Literal["available", "planned", "unavailable", "degraded"]
+ScheduledTaskPreviewMode = Literal["create", "update"]
+ScheduledTaskPreviewStatus = Literal["valid", "invalid", "expired", "consumed"]
+ScheduledTaskDefinitionLifecycle = Literal["configured", "paused", "archived", "disabled"]
+ScheduledTaskDefinitionHealth = Literal[
+    "ready",
+    "execution_unavailable",
+    "capability_unavailable",
+    "needs_attention",
+    "permission_required",
+]
+
+
+class ScheduledTaskActionCapability(BaseModel):
+    status: ScheduledTaskAutomationActionStatus
+    reason: str | None = None
+    required_permissions: list[str] = Field(default_factory=list)
+
+
+class ScheduledTaskAutomationCapability(BaseModel):
+    family: ScheduledTaskAutomationFamily
+    family_availability: ScheduledTaskAutomationFamilyAvailability
+    actions: dict[str, ScheduledTaskActionCapability]
+    missing_dependencies: list[str] = Field(default_factory=list)
+    related_capabilities: dict[str, Any] = Field(default_factory=dict)
+    reason: str | None = None
+    schema_version: str = "2026-06-09"
+
+
+class ScheduledTaskAutomationCapabilitiesResponse(BaseModel):
+    items: list[ScheduledTaskAutomationCapability] = Field(default_factory=list)
+```
+
+Also define request/response model placeholders needed by later tasks:
+
+- `ScheduledTaskPreviewCreateRequest`
+- `ScheduledTaskPreviewResponse`
+- `ScheduledTaskDefinitionCreateRequest`
+- `ScheduledTaskDefinitionUpdateRequest`
+- `ScheduledTaskDefinitionResponse`
+- `ScheduledTaskDefinitionListResponse`
+- `ScheduledTaskAuditEventResponse`
+- `ScheduledTaskAuditListResponse`
+- `ScheduledTaskDuplicateRequest`
+
+Use typed fields from the spec, but keep nested `config`, `input`, `schedule`, `visibility_policy`, and `notification_policy` as structured `dict[str, Any]` initially. Later tasks tighten validation in the service layer.
+
+- [ ] **Step 4: Extend normalized primitive type**
+
+In `scheduled_tasks_control_plane_schemas.py`, change:
+
+```python
+ScheduledTaskPrimitive = Literal["reminder_task", "watchlist_job"]
+```
+
+to:
+
+```python
+ScheduledTaskPrimitive = Literal["reminder_task", "watchlist_job", "automation_definition"]
+```
+
+- [ ] **Step 5: Add route skeleton before `/{task_id}`**
+
+In `scheduled_tasks_control_plane.py`, register these routes before the existing `@router.get("/{task_id}")`:
+
+```python
+@router.get(
+    "/capabilities",
+    response_model=ScheduledTaskAutomationCapabilitiesResponse,
+    dependencies=[Depends(rbac_rate_limit("tasks.read"))],
+)
+async def get_scheduled_task_automation_capabilities(
+    _principal=Depends(RequirePermission(TASKS_READ)),  # noqa: B008
+    service: ScheduledTaskAutomationService = Depends(get_scheduled_task_automation_service),
+) -> ScheduledTaskAutomationCapabilitiesResponse:
+    return service.get_capabilities()
+```
+
+Add skeleton `GET /previews`, `GET /definitions`, and `GET /definitions/{definition_id}/audit` routes that return empty paginated responses until later tasks implement storage. Add `POST /previews`, `POST /definitions`, `PATCH /definitions/{definition_id}`, and lifecycle route skeletons that call service methods.
+
+- [ ] **Step 6: Implement minimal capability service**
+
+Create `tldw_Server_API/app/services/scheduled_task_automation_service.py` with:
+
+```python
+class ScheduledTaskAutomationService:
+    """Business service for Scheduled Tasks-owned automation definitions."""
+
+    def get_capabilities(self) -> ScheduledTaskAutomationCapabilitiesResponse:
+        actions = {
+            "preview": ScheduledTaskActionCapability(status="available", required_permissions=[TASKS_CONTROL]),
+            "create_definition": ScheduledTaskActionCapability(status="available", required_permissions=[TASKS_CONTROL]),
+            "update_definition": ScheduledTaskActionCapability(status="available", required_permissions=[TASKS_CONTROL]),
+            "pause": ScheduledTaskActionCapability(status="available", required_permissions=[TASKS_CONTROL]),
+            "resume": ScheduledTaskActionCapability(status="available", required_permissions=[TASKS_CONTROL]),
+            "archive": ScheduledTaskActionCapability(status="available", required_permissions=[TASKS_CONTROL]),
+            "duplicate": ScheduledTaskActionCapability(status="available", required_permissions=[TASKS_CONTROL]),
+            "execute": ScheduledTaskActionCapability(
+                status="unavailable",
+                reason="execution_not_implemented",
+                required_permissions=[TASKS_CONTROL],
+            ),
+        }
+        return ScheduledTaskAutomationCapabilitiesResponse(
+            items=[
+                ScheduledTaskAutomationCapability(
+                    family="recurring_question",
+                    family_availability="available",
+                    actions=actions,
+                    related_capabilities={"rag": {"status": "not_checked"}},
+                ),
+                ScheduledTaskAutomationCapability(
+                    family="agent_task",
+                    family_availability="available",
+                    actions=actions,
+                    related_capabilities={"acp": {"status": "not_checked"}},
+                ),
+            ]
+        )
+```
+
+- [ ] **Step 7: Run route/schema tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py -q
+python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_tasks_control_plane.py -q
+```
+
+Expected: PASS for capability/static route tests and existing control-plane tests.
+
+- [ ] **Step 8: Commit schema and route skeleton**
+
+```bash
+git add \
+  tldw_Server_API/app/api/v1/schemas/scheduled_tasks_automation_schemas.py \
+  tldw_Server_API/app/api/v1/schemas/scheduled_tasks_control_plane_schemas.py \
+  tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py \
+  tldw_Server_API/app/services/scheduled_task_automation_service.py \
+  tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
+git commit -m "feat: add scheduled task automation API skeleton"
+```
+
+## Task 2: Repository And Per-User SQLite Storage
+
+**Files:**
+- Create: `tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py`
+- Create: `tldw_Server_API/tests/Notifications/test_scheduled_task_automation_db.py`
+
+- [ ] **Step 1: Write failing repository tests**
+
+Test per-user isolation, preview persistence, definition persistence, disabled lock fields, audit events, idempotency scoping, pagination, filtering, and redacted Agent Task storage.
+
+```python
+def test_scheduled_tasks_repository_isolates_users(tmp_path, monkeypatch):
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(tmp_path))
+    repo_a = ScheduledTasksDatabase.for_user(user_id=101)
+    repo_b = ScheduledTasksDatabase.for_user(user_id=202)
+    repo_a.ensure_schema()
+    repo_b.ensure_schema()
+
+    preview = repo_a.create_preview(
+        owner_id=101,
+        mode="create",
+        family="recurring_question",
+        definition_id=None,
+        definition_version=None,
+        status="valid",
+        payload_hash="hash-a",
+        normalized_config={"name": "Question", "input": {"question": "What changed?"}},
+        validation_errors=[],
+        warnings=[],
+        risk_class=None,
+        visibility_policy="findings_only",
+        schedule_preview={"summary": "daily"},
+        redaction_policy={"mode": "none"},
+        expires_at="2026-06-10T00:00:00+00:00",
+        created_by="101",
+    )
+
+    assert repo_a.get_preview(owner_id=101, preview_id=preview.id).id == preview.id
+    assert repo_b.get_preview(owner_id=202, preview_id=preview.id) is None
+```
+
+Add separate tests:
+
+- `test_create_definition_and_audit_roundtrip`
+- `test_update_preview_consumption_sets_consumed_at`
+- `test_idempotency_records_are_owner_and_route_scoped`
+- `test_list_definitions_filters_by_family_lifecycle_health_and_query`
+- `test_definition_persists_disabled_lock_kind_and_reason`
+- `test_agent_task_definition_and_audit_storage_do_not_contain_raw_message_secret`
+
+- [ ] **Step 2: Run repository tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_task_automation_db.py -q
+```
+
+Expected: FAIL because `Scheduled_Tasks_DB.py` does not exist.
+
+- [ ] **Step 3: Implement row dataclasses and schema**
+
+Create `Scheduled_Tasks_DB.py` with:
+
+- `PreviewRow`
+- `DefinitionRow`
+- `AuditEventRow`
+- `IdempotencyRecordRow`
+- `ScheduledTasksDatabase`
+
+Use SQLite tables:
+
+```sql
+CREATE TABLE IF NOT EXISTS scheduled_task_previews (
+    id TEXT PRIMARY KEY,
+    owner_id INTEGER NOT NULL,
+    mode TEXT NOT NULL,
+    family TEXT NOT NULL,
+    definition_id TEXT,
+    definition_version INTEGER,
+    status TEXT NOT NULL,
+    payload_hash TEXT NOT NULL,
+    normalized_config_json TEXT NOT NULL,
+    validation_errors_json TEXT NOT NULL,
+    warnings_json TEXT NOT NULL,
+    risk_class TEXT,
+    visibility_policy TEXT NOT NULL,
+    schedule_preview_json TEXT NOT NULL,
+    redaction_policy_json TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    created_by TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    consumed_at TEXT,
+    created_definition_id TEXT
+);
+```
+
+Also create:
+
+- `scheduled_task_definitions`
+- `scheduled_task_audit_events`
+- `scheduled_task_idempotency`
+
+`scheduled_task_definitions` must include:
+
+- `disabled_lock_kind TEXT NOT NULL DEFAULT 'none'`
+- `disabled_reason TEXT`
+
+Use `disabled_lock_kind` values `none`, `admin`, `security`, and `system`. This field is required by duplicate guardrails: admin/security locked disabled definitions cannot be copied into a future runnable state.
+
+Indexes:
+
+- previews: `(owner_id, created_at)`, `(owner_id, definition_id)`, `(owner_id, status)`
+- definitions: `(owner_id, family)`, `(owner_id, lifecycle)`, `(owner_id, health)`, `(owner_id, updated_at)`
+- audit: `(definition_id, created_at)`
+- idempotency: unique `(owner_id, route, key)`
+
+- [ ] **Step 4: Implement repository methods**
+
+Add focused methods:
+
+- `for_user(user_id: int) -> ScheduledTasksDatabase`
+- `ensure_schema() -> None`
+- `create_preview(...) -> PreviewRow`
+- `get_preview(owner_id: int, preview_id: str) -> PreviewRow | None`
+- `list_previews(owner_id: int, filters..., limit: int, offset: int) -> tuple[list[PreviewRow], int]`
+- `mark_preview_consumed(owner_id: int, preview_id: str, created_definition_id: str | None) -> PreviewRow`
+- `create_definition(...) -> DefinitionRow`
+- `get_definition(owner_id: int, definition_id: str) -> DefinitionRow | None`
+- `list_definitions(owner_id: int, filters..., limit: int, offset: int) -> tuple[list[DefinitionRow], int]`
+- `update_definition(owner_id: int, definition_id: str, patch: dict[str, Any], expected_version: int | None) -> DefinitionRow`
+- `create_audit_event(...) -> AuditEventRow`
+- `list_audit_events(owner_id: int, definition_id: str, filters..., limit: int, offset: int)`
+- `get_idempotency_record(owner_id: int, route: str, key: str) -> IdempotencyRecordRow | None`
+- `create_idempotency_record(...) -> IdempotencyRecordRow`
+
+Use JSON helpers that always encode dictionaries/lists with sorted keys.
+
+- [ ] **Step 5: Run repository tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_task_automation_db.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit repository**
+
+```bash
+git add \
+  tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py \
+  tldw_Server_API/tests/Notifications/test_scheduled_task_automation_db.py
+git commit -m "feat: add scheduled task automation repository"
+```
+
+## Task 3: Preview Validation And Definition Lifecycle Service
+
+**Files:**
+- Modify: `tldw_Server_API/app/services/scheduled_task_automation_service.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/scheduled_tasks_automation_schemas.py`
+- Create: `tldw_Server_API/tests/Notifications/test_scheduled_task_automation_service.py`
+
+- [ ] **Step 1: Write failing service tests for preview validation**
+
+Cover valid, invalid, expired, stale, consumed, cross-user, and redacted Agent Task previews.
+
+```python
+def test_create_preview_persists_invalid_semantic_preview(tmp_path, monkeypatch):
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(tmp_path))
+    service = ScheduledTaskAutomationService()
+
+    preview = service.create_preview(
+        owner_id=880,
+        actor="880",
+        payload=ScheduledTaskPreviewCreateRequest(
+            mode="create",
+            family="recurring_question",
+            definition_id=None,
+            definition_version=None,
+            config={
+                "name": "",
+                "input": {"question": ""},
+                "schedule": {},
+                "visibility_policy": "findings_only",
+                "notification_policy": {},
+            },
+        ),
+    )
+
+    assert preview.status == "invalid"
+    assert preview.validation_errors
+    assert preview.id
+```
+
+```python
+def test_agent_task_preview_redacts_raw_message(tmp_path, monkeypatch):
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(tmp_path))
+    service = ScheduledTaskAutomationService()
+
+    preview = service.create_preview(
+        owner_id=880,
+        actor="880",
+        payload=ScheduledTaskPreviewCreateRequest(
+            mode="create",
+            family="agent_task",
+            definition_id=None,
+            definition_version=None,
+            config={
+                "name": "Agent check",
+                "input": {
+                    "agent_ref": {"kind": "acp_agent", "id": "codex"},
+                    "message": "secret api key sk-test-123 should not leak",
+                    "allowed_tool_classes": [],
+                    "denied_tool_classes": [],
+                    "approval_policy": {"mode": "none"},
+                },
+                "schedule": {"kind": "daily", "timezone": "UTC"},
+                "visibility_policy": "failures_and_approvals",
+                "notification_policy": {},
+            },
+        ),
+    )
+
+    serialized = preview.model_dump_json()
+    assert "sk-test-123" not in serialized
+    assert preview.normalized_config["input"]["message_payload"]["storage_mode"] == "redacted_only"
+```
+
+Add tests for:
+
+- create consumes valid preview;
+- update requires preview version match;
+- duplicate creates paused copy and two audit events;
+- duplicate of disabled definitions succeeds only for non-admin/non-security lock kinds;
+- duplicate of `disabled_lock_kind` `admin` or `security` fails and creates no copy;
+- pause/resume/archive transition matrix;
+- preview idempotency replay and same-key/different-payload conflict;
+- create idempotency replay before preview consumption;
+- update idempotency replay after preview consumption;
+- duplicate idempotency replay without creating a second copy or second audit pair;
+- pause/resume/archive idempotency replay without extra audit events;
+- same key different payload conflict for representative preview/create/lifecycle routes;
+- no-key consumed preview reuse fails.
+- Agent Task raw secret strings are absent from preview response, created definition response, definition list/detail response models, and audit response models.
+
+- [ ] **Step 2: Run service tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_task_automation_service.py -q
+```
+
+Expected: FAIL because service methods are not implemented.
+
+- [ ] **Step 3: Implement canonical hashing and validation helpers**
+
+In `scheduled_task_automation_service.py`, add private helpers:
+
+```python
+def _canonical_hash(payload: dict[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+```
+
+Validation helpers:
+
+- `_validate_recurring_question_config(config) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]`
+- `_validate_agent_task_config(config) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]`
+- `_validate_schedule(schedule) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]`
+- `_normalize_visibility_policy(family, value) -> str`
+- `_redact_agent_message(message: str) -> dict[str, Any]`
+
+Keep validation conservative:
+
+- require non-empty `name`;
+- require Recurring Question `input.question`;
+- require Agent Task `input.agent_ref` and `input.message`;
+- validate schedule `kind` only against `one_time`, `interval`, `daily`, `weekly`, `cron`;
+- do not call RAG or ACP live execution APIs in 4B.
+
+- [ ] **Step 4: Implement preview creation**
+
+`create_preview(owner_id, actor, payload)` should:
+
+- compute preview payload hash from `mode`, `family`, `definition_id`, `definition_version`, `config`;
+- persist `valid` or `invalid` preview;
+- set default expiry using a documented constant, for example 24 hours;
+- return `201`-safe response model through API later;
+- never persist raw Agent Task messages inline in normalized config.
+
+For Agent Task tests, use a unique sentinel such as `RAW_AGENT_SECRET_DO_NOT_LEAK_4B`. Assert this string is absent from:
+
+- preview response serialization;
+- repository `normalized_config_json`;
+- definition response serialization after create;
+- definition list/detail serialization;
+- audit `before`/`after` metadata;
+- repository audit JSON.
+
+- [ ] **Step 5: Implement definition create/update lifecycle**
+
+Rules:
+
+- create/update require valid preview;
+- preview owner must match current user;
+- preview status must be `valid`;
+- preview must be unexpired and unconsumed;
+- create preview has no `definition_id`;
+- update preview `definition_id` matches route and `definition_version` matches current definition version;
+- successful create/update marks preview consumed;
+- create/update writes deterministic audit events;
+- definitions default health is `execution_unavailable`.
+
+- [ ] **Step 6: Implement lifecycle and duplicate**
+
+Implement:
+
+- `pause_definition`
+- `resume_definition`
+- `archive_definition`
+- `duplicate_definition`
+
+Follow the transition matrix:
+
+- pause paused: idempotent 200, no audit;
+- resume configured: idempotent 200, no audit;
+- archive archived: idempotent 200;
+- update/pause/resume archived: conflict;
+- duplicate archived: conflict;
+- duplicate disabled only if `disabled_lock_kind` is not `admin` or `security`;
+- duplicate always creates `paused` copy;
+- duplicate audit records both `definition_duplicated` and `definition_duplicate_created`.
+
+- [ ] **Step 7: Implement idempotency wrapper**
+
+Add a service-level helper:
+
+```python
+def _with_idempotency(
+    self,
+    *,
+    owner_id: int,
+    route: str,
+    key: str | None,
+    payload_hash: str,
+    operation: Callable[[], BaseModel],
+) -> BaseModel:
+    ...
+```
+
+Behavior:
+
+- no key: run operation normally;
+- same owner + route + key + same hash: return stored response;
+- same owner + route + key + different hash: raise `scheduled_task_idempotency_conflict`;
+- idempotency lookup happens before preview validation/consumption for mutation replay.
+
+Apply the wrapper to all 4B mutating routes that accept `Idempotency-Key`: preview, create, update, duplicate, pause, resume, and archive.
+
+- [ ] **Step 8: Run service tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_task_automation_service.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit service layer**
+
+```bash
+git add \
+  tldw_Server_API/app/services/scheduled_task_automation_service.py \
+  tldw_Server_API/app/api/v1/schemas/scheduled_tasks_automation_schemas.py \
+  tldw_Server_API/tests/Notifications/test_scheduled_task_automation_service.py
+git commit -m "feat: implement scheduled task definition service"
+```
+
+## Task 4: API Endpoints, Errors, Permissions, And OpenAPI Contract
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/scheduled_tasks_automation_schemas.py`
+- Modify: `tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py`
+
+- [ ] **Step 1: Write failing endpoint integration tests**
+
+Add endpoint tests for:
+
+- preview valid/invalid responses;
+- create from preview;
+- update from preview;
+- pause/resume/archive/duplicate;
+- audit list;
+- filters and pagination;
+- permission failures;
+- cross-user preview/definition denial;
+- Agent Task sentinel redaction across preview, create, list, detail, and audit responses;
+- idempotent preview replay and conflict;
+- idempotent create replay after preview consumed;
+- idempotent update replay after preview consumed;
+- idempotent duplicate replay without a second copy or duplicate audit pair;
+- idempotent pause/resume/archive replay without extra audit events;
+- same idempotency key with different payload conflict;
+- representative validation error envelopes for schedule invalid, scope invalid, agent ref invalid, permission policy invalid, family unavailable, and execution unavailable.
+
+Example:
+
+```python
+def test_create_definition_consumes_preview_and_exposes_audit(scheduled_tasks_client, auth_headers):
+    preview_response = scheduled_tasks_client.post(
+        "/api/v1/scheduled-tasks/previews",
+        headers=auth_headers,
+        json={
+            "mode": "create",
+            "family": "recurring_question",
+            "definition_id": None,
+            "definition_version": None,
+            "config": {
+                "name": "Track licensing answer",
+                "input": {"question": "Has the licensing answer appeared?"},
+                "schedule": {"kind": "daily", "timezone": "UTC"},
+                "visibility_policy": "findings_only",
+                "notification_policy": {"home_enabled": True},
+            },
+        },
+    )
+    assert preview_response.status_code == 201, preview_response.text
+    preview_id = preview_response.json()["id"]
+
+    create_response = scheduled_tasks_client.post(
+        "/api/v1/scheduled-tasks/definitions",
+        headers=auth_headers,
+        json={"preview_id": preview_id, "initial_lifecycle": "configured"},
+    )
+
+    assert create_response.status_code == 201, create_response.text
+    definition = create_response.json()
+    assert definition["family"] == "recurring_question"
+    assert definition["lifecycle"] == "configured"
+    assert definition["health"] == "execution_unavailable"
+
+    audit_response = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/audit",
+        headers=auth_headers,
+    )
+    assert audit_response.status_code == 200, audit_response.text
+    assert audit_response.json()["items"][0]["event_type"] == "definition_created"
+```
+
+- [ ] **Step 2: Run endpoint tests to verify failures**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py -q
+```
+
+Expected: FAIL for unimplemented routes/error mapping.
+
+- [ ] **Step 3: Add endpoint error helper**
+
+Use a local helper in the endpoint module to map service exceptions to consistent error bodies:
+
+```python
+def _scheduled_task_error(
+    *,
+    request: Request,
+    status_code: int,
+    code: str,
+    message: str,
+    details: dict[str, Any] | None = None,
+    retryable: bool = False,
+) -> HTTPException:
+    correlation_id = getattr(getattr(request, "state", None), "request_id", None)
+    return HTTPException(
+        status_code=status_code,
+        detail={
+            "code": code,
+            "message": message,
+            "details": details or {},
+            "field_errors": [],
+            "retryable": retryable,
+            "correlation_id": correlation_id,
+        },
+    )
+```
+
+Map service exceptions:
+
+- `scheduled_task_family_unavailable`: 409;
+- `scheduled_task_preview_required`: 400;
+- `scheduled_task_definition_not_found`: 404;
+- `scheduled_task_preview_mismatch`: 409;
+- `scheduled_task_preview_expired`: 409;
+- `scheduled_task_schedule_invalid`: 422;
+- `scheduled_task_scope_invalid`: 422;
+- `scheduled_task_agent_ref_invalid`: 422;
+- `scheduled_task_permission_policy_invalid`: 422;
+- `scheduled_task_execution_unavailable`: 409;
+- `scheduled_task_definition_version_conflict`: 409;
+- `scheduled_task_definition_archived`: 409;
+- `scheduled_task_lifecycle_transition_invalid`: 409;
+- `scheduled_task_idempotency_conflict`: 409.
+
+Every mapped error body should include `code`, `message`, `details`, `field_errors`, `retryable`, and `correlation_id`. Tests should assert the envelope shape for at least one 409 conflict and one 422 validation error.
+
+- [ ] **Step 4: Implement all endpoint handlers**
+
+Endpoints:
+
+- `GET /api/v1/scheduled-tasks/capabilities`
+- `POST /api/v1/scheduled-tasks/previews`
+- `GET /api/v1/scheduled-tasks/previews`
+- `GET /api/v1/scheduled-tasks/previews/{preview_id}`
+- `POST /api/v1/scheduled-tasks/definitions`
+- `GET /api/v1/scheduled-tasks/definitions`
+- `GET /api/v1/scheduled-tasks/definitions/{definition_id}`
+- `PATCH /api/v1/scheduled-tasks/definitions/{definition_id}`
+- `POST /api/v1/scheduled-tasks/definitions/{definition_id}/pause`
+- `POST /api/v1/scheduled-tasks/definitions/{definition_id}/resume`
+- `POST /api/v1/scheduled-tasks/definitions/{definition_id}/archive`
+- `POST /api/v1/scheduled-tasks/definitions/{definition_id}/duplicate`
+- `GET /api/v1/scheduled-tasks/definitions/{definition_id}/audit`
+
+Read `Idempotency-Key` from the request headers for mutating routes.
+
+- [ ] **Step 5: Add pagination/filter query parameters**
+
+Use explicit query params:
+
+- `limit: int = Query(50, ge=1, le=200)`
+- `offset: int = Query(0, ge=0)`
+- definitions: `family`, `lifecycle`, `health`, `visibility_policy`, `q`, `created_from`, `created_to`
+- previews: `family`, `mode`, `status`, `definition_id`, `expired`
+- audit: `event_type`, `actor`, `created_from`, `created_to`, `idempotency_key`, `request_id`
+
+- [ ] **Step 6: Run endpoint and existing control-plane tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py \
+  tldw_Server_API/tests/Notifications/test_scheduled_tasks_control_plane.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit endpoint implementation**
+
+```bash
+git add \
+  tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py \
+  tldw_Server_API/app/api/v1/schemas/scheduled_tasks_automation_schemas.py \
+  tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
+git commit -m "feat: expose scheduled task automation endpoints"
+```
+
+## Task 5: Unified Control-Plane Projection
+
+**Files:**
+- Modify: `tldw_Server_API/app/services/scheduled_tasks_control_plane_service.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/scheduled_tasks_control_plane_schemas.py`
+- Modify: `tldw_Server_API/tests/Notifications/test_scheduled_tasks_control_plane.py`
+
+- [ ] **Step 1: Write failing projection tests**
+
+Extend `test_scheduled_tasks_endpoint_combines_reminders_and_watchlist_jobs` or add a new test:
+
+```python
+def test_scheduled_tasks_endpoint_projects_automation_definitions(scheduled_tasks_client, auth_headers):
+    # Create preview and definition through API so the projection reads real storage.
+    preview_response = scheduled_tasks_client.post(
+        "/api/v1/scheduled-tasks/previews",
+        headers=auth_headers,
+        json={
+            "mode": "create",
+            "family": "recurring_question",
+            "definition_id": None,
+            "definition_version": None,
+            "config": {
+                "name": "Track API question",
+                "input": {"question": "Any new answer?"},
+                "schedule": {"kind": "daily", "timezone": "UTC"},
+                "visibility_policy": "findings_only",
+                "notification_policy": {},
+            },
+        },
+    )
+    definition_response = scheduled_tasks_client.post(
+        "/api/v1/scheduled-tasks/definitions",
+        headers=auth_headers,
+        json={"preview_id": preview_response.json()["id"], "initial_lifecycle": "configured"},
+    )
+    definition_id = definition_response.json()["id"]
+
+    list_response = scheduled_tasks_client.get("/api/v1/scheduled-tasks", headers=auth_headers)
+
+    assert list_response.status_code == 200, list_response.text
+    item = next(item for item in list_response.json()["items"] if item["primitive"] == "automation_definition")
+    assert item["id"] == f"automation_definition:{definition_id}"
+    assert item["status"] == "configured_execution_unavailable"
+    assert item["enabled"] is True
+    assert item["edit_mode"] == "native"
+    assert item["next_run_at"] is None
+    assert item["last_run_at"] is None
+    assert item["source_ref"]["family"] == "recurring_question"
+    assert item["source_ref"]["health"] == "execution_unavailable"
+    assert item["source_ref"]["execution_available"] is False
+```
+
+Add compatibility checks:
+
+- reminders still use `reminder_task`;
+- Watchlists still use `watchlist_job` and `external`;
+- get detail works for `automation_definition:{definition_id}`;
+- paused/archived definitions do not project as generic disabled unless status token says so.
+
+- [ ] **Step 2: Run projection tests to verify failures**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_tasks_control_plane.py -q
+```
+
+Expected: FAIL until projection is implemented.
+
+- [ ] **Step 3: Compose automation repository into control-plane service**
+
+In `ScheduledTasksControlPlaneService`:
+
+- add `_scheduled_tasks_db(user_id: int) -> ScheduledTasksDatabase`;
+- list active definitions and append normalized rows;
+- catch noncritical automation read errors and append `automation_definitions_unavailable` to partial errors;
+- implement detail lookup for `automation_definition:{definition_id}`.
+
+Projection helper:
+
+```python
+def _automation_definition_status(row: DefinitionRow) -> tuple[bool, str]:
+    if row.lifecycle == "configured":
+        if row.health == "execution_unavailable":
+            return True, "configured_execution_unavailable"
+        if row.health == "capability_unavailable":
+            return True, "blocked_capability_unavailable"
+        if row.health == "permission_required":
+            return True, "blocked_permission_required"
+        return True, row.health
+    if row.lifecycle == "paused":
+        return False, "paused"
+    if row.lifecycle == "archived":
+        return False, "archived"
+    if row.lifecycle == "disabled":
+        return False, "disabled"
+    return False, "needs_attention"
+```
+
+- [ ] **Step 4: Run projection tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_tasks_control_plane.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit projection**
+
+```bash
+git add \
+  tldw_Server_API/app/services/scheduled_tasks_control_plane_service.py \
+  tldw_Server_API/app/api/v1/schemas/scheduled_tasks_control_plane_schemas.py \
+  tldw_Server_API/tests/Notifications/test_scheduled_tasks_control_plane.py
+git commit -m "feat: project automation definitions into scheduled tasks"
+```
+
+## Task 6: Frontend API Client And Status Helpers
+
+**Files:**
+- Modify: `apps/packages/ui/src/services/scheduled-tasks-control-plane.ts`
+- Create: `apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-automation-status.ts`
+- Create: `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-automation-status.test.ts`
+- Modify: `apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-status.ts`
+
+- [ ] **Step 1: Write failing frontend helper tests**
+
+```ts
+import { describe, expect, it } from "vitest"
+
+import {
+  getAutomationDefinitionFamilyLabel,
+  getAutomationDefinitionProductStatus,
+  isAutomationDefinitionTask
+} from "../scheduled-task-automation-status"
+
+describe("scheduled task automation status", () => {
+  it("labels configured non-executable definitions without waiting-for-run copy", () => {
+    const task = {
+      id: "automation_definition:def_1",
+      primitive: "automation_definition",
+      title: "Track answer",
+      status: "configured_execution_unavailable",
+      enabled: true,
+      edit_mode: "native",
+      source_ref: {
+        family: "recurring_question",
+        lifecycle: "configured",
+        health: "execution_unavailable",
+        execution_available: false
+      }
+    } as const
+
+    expect(isAutomationDefinitionTask(task)).toBe(true)
+    expect(getAutomationDefinitionFamilyLabel(task)).toBe("Recurring question")
+    expect(getAutomationDefinitionProductStatus(task).label).toBe("Configured, execution unavailable")
+  })
+
+  it("does not collapse paused automation definitions into disabled", () => {
+    const status = getAutomationDefinitionProductStatus({
+      id: "automation_definition:def_2",
+      primitive: "automation_definition",
+      title: "Agent task",
+      status: "paused",
+      enabled: false,
+      edit_mode: "native",
+      source_ref: { family: "agent_task", lifecycle: "paused", health: "execution_unavailable" }
+    } as const)
+
+    expect(status.label).toBe("Paused")
+  })
+})
+```
+
+- [ ] **Step 2: Run helper tests to verify failure**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/ScheduledTasks/__tests__/scheduled-task-automation-status.test.ts
+```
+
+Expected: FAIL because helper does not exist and client primitive type does not include `automation_definition`.
+
+- [ ] **Step 3: Extend frontend client types and methods**
+
+In `scheduled-tasks-control-plane.ts`:
+
+- extend `ScheduledTaskPrimitive` with `"automation_definition"`;
+- add family, action, preview, definition, audit, and lifecycle TypeScript interfaces matching backend schemas;
+- add API methods:
+  - `getScheduledTaskCapabilities`
+  - `createScheduledTaskPreview`
+  - `listScheduledTaskPreviews`
+  - `getScheduledTaskPreview`
+  - `createScheduledTaskDefinition`
+  - `listScheduledTaskDefinitions`
+  - `getScheduledTaskDefinition`
+  - `updateScheduledTaskDefinition`
+  - `pauseScheduledTaskDefinition`
+  - `resumeScheduledTaskDefinition`
+  - `archiveScheduledTaskDefinition`
+  - `duplicateScheduledTaskDefinition`
+  - `listScheduledTaskDefinitionAudit`
+
+- [ ] **Step 4: Implement status helper**
+
+`scheduled-task-automation-status.ts` should:
+
+- detect `task.primitive === "automation_definition"`;
+- label family `recurring_question` as "Recurring question";
+- label family `agent_task` as "Agent task";
+- map `configured_execution_unavailable` to "Configured, execution unavailable";
+- map lifecycle `paused`, `archived`, `disabled` before generic `enabled === false`;
+- return copy that says execution is unavailable, not waiting.
+
+Then update `scheduled-task-status.ts`:
+
+- call automation helper first in `getScheduledTaskProductStatus`;
+- call automation family helper first in `getScheduledTaskTypeLabel`;
+- keep reminder/watchlist behavior unchanged.
+
+- [ ] **Step 5: Run helper tests**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/ScheduledTasks/__tests__/scheduled-task-automation-status.test.ts src/components/Option/ScheduledTasks/__tests__/scheduled-task-status.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit client and helpers**
+
+```bash
+git add \
+  apps/packages/ui/src/services/scheduled-tasks-control-plane.ts \
+  apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-automation-status.ts \
+  apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-status.ts \
+  apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-automation-status.test.ts
+git commit -m "feat: add scheduled task automation frontend client types"
+```
+
+## Task 7: WebUI Reference Client Create, Detail, And Lifecycle Flows
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskAutomationDefinitionEditor.tsx`
+- Create: `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskAutomationDefinitionEditor.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx`
+- Modify: `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskTable.tsx`
+- Modify: `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskDetailDrawer.tsx`
+- Modify: `apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx`
+- Modify: `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskDetailDrawer.test.tsx`
+
+- [ ] **Step 1: Write failing editor tests**
+
+Cover:
+
+- Recurring Question preview before save;
+- Agent Task preview redaction copy;
+- expired preview error prompts another preview;
+- save disabled until preview is valid;
+- create sends only `preview_id` and `initial_lifecycle`;
+- update sends only `preview_id`.
+
+```ts
+it("previews and creates a recurring question definition", async () => {
+  const onPreview = vi.fn().mockResolvedValue({
+    id: "preview_1",
+    status: "valid",
+    family: "recurring_question",
+    normalized_config: { name: "Track answer" },
+    validation_errors: [],
+    warnings: [],
+    expires_at: "2026-06-10T00:00:00Z"
+  })
+  const onCreate = vi.fn().mockResolvedValue({ id: "definition_1" })
+
+  render(
+    <ScheduledTaskAutomationDefinitionEditor
+      family="recurring_question"
+      mode="create"
+      onPreview={onPreview}
+      onCreate={onCreate}
+      onCancel={vi.fn()}
+    />
+  )
+
+  await userEvent.type(screen.getByLabelText("Question"), "Has the answer appeared?")
+  await userEvent.click(screen.getByRole("button", { name: "Preview" }))
+  await screen.findByText("Preview ready")
+  await userEvent.click(screen.getByRole("button", { name: "Save definition" }))
+
+  expect(onCreate).toHaveBeenCalledWith({ preview_id: "preview_1", initial_lifecycle: "configured" })
+})
+```
+
+- [ ] **Step 2: Run editor tests to verify failure**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/ScheduledTasks/__tests__/ScheduledTaskAutomationDefinitionEditor.test.tsx
+```
+
+Expected: FAIL because editor does not exist.
+
+- [ ] **Step 3: Implement editor component**
+
+Keep the editor focused:
+
+- common fields: name, description, schedule kind, timezone, visibility;
+- Recurring Question fields: question, success criteria, scope JSON textarea;
+- Agent Task fields: agent ref JSON/text, message, allowed/denied tool classes, approval mode;
+- Preview button builds full config and calls `onPreview`;
+- Save button consumes preview via `onCreate` or `onUpdate`;
+- Show validation errors from preview response;
+- Show "Execution is not available yet" after valid preview and save.
+
+Do not implement advanced schedule builders in this task. Use basic fields and JSON textareas where necessary to keep the reference client honest and API-first.
+
+- [ ] **Step 4: Wire create panel and page**
+
+In `ScheduledTasksPage.tsx`:
+
+- fetch capabilities on load;
+- if `create_definition` for Recurring Question or Agent Task is available, render editor instead of planned-only panel;
+- call API client preview/create/update methods;
+- refresh list after successful create/update/lifecycle;
+- show API error messages from `detail.code`/`detail.message`.
+
+In `ScheduledTaskCreatePanel.tsx`:
+
+- keep existing Reminder and Watch/Ingest behavior unchanged;
+- for API-available `recurring_question` and `agent_task`, expose create affordance;
+- keep planned copy when capability fetch fails or action is unavailable.
+
+- [ ] **Step 5: Wire table and detail drawer**
+
+Table:
+
+- add `automation_definition` type filter option;
+- label family using helper;
+- show lifecycle actions for automation definitions;
+- do not show Results button unless real results exist.
+
+Detail drawer:
+
+- show lifecycle, health, schedule, visibility, notification policy;
+- show preview history and audit events;
+- show "Execution is not available yet";
+- show pause/resume/archive/duplicate actions;
+- no fake run rows.
+
+- [ ] **Step 6: Run frontend tests**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run \
+  src/components/Option/ScheduledTasks/__tests__/ScheduledTaskAutomationDefinitionEditor.test.tsx \
+  src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx \
+  src/components/Option/ScheduledTasks/__tests__/ScheduledTaskDetailDrawer.test.tsx \
+  src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx \
+  src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit WebUI wiring**
+
+```bash
+git add \
+  apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskAutomationDefinitionEditor.tsx \
+  apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx \
+  apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskTable.tsx \
+  apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskDetailDrawer.tsx \
+  apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx \
+  apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskAutomationDefinitionEditor.test.tsx \
+  apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx \
+  apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskDetailDrawer.test.tsx \
+  apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
+git commit -m "feat: wire scheduled task automation reference client"
+```
+
+## Task 8: Focused End-To-End Verification, Docs, And Cleanup
+
+**Files:**
+- Modify: `Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md`
+- Modify: `backlog/tasks/task-2350 - Plan-Scheduled-Tasks-Phase-4B-backend-API-foundation-implementation.md`
+- Optional modify: `Docs/Development/Scheduled_Tasks.md` if an existing scheduled-tasks API doc exists.
+
+- [ ] **Step 1: Run backend focused tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Notifications/test_scheduled_task_automation_db.py \
+  tldw_Server_API/tests/Notifications/test_scheduled_task_automation_service.py \
+  tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py \
+  tldw_Server_API/tests/Notifications/test_scheduled_tasks_control_plane.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run frontend focused tests**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run \
+  src/components/Option/ScheduledTasks/__tests__/scheduled-task-automation-status.test.ts \
+  src/components/Option/ScheduledTasks/__tests__/ScheduledTaskAutomationDefinitionEditor.test.tsx \
+  src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx \
+  src/components/Option/ScheduledTasks/__tests__/ScheduledTaskDetailDrawer.test.tsx \
+  src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx \
+  src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run Bandit on touched backend scope**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py \
+  tldw_Server_API/app/api/v1/schemas/scheduled_tasks_automation_schemas.py \
+  tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py \
+  tldw_Server_API/app/services/scheduled_task_automation_service.py \
+  -f json -o /tmp/bandit_scheduled_tasks_phase4b.json
+```
+
+Expected: no new findings in touched code. If Bandit reports findings, inspect `/tmp/bandit_scheduled_tasks_phase4b.json` and fix before continuing.
+
+- [ ] **Step 4: Verify no execution paths were added**
+
+Run:
+
+```bash
+rg -n "enqueue|Scheduler|APScheduler|run_now|manual run|execute" \
+  tldw_Server_API/app/services/scheduled_task_automation_service.py \
+  tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py \
+  apps/packages/ui/src/components/Option/ScheduledTasks
+```
+
+Expected: only capability/status/copy references such as `execution_unavailable` and `execution_not_implemented`; no Jobs enqueue, Scheduler registration, or run execution code.
+
+- [ ] **Step 5: Verify OpenAPI generation/import health**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python - <<'PY'
+from tldw_Server_API.app.main import app
+schema = app.openapi()
+paths = schema["paths"]
+required = [
+    "/api/v1/scheduled-tasks/capabilities",
+    "/api/v1/scheduled-tasks/previews",
+    "/api/v1/scheduled-tasks/definitions",
+]
+missing = [path for path in required if path not in paths]
+if missing:
+    raise SystemExit(f"missing OpenAPI paths: {missing}")
+print("scheduled task automation OpenAPI paths present")
+PY
+```
+
+Expected: prints `scheduled task automation OpenAPI paths present`.
+
+- [ ] **Step 6: Update Backlog task and plan statuses**
+
+Update `TASK-2350` notes with:
+
+- commits completed;
+- backend test command result;
+- frontend test command result;
+- Bandit result path;
+- any known skips.
+
+If the implementation required a doc update, add it under `modified_files`.
+
+- [ ] **Step 7: Final self-review**
+
+Review:
+
+```bash
+git status --short
+git diff --stat origin/dev...HEAD
+git diff --check origin/dev...HEAD
+```
+
+Expected:
+
+- only intended files changed;
+- no whitespace errors;
+- no unrelated dirty files.
+
+- [ ] **Step 8: Commit verification/docs cleanup**
+
+```bash
+git add Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md \
+  'backlog/tasks/task-2350 - Plan-Scheduled-Tasks-Phase-4B-backend-API-foundation-implementation.md'
+git commit -m "docs: record scheduled tasks phase 4b verification"
+```
+
+## Final Acceptance Checklist
+
+- [ ] `GET /api/v1/scheduled-tasks/capabilities` exposes Recurring Question and Agent Task with execution unavailable.
+- [ ] Preview records persist valid and invalid semantic validations.
+- [ ] Create/update require preview consumption and reject expired, consumed, wrong-user, mismatched, and stale previews.
+- [ ] Agent Task raw prompt text is not returned from preview, definition, list, or audit responses by default.
+- [ ] Agent Task raw prompt sentinel strings are absent from persisted preview, definition, and audit JSON by default.
+- [ ] Definitions can be listed, read, updated, paused, resumed, archived, and duplicated.
+- [ ] Duplicate creates a paused copy and deterministic source/copy audit events.
+- [ ] Duplicate cannot bypass `admin` or `security` disabled locks.
+- [ ] Optional idempotency works for replay and conflict across preview, create, update, duplicate, pause, resume, and archive, scoped by owner and route.
+- [ ] Error responses use the documented envelope including `correlation_id`.
+- [ ] `/api/v1/scheduled-tasks` projects `automation_definition` rows without breaking reminders or Watchlists.
+- [ ] WebUI can preview, create, inspect, edit, pause/resume, archive, and duplicate definitions using the API.
+- [ ] WebUI shows execution-unavailable states and does not create fake results or fake Home items.
+- [ ] Focused backend tests pass.
+- [ ] Focused frontend tests pass.
+- [ ] Bandit passes for touched backend scope.
+- [ ] No Jobs, Scheduler, RAG execution, ACP dispatch, notifications, or approval queue mutations were implemented.
+
+## Plan Review
+
+Reviewed with a `plan-document-reviewer`-style subagent on 2026-06-09.
+
+Review pass 1 found four issues:
+
+- Agent Task redaction coverage did not explicitly include definition/list/detail/audit responses or persisted JSON.
+- Idempotency coverage did not cover every required 4B mutating route.
+- Disabled duplicate guardrails lacked data-model support.
+- Error envelope and mappings did not fully match the spec.
+
+The plan was revised to add redaction sentinel tests, full idempotency route coverage, `disabled_lock_kind`/`disabled_reason`, duplicate lock tests, and complete error-envelope requirements including `correlation_id`.
+
+Review pass 2 approved the revised plan and spec with no remaining blocking issues.

--- a/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
@@ -1128,7 +1128,7 @@ git commit -m "feat: add scheduled task automation frontend client types"
 - Modify: `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx`
 - Modify: `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskDetailDrawer.test.tsx`
 
-- [ ] **Step 1: Write failing editor tests**
+- [x] **Step 1: Write failing editor tests**
 
 Cover:
 
@@ -1171,7 +1171,7 @@ it("previews and creates a recurring question definition", async () => {
 })
 ```
 
-- [ ] **Step 2: Run editor tests to verify failure**
+- [x] **Step 2: Run editor tests to verify failure**
 
 Run:
 
@@ -1182,7 +1182,7 @@ bunx vitest run src/components/Option/ScheduledTasks/__tests__/ScheduledTaskAuto
 
 Expected: FAIL because editor does not exist.
 
-- [ ] **Step 3: Implement editor component**
+- [x] **Step 3: Implement editor component**
 
 Keep the editor focused:
 
@@ -1196,7 +1196,7 @@ Keep the editor focused:
 
 Do not implement advanced schedule builders in this task. Use basic fields and JSON textareas where necessary to keep the reference client honest and API-first.
 
-- [ ] **Step 4: Wire create panel and page**
+- [x] **Step 4: Wire create panel and page**
 
 In `ScheduledTasksPage.tsx`:
 
@@ -1212,7 +1212,7 @@ In `ScheduledTaskCreatePanel.tsx`:
 - for API-available `recurring_question` and `agent_task`, expose create affordance;
 - keep planned copy when capability fetch fails or action is unavailable.
 
-- [ ] **Step 5: Wire table and detail drawer**
+- [x] **Step 5: Wire table and detail drawer**
 
 Table:
 
@@ -1229,7 +1229,7 @@ Detail drawer:
 - show pause/resume/archive/duplicate actions;
 - no fake run rows.
 
-- [ ] **Step 6: Run frontend tests**
+- [x] **Step 6: Run frontend tests**
 
 Run:
 
@@ -1245,7 +1245,7 @@ bunx vitest run \
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit WebUI wiring**
+- [x] **Step 7: Commit WebUI wiring**
 
 ```bash
 git add \

--- a/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
@@ -872,7 +872,7 @@ Task 4 review hardening also added direct public error-code aliases, audit reque
 - Modify: `tldw_Server_API/app/api/v1/schemas/scheduled_tasks_control_plane_schemas.py`
 - Modify: `tldw_Server_API/tests/Notifications/test_scheduled_tasks_control_plane.py`
 
-- [ ] **Step 1: Write failing projection tests**
+- [x] **Step 1: Write failing projection tests**
 
 Extend `test_scheduled_tasks_endpoint_combines_reminders_and_watchlist_jobs` or add a new test:
 
@@ -925,7 +925,7 @@ Add compatibility checks:
 - get detail works for `automation_definition:{definition_id}`;
 - paused/archived definitions do not project as generic disabled unless status token says so.
 
-- [ ] **Step 2: Run projection tests to verify failures**
+- [x] **Step 2: Run projection tests to verify failures**
 
 Run:
 
@@ -936,7 +936,7 @@ python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_tasks_contro
 
 Expected: FAIL until projection is implemented.
 
-- [ ] **Step 3: Compose automation repository into control-plane service**
+- [x] **Step 3: Compose automation repository into control-plane service**
 
 In `ScheduledTasksControlPlaneService`:
 
@@ -966,7 +966,7 @@ def _automation_definition_status(row: DefinitionRow) -> tuple[bool, str]:
     return False, "needs_attention"
 ```
 
-- [ ] **Step 4: Run projection tests**
+- [x] **Step 4: Run projection tests**
 
 Run:
 
@@ -977,7 +977,7 @@ python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_tasks_contro
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit projection**
+- [x] **Step 5: Commit projection**
 
 ```bash
 git add \

--- a/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
@@ -89,7 +89,7 @@ Out of scope:
 - Modify: `tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py`
 - Create: `tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py`
 
-- [ ] **Step 1: Write failing route and schema tests**
+- [x] **Step 1: Write failing route and schema tests**
 
 Add tests that prove static child routes are not captured by `/{task_id}` and that capabilities return explicit unavailable execution actions.
 
@@ -122,7 +122,7 @@ def test_capabilities_report_definition_actions_but_no_execution(scheduled_tasks
         assert actions["execute"]["reason"] == "execution_not_implemented"
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run:
 
@@ -133,7 +133,7 @@ python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_task_automat
 
 Expected: FAIL because schemas/routes do not exist or static routes are shadowed.
 
-- [ ] **Step 3: Add schema types**
+- [x] **Step 3: Add schema types**
 
 Create `scheduled_tasks_automation_schemas.py` with Pydantic models and literal aliases. Include at minimum:
 
@@ -193,7 +193,7 @@ Also define request/response model placeholders needed by later tasks:
 
 Use typed fields from the spec, but keep nested `config`, `input`, `schedule`, `visibility_policy`, and `notification_policy` as structured `dict[str, Any]` initially. Later tasks tighten validation in the service layer.
 
-- [ ] **Step 4: Extend normalized primitive type**
+- [x] **Step 4: Extend normalized primitive type**
 
 In `scheduled_tasks_control_plane_schemas.py`, change:
 
@@ -207,7 +207,7 @@ to:
 ScheduledTaskPrimitive = Literal["reminder_task", "watchlist_job", "automation_definition"]
 ```
 
-- [ ] **Step 5: Add route skeleton before `/{task_id}`**
+- [x] **Step 5: Add route skeleton before `/{task_id}`**
 
 In `scheduled_tasks_control_plane.py`, register these routes before the existing `@router.get("/{task_id}")`:
 
@@ -224,9 +224,9 @@ async def get_scheduled_task_automation_capabilities(
     return service.get_capabilities()
 ```
 
-Add skeleton `GET /previews`, `GET /definitions`, and `GET /definitions/{definition_id}/audit` routes that return empty paginated responses until later tasks implement storage. Add `POST /previews`, `POST /definitions`, `PATCH /definitions/{definition_id}`, and lifecycle route skeletons that call service methods.
+Add skeleton `GET /previews`, `GET /definitions`, and `GET /definitions/{definition_id}/audit` routes that return empty paginated responses until later tasks implement storage. Add `POST /previews`, `POST /definitions`, `PATCH /definitions/{definition_id}`, and lifecycle route skeletons that call service methods or return explicit `501` not-implemented responses while preserving route shape.
 
-- [ ] **Step 6: Implement minimal capability service**
+- [x] **Step 6: Implement minimal capability service**
 
 Create `tldw_Server_API/app/services/scheduled_task_automation_service.py` with:
 
@@ -267,7 +267,7 @@ class ScheduledTaskAutomationService:
         )
 ```
 
-- [ ] **Step 7: Run route/schema tests**
+- [x] **Step 7: Run route/schema tests**
 
 Run:
 
@@ -279,7 +279,7 @@ python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_tasks_contro
 
 Expected: PASS for capability/static route tests and existing control-plane tests.
 
-- [ ] **Step 8: Commit schema and route skeleton**
+- [x] **Step 8: Commit schema and route skeleton**
 
 ```bash
 git add \

--- a/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
@@ -1265,10 +1265,11 @@ git commit -m "feat: wire scheduled task automation reference client"
 
 **Files:**
 - Modify: `Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md`
-- Modify: `backlog/tasks/task-2350 - Plan-Scheduled-Tasks-Phase-4B-backend-API-foundation-implementation.md`
+- Modify: `backlog/tasks/task-2351 - Implement-Scheduled-Tasks-Phase-4B-backend-API-foundation.md`
+- Modify: `tldw_Server_API/Config_Files/config.txt`
 - Optional modify: `Docs/Development/Scheduled_Tasks.md` if an existing scheduled-tasks API doc exists.
 
-- [ ] **Step 1: Run backend focused tests**
+- [x] **Step 1: Run backend focused tests**
 
 Run:
 
@@ -1284,7 +1285,9 @@ python -m pytest \
 
 Expected: PASS.
 
-- [ ] **Step 2: Run frontend focused tests**
+Result: PASS, `82 passed, 13 warnings in 65.27s`.
+
+- [x] **Step 2: Run frontend focused tests**
 
 Run:
 
@@ -1301,7 +1304,9 @@ bunx vitest run \
 
 Expected: PASS.
 
-- [ ] **Step 3: Run Bandit on touched backend scope**
+Result: PASS, `102 passed`.
+
+- [x] **Step 3: Run Bandit on touched backend scope**
 
 Run:
 
@@ -1317,7 +1322,9 @@ python -m bandit -r \
 
 Expected: no new findings in touched code. If Bandit reports findings, inspect `/tmp/bandit_scheduled_tasks_phase4b.json` and fix before continuing.
 
-- [ ] **Step 4: Verify no execution paths were added**
+Result: PASS, `/tmp/bandit_scheduled_tasks_phase4b.json` reported 0 errors and 0 findings.
+
+- [x] **Step 4: Verify no execution paths were added**
 
 Run:
 
@@ -1330,7 +1337,9 @@ rg -n "enqueue|Scheduler|APScheduler|run_now|manual run|execute" \
 
 Expected: only capability/status/copy references such as `execution_unavailable` and `execution_not_implemented`; no Jobs enqueue, Scheduler registration, or run execution code.
 
-- [ ] **Step 5: Verify OpenAPI generation/import health**
+Result: PASS. Matches were limited to the unsupported `execute` action capability and existing APScheduler reminder utility tests; no enqueue, Scheduler registration, `run_now`, manual-run, RAG execution, ACP dispatch, notification, fake run, fake result, or Home surfacing code was added.
+
+- [x] **Step 5: Verify OpenAPI generation/import health**
 
 Run:
 
@@ -1354,9 +1363,11 @@ PY
 
 Expected: prints `scheduled task automation OpenAPI paths present`.
 
-- [ ] **Step 6: Update Backlog task and plan statuses**
+Result: PASS. Verification initially found the full app route policy did not enable the new scheduled-tasks control-plane route from default config, so `scheduled-tasks` was added to `[API-Routes].enable`. Rerunning OpenAPI import with only auth configured printed `scheduled task automation OpenAPI paths present`.
 
-Update `TASK-2350` notes with:
+- [x] **Step 6: Update Backlog task and plan statuses**
+
+Update `TASK-2351` notes with:
 
 - commits completed;
 - backend test command result;
@@ -1366,7 +1377,7 @@ Update `TASK-2350` notes with:
 
 If the implementation required a doc update, add it under `modified_files`.
 
-- [ ] **Step 7: Final self-review**
+- [x] **Step 7: Final self-review**
 
 Review:
 
@@ -1382,33 +1393,37 @@ Expected:
 - no whitespace errors;
 - no unrelated dirty files.
 
-- [ ] **Step 8: Commit verification/docs cleanup**
+Result: PASS. `git status --short` showed only intended final edits plus two unrelated untracked Watchlists template files. `git diff --check origin/dev...HEAD` and `git diff --check` returned no whitespace errors.
+
+- [x] **Step 8: Commit verification/docs cleanup**
 
 ```bash
 git add Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md \
-  'backlog/tasks/task-2350 - Plan-Scheduled-Tasks-Phase-4B-backend-API-foundation-implementation.md'
+  'backlog/tasks/task-2351 - Implement-Scheduled-Tasks-Phase-4B-backend-API-foundation.md' \
+  apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx \
+  tldw_Server_API/Config_Files/config.txt
 git commit -m "docs: record scheduled tasks phase 4b verification"
 ```
 
 ## Final Acceptance Checklist
 
-- [ ] `GET /api/v1/scheduled-tasks/capabilities` exposes Recurring Question and Agent Task with execution unavailable.
-- [ ] Preview records persist valid and invalid semantic validations.
-- [ ] Create/update require preview consumption and reject expired, consumed, wrong-user, mismatched, and stale previews.
-- [ ] Agent Task raw prompt text is not returned from preview, definition, list, or audit responses by default.
-- [ ] Agent Task raw prompt sentinel strings are absent from persisted preview, definition, and audit JSON by default.
-- [ ] Definitions can be listed, read, updated, paused, resumed, archived, and duplicated.
-- [ ] Duplicate creates a paused copy and deterministic source/copy audit events.
-- [ ] Duplicate cannot bypass `admin` or `security` disabled locks.
-- [ ] Optional idempotency works for replay and conflict across preview, create, update, duplicate, pause, resume, and archive, scoped by owner and route.
-- [ ] Error responses use the documented envelope including `correlation_id`.
-- [ ] `/api/v1/scheduled-tasks` projects `automation_definition` rows without breaking reminders or Watchlists.
-- [ ] WebUI can preview, create, inspect, edit, pause/resume, archive, and duplicate definitions using the API.
-- [ ] WebUI shows execution-unavailable states and does not create fake results or fake Home items.
-- [ ] Focused backend tests pass.
-- [ ] Focused frontend tests pass.
-- [ ] Bandit passes for touched backend scope.
-- [ ] No Jobs, Scheduler, RAG execution, ACP dispatch, notifications, or approval queue mutations were implemented.
+- [x] `GET /api/v1/scheduled-tasks/capabilities` exposes Recurring Question and Agent Task with execution unavailable.
+- [x] Preview records persist valid and invalid semantic validations.
+- [x] Create/update require preview consumption and reject expired, consumed, wrong-user, mismatched, and stale previews.
+- [x] Agent Task raw prompt text is not returned from preview, definition, list, or audit responses by default.
+- [x] Agent Task raw prompt sentinel strings are absent from persisted preview, definition, and audit JSON by default.
+- [x] Definitions can be listed, read, updated, paused, resumed, archived, and duplicated.
+- [x] Duplicate creates a paused copy and deterministic source/copy audit events.
+- [x] Duplicate cannot bypass `admin` or `security` disabled locks.
+- [x] Optional idempotency works for replay and conflict across preview, create, update, duplicate, pause, resume, and archive, scoped by owner and route.
+- [x] Error responses use the documented envelope including `correlation_id`.
+- [x] `/api/v1/scheduled-tasks` projects `automation_definition` rows without breaking reminders or Watchlists.
+- [x] WebUI can preview, create, inspect, edit, pause/resume, archive, and duplicate definitions using the API.
+- [x] WebUI shows execution-unavailable states and does not create fake results or fake Home items.
+- [x] Focused backend tests pass.
+- [x] Focused frontend tests pass.
+- [x] Bandit passes for touched backend scope.
+- [x] No Jobs, Scheduler, RAG execution, ACP dispatch, notifications, or approval queue mutations were implemented.
 
 ## Plan Review
 

--- a/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
@@ -457,7 +457,7 @@ git commit -m "feat: add scheduled task automation repository"
 - Modify: `tldw_Server_API/app/api/v1/schemas/scheduled_tasks_automation_schemas.py`
 - Create: `tldw_Server_API/tests/Notifications/test_scheduled_task_automation_service.py`
 
-- [ ] **Step 1: Write failing service tests for preview validation**
+- [x] **Step 1: Write failing service tests for preview validation**
 
 Cover valid, invalid, expired, stale, consumed, cross-user, and redacted Agent Task previews.
 
@@ -540,7 +540,7 @@ Add tests for:
 - no-key consumed preview reuse fails.
 - Agent Task raw secret strings are absent from preview response, created definition response, definition list/detail response models, and audit response models.
 
-- [ ] **Step 2: Run service tests to verify they fail**
+- [x] **Step 2: Run service tests to verify they fail**
 
 Run:
 
@@ -551,7 +551,7 @@ python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_task_automat
 
 Expected: FAIL because service methods are not implemented.
 
-- [ ] **Step 3: Implement canonical hashing and validation helpers**
+- [x] **Step 3: Implement canonical hashing and validation helpers**
 
 In `scheduled_task_automation_service.py`, add private helpers:
 
@@ -577,7 +577,7 @@ Keep validation conservative:
 - validate schedule `kind` only against `one_time`, `interval`, `daily`, `weekly`, `cron`;
 - do not call RAG or ACP live execution APIs in 4B.
 
-- [ ] **Step 4: Implement preview creation**
+- [x] **Step 4: Implement preview creation**
 
 `create_preview(owner_id, actor, payload)` should:
 
@@ -596,7 +596,7 @@ For Agent Task tests, use a unique sentinel such as `RAW_AGENT_SECRET_DO_NOT_LEA
 - audit `before`/`after` metadata;
 - repository audit JSON.
 
-- [ ] **Step 5: Implement definition create/update lifecycle**
+- [x] **Step 5: Implement definition create/update lifecycle**
 
 Rules:
 
@@ -610,7 +610,7 @@ Rules:
 - create/update writes deterministic audit events;
 - definitions default health is `execution_unavailable`.
 
-- [ ] **Step 6: Implement lifecycle and duplicate**
+- [x] **Step 6: Implement lifecycle and duplicate**
 
 Implement:
 
@@ -630,7 +630,7 @@ Follow the transition matrix:
 - duplicate always creates `paused` copy;
 - duplicate audit records both `definition_duplicated` and `definition_duplicate_created`.
 
-- [ ] **Step 7: Implement idempotency wrapper**
+- [x] **Step 7: Implement idempotency wrapper**
 
 Add a service-level helper:
 
@@ -656,7 +656,7 @@ Behavior:
 
 Apply the wrapper to all 4B mutating routes that accept `Idempotency-Key`: preview, create, update, duplicate, pause, resume, and archive.
 
-- [ ] **Step 8: Run service tests**
+- [x] **Step 8: Run service tests**
 
 Run:
 
@@ -667,7 +667,7 @@ python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_task_automat
 
 Expected: PASS.
 
-- [ ] **Step 9: Commit service layer**
+- [x] **Step 9: Commit service layer**
 
 ```bash
 git add \
@@ -676,6 +676,8 @@ git add \
   tldw_Server_API/tests/Notifications/test_scheduled_task_automation_service.py
 git commit -m "feat: implement scheduled task definition service"
 ```
+
+Task 3 review hardening also added repository write-transaction support so idempotency lookup, domain mutation, audit writes, preview consumption, and response snapshot persistence commit as one durable command.
 
 ## Task 4: API Endpoints, Errors, Permissions, And OpenAPI Contract
 

--- a/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
@@ -297,7 +297,7 @@ git commit -m "feat: add scheduled task automation API skeleton"
 - Create: `tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py`
 - Create: `tldw_Server_API/tests/Notifications/test_scheduled_task_automation_db.py`
 
-- [ ] **Step 1: Write failing repository tests**
+- [x] **Step 1: Write failing repository tests**
 
 Test per-user isolation, preview persistence, definition persistence, disabled lock fields, audit events, idempotency scoping, pagination, filtering, and redacted Agent Task storage.
 
@@ -341,7 +341,7 @@ Add separate tests:
 - `test_definition_persists_disabled_lock_kind_and_reason`
 - `test_agent_task_definition_and_audit_storage_do_not_contain_raw_message_secret`
 
-- [ ] **Step 2: Run repository tests to verify they fail**
+- [x] **Step 2: Run repository tests to verify they fail**
 
 Run:
 
@@ -352,7 +352,7 @@ python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_task_automat
 
 Expected: FAIL because `Scheduled_Tasks_DB.py` does not exist.
 
-- [ ] **Step 3: Implement row dataclasses and schema**
+- [x] **Step 3: Implement row dataclasses and schema**
 
 Create `Scheduled_Tasks_DB.py` with:
 
@@ -409,7 +409,7 @@ Indexes:
 - audit: `(definition_id, created_at)`
 - idempotency: unique `(owner_id, route, key)`
 
-- [ ] **Step 4: Implement repository methods**
+- [x] **Step 4: Implement repository methods**
 
 Add focused methods:
 
@@ -430,7 +430,7 @@ Add focused methods:
 
 Use JSON helpers that always encode dictionaries/lists with sorted keys.
 
-- [ ] **Step 5: Run repository tests**
+- [x] **Step 5: Run repository tests**
 
 Run:
 
@@ -441,7 +441,7 @@ python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_task_automat
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit repository**
+- [x] **Step 6: Commit repository**
 
 ```bash
 git add \

--- a/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
@@ -995,7 +995,7 @@ git commit -m "feat: project automation definitions into scheduled tasks"
 - Create: `apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-automation-status.test.ts`
 - Modify: `apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-status.ts`
 
-- [ ] **Step 1: Write failing frontend helper tests**
+- [x] **Step 1: Write failing frontend helper tests**
 
 ```ts
 import { describe, expect, it } from "vitest"
@@ -1044,7 +1044,7 @@ describe("scheduled task automation status", () => {
 })
 ```
 
-- [ ] **Step 2: Run helper tests to verify failure**
+- [x] **Step 2: Run helper tests to verify failure**
 
 Run:
 
@@ -1055,7 +1055,7 @@ bunx vitest run src/components/Option/ScheduledTasks/__tests__/scheduled-task-au
 
 Expected: FAIL because helper does not exist and client primitive type does not include `automation_definition`.
 
-- [ ] **Step 3: Extend frontend client types and methods**
+- [x] **Step 3: Extend frontend client types and methods**
 
 In `scheduled-tasks-control-plane.ts`:
 
@@ -1076,7 +1076,7 @@ In `scheduled-tasks-control-plane.ts`:
   - `duplicateScheduledTaskDefinition`
   - `listScheduledTaskDefinitionAudit`
 
-- [ ] **Step 4: Implement status helper**
+- [x] **Step 4: Implement status helper**
 
 `scheduled-task-automation-status.ts` should:
 
@@ -1093,7 +1093,7 @@ Then update `scheduled-task-status.ts`:
 - call automation family helper first in `getScheduledTaskTypeLabel`;
 - keep reminder/watchlist behavior unchanged.
 
-- [ ] **Step 5: Run helper tests**
+- [x] **Step 5: Run helper tests**
 
 Run:
 
@@ -1104,7 +1104,7 @@ bunx vitest run src/components/Option/ScheduledTasks/__tests__/scheduled-task-au
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit client and helpers**
+- [x] **Step 6: Commit client and helpers**
 
 ```bash
 git add \

--- a/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
@@ -686,7 +686,7 @@ Task 3 review hardening also added repository write-transaction support so idemp
 - Modify: `tldw_Server_API/app/api/v1/schemas/scheduled_tasks_automation_schemas.py`
 - Modify: `tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py`
 
-- [ ] **Step 1: Write failing endpoint integration tests**
+- [x] **Step 1: Write failing endpoint integration tests**
 
 Add endpoint tests for:
 
@@ -751,7 +751,7 @@ def test_create_definition_consumes_preview_and_exposes_audit(scheduled_tasks_cl
     assert audit_response.json()["items"][0]["event_type"] == "definition_created"
 ```
 
-- [ ] **Step 2: Run endpoint tests to verify failures**
+- [x] **Step 2: Run endpoint tests to verify failures**
 
 Run:
 
@@ -762,7 +762,7 @@ python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_task_automat
 
 Expected: FAIL for unimplemented routes/error mapping.
 
-- [ ] **Step 3: Add endpoint error helper**
+- [x] **Step 3: Add endpoint error helper**
 
 Use a local helper in the endpoint module to map service exceptions to consistent error bodies:
 
@@ -809,7 +809,7 @@ Map service exceptions:
 
 Every mapped error body should include `code`, `message`, `details`, `field_errors`, `retryable`, and `correlation_id`. Tests should assert the envelope shape for at least one 409 conflict and one 422 validation error.
 
-- [ ] **Step 4: Implement all endpoint handlers**
+- [x] **Step 4: Implement all endpoint handlers**
 
 Endpoints:
 
@@ -829,7 +829,7 @@ Endpoints:
 
 Read `Idempotency-Key` from the request headers for mutating routes.
 
-- [ ] **Step 5: Add pagination/filter query parameters**
+- [x] **Step 5: Add pagination/filter query parameters**
 
 Use explicit query params:
 
@@ -839,7 +839,7 @@ Use explicit query params:
 - previews: `family`, `mode`, `status`, `definition_id`, `expired`
 - audit: `event_type`, `actor`, `created_from`, `created_to`, `idempotency_key`, `request_id`
 
-- [ ] **Step 6: Run endpoint and existing control-plane tests**
+- [x] **Step 6: Run endpoint and existing control-plane tests**
 
 Run:
 
@@ -853,7 +853,7 @@ python -m pytest \
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit endpoint implementation**
+- [x] **Step 7: Commit endpoint implementation**
 
 ```bash
 git add \
@@ -862,6 +862,8 @@ git add \
   tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
 git commit -m "feat: expose scheduled task automation endpoints"
 ```
+
+Task 4 review hardening also added direct public error-code aliases, audit request-id propagation/filtering, and timezone-aware datetime filter validation/normalization.
 
 ## Task 5: Unified Control-Plane Projection
 

--- a/Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-design.md
+++ b/Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-design.md
@@ -1,7 +1,7 @@
 # Scheduled Tasks Phase 4B Backend API Foundation Design
 
 Date: 2026-06-09
-Status: Needs User Review
+Status: Approved For Implementation Planning
 Owner: Codex brainstorming session
 Backlog: TASK-2349
 
@@ -178,7 +178,7 @@ Related capabilities can report RAG or ACP readiness, but related readiness must
 | --- | --- |
 | Capability | `family`, `family_availability`, `actions`, `missing_dependencies`, `related_capabilities`, `reason`, `schema_version` |
 | Preview | `id`, `owner_id`, `mode`, `family`, `definition_id?`, `definition_version?`, `status`, `payload_hash`, `normalized_config`, `validation_errors`, `warnings`, `risk_class`, `visibility_policy`, `schedule_preview`, `redaction_policy`, `expires_at`, `created_by`, `created_at`, `consumed_at?`, `created_definition_id?` |
-| Definition | `id`, `owner_id`, `version`, `family`, `name`, `description`, `lifecycle`, `health`, `schedule`, `input`, `visibility_policy`, `notification_policy`, `approval_policy`, `preview_id`, `created_by`, `updated_by`, timestamps |
+| Definition | `id`, `owner_id`, `version`, `family`, `name`, `description`, `lifecycle`, `health`, `disabled_lock_kind?`, `disabled_reason?`, `schedule`, `input`, `visibility_policy`, `notification_policy`, `approval_policy`, `preview_id`, `created_by`, `updated_by`, timestamps |
 | Audit event | `id`, `definition_id`, `event_type`, `actor`, `summary`, `before`, `after`, `created_at`, `request_id`, `idempotency_key` |
 | Idempotency record | `owner_id`, `key`, `route`, `payload_hash`, `response_ref`, `created_at`, `expires_at` |
 
@@ -200,6 +200,13 @@ Lifecycle values:
 - `paused`
 - `archived`
 - `disabled`
+
+Disabled lock kinds:
+
+- `none`
+- `admin`
+- `security`
+- `system`
 
 Health values:
 
@@ -979,6 +986,6 @@ Additional human-requested self-review before implementation planning found impl
 - make `owner_id` part of Preview, Definition, and Idempotency record contracts, with explicit cross-user isolation expectations;
 - define health precedence so related capability readiness does not blur into execution support;
 - make duplicate audit deterministic on both source and copied definitions;
-- require duplicate to re-evaluate health and avoid bypassing admin/security disabled states;
+- add `disabled_lock_kind`/`disabled_reason` so duplicate can re-evaluate health and avoid bypassing admin/security disabled states;
 - define `automation_definition` projection fields and status tokens for the existing `/scheduled-tasks` list model;
 - require WebUI status handling to interpret automation definition lifecycle/health before legacy `enabled` fallbacks.

--- a/Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-design.md
+++ b/Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-design.md
@@ -1,0 +1,984 @@
+# Scheduled Tasks Phase 4B Backend API Foundation Design
+
+Date: 2026-06-09
+Status: Needs User Review
+Owner: Codex brainstorming session
+Backlog: TASK-2349
+
+Related:
+
+- `Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase4-recurring-question-agent-task-api-contract-design.md`
+- `Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4a-api-first-planned-shell-implementation-plan.md`
+- `Docs/superpowers/specs/2026-06-01-scheduled-tasks-automation-workbench-prd-design.md`
+- `Docs/superpowers/specs/2026-06-08-scheduled-tasks-automation-workbench-phase2-creation-design.md`
+- `Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase2b-watch-ingest-product-contract-design.md`
+- `Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase3-results-inbox-home-surfacing-implementation-plan.md`
+- `Docs/ADR/003-jobs-vs-scheduler-default.md`
+
+## Summary
+
+Phase 4B turns the Phase 4A planned Recurring Question and Agent Task shell into a real API-managed foundation. It adds Scheduled Tasks-owned durable definitions, durable preview records, lifecycle mutations, definition audit, capability discovery, and reference-client WebUI behavior.
+
+4B does not execute scheduled work. It does not dispatch RAG queries, send agent messages, create run history, create results, enqueue Jobs, create approval requests, or deliver notifications. Its purpose is to make the API contract, storage boundary, validation behavior, and client management workflow stable before 4C Recurring Question execution and 4D Agent Task execution.
+
+The API remains the product source of truth. The WebUI is the reference and main enterprise client over this API, not the only client.
+
+## Product Decision
+
+Use **Scheduled Tasks-owned persisted definitions** for `recurring_question` and `agent_task`.
+
+RAG and ACP are related capability providers. They do not own the new definitions in 4B. Existing `/acp/schedules` remains a separate expert surface and must not be treated as full Agent Task support until preview, risk, approval, result, and audit contracts are implemented.
+
+Definitions are persisted after successful server preview. Create and update require a valid, unexpired preview record. Duplicate copies an existing definition into `paused` lifecycle without requiring a fresh preview and does not accept inline config overrides in 4B. If the user edits the duplicate, the follow-up update requires a new update preview.
+
+## Scope
+
+In scope:
+
+- capability discovery for Scheduled Tasks automation families;
+- durable preview records for `create` and `update` preview modes;
+- persisted definitions for `recurring_question` and `agent_task`;
+- lifecycle mutations: create, update, pause, resume, archive, duplicate;
+- definition audit events;
+- pagination and filtering for definitions, previews, and audit events;
+- optional `Idempotency-Key` support for preview, create, update, duplicate, and lifecycle mutations;
+- dedicated Scheduled Tasks repository interface with per-user SQLite as the first backend;
+- normalized control-plane projection of new definitions into `/api/v1/scheduled-tasks`;
+- WebUI reference-client wiring for capabilities, preview, create/edit, lifecycle, preview history, and definition audit;
+- explicit execution-unavailable states in task detail, Results, and Home copy.
+
+Out of scope:
+
+- scheduled execution;
+- manual run;
+- Jobs enqueueing or worker implementation;
+- Scheduler integration;
+- RAG query execution;
+- ACP/API agent dispatch;
+- approval queue APIs and approve/deny mutations;
+- run list/detail endpoints;
+- result list/detail endpoints beyond existing Phase 3 projected behavior;
+- notification delivery;
+- hard delete or retention purge;
+- migration, wrapping, or replacement of `/acp/schedules`;
+- moving or reducing Watchlists functionality.
+
+## Current System Constraints
+
+Current `origin/dev` constraints that shape this design:
+
+- `GET /api/v1/scheduled-tasks` normalizes reminder tasks and Watchlists jobs.
+- Reminder tasks are native to `/scheduled-tasks`; Watchlists jobs are externally managed and deep-link to Watchlists.
+- `ScheduledTaskPrimitive` currently includes `reminder_task` and `watchlist_job`.
+- `ScheduledTasksControlPlaneService` reads reminders from `CollectionsDatabase` and Watchlists jobs from `WatchlistsDatabase`.
+- Phase 3 Results/Home surfacing supports projected signals and future normalized results modes.
+- Phase 4A WebUI shows Recurring Question and Agent Task as honest planned templates.
+- `Docs/ADR/003-jobs-vs-scheduler-default.md` says new user-visible execution should default to Jobs unless an explicit Scheduler exception is accepted.
+
+4B must be additive and compatibility-preserving.
+
+## Architecture
+
+4B adds a backend module with three separable responsibilities.
+
+| Unit | Responsibility |
+| --- | --- |
+| API schemas | Stable request and response models for capabilities, previews, definitions, schedules, visibility, lifecycle, idempotency, and audit. |
+| Scheduled Tasks store | Repository interface plus first per-user SQLite implementation for definitions, previews, idempotency records, and audit events. |
+| Control-plane service | Capability evaluation, preview validation, definition lifecycle, audit recording, and normalized task projection. |
+
+Storage should be interface-first. The first backend should be per-user SQLite:
+
+`Databases/user_databases/<user_id>/ScheduledTasks.db`
+
+The API contract must not expose this storage topology. A future shared tenant database can implement the same repository interface.
+
+The existing `ScheduledTasksControlPlaneService` can either be extended or composed with a new collaborator. It should continue to project reminders and Watchlists jobs exactly as today, then add `automation_definition` rows for the new Scheduled Tasks-owned definitions.
+
+## API Resource Shape
+
+Use resource-oriented endpoints under the existing namespace.
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /api/v1/scheduled-tasks/capabilities` | Discover family support, related dependency readiness, supported actions, and disabled reasons. |
+| `POST /api/v1/scheduled-tasks/previews` | Validate and normalize a proposed definition; persist a durable preview record. |
+| `GET /api/v1/scheduled-tasks/previews` | Paginated and filterable preview history. |
+| `GET /api/v1/scheduled-tasks/previews/{preview_id}` | Inspect preview output, validation errors, normalized config, and expiry. |
+| `POST /api/v1/scheduled-tasks/definitions` | Create a definition from a valid preview record. |
+| `GET /api/v1/scheduled-tasks/definitions` | Paginated and filterable persisted definitions. |
+| `GET /api/v1/scheduled-tasks/definitions/{definition_id}` | Inspect a full definition. |
+| `PATCH /api/v1/scheduled-tasks/definitions/{definition_id}` | Update a definition through preview-backed validation. |
+| `POST /api/v1/scheduled-tasks/definitions/{definition_id}/pause` | Pause a definition. |
+| `POST /api/v1/scheduled-tasks/definitions/{definition_id}/resume` | Resume a definition. |
+| `POST /api/v1/scheduled-tasks/definitions/{definition_id}/archive` | Archive a definition. |
+| `POST /api/v1/scheduled-tasks/definitions/{definition_id}/duplicate` | Copy config without history into `paused` lifecycle. |
+| `GET /api/v1/scheduled-tasks/definitions/{definition_id}/audit` | Paginated and filterable definition audit events. |
+
+Static child routes must be registered before the existing `GET /api/v1/scheduled-tasks/{task_id}` route. `GET /capabilities`, `GET /previews`, and `GET /definitions` must never be interpreted as task IDs. Add route regression tests that assert these static routes resolve to their intended handlers.
+
+Existing endpoints stay intact:
+
+- `GET /api/v1/scheduled-tasks`
+- `GET /api/v1/scheduled-tasks/{task_id}`
+- reminder mutation endpoints
+
+## Capability Discovery
+
+`GET /api/v1/scheduled-tasks/capabilities` is the first-class discovery endpoint for Scheduled Tasks automation families.
+
+The response should separate **Scheduled Tasks family availability** from **related domain readiness**.
+
+Example fields:
+
+- `family`
+- `family_availability`
+- `actions`
+- `missing_dependencies`
+- `related_capabilities`
+- `reason`
+- `schema_version`
+
+Availability values:
+
+- `available`
+- `planned`
+- `unavailable`
+- `degraded`
+
+Actions should be explicit per-action status objects instead of a flat supported list:
+
+- `preview`
+- `create_definition`
+- `update_definition`
+- `pause`
+- `resume`
+- `archive`
+- `duplicate`
+- `execute`
+
+Each action reports `status`, `reason?`, and `required_permissions?`.
+
+Action status values:
+
+- `available`
+- `unavailable`
+- `planned`
+- `disabled`
+
+In 4B, `preview`, definition management, and lifecycle actions can be available. `execute` must be returned as unavailable for both families with a disabled reason such as `execution_not_implemented`.
+
+Related capabilities can report RAG or ACP readiness, but related readiness must never make Scheduled Tasks execution look available by itself.
+
+## Core Data Model
+
+4B separates definition lifecycle, execution readiness, and future run state.
+
+| Model | Key fields |
+| --- | --- |
+| Capability | `family`, `family_availability`, `actions`, `missing_dependencies`, `related_capabilities`, `reason`, `schema_version` |
+| Preview | `id`, `owner_id`, `mode`, `family`, `definition_id?`, `definition_version?`, `status`, `payload_hash`, `normalized_config`, `validation_errors`, `warnings`, `risk_class`, `visibility_policy`, `schedule_preview`, `redaction_policy`, `expires_at`, `created_by`, `created_at`, `consumed_at?`, `created_definition_id?` |
+| Definition | `id`, `owner_id`, `version`, `family`, `name`, `description`, `lifecycle`, `health`, `schedule`, `input`, `visibility_policy`, `notification_policy`, `approval_policy`, `preview_id`, `created_by`, `updated_by`, timestamps |
+| Audit event | `id`, `definition_id`, `event_type`, `actor`, `summary`, `before`, `after`, `created_at`, `request_id`, `idempotency_key` |
+| Idempotency record | `owner_id`, `key`, `route`, `payload_hash`, `response_ref`, `created_at`, `expires_at` |
+
+`owner_id` must be part of the logical repository contract even when the first implementation stores data in per-user SQLite files. Per-user files can make owner scoping implicit physically, but API behavior, tests, and any future shared tenant database must treat previews, definitions, audit reads, and idempotency records as owner-scoped resources.
+
+Families:
+
+- `recurring_question`
+- `agent_task`
+
+Preview modes:
+
+- `create`
+- `update`
+
+Lifecycle values:
+
+- `configured`
+- `paused`
+- `archived`
+- `disabled`
+
+Health values:
+
+- `ready`
+- `execution_unavailable`
+- `capability_unavailable`
+- `needs_attention`
+- `permission_required`
+
+In 4B, definitions can be created as `configured` or `paused`, but their health should normally be `execution_unavailable`. That means the definition is valid and manageable, but no run engine will execute it until 4C or 4D.
+
+When several health conditions apply, use a stable precedence so clients do not guess:
+
+1. `permission_required`
+2. `capability_unavailable`
+3. `needs_attention`
+4. `execution_unavailable`
+5. `ready`
+
+In 4B, `execution_unavailable` is expected even when related RAG or ACP readiness is healthy. If related readiness is missing and would block future execution, return `capability_unavailable` with explicit related capability details, not a fake execution status.
+
+Deletion is intentionally absent. `archive` is the user-facing removal workflow. Hard purge is a future admin or privacy retention feature.
+
+### Lifecycle Transitions
+
+Lifecycle transitions should be explicit and testable.
+
+| Mutation | Allowed from | Result | Notes |
+| --- | --- | --- | --- |
+| create | valid create preview | `configured` or `paused` | Default is `configured` unless request asks for `paused`. Health is normally `execution_unavailable`. |
+| update | `configured`, `paused`, `disabled` | same lifecycle | Requires valid update preview for the current definition version. |
+| pause | `configured` | `paused` | Records audit event. |
+| pause | `paused` | `paused` | Idempotent no-op; return current definition without a new audit event. |
+| resume | `paused` | `configured` | Records audit event. |
+| resume | `configured` | `configured` | Idempotent no-op; return current definition without a new audit event. |
+| resume | `disabled` | error | `disabled` is system/admin controlled and not user-resumable. |
+| archive | `configured`, `paused`, `disabled` | `archived` | Records audit event. |
+| archive | `archived` | `archived` | Idempotent no-op; return current definition. |
+| duplicate | `configured`, `paused`, `disabled` | new `paused` definition | Copies config only; no run/result/history copy; records deterministic audit on source and copy. Disabled sources may be duplicated only when the disabled reason is not an admin/security lock. |
+| duplicate | `archived` | error | Archived definitions are not duplicated in 4B. |
+| update/pause/resume archived | `archived` | error | Return `scheduled_task_definition_archived`. |
+
+Every update preview must capture the base `definition_version`. Update mutations reject stale previews with `scheduled_task_definition_version_conflict` when the current definition version no longer matches the preview.
+
+Lifecycle response rules:
+
+- successful create returns `201`;
+- successful update/lifecycle/duplicate returns `200`;
+- idempotent no-op lifecycle mutations return `200` with the current definition;
+- invalid lifecycle transitions return `409` with a typed error;
+- archived-definition mutations return `409` with `scheduled_task_definition_archived`, except archive of an already archived definition, which returns `200`.
+
+## Durable Preview Contract
+
+Preview is required for create and update. Preview is a durable server-side validation artifact, not a transient client hint.
+
+Preview records should include:
+
+- normalized config;
+- validation errors;
+- warnings;
+- schedule interpretation;
+- future result routing explanation;
+- missing dependencies;
+- related capability status;
+- expiry;
+- redaction policy;
+- risk class for Agent Task when possible.
+
+Create and update must consume a valid, unexpired preview record. Expired, mismatched, or cross-user previews fail with typed errors.
+
+Agent Task previews must not become accidental secret storage. They should store redacted message previews by default. Raw sensitive payload retention should be avoided or explicitly controlled by configuration.
+
+Preview statuses:
+
+- `valid`: semantic validation passed and the preview can be used for create/update until expiry or consumption.
+- `invalid`: request shape was syntactically accepted, but semantic validation failed; the record is inspectable but cannot be used for create/update.
+- `expired`: preview is past `expires_at`; expiry can be materialized lazily during read or mutation.
+- `consumed`: preview was used by a successful create/update and cannot be reused.
+
+Malformed requests still use normal request validation errors and do not need a preview record. Semantic validation failures should persist an `invalid` preview record and return a successful preview response with validation details so clients can inspect history.
+
+Preview consumption checklist:
+
+- owner matches the current user;
+- status is `valid`;
+- preview is not expired;
+- preview is not consumed;
+- preview family is supported by the target mutation;
+- preview mode matches the mutation, `create` for create and `update` for update;
+- create previews have no target `definition_id`;
+- update previews have `definition_id` equal to the route `{definition_id}`;
+- update preview `definition_version` equals the current stored definition version;
+- preview payload hash is the hash of the preview artifact's canonical config, not the idempotency request hash.
+
+Only previews that pass the full checklist can be consumed by create/update.
+
+Preview response rules:
+
+- syntactically valid preview requests return `201` with a persisted preview record, even when `status` is `invalid`;
+- malformed preview requests return normal request validation errors and do not persist a preview;
+- create/update with a missing preview returns `400` with `scheduled_task_preview_required`;
+- create/update with expired, consumed, mismatched, wrong-user, or wrong-version preview returns `409` with the matching typed error.
+
+Cross-user preview reads and mutations must not reveal preview existence. A preview owned by another user should behave like a missing or mismatched preview: detail reads return 404, and create/update use returns `scheduled_task_preview_mismatch` without ownership detail.
+
+## Request Shapes And Preview Consumption
+
+Preview requests carry the full proposed config. Create/update mutations consume the preview record rather than accepting a second copy of the full config.
+
+Minimal preview request:
+
+```json
+{
+  "mode": "create",
+  "family": "recurring_question",
+  "definition_id": null,
+  "definition_version": null,
+  "config": {
+    "name": "Track unanswered licensing question",
+    "description": null,
+    "input": {},
+    "schedule": {},
+    "visibility_policy": "findings_only",
+    "notification_policy": {}
+  }
+}
+```
+
+Minimal create request:
+
+```json
+{
+  "preview_id": "preview_123",
+  "initial_lifecycle": "configured"
+}
+```
+
+Minimal update preview request:
+
+```json
+{
+  "mode": "update",
+  "family": "agent_task",
+  "definition_id": "definition_123",
+  "definition_version": 4,
+  "config": {
+    "name": "Weekly agent check",
+    "description": null,
+    "input": {},
+    "schedule": {},
+    "visibility_policy": "failures_and_approvals",
+    "notification_policy": {}
+  }
+}
+```
+
+Minimal update request:
+
+```json
+{
+  "preview_id": "preview_456"
+}
+```
+
+Minimal duplicate request:
+
+```json
+{
+  "name": "Copy of Weekly agent check"
+}
+```
+
+Duplicate does not accept config overrides in 4B. It copies the source definition's normalized config, applies a new name when provided, and creates the copy in `paused` lifecycle. Any further config edits require an update preview.
+
+Duplicate should re-evaluate capability and permission health for the copied definition at creation time. It must not let a user bypass an admin/security `disabled` state by copying the definition into a runnable future state. In 4B the copy is always `paused`; in later execution slices, resuming the copy still requires normal health and permission checks.
+
+Canonical payload hash:
+
+- For previews, hash the canonical JSON form of `mode`, `family`, `definition_id`, `definition_version`, and `config`.
+- For create, the payload hash used for idempotency covers `preview_id` and `initial_lifecycle`.
+- For update, the payload hash used for idempotency covers `preview_id`.
+- For duplicate, the payload hash used for idempotency covers the optional new name and source definition ID.
+- Canonicalization should sort object keys and exclude transport-only metadata such as request IDs.
+
+## Recurring Question Contract
+
+Recurring Question stores a user's recurring research intent and searchable scope, but it does not run in 4B.
+
+Input fields:
+
+- `question`
+- `success_criteria?`
+- `freshness_expectation?`
+- `answer_policy`
+- `rag_profile_ref?`
+- `scope`
+
+Scope should support:
+
+- all searchable library;
+- collection IDs;
+- tags;
+- saved search IDs;
+- source types;
+- date windows;
+- future custom filters as a versioned scope object.
+
+Preview validates:
+
+- question is present and safe to store;
+- scope object is syntactically valid;
+- RAG capability and readiness are reported separately from Scheduled Tasks execution support;
+- schedule is valid;
+- visibility policy is valid;
+- no execution will occur in 4B.
+
+Default visibility:
+
+- `findings_only`
+
+## Agent Task Contract
+
+Agent Task stores a scheduled message and selected agent contract, but it does not dispatch in 4B.
+
+Input fields:
+
+- `agent_ref`
+- `message_payload`
+- `context_ref?`
+- `allowed_tool_classes`
+- `denied_tool_classes`
+- `approval_policy`
+- `redaction_policy`
+
+Preview validates:
+
+- agent reference shape;
+- message is present;
+- schedule is valid;
+- allowed and denied tool classes are syntactically valid;
+- risk class is estimated where possible;
+- preview output is redacted by default;
+- no execution will occur in 4B.
+
+Default visibility:
+
+- `failures_and_approvals`
+
+Risk classes:
+
+- `low`
+- `medium`
+- `high`
+- `unknown`
+
+Risk classes are API terms in 4B. Enforcement and approval queues wait for 4D.
+
+### Agent Task Sensitive Payload Policy
+
+Agent Task definitions must not store raw prompt/message text inline in `Definition.input`.
+
+Use a `message_payload` object:
+
+- `redacted_preview`: safe preview text returned by list/detail/preview/audit responses.
+- `storage_mode`: `redacted_only` or `encrypted_payload_ref`.
+- `payload_ref?`: opaque reference to encrypted payload storage when configured.
+- `raw_retention_allowed`: boolean explaining whether the server accepted raw retention.
+
+Default 4B behavior is `redacted_only`. If secure encrypted payload storage is not configured, raw message retention is not allowed. A future 4D execution implementation may require `encrypted_payload_ref` or a fresh update preview before an Agent Task can execute.
+
+List, detail, preview, and audit responses must never return raw Agent Task message text by default. Tests must prove that previews, definitions, and audit events do not leak raw prompts.
+
+## Schedule Policy
+
+4B should define safe schedule policy values because later execution will inherit these definitions.
+
+Supported schedule kinds:
+
+- `one_time`
+- `interval`
+- `daily`
+- `weekly`
+- `cron`
+
+All schedules include:
+
+- `timezone`
+- `start_at?`
+- `end_at?`
+- `dst_policy`
+- `missed_run_policy`
+- `overlap_policy`
+- `retry_policy`
+
+`next_run_preview` is response output only. It is not persisted as the canonical schedule source.
+
+Supported `dst_policy` values:
+
+- `preserve_wall_time`
+- `preserve_elapsed_interval`
+
+Supported `missed_run_policy` values in 4B:
+
+- `skip`
+- `run_once`
+
+`run_all` is deferred as a future/admin-only option.
+
+Supported `overlap_policy` values in 4B:
+
+- `skip_new`
+- `cancel_existing`
+
+`allow_parallel` is deferred unless a future capability explicitly enables it.
+
+Retry policy fields:
+
+- `strategy`: `none`, `fixed`, `exponential`
+- `max_attempts`
+- `initial_delay_seconds`
+- `max_delay_seconds`
+- `backoff_multiplier?`
+
+Cron is allowed as an advanced schedule kind, but it requires timezone, DST policy, and clear validation errors.
+
+## Visibility And Notification Policies
+
+Visibility policy is authoritative. It determines which future run outputs may appear outside task history.
+
+Defaults:
+
+- Recurring Question: `findings_only`
+- Agent Task: `failures_and_approvals`
+
+Supported policy values:
+
+- `every_run`
+- `findings_only`
+- `failures_only`
+- `failures_and_approvals`
+- `task_history_only`
+
+4B stores the policy and uses it in preview copy. It does not create Home/results items from these definitions.
+
+Notification policy is subordinate to visibility policy. It can further restrict delivery, but it cannot cause Home, Results, or notifications to receive content that visibility policy excludes.
+
+Fields:
+
+- `home_enabled`
+- `results_enabled`
+- `notifications_enabled`
+- `dedupe_key_strategy`
+- `failure_severity_threshold?`
+- `finding_confidence_threshold?`
+
+Preview should explain:
+
+- run history is complete once execution exists;
+- Home/results receive only what visibility policy allows;
+- notification settings can narrow that surfacing;
+- no run, result, or notification will be created in 4B.
+
+## Audit Contract
+
+4B should persist audit events for real definition lifecycle activity. Preview history is its own durable record and is not definition audit unless the preview is consumed into a definition.
+
+Audit event types:
+
+- `definition_created`
+- `definition_updated`
+- `definition_paused`
+- `definition_resumed`
+- `definition_archived`
+- `definition_duplicated`
+- `definition_duplicate_created`
+
+Create previews, invalid previews, and abandoned previews may not have a `definition_id`; they are inspectable through preview history, not through `definitions/{definition_id}/audit`.
+
+When a create preview is consumed successfully, the preview record should set `created_definition_id`, and the new definition audit should include `definition_created` with `preview_id`.
+
+When an update preview is consumed successfully, the target definition audit should include `definition_updated` with `preview_id` and the consumed preview's base version.
+
+When a duplicate succeeds, audit should be deterministic:
+
+- source definition receives `definition_duplicated` with `new_definition_id`;
+- copied definition receives `definition_duplicate_created` with `source_definition_id`;
+- both events use redacted metadata and the same `request_id`/`idempotency_key` when present.
+
+Audit `before` and `after` metadata must be concise and redacted. For Agent Task, message/input fields must be redacted or summarized. Audit must not copy raw prompts into metadata by default.
+
+4B exposes audit through a nested per-definition endpoint. A cross-definition audit endpoint is useful later, but out of scope for 4B.
+
+`scheduled_task_idempotency_conflict` is not a per-definition audit event in 4B because conflicts can occur before any definition exists. It should be returned as a typed error and may be recorded in service logs. A future global/security audit surface can model cross-resource idempotency conflicts.
+
+## Idempotency
+
+4B should support optional `Idempotency-Key` for preview, create, update, duplicate, and lifecycle mutations.
+
+Behavior:
+
+- same route + same key + same payload hash returns the original response;
+- same route + same key + different payload hash returns `scheduled_task_idempotency_conflict`;
+- records expire on a documented server policy;
+- records should store payload hashes and response references, not raw request bodies.
+
+For mutating requests, idempotency lookup must happen before preview validation or preview consumption. This lets a retried successful create/update return the original response even though the preview was already consumed by the first request. Without an idempotency key, reusing a consumed preview fails.
+
+This gives enterprise clients a safe path without making idempotency mandatory for every early client.
+
+## Error Handling
+
+Errors should use a consistent envelope:
+
+```json
+{
+  "code": "scheduled_task_preview_expired",
+  "message": "Preview expired. Run preview again before saving.",
+  "details": {},
+  "field_errors": [],
+  "retryable": true,
+  "correlation_id": "..."
+}
+```
+
+Core 4B error codes:
+
+- `scheduled_task_family_unavailable`
+- `scheduled_task_preview_required`
+- `scheduled_task_preview_expired`
+- `scheduled_task_preview_mismatch`
+- `scheduled_task_definition_not_found`
+- `scheduled_task_definition_archived`
+- `scheduled_task_schedule_invalid`
+- `scheduled_task_scope_invalid`
+- `scheduled_task_agent_ref_invalid`
+- `scheduled_task_permission_policy_invalid`
+- `scheduled_task_idempotency_conflict`
+- `scheduled_task_execution_unavailable`
+- `scheduled_task_definition_version_conflict`
+- `scheduled_task_lifecycle_transition_invalid`
+
+Later execution-only error code:
+
+- `scheduled_task_agent_unavailable`
+
+The 4B Agent Task API should use `scheduled_task_agent_ref_invalid` when only reference shape can be validated. It should not imply live agent health checks unless the implementation actually performs them.
+
+## Permissions
+
+Use current permissions for 4B implementation:
+
+| Permission | Endpoints |
+| --- | --- |
+| `TASKS_READ` | capabilities, definition list/detail, preview list/detail, audit read |
+| `TASKS_CONTROL` | preview create, definition create/update, pause, resume, archive, duplicate |
+
+Future granular permissions should be defined as terms but not required for 4B:
+
+- definition read;
+- definition write;
+- preview create/read;
+- lifecycle control;
+- audit read;
+- approval read/write;
+- export;
+- admin purge.
+
+Unauthenticated capability discovery is out of scope.
+
+## WebUI Reference Client Behavior
+
+The WebUI should prove the API contract works without pretending execution is available.
+
+Create tab:
+
+- Fetch `GET /scheduled-tasks/capabilities`.
+- Replace hardcoded planned state for Recurring Question and Agent Task when API capability data exists.
+- Show preview/create when capability says definition management is supported.
+- Keep "not executable yet" messaging visible after create.
+
+Create/edit forms:
+
+- Recurring Question form: question, success criteria, RAG scope, schedule, visibility.
+- Agent Task form: agent ref, message, allowed/denied tool classes, approval policy, schedule, visibility.
+- Both forms use preview before save.
+- Create/update consumes an unexpired preview record.
+
+Task list:
+
+- Include 4B definitions as normalized scheduled task rows.
+- Show family, lifecycle, health, schedule summary, last run as `Not run yet`, next run as `Execution unavailable` or equivalent.
+- Do not show fake run or result counts.
+
+Detail drawer:
+
+- Show definition summary, lifecycle controls, health explanation, schedule, visibility/notification policy.
+- Show preview history and definition audit events.
+- Show "Execution is not available yet" in the run/result area.
+- Show no fake run rows.
+
+Results tab and Home:
+
+- Continue showing existing projected/real items only.
+- Do not create placeholder result cards for 4B definitions.
+- Empty/copy states can mention future outputs route by visibility policy.
+
+Power-user actions:
+
+- pause/resume/archive/duplicate from table or detail;
+- filters for family, lifecycle, health, visibility, text search;
+- audit/preview history reachable from detail.
+
+## Control Plane Projection
+
+The unified `/api/v1/scheduled-tasks` list should remain backward compatible.
+
+Add a new primitive for persisted 4B definitions without redefining existing primitives:
+
+- `automation_definition`
+
+This is an explicit 4B compatibility decision. `ScheduledTaskPrimitive` should be extended to include `automation_definition`, and WebUI/service clients must be updated to handle it. Existing primitive values retain their meaning.
+
+Projected rows should include:
+
+- stable task ID prefix, such as `automation_definition:{definition_id}`;
+- `primitive: "automation_definition"`;
+- `enabled`: true only for lifecycle `configured`; false for `paused`, `archived`, and `disabled`;
+- `status`: a stable product-status token derived from lifecycle and health, not raw scheduler state;
+- `source_ref.family` with `recurring_question` or `agent_task`;
+- `source_ref.definition_id`;
+- `source_ref.lifecycle`;
+- `source_ref.health`;
+- `source_ref.execution_available: false` in 4B;
+- schedule summary;
+- timezone;
+- edit mode `native`;
+- no last run;
+- no real next run when health is `execution_unavailable`;
+- source references for definition ID and family.
+
+Reminder and Watchlists behavior must remain unchanged.
+
+Projection status mapping should avoid both fake scheduler language and current WebUI fallback traps:
+
+| Definition state | Projected `enabled` | Projected `status` | Product meaning |
+| --- | --- | --- | --- |
+| `configured` + `execution_unavailable` | true | `configured_execution_unavailable` | Valid definition, execution not implemented. |
+| `configured` + `capability_unavailable` | true | `blocked_capability_unavailable` | Definition is valid, but a related capability blocks future execution. |
+| `configured` + `permission_required` | true | `blocked_permission_required` | Definition needs permission/config recovery. |
+| `paused` | false | `paused` | User-paused definition. |
+| `disabled` | false | `disabled` | System/admin-disabled definition. |
+| `archived` | false | `archived` | Removed from normal active management views unless filters include archived. |
+
+The WebUI should add `automation_definition`-aware status and type handling instead of relying on generic substring matching. For automation definitions, lifecycle/health must be interpreted before the legacy `enabled === false` fallback so `paused` renders as "Paused" and `archived` renders as "Archived" instead of both collapsing into "Disabled." In particular, `configured_execution_unavailable` should render as "Configured, execution unavailable" or equivalent, not "Waiting for next run" and not a generic dependency failure.
+
+## Repository And Storage Requirements
+
+The repository interface should support:
+
+- create/list/get/update/archive definitions;
+- pause/resume definitions;
+- duplicate definitions;
+- create/list/get previews;
+- create/list audit events;
+- create/read idempotency records;
+- pagination and filtering;
+- per-user isolation.
+
+First implementation:
+
+- per-user SQLite under `Databases/user_databases/<user_id>/ScheduledTasks.db`;
+- schema initialization through the store/service layer;
+- no raw SQL outside DB management abstractions;
+- repository tests that can later be reused against a shared tenant DB implementation.
+
+## Pagination And Filtering
+
+4B list endpoints should not be unbounded.
+
+Definitions should filter by:
+
+- family;
+- lifecycle;
+- health;
+- visibility policy;
+- text query;
+- created/updated date window.
+
+Previews should filter by:
+
+- family;
+- mode;
+- status;
+- definition ID;
+- created date window;
+- expired/not expired.
+
+Audit should filter by:
+
+- event type;
+- actor;
+- created date window;
+- idempotency key;
+- request/correlation ID.
+
+Use the repository's existing pagination conventions where practical. If multiple pagination styles exist, the implementation plan should choose one and apply it consistently to new 4B endpoints.
+
+## Trust Copy
+
+Recommended copy for API clients and WebUI:
+
+- `Definition saved. Execution is not available on this server yet.`
+- `Preview expired. Run preview again before saving.`
+- `This Agent Task preview is redacted. Raw prompt retention is disabled.`
+- `RAG is available, but scheduled Recurring Question execution is not enabled.`
+- `This task is configured but will not run until scheduled execution is enabled.`
+
+Avoid:
+
+- `Scheduled` for definitions that cannot execute.
+- `Agent unavailable` when 4B only validated agent reference shape.
+- `No result` without explaining execution has not run.
+
+## Testing Requirements
+
+Backend tests:
+
+- capability discovery returns Recurring Question and Agent Task family states separately from RAG/ACP related readiness;
+- static child routes such as `/capabilities`, `/previews`, and `/definitions` are not shadowed by `/{task_id}`;
+- preview creation persists durable preview records with expiry and redacted Agent Task message preview;
+- create/update require valid preview records;
+- invalid previews are persisted as inspectable records but cannot be consumed;
+- create previews without definitions remain visible in preview history but do not appear in definition audit;
+- consumed create previews link to the created definition;
+- expired and mismatched previews fail with typed errors;
+- cross-user preview reads and create/update attempts do not reveal preview existence;
+- stale update previews fail when the definition version has changed;
+- definitions can be listed, filtered, read, updated, paused, resumed, archived, and duplicated;
+- duplicate creates a paused copy without run/result history;
+- duplicate does not accept inline config overrides in 4B;
+- audit events are recorded for create, update, pause, resume, archive, and duplicate;
+- optional idempotency replays same-payload responses and rejects same-key/different-payload conflicts;
+- idempotency keys are scoped by owner and route, so one user's key cannot replay or conflict with another user's mutation;
+- idempotent create/update replay succeeds after the original request consumed the preview;
+- no-key reuse of a consumed preview fails;
+- duplicate records deterministic audit events on both source and copied definitions;
+- duplicate cannot bypass an admin/security disabled source into a future runnable state;
+- automation definitions project into `/scheduled-tasks` with explicit `enabled`, `status`, `source_ref.lifecycle`, `source_ref.health`, and `source_ref.execution_available`;
+- existing reminder and Watchlists list/detail behavior remains compatible.
+
+Storage tests:
+
+- repository interface behavior;
+- per-user SQLite isolation;
+- pagination/filtering for definitions, previews, and audit;
+- no raw Agent Task prompt leakage in preview, definition list/detail, or audit records by default.
+
+Frontend tests:
+
+- capabilities enable 4B create/manage affordances only when advertised;
+- preview-before-save flow for both families;
+- definition detail shows preview history, audit events, and execution-unavailable state;
+- `automation_definition` rows render family, lifecycle, health, and execution-unavailable copy without falling through to generic reminder/watchlist labels;
+- configured non-executable definitions do not render as "Waiting for next run" and do not create fake result buttons;
+- paused and archived automation definitions do not collapse into the generic "Disabled" state when `enabled` is false;
+- lifecycle actions update UI without fake run/result rows;
+- existing Reminder, Watch/Ingest, Results, Home, and Watchlists behavior remains unchanged.
+
+Security tests:
+
+- Agent Task preview and audit redaction;
+- permission mapping for `TASKS_READ` and `TASKS_CONTROL`;
+- idempotency conflict behavior;
+- owner-scoped idempotency replay behavior;
+- cross-user preview/definition access denial.
+
+## Acceptance Criteria
+
+4B is complete when:
+
+- API clients can discover, preview, create, inspect, update, pause, resume, archive, and duplicate Recurring Question and Agent Task definitions.
+- Persisted definitions are Scheduled Tasks-owned.
+- Durable preview records are required for create/update and are redacted for Agent Task by default.
+- Agent Task definitions do not expose raw prompt/message text in list/detail/preview/audit responses by default.
+- Definition audit events are persisted and visible per definition.
+- Definitions are projected into the unified scheduled tasks list without breaking existing reminder or Watchlists behavior.
+- No execution, manual run, approval queue, run result, notification delivery, RAG dispatch, or agent dispatch is implemented.
+- WebUI demonstrates the 4B API without pretending execution exists.
+- Watchlists remains independent and unchanged.
+- OpenAPI docs expose the new schemas and endpoint contracts.
+- Bandit and focused backend/frontend tests pass for touched scope.
+
+## Risks And Mitigations
+
+| Risk | Why it matters | Mitigation |
+| --- | --- | --- |
+| Persisted definitions look executable | Users and API clients may assume work will run. | Use lifecycle `configured` and health `execution_unavailable`; avoid `scheduled` until execution exists. |
+| Durable previews leak secrets | Agent prompts may contain sensitive data. | Store redacted message previews by default; audit before/after is redacted/summarized. |
+| Durable definitions leak secrets | Raw Agent Task messages could persist without hard purge in 4B. | Do not store raw message inline; use redacted-only default or encrypted payload references when configured. |
+| Capability discovery conflates related readiness with execution support | RAG/ACP being available could incorrectly enable create/run. | Separate family availability from related capabilities; `execute` remains unavailable in 4B. |
+| Normalized rows are mislabeled by legacy WebUI status mapping | `execution_unavailable` can look like a generic dependency failure or "waiting for next run." | Project explicit lifecycle/health fields and add `automation_definition`-aware WebUI status handling. |
+| Idempotency keys leak across users in a future shared store | A retry key could expose or conflict with another user's mutation. | Include `owner_id` in the logical idempotency key scope and test cross-user isolation. |
+| Per-user SQLite limits future enterprise reporting | Admin audit may need tenant-wide views. | Define repository interface; do not expose storage topology in API. |
+| Optional idempotency behaves inconsistently | Clients cannot safely retry. | Define same-key replay and conflict semantics. |
+| Archive without delete frustrates privacy needs | Users may expect removal of sensitive prompts. | Minimize/redact stored sensitive data now; define hard purge as future admin/privacy feature. |
+| WebUI overpromises by showing Results/Home items | Trust loss and fake data. | Do not create fake runs/results; show execution-unavailable states. |
+| Existing `/acp/schedules` mistaken for Agent Task support | Unsafe unattended work could be implied. | Leave `/acp/schedules` separate and link only as related context. |
+
+## Future Slices
+
+4C Recurring Question execution:
+
+- Jobs-backed or explicitly approved Scheduler-backed execution;
+- schedule activation;
+- RAG query execution;
+- every-run summaries;
+- no-useful-match summaries;
+- result routing by visibility policy.
+
+4D Agent Task execution:
+
+- agent availability checks;
+- dispatch;
+- risk enforcement;
+- approval queue;
+- run transcript/output references;
+- audit events for tool/permission boundaries.
+
+Future cross-cutting work:
+
+- approval APIs;
+- run/result APIs;
+- global audit endpoint;
+- export APIs;
+- admin purge and retention controls;
+- migration or normalization strategy for `/acp/schedules`.
+
+## Open Questions For Implementation Planning
+
+- Which pagination convention should be used for new endpoints if existing modules differ?
+- What expiry window should durable preview records use?
+- What retention period should preview and audit records use by default?
+- How much live RAG/ACP readiness should capability discovery check in 4B versus returning static related capability status?
+- Should secure encrypted payload storage be required before Agent Task definitions can move from 4B management to 4D execution?
+
+## Spec Review
+
+Reviewed with `spec-document-reviewer`-style subagents on 2026-06-09.
+
+Review pass 1 found blocking issues in control-plane primitive compatibility, static route shadowing, Agent Task raw prompt retention, preview status semantics, duplicate preview behavior, update-version checks, capability action modeling, and lifecycle transitions. The spec was revised to:
+
+- explicitly add `automation_definition` as the new primitive;
+- require static routes before `/{task_id}` plus route regression tests;
+- define Agent Task redacted/default payload storage;
+- enumerate preview statuses and lifecycle transitions;
+- remove duplicate preview mode;
+- add definition version checks;
+- model capability actions with per-action statuses.
+
+Review pass 2 found issues in preview audit ownership, idempotency replay ordering, request body shape, and cross-user preview enumeration. The spec was revised to:
+
+- separate preview history from per-definition audit;
+- define idempotency lookup before preview validation/consumption for replay;
+- add minimal preview/create/update/duplicate request shapes and canonical hash rules;
+- require non-enumerating cross-user preview behavior.
+
+Review pass 3 found two remaining issues: preview consumption still used generic "matches mutation payload" wording, and `idempotency_conflict` still appeared as a per-definition audit event. The spec was revised locally to:
+
+- replace generic preview matching with an explicit preview consumption checklist;
+- remove `idempotency_conflict` from per-definition audit and scope it to typed errors/service logs until a future global audit surface exists.
+
+No fourth subagent review was dispatched because the brainstorming workflow caps review iterations at three. These final review findings are addressed in this draft and should be checked during user review before implementation planning.
+
+Additional human-requested self-review before implementation planning found implementation-risk gaps in owner scoping, health precedence, duplicate audit determinism, and normalized WebUI projection. The spec was revised to:
+
+- make `owner_id` part of Preview, Definition, and Idempotency record contracts, with explicit cross-user isolation expectations;
+- define health precedence so related capability readiness does not blur into execution support;
+- make duplicate audit deterministic on both source and copied definitions;
+- require duplicate to re-evaluate health and avoid bypassing admin/security disabled states;
+- define `automation_definition` projection fields and status tokens for the existing `/scheduled-tasks` list model;
+- require WebUI status handling to interpret automation definition lifecycle/health before legacy `enabled` fallbacks.

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskAutomationDefinitionEditor.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskAutomationDefinitionEditor.tsx
@@ -16,7 +16,8 @@ import { getAutomationDefinitionFamilyLabel } from "./scheduled-task-automation-
 export interface ScheduledTaskAutomationDefinitionEditorValues {
   name?: string
   description?: string
-  scheduleKind?: "manual" | "cron"
+  scheduleKind?: ScheduledTaskAutomationEditorScheduleKind
+  schedule?: Record<string, unknown>
   cron?: string
   timezone?: string
   visibility?: "private" | "shared"
@@ -51,7 +52,23 @@ export interface ScheduledTaskAutomationDefinitionEditorProps {
 }
 
 const DEFAULT_SCOPE_JSON = "{}"
-const DEFAULT_AGENT_REF_JSON = "{}"
+const DEFAULT_AGENT_REF = ""
+
+export type ScheduledTaskAutomationEditorScheduleKind =
+  | "one_time"
+  | "interval"
+  | "daily"
+  | "weekly"
+  | "cron"
+
+const DEFAULT_SCHEDULE_KIND: ScheduledTaskAutomationEditorScheduleKind = "daily"
+const SUPPORTED_SCHEDULE_KINDS = new Set<string>([
+  "one_time",
+  "interval",
+  "daily",
+  "weekly",
+  "cron"
+])
 
 const toStringList = (value: string): string[] =>
   value
@@ -59,23 +76,50 @@ const toStringList = (value: string): string[] =>
     .map((item) => item.trim())
     .filter(Boolean)
 
-const parseJsonObject = (value: string, fallback: Record<string, unknown>): Record<string, unknown> => {
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value)
+
+const isSupportedScheduleKind = (
+  value: unknown
+): value is ScheduledTaskAutomationEditorScheduleKind =>
+  typeof value === "string" && SUPPORTED_SCHEDULE_KINDS.has(value)
+
+const normalizeScheduleKind = (
+  value: unknown
+): ScheduledTaskAutomationEditorScheduleKind =>
+  isSupportedScheduleKind(value) ? value : DEFAULT_SCHEDULE_KIND
+
+const parseJsonObject = (
+  value: string,
+  fieldLabel: string
+): { value: Record<string, unknown> } | { error: string } => {
   const trimmed = value.trim()
-  if (!trimmed) return fallback
+  if (!trimmed) return { value: {} }
 
   try {
     const parsed = JSON.parse(trimmed)
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : fallback
+    return isRecord(parsed)
+      ? { value: parsed }
+      : { error: `${fieldLabel} must be a valid JSON object` }
   } catch {
-    return fallback
+    return { error: `${fieldLabel} must be a valid JSON object` }
   }
+}
+
+const readErrorDetail = (error: unknown): unknown => {
+  if (!isRecord(error)) return null
+
+  const details = error.details
+  if (isRecord(details) && isRecord(details.detail)) {
+    return details.detail
+  }
+
+  return isRecord(error.detail) ? error.detail : null
 }
 
 const readErrorMessage = (error: unknown, fallback: string): string => {
   if (error && typeof error === "object") {
-    const detail = "detail" in error ? (error as { detail?: unknown }).detail : null
+    const detail = readErrorDetail(error)
     if (detail && typeof detail === "object") {
       const code = "code" in detail ? String((detail as { code?: unknown }).code || "") : ""
       const message =
@@ -111,6 +155,31 @@ const isPreviewUsable = (
 const getFamilyLabel = (family: ScheduledTaskAutomationFamily): string =>
   getAutomationDefinitionFamilyLabel({ source_ref: { family } })
 
+const buildSchedule = (
+  values: Required<ScheduledTaskAutomationDefinitionEditorValues>
+): Record<string, unknown> => {
+  const timezone = values.timezone.trim() || "UTC"
+  const scheduleKind = normalizeScheduleKind(values.scheduleKind)
+  const existingSchedule = isRecord(values.schedule) ? values.schedule : {}
+  const baseSchedule =
+    existingSchedule.kind === scheduleKind ? { ...existingSchedule } : {}
+
+  if (scheduleKind === "cron") {
+    return {
+      ...baseSchedule,
+      kind: "cron",
+      cron: values.cron.trim(),
+      timezone
+    }
+  }
+
+  return {
+    ...baseSchedule,
+    kind: scheduleKind,
+    timezone
+  }
+}
+
 export const buildAutomationDefinitionPreviewPayload = ({
   family,
   mode,
@@ -124,21 +193,16 @@ export const buildAutomationDefinitionPreviewPayload = ({
   definitionVersion?: number | null
   values: Required<ScheduledTaskAutomationDefinitionEditorValues>
 }): ScheduledTaskPreviewCreateRequest => {
-  const schedule =
-    values.scheduleKind === "cron"
-      ? {
-          kind: "cron",
-          cron: values.cron.trim(),
-          timezone: values.timezone.trim()
-        }
-      : {
-          kind: "manual",
-          timezone: values.timezone.trim()
-        }
+  const schedule = buildSchedule(values)
   const visibility_policy = { visibility: values.visibility }
   const notification_policy = { channels: [] }
 
   if (family === "recurring_question") {
+    const parsedScope = parseJsonObject(values.scopeJson, "Scope JSON")
+    if ("error" in parsedScope) {
+      throw new Error(parsedScope.error)
+    }
+
     return {
       mode,
       family,
@@ -149,7 +213,7 @@ export const buildAutomationDefinitionPreviewPayload = ({
       input: {
         question: values.question.trim(),
         success_criteria: values.successCriteria.trim() || null,
-        scope: parseJsonObject(values.scopeJson, {})
+        scope: parsedScope.value
       },
       config: {},
       schedule,
@@ -167,7 +231,7 @@ export const buildAutomationDefinitionPreviewPayload = ({
     name: values.name.trim() || "Agent task",
     description: values.description.trim() || null,
     input: {
-      agent_ref: parseJsonObject(values.agentRef, { raw: values.agentRef.trim() }),
+      agent_ref: values.agentRef.trim(),
       message: values.message.trim()
     },
     config: {
@@ -198,14 +262,15 @@ export const ScheduledTaskAutomationDefinitionEditor: React.FC<
   const [values, setValues] = React.useState<Required<ScheduledTaskAutomationDefinitionEditorValues>>({
     name: initialValues?.name ?? "",
     description: initialValues?.description ?? "",
-    scheduleKind: initialValues?.scheduleKind ?? "manual",
+    scheduleKind: normalizeScheduleKind(initialValues?.scheduleKind),
+    schedule: initialValues?.schedule ?? {},
     cron: initialValues?.cron ?? "",
     timezone: initialValues?.timezone ?? "UTC",
     visibility: initialValues?.visibility ?? "private",
     question: initialValues?.question ?? "",
     successCriteria: initialValues?.successCriteria ?? "",
     scopeJson: initialValues?.scopeJson ?? DEFAULT_SCOPE_JSON,
-    agentRef: initialValues?.agentRef ?? DEFAULT_AGENT_REF_JSON,
+    agentRef: initialValues?.agentRef ?? DEFAULT_AGENT_REF,
     message: initialValues?.message ?? "",
     allowedToolClasses: initialValues?.allowedToolClasses ?? "",
     deniedToolClasses: initialValues?.deniedToolClasses ?? "",
@@ -217,36 +282,56 @@ export const ScheduledTaskAutomationDefinitionEditor: React.FC<
   const [saving, setSaving] = React.useState(false)
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null)
   const [saved, setSaved] = React.useState(false)
+  const valuesSignatureRef = React.useRef(JSON.stringify(values))
+  const latestPreviewRequestRef = React.useRef(0)
 
   const updateValue = <K extends keyof ScheduledTaskAutomationDefinitionEditorValues>(
     key: K,
     value: Required<ScheduledTaskAutomationDefinitionEditorValues>[K]
   ) => {
-    setValues((current) => ({ ...current, [key]: value }))
+    setValues((current) => {
+      const nextValues = { ...current, [key]: value }
+      valuesSignatureRef.current = JSON.stringify(nextValues)
+      return nextValues
+    })
     setPreview(null)
     setSaved(false)
   }
 
   const handlePreview = async () => {
+    const requestId = latestPreviewRequestRef.current + 1
+    latestPreviewRequestRef.current = requestId
+    const requestSignature = valuesSignatureRef.current
     setPreviewing(true)
     setErrorMessage(null)
     setSaved(false)
     try {
-      const nextPreview = await onPreview(
-        buildAutomationDefinitionPreviewPayload({
-          family,
-          mode,
-          definitionId,
-          definitionVersion,
-          values
-        })
-      )
-      setPreview(nextPreview)
+      const payload = buildAutomationDefinitionPreviewPayload({
+        family,
+        mode,
+        definitionId,
+        definitionVersion,
+        values
+      })
+      const nextPreview = await onPreview(payload)
+      if (
+        latestPreviewRequestRef.current === requestId &&
+        valuesSignatureRef.current === requestSignature
+      ) {
+        setPreview(nextPreview)
+      }
     } catch (error) {
-      setPreview(null)
-      setErrorMessage(readErrorMessage(error, "Unable to preview definition"))
+      if (
+        latestPreviewRequestRef.current === requestId &&
+        valuesSignatureRef.current === requestSignature
+      ) {
+        setPreview(null)
+        setErrorMessage(readErrorMessage(error, "Unable to preview definition"))
+      }
     } finally {
-      setPreviewing(false)
+      if (latestPreviewRequestRef.current === requestId) {
+        setPreviewing(false)
+      }
     }
   }
 
@@ -301,7 +386,10 @@ export const ScheduledTaskAutomationDefinitionEditor: React.FC<
             value={values.scheduleKind}
             onChange={(value) => updateValue("scheduleKind", value)}
             options={[
-              { value: "manual", label: "Manual" },
+              { value: "daily", label: "Daily" },
+              { value: "weekly", label: "Weekly" },
+              { value: "interval", label: "Interval" },
+              { value: "one_time", label: "One time" },
               { value: "cron", label: "Cron" }
             ]}
             style={{ width: 140 }}

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskAutomationDefinitionEditor.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskAutomationDefinitionEditor.tsx
@@ -109,12 +109,13 @@ const parseJsonObject = (
 const readErrorDetail = (error: unknown): unknown => {
   if (!isRecord(error)) return null
 
-  const details = error.details
-  if (isRecord(details) && isRecord(details.detail)) {
-    return details.detail
+  const details = error["details"]
+  if (isRecord(details) && isRecord(details["detail"])) {
+    return details["detail"]
   }
 
-  return isRecord(error.detail) ? error.detail : null
+  const detail = error["detail"]
+  return isRecord(detail) ? detail : null
 }
 
 const readErrorMessage = (error: unknown, fallback: string): string => {
@@ -139,10 +140,10 @@ const readErrorMessage = (error: unknown, fallback: string): string => {
 
 const getValidationMessage = (entry: Record<string, unknown>): string => {
   const message =
-    typeof entry.message === "string"
-      ? entry.message
-      : typeof entry.detail === "string"
-        ? entry.detail
+    typeof entry["message"] === "string"
+      ? entry["message"]
+      : typeof entry["detail"] === "string"
+        ? entry["detail"]
         : JSON.stringify(entry)
 
   return message
@@ -162,7 +163,7 @@ const buildSchedule = (
   const scheduleKind = normalizeScheduleKind(values.scheduleKind)
   const existingSchedule = isRecord(values.schedule) ? values.schedule : {}
   const baseSchedule =
-    existingSchedule.kind === scheduleKind ? { ...existingSchedule } : {}
+    existingSchedule["kind"] === scheduleKind ? { ...existingSchedule } : {}
 
   if (scheduleKind === "cron") {
     return {
@@ -344,13 +345,21 @@ export const ScheduledTaskAutomationDefinitionEditor: React.FC<
     setSaving(true)
     setErrorMessage(null)
     try {
-      const result =
-        mode === "create"
-          ? await onCreate?.({
-              preview_id: preview.id,
-              initial_lifecycle: values.initialLifecycle
-            })
-          : await onUpdate?.({ preview_id: preview.id })
+      let result: ScheduledTaskDefinitionResponse
+      if (mode === "create") {
+        if (!onCreate) {
+          throw new Error("Create handler is not configured")
+        }
+        result = await onCreate({
+          preview_id: preview.id,
+          initial_lifecycle: values.initialLifecycle
+        })
+      } else {
+        if (!onUpdate) {
+          throw new Error("Update handler is not configured")
+        }
+        result = await onUpdate({ preview_id: preview.id })
+      }
       setSaved(true)
       onSaved?.(result)
     } catch (error) {
@@ -363,8 +372,10 @@ export const ScheduledTaskAutomationDefinitionEditor: React.FC<
   const validationErrors = preview?.validation_errors ?? []
   const previewNeedsRefresh =
     preview && ["expired", "invalid", "consumed"].includes(preview.status)
-  const redactedFields = Array.isArray(preview?.redaction_policy?.redacted_fields)
-    ? (preview?.redaction_policy?.redacted_fields as unknown[]).filter(
+  const redactionPolicy = isRecord(preview?.redaction_policy) ? preview.redaction_policy : {}
+  const redactedFieldValues = redactionPolicy["redacted_fields"]
+  const redactedFields = Array.isArray(redactedFieldValues)
+    ? redactedFieldValues.filter(
         (field): field is string => typeof field === "string" && Boolean(field.trim())
       )
     : []

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskAutomationDefinitionEditor.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskAutomationDefinitionEditor.tsx
@@ -1,0 +1,453 @@
+import React from "react"
+import { Button, Card, Input, Select, Space, Typography } from "antd"
+
+import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
+import type {
+  ScheduledTaskAutomationFamily,
+  ScheduledTaskDefinitionCreateLifecycle,
+  ScheduledTaskDefinitionCreateRequest,
+  ScheduledTaskDefinitionResponse,
+  ScheduledTaskDefinitionUpdateRequest,
+  ScheduledTaskPreviewCreateRequest,
+  ScheduledTaskPreviewResponse
+} from "@/services/scheduled-tasks-control-plane"
+import { getAutomationDefinitionFamilyLabel } from "./scheduled-task-automation-status"
+
+export interface ScheduledTaskAutomationDefinitionEditorValues {
+  name?: string
+  description?: string
+  scheduleKind?: "manual" | "cron"
+  cron?: string
+  timezone?: string
+  visibility?: "private" | "shared"
+  question?: string
+  successCriteria?: string
+  scopeJson?: string
+  agentRef?: string
+  message?: string
+  allowedToolClasses?: string
+  deniedToolClasses?: string
+  approvalMode?: "none" | "manual"
+  initialLifecycle?: ScheduledTaskDefinitionCreateLifecycle
+}
+
+export interface ScheduledTaskAutomationDefinitionEditorProps {
+  family: ScheduledTaskAutomationFamily
+  mode: "create" | "update"
+  definitionId?: string | null
+  definitionVersion?: number | null
+  initialValues?: ScheduledTaskAutomationDefinitionEditorValues
+  onPreview: (
+    payload: ScheduledTaskPreviewCreateRequest
+  ) => Promise<ScheduledTaskPreviewResponse> | ScheduledTaskPreviewResponse
+  onCreate?: (
+    payload: ScheduledTaskDefinitionCreateRequest
+  ) => Promise<ScheduledTaskDefinitionResponse | unknown> | ScheduledTaskDefinitionResponse | unknown
+  onUpdate?: (
+    payload: ScheduledTaskDefinitionUpdateRequest
+  ) => Promise<ScheduledTaskDefinitionResponse | unknown> | ScheduledTaskDefinitionResponse | unknown
+  onCancel: () => void
+  onSaved?: (definition: ScheduledTaskDefinitionResponse | unknown) => void
+}
+
+const DEFAULT_SCOPE_JSON = "{}"
+const DEFAULT_AGENT_REF_JSON = "{}"
+
+const toStringList = (value: string): string[] =>
+  value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean)
+
+const parseJsonObject = (value: string, fallback: Record<string, unknown>): Record<string, unknown> => {
+  const trimmed = value.trim()
+  if (!trimmed) return fallback
+
+  try {
+    const parsed = JSON.parse(trimmed)
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : fallback
+  } catch {
+    return fallback
+  }
+}
+
+const readErrorMessage = (error: unknown, fallback: string): string => {
+  if (error && typeof error === "object") {
+    const detail = "detail" in error ? (error as { detail?: unknown }).detail : null
+    if (detail && typeof detail === "object") {
+      const code = "code" in detail ? String((detail as { code?: unknown }).code || "") : ""
+      const message =
+        "message" in detail ? String((detail as { message?: unknown }).message || "") : ""
+      if (code && message) return `${code}: ${message}`
+      if (message) return message
+      if (code) return code
+    }
+
+    if ("message" in error && typeof (error as { message?: unknown }).message === "string") {
+      return (error as { message: string }).message
+    }
+  }
+
+  return fallback
+}
+
+const getValidationMessage = (entry: Record<string, unknown>): string => {
+  const message =
+    typeof entry.message === "string"
+      ? entry.message
+      : typeof entry.detail === "string"
+        ? entry.detail
+        : JSON.stringify(entry)
+
+  return message
+}
+
+const isPreviewUsable = (
+  preview: ScheduledTaskPreviewResponse | null
+): preview is ScheduledTaskPreviewResponse => preview?.status === "valid"
+
+const getFamilyLabel = (family: ScheduledTaskAutomationFamily): string =>
+  getAutomationDefinitionFamilyLabel({ source_ref: { family } })
+
+export const buildAutomationDefinitionPreviewPayload = ({
+  family,
+  mode,
+  definitionId,
+  definitionVersion,
+  values
+}: {
+  family: ScheduledTaskAutomationFamily
+  mode: "create" | "update"
+  definitionId?: string | null
+  definitionVersion?: number | null
+  values: Required<ScheduledTaskAutomationDefinitionEditorValues>
+}): ScheduledTaskPreviewCreateRequest => {
+  const schedule =
+    values.scheduleKind === "cron"
+      ? {
+          kind: "cron",
+          cron: values.cron.trim(),
+          timezone: values.timezone.trim()
+        }
+      : {
+          kind: "manual",
+          timezone: values.timezone.trim()
+        }
+  const visibility_policy = { visibility: values.visibility }
+  const notification_policy = { channels: [] }
+
+  if (family === "recurring_question") {
+    return {
+      mode,
+      family,
+      definition_id: mode === "update" ? definitionId ?? null : undefined,
+      definition_version: mode === "update" ? definitionVersion ?? null : undefined,
+      name: values.name.trim() || values.question.trim() || "Recurring question",
+      description: values.description.trim() || null,
+      input: {
+        question: values.question.trim(),
+        success_criteria: values.successCriteria.trim() || null,
+        scope: parseJsonObject(values.scopeJson, {})
+      },
+      config: {},
+      schedule,
+      visibility_policy,
+      notification_policy,
+      approval_policy: { mode: "none" }
+    }
+  }
+
+  return {
+    mode,
+    family,
+    definition_id: mode === "update" ? definitionId ?? null : undefined,
+    definition_version: mode === "update" ? definitionVersion ?? null : undefined,
+    name: values.name.trim() || "Agent task",
+    description: values.description.trim() || null,
+    input: {
+      agent_ref: parseJsonObject(values.agentRef, { raw: values.agentRef.trim() }),
+      message: values.message.trim()
+    },
+    config: {
+      allowed_tool_classes: toStringList(values.allowedToolClasses),
+      denied_tool_classes: toStringList(values.deniedToolClasses)
+    },
+    schedule,
+    visibility_policy,
+    notification_policy,
+    approval_policy: { mode: values.approvalMode }
+  }
+}
+
+export const ScheduledTaskAutomationDefinitionEditor: React.FC<
+  ScheduledTaskAutomationDefinitionEditorProps
+> = ({
+  family,
+  mode,
+  definitionId,
+  definitionVersion,
+  initialValues,
+  onPreview,
+  onCreate,
+  onUpdate,
+  onCancel,
+  onSaved
+}) => {
+  const [values, setValues] = React.useState<Required<ScheduledTaskAutomationDefinitionEditorValues>>({
+    name: initialValues?.name ?? "",
+    description: initialValues?.description ?? "",
+    scheduleKind: initialValues?.scheduleKind ?? "manual",
+    cron: initialValues?.cron ?? "",
+    timezone: initialValues?.timezone ?? "UTC",
+    visibility: initialValues?.visibility ?? "private",
+    question: initialValues?.question ?? "",
+    successCriteria: initialValues?.successCriteria ?? "",
+    scopeJson: initialValues?.scopeJson ?? DEFAULT_SCOPE_JSON,
+    agentRef: initialValues?.agentRef ?? DEFAULT_AGENT_REF_JSON,
+    message: initialValues?.message ?? "",
+    allowedToolClasses: initialValues?.allowedToolClasses ?? "",
+    deniedToolClasses: initialValues?.deniedToolClasses ?? "",
+    approvalMode: initialValues?.approvalMode ?? "none",
+    initialLifecycle: initialValues?.initialLifecycle ?? "configured"
+  })
+  const [preview, setPreview] = React.useState<ScheduledTaskPreviewResponse | null>(null)
+  const [previewing, setPreviewing] = React.useState(false)
+  const [saving, setSaving] = React.useState(false)
+  const [errorMessage, setErrorMessage] = React.useState<string | null>(null)
+  const [saved, setSaved] = React.useState(false)
+
+  const updateValue = <K extends keyof ScheduledTaskAutomationDefinitionEditorValues>(
+    key: K,
+    value: Required<ScheduledTaskAutomationDefinitionEditorValues>[K]
+  ) => {
+    setValues((current) => ({ ...current, [key]: value }))
+    setPreview(null)
+    setSaved(false)
+  }
+
+  const handlePreview = async () => {
+    setPreviewing(true)
+    setErrorMessage(null)
+    setSaved(false)
+    try {
+      const nextPreview = await onPreview(
+        buildAutomationDefinitionPreviewPayload({
+          family,
+          mode,
+          definitionId,
+          definitionVersion,
+          values
+        })
+      )
+      setPreview(nextPreview)
+    } catch (error) {
+      setPreview(null)
+      setErrorMessage(readErrorMessage(error, "Unable to preview definition"))
+    } finally {
+      setPreviewing(false)
+    }
+  }
+
+  const handleSave = async () => {
+    if (!isPreviewUsable(preview)) {
+      setErrorMessage("Preview again before saving")
+      return
+    }
+
+    setSaving(true)
+    setErrorMessage(null)
+    try {
+      const result =
+        mode === "create"
+          ? await onCreate?.({
+              preview_id: preview.id,
+              initial_lifecycle: values.initialLifecycle
+            })
+          : await onUpdate?.({ preview_id: preview.id })
+      setSaved(true)
+      onSaved?.(result)
+    } catch (error) {
+      setErrorMessage(readErrorMessage(error, "Unable to save definition"))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const validationErrors = preview?.validation_errors ?? []
+  const previewNeedsRefresh =
+    preview && ["expired", "invalid", "consumed"].includes(preview.status)
+  const redactedFields = Array.isArray(preview?.redaction_policy?.redacted_fields)
+    ? (preview?.redaction_policy?.redacted_fields as unknown[]).filter(
+        (field): field is string => typeof field === "string" && Boolean(field.trim())
+      )
+    : []
+  const saveDisabled = !isPreviewUsable(preview) || saving || previewing
+
+  return (
+    <Card title={mode === "create" ? `Create ${getFamilyLabel(family)}` : `Update ${getFamilyLabel(family)}`} size="small">
+      <Space orientation="vertical" size={12} style={{ width: "100%" }}>
+        <Space wrap style={{ width: "100%" }}>
+          <Input
+            aria-label="Name"
+            placeholder="Name"
+            value={values.name}
+            onChange={(event) => updateValue("name", event.target.value)}
+            style={{ minWidth: 240 }}
+          />
+          <Select
+            aria-label="Schedule kind"
+            value={values.scheduleKind}
+            onChange={(value) => updateValue("scheduleKind", value)}
+            options={[
+              { value: "manual", label: "Manual" },
+              { value: "cron", label: "Cron" }
+            ]}
+            style={{ width: 140 }}
+          />
+          <Input
+            aria-label="Timezone"
+            value={values.timezone}
+            onChange={(event) => updateValue("timezone", event.target.value)}
+            style={{ width: 180 }}
+          />
+          <Select
+            aria-label="Visibility"
+            value={values.visibility}
+            onChange={(value) => updateValue("visibility", value)}
+            options={[
+              { value: "private", label: "Private" },
+              { value: "shared", label: "Shared" }
+            ]}
+            style={{ width: 140 }}
+          />
+        </Space>
+
+        {values.scheduleKind === "cron" ? (
+          <Input
+            aria-label="Cron"
+            placeholder="0 9 * * *"
+            value={values.cron}
+            onChange={(event) => updateValue("cron", event.target.value)}
+          />
+        ) : null}
+
+        <Input.TextArea
+          aria-label="Description"
+          placeholder="Description"
+          rows={2}
+          value={values.description}
+          onChange={(event) => updateValue("description", event.target.value)}
+        />
+
+        {family === "recurring_question" ? (
+          <>
+            <Input.TextArea
+              aria-label="Question"
+              placeholder="Question"
+              rows={3}
+              value={values.question}
+              onChange={(event) => updateValue("question", event.target.value)}
+            />
+            <Input.TextArea
+              aria-label="Success criteria"
+              placeholder="Success criteria"
+              rows={2}
+              value={values.successCriteria}
+              onChange={(event) => updateValue("successCriteria", event.target.value)}
+            />
+            <Input.TextArea
+              aria-label="Scope JSON"
+              value={values.scopeJson}
+              rows={4}
+              onChange={(event) => updateValue("scopeJson", event.target.value)}
+            />
+          </>
+        ) : (
+          <>
+            <Input.TextArea
+              aria-label="Agent ref"
+              value={values.agentRef}
+              rows={3}
+              onChange={(event) => updateValue("agentRef", event.target.value)}
+            />
+            <Input.TextArea
+              aria-label="Message"
+              placeholder="Message"
+              rows={3}
+              value={values.message}
+              onChange={(event) => updateValue("message", event.target.value)}
+            />
+            <Input
+              aria-label="Allowed tool classes"
+              placeholder="Allowed tool classes"
+              value={values.allowedToolClasses}
+              onChange={(event) => updateValue("allowedToolClasses", event.target.value)}
+            />
+            <Input
+              aria-label="Denied tool classes"
+              placeholder="Denied tool classes"
+              value={values.deniedToolClasses}
+              onChange={(event) => updateValue("deniedToolClasses", event.target.value)}
+            />
+            <Select
+              aria-label="Approval mode"
+              value={values.approvalMode}
+              onChange={(value) => updateValue("approvalMode", value)}
+              options={[
+                { value: "none", label: "No approval" },
+                { value: "manual", label: "Manual approval" }
+              ]}
+              style={{ width: 180 }}
+            />
+          </>
+        )}
+
+        {preview?.status === "valid" ? (
+          <DesignSystemAlert variant="success" title="Preview ready" />
+        ) : null}
+        {previewNeedsRefresh ? (
+          <DesignSystemAlert variant="warning" title="Preview again before saving" />
+        ) : null}
+        {validationErrors.length > 0 ? (
+          <Space orientation="vertical" size={4}>
+            {validationErrors.map((entry, index) => (
+              <Typography.Text key={index} type="danger">
+                {getValidationMessage(entry)}
+              </Typography.Text>
+            ))}
+          </Space>
+        ) : null}
+        {redactedFields.length > 0 ? (
+          <Typography.Text type="secondary">
+            {`Redacted: ${redactedFields.join(", ")}`}
+          </Typography.Text>
+        ) : null}
+        {errorMessage ? (
+          <DesignSystemAlert variant="error" title={errorMessage} />
+        ) : null}
+        {(preview?.status === "valid" || saved) ? (
+          <Typography.Text type="secondary">Execution is not available yet</Typography.Text>
+        ) : null}
+
+        <Space wrap>
+          <Button onClick={onCancel}>Cancel</Button>
+          <Button onClick={handlePreview} loading={previewing}>
+            Preview
+          </Button>
+          <Button
+            type="primary"
+            disabled={saveDisabled}
+            loading={saving}
+            onClick={handleSave}
+          >
+            Save definition
+          </Button>
+        </Space>
+      </Space>
+    </Card>
+  )
+}
+
+export default ScheduledTaskAutomationDefinitionEditor

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskCreatePanel.tsx
@@ -9,8 +9,17 @@ import {
   Badge as DesignSystemBadge,
   type BadgeVariant
 } from "@/components/ui/primitives"
-import type { CreateScheduledTaskReminderPayload } from "@/services/scheduled-tasks-control-plane"
+import type {
+  CreateScheduledTaskReminderPayload,
+  ScheduledTaskAutomationCapabilitiesResponse,
+  ScheduledTaskAutomationFamily,
+  ScheduledTaskDefinitionCreateRequest,
+  ScheduledTaskDefinitionResponse,
+  ScheduledTaskPreviewCreateRequest,
+  ScheduledTaskPreviewResponse
+} from "@/services/scheduled-tasks-control-plane"
 import { ReminderTaskEditor } from "./ReminderTaskEditor"
+import { ScheduledTaskAutomationDefinitionEditor } from "./ScheduledTaskAutomationDefinitionEditor"
 import {
   applyScheduledTaskTemplateCapabilities,
   buildNotificationPolicyCopy,
@@ -45,6 +54,14 @@ export interface ScheduledTaskCreatePanelProps {
   onCreateReminder: (payload: CreateScheduledTaskReminderPayload) => Promise<void> | void
   savingReminder?: boolean
   templateCapabilities?: ScheduledTaskTemplateCapabilityMap
+  automationCapabilities?: ScheduledTaskAutomationCapabilitiesResponse | null
+  onPreviewAutomationDefinition?: (
+    payload: ScheduledTaskPreviewCreateRequest
+  ) => Promise<ScheduledTaskPreviewResponse> | ScheduledTaskPreviewResponse
+  onCreateAutomationDefinition?: (
+    payload: ScheduledTaskDefinitionCreateRequest
+  ) => Promise<ScheduledTaskDefinitionResponse | unknown> | ScheduledTaskDefinitionResponse | unknown
+  onAutomationDefinitionCreated?: (definition: ScheduledTaskDefinitionResponse | unknown) => void
 }
 
 const WATCHLISTS_HREF = "/watchlists"
@@ -54,6 +71,23 @@ const isTemplateFilterId = (value: SegmentedValue): value is ScheduledTaskTempla
 
 const requiresWatchlistsHandoff = (template: ScheduledTaskTemplate): boolean =>
   template.id === "watch" || template.id === "ingest"
+
+const templateIdToAutomationFamily = (
+  templateId: ScheduledTaskTemplateId
+): ScheduledTaskAutomationFamily | null =>
+  templateId === "recurring_question" || templateId === "agent_task"
+    ? templateId
+    : null
+
+const canCreateAutomationDefinition = (
+  capabilities: ScheduledTaskAutomationCapabilitiesResponse | null | undefined,
+  family: ScheduledTaskAutomationFamily
+): boolean =>
+  capabilities?.items.some(
+    (capability) =>
+      capability.family === family &&
+      capability.actions.create_definition?.status === "available"
+  ) ?? false
 
 const templateStateToBadgeVariant = (
   state: ScheduledTaskTemplate["state"]
@@ -341,7 +375,11 @@ export const ScheduledTaskCreatePanel: React.FC<ScheduledTaskCreatePanelProps> =
   onSelectTemplate,
   onCreateReminder,
   savingReminder,
-  templateCapabilities
+  templateCapabilities,
+  automationCapabilities,
+  onPreviewAutomationDefinition,
+  onCreateAutomationDefinition,
+  onAutomationDefinitionCreated
 }) => {
   const [finderText, setFinderText] = useState("")
   const [filterId, setFilterId] = useState<ScheduledTaskTemplateFilterId>("all")
@@ -381,6 +419,25 @@ export const ScheduledTaskCreatePanel: React.FC<ScheduledTaskCreatePanelProps> =
           saving={savingReminder}
           onClose={() => onSelectTemplate(null)}
           onSubmit={(payload) => onCreateReminder(payload as CreateScheduledTaskReminderPayload)}
+        />
+      )
+    }
+
+    const automationFamily = templateIdToAutomationFamily(selectedTemplate.id)
+    if (
+      automationFamily &&
+      canCreateAutomationDefinition(automationCapabilities, automationFamily) &&
+      onPreviewAutomationDefinition &&
+      onCreateAutomationDefinition
+    ) {
+      return (
+        <ScheduledTaskAutomationDefinitionEditor
+          family={automationFamily}
+          mode="create"
+          onPreview={onPreviewAutomationDefinition}
+          onCreate={onCreateAutomationDefinition}
+          onSaved={onAutomationDefinitionCreated}
+          onCancel={() => onSelectTemplate(null)}
         />
       )
     }

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskDetailDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskDetailDrawer.tsx
@@ -28,6 +28,7 @@ export interface ScheduledTaskDetailDrawerProps {
   onClose: () => void
   onEditReminder: (task: ScheduledTask) => void
   onDeleteReminder: (task: ScheduledTask) => void
+  onEditAutomationDefinition?: (task: ScheduledTask) => void
   onPauseAutomationDefinition?: (task: ScheduledTask) => void
   onResumeAutomationDefinition?: (task: ScheduledTask) => void
   onArchiveAutomationDefinition?: (task: ScheduledTask) => void
@@ -112,6 +113,7 @@ const renderTaskActions = ({
   task,
   onEditReminder,
   onDeleteReminder,
+  onEditAutomationDefinition,
   onPauseAutomationDefinition,
   onResumeAutomationDefinition,
   onArchiveAutomationDefinition,
@@ -120,6 +122,7 @@ const renderTaskActions = ({
   task: ScheduledTask
   onEditReminder: (task: ScheduledTask) => void
   onDeleteReminder: (task: ScheduledTask) => void
+  onEditAutomationDefinition?: (task: ScheduledTask) => void
   onPauseAutomationDefinition?: (task: ScheduledTask) => void
   onResumeAutomationDefinition?: (task: ScheduledTask) => void
   onArchiveAutomationDefinition?: (task: ScheduledTask) => void
@@ -146,6 +149,9 @@ const renderTaskActions = ({
 
     return (
       <Space wrap>
+        <Button type="primary" onClick={() => onEditAutomationDefinition?.(task)}>
+          Edit definition
+        </Button>
         {isPaused ? (
           <Button onClick={() => onResumeAutomationDefinition?.(task)}>
             Resume definition
@@ -191,6 +197,7 @@ export const ScheduledTaskDetailDrawer: React.FC<ScheduledTaskDetailDrawerProps>
   onClose,
   onEditReminder,
   onDeleteReminder,
+  onEditAutomationDefinition,
   onPauseAutomationDefinition,
   onResumeAutomationDefinition,
   onArchiveAutomationDefinition,
@@ -283,6 +290,7 @@ export const ScheduledTaskDetailDrawer: React.FC<ScheduledTaskDetailDrawerProps>
                 task,
                 onEditReminder,
                 onDeleteReminder,
+                onEditAutomationDefinition,
                 onPauseAutomationDefinition,
                 onResumeAutomationDefinition,
                 onArchiveAutomationDefinition,

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskDetailDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskDetailDrawer.tsx
@@ -1,7 +1,12 @@
 import React from "react"
 import { Button, Descriptions, Drawer, Space, Typography } from "antd"
 import { Badge as DesignSystemBadge } from "@/components/ui/primitives"
-import type { ScheduledTask } from "@/services/scheduled-tasks-control-plane"
+import type {
+  ScheduledTask,
+  ScheduledTaskAuditEventResponse,
+  ScheduledTaskDefinitionResponse,
+  ScheduledTaskPreviewResponse
+} from "@/services/scheduled-tasks-control-plane"
 import {
   formatScheduledTaskTimestamp,
   getScheduledTaskProductStatus,
@@ -9,6 +14,7 @@ import {
   isNativeReminderTask,
   scheduledTaskStatusToneToBadgeVariant
 } from "./scheduled-task-status"
+import { isAutomationDefinitionTask } from "./scheduled-task-automation-status"
 import { WatchlistTaskActionLinks } from "./WatchlistTaskActionLinks"
 import type { ScheduledTaskResultItem } from "./scheduled-task-results"
 
@@ -16,9 +22,16 @@ export interface ScheduledTaskDetailDrawerProps {
   open: boolean
   task: ScheduledTask | null
   latestResult?: ScheduledTaskResultItem | null
+  automationDefinition?: ScheduledTaskDefinitionResponse | null
+  automationPreviewHistory?: ScheduledTaskPreviewResponse[]
+  automationAuditEvents?: ScheduledTaskAuditEventResponse[]
   onClose: () => void
   onEditReminder: (task: ScheduledTask) => void
   onDeleteReminder: (task: ScheduledTask) => void
+  onPauseAutomationDefinition?: (task: ScheduledTask) => void
+  onResumeAutomationDefinition?: (task: ScheduledTask) => void
+  onArchiveAutomationDefinition?: (task: ScheduledTask) => void
+  onDuplicateAutomationDefinition?: (task: ScheduledTask) => void
 }
 
 const WATCHLISTS_WORKSPACE_COPY =
@@ -64,6 +77,18 @@ const renderOptionalDescriptionItem = (
 const renderSourceReferenceItems = (task: ScheduledTask): React.ReactNode => {
   const sourceRef = task.source_ref || {}
 
+  if (task.primitive === "automation_definition") {
+    return (
+      <>
+        {renderOptionalDescriptionItem("Definition id", sourceRef.definition_id)}
+        {renderOptionalDescriptionItem("Lifecycle", sourceRef.lifecycle)}
+        {renderOptionalDescriptionItem("Health", sourceRef.health)}
+        {renderOptionalDescriptionItem("Visibility", sourceRef.visibility)}
+        {renderOptionalDescriptionItem("Notification policy", sourceRef.notification_policy)}
+      </>
+    )
+  }
+
   if (task.primitive === "watchlist_job") {
     return (
       <>
@@ -86,11 +111,19 @@ const renderSourceReferenceItems = (task: ScheduledTask): React.ReactNode => {
 const renderTaskActions = ({
   task,
   onEditReminder,
-  onDeleteReminder
+  onDeleteReminder,
+  onPauseAutomationDefinition,
+  onResumeAutomationDefinition,
+  onArchiveAutomationDefinition,
+  onDuplicateAutomationDefinition
 }: {
   task: ScheduledTask
   onEditReminder: (task: ScheduledTask) => void
   onDeleteReminder: (task: ScheduledTask) => void
+  onPauseAutomationDefinition?: (task: ScheduledTask) => void
+  onResumeAutomationDefinition?: (task: ScheduledTask) => void
+  onArchiveAutomationDefinition?: (task: ScheduledTask) => void
+  onDuplicateAutomationDefinition?: (task: ScheduledTask) => void
 }): React.ReactNode => {
   if (isNativeReminderTask(task)) {
     return (
@@ -105,18 +138,66 @@ const renderTaskActions = ({
     )
   }
 
+  if (isAutomationDefinitionTask(task)) {
+    const lifecycle =
+      typeof task.source_ref?.lifecycle === "string" ? task.source_ref.lifecycle : task.status
+    const isPaused = lifecycle === "paused"
+    const isArchived = lifecycle === "archived"
+
+    return (
+      <Space wrap>
+        {isPaused ? (
+          <Button onClick={() => onResumeAutomationDefinition?.(task)}>
+            Resume definition
+          </Button>
+        ) : !isArchived ? (
+          <Button onClick={() => onPauseAutomationDefinition?.(task)}>
+            Pause definition
+          </Button>
+        ) : null}
+        {!isArchived ? (
+          <Button onClick={() => onArchiveAutomationDefinition?.(task)}>
+            Archive definition
+          </Button>
+        ) : null}
+        <Button onClick={() => onDuplicateAutomationDefinition?.(task)}>
+          Duplicate definition
+        </Button>
+      </Space>
+    )
+  }
+
   return <WatchlistTaskActionLinks task={task} />
+}
+
+const stringifyCompact = (value: unknown): string => {
+  if (value === null || value === undefined) return "None"
+  if (typeof value === "string") return value || "None"
+  if (typeof value === "number" || typeof value === "boolean") return String(value)
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return "Unavailable"
+  }
 }
 
 export const ScheduledTaskDetailDrawer: React.FC<ScheduledTaskDetailDrawerProps> = ({
   open,
   task,
   latestResult = null,
+  automationDefinition = null,
+  automationPreviewHistory = [],
+  automationAuditEvents = [],
   onClose,
   onEditReminder,
-  onDeleteReminder
+  onDeleteReminder,
+  onPauseAutomationDefinition,
+  onResumeAutomationDefinition,
+  onArchiveAutomationDefinition,
+  onDuplicateAutomationDefinition
 }) => {
   const productStatus = task ? getScheduledTaskProductStatus(task) : null
+  const isAutomationTask = task ? isAutomationDefinitionTask(task) : false
 
   return (
     <Drawer
@@ -150,7 +231,9 @@ export const ScheduledTaskDetailDrawer: React.FC<ScheduledTaskDetailDrawerProps>
               {getScheduledTaskTypeLabel(task)}
             </Descriptions.Item>
             <Descriptions.Item label="Management owner">
-              {isNativeReminderTask(task) ? "Managed here" : "Managed in Watchlists"}
+              {isNativeReminderTask(task) || isAutomationTask
+                ? "Managed here"
+                : "Managed in Watchlists"}
             </Descriptions.Item>
             <Descriptions.Item label="Schedule summary">
               {task.schedule_summary || "Manual"}
@@ -165,6 +248,25 @@ export const ScheduledTaskDetailDrawer: React.FC<ScheduledTaskDetailDrawerProps>
               {formatScheduledTaskTimestamp(task.next_run_at, "No upcoming run")}
             </Descriptions.Item>
             {renderSourceReferenceItems(task)}
+            {isAutomationTask && automationDefinition ? (
+              <>
+                <Descriptions.Item label="Definition lifecycle">
+                  {automationDefinition.lifecycle}
+                </Descriptions.Item>
+                <Descriptions.Item label="Definition health">
+                  {automationDefinition.health}
+                </Descriptions.Item>
+                <Descriptions.Item label="Definition schedule">
+                  {stringifyCompact(automationDefinition.schedule)}
+                </Descriptions.Item>
+                <Descriptions.Item label="Definition visibility">
+                  {stringifyCompact(automationDefinition.visibility_policy?.visibility)}
+                </Descriptions.Item>
+                <Descriptions.Item label="Definition notifications">
+                  {stringifyCompact(automationDefinition.notification_policy)}
+                </Descriptions.Item>
+              </>
+            ) : null}
           </Descriptions>
 
           <div>
@@ -177,9 +279,53 @@ export const ScheduledTaskDetailDrawer: React.FC<ScheduledTaskDetailDrawerProps>
                   </Button>
                 </div>
               ) : null}
-              {renderTaskActions({ task, onEditReminder, onDeleteReminder })}
+              {renderTaskActions({
+                task,
+                onEditReminder,
+                onDeleteReminder,
+                onPauseAutomationDefinition,
+                onResumeAutomationDefinition,
+                onArchiveAutomationDefinition,
+                onDuplicateAutomationDefinition
+              })}
             </Space>
           </div>
+
+          {isAutomationTask ? (
+            <>
+              <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
+                Execution is not available yet
+              </Typography.Paragraph>
+              <div>
+                <Typography.Title level={5}>Preview history</Typography.Title>
+                {automationPreviewHistory.length > 0 ? (
+                  <Space orientation="vertical" size={4}>
+                    {automationPreviewHistory.map((preview) => (
+                      <Typography.Text key={preview.id}>
+                        {preview.id} · {preview.status}
+                      </Typography.Text>
+                    ))}
+                  </Space>
+                ) : (
+                  <Typography.Text type="secondary">No previews loaded.</Typography.Text>
+                )}
+              </div>
+              <div>
+                <Typography.Title level={5}>Audit events</Typography.Title>
+                {automationAuditEvents.length > 0 ? (
+                  <Space orientation="vertical" size={4}>
+                    {automationAuditEvents.map((event) => (
+                      <Typography.Text key={event.id}>
+                        {event.summary || event.event_type}
+                      </Typography.Text>
+                    ))}
+                  </Space>
+                ) : (
+                  <Typography.Text type="secondary">No audit events loaded.</Typography.Text>
+                )}
+              </div>
+            </>
+          ) : null}
 
           {task.primitive === "watchlist_job" ? (
             <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskDetailDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskDetailDrawer.tsx
@@ -81,11 +81,11 @@ const renderSourceReferenceItems = (task: ScheduledTask): React.ReactNode => {
   if (task.primitive === "automation_definition") {
     return (
       <>
-        {renderOptionalDescriptionItem("Definition id", sourceRef.definition_id)}
-        {renderOptionalDescriptionItem("Lifecycle", sourceRef.lifecycle)}
-        {renderOptionalDescriptionItem("Health", sourceRef.health)}
-        {renderOptionalDescriptionItem("Visibility", sourceRef.visibility)}
-        {renderOptionalDescriptionItem("Notification policy", sourceRef.notification_policy)}
+        {renderOptionalDescriptionItem("Definition id", sourceRef["definition_id"])}
+        {renderOptionalDescriptionItem("Lifecycle", sourceRef["lifecycle"])}
+        {renderOptionalDescriptionItem("Health", sourceRef["health"])}
+        {renderOptionalDescriptionItem("Visibility", sourceRef["visibility"])}
+        {renderOptionalDescriptionItem("Notification policy", sourceRef["notification_policy"])}
       </>
     )
   }
@@ -93,18 +93,18 @@ const renderSourceReferenceItems = (task: ScheduledTask): React.ReactNode => {
   if (task.primitive === "watchlist_job") {
     return (
       <>
-        {renderOptionalDescriptionItem("Watchlists job id", sourceRef.job_id)}
-        {renderOptionalDescriptionItem("Watchlists scope", sourceRef.scope)}
+        {renderOptionalDescriptionItem("Watchlists job id", sourceRef["job_id"])}
+        {renderOptionalDescriptionItem("Watchlists scope", sourceRef["scope"])}
       </>
     )
   }
 
   return (
     <>
-      {renderOptionalDescriptionItem("Reminder task id", sourceRef.task_id)}
-      {renderOptionalDescriptionItem("Link type", sourceRef.link_type)}
-      {renderOptionalDescriptionItem("Link id", sourceRef.link_id)}
-      {renderOptionalDescriptionItem("Link URL", sourceRef.link_url)}
+      {renderOptionalDescriptionItem("Reminder task id", sourceRef["task_id"])}
+      {renderOptionalDescriptionItem("Link type", sourceRef["link_type"])}
+      {renderOptionalDescriptionItem("Link id", sourceRef["link_id"])}
+      {renderOptionalDescriptionItem("Link URL", sourceRef["link_url"])}
     </>
   )
 }
@@ -143,30 +143,46 @@ const renderTaskActions = ({
 
   if (isAutomationDefinitionTask(task)) {
     const lifecycle =
-      typeof task.source_ref?.lifecycle === "string" ? task.source_ref.lifecycle : task.status
+      typeof task.source_ref?.["lifecycle"] === "string" ? task.source_ref["lifecycle"] : task.status
     const isPaused = lifecycle === "paused"
     const isArchived = lifecycle === "archived"
 
     return (
       <Space wrap>
-        <Button type="primary" onClick={() => onEditAutomationDefinition?.(task)}>
+        <Button
+          type="primary"
+          onClick={() => onEditAutomationDefinition?.(task)}
+          disabled={!onEditAutomationDefinition}
+        >
           Edit definition
         </Button>
         {isPaused ? (
-          <Button onClick={() => onResumeAutomationDefinition?.(task)}>
+          <Button
+            onClick={() => onResumeAutomationDefinition?.(task)}
+            disabled={!onResumeAutomationDefinition}
+          >
             Resume definition
           </Button>
         ) : !isArchived ? (
-          <Button onClick={() => onPauseAutomationDefinition?.(task)}>
+          <Button
+            onClick={() => onPauseAutomationDefinition?.(task)}
+            disabled={!onPauseAutomationDefinition}
+          >
             Pause definition
           </Button>
         ) : null}
         {!isArchived ? (
-          <Button onClick={() => onArchiveAutomationDefinition?.(task)}>
+          <Button
+            onClick={() => onArchiveAutomationDefinition?.(task)}
+            disabled={!onArchiveAutomationDefinition}
+          >
             Archive definition
           </Button>
         ) : null}
-        <Button onClick={() => onDuplicateAutomationDefinition?.(task)}>
+        <Button
+          onClick={() => onDuplicateAutomationDefinition?.(task)}
+          disabled={!onDuplicateAutomationDefinition}
+        >
           Duplicate definition
         </Button>
       </Space>
@@ -267,7 +283,7 @@ export const ScheduledTaskDetailDrawer: React.FC<ScheduledTaskDetailDrawerProps>
                   {stringifyCompact(automationDefinition.schedule)}
                 </Descriptions.Item>
                 <Descriptions.Item label="Definition visibility">
-                  {stringifyCompact(automationDefinition.visibility_policy?.visibility)}
+                  {stringifyCompact(automationDefinition.visibility_policy?.["visibility"])}
                 </Descriptions.Item>
                 <Descriptions.Item label="Definition notifications">
                   {stringifyCompact(automationDefinition.notification_policy)}

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskTable.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskTable.tsx
@@ -95,6 +95,7 @@ const statusFilterOptions: Array<{
   { value: "blocked", label: BLOCKED_STATE_LABEL },
   { value: "paused", label: "Paused" },
   { value: "disabled", label: "Disabled" },
+  { value: "archived", label: "Archived" },
   { value: "draft", label: "Draft" },
   { value: "completed", label: "Completed" }
 ]
@@ -168,7 +169,7 @@ export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
 
   const renderAutomationActions = (task: ScheduledTask) => {
     const lifecycle =
-      typeof task.source_ref?.lifecycle === "string" ? task.source_ref.lifecycle : task.status
+      typeof task.source_ref?.["lifecycle"] === "string" ? task.source_ref["lifecycle"] : task.status
     const isPaused = lifecycle === "paused"
     const isArchived = lifecycle === "archived"
 
@@ -185,6 +186,7 @@ export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
           size="small"
           aria-label={rowActionLabel("Edit", task)}
           onClick={() => onEditAutomationDefinition?.(task)}
+          disabled={!onEditAutomationDefinition}
         >
           Edit
         </Button>
@@ -194,6 +196,7 @@ export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
             size="small"
             aria-label={rowActionLabel("Resume", task)}
             onClick={() => onResumeAutomationDefinition?.(task)}
+            disabled={!onResumeAutomationDefinition}
           >
             Resume
           </Button>
@@ -202,6 +205,7 @@ export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
             size="small"
             aria-label={rowActionLabel("Pause", task)}
             onClick={() => onPauseAutomationDefinition?.(task)}
+            disabled={!onPauseAutomationDefinition}
           >
             Pause
           </Button>
@@ -211,6 +215,7 @@ export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
             size="small"
             aria-label={rowActionLabel("Archive", task)}
             onClick={() => onArchiveAutomationDefinition?.(task)}
+            disabled={!onArchiveAutomationDefinition}
           >
             Archive
           </Button>
@@ -219,6 +224,7 @@ export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
           size="small"
           aria-label={rowActionLabel("Duplicate", task)}
           onClick={() => onDuplicateAutomationDefinition?.(task)}
+          disabled={!onDuplicateAutomationDefinition}
         >
           Duplicate
         </Button>

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskTable.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskTable.tsx
@@ -36,6 +36,7 @@ export interface ScheduledTaskTableProps {
   onOpenTaskResults?: (task: ScheduledTask) => void
   onEditReminder: (task: ScheduledTask) => void
   onDeleteReminder: (task: ScheduledTask) => void
+  onEditAutomationDefinition?: (task: ScheduledTask) => void
   onPauseAutomationDefinition?: (task: ScheduledTask) => void
   onResumeAutomationDefinition?: (task: ScheduledTask) => void
   onArchiveAutomationDefinition?: (task: ScheduledTask) => void
@@ -116,6 +117,7 @@ export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
   onOpenTaskResults,
   onEditReminder,
   onDeleteReminder,
+  onEditAutomationDefinition,
   onPauseAutomationDefinition,
   onResumeAutomationDefinition,
   onArchiveAutomationDefinition,
@@ -142,6 +144,7 @@ export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
   const resultCountByTaskId = useMemo(() => {
     const counts = new Map<string, number>()
     results.forEach((result) => {
+      if (result.signalKind !== "result") return
       counts.set(result.taskId, (counts.get(result.taskId) ?? 0) + 1)
     })
     return counts
@@ -177,6 +180,13 @@ export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
           onClick={() => onInspectTask(task)}
         >
           Inspect
+        </Button>
+        <Button
+          size="small"
+          aria-label={rowActionLabel("Edit", task)}
+          onClick={() => onEditAutomationDefinition?.(task)}
+        >
+          Edit
         </Button>
         {renderResultsButton(task)}
         {isPaused ? (

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskTable.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTaskTable.tsx
@@ -20,6 +20,7 @@ import {
   type ScheduledTaskProductStatus,
   type ScheduledTaskStatusKey
 } from "./scheduled-task-status"
+import { isAutomationDefinitionTask } from "./scheduled-task-automation-status"
 import { WatchlistTaskActionLinks } from "./WatchlistTaskActionLinks"
 import type { ScheduledTaskResultItem } from "./scheduled-task-results"
 
@@ -35,6 +36,10 @@ export interface ScheduledTaskTableProps {
   onOpenTaskResults?: (task: ScheduledTask) => void
   onEditReminder: (task: ScheduledTask) => void
   onDeleteReminder: (task: ScheduledTask) => void
+  onPauseAutomationDefinition?: (task: ScheduledTask) => void
+  onResumeAutomationDefinition?: (task: ScheduledTask) => void
+  onArchiveAutomationDefinition?: (task: ScheduledTask) => void
+  onDuplicateAutomationDefinition?: (task: ScheduledTask) => void
 }
 
 type ScheduledTaskStatusFilter = "all" | ScheduledTaskStatusKey
@@ -99,7 +104,8 @@ const typeFilterOptions: Array<{
 }> = [
   { value: "all", label: "All types" },
   { value: "reminder_task", label: "Reminder" },
-  { value: "watchlist_job", label: "Watchlist monitor" }
+  { value: "watchlist_job", label: "Watchlist monitor" },
+  { value: "automation_definition", label: "Automation definition" }
 ]
 
 export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
@@ -109,7 +115,11 @@ export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
   onInspectTask,
   onOpenTaskResults,
   onEditReminder,
-  onDeleteReminder
+  onDeleteReminder,
+  onPauseAutomationDefinition,
+  onResumeAutomationDefinition,
+  onArchiveAutomationDefinition,
+  onDuplicateAutomationDefinition
 }) => {
   const [searchText, setSearchText] = useState("")
   const [statusFilter, setStatusFilter] =
@@ -150,6 +160,59 @@ export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
       >
         Results
       </Button>
+    )
+  }
+
+  const renderAutomationActions = (task: ScheduledTask) => {
+    const lifecycle =
+      typeof task.source_ref?.lifecycle === "string" ? task.source_ref.lifecycle : task.status
+    const isPaused = lifecycle === "paused"
+    const isArchived = lifecycle === "archived"
+
+    return (
+      <Space wrap>
+        <Button
+          size="small"
+          aria-label={rowActionLabel("Inspect", task)}
+          onClick={() => onInspectTask(task)}
+        >
+          Inspect
+        </Button>
+        {renderResultsButton(task)}
+        {isPaused ? (
+          <Button
+            size="small"
+            aria-label={rowActionLabel("Resume", task)}
+            onClick={() => onResumeAutomationDefinition?.(task)}
+          >
+            Resume
+          </Button>
+        ) : !isArchived ? (
+          <Button
+            size="small"
+            aria-label={rowActionLabel("Pause", task)}
+            onClick={() => onPauseAutomationDefinition?.(task)}
+          >
+            Pause
+          </Button>
+        ) : null}
+        {!isArchived ? (
+          <Button
+            size="small"
+            aria-label={rowActionLabel("Archive", task)}
+            onClick={() => onArchiveAutomationDefinition?.(task)}
+          >
+            Archive
+          </Button>
+        ) : null}
+        <Button
+          size="small"
+          aria-label={rowActionLabel("Duplicate", task)}
+          onClick={() => onDuplicateAutomationDefinition?.(task)}
+        >
+          Duplicate
+        </Button>
+      </Space>
     )
   }
 
@@ -228,8 +291,12 @@ export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
       title: "Management",
       key: "management",
       render: (_, task) => (
-        <DesignSystemBadge variant={isNativeReminderTask(task) ? "info" : "warning"}>
-          {isNativeReminderTask(task) ? "Managed here" : "Managed in Watchlists"}
+        <DesignSystemBadge
+          variant={isNativeReminderTask(task) || isAutomationDefinitionTask(task) ? "info" : "warning"}
+        >
+          {isNativeReminderTask(task) || isAutomationDefinitionTask(task)
+            ? "Managed here"
+            : "Managed in Watchlists"}
         </DesignSystemBadge>
       )
     },
@@ -265,6 +332,10 @@ export const ScheduledTaskTable: React.FC<ScheduledTaskTableProps> = ({
               </Button>
             </Space>
           )
+        }
+
+        if (isAutomationDefinitionTask(task)) {
+          return renderAutomationActions(task)
         }
 
         return (

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { Button, Space, Tabs, Typography, message } from "antd"
+import { Drawer, Space, Tabs, Typography, message } from "antd"
 import { useQuery } from "@tanstack/react-query"
 import { useTranslation } from "react-i18next"
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom"
@@ -34,6 +34,10 @@ import { ReminderTaskEditor } from "./ReminderTaskEditor"
 import { ScheduledTaskOverview } from "./ScheduledTaskOverview"
 import { ScheduledTaskDetailDrawer } from "./ScheduledTaskDetailDrawer"
 import { ScheduledTaskCreatePanel } from "./ScheduledTaskCreatePanel"
+import {
+  ScheduledTaskAutomationDefinitionEditor,
+  type ScheduledTaskAutomationDefinitionEditorValues
+} from "./ScheduledTaskAutomationDefinitionEditor"
 import { ScheduledTaskResultsPanel } from "./ScheduledTaskResultsPanel"
 import { ScheduledTaskResultDetailDrawer } from "./ScheduledTaskResultDetailDrawer"
 import { DEFAULT_SCHEDULED_TASK_TEMPLATE_CAPABILITIES } from "./scheduled-task-template-capabilities"
@@ -56,6 +60,81 @@ import {
 const SCHEDULED_TASKS_PATH = "/api/v1/scheduled-tasks"
 const SCHEDULED_TASKS_SUPPORT_PROBE_TIMEOUT_MS = 8000
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value)
+
+const readStringField = (
+  source: Record<string, unknown> | null | undefined,
+  key: string
+): string => {
+  const value = source?.[key]
+  return typeof value === "string" ? value : ""
+}
+
+const readStringListField = (
+  source: Record<string, unknown> | null | undefined,
+  key: string
+): string => {
+  const value = source?.[key]
+  if (Array.isArray(value)) {
+    return value
+      .filter((entry): entry is string => typeof entry === "string" && Boolean(entry.trim()))
+      .join(", ")
+  }
+  return typeof value === "string" ? value : ""
+}
+
+const stringifyEditorJson = (value: unknown): string => {
+  if (!isRecord(value)) return "{}"
+
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return "{}"
+  }
+}
+
+const getAutomationDefinitionIdForTask = (task: ScheduledTask): string => {
+  const sourceDefinitionId = task.source_ref?.definition_id
+  if (typeof sourceDefinitionId === "string" && sourceDefinitionId.trim()) {
+    return sourceDefinitionId
+  }
+  return task.id
+}
+
+const buildAutomationEditorInitialValues = (
+  definition: ScheduledTaskDefinitionResponse
+): ScheduledTaskAutomationDefinitionEditorValues => {
+  const schedule = isRecord(definition.schedule) ? definition.schedule : {}
+  const input = isRecord(definition.input) ? definition.input : {}
+  const config = isRecord(definition.config) ? definition.config : {}
+  const visibilityPolicy = isRecord(definition.visibility_policy)
+    ? definition.visibility_policy
+    : {}
+  const approvalPolicy = isRecord(definition.approval_policy)
+    ? definition.approval_policy
+    : {}
+  const visibility = visibilityPolicy.visibility === "shared" ? "shared" : "private"
+  const approvalMode = approvalPolicy.mode === "manual" ? "manual" : "none"
+
+  return {
+    name: definition.name,
+    description: definition.description ?? "",
+    scheduleKind: schedule.kind === "cron" ? "cron" : "manual",
+    cron: readStringField(schedule, "cron"),
+    timezone: readStringField(schedule, "timezone") || "UTC",
+    visibility,
+    question: readStringField(input, "question"),
+    successCriteria: readStringField(input, "success_criteria"),
+    scopeJson: stringifyEditorJson(input.scope),
+    agentRef: stringifyEditorJson(input.agent_ref),
+    message: readStringField(input, "message"),
+    allowedToolClasses: readStringListField(config, "allowed_tool_classes"),
+    deniedToolClasses: readStringListField(config, "denied_tool_classes"),
+    approvalMode
+  }
+}
+
 export const ScheduledTasksPage: React.FC = () => {
   const location = useLocation()
   const navigate = useNavigate()
@@ -65,6 +144,8 @@ export const ScheduledTasksPage: React.FC = () => {
     useCanonicalConnectionConfig()
   const [editorOpen, setEditorOpen] = useState(false)
   const [editingTask, setEditingTask] = useState<ScheduledTask | null>(null)
+  const [editingAutomationTask, setEditingAutomationTask] =
+    useState<ScheduledTask | null>(null)
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null)
   const [createdTaskFallback, setCreatedTaskFallback] = useState<ScheduledTask | null>(null)
   const [saving, setSaving] = useState(false)
@@ -233,6 +314,18 @@ export const ScheduledTasksPage: React.FC = () => {
       }),
     enabled: Boolean(selectedAutomationDefinitionId)
   })
+  const editingAutomationDefinitionId = React.useMemo(
+    () =>
+      editingAutomationTask
+        ? getAutomationDefinitionIdForTask(editingAutomationTask)
+        : null,
+    [editingAutomationTask]
+  )
+  const editingAutomationDefinitionQuery = useQuery({
+    queryKey: ["scheduled-task-definition-edit", editingAutomationDefinitionId],
+    queryFn: () => getScheduledTaskDefinition(editingAutomationDefinitionId as string),
+    enabled: Boolean(editingAutomationDefinitionId)
+  })
   const hasLoadedTasks = Boolean(tasksQuery.data)
   const hasWatchlistJob = tasks.some((task) => task.primitive === "watchlist_job")
   const selectedTemplate = React.useMemo(
@@ -337,6 +430,13 @@ export const ScheduledTasksPage: React.FC = () => {
     setEditorOpen(true)
   }
 
+  const openEditAutomationDefinition = (task: ScheduledTask) => {
+    setAutomationErrorMessage(null)
+    setEditorOpen(false)
+    setEditingTask(null)
+    setEditingAutomationTask(task)
+  }
+
   const openTaskDetail = (task: ScheduledTask) => {
     if (createdTaskFallback?.id !== task.id) {
       setCreatedTaskFallback(null)
@@ -348,6 +448,10 @@ export const ScheduledTasksPage: React.FC = () => {
   const closeEditor = () => {
     setEditorOpen(false)
     setEditingTask(null)
+  }
+
+  const closeAutomationDefinitionEditor = () => {
+    setEditingAutomationTask(null)
   }
 
   const refreshTasks = async () => {
@@ -650,6 +754,7 @@ export const ScheduledTasksPage: React.FC = () => {
           onOpenTaskResults={openTaskResults}
           onEditReminder={openEditReminder}
           onDeleteReminder={handleDeleteReminder}
+          onEditAutomationDefinition={openEditAutomationDefinition}
           onPauseAutomationDefinition={(task) => {
             void handleAutomationLifecycleAction(task, "pause")
           }}
@@ -807,6 +912,7 @@ export const ScheduledTasksPage: React.FC = () => {
               onClose={closeTaskDetail}
               onEditReminder={openEditReminder}
               onDeleteReminder={handleDeleteReminder}
+              onEditAutomationDefinition={openEditAutomationDefinition}
               onPauseAutomationDefinition={(task) => {
                 void handleAutomationLifecycleAction(task, "pause")
               }}
@@ -820,6 +926,51 @@ export const ScheduledTasksPage: React.FC = () => {
                 void handleAutomationLifecycleAction(task, "duplicate")
               }}
             />
+          ) : null}
+          {editingAutomationTask ? (
+            <Drawer
+              title="Edit automation definition"
+              open
+              onClose={closeAutomationDefinitionEditor}
+              size={680}
+            >
+              {editingAutomationDefinitionQuery.isLoading ? (
+                <div role="status" aria-live="polite">
+                  <DesignSystemLoadingState
+                    mode="inline"
+                    size="sm"
+                    label="Loading automation definition"
+                    className="w-full"
+                  />
+                </div>
+              ) : editingAutomationDefinitionQuery.data ? (
+                <ScheduledTaskAutomationDefinitionEditor
+                  key={`${editingAutomationDefinitionQuery.data.id}:${editingAutomationDefinitionQuery.data.version}`}
+                  family={editingAutomationDefinitionQuery.data.family}
+                  mode="update"
+                  definitionId={editingAutomationDefinitionQuery.data.id}
+                  definitionVersion={editingAutomationDefinitionQuery.data.version}
+                  initialValues={buildAutomationEditorInitialValues(
+                    editingAutomationDefinitionQuery.data
+                  )}
+                  onPreview={handlePreviewAutomationDefinition}
+                  onUpdate={(payload) =>
+                    handleUpdateAutomationDefinition(
+                      editingAutomationDefinitionQuery.data.id,
+                      payload
+                    )
+                  }
+                  onCancel={closeAutomationDefinitionEditor}
+                  onSaved={() => {
+                    closeAutomationDefinitionEditor()
+                  }}
+                />
+              ) : (
+                <Typography.Text type="secondary">
+                  Automation definition could not be loaded.
+                </Typography.Text>
+              )}
+            </Drawer>
           ) : null}
           {routeState.tab === "results" && selectedResult ? (
             <ScheduledTaskResultDetailDrawer

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
@@ -121,7 +121,7 @@ const normalizeAutomationScheduleKind = (
     : "daily"
 
 const getAutomationDefinitionIdForTask = (task: ScheduledTask): string => {
-  const sourceDefinitionId = task.source_ref?.definition_id
+  const sourceDefinitionId = task.source_ref?.["definition_id"]
   if (typeof sourceDefinitionId === "string" && sourceDefinitionId.trim()) {
     return sourceDefinitionId
   }
@@ -140,8 +140,8 @@ const buildAutomationEditorInitialValues = (
   const approvalPolicy = isRecord(definition.approval_policy)
     ? definition.approval_policy
     : {}
-  const visibility = visibilityPolicy.visibility === "shared" ? "shared" : "private"
-  const approvalMode = approvalPolicy.mode === "manual" ? "manual" : "none"
+  const visibility = visibilityPolicy["visibility"] === "shared" ? "shared" : "private"
+  const approvalMode = approvalPolicy["mode"] === "manual" ? "manual" : "none"
 
   return {
     name: definition.name,
@@ -314,7 +314,7 @@ export const ScheduledTasksPage: React.FC = () => {
   )
   const selectedAutomationDefinitionId = React.useMemo(() => {
     if (selectedTask?.primitive !== "automation_definition") return null
-    const sourceDefinitionId = selectedTask.source_ref?.definition_id
+    const sourceDefinitionId = selectedTask.source_ref?.["definition_id"]
     return typeof sourceDefinitionId === "string" && sourceDefinitionId.trim()
       ? sourceDefinitionId
       : selectedTask.id
@@ -459,6 +459,7 @@ export const ScheduledTasksPage: React.FC = () => {
 
   const openEditAutomationDefinition = (task: ScheduledTask) => {
     setAutomationErrorMessage(null)
+    closeTaskDetail()
     setEditorOpen(false)
     setEditingTask(null)
     setEditingAutomationTask(task)
@@ -489,27 +490,27 @@ export const ScheduledTasksPage: React.FC = () => {
     error: unknown,
     fallback: string
   ): string => {
-    if (error && typeof error === "object") {
-      const details = "details" in error ? (error as { details?: unknown }).details : null
+    if (isRecord(error)) {
+      const details = error["details"]
       const detail =
-        details && typeof details === "object" && "detail" in details
-          ? (details as { detail?: unknown }).detail
+        isRecord(details) && "detail" in details
+          ? details["detail"]
           : "detail" in error
-            ? (error as { detail?: unknown }).detail
+            ? error["detail"]
             : null
-      if (detail && typeof detail === "object") {
+      if (isRecord(detail)) {
         const code =
-          "code" in detail ? String((detail as { code?: unknown }).code || "") : ""
+          "code" in detail ? String(detail["code"] || "") : ""
         const detailMessage =
           "message" in detail
-            ? String((detail as { message?: unknown }).message || "")
+            ? String(detail["message"] || "")
             : ""
         if (code && detailMessage) return `${code}: ${detailMessage}`
         if (detailMessage) return detailMessage
         if (code) return code
       }
-      if ("message" in error && typeof (error as { message?: unknown }).message === "string") {
-        return (error as { message: string }).message
+      if ("message" in error && typeof error["message"] === "string") {
+        return error["message"]
       }
     }
     return fallback
@@ -623,14 +624,15 @@ export const ScheduledTasksPage: React.FC = () => {
   ) => {
     setAutomationErrorMessage(null)
     try {
+      const definitionId = getAutomationDefinitionIdForTask(task)
       if (action === "pause") {
-        await pauseScheduledTaskDefinition(task.id)
+        await pauseScheduledTaskDefinition(definitionId)
       } else if (action === "resume") {
-        await resumeScheduledTaskDefinition(task.id)
+        await resumeScheduledTaskDefinition(definitionId)
       } else if (action === "archive") {
-        await archiveScheduledTaskDefinition(task.id)
+        await archiveScheduledTaskDefinition(definitionId)
       } else {
-        await duplicateScheduledTaskDefinition(task.id, {
+        await duplicateScheduledTaskDefinition(definitionId, {
           name: `${task.title} copy`
         })
       }

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
@@ -36,6 +36,7 @@ import { ScheduledTaskDetailDrawer } from "./ScheduledTaskDetailDrawer"
 import { ScheduledTaskCreatePanel } from "./ScheduledTaskCreatePanel"
 import {
   ScheduledTaskAutomationDefinitionEditor,
+  type ScheduledTaskAutomationEditorScheduleKind,
   type ScheduledTaskAutomationDefinitionEditorValues
 } from "./ScheduledTaskAutomationDefinitionEditor"
 import { ScheduledTaskResultsPanel } from "./ScheduledTaskResultsPanel"
@@ -59,6 +60,13 @@ import {
 
 const SCHEDULED_TASKS_PATH = "/api/v1/scheduled-tasks"
 const SCHEDULED_TASKS_SUPPORT_PROBE_TIMEOUT_MS = 8000
+const SUPPORTED_AUTOMATION_SCHEDULE_KINDS = new Set([
+  "one_time",
+  "interval",
+  "daily",
+  "weekly",
+  "cron"
+])
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value) && typeof value === "object" && !Array.isArray(value)
@@ -94,6 +102,24 @@ const stringifyEditorJson = (value: unknown): string => {
   }
 }
 
+const stringifyEditorText = (value: unknown): string => {
+  if (typeof value === "string") return value
+  if (!isRecord(value)) return ""
+
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return ""
+  }
+}
+
+const normalizeAutomationScheduleKind = (
+  value: unknown
+): ScheduledTaskAutomationEditorScheduleKind =>
+  typeof value === "string" && SUPPORTED_AUTOMATION_SCHEDULE_KINDS.has(value)
+    ? (value as ScheduledTaskAutomationEditorScheduleKind)
+    : "daily"
+
 const getAutomationDefinitionIdForTask = (task: ScheduledTask): string => {
   const sourceDefinitionId = task.source_ref?.definition_id
   if (typeof sourceDefinitionId === "string" && sourceDefinitionId.trim()) {
@@ -120,14 +146,15 @@ const buildAutomationEditorInitialValues = (
   return {
     name: definition.name,
     description: definition.description ?? "",
-    scheduleKind: schedule.kind === "cron" ? "cron" : "manual",
+    schedule,
+    scheduleKind: normalizeAutomationScheduleKind(schedule.kind),
     cron: readStringField(schedule, "cron"),
     timezone: readStringField(schedule, "timezone") || "UTC",
     visibility,
     question: readStringField(input, "question"),
     successCriteria: readStringField(input, "success_criteria"),
     scopeJson: stringifyEditorJson(input.scope),
-    agentRef: stringifyEditorJson(input.agent_ref),
+    agentRef: stringifyEditorText(input.agent_ref),
     message: readStringField(input, "message"),
     allowedToolClasses: readStringListField(config, "allowed_tool_classes"),
     deniedToolClasses: readStringListField(config, "denied_tool_classes"),
@@ -463,7 +490,13 @@ export const ScheduledTasksPage: React.FC = () => {
     fallback: string
   ): string => {
     if (error && typeof error === "object") {
-      const detail = "detail" in error ? (error as { detail?: unknown }).detail : null
+      const details = "details" in error ? (error as { details?: unknown }).details : null
+      const detail =
+        details && typeof details === "object" && "detail" in details
+          ? (details as { detail?: unknown }).detail
+          : "detail" in error
+            ? (error as { detail?: unknown }).detail
+            : null
       if (detail && typeof detail === "object") {
         const code =
           "code" in detail ? String((detail as { code?: unknown }).code || "") : ""

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/ScheduledTasksPage.tsx
@@ -8,11 +8,24 @@ import { Alert as DesignSystemAlert } from "@/components/ui/primitives"
 import { RecoveryCallout, buildCapabilityState } from "@/components/ui/state"
 import { useCanonicalConnectionConfig } from "@/hooks/useCanonicalConnectionConfig"
 import {
+  archiveScheduledTaskDefinition,
+  createScheduledTaskDefinition,
   createScheduledTaskReminder,
+  createScheduledTaskPreview,
   deleteScheduledTaskReminder,
+  duplicateScheduledTaskDefinition,
+  getScheduledTaskCapabilities,
+  getScheduledTaskDefinition,
+  listScheduledTaskDefinitionAudit,
+  listScheduledTaskPreviews,
   listScheduledTasks,
+  pauseScheduledTaskDefinition,
+  resumeScheduledTaskDefinition,
+  updateScheduledTaskDefinition,
   updateScheduledTaskReminder,
   type ScheduledTask,
+  type ScheduledTaskDefinitionResponse,
+  type ScheduledTaskPreviewCreateRequest,
   type CreateScheduledTaskReminderPayload,
   type UpdateScheduledTaskReminderPayload
 } from "@/services/scheduled-tasks-control-plane"
@@ -55,6 +68,7 @@ export const ScheduledTasksPage: React.FC = () => {
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null)
   const [createdTaskFallback, setCreatedTaskFallback] = useState<ScheduledTask | null>(null)
   const [saving, setSaving] = useState(false)
+  const [automationErrorMessage, setAutomationErrorMessage] = useState<string | null>(null)
   const [scheduledTasksSupported, setScheduledTasksSupported] = useState<
     boolean | null
   >(null)
@@ -157,6 +171,11 @@ export const ScheduledTasksPage: React.FC = () => {
     queryFn: listScheduledTasks,
     enabled: scheduledTasksSupported === true
   })
+  const automationCapabilitiesQuery = useQuery({
+    queryKey: ["scheduled-task-automation-capabilities"],
+    queryFn: getScheduledTaskCapabilities,
+    enabled: scheduledTasksSupported === true
+  })
 
   const tasks = tasksQuery.data?.items ?? []
   const projectedResults = React.useMemo(
@@ -185,6 +204,35 @@ export const ScheduledTasksPage: React.FC = () => {
         : null,
     [projectedResults, selectedTask]
   )
+  const selectedAutomationDefinitionId = React.useMemo(() => {
+    if (selectedTask?.primitive !== "automation_definition") return null
+    const sourceDefinitionId = selectedTask.source_ref?.definition_id
+    return typeof sourceDefinitionId === "string" && sourceDefinitionId.trim()
+      ? sourceDefinitionId
+      : selectedTask.id
+  }, [selectedTask])
+  const selectedAutomationDefinitionQuery = useQuery({
+    queryKey: ["scheduled-task-definition", selectedAutomationDefinitionId],
+    queryFn: () => getScheduledTaskDefinition(selectedAutomationDefinitionId as string),
+    enabled: Boolean(selectedAutomationDefinitionId)
+  })
+  const selectedAutomationPreviewsQuery = useQuery({
+    queryKey: ["scheduled-task-definition-previews", selectedAutomationDefinitionId],
+    queryFn: () =>
+      listScheduledTaskPreviews({
+        definition_id: selectedAutomationDefinitionId,
+        limit: 10
+      }),
+    enabled: Boolean(selectedAutomationDefinitionId)
+  })
+  const selectedAutomationAuditQuery = useQuery({
+    queryKey: ["scheduled-task-definition-audit", selectedAutomationDefinitionId],
+    queryFn: () =>
+      listScheduledTaskDefinitionAudit(selectedAutomationDefinitionId as string, {
+        limit: 10
+      }),
+    enabled: Boolean(selectedAutomationDefinitionId)
+  })
   const hasLoadedTasks = Boolean(tasksQuery.data)
   const hasWatchlistJob = tasks.some((task) => task.primitive === "watchlist_job")
   const selectedTemplate = React.useMemo(
@@ -306,6 +354,30 @@ export const ScheduledTasksPage: React.FC = () => {
     await tasksQuery.refetch()
   }
 
+  const readScheduledTaskControlPlaneError = (
+    error: unknown,
+    fallback: string
+  ): string => {
+    if (error && typeof error === "object") {
+      const detail = "detail" in error ? (error as { detail?: unknown }).detail : null
+      if (detail && typeof detail === "object") {
+        const code =
+          "code" in detail ? String((detail as { code?: unknown }).code || "") : ""
+        const detailMessage =
+          "message" in detail
+            ? String((detail as { message?: unknown }).message || "")
+            : ""
+        if (code && detailMessage) return `${code}: ${detailMessage}`
+        if (detailMessage) return detailMessage
+        if (code) return code
+      }
+      if ("message" in error && typeof (error as { message?: unknown }).message === "string") {
+        return (error as { message: string }).message
+      }
+    }
+    return fallback
+  }
+
   const handleSubmit = async (
     payload: CreateScheduledTaskReminderPayload | UpdateScheduledTaskReminderPayload
   ) => {
@@ -342,6 +414,97 @@ export const ScheduledTasksPage: React.FC = () => {
       message.error(error?.message || "Unable to save reminder task")
     } finally {
       setSaving(false)
+    }
+  }
+
+  const handlePreviewAutomationDefinition = async (
+    payload: ScheduledTaskPreviewCreateRequest
+  ) => {
+    setAutomationErrorMessage(null)
+    try {
+      return await createScheduledTaskPreview(payload)
+    } catch (error) {
+      const messageText = readScheduledTaskControlPlaneError(
+        error,
+        "Unable to preview definition"
+      )
+      setAutomationErrorMessage(messageText)
+      throw error
+    }
+  }
+
+  const handleCreateAutomationDefinition = async (payload: {
+    preview_id: string
+    initial_lifecycle?: "configured" | "paused"
+  }) => {
+    setAutomationErrorMessage(null)
+    try {
+      return await createScheduledTaskDefinition(payload)
+    } catch (error) {
+      const messageText = readScheduledTaskControlPlaneError(
+        error,
+        "Unable to save definition"
+      )
+      setAutomationErrorMessage(messageText)
+      throw error
+    }
+  }
+
+  const handleAutomationDefinitionCreated = async (
+    definition: ScheduledTaskDefinitionResponse | unknown
+  ) => {
+    await refreshTasks()
+    const definitionId =
+      definition && typeof definition === "object" && "id" in definition
+        ? String((definition as { id?: unknown }).id || "")
+        : ""
+    if (definitionId) {
+      setSelectedTaskId(`automation_definition:${definitionId}`)
+    }
+    updateRoute({ tab: "tasks", taskId: definitionId ? `automation_definition:${definitionId}` : null })
+  }
+
+  const handleUpdateAutomationDefinition = async (definitionId: string, payload: { preview_id: string }) => {
+    setAutomationErrorMessage(null)
+    try {
+      const updated = await updateScheduledTaskDefinition(definitionId, payload)
+      await refreshTasks()
+      return updated
+    } catch (error) {
+      const messageText = readScheduledTaskControlPlaneError(
+        error,
+        "Unable to update definition"
+      )
+      setAutomationErrorMessage(messageText)
+      throw error
+    }
+  }
+
+  const handleAutomationLifecycleAction = async (
+    task: ScheduledTask,
+    action: "pause" | "resume" | "archive" | "duplicate"
+  ) => {
+    setAutomationErrorMessage(null)
+    try {
+      if (action === "pause") {
+        await pauseScheduledTaskDefinition(task.id)
+      } else if (action === "resume") {
+        await resumeScheduledTaskDefinition(task.id)
+      } else if (action === "archive") {
+        await archiveScheduledTaskDefinition(task.id)
+      } else {
+        await duplicateScheduledTaskDefinition(task.id, {
+          name: `${task.title} copy`
+        })
+      }
+      await refreshTasks()
+    } catch (error) {
+      const messageText = readScheduledTaskControlPlaneError(
+        error,
+        "Unable to update automation definition"
+      )
+      setAutomationErrorMessage(messageText)
+      message.error(messageText)
     }
   }
 
@@ -487,6 +650,18 @@ export const ScheduledTasksPage: React.FC = () => {
           onOpenTaskResults={openTaskResults}
           onEditReminder={openEditReminder}
           onDeleteReminder={handleDeleteReminder}
+          onPauseAutomationDefinition={(task) => {
+            void handleAutomationLifecycleAction(task, "pause")
+          }}
+          onResumeAutomationDefinition={(task) => {
+            void handleAutomationLifecycleAction(task, "resume")
+          }}
+          onArchiveAutomationDefinition={(task) => {
+            void handleAutomationLifecycleAction(task, "archive")
+          }}
+          onDuplicateAutomationDefinition={(task) => {
+            void handleAutomationLifecycleAction(task, "duplicate")
+          }}
         />
       ) : null}
     </Space>
@@ -577,6 +752,9 @@ export const ScheduledTasksPage: React.FC = () => {
           }}
         />
       ) : null}
+      {automationErrorMessage ? (
+        <DesignSystemAlert variant="error" title={automationErrorMessage} />
+      ) : null}
 
       {canShowScheduledTasksWorkbench ? (
         <>
@@ -600,6 +778,12 @@ export const ScheduledTasksPage: React.FC = () => {
                           onCreateReminder={handleCreateReminderFromPanel}
                           savingReminder={saving}
                           templateCapabilities={DEFAULT_SCHEDULED_TASK_TEMPLATE_CAPABILITIES}
+                          automationCapabilities={automationCapabilitiesQuery.data ?? null}
+                          onPreviewAutomationDefinition={handlePreviewAutomationDefinition}
+                          onCreateAutomationDefinition={handleCreateAutomationDefinition}
+                          onAutomationDefinitionCreated={(definition) => {
+                            void handleAutomationDefinitionCreated(definition)
+                          }}
                         />
                       )
             }))}
@@ -617,9 +801,24 @@ export const ScheduledTasksPage: React.FC = () => {
               open
               task={selectedTask}
               latestResult={selectedTaskLatestResult}
+              automationDefinition={selectedAutomationDefinitionQuery.data ?? null}
+              automationPreviewHistory={selectedAutomationPreviewsQuery.data?.items ?? []}
+              automationAuditEvents={selectedAutomationAuditQuery.data?.items ?? []}
               onClose={closeTaskDetail}
               onEditReminder={openEditReminder}
               onDeleteReminder={handleDeleteReminder}
+              onPauseAutomationDefinition={(task) => {
+                void handleAutomationLifecycleAction(task, "pause")
+              }}
+              onResumeAutomationDefinition={(task) => {
+                void handleAutomationLifecycleAction(task, "resume")
+              }}
+              onArchiveAutomationDefinition={(task) => {
+                void handleAutomationLifecycleAction(task, "archive")
+              }}
+              onDuplicateAutomationDefinition={(task) => {
+                void handleAutomationLifecycleAction(task, "duplicate")
+              }}
             />
           ) : null}
           {routeState.tab === "results" && selectedResult ? (

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskAutomationDefinitionEditor.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskAutomationDefinitionEditor.test.tsx
@@ -1,0 +1,234 @@
+// @vitest-environment jsdom
+
+import React from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import type {
+  ScheduledTaskDefinitionResponse,
+  ScheduledTaskPreviewResponse
+} from "@/services/scheduled-tasks-control-plane"
+import { ScheduledTaskAutomationDefinitionEditor } from "../ScheduledTaskAutomationDefinitionEditor"
+
+const validPreview = (
+  overrides: Partial<ScheduledTaskPreviewResponse> = {}
+): ScheduledTaskPreviewResponse => ({
+  id: "preview_1",
+  mode: "create",
+  status: "valid",
+  family: "recurring_question",
+  normalized_config: { name: "Track answer" },
+  validation_errors: [],
+  warnings: [],
+  visibility_policy: { visibility: "private" },
+  schedule_preview: { kind: "manual" },
+  redaction_policy: { redacted_fields: [] },
+  expires_at: "2026-06-10T00:00:00Z",
+  ...overrides
+})
+
+const definitionResponse = (
+  overrides: Partial<ScheduledTaskDefinitionResponse> = {}
+): ScheduledTaskDefinitionResponse => ({
+  id: "definition_1",
+  version: 1,
+  family: "recurring_question",
+  name: "Track answer",
+  description: null,
+  lifecycle: "configured",
+  health: "execution_unavailable",
+  schedule: {},
+  input: {},
+  config: {},
+  visibility_policy: { visibility: "private" },
+  notification_policy: {},
+  approval_policy: {},
+  ...overrides
+})
+
+describe("ScheduledTaskAutomationDefinitionEditor", () => {
+  it("previews and creates a recurring question definition", async () => {
+    const user = userEvent.setup()
+    const onPreview = vi.fn().mockResolvedValue(validPreview())
+    const onCreate = vi.fn().mockResolvedValue(definitionResponse())
+
+    render(
+      <ScheduledTaskAutomationDefinitionEditor
+        family="recurring_question"
+        mode="create"
+        onPreview={onPreview}
+        onCreate={onCreate}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.type(screen.getByLabelText("Question"), "Has the answer appeared?")
+    await user.click(screen.getByRole("button", { name: "Preview" }))
+    await screen.findByText("Preview ready")
+    await user.click(screen.getByRole("button", { name: "Save definition" }))
+
+    expect(onPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "create",
+        family: "recurring_question",
+        input: expect.objectContaining({
+          question: "Has the answer appeared?"
+        })
+      })
+    )
+    expect(onCreate).toHaveBeenCalledWith({
+      preview_id: "preview_1",
+      initial_lifecycle: "configured"
+    })
+    expect(await screen.findByText("Execution is not available yet")).toBeInTheDocument()
+  })
+
+  it("shows agent task preview redaction copy", async () => {
+    const user = userEvent.setup()
+    const onPreview = vi.fn().mockResolvedValue(
+      validPreview({
+        family: "agent_task",
+        normalized_config: { name: "Dispatch agent" },
+        redaction_policy: {
+          redacted_fields: ["agent_ref.api_key", "message.secret"]
+        }
+      })
+    )
+
+    render(
+      <ScheduledTaskAutomationDefinitionEditor
+        family="agent_task"
+        mode="create"
+        onPreview={onPreview}
+        onCreate={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    fireEvent.change(screen.getByLabelText("Agent ref"), {
+      target: { value: '{"agent_id":"agent_1","api_key":"secret"}' }
+    })
+    await user.type(screen.getByLabelText("Message"), "Summarize the private report")
+    await user.click(screen.getByRole("button", { name: "Preview" }))
+
+    expect(await screen.findByText("Preview ready")).toBeInTheDocument()
+    expect(screen.getByText("Redacted: agent_ref.api_key, message.secret")).toBeInTheDocument()
+  })
+
+  it("prompts for another preview when the preview is expired", async () => {
+    const user = userEvent.setup()
+    const onCreate = vi.fn()
+    const onPreview = vi.fn().mockResolvedValue(
+      validPreview({
+        status: "expired",
+        validation_errors: [{ message: "Preview expired" }]
+      })
+    )
+
+    render(
+      <ScheduledTaskAutomationDefinitionEditor
+        family="recurring_question"
+        mode="create"
+        onPreview={onPreview}
+        onCreate={onCreate}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.type(screen.getByLabelText("Question"), "Has the answer appeared?")
+    await user.click(screen.getByRole("button", { name: "Preview" }))
+
+    expect(await screen.findByText("Preview again before saving")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Save definition" })).toBeDisabled()
+    await user.click(screen.getByRole("button", { name: "Save definition" }))
+    expect(onCreate).not.toHaveBeenCalled()
+  })
+
+  it("keeps save disabled until preview is valid", async () => {
+    const user = userEvent.setup()
+    const onPreview = vi.fn().mockResolvedValue(
+      validPreview({
+        status: "invalid",
+        validation_errors: [{ field: "question", message: "Question is required" }]
+      })
+    )
+
+    render(
+      <ScheduledTaskAutomationDefinitionEditor
+        family="recurring_question"
+        mode="create"
+        onPreview={onPreview}
+        onCreate={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: "Save definition" })).toBeDisabled()
+    await user.click(screen.getByRole("button", { name: "Preview" }))
+
+    expect(await screen.findByText("Question is required")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Save definition" })).toBeDisabled()
+  })
+
+  it("sends only preview id and lifecycle when creating", async () => {
+    const user = userEvent.setup()
+    const onCreate = vi.fn().mockResolvedValue(definitionResponse())
+
+    render(
+      <ScheduledTaskAutomationDefinitionEditor
+        family="recurring_question"
+        mode="create"
+        onPreview={vi.fn().mockResolvedValue(validPreview({ id: "preview_create" }))}
+        onCreate={onCreate}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.type(screen.getByLabelText("Question"), "Has the answer appeared?")
+    await user.click(screen.getByRole("button", { name: "Preview" }))
+    await screen.findByText("Preview ready")
+    await user.click(screen.getByRole("button", { name: "Save definition" }))
+
+    expect(onCreate).toHaveBeenCalledTimes(1)
+    expect(onCreate).toHaveBeenCalledWith({
+      preview_id: "preview_create",
+      initial_lifecycle: "configured"
+    })
+  })
+
+  it("sends only preview id when updating", async () => {
+    const user = userEvent.setup()
+    const onUpdate = vi.fn().mockResolvedValue(definitionResponse())
+
+    render(
+      <ScheduledTaskAutomationDefinitionEditor
+        family="agent_task"
+        mode="update"
+        definitionId="definition_1"
+        definitionVersion={3}
+        initialValues={{
+          name: "Dispatch agent",
+          agentRef: '{"agent_id":"agent_1"}',
+          message: "Summarize the report"
+        }}
+        onPreview={vi.fn().mockResolvedValue(
+          validPreview({
+            id: "preview_update",
+            family: "agent_task",
+            mode: "update"
+          })
+        )}
+        onUpdate={onUpdate}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: "Preview" }))
+    await screen.findByText("Preview ready")
+    await user.click(screen.getByRole("button", { name: "Save definition" }))
+
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1))
+    expect(onUpdate).toHaveBeenCalledWith({ preview_id: "preview_update" })
+  })
+})

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskAutomationDefinitionEditor.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskAutomationDefinitionEditor.test.tsx
@@ -48,6 +48,14 @@ const definitionResponse = (
 })
 
 describe("ScheduledTaskAutomationDefinitionEditor", () => {
+  const deferred = <T,>() => {
+    let resolve!: (value: T) => void
+    const promise = new Promise<T>((promiseResolve) => {
+      resolve = promiseResolve
+    })
+    return { promise, resolve }
+  }
+
   it("previews and creates a recurring question definition", async () => {
     const user = userEvent.setup()
     const onPreview = vi.fn().mockResolvedValue(validPreview())
@@ -72,6 +80,10 @@ describe("ScheduledTaskAutomationDefinitionEditor", () => {
       expect.objectContaining({
         mode: "create",
         family: "recurring_question",
+        schedule: expect.objectContaining({
+          kind: "daily",
+          timezone: "UTC"
+        }),
         input: expect.objectContaining({
           question: "Has the answer appeared?"
         })
@@ -113,7 +125,74 @@ describe("ScheduledTaskAutomationDefinitionEditor", () => {
     await user.click(screen.getByRole("button", { name: "Preview" }))
 
     expect(await screen.findByText("Preview ready")).toBeInTheDocument()
+    expect(onPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          agent_ref: '{"agent_id":"agent_1","api_key":"secret"}'
+        })
+      })
+    )
     expect(screen.getByText("Redacted: agent_ref.api_key, message.secret")).toBeInTheDocument()
+  })
+
+  it("does not allow an older in-flight preview to become saveable after fields change", async () => {
+    const user = userEvent.setup()
+    const firstPreview = deferred<ScheduledTaskPreviewResponse>()
+    const onPreview = vi.fn().mockReturnValue(firstPreview.promise)
+    const onCreate = vi.fn().mockResolvedValue(definitionResponse())
+
+    render(
+      <ScheduledTaskAutomationDefinitionEditor
+        family="recurring_question"
+        mode="create"
+        onPreview={onPreview}
+        onCreate={onCreate}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.type(screen.getByLabelText("Question"), "Has the answer appeared?")
+    await user.click(screen.getByRole("button", { name: "Preview" }))
+    fireEvent.change(screen.getByLabelText("Question"), {
+      target: { value: "Has the answer changed?" }
+    })
+    firstPreview.resolve(validPreview({ id: "preview_stale" }))
+
+    await waitFor(() => expect(onPreview).toHaveBeenCalledTimes(1))
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save definition" })).toBeDisabled()
+    })
+    expect(screen.queryByText("Preview ready")).not.toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Save definition" }))
+    expect(onCreate).not.toHaveBeenCalled()
+  })
+
+  it("blocks preview and save when scope JSON is malformed", async () => {
+    const user = userEvent.setup()
+    const onPreview = vi.fn().mockResolvedValue(validPreview())
+    const onCreate = vi.fn().mockResolvedValue(definitionResponse())
+
+    render(
+      <ScheduledTaskAutomationDefinitionEditor
+        family="recurring_question"
+        mode="create"
+        onPreview={onPreview}
+        onCreate={onCreate}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.type(screen.getByLabelText("Question"), "Has the answer appeared?")
+    fireEvent.change(screen.getByLabelText("Scope JSON"), {
+      target: { value: '{"collection_id":' }
+    })
+    await user.click(screen.getByRole("button", { name: "Preview" }))
+
+    expect(await screen.findByText("Scope JSON must be a valid JSON object")).toBeInTheDocument()
+    expect(onPreview).not.toHaveBeenCalled()
+    expect(screen.getByRole("button", { name: "Save definition" })).toBeDisabled()
+    await user.click(screen.getByRole("button", { name: "Save definition" }))
+    expect(onCreate).not.toHaveBeenCalled()
   })
 
   it("prompts for another preview when the preview is expired", async () => {

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskAutomationDefinitionEditor.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskAutomationDefinitionEditor.test.tsx
@@ -167,6 +167,30 @@ describe("ScheduledTaskAutomationDefinitionEditor", () => {
     expect(onCreate).not.toHaveBeenCalled()
   })
 
+  it("does not report saved when the create mutation handler is missing", async () => {
+    const user = userEvent.setup()
+    const onPreview = vi.fn().mockResolvedValue(validPreview())
+    const onSaved = vi.fn()
+
+    render(
+      <ScheduledTaskAutomationDefinitionEditor
+        family="recurring_question"
+        mode="create"
+        onPreview={onPreview}
+        onCancel={vi.fn()}
+        onSaved={onSaved}
+      />
+    )
+
+    await user.type(screen.getByLabelText("Question"), "Has the answer appeared?")
+    await user.click(screen.getByRole("button", { name: "Preview" }))
+    await screen.findByText("Preview ready")
+    await user.click(screen.getByRole("button", { name: "Save definition" }))
+
+    expect(await screen.findByText("Create handler is not configured")).toBeInTheDocument()
+    expect(onSaved).not.toHaveBeenCalled()
+  })
+
   it("blocks preview and save when scope JSON is malformed", async () => {
     const user = userEvent.setup()
     const onPreview = vi.fn().mockResolvedValue(validPreview())

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx
@@ -32,6 +32,29 @@ import {
   REQUIRED_WATCH_AVAILABILITY_GATES,
   buildScheduledTaskTemplateCapability
 } from "../scheduled-task-template-capabilities"
+import type { ScheduledTaskAutomationCapabilitiesResponse } from "@/services/scheduled-tasks-control-plane"
+
+const automationCapabilities = (
+  family: "recurring_question" | "agent_task",
+  createStatus: "available" | "planned" | "unavailable" | "disabled" = "available"
+): ScheduledTaskAutomationCapabilitiesResponse => ({
+  items: [
+    {
+      family,
+      family_availability: createStatus === "available" ? "available" : "planned",
+      actions: {
+        create_definition: {
+          status: createStatus,
+          reason: createStatus === "available" ? null : "API creation is not available.",
+          required_permissions: []
+        }
+      },
+      missing_dependencies: [],
+      related_capabilities: {},
+      schema_version: "2026-06-10"
+    }
+  ]
+})
 
 describe("ScheduledTaskCreatePanel", () => {
   it("renders intent templates by state without source-vendor IA", () => {
@@ -343,6 +366,68 @@ describe("ScheduledTaskCreatePanel", () => {
       "/scheduled-tasks/results"
     )
     expect(screen.queryByRole("button", { name: /Create/i })).not.toBeInTheDocument()
+  })
+
+  it("renders the Recurring Question API editor when definition creation is available", () => {
+    render(
+      <ScheduledTaskCreatePanel
+        selectedTemplateId="recurring_question"
+        onSelectTemplate={vi.fn()}
+        onCreateReminder={vi.fn()}
+        automationCapabilities={automationCapabilities("recurring_question")}
+        onPreviewAutomationDefinition={vi.fn()}
+        onCreateAutomationDefinition={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText("Create Recurring question")).toBeInTheDocument()
+    expect(screen.getByLabelText("Question")).toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        "Recurring Question scheduling is planned for the API contract and is not executable in this client yet."
+      )
+    ).not.toBeInTheDocument()
+  })
+
+  it("renders the Agent Task API editor when definition creation is available", () => {
+    render(
+      <ScheduledTaskCreatePanel
+        selectedTemplateId="agent_task"
+        onSelectTemplate={vi.fn()}
+        onCreateReminder={vi.fn()}
+        automationCapabilities={automationCapabilities("agent_task")}
+        onPreviewAutomationDefinition={vi.fn()}
+        onCreateAutomationDefinition={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText("Create Agent task")).toBeInTheDocument()
+    expect(screen.getByLabelText("Agent ref")).toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        "Agent Task scheduling is planned for the API contract and is not executable in this client yet."
+      )
+    ).not.toBeInTheDocument()
+  })
+
+  it("keeps planned Recurring Question copy when API creation is unavailable", () => {
+    render(
+      <ScheduledTaskCreatePanel
+        selectedTemplateId="recurring_question"
+        onSelectTemplate={vi.fn()}
+        onCreateReminder={vi.fn()}
+        automationCapabilities={automationCapabilities("recurring_question", "planned")}
+        onPreviewAutomationDefinition={vi.fn()}
+        onCreateAutomationDefinition={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.getByText(
+        "Recurring Question scheduling is planned for the API contract and is not executable in this client yet."
+      )
+    ).toBeInTheDocument()
+    expect(screen.queryByLabelText("Question")).not.toBeInTheDocument()
   })
 
   it("renders rich planned Agent Task guidance without create controls", () => {

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskDetailDrawer.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskDetailDrawer.test.tsx
@@ -3,7 +3,12 @@
 import React from "react"
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
-import type { ScheduledTask } from "@/services/scheduled-tasks-control-plane"
+import type {
+  ScheduledTask,
+  ScheduledTaskAuditEventResponse,
+  ScheduledTaskDefinitionResponse,
+  ScheduledTaskPreviewResponse
+} from "@/services/scheduled-tasks-control-plane"
 import { ScheduledTaskDetailDrawer } from "../ScheduledTaskDetailDrawer"
 import { projectScheduledTaskResults } from "../scheduled-task-results"
 
@@ -50,6 +55,77 @@ const watchlistTask: ScheduledTask = {
     latest_output_id: 202
   }
 }
+
+const automationTask: ScheduledTask = {
+  id: "automation_definition:definition_1",
+  primitive: "automation_definition",
+  title: "Track answer",
+  description: "Ask until the answer appears",
+  status: "configured_execution_unavailable",
+  enabled: true,
+  schedule_summary: "0 9 * * *",
+  timezone: "UTC",
+  next_run_at: null,
+  last_run_at: null,
+  edit_mode: "native",
+  manage_url: null,
+  source_ref: {
+    definition_id: "definition_1",
+    family: "recurring_question",
+    lifecycle: "configured",
+    health: "execution_unavailable",
+    visibility: "private",
+    notification_policy: "none"
+  }
+}
+
+const automationDefinition: ScheduledTaskDefinitionResponse = {
+  id: "definition_1",
+  version: 2,
+  family: "recurring_question",
+  name: "Track answer",
+  description: "Ask until the answer appears",
+  lifecycle: "configured",
+  health: "execution_unavailable",
+  schedule: { kind: "cron", cron: "0 9 * * *", timezone: "UTC" },
+  input: { question: "Has the answer appeared?" },
+  config: {},
+  visibility_policy: { visibility: "private" },
+  notification_policy: { channels: [] },
+  approval_policy: { mode: "none" },
+  preview_id: "preview_1",
+  created_at: "2026-06-10T00:00:00Z",
+  updated_at: "2026-06-10T01:00:00Z"
+}
+
+const previewHistory: ScheduledTaskPreviewResponse[] = [
+  {
+    id: "preview_1",
+    mode: "create",
+    family: "recurring_question",
+    definition_id: "definition_1",
+    definition_version: 2,
+    status: "valid",
+    normalized_config: { name: "Track answer" },
+    validation_errors: [],
+    warnings: [],
+    visibility_policy: { visibility: "private" },
+    schedule_preview: { summary: "0 9 * * *" },
+    redaction_policy: { redacted_fields: [] },
+    expires_at: "2026-06-11T00:00:00Z"
+  }
+]
+
+const auditEvents: ScheduledTaskAuditEventResponse[] = [
+  {
+    id: "audit_1",
+    definition_id: "definition_1",
+    event_type: "definition.created",
+    actor: "user:1",
+    summary: "Definition created",
+    created_at: "2026-06-10T00:00:00Z"
+  }
+]
 
 describe("ScheduledTaskDetailDrawer", () => {
   it("shows reminder task details and native reminder actions", () => {
@@ -141,5 +217,40 @@ describe("ScheduledTaskDetailDrawer", () => {
       "/scheduled-tasks?tab=results&result_id=202"
     )
     expect(screen.getByText(/Watchlists remains the full workspace/i)).toBeInTheDocument()
+  })
+
+  it("shows automation definition details, preview history, audit, and lifecycle actions", () => {
+    render(
+      <ScheduledTaskDetailDrawer
+        open
+        task={automationTask}
+        automationDefinition={automationDefinition}
+        automationPreviewHistory={previewHistory}
+        automationAuditEvents={auditEvents}
+        onClose={vi.fn()}
+        onEditReminder={vi.fn()}
+        onDeleteReminder={vi.fn()}
+        onPauseAutomationDefinition={vi.fn()}
+        onResumeAutomationDefinition={vi.fn()}
+        onArchiveAutomationDefinition={vi.fn()}
+        onDuplicateAutomationDefinition={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole("dialog", { name: /Track answer/i })).toBeInTheDocument()
+    expect(screen.getByText("Recurring question")).toBeInTheDocument()
+    expect(screen.getByText("Managed here")).toBeInTheDocument()
+    expect(screen.getAllByText("configured").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("execution_unavailable").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("private").length).toBeGreaterThan(0)
+    expect(screen.getByText("Execution is not available yet")).toBeInTheDocument()
+    expect(screen.getByText("Preview history")).toBeInTheDocument()
+    expect(screen.getByText(/preview_1/)).toBeInTheDocument()
+    expect(screen.getByText("Audit events")).toBeInTheDocument()
+    expect(screen.getByText("Definition created")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Pause definition" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Archive definition" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Duplicate definition" })).toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: "Open activity" })).not.toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskDetailDrawer.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTaskDetailDrawer.test.tsx
@@ -220,6 +220,8 @@ describe("ScheduledTaskDetailDrawer", () => {
   })
 
   it("shows automation definition details, preview history, audit, and lifecycle actions", () => {
+    const onEditAutomationDefinition = vi.fn()
+
     render(
       <ScheduledTaskDetailDrawer
         open
@@ -230,6 +232,7 @@ describe("ScheduledTaskDetailDrawer", () => {
         onClose={vi.fn()}
         onEditReminder={vi.fn()}
         onDeleteReminder={vi.fn()}
+        onEditAutomationDefinition={onEditAutomationDefinition}
         onPauseAutomationDefinition={vi.fn()}
         onResumeAutomationDefinition={vi.fn()}
         onArchiveAutomationDefinition={vi.fn()}
@@ -248,6 +251,7 @@ describe("ScheduledTaskDetailDrawer", () => {
     expect(screen.getByText(/preview_1/)).toBeInTheDocument()
     expect(screen.getByText("Audit events")).toBeInTheDocument()
     expect(screen.getByText("Definition created")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Edit definition" })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Pause definition" })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Archive definition" })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Duplicate definition" })).toBeInTheDocument()

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
@@ -883,7 +883,7 @@ describe("ScheduledTasksPage", () => {
     mocks.getScheduledTaskCapabilities.mockResolvedValue(availableAutomationCapabilities)
     mocks.listScheduledTasks.mockResolvedValue({
       items: [
-        automationTask(),
+        automationTask({ id: "automation_definition:projected_definition_1" }),
         automationTask({
           id: "automation_definition:paused",
           title: "Paused agent",
@@ -905,29 +905,23 @@ describe("ScheduledTasksPage", () => {
 
     await user.click(await screen.findByRole("button", { name: "Pause Track answer" }))
     await waitFor(() => {
-      expect(mocks.pauseScheduledTaskDefinition).toHaveBeenCalledWith(
-        "automation_definition:definition_1"
-      )
+      expect(mocks.pauseScheduledTaskDefinition).toHaveBeenCalledWith("definition_1")
     })
 
     await user.click(await screen.findByRole("button", { name: "Resume Paused agent" }))
     await waitFor(() => {
-      expect(mocks.resumeScheduledTaskDefinition).toHaveBeenCalledWith(
-        "automation_definition:paused"
-      )
+      expect(mocks.resumeScheduledTaskDefinition).toHaveBeenCalledWith("paused")
     })
 
     await user.click(await screen.findByRole("button", { name: "Archive Track answer" }))
     await waitFor(() => {
-      expect(mocks.archiveScheduledTaskDefinition).toHaveBeenCalledWith(
-        "automation_definition:definition_1"
-      )
+      expect(mocks.archiveScheduledTaskDefinition).toHaveBeenCalledWith("definition_1")
     })
 
     await user.click(await screen.findByRole("button", { name: "Duplicate Track answer" }))
     await waitFor(() => {
       expect(mocks.duplicateScheduledTaskDefinition).toHaveBeenCalledWith(
-        "automation_definition:definition_1",
+        "definition_1",
         expect.objectContaining({ name: expect.stringContaining("Track answer") })
       )
     })
@@ -1366,6 +1360,31 @@ describe("ScheduledTasksPage", () => {
     })
   }, SLOW_SCHEDULE_FORM_TIMEOUT_MS)
 
+  it("opens the automation editor from the detail drawer without leaving the drawer open", async () => {
+    const user = userEvent.setup()
+
+    mocks.getScheduledTaskCapabilities.mockResolvedValue(availableAutomationCapabilities)
+    mocks.listScheduledTasks.mockResolvedValue({
+      items: [automationTask()],
+      total: 1,
+      partial: false,
+      errors: []
+    })
+    mocks.getScheduledTaskDefinition.mockResolvedValue(definitionResponse())
+
+    renderWithQueryClient(<ScheduledTasksPage />, "/scheduled-tasks?tab=tasks")
+
+    await user.click(await screen.findByRole("button", { name: "Inspect Track answer" }))
+    expect(await screen.findByRole("dialog", { name: /Track answer/i })).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Edit definition" }))
+
+    expect(await screen.findByText("Update Recurring question")).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: /Track answer/i })).not.toBeInTheDocument()
+    })
+  }, SLOW_SCHEDULE_FORM_TIMEOUT_MS)
+
   it("deletes the selected reminder from the detail drawer and does not leave stale drawer state", async () => {
     const user = userEvent.setup()
 
@@ -1450,9 +1469,20 @@ describe("ScheduledTasksPage", () => {
           edit_mode: "external",
           manage_url: "/watchlists?tab=jobs",
           source_ref: { job_id: 42 }
-        }
+        },
+        automationTask({
+          id: "automation_definition:archived",
+          title: "Archived automation",
+          status: "archived",
+          source_ref: {
+            definition_id: "archived",
+            family: "recurring_question",
+            lifecycle: "archived",
+            health: "execution_unavailable"
+          }
+        })
       ],
-      total: 2,
+      total: 3,
       partial: false,
       errors: []
     })
@@ -1461,6 +1491,7 @@ describe("ScheduledTasksPage", () => {
 
     expect(await screen.findByText("Healthy reminder")).toBeInTheDocument()
     expect(screen.getByText("Blocked monitor")).toBeInTheDocument()
+    expect(screen.getByText("Archived automation")).toBeInTheDocument()
     const healthyRow = screen.getByText("Healthy reminder").closest("tr")
     expect(healthyRow).not.toBeNull()
     expect(within(healthyRow as HTMLElement).getByText("Waiting for next run")).toBeInTheDocument()
@@ -1471,6 +1502,14 @@ describe("ScheduledTasksPage", () => {
 
     expect(screen.queryByText("Healthy reminder")).not.toBeInTheDocument()
     expect(screen.getByText("Blocked monitor")).toBeInTheDocument()
+    expect(screen.queryByText("Archived automation")).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("combobox", { name: "Status filter" }))
+    await user.click(await screen.findByTitle("Archived"))
+
+    expect(screen.queryByText("Healthy reminder")).not.toBeInTheDocument()
+    expect(screen.queryByText("Blocked monitor")).not.toBeInTheDocument()
+    expect(screen.getByText("Archived automation")).toBeInTheDocument()
 
     await user.click(screen.getByRole("combobox", { name: "Status filter" }))
     await user.click(await screen.findByTitle("All statuses"))

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
@@ -12,6 +12,17 @@ import { expectInsideDesignSystemAlert } from "@/test-utils/designSystemAlert"
 const mocks = vi.hoisted(() => ({
   useCanonicalConnectionConfig: vi.fn(),
   listScheduledTasks: vi.fn(),
+  getScheduledTaskCapabilities: vi.fn(),
+  createScheduledTaskPreview: vi.fn(),
+  createScheduledTaskDefinition: vi.fn(),
+  updateScheduledTaskDefinition: vi.fn(),
+  getScheduledTaskDefinition: vi.fn(),
+  listScheduledTaskPreviews: vi.fn(),
+  listScheduledTaskDefinitionAudit: vi.fn(),
+  pauseScheduledTaskDefinition: vi.fn(),
+  resumeScheduledTaskDefinition: vi.fn(),
+  archiveScheduledTaskDefinition: vi.fn(),
+  duplicateScheduledTaskDefinition: vi.fn(),
   createScheduledTaskReminder: vi.fn(),
   updateScheduledTaskReminder: vi.fn(),
   deleteScheduledTaskReminder: vi.fn()
@@ -24,6 +35,28 @@ vi.mock("@/hooks/useCanonicalConnectionConfig", () => ({
 
 vi.mock("@/services/scheduled-tasks-control-plane", () => ({
   listScheduledTasks: (...args: unknown[]) => mocks.listScheduledTasks(...args),
+  getScheduledTaskCapabilities: (...args: unknown[]) =>
+    mocks.getScheduledTaskCapabilities(...args),
+  createScheduledTaskPreview: (...args: unknown[]) =>
+    mocks.createScheduledTaskPreview(...args),
+  createScheduledTaskDefinition: (...args: unknown[]) =>
+    mocks.createScheduledTaskDefinition(...args),
+  updateScheduledTaskDefinition: (...args: unknown[]) =>
+    mocks.updateScheduledTaskDefinition(...args),
+  getScheduledTaskDefinition: (...args: unknown[]) =>
+    mocks.getScheduledTaskDefinition(...args),
+  listScheduledTaskPreviews: (...args: unknown[]) =>
+    mocks.listScheduledTaskPreviews(...args),
+  listScheduledTaskDefinitionAudit: (...args: unknown[]) =>
+    mocks.listScheduledTaskDefinitionAudit(...args),
+  pauseScheduledTaskDefinition: (...args: unknown[]) =>
+    mocks.pauseScheduledTaskDefinition(...args),
+  resumeScheduledTaskDefinition: (...args: unknown[]) =>
+    mocks.resumeScheduledTaskDefinition(...args),
+  archiveScheduledTaskDefinition: (...args: unknown[]) =>
+    mocks.archiveScheduledTaskDefinition(...args),
+  duplicateScheduledTaskDefinition: (...args: unknown[]) =>
+    mocks.duplicateScheduledTaskDefinition(...args),
   createScheduledTaskReminder: (...args: unknown[]) => mocks.createScheduledTaskReminder(...args),
   updateScheduledTaskReminder: (...args: unknown[]) => mocks.updateScheduledTaskReminder(...args),
   deleteScheduledTaskReminder: (...args: unknown[]) => mocks.deleteScheduledTaskReminder(...args)
@@ -46,6 +79,88 @@ const fetchMock = vi.fn()
 vi.stubGlobal("fetch", fetchMock)
 
 const SLOW_SCHEDULE_FORM_TIMEOUT_MS = 20000
+
+const availableAutomationCapabilities = {
+  items: [
+    {
+      family: "recurring_question",
+      family_availability: "available",
+      actions: {
+        create_definition: {
+          status: "available",
+          reason: null,
+          required_permissions: []
+        },
+        update_definition: {
+          status: "available",
+          reason: null,
+          required_permissions: []
+        }
+      },
+      missing_dependencies: [],
+      related_capabilities: {},
+      schema_version: "2026-06-10"
+    },
+    {
+      family: "agent_task",
+      family_availability: "available",
+      actions: {
+        create_definition: {
+          status: "available",
+          reason: null,
+          required_permissions: []
+        }
+      },
+      missing_dependencies: [],
+      related_capabilities: {},
+      schema_version: "2026-06-10"
+    }
+  ]
+}
+
+const emptyAutomationCapabilities = {
+  items: []
+}
+
+const automationTask = (overrides: Record<string, unknown> = {}) => ({
+  id: "automation_definition:definition_1",
+  primitive: "automation_definition",
+  title: "Track answer",
+  description: "Ask until the answer appears",
+  status: "configured_execution_unavailable",
+  enabled: true,
+  schedule_summary: "0 9 * * *",
+  timezone: "UTC",
+  next_run_at: null,
+  last_run_at: null,
+  edit_mode: "native",
+  manage_url: null,
+  source_ref: {
+    definition_id: "definition_1",
+    family: "recurring_question",
+    lifecycle: "configured",
+    health: "execution_unavailable",
+    visibility: "private"
+  },
+  ...overrides
+})
+
+const definitionResponse = (overrides: Record<string, unknown> = {}) => ({
+  id: "definition_1",
+  version: 1,
+  family: "recurring_question",
+  name: "Track answer",
+  description: null,
+  lifecycle: "configured",
+  health: "execution_unavailable",
+  schedule: {},
+  input: {},
+  config: {},
+  visibility_policy: { visibility: "private" },
+  notification_policy: {},
+  approval_policy: {},
+  ...overrides
+})
 
 const expectInsideDesignSystemComponent = (
   text: string | RegExp,
@@ -98,6 +213,43 @@ describe("ScheduledTasksPage", () => {
         }
       })
     })
+    mocks.getScheduledTaskCapabilities.mockResolvedValue(emptyAutomationCapabilities)
+    mocks.createScheduledTaskPreview.mockResolvedValue({
+      id: "preview_1",
+      mode: "create",
+      family: "recurring_question",
+      status: "valid",
+      normalized_config: {},
+      validation_errors: [],
+      warnings: [],
+      visibility_policy: {},
+      schedule_preview: {},
+      redaction_policy: {},
+      expires_at: "2026-06-10T00:00:00Z"
+    })
+    mocks.createScheduledTaskDefinition.mockResolvedValue(definitionResponse())
+    mocks.updateScheduledTaskDefinition.mockResolvedValue(definitionResponse())
+    mocks.getScheduledTaskDefinition.mockResolvedValue(definitionResponse())
+    mocks.listScheduledTaskPreviews.mockResolvedValue({
+      items: [],
+      total: 0,
+      limit: 20,
+      offset: 0,
+      has_more: false
+    })
+    mocks.listScheduledTaskDefinitionAudit.mockResolvedValue({
+      items: [],
+      total: 0,
+      limit: 20,
+      offset: 0,
+      has_more: false
+    })
+    mocks.pauseScheduledTaskDefinition.mockResolvedValue(definitionResponse({ lifecycle: "paused" }))
+    mocks.resumeScheduledTaskDefinition.mockResolvedValue(definitionResponse({ lifecycle: "configured" }))
+    mocks.archiveScheduledTaskDefinition.mockResolvedValue(definitionResponse({ lifecycle: "archived" }))
+    mocks.duplicateScheduledTaskDefinition.mockResolvedValue(
+      definitionResponse({ id: "definition_copy", lifecycle: "paused" })
+    )
   })
 
   it("shows an unsupported-state message without calling the list endpoint when scheduled tasks are unavailable", async () => {
@@ -425,6 +577,169 @@ describe("ScheduledTasksPage", () => {
       "/acp-playground"
     )
     expect(screen.queryByRole("button", { name: /Create/i })).not.toBeInTheDocument()
+  })
+
+  it("loads automation capabilities for API-first create flows", async () => {
+    mocks.listScheduledTasks.mockResolvedValue({
+      items: [],
+      total: 0,
+      partial: false,
+      errors: []
+    })
+    mocks.getScheduledTaskCapabilities.mockResolvedValue(availableAutomationCapabilities)
+
+    renderWithQueryClient(
+      <ScheduledTasksPage />,
+      "/scheduled-tasks?tab=create&template=recurring_question"
+    )
+
+    expect(await screen.findByText("Create Recurring question")).toBeInTheDocument()
+    expect(mocks.getScheduledTaskCapabilities).toHaveBeenCalledTimes(1)
+    expect(screen.getByLabelText("Question")).toBeInTheDocument()
+  })
+
+  it("creates a Recurring Question definition through preview and create APIs", async () => {
+    const user = userEvent.setup()
+    mocks.getScheduledTaskCapabilities.mockResolvedValue(availableAutomationCapabilities)
+    mocks.listScheduledTasks
+      .mockResolvedValueOnce({
+        items: [],
+        total: 0,
+        partial: false,
+        errors: []
+      })
+      .mockResolvedValueOnce({
+        items: [automationTask()],
+        total: 1,
+        partial: false,
+        errors: []
+      })
+    mocks.createScheduledTaskPreview.mockResolvedValue({
+      id: "preview_recurring",
+      mode: "create",
+      family: "recurring_question",
+      status: "valid",
+      normalized_config: { name: "Track answer" },
+      validation_errors: [],
+      warnings: [],
+      visibility_policy: { visibility: "private" },
+      schedule_preview: { summary: "Manual" },
+      redaction_policy: {},
+      expires_at: "2026-06-10T00:00:00Z"
+    })
+    mocks.createScheduledTaskDefinition.mockResolvedValue(definitionResponse())
+
+    renderWithQueryClient(
+      <ScheduledTasksPage />,
+      "/scheduled-tasks?tab=create&template=recurring_question"
+    )
+
+    await user.type(await screen.findByLabelText("Question"), "Has the answer appeared?")
+    await user.click(screen.getByRole("button", { name: "Preview" }))
+    expect(await screen.findByText("Preview ready")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Save definition" }))
+
+    await waitFor(() => {
+      expect(mocks.createScheduledTaskPreview).toHaveBeenCalledWith(
+        expect.objectContaining({
+          family: "recurring_question",
+          input: expect.objectContaining({
+            question: "Has the answer appeared?"
+          })
+        })
+      )
+    })
+    expect(mocks.createScheduledTaskDefinition).toHaveBeenCalledWith({
+      preview_id: "preview_recurring",
+      initial_lifecycle: "configured"
+    })
+    await waitFor(() => expect(mocks.listScheduledTasks).toHaveBeenCalledTimes(2))
+    await waitFor(() => {
+      expect(screen.getAllByText("Track answer").length).toBeGreaterThan(0)
+    })
+  })
+
+  it("runs automation definition lifecycle actions from rows and refreshes the list", async () => {
+    const user = userEvent.setup()
+    mocks.getScheduledTaskCapabilities.mockResolvedValue(availableAutomationCapabilities)
+    mocks.listScheduledTasks.mockResolvedValue({
+      items: [
+        automationTask(),
+        automationTask({
+          id: "automation_definition:paused",
+          title: "Paused agent",
+          status: "paused",
+          source_ref: {
+            definition_id: "paused",
+            family: "agent_task",
+            lifecycle: "paused",
+            health: "execution_unavailable"
+          }
+        })
+      ],
+      total: 2,
+      partial: false,
+      errors: []
+    })
+
+    renderWithQueryClient(<ScheduledTasksPage />, "/scheduled-tasks?tab=tasks")
+
+    await user.click(await screen.findByRole("button", { name: "Pause Track answer" }))
+    await waitFor(() => {
+      expect(mocks.pauseScheduledTaskDefinition).toHaveBeenCalledWith(
+        "automation_definition:definition_1"
+      )
+    })
+
+    await user.click(await screen.findByRole("button", { name: "Resume Paused agent" }))
+    await waitFor(() => {
+      expect(mocks.resumeScheduledTaskDefinition).toHaveBeenCalledWith(
+        "automation_definition:paused"
+      )
+    })
+
+    await user.click(await screen.findByRole("button", { name: "Archive Track answer" }))
+    await waitFor(() => {
+      expect(mocks.archiveScheduledTaskDefinition).toHaveBeenCalledWith(
+        "automation_definition:definition_1"
+      )
+    })
+
+    await user.click(await screen.findByRole("button", { name: "Duplicate Track answer" }))
+    await waitFor(() => {
+      expect(mocks.duplicateScheduledTaskDefinition).toHaveBeenCalledWith(
+        "automation_definition:definition_1",
+        expect.objectContaining({ name: expect.stringContaining("Track answer") })
+      )
+    })
+    await waitFor(() => expect(mocks.listScheduledTasks).toHaveBeenCalledTimes(5))
+  }, SLOW_SCHEDULE_FORM_TIMEOUT_MS)
+
+  it("shows API error detail code and message for automation lifecycle failures", async () => {
+    const user = userEvent.setup()
+    mocks.getScheduledTaskCapabilities.mockResolvedValue(availableAutomationCapabilities)
+    mocks.listScheduledTasks.mockResolvedValue({
+      items: [automationTask()],
+      total: 1,
+      partial: false,
+      errors: []
+    })
+    mocks.pauseScheduledTaskDefinition.mockRejectedValue({
+      detail: {
+        code: "definition_locked",
+        message: "Definition is locked by policy."
+      }
+    })
+
+    renderWithQueryClient(<ScheduledTasksPage />, "/scheduled-tasks?tab=tasks")
+
+    await user.click(await screen.findByRole("button", { name: "Pause Track answer" }))
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("definition_locked: Definition is locked by policy.").length
+      ).toBeGreaterThan(0)
+    })
   })
 
   it("opens a task detail deep link after task data loads", async () => {

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
@@ -659,6 +659,91 @@ describe("ScheduledTasksPage", () => {
     })
   })
 
+  it("updates an automation definition through preview and update APIs", async () => {
+    const user = userEvent.setup()
+    mocks.getScheduledTaskCapabilities.mockResolvedValue(availableAutomationCapabilities)
+    mocks.listScheduledTasks
+      .mockResolvedValueOnce({
+        items: [automationTask()],
+        total: 1,
+        partial: false,
+        errors: []
+      })
+      .mockResolvedValueOnce({
+        items: [
+          automationTask({
+            title: "Track answer updated",
+            description: "Updated definition"
+          })
+        ],
+        total: 1,
+        partial: false,
+        errors: []
+      })
+    mocks.getScheduledTaskDefinition.mockResolvedValue(
+      definitionResponse({
+        version: 3,
+        input: {
+          question: "Has the answer appeared?",
+          success_criteria: "Answer found",
+          scope: { collection_id: "research" }
+        },
+        schedule: { kind: "cron", cron: "0 9 * * *", timezone: "UTC" },
+        visibility_policy: { visibility: "private" }
+      })
+    )
+    mocks.createScheduledTaskPreview.mockResolvedValue({
+      id: "preview_update",
+      mode: "update",
+      family: "recurring_question",
+      definition_id: "definition_1",
+      definition_version: 3,
+      status: "valid",
+      normalized_config: { name: "Track answer updated" },
+      validation_errors: [],
+      warnings: [],
+      visibility_policy: { visibility: "private" },
+      schedule_preview: { summary: "0 9 * * *" },
+      redaction_policy: {},
+      expires_at: "2026-06-10T00:00:00Z"
+    })
+    mocks.updateScheduledTaskDefinition.mockResolvedValue(
+      definitionResponse({
+        name: "Track answer updated",
+        version: 4
+      })
+    )
+
+    renderWithQueryClient(<ScheduledTasksPage />, "/scheduled-tasks?tab=tasks")
+
+    await user.click(await screen.findByRole("button", { name: "Edit Track answer" }))
+    expect(await screen.findByText("Update Recurring question")).toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText("Question"), {
+      target: { value: "Has the answer appeared now?" }
+    })
+    await user.click(screen.getByRole("button", { name: "Preview" }))
+    expect(await screen.findByText("Preview ready")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Save definition" }))
+
+    await waitFor(() => {
+      expect(mocks.createScheduledTaskPreview).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: "update",
+          family: "recurring_question",
+          definition_id: "definition_1",
+          definition_version: 3,
+          input: expect.objectContaining({
+            question: "Has the answer appeared now?"
+          })
+        })
+      )
+    })
+    expect(mocks.updateScheduledTaskDefinition).toHaveBeenCalledWith("definition_1", {
+      preview_id: "preview_update"
+    })
+    await waitFor(() => expect(mocks.listScheduledTasks).toHaveBeenCalledTimes(2))
+  }, SLOW_SCHEDULE_FORM_TIMEOUT_MS)
+
   it("runs automation definition lifecycle actions from rows and refreshes the list", async () => {
     const user = userEvent.setup()
     mocks.getScheduledTaskCapabilities.mockResolvedValue(availableAutomationCapabilities)
@@ -740,6 +825,70 @@ describe("ScheduledTasksPage", () => {
         screen.getAllByText("definition_locked: Definition is locked by policy.").length
       ).toBeGreaterThan(0)
     })
+  })
+
+  it("shows row Results buttons only for real result signals", async () => {
+    mocks.getScheduledTaskCapabilities.mockResolvedValue(availableAutomationCapabilities)
+    mocks.listScheduledTasks.mockResolvedValue({
+      items: [
+        {
+          id: "reminder_task:completed",
+          primitive: "reminder_task",
+          title: "Completed review",
+          description: "No output was produced",
+          status: "completed",
+          enabled: true,
+          schedule_summary: "One-time reminder",
+          timezone: "UTC",
+          next_run_at: null,
+          last_run_at: "2030-04-05T12:30:00+00:00",
+          edit_mode: "native",
+          manage_url: null,
+          source_ref: { task_id: "completed" }
+        },
+        automationTask({
+          id: "automation_definition:no_result",
+          title: "Automation no result",
+          source_ref: {
+            definition_id: "no_result",
+            family: "recurring_question",
+            lifecycle: "configured",
+            health: "execution_unavailable"
+          }
+        }),
+        automationTask({
+          id: "automation_definition:with_result",
+          title: "Automation result",
+          status: "configured",
+          source_ref: {
+            definition_id: "with_result",
+            family: "recurring_question",
+            lifecycle: "configured",
+            health: "ready",
+            latest_result_id: "909",
+            result_count: 1
+          }
+        })
+      ],
+      total: 3,
+      partial: false,
+      errors: []
+    })
+
+    renderWithQueryClient(<ScheduledTasksPage />, "/scheduled-tasks?tab=tasks")
+
+    expect(await screen.findByText("Completed review")).toBeInTheDocument()
+    expect(screen.getByText("Automation no result")).toBeInTheDocument()
+    expect(screen.getByText("Automation result")).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "View results for Completed review" })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "View results for Automation no result" })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "View results for Automation result" })
+    ).toBeInTheDocument()
   })
 
   it("opens a task detail deep link after task data loads", async () => {

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
@@ -744,6 +744,140 @@ describe("ScheduledTasksPage", () => {
     await waitFor(() => expect(mocks.listScheduledTasks).toHaveBeenCalledTimes(2))
   }, SLOW_SCHEDULE_FORM_TIMEOUT_MS)
 
+  it.each(["daily", "weekly", "interval", "one_time"])(
+    "preserves %s schedule kind when updating an automation definition",
+    async (scheduleKind) => {
+      const user = userEvent.setup()
+      mocks.getScheduledTaskCapabilities.mockResolvedValue(availableAutomationCapabilities)
+      mocks.listScheduledTasks.mockResolvedValue({
+        items: [automationTask()],
+        total: 1,
+        partial: false,
+        errors: []
+      })
+      mocks.getScheduledTaskDefinition.mockResolvedValue(
+        definitionResponse({
+          version: 5,
+          input: {
+            question: "Has the answer appeared?",
+            scope: { collection_id: "research" }
+          },
+          schedule: {
+            kind: scheduleKind,
+            timezone: "America/New_York",
+            run_at: "2030-04-05T12:30:00Z",
+            every_seconds: 3600,
+            day_of_week: "monday"
+          }
+        })
+      )
+      mocks.createScheduledTaskPreview.mockResolvedValue({
+        id: `preview_${scheduleKind}`,
+        mode: "update",
+        family: "recurring_question",
+        definition_id: "definition_1",
+        definition_version: 5,
+        status: "valid",
+        normalized_config: { name: "Track answer" },
+        validation_errors: [],
+        warnings: [],
+        visibility_policy: { visibility: "private" },
+        schedule_preview: { summary: scheduleKind },
+        redaction_policy: {},
+        expires_at: "2026-06-10T00:00:00Z"
+      })
+
+      renderWithQueryClient(<ScheduledTasksPage />, "/scheduled-tasks?tab=tasks")
+
+      await user.click(await screen.findByRole("button", { name: "Edit Track answer" }))
+      expect(await screen.findByText("Update Recurring question")).toBeInTheDocument()
+      await user.click(screen.getByRole("button", { name: "Preview" }))
+
+      await waitFor(() => {
+        expect(mocks.createScheduledTaskPreview).toHaveBeenCalledWith(
+          expect.objectContaining({
+            mode: "update",
+            definition_id: "definition_1",
+            schedule: expect.objectContaining({
+              kind: scheduleKind,
+              timezone: "America/New_York"
+            })
+          })
+        )
+      })
+    },
+    SLOW_SCHEDULE_FORM_TIMEOUT_MS
+  )
+
+  it("preserves an Agent Task string agent ref when updating", async () => {
+    const user = userEvent.setup()
+    mocks.getScheduledTaskCapabilities.mockResolvedValue(availableAutomationCapabilities)
+    mocks.listScheduledTasks.mockResolvedValue({
+      items: [
+        automationTask({
+          title: "Dispatch agent",
+          source_ref: {
+            definition_id: "agent_definition",
+            family: "agent_task",
+            lifecycle: "configured",
+            health: "execution_unavailable",
+            visibility: "private"
+          }
+        })
+      ],
+      total: 1,
+      partial: false,
+      errors: []
+    })
+    mocks.getScheduledTaskDefinition.mockResolvedValue(
+      definitionResponse({
+        id: "agent_definition",
+        version: 2,
+        family: "agent_task",
+        name: "Dispatch agent",
+        input: {
+          agent_ref: "agent://primary",
+          message: "Summarize the report"
+        },
+        schedule: { kind: "daily", timezone: "UTC" }
+      })
+    )
+    mocks.createScheduledTaskPreview.mockResolvedValue({
+      id: "preview_agent_update",
+      mode: "update",
+      family: "agent_task",
+      definition_id: "agent_definition",
+      definition_version: 2,
+      status: "valid",
+      normalized_config: { name: "Dispatch agent" },
+      validation_errors: [],
+      warnings: [],
+      visibility_policy: { visibility: "private" },
+      schedule_preview: { summary: "Daily" },
+      redaction_policy: {},
+      expires_at: "2026-06-10T00:00:00Z"
+    })
+
+    renderWithQueryClient(<ScheduledTasksPage />, "/scheduled-tasks?tab=tasks")
+
+    await user.click(await screen.findByRole("button", { name: "Edit Dispatch agent" }))
+    expect(await screen.findByDisplayValue("agent://primary")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Preview" }))
+
+    await waitFor(() => {
+      expect(mocks.createScheduledTaskPreview).toHaveBeenCalledWith(
+        expect.objectContaining({
+          family: "agent_task",
+          definition_id: "agent_definition",
+          input: expect.objectContaining({
+            agent_ref: "agent://primary",
+            message: "Summarize the report"
+          })
+        })
+      )
+    })
+  }, SLOW_SCHEDULE_FORM_TIMEOUT_MS)
+
   it("runs automation definition lifecycle actions from rows and refreshes the list", async () => {
     const user = userEvent.setup()
     mocks.getScheduledTaskCapabilities.mockResolvedValue(availableAutomationCapabilities)
@@ -810,9 +944,11 @@ describe("ScheduledTasksPage", () => {
       errors: []
     })
     mocks.pauseScheduledTaskDefinition.mockRejectedValue({
-      detail: {
-        code: "definition_locked",
-        message: "Definition is locked by policy."
+      details: {
+        detail: {
+          code: "definition_locked",
+          message: "Definition is locked by policy."
+        }
       }
     })
 

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx
@@ -1773,7 +1773,7 @@ describe("ScheduledTasksPage", () => {
         })
       )
     })
-  })
+  }, SLOW_SCHEDULE_FORM_TIMEOUT_MS)
 
   it("does not create a recurring reminder without cron and timezone", async () => {
     const user = userEvent.setup()

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-automation-status.test.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-automation-status.test.ts
@@ -48,6 +48,94 @@ describe("scheduled task automation status", () => {
     expect(status.label).toBe("Paused")
   })
 
+  it("maps ready backend-projected definitions to configured", () => {
+    const status = getAutomationDefinitionProductStatus({
+      id: "automation_definition:def_ready",
+      primitive: "automation_definition",
+      title: "Ready task",
+      status: "ready",
+      enabled: true,
+      edit_mode: "native",
+      source_ref: {
+        family: "agent_task",
+        lifecycle: "configured",
+        health: "ready"
+      }
+    } as const)
+
+    expect(status).toMatchObject({
+      key: "waiting",
+      label: "Configured",
+      tone: "processing"
+    })
+  })
+
+  it("maps capability-blocked backend projection to blocked warning copy", () => {
+    const status = getAutomationDefinitionProductStatus({
+      id: "automation_definition:def_capability",
+      primitive: "automation_definition",
+      title: "Capability blocked task",
+      status: "blocked_capability_unavailable",
+      enabled: true,
+      edit_mode: "native",
+      source_ref: {
+        family: "agent_task",
+        lifecycle: "configured",
+        health: "capability_unavailable"
+      }
+    } as const)
+
+    expect(status).toMatchObject({
+      key: "blocked",
+      label: "Execution unavailable",
+      tone: "warning"
+    })
+  })
+
+  it("maps permission-blocked backend projection to blocked warning copy", () => {
+    const status = getAutomationDefinitionProductStatus({
+      id: "automation_definition:def_permission",
+      primitive: "automation_definition",
+      title: "Permission blocked task",
+      status: "blocked_permission_required",
+      enabled: true,
+      edit_mode: "native",
+      source_ref: {
+        family: "recurring_question",
+        lifecycle: "configured",
+        health: "permission_required"
+      }
+    } as const)
+
+    expect(status).toMatchObject({
+      key: "blocked",
+      label: "Execution unavailable",
+      tone: "warning"
+    })
+  })
+
+  it("maps needs-attention backend projection intentionally", () => {
+    const status = getAutomationDefinitionProductStatus({
+      id: "automation_definition:def_attention",
+      primitive: "automation_definition",
+      title: "Attention task",
+      status: "needs_attention",
+      enabled: true,
+      edit_mode: "native",
+      source_ref: {
+        family: "agent_task",
+        lifecycle: "configured",
+        health: "needs_attention"
+      }
+    } as const)
+
+    expect(status).toMatchObject({
+      key: "needs_attention",
+      label: "Needs attention",
+      tone: "error"
+    })
+  })
+
   it("treats unknown automation lifecycle and status as needing attention", () => {
     const status = getAutomationDefinitionProductStatus({
       id: "automation_definition:def_3",

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-automation-status.test.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-automation-status.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  getAutomationDefinitionFamilyLabel,
+  getAutomationDefinitionProductStatus,
+  isAutomationDefinitionTask
+} from "../scheduled-task-automation-status"
+
+describe("scheduled task automation status", () => {
+  it("labels configured non-executable definitions without waiting-for-run copy", () => {
+    const task = {
+      id: "automation_definition:def_1",
+      primitive: "automation_definition",
+      title: "Track answer",
+      status: "configured_execution_unavailable",
+      enabled: true,
+      edit_mode: "native",
+      source_ref: {
+        family: "recurring_question",
+        lifecycle: "configured",
+        health: "execution_unavailable",
+        execution_available: false
+      }
+    } as const
+
+    expect(isAutomationDefinitionTask(task)).toBe(true)
+    expect(getAutomationDefinitionFamilyLabel(task)).toBe("Recurring question")
+    expect(getAutomationDefinitionProductStatus(task).label).toBe(
+      "Configured, execution unavailable"
+    )
+  })
+
+  it("does not collapse paused automation definitions into disabled", () => {
+    const status = getAutomationDefinitionProductStatus({
+      id: "automation_definition:def_2",
+      primitive: "automation_definition",
+      title: "Agent task",
+      status: "paused",
+      enabled: false,
+      edit_mode: "native",
+      source_ref: {
+        family: "agent_task",
+        lifecycle: "paused",
+        health: "execution_unavailable"
+      }
+    } as const)
+
+    expect(status.label).toBe("Paused")
+  })
+})

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-automation-status.test.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-automation-status.test.ts
@@ -47,4 +47,64 @@ describe("scheduled task automation status", () => {
 
     expect(status.label).toBe("Paused")
   })
+
+  it("treats unknown automation lifecycle and status as needing attention", () => {
+    const status = getAutomationDefinitionProductStatus({
+      id: "automation_definition:def_3",
+      primitive: "automation_definition",
+      title: "Future task",
+      status: "warming_up",
+      enabled: true,
+      edit_mode: "native",
+      source_ref: {
+        family: "agent_task",
+        lifecycle: "warming_up",
+        health: "initializing"
+      }
+    } as const)
+
+    expect(status).toMatchObject({
+      key: "needs_attention",
+      label: "Needs attention"
+    })
+    expect(status.description).toContain("unrecognized")
+  })
+
+  it("does not treat unknown automation status as ready when lifecycle is configured", () => {
+    const status = getAutomationDefinitionProductStatus({
+      id: "automation_definition:def_5",
+      primitive: "automation_definition",
+      title: "Future status",
+      status: "awaiting_worker",
+      enabled: true,
+      edit_mode: "native",
+      source_ref: {
+        family: "agent_task",
+        lifecycle: "configured",
+        health: "ready"
+      }
+    } as const)
+
+    expect(status).toMatchObject({
+      key: "needs_attention",
+      label: "Needs attention"
+    })
+  })
+
+  it("does not mark automation definitions with missing source metadata as configured", () => {
+    const status = getAutomationDefinitionProductStatus({
+      id: "automation_definition:def_4",
+      primitive: "automation_definition",
+      title: "Missing metadata",
+      status: "configured",
+      enabled: true,
+      edit_mode: "native",
+      source_ref: {}
+    } as const)
+
+    expect(status).toMatchObject({
+      key: "needs_attention",
+      label: "Needs attention"
+    })
+  })
 })

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts
@@ -140,6 +140,27 @@ describe("scheduled task result helpers", () => {
     expect(buildScheduledTaskAutomationHomeItems([result])).toEqual([])
   })
 
+  it("does not project automation definition lifecycle states as fake result rows", () => {
+    const results = projectScheduledTaskResults([
+      buildTask({
+        id: "automation_definition:definition_1",
+        primitive: "automation_definition",
+        title: "Track answer",
+        status: "configured_execution_unavailable",
+        edit_mode: "native",
+        manage_url: null,
+        source_ref: {
+          definition_id: "definition_1",
+          family: "recurring_question",
+          lifecycle: "configured",
+          health: "execution_unavailable"
+        }
+      })
+    ])
+
+    expect(results).toEqual([])
+  })
+
   it("uses the canonical blocked label for blocked automation home items", () => {
     const [result] = projectScheduledTaskResults([
       buildTask({

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-status.test.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-status.test.ts
@@ -27,6 +27,28 @@ describe("scheduled task status helpers", () => {
     })
   })
 
+  it("uses automation status before generic disabled mapping", () => {
+    expect(
+      getScheduledTaskProductStatus({
+        id: "automation_definition:def_2",
+        primitive: "automation_definition",
+        title: "Agent task",
+        status: "paused",
+        enabled: false,
+        edit_mode: "native",
+        source_ref: {
+          family: "agent_task",
+          lifecycle: "paused",
+          health: "execution_unavailable"
+        }
+      })
+    ).toMatchObject({
+      key: "paused",
+      label: "Paused",
+      tone: "warning"
+    })
+  })
+
   it("maps failed-like statuses to Needs attention", () => {
     expect(
       getScheduledTaskProductStatus({
@@ -262,6 +284,12 @@ describe("scheduled task status helpers", () => {
     expect(getScheduledTaskTypeLabel({ primitive: "watchlist_job" })).toBe(
       "Watchlist monitor"
     )
+    expect(
+      getScheduledTaskTypeLabel({
+        primitive: "automation_definition",
+        source_ref: { family: "recurring_question" }
+      })
+    ).toBe("Recurring question")
     expect(getScheduledTaskTypeLabel({ primitive: "future_task" })).toBe("Scheduled task")
   })
 })

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-status.test.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/__tests__/scheduled-task-status.test.ts
@@ -49,6 +49,28 @@ describe("scheduled task status helpers", () => {
     })
   })
 
+  it("surfaces unknown automation states before generic waiting copy", () => {
+    expect(
+      getScheduledTaskProductStatus({
+        id: "automation_definition:def_unknown",
+        primitive: "automation_definition",
+        title: "Unknown automation",
+        status: "future_state",
+        enabled: true,
+        edit_mode: "native",
+        source_ref: {
+          family: "recurring_question",
+          lifecycle: "future_state",
+          health: "future_health"
+        }
+      })
+    ).toMatchObject({
+      key: "needs_attention",
+      label: "Needs attention",
+      tone: "error"
+    })
+  })
+
   it("maps failed-like statuses to Needs attention", () => {
     expect(
       getScheduledTaskProductStatus({

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-automation-status.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-automation-status.ts
@@ -31,6 +31,29 @@ const isKnownAutomationFamily = (
 ): value is ScheduledTaskAutomationFamily =>
   value === "recurring_question" || value === "agent_task"
 
+const KNOWN_AUTOMATION_LIFECYCLES = new Set([
+  "configured",
+  "paused",
+  "archived",
+  "disabled"
+])
+
+const KNOWN_AUTOMATION_HEALTH = new Set([
+  "ready",
+  "execution_unavailable",
+  "capability_unavailable",
+  "needs_attention",
+  "permission_required"
+])
+
+const KNOWN_AUTOMATION_STATUSES = new Set([
+  "configured",
+  "configured_execution_unavailable",
+  "paused",
+  "archived",
+  "disabled"
+])
+
 const makeAutomationStatus = (
   key: ScheduledTaskStatusKey,
   label: string,
@@ -42,6 +65,14 @@ const makeAutomationStatus = (
   tone,
   description
 })
+
+const makeUnknownAutomationStatus = (): ScheduledTaskProductStatus =>
+  makeAutomationStatus(
+    "needs_attention",
+    "Needs attention",
+    "error",
+    "This automation definition has unrecognized status metadata and should be reviewed before it runs."
+  )
 
 export const isAutomationDefinitionTask = (
   task: AutomationDefinitionTaskInput
@@ -91,6 +122,16 @@ export const getAutomationDefinitionProductStatus = (
     )
   }
 
+  const hasUnknownLifecycle =
+    Boolean(lifecycle) && !KNOWN_AUTOMATION_LIFECYCLES.has(lifecycle)
+  const hasUnknownHealth = Boolean(health) && !KNOWN_AUTOMATION_HEALTH.has(health)
+  const hasUnknownStatus =
+    Boolean(status) && !KNOWN_AUTOMATION_STATUSES.has(status)
+
+  if (hasUnknownLifecycle || hasUnknownHealth || hasUnknownStatus) {
+    return makeUnknownAutomationStatus()
+  }
+
   if (
     status === "configured_execution_unavailable" ||
     (lifecycle === "configured" && health === "execution_unavailable")
@@ -121,7 +162,7 @@ export const getAutomationDefinitionProductStatus = (
     )
   }
 
-  if (lifecycle === "configured" || status === "configured" || health === "ready") {
+  if (lifecycle === "configured" && health === "ready") {
     return makeAutomationStatus(
       "waiting",
       "Configured",
@@ -139,10 +180,5 @@ export const getAutomationDefinitionProductStatus = (
     )
   }
 
-  return makeAutomationStatus(
-    "waiting",
-    "Configured",
-    "processing",
-    "This automation definition is configured and ready for execution."
-  )
+  return makeUnknownAutomationStatus()
 }

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-automation-status.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-automation-status.ts
@@ -85,7 +85,7 @@ export const isAutomationDefinitionTask = (
 export const getAutomationDefinitionFamilyLabel = (
   task: Pick<AutomationDefinitionTaskInput, "source_ref">
 ): string => {
-  const family = task.source_ref?.family
+  const family = task.source_ref?.["family"]
   return isKnownAutomationFamily(family)
     ? AUTOMATION_FAMILY_LABELS[family]
     : "Automation"
@@ -96,8 +96,8 @@ export const getAutomationDefinitionProductStatus = (
 ): ScheduledTaskProductStatus => {
   const status = task.status || ""
   const sourceRef = task.source_ref || {}
-  const lifecycle = typeof sourceRef.lifecycle === "string" ? sourceRef.lifecycle : ""
-  const health = typeof sourceRef.health === "string" ? sourceRef.health : ""
+  const lifecycle = typeof sourceRef["lifecycle"] === "string" ? sourceRef["lifecycle"] : ""
+  const health = typeof sourceRef["health"] === "string" ? sourceRef["health"] : ""
 
   if (lifecycle === "paused" || status === "paused") {
     return makeAutomationStatus(

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-automation-status.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-automation-status.ts
@@ -1,0 +1,148 @@
+import type {
+  ScheduledTask,
+  ScheduledTaskAutomationFamily
+} from "@/services/scheduled-tasks-control-plane"
+
+import type {
+  ScheduledTaskProductStatus,
+  ScheduledTaskStatusKey
+} from "./scheduled-task-status"
+
+type AutomationDefinitionTaskInput =
+  | ScheduledTask
+  | {
+      primitive?: unknown
+      status?: string
+      enabled?: boolean
+      source_ref?: Record<string, unknown>
+    }
+
+type AutomationDefinitionTask = AutomationDefinitionTaskInput & {
+  primitive: "automation_definition"
+}
+
+const AUTOMATION_FAMILY_LABELS: Record<ScheduledTaskAutomationFamily, string> = {
+  recurring_question: "Recurring question",
+  agent_task: "Agent task"
+}
+
+const isKnownAutomationFamily = (
+  value: unknown
+): value is ScheduledTaskAutomationFamily =>
+  value === "recurring_question" || value === "agent_task"
+
+const makeAutomationStatus = (
+  key: ScheduledTaskStatusKey,
+  label: string,
+  tone: ScheduledTaskProductStatus["tone"],
+  description: string
+): ScheduledTaskProductStatus => ({
+  key,
+  label,
+  tone,
+  description
+})
+
+export const isAutomationDefinitionTask = (
+  task: AutomationDefinitionTaskInput
+): task is AutomationDefinitionTask => task.primitive === "automation_definition"
+
+export const getAutomationDefinitionFamilyLabel = (
+  task: Pick<AutomationDefinitionTaskInput, "source_ref">
+): string => {
+  const family = task.source_ref?.family
+  return isKnownAutomationFamily(family)
+    ? AUTOMATION_FAMILY_LABELS[family]
+    : "Automation"
+}
+
+export const getAutomationDefinitionProductStatus = (
+  task: AutomationDefinitionTask
+): ScheduledTaskProductStatus => {
+  const status = task.status || ""
+  const sourceRef = task.source_ref || {}
+  const lifecycle = typeof sourceRef.lifecycle === "string" ? sourceRef.lifecycle : ""
+  const health = typeof sourceRef.health === "string" ? sourceRef.health : ""
+
+  if (lifecycle === "paused" || status === "paused") {
+    return makeAutomationStatus(
+      "paused",
+      "Paused",
+      "warning",
+      "This automation definition is paused and will not run until resumed."
+    )
+  }
+
+  if (lifecycle === "archived" || status === "archived") {
+    return makeAutomationStatus(
+      "archived",
+      "Archived",
+      "default",
+      "This automation definition is archived and cannot run."
+    )
+  }
+
+  if (lifecycle === "disabled" || status === "disabled") {
+    return makeAutomationStatus(
+      "disabled",
+      "Disabled",
+      "default",
+      "This automation definition is disabled and cannot run."
+    )
+  }
+
+  if (
+    status === "configured_execution_unavailable" ||
+    (lifecycle === "configured" && health === "execution_unavailable")
+  ) {
+    return makeAutomationStatus(
+      "blocked",
+      "Configured, execution unavailable",
+      "warning",
+      "This automation definition is configured, but execution is unavailable."
+    )
+  }
+
+  if (health === "permission_required" || health === "capability_unavailable") {
+    return makeAutomationStatus(
+      "blocked",
+      "Execution unavailable",
+      "warning",
+      "This automation definition cannot run until the required capability is available."
+    )
+  }
+
+  if (health === "needs_attention") {
+    return makeAutomationStatus(
+      "needs_attention",
+      "Needs attention",
+      "error",
+      "This automation definition needs attention before it can run reliably."
+    )
+  }
+
+  if (lifecycle === "configured" || status === "configured" || health === "ready") {
+    return makeAutomationStatus(
+      "waiting",
+      "Configured",
+      "processing",
+      "This automation definition is configured and ready for execution."
+    )
+  }
+
+  if (task.enabled === false) {
+    return makeAutomationStatus(
+      "disabled",
+      "Disabled",
+      "default",
+      "This automation definition is disabled and cannot run."
+    )
+  }
+
+  return makeAutomationStatus(
+    "waiting",
+    "Configured",
+    "processing",
+    "This automation definition is configured and ready for execution."
+  )
+}

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-automation-status.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-automation-status.ts
@@ -49,6 +49,10 @@ const KNOWN_AUTOMATION_HEALTH = new Set([
 const KNOWN_AUTOMATION_STATUSES = new Set([
   "configured",
   "configured_execution_unavailable",
+  "ready",
+  "blocked_capability_unavailable",
+  "blocked_permission_required",
+  "needs_attention",
   "paused",
   "archived",
   "disabled"

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-results.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-results.ts
@@ -562,6 +562,13 @@ export const projectScheduledTaskResults = (
 
     const status = task.status || ""
     const sourceRef = isRecord(task.source_ref) ? task.source_ref : {}
+    if (
+      task.primitive === "automation_definition" &&
+      !hasPositiveResultSignal(sourceRef)
+    ) {
+      return
+    }
+
     const productStatus = getScheduledTaskProductStatus(task)
     const hasFailure =
       productStatus.key === "needs_attention" || statusIncludes(status, FAILURE_STATUS_TOKENS)

--- a/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-status.ts
+++ b/apps/packages/ui/src/components/Option/ScheduledTasks/scheduled-task-status.ts
@@ -1,6 +1,11 @@
 import type { ScheduledTask } from "@/services/scheduled-tasks-control-plane"
 import { BLOCKED_STATE_LABEL } from "@/design-system"
 import type { BadgeVariant } from "@/components/ui/primitives"
+import {
+  getAutomationDefinitionFamilyLabel,
+  getAutomationDefinitionProductStatus,
+  isAutomationDefinitionTask
+} from "./scheduled-task-automation-status"
 
 export type ScheduledTaskStatusTone =
   | "success"
@@ -16,6 +21,7 @@ export type ScheduledTaskStatusKey =
   | "waiting"
   | "found_results"
   | "paused"
+  | "archived"
   | "disabled"
   | "draft"
   | "completed"
@@ -45,6 +51,7 @@ type ScheduledTaskStatusInput =
 
 type ScheduledTaskTypeInput = {
   primitive?: unknown
+  source_ref?: Record<string, unknown>
 }
 
 type WatchlistTaskLinkInput =
@@ -194,6 +201,10 @@ const hasPositiveResultSignal = (sourceRef: Record<string, unknown>): boolean =>
 export const getScheduledTaskProductStatus = (
   task: ScheduledTaskStatusInput
 ): ScheduledTaskProductStatus => {
+  if (isAutomationDefinitionTask(task)) {
+    return getAutomationDefinitionProductStatus(task)
+  }
+
   if (!task.enabled) {
     return {
       key: "disabled",
@@ -297,6 +308,10 @@ export const getScheduledTaskProductStatus = (
 }
 
 export const getScheduledTaskTypeLabel = (task: ScheduledTaskTypeInput): string => {
+  if (task.primitive === "automation_definition") {
+    return getAutomationDefinitionFamilyLabel(task)
+  }
+
   switch (task.primitive) {
     case "reminder_task":
       return "Reminder"

--- a/apps/packages/ui/src/services/__tests__/scheduled-tasks-control-plane.test.ts
+++ b/apps/packages/ui/src/services/__tests__/scheduled-tasks-control-plane.test.ts
@@ -9,12 +9,20 @@ vi.mock("@/services/background-proxy", () => ({
 }))
 
 import {
+  archiveScheduledTaskDefinition,
+  createScheduledTaskPreview,
   createScheduledTaskReminder,
   deleteScheduledTaskReminder,
+  getScheduledTaskCapabilities,
+  getScheduledTaskDefinition,
   getScheduledTask,
+  listScheduledTaskDefinitionAudit,
+  listScheduledTaskDefinitions,
   listScheduledTasks,
+  pauseScheduledTaskDefinition,
   updateScheduledTaskReminder,
   type CreateScheduledTaskReminderPayload,
+  type ScheduledTaskPreviewCreateRequest,
   type UpdateScheduledTaskReminderPayload
 } from "@/services/scheduled-tasks-control-plane"
 
@@ -170,6 +178,108 @@ describe("scheduled-tasks control-plane contract", () => {
         } as unknown as UpdateScheduledTaskReminderPayload
       )
     ).rejects.toThrow("title cannot be null")
+
+    expect(mocks.bgRequest).not.toHaveBeenCalled()
+  })
+
+  it("fetches automation capabilities from the capabilities endpoint", async () => {
+    mocks.bgRequest.mockResolvedValue({ items: [] })
+
+    await getScheduledTaskCapabilities()
+
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "GET",
+        path: "/api/v1/scheduled-tasks/capabilities"
+      })
+    )
+  })
+
+  it("creates automation previews with body and optional idempotency header", async () => {
+    const payload: ScheduledTaskPreviewCreateRequest = {
+      family: "recurring_question",
+      mode: "create",
+      name: "Track answer",
+      schedule: { kind: "cron", cron: "0 9 * * *" }
+    }
+    mocks.bgRequest.mockResolvedValue({ id: "preview_1" })
+
+    await createScheduledTaskPreview(payload, { idempotencyKey: "preview-key-1" })
+
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/v1/scheduled-tasks/previews",
+        body: payload,
+        headers: { "Idempotency-Key": "preview-key-1" }
+      })
+    )
+  })
+
+  it("encodes automation definition list query parameters", async () => {
+    mocks.bgRequest.mockResolvedValue({ items: [], total: 0 })
+
+    await listScheduledTaskDefinitions({
+      limit: 25,
+      offset: 10,
+      family: "agent_task",
+      lifecycle: "paused",
+      q: "agent task"
+    })
+
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "GET",
+        path: "/api/v1/scheduled-tasks/definitions?limit=25&offset=10&family=agent_task&lifecycle=paused&q=agent+task"
+      })
+    )
+  })
+
+  it("normalizes projected automation ids for lifecycle definition routes", async () => {
+    mocks.bgRequest.mockResolvedValue({ id: "def_1" })
+
+    await pauseScheduledTaskDefinition("automation_definition:def_1", {
+      idempotencyKey: "pause-key-1"
+    })
+
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/v1/scheduled-tasks/definitions/def_1/pause",
+        headers: { "Idempotency-Key": "pause-key-1" }
+      })
+    )
+  })
+
+  it("normalizes raw and projected automation ids for detail and audit routes", async () => {
+    mocks.bgRequest.mockResolvedValue({ id: "def_1" })
+
+    await getScheduledTaskDefinition("def_1")
+    await listScheduledTaskDefinitionAudit("automation_definition:def_1", {
+      limit: 10,
+      event_type: "paused"
+    })
+
+    expect(mocks.bgRequest).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        method: "GET",
+        path: "/api/v1/scheduled-tasks/definitions/def_1"
+      })
+    )
+    expect(mocks.bgRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        method: "GET",
+        path: "/api/v1/scheduled-tasks/definitions/def_1/audit?limit=10&event_type=paused"
+      })
+    )
+  })
+
+  it("rejects wrong projected primitive prefixes before definition mutations", async () => {
+    await expect(
+      archiveScheduledTaskDefinition("watchlist_job:def_1")
+    ).rejects.toThrow("Definition mutations require an automation_definition id")
 
     expect(mocks.bgRequest).not.toHaveBeenCalled()
   })

--- a/apps/packages/ui/src/services/__tests__/scheduled-tasks-control-plane.test.ts
+++ b/apps/packages/ui/src/services/__tests__/scheduled-tasks-control-plane.test.ts
@@ -283,4 +283,12 @@ describe("scheduled-tasks control-plane contract", () => {
 
     expect(mocks.bgRequest).not.toHaveBeenCalled()
   })
+
+  it("rejects empty projected automation ids before definition mutations", async () => {
+    await expect(
+      pauseScheduledTaskDefinition("automation_definition:")
+    ).rejects.toThrow("definitionId is required")
+
+    expect(mocks.bgRequest).not.toHaveBeenCalled()
+  })
 })

--- a/apps/packages/ui/src/services/scheduled-tasks-control-plane.ts
+++ b/apps/packages/ui/src/services/scheduled-tasks-control-plane.ts
@@ -318,7 +318,11 @@ const normalizeAutomationDefinitionMutationId = (definitionId: string): string =
     throw new Error("definitionId is required")
   }
   if (normalized.startsWith("automation_definition:")) {
-    return normalized.slice("automation_definition:".length)
+    const stripped = normalized.slice("automation_definition:".length).trim()
+    if (!stripped) {
+      throw new Error("definitionId is required")
+    }
+    return stripped
   }
   if (normalized.includes(":")) {
     throw new Error("Definition mutations require an automation_definition id")

--- a/apps/packages/ui/src/services/scheduled-tasks-control-plane.ts
+++ b/apps/packages/ui/src/services/scheduled-tasks-control-plane.ts
@@ -5,9 +5,42 @@
 import { bgRequest } from "@/services/background-proxy"
 import { toAllowedPath } from "@/services/tldw/path-utils"
 
-export type ScheduledTaskPrimitive = "reminder_task" | "watchlist_job"
+export type ScheduledTaskPrimitive =
+  | "reminder_task"
+  | "watchlist_job"
+  | "automation_definition"
 export type ScheduledTaskEditMode = "native" | "external"
 export type ReminderScheduleKind = "one_time" | "recurring"
+export type ScheduledTaskAutomationFamily = "recurring_question" | "agent_task"
+export type ScheduledTaskAutomationActionStatus =
+  | "available"
+  | "unavailable"
+  | "planned"
+  | "disabled"
+export type ScheduledTaskAutomationFamilyAvailability =
+  | "available"
+  | "planned"
+  | "unavailable"
+  | "degraded"
+export type ScheduledTaskPreviewMode = "create" | "update"
+export type ScheduledTaskPreviewStatus = "valid" | "invalid" | "expired" | "consumed"
+export type ScheduledTaskDefinitionLifecycle =
+  | "configured"
+  | "paused"
+  | "archived"
+  | "disabled"
+export type ScheduledTaskDefinitionCreateLifecycle = "configured" | "paused"
+export type ScheduledTaskDefinitionHealth =
+  | "ready"
+  | "execution_unavailable"
+  | "capability_unavailable"
+  | "needs_attention"
+  | "permission_required"
+export type ScheduledTaskDefinitionDisabledLockKind =
+  | "none"
+  | "admin"
+  | "security"
+  | "system"
 
 export interface ScheduledTask {
   id: string
@@ -36,6 +69,152 @@ export interface ScheduledTaskDeleteResponse {
   deleted: boolean
 }
 
+export interface ScheduledTaskActionCapability {
+  status: ScheduledTaskAutomationActionStatus
+  reason?: string | null
+  required_permissions: string[]
+}
+
+export interface ScheduledTaskAutomationCapability {
+  family: ScheduledTaskAutomationFamily
+  family_availability: ScheduledTaskAutomationFamilyAvailability
+  actions: Record<string, ScheduledTaskActionCapability>
+  missing_dependencies: string[]
+  related_capabilities: Record<string, unknown>
+  reason?: string | null
+  schema_version: string
+}
+
+export interface ScheduledTaskAutomationCapabilitiesResponse {
+  items: ScheduledTaskAutomationCapability[]
+}
+
+export interface ScheduledTaskPreviewCreateRequest {
+  mode?: ScheduledTaskPreviewMode
+  family: ScheduledTaskAutomationFamily
+  definition_id?: string | null
+  definition_version?: number | null
+  name?: string | null
+  description?: string | null
+  config?: Record<string, unknown>
+  input?: Record<string, unknown>
+  schedule?: Record<string, unknown>
+  visibility_policy?: Record<string, unknown>
+  notification_policy?: Record<string, unknown>
+  approval_policy?: Record<string, unknown>
+}
+
+export interface ScheduledTaskPreviewResponse {
+  id: string
+  owner_id?: string | null
+  mode: ScheduledTaskPreviewMode
+  family: ScheduledTaskAutomationFamily
+  definition_id?: string | null
+  definition_version?: number | null
+  status: ScheduledTaskPreviewStatus
+  payload_hash?: string | null
+  normalized_config: Record<string, unknown>
+  validation_errors: Record<string, unknown>[]
+  warnings: Record<string, unknown>[]
+  risk_class?: string | null
+  visibility_policy: Record<string, unknown>
+  schedule_preview: Record<string, unknown>
+  redaction_policy: Record<string, unknown>
+  expires_at?: string | null
+  created_by?: string | null
+  created_at?: string | null
+  consumed_at?: string | null
+  created_definition_id?: string | null
+}
+
+export interface ScheduledTaskPreviewListResponse {
+  items: ScheduledTaskPreviewResponse[]
+  total: number
+  limit: number
+  offset: number
+  has_more: boolean
+  next_offset?: number | null
+}
+
+export interface ScheduledTaskDefinitionCreateRequest {
+  preview_id: string
+  initial_lifecycle?: ScheduledTaskDefinitionCreateLifecycle
+}
+
+export interface ScheduledTaskDefinitionUpdateRequest {
+  preview_id: string
+}
+
+export interface ScheduledTaskDefinitionResponse {
+  id: string
+  owner_id?: string | null
+  version: number
+  family: ScheduledTaskAutomationFamily
+  name: string
+  description?: string | null
+  lifecycle: ScheduledTaskDefinitionLifecycle
+  health: ScheduledTaskDefinitionHealth
+  disabled_lock_kind?: ScheduledTaskDefinitionDisabledLockKind | null
+  disabled_reason?: string | null
+  schedule: Record<string, unknown>
+  input: Record<string, unknown>
+  config: Record<string, unknown>
+  visibility_policy: Record<string, unknown>
+  notification_policy: Record<string, unknown>
+  approval_policy: Record<string, unknown>
+  preview_id?: string | null
+  created_by?: string | null
+  updated_by?: string | null
+  created_at?: string | null
+  updated_at?: string | null
+  archived_at?: string | null
+}
+
+export interface ScheduledTaskDefinitionListResponse {
+  items: ScheduledTaskDefinitionResponse[]
+  total: number
+  limit: number
+  offset: number
+  has_more: boolean
+  next_offset?: number | null
+}
+
+export interface ScheduledTaskDuplicateRequest {
+  name?: string | null
+  description?: string | null
+}
+
+export interface ScheduledTaskAuditEventResponse {
+  id: string
+  definition_id: string
+  event_type: string
+  actor?: string | null
+  summary?: string | null
+  before?: Record<string, unknown> | null
+  after?: Record<string, unknown> | null
+  created_at?: string | null
+  request_id?: string | null
+  idempotency_key?: string | null
+}
+
+export interface ScheduledTaskAuditListResponse {
+  items: ScheduledTaskAuditEventResponse[]
+  total: number
+  limit: number
+  offset: number
+  has_more: boolean
+  next_offset?: number | null
+}
+
+export interface ScheduledTaskErrorEnvelope {
+  code: string
+  message: string
+  details: Record<string, unknown>
+  field_errors: Record<string, unknown>[]
+  retryable: boolean
+  correlation_id?: string | null
+}
+
 export interface CreateScheduledTaskReminderPayload {
   title: string
   body?: string | null
@@ -60,6 +239,63 @@ export interface UpdateScheduledTaskReminderPayload {
   link_id?: string | null
   link_url?: string | null
   enabled?: boolean
+}
+
+export interface ScheduledTaskPreviewListParams {
+  limit?: number
+  offset?: number
+  family?: ScheduledTaskAutomationFamily | string | null
+  mode?: ScheduledTaskPreviewMode | string | null
+  status?: ScheduledTaskPreviewStatus | string | null
+  definition_id?: string | null
+  expired?: boolean | null
+}
+
+export interface ScheduledTaskDefinitionListParams {
+  limit?: number
+  offset?: number
+  family?: ScheduledTaskAutomationFamily | string | null
+  lifecycle?: ScheduledTaskDefinitionLifecycle | string | null
+  health?: ScheduledTaskDefinitionHealth | string | null
+  visibility_policy?: string | null
+  q?: string | null
+  created_from?: string | null
+  created_to?: string | null
+}
+
+export interface ScheduledTaskAuditListParams {
+  limit?: number
+  offset?: number
+  event_type?: string | null
+  actor?: string | null
+  created_from?: string | null
+  created_to?: string | null
+  idempotency_key?: string | null
+  request_id?: string | null
+}
+
+export interface ScheduledTaskMutationOptions {
+  idempotencyKey?: string | null
+}
+
+const withIdempotency = (
+  key?: string | null
+): Record<string, string> | undefined => {
+  const trimmed = typeof key === "string" ? key.trim() : ""
+  return trimmed ? { "Idempotency-Key": trimmed } : undefined
+}
+
+const buildQuery = (params?: Record<string, unknown>): string => {
+  if (!params) return ""
+
+  const query = new URLSearchParams()
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null) return
+    query.set(key, String(value))
+  })
+
+  const queryString = query.toString()
+  return queryString ? `?${queryString}` : ""
 }
 
 const normalizeReminderTaskMutationId = (taskId: string): string => {
@@ -132,5 +368,159 @@ export async function deleteScheduledTaskReminder(taskId: string): Promise<Sched
       `/api/v1/scheduled-tasks/reminders/${encodeURIComponent(normalizeReminderTaskMutationId(taskId))}`
     ),
     method: "DELETE"
+  })
+}
+
+export async function getScheduledTaskCapabilities(): Promise<ScheduledTaskAutomationCapabilitiesResponse> {
+  return await bgRequest<ScheduledTaskAutomationCapabilitiesResponse>({
+    path: toAllowedPath("/api/v1/scheduled-tasks/capabilities"),
+    method: "GET"
+  })
+}
+
+export async function createScheduledTaskPreview(
+  payload: ScheduledTaskPreviewCreateRequest,
+  options?: ScheduledTaskMutationOptions
+): Promise<ScheduledTaskPreviewResponse> {
+  return await bgRequest<ScheduledTaskPreviewResponse>({
+    path: toAllowedPath("/api/v1/scheduled-tasks/previews"),
+    method: "POST",
+    body: payload,
+    headers: withIdempotency(options?.idempotencyKey)
+  })
+}
+
+export async function listScheduledTaskPreviews(
+  params?: ScheduledTaskPreviewListParams
+): Promise<ScheduledTaskPreviewListResponse> {
+  return await bgRequest<ScheduledTaskPreviewListResponse>({
+    path: toAllowedPath(`/api/v1/scheduled-tasks/previews${buildQuery(params)}`),
+    method: "GET"
+  })
+}
+
+export async function getScheduledTaskPreview(
+  previewId: string
+): Promise<ScheduledTaskPreviewResponse> {
+  return await bgRequest<ScheduledTaskPreviewResponse>({
+    path: toAllowedPath(
+      `/api/v1/scheduled-tasks/previews/${encodeURIComponent(previewId)}`
+    ),
+    method: "GET"
+  })
+}
+
+export async function createScheduledTaskDefinition(
+  payload: ScheduledTaskDefinitionCreateRequest,
+  options?: ScheduledTaskMutationOptions
+): Promise<ScheduledTaskDefinitionResponse> {
+  return await bgRequest<ScheduledTaskDefinitionResponse>({
+    path: toAllowedPath("/api/v1/scheduled-tasks/definitions"),
+    method: "POST",
+    body: payload,
+    headers: withIdempotency(options?.idempotencyKey)
+  })
+}
+
+export async function listScheduledTaskDefinitions(
+  params?: ScheduledTaskDefinitionListParams
+): Promise<ScheduledTaskDefinitionListResponse> {
+  return await bgRequest<ScheduledTaskDefinitionListResponse>({
+    path: toAllowedPath(`/api/v1/scheduled-tasks/definitions${buildQuery(params)}`),
+    method: "GET"
+  })
+}
+
+export async function getScheduledTaskDefinition(
+  definitionId: string
+): Promise<ScheduledTaskDefinitionResponse> {
+  return await bgRequest<ScheduledTaskDefinitionResponse>({
+    path: toAllowedPath(
+      `/api/v1/scheduled-tasks/definitions/${encodeURIComponent(definitionId)}`
+    ),
+    method: "GET"
+  })
+}
+
+export async function updateScheduledTaskDefinition(
+  definitionId: string,
+  payload: ScheduledTaskDefinitionUpdateRequest,
+  options?: ScheduledTaskMutationOptions
+): Promise<ScheduledTaskDefinitionResponse> {
+  return await bgRequest<ScheduledTaskDefinitionResponse>({
+    path: toAllowedPath(
+      `/api/v1/scheduled-tasks/definitions/${encodeURIComponent(definitionId)}`
+    ),
+    method: "PATCH",
+    body: payload,
+    headers: withIdempotency(options?.idempotencyKey)
+  })
+}
+
+export async function pauseScheduledTaskDefinition(
+  definitionId: string,
+  options?: ScheduledTaskMutationOptions
+): Promise<ScheduledTaskDefinitionResponse> {
+  return await bgRequest<ScheduledTaskDefinitionResponse>({
+    path: toAllowedPath(
+      `/api/v1/scheduled-tasks/definitions/${encodeURIComponent(definitionId)}/pause`
+    ),
+    method: "POST",
+    headers: withIdempotency(options?.idempotencyKey)
+  })
+}
+
+export async function resumeScheduledTaskDefinition(
+  definitionId: string,
+  options?: ScheduledTaskMutationOptions
+): Promise<ScheduledTaskDefinitionResponse> {
+  return await bgRequest<ScheduledTaskDefinitionResponse>({
+    path: toAllowedPath(
+      `/api/v1/scheduled-tasks/definitions/${encodeURIComponent(definitionId)}/resume`
+    ),
+    method: "POST",
+    headers: withIdempotency(options?.idempotencyKey)
+  })
+}
+
+export async function archiveScheduledTaskDefinition(
+  definitionId: string,
+  options?: ScheduledTaskMutationOptions
+): Promise<ScheduledTaskDefinitionResponse> {
+  return await bgRequest<ScheduledTaskDefinitionResponse>({
+    path: toAllowedPath(
+      `/api/v1/scheduled-tasks/definitions/${encodeURIComponent(definitionId)}/archive`
+    ),
+    method: "POST",
+    headers: withIdempotency(options?.idempotencyKey)
+  })
+}
+
+export async function duplicateScheduledTaskDefinition(
+  definitionId: string,
+  payload: ScheduledTaskDuplicateRequest = {},
+  options?: ScheduledTaskMutationOptions
+): Promise<ScheduledTaskDefinitionResponse> {
+  return await bgRequest<ScheduledTaskDefinitionResponse>({
+    path: toAllowedPath(
+      `/api/v1/scheduled-tasks/definitions/${encodeURIComponent(definitionId)}/duplicate`
+    ),
+    method: "POST",
+    body: payload,
+    headers: withIdempotency(options?.idempotencyKey)
+  })
+}
+
+export async function listScheduledTaskDefinitionAudit(
+  definitionId: string,
+  params?: ScheduledTaskAuditListParams
+): Promise<ScheduledTaskAuditListResponse> {
+  return await bgRequest<ScheduledTaskAuditListResponse>({
+    path: toAllowedPath(
+      `/api/v1/scheduled-tasks/definitions/${encodeURIComponent(
+        definitionId
+      )}/audit${buildQuery(params)}`
+    ),
+    method: "GET"
   })
 }

--- a/apps/packages/ui/src/services/scheduled-tasks-control-plane.ts
+++ b/apps/packages/ui/src/services/scheduled-tasks-control-plane.ts
@@ -312,6 +312,20 @@ const normalizeReminderTaskMutationId = (taskId: string): string => {
   return normalized
 }
 
+const normalizeAutomationDefinitionMutationId = (definitionId: string): string => {
+  const normalized = String(definitionId || "").trim()
+  if (!normalized) {
+    throw new Error("definitionId is required")
+  }
+  if (normalized.startsWith("automation_definition:")) {
+    return normalized.slice("automation_definition:".length)
+  }
+  if (normalized.includes(":")) {
+    throw new Error("Definition mutations require an automation_definition id")
+  }
+  return normalized
+}
+
 const assertReminderUpdatePayload = (payload: Record<string, unknown>): void => {
   if (payload.title === null) {
     throw new Error("title cannot be null")
@@ -434,9 +448,10 @@ export async function listScheduledTaskDefinitions(
 export async function getScheduledTaskDefinition(
   definitionId: string
 ): Promise<ScheduledTaskDefinitionResponse> {
+  const normalizedDefinitionId = normalizeAutomationDefinitionMutationId(definitionId)
   return await bgRequest<ScheduledTaskDefinitionResponse>({
     path: toAllowedPath(
-      `/api/v1/scheduled-tasks/definitions/${encodeURIComponent(definitionId)}`
+      `/api/v1/scheduled-tasks/definitions/${encodeURIComponent(normalizedDefinitionId)}`
     ),
     method: "GET"
   })
@@ -447,9 +462,10 @@ export async function updateScheduledTaskDefinition(
   payload: ScheduledTaskDefinitionUpdateRequest,
   options?: ScheduledTaskMutationOptions
 ): Promise<ScheduledTaskDefinitionResponse> {
+  const normalizedDefinitionId = normalizeAutomationDefinitionMutationId(definitionId)
   return await bgRequest<ScheduledTaskDefinitionResponse>({
     path: toAllowedPath(
-      `/api/v1/scheduled-tasks/definitions/${encodeURIComponent(definitionId)}`
+      `/api/v1/scheduled-tasks/definitions/${encodeURIComponent(normalizedDefinitionId)}`
     ),
     method: "PATCH",
     body: payload,
@@ -461,9 +477,12 @@ export async function pauseScheduledTaskDefinition(
   definitionId: string,
   options?: ScheduledTaskMutationOptions
 ): Promise<ScheduledTaskDefinitionResponse> {
+  const normalizedDefinitionId = normalizeAutomationDefinitionMutationId(definitionId)
   return await bgRequest<ScheduledTaskDefinitionResponse>({
     path: toAllowedPath(
-      `/api/v1/scheduled-tasks/definitions/${encodeURIComponent(definitionId)}/pause`
+      `/api/v1/scheduled-tasks/definitions/${encodeURIComponent(
+        normalizedDefinitionId
+      )}/pause`
     ),
     method: "POST",
     headers: withIdempotency(options?.idempotencyKey)
@@ -474,9 +493,12 @@ export async function resumeScheduledTaskDefinition(
   definitionId: string,
   options?: ScheduledTaskMutationOptions
 ): Promise<ScheduledTaskDefinitionResponse> {
+  const normalizedDefinitionId = normalizeAutomationDefinitionMutationId(definitionId)
   return await bgRequest<ScheduledTaskDefinitionResponse>({
     path: toAllowedPath(
-      `/api/v1/scheduled-tasks/definitions/${encodeURIComponent(definitionId)}/resume`
+      `/api/v1/scheduled-tasks/definitions/${encodeURIComponent(
+        normalizedDefinitionId
+      )}/resume`
     ),
     method: "POST",
     headers: withIdempotency(options?.idempotencyKey)
@@ -487,9 +509,12 @@ export async function archiveScheduledTaskDefinition(
   definitionId: string,
   options?: ScheduledTaskMutationOptions
 ): Promise<ScheduledTaskDefinitionResponse> {
+  const normalizedDefinitionId = normalizeAutomationDefinitionMutationId(definitionId)
   return await bgRequest<ScheduledTaskDefinitionResponse>({
     path: toAllowedPath(
-      `/api/v1/scheduled-tasks/definitions/${encodeURIComponent(definitionId)}/archive`
+      `/api/v1/scheduled-tasks/definitions/${encodeURIComponent(
+        normalizedDefinitionId
+      )}/archive`
     ),
     method: "POST",
     headers: withIdempotency(options?.idempotencyKey)
@@ -501,9 +526,12 @@ export async function duplicateScheduledTaskDefinition(
   payload: ScheduledTaskDuplicateRequest = {},
   options?: ScheduledTaskMutationOptions
 ): Promise<ScheduledTaskDefinitionResponse> {
+  const normalizedDefinitionId = normalizeAutomationDefinitionMutationId(definitionId)
   return await bgRequest<ScheduledTaskDefinitionResponse>({
     path: toAllowedPath(
-      `/api/v1/scheduled-tasks/definitions/${encodeURIComponent(definitionId)}/duplicate`
+      `/api/v1/scheduled-tasks/definitions/${encodeURIComponent(
+        normalizedDefinitionId
+      )}/duplicate`
     ),
     method: "POST",
     body: payload,
@@ -515,10 +543,11 @@ export async function listScheduledTaskDefinitionAudit(
   definitionId: string,
   params?: ScheduledTaskAuditListParams
 ): Promise<ScheduledTaskAuditListResponse> {
+  const normalizedDefinitionId = normalizeAutomationDefinitionMutationId(definitionId)
   return await bgRequest<ScheduledTaskAuditListResponse>({
     path: toAllowedPath(
       `/api/v1/scheduled-tasks/definitions/${encodeURIComponent(
-        definitionId
+        normalizedDefinitionId
       )}/audit${buildQuery(params)}`
     ),
     method: "GET"

--- a/backlog/tasks/task-2349 - Design-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
+++ b/backlog/tasks/task-2349 - Design-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2349
 title: Design Scheduled Tasks Phase 4B backend API foundation
-status: In Progress
+status: Done
 assignee: []
 created_date: ''
 updated_date: 2026-06-09 23:47
@@ -28,9 +28,9 @@ Write the Scheduled Tasks Phase 4B backend/API foundation design spec for API-ow
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Phase 4B design spec captures approved scope: Scheduled Tasks-owned persisted definitions, durable previews, lifecycle management, audit, and WebUI reference-client behavior without execution.
-- [ ] #2 Spec review loop findings are addressed or surfaced for user review.
-- [ ] #3 Spec document is committed on an isolated worktree branch.
+- [x] #1 Phase 4B design spec captures approved scope: Scheduled Tasks-owned persisted definitions, durable previews, lifecycle management, audit, and WebUI reference-client behavior without execution.
+- [x] #2 Spec review loop findings are addressed or surfaced for user review.
+- [x] #3 Spec document is committed on an isolated worktree branch.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -41,6 +41,7 @@ Created isolated worktree branch codex/scheduled-tasks-phase4b-api-foundation-sp
 Ran three spec-review subagent passes. Passes 1 and 2 found blocking/important issues and the spec was revised. Pass 3 found two remaining important issues; both were patched locally and recorded in the Spec Review section.
 Spec status is Needs User Review because the review workflow capped at three subagent iterations and the final corrections need human review before implementation planning.
 User-requested self-review found additional implementation-risk gaps: owner scoping in the data model/idempotency contract, health precedence, duplicate audit determinism, disabled-source duplicate guardrails, and normalized `automation_definition` status mapping for the existing WebUI list model. The spec was revised and the addendum was recorded in the Spec Review section.
+Implementation-plan review added `disabled_lock_kind` and `disabled_reason` to make the disabled duplicate guardrail implementable.
 Verification: git diff --check HEAD^ HEAD passed after the amended self-review commit; git status --short --branch showed the worktree clean and ahead of origin/dev by one commit.
 Bandit: not run because this task touched only documentation and Backlog metadata, no Python/code paths.
 <!-- SECTION:NOTES:END -->
@@ -48,14 +49,15 @@ Bandit: not run because this task touched only documentation and Backlog metadat
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed and reviewed the Phase 4B backend/API foundation design spec. The spec is approved for implementation planning.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2349 - Design-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
+++ b/backlog/tasks/task-2349 - Design-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
@@ -1,0 +1,61 @@
+---
+id: TASK-2349
+title: Design Scheduled Tasks Phase 4B backend API foundation
+status: In Progress
+assignee: []
+created_date: ''
+updated_date: 2026-06-09 23:47
+labels:
+- scheduled-tasks
+- api
+- design
+dependencies: []
+references:
+- Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase4-recurring-question-agent-task-api-contract-design.md
+documentation:
+- Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-design.md
+priority: high
+modified_files:
+- Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-design.md
+- backlog/tasks/task-2349 - Design-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write the Scheduled Tasks Phase 4B backend/API foundation design spec for API-owned Recurring Question and Agent Task definitions, durable previews, lifecycle management, audit, and WebUI reference-client behavior without execution.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Phase 4B design spec captures approved scope: Scheduled Tasks-owned persisted definitions, durable previews, lifecycle management, audit, and WebUI reference-client behavior without execution.
+- [ ] #2 Spec review loop findings are addressed or surfaced for user review.
+- [ ] #3 Spec document is committed on an isolated worktree branch.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Drafted the Phase 4B backend/API foundation spec from the approved brainstorming sections.
+Created isolated worktree branch codex/scheduled-tasks-phase4b-api-foundation-spec from origin/dev to avoid the dirty main checkout.
+Ran three spec-review subagent passes. Passes 1 and 2 found blocking/important issues and the spec was revised. Pass 3 found two remaining important issues; both were patched locally and recorded in the Spec Review section.
+Spec status is Needs User Review because the review workflow capped at three subagent iterations and the final corrections need human review before implementation planning.
+User-requested self-review found additional implementation-risk gaps: owner scoping in the data model/idempotency contract, health precedence, duplicate audit determinism, disabled-source duplicate guardrails, and normalized `automation_definition` status mapping for the existing WebUI list model. The spec was revised and the addendum was recorded in the Spec Review section.
+Verification: git diff --check HEAD^ HEAD passed after the amended self-review commit; git status --short --branch showed the worktree clean and ahead of origin/dev by one commit.
+Bandit: not run because this task touched only documentation and Backlog metadata, no Python/code paths.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2350 - Plan-Scheduled-Tasks-Phase-4B-backend-API-foundation-implementation.md
+++ b/backlog/tasks/task-2350 - Plan-Scheduled-Tasks-Phase-4B-backend-API-foundation-implementation.md
@@ -1,0 +1,58 @@
+---
+id: TASK-2350
+title: Plan Scheduled Tasks Phase 4B backend API foundation implementation
+status: Done
+labels:
+- scheduled-tasks
+- api
+- planning
+priority: high
+references:
+- TASK-2349
+documentation:
+- Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-design.md
+- Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
+modified_files:
+- Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write the Scheduled Tasks Phase 4B implementation plan for durable definitions, previews, lifecycle, audit, control-plane projection, and WebUI reference-client wiring from the approved backend/API foundation design spec.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Implementation plan covers approved Phase 4B scope without adding execution, Jobs enqueueing, Scheduler integration, RAG execution, ACP dispatch, notifications, or fake results.
+- [x] #2 Plan identifies concrete backend, storage, service, API, control-plane, frontend, and test files.
+- [x] #3 Plan includes task-by-task TDD steps with commands and expected outcomes.
+- [x] #4 Plan review findings are addressed or surfaced for user review.
+- [x] #5 Plan document and Backlog task are committed on the isolated worktree branch.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Drafted implementation plan from the approved Phase 4B backend/API foundation spec.
+Plan review pass 1 found gaps in Agent Task redaction coverage, idempotency coverage, disabled duplicate data-model support, and error-envelope mapping.
+Revised the plan and spec to add redaction sentinel tests, idempotency route coverage, `disabled_lock_kind`/`disabled_reason`, duplicate lock tests, and complete error-envelope requirements including `correlation_id`.
+Plan review pass 2 approved the revised plan and spec with no remaining blocking issues.
+Verification: git diff --check passed before commit; no code tests or Bandit were run because this task touched only docs and Backlog metadata.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed the Scheduled Tasks Phase 4B implementation plan and addressed plan-review findings. The plan is ready for execution handoff.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2351 - Implement-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
+++ b/backlog/tasks/task-2351 - Implement-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
@@ -37,6 +37,9 @@ Execute the reviewed Scheduled Tasks Phase 4B implementation plan: durable autom
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Implementation will follow `Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md` using subagent-driven development with TDD and review checkpoints per task.
+Task 1 completed in commit 8e2dd7b1fc: added automation schemas, route skeletons, capability service, primitive extension, and route/capability tests.
+Task 1 verification: focused pytest for `test_scheduled_task_automation_api.py` and `test_scheduled_tasks_control_plane.py` passed with 6 tests; touched-scope Bandit reported zero findings; git diff --check was clean.
+Task 1 review: spec-compliance reviewer approved; code-quality reviewer approved with one minor suggestion to add extra 501 skeleton assertions if useful before later endpoint wiring.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2351 - Implement-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
+++ b/backlog/tasks/task-2351 - Implement-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
@@ -46,6 +46,9 @@ Task 2 review: spec-compliance reviewer approved. Code-quality review initially 
 Task 3 completed across commits 3a10dd3723, 4ca66f690, and 126f93fb38: implemented preview validation, Agent Task redaction, definition create/update lifecycle, pause/resume/archive, duplicate, service idempotency replay/conflict behavior, and review-driven repository write transactions for atomic command units.
 Task 3 verification: service pytest passed with 26 tests; repository and API pytest passed with 21 tests; git diff --check and Bandit touched-scope scan passed in worker verification.
 Task 3 review: spec-compliance review initially found stale idempotency replay responses; worker fixed this with response snapshots. Code-quality review then found idempotency race and multi-step atomicity risks; worker fixed them with immediate write transactions and rollback/race coverage. Final spec and code-quality re-reviews approved.
+Task 4 completed across commits f3050f3c13, 688ce4c5e5, and b6d8caef1c: exposed preview, definition, lifecycle, duplicate, audit, idempotency, filter, and public error-envelope API endpoints with owner scoping and no execution behavior.
+Task 4 verification: endpoint/control-plane pytest passed with 34 tests; service/db pytest passed with 45 tests; targeted endpoint pytest passed with 30 tests; git diff --check and Bandit touched-scope scan passed in worker/reviewer verification.
+Task 4 review: spec-compliance review found a missing direct public `scheduled_task_definition_not_found` alias and worker fixed it. Code-quality review found audit request-id and datetime filter correctness issues and worker/coordinator fixed them. Final spec and code-quality re-reviews approved.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2351 - Implement-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
+++ b/backlog/tasks/task-2351 - Implement-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
@@ -43,6 +43,9 @@ Task 1 review: spec-compliance reviewer approved; code-quality reviewer approved
 Task 2 completed across commits 84a7007f37, d6f528ba1a, and cea06ef558: added the per-user SQLite repository, repository tests, and review-driven hardening for optimistic locking, preview ownership, single-use preview consumption, idempotency expiry/reuse, shared SQLite policy, strict JSON encoding, atomic create-from-preview, owner-checked update preview references, and owner-checked audit writes.
 Task 2 verification: repository pytest passed with 19 tests; formatting, py_compile, Bandit touched-scope scan, and git diff --check passed in the worker verification.
 Task 2 review: spec-compliance reviewer approved. Code-quality review initially found repository lifecycle/ownership issues; worker fixed them in two follow-up commits. Final code-quality re-review approved with no remaining issues.
+Task 3 completed across commits 3a10dd3723, 4ca66f690, and 126f93fb38: implemented preview validation, Agent Task redaction, definition create/update lifecycle, pause/resume/archive, duplicate, service idempotency replay/conflict behavior, and review-driven repository write transactions for atomic command units.
+Task 3 verification: service pytest passed with 26 tests; repository and API pytest passed with 21 tests; git diff --check and Bandit touched-scope scan passed in worker verification.
+Task 3 review: spec-compliance review initially found stale idempotency replay responses; worker fixed this with response snapshots. Code-quality review then found idempotency race and multi-step atomicity risks; worker fixed them with immediate write transactions and rollback/race coverage. Final spec and code-quality re-reviews approved.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2351 - Implement-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
+++ b/backlog/tasks/task-2351 - Implement-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
@@ -40,6 +40,9 @@ Implementation will follow `Docs/superpowers/plans/2026-06-09-scheduled-tasks-ph
 Task 1 completed in commit 8e2dd7b1fc: added automation schemas, route skeletons, capability service, primitive extension, and route/capability tests.
 Task 1 verification: focused pytest for `test_scheduled_task_automation_api.py` and `test_scheduled_tasks_control_plane.py` passed with 6 tests; touched-scope Bandit reported zero findings; git diff --check was clean.
 Task 1 review: spec-compliance reviewer approved; code-quality reviewer approved with one minor suggestion to add extra 501 skeleton assertions if useful before later endpoint wiring.
+Task 2 completed across commits 84a7007f37, d6f528ba1a, and cea06ef558: added the per-user SQLite repository, repository tests, and review-driven hardening for optimistic locking, preview ownership, single-use preview consumption, idempotency expiry/reuse, shared SQLite policy, strict JSON encoding, atomic create-from-preview, owner-checked update preview references, and owner-checked audit writes.
+Task 2 verification: repository pytest passed with 19 tests; formatting, py_compile, Bandit touched-scope scan, and git diff --check passed in the worker verification.
+Task 2 review: spec-compliance reviewer approved. Code-quality review initially found repository lifecycle/ownership issues; worker fixed them in two follow-up commits. Final code-quality re-review approved with no remaining issues.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2351 - Implement-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
+++ b/backlog/tasks/task-2351 - Implement-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
@@ -49,6 +49,9 @@ Task 3 review: spec-compliance review initially found stale idempotency replay r
 Task 4 completed across commits f3050f3c13, 688ce4c5e5, and b6d8caef1c: exposed preview, definition, lifecycle, duplicate, audit, idempotency, filter, and public error-envelope API endpoints with owner scoping and no execution behavior.
 Task 4 verification: endpoint/control-plane pytest passed with 34 tests; service/db pytest passed with 45 tests; targeted endpoint pytest passed with 30 tests; git diff --check and Bandit touched-scope scan passed in worker/reviewer verification.
 Task 4 review: spec-compliance review found a missing direct public `scheduled_task_definition_not_found` alias and worker fixed it. Code-quality review found audit request-id and datetime filter correctness issues and worker/coordinator fixed them. Final spec and code-quality re-reviews approved.
+Task 5 completed in commit 5f7f6cd632: projected automation definitions into the unified `/api/v1/scheduled-tasks` control-plane list/detail responses while preserving reminder and Watchlists behavior.
+Task 5 verification: control-plane pytest passed with 7 tests; automation API pytest passed with 30 tests; git diff --check and Bandit touched-scope scan passed in worker/reviewer verification.
+Task 5 review: spec-compliance reviewer approved. Code-quality reviewer approved with only residual optional coverage suggestions for disabled lifecycle and cross-user/missing detail behavior.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2351 - Implement-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
+++ b/backlog/tasks/task-2351 - Implement-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2351
 title: Implement Scheduled Tasks Phase 4B backend API foundation
-status: In Progress
+status: Done
 labels:
 - scheduled-tasks
 - api
@@ -24,13 +24,13 @@ Execute the reviewed Scheduled Tasks Phase 4B implementation plan: durable autom
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Capability, preview, definition, lifecycle, audit, idempotency, and projection backend APIs are implemented without execution.
-- [ ] #2 Agent Task raw message text is redacted from preview, definition, list/detail, audit, and persisted JSON by default.
-- [ ] #3 `/api/v1/scheduled-tasks` projects `automation_definition` rows without breaking reminder or Watchlists behavior.
-- [ ] #4 WebUI reference client can preview, create, inspect, edit, pause/resume, archive, and duplicate definitions using the API.
-- [ ] #5 Focused backend and frontend tests pass for the touched scope.
-- [ ] #6 Bandit passes for touched backend scope or any findings are fixed.
-- [ ] #7 No Jobs enqueueing, Scheduler integration, RAG execution, ACP dispatch, notifications, fake runs, fake results, or fake Home items are implemented.
+- [x] #1 Capability, preview, definition, lifecycle, audit, idempotency, and projection backend APIs are implemented without execution.
+- [x] #2 Agent Task raw message text is redacted from preview, definition, list/detail, audit, and persisted JSON by default.
+- [x] #3 `/api/v1/scheduled-tasks` projects `automation_definition` rows without breaking reminder or Watchlists behavior.
+- [x] #4 WebUI reference client can preview, create, inspect, edit, pause/resume, archive, and duplicate definitions using the API.
+- [x] #5 Focused backend and frontend tests pass for the touched scope.
+- [x] #6 Bandit passes for touched backend scope or any findings are fixed.
+- [x] #7 No Jobs enqueueing, Scheduler integration, RAG execution, ACP dispatch, notifications, fake runs, fake results, or fake Home items are implemented.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -58,20 +58,30 @@ Task 6 review: spec-compliance reviewer approved. Code-quality review found proj
 Task 7 completed across commits 4f3924e128, 18cd196bb5, and 27afbc9dc2: wired the WebUI reference client for automation definition preview/create/update, lifecycle actions, duplicate, detail/audit display, real-results-only row actions, and API error display without execution behavior.
 Task 7 verification: focused Scheduled Tasks Vitest suite passed with 93 tests; git diff --check and touched-scope Bandit scans passed in worker/reviewer verification.
 Task 7 review: spec-compliance review initially found missing update reachability and row-level fake Results actions; worker fixed both. Code-quality review found schedule/agent_ref contract, stale preview, JSON validation, and API error parsing issues; worker fixed them. Final spec and code-quality re-reviews approved.
+Task 8 verification completed: focused backend pytest passed with 82 tests; focused Scheduled Tasks Vitest suite passed with 102 tests after aligning one slow form test with the existing long timeout; touched-scope Bandit reported 0 errors and 0 findings at `/tmp/bandit_scheduled_tasks_phase4b.json`; OpenAPI import confirmed scheduled task automation paths are present after adding `scheduled-tasks` to the default `[API-Routes].enable` list; no-execution scan found only the unsupported `execute` action capability and existing APScheduler reminder utility tests.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Scheduled Tasks Phase 4B backend API foundation and reference WebUI client. The work adds durable automation previews and definitions, lifecycle/audit/idempotency APIs, capability discovery, `automation_definition` projection into `/api/v1/scheduled-tasks`, Agent Task redaction safeguards, and WebUI preview/create/edit/lifecycle flows that clearly show execution is unavailable. Default config now enables the scheduled-tasks control-plane route so the main API exposes the new paths without a manual route-policy override.
 
+Verification:
+- Backend: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_task_automation_db.py tldw_Server_API/tests/Notifications/test_scheduled_task_automation_service.py tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py tldw_Server_API/tests/Notifications/test_scheduled_tasks_control_plane.py -q` passed with 82 tests.
+- Frontend: `bunx vitest run` on the focused Scheduled Tasks test suite passed with 102 tests.
+- Security: Bandit on touched backend scope reported 0 errors and 0 findings in `/tmp/bandit_scheduled_tasks_phase4b.json`.
+- OpenAPI: app import with `SINGLE_USER_API_KEY` configured confirmed `/api/v1/scheduled-tasks/capabilities`, `/api/v1/scheduled-tasks/previews`, and `/api/v1/scheduled-tasks/definitions` are present.
+- Execution boundary: scan found no Jobs enqueueing, Scheduler registration, run-now/manual-run handling, RAG execution, ACP dispatch, notifications, fake runs, fake results, or fake Home surfacing.
+
+Known skips/blockers: none. Existing unrelated untracked Watchlists template files remain intentionally untouched.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2351 - Implement-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
+++ b/backlog/tasks/task-2351 - Implement-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
@@ -55,6 +55,9 @@ Task 5 review: spec-compliance reviewer approved. Code-quality reviewer approved
 Task 6 completed across commits e27c3ec169, e269e62004, and a0a2485fec: added frontend automation client types/methods, automation definition status/type helpers, projected-id normalization, idempotency header support, and backend-aligned status handling.
 Task 6 verification: targeted Vitest helper/client suite passed with 34 tests; git diff --check passed in worker/reviewer verification.
 Task 6 review: spec-compliance reviewer approved. Code-quality review found projected-id normalization, unknown-status, and client-method coverage gaps; worker fixed them and aligned helper statuses with backend projection. Final spec and code-quality re-reviews approved.
+Task 7 completed across commits 4f3924e128, 18cd196bb5, and 27afbc9dc2: wired the WebUI reference client for automation definition preview/create/update, lifecycle actions, duplicate, detail/audit display, real-results-only row actions, and API error display without execution behavior.
+Task 7 verification: focused Scheduled Tasks Vitest suite passed with 93 tests; git diff --check and touched-scope Bandit scans passed in worker/reviewer verification.
+Task 7 review: spec-compliance review initially found missing update reachability and row-level fake Results actions; worker fixed both. Code-quality review found schedule/agent_ref contract, stale preview, JSON validation, and API error parsing issues; worker fixed them. Final spec and code-quality re-reviews approved.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2351 - Implement-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
+++ b/backlog/tasks/task-2351 - Implement-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
@@ -52,6 +52,9 @@ Task 4 review: spec-compliance review found a missing direct public `scheduled_t
 Task 5 completed in commit 5f7f6cd632: projected automation definitions into the unified `/api/v1/scheduled-tasks` control-plane list/detail responses while preserving reminder and Watchlists behavior.
 Task 5 verification: control-plane pytest passed with 7 tests; automation API pytest passed with 30 tests; git diff --check and Bandit touched-scope scan passed in worker/reviewer verification.
 Task 5 review: spec-compliance reviewer approved. Code-quality reviewer approved with only residual optional coverage suggestions for disabled lifecycle and cross-user/missing detail behavior.
+Task 6 completed across commits e27c3ec169, e269e62004, and a0a2485fec: added frontend automation client types/methods, automation definition status/type helpers, projected-id normalization, idempotency header support, and backend-aligned status handling.
+Task 6 verification: targeted Vitest helper/client suite passed with 34 tests; git diff --check passed in worker/reviewer verification.
+Task 6 review: spec-compliance reviewer approved. Code-quality review found projected-id normalization, unknown-status, and client-method coverage gaps; worker fixed them and aligned helper statuses with backend projection. Final spec and code-quality re-reviews approved.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2351 - Implement-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
+++ b/backlog/tasks/task-2351 - Implement-Scheduled-Tasks-Phase-4B-backend-API-foundation.md
@@ -1,0 +1,56 @@
+---
+id: TASK-2351
+title: Implement Scheduled Tasks Phase 4B backend API foundation
+status: In Progress
+labels:
+- scheduled-tasks
+- api
+- backend
+- frontend
+priority: high
+references:
+- TASK-2350
+- TASK-2349
+documentation:
+- Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md
+- Docs/superpowers/specs/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Execute the reviewed Scheduled Tasks Phase 4B implementation plan: durable automation definitions, previews, lifecycle, audit, idempotency, control-plane projection, and reference WebUI client without execution.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Capability, preview, definition, lifecycle, audit, idempotency, and projection backend APIs are implemented without execution.
+- [ ] #2 Agent Task raw message text is redacted from preview, definition, list/detail, audit, and persisted JSON by default.
+- [ ] #3 `/api/v1/scheduled-tasks` projects `automation_definition` rows without breaking reminder or Watchlists behavior.
+- [ ] #4 WebUI reference client can preview, create, inspect, edit, pause/resume, archive, and duplicate definitions using the API.
+- [ ] #5 Focused backend and frontend tests pass for the touched scope.
+- [ ] #6 Bandit passes for touched backend scope or any findings are fixed.
+- [ ] #7 No Jobs enqueueing, Scheduler integration, RAG execution, ACP dispatch, notifications, fake runs, fake results, or fake Home items are implemented.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implementation will follow `Docs/superpowers/plans/2026-06-09-scheduled-tasks-phase4b-backend-api-foundation-implementation-plan.md` using subagent-driven development with TDD and review checkpoints per task.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2352 - Address-PR-2343-review-feedback-and-rebase-Scheduled-Tasks-Phase-4B.md
+++ b/backlog/tasks/task-2352 - Address-PR-2343-review-feedback-and-rebase-Scheduled-Tasks-Phase-4B.md
@@ -1,0 +1,62 @@
+---
+id: TASK-2352
+title: Address PR 2343 review feedback and rebase Scheduled Tasks Phase 4B
+status: Done
+labels:
+- scheduled-tasks
+- api
+- frontend
+- review
+priority: high
+references:
+- TASK-2351
+- https://github.com/rmusser01/tldw_server/pull/2343
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase PR #2343 onto latest dev and address all actionable PR review comments/check failures for Scheduled Tasks Phase 4B API foundation. Track verification and final PR update evidence here.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PR #2343 rebased onto latest origin/dev without dropping intended work.
+- [x] #2 All actionable PR review comments are evaluated and either fixed or documented with technical rationale.
+- [x] #3 Focused backend/frontend tests and Bandit are rerun for touched scope.
+- [x] #4 PR branch is pushed after fixes.
+- [x] #5 Known unrelated local files remain untouched.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Rebased branch `codex/scheduled-tasks-phase4b-api-foundation-spec` onto `origin/dev`; final fetch showed `HEAD...origin/dev` as `28 0`, so `origin/dev` was not ahead.
+- Addressed Gemini comments by closing per-call SQLite connections, replacing API-boundary catches of generic automation `KeyError`/`ValueError` with `ScheduledTaskAutomationError`, defensively validating non-object schedules, and converting strict TypeScript record reads to index access.
+- Addressed Qodo comments by splitting preview read-path not-found errors to 404 while keeping missing preview preconditions as 400, converting synchronous automation handlers from `async def` to `def`, bulk-loading previews for definition list responses, and caching schema setup per service/repository key.
+- Addressed CodeRabbit comments by guarding missing editor mutation handlers, closing the task detail drawer before opening the automation editor, using canonical definition IDs for lifecycle actions, disabling optional automation action buttons, rejecting empty projected automation IDs, constraining automation filter query params, deriving effective expired preview status from `expires_at`, enforcing preview create/update linkage invariants, using runtime-future test expirations, and exposing the Archived task filter.
+- Left unrelated untracked watchlist template files unstaged and untouched:
+  - `tldw_Server_API/Config_Files/templates/watchlists/cti_osint_report_markdown.md`
+  - `tldw_Server_API/Config_Files/templates/watchlists/news_briefing_markdown.md`
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+- Rebased PR #2343 onto latest `origin/dev`, resolved actionable review feedback across backend API/service/DB code and WebUI/client scheduled task flows, reran focused verification, and prepared the branch for push.
+- Verification:
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_task_automation_db.py tldw_Server_API/tests/Notifications/test_scheduled_task_automation_service.py tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py -q` -> `90 passed, 14 warnings`
+  - `bunx vitest run src/components/Option/ScheduledTasks/__tests__/scheduled-task-automation-status.test.ts src/components/Option/ScheduledTasks/__tests__/ScheduledTaskAutomationDefinitionEditor.test.tsx src/components/Option/ScheduledTasks/__tests__/ScheduledTaskDetailDrawer.test.tsx src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx src/services/__tests__/scheduled-tasks-control-plane.test.ts --maxWorkers=1 --no-file-parallelism` -> `5 passed`, `82 passed`
+  - `bun run compile` in `apps/extension` -> `tsc --noEmit -p tsconfig.compile.json`
+  - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py tldw_Server_API/app/services/scheduled_task_automation_service.py tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py -f json -o /tmp/bandit_scheduled_tasks_phase4b_review.json` -> zero findings
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2353 - Rebase-PR-2343-on-latest-dev-and-address-follow-up-review-comments.md
+++ b/backlog/tasks/task-2353 - Rebase-PR-2343-on-latest-dev-and-address-follow-up-review-comments.md
@@ -1,0 +1,66 @@
+---
+id: TASK-2353
+title: Rebase PR 2343 on latest dev and address follow-up review comments
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-10 13:37'
+labels:
+  - scheduled-tasks
+  - review
+  - rebase
+dependencies: []
+references:
+  - TASK-2352
+  - 'https://github.com/rmusser01/tldw_server/pull/2343'
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase PR #2343 onto the latest dev branch, inspect current PR review threads and checks, address any new actionable feedback, rerun focused verification, and push the updated branch.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PR #2343 is rebased onto the latest origin/dev without dropping intended work.
+- [x] #2 Current active PR review threads and comments are inspected; any actionable new feedback is fixed or documented with rationale.
+- [x] #3 Focused verification is rerun for touched scope, including Bandit if backend code changes.
+- [x] #4 PR branch is pushed after the rebase/fixes.
+- [x] #5 Unrelated local files remain untouched.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Follow-up findings:
+- Fetched `origin` and ran `git rebase origin/dev`; branch was already up to date with latest `origin/dev`.
+- `git rev-list --left-right --count HEAD...origin/dev` before the explicit rebase reported `29 0`.
+- GraphQL review-thread query returned no active unresolved, non-outdated review threads.
+- `gh pr checks` showed all targeted/required checks passing. The remaining red entries are old Full Suite matrix jobs from CI run `27256970979` whose run conclusion is `cancelled`; failed-step inspection shows cancelled long-running module steps plus synthetic `Fail if any module failed` steps, not a new scheduled-tasks source failure.
+- No scheduled-task source changes were needed in this follow-up pass.
+- Unrelated untracked watchlist templates remain untouched.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+- Fetched latest `origin` and ran `git rebase origin/dev`; branch was already up to date.
+- Confirmed no active unresolved, non-outdated PR review threads remain.
+- Inspected PR checks and CI run `27256970979`; targeted/required checks are passing, while old Full Suite matrix entries are cancelled long-running jobs/synthetic fail-if-any-module-failed steps rather than new scheduled-task source failures.
+- No source code changes were needed in this follow-up pass. Verification: `git diff --check` returned clean for tracked changes; source tests/Bandit were not rerun because no backend/frontend source files changed in this pass.
+- Left unrelated untracked watchlist template files untouched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/Config_Files/config.txt
+++ b/tldw_Server_API/Config_Files/config.txt
@@ -1405,7 +1405,7 @@ stable_only = false
 disable =
 
 # Comma-separated list of route keys to force-enable (useful when stable_only = true)
-enable = tools, jobs, acp, workflows, scheduler, ingestion-sources
+enable = tools, jobs, acp, workflows, scheduler, ingestion-sources, scheduled-tasks
 
 # Optionally extend the curated experimental set (comma-separated)
 experimental_routes =

--- a/tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py
+++ b/tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py
@@ -1,11 +1,25 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, Path, status
+from typing import NoReturn
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, RequirePermission, User
 
 from tldw_Server_API.app.api.v1.schemas.reminders_schemas import (
     ReminderTaskCreateRequest,
     ReminderTaskUpdateRequest,
+)
+from tldw_Server_API.app.api.v1.schemas.scheduled_tasks_automation_schemas import (
+    ScheduledTaskAuditListResponse,
+    ScheduledTaskAutomationCapabilitiesResponse,
+    ScheduledTaskDefinitionCreateRequest,
+    ScheduledTaskDefinitionListResponse,
+    ScheduledTaskDefinitionResponse,
+    ScheduledTaskDefinitionUpdateRequest,
+    ScheduledTaskDuplicateRequest,
+    ScheduledTaskPreviewCreateRequest,
+    ScheduledTaskPreviewListResponse,
+    ScheduledTaskPreviewResponse,
 )
 from tldw_Server_API.app.api.v1.schemas.scheduled_tasks_control_plane_schemas import (
     ScheduledTask,
@@ -13,6 +27,7 @@ from tldw_Server_API.app.api.v1.schemas.scheduled_tasks_control_plane_schemas im
     ScheduledTaskListResponse,
 )
 from tldw_Server_API.app.core.AuthNZ.permissions import TASKS_CONTROL, TASKS_READ
+from tldw_Server_API.app.services.scheduled_task_automation_service import ScheduledTaskAutomationService
 from tldw_Server_API.app.services.scheduled_tasks_control_plane_service import ScheduledTasksControlPlaneService
 
 router = APIRouter(prefix="/scheduled-tasks", tags=["scheduled-tasks"])
@@ -20,6 +35,14 @@ router = APIRouter(prefix="/scheduled-tasks", tags=["scheduled-tasks"])
 
 def get_scheduled_tasks_control_plane_service() -> ScheduledTasksControlPlaneService:
     return ScheduledTasksControlPlaneService()
+
+
+def get_scheduled_task_automation_service() -> ScheduledTaskAutomationService:
+    return ScheduledTaskAutomationService()
+
+
+def _raise_automation_not_implemented(detail: str) -> NoReturn:
+    raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail=detail)
 
 
 @router.get(
@@ -33,6 +56,173 @@ async def list_scheduled_tasks(
     service: ScheduledTasksControlPlaneService = Depends(get_scheduled_tasks_control_plane_service),
 ) -> ScheduledTaskListResponse:
     return await service.list_tasks(user_id=int(current_user.id))
+
+
+@router.get(
+    "/capabilities",
+    response_model=ScheduledTaskAutomationCapabilitiesResponse,
+    dependencies=[Depends(rbac_rate_limit("tasks.read"))],
+)
+async def get_scheduled_task_automation_capabilities(
+    _principal=Depends(RequirePermission(TASKS_READ)),  # noqa: B008
+    service: ScheduledTaskAutomationService = Depends(get_scheduled_task_automation_service),
+) -> ScheduledTaskAutomationCapabilitiesResponse:
+    return service.get_capabilities()
+
+
+@router.get(
+    "/previews",
+    response_model=ScheduledTaskPreviewListResponse,
+    dependencies=[Depends(rbac_rate_limit("tasks.read"))],
+)
+async def list_scheduled_task_automation_previews(
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    _principal=Depends(RequirePermission(TASKS_READ)),  # noqa: B008
+    service: ScheduledTaskAutomationService = Depends(get_scheduled_task_automation_service),
+) -> ScheduledTaskPreviewListResponse:
+    return service.list_previews(limit=limit, offset=offset)
+
+
+@router.post(
+    "/previews",
+    response_model=ScheduledTaskPreviewResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(rbac_rate_limit("tasks.control"))],
+)
+async def create_scheduled_task_automation_preview(
+    _payload: ScheduledTaskPreviewCreateRequest,
+    _principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+) -> ScheduledTaskPreviewResponse:
+    _raise_automation_not_implemented("scheduled_task_preview_storage_not_implemented")
+
+
+@router.get(
+    "/previews/{preview_id}",
+    response_model=ScheduledTaskPreviewResponse,
+    dependencies=[Depends(rbac_rate_limit("tasks.read"))],
+)
+async def get_scheduled_task_automation_preview(
+    preview_id: str = Path(..., min_length=1),
+    _principal=Depends(RequirePermission(TASKS_READ)),  # noqa: B008
+) -> ScheduledTaskPreviewResponse:
+    _raise_automation_not_implemented("scheduled_task_preview_storage_not_implemented")
+
+
+@router.get(
+    "/definitions",
+    response_model=ScheduledTaskDefinitionListResponse,
+    dependencies=[Depends(rbac_rate_limit("tasks.read"))],
+)
+async def list_scheduled_task_automation_definitions(
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    _principal=Depends(RequirePermission(TASKS_READ)),  # noqa: B008
+    service: ScheduledTaskAutomationService = Depends(get_scheduled_task_automation_service),
+) -> ScheduledTaskDefinitionListResponse:
+    return service.list_definitions(limit=limit, offset=offset)
+
+
+@router.post(
+    "/definitions",
+    response_model=ScheduledTaskDefinitionResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(rbac_rate_limit("tasks.control"))],
+)
+async def create_scheduled_task_automation_definition(
+    _payload: ScheduledTaskDefinitionCreateRequest,
+    _principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+) -> ScheduledTaskDefinitionResponse:
+    _raise_automation_not_implemented("scheduled_task_definition_storage_not_implemented")
+
+
+@router.get(
+    "/definitions/{definition_id}/audit",
+    response_model=ScheduledTaskAuditListResponse,
+    dependencies=[Depends(rbac_rate_limit("tasks.read"))],
+)
+async def list_scheduled_task_automation_definition_audit(
+    definition_id: str = Path(..., min_length=1),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    _principal=Depends(RequirePermission(TASKS_READ)),  # noqa: B008
+    service: ScheduledTaskAutomationService = Depends(get_scheduled_task_automation_service),
+) -> ScheduledTaskAuditListResponse:
+    return service.list_audit_events(limit=limit, offset=offset)
+
+
+@router.get(
+    "/definitions/{definition_id}",
+    response_model=ScheduledTaskDefinitionResponse,
+    dependencies=[Depends(rbac_rate_limit("tasks.read"))],
+)
+async def get_scheduled_task_automation_definition(
+    definition_id: str = Path(..., min_length=1),
+    _principal=Depends(RequirePermission(TASKS_READ)),  # noqa: B008
+) -> ScheduledTaskDefinitionResponse:
+    _raise_automation_not_implemented("scheduled_task_definition_storage_not_implemented")
+
+
+@router.patch(
+    "/definitions/{definition_id}",
+    response_model=ScheduledTaskDefinitionResponse,
+    dependencies=[Depends(rbac_rate_limit("tasks.control"))],
+)
+async def update_scheduled_task_automation_definition(
+    _payload: ScheduledTaskDefinitionUpdateRequest,
+    definition_id: str = Path(..., min_length=1),
+    _principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+) -> ScheduledTaskDefinitionResponse:
+    _raise_automation_not_implemented("scheduled_task_definition_storage_not_implemented")
+
+
+@router.post(
+    "/definitions/{definition_id}/pause",
+    response_model=ScheduledTaskDefinitionResponse,
+    dependencies=[Depends(rbac_rate_limit("tasks.control"))],
+)
+async def pause_scheduled_task_automation_definition(
+    definition_id: str = Path(..., min_length=1),
+    _principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+) -> ScheduledTaskDefinitionResponse:
+    _raise_automation_not_implemented("scheduled_task_definition_lifecycle_not_implemented")
+
+
+@router.post(
+    "/definitions/{definition_id}/resume",
+    response_model=ScheduledTaskDefinitionResponse,
+    dependencies=[Depends(rbac_rate_limit("tasks.control"))],
+)
+async def resume_scheduled_task_automation_definition(
+    definition_id: str = Path(..., min_length=1),
+    _principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+) -> ScheduledTaskDefinitionResponse:
+    _raise_automation_not_implemented("scheduled_task_definition_lifecycle_not_implemented")
+
+
+@router.post(
+    "/definitions/{definition_id}/archive",
+    response_model=ScheduledTaskDefinitionResponse,
+    dependencies=[Depends(rbac_rate_limit("tasks.control"))],
+)
+async def archive_scheduled_task_automation_definition(
+    definition_id: str = Path(..., min_length=1),
+    _principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+) -> ScheduledTaskDefinitionResponse:
+    _raise_automation_not_implemented("scheduled_task_definition_lifecycle_not_implemented")
+
+
+@router.post(
+    "/definitions/{definition_id}/duplicate",
+    response_model=ScheduledTaskDefinitionResponse,
+    dependencies=[Depends(rbac_rate_limit("tasks.control"))],
+)
+async def duplicate_scheduled_task_automation_definition(
+    _payload: ScheduledTaskDuplicateRequest,
+    definition_id: str = Path(..., min_length=1),
+    _principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+) -> ScheduledTaskDefinitionResponse:
+    _raise_automation_not_implemented("scheduled_task_definition_lifecycle_not_implemented")
 
 
 @router.get(

--- a/tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py
+++ b/tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any, NoReturn
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
@@ -229,6 +230,40 @@ def _idempotency_key(request: Request) -> str | None:
     return value.strip() if isinstance(value, str) and value.strip() else None
 
 
+def _request_id(request: Request) -> str | None:
+    value = getattr(getattr(request, "state", None), "request_id", None)
+    return str(value) if value else None
+
+
+def _normalize_datetime_filter(
+    *,
+    request: Request,
+    value: str | None,
+    field: str,
+) -> str | None:
+    if value is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise _scheduled_task_error(
+            request=request,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            code="scheduled_task_filter_invalid",
+            message="Scheduled task datetime filter is invalid.",
+            details={"field": field, "value": value},
+        ) from exc
+    if parsed.tzinfo is None:
+        raise _scheduled_task_error(
+            request=request,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            code="scheduled_task_filter_invalid",
+            message="Scheduled task datetime filter must include a timezone.",
+            details={"field": field, "value": value},
+        )
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
 @router.get(
     "",
     response_model=ScheduledTaskListResponse,
@@ -331,6 +366,7 @@ async def get_scheduled_task_automation_preview(
     dependencies=[Depends(rbac_rate_limit("tasks.read"))],
 )
 async def list_scheduled_task_automation_definitions(
+    request: Request,
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
     family: str | None = Query(default=None),
@@ -344,6 +380,16 @@ async def list_scheduled_task_automation_definitions(
     _principal=Depends(RequirePermission(TASKS_READ)),  # noqa: B008
     service: ScheduledTaskAutomationService = Depends(get_scheduled_task_automation_service),
 ) -> ScheduledTaskDefinitionListResponse:
+    normalized_created_from = _normalize_datetime_filter(
+        request=request,
+        value=created_from,
+        field="created_from",
+    )
+    normalized_created_to = _normalize_datetime_filter(
+        request=request,
+        value=created_to,
+        field="created_to",
+    )
     return service.list_definitions(
         owner_id=int(current_user.id),
         limit=limit,
@@ -353,8 +399,8 @@ async def list_scheduled_task_automation_definitions(
         health=health,
         visibility_policy=visibility_policy,
         query=q,
-        created_from=created_from,
-        created_to=created_to,
+        created_from=normalized_created_from,
+        created_to=normalized_created_to,
     )
 
 
@@ -377,6 +423,7 @@ async def create_scheduled_task_automation_definition(
             actor=_actor_from_principal(principal, current_user),
             payload=payload,
             idempotency_key=_idempotency_key(request),
+            request_id=_request_id(request),
         )
     except (KeyError, ValueError) as exc:
         _raise_automation_error(request, exc)
@@ -402,6 +449,16 @@ async def list_scheduled_task_automation_definition_audit(
     _principal=Depends(RequirePermission(TASKS_READ)),  # noqa: B008
     service: ScheduledTaskAutomationService = Depends(get_scheduled_task_automation_service),
 ) -> ScheduledTaskAuditListResponse:
+    normalized_created_from = _normalize_datetime_filter(
+        request=request,
+        value=created_from,
+        field="created_from",
+    )
+    normalized_created_to = _normalize_datetime_filter(
+        request=request,
+        value=created_to,
+        field="created_to",
+    )
     try:
         return service.list_audit_events(
             owner_id=int(current_user.id),
@@ -410,8 +467,8 @@ async def list_scheduled_task_automation_definition_audit(
             offset=offset,
             event_type=event_type,
             actor=actor,
-            created_from=created_from,
-            created_to=created_to,
+            created_from=normalized_created_from,
+            created_to=normalized_created_to,
             idempotency_key=idempotency_key,
             request_id=request_id,
         )
@@ -457,6 +514,7 @@ async def update_scheduled_task_automation_definition(
             definition_id=definition_id,
             payload=payload,
             idempotency_key=_idempotency_key(request),
+            request_id=_request_id(request),
         )
     except (KeyError, ValueError) as exc:
         _raise_automation_error(request, exc)
@@ -480,6 +538,7 @@ async def pause_scheduled_task_automation_definition(
             actor=_actor_from_principal(principal, current_user),
             definition_id=definition_id,
             idempotency_key=_idempotency_key(request),
+            request_id=_request_id(request),
         )
     except (KeyError, ValueError) as exc:
         _raise_automation_error(request, exc)
@@ -503,6 +562,7 @@ async def resume_scheduled_task_automation_definition(
             actor=_actor_from_principal(principal, current_user),
             definition_id=definition_id,
             idempotency_key=_idempotency_key(request),
+            request_id=_request_id(request),
         )
     except (KeyError, ValueError) as exc:
         _raise_automation_error(request, exc)
@@ -526,6 +586,7 @@ async def archive_scheduled_task_automation_definition(
             actor=_actor_from_principal(principal, current_user),
             definition_id=definition_id,
             idempotency_key=_idempotency_key(request),
+            request_id=_request_id(request),
         )
     except (KeyError, ValueError) as exc:
         _raise_automation_error(request, exc)
@@ -551,6 +612,7 @@ async def duplicate_scheduled_task_automation_definition(
             definition_id=definition_id,
             payload=payload,
             idempotency_key=_idempotency_key(request),
+            request_id=_request_id(request),
         )
     except (KeyError, ValueError) as exc:
         _raise_automation_error(request, exc)

--- a/tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py
+++ b/tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py
@@ -75,6 +75,11 @@ _VALUE_ERROR_MAP: dict[str, tuple[int, str, str]] = {
         "scheduled_task_preview_required",
         "A valid scheduled task preview is required.",
     ),
+    "scheduled_task_definition_not_found": (
+        status.HTTP_404_NOT_FOUND,
+        "scheduled_task_definition_not_found",
+        "Scheduled task definition was not found.",
+    ),
     "scheduled_task_preview_mismatch": (
         status.HTTP_409_CONFLICT,
         "scheduled_task_preview_mismatch",

--- a/tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py
+++ b/tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import NoReturn
+from typing import Any, NoReturn
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, RequirePermission, User
 
 from tldw_Server_API.app.api.v1.schemas.reminders_schemas import (
@@ -41,8 +41,187 @@ def get_scheduled_task_automation_service() -> ScheduledTaskAutomationService:
     return ScheduledTaskAutomationService()
 
 
-def _raise_automation_not_implemented(detail: str) -> NoReturn:
-    raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail=detail)
+def _scheduled_task_error(
+    *,
+    request: Request,
+    status_code: int,
+    code: str,
+    message: str,
+    details: dict[str, Any] | None = None,
+    retryable: bool = False,
+) -> HTTPException:
+    correlation_id = getattr(getattr(request, "state", None), "request_id", None)
+    return HTTPException(
+        status_code=status_code,
+        detail={
+            "code": code,
+            "message": message,
+            "details": details or {},
+            "field_errors": [],
+            "retryable": retryable,
+            "correlation_id": correlation_id,
+        },
+    )
+
+
+_VALUE_ERROR_MAP: dict[str, tuple[int, str, str]] = {
+    "scheduled_task_family_unavailable": (
+        status.HTTP_409_CONFLICT,
+        "scheduled_task_family_unavailable",
+        "Scheduled task automation family is unavailable.",
+    ),
+    "scheduled_task_preview_required": (
+        status.HTTP_400_BAD_REQUEST,
+        "scheduled_task_preview_required",
+        "A valid scheduled task preview is required.",
+    ),
+    "scheduled_task_preview_mismatch": (
+        status.HTTP_409_CONFLICT,
+        "scheduled_task_preview_mismatch",
+        "Scheduled task preview does not match the requested operation.",
+    ),
+    "scheduled_task_preview_expired": (
+        status.HTTP_409_CONFLICT,
+        "scheduled_task_preview_expired",
+        "Scheduled task preview has expired.",
+    ),
+    "scheduled_task_schedule_invalid": (
+        status.HTTP_422_UNPROCESSABLE_ENTITY,
+        "scheduled_task_schedule_invalid",
+        "Scheduled task schedule is invalid.",
+    ),
+    "scheduled_task_scope_invalid": (
+        status.HTTP_422_UNPROCESSABLE_ENTITY,
+        "scheduled_task_scope_invalid",
+        "Scheduled task scope is invalid.",
+    ),
+    "scheduled_task_agent_ref_invalid": (
+        status.HTTP_422_UNPROCESSABLE_ENTITY,
+        "scheduled_task_agent_ref_invalid",
+        "Scheduled task agent reference is invalid.",
+    ),
+    "scheduled_task_permission_policy_invalid": (
+        status.HTTP_422_UNPROCESSABLE_ENTITY,
+        "scheduled_task_permission_policy_invalid",
+        "Scheduled task permission policy is invalid.",
+    ),
+    "scheduled_task_execution_unavailable": (
+        status.HTTP_409_CONFLICT,
+        "scheduled_task_execution_unavailable",
+        "Scheduled task execution is unavailable.",
+    ),
+    "scheduled_task_definition_version_conflict": (
+        status.HTTP_409_CONFLICT,
+        "scheduled_task_definition_version_conflict",
+        "Scheduled task definition version conflict.",
+    ),
+    "scheduled_task_definition_archived": (
+        status.HTTP_409_CONFLICT,
+        "scheduled_task_definition_archived",
+        "Scheduled task definition is archived.",
+    ),
+    "scheduled_task_lifecycle_transition_invalid": (
+        status.HTTP_409_CONFLICT,
+        "scheduled_task_lifecycle_transition_invalid",
+        "Scheduled task lifecycle transition is invalid.",
+    ),
+    "scheduled_task_idempotency_conflict": (
+        status.HTTP_409_CONFLICT,
+        "scheduled_task_idempotency_conflict",
+        "Idempotency key was already used with a different payload.",
+    ),
+    "preview_not_found": (
+        status.HTTP_400_BAD_REQUEST,
+        "scheduled_task_preview_required",
+        "A valid scheduled task preview is required.",
+    ),
+    "preview_invalid": (
+        status.HTTP_422_UNPROCESSABLE_ENTITY,
+        "scheduled_task_schedule_invalid",
+        "Scheduled task preview is invalid.",
+    ),
+    "preview_expired": (
+        status.HTTP_409_CONFLICT,
+        "scheduled_task_preview_expired",
+        "Scheduled task preview has expired.",
+    ),
+    "preview_consumed": (
+        status.HTTP_409_CONFLICT,
+        "scheduled_task_preview_mismatch",
+        "Scheduled task preview has already been consumed.",
+    ),
+    "preview_mode_mismatch": (
+        status.HTTP_409_CONFLICT,
+        "scheduled_task_preview_mismatch",
+        "Scheduled task preview mode does not match the requested operation.",
+    ),
+    "preview_definition_mismatch": (
+        status.HTTP_409_CONFLICT,
+        "scheduled_task_preview_mismatch",
+        "Scheduled task preview definition does not match the requested definition.",
+    ),
+    "definition_not_found": (
+        status.HTTP_404_NOT_FOUND,
+        "scheduled_task_definition_not_found",
+        "Scheduled task definition was not found.",
+    ),
+    "definition_archived": (
+        status.HTTP_409_CONFLICT,
+        "scheduled_task_definition_archived",
+        "Scheduled task definition is archived.",
+    ),
+    "definition_version_mismatch": (
+        status.HTTP_409_CONFLICT,
+        "scheduled_task_definition_version_conflict",
+        "Scheduled task definition version conflict.",
+    ),
+    "definition_disabled": (
+        status.HTTP_409_CONFLICT,
+        "scheduled_task_lifecycle_transition_invalid",
+        "Scheduled task definition is disabled.",
+    ),
+    "definition_disabled_locked": (
+        status.HTTP_409_CONFLICT,
+        "scheduled_task_lifecycle_transition_invalid",
+        "Scheduled task definition is locked by policy.",
+    ),
+}
+
+
+def _raise_automation_error(request: Request, exc: Exception) -> NoReturn:
+    raw_code = str(exc)
+    if isinstance(exc, KeyError):
+        raw_code = raw_code.strip("'")
+        if "definition" in raw_code:
+            status_code, code, message = _VALUE_ERROR_MAP["definition_not_found"]
+        else:
+            status_code, code, message = _VALUE_ERROR_MAP["preview_not_found"]
+    else:
+        status_code, code, message = _VALUE_ERROR_MAP.get(
+            raw_code,
+            (
+                status.HTTP_409_CONFLICT,
+                "scheduled_task_lifecycle_transition_invalid",
+                "Scheduled task automation request could not be completed.",
+            ),
+        )
+    raise _scheduled_task_error(
+        request=request,
+        status_code=status_code,
+        code=code,
+        message=message,
+        details={"reason": raw_code},
+    ) from exc
+
+
+def _actor_from_principal(principal: Any, current_user: User) -> str:
+    subject = getattr(principal, "subject", None)
+    return str(subject or current_user.id)
+
+
+def _idempotency_key(request: Request) -> str | None:
+    value = request.headers.get("Idempotency-Key")
+    return value.strip() if isinstance(value, str) and value.strip() else None
 
 
 @router.get(
@@ -78,10 +257,25 @@ async def get_scheduled_task_automation_capabilities(
 async def list_scheduled_task_automation_previews(
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
+    family: str | None = Query(default=None),
+    mode: str | None = Query(default=None),
+    status: str | None = Query(default=None),
+    definition_id: str | None = Query(default=None),
+    expired: bool | None = Query(default=None),
+    current_user: User = Depends(get_request_user),
     _principal=Depends(RequirePermission(TASKS_READ)),  # noqa: B008
     service: ScheduledTaskAutomationService = Depends(get_scheduled_task_automation_service),
 ) -> ScheduledTaskPreviewListResponse:
-    return service.list_previews(limit=limit, offset=offset)
+    return service.list_previews(
+        owner_id=int(current_user.id),
+        limit=limit,
+        offset=offset,
+        family=family,
+        mode=mode,
+        status=status,
+        definition_id=definition_id,
+        expired=expired,
+    )
 
 
 @router.post(
@@ -91,10 +285,21 @@ async def list_scheduled_task_automation_previews(
     dependencies=[Depends(rbac_rate_limit("tasks.control"))],
 )
 async def create_scheduled_task_automation_preview(
-    _payload: ScheduledTaskPreviewCreateRequest,
-    _principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+    payload: ScheduledTaskPreviewCreateRequest,
+    request: Request,
+    current_user: User = Depends(get_request_user),
+    principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+    service: ScheduledTaskAutomationService = Depends(get_scheduled_task_automation_service),
 ) -> ScheduledTaskPreviewResponse:
-    _raise_automation_not_implemented("scheduled_task_preview_storage_not_implemented")
+    try:
+        return service.create_preview(
+            owner_id=int(current_user.id),
+            actor=_actor_from_principal(principal, current_user),
+            payload=payload,
+            idempotency_key=_idempotency_key(request),
+        )
+    except (KeyError, ValueError) as exc:
+        _raise_automation_error(request, exc)
 
 
 @router.get(
@@ -103,10 +308,16 @@ async def create_scheduled_task_automation_preview(
     dependencies=[Depends(rbac_rate_limit("tasks.read"))],
 )
 async def get_scheduled_task_automation_preview(
+    request: Request,
     preview_id: str = Path(..., min_length=1),
+    current_user: User = Depends(get_request_user),
     _principal=Depends(RequirePermission(TASKS_READ)),  # noqa: B008
+    service: ScheduledTaskAutomationService = Depends(get_scheduled_task_automation_service),
 ) -> ScheduledTaskPreviewResponse:
-    _raise_automation_not_implemented("scheduled_task_preview_storage_not_implemented")
+    try:
+        return service.get_preview(owner_id=int(current_user.id), preview_id=preview_id)
+    except (KeyError, ValueError) as exc:
+        _raise_automation_error(request, exc)
 
 
 @router.get(
@@ -117,10 +328,29 @@ async def get_scheduled_task_automation_preview(
 async def list_scheduled_task_automation_definitions(
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
+    family: str | None = Query(default=None),
+    lifecycle: str | None = Query(default=None),
+    health: str | None = Query(default=None),
+    visibility_policy: str | None = Query(default=None),
+    q: str | None = Query(default=None),
+    created_from: str | None = Query(default=None),
+    created_to: str | None = Query(default=None),
+    current_user: User = Depends(get_request_user),
     _principal=Depends(RequirePermission(TASKS_READ)),  # noqa: B008
     service: ScheduledTaskAutomationService = Depends(get_scheduled_task_automation_service),
 ) -> ScheduledTaskDefinitionListResponse:
-    return service.list_definitions(limit=limit, offset=offset)
+    return service.list_definitions(
+        owner_id=int(current_user.id),
+        limit=limit,
+        offset=offset,
+        family=family,
+        lifecycle=lifecycle,
+        health=health,
+        visibility_policy=visibility_policy,
+        query=q,
+        created_from=created_from,
+        created_to=created_to,
+    )
 
 
 @router.post(
@@ -130,10 +360,21 @@ async def list_scheduled_task_automation_definitions(
     dependencies=[Depends(rbac_rate_limit("tasks.control"))],
 )
 async def create_scheduled_task_automation_definition(
-    _payload: ScheduledTaskDefinitionCreateRequest,
-    _principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+    payload: ScheduledTaskDefinitionCreateRequest,
+    request: Request,
+    current_user: User = Depends(get_request_user),
+    principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+    service: ScheduledTaskAutomationService = Depends(get_scheduled_task_automation_service),
 ) -> ScheduledTaskDefinitionResponse:
-    _raise_automation_not_implemented("scheduled_task_definition_storage_not_implemented")
+    try:
+        return service.create_definition(
+            owner_id=int(current_user.id),
+            actor=_actor_from_principal(principal, current_user),
+            payload=payload,
+            idempotency_key=_idempotency_key(request),
+        )
+    except (KeyError, ValueError) as exc:
+        _raise_automation_error(request, exc)
 
 
 @router.get(
@@ -142,13 +383,35 @@ async def create_scheduled_task_automation_definition(
     dependencies=[Depends(rbac_rate_limit("tasks.read"))],
 )
 async def list_scheduled_task_automation_definition_audit(
+    request: Request,
     definition_id: str = Path(..., min_length=1),
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
+    event_type: str | None = Query(default=None),
+    actor: str | None = Query(default=None),
+    created_from: str | None = Query(default=None),
+    created_to: str | None = Query(default=None),
+    idempotency_key: str | None = Query(default=None),
+    request_id: str | None = Query(default=None),
+    current_user: User = Depends(get_request_user),
     _principal=Depends(RequirePermission(TASKS_READ)),  # noqa: B008
     service: ScheduledTaskAutomationService = Depends(get_scheduled_task_automation_service),
 ) -> ScheduledTaskAuditListResponse:
-    return service.list_audit_events(limit=limit, offset=offset)
+    try:
+        return service.list_audit_events(
+            owner_id=int(current_user.id),
+            definition_id=definition_id,
+            limit=limit,
+            offset=offset,
+            event_type=event_type,
+            actor=actor,
+            created_from=created_from,
+            created_to=created_to,
+            idempotency_key=idempotency_key,
+            request_id=request_id,
+        )
+    except (KeyError, ValueError) as exc:
+        _raise_automation_error(request, exc)
 
 
 @router.get(
@@ -157,10 +420,16 @@ async def list_scheduled_task_automation_definition_audit(
     dependencies=[Depends(rbac_rate_limit("tasks.read"))],
 )
 async def get_scheduled_task_automation_definition(
+    request: Request,
     definition_id: str = Path(..., min_length=1),
+    current_user: User = Depends(get_request_user),
     _principal=Depends(RequirePermission(TASKS_READ)),  # noqa: B008
+    service: ScheduledTaskAutomationService = Depends(get_scheduled_task_automation_service),
 ) -> ScheduledTaskDefinitionResponse:
-    _raise_automation_not_implemented("scheduled_task_definition_storage_not_implemented")
+    try:
+        return service.get_definition(owner_id=int(current_user.id), definition_id=definition_id)
+    except (KeyError, ValueError) as exc:
+        _raise_automation_error(request, exc)
 
 
 @router.patch(
@@ -169,11 +438,23 @@ async def get_scheduled_task_automation_definition(
     dependencies=[Depends(rbac_rate_limit("tasks.control"))],
 )
 async def update_scheduled_task_automation_definition(
-    _payload: ScheduledTaskDefinitionUpdateRequest,
+    payload: ScheduledTaskDefinitionUpdateRequest,
+    request: Request,
     definition_id: str = Path(..., min_length=1),
-    _principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+    current_user: User = Depends(get_request_user),
+    principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+    service: ScheduledTaskAutomationService = Depends(get_scheduled_task_automation_service),
 ) -> ScheduledTaskDefinitionResponse:
-    _raise_automation_not_implemented("scheduled_task_definition_storage_not_implemented")
+    try:
+        return service.update_definition(
+            owner_id=int(current_user.id),
+            actor=_actor_from_principal(principal, current_user),
+            definition_id=definition_id,
+            payload=payload,
+            idempotency_key=_idempotency_key(request),
+        )
+    except (KeyError, ValueError) as exc:
+        _raise_automation_error(request, exc)
 
 
 @router.post(
@@ -182,10 +463,21 @@ async def update_scheduled_task_automation_definition(
     dependencies=[Depends(rbac_rate_limit("tasks.control"))],
 )
 async def pause_scheduled_task_automation_definition(
+    request: Request,
     definition_id: str = Path(..., min_length=1),
-    _principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+    current_user: User = Depends(get_request_user),
+    principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+    service: ScheduledTaskAutomationService = Depends(get_scheduled_task_automation_service),
 ) -> ScheduledTaskDefinitionResponse:
-    _raise_automation_not_implemented("scheduled_task_definition_lifecycle_not_implemented")
+    try:
+        return service.pause_definition(
+            owner_id=int(current_user.id),
+            actor=_actor_from_principal(principal, current_user),
+            definition_id=definition_id,
+            idempotency_key=_idempotency_key(request),
+        )
+    except (KeyError, ValueError) as exc:
+        _raise_automation_error(request, exc)
 
 
 @router.post(
@@ -194,10 +486,21 @@ async def pause_scheduled_task_automation_definition(
     dependencies=[Depends(rbac_rate_limit("tasks.control"))],
 )
 async def resume_scheduled_task_automation_definition(
+    request: Request,
     definition_id: str = Path(..., min_length=1),
-    _principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+    current_user: User = Depends(get_request_user),
+    principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+    service: ScheduledTaskAutomationService = Depends(get_scheduled_task_automation_service),
 ) -> ScheduledTaskDefinitionResponse:
-    _raise_automation_not_implemented("scheduled_task_definition_lifecycle_not_implemented")
+    try:
+        return service.resume_definition(
+            owner_id=int(current_user.id),
+            actor=_actor_from_principal(principal, current_user),
+            definition_id=definition_id,
+            idempotency_key=_idempotency_key(request),
+        )
+    except (KeyError, ValueError) as exc:
+        _raise_automation_error(request, exc)
 
 
 @router.post(
@@ -206,10 +509,21 @@ async def resume_scheduled_task_automation_definition(
     dependencies=[Depends(rbac_rate_limit("tasks.control"))],
 )
 async def archive_scheduled_task_automation_definition(
+    request: Request,
     definition_id: str = Path(..., min_length=1),
-    _principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+    current_user: User = Depends(get_request_user),
+    principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+    service: ScheduledTaskAutomationService = Depends(get_scheduled_task_automation_service),
 ) -> ScheduledTaskDefinitionResponse:
-    _raise_automation_not_implemented("scheduled_task_definition_lifecycle_not_implemented")
+    try:
+        return service.archive_definition(
+            owner_id=int(current_user.id),
+            actor=_actor_from_principal(principal, current_user),
+            definition_id=definition_id,
+            idempotency_key=_idempotency_key(request),
+        )
+    except (KeyError, ValueError) as exc:
+        _raise_automation_error(request, exc)
 
 
 @router.post(
@@ -218,11 +532,23 @@ async def archive_scheduled_task_automation_definition(
     dependencies=[Depends(rbac_rate_limit("tasks.control"))],
 )
 async def duplicate_scheduled_task_automation_definition(
-    _payload: ScheduledTaskDuplicateRequest,
+    payload: ScheduledTaskDuplicateRequest,
+    request: Request,
     definition_id: str = Path(..., min_length=1),
-    _principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+    current_user: User = Depends(get_request_user),
+    principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
+    service: ScheduledTaskAutomationService = Depends(get_scheduled_task_automation_service),
 ) -> ScheduledTaskDefinitionResponse:
-    _raise_automation_not_implemented("scheduled_task_definition_lifecycle_not_implemented")
+    try:
+        return service.duplicate_definition(
+            owner_id=int(current_user.id),
+            actor=_actor_from_principal(principal, current_user),
+            definition_id=definition_id,
+            payload=payload,
+            idempotency_key=_idempotency_key(request),
+        )
+    except (KeyError, ValueError) as exc:
+        _raise_automation_error(request, exc)
 
 
 @router.get(

--- a/tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py
+++ b/tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py
@@ -13,14 +13,19 @@ from tldw_Server_API.app.api.v1.schemas.reminders_schemas import (
 from tldw_Server_API.app.api.v1.schemas.scheduled_tasks_automation_schemas import (
     ScheduledTaskAuditListResponse,
     ScheduledTaskAutomationCapabilitiesResponse,
+    ScheduledTaskAutomationFamily,
     ScheduledTaskDefinitionCreateRequest,
+    ScheduledTaskDefinitionHealth,
+    ScheduledTaskDefinitionLifecycle,
     ScheduledTaskDefinitionListResponse,
     ScheduledTaskDefinitionResponse,
     ScheduledTaskDefinitionUpdateRequest,
     ScheduledTaskDuplicateRequest,
     ScheduledTaskPreviewCreateRequest,
     ScheduledTaskPreviewListResponse,
+    ScheduledTaskPreviewMode,
     ScheduledTaskPreviewResponse,
+    ScheduledTaskPreviewStatus,
 )
 from tldw_Server_API.app.api.v1.schemas.scheduled_tasks_control_plane_schemas import (
     ScheduledTask,
@@ -28,7 +33,10 @@ from tldw_Server_API.app.api.v1.schemas.scheduled_tasks_control_plane_schemas im
     ScheduledTaskListResponse,
 )
 from tldw_Server_API.app.core.AuthNZ.permissions import TASKS_CONTROL, TASKS_READ
-from tldw_Server_API.app.services.scheduled_task_automation_service import ScheduledTaskAutomationService
+from tldw_Server_API.app.services.scheduled_task_automation_service import (
+    ScheduledTaskAutomationError,
+    ScheduledTaskAutomationService,
+)
 from tldw_Server_API.app.services.scheduled_tasks_control_plane_service import ScheduledTasksControlPlaneService
 
 router = APIRouter(prefix="/scheduled-tasks", tags=["scheduled-tasks"])
@@ -65,7 +73,7 @@ def _scheduled_task_error(
     )
 
 
-_VALUE_ERROR_MAP: dict[str, tuple[int, str, str]] = {
+_AUTOMATION_ERROR_MAP: dict[str, tuple[int, str, str]] = {
     "scheduled_task_family_unavailable": (
         status.HTTP_409_CONFLICT,
         "scheduled_task_family_unavailable",
@@ -136,10 +144,20 @@ _VALUE_ERROR_MAP: dict[str, tuple[int, str, str]] = {
         "scheduled_task_idempotency_conflict",
         "Idempotency key was already used with a different payload.",
     ),
+    "scheduled_task_idempotency_response_unavailable": (
+        status.HTTP_409_CONFLICT,
+        "scheduled_task_execution_unavailable",
+        "Scheduled task idempotency response is unavailable.",
+    ),
     "preview_not_found": (
         status.HTTP_400_BAD_REQUEST,
         "scheduled_task_preview_required",
         "A valid scheduled task preview is required.",
+    ),
+    "preview_resource_not_found": (
+        status.HTTP_404_NOT_FOUND,
+        "scheduled_task_preview_not_found",
+        "Scheduled task preview was not found.",
     ),
     "preview_invalid": (
         status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -194,23 +212,16 @@ _VALUE_ERROR_MAP: dict[str, tuple[int, str, str]] = {
 }
 
 
-def _raise_automation_error(request: Request, exc: Exception) -> NoReturn:
-    raw_code = str(exc)
-    if isinstance(exc, KeyError):
-        raw_code = raw_code.strip("'")
-        if "definition" in raw_code:
-            status_code, code, message = _VALUE_ERROR_MAP["definition_not_found"]
-        else:
-            status_code, code, message = _VALUE_ERROR_MAP["preview_not_found"]
-    else:
-        status_code, code, message = _VALUE_ERROR_MAP.get(
-            raw_code,
-            (
-                status.HTTP_409_CONFLICT,
-                "scheduled_task_lifecycle_transition_invalid",
-                "Scheduled task automation request could not be completed.",
-            ),
-        )
+def _raise_automation_error(request: Request, exc: ScheduledTaskAutomationError) -> NoReturn:
+    raw_code = exc.code
+    status_code, code, message = _AUTOMATION_ERROR_MAP.get(
+        raw_code,
+        (
+            status.HTTP_409_CONFLICT,
+            "scheduled_task_lifecycle_transition_invalid",
+            "Scheduled task automation request could not be completed.",
+        ),
+    )
     raise _scheduled_task_error(
         request=request,
         status_code=status_code,
@@ -282,7 +293,7 @@ async def list_scheduled_tasks(
     response_model=ScheduledTaskAutomationCapabilitiesResponse,
     dependencies=[Depends(rbac_rate_limit("tasks.read"))],
 )
-async def get_scheduled_task_automation_capabilities(
+def get_scheduled_task_automation_capabilities(
     _principal=Depends(RequirePermission(TASKS_READ)),  # noqa: B008
     service: ScheduledTaskAutomationService = Depends(get_scheduled_task_automation_service),
 ) -> ScheduledTaskAutomationCapabilitiesResponse:
@@ -294,12 +305,12 @@ async def get_scheduled_task_automation_capabilities(
     response_model=ScheduledTaskPreviewListResponse,
     dependencies=[Depends(rbac_rate_limit("tasks.read"))],
 )
-async def list_scheduled_task_automation_previews(
+def list_scheduled_task_automation_previews(
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
-    family: str | None = Query(default=None),
-    mode: str | None = Query(default=None),
-    status: str | None = Query(default=None),
+    family: ScheduledTaskAutomationFamily | None = Query(default=None),
+    mode: ScheduledTaskPreviewMode | None = Query(default=None),
+    status: ScheduledTaskPreviewStatus | None = Query(default=None),
     definition_id: str | None = Query(default=None),
     expired: bool | None = Query(default=None),
     current_user: User = Depends(get_request_user),
@@ -324,7 +335,7 @@ async def list_scheduled_task_automation_previews(
     status_code=status.HTTP_201_CREATED,
     dependencies=[Depends(rbac_rate_limit("tasks.control"))],
 )
-async def create_scheduled_task_automation_preview(
+def create_scheduled_task_automation_preview(
     payload: ScheduledTaskPreviewCreateRequest,
     request: Request,
     current_user: User = Depends(get_request_user),
@@ -338,7 +349,7 @@ async def create_scheduled_task_automation_preview(
             payload=payload,
             idempotency_key=_idempotency_key(request),
         )
-    except (KeyError, ValueError) as exc:
+    except ScheduledTaskAutomationError as exc:
         _raise_automation_error(request, exc)
 
 
@@ -347,7 +358,7 @@ async def create_scheduled_task_automation_preview(
     response_model=ScheduledTaskPreviewResponse,
     dependencies=[Depends(rbac_rate_limit("tasks.read"))],
 )
-async def get_scheduled_task_automation_preview(
+def get_scheduled_task_automation_preview(
     request: Request,
     preview_id: str = Path(..., min_length=1),
     current_user: User = Depends(get_request_user),
@@ -356,7 +367,7 @@ async def get_scheduled_task_automation_preview(
 ) -> ScheduledTaskPreviewResponse:
     try:
         return service.get_preview(owner_id=int(current_user.id), preview_id=preview_id)
-    except (KeyError, ValueError) as exc:
+    except ScheduledTaskAutomationError as exc:
         _raise_automation_error(request, exc)
 
 
@@ -365,13 +376,13 @@ async def get_scheduled_task_automation_preview(
     response_model=ScheduledTaskDefinitionListResponse,
     dependencies=[Depends(rbac_rate_limit("tasks.read"))],
 )
-async def list_scheduled_task_automation_definitions(
+def list_scheduled_task_automation_definitions(
     request: Request,
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
-    family: str | None = Query(default=None),
-    lifecycle: str | None = Query(default=None),
-    health: str | None = Query(default=None),
+    family: ScheduledTaskAutomationFamily | None = Query(default=None),
+    lifecycle: ScheduledTaskDefinitionLifecycle | None = Query(default=None),
+    health: ScheduledTaskDefinitionHealth | None = Query(default=None),
     visibility_policy: str | None = Query(default=None),
     q: str | None = Query(default=None),
     created_from: str | None = Query(default=None),
@@ -410,7 +421,7 @@ async def list_scheduled_task_automation_definitions(
     status_code=status.HTTP_201_CREATED,
     dependencies=[Depends(rbac_rate_limit("tasks.control"))],
 )
-async def create_scheduled_task_automation_definition(
+def create_scheduled_task_automation_definition(
     payload: ScheduledTaskDefinitionCreateRequest,
     request: Request,
     current_user: User = Depends(get_request_user),
@@ -425,7 +436,7 @@ async def create_scheduled_task_automation_definition(
             idempotency_key=_idempotency_key(request),
             request_id=_request_id(request),
         )
-    except (KeyError, ValueError) as exc:
+    except ScheduledTaskAutomationError as exc:
         _raise_automation_error(request, exc)
 
 
@@ -434,7 +445,7 @@ async def create_scheduled_task_automation_definition(
     response_model=ScheduledTaskAuditListResponse,
     dependencies=[Depends(rbac_rate_limit("tasks.read"))],
 )
-async def list_scheduled_task_automation_definition_audit(
+def list_scheduled_task_automation_definition_audit(
     request: Request,
     definition_id: str = Path(..., min_length=1),
     limit: int = Query(default=50, ge=1, le=200),
@@ -472,7 +483,7 @@ async def list_scheduled_task_automation_definition_audit(
             idempotency_key=idempotency_key,
             request_id=request_id,
         )
-    except (KeyError, ValueError) as exc:
+    except ScheduledTaskAutomationError as exc:
         _raise_automation_error(request, exc)
 
 
@@ -481,7 +492,7 @@ async def list_scheduled_task_automation_definition_audit(
     response_model=ScheduledTaskDefinitionResponse,
     dependencies=[Depends(rbac_rate_limit("tasks.read"))],
 )
-async def get_scheduled_task_automation_definition(
+def get_scheduled_task_automation_definition(
     request: Request,
     definition_id: str = Path(..., min_length=1),
     current_user: User = Depends(get_request_user),
@@ -490,7 +501,7 @@ async def get_scheduled_task_automation_definition(
 ) -> ScheduledTaskDefinitionResponse:
     try:
         return service.get_definition(owner_id=int(current_user.id), definition_id=definition_id)
-    except (KeyError, ValueError) as exc:
+    except ScheduledTaskAutomationError as exc:
         _raise_automation_error(request, exc)
 
 
@@ -499,7 +510,7 @@ async def get_scheduled_task_automation_definition(
     response_model=ScheduledTaskDefinitionResponse,
     dependencies=[Depends(rbac_rate_limit("tasks.control"))],
 )
-async def update_scheduled_task_automation_definition(
+def update_scheduled_task_automation_definition(
     payload: ScheduledTaskDefinitionUpdateRequest,
     request: Request,
     definition_id: str = Path(..., min_length=1),
@@ -516,7 +527,7 @@ async def update_scheduled_task_automation_definition(
             idempotency_key=_idempotency_key(request),
             request_id=_request_id(request),
         )
-    except (KeyError, ValueError) as exc:
+    except ScheduledTaskAutomationError as exc:
         _raise_automation_error(request, exc)
 
 
@@ -525,7 +536,7 @@ async def update_scheduled_task_automation_definition(
     response_model=ScheduledTaskDefinitionResponse,
     dependencies=[Depends(rbac_rate_limit("tasks.control"))],
 )
-async def pause_scheduled_task_automation_definition(
+def pause_scheduled_task_automation_definition(
     request: Request,
     definition_id: str = Path(..., min_length=1),
     current_user: User = Depends(get_request_user),
@@ -540,7 +551,7 @@ async def pause_scheduled_task_automation_definition(
             idempotency_key=_idempotency_key(request),
             request_id=_request_id(request),
         )
-    except (KeyError, ValueError) as exc:
+    except ScheduledTaskAutomationError as exc:
         _raise_automation_error(request, exc)
 
 
@@ -549,7 +560,7 @@ async def pause_scheduled_task_automation_definition(
     response_model=ScheduledTaskDefinitionResponse,
     dependencies=[Depends(rbac_rate_limit("tasks.control"))],
 )
-async def resume_scheduled_task_automation_definition(
+def resume_scheduled_task_automation_definition(
     request: Request,
     definition_id: str = Path(..., min_length=1),
     current_user: User = Depends(get_request_user),
@@ -564,7 +575,7 @@ async def resume_scheduled_task_automation_definition(
             idempotency_key=_idempotency_key(request),
             request_id=_request_id(request),
         )
-    except (KeyError, ValueError) as exc:
+    except ScheduledTaskAutomationError as exc:
         _raise_automation_error(request, exc)
 
 
@@ -573,7 +584,7 @@ async def resume_scheduled_task_automation_definition(
     response_model=ScheduledTaskDefinitionResponse,
     dependencies=[Depends(rbac_rate_limit("tasks.control"))],
 )
-async def archive_scheduled_task_automation_definition(
+def archive_scheduled_task_automation_definition(
     request: Request,
     definition_id: str = Path(..., min_length=1),
     current_user: User = Depends(get_request_user),
@@ -588,7 +599,7 @@ async def archive_scheduled_task_automation_definition(
             idempotency_key=_idempotency_key(request),
             request_id=_request_id(request),
         )
-    except (KeyError, ValueError) as exc:
+    except ScheduledTaskAutomationError as exc:
         _raise_automation_error(request, exc)
 
 
@@ -597,7 +608,7 @@ async def archive_scheduled_task_automation_definition(
     response_model=ScheduledTaskDefinitionResponse,
     dependencies=[Depends(rbac_rate_limit("tasks.control"))],
 )
-async def duplicate_scheduled_task_automation_definition(
+def duplicate_scheduled_task_automation_definition(
     payload: ScheduledTaskDuplicateRequest,
     request: Request,
     definition_id: str = Path(..., min_length=1),
@@ -614,7 +625,7 @@ async def duplicate_scheduled_task_automation_definition(
             idempotency_key=_idempotency_key(request),
             request_id=_request_id(request),
         )
-    except (KeyError, ValueError) as exc:
+    except ScheduledTaskAutomationError as exc:
         _raise_automation_error(request, exc)
 
 

--- a/tldw_Server_API/app/api/v1/schemas/scheduled_tasks_automation_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/scheduled_tasks_automation_schemas.py
@@ -1,0 +1,187 @@
+"""Schemas for Scheduled Tasks automation definition contracts."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+ScheduledTaskAutomationFamily = Literal["recurring_question", "agent_task"]
+ScheduledTaskAutomationActionStatus = Literal["available", "unavailable", "planned", "disabled"]
+ScheduledTaskAutomationFamilyAvailability = Literal["available", "planned", "unavailable", "degraded"]
+ScheduledTaskPreviewMode = Literal["create", "update"]
+ScheduledTaskPreviewStatus = Literal["valid", "invalid", "expired", "consumed"]
+ScheduledTaskDefinitionLifecycle = Literal["configured", "paused", "archived", "disabled"]
+ScheduledTaskDefinitionCreateLifecycle = Literal["configured", "paused"]
+ScheduledTaskDefinitionHealth = Literal[
+    "ready",
+    "execution_unavailable",
+    "capability_unavailable",
+    "needs_attention",
+    "permission_required",
+]
+ScheduledTaskDefinitionDisabledLockKind = Literal["none", "admin", "security", "system"]
+
+
+class ScheduledTaskActionCapability(BaseModel):
+    """Capability status for a single Scheduled Tasks automation action."""
+
+    status: ScheduledTaskAutomationActionStatus
+    reason: str | None = None
+    required_permissions: list[str] = Field(default_factory=list)
+
+
+class ScheduledTaskAutomationCapability(BaseModel):
+    """Capability report for a Scheduled Tasks automation family."""
+
+    family: ScheduledTaskAutomationFamily
+    family_availability: ScheduledTaskAutomationFamilyAvailability
+    actions: dict[str, ScheduledTaskActionCapability]
+    missing_dependencies: list[str] = Field(default_factory=list)
+    related_capabilities: dict[str, Any] = Field(default_factory=dict)
+    reason: str | None = None
+    schema_version: str = "2026-06-09"
+
+
+class ScheduledTaskAutomationCapabilitiesResponse(BaseModel):
+    """Response for Scheduled Tasks automation capability discovery."""
+
+    items: list[ScheduledTaskAutomationCapability] = Field(default_factory=list)
+
+
+class ScheduledTaskPreviewCreateRequest(BaseModel):
+    """Request to validate and persist a Scheduled Tasks automation preview."""
+
+    mode: ScheduledTaskPreviewMode = "create"
+    family: ScheduledTaskAutomationFamily
+    definition_id: str | None = None
+    definition_version: int | None = Field(default=None, ge=1)
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = None
+    config: dict[str, Any] = Field(default_factory=dict)
+    input: dict[str, Any] = Field(default_factory=dict)
+    schedule: dict[str, Any] = Field(default_factory=dict)
+    visibility_policy: dict[str, Any] = Field(default_factory=dict)
+    notification_policy: dict[str, Any] = Field(default_factory=dict)
+    approval_policy: dict[str, Any] = Field(default_factory=dict)
+
+
+class ScheduledTaskPreviewResponse(BaseModel):
+    """Persisted Scheduled Tasks automation preview response."""
+
+    id: str
+    owner_id: str | None = None
+    mode: ScheduledTaskPreviewMode
+    family: ScheduledTaskAutomationFamily
+    definition_id: str | None = None
+    definition_version: int | None = Field(default=None, ge=1)
+    status: ScheduledTaskPreviewStatus
+    payload_hash: str | None = None
+    normalized_config: dict[str, Any] = Field(default_factory=dict)
+    validation_errors: list[dict[str, Any]] = Field(default_factory=list)
+    warnings: list[dict[str, Any]] = Field(default_factory=list)
+    risk_class: str | None = None
+    visibility_policy: dict[str, Any] = Field(default_factory=dict)
+    schedule_preview: dict[str, Any] = Field(default_factory=dict)
+    redaction_policy: dict[str, Any] = Field(default_factory=dict)
+    expires_at: datetime | None = None
+    created_by: str | None = None
+    created_at: datetime | None = None
+    consumed_at: datetime | None = None
+    created_definition_id: str | None = None
+
+
+class ScheduledTaskPreviewListResponse(BaseModel):
+    """Paginated list of Scheduled Tasks automation previews."""
+
+    items: list[ScheduledTaskPreviewResponse] = Field(default_factory=list)
+    total: int = Field(default=0, ge=0)
+    limit: int = Field(default=50, ge=1)
+    offset: int = Field(default=0, ge=0)
+    has_more: bool = False
+    next_offset: int | None = Field(default=None, ge=0)
+
+
+class ScheduledTaskDefinitionCreateRequest(BaseModel):
+    """Request to create a definition from a valid preview."""
+
+    preview_id: str = Field(..., min_length=1)
+    initial_lifecycle: ScheduledTaskDefinitionCreateLifecycle = "configured"
+
+
+class ScheduledTaskDefinitionUpdateRequest(BaseModel):
+    """Request to update a definition from a valid update preview."""
+
+    preview_id: str = Field(..., min_length=1)
+
+
+class ScheduledTaskDefinitionResponse(BaseModel):
+    """Persisted Scheduled Tasks automation definition response."""
+
+    id: str
+    owner_id: str | None = None
+    version: int = Field(default=1, ge=1)
+    family: ScheduledTaskAutomationFamily
+    name: str
+    description: str | None = None
+    lifecycle: ScheduledTaskDefinitionLifecycle
+    health: ScheduledTaskDefinitionHealth
+    disabled_lock_kind: ScheduledTaskDefinitionDisabledLockKind | None = None
+    disabled_reason: str | None = None
+    schedule: dict[str, Any] = Field(default_factory=dict)
+    input: dict[str, Any] = Field(default_factory=dict)
+    config: dict[str, Any] = Field(default_factory=dict)
+    visibility_policy: dict[str, Any] = Field(default_factory=dict)
+    notification_policy: dict[str, Any] = Field(default_factory=dict)
+    approval_policy: dict[str, Any] = Field(default_factory=dict)
+    preview_id: str | None = None
+    created_by: str | None = None
+    updated_by: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    archived_at: datetime | None = None
+
+
+class ScheduledTaskDefinitionListResponse(BaseModel):
+    """Paginated list of Scheduled Tasks automation definitions."""
+
+    items: list[ScheduledTaskDefinitionResponse] = Field(default_factory=list)
+    total: int = Field(default=0, ge=0)
+    limit: int = Field(default=50, ge=1)
+    offset: int = Field(default=0, ge=0)
+    has_more: bool = False
+    next_offset: int | None = Field(default=None, ge=0)
+
+
+class ScheduledTaskAuditEventResponse(BaseModel):
+    """Audit event for a Scheduled Tasks automation definition."""
+
+    id: str
+    definition_id: str
+    event_type: str
+    actor: str | None = None
+    summary: str | None = None
+    before: dict[str, Any] | None = None
+    after: dict[str, Any] | None = None
+    created_at: datetime | None = None
+    request_id: str | None = None
+    idempotency_key: str | None = None
+
+
+class ScheduledTaskAuditListResponse(BaseModel):
+    """Paginated audit list for a Scheduled Tasks automation definition."""
+
+    items: list[ScheduledTaskAuditEventResponse] = Field(default_factory=list)
+    total: int = Field(default=0, ge=0)
+    limit: int = Field(default=50, ge=1)
+    offset: int = Field(default=0, ge=0)
+    has_more: bool = False
+    next_offset: int | None = Field(default=None, ge=0)
+
+
+class ScheduledTaskDuplicateRequest(BaseModel):
+    """Request to duplicate an existing Scheduled Tasks automation definition."""
+
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = None

--- a/tldw_Server_API/app/api/v1/schemas/scheduled_tasks_control_plane_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/scheduled_tasks_control_plane_schemas.py
@@ -6,7 +6,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-ScheduledTaskPrimitive = Literal["reminder_task", "watchlist_job"]
+ScheduledTaskPrimitive = Literal["reminder_task", "watchlist_job", "automation_definition"]
 ScheduledTaskEditMode = Literal["native", "external"]
 
 

--- a/tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py
@@ -8,8 +8,10 @@ validation and lifecycle rules; this layer provides owner-scoped persistence.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import sqlite3
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -583,6 +585,12 @@ def _is_expired(expires_at: str) -> bool:
     return _parse_iso_datetime(expires_at) <= datetime.now(timezone.utc)
 
 
+def _effective_preview_status(status: str, expires_at: str) -> str:
+    if status == "valid" and _is_expired(expires_at):
+        return "expired"
+    return status
+
+
 def _prune_expired_idempotency_record(
     conn: sqlite3.Connection,
     *,
@@ -618,7 +626,7 @@ def _preview_from_row(row: sqlite3.Row | None) -> PreviewRow | None:
         family=row["family"],
         definition_id=row["definition_id"],
         definition_version=row["definition_version"],
-        status=row["status"],
+        status=_effective_preview_status(row["status"], row["expires_at"]),
         payload_hash=row["payload_hash"],
         normalized_config=_json_loads(row["normalized_config_json"]),
         validation_errors=_json_loads(row["validation_errors_json"]),
@@ -883,6 +891,22 @@ class ScheduledTasksDatabase:
             ).fetchone()
         return _preview_from_row(row)
 
+    def get_previews_by_ids(self, owner_id: int, preview_ids: Iterable[str]) -> dict[str, PreviewRow]:
+        unique_ids = list(dict.fromkeys(preview_id for preview_id in preview_ids if preview_id))
+        if not unique_ids:
+            return {}
+
+        placeholders = ",".join("?" for _ in unique_ids)
+        with self._connect() as conn:
+            # The IN placeholder list is generated; preview IDs remain bound parameters.
+            query = f"SELECT * FROM scheduled_task_previews WHERE owner_id = ? AND id IN ({placeholders})"  # nosec
+            rows = conn.execute(
+                query,
+                [owner_id, *unique_ids],
+            ).fetchall()
+        previews = [_preview_from_row(row) for row in rows]
+        return {preview.id: preview for preview in previews if preview is not None}
+
     def list_previews(
         self,
         owner_id: int,
@@ -904,6 +928,7 @@ class ScheduledTasksDatabase:
             mode,
             mode,
             status,
+            now,
             status,
             definition_id,
             definition_id,
@@ -921,12 +946,18 @@ class ScheduledTasksDatabase:
                 WHERE owner_id = ?
                     AND (? IS NULL OR family = ?)
                     AND (? IS NULL OR mode = ?)
-                    AND (? IS NULL OR status = ?)
+                    AND (? IS NULL OR (
+                        CASE WHEN status = 'valid' AND expires_at <= ? THEN 'expired' ELSE status END
+                    ) = ?)
                     AND (? IS NULL OR definition_id = ?)
                     AND (
                         ? IS NULL
-                        OR (? = 1 AND (status = 'expired' OR expires_at <= ?))
-                        OR (? = 0 AND status != 'expired' AND expires_at > ?)
+                        OR (? = 1 AND (
+                            CASE WHEN status = 'valid' AND expires_at <= ? THEN 'expired' ELSE status END
+                        ) = 'expired')
+                        OR (? = 0 AND (
+                            CASE WHEN status = 'valid' AND expires_at <= ? THEN 'expired' ELSE status END
+                        ) != 'expired')
                     )
                 """,
                 filter_params,
@@ -938,12 +969,18 @@ class ScheduledTasksDatabase:
                 WHERE owner_id = ?
                     AND (? IS NULL OR family = ?)
                     AND (? IS NULL OR mode = ?)
-                    AND (? IS NULL OR status = ?)
+                    AND (? IS NULL OR (
+                        CASE WHEN status = 'valid' AND expires_at <= ? THEN 'expired' ELSE status END
+                    ) = ?)
                     AND (? IS NULL OR definition_id = ?)
                     AND (
                         ? IS NULL
-                        OR (? = 1 AND (status = 'expired' OR expires_at <= ?))
-                        OR (? = 0 AND status != 'expired' AND expires_at > ?)
+                        OR (? = 1 AND (
+                            CASE WHEN status = 'valid' AND expires_at <= ? THEN 'expired' ELSE status END
+                        ) = 'expired')
+                        OR (? = 0 AND (
+                            CASE WHEN status = 'valid' AND expires_at <= ? THEN 'expired' ELSE status END
+                        ) != 'expired')
                     )
                 ORDER BY created_at DESC, id DESC
                 LIMIT ? OFFSET ?
@@ -1457,9 +1494,14 @@ class ScheduledTasksDatabase:
             raise RuntimeError("created idempotency record could not be loaded")
         return created
 
-    def _connect(self) -> sqlite3.Connection:
+    @contextlib.contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         conn = sqlite3.connect(str(self.db_path))
         conn.row_factory = sqlite3.Row
         configure_sqlite_connection(conn)
-        return conn
+        try:
+            with conn:
+                yield conn
+        finally:
+            conn.close()

--- a/tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py
@@ -13,7 +13,7 @@ import sqlite3
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 from uuid import uuid4
 
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
@@ -98,6 +98,441 @@ class IdempotencyRecordRow:
     response_ref: dict[str, Any]
     created_at: str
     expires_at: str
+
+
+class ScheduledTasksTransaction:
+    """Repository write transaction for Scheduled Tasks automation commands."""
+
+    def __init__(self, conn: sqlite3.Connection):
+        self._conn = conn
+
+    def create_preview(
+        self,
+        *,
+        owner_id: int,
+        mode: str,
+        family: str,
+        definition_id: str | None,
+        definition_version: int | None,
+        status: str,
+        payload_hash: str,
+        normalized_config: dict[str, Any],
+        validation_errors: list[Any],
+        warnings: list[Any],
+        risk_class: str | None,
+        visibility_policy: str,
+        schedule_preview: dict[str, Any],
+        redaction_policy: dict[str, Any],
+        expires_at: str,
+        created_by: str,
+    ) -> PreviewRow:
+        preview_id = _new_id()
+        created_at = _utcnow_iso()
+        self._conn.execute(
+            """
+            INSERT INTO scheduled_task_previews (
+                id, owner_id, mode, family, definition_id, definition_version,
+                status, payload_hash, normalized_config_json,
+                validation_errors_json, warnings_json, risk_class,
+                visibility_policy, schedule_preview_json, redaction_policy_json,
+                expires_at, created_by, created_at, consumed_at,
+                created_definition_id
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)
+            """,
+            [
+                preview_id,
+                owner_id,
+                mode,
+                family,
+                definition_id,
+                definition_version,
+                status,
+                payload_hash,
+                _json_dumps(normalized_config),
+                _json_dumps(validation_errors),
+                _json_dumps(warnings),
+                risk_class,
+                visibility_policy,
+                _json_dumps(schedule_preview),
+                _json_dumps(redaction_policy),
+                expires_at,
+                created_by,
+                created_at,
+            ],
+        )
+        row = self._conn.execute(
+            "SELECT * FROM scheduled_task_previews WHERE owner_id = ? AND id = ?",
+            [owner_id, preview_id],
+        ).fetchone()
+        created = _preview_from_row(row)
+        if created is None:
+            raise RuntimeError("created preview could not be loaded")
+        return created
+
+    def get_preview(self, owner_id: int, preview_id: str) -> PreviewRow | None:
+        row = self._conn.execute(
+            "SELECT * FROM scheduled_task_previews WHERE owner_id = ? AND id = ?",
+            [owner_id, preview_id],
+        ).fetchone()
+        return _preview_from_row(row)
+
+    def mark_preview_consumed(
+        self,
+        owner_id: int,
+        preview_id: str,
+        created_definition_id: str | None,
+    ) -> PreviewRow:
+        consumed_at = _utcnow_iso()
+        cursor = self._conn.execute(
+            """
+            UPDATE scheduled_task_previews
+            SET status = 'consumed',
+                consumed_at = ?,
+                created_definition_id = ?
+            WHERE owner_id = ?
+                AND id = ?
+                AND consumed_at IS NULL
+                AND status != 'consumed'
+            """,
+            [consumed_at, created_definition_id, owner_id, preview_id],
+        )
+        updated_count = cursor.rowcount
+        row = self._conn.execute(
+            "SELECT * FROM scheduled_task_previews WHERE owner_id = ? AND id = ?",
+            [owner_id, preview_id],
+        ).fetchone()
+        consumed = _preview_from_row(row)
+        if consumed is None:
+            raise KeyError(f"preview not found: {preview_id}")
+        if updated_count == 0:
+            raise ValueError("preview already consumed")
+        return consumed
+
+    def create_definition(
+        self,
+        *,
+        owner_id: int,
+        family: str,
+        name: str,
+        description: str | None,
+        lifecycle: str,
+        health: str,
+        schedule: dict[str, Any],
+        input: dict[str, Any],
+        visibility_policy: str,
+        notification_policy: dict[str, Any],
+        approval_policy: dict[str, Any],
+        preview_id: str,
+        created_by: str,
+        updated_by: str,
+        disabled_lock_kind: str = "none",
+        disabled_reason: str | None = None,
+        version: int = 1,
+    ) -> DefinitionRow:
+        _validate_disabled_lock_kind(disabled_lock_kind)
+        definition_id = _new_id()
+        created_at = _utcnow_iso()
+        preview_exists = self._conn.execute(
+            """
+            SELECT 1
+            FROM scheduled_task_previews
+            WHERE owner_id = ? AND id = ?
+            """,
+            [owner_id, preview_id],
+        ).fetchone()
+        if preview_exists is None:
+            raise KeyError(f"preview not found: {preview_id}")
+        preview_cursor = self._conn.execute(
+            """
+            UPDATE scheduled_task_previews
+            SET status = 'consumed',
+                consumed_at = ?,
+                created_definition_id = ?
+            WHERE owner_id = ?
+                AND id = ?
+                AND consumed_at IS NULL
+                AND status != 'consumed'
+            """,
+            [created_at, definition_id, owner_id, preview_id],
+        )
+        if preview_cursor.rowcount == 0:
+            raise ValueError("preview already consumed")
+        self._conn.execute(
+            """
+            INSERT INTO scheduled_task_definitions (
+                id, owner_id, version, family, name, description, lifecycle,
+                health, disabled_lock_kind, disabled_reason, schedule_json,
+                input_json, visibility_policy, notification_policy_json,
+                approval_policy_json, preview_id, created_by, updated_by,
+                created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                definition_id,
+                owner_id,
+                version,
+                family,
+                name,
+                description,
+                lifecycle,
+                health,
+                disabled_lock_kind,
+                disabled_reason,
+                _json_dumps(schedule),
+                _json_dumps(input),
+                visibility_policy,
+                _json_dumps(notification_policy),
+                _json_dumps(approval_policy),
+                preview_id,
+                created_by,
+                updated_by,
+                created_at,
+                created_at,
+            ],
+        )
+        row = self._conn.execute(
+            "SELECT * FROM scheduled_task_definitions WHERE owner_id = ? AND id = ?",
+            [owner_id, definition_id],
+        ).fetchone()
+        created = _definition_from_row(row)
+        if created is None:
+            raise RuntimeError("created definition could not be loaded")
+        return created
+
+    def get_definition(self, owner_id: int, definition_id: str) -> DefinitionRow | None:
+        row = self._conn.execute(
+            "SELECT * FROM scheduled_task_definitions WHERE owner_id = ? AND id = ?",
+            [owner_id, definition_id],
+        ).fetchone()
+        return _definition_from_row(row)
+
+    def update_definition(
+        self,
+        owner_id: int,
+        definition_id: str,
+        patch: dict[str, Any],
+        expected_version: int | None = None,
+    ) -> DefinitionRow:
+        current = self.get_definition(owner_id=owner_id, definition_id=definition_id)
+        if current is None:
+            raise KeyError(f"definition not found: {definition_id}")
+        if "disabled_lock_kind" in patch:
+            _validate_disabled_lock_kind(str(patch["disabled_lock_kind"]))
+
+        next_values = {
+            "version": current.version + 1,
+            "family": patch.get("family", current.family),
+            "name": patch.get("name", current.name),
+            "description": patch.get("description", current.description),
+            "lifecycle": patch.get("lifecycle", current.lifecycle),
+            "health": patch.get("health", current.health),
+            "disabled_lock_kind": patch.get("disabled_lock_kind", current.disabled_lock_kind),
+            "disabled_reason": patch.get("disabled_reason", current.disabled_reason),
+            "schedule": patch.get("schedule", current.schedule),
+            "input": patch.get("input", current.input),
+            "visibility_policy": patch.get("visibility_policy", current.visibility_policy),
+            "notification_policy": patch.get("notification_policy", current.notification_policy),
+            "approval_policy": patch.get("approval_policy", current.approval_policy),
+            "preview_id": patch.get("preview_id", current.preview_id),
+            "updated_by": patch.get("updated_by", current.updated_by),
+            "updated_at": _utcnow_iso(),
+        }
+        if "preview_id" in patch:
+            preview_exists = self._conn.execute(
+                """
+                SELECT 1
+                FROM scheduled_task_previews
+                WHERE owner_id = ? AND id = ?
+                """,
+                [owner_id, patch["preview_id"]],
+            ).fetchone()
+            if preview_exists is None:
+                raise KeyError(f"preview not found: {patch['preview_id']}")
+        cursor = self._conn.execute(
+            """
+            UPDATE scheduled_task_definitions
+            SET version = ?,
+                family = ?,
+                name = ?,
+                description = ?,
+                lifecycle = ?,
+                health = ?,
+                disabled_lock_kind = ?,
+                disabled_reason = ?,
+                schedule_json = ?,
+                input_json = ?,
+                visibility_policy = ?,
+                notification_policy_json = ?,
+                approval_policy_json = ?,
+                preview_id = ?,
+                updated_by = ?,
+                updated_at = ?
+            WHERE owner_id = ? AND id = ?
+                AND (? IS NULL OR version = ?)
+            """,
+            [
+                next_values["version"],
+                next_values["family"],
+                next_values["name"],
+                next_values["description"],
+                next_values["lifecycle"],
+                next_values["health"],
+                next_values["disabled_lock_kind"],
+                next_values["disabled_reason"],
+                _json_dumps(next_values["schedule"]),
+                _json_dumps(next_values["input"]),
+                next_values["visibility_policy"],
+                _json_dumps(next_values["notification_policy"]),
+                _json_dumps(next_values["approval_policy"]),
+                next_values["preview_id"],
+                next_values["updated_by"],
+                next_values["updated_at"],
+                owner_id,
+                definition_id,
+                expected_version,
+                expected_version,
+            ],
+        )
+        updated_count = cursor.rowcount
+        row = self._conn.execute(
+            "SELECT * FROM scheduled_task_definitions WHERE owner_id = ? AND id = ?",
+            [owner_id, definition_id],
+        ).fetchone()
+        updated = _definition_from_row(row)
+        if updated is None:
+            raise KeyError(f"definition not found after update: {definition_id}")
+        if updated_count == 0:
+            if expected_version is not None:
+                raise ValueError("definition version conflict")
+            raise KeyError(f"definition not found after update: {definition_id}")
+        return updated
+
+    def create_audit_event(
+        self,
+        *,
+        owner_id: int,
+        definition_id: str,
+        event_type: str,
+        actor: str,
+        summary: str,
+        before: dict[str, Any] | None,
+        after: dict[str, Any] | None,
+        request_id: str | None = None,
+        idempotency_key: str | None = None,
+    ) -> AuditEventRow:
+        event_id = _new_id()
+        created_at = _utcnow_iso()
+        definition_exists = self._conn.execute(
+            """
+            SELECT 1
+            FROM scheduled_task_definitions
+            WHERE owner_id = ? AND id = ?
+            """,
+            [owner_id, definition_id],
+        ).fetchone()
+        if definition_exists is None:
+            raise KeyError(f"definition not found: {definition_id}")
+        self._conn.execute(
+            """
+            INSERT INTO scheduled_task_audit_events (
+                id, owner_id, definition_id, event_type, actor, summary,
+                before_json, after_json, created_at, request_id,
+                idempotency_key
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                event_id,
+                owner_id,
+                definition_id,
+                event_type,
+                actor,
+                summary,
+                _optional_json_dumps(before),
+                _optional_json_dumps(after),
+                created_at,
+                request_id,
+                idempotency_key,
+            ],
+        )
+        row = self._conn.execute(
+            "SELECT * FROM scheduled_task_audit_events WHERE owner_id = ? AND id = ?",
+            [owner_id, event_id],
+        ).fetchone()
+        created = _audit_event_from_row(row)
+        if created is None:
+            raise RuntimeError("created audit event could not be loaded")
+        return created
+
+    def get_idempotency_record(
+        self,
+        owner_id: int,
+        route: str,
+        key: str,
+    ) -> IdempotencyRecordRow | None:
+        _prune_expired_idempotency_record(
+            self._conn,
+            owner_id=owner_id,
+            route=route,
+            key=key,
+        )
+        row = self._conn.execute(
+            """
+            SELECT * FROM scheduled_task_idempotency
+            WHERE owner_id = ? AND route = ? AND key = ?
+            """,
+            [owner_id, route, key],
+        ).fetchone()
+        return _idempotency_record_from_row(row)
+
+    def create_idempotency_record(
+        self,
+        *,
+        owner_id: int,
+        route: str,
+        key: str,
+        payload_hash: str,
+        response_ref: dict[str, Any],
+        expires_at: str,
+    ) -> IdempotencyRecordRow:
+        created_at = _utcnow_iso()
+        _prune_expired_idempotency_record(
+            self._conn,
+            owner_id=owner_id,
+            route=route,
+            key=key,
+        )
+        self._conn.execute(
+            """
+            INSERT INTO scheduled_task_idempotency (
+                owner_id, route, key, payload_hash, response_ref_json,
+                created_at, expires_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                owner_id,
+                route,
+                key,
+                payload_hash,
+                _json_dumps(response_ref),
+                created_at,
+                expires_at,
+            ],
+        )
+        row = self._conn.execute(
+            """
+            SELECT * FROM scheduled_task_idempotency
+            WHERE owner_id = ? AND route = ? AND key = ?
+            """,
+            [owner_id, route, key],
+        ).fetchone()
+        created = _idempotency_record_from_row(row)
+        if created is None:
+            raise RuntimeError("created idempotency record could not be loaded")
+        return created
 
 
 def _utcnow_iso() -> str:
@@ -368,6 +803,12 @@ class ScheduledTasksDatabase:
                     ON scheduled_task_idempotency(owner_id, route, key);
                 """
             )
+
+    def write_transaction(self, operation: Callable[[ScheduledTasksTransaction], Any]) -> Any:
+        """Run ``operation`` inside one immediate write transaction."""
+        with self._connect() as conn:
+            begin_immediate_if_needed(conn)
+            return operation(ScheduledTasksTransaction(conn))
 
     def create_preview(
         self,

--- a/tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py
@@ -17,6 +17,10 @@ from typing import Any
 from uuid import uuid4
 
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+from tldw_Server_API.app.core.DB_Management.sqlite_policy import (
+    begin_immediate_if_needed,
+    configure_sqlite_connection,
+)
 
 _SCHEDULED_TASKS_DB_NAME = "ScheduledTasks.db"
 _DISABLED_LOCK_KINDS = {"none", "admin", "security", "system"}
@@ -105,7 +109,7 @@ def _new_id() -> str:
 
 
 def _json_dumps(value: Any) -> str:
-    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False)
 
 
 def _json_loads(raw_value: str) -> Any:
@@ -130,6 +134,43 @@ def _validate_limit_offset(limit: int, offset: int) -> None:
 def _validate_disabled_lock_kind(value: str) -> None:
     if value not in _DISABLED_LOCK_KINDS:
         raise ValueError(f"invalid disabled_lock_kind: {value!r}")
+
+
+def _parse_iso_datetime(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _is_expired(expires_at: str) -> bool:
+    return _parse_iso_datetime(expires_at) <= datetime.now(timezone.utc)
+
+
+def _prune_expired_idempotency_record(
+    conn: sqlite3.Connection,
+    *,
+    owner_id: int,
+    route: str,
+    key: str,
+) -> None:
+    row = conn.execute(
+        """
+        SELECT expires_at
+        FROM scheduled_task_idempotency
+        WHERE owner_id = ? AND route = ? AND key = ?
+        """,
+        [owner_id, route, key],
+    ).fetchone()
+    if row is not None and _is_expired(row["expires_at"]):
+        conn.execute(
+            """
+            DELETE FROM scheduled_task_idempotency
+            WHERE owner_id = ? AND route = ? AND key = ?
+            """,
+            [owner_id, route, key],
+        )
 
 
 def _preview_from_row(row: sqlite3.Row | None) -> PreviewRow | None:
@@ -462,16 +503,20 @@ class ScheduledTasksDatabase:
     ) -> PreviewRow:
         consumed_at = _utcnow_iso()
         with self._connect() as conn:
-            conn.execute(
+            cursor = conn.execute(
                 """
                 UPDATE scheduled_task_previews
                 SET status = 'consumed',
                     consumed_at = ?,
                     created_definition_id = ?
-                WHERE owner_id = ? AND id = ?
+                WHERE owner_id = ?
+                    AND id = ?
+                    AND consumed_at IS NULL
+                    AND status != 'consumed'
                 """,
                 [consumed_at, created_definition_id, owner_id, preview_id],
             )
+            updated_count = cursor.rowcount
             row = conn.execute(
                 "SELECT * FROM scheduled_task_previews WHERE owner_id = ? AND id = ?",
                 [owner_id, preview_id],
@@ -479,6 +524,8 @@ class ScheduledTasksDatabase:
         consumed = _preview_from_row(row)
         if consumed is None:
             raise KeyError(f"preview not found: {preview_id}")
+        if updated_count == 0:
+            raise ValueError("preview already consumed")
         return consumed
 
     def create_definition(
@@ -506,6 +553,17 @@ class ScheduledTasksDatabase:
         definition_id = _new_id()
         created_at = _utcnow_iso()
         with self._connect() as conn:
+            begin_immediate_if_needed(conn)
+            preview_exists = conn.execute(
+                """
+                SELECT 1
+                FROM scheduled_task_previews
+                WHERE owner_id = ? AND id = ?
+                """,
+                [owner_id, preview_id],
+            ).fetchone()
+            if preview_exists is None:
+                raise KeyError(f"preview not found: {preview_id}")
             conn.execute(
                 """
                 INSERT INTO scheduled_task_definitions (
@@ -622,8 +680,6 @@ class ScheduledTasksDatabase:
         current = self.get_definition(owner_id=owner_id, definition_id=definition_id)
         if current is None:
             raise KeyError(f"definition not found: {definition_id}")
-        if expected_version is not None and current.version != expected_version:
-            raise ValueError("definition version conflict")
         if "disabled_lock_kind" in patch:
             _validate_disabled_lock_kind(str(patch["disabled_lock_kind"]))
 
@@ -646,7 +702,7 @@ class ScheduledTasksDatabase:
             "updated_at": _utcnow_iso(),
         }
         with self._connect() as conn:
-            conn.execute(
+            cursor = conn.execute(
                 """
                 UPDATE scheduled_task_definitions
                 SET version = ?,
@@ -666,6 +722,7 @@ class ScheduledTasksDatabase:
                     updated_by = ?,
                     updated_at = ?
                 WHERE owner_id = ? AND id = ?
+                    AND (? IS NULL OR version = ?)
                 """,
                 [
                     next_values["version"],
@@ -686,14 +743,21 @@ class ScheduledTasksDatabase:
                     next_values["updated_at"],
                     owner_id,
                     definition_id,
+                    expected_version,
+                    expected_version,
                 ],
             )
+            updated_count = cursor.rowcount
             row = conn.execute(
                 "SELECT * FROM scheduled_task_definitions WHERE owner_id = ? AND id = ?",
                 [owner_id, definition_id],
             ).fetchone()
         updated = _definition_from_row(row)
         if updated is None:
+            raise KeyError(f"definition not found after update: {definition_id}")
+        if updated_count == 0:
+            if expected_version is not None:
+                raise ValueError("definition version conflict")
             raise KeyError(f"definition not found after update: {definition_id}")
         return updated
 
@@ -799,6 +863,12 @@ class ScheduledTasksDatabase:
         key: str,
     ) -> IdempotencyRecordRow | None:
         with self._connect() as conn:
+            _prune_expired_idempotency_record(
+                conn,
+                owner_id=owner_id,
+                route=route,
+                key=key,
+            )
             row = conn.execute(
                 """
                 SELECT * FROM scheduled_task_idempotency
@@ -820,6 +890,12 @@ class ScheduledTasksDatabase:
     ) -> IdempotencyRecordRow:
         created_at = _utcnow_iso()
         with self._connect() as conn:
+            _prune_expired_idempotency_record(
+                conn,
+                owner_id=owner_id,
+                route=route,
+                key=key,
+            )
             conn.execute(
                 """
                 INSERT INTO scheduled_task_idempotency (
@@ -854,5 +930,5 @@ class ScheduledTasksDatabase:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         conn = sqlite3.connect(str(self.db_path))
         conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA foreign_keys = ON")
+        configure_sqlite_connection(conn)
         return conn

--- a/tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py
@@ -891,10 +891,12 @@ class ScheduledTasksDatabase:
         mode: str | None = None,
         status: str | None = None,
         definition_id: str | None = None,
+        expired: bool | None = None,
         limit: int = 50,
         offset: int = 0,
     ) -> tuple[list[PreviewRow], int]:
         _validate_limit_offset(limit, offset)
+        now = _utcnow_iso()
         filter_params: list[Any] = [
             owner_id,
             family,
@@ -905,6 +907,11 @@ class ScheduledTasksDatabase:
             status,
             definition_id,
             definition_id,
+            expired,
+            expired,
+            now,
+            expired,
+            now,
         ]
         with self._connect() as conn:
             total_row = conn.execute(
@@ -916,6 +923,11 @@ class ScheduledTasksDatabase:
                     AND (? IS NULL OR mode = ?)
                     AND (? IS NULL OR status = ?)
                     AND (? IS NULL OR definition_id = ?)
+                    AND (
+                        ? IS NULL
+                        OR (? = 1 AND (status = 'expired' OR expires_at <= ?))
+                        OR (? = 0 AND status != 'expired' AND expires_at > ?)
+                    )
                 """,
                 filter_params,
             ).fetchone()
@@ -928,6 +940,11 @@ class ScheduledTasksDatabase:
                     AND (? IS NULL OR mode = ?)
                     AND (? IS NULL OR status = ?)
                     AND (? IS NULL OR definition_id = ?)
+                    AND (
+                        ? IS NULL
+                        OR (? = 1 AND (status = 'expired' OR expires_at <= ?))
+                        OR (? = 0 AND status != 'expired' AND expires_at > ?)
+                    )
                 ORDER BY created_at DESC, id DESC
                 LIMIT ? OFFSET ?
                 """,
@@ -1078,7 +1095,10 @@ class ScheduledTasksDatabase:
         family: str | None = None,
         lifecycle: str | None = None,
         health: str | None = None,
+        visibility_policy: str | None = None,
         query: str | None = None,
+        created_from: str | None = None,
+        created_to: str | None = None,
         limit: int = 50,
         offset: int = 0,
     ) -> tuple[list[DefinitionRow], int]:
@@ -1092,9 +1112,15 @@ class ScheduledTasksDatabase:
             lifecycle,
             health,
             health,
+            visibility_policy,
+            visibility_policy,
             pattern,
             pattern,
             pattern,
+            created_from,
+            created_from,
+            created_to,
+            created_to,
         ]
         with self._connect() as conn:
             total_row = conn.execute(
@@ -1105,7 +1131,10 @@ class ScheduledTasksDatabase:
                     AND (? IS NULL OR family = ?)
                     AND (? IS NULL OR lifecycle = ?)
                     AND (? IS NULL OR health = ?)
+                    AND (? IS NULL OR visibility_policy = ?)
                     AND (? IS NULL OR name LIKE ? OR description LIKE ?)
+                    AND (? IS NULL OR created_at >= ?)
+                    AND (? IS NULL OR created_at <= ?)
                 """,
                 filter_params,
             ).fetchone()
@@ -1117,7 +1146,10 @@ class ScheduledTasksDatabase:
                     AND (? IS NULL OR family = ?)
                     AND (? IS NULL OR lifecycle = ?)
                     AND (? IS NULL OR health = ?)
+                    AND (? IS NULL OR visibility_policy = ?)
                     AND (? IS NULL OR name LIKE ? OR description LIKE ?)
+                    AND (? IS NULL OR created_at >= ?)
+                    AND (? IS NULL OR created_at <= ?)
                 ORDER BY updated_at DESC, id DESC
                 LIMIT ? OFFSET ?
                 """,
@@ -1295,6 +1327,10 @@ class ScheduledTasksDatabase:
         *,
         event_type: str | None = None,
         actor: str | None = None,
+        created_from: str | None = None,
+        created_to: str | None = None,
+        idempotency_key: str | None = None,
+        request_id: str | None = None,
         limit: int = 50,
         offset: int = 0,
     ) -> tuple[list[AuditEventRow], int]:
@@ -1306,6 +1342,14 @@ class ScheduledTasksDatabase:
             event_type,
             actor,
             actor,
+            created_from,
+            created_from,
+            created_to,
+            created_to,
+            idempotency_key,
+            idempotency_key,
+            request_id,
+            request_id,
         ]
         with self._connect() as conn:
             total_row = conn.execute(
@@ -1316,6 +1360,10 @@ class ScheduledTasksDatabase:
                     AND definition_id = ?
                     AND (? IS NULL OR event_type = ?)
                     AND (? IS NULL OR actor = ?)
+                    AND (? IS NULL OR created_at >= ?)
+                    AND (? IS NULL OR created_at <= ?)
+                    AND (? IS NULL OR idempotency_key = ?)
+                    AND (? IS NULL OR request_id = ?)
                 """,
                 filter_params,
             ).fetchone()
@@ -1327,6 +1375,10 @@ class ScheduledTasksDatabase:
                     AND definition_id = ?
                     AND (? IS NULL OR event_type = ?)
                     AND (? IS NULL OR actor = ?)
+                    AND (? IS NULL OR created_at >= ?)
+                    AND (? IS NULL OR created_at <= ?)
+                    AND (? IS NULL OR idempotency_key = ?)
+                    AND (? IS NULL OR request_id = ?)
                 ORDER BY created_at DESC, id DESC
                 LIMIT ? OFFSET ?
                 """,

--- a/tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py
@@ -564,6 +564,21 @@ class ScheduledTasksDatabase:
             ).fetchone()
             if preview_exists is None:
                 raise KeyError(f"preview not found: {preview_id}")
+            preview_cursor = conn.execute(
+                """
+                UPDATE scheduled_task_previews
+                SET status = 'consumed',
+                    consumed_at = ?,
+                    created_definition_id = ?
+                WHERE owner_id = ?
+                    AND id = ?
+                    AND consumed_at IS NULL
+                    AND status != 'consumed'
+                """,
+                [created_at, definition_id, owner_id, preview_id],
+            )
+            if preview_cursor.rowcount == 0:
+                raise ValueError("preview already consumed")
             conn.execute(
                 """
                 INSERT INTO scheduled_task_definitions (
@@ -702,6 +717,18 @@ class ScheduledTasksDatabase:
             "updated_at": _utcnow_iso(),
         }
         with self._connect() as conn:
+            begin_immediate_if_needed(conn)
+            if "preview_id" in patch:
+                preview_exists = conn.execute(
+                    """
+                    SELECT 1
+                    FROM scheduled_task_previews
+                    WHERE owner_id = ? AND id = ?
+                    """,
+                    [owner_id, patch["preview_id"]],
+                ).fetchone()
+                if preview_exists is None:
+                    raise KeyError(f"preview not found: {patch['preview_id']}")
             cursor = conn.execute(
                 """
                 UPDATE scheduled_task_definitions
@@ -777,6 +804,17 @@ class ScheduledTasksDatabase:
         event_id = _new_id()
         created_at = _utcnow_iso()
         with self._connect() as conn:
+            begin_immediate_if_needed(conn)
+            definition_exists = conn.execute(
+                """
+                SELECT 1
+                FROM scheduled_task_definitions
+                WHERE owner_id = ? AND id = ?
+                """,
+                [owner_id, definition_id],
+            ).fetchone()
+            if definition_exists is None:
+                raise KeyError(f"definition not found: {definition_id}")
             conn.execute(
                 """
                 INSERT INTO scheduled_task_audit_events (

--- a/tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py
@@ -1,0 +1,858 @@
+"""
+Per-user SQLite repository for Scheduled Tasks automation definitions.
+
+This module stores durable previews, definitions, audit events, and idempotency
+records for the Scheduled Tasks API foundation. The API/service layers own
+validation and lifecycle rules; this layer provides owner-scoped persistence.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+
+_SCHEDULED_TASKS_DB_NAME = "ScheduledTasks.db"
+_DISABLED_LOCK_KINDS = {"none", "admin", "security", "system"}
+
+
+@dataclass(frozen=True)
+class PreviewRow:
+    id: str
+    owner_id: int
+    mode: str
+    family: str
+    definition_id: str | None
+    definition_version: int | None
+    status: str
+    payload_hash: str
+    normalized_config: dict[str, Any]
+    validation_errors: list[Any]
+    warnings: list[Any]
+    risk_class: str | None
+    visibility_policy: str
+    schedule_preview: dict[str, Any]
+    redaction_policy: dict[str, Any]
+    expires_at: str
+    created_by: str
+    created_at: str
+    consumed_at: str | None
+    created_definition_id: str | None
+
+
+@dataclass(frozen=True)
+class DefinitionRow:
+    id: str
+    owner_id: int
+    version: int
+    family: str
+    name: str
+    description: str | None
+    lifecycle: str
+    health: str
+    disabled_lock_kind: str
+    disabled_reason: str | None
+    schedule: dict[str, Any]
+    input: dict[str, Any]
+    visibility_policy: str
+    notification_policy: dict[str, Any]
+    approval_policy: dict[str, Any]
+    preview_id: str
+    created_by: str
+    updated_by: str
+    created_at: str
+    updated_at: str
+
+
+@dataclass(frozen=True)
+class AuditEventRow:
+    id: str
+    owner_id: int
+    definition_id: str
+    event_type: str
+    actor: str
+    summary: str
+    before: dict[str, Any] | None
+    after: dict[str, Any] | None
+    created_at: str
+    request_id: str | None
+    idempotency_key: str | None
+
+
+@dataclass(frozen=True)
+class IdempotencyRecordRow:
+    owner_id: int
+    route: str
+    key: str
+    payload_hash: str
+    response_ref: dict[str, Any]
+    created_at: str
+    expires_at: str
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _new_id() -> str:
+    return uuid4().hex
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _json_loads(raw_value: str) -> Any:
+    return json.loads(raw_value)
+
+
+def _optional_json_dumps(value: dict[str, Any] | None) -> str | None:
+    return None if value is None else _json_dumps(value)
+
+
+def _optional_json_loads(raw_value: str | None) -> dict[str, Any] | None:
+    return None if raw_value is None else _json_loads(raw_value)
+
+
+def _validate_limit_offset(limit: int, offset: int) -> None:
+    if limit < 1:
+        raise ValueError("limit must be greater than zero")
+    if offset < 0:
+        raise ValueError("offset must not be negative")
+
+
+def _validate_disabled_lock_kind(value: str) -> None:
+    if value not in _DISABLED_LOCK_KINDS:
+        raise ValueError(f"invalid disabled_lock_kind: {value!r}")
+
+
+def _preview_from_row(row: sqlite3.Row | None) -> PreviewRow | None:
+    if row is None:
+        return None
+    return PreviewRow(
+        id=row["id"],
+        owner_id=int(row["owner_id"]),
+        mode=row["mode"],
+        family=row["family"],
+        definition_id=row["definition_id"],
+        definition_version=row["definition_version"],
+        status=row["status"],
+        payload_hash=row["payload_hash"],
+        normalized_config=_json_loads(row["normalized_config_json"]),
+        validation_errors=_json_loads(row["validation_errors_json"]),
+        warnings=_json_loads(row["warnings_json"]),
+        risk_class=row["risk_class"],
+        visibility_policy=row["visibility_policy"],
+        schedule_preview=_json_loads(row["schedule_preview_json"]),
+        redaction_policy=_json_loads(row["redaction_policy_json"]),
+        expires_at=row["expires_at"],
+        created_by=row["created_by"],
+        created_at=row["created_at"],
+        consumed_at=row["consumed_at"],
+        created_definition_id=row["created_definition_id"],
+    )
+
+
+def _definition_from_row(row: sqlite3.Row | None) -> DefinitionRow | None:
+    if row is None:
+        return None
+    return DefinitionRow(
+        id=row["id"],
+        owner_id=int(row["owner_id"]),
+        version=int(row["version"]),
+        family=row["family"],
+        name=row["name"],
+        description=row["description"],
+        lifecycle=row["lifecycle"],
+        health=row["health"],
+        disabled_lock_kind=row["disabled_lock_kind"],
+        disabled_reason=row["disabled_reason"],
+        schedule=_json_loads(row["schedule_json"]),
+        input=_json_loads(row["input_json"]),
+        visibility_policy=row["visibility_policy"],
+        notification_policy=_json_loads(row["notification_policy_json"]),
+        approval_policy=_json_loads(row["approval_policy_json"]),
+        preview_id=row["preview_id"],
+        created_by=row["created_by"],
+        updated_by=row["updated_by"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def _audit_event_from_row(row: sqlite3.Row | None) -> AuditEventRow | None:
+    if row is None:
+        return None
+    return AuditEventRow(
+        id=row["id"],
+        owner_id=int(row["owner_id"]),
+        definition_id=row["definition_id"],
+        event_type=row["event_type"],
+        actor=row["actor"],
+        summary=row["summary"],
+        before=_optional_json_loads(row["before_json"]),
+        after=_optional_json_loads(row["after_json"]),
+        created_at=row["created_at"],
+        request_id=row["request_id"],
+        idempotency_key=row["idempotency_key"],
+    )
+
+
+def _idempotency_record_from_row(row: sqlite3.Row | None) -> IdempotencyRecordRow | None:
+    if row is None:
+        return None
+    return IdempotencyRecordRow(
+        owner_id=int(row["owner_id"]),
+        route=row["route"],
+        key=row["key"],
+        payload_hash=row["payload_hash"],
+        response_ref=_json_loads(row["response_ref_json"]),
+        created_at=row["created_at"],
+        expires_at=row["expires_at"],
+    )
+
+
+class ScheduledTasksDatabase:
+    """SQLite repository for one user's Scheduled Tasks automation database."""
+
+    def __init__(self, db_path: str | Path):
+        self.db_path = Path(db_path)
+
+    @classmethod
+    def for_user(cls, user_id: int) -> ScheduledTasksDatabase:
+        """Return the per-user Scheduled Tasks repository for ``user_id``."""
+        user_dir = DatabasePaths.get_user_base_directory(user_id)
+        return cls(user_dir / _SCHEDULED_TASKS_DB_NAME)
+
+    def ensure_schema(self) -> None:
+        """Create Scheduled Tasks automation tables and indexes if needed."""
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS scheduled_task_previews (
+                    id TEXT PRIMARY KEY,
+                    owner_id INTEGER NOT NULL,
+                    mode TEXT NOT NULL,
+                    family TEXT NOT NULL,
+                    definition_id TEXT,
+                    definition_version INTEGER,
+                    status TEXT NOT NULL,
+                    payload_hash TEXT NOT NULL,
+                    normalized_config_json TEXT NOT NULL,
+                    validation_errors_json TEXT NOT NULL,
+                    warnings_json TEXT NOT NULL,
+                    risk_class TEXT,
+                    visibility_policy TEXT NOT NULL,
+                    schedule_preview_json TEXT NOT NULL,
+                    redaction_policy_json TEXT NOT NULL,
+                    expires_at TEXT NOT NULL,
+                    created_by TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    consumed_at TEXT,
+                    created_definition_id TEXT
+                );
+
+                CREATE TABLE IF NOT EXISTS scheduled_task_definitions (
+                    id TEXT PRIMARY KEY,
+                    owner_id INTEGER NOT NULL,
+                    version INTEGER NOT NULL,
+                    family TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    description TEXT,
+                    lifecycle TEXT NOT NULL,
+                    health TEXT NOT NULL,
+                    disabled_lock_kind TEXT NOT NULL DEFAULT 'none'
+                        CHECK (disabled_lock_kind IN ('none', 'admin', 'security', 'system')),
+                    disabled_reason TEXT,
+                    schedule_json TEXT NOT NULL,
+                    input_json TEXT NOT NULL,
+                    visibility_policy TEXT NOT NULL,
+                    notification_policy_json TEXT NOT NULL,
+                    approval_policy_json TEXT NOT NULL,
+                    preview_id TEXT NOT NULL,
+                    created_by TEXT NOT NULL,
+                    updated_by TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS scheduled_task_audit_events (
+                    id TEXT PRIMARY KEY,
+                    owner_id INTEGER NOT NULL,
+                    definition_id TEXT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    actor TEXT NOT NULL,
+                    summary TEXT NOT NULL,
+                    before_json TEXT,
+                    after_json TEXT,
+                    created_at TEXT NOT NULL,
+                    request_id TEXT,
+                    idempotency_key TEXT
+                );
+
+                CREATE TABLE IF NOT EXISTS scheduled_task_idempotency (
+                    owner_id INTEGER NOT NULL,
+                    route TEXT NOT NULL,
+                    key TEXT NOT NULL,
+                    payload_hash TEXT NOT NULL,
+                    response_ref_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    expires_at TEXT NOT NULL,
+                    PRIMARY KEY (owner_id, route, key)
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_scheduled_task_previews_owner_created
+                    ON scheduled_task_previews(owner_id, created_at);
+                CREATE INDEX IF NOT EXISTS idx_scheduled_task_previews_owner_definition
+                    ON scheduled_task_previews(owner_id, definition_id);
+                CREATE INDEX IF NOT EXISTS idx_scheduled_task_previews_owner_status
+                    ON scheduled_task_previews(owner_id, status);
+                CREATE INDEX IF NOT EXISTS idx_scheduled_task_definitions_owner_family
+                    ON scheduled_task_definitions(owner_id, family);
+                CREATE INDEX IF NOT EXISTS idx_scheduled_task_definitions_owner_lifecycle
+                    ON scheduled_task_definitions(owner_id, lifecycle);
+                CREATE INDEX IF NOT EXISTS idx_scheduled_task_definitions_owner_health
+                    ON scheduled_task_definitions(owner_id, health);
+                CREATE INDEX IF NOT EXISTS idx_scheduled_task_definitions_owner_updated
+                    ON scheduled_task_definitions(owner_id, updated_at);
+                CREATE INDEX IF NOT EXISTS idx_scheduled_task_audit_definition_created
+                    ON scheduled_task_audit_events(definition_id, created_at);
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_scheduled_task_idempotency_owner_route_key
+                    ON scheduled_task_idempotency(owner_id, route, key);
+                """
+            )
+
+    def create_preview(
+        self,
+        *,
+        owner_id: int,
+        mode: str,
+        family: str,
+        definition_id: str | None,
+        definition_version: int | None,
+        status: str,
+        payload_hash: str,
+        normalized_config: dict[str, Any],
+        validation_errors: list[Any],
+        warnings: list[Any],
+        risk_class: str | None,
+        visibility_policy: str,
+        schedule_preview: dict[str, Any],
+        redaction_policy: dict[str, Any],
+        expires_at: str,
+        created_by: str,
+    ) -> PreviewRow:
+        preview_id = _new_id()
+        created_at = _utcnow_iso()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO scheduled_task_previews (
+                    id, owner_id, mode, family, definition_id, definition_version,
+                    status, payload_hash, normalized_config_json,
+                    validation_errors_json, warnings_json, risk_class,
+                    visibility_policy, schedule_preview_json, redaction_policy_json,
+                    expires_at, created_by, created_at, consumed_at,
+                    created_definition_id
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)
+                """,
+                [
+                    preview_id,
+                    owner_id,
+                    mode,
+                    family,
+                    definition_id,
+                    definition_version,
+                    status,
+                    payload_hash,
+                    _json_dumps(normalized_config),
+                    _json_dumps(validation_errors),
+                    _json_dumps(warnings),
+                    risk_class,
+                    visibility_policy,
+                    _json_dumps(schedule_preview),
+                    _json_dumps(redaction_policy),
+                    expires_at,
+                    created_by,
+                    created_at,
+                ],
+            )
+            row = conn.execute(
+                "SELECT * FROM scheduled_task_previews WHERE owner_id = ? AND id = ?",
+                [owner_id, preview_id],
+            ).fetchone()
+        created = _preview_from_row(row)
+        if created is None:
+            raise RuntimeError("created preview could not be loaded")
+        return created
+
+    def get_preview(self, owner_id: int, preview_id: str) -> PreviewRow | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM scheduled_task_previews WHERE owner_id = ? AND id = ?",
+                [owner_id, preview_id],
+            ).fetchone()
+        return _preview_from_row(row)
+
+    def list_previews(
+        self,
+        owner_id: int,
+        *,
+        family: str | None = None,
+        mode: str | None = None,
+        status: str | None = None,
+        definition_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[PreviewRow], int]:
+        _validate_limit_offset(limit, offset)
+        filter_params: list[Any] = [
+            owner_id,
+            family,
+            family,
+            mode,
+            mode,
+            status,
+            status,
+            definition_id,
+            definition_id,
+        ]
+        with self._connect() as conn:
+            total_row = conn.execute(
+                """
+                SELECT COUNT(*) AS total
+                FROM scheduled_task_previews
+                WHERE owner_id = ?
+                    AND (? IS NULL OR family = ?)
+                    AND (? IS NULL OR mode = ?)
+                    AND (? IS NULL OR status = ?)
+                    AND (? IS NULL OR definition_id = ?)
+                """,
+                filter_params,
+            ).fetchone()
+            rows = conn.execute(
+                """
+                SELECT *
+                FROM scheduled_task_previews
+                WHERE owner_id = ?
+                    AND (? IS NULL OR family = ?)
+                    AND (? IS NULL OR mode = ?)
+                    AND (? IS NULL OR status = ?)
+                    AND (? IS NULL OR definition_id = ?)
+                ORDER BY created_at DESC, id DESC
+                LIMIT ? OFFSET ?
+                """,
+                [*filter_params, limit, offset],
+            ).fetchall()
+        total = int(total_row["total"] if total_row is not None else 0)
+        return [row for row in (_preview_from_row(row) for row in rows) if row is not None], total
+
+    def mark_preview_consumed(
+        self,
+        owner_id: int,
+        preview_id: str,
+        created_definition_id: str | None,
+    ) -> PreviewRow:
+        consumed_at = _utcnow_iso()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE scheduled_task_previews
+                SET status = 'consumed',
+                    consumed_at = ?,
+                    created_definition_id = ?
+                WHERE owner_id = ? AND id = ?
+                """,
+                [consumed_at, created_definition_id, owner_id, preview_id],
+            )
+            row = conn.execute(
+                "SELECT * FROM scheduled_task_previews WHERE owner_id = ? AND id = ?",
+                [owner_id, preview_id],
+            ).fetchone()
+        consumed = _preview_from_row(row)
+        if consumed is None:
+            raise KeyError(f"preview not found: {preview_id}")
+        return consumed
+
+    def create_definition(
+        self,
+        *,
+        owner_id: int,
+        family: str,
+        name: str,
+        description: str | None,
+        lifecycle: str,
+        health: str,
+        schedule: dict[str, Any],
+        input: dict[str, Any],
+        visibility_policy: str,
+        notification_policy: dict[str, Any],
+        approval_policy: dict[str, Any],
+        preview_id: str,
+        created_by: str,
+        updated_by: str,
+        disabled_lock_kind: str = "none",
+        disabled_reason: str | None = None,
+        version: int = 1,
+    ) -> DefinitionRow:
+        _validate_disabled_lock_kind(disabled_lock_kind)
+        definition_id = _new_id()
+        created_at = _utcnow_iso()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO scheduled_task_definitions (
+                    id, owner_id, version, family, name, description, lifecycle,
+                    health, disabled_lock_kind, disabled_reason, schedule_json,
+                    input_json, visibility_policy, notification_policy_json,
+                    approval_policy_json, preview_id, created_by, updated_by,
+                    created_at, updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    definition_id,
+                    owner_id,
+                    version,
+                    family,
+                    name,
+                    description,
+                    lifecycle,
+                    health,
+                    disabled_lock_kind,
+                    disabled_reason,
+                    _json_dumps(schedule),
+                    _json_dumps(input),
+                    visibility_policy,
+                    _json_dumps(notification_policy),
+                    _json_dumps(approval_policy),
+                    preview_id,
+                    created_by,
+                    updated_by,
+                    created_at,
+                    created_at,
+                ],
+            )
+            row = conn.execute(
+                "SELECT * FROM scheduled_task_definitions WHERE owner_id = ? AND id = ?",
+                [owner_id, definition_id],
+            ).fetchone()
+        created = _definition_from_row(row)
+        if created is None:
+            raise RuntimeError("created definition could not be loaded")
+        return created
+
+    def get_definition(self, owner_id: int, definition_id: str) -> DefinitionRow | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM scheduled_task_definitions WHERE owner_id = ? AND id = ?",
+                [owner_id, definition_id],
+            ).fetchone()
+        return _definition_from_row(row)
+
+    def list_definitions(
+        self,
+        owner_id: int,
+        *,
+        family: str | None = None,
+        lifecycle: str | None = None,
+        health: str | None = None,
+        query: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[DefinitionRow], int]:
+        _validate_limit_offset(limit, offset)
+        pattern = f"%{query}%" if query else None
+        filter_params: list[Any] = [
+            owner_id,
+            family,
+            family,
+            lifecycle,
+            lifecycle,
+            health,
+            health,
+            pattern,
+            pattern,
+            pattern,
+        ]
+        with self._connect() as conn:
+            total_row = conn.execute(
+                """
+                SELECT COUNT(*) AS total
+                FROM scheduled_task_definitions
+                WHERE owner_id = ?
+                    AND (? IS NULL OR family = ?)
+                    AND (? IS NULL OR lifecycle = ?)
+                    AND (? IS NULL OR health = ?)
+                    AND (? IS NULL OR name LIKE ? OR description LIKE ?)
+                """,
+                filter_params,
+            ).fetchone()
+            rows = conn.execute(
+                """
+                SELECT *
+                FROM scheduled_task_definitions
+                WHERE owner_id = ?
+                    AND (? IS NULL OR family = ?)
+                    AND (? IS NULL OR lifecycle = ?)
+                    AND (? IS NULL OR health = ?)
+                    AND (? IS NULL OR name LIKE ? OR description LIKE ?)
+                ORDER BY updated_at DESC, id DESC
+                LIMIT ? OFFSET ?
+                """,
+                [*filter_params, limit, offset],
+            ).fetchall()
+        total = int(total_row["total"] if total_row is not None else 0)
+        return [row for row in (_definition_from_row(row) for row in rows) if row is not None], total
+
+    def update_definition(
+        self,
+        owner_id: int,
+        definition_id: str,
+        patch: dict[str, Any],
+        expected_version: int | None = None,
+    ) -> DefinitionRow:
+        current = self.get_definition(owner_id=owner_id, definition_id=definition_id)
+        if current is None:
+            raise KeyError(f"definition not found: {definition_id}")
+        if expected_version is not None and current.version != expected_version:
+            raise ValueError("definition version conflict")
+        if "disabled_lock_kind" in patch:
+            _validate_disabled_lock_kind(str(patch["disabled_lock_kind"]))
+
+        next_values = {
+            "version": current.version + 1,
+            "family": patch.get("family", current.family),
+            "name": patch.get("name", current.name),
+            "description": patch.get("description", current.description),
+            "lifecycle": patch.get("lifecycle", current.lifecycle),
+            "health": patch.get("health", current.health),
+            "disabled_lock_kind": patch.get("disabled_lock_kind", current.disabled_lock_kind),
+            "disabled_reason": patch.get("disabled_reason", current.disabled_reason),
+            "schedule": patch.get("schedule", current.schedule),
+            "input": patch.get("input", current.input),
+            "visibility_policy": patch.get("visibility_policy", current.visibility_policy),
+            "notification_policy": patch.get("notification_policy", current.notification_policy),
+            "approval_policy": patch.get("approval_policy", current.approval_policy),
+            "preview_id": patch.get("preview_id", current.preview_id),
+            "updated_by": patch.get("updated_by", current.updated_by),
+            "updated_at": _utcnow_iso(),
+        }
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE scheduled_task_definitions
+                SET version = ?,
+                    family = ?,
+                    name = ?,
+                    description = ?,
+                    lifecycle = ?,
+                    health = ?,
+                    disabled_lock_kind = ?,
+                    disabled_reason = ?,
+                    schedule_json = ?,
+                    input_json = ?,
+                    visibility_policy = ?,
+                    notification_policy_json = ?,
+                    approval_policy_json = ?,
+                    preview_id = ?,
+                    updated_by = ?,
+                    updated_at = ?
+                WHERE owner_id = ? AND id = ?
+                """,
+                [
+                    next_values["version"],
+                    next_values["family"],
+                    next_values["name"],
+                    next_values["description"],
+                    next_values["lifecycle"],
+                    next_values["health"],
+                    next_values["disabled_lock_kind"],
+                    next_values["disabled_reason"],
+                    _json_dumps(next_values["schedule"]),
+                    _json_dumps(next_values["input"]),
+                    next_values["visibility_policy"],
+                    _json_dumps(next_values["notification_policy"]),
+                    _json_dumps(next_values["approval_policy"]),
+                    next_values["preview_id"],
+                    next_values["updated_by"],
+                    next_values["updated_at"],
+                    owner_id,
+                    definition_id,
+                ],
+            )
+            row = conn.execute(
+                "SELECT * FROM scheduled_task_definitions WHERE owner_id = ? AND id = ?",
+                [owner_id, definition_id],
+            ).fetchone()
+        updated = _definition_from_row(row)
+        if updated is None:
+            raise KeyError(f"definition not found after update: {definition_id}")
+        return updated
+
+    def create_audit_event(
+        self,
+        *,
+        owner_id: int,
+        definition_id: str,
+        event_type: str,
+        actor: str,
+        summary: str,
+        before: dict[str, Any] | None,
+        after: dict[str, Any] | None,
+        request_id: str | None = None,
+        idempotency_key: str | None = None,
+    ) -> AuditEventRow:
+        event_id = _new_id()
+        created_at = _utcnow_iso()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO scheduled_task_audit_events (
+                    id, owner_id, definition_id, event_type, actor, summary,
+                    before_json, after_json, created_at, request_id,
+                    idempotency_key
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    event_id,
+                    owner_id,
+                    definition_id,
+                    event_type,
+                    actor,
+                    summary,
+                    _optional_json_dumps(before),
+                    _optional_json_dumps(after),
+                    created_at,
+                    request_id,
+                    idempotency_key,
+                ],
+            )
+            row = conn.execute(
+                "SELECT * FROM scheduled_task_audit_events WHERE owner_id = ? AND id = ?",
+                [owner_id, event_id],
+            ).fetchone()
+        created = _audit_event_from_row(row)
+        if created is None:
+            raise RuntimeError("created audit event could not be loaded")
+        return created
+
+    def list_audit_events(
+        self,
+        owner_id: int,
+        definition_id: str,
+        *,
+        event_type: str | None = None,
+        actor: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[AuditEventRow], int]:
+        _validate_limit_offset(limit, offset)
+        filter_params: list[Any] = [
+            owner_id,
+            definition_id,
+            event_type,
+            event_type,
+            actor,
+            actor,
+        ]
+        with self._connect() as conn:
+            total_row = conn.execute(
+                """
+                SELECT COUNT(*) AS total
+                FROM scheduled_task_audit_events
+                WHERE owner_id = ?
+                    AND definition_id = ?
+                    AND (? IS NULL OR event_type = ?)
+                    AND (? IS NULL OR actor = ?)
+                """,
+                filter_params,
+            ).fetchone()
+            rows = conn.execute(
+                """
+                SELECT *
+                FROM scheduled_task_audit_events
+                WHERE owner_id = ?
+                    AND definition_id = ?
+                    AND (? IS NULL OR event_type = ?)
+                    AND (? IS NULL OR actor = ?)
+                ORDER BY created_at DESC, id DESC
+                LIMIT ? OFFSET ?
+                """,
+                [*filter_params, limit, offset],
+            ).fetchall()
+        total = int(total_row["total"] if total_row is not None else 0)
+        return [row for row in (_audit_event_from_row(row) for row in rows) if row is not None], total
+
+    def get_idempotency_record(
+        self,
+        owner_id: int,
+        route: str,
+        key: str,
+    ) -> IdempotencyRecordRow | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT * FROM scheduled_task_idempotency
+                WHERE owner_id = ? AND route = ? AND key = ?
+                """,
+                [owner_id, route, key],
+            ).fetchone()
+        return _idempotency_record_from_row(row)
+
+    def create_idempotency_record(
+        self,
+        *,
+        owner_id: int,
+        route: str,
+        key: str,
+        payload_hash: str,
+        response_ref: dict[str, Any],
+        expires_at: str,
+    ) -> IdempotencyRecordRow:
+        created_at = _utcnow_iso()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO scheduled_task_idempotency (
+                    owner_id, route, key, payload_hash, response_ref_json,
+                    created_at, expires_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    owner_id,
+                    route,
+                    key,
+                    payload_hash,
+                    _json_dumps(response_ref),
+                    created_at,
+                    expires_at,
+                ],
+            )
+            row = conn.execute(
+                """
+                SELECT * FROM scheduled_task_idempotency
+                WHERE owner_id = ? AND route = ? AND key = ?
+                """,
+                [owner_id, route, key],
+            ).fetchone()
+        created = _idempotency_record_from_row(row)
+        if created is None:
+            raise RuntimeError("created idempotency record could not be loaded")
+        return created
+
+    def _connect(self) -> sqlite3.Connection:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self.db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn

--- a/tldw_Server_API/app/services/scheduled_task_automation_service.py
+++ b/tldw_Server_API/app/services/scheduled_task_automation_service.py
@@ -1,0 +1,86 @@
+"""Service layer for Scheduled Tasks automation definition foundations."""
+
+from __future__ import annotations
+
+from tldw_Server_API.app.api.v1.schemas.scheduled_tasks_automation_schemas import (
+    ScheduledTaskActionCapability,
+    ScheduledTaskAuditListResponse,
+    ScheduledTaskAutomationCapabilitiesResponse,
+    ScheduledTaskAutomationCapability,
+    ScheduledTaskDefinitionListResponse,
+    ScheduledTaskPreviewListResponse,
+)
+from tldw_Server_API.app.core.AuthNZ.permissions import TASKS_CONTROL
+
+
+class ScheduledTaskAutomationService:
+    """Business service for Scheduled Tasks-owned automation definitions."""
+
+    def get_capabilities(self) -> ScheduledTaskAutomationCapabilitiesResponse:
+        """Return Phase 4B capabilities without exposing execution support."""
+        return ScheduledTaskAutomationCapabilitiesResponse(
+            items=[
+                ScheduledTaskAutomationCapability(
+                    family="recurring_question",
+                    family_availability="available",
+                    actions=self._definition_actions(),
+                    related_capabilities={"rag": {"status": "not_checked"}},
+                ),
+                ScheduledTaskAutomationCapability(
+                    family="agent_task",
+                    family_availability="available",
+                    actions=self._definition_actions(),
+                    related_capabilities={"acp": {"status": "not_checked"}},
+                ),
+            ]
+        )
+
+    def list_previews(self, *, limit: int, offset: int) -> ScheduledTaskPreviewListResponse:
+        """Return an empty preview page until durable preview storage lands."""
+        return ScheduledTaskPreviewListResponse(limit=limit, offset=offset)
+
+    def list_definitions(self, *, limit: int, offset: int) -> ScheduledTaskDefinitionListResponse:
+        """Return an empty definition page until definition storage lands."""
+        return ScheduledTaskDefinitionListResponse(limit=limit, offset=offset)
+
+    def list_audit_events(self, *, limit: int, offset: int) -> ScheduledTaskAuditListResponse:
+        """Return an empty audit page until definition audit storage lands."""
+        return ScheduledTaskAuditListResponse(limit=limit, offset=offset)
+
+    @staticmethod
+    def _definition_actions() -> dict[str, ScheduledTaskActionCapability]:
+        return {
+            "preview": ScheduledTaskActionCapability(
+                status="available",
+                required_permissions=[TASKS_CONTROL],
+            ),
+            "create_definition": ScheduledTaskActionCapability(
+                status="available",
+                required_permissions=[TASKS_CONTROL],
+            ),
+            "update_definition": ScheduledTaskActionCapability(
+                status="available",
+                required_permissions=[TASKS_CONTROL],
+            ),
+            "pause": ScheduledTaskActionCapability(
+                status="available",
+                required_permissions=[TASKS_CONTROL],
+            ),
+            "resume": ScheduledTaskActionCapability(
+                status="available",
+                required_permissions=[TASKS_CONTROL],
+            ),
+            "archive": ScheduledTaskActionCapability(
+                status="available",
+                required_permissions=[TASKS_CONTROL],
+            ),
+            "duplicate": ScheduledTaskActionCapability(
+                status="available",
+                required_permissions=[TASKS_CONTROL],
+            ),
+            "execute": ScheduledTaskActionCapability(
+                status="unavailable",
+                reason="execution_not_implemented",
+                required_permissions=[TASKS_CONTROL],
+            ),
+        }

--- a/tldw_Server_API/app/services/scheduled_task_automation_service.py
+++ b/tldw_Server_API/app/services/scheduled_task_automation_service.py
@@ -2,19 +2,159 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+from pydantic import BaseModel
+
 from tldw_Server_API.app.api.v1.schemas.scheduled_tasks_automation_schemas import (
     ScheduledTaskActionCapability,
+    ScheduledTaskAuditEventResponse,
     ScheduledTaskAuditListResponse,
     ScheduledTaskAutomationCapabilitiesResponse,
     ScheduledTaskAutomationCapability,
+    ScheduledTaskDefinitionCreateRequest,
     ScheduledTaskDefinitionListResponse,
+    ScheduledTaskDefinitionResponse,
+    ScheduledTaskDefinitionUpdateRequest,
+    ScheduledTaskDuplicateRequest,
+    ScheduledTaskPreviewCreateRequest,
     ScheduledTaskPreviewListResponse,
+    ScheduledTaskPreviewResponse,
 )
 from tldw_Server_API.app.core.AuthNZ.permissions import TASKS_CONTROL
+from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
+    AuditEventRow,
+    DefinitionRow,
+    PreviewRow,
+    ScheduledTasksDatabase,
+)
+
+PREVIEW_TTL = timedelta(hours=24)
+IDEMPOTENCY_TTL = timedelta(hours=24)
+DEFAULT_DEFINITION_HEALTH = "execution_unavailable"
+_SUPPORTED_SCHEDULE_KINDS = {"one_time", "interval", "daily", "weekly", "cron"}
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _parse_iso(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _canonical_hash(payload: dict[str, Any]) -> str:
+    """Return a stable SHA-256 hash for JSON-compatible idempotency payloads."""
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _field_error(field: str, code: str, message: str) -> dict[str, Any]:
+    return {"field": field, "code": code, "message": message}
+
+
+def _redact_agent_message(message: str) -> dict[str, Any]:
+    """Return safe Agent Task message metadata without the raw message."""
+    digest = hashlib.sha256(message.encode("utf-8")).hexdigest()
+    return {
+        "message_redacted": True,
+        "message_ref": f"sha256:{digest}",
+        "message_preview": "[redacted]",
+        "message_length": len(message),
+    }
+
+
+def _validate_schedule(schedule: dict[str, Any]) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
+    errors: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    normalized = dict(schedule or {})
+    kind = normalized.get("kind")
+    if not isinstance(kind, str) or not kind.strip():
+        errors.append(_field_error("schedule.kind", "required", "Schedule kind is required."))
+    elif kind not in _SUPPORTED_SCHEDULE_KINDS:
+        errors.append(_field_error("schedule.kind", "unsupported", f"Unsupported schedule kind: {kind}"))
+    else:
+        normalized["kind"] = kind
+    return normalized, errors, warnings
+
+
+def _validate_recurring_question_config(
+    config: dict[str, Any],
+) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
+    errors: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    name = str(config.get("name") or "").strip()
+    input_config = dict(config.get("input") or {})
+    question = str(input_config.get("question") or "").strip()
+
+    if not name:
+        errors.append(_field_error("name", "required", "Name is required."))
+    if not question:
+        errors.append(_field_error("input.question", "required", "Question is required."))
+
+    normalized = dict(config)
+    normalized["name"] = name
+    normalized["input"] = {**input_config, "question": question}
+    return normalized, errors, warnings
+
+
+def _validate_agent_task_config(config: dict[str, Any]) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
+    errors: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    name = str(config.get("name") or "").strip()
+    input_config = dict(config.get("input") or {})
+    agent_ref = str(input_config.get("agent_ref") or "").strip()
+    message = str(input_config.get("message") or "")
+
+    if not name:
+        errors.append(_field_error("name", "required", "Name is required."))
+    if not agent_ref:
+        errors.append(_field_error("input.agent_ref", "required", "Agent reference is required."))
+    if not message.strip():
+        errors.append(_field_error("input.message", "required", "Agent message is required."))
+
+    safe_input = {key: value for key, value in input_config.items() if key != "message"}
+    if message:
+        safe_input.update(_redact_agent_message(message))
+    safe_input["agent_ref"] = agent_ref
+
+    normalized = dict(config)
+    normalized["name"] = name
+    normalized["input"] = safe_input
+    normalized["redaction_policy"] = {"fields": ["input.message"], "mode": "metadata_only"}
+    return normalized, errors, warnings
+
+
+def _normalize_visibility_policy(family: str, value: Any) -> str:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    if isinstance(value, dict):
+        mode = value.get("mode") or value.get("visibility") or value.get("policy")
+        if isinstance(mode, str) and mode.strip():
+            return mode.strip()
+    return "metadata_only" if family == "agent_task" else "findings_only"
 
 
 class ScheduledTaskAutomationService:
     """Business service for Scheduled Tasks-owned automation definitions."""
+
+    def __init__(self, repository: ScheduledTasksDatabase | None = None):
+        self._repository = repository
 
     def get_capabilities(self) -> ScheduledTaskAutomationCapabilitiesResponse:
         """Return Phase 4B capabilities without exposing execution support."""
@@ -35,17 +175,725 @@ class ScheduledTaskAutomationService:
             ]
         )
 
-    def list_previews(self, *, limit: int, offset: int) -> ScheduledTaskPreviewListResponse:
-        """Return an empty preview page until durable preview storage lands."""
-        return ScheduledTaskPreviewListResponse(limit=limit, offset=offset)
+    def create_preview(
+        self,
+        *,
+        owner_id: int,
+        actor: str,
+        payload: ScheduledTaskPreviewCreateRequest | dict[str, Any],
+        idempotency_key: str | None = None,
+    ) -> ScheduledTaskPreviewResponse:
+        request = payload if isinstance(payload, ScheduledTaskPreviewCreateRequest) else ScheduledTaskPreviewCreateRequest(**payload)
+        payload_hash = _canonical_hash(self._preview_hash_payload(request))
+        return self._with_idempotency(
+            owner_id=owner_id,
+            route="scheduled_task_automation.preview",
+            key=idempotency_key,
+            payload_hash=payload_hash,
+            operation=lambda: self._create_preview(owner_id=owner_id, actor=actor, request=request, payload_hash=payload_hash),
+        )
 
-    def list_definitions(self, *, limit: int, offset: int) -> ScheduledTaskDefinitionListResponse:
-        """Return an empty definition page until definition storage lands."""
-        return ScheduledTaskDefinitionListResponse(limit=limit, offset=offset)
+    def get_preview(self, *, owner_id: int, preview_id: str) -> ScheduledTaskPreviewResponse:
+        preview = self._repo(owner_id).get_preview(owner_id=owner_id, preview_id=preview_id)
+        if preview is None:
+            raise KeyError("preview_not_found")
+        return self._preview_response(preview)
 
-    def list_audit_events(self, *, limit: int, offset: int) -> ScheduledTaskAuditListResponse:
-        """Return an empty audit page until definition audit storage lands."""
-        return ScheduledTaskAuditListResponse(limit=limit, offset=offset)
+    def list_previews(
+        self,
+        *,
+        owner_id: int | None = None,
+        limit: int,
+        offset: int,
+    ) -> ScheduledTaskPreviewListResponse:
+        """Return a page of owner-scoped previews."""
+        if owner_id is None:
+            return ScheduledTaskPreviewListResponse(limit=limit, offset=offset)
+        rows, total = self._repo(owner_id).list_previews(owner_id=owner_id, limit=limit, offset=offset)
+        return ScheduledTaskPreviewListResponse(
+            items=[self._preview_response(row) for row in rows],
+            total=total,
+            limit=limit,
+            offset=offset,
+            has_more=offset + len(rows) < total,
+            next_offset=offset + len(rows) if offset + len(rows) < total else None,
+        )
+
+    def create_definition(
+        self,
+        *,
+        owner_id: int,
+        actor: str,
+        payload: ScheduledTaskDefinitionCreateRequest | dict[str, Any],
+        idempotency_key: str | None = None,
+    ) -> ScheduledTaskDefinitionResponse:
+        request = (
+            payload
+            if isinstance(payload, ScheduledTaskDefinitionCreateRequest)
+            else ScheduledTaskDefinitionCreateRequest(**payload)
+        )
+        payload_hash = _canonical_hash(request.model_dump(mode="json"))
+        return self._with_idempotency(
+            owner_id=owner_id,
+            route="scheduled_task_automation.definition.create",
+            key=idempotency_key,
+            payload_hash=payload_hash,
+            operation=lambda: self._create_definition(owner_id=owner_id, actor=actor, request=request, idempotency_key=idempotency_key),
+        )
+
+    def update_definition(
+        self,
+        *,
+        owner_id: int,
+        actor: str,
+        definition_id: str,
+        payload: ScheduledTaskDefinitionUpdateRequest | dict[str, Any],
+        idempotency_key: str | None = None,
+    ) -> ScheduledTaskDefinitionResponse:
+        request = (
+            payload
+            if isinstance(payload, ScheduledTaskDefinitionUpdateRequest)
+            else ScheduledTaskDefinitionUpdateRequest(**payload)
+        )
+        payload_hash = _canonical_hash({"definition_id": definition_id, **request.model_dump(mode="json")})
+        return self._with_idempotency(
+            owner_id=owner_id,
+            route="scheduled_task_automation.definition.update",
+            key=idempotency_key,
+            payload_hash=payload_hash,
+            operation=lambda: self._update_definition(
+                owner_id=owner_id,
+                actor=actor,
+                definition_id=definition_id,
+                request=request,
+                idempotency_key=idempotency_key,
+            ),
+        )
+
+    def get_definition(self, *, owner_id: int, definition_id: str) -> ScheduledTaskDefinitionResponse:
+        definition = self._get_definition_row(owner_id=owner_id, definition_id=definition_id)
+        return self._definition_response(definition)
+
+    def list_definitions(
+        self,
+        *,
+        owner_id: int | None = None,
+        limit: int,
+        offset: int,
+    ) -> ScheduledTaskDefinitionListResponse:
+        """Return a page of owner-scoped automation definitions."""
+        if owner_id is None:
+            return ScheduledTaskDefinitionListResponse(limit=limit, offset=offset)
+        rows, total = self._repo(owner_id).list_definitions(owner_id=owner_id, limit=limit, offset=offset)
+        return ScheduledTaskDefinitionListResponse(
+            items=[self._definition_response(row) for row in rows],
+            total=total,
+            limit=limit,
+            offset=offset,
+            has_more=offset + len(rows) < total,
+            next_offset=offset + len(rows) if offset + len(rows) < total else None,
+        )
+
+    def pause_definition(
+        self,
+        *,
+        owner_id: int,
+        actor: str,
+        definition_id: str,
+        idempotency_key: str | None = None,
+    ) -> ScheduledTaskDefinitionResponse:
+        payload_hash = _canonical_hash({"definition_id": definition_id, "action": "pause"})
+        return self._with_idempotency(
+            owner_id=owner_id,
+            route="scheduled_task_automation.definition.pause",
+            key=idempotency_key,
+            payload_hash=payload_hash,
+            operation=lambda: self._transition_definition(
+                owner_id=owner_id,
+                actor=actor,
+                definition_id=definition_id,
+                target_lifecycle="paused",
+                idempotent_lifecycle="paused",
+                event_type="definition.paused",
+                summary="Paused definition",
+                idempotency_key=idempotency_key,
+            ),
+        )
+
+    def resume_definition(
+        self,
+        *,
+        owner_id: int,
+        actor: str,
+        definition_id: str,
+        idempotency_key: str | None = None,
+    ) -> ScheduledTaskDefinitionResponse:
+        payload_hash = _canonical_hash({"definition_id": definition_id, "action": "resume"})
+        return self._with_idempotency(
+            owner_id=owner_id,
+            route="scheduled_task_automation.definition.resume",
+            key=idempotency_key,
+            payload_hash=payload_hash,
+            operation=lambda: self._transition_definition(
+                owner_id=owner_id,
+                actor=actor,
+                definition_id=definition_id,
+                target_lifecycle="configured",
+                idempotent_lifecycle="configured",
+                event_type="definition.resumed",
+                summary="Resumed definition",
+                idempotency_key=idempotency_key,
+            ),
+        )
+
+    def archive_definition(
+        self,
+        *,
+        owner_id: int,
+        actor: str,
+        definition_id: str,
+        idempotency_key: str | None = None,
+    ) -> ScheduledTaskDefinitionResponse:
+        payload_hash = _canonical_hash({"definition_id": definition_id, "action": "archive"})
+        return self._with_idempotency(
+            owner_id=owner_id,
+            route="scheduled_task_automation.definition.archive",
+            key=idempotency_key,
+            payload_hash=payload_hash,
+            operation=lambda: self._archive_definition(
+                owner_id=owner_id,
+                actor=actor,
+                definition_id=definition_id,
+                idempotency_key=idempotency_key,
+            ),
+        )
+
+    def duplicate_definition(
+        self,
+        *,
+        owner_id: int,
+        actor: str,
+        definition_id: str,
+        payload: ScheduledTaskDuplicateRequest | dict[str, Any],
+        idempotency_key: str | None = None,
+    ) -> ScheduledTaskDefinitionResponse:
+        request = payload if isinstance(payload, ScheduledTaskDuplicateRequest) else ScheduledTaskDuplicateRequest(**payload)
+        payload_hash = _canonical_hash({"definition_id": definition_id, **request.model_dump(mode="json")})
+        return self._with_idempotency(
+            owner_id=owner_id,
+            route="scheduled_task_automation.definition.duplicate",
+            key=idempotency_key,
+            payload_hash=payload_hash,
+            operation=lambda: self._duplicate_definition(
+                owner_id=owner_id,
+                actor=actor,
+                definition_id=definition_id,
+                request=request,
+                idempotency_key=idempotency_key,
+            ),
+        )
+
+    def list_audit_events(
+        self,
+        *,
+        owner_id: int | None = None,
+        definition_id: str | None = None,
+        limit: int,
+        offset: int,
+    ) -> ScheduledTaskAuditListResponse:
+        """Return a page of owner-scoped definition audit events."""
+        if owner_id is None or definition_id is None:
+            return ScheduledTaskAuditListResponse(limit=limit, offset=offset)
+        rows, total = self._repo(owner_id).list_audit_events(
+            owner_id=owner_id,
+            definition_id=definition_id,
+            limit=limit,
+            offset=offset,
+        )
+        return ScheduledTaskAuditListResponse(
+            items=[self._audit_response(row) for row in rows],
+            total=total,
+            limit=limit,
+            offset=offset,
+            has_more=offset + len(rows) < total,
+            next_offset=offset + len(rows) if offset + len(rows) < total else None,
+        )
+
+    def _repo(self, owner_id: int) -> ScheduledTasksDatabase:
+        repo = self._repository or ScheduledTasksDatabase.for_user(owner_id)
+        repo.ensure_schema()
+        return repo
+
+    def _create_preview(
+        self,
+        *,
+        owner_id: int,
+        actor: str,
+        request: ScheduledTaskPreviewCreateRequest,
+        payload_hash: str,
+    ) -> ScheduledTaskPreviewResponse:
+        normalized, validation_errors, warnings = self._normalize_preview(request)
+        status = "invalid" if validation_errors else "valid"
+        row = self._repo(owner_id).create_preview(
+            owner_id=owner_id,
+            mode=request.mode,
+            family=request.family,
+            definition_id=request.definition_id,
+            definition_version=request.definition_version,
+            status=status,
+            payload_hash=payload_hash,
+            normalized_config=normalized,
+            validation_errors=validation_errors,
+            warnings=[{"message": warning} for warning in warnings],
+            risk_class=None,
+            visibility_policy=normalized["visibility_policy"],
+            schedule_preview=normalized["schedule"],
+            redaction_policy=normalized.get("redaction_policy", {"mode": "none", "fields": []}),
+            expires_at=_iso(_utcnow() + PREVIEW_TTL),
+            created_by=actor,
+        )
+        return self._preview_response(row)
+
+    def _create_definition(
+        self,
+        *,
+        owner_id: int,
+        actor: str,
+        request: ScheduledTaskDefinitionCreateRequest,
+        idempotency_key: str | None,
+    ) -> ScheduledTaskDefinitionResponse:
+        preview = self._require_valid_preview(owner_id=owner_id, preview_id=request.preview_id)
+        if preview.mode != "create" or preview.definition_id is not None:
+            raise ValueError("preview_mode_mismatch")
+        normalized = preview.normalized_config
+        definition = self._repo(owner_id).create_definition(
+            owner_id=owner_id,
+            family=preview.family,
+            name=normalized["name"],
+            description=normalized.get("description"),
+            lifecycle=request.initial_lifecycle,
+            health=DEFAULT_DEFINITION_HEALTH,
+            schedule=normalized["schedule"],
+            input=normalized["input"],
+            visibility_policy=preview.visibility_policy,
+            notification_policy=normalized.get("notification_policy", {}),
+            approval_policy=normalized.get("approval_policy", {}),
+            preview_id=preview.id,
+            created_by=actor,
+            updated_by=actor,
+        )
+        response = self._definition_response(definition)
+        self._create_audit(
+            owner_id=owner_id,
+            definition_id=definition.id,
+            event_type="definition.created",
+            actor=actor,
+            summary="Created definition",
+            before=None,
+            after=response.model_dump(mode="json"),
+            idempotency_key=idempotency_key,
+        )
+        return response
+
+    def _update_definition(
+        self,
+        *,
+        owner_id: int,
+        actor: str,
+        definition_id: str,
+        request: ScheduledTaskDefinitionUpdateRequest,
+        idempotency_key: str | None,
+    ) -> ScheduledTaskDefinitionResponse:
+        current = self._get_definition_row(owner_id=owner_id, definition_id=definition_id)
+        if current.lifecycle == "archived":
+            raise ValueError("definition_archived")
+        preview = self._require_valid_preview(owner_id=owner_id, preview_id=request.preview_id)
+        if preview.mode != "update" or preview.definition_id != definition_id:
+            raise ValueError("preview_definition_mismatch")
+        if preview.definition_version != current.version:
+            raise ValueError("definition_version_mismatch")
+        normalized = preview.normalized_config
+        updated = self._repo(owner_id).update_definition(
+            owner_id=owner_id,
+            definition_id=definition_id,
+            patch={
+                "family": preview.family,
+                "name": normalized["name"],
+                "description": normalized.get("description"),
+                "schedule": normalized["schedule"],
+                "input": normalized["input"],
+                "visibility_policy": preview.visibility_policy,
+                "notification_policy": normalized.get("notification_policy", {}),
+                "approval_policy": normalized.get("approval_policy", {}),
+                "preview_id": preview.id,
+                "updated_by": actor,
+            },
+            expected_version=current.version,
+        )
+        self._repo(owner_id).mark_preview_consumed(
+            owner_id=owner_id,
+            preview_id=preview.id,
+            created_definition_id=definition_id,
+        )
+        response = self._definition_response(updated)
+        self._create_audit(
+            owner_id=owner_id,
+            definition_id=definition_id,
+            event_type="definition.updated",
+            actor=actor,
+            summary="Updated definition",
+            before=self._definition_response(current).model_dump(mode="json"),
+            after=response.model_dump(mode="json"),
+            idempotency_key=idempotency_key,
+        )
+        return response
+
+    def _transition_definition(
+        self,
+        *,
+        owner_id: int,
+        actor: str,
+        definition_id: str,
+        target_lifecycle: str,
+        idempotent_lifecycle: str,
+        event_type: str,
+        summary: str,
+        idempotency_key: str | None,
+    ) -> ScheduledTaskDefinitionResponse:
+        current = self._get_definition_row(owner_id=owner_id, definition_id=definition_id)
+        if current.lifecycle == "archived":
+            raise ValueError("definition_archived")
+        if current.lifecycle == idempotent_lifecycle:
+            return self._definition_response(current)
+        if current.lifecycle == "disabled":
+            raise ValueError("definition_disabled")
+        updated = self._repo(owner_id).update_definition(
+            owner_id=owner_id,
+            definition_id=definition_id,
+            patch={"lifecycle": target_lifecycle, "updated_by": actor},
+            expected_version=current.version,
+        )
+        response = self._definition_response(updated)
+        self._create_audit(
+            owner_id=owner_id,
+            definition_id=definition_id,
+            event_type=event_type,
+            actor=actor,
+            summary=summary,
+            before=self._definition_response(current).model_dump(mode="json"),
+            after=response.model_dump(mode="json"),
+            idempotency_key=idempotency_key,
+        )
+        return response
+
+    def _archive_definition(
+        self,
+        *,
+        owner_id: int,
+        actor: str,
+        definition_id: str,
+        idempotency_key: str | None,
+    ) -> ScheduledTaskDefinitionResponse:
+        current = self._get_definition_row(owner_id=owner_id, definition_id=definition_id)
+        if current.lifecycle == "archived":
+            return self._definition_response(current)
+        updated = self._repo(owner_id).update_definition(
+            owner_id=owner_id,
+            definition_id=definition_id,
+            patch={"lifecycle": "archived", "updated_by": actor},
+            expected_version=current.version,
+        )
+        response = self._definition_response(updated)
+        self._create_audit(
+            owner_id=owner_id,
+            definition_id=definition_id,
+            event_type="definition.archived",
+            actor=actor,
+            summary="Archived definition",
+            before=self._definition_response(current).model_dump(mode="json"),
+            after=response.model_dump(mode="json"),
+            idempotency_key=idempotency_key,
+        )
+        return response
+
+    def _duplicate_definition(
+        self,
+        *,
+        owner_id: int,
+        actor: str,
+        definition_id: str,
+        request: ScheduledTaskDuplicateRequest,
+        idempotency_key: str | None,
+    ) -> ScheduledTaskDefinitionResponse:
+        source = self._get_definition_row(owner_id=owner_id, definition_id=definition_id)
+        if source.lifecycle == "archived":
+            raise ValueError("definition_archived")
+        if source.lifecycle == "disabled" and source.disabled_lock_kind in {"admin", "security"}:
+            raise ValueError("definition_disabled_locked")
+        copy_name = request.name or f"{source.name} copy"
+        copy_description = request.description if request.description is not None else source.description
+        normalized = {
+            "family": source.family,
+            "name": copy_name,
+            "description": copy_description,
+            "schedule": source.schedule,
+            "input": source.input,
+            "visibility_policy": source.visibility_policy,
+            "notification_policy": source.notification_policy,
+            "approval_policy": source.approval_policy,
+            "config": {},
+            "redaction_policy": {"fields": ["input.message"], "mode": "metadata_only"}
+            if source.family == "agent_task"
+            else {"fields": [], "mode": "none"},
+        }
+        preview = self._repo(owner_id).create_preview(
+            owner_id=owner_id,
+            mode="create",
+            family=source.family,
+            definition_id=None,
+            definition_version=None,
+            status="valid",
+            payload_hash=_canonical_hash({"duplicate_of": definition_id, "name": copy_name}),
+            normalized_config=normalized,
+            validation_errors=[],
+            warnings=[],
+            risk_class=None,
+            visibility_policy=source.visibility_policy,
+            schedule_preview=source.schedule,
+            redaction_policy=normalized["redaction_policy"],
+            expires_at=_iso(_utcnow() + PREVIEW_TTL),
+            created_by=actor,
+        )
+        created = self._repo(owner_id).create_definition(
+            owner_id=owner_id,
+            family=source.family,
+            name=copy_name,
+            description=copy_description,
+            lifecycle="paused",
+            health=DEFAULT_DEFINITION_HEALTH,
+            schedule=source.schedule,
+            input=source.input,
+            visibility_policy=source.visibility_policy,
+            notification_policy=source.notification_policy,
+            approval_policy=source.approval_policy,
+            preview_id=preview.id,
+            created_by=actor,
+            updated_by=actor,
+            disabled_lock_kind="none",
+            disabled_reason=None,
+        )
+        response = self._definition_response(created)
+        source_response = self._definition_response(source)
+        self._create_audit(
+            owner_id=owner_id,
+            definition_id=source.id,
+            event_type="definition_duplicated",
+            actor=actor,
+            summary="Duplicated definition",
+            before=source_response.model_dump(mode="json"),
+            after={"duplicate_definition_id": created.id, "name": copy_name},
+            idempotency_key=idempotency_key,
+        )
+        self._create_audit(
+            owner_id=owner_id,
+            definition_id=created.id,
+            event_type="definition_duplicate_created",
+            actor=actor,
+            summary="Created duplicate definition",
+            before=None,
+            after={**response.model_dump(mode="json"), "source_definition_id": source.id},
+            idempotency_key=idempotency_key,
+        )
+        return response
+
+    def _with_idempotency(
+        self,
+        *,
+        owner_id: int,
+        route: str,
+        key: str | None,
+        payload_hash: str,
+        operation: Callable[[], BaseModel],
+    ) -> BaseModel:
+        if key is None:
+            return operation()
+        repo = self._repo(owner_id)
+        existing = repo.get_idempotency_record(owner_id=owner_id, route=route, key=key)
+        if existing is not None:
+            if existing.payload_hash != payload_hash:
+                raise ValueError("scheduled_task_idempotency_conflict")
+            return self._load_response_ref(owner_id=owner_id, response_ref=existing.response_ref)
+        response = operation()
+        repo.create_idempotency_record(
+            owner_id=owner_id,
+            route=route,
+            key=key,
+            payload_hash=payload_hash,
+            response_ref=self._response_ref(response),
+            expires_at=_iso(_utcnow() + IDEMPOTENCY_TTL),
+        )
+        return response
+
+    def _normalize_preview(
+        self,
+        request: ScheduledTaskPreviewCreateRequest,
+    ) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
+        base = self._preview_hash_payload(request)["config"]
+        schedule, schedule_errors, schedule_warnings = _validate_schedule(base["schedule"])
+        base["schedule"] = schedule
+        base["visibility_policy"] = _normalize_visibility_policy(request.family, base["visibility_policy"])
+        if request.family == "recurring_question":
+            normalized, errors, warnings = _validate_recurring_question_config(base)
+        else:
+            normalized, errors, warnings = _validate_agent_task_config(base)
+        normalized["family"] = request.family
+        normalized["schedule"] = schedule
+        normalized["visibility_policy"] = base["visibility_policy"]
+        return normalized, [*errors, *schedule_errors], [*warnings, *schedule_warnings]
+
+    def _preview_hash_payload(self, request: ScheduledTaskPreviewCreateRequest) -> dict[str, Any]:
+        payload = request.model_dump(mode="json")
+        config = {
+            "name": payload.get("name"),
+            "description": payload.get("description"),
+            "config": payload.get("config") or {},
+            "input": payload.get("input") or {},
+            "schedule": payload.get("schedule") or {},
+            "visibility_policy": payload.get("visibility_policy") or {},
+            "notification_policy": payload.get("notification_policy") or {},
+            "approval_policy": payload.get("approval_policy") or {},
+        }
+        return {
+            "mode": payload["mode"],
+            "family": payload["family"],
+            "definition_id": payload.get("definition_id"),
+            "definition_version": payload.get("definition_version"),
+            "config": config,
+        }
+
+    def _require_valid_preview(self, *, owner_id: int, preview_id: str) -> PreviewRow:
+        preview = self._repo(owner_id).get_preview(owner_id=owner_id, preview_id=preview_id)
+        if preview is None:
+            raise KeyError("preview_not_found")
+        if preview.status == "consumed":
+            raise ValueError("preview_consumed")
+        if preview.status == "expired" or _parse_iso(preview.expires_at) <= _utcnow():
+            raise ValueError("preview_expired")
+        if preview.status != "valid":
+            raise ValueError("preview_invalid")
+        return preview
+
+    def _get_definition_row(self, *, owner_id: int, definition_id: str) -> DefinitionRow:
+        definition = self._repo(owner_id).get_definition(owner_id=owner_id, definition_id=definition_id)
+        if definition is None:
+            raise KeyError("definition_not_found")
+        return definition
+
+    def _create_audit(
+        self,
+        *,
+        owner_id: int,
+        definition_id: str,
+        event_type: str,
+        actor: str,
+        summary: str,
+        before: dict[str, Any] | None,
+        after: dict[str, Any] | None,
+        idempotency_key: str | None,
+    ) -> None:
+        self._repo(owner_id).create_audit_event(
+            owner_id=owner_id,
+            definition_id=definition_id,
+            event_type=event_type,
+            actor=actor,
+            summary=summary,
+            before=before,
+            after=after,
+            request_id=None,
+            idempotency_key=idempotency_key,
+        )
+
+    def _load_response_ref(self, *, owner_id: int, response_ref: dict[str, Any]) -> BaseModel:
+        if response_ref.get("type") == "preview":
+            return self.get_preview(owner_id=owner_id, preview_id=str(response_ref["id"]))
+        if response_ref.get("type") == "definition":
+            return self.get_definition(owner_id=owner_id, definition_id=str(response_ref["id"]))
+        raise ValueError("scheduled_task_idempotency_response_unavailable")
+
+    @staticmethod
+    def _response_ref(response: BaseModel) -> dict[str, Any]:
+        if isinstance(response, ScheduledTaskPreviewResponse):
+            return {"type": "preview", "id": response.id}
+        if isinstance(response, ScheduledTaskDefinitionResponse):
+            return {"type": "definition", "id": response.id}
+        raise TypeError(f"unsupported idempotency response type: {type(response)!r}")
+
+    def _preview_response(self, row: PreviewRow) -> ScheduledTaskPreviewResponse:
+        return ScheduledTaskPreviewResponse(
+            id=row.id,
+            owner_id=str(row.owner_id),
+            mode=row.mode,
+            family=row.family,
+            definition_id=row.definition_id,
+            definition_version=row.definition_version,
+            status=row.status,
+            payload_hash=row.payload_hash,
+            normalized_config=row.normalized_config,
+            validation_errors=row.validation_errors,
+            warnings=row.warnings,
+            risk_class=row.risk_class,
+            visibility_policy={"mode": row.visibility_policy},
+            schedule_preview=row.schedule_preview,
+            redaction_policy=row.redaction_policy,
+            expires_at=row.expires_at,
+            created_by=row.created_by,
+            created_at=row.created_at,
+            consumed_at=row.consumed_at,
+            created_definition_id=row.created_definition_id,
+        )
+
+    def _definition_response(self, row: DefinitionRow) -> ScheduledTaskDefinitionResponse:
+        preview = self._repo(row.owner_id).get_preview(owner_id=row.owner_id, preview_id=row.preview_id)
+        config = preview.normalized_config.get("config", {}) if preview is not None else {}
+        return ScheduledTaskDefinitionResponse(
+            id=row.id,
+            owner_id=str(row.owner_id),
+            version=row.version,
+            family=row.family,
+            name=row.name,
+            description=row.description,
+            lifecycle=row.lifecycle,
+            health=row.health,
+            disabled_lock_kind=row.disabled_lock_kind,
+            disabled_reason=row.disabled_reason,
+            schedule=row.schedule,
+            input=row.input,
+            config=config,
+            visibility_policy={"mode": row.visibility_policy},
+            notification_policy=row.notification_policy,
+            approval_policy=row.approval_policy,
+            preview_id=row.preview_id,
+            created_by=row.created_by,
+            updated_by=row.updated_by,
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+            archived_at=row.updated_at if row.lifecycle == "archived" else None,
+        )
+
+    @staticmethod
+    def _audit_response(row: AuditEventRow) -> ScheduledTaskAuditEventResponse:
+        return ScheduledTaskAuditEventResponse(
+            id=row.id,
+            definition_id=row.definition_id,
+            event_type=row.event_type,
+            actor=row.actor,
+            summary=row.summary,
+            before=row.before,
+            after=row.after,
+            created_at=row.created_at,
+            request_id=row.request_id,
+            idempotency_key=row.idempotency_key,
+        )
 
     @staticmethod
     def _definition_actions() -> dict[str, ScheduledTaskActionCapability]:

--- a/tldw_Server_API/app/services/scheduled_task_automation_service.py
+++ b/tldw_Server_API/app/services/scheduled_task_automation_service.py
@@ -246,6 +246,7 @@ class ScheduledTaskAutomationService:
         actor: str,
         payload: ScheduledTaskDefinitionCreateRequest | dict[str, Any],
         idempotency_key: str | None = None,
+        request_id: str | None = None,
     ) -> ScheduledTaskDefinitionResponse:
         request = (
             payload
@@ -264,6 +265,7 @@ class ScheduledTaskAutomationService:
                 actor=actor,
                 request=request,
                 idempotency_key=idempotency_key,
+                request_id=request_id,
             ),
         )
 
@@ -275,6 +277,7 @@ class ScheduledTaskAutomationService:
         definition_id: str,
         payload: ScheduledTaskDefinitionUpdateRequest | dict[str, Any],
         idempotency_key: str | None = None,
+        request_id: str | None = None,
     ) -> ScheduledTaskDefinitionResponse:
         request = (
             payload
@@ -294,6 +297,7 @@ class ScheduledTaskAutomationService:
                 definition_id=definition_id,
                 request=request,
                 idempotency_key=idempotency_key,
+                request_id=request_id,
             ),
         )
 
@@ -346,6 +350,7 @@ class ScheduledTaskAutomationService:
         actor: str,
         definition_id: str,
         idempotency_key: str | None = None,
+        request_id: str | None = None,
     ) -> ScheduledTaskDefinitionResponse:
         payload_hash = _canonical_hash({"definition_id": definition_id, "action": "pause"})
         return self._with_idempotency(
@@ -363,6 +368,7 @@ class ScheduledTaskAutomationService:
                 event_type="definition.paused",
                 summary="Paused definition",
                 idempotency_key=idempotency_key,
+                request_id=request_id,
             ),
         )
 
@@ -373,6 +379,7 @@ class ScheduledTaskAutomationService:
         actor: str,
         definition_id: str,
         idempotency_key: str | None = None,
+        request_id: str | None = None,
     ) -> ScheduledTaskDefinitionResponse:
         payload_hash = _canonical_hash({"definition_id": definition_id, "action": "resume"})
         return self._with_idempotency(
@@ -390,6 +397,7 @@ class ScheduledTaskAutomationService:
                 event_type="definition.resumed",
                 summary="Resumed definition",
                 idempotency_key=idempotency_key,
+                request_id=request_id,
             ),
         )
 
@@ -400,6 +408,7 @@ class ScheduledTaskAutomationService:
         actor: str,
         definition_id: str,
         idempotency_key: str | None = None,
+        request_id: str | None = None,
     ) -> ScheduledTaskDefinitionResponse:
         payload_hash = _canonical_hash({"definition_id": definition_id, "action": "archive"})
         return self._with_idempotency(
@@ -413,6 +422,7 @@ class ScheduledTaskAutomationService:
                 actor=actor,
                 definition_id=definition_id,
                 idempotency_key=idempotency_key,
+                request_id=request_id,
             ),
         )
 
@@ -424,6 +434,7 @@ class ScheduledTaskAutomationService:
         definition_id: str,
         payload: ScheduledTaskDuplicateRequest | dict[str, Any],
         idempotency_key: str | None = None,
+        request_id: str | None = None,
     ) -> ScheduledTaskDefinitionResponse:
         request = payload if isinstance(payload, ScheduledTaskDuplicateRequest) else ScheduledTaskDuplicateRequest(**payload)
         payload_hash = _canonical_hash({"definition_id": definition_id, **request.model_dump(mode="json")})
@@ -439,6 +450,7 @@ class ScheduledTaskAutomationService:
                 definition_id=definition_id,
                 request=request,
                 idempotency_key=idempotency_key,
+                request_id=request_id,
             ),
         )
 
@@ -525,6 +537,7 @@ class ScheduledTaskAutomationService:
         actor: str,
         request: ScheduledTaskDefinitionCreateRequest,
         idempotency_key: str | None,
+        request_id: str | None,
     ) -> ScheduledTaskDefinitionResponse:
         preview = self._require_valid_preview(tx=tx, owner_id=owner_id, preview_id=request.preview_id)
         if preview.mode != "create" or preview.definition_id is not None:
@@ -557,6 +570,7 @@ class ScheduledTaskAutomationService:
             before=None,
             after=response.model_dump(mode="json"),
             idempotency_key=idempotency_key,
+            request_id=request_id,
         )
         return response
 
@@ -569,6 +583,7 @@ class ScheduledTaskAutomationService:
         definition_id: str,
         request: ScheduledTaskDefinitionUpdateRequest,
         idempotency_key: str | None,
+        request_id: str | None,
     ) -> ScheduledTaskDefinitionResponse:
         current = self._get_definition_row(tx=tx, owner_id=owner_id, definition_id=definition_id)
         if current.lifecycle == "archived":
@@ -612,6 +627,7 @@ class ScheduledTaskAutomationService:
             before=self._definition_response(current).model_dump(mode="json"),
             after=response.model_dump(mode="json"),
             idempotency_key=idempotency_key,
+            request_id=request_id,
         )
         return response
 
@@ -627,6 +643,7 @@ class ScheduledTaskAutomationService:
         event_type: str,
         summary: str,
         idempotency_key: str | None,
+        request_id: str | None,
     ) -> ScheduledTaskDefinitionResponse:
         current = self._get_definition_row(tx=tx, owner_id=owner_id, definition_id=definition_id)
         if current.lifecycle == "archived":
@@ -652,6 +669,7 @@ class ScheduledTaskAutomationService:
             before=self._definition_response(current).model_dump(mode="json"),
             after=response.model_dump(mode="json"),
             idempotency_key=idempotency_key,
+            request_id=request_id,
         )
         return response
 
@@ -663,6 +681,7 @@ class ScheduledTaskAutomationService:
         actor: str,
         definition_id: str,
         idempotency_key: str | None,
+        request_id: str | None,
     ) -> ScheduledTaskDefinitionResponse:
         current = self._get_definition_row(tx=tx, owner_id=owner_id, definition_id=definition_id)
         if current.lifecycle == "archived":
@@ -684,6 +703,7 @@ class ScheduledTaskAutomationService:
             before=self._definition_response(current).model_dump(mode="json"),
             after=response.model_dump(mode="json"),
             idempotency_key=idempotency_key,
+            request_id=request_id,
         )
         return response
 
@@ -696,6 +716,7 @@ class ScheduledTaskAutomationService:
         definition_id: str,
         request: ScheduledTaskDuplicateRequest,
         idempotency_key: str | None,
+        request_id: str | None,
     ) -> ScheduledTaskDefinitionResponse:
         source = self._get_definition_row(tx=tx, owner_id=owner_id, definition_id=definition_id)
         if source.lifecycle == "archived":
@@ -766,6 +787,7 @@ class ScheduledTaskAutomationService:
             before=source_response.model_dump(mode="json"),
             after={"duplicate_definition_id": created.id, "name": copy_name},
             idempotency_key=idempotency_key,
+            request_id=request_id,
         )
         self._create_audit(
             tx=tx,
@@ -777,6 +799,7 @@ class ScheduledTaskAutomationService:
             before=None,
             after={**response.model_dump(mode="json"), "source_definition_id": source.id},
             idempotency_key=idempotency_key,
+            request_id=request_id,
         )
         return response
 
@@ -899,6 +922,7 @@ class ScheduledTaskAutomationService:
         before: dict[str, Any] | None,
         after: dict[str, Any] | None,
         idempotency_key: str | None,
+        request_id: str | None = None,
     ) -> None:
         target = tx if tx is not None else self._repo(owner_id)
         target.create_audit_event(
@@ -909,7 +933,7 @@ class ScheduledTaskAutomationService:
             summary=summary,
             before=before,
             after=after,
-            request_id=None,
+            request_id=request_id,
             idempotency_key=idempotency_key,
         )
 

--- a/tldw_Server_API/app/services/scheduled_task_automation_service.py
+++ b/tldw_Server_API/app/services/scheduled_task_automation_service.py
@@ -814,6 +814,12 @@ class ScheduledTaskAutomationService:
         )
 
     def _load_response_ref(self, *, owner_id: int, response_ref: dict[str, Any]) -> BaseModel:
+        snapshot = response_ref.get("snapshot")
+        if isinstance(snapshot, dict):
+            if response_ref.get("type") == "preview":
+                return ScheduledTaskPreviewResponse.model_validate(snapshot)
+            if response_ref.get("type") == "definition":
+                return ScheduledTaskDefinitionResponse.model_validate(snapshot)
         if response_ref.get("type") == "preview":
             return self.get_preview(owner_id=owner_id, preview_id=str(response_ref["id"]))
         if response_ref.get("type") == "definition":
@@ -823,9 +829,17 @@ class ScheduledTaskAutomationService:
     @staticmethod
     def _response_ref(response: BaseModel) -> dict[str, Any]:
         if isinstance(response, ScheduledTaskPreviewResponse):
-            return {"type": "preview", "id": response.id}
+            return {
+                "type": "preview",
+                "id": response.id,
+                "snapshot": response.model_dump(mode="json"),
+            }
         if isinstance(response, ScheduledTaskDefinitionResponse):
-            return {"type": "definition", "id": response.id}
+            return {
+                "type": "definition",
+                "id": response.id,
+                "snapshot": response.model_dump(mode="json"),
+            }
         raise TypeError(f"unsupported idempotency response type: {type(response)!r}")
 
     def _preview_response(self, row: PreviewRow) -> ScheduledTaskPreviewResponse:

--- a/tldw_Server_API/app/services/scheduled_task_automation_service.py
+++ b/tldw_Server_API/app/services/scheduled_task_automation_service.py
@@ -211,11 +211,25 @@ class ScheduledTaskAutomationService:
         owner_id: int | None = None,
         limit: int,
         offset: int,
+        family: str | None = None,
+        mode: str | None = None,
+        status: str | None = None,
+        definition_id: str | None = None,
+        expired: bool | None = None,
     ) -> ScheduledTaskPreviewListResponse:
         """Return a page of owner-scoped previews."""
         if owner_id is None:
             return ScheduledTaskPreviewListResponse(limit=limit, offset=offset)
-        rows, total = self._repo(owner_id).list_previews(owner_id=owner_id, limit=limit, offset=offset)
+        rows, total = self._repo(owner_id).list_previews(
+            owner_id=owner_id,
+            limit=limit,
+            offset=offset,
+            family=family,
+            mode=mode,
+            status=status,
+            definition_id=definition_id,
+            expired=expired,
+        )
         return ScheduledTaskPreviewListResponse(
             items=[self._preview_response(row) for row in rows],
             total=total,
@@ -293,11 +307,29 @@ class ScheduledTaskAutomationService:
         owner_id: int | None = None,
         limit: int,
         offset: int,
+        family: str | None = None,
+        lifecycle: str | None = None,
+        health: str | None = None,
+        visibility_policy: str | None = None,
+        query: str | None = None,
+        created_from: str | None = None,
+        created_to: str | None = None,
     ) -> ScheduledTaskDefinitionListResponse:
         """Return a page of owner-scoped automation definitions."""
         if owner_id is None:
             return ScheduledTaskDefinitionListResponse(limit=limit, offset=offset)
-        rows, total = self._repo(owner_id).list_definitions(owner_id=owner_id, limit=limit, offset=offset)
+        rows, total = self._repo(owner_id).list_definitions(
+            owner_id=owner_id,
+            limit=limit,
+            offset=offset,
+            family=family,
+            lifecycle=lifecycle,
+            health=health,
+            visibility_policy=visibility_policy,
+            query=query,
+            created_from=created_from,
+            created_to=created_to,
+        )
         return ScheduledTaskDefinitionListResponse(
             items=[self._definition_response(row) for row in rows],
             total=total,
@@ -417,15 +449,28 @@ class ScheduledTaskAutomationService:
         definition_id: str | None = None,
         limit: int,
         offset: int,
+        event_type: str | None = None,
+        actor: str | None = None,
+        created_from: str | None = None,
+        created_to: str | None = None,
+        idempotency_key: str | None = None,
+        request_id: str | None = None,
     ) -> ScheduledTaskAuditListResponse:
         """Return a page of owner-scoped definition audit events."""
         if owner_id is None or definition_id is None:
             return ScheduledTaskAuditListResponse(limit=limit, offset=offset)
+        self._get_definition_row(owner_id=owner_id, definition_id=definition_id)
         rows, total = self._repo(owner_id).list_audit_events(
             owner_id=owner_id,
             definition_id=definition_id,
             limit=limit,
             offset=offset,
+            event_type=event_type,
+            actor=actor,
+            created_from=created_from,
+            created_to=created_to,
+            idempotency_key=idempotency_key,
+            request_id=request_id,
         )
         return ScheduledTaskAuditListResponse(
             items=[self._audit_response(row) for row in rows],

--- a/tldw_Server_API/app/services/scheduled_task_automation_service.py
+++ b/tldw_Server_API/app/services/scheduled_task_automation_service.py
@@ -40,6 +40,14 @@ DEFAULT_DEFINITION_HEALTH = "execution_unavailable"
 _SUPPORTED_SCHEDULE_KINDS = {"one_time", "interval", "daily", "weekly", "cron"}
 
 
+class ScheduledTaskAutomationError(Exception):
+    """Expected, user-actionable scheduled task automation failure."""
+
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
@@ -79,10 +87,13 @@ def _redact_agent_message(message: str) -> dict[str, Any]:
     }
 
 
-def _validate_schedule(schedule: dict[str, Any]) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
+def _validate_schedule(schedule: Any) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
     errors: list[dict[str, Any]] = []
     warnings: list[str] = []
-    normalized = dict(schedule or {})
+    if not isinstance(schedule, dict):
+        return {}, [_field_error("schedule", "invalid_type", "Schedule must be an object.")], warnings
+
+    normalized = dict(schedule)
     kind = normalized.get("kind")
     if not isinstance(kind, str) or not kind.strip():
         errors.append(_field_error("schedule.kind", "required", "Schedule kind is required."))
@@ -155,6 +166,7 @@ class ScheduledTaskAutomationService:
 
     def __init__(self, repository: ScheduledTasksDatabase | None = None):
         self._repository = repository
+        self._schema_ready_keys: set[tuple[int, str]] = set()
 
     def get_capabilities(self) -> ScheduledTaskAutomationCapabilitiesResponse:
         """Return Phase 4B capabilities without exposing execution support."""
@@ -202,7 +214,7 @@ class ScheduledTaskAutomationService:
     def get_preview(self, *, owner_id: int, preview_id: str) -> ScheduledTaskPreviewResponse:
         preview = self._repo(owner_id).get_preview(owner_id=owner_id, preview_id=preview_id)
         if preview is None:
-            raise KeyError("preview_not_found")
+            raise ScheduledTaskAutomationError("preview_resource_not_found")
         return self._preview_response(preview)
 
     def list_previews(
@@ -322,7 +334,8 @@ class ScheduledTaskAutomationService:
         """Return a page of owner-scoped automation definitions."""
         if owner_id is None:
             return ScheduledTaskDefinitionListResponse(limit=limit, offset=offset)
-        rows, total = self._repo(owner_id).list_definitions(
+        repo = self._repo(owner_id)
+        rows, total = repo.list_definitions(
             owner_id=owner_id,
             limit=limit,
             offset=offset,
@@ -334,8 +347,16 @@ class ScheduledTaskAutomationService:
             created_from=created_from,
             created_to=created_to,
         )
+        previews_by_id = repo.get_previews_by_ids(owner_id=owner_id, preview_ids=[row.preview_id for row in rows])
         return ScheduledTaskDefinitionListResponse(
-            items=[self._definition_response(row) for row in rows],
+            items=[
+                self._definition_response(
+                    row,
+                    preview=previews_by_id.get(row.preview_id),
+                    lookup_preview=False,
+                )
+                for row in rows
+            ],
             total=total,
             limit=limit,
             offset=offset,
@@ -495,7 +516,10 @@ class ScheduledTaskAutomationService:
 
     def _repo(self, owner_id: int) -> ScheduledTasksDatabase:
         repo = self._repository or ScheduledTasksDatabase.for_user(owner_id)
-        repo.ensure_schema()
+        schema_key = (owner_id, str(repo.db_path))
+        if schema_key not in self._schema_ready_keys:
+            repo.ensure_schema()
+            self._schema_ready_keys.add(schema_key)
         return repo
 
     def _create_preview(
@@ -541,7 +565,7 @@ class ScheduledTaskAutomationService:
     ) -> ScheduledTaskDefinitionResponse:
         preview = self._require_valid_preview(tx=tx, owner_id=owner_id, preview_id=request.preview_id)
         if preview.mode != "create" or preview.definition_id is not None:
-            raise ValueError("preview_mode_mismatch")
+            raise ScheduledTaskAutomationError("preview_mode_mismatch")
         normalized = preview.normalized_config
         definition = tx.create_definition(
             owner_id=owner_id,
@@ -587,12 +611,12 @@ class ScheduledTaskAutomationService:
     ) -> ScheduledTaskDefinitionResponse:
         current = self._get_definition_row(tx=tx, owner_id=owner_id, definition_id=definition_id)
         if current.lifecycle == "archived":
-            raise ValueError("definition_archived")
+            raise ScheduledTaskAutomationError("definition_archived")
         preview = self._require_valid_preview(tx=tx, owner_id=owner_id, preview_id=request.preview_id)
         if preview.mode != "update" or preview.definition_id != definition_id:
-            raise ValueError("preview_definition_mismatch")
+            raise ScheduledTaskAutomationError("preview_definition_mismatch")
         if preview.definition_version != current.version:
-            raise ValueError("definition_version_mismatch")
+            raise ScheduledTaskAutomationError("definition_version_mismatch")
         normalized = preview.normalized_config
         updated = tx.update_definition(
             owner_id=owner_id,
@@ -647,11 +671,11 @@ class ScheduledTaskAutomationService:
     ) -> ScheduledTaskDefinitionResponse:
         current = self._get_definition_row(tx=tx, owner_id=owner_id, definition_id=definition_id)
         if current.lifecycle == "archived":
-            raise ValueError("definition_archived")
+            raise ScheduledTaskAutomationError("definition_archived")
         if current.lifecycle == idempotent_lifecycle:
             return self._definition_response(current)
         if current.lifecycle == "disabled":
-            raise ValueError("definition_disabled")
+            raise ScheduledTaskAutomationError("definition_disabled")
         updated = tx.update_definition(
             owner_id=owner_id,
             definition_id=definition_id,
@@ -720,9 +744,9 @@ class ScheduledTaskAutomationService:
     ) -> ScheduledTaskDefinitionResponse:
         source = self._get_definition_row(tx=tx, owner_id=owner_id, definition_id=definition_id)
         if source.lifecycle == "archived":
-            raise ValueError("definition_archived")
+            raise ScheduledTaskAutomationError("definition_archived")
         if source.lifecycle == "disabled" and source.disabled_lock_kind in {"admin", "security"}:
-            raise ValueError("definition_disabled_locked")
+            raise ScheduledTaskAutomationError("definition_disabled_locked")
         copy_name = request.name or f"{source.name} copy"
         copy_description = request.description if request.description is not None else source.description
         normalized = {
@@ -820,7 +844,7 @@ class ScheduledTaskAutomationService:
             existing = tx.get_idempotency_record(owner_id=owner_id, route=route, key=key)
             if existing is not None:
                 if existing.payload_hash != payload_hash:
-                    raise ValueError("scheduled_task_idempotency_conflict")
+                    raise ScheduledTaskAutomationError("scheduled_task_idempotency_conflict")
                 return self._load_response_ref(owner_id=owner_id, response_ref=existing.response_ref)
             response = operation(tx)
             tx.create_idempotency_record(
@@ -843,6 +867,41 @@ class ScheduledTaskAutomationService:
         schedule, schedule_errors, schedule_warnings = _validate_schedule(base["schedule"])
         base["schedule"] = schedule
         base["visibility_policy"] = _normalize_visibility_policy(request.family, base["visibility_policy"])
+        mode_errors: list[dict[str, Any]] = []
+        if request.mode == "update":
+            if not request.definition_id:
+                mode_errors.append(
+                    _field_error(
+                        "definition_id",
+                        "required_for_update",
+                        "Definition id is required for update previews.",
+                    )
+                )
+            if request.definition_version is None:
+                mode_errors.append(
+                    _field_error(
+                        "definition_version",
+                        "required_for_update",
+                        "Definition version is required for update previews.",
+                    )
+                )
+        else:
+            if request.definition_id is not None:
+                mode_errors.append(
+                    _field_error(
+                        "definition_id",
+                        "not_allowed_for_create",
+                        "Definition id is not allowed for create previews.",
+                    )
+                )
+            if request.definition_version is not None:
+                mode_errors.append(
+                    _field_error(
+                        "definition_version",
+                        "not_allowed_for_create",
+                        "Definition version is not allowed for create previews.",
+                    )
+                )
         if request.family == "recurring_question":
             normalized, errors, warnings = _validate_recurring_question_config(base)
         else:
@@ -850,7 +909,7 @@ class ScheduledTaskAutomationService:
         normalized["family"] = request.family
         normalized["schedule"] = schedule
         normalized["visibility_policy"] = base["visibility_policy"]
-        return normalized, [*errors, *schedule_errors], [*warnings, *schedule_warnings]
+        return normalized, [*mode_errors, *errors, *schedule_errors], [*warnings, *schedule_warnings]
 
     def _preview_hash_payload(self, request: ScheduledTaskPreviewCreateRequest) -> dict[str, Any]:
         payload = request.model_dump(mode="json")
@@ -885,13 +944,13 @@ class ScheduledTaskAutomationService:
             else self._repo(owner_id).get_preview(owner_id=owner_id, preview_id=preview_id)
         )
         if preview is None:
-            raise KeyError("preview_not_found")
+            raise ScheduledTaskAutomationError("preview_not_found")
         if preview.status == "consumed":
-            raise ValueError("preview_consumed")
+            raise ScheduledTaskAutomationError("preview_consumed")
         if preview.status == "expired" or _parse_iso(preview.expires_at) <= _utcnow():
-            raise ValueError("preview_expired")
+            raise ScheduledTaskAutomationError("preview_expired")
         if preview.status != "valid":
-            raise ValueError("preview_invalid")
+            raise ScheduledTaskAutomationError("preview_invalid")
         return preview
 
     def _get_definition_row(
@@ -907,7 +966,7 @@ class ScheduledTaskAutomationService:
             else self._repo(owner_id).get_definition(owner_id=owner_id, definition_id=definition_id)
         )
         if definition is None:
-            raise KeyError("definition_not_found")
+            raise ScheduledTaskAutomationError("definition_not_found")
         return definition
 
     def _create_audit(
@@ -948,7 +1007,7 @@ class ScheduledTaskAutomationService:
             return self.get_preview(owner_id=owner_id, preview_id=str(response_ref["id"]))
         if response_ref.get("type") == "definition":
             return self.get_definition(owner_id=owner_id, definition_id=str(response_ref["id"]))
-        raise ValueError("scheduled_task_idempotency_response_unavailable")
+        raise ScheduledTaskAutomationError("scheduled_task_idempotency_response_unavailable")
 
     @staticmethod
     def _response_ref(response: BaseModel) -> dict[str, Any]:
@@ -990,8 +1049,15 @@ class ScheduledTaskAutomationService:
             created_definition_id=row.created_definition_id,
         )
 
-    def _definition_response(self, row: DefinitionRow) -> ScheduledTaskDefinitionResponse:
-        preview = self._repo(row.owner_id).get_preview(owner_id=row.owner_id, preview_id=row.preview_id)
+    def _definition_response(
+        self,
+        row: DefinitionRow,
+        *,
+        preview: PreviewRow | None = None,
+        lookup_preview: bool = True,
+    ) -> ScheduledTaskDefinitionResponse:
+        if lookup_preview:
+            preview = self._repo(row.owner_id).get_preview(owner_id=row.owner_id, preview_id=row.preview_id)
         config = preview.normalized_config.get("config", {}) if preview is not None else {}
         return ScheduledTaskDefinitionResponse(
             id=row.id,

--- a/tldw_Server_API/app/services/scheduled_task_automation_service.py
+++ b/tldw_Server_API/app/services/scheduled_task_automation_service.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
+from uuid import uuid4
 
 from pydantic import BaseModel
 
@@ -29,6 +30,7 @@ from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import (
     AuditEventRow,
     DefinitionRow,
     PreviewRow,
+    ScheduledTasksTransaction,
     ScheduledTasksDatabase,
 )
 
@@ -70,12 +72,10 @@ def _field_error(field: str, code: str, message: str) -> dict[str, Any]:
 
 def _redact_agent_message(message: str) -> dict[str, Any]:
     """Return safe Agent Task message metadata without the raw message."""
-    digest = hashlib.sha256(message.encode("utf-8")).hexdigest()
     return {
         "message_redacted": True,
-        "message_ref": f"sha256:{digest}",
+        "message_ref": f"redacted:{uuid4().hex}",
         "message_preview": "[redacted]",
-        "message_length": len(message),
     }
 
 
@@ -190,7 +190,13 @@ class ScheduledTaskAutomationService:
             route="scheduled_task_automation.preview",
             key=idempotency_key,
             payload_hash=payload_hash,
-            operation=lambda: self._create_preview(owner_id=owner_id, actor=actor, request=request, payload_hash=payload_hash),
+            operation=lambda tx: self._create_preview(
+                tx=tx,
+                owner_id=owner_id,
+                actor=actor,
+                request=request,
+                payload_hash=payload_hash,
+            ),
         )
 
     def get_preview(self, *, owner_id: int, preview_id: str) -> ScheduledTaskPreviewResponse:
@@ -238,7 +244,13 @@ class ScheduledTaskAutomationService:
             route="scheduled_task_automation.definition.create",
             key=idempotency_key,
             payload_hash=payload_hash,
-            operation=lambda: self._create_definition(owner_id=owner_id, actor=actor, request=request, idempotency_key=idempotency_key),
+            operation=lambda tx: self._create_definition(
+                tx=tx,
+                owner_id=owner_id,
+                actor=actor,
+                request=request,
+                idempotency_key=idempotency_key,
+            ),
         )
 
     def update_definition(
@@ -261,7 +273,8 @@ class ScheduledTaskAutomationService:
             route="scheduled_task_automation.definition.update",
             key=idempotency_key,
             payload_hash=payload_hash,
-            operation=lambda: self._update_definition(
+            operation=lambda tx: self._update_definition(
+                tx=tx,
                 owner_id=owner_id,
                 actor=actor,
                 definition_id=definition_id,
@@ -308,7 +321,8 @@ class ScheduledTaskAutomationService:
             route="scheduled_task_automation.definition.pause",
             key=idempotency_key,
             payload_hash=payload_hash,
-            operation=lambda: self._transition_definition(
+            operation=lambda tx: self._transition_definition(
+                tx=tx,
                 owner_id=owner_id,
                 actor=actor,
                 definition_id=definition_id,
@@ -334,7 +348,8 @@ class ScheduledTaskAutomationService:
             route="scheduled_task_automation.definition.resume",
             key=idempotency_key,
             payload_hash=payload_hash,
-            operation=lambda: self._transition_definition(
+            operation=lambda tx: self._transition_definition(
+                tx=tx,
                 owner_id=owner_id,
                 actor=actor,
                 definition_id=definition_id,
@@ -360,7 +375,8 @@ class ScheduledTaskAutomationService:
             route="scheduled_task_automation.definition.archive",
             key=idempotency_key,
             payload_hash=payload_hash,
-            operation=lambda: self._archive_definition(
+            operation=lambda tx: self._archive_definition(
+                tx=tx,
                 owner_id=owner_id,
                 actor=actor,
                 definition_id=definition_id,
@@ -384,7 +400,8 @@ class ScheduledTaskAutomationService:
             route="scheduled_task_automation.definition.duplicate",
             key=idempotency_key,
             payload_hash=payload_hash,
-            operation=lambda: self._duplicate_definition(
+            operation=lambda tx: self._duplicate_definition(
+                tx=tx,
                 owner_id=owner_id,
                 actor=actor,
                 definition_id=definition_id,
@@ -427,6 +444,7 @@ class ScheduledTaskAutomationService:
     def _create_preview(
         self,
         *,
+        tx: ScheduledTasksTransaction,
         owner_id: int,
         actor: str,
         request: ScheduledTaskPreviewCreateRequest,
@@ -434,7 +452,7 @@ class ScheduledTaskAutomationService:
     ) -> ScheduledTaskPreviewResponse:
         normalized, validation_errors, warnings = self._normalize_preview(request)
         status = "invalid" if validation_errors else "valid"
-        row = self._repo(owner_id).create_preview(
+        row = tx.create_preview(
             owner_id=owner_id,
             mode=request.mode,
             family=request.family,
@@ -457,16 +475,17 @@ class ScheduledTaskAutomationService:
     def _create_definition(
         self,
         *,
+        tx: ScheduledTasksTransaction,
         owner_id: int,
         actor: str,
         request: ScheduledTaskDefinitionCreateRequest,
         idempotency_key: str | None,
     ) -> ScheduledTaskDefinitionResponse:
-        preview = self._require_valid_preview(owner_id=owner_id, preview_id=request.preview_id)
+        preview = self._require_valid_preview(tx=tx, owner_id=owner_id, preview_id=request.preview_id)
         if preview.mode != "create" or preview.definition_id is not None:
             raise ValueError("preview_mode_mismatch")
         normalized = preview.normalized_config
-        definition = self._repo(owner_id).create_definition(
+        definition = tx.create_definition(
             owner_id=owner_id,
             family=preview.family,
             name=normalized["name"],
@@ -484,6 +503,7 @@ class ScheduledTaskAutomationService:
         )
         response = self._definition_response(definition)
         self._create_audit(
+            tx=tx,
             owner_id=owner_id,
             definition_id=definition.id,
             event_type="definition.created",
@@ -498,22 +518,23 @@ class ScheduledTaskAutomationService:
     def _update_definition(
         self,
         *,
+        tx: ScheduledTasksTransaction,
         owner_id: int,
         actor: str,
         definition_id: str,
         request: ScheduledTaskDefinitionUpdateRequest,
         idempotency_key: str | None,
     ) -> ScheduledTaskDefinitionResponse:
-        current = self._get_definition_row(owner_id=owner_id, definition_id=definition_id)
+        current = self._get_definition_row(tx=tx, owner_id=owner_id, definition_id=definition_id)
         if current.lifecycle == "archived":
             raise ValueError("definition_archived")
-        preview = self._require_valid_preview(owner_id=owner_id, preview_id=request.preview_id)
+        preview = self._require_valid_preview(tx=tx, owner_id=owner_id, preview_id=request.preview_id)
         if preview.mode != "update" or preview.definition_id != definition_id:
             raise ValueError("preview_definition_mismatch")
         if preview.definition_version != current.version:
             raise ValueError("definition_version_mismatch")
         normalized = preview.normalized_config
-        updated = self._repo(owner_id).update_definition(
+        updated = tx.update_definition(
             owner_id=owner_id,
             definition_id=definition_id,
             patch={
@@ -530,13 +551,14 @@ class ScheduledTaskAutomationService:
             },
             expected_version=current.version,
         )
-        self._repo(owner_id).mark_preview_consumed(
+        tx.mark_preview_consumed(
             owner_id=owner_id,
             preview_id=preview.id,
             created_definition_id=definition_id,
         )
         response = self._definition_response(updated)
         self._create_audit(
+            tx=tx,
             owner_id=owner_id,
             definition_id=definition_id,
             event_type="definition.updated",
@@ -551,6 +573,7 @@ class ScheduledTaskAutomationService:
     def _transition_definition(
         self,
         *,
+        tx: ScheduledTasksTransaction,
         owner_id: int,
         actor: str,
         definition_id: str,
@@ -560,14 +583,14 @@ class ScheduledTaskAutomationService:
         summary: str,
         idempotency_key: str | None,
     ) -> ScheduledTaskDefinitionResponse:
-        current = self._get_definition_row(owner_id=owner_id, definition_id=definition_id)
+        current = self._get_definition_row(tx=tx, owner_id=owner_id, definition_id=definition_id)
         if current.lifecycle == "archived":
             raise ValueError("definition_archived")
         if current.lifecycle == idempotent_lifecycle:
             return self._definition_response(current)
         if current.lifecycle == "disabled":
             raise ValueError("definition_disabled")
-        updated = self._repo(owner_id).update_definition(
+        updated = tx.update_definition(
             owner_id=owner_id,
             definition_id=definition_id,
             patch={"lifecycle": target_lifecycle, "updated_by": actor},
@@ -575,6 +598,7 @@ class ScheduledTaskAutomationService:
         )
         response = self._definition_response(updated)
         self._create_audit(
+            tx=tx,
             owner_id=owner_id,
             definition_id=definition_id,
             event_type=event_type,
@@ -589,15 +613,16 @@ class ScheduledTaskAutomationService:
     def _archive_definition(
         self,
         *,
+        tx: ScheduledTasksTransaction,
         owner_id: int,
         actor: str,
         definition_id: str,
         idempotency_key: str | None,
     ) -> ScheduledTaskDefinitionResponse:
-        current = self._get_definition_row(owner_id=owner_id, definition_id=definition_id)
+        current = self._get_definition_row(tx=tx, owner_id=owner_id, definition_id=definition_id)
         if current.lifecycle == "archived":
             return self._definition_response(current)
-        updated = self._repo(owner_id).update_definition(
+        updated = tx.update_definition(
             owner_id=owner_id,
             definition_id=definition_id,
             patch={"lifecycle": "archived", "updated_by": actor},
@@ -605,6 +630,7 @@ class ScheduledTaskAutomationService:
         )
         response = self._definition_response(updated)
         self._create_audit(
+            tx=tx,
             owner_id=owner_id,
             definition_id=definition_id,
             event_type="definition.archived",
@@ -619,13 +645,14 @@ class ScheduledTaskAutomationService:
     def _duplicate_definition(
         self,
         *,
+        tx: ScheduledTasksTransaction,
         owner_id: int,
         actor: str,
         definition_id: str,
         request: ScheduledTaskDuplicateRequest,
         idempotency_key: str | None,
     ) -> ScheduledTaskDefinitionResponse:
-        source = self._get_definition_row(owner_id=owner_id, definition_id=definition_id)
+        source = self._get_definition_row(tx=tx, owner_id=owner_id, definition_id=definition_id)
         if source.lifecycle == "archived":
             raise ValueError("definition_archived")
         if source.lifecycle == "disabled" and source.disabled_lock_kind in {"admin", "security"}:
@@ -646,7 +673,7 @@ class ScheduledTaskAutomationService:
             if source.family == "agent_task"
             else {"fields": [], "mode": "none"},
         }
-        preview = self._repo(owner_id).create_preview(
+        preview = tx.create_preview(
             owner_id=owner_id,
             mode="create",
             family=source.family,
@@ -664,7 +691,7 @@ class ScheduledTaskAutomationService:
             expires_at=_iso(_utcnow() + PREVIEW_TTL),
             created_by=actor,
         )
-        created = self._repo(owner_id).create_definition(
+        created = tx.create_definition(
             owner_id=owner_id,
             family=source.family,
             name=copy_name,
@@ -685,6 +712,7 @@ class ScheduledTaskAutomationService:
         response = self._definition_response(created)
         source_response = self._definition_response(source)
         self._create_audit(
+            tx=tx,
             owner_id=owner_id,
             definition_id=source.id,
             event_type="definition_duplicated",
@@ -695,6 +723,7 @@ class ScheduledTaskAutomationService:
             idempotency_key=idempotency_key,
         )
         self._create_audit(
+            tx=tx,
             owner_id=owner_id,
             definition_id=created.id,
             event_type="definition_duplicate_created",
@@ -713,26 +742,30 @@ class ScheduledTaskAutomationService:
         route: str,
         key: str | None,
         payload_hash: str,
-        operation: Callable[[], BaseModel],
+        operation: Callable[[ScheduledTasksTransaction], BaseModel],
     ) -> BaseModel:
-        if key is None:
-            return operation()
         repo = self._repo(owner_id)
-        existing = repo.get_idempotency_record(owner_id=owner_id, route=route, key=key)
-        if existing is not None:
-            if existing.payload_hash != payload_hash:
-                raise ValueError("scheduled_task_idempotency_conflict")
-            return self._load_response_ref(owner_id=owner_id, response_ref=existing.response_ref)
-        response = operation()
-        repo.create_idempotency_record(
-            owner_id=owner_id,
-            route=route,
-            key=key,
-            payload_hash=payload_hash,
-            response_ref=self._response_ref(response),
-            expires_at=_iso(_utcnow() + IDEMPOTENCY_TTL),
-        )
-        return response
+
+        def _run(tx: ScheduledTasksTransaction) -> BaseModel:
+            if key is None:
+                return operation(tx)
+            existing = tx.get_idempotency_record(owner_id=owner_id, route=route, key=key)
+            if existing is not None:
+                if existing.payload_hash != payload_hash:
+                    raise ValueError("scheduled_task_idempotency_conflict")
+                return self._load_response_ref(owner_id=owner_id, response_ref=existing.response_ref)
+            response = operation(tx)
+            tx.create_idempotency_record(
+                owner_id=owner_id,
+                route=route,
+                key=key,
+                payload_hash=payload_hash,
+                response_ref=self._response_ref(response),
+                expires_at=_iso(_utcnow() + IDEMPOTENCY_TTL),
+            )
+            return response
+
+        return repo.write_transaction(_run)
 
     def _normalize_preview(
         self,
@@ -771,8 +804,18 @@ class ScheduledTaskAutomationService:
             "config": config,
         }
 
-    def _require_valid_preview(self, *, owner_id: int, preview_id: str) -> PreviewRow:
-        preview = self._repo(owner_id).get_preview(owner_id=owner_id, preview_id=preview_id)
+    def _require_valid_preview(
+        self,
+        *,
+        tx: ScheduledTasksTransaction | None = None,
+        owner_id: int,
+        preview_id: str,
+    ) -> PreviewRow:
+        preview = (
+            tx.get_preview(owner_id=owner_id, preview_id=preview_id)
+            if tx is not None
+            else self._repo(owner_id).get_preview(owner_id=owner_id, preview_id=preview_id)
+        )
         if preview is None:
             raise KeyError("preview_not_found")
         if preview.status == "consumed":
@@ -783,8 +826,18 @@ class ScheduledTaskAutomationService:
             raise ValueError("preview_invalid")
         return preview
 
-    def _get_definition_row(self, *, owner_id: int, definition_id: str) -> DefinitionRow:
-        definition = self._repo(owner_id).get_definition(owner_id=owner_id, definition_id=definition_id)
+    def _get_definition_row(
+        self,
+        *,
+        tx: ScheduledTasksTransaction | None = None,
+        owner_id: int,
+        definition_id: str,
+    ) -> DefinitionRow:
+        definition = (
+            tx.get_definition(owner_id=owner_id, definition_id=definition_id)
+            if tx is not None
+            else self._repo(owner_id).get_definition(owner_id=owner_id, definition_id=definition_id)
+        )
         if definition is None:
             raise KeyError("definition_not_found")
         return definition
@@ -792,6 +845,7 @@ class ScheduledTaskAutomationService:
     def _create_audit(
         self,
         *,
+        tx: ScheduledTasksTransaction | None = None,
         owner_id: int,
         definition_id: str,
         event_type: str,
@@ -801,7 +855,8 @@ class ScheduledTaskAutomationService:
         after: dict[str, Any] | None,
         idempotency_key: str | None,
     ) -> None:
-        self._repo(owner_id).create_audit_event(
+        target = tx if tx is not None else self._repo(owner_id)
+        target.create_audit_event(
             owner_id=owner_id,
             definition_id=definition_id,
             event_type=event_type,

--- a/tldw_Server_API/app/services/scheduled_tasks_control_plane_service.py
+++ b/tldw_Server_API/app/services/scheduled_tasks_control_plane_service.py
@@ -23,6 +23,7 @@ from tldw_Server_API.app.core.Personalization.companion_activity import (
     record_reminder_task_updated,
 )
 from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase, ReminderTaskRow
+from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import DefinitionRow, ScheduledTasksDatabase
 from tldw_Server_API.app.core.DB_Management.Watchlists_DB import JobRow, WatchlistsDatabase
 from tldw_Server_API.app.services.reminders_scheduler import get_reminders_scheduler
 
@@ -47,6 +48,7 @@ _NONCRITICAL_READ_EXCEPTIONS = (
 
 _REMINDER_PREFIX = "reminder_task"
 _WATCHLIST_PREFIX = "watchlist_job"
+_AUTOMATION_DEFINITION_PREFIX = "automation_definition"
 
 
 def _load_json_object(raw: str | None) -> dict[str, Any]:
@@ -77,6 +79,58 @@ def _watchlist_schedule_summary(row: JobRow) -> str | None:
     return "Manual"
 
 
+def _automation_schedule_summary(row: DefinitionRow) -> str | None:
+    kind = row.schedule.get("kind")
+    if not isinstance(kind, str) or not kind:
+        return None
+    timezone = row.schedule.get("timezone")
+    if kind == "daily":
+        time = row.schedule.get("time")
+        summary = f"Daily at {time}" if isinstance(time, str) and time else "Daily"
+    elif kind == "weekly":
+        day = row.schedule.get("day")
+        time = row.schedule.get("time")
+        parts = ["Weekly"]
+        if isinstance(day, str) and day:
+            parts.append(day)
+        if isinstance(time, str) and time:
+            parts.append(f"at {time}")
+        summary = " ".join(parts)
+    elif kind == "cron":
+        expr = row.schedule.get("cron") or row.schedule.get("expr")
+        summary = str(expr) if expr else "Cron"
+    elif kind == "one_time":
+        run_at = row.schedule.get("run_at")
+        summary = str(run_at) if run_at else "One time"
+    elif kind == "interval":
+        every = row.schedule.get("every")
+        unit = row.schedule.get("unit")
+        summary = f"Every {every} {unit}" if every and unit else "Interval"
+    else:
+        summary = kind
+    if isinstance(timezone, str) and timezone:
+        return f"{summary} ({timezone})"
+    return summary
+
+
+def _automation_definition_status(row: DefinitionRow) -> tuple[bool, str]:
+    if row.lifecycle == "configured":
+        if row.health == "execution_unavailable":
+            return True, "configured_execution_unavailable"
+        if row.health == "capability_unavailable":
+            return True, "blocked_capability_unavailable"
+        if row.health == "permission_required":
+            return True, "blocked_permission_required"
+        return True, row.health
+    if row.lifecycle == "paused":
+        return False, "paused"
+    if row.lifecycle == "archived":
+        return False, "archived"
+    if row.lifecycle == "disabled":
+        return False, "disabled"
+    return False, "needs_attention"
+
+
 def _reminder_row_to_activity_payload(row: ReminderTaskRow) -> dict[str, Any]:
     return {
         "id": row.id,
@@ -104,6 +158,12 @@ class ScheduledTasksControlPlaneService:
         db = WatchlistsDatabase.for_user(user_id=user_id)
         with suppress(Exception):
             db.ensure_schema()
+        return db
+
+    @staticmethod
+    def _scheduled_tasks_db(user_id: int) -> ScheduledTasksDatabase:
+        db = ScheduledTasksDatabase.for_user(user_id=user_id)
+        db.ensure_schema()
         return db
 
     @staticmethod
@@ -158,6 +218,36 @@ class ScheduledTasksControlPlaneService:
             },
         )
 
+    @staticmethod
+    def _normalize_automation_definition(row: DefinitionRow) -> ScheduledTask:
+        enabled, status = _automation_definition_status(row)
+        timezone = row.schedule.get("timezone")
+        return ScheduledTask(
+            id=f"{_AUTOMATION_DEFINITION_PREFIX}:{row.id}",
+            primitive="automation_definition",
+            title=row.name,
+            description=row.description,
+            status=status,
+            enabled=enabled,
+            schedule_summary=_automation_schedule_summary(row),
+            timezone=timezone if isinstance(timezone, str) else None,
+            next_run_at=None,
+            last_run_at=None,
+            edit_mode="native",
+            manage_url=None,
+            source_ref={
+                "definition_id": row.id,
+                "family": row.family,
+                "lifecycle": row.lifecycle,
+                "health": row.health,
+                "version": row.version,
+                "visibility_policy": row.visibility_policy,
+                "execution_available": False,
+                "disabled_lock_kind": row.disabled_lock_kind,
+                "disabled_reason": row.disabled_reason,
+            },
+        )
+
     async def _reconcile_reminder_task_best_effort(self, *, task_id: str, user_id: int) -> None:
         try:
             await get_reminders_scheduler().reconcile_task(task_id=task_id, user_id=user_id)
@@ -196,6 +286,21 @@ class ScheduledTasksControlPlaneService:
             )
             errors.append("watchlist_jobs_unavailable")
 
+        try:
+            definition_rows, _ = self._scheduled_tasks_db(user_id).list_definitions(
+                owner_id=user_id,
+                limit=500,
+                offset=0,
+            )
+            items.extend(self._normalize_automation_definition(row) for row in definition_rows)
+        except _NONCRITICAL_READ_EXCEPTIONS as exc:
+            logger.warning(
+                "scheduled tasks control plane could not list automation definitions user_id={} error={}",
+                user_id,
+                exc,
+            )
+            errors.append("automation_definitions_unavailable")
+
         return ScheduledTaskListResponse(
             items=items,
             total=len(items),
@@ -213,6 +318,13 @@ class ScheduledTasksControlPlaneService:
             raw_task_id = task_id.removeprefix(f"{_WATCHLIST_PREFIX}:")
             row = self._watchlists_db(user_id).get_job(int(raw_task_id))
             return self._normalize_watchlist_job(row)
+
+        if task_id.startswith(f"{_AUTOMATION_DEFINITION_PREFIX}:"):
+            raw_task_id = task_id.removeprefix(f"{_AUTOMATION_DEFINITION_PREFIX}:")
+            row = self._scheduled_tasks_db(user_id).get_definition(owner_id=user_id, definition_id=raw_task_id)
+            if row is None:
+                raise KeyError("scheduled_task_not_found")
+            return self._normalize_automation_definition(row)
 
         raise KeyError("scheduled_task_not_found")
 

--- a/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import Request
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.core.AuthNZ.permissions import TASKS_CONTROL, TASKS_READ
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
+
+
+def _make_principal(*, permissions: list[str] | None = None) -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=880,
+        api_key_id=None,
+        subject="scheduled-task-automation-api-test",
+        token_type="access",  # nosec B106
+        jti=None,
+        roles=[],
+        permissions=[TASKS_READ, TASKS_CONTROL] if permissions is None else list(permissions),
+        is_admin=False,
+        org_ids=[],
+        team_ids=[],
+        active_org_id=None,
+        active_team_id=None,
+    )
+
+
+def _override_auth(client, *, permissions: list[str] | None = None) -> None:
+    principal = _make_principal(permissions=permissions)
+
+    async def _fake_get_auth_principal(request: Request) -> AuthPrincipal:
+        request.state.auth = AuthContext(principal=principal, ip=None, user_agent=None, request_id=None)
+        return principal
+
+    async def _fake_get_request_user() -> User:
+        return User(id=880, username="scheduled-user", email=None, is_active=True)
+
+    client.app.dependency_overrides[get_auth_principal] = _fake_get_auth_principal
+    client.app.dependency_overrides[get_request_user] = _fake_get_request_user
+
+
+@pytest.fixture()
+def scheduled_tasks_client(client_user_only):
+    _override_auth(client_user_only)
+    yield client_user_only
+    client_user_only.app.dependency_overrides.pop(get_auth_principal, None)
+    client_user_only.app.dependency_overrides.pop(get_request_user, None)
+
+
+def test_scheduled_task_static_child_routes_do_not_resolve_as_task_ids(scheduled_tasks_client, auth_headers):
+    for path in (
+        "/api/v1/scheduled-tasks/capabilities",
+        "/api/v1/scheduled-tasks/previews",
+        "/api/v1/scheduled-tasks/definitions",
+    ):
+        response = scheduled_tasks_client.get(path, headers=auth_headers)
+        assert response.status_code != 404, response.text  # nosec B101
+        assert response.text != "scheduled_task_not_found"  # nosec B101
+
+
+def test_capabilities_report_definition_actions_but_no_execution(scheduled_tasks_client, auth_headers):
+    response = scheduled_tasks_client.get("/api/v1/scheduled-tasks/capabilities", headers=auth_headers)
+
+    assert response.status_code == 200, response.text  # nosec B101
+    body = response.json()
+    families = {item["family"]: item for item in body["items"]}
+    assert {"recurring_question", "agent_task"} <= set(families)  # nosec B101
+    for family in ("recurring_question", "agent_task"):
+        actions = families[family]["actions"]
+        assert actions["preview"]["status"] == "available"  # nosec B101
+        assert actions["create_definition"]["status"] == "available"  # nosec B101
+        assert actions["execute"]["status"] == "unavailable"  # nosec B101
+        assert actions["execute"]["reason"] == "execution_not_implemented"  # nosec B101

--- a/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import json
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -13,7 +14,10 @@ from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_u
 from tldw_Server_API.app.core.AuthNZ.permissions import TASKS_CONTROL, TASKS_READ
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
 from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import ScheduledTasksDatabase
-from tldw_Server_API.app.services.scheduled_task_automation_service import ScheduledTaskAutomationService
+from tldw_Server_API.app.services.scheduled_task_automation_service import (
+    ScheduledTaskAutomationError,
+    ScheduledTaskAutomationService,
+)
 
 RAW_SENTINEL = "RAW_AGENT_SECRET_DO_NOT_LEAK_ENDPOINT_4B"
 
@@ -302,6 +306,23 @@ def test_definition_filters_preview_filters_audit_filters_and_pagination(schedul
     assert audit.json()["items"][0]["event_type"] == "definition.paused"  # nosec B101
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/v1/scheduled-tasks/previews?family=unknown",
+        "/api/v1/scheduled-tasks/previews?mode=delete",
+        "/api/v1/scheduled-tasks/previews?status=ready",
+        "/api/v1/scheduled-tasks/definitions?family=unknown",
+        "/api/v1/scheduled-tasks/definitions?lifecycle=running",
+        "/api/v1/scheduled-tasks/definitions?health=healthy",
+    ],
+)
+def test_invalid_automation_filter_values_return_422(scheduled_tasks_client, auth_headers, path):
+    response = scheduled_tasks_client.get(path, headers=auth_headers)
+
+    assert response.status_code == 422, response.text  # nosec B101
+
+
 def test_api_created_audit_events_store_and_filter_by_request_id(scheduled_tasks_client, auth_headers):
     definition = _create_definition(scheduled_tasks_client, auth_headers, name="Request id audit")
 
@@ -401,7 +422,7 @@ def test_cross_user_preview_and_definition_access_is_denied(scheduled_tasks_clie
         json={"preview_id": preview["id"]},
     )
 
-    _assert_error_envelope(preview_detail, code="scheduled_task_preview_required", status_code=400)
+    _assert_error_envelope(preview_detail, code="scheduled_task_preview_not_found", status_code=404)
     _assert_error_envelope(definition_detail, code="scheduled_task_definition_not_found", status_code=404)
     _assert_error_envelope(audit_list, code="scheduled_task_definition_not_found", status_code=404)
     _assert_error_envelope(cross_create, code="scheduled_task_preview_required", status_code=400)
@@ -582,6 +603,7 @@ def test_same_idempotency_key_with_different_payload_conflicts_on_mutating_route
     [
         ("scheduled_task_family_unavailable", "scheduled_task_family_unavailable", 409),
         ("scheduled_task_preview_required", "scheduled_task_preview_required", 400),
+        ("preview_resource_not_found", "scheduled_task_preview_not_found", 404),
         ("scheduled_task_definition_not_found", "scheduled_task_definition_not_found", 404),
         ("scheduled_task_preview_mismatch", "scheduled_task_preview_mismatch", 409),
         ("scheduled_task_preview_expired", "scheduled_task_preview_expired", 409),
@@ -606,7 +628,7 @@ def test_required_public_error_code_aliases_use_public_error_envelopes(
 ):
     class _FailingService:
         def create_preview(self, **_kwargs):
-            raise ValueError(service_error)
+            raise ScheduledTaskAutomationError(service_error)
 
     scheduled_tasks_client.app.dependency_overrides[
         scheduled_tasks_control_plane.get_scheduled_task_automation_service
@@ -619,3 +641,45 @@ def test_required_public_error_code_aliases_use_public_error_envelopes(
     )
 
     _assert_error_envelope(response, code=public_code, status_code=status_code)
+
+
+def test_plain_service_value_error_is_not_mapped_as_public_automation_error(
+    scheduled_tasks_client,
+    auth_headers,
+):
+    class _FailingService:
+        def create_preview(self, **_kwargs):
+            raise ValueError("unexpected_bug")
+
+    scheduled_tasks_client.app.dependency_overrides[
+        scheduled_tasks_control_plane.get_scheduled_task_automation_service
+    ] = lambda: _FailingService()
+
+    with pytest.raises(ValueError, match="unexpected_bug"):
+        scheduled_tasks_client.post(
+            "/api/v1/scheduled-tasks/previews",
+            headers=auth_headers,
+            json=_payload(),
+        )
+
+
+def test_sync_automation_handlers_do_not_run_sqlite_work_on_event_loop():
+    automation_handlers = [
+        scheduled_tasks_control_plane.get_scheduled_task_automation_capabilities,
+        scheduled_tasks_control_plane.list_scheduled_task_automation_previews,
+        scheduled_tasks_control_plane.create_scheduled_task_automation_preview,
+        scheduled_tasks_control_plane.get_scheduled_task_automation_preview,
+        scheduled_tasks_control_plane.list_scheduled_task_automation_definitions,
+        scheduled_tasks_control_plane.create_scheduled_task_automation_definition,
+        scheduled_tasks_control_plane.list_scheduled_task_automation_definition_audit,
+        scheduled_tasks_control_plane.get_scheduled_task_automation_definition,
+        scheduled_tasks_control_plane.update_scheduled_task_automation_definition,
+        scheduled_tasks_control_plane.pause_scheduled_task_automation_definition,
+        scheduled_tasks_control_plane.resume_scheduled_task_automation_definition,
+        scheduled_tasks_control_plane.archive_scheduled_task_automation_definition,
+        scheduled_tasks_control_plane.duplicate_scheduled_task_automation_definition,
+    ]
+
+    assert all(not inspect.iscoroutinefunction(handler) for handler in automation_handlers)  # nosec B101
+    assert inspect.iscoroutinefunction(scheduled_tasks_control_plane.list_scheduled_tasks)  # nosec B101
+    assert inspect.iscoroutinefunction(scheduled_tasks_control_plane.create_scheduled_task_reminder)  # nosec B101

--- a/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
@@ -525,15 +525,24 @@ def test_same_idempotency_key_with_different_payload_conflicts_on_mutating_route
 @pytest.mark.parametrize(
     ("service_error", "public_code", "status_code"),
     [
-        ("preview_invalid", "scheduled_task_schedule_invalid", 422),
+        ("scheduled_task_family_unavailable", "scheduled_task_family_unavailable", 409),
+        ("scheduled_task_preview_required", "scheduled_task_preview_required", 400),
+        ("scheduled_task_definition_not_found", "scheduled_task_definition_not_found", 404),
+        ("scheduled_task_preview_mismatch", "scheduled_task_preview_mismatch", 409),
+        ("scheduled_task_preview_expired", "scheduled_task_preview_expired", 409),
+        ("scheduled_task_schedule_invalid", "scheduled_task_schedule_invalid", 422),
         ("scheduled_task_scope_invalid", "scheduled_task_scope_invalid", 422),
         ("scheduled_task_agent_ref_invalid", "scheduled_task_agent_ref_invalid", 422),
         ("scheduled_task_permission_policy_invalid", "scheduled_task_permission_policy_invalid", 422),
-        ("scheduled_task_family_unavailable", "scheduled_task_family_unavailable", 409),
         ("scheduled_task_execution_unavailable", "scheduled_task_execution_unavailable", 409),
+        ("scheduled_task_definition_version_conflict", "scheduled_task_definition_version_conflict", 409),
+        ("scheduled_task_definition_archived", "scheduled_task_definition_archived", 409),
+        ("scheduled_task_lifecycle_transition_invalid", "scheduled_task_lifecycle_transition_invalid", 409),
+        ("scheduled_task_idempotency_conflict", "scheduled_task_idempotency_conflict", 409),
+        ("preview_invalid", "scheduled_task_schedule_invalid", 422),
     ],
 )
-def test_validation_and_capability_errors_use_public_error_envelopes(
+def test_required_public_error_code_aliases_use_public_error_envelopes(
     scheduled_tasks_client,
     auth_headers,
     service_error,

--- a/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import pytest
@@ -299,6 +300,60 @@ def test_definition_filters_preview_filters_audit_filters_and_pagination(schedul
     assert audit.status_code == 200, audit.text  # nosec B101
     assert audit.json()["total"] == 1  # nosec B101
     assert audit.json()["items"][0]["event_type"] == "definition.paused"  # nosec B101
+
+
+def test_api_created_audit_events_store_and_filter_by_request_id(scheduled_tasks_client, auth_headers):
+    definition = _create_definition(scheduled_tasks_client, auth_headers, name="Request id audit")
+
+    audit = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/audit?request_id=test-request-id",
+        headers=auth_headers,
+    )
+
+    assert audit.status_code == 200, audit.text  # nosec B101
+    body = audit.json()
+    assert body["total"] == 1  # nosec B101
+    assert body["items"][0]["event_type"] == "definition.created"  # nosec B101
+    assert body["items"][0]["request_id"] == "test-request-id"  # nosec B101
+
+
+def test_datetime_filters_reject_invalid_values_with_error_envelope(scheduled_tasks_client, auth_headers):
+    definition = _create_definition(scheduled_tasks_client, auth_headers, name="Invalid datetime filters")
+
+    definitions = scheduled_tasks_client.get(
+        "/api/v1/scheduled-tasks/definitions?created_from=not-a-date",
+        headers=auth_headers,
+    )
+    audit = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/audit?created_to=not-a-date",
+        headers=auth_headers,
+    )
+
+    _assert_error_envelope(definitions, code="scheduled_task_filter_invalid", status_code=422)
+    _assert_error_envelope(audit, code="scheduled_task_filter_invalid", status_code=422)
+
+
+def test_datetime_filters_normalize_offset_timestamps(scheduled_tasks_client, auth_headers):
+    definition = _create_definition(scheduled_tasks_client, auth_headers, name="Offset datetime filters")
+    created_at = datetime.fromisoformat(definition["created_at"])
+    created_from = created_at.astimezone(timezone(timedelta(hours=5, minutes=30))).isoformat()
+
+    definitions = scheduled_tasks_client.get(
+        "/api/v1/scheduled-tasks/definitions",
+        headers=auth_headers,
+        params={"created_from": created_from},
+    )
+    audit = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/audit",
+        headers=auth_headers,
+        params={"created_from": created_from},
+    )
+
+    assert definitions.status_code == 200, definitions.text  # nosec B101
+    assert [item["id"] for item in definitions.json()["items"]] == [definition["id"]]  # nosec B101
+    assert audit.status_code == 200, audit.text  # nosec B101
+    assert audit.json()["total"] == 1  # nosec B101
+    assert audit.json()["items"][0]["definition_id"] == definition["id"]  # nosec B101
 
 
 def test_routes_require_read_or_control_permissions(client_user_only, auth_headers):

--- a/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py
@@ -1,20 +1,33 @@
 from __future__ import annotations
 
+import json
+from typing import Any
+
 import pytest
 from fastapi import Request
 
+from tldw_Server_API.app.api.v1.endpoints import scheduled_tasks_control_plane
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.AuthNZ.permissions import TASKS_CONTROL, TASKS_READ
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
+from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import ScheduledTasksDatabase
+from tldw_Server_API.app.services.scheduled_task_automation_service import ScheduledTaskAutomationService
+
+RAW_SENTINEL = "RAW_AGENT_SECRET_DO_NOT_LEAK_ENDPOINT_4B"
 
 
-def _make_principal(*, permissions: list[str] | None = None) -> AuthPrincipal:
+def _make_principal(
+    *,
+    permissions: list[str] | None = None,
+    user_id: int = 880,
+    subject: str = "scheduled-task-automation-api-test",
+) -> AuthPrincipal:
     return AuthPrincipal(
         kind="user",
-        user_id=880,
+        user_id=user_id,
         api_key_id=None,
-        subject="scheduled-task-automation-api-test",
+        subject=subject,
         token_type="access",  # nosec B106
         jti=None,
         roles=[],
@@ -27,26 +40,113 @@ def _make_principal(*, permissions: list[str] | None = None) -> AuthPrincipal:
     )
 
 
-def _override_auth(client, *, permissions: list[str] | None = None) -> None:
-    principal = _make_principal(permissions=permissions)
+def _override_auth(
+    client,
+    *,
+    permissions: list[str] | None = None,
+    user_id: int = 880,
+    subject: str = "scheduled-task-automation-api-test",
+) -> None:
+    principal = _make_principal(permissions=permissions, user_id=user_id, subject=subject)
 
     async def _fake_get_auth_principal(request: Request) -> AuthPrincipal:
-        request.state.auth = AuthContext(principal=principal, ip=None, user_agent=None, request_id=None)
+        request.state.request_id = "test-request-id"
+        request.state.auth = AuthContext(principal=principal, ip=None, user_agent=None, request_id="test-request-id")
         return principal
 
     async def _fake_get_request_user() -> User:
-        return User(id=880, username="scheduled-user", email=None, is_active=True)
+        return User(id=user_id, username=f"scheduled-user-{user_id}", email=None, is_active=True)
 
     client.app.dependency_overrides[get_auth_principal] = _fake_get_auth_principal
     client.app.dependency_overrides[get_request_user] = _fake_get_request_user
 
 
 @pytest.fixture()
-def scheduled_tasks_client(client_user_only):
+def scheduled_tasks_client(client_user_only, tmp_path):
+    repo = ScheduledTasksDatabase(tmp_path / "scheduled_task_automation_api.db")
+    repo.ensure_schema()
+    service = ScheduledTaskAutomationService(repository=repo)
     _override_auth(client_user_only)
+    client_user_only.app.dependency_overrides[
+        scheduled_tasks_control_plane.get_scheduled_task_automation_service
+    ] = lambda: service
+    client_user_only.scheduled_task_automation_service = service
+    client_user_only.scheduled_task_automation_repo = repo
     yield client_user_only
     client_user_only.app.dependency_overrides.pop(get_auth_principal, None)
     client_user_only.app.dependency_overrides.pop(get_request_user, None)
+    client_user_only.app.dependency_overrides.pop(
+        scheduled_tasks_control_plane.get_scheduled_task_automation_service,
+        None,
+    )
+
+
+def _payload(
+    *,
+    family: str = "recurring_question",
+    mode: str = "create",
+    definition_id: str | None = None,
+    definition_version: int | None = None,
+    name: str = "Daily research check",
+    input_payload: dict[str, Any] | None = None,
+    schedule: dict[str, Any] | None = None,
+    visibility_policy: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if input_payload is None:
+        input_payload = (
+            {"question": "What changed in the selected sources?"}
+            if family == "recurring_question"
+            else {"agent_ref": "agent:triage", "message": "Summarize priority changes."}
+        )
+    return {
+        "mode": mode,
+        "family": family,
+        "definition_id": definition_id,
+        "definition_version": definition_version,
+        "name": name,
+        "description": "Endpoint lifecycle test",
+        "input": input_payload,
+        "schedule": schedule or {"kind": "daily", "time": "09:00", "timezone": "UTC"},
+        "visibility_policy": visibility_policy or {"mode": "findings_only"},
+        "notification_policy": {"channels": ["in_app"]},
+        "approval_policy": {"required": False},
+    }
+
+
+def _create_preview(client, auth_headers, **payload_kwargs) -> dict[str, Any]:
+    response = client.post(
+        "/api/v1/scheduled-tasks/previews",
+        headers=auth_headers,
+        json=_payload(**payload_kwargs),
+    )
+    assert response.status_code == 201, response.text  # nosec B101
+    return response.json()
+
+
+def _create_definition(client, auth_headers, **payload_kwargs) -> dict[str, Any]:
+    preview = _create_preview(client, auth_headers, **payload_kwargs)
+    response = client.post(
+        "/api/v1/scheduled-tasks/definitions",
+        headers=auth_headers,
+        json={"preview_id": preview["id"], "initial_lifecycle": "configured"},
+    )
+    assert response.status_code == 201, response.text  # nosec B101
+    return response.json()
+
+
+def _assert_no_raw_sentinel(value: Any) -> None:
+    assert RAW_SENTINEL not in json.dumps(value, sort_keys=True)  # nosec B101
+
+
+def _assert_error_envelope(response, *, code: str, status_code: int) -> None:
+    assert response.status_code == status_code, response.text  # nosec B101
+    detail = response.json()["detail"]
+    assert detail["code"] == code  # nosec B101
+    assert isinstance(detail["message"], str) and detail["message"]  # nosec B101
+    assert isinstance(detail["details"], dict)  # nosec B101
+    assert isinstance(detail["field_errors"], list)  # nosec B101
+    assert detail["retryable"] is False  # nosec B101
+    assert "correlation_id" in detail  # nosec B101
 
 
 def test_scheduled_task_static_child_routes_do_not_resolve_as_task_ids(scheduled_tasks_client, auth_headers):
@@ -73,3 +173,385 @@ def test_capabilities_report_definition_actions_but_no_execution(scheduled_tasks
         assert actions["create_definition"]["status"] == "available"  # nosec B101
         assert actions["execute"]["status"] == "unavailable"  # nosec B101
         assert actions["execute"]["reason"] == "execution_not_implemented"  # nosec B101
+
+
+def test_preview_create_list_and_detail_return_valid_and_invalid_statuses(scheduled_tasks_client, auth_headers):
+    valid = _create_preview(scheduled_tasks_client, auth_headers)
+    invalid = _create_preview(
+        scheduled_tasks_client,
+        auth_headers,
+        name="Invalid preview",
+        input_payload={"question": "   "},
+        schedule={"kind": "not-a-schedule"},
+    )
+
+    detail = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/previews/{valid['id']}",
+        headers=auth_headers,
+    )
+    listed = scheduled_tasks_client.get("/api/v1/scheduled-tasks/previews?status=invalid", headers=auth_headers)
+
+    assert valid["status"] == "valid"  # nosec B101
+    assert invalid["status"] == "invalid"  # nosec B101
+    assert invalid["validation_errors"]  # nosec B101
+    assert detail.status_code == 200, detail.text  # nosec B101
+    assert detail.json()["id"] == valid["id"]  # nosec B101
+    assert listed.status_code == 200, listed.text  # nosec B101
+    assert [item["id"] for item in listed.json()["items"]] == [invalid["id"]]  # nosec B101
+
+
+def test_create_update_lifecycle_duplicate_and_audit_routes(scheduled_tasks_client, auth_headers):
+    definition = _create_definition(scheduled_tasks_client, auth_headers)
+    update_preview = _create_preview(
+        scheduled_tasks_client,
+        auth_headers,
+        mode="update",
+        definition_id=definition["id"],
+        definition_version=definition["version"],
+        name="Updated question",
+    )
+    updated = scheduled_tasks_client.patch(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}",
+        headers=auth_headers,
+        json={"preview_id": update_preview["id"]},
+    )
+    paused = scheduled_tasks_client.post(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/pause",
+        headers=auth_headers,
+    )
+    resumed = scheduled_tasks_client.post(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/resume",
+        headers=auth_headers,
+    )
+    duplicate = scheduled_tasks_client.post(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/duplicate",
+        headers=auth_headers,
+        json={"name": "Duplicate copy"},
+    )
+    archived = scheduled_tasks_client.post(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/archive",
+        headers=auth_headers,
+    )
+    audit = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/audit",
+        headers=auth_headers,
+    )
+
+    assert updated.status_code == 200, updated.text  # nosec B101
+    assert updated.json()["name"] == "Updated question"  # nosec B101
+    assert paused.status_code == 200, paused.text  # nosec B101
+    assert paused.json()["lifecycle"] == "paused"  # nosec B101
+    assert resumed.status_code == 200, resumed.text  # nosec B101
+    assert resumed.json()["lifecycle"] == "configured"  # nosec B101
+    assert duplicate.status_code == 200, duplicate.text  # nosec B101
+    assert duplicate.json()["id"] != definition["id"]  # nosec B101
+    assert duplicate.json()["lifecycle"] == "paused"  # nosec B101
+    assert archived.status_code == 200, archived.text  # nosec B101
+    assert archived.json()["lifecycle"] == "archived"  # nosec B101
+    assert audit.status_code == 200, audit.text  # nosec B101
+    assert {item["event_type"] for item in audit.json()["items"]} >= {  # nosec B101
+        "definition.created",
+        "definition.updated",
+        "definition.paused",
+        "definition.resumed",
+        "definition.archived",
+        "definition_duplicated",
+    }
+
+
+def test_definition_filters_preview_filters_audit_filters_and_pagination(scheduled_tasks_client, auth_headers):
+    alpha = _create_definition(scheduled_tasks_client, auth_headers, name="Alpha daily")
+    _create_definition(
+        scheduled_tasks_client,
+        auth_headers,
+        family="agent_task",
+        name="Beta agent",
+        input_payload={"agent_ref": "agent:triage", "message": "Review alerts"},
+        visibility_policy={"mode": "metadata_only"},
+    )
+    scheduled_tasks_client.post(
+        f"/api/v1/scheduled-tasks/definitions/{alpha['id']}/pause",
+        headers={**auth_headers, "Idempotency-Key": "pause-filter-key"},
+    )
+
+    definitions = scheduled_tasks_client.get(
+        "/api/v1/scheduled-tasks/definitions?family=recurring_question&lifecycle=paused&q=Alpha&limit=1&offset=0",
+        headers=auth_headers,
+    )
+    previews = scheduled_tasks_client.get(
+        "/api/v1/scheduled-tasks/previews?family=agent_task&mode=create&status=consumed&limit=1&offset=0",
+        headers=auth_headers,
+    )
+    audit = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/definitions/{alpha['id']}/audit"
+        "?event_type=definition.paused&actor=scheduled-task-automation-api-test"
+        "&idempotency_key=pause-filter-key&limit=1&offset=0",
+        headers=auth_headers,
+    )
+
+    assert definitions.status_code == 200, definitions.text  # nosec B101
+    assert definitions.json()["total"] == 1  # nosec B101
+    assert definitions.json()["items"][0]["id"] == alpha["id"]  # nosec B101
+    assert definitions.json()["limit"] == 1  # nosec B101
+    assert previews.status_code == 200, previews.text  # nosec B101
+    assert previews.json()["total"] == 1  # nosec B101
+    assert previews.json()["items"][0]["family"] == "agent_task"  # nosec B101
+    assert audit.status_code == 200, audit.text  # nosec B101
+    assert audit.json()["total"] == 1  # nosec B101
+    assert audit.json()["items"][0]["event_type"] == "definition.paused"  # nosec B101
+
+
+def test_routes_require_read_or_control_permissions(client_user_only, auth_headers):
+    try:
+        _override_auth(client_user_only, permissions=[])
+        read_response = client_user_only.get("/api/v1/scheduled-tasks/previews", headers=auth_headers)
+        assert read_response.status_code == 403, read_response.text  # nosec B101
+
+        _override_auth(client_user_only, permissions=[TASKS_READ])
+        control_response = client_user_only.post(
+            "/api/v1/scheduled-tasks/previews",
+            headers=auth_headers,
+            json=_payload(),
+        )
+        assert control_response.status_code == 403, control_response.text  # nosec B101
+    finally:
+        client_user_only.app.dependency_overrides.pop(get_auth_principal, None)
+        client_user_only.app.dependency_overrides.pop(get_request_user, None)
+
+
+def test_cross_user_preview_and_definition_access_is_denied(scheduled_tasks_client, auth_headers):
+    preview = _create_preview(scheduled_tasks_client, auth_headers)
+    definition = scheduled_tasks_client.post(
+        "/api/v1/scheduled-tasks/definitions",
+        headers=auth_headers,
+        json={"preview_id": preview["id"]},
+    ).json()
+    _override_auth(scheduled_tasks_client, user_id=881, subject="other-user")
+
+    preview_detail = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/previews/{preview['id']}",
+        headers=auth_headers,
+    )
+    definition_detail = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}",
+        headers=auth_headers,
+    )
+    audit_list = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/audit",
+        headers=auth_headers,
+    )
+    cross_create = scheduled_tasks_client.post(
+        "/api/v1/scheduled-tasks/definitions",
+        headers=auth_headers,
+        json={"preview_id": preview["id"]},
+    )
+
+    _assert_error_envelope(preview_detail, code="scheduled_task_preview_required", status_code=400)
+    _assert_error_envelope(definition_detail, code="scheduled_task_definition_not_found", status_code=404)
+    _assert_error_envelope(audit_list, code="scheduled_task_definition_not_found", status_code=404)
+    _assert_error_envelope(cross_create, code="scheduled_task_preview_required", status_code=400)
+
+
+def test_agent_task_sentinel_is_redacted_across_preview_definition_list_detail_and_audit(
+    scheduled_tasks_client,
+    auth_headers,
+):
+    preview = _create_preview(
+        scheduled_tasks_client,
+        auth_headers,
+        family="agent_task",
+        name="Agent redaction",
+        input_payload={"agent_ref": "agent:security", "message": RAW_SENTINEL},
+        visibility_policy={"mode": "metadata_only"},
+    )
+    definition = scheduled_tasks_client.post(
+        "/api/v1/scheduled-tasks/definitions",
+        headers=auth_headers,
+        json={"preview_id": preview["id"]},
+    ).json()
+    preview_detail = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/previews/{preview['id']}",
+        headers=auth_headers,
+    ).json()
+    definitions = scheduled_tasks_client.get("/api/v1/scheduled-tasks/definitions", headers=auth_headers).json()
+    detail = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}",
+        headers=auth_headers,
+    ).json()
+    audit = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/audit",
+        headers=auth_headers,
+    ).json()
+
+    for response_body in (preview, preview_detail, definition, definitions, detail, audit):
+        _assert_no_raw_sentinel(response_body)
+
+
+def test_idempotent_preview_replay_and_conflict(scheduled_tasks_client, auth_headers):
+    headers = {**auth_headers, "Idempotency-Key": "preview-key"}
+    first = scheduled_tasks_client.post("/api/v1/scheduled-tasks/previews", headers=headers, json=_payload())
+    replay = scheduled_tasks_client.post("/api/v1/scheduled-tasks/previews", headers=headers, json=_payload())
+    conflict = scheduled_tasks_client.post(
+        "/api/v1/scheduled-tasks/previews",
+        headers=headers,
+        json=_payload(name="Different preview"),
+    )
+
+    assert first.status_code == 201, first.text  # nosec B101
+    assert replay.status_code == 201, replay.text  # nosec B101
+    assert replay.json()["id"] == first.json()["id"]  # nosec B101
+    _assert_error_envelope(conflict, code="scheduled_task_idempotency_conflict", status_code=409)
+
+
+def test_idempotent_create_and_update_replay_after_preview_consumed(scheduled_tasks_client, auth_headers):
+    preview = _create_preview(scheduled_tasks_client, auth_headers, name="Idempotent create")
+    create_headers = {**auth_headers, "Idempotency-Key": "create-key"}
+    first_create = scheduled_tasks_client.post(
+        "/api/v1/scheduled-tasks/definitions",
+        headers=create_headers,
+        json={"preview_id": preview["id"]},
+    )
+    replay_create = scheduled_tasks_client.post(
+        "/api/v1/scheduled-tasks/definitions",
+        headers=create_headers,
+        json={"preview_id": preview["id"]},
+    )
+    update_preview = _create_preview(
+        scheduled_tasks_client,
+        auth_headers,
+        mode="update",
+        definition_id=first_create.json()["id"],
+        definition_version=first_create.json()["version"],
+        name="Idempotent update",
+    )
+    update_headers = {**auth_headers, "Idempotency-Key": "update-key"}
+    first_update = scheduled_tasks_client.patch(
+        f"/api/v1/scheduled-tasks/definitions/{first_create.json()['id']}",
+        headers=update_headers,
+        json={"preview_id": update_preview["id"]},
+    )
+    replay_update = scheduled_tasks_client.patch(
+        f"/api/v1/scheduled-tasks/definitions/{first_create.json()['id']}",
+        headers=update_headers,
+        json={"preview_id": update_preview["id"]},
+    )
+
+    assert first_create.status_code == 201, first_create.text  # nosec B101
+    assert replay_create.status_code == 201, replay_create.text  # nosec B101
+    assert replay_create.json() == first_create.json()  # nosec B101
+    assert first_update.status_code == 200, first_update.text  # nosec B101
+    assert replay_update.status_code == 200, replay_update.text  # nosec B101
+    assert replay_update.json() == first_update.json()  # nosec B101
+
+
+def test_idempotent_duplicate_and_lifecycle_replay_without_extra_audit_events(scheduled_tasks_client, auth_headers):
+    definition = _create_definition(scheduled_tasks_client, auth_headers, name="Replay source")
+    duplicate_headers = {**auth_headers, "Idempotency-Key": "duplicate-key"}
+
+    first_duplicate = scheduled_tasks_client.post(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/duplicate",
+        headers=duplicate_headers,
+        json={"name": "Replay duplicate"},
+    )
+    replay_duplicate = scheduled_tasks_client.post(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/duplicate",
+        headers=duplicate_headers,
+        json={"name": "Replay duplicate"},
+    )
+    paused = scheduled_tasks_client.post(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/pause",
+        headers={**auth_headers, "Idempotency-Key": "pause-key"},
+    )
+    pause_replay = scheduled_tasks_client.post(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/pause",
+        headers={**auth_headers, "Idempotency-Key": "pause-key"},
+    )
+    resumed = scheduled_tasks_client.post(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/resume",
+        headers={**auth_headers, "Idempotency-Key": "resume-key"},
+    )
+    resume_replay = scheduled_tasks_client.post(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/resume",
+        headers={**auth_headers, "Idempotency-Key": "resume-key"},
+    )
+    archived = scheduled_tasks_client.post(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/archive",
+        headers={**auth_headers, "Idempotency-Key": "archive-key"},
+    )
+    archive_replay = scheduled_tasks_client.post(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/archive",
+        headers={**auth_headers, "Idempotency-Key": "archive-key"},
+    )
+    definitions = scheduled_tasks_client.get("/api/v1/scheduled-tasks/definitions", headers=auth_headers).json()
+    source_audit = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/definitions/{definition['id']}/audit",
+        headers=auth_headers,
+    ).json()
+    copy_audit = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/definitions/{first_duplicate.json()['id']}/audit",
+        headers=auth_headers,
+    ).json()
+
+    assert replay_duplicate.json() == first_duplicate.json()  # nosec B101
+    assert pause_replay.json() == paused.json()  # nosec B101
+    assert resume_replay.json() == resumed.json()  # nosec B101
+    assert archive_replay.json() == archived.json()  # nosec B101
+    assert definitions["total"] == 2  # nosec B101
+    assert len(source_audit["items"]) == 5  # created, duplicated, paused, resumed, archived  # nosec B101
+    assert len(copy_audit["items"]) == 1  # duplicate created only  # nosec B101
+
+
+def test_same_idempotency_key_with_different_payload_conflicts_on_mutating_routes(
+    scheduled_tasks_client,
+    auth_headers,
+):
+    first_preview = _create_preview(scheduled_tasks_client, auth_headers, name="Create one")
+    headers = {**auth_headers, "Idempotency-Key": "create-conflict-key"}
+    scheduled_tasks_client.post(
+        "/api/v1/scheduled-tasks/definitions",
+        headers=headers,
+        json={"preview_id": first_preview["id"]},
+    )
+    second_preview = _create_preview(scheduled_tasks_client, auth_headers, name="Create two")
+    response = scheduled_tasks_client.post(
+        "/api/v1/scheduled-tasks/definitions",
+        headers=headers,
+        json={"preview_id": second_preview["id"]},
+    )
+
+    _assert_error_envelope(response, code="scheduled_task_idempotency_conflict", status_code=409)
+
+
+@pytest.mark.parametrize(
+    ("service_error", "public_code", "status_code"),
+    [
+        ("preview_invalid", "scheduled_task_schedule_invalid", 422),
+        ("scheduled_task_scope_invalid", "scheduled_task_scope_invalid", 422),
+        ("scheduled_task_agent_ref_invalid", "scheduled_task_agent_ref_invalid", 422),
+        ("scheduled_task_permission_policy_invalid", "scheduled_task_permission_policy_invalid", 422),
+        ("scheduled_task_family_unavailable", "scheduled_task_family_unavailable", 409),
+        ("scheduled_task_execution_unavailable", "scheduled_task_execution_unavailable", 409),
+    ],
+)
+def test_validation_and_capability_errors_use_public_error_envelopes(
+    scheduled_tasks_client,
+    auth_headers,
+    service_error,
+    public_code,
+    status_code,
+):
+    class _FailingService:
+        def create_preview(self, **_kwargs):
+            raise ValueError(service_error)
+
+    scheduled_tasks_client.app.dependency_overrides[
+        scheduled_tasks_control_plane.get_scheduled_task_automation_service
+    ] = lambda: _FailingService()
+
+    response = scheduled_tasks_client.post(
+        "/api/v1/scheduled-tasks/previews",
+        headers=auth_headers,
+        json=_payload(),
+    )
+
+    _assert_error_envelope(response, code=public_code, status_code=status_code)

--- a/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_db.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_db.py
@@ -4,6 +4,7 @@ import json
 import math
 import sqlite3
 from dataclasses import asdict
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -27,6 +28,10 @@ def _database_bytes(repo: ScheduledTasksDatabase) -> bytes:
     return payload
 
 
+def _future_expires_at() -> str:
+    return (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
+
+
 def _create_preview(
     repo: ScheduledTasksDatabase,
     *,
@@ -35,6 +40,8 @@ def _create_preview(
     mode: str = "create",
     definition_id: str | None = None,
     definition_version: int | None = None,
+    status: str = "valid",
+    expires_at: str | None = None,
     normalized_config: dict[str, Any] | None = None,
 ):
     return repo.create_preview(
@@ -43,7 +50,7 @@ def _create_preview(
         family=family,
         definition_id=definition_id,
         definition_version=definition_version,
-        status="valid",
+        status=status,
         payload_hash=f"hash-{owner_id}-{family}-{mode}",
         normalized_config=normalized_config
         or {
@@ -57,7 +64,7 @@ def _create_preview(
         visibility_policy="findings_only",
         schedule_preview={"summary": "daily"},
         redaction_policy={"mode": "none"},
-        expires_at="2026-06-10T00:00:00+00:00",
+        expires_at=expires_at or _future_expires_at(),
         created_by=str(owner_id),
     )
 
@@ -95,6 +102,19 @@ def _create_definition(
     )
 
 
+def test_connect_context_manager_closes_connection(tmp_path):
+    repo = ScheduledTasksDatabase(tmp_path / "scheduled_tasks.db")
+
+    with repo._connect() as conn:
+        conn.execute("SELECT 1")
+
+    try:
+        with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+            conn.execute("SELECT 1")
+    finally:
+        conn.close()
+
+
 def test_scheduled_tasks_repository_isolates_users(tmp_path, monkeypatch):
     monkeypatch.setenv("USER_DB_BASE_DIR", str(tmp_path))
     repo_a = ScheduledTasksDatabase.for_user(user_id=101)
@@ -117,12 +137,48 @@ def test_scheduled_tasks_repository_isolates_users(tmp_path, monkeypatch):
         visibility_policy="findings_only",
         schedule_preview={"summary": "daily"},
         redaction_policy={"mode": "none"},
-        expires_at="2026-06-10T00:00:00+00:00",
+        expires_at=_future_expires_at(),
         created_by="101",
     )
 
     assert repo_a.get_preview(owner_id=101, preview_id=preview.id).id == preview.id  # nosec B101
     assert repo_b.get_preview(owner_id=202, preview_id=preview.id) is None  # nosec B101
+
+
+def test_bulk_preview_lookup_returns_owner_scoped_preview_map(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, monkeypatch)
+    preview_a = _create_preview(repo, owner_id=101, normalized_config={"config": {"rank": 1}})
+    preview_b = _create_preview(repo, owner_id=101, normalized_config={"config": {"rank": 2}})
+    other_owner_preview = _create_preview(repo, owner_id=202, normalized_config={"config": {"rank": 3}})
+
+    previews = repo.get_previews_by_ids(
+        owner_id=101,
+        preview_ids=[preview_a.id, preview_b.id, preview_a.id, other_owner_preview.id, "missing"],
+    )
+
+    assert set(previews) == {preview_a.id, preview_b.id}  # nosec B101
+    assert previews[preview_a.id].normalized_config["config"] == {"rank": 1}  # nosec B101
+    assert previews[preview_b.id].normalized_config["config"] == {"rank": 2}  # nosec B101
+
+
+def test_time_expired_valid_previews_read_and_filter_as_expired(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, monkeypatch)
+    expired = _create_preview(
+        repo,
+        expires_at=(datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat(),
+    )
+    active = _create_preview(repo)
+
+    detail = repo.get_preview(owner_id=101, preview_id=expired.id)
+    expired_rows, expired_total = repo.list_previews(owner_id=101, status="expired")
+    valid_rows, valid_total = repo.list_previews(owner_id=101, status="valid")
+
+    assert detail is not None  # nosec B101
+    assert detail.status == "expired"  # nosec B101
+    assert expired_total == 1  # nosec B101
+    assert [row.id for row in expired_rows] == [expired.id]  # nosec B101
+    assert valid_total == 1  # nosec B101
+    assert [row.id for row in valid_rows] == [active.id]  # nosec B101
 
 
 def test_create_definition_and_audit_roundtrip(tmp_path, monkeypatch):

--- a/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_db.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_db.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import math
 import sqlite3
 from dataclasses import asdict
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -15,6 +17,14 @@ def _repo(tmp_path, monkeypatch, *, user_id: int = 101) -> ScheduledTasksDatabas
     repo = ScheduledTasksDatabase.for_user(user_id=user_id)
     repo.ensure_schema()
     return repo
+
+
+def _database_bytes(repo: ScheduledTasksDatabase) -> bytes:
+    payload = repo.db_path.read_bytes()
+    wal_path = Path(f"{repo.db_path}-wal")
+    if wal_path.exists():
+        payload += wal_path.read_bytes()
+    return payload
 
 
 def _create_preview(
@@ -157,7 +167,7 @@ def test_create_definition_and_audit_roundtrip(tmp_path, monkeypatch):
         limit=10,
         offset=0,
     )
-    db_bytes = repo.db_path.read_bytes()
+    db_bytes = _database_bytes(repo)
 
     assert loaded == definition  # nosec B101
     assert audit.id == events[0].id  # nosec B101
@@ -183,6 +193,27 @@ def test_update_preview_consumption_sets_consumed_at(tmp_path, monkeypatch):
     assert consumed.created_definition_id == "definition-1"  # nosec B101
 
 
+def test_mark_preview_consumed_rejects_second_consume_and_preserves_definition_id(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, monkeypatch)
+    preview = _create_preview(repo)
+    first = repo.mark_preview_consumed(
+        owner_id=101,
+        preview_id=preview.id,
+        created_definition_id="definition-1",
+    )
+
+    with pytest.raises(ValueError, match="preview already consumed"):
+        repo.mark_preview_consumed(
+            owner_id=101,
+            preview_id=preview.id,
+            created_definition_id="definition-2",
+        )
+
+    loaded = repo.get_preview(owner_id=101, preview_id=preview.id)
+    assert loaded.consumed_at == first.consumed_at  # nosec B101
+    assert loaded.created_definition_id == "definition-1"  # nosec B101
+
+
 def test_idempotency_records_are_owner_and_route_scoped(tmp_path, monkeypatch):
     repo = _repo(tmp_path, monkeypatch)
     first = repo.create_idempotency_record(
@@ -191,7 +222,7 @@ def test_idempotency_records_are_owner_and_route_scoped(tmp_path, monkeypatch):
         key="same-key",
         payload_hash="hash-1",
         response_ref={"preview_id": "preview-1"},
-        expires_at="2026-06-10T00:00:00+00:00",
+        expires_at="2099-01-01T00:00:00+00:00",
     )
     by_route = repo.create_idempotency_record(
         owner_id=101,
@@ -199,7 +230,7 @@ def test_idempotency_records_are_owner_and_route_scoped(tmp_path, monkeypatch):
         key="same-key",
         payload_hash="hash-2",
         response_ref={"definition_id": "definition-1"},
-        expires_at="2026-06-10T00:00:00+00:00",
+        expires_at="2099-01-01T00:00:00+00:00",
     )
     by_owner = repo.create_idempotency_record(
         owner_id=202,
@@ -207,7 +238,7 @@ def test_idempotency_records_are_owner_and_route_scoped(tmp_path, monkeypatch):
         key="same-key",
         payload_hash="hash-3",
         response_ref={"preview_id": "preview-2"},
-        expires_at="2026-06-10T00:00:00+00:00",
+        expires_at="2099-01-01T00:00:00+00:00",
     )
 
     assert (
@@ -242,8 +273,40 @@ def test_idempotency_records_are_owner_and_route_scoped(tmp_path, monkeypatch):
             key="same-key",
             payload_hash="hash-conflict",
             response_ref={"preview_id": "preview-conflict"},
-            expires_at="2026-06-10T00:00:00+00:00",
+            expires_at="2099-01-01T00:00:00+00:00",
         )
+
+
+def test_expired_idempotency_record_lookup_returns_none_and_key_can_be_reused(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, monkeypatch)
+    repo.create_idempotency_record(
+        owner_id=101,
+        route="/api/v1/scheduled-tasks/previews",
+        key="reusable-key",
+        payload_hash="old-hash",
+        response_ref={"preview_id": "old-preview"},
+        expires_at="2020-01-01T00:00:00+00:00",
+    )
+
+    assert (  # nosec B101
+        repo.get_idempotency_record(
+            owner_id=101,
+            route="/api/v1/scheduled-tasks/previews",
+            key="reusable-key",
+        )
+        is None
+    )
+    replacement = repo.create_idempotency_record(
+        owner_id=101,
+        route="/api/v1/scheduled-tasks/previews",
+        key="reusable-key",
+        payload_hash="new-hash",
+        response_ref={"preview_id": "new-preview"},
+        expires_at="2099-01-01T00:00:00+00:00",
+    )
+
+    assert replacement.payload_hash == "new-hash"  # nosec B101
+    assert replacement.response_ref == {"preview_id": "new-preview"}  # nosec B101
 
 
 def test_list_definitions_filters_by_family_lifecycle_health_and_query(tmp_path, monkeypatch):
@@ -311,6 +374,121 @@ def test_definition_persists_disabled_lock_kind_and_reason(tmp_path, monkeypatch
     assert loaded.disabled_reason == "Agent capability was disabled by policy"  # nosec B101
 
 
+def test_update_definition_with_expected_version_updates_and_conflicts_on_wrong_version(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, monkeypatch)
+    definition = _create_definition(repo, name="Original")
+
+    updated = repo.update_definition(
+        owner_id=101,
+        definition_id=definition.id,
+        patch={"name": "Updated", "updated_by": "101"},
+        expected_version=1,
+    )
+
+    assert updated.version == 2  # nosec B101
+    assert updated.name == "Updated"  # nosec B101
+    with pytest.raises(ValueError, match="definition version conflict"):
+        repo.update_definition(
+            owner_id=101,
+            definition_id=definition.id,
+            patch={"name": "Stale update", "updated_by": "101"},
+            expected_version=1,
+        )
+
+
+def test_update_definition_expected_version_conflicts_if_row_changes_between_read_and_write(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, monkeypatch)
+    definition = _create_definition(repo, name="Original")
+    concurrent_repo = ScheduledTasksDatabase(repo.db_path)
+    original_get_definition = repo.get_definition
+    raced = False
+
+    def _get_definition_after_concurrent_update(owner_id: int, definition_id: str):
+        nonlocal raced
+        row = original_get_definition(owner_id=owner_id, definition_id=definition_id)
+        if row is not None and not raced:
+            raced = True
+            concurrent_repo.update_definition(
+                owner_id=owner_id,
+                definition_id=definition_id,
+                patch={
+                    "name": "Concurrent update",
+                    "updated_by": "202",
+                },
+                expected_version=None,
+            )
+        return row
+
+    monkeypatch.setattr(repo, "get_definition", _get_definition_after_concurrent_update)
+
+    with pytest.raises(ValueError, match="definition version conflict"):
+        repo.update_definition(
+            owner_id=101,
+            definition_id=definition.id,
+            patch={"name": "Stale update", "updated_by": "101"},
+            expected_version=1,
+        )
+
+    loaded = original_get_definition(owner_id=101, definition_id=definition.id)
+    assert loaded.version == 2  # nosec B101
+    assert loaded.name == "Concurrent update"  # nosec B101
+
+
+def test_create_definition_rejects_missing_preview(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, monkeypatch)
+
+    with pytest.raises(KeyError, match="preview not found"):
+        repo.create_definition(
+            owner_id=101,
+            family="recurring_question",
+            name="Missing preview",
+            description=None,
+            lifecycle="configured",
+            health="execution_unavailable",
+            schedule={"cron": "0 9 * * *"},
+            input={"question": "What changed?"},
+            visibility_policy="findings_only",
+            notification_policy={"channels": []},
+            approval_policy={"required": False},
+            preview_id="missing-preview",
+            created_by="101",
+            updated_by="101",
+        )
+
+
+def test_create_definition_rejects_cross_owner_preview(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, monkeypatch)
+    owner_202_preview = _create_preview(repo, owner_id=202)
+
+    with pytest.raises(KeyError, match="preview not found"):
+        repo.create_definition(
+            owner_id=101,
+            family="recurring_question",
+            name="Cross-owner preview",
+            description=None,
+            lifecycle="configured",
+            health="execution_unavailable",
+            schedule={"cron": "0 9 * * *"},
+            input={"question": "What changed?"},
+            visibility_policy="findings_only",
+            notification_policy={"channels": []},
+            approval_policy={"required": False},
+            preview_id=owner_202_preview.id,
+            created_by="101",
+            updated_by="101",
+        )
+
+
+def test_json_persistence_rejects_nan_values(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, monkeypatch)
+
+    with pytest.raises(ValueError):
+        _create_preview(
+            repo,
+            normalized_config={"threshold": math.nan},
+        )
+
+
 def test_agent_task_definition_and_audit_storage_do_not_contain_raw_message_secret(tmp_path, monkeypatch):
     repo = _repo(tmp_path, monkeypatch)
     sentinel = "RAW_AGENT_TASK_SENTINEL_SHOULD_NOT_PERSIST"
@@ -361,4 +539,4 @@ def test_agent_task_definition_and_audit_storage_do_not_contain_raw_message_secr
     persisted_text = json.dumps([preview_payload, definition_payload, audit_payloads], sort_keys=True)
 
     assert sentinel not in persisted_text  # nosec B101
-    assert sentinel.encode("utf-8") not in repo.db_path.read_bytes()  # nosec B101
+    assert sentinel.encode("utf-8") not in _database_bytes(repo)  # nosec B101

--- a/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_db.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_db.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import asdict
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import ScheduledTasksDatabase
+
+
+def _repo(tmp_path, monkeypatch, *, user_id: int = 101) -> ScheduledTasksDatabase:
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(tmp_path))
+    repo = ScheduledTasksDatabase.for_user(user_id=user_id)
+    repo.ensure_schema()
+    return repo
+
+
+def _create_preview(
+    repo: ScheduledTasksDatabase,
+    *,
+    owner_id: int = 101,
+    family: str = "recurring_question",
+    mode: str = "create",
+    definition_id: str | None = None,
+    definition_version: int | None = None,
+    normalized_config: dict[str, Any] | None = None,
+):
+    return repo.create_preview(
+        owner_id=owner_id,
+        mode=mode,
+        family=family,
+        definition_id=definition_id,
+        definition_version=definition_version,
+        status="valid",
+        payload_hash=f"hash-{owner_id}-{family}-{mode}",
+        normalized_config=normalized_config
+        or {
+            "input": {"question": "What changed?"},
+            "name": "Question",
+            "schedule": {"cron": "0 9 * * *"},
+        },
+        validation_errors=[],
+        warnings=[],
+        risk_class=None,
+        visibility_policy="findings_only",
+        schedule_preview={"summary": "daily"},
+        redaction_policy={"mode": "none"},
+        expires_at="2026-06-10T00:00:00+00:00",
+        created_by=str(owner_id),
+    )
+
+
+def _create_definition(
+    repo: ScheduledTasksDatabase,
+    *,
+    owner_id: int = 101,
+    family: str = "recurring_question",
+    name: str = "Daily question",
+    lifecycle: str = "configured",
+    health: str = "execution_unavailable",
+    description: str | None = "Ask the question every day",
+    disabled_lock_kind: str = "none",
+    disabled_reason: str | None = None,
+):
+    preview = _create_preview(repo, owner_id=owner_id, family=family)
+    return repo.create_definition(
+        owner_id=owner_id,
+        family=family,
+        name=name,
+        description=description,
+        lifecycle=lifecycle,
+        health=health,
+        disabled_lock_kind=disabled_lock_kind,
+        disabled_reason=disabled_reason,
+        schedule={"timezone": "UTC", "cron": "0 9 * * *"},
+        input={"question": "What changed?"},
+        visibility_policy="findings_only",
+        notification_policy={"channels": []},
+        approval_policy={"required": False},
+        preview_id=preview.id,
+        created_by=str(owner_id),
+        updated_by=str(owner_id),
+    )
+
+
+def test_scheduled_tasks_repository_isolates_users(tmp_path, monkeypatch):
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(tmp_path))
+    repo_a = ScheduledTasksDatabase.for_user(user_id=101)
+    repo_b = ScheduledTasksDatabase.for_user(user_id=202)
+    repo_a.ensure_schema()
+    repo_b.ensure_schema()
+
+    preview = repo_a.create_preview(
+        owner_id=101,
+        mode="create",
+        family="recurring_question",
+        definition_id=None,
+        definition_version=None,
+        status="valid",
+        payload_hash="hash-a",
+        normalized_config={"name": "Question", "input": {"question": "What changed?"}},
+        validation_errors=[],
+        warnings=[],
+        risk_class=None,
+        visibility_policy="findings_only",
+        schedule_preview={"summary": "daily"},
+        redaction_policy={"mode": "none"},
+        expires_at="2026-06-10T00:00:00+00:00",
+        created_by="101",
+    )
+
+    assert repo_a.get_preview(owner_id=101, preview_id=preview.id).id == preview.id  # nosec B101
+    assert repo_b.get_preview(owner_id=202, preview_id=preview.id) is None  # nosec B101
+
+
+def test_create_definition_and_audit_roundtrip(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, monkeypatch)
+    preview = _create_preview(
+        repo,
+        normalized_config={"z": "last", "a": {"nested": True}},
+    )
+
+    definition = repo.create_definition(
+        owner_id=101,
+        family="recurring_question",
+        name="Daily research check",
+        description="Ask about new research",
+        lifecycle="configured",
+        health="execution_unavailable",
+        schedule={"b": 2, "a": 1},
+        input={"question": "What changed?"},
+        visibility_policy="findings_only",
+        notification_policy={"channels": ["in_app"]},
+        approval_policy={"required": False},
+        preview_id=preview.id,
+        created_by="101",
+        updated_by="101",
+    )
+    audit = repo.create_audit_event(
+        owner_id=101,
+        definition_id=definition.id,
+        event_type="definition.created",
+        actor="101",
+        summary="Created definition",
+        before=None,
+        after={"name": definition.name, "version": definition.version},
+        request_id="req-1",
+        idempotency_key="idem-1",
+    )
+
+    loaded = repo.get_definition(owner_id=101, definition_id=definition.id)
+    events, total = repo.list_audit_events(
+        owner_id=101,
+        definition_id=definition.id,
+        limit=10,
+        offset=0,
+    )
+    db_bytes = repo.db_path.read_bytes()
+
+    assert loaded == definition  # nosec B101
+    assert audit.id == events[0].id  # nosec B101
+    assert total == 1  # nosec B101
+    assert events[0].after == {"name": definition.name, "version": 1}  # nosec B101
+    assert b'{"a":1,"b":2}' in db_bytes  # nosec B101
+    assert b'{"b":2,"a":1}' not in db_bytes  # nosec B101
+
+
+def test_update_preview_consumption_sets_consumed_at(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, monkeypatch)
+    preview = _create_preview(repo)
+
+    consumed = repo.mark_preview_consumed(
+        owner_id=101,
+        preview_id=preview.id,
+        created_definition_id="definition-1",
+    )
+
+    assert consumed.id == preview.id  # nosec B101
+    assert consumed.status == "consumed"  # nosec B101
+    assert consumed.consumed_at is not None  # nosec B101
+    assert consumed.created_definition_id == "definition-1"  # nosec B101
+
+
+def test_idempotency_records_are_owner_and_route_scoped(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, monkeypatch)
+    first = repo.create_idempotency_record(
+        owner_id=101,
+        route="/api/v1/scheduled-tasks/previews",
+        key="same-key",
+        payload_hash="hash-1",
+        response_ref={"preview_id": "preview-1"},
+        expires_at="2026-06-10T00:00:00+00:00",
+    )
+    by_route = repo.create_idempotency_record(
+        owner_id=101,
+        route="/api/v1/scheduled-tasks/definitions",
+        key="same-key",
+        payload_hash="hash-2",
+        response_ref={"definition_id": "definition-1"},
+        expires_at="2026-06-10T00:00:00+00:00",
+    )
+    by_owner = repo.create_idempotency_record(
+        owner_id=202,
+        route="/api/v1/scheduled-tasks/previews",
+        key="same-key",
+        payload_hash="hash-3",
+        response_ref={"preview_id": "preview-2"},
+        expires_at="2026-06-10T00:00:00+00:00",
+    )
+
+    assert (
+        repo.get_idempotency_record(  # nosec B101
+            owner_id=101,
+            route="/api/v1/scheduled-tasks/previews",
+            key="same-key",
+        )
+        == first
+    )
+    assert (
+        repo.get_idempotency_record(  # nosec B101
+            owner_id=101,
+            route="/api/v1/scheduled-tasks/definitions",
+            key="same-key",
+        )
+        == by_route
+    )
+    assert (
+        repo.get_idempotency_record(  # nosec B101
+            owner_id=202,
+            route="/api/v1/scheduled-tasks/previews",
+            key="same-key",
+        )
+        == by_owner
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        repo.create_idempotency_record(
+            owner_id=101,
+            route="/api/v1/scheduled-tasks/previews",
+            key="same-key",
+            payload_hash="hash-conflict",
+            response_ref={"preview_id": "preview-conflict"},
+            expires_at="2026-06-10T00:00:00+00:00",
+        )
+
+
+def test_list_definitions_filters_by_family_lifecycle_health_and_query(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, monkeypatch)
+    _create_definition(
+        repo,
+        family="recurring_question",
+        name="Daily climate question",
+        lifecycle="configured",
+        health="execution_unavailable",
+    )
+    _create_definition(
+        repo,
+        family="agent_task",
+        name="Weekly agent triage",
+        lifecycle="paused",
+        health="needs_attention",
+    )
+    _create_definition(
+        repo,
+        family="recurring_question",
+        name="Weekly finance question",
+        lifecycle="paused",
+        health="ready",
+    )
+    _create_definition(
+        repo,
+        family="recurring_question",
+        name="Archived question",
+        lifecycle="archived",
+        health="ready",
+    )
+
+    family_rows, family_total = repo.list_definitions(owner_id=101, family="recurring_question", limit=10, offset=0)
+    lifecycle_rows, lifecycle_total = repo.list_definitions(owner_id=101, lifecycle="paused", limit=10, offset=0)
+    health_rows, health_total = repo.list_definitions(owner_id=101, health="ready", limit=10, offset=0)
+    query_rows, query_total = repo.list_definitions(owner_id=101, query="climate", limit=10, offset=0)
+    page_rows, page_total = repo.list_definitions(owner_id=101, limit=2, offset=1)
+
+    assert family_total == 3  # nosec B101
+    assert {row.family for row in family_rows} == {"recurring_question"}  # nosec B101
+    assert lifecycle_total == 2  # nosec B101
+    assert {row.lifecycle for row in lifecycle_rows} == {"paused"}  # nosec B101
+    assert health_total == 2  # nosec B101
+    assert {row.health for row in health_rows} == {"ready"}  # nosec B101
+    assert query_total == 1  # nosec B101
+    assert query_rows[0].name == "Daily climate question"  # nosec B101
+    assert page_total == 4  # nosec B101
+    assert len(page_rows) == 2  # nosec B101
+
+
+def test_definition_persists_disabled_lock_kind_and_reason(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, monkeypatch)
+
+    definition = _create_definition(
+        repo,
+        lifecycle="disabled",
+        health="capability_unavailable",
+        disabled_lock_kind="security",
+        disabled_reason="Agent capability was disabled by policy",
+    )
+
+    loaded = repo.get_definition(owner_id=101, definition_id=definition.id)
+    assert loaded.disabled_lock_kind == "security"  # nosec B101
+    assert loaded.disabled_reason == "Agent capability was disabled by policy"  # nosec B101
+
+
+def test_agent_task_definition_and_audit_storage_do_not_contain_raw_message_secret(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, monkeypatch)
+    sentinel = "RAW_AGENT_TASK_SENTINEL_SHOULD_NOT_PERSIST"
+    raw_requested_payload = {"input": {"message": sentinel}}
+    redacted_input = {"message_ref": "msg_123", "message_preview": "[redacted]"}
+    preview = _create_preview(
+        repo,
+        family="agent_task",
+        normalized_config={
+            "family": "agent_task",
+            "input": redacted_input,
+            "redaction_policy": {"fields": ["input.message"]},
+        },
+    )
+    definition = repo.create_definition(
+        owner_id=101,
+        family="agent_task",
+        name="Agent follow-up",
+        description=None,
+        lifecycle="paused",
+        health="execution_unavailable",
+        schedule={"cron": "0 12 * * *", "timezone": "UTC"},
+        input=redacted_input,
+        visibility_policy="findings_only",
+        notification_policy={"channels": []},
+        approval_policy={"required": True},
+        preview_id=preview.id,
+        created_by="101",
+        updated_by="101",
+    )
+    repo.create_audit_event(
+        owner_id=101,
+        definition_id=definition.id,
+        event_type="definition.created",
+        actor="101",
+        summary="Created redacted Agent Task definition",
+        before=None,
+        after={"input": redacted_input, "source_payload_keys": list(raw_requested_payload.keys())},
+        request_id=None,
+        idempotency_key=None,
+    )
+
+    preview_payload = asdict(repo.get_preview(owner_id=101, preview_id=preview.id))
+    definition_payload = asdict(repo.get_definition(owner_id=101, definition_id=definition.id))
+    audit_payloads = [
+        asdict(row) for row in repo.list_audit_events(owner_id=101, definition_id=definition.id, limit=10, offset=0)[0]
+    ]
+    persisted_text = json.dumps([preview_payload, definition_payload, audit_payloads], sort_keys=True)
+
+    assert sentinel not in persisted_text  # nosec B101
+    assert sentinel.encode("utf-8") not in repo.db_path.read_bytes()  # nosec B101

--- a/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_db.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_db.py
@@ -479,6 +479,126 @@ def test_create_definition_rejects_cross_owner_preview(tmp_path, monkeypatch):
         )
 
 
+def test_create_definition_consumes_preview_and_rejects_second_definition(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, monkeypatch)
+    preview = _create_preview(repo)
+    first_definition = repo.create_definition(
+        owner_id=101,
+        family="recurring_question",
+        name="First definition",
+        description=None,
+        lifecycle="configured",
+        health="execution_unavailable",
+        schedule={"cron": "0 9 * * *"},
+        input={"question": "What changed?"},
+        visibility_policy="findings_only",
+        notification_policy={"channels": []},
+        approval_policy={"required": False},
+        preview_id=preview.id,
+        created_by="101",
+        updated_by="101",
+    )
+
+    with pytest.raises(ValueError, match="preview already consumed"):
+        repo.create_definition(
+            owner_id=101,
+            family="recurring_question",
+            name="Second definition",
+            description=None,
+            lifecycle="configured",
+            health="execution_unavailable",
+            schedule={"cron": "0 9 * * *"},
+            input={"question": "What changed?"},
+            visibility_policy="findings_only",
+            notification_policy={"channels": []},
+            approval_policy={"required": False},
+            preview_id=preview.id,
+            created_by="101",
+            updated_by="101",
+        )
+
+    loaded_preview = repo.get_preview(owner_id=101, preview_id=preview.id)
+    assert loaded_preview.status == "consumed"  # nosec B101
+    assert loaded_preview.created_definition_id == first_definition.id  # nosec B101
+    definitions, total = repo.list_definitions(owner_id=101, limit=10, offset=0)
+    assert total == 1  # nosec B101
+    assert definitions[0].id == first_definition.id  # nosec B101
+
+
+def test_update_definition_rejects_missing_preview_patch(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, monkeypatch)
+    definition = _create_definition(repo)
+
+    with pytest.raises(KeyError, match="preview not found"):
+        repo.update_definition(
+            owner_id=101,
+            definition_id=definition.id,
+            patch={
+                "preview_id": "missing-preview",
+                "updated_by": "101",
+            },
+            expected_version=1,
+        )
+
+
+def test_update_definition_rejects_cross_owner_preview_patch(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, monkeypatch)
+    definition = _create_definition(repo)
+    owner_202_preview = _create_preview(
+        repo,
+        owner_id=202,
+        mode="update",
+        definition_id=definition.id,
+        definition_version=definition.version,
+    )
+
+    with pytest.raises(KeyError, match="preview not found"):
+        repo.update_definition(
+            owner_id=101,
+            definition_id=definition.id,
+            patch={
+                "preview_id": owner_202_preview.id,
+                "updated_by": "101",
+            },
+            expected_version=1,
+        )
+
+
+def test_create_audit_event_rejects_missing_definition(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, monkeypatch)
+
+    with pytest.raises(KeyError, match="definition not found"):
+        repo.create_audit_event(
+            owner_id=101,
+            definition_id="missing-definition",
+            event_type="definition.created",
+            actor="101",
+            summary="Should fail",
+            before=None,
+            after={"name": "Missing"},
+        )
+
+
+def test_create_audit_event_rejects_cross_owner_definition(tmp_path, monkeypatch):
+    repo = _repo(tmp_path, monkeypatch)
+    owner_202_definition = _create_definition(
+        repo,
+        owner_id=202,
+        name="Other owner definition",
+    )
+
+    with pytest.raises(KeyError, match="definition not found"):
+        repo.create_audit_event(
+            owner_id=101,
+            definition_id=owner_202_definition.id,
+            event_type="definition.updated",
+            actor="101",
+            summary="Should fail",
+            before=None,
+            after={"name": "Other owner definition"},
+        )
+
+
 def test_json_persistence_rejects_nan_values(tmp_path, monkeypatch):
     repo = _repo(tmp_path, monkeypatch)
 

--- a/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_service.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_service.py
@@ -538,6 +538,133 @@ def test_pause_resume_archive_idempotency_replay_without_extra_audit_events(tmp_
     assert _audit_count(repo, definition.id) == 4  # created, paused, resumed, archived  # nosec B101
 
 
+def test_lifecycle_idempotency_replay_returns_original_snapshot_after_later_mutation(tmp_path):
+    service, repo = _service(tmp_path)
+    definition = _create_definition(service)
+
+    paused_snapshot = service.pause_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        idempotency_key="snapshot-pause-key",
+    )
+    service.resume_definition(owner_id=OWNER_ID, actor=ACTOR, definition_id=definition.id)
+    replay = service.pause_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        idempotency_key="snapshot-pause-key",
+    )
+    current = repo.get_definition(owner_id=OWNER_ID, definition_id=definition.id)
+
+    assert paused_snapshot.lifecycle == "paused"  # nosec B101
+    assert paused_snapshot.version == 2  # nosec B101
+    assert current.lifecycle == "configured"  # nosec B101
+    assert current.version == 3  # nosec B101
+    assert replay.model_dump(mode="json") == paused_snapshot.model_dump(mode="json")  # nosec B101
+
+
+def test_create_idempotency_replay_returns_original_snapshot_after_later_mutation(tmp_path):
+    service, _repo = _service(tmp_path)
+    preview = service.create_preview(owner_id=OWNER_ID, actor=ACTOR, payload=_payload())
+    payload = ScheduledTaskDefinitionCreateRequest(preview_id=preview.id)
+
+    created_snapshot = service.create_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=payload,
+        idempotency_key="snapshot-create-key",
+    )
+    service.pause_definition(owner_id=OWNER_ID, actor=ACTOR, definition_id=created_snapshot.id)
+    replay = service.create_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=payload,
+        idempotency_key="snapshot-create-key",
+    )
+
+    assert created_snapshot.lifecycle == "configured"  # nosec B101
+    assert created_snapshot.version == 1  # nosec B101
+    assert replay.model_dump(mode="json") == created_snapshot.model_dump(mode="json")  # nosec B101
+
+
+def test_update_idempotency_replay_returns_original_snapshot_after_later_update(tmp_path):
+    service, _repo = _service(tmp_path)
+    definition = _create_definition(service)
+    first_preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_payload(
+            mode="update",
+            definition_id=definition.id,
+            definition_version=definition.version,
+            name="First keyed update",
+        ),
+    )
+    first_payload = ScheduledTaskDefinitionUpdateRequest(preview_id=first_preview.id)
+    first_snapshot = service.update_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        payload=first_payload,
+        idempotency_key="snapshot-update-key",
+    )
+    second_preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_payload(
+            mode="update",
+            definition_id=definition.id,
+            definition_version=first_snapshot.version,
+            name="Second unkeyed update",
+        ),
+    )
+    service.update_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        payload=ScheduledTaskDefinitionUpdateRequest(preview_id=second_preview.id),
+    )
+
+    replay = service.update_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        payload=first_payload,
+        idempotency_key="snapshot-update-key",
+    )
+
+    assert first_snapshot.name == "First keyed update"  # nosec B101
+    assert first_snapshot.version == 2  # nosec B101
+    assert replay.model_dump(mode="json") == first_snapshot.model_dump(mode="json")  # nosec B101
+
+
+def test_duplicate_idempotency_replay_returns_original_snapshot_after_copy_mutation(tmp_path):
+    service, _repo = _service(tmp_path)
+    definition = _create_definition(service)
+    payload = ScheduledTaskDuplicateRequest(name="Snapshot duplicate")
+
+    duplicate_snapshot = service.duplicate_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        payload=payload,
+        idempotency_key="snapshot-duplicate-key",
+    )
+    service.resume_definition(owner_id=OWNER_ID, actor=ACTOR, definition_id=duplicate_snapshot.id)
+    replay = service.duplicate_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        payload=payload,
+        idempotency_key="snapshot-duplicate-key",
+    )
+
+    assert duplicate_snapshot.lifecycle == "paused"  # nosec B101
+    assert duplicate_snapshot.version == 1  # nosec B101
+    assert replay.model_dump(mode="json") == duplicate_snapshot.model_dump(mode="json")  # nosec B101
+
+
 def test_same_key_different_payload_conflict_for_create_update_duplicate_and_lifecycle_routes(tmp_path):
     service, _repo = _service(tmp_path)
     preview = service.create_preview(owner_id=OWNER_ID, actor=ACTOR, payload=_payload(name="Create one"))

--- a/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_service.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_service.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
@@ -112,6 +114,33 @@ def _audit_count(repo: ScheduledTasksDatabase, definition_id: str) -> int:
     )[1]
 
 
+def _install_idempotency_miss_barrier(
+    monkeypatch: pytest.MonkeyPatch,
+    repo: ScheduledTasksDatabase,
+    *,
+    parties: int = 2,
+) -> None:
+    original_get_idempotency_record = repo.get_idempotency_record
+    barrier = threading.Barrier(parties)
+    lock = threading.Lock()
+    waits_remaining = parties
+
+    def _raced_get_idempotency_record(owner_id: int, route: str, key: str):
+        nonlocal waits_remaining
+        row = original_get_idempotency_record(owner_id, route, key)
+        should_wait = False
+        if row is None:
+            with lock:
+                if waits_remaining > 0:
+                    waits_remaining -= 1
+                    should_wait = True
+        if should_wait:
+            barrier.wait(timeout=5)
+        return row
+
+    monkeypatch.setattr(repo, "get_idempotency_record", _raced_get_idempotency_record)
+
+
 def test_invalid_semantic_preview_is_persisted_with_errors_and_id(tmp_path):
     service, repo = _service(tmp_path)
 
@@ -145,6 +174,8 @@ def test_agent_task_preview_redacts_raw_message_in_responses_and_storage(tmp_pat
     stored = repo.get_preview(owner_id=OWNER_ID, preview_id=preview.id)
     assert preview.status == "valid"  # nosec B101
     assert preview.normalized_config["input"]["message_redacted"] is True  # nosec B101
+    assert "message_length" not in preview.normalized_config["input"]  # nosec B101
+    assert not preview.normalized_config["input"]["message_ref"].startswith("sha256:")  # nosec B101
     assert RAW_SENTINEL not in _as_json_text(preview)  # nosec B101
     assert stored is not None  # nosec B101
     assert RAW_SENTINEL not in json.dumps(stored.normalized_config, sort_keys=True)  # nosec B101
@@ -406,6 +437,29 @@ def test_preview_idempotency_replay_and_same_key_different_payload_conflict(tmp_
     assert previews[0].id == first.id  # nosec B101
 
 
+def test_preview_idempotency_race_executes_side_effects_once(tmp_path, monkeypatch):
+    service, repo = _service(tmp_path)
+    _install_idempotency_miss_barrier(monkeypatch, repo)
+    payload = _payload(name="Raced preview")
+
+    def _create_preview():
+        return service.create_preview(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            payload=payload,
+            idempotency_key="preview-race-key",
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(_create_preview) for _ in range(2)]
+        responses = [future.result(timeout=10) for future in futures]
+
+    previews, total = repo.list_previews(owner_id=OWNER_ID, limit=10, offset=0)
+    assert responses[0].id == responses[1].id  # nosec B101
+    assert total == 1  # nosec B101
+    assert previews[0].id == responses[0].id  # nosec B101
+
+
 def test_create_idempotency_replay_before_preview_consumption(tmp_path):
     service, repo = _service(tmp_path)
     preview = service.create_preview(owner_id=OWNER_ID, actor=ACTOR, payload=_payload())
@@ -427,6 +481,34 @@ def test_create_idempotency_replay_before_preview_consumption(tmp_path):
     assert replay.id == first.id  # nosec B101
     assert repo.list_definitions(owner_id=OWNER_ID, limit=10, offset=0)[1] == 1  # nosec B101
     assert _audit_count(repo, first.id) == 1  # nosec B101
+
+
+def test_duplicate_idempotency_race_does_not_create_extra_definitions_or_audits(tmp_path, monkeypatch):
+    service, repo = _service(tmp_path)
+    source = _create_definition(service, name="Duplicate race source")
+    _install_idempotency_miss_barrier(monkeypatch, repo)
+    payload = ScheduledTaskDuplicateRequest(name="Raced duplicate")
+
+    def _duplicate_definition():
+        return service.duplicate_definition(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            definition_id=source.id,
+            payload=payload,
+            idempotency_key="duplicate-race-key",
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(_duplicate_definition) for _ in range(2)]
+        responses = [future.result(timeout=10) for future in futures]
+
+    definitions, total = repo.list_definitions(owner_id=OWNER_ID, limit=10, offset=0)
+    copy_ids = {definition.id for definition in definitions if definition.id != source.id}
+    assert responses[0].id == responses[1].id  # nosec B101
+    assert total == 2  # nosec B101
+    assert copy_ids == {responses[0].id}  # nosec B101
+    assert _audit_count(repo, source.id) == 2  # created + duplicated  # nosec B101
+    assert _audit_count(repo, responses[0].id) == 1  # duplicate created  # nosec B101
 
 
 def test_update_idempotency_replay_after_preview_consumption(tmp_path):
@@ -536,6 +618,73 @@ def test_pause_resume_archive_idempotency_replay_without_extra_audit_events(tmp_
     assert resume_replay.version == resumed.version  # nosec B101
     assert archive_replay.version == archived.version  # nosec B101
     assert _audit_count(repo, definition.id) == 4  # created, paused, resumed, archived  # nosec B101
+
+
+def test_update_rolls_back_definition_and_preview_consumption_when_audit_fails(tmp_path, monkeypatch):
+    service, repo = _service(tmp_path)
+    definition = _create_definition(service)
+    preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_payload(
+            mode="update",
+            definition_id=definition.id,
+            definition_version=definition.version,
+            name="Should roll back",
+        ),
+    )
+
+    def _fail_audit(**_kwargs):
+        raise RuntimeError("injected_audit_failure")
+
+    monkeypatch.setattr(service, "_create_audit", _fail_audit)
+
+    with pytest.raises(RuntimeError, match="injected_audit_failure"):
+        service.update_definition(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            definition_id=definition.id,
+            payload=ScheduledTaskDefinitionUpdateRequest(preview_id=preview.id),
+        )
+
+    loaded_definition = repo.get_definition(owner_id=OWNER_ID, definition_id=definition.id)
+    loaded_preview = repo.get_preview(owner_id=OWNER_ID, preview_id=preview.id)
+    assert loaded_definition.version == definition.version  # nosec B101
+    assert loaded_definition.name == definition.name  # nosec B101
+    assert loaded_preview.status == "valid"  # nosec B101
+    assert loaded_preview.consumed_at is None  # nosec B101
+    assert _audit_count(repo, definition.id) == 1  # created only  # nosec B101
+
+
+def test_lifecycle_rolls_back_mutation_and_audit_when_idempotency_snapshot_fails(tmp_path, monkeypatch):
+    service, repo = _service(tmp_path)
+    definition = _create_definition(service)
+
+    def _fail_response_ref(_response):
+        raise RuntimeError("injected_snapshot_failure")
+
+    monkeypatch.setattr(service, "_response_ref", _fail_response_ref)
+
+    with pytest.raises(RuntimeError, match="injected_snapshot_failure"):
+        service.pause_definition(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            definition_id=definition.id,
+            idempotency_key="snapshot-failure-key",
+        )
+
+    loaded_definition = repo.get_definition(owner_id=OWNER_ID, definition_id=definition.id)
+    assert loaded_definition.lifecycle == "configured"  # nosec B101
+    assert loaded_definition.version == definition.version  # nosec B101
+    assert _audit_count(repo, definition.id) == 1  # created only  # nosec B101
+    assert (  # nosec B101
+        repo.get_idempotency_record(
+            owner_id=OWNER_ID,
+            route="scheduled_task_automation.definition.pause",
+            key="snapshot-failure-key",
+        )
+        is None
+    )
 
 
 def test_lifecycle_idempotency_replay_returns_original_snapshot_after_later_mutation(tmp_path):

--- a/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_service.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_service.py
@@ -1,0 +1,671 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.api.v1.schemas.scheduled_tasks_automation_schemas import (
+    ScheduledTaskDefinitionCreateRequest,
+    ScheduledTaskDefinitionUpdateRequest,
+    ScheduledTaskDuplicateRequest,
+    ScheduledTaskPreviewCreateRequest,
+)
+from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import ScheduledTasksDatabase
+from tldw_Server_API.app.services.scheduled_task_automation_service import ScheduledTaskAutomationService
+
+OWNER_ID = 4101
+OTHER_OWNER_ID = 4102
+ACTOR = "task-service-test"
+RAW_SENTINEL = "RAW_AGENT_SECRET_DO_NOT_LEAK_4B"
+
+
+def _service(tmp_path: Path) -> tuple[ScheduledTaskAutomationService, ScheduledTasksDatabase]:
+    repo = ScheduledTasksDatabase(tmp_path / "scheduled_tasks_service.db")
+    repo.ensure_schema()
+    return ScheduledTaskAutomationService(repository=repo), repo
+
+
+def _payload(
+    *,
+    family: str = "recurring_question",
+    mode: str = "create",
+    definition_id: str | None = None,
+    definition_version: int | None = None,
+    name: str = "Daily research check",
+    input_payload: dict[str, Any] | None = None,
+    schedule: dict[str, Any] | None = None,
+) -> ScheduledTaskPreviewCreateRequest:
+    if input_payload is None:
+        input_payload = (
+            {"question": "What changed in the selected sources?"}
+            if family == "recurring_question"
+            else {"agent_ref": "agent:triage", "message": "Summarize high priority changes."}
+        )
+    return ScheduledTaskPreviewCreateRequest(
+        mode=mode,
+        family=family,
+        definition_id=definition_id,
+        definition_version=definition_version,
+        name=name,
+        description="Service lifecycle test",
+        input=input_payload,
+        schedule=schedule or {"kind": "daily", "time": "09:00", "timezone": "UTC"},
+        visibility_policy={"mode": "findings_only"},
+        notification_policy={"channels": ["in_app"]},
+        approval_policy={"required": False},
+    )
+
+
+def _create_definition(
+    service: ScheduledTaskAutomationService,
+    *,
+    owner_id: int = OWNER_ID,
+    name: str = "Daily research check",
+    initial_lifecycle: str = "configured",
+):
+    preview = service.create_preview(
+        owner_id=owner_id,
+        actor=ACTOR,
+        payload=_payload(name=name),
+    )
+    return service.create_definition(
+        owner_id=owner_id,
+        actor=ACTOR,
+        payload=ScheduledTaskDefinitionCreateRequest(
+            preview_id=preview.id,
+            initial_lifecycle=initial_lifecycle,
+        ),
+    )
+
+
+def _as_json_text(value: Any) -> str:
+    if hasattr(value, "model_dump"):
+        value = value.model_dump(mode="json")
+    return json.dumps(value, sort_keys=True)
+
+
+def _database_bytes(repo: ScheduledTasksDatabase) -> bytes:
+    payload = repo.db_path.read_bytes()
+    wal_path = Path(f"{repo.db_path}-wal")
+    if wal_path.exists():
+        payload += wal_path.read_bytes()
+    return payload
+
+
+def _set_preview_expires_at(repo: ScheduledTasksDatabase, *, preview_id: str, expires_at: str) -> None:
+    with sqlite3.connect(repo.db_path) as conn:
+        conn.execute(
+            "UPDATE scheduled_task_previews SET expires_at = ? WHERE id = ?",
+            [expires_at, preview_id],
+        )
+
+
+def _audit_count(repo: ScheduledTasksDatabase, definition_id: str) -> int:
+    return repo.list_audit_events(
+        owner_id=OWNER_ID,
+        definition_id=definition_id,
+        limit=100,
+        offset=0,
+    )[1]
+
+
+def test_invalid_semantic_preview_is_persisted_with_errors_and_id(tmp_path):
+    service, repo = _service(tmp_path)
+
+    preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_payload(input_payload={"question": "   "}, schedule={"kind": "not-a-schedule"}),
+    )
+
+    stored = repo.get_preview(owner_id=OWNER_ID, preview_id=preview.id)
+    assert preview.id  # nosec B101
+    assert preview.status == "invalid"  # nosec B101
+    assert preview.validation_errors  # nosec B101
+    assert stored is not None  # nosec B101
+    assert stored.status == "invalid"  # nosec B101
+    assert stored.validation_errors == preview.validation_errors  # nosec B101
+
+
+def test_agent_task_preview_redacts_raw_message_in_responses_and_storage(tmp_path):
+    service, repo = _service(tmp_path)
+
+    preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_payload(
+            family="agent_task",
+            input_payload={"agent_ref": "agent:incident-triage", "message": RAW_SENTINEL},
+        ),
+    )
+
+    stored = repo.get_preview(owner_id=OWNER_ID, preview_id=preview.id)
+    assert preview.status == "valid"  # nosec B101
+    assert preview.normalized_config["input"]["message_redacted"] is True  # nosec B101
+    assert RAW_SENTINEL not in _as_json_text(preview)  # nosec B101
+    assert stored is not None  # nosec B101
+    assert RAW_SENTINEL not in json.dumps(stored.normalized_config, sort_keys=True)  # nosec B101
+    assert RAW_SENTINEL.encode("utf-8") not in _database_bytes(repo)  # nosec B101
+
+
+def test_create_consumes_valid_preview_and_rejects_consumed_reuse_without_idempotency_key(tmp_path):
+    service, repo = _service(tmp_path)
+    preview = service.create_preview(owner_id=OWNER_ID, actor=ACTOR, payload=_payload())
+
+    definition = service.create_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=ScheduledTaskDefinitionCreateRequest(preview_id=preview.id),
+    )
+
+    consumed = repo.get_preview(owner_id=OWNER_ID, preview_id=preview.id)
+    assert definition.preview_id == preview.id  # nosec B101
+    assert definition.health == "execution_unavailable"  # nosec B101
+    assert consumed.status == "consumed"  # nosec B101
+    with pytest.raises(ValueError, match="preview_consumed"):
+        service.create_definition(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            payload=ScheduledTaskDefinitionCreateRequest(preview_id=preview.id),
+        )
+
+
+def test_preview_validation_rejects_expired_stale_consumed_and_cross_user_previews(tmp_path):
+    service, repo = _service(tmp_path)
+    expired = service.create_preview(owner_id=OWNER_ID, actor=ACTOR, payload=_payload())
+    _set_preview_expires_at(repo, preview_id=expired.id, expires_at="2020-01-01T00:00:00+00:00")
+
+    with pytest.raises(ValueError, match="preview_expired"):
+        service.create_definition(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            payload=ScheduledTaskDefinitionCreateRequest(preview_id=expired.id),
+        )
+
+    definition = _create_definition(service)
+    stale_preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_payload(
+            mode="update",
+            definition_id=definition.id,
+            definition_version=definition.version,
+            name="Updated name",
+        ),
+    )
+    service.pause_definition(owner_id=OWNER_ID, actor=ACTOR, definition_id=definition.id)
+
+    with pytest.raises(ValueError, match="definition_version_mismatch"):
+        service.update_definition(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            definition_id=definition.id,
+            payload=ScheduledTaskDefinitionUpdateRequest(preview_id=stale_preview.id),
+        )
+
+    consumed_preview = service.create_preview(owner_id=OWNER_ID, actor=ACTOR, payload=_payload(name="Consumed"))
+    service.create_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=ScheduledTaskDefinitionCreateRequest(preview_id=consumed_preview.id),
+    )
+    with pytest.raises(ValueError, match="preview_consumed"):
+        service.create_definition(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            payload=ScheduledTaskDefinitionCreateRequest(preview_id=consumed_preview.id),
+        )
+
+    other_preview = service.create_preview(owner_id=OTHER_OWNER_ID, actor=ACTOR, payload=_payload())
+    with pytest.raises(KeyError, match="preview_not_found"):
+        service.create_definition(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            payload=ScheduledTaskDefinitionCreateRequest(preview_id=other_preview.id),
+        )
+
+
+def test_update_requires_preview_version_match_and_consumes_preview(tmp_path):
+    service, repo = _service(tmp_path)
+    definition = _create_definition(service)
+    preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_payload(
+            mode="update",
+            definition_id=definition.id,
+            definition_version=definition.version,
+            name="Renamed question",
+        ),
+    )
+
+    updated = service.update_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        payload=ScheduledTaskDefinitionUpdateRequest(preview_id=preview.id),
+    )
+
+    consumed = repo.get_preview(owner_id=OWNER_ID, preview_id=preview.id)
+    assert updated.version == definition.version + 1  # nosec B101
+    assert updated.name == "Renamed question"  # nosec B101
+    assert consumed.status == "consumed"  # nosec B101
+
+
+def test_duplicate_creates_paused_copy_and_two_audit_events(tmp_path):
+    service, repo = _service(tmp_path)
+    definition = _create_definition(service)
+
+    copy = service.duplicate_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        payload=ScheduledTaskDuplicateRequest(name="Paused copy"),
+    )
+
+    original_events, original_total = repo.list_audit_events(
+        owner_id=OWNER_ID,
+        definition_id=definition.id,
+        limit=10,
+        offset=0,
+    )
+    copy_events, copy_total = repo.list_audit_events(
+        owner_id=OWNER_ID,
+        definition_id=copy.id,
+        limit=10,
+        offset=0,
+    )
+    assert copy.id != definition.id  # nosec B101
+    assert copy.lifecycle == "paused"  # nosec B101
+    assert copy.name == "Paused copy"  # nosec B101
+    assert original_total == 2  # nosec B101
+    assert copy_total == 1  # nosec B101
+    assert {event.event_type for event in original_events + copy_events} >= {  # nosec B101
+        "definition.created",
+        "definition_duplicated",
+        "definition_duplicate_created",
+    }
+
+
+@pytest.mark.parametrize("lock_kind", ["none", "system"])
+def test_duplicate_disabled_definition_succeeds_for_non_admin_non_security_locks(tmp_path, lock_kind):
+    service, repo = _service(tmp_path)
+    definition = _create_definition(service)
+    repo.update_definition(
+        owner_id=OWNER_ID,
+        definition_id=definition.id,
+        patch={
+            "lifecycle": "disabled",
+            "disabled_lock_kind": lock_kind,
+            "disabled_reason": "Temporarily unavailable",
+            "updated_by": ACTOR,
+        },
+        expected_version=definition.version,
+    )
+
+    copy = service.duplicate_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        payload=ScheduledTaskDuplicateRequest(name=f"Copy {lock_kind}"),
+    )
+
+    assert copy.lifecycle == "paused"  # nosec B101
+    assert copy.disabled_lock_kind == "none"  # nosec B101
+
+
+@pytest.mark.parametrize("lock_kind", ["admin", "security"])
+def test_duplicate_disabled_definition_with_admin_or_security_lock_fails_without_copy(tmp_path, lock_kind):
+    service, repo = _service(tmp_path)
+    definition = _create_definition(service)
+    repo.update_definition(
+        owner_id=OWNER_ID,
+        definition_id=definition.id,
+        patch={
+            "lifecycle": "disabled",
+            "disabled_lock_kind": lock_kind,
+            "disabled_reason": "Locked by policy",
+            "updated_by": ACTOR,
+        },
+        expected_version=definition.version,
+    )
+
+    with pytest.raises(ValueError, match="definition_disabled_locked"):
+        service.duplicate_definition(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            definition_id=definition.id,
+            payload=ScheduledTaskDuplicateRequest(name="Should not exist"),
+        )
+
+    definitions, total = repo.list_definitions(owner_id=OWNER_ID, limit=10, offset=0)
+    assert total == 1  # nosec B101
+    assert definitions[0].id == definition.id  # nosec B101
+
+
+def test_pause_resume_archive_transition_matrix(tmp_path):
+    service, repo = _service(tmp_path)
+    definition = _create_definition(service)
+
+    paused = service.pause_definition(owner_id=OWNER_ID, actor=ACTOR, definition_id=definition.id)
+    paused_again = service.pause_definition(owner_id=OWNER_ID, actor=ACTOR, definition_id=definition.id)
+    resumed = service.resume_definition(owner_id=OWNER_ID, actor=ACTOR, definition_id=definition.id)
+    resumed_again = service.resume_definition(owner_id=OWNER_ID, actor=ACTOR, definition_id=definition.id)
+    archived = service.archive_definition(owner_id=OWNER_ID, actor=ACTOR, definition_id=definition.id)
+    archived_again = service.archive_definition(owner_id=OWNER_ID, actor=ACTOR, definition_id=definition.id)
+
+    assert paused.lifecycle == "paused"  # nosec B101
+    assert paused_again.lifecycle == "paused"  # nosec B101
+    assert resumed.lifecycle == "configured"  # nosec B101
+    assert resumed_again.lifecycle == "configured"  # nosec B101
+    assert archived.lifecycle == "archived"  # nosec B101
+    assert archived_again.lifecycle == "archived"  # nosec B101
+    assert _audit_count(repo, definition.id) == 4  # created, paused, resumed, archived  # nosec B101
+
+    for operation in (
+        lambda: service.pause_definition(owner_id=OWNER_ID, actor=ACTOR, definition_id=definition.id),
+        lambda: service.resume_definition(owner_id=OWNER_ID, actor=ACTOR, definition_id=definition.id),
+        lambda: service.update_definition(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            definition_id=definition.id,
+            payload=ScheduledTaskDefinitionUpdateRequest(preview_id="unused"),
+        ),
+        lambda: service.duplicate_definition(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            definition_id=definition.id,
+            payload=ScheduledTaskDuplicateRequest(name="Archived copy"),
+        ),
+    ):
+        with pytest.raises(ValueError, match="definition_archived"):
+            operation()
+
+
+def test_preview_idempotency_replay_and_same_key_different_payload_conflict(tmp_path):
+    service, repo = _service(tmp_path)
+    payload = _payload(name="Idempotent preview")
+
+    first = service.create_preview(owner_id=OWNER_ID, actor=ACTOR, payload=payload, idempotency_key="preview-key")
+    replay = service.create_preview(owner_id=OWNER_ID, actor=ACTOR, payload=payload, idempotency_key="preview-key")
+
+    with pytest.raises(ValueError, match="scheduled_task_idempotency_conflict"):
+        service.create_preview(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            payload=_payload(name="Different preview"),
+            idempotency_key="preview-key",
+        )
+
+    previews, total = repo.list_previews(owner_id=OWNER_ID, limit=10, offset=0)
+    assert replay.id == first.id  # nosec B101
+    assert total == 1  # nosec B101
+    assert previews[0].id == first.id  # nosec B101
+
+
+def test_create_idempotency_replay_before_preview_consumption(tmp_path):
+    service, repo = _service(tmp_path)
+    preview = service.create_preview(owner_id=OWNER_ID, actor=ACTOR, payload=_payload())
+    payload = ScheduledTaskDefinitionCreateRequest(preview_id=preview.id)
+
+    first = service.create_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=payload,
+        idempotency_key="create-key",
+    )
+    replay = service.create_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=payload,
+        idempotency_key="create-key",
+    )
+
+    assert replay.id == first.id  # nosec B101
+    assert repo.list_definitions(owner_id=OWNER_ID, limit=10, offset=0)[1] == 1  # nosec B101
+    assert _audit_count(repo, first.id) == 1  # nosec B101
+
+
+def test_update_idempotency_replay_after_preview_consumption(tmp_path):
+    service, repo = _service(tmp_path)
+    definition = _create_definition(service)
+    preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_payload(
+            mode="update",
+            definition_id=definition.id,
+            definition_version=definition.version,
+            name="Idempotently updated",
+        ),
+    )
+    payload = ScheduledTaskDefinitionUpdateRequest(preview_id=preview.id)
+
+    first = service.update_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        payload=payload,
+        idempotency_key="update-key",
+    )
+    replay = service.update_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        payload=payload,
+        idempotency_key="update-key",
+    )
+
+    assert replay.id == first.id  # nosec B101
+    assert replay.version == first.version  # nosec B101
+    assert repo.get_definition(owner_id=OWNER_ID, definition_id=definition.id).version == first.version  # nosec B101
+    assert _audit_count(repo, definition.id) == 2  # created + updated  # nosec B101
+
+
+def test_duplicate_idempotency_replay_does_not_create_second_copy_or_audit_pair(tmp_path):
+    service, repo = _service(tmp_path)
+    definition = _create_definition(service)
+    payload = ScheduledTaskDuplicateRequest(name="Idempotent duplicate")
+
+    first = service.duplicate_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        payload=payload,
+        idempotency_key="duplicate-key",
+    )
+    replay = service.duplicate_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        payload=payload,
+        idempotency_key="duplicate-key",
+    )
+
+    assert replay.id == first.id  # nosec B101
+    assert repo.list_definitions(owner_id=OWNER_ID, limit=10, offset=0)[1] == 2  # nosec B101
+    assert _audit_count(repo, definition.id) == 2  # created + duplicated  # nosec B101
+    assert _audit_count(repo, first.id) == 1  # duplicate created only  # nosec B101
+
+
+def test_pause_resume_archive_idempotency_replay_without_extra_audit_events(tmp_path):
+    service, repo = _service(tmp_path)
+    definition = _create_definition(service)
+
+    paused = service.pause_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        idempotency_key="pause-key",
+    )
+    pause_replay = service.pause_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        idempotency_key="pause-key",
+    )
+    resumed = service.resume_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        idempotency_key="resume-key",
+    )
+    resume_replay = service.resume_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        idempotency_key="resume-key",
+    )
+    archived = service.archive_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        idempotency_key="archive-key",
+    )
+    archive_replay = service.archive_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        idempotency_key="archive-key",
+    )
+
+    assert pause_replay.version == paused.version  # nosec B101
+    assert resume_replay.version == resumed.version  # nosec B101
+    assert archive_replay.version == archived.version  # nosec B101
+    assert _audit_count(repo, definition.id) == 4  # created, paused, resumed, archived  # nosec B101
+
+
+def test_same_key_different_payload_conflict_for_create_update_duplicate_and_lifecycle_routes(tmp_path):
+    service, _repo = _service(tmp_path)
+    preview = service.create_preview(owner_id=OWNER_ID, actor=ACTOR, payload=_payload(name="Create one"))
+    service.create_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=ScheduledTaskDefinitionCreateRequest(preview_id=preview.id),
+        idempotency_key="create-conflict",
+    )
+    other_preview = service.create_preview(owner_id=OWNER_ID, actor=ACTOR, payload=_payload(name="Create two"))
+    with pytest.raises(ValueError, match="scheduled_task_idempotency_conflict"):
+        service.create_definition(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            payload=ScheduledTaskDefinitionCreateRequest(preview_id=other_preview.id),
+            idempotency_key="create-conflict",
+        )
+
+    definition = _create_definition(service, name="Update conflict")
+    update_preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_payload(
+            mode="update",
+            definition_id=definition.id,
+            definition_version=definition.version,
+            name="Update one",
+        ),
+    )
+    service.update_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=definition.id,
+        payload=ScheduledTaskDefinitionUpdateRequest(preview_id=update_preview.id),
+        idempotency_key="update-conflict",
+    )
+    next_update_preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_payload(
+            mode="update",
+            definition_id=definition.id,
+            definition_version=definition.version + 1,
+            name="Update two",
+        ),
+    )
+    with pytest.raises(ValueError, match="scheduled_task_idempotency_conflict"):
+        service.update_definition(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            definition_id=definition.id,
+            payload=ScheduledTaskDefinitionUpdateRequest(preview_id=next_update_preview.id),
+            idempotency_key="update-conflict",
+        )
+
+    duplicate_source = _create_definition(service, name="Duplicate conflict")
+    service.duplicate_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=duplicate_source.id,
+        payload=ScheduledTaskDuplicateRequest(name="Duplicate one"),
+        idempotency_key="duplicate-conflict",
+    )
+    with pytest.raises(ValueError, match="scheduled_task_idempotency_conflict"):
+        service.duplicate_definition(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            definition_id=duplicate_source.id,
+            payload=ScheduledTaskDuplicateRequest(name="Duplicate two"),
+            idempotency_key="duplicate-conflict",
+        )
+
+    lifecycle_definition = _create_definition(service, name="Lifecycle conflict one")
+    other_lifecycle_definition = _create_definition(service, name="Lifecycle conflict two")
+    service.pause_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        definition_id=lifecycle_definition.id,
+        idempotency_key="lifecycle-conflict",
+    )
+    with pytest.raises(ValueError, match="scheduled_task_idempotency_conflict"):
+        service.pause_definition(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            definition_id=other_lifecycle_definition.id,
+            idempotency_key="lifecycle-conflict",
+        )
+
+
+def test_agent_task_raw_sentinel_absent_from_all_response_and_repository_surfaces(tmp_path):
+    service, repo = _service(tmp_path)
+    preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_payload(
+            family="agent_task",
+            input_payload={"agent_ref": "agent:security", "message": RAW_SENTINEL},
+            name="Agent redaction",
+        ),
+    )
+    definition = service.create_definition(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=ScheduledTaskDefinitionCreateRequest(preview_id=preview.id, initial_lifecycle="paused"),
+    )
+    detail = service.get_definition(owner_id=OWNER_ID, definition_id=definition.id)
+    definitions = service.list_definitions(owner_id=OWNER_ID, limit=10, offset=0)
+    audits = service.list_audit_events(
+        owner_id=OWNER_ID,
+        definition_id=definition.id,
+        limit=10,
+        offset=0,
+    )
+    stored_preview = repo.get_preview(owner_id=OWNER_ID, preview_id=preview.id)
+    stored_definition = repo.get_definition(owner_id=OWNER_ID, definition_id=definition.id)
+    stored_audits = repo.list_audit_events(owner_id=OWNER_ID, definition_id=definition.id, limit=10, offset=0)[0]
+
+    all_serialized = "\n".join(
+        [
+            _as_json_text(preview),
+            _as_json_text(definition),
+            _as_json_text(detail),
+            _as_json_text(definitions),
+            _as_json_text(audits),
+            json.dumps(stored_preview.normalized_config, sort_keys=True),
+            json.dumps(stored_definition.input, sort_keys=True),
+            json.dumps([event.after for event in stored_audits], sort_keys=True),
+        ]
+    )
+    assert RAW_SENTINEL not in all_serialized  # nosec B101
+    assert RAW_SENTINEL.encode("utf-8") not in _database_bytes(repo)  # nosec B101

--- a/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_service.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_task_automation_service.py
@@ -16,7 +16,10 @@ from tldw_Server_API.app.api.v1.schemas.scheduled_tasks_automation_schemas impor
     ScheduledTaskPreviewCreateRequest,
 )
 from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import ScheduledTasksDatabase
-from tldw_Server_API.app.services.scheduled_task_automation_service import ScheduledTaskAutomationService
+from tldw_Server_API.app.services.scheduled_task_automation_service import (
+    ScheduledTaskAutomationError,
+    ScheduledTaskAutomationService,
+)
 
 OWNER_ID = 4101
 OTHER_OWNER_ID = 4102
@@ -37,6 +40,7 @@ def _payload(
     definition_id: str | None = None,
     definition_version: int | None = None,
     name: str = "Daily research check",
+    config_payload: dict[str, Any] | None = None,
     input_payload: dict[str, Any] | None = None,
     schedule: dict[str, Any] | None = None,
 ) -> ScheduledTaskPreviewCreateRequest:
@@ -53,6 +57,7 @@ def _payload(
         definition_version=definition_version,
         name=name,
         description="Service lifecycle test",
+        config=config_payload or {},
         input=input_payload,
         schedule=schedule or {"kind": "daily", "time": "09:00", "timezone": "UTC"},
         visibility_policy={"mode": "findings_only"},
@@ -159,6 +164,58 @@ def test_invalid_semantic_preview_is_persisted_with_errors_and_id(tmp_path):
     assert stored.validation_errors == preview.validation_errors  # nosec B101
 
 
+def test_non_object_schedule_preview_is_persisted_as_invalid(tmp_path):
+    service, repo = _service(tmp_path)
+    payload = _payload()
+    raw_payload = payload.model_dump(mode="json")
+    raw_payload["schedule"] = ["not", "an", "object"]
+    constructed_payload = ScheduledTaskPreviewCreateRequest.model_construct(**raw_payload)
+
+    preview = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=constructed_payload,
+    )
+
+    stored = repo.get_preview(owner_id=OWNER_ID, preview_id=preview.id)
+    assert preview.status == "invalid"  # nosec B101
+    assert preview.validation_errors == [
+        {"field": "schedule", "code": "invalid_type", "message": "Schedule must be an object."}
+    ]  # nosec B101
+    assert stored is not None  # nosec B101
+    assert stored.validation_errors == preview.validation_errors  # nosec B101
+
+
+def test_preview_mode_linkage_invariants_are_persisted_as_invalid(tmp_path):
+    service, _repo = _service(tmp_path)
+
+    update_without_definition = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_payload(mode="update", definition_id=None, definition_version=None),
+    )
+    create_with_definition_linkage = service.create_preview(
+        owner_id=OWNER_ID,
+        actor=ACTOR,
+        payload=_payload(mode="create", definition_id="definition_1", definition_version=1),
+    )
+
+    assert update_without_definition.status == "invalid"  # nosec B101
+    assert {
+        (error["field"], error["code"]) for error in update_without_definition.validation_errors
+    } >= {
+        ("definition_id", "required_for_update"),
+        ("definition_version", "required_for_update"),
+    }  # nosec B101
+    assert create_with_definition_linkage.status == "invalid"  # nosec B101
+    assert {
+        (error["field"], error["code"]) for error in create_with_definition_linkage.validation_errors
+    } >= {
+        ("definition_id", "not_allowed_for_create"),
+        ("definition_version", "not_allowed_for_create"),
+    }  # nosec B101
+
+
 def test_agent_task_preview_redacts_raw_message_in_responses_and_storage(tmp_path):
     service, repo = _service(tmp_path)
 
@@ -196,7 +253,7 @@ def test_create_consumes_valid_preview_and_rejects_consumed_reuse_without_idempo
     assert definition.preview_id == preview.id  # nosec B101
     assert definition.health == "execution_unavailable"  # nosec B101
     assert consumed.status == "consumed"  # nosec B101
-    with pytest.raises(ValueError, match="preview_consumed"):
+    with pytest.raises(ScheduledTaskAutomationError, match="preview_consumed"):
         service.create_definition(
             owner_id=OWNER_ID,
             actor=ACTOR,
@@ -209,7 +266,7 @@ def test_preview_validation_rejects_expired_stale_consumed_and_cross_user_previe
     expired = service.create_preview(owner_id=OWNER_ID, actor=ACTOR, payload=_payload())
     _set_preview_expires_at(repo, preview_id=expired.id, expires_at="2020-01-01T00:00:00+00:00")
 
-    with pytest.raises(ValueError, match="preview_expired"):
+    with pytest.raises(ScheduledTaskAutomationError, match="preview_expired"):
         service.create_definition(
             owner_id=OWNER_ID,
             actor=ACTOR,
@@ -229,7 +286,7 @@ def test_preview_validation_rejects_expired_stale_consumed_and_cross_user_previe
     )
     service.pause_definition(owner_id=OWNER_ID, actor=ACTOR, definition_id=definition.id)
 
-    with pytest.raises(ValueError, match="definition_version_mismatch"):
+    with pytest.raises(ScheduledTaskAutomationError, match="definition_version_mismatch"):
         service.update_definition(
             owner_id=OWNER_ID,
             actor=ACTOR,
@@ -243,7 +300,7 @@ def test_preview_validation_rejects_expired_stale_consumed_and_cross_user_previe
         actor=ACTOR,
         payload=ScheduledTaskDefinitionCreateRequest(preview_id=consumed_preview.id),
     )
-    with pytest.raises(ValueError, match="preview_consumed"):
+    with pytest.raises(ScheduledTaskAutomationError, match="preview_consumed"):
         service.create_definition(
             owner_id=OWNER_ID,
             actor=ACTOR,
@@ -251,7 +308,7 @@ def test_preview_validation_rejects_expired_stale_consumed_and_cross_user_previe
         )
 
     other_preview = service.create_preview(owner_id=OTHER_OWNER_ID, actor=ACTOR, payload=_payload())
-    with pytest.raises(KeyError, match="preview_not_found"):
+    with pytest.raises(ScheduledTaskAutomationError, match="preview_not_found"):
         service.create_definition(
             owner_id=OWNER_ID,
             actor=ACTOR,
@@ -364,7 +421,7 @@ def test_duplicate_disabled_definition_with_admin_or_security_lock_fails_without
         expected_version=definition.version,
     )
 
-    with pytest.raises(ValueError, match="definition_disabled_locked"):
+    with pytest.raises(ScheduledTaskAutomationError, match="definition_disabled_locked"):
         service.duplicate_definition(
             owner_id=OWNER_ID,
             actor=ACTOR,
@@ -412,7 +469,7 @@ def test_pause_resume_archive_transition_matrix(tmp_path):
             payload=ScheduledTaskDuplicateRequest(name="Archived copy"),
         ),
     ):
-        with pytest.raises(ValueError, match="definition_archived"):
+        with pytest.raises(ScheduledTaskAutomationError, match="definition_archived"):
             operation()
 
 
@@ -423,7 +480,7 @@ def test_preview_idempotency_replay_and_same_key_different_payload_conflict(tmp_
     first = service.create_preview(owner_id=OWNER_ID, actor=ACTOR, payload=payload, idempotency_key="preview-key")
     replay = service.create_preview(owner_id=OWNER_ID, actor=ACTOR, payload=payload, idempotency_key="preview-key")
 
-    with pytest.raises(ValueError, match="scheduled_task_idempotency_conflict"):
+    with pytest.raises(ScheduledTaskAutomationError, match="scheduled_task_idempotency_conflict"):
         service.create_preview(
             owner_id=OWNER_ID,
             actor=ACTOR,
@@ -435,6 +492,34 @@ def test_preview_idempotency_replay_and_same_key_different_payload_conflict(tmp_
     assert replay.id == first.id  # nosec B101
     assert total == 1  # nosec B101
     assert previews[0].id == first.id  # nosec B101
+
+
+def test_list_definitions_uses_bulk_preview_lookup_for_config(tmp_path, monkeypatch):
+    service, repo = _service(tmp_path)
+    for index in range(3):
+        preview = service.create_preview(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            payload=_payload(
+                name=f"Bulk config {index}",
+                config_payload={"rank": index},
+            ),
+        )
+        service.create_definition(
+            owner_id=OWNER_ID,
+            actor=ACTOR,
+            payload=ScheduledTaskDefinitionCreateRequest(preview_id=preview.id),
+        )
+
+    def _unexpected_get_preview(*_args, **_kwargs):
+        raise AssertionError("list_definitions should use bulk preview lookup")
+
+    monkeypatch.setattr(repo, "get_preview", _unexpected_get_preview)
+
+    definitions = service.list_definitions(owner_id=OWNER_ID, limit=10, offset=0)
+
+    assert definitions.total == 3  # nosec B101
+    assert {item.config["rank"] for item in definitions.items} == {0, 1, 2}  # nosec B101
 
 
 def test_preview_idempotency_race_executes_side_effects_once(tmp_path, monkeypatch):
@@ -824,7 +909,7 @@ def test_same_key_different_payload_conflict_for_create_update_duplicate_and_lif
         idempotency_key="create-conflict",
     )
     other_preview = service.create_preview(owner_id=OWNER_ID, actor=ACTOR, payload=_payload(name="Create two"))
-    with pytest.raises(ValueError, match="scheduled_task_idempotency_conflict"):
+    with pytest.raises(ScheduledTaskAutomationError, match="scheduled_task_idempotency_conflict"):
         service.create_definition(
             owner_id=OWNER_ID,
             actor=ACTOR,
@@ -860,7 +945,7 @@ def test_same_key_different_payload_conflict_for_create_update_duplicate_and_lif
             name="Update two",
         ),
     )
-    with pytest.raises(ValueError, match="scheduled_task_idempotency_conflict"):
+    with pytest.raises(ScheduledTaskAutomationError, match="scheduled_task_idempotency_conflict"):
         service.update_definition(
             owner_id=OWNER_ID,
             actor=ACTOR,
@@ -877,7 +962,7 @@ def test_same_key_different_payload_conflict_for_create_update_duplicate_and_lif
         payload=ScheduledTaskDuplicateRequest(name="Duplicate one"),
         idempotency_key="duplicate-conflict",
     )
-    with pytest.raises(ValueError, match="scheduled_task_idempotency_conflict"):
+    with pytest.raises(ScheduledTaskAutomationError, match="scheduled_task_idempotency_conflict"):
         service.duplicate_definition(
             owner_id=OWNER_ID,
             actor=ACTOR,
@@ -894,7 +979,7 @@ def test_same_key_different_payload_conflict_for_create_update_duplicate_and_lif
         definition_id=lifecycle_definition.id,
         idempotency_key="lifecycle-conflict",
     )
-    with pytest.raises(ValueError, match="scheduled_task_idempotency_conflict"):
+    with pytest.raises(ScheduledTaskAutomationError, match="scheduled_task_idempotency_conflict"):
         service.pause_definition(
             owner_id=OWNER_ID,
             actor=ACTOR,

--- a/tldw_Server_API/tests/Notifications/test_scheduled_tasks_control_plane.py
+++ b/tldw_Server_API/tests/Notifications/test_scheduled_tasks_control_plane.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import pytest
 from fastapi import Request
 
+from tldw_Server_API.app.api.v1.endpoints import scheduled_tasks_control_plane
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.AuthNZ.permissions import TASKS_CONTROL, TASKS_READ
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
 from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
+from tldw_Server_API.app.core.DB_Management.Scheduled_Tasks_DB import ScheduledTasksDatabase
 from tldw_Server_API.app.core.DB_Management.Watchlists_DB import WatchlistsDatabase
+from tldw_Server_API.app.services.scheduled_task_automation_service import ScheduledTaskAutomationService
 from tldw_Server_API.app.services.scheduled_tasks_control_plane_service import ScheduledTasksControlPlaneService
 
 
@@ -47,11 +51,69 @@ def _override_auth(client, *, permissions: list[str] | None = None) -> None:
 
 
 @pytest.fixture()
-def scheduled_tasks_client(client_user_only):
+def scheduled_tasks_client(client_user_only, tmp_path, monkeypatch):
+    automation_repo = ScheduledTasksDatabase(tmp_path / "scheduled_tasks_control_plane_automation.db")
+    automation_repo.ensure_schema()
+    automation_service = ScheduledTaskAutomationService(repository=automation_repo)
     _override_auth(client_user_only)
+    client_user_only.app.dependency_overrides[
+        scheduled_tasks_control_plane.get_scheduled_task_automation_service
+    ] = lambda: automation_service
+    monkeypatch.setattr(
+        ScheduledTasksControlPlaneService,
+        "_scheduled_tasks_db",
+        staticmethod(lambda user_id: automation_repo),
+        raising=False,
+    )
     yield client_user_only
     client_user_only.app.dependency_overrides.pop(get_auth_principal, None)
     client_user_only.app.dependency_overrides.pop(get_request_user, None)
+    client_user_only.app.dependency_overrides.pop(
+        scheduled_tasks_control_plane.get_scheduled_task_automation_service,
+        None,
+    )
+
+
+def _automation_payload(
+    *,
+    name: str = "Daily research check",
+    family: str = "recurring_question",
+) -> dict[str, Any]:
+    return {
+        "mode": "create",
+        "family": family,
+        "definition_id": None,
+        "definition_version": None,
+        "name": name,
+        "description": "Control-plane projection test",
+        "input": {"question": "Any new answer?"},
+        "schedule": {"kind": "daily", "time": "09:00", "timezone": "UTC"},
+        "visibility_policy": {"mode": "findings_only"},
+        "notification_policy": {},
+        "approval_policy": {"required": False},
+    }
+
+
+def _create_automation_definition(
+    client,
+    auth_headers,
+    *,
+    name: str = "Daily research check",
+    initial_lifecycle: str = "configured",
+) -> dict[str, Any]:
+    preview_response = client.post(
+        "/api/v1/scheduled-tasks/previews",
+        headers=auth_headers,
+        json=_automation_payload(name=name),
+    )
+    assert preview_response.status_code == 201, preview_response.text  # nosec B101
+    definition_response = client.post(
+        "/api/v1/scheduled-tasks/definitions",
+        headers=auth_headers,
+        json={"preview_id": preview_response.json()["id"], "initial_lifecycle": initial_lifecycle},
+    )
+    assert definition_response.status_code == 201, definition_response.text  # nosec B101
+    return definition_response.json()
 
 
 def test_scheduled_tasks_endpoint_combines_reminders_and_watchlist_jobs(scheduled_tasks_client, auth_headers):
@@ -89,11 +151,79 @@ def test_scheduled_tasks_endpoint_combines_reminders_and_watchlist_jobs(schedule
     assert body["errors"] == []  # nosec B101 - pytest assertion
     assert {item["primitive"] for item in body["items"]} == {"reminder_task", "watchlist_job"}  # nosec B101
     reminder_item = next(item for item in body["items"] if item["primitive"] == "reminder_task")
+    assert reminder_item["primitive"] == "reminder_task"  # nosec B101 - pytest assertion
     assert reminder_item["source_ref"]["task_id"] == reminder_task_id  # nosec B101 - pytest assertion
     watchlist_item = next(item for item in body["items"] if item["primitive"] == "watchlist_job")
+    assert watchlist_item["primitive"] == "watchlist_job"  # nosec B101 - pytest assertion
     assert watchlist_item["source_ref"]["job_id"] == watchlist_job.id  # nosec B101 - pytest assertion
     assert watchlist_item["edit_mode"] == "external"  # nosec B101 - pytest assertion
     assert watchlist_item["manage_url"] == "/watchlists?tab=jobs"  # nosec B101 - pytest assertion
+
+
+def test_scheduled_tasks_endpoint_projects_automation_definitions(scheduled_tasks_client, auth_headers):
+    definition = _create_automation_definition(
+        scheduled_tasks_client,
+        auth_headers,
+        name="Track API question",
+    )
+    definition_id = definition["id"]
+
+    list_response = scheduled_tasks_client.get("/api/v1/scheduled-tasks", headers=auth_headers)
+
+    assert list_response.status_code == 200, list_response.text  # nosec B101
+    body = list_response.json()
+    assert body["partial"] is False  # nosec B101
+    item = next(item for item in body["items"] if item["primitive"] == "automation_definition")
+    assert item["id"] == f"automation_definition:{definition_id}"  # nosec B101
+    assert item["status"] == "configured_execution_unavailable"  # nosec B101
+    assert item["enabled"] is True  # nosec B101
+    assert item["edit_mode"] == "native"  # nosec B101
+    assert item["next_run_at"] is None  # nosec B101
+    assert item["last_run_at"] is None  # nosec B101
+    assert item["source_ref"]["family"] == "recurring_question"  # nosec B101
+    assert item["source_ref"]["health"] == "execution_unavailable"  # nosec B101
+    assert item["source_ref"]["execution_available"] is False  # nosec B101
+
+    detail_response = scheduled_tasks_client.get(
+        f"/api/v1/scheduled-tasks/automation_definition:{definition_id}",
+        headers=auth_headers,
+    )
+
+    assert detail_response.status_code == 200, detail_response.text  # nosec B101
+    assert detail_response.json() == item  # nosec B101
+
+
+def test_scheduled_tasks_endpoint_projects_paused_and_archived_automation_statuses(
+    scheduled_tasks_client,
+    auth_headers,
+):
+    paused_definition = _create_automation_definition(
+        scheduled_tasks_client,
+        auth_headers,
+        name="Paused API question",
+        initial_lifecycle="paused",
+    )
+    configured_definition = _create_automation_definition(
+        scheduled_tasks_client,
+        auth_headers,
+        name="Archived API question",
+    )
+    archived_response = scheduled_tasks_client.post(
+        f"/api/v1/scheduled-tasks/definitions/{configured_definition['id']}/archive",
+        headers=auth_headers,
+    )
+    assert archived_response.status_code == 200, archived_response.text  # nosec B101
+
+    response = scheduled_tasks_client.get("/api/v1/scheduled-tasks", headers=auth_headers)
+
+    assert response.status_code == 200, response.text  # nosec B101
+    items = {item["id"]: item for item in response.json()["items"] if item["primitive"] == "automation_definition"}
+    paused_item = items[f"automation_definition:{paused_definition['id']}"]
+    archived_item = items[f"automation_definition:{configured_definition['id']}"]
+    assert paused_item["enabled"] is False  # nosec B101
+    assert paused_item["status"] == "paused"  # nosec B101
+    assert archived_item["enabled"] is False  # nosec B101
+    assert archived_item["status"] == "archived"  # nosec B101
 
 
 def test_scheduled_tasks_endpoint_returns_partial_payload_when_watchlist_jobs_fail(
@@ -130,6 +260,58 @@ def test_scheduled_tasks_endpoint_returns_partial_payload_when_watchlist_jobs_fa
     assert body["errors"] == ["watchlist_jobs_unavailable"]  # nosec B101 - pytest assertion
     assert {item["primitive"] for item in body["items"]} == {"reminder_task"}  # nosec B101 - pytest assertion
     assert any(item["source_ref"]["task_id"] == reminder_task_id for item in body["items"])  # nosec B101
+
+
+def test_scheduled_tasks_endpoint_returns_partial_payload_when_automation_definitions_fail(
+    scheduled_tasks_client,
+    auth_headers,
+    monkeypatch,
+):
+    collections_db = CollectionsDatabase.for_user(user_id=880)
+    reminder_task_id = collections_db.create_reminder_task(
+        title="Partial automation reminder",
+        body="Should still render",
+        schedule_kind="one_time",
+        run_at="2026-03-24T09:00:00+00:00",
+        cron=None,
+        timezone=None,
+        enabled=True,
+    )
+    watchlists_db = WatchlistsDatabase.for_user(user_id=880)
+    watchlists_db.ensure_schema()
+    watchlist_job = watchlists_db.create_job(
+        name="Partial automation watchlist",
+        description=None,
+        scope_json=json.dumps({"sources": [2]}),
+        schedule_expr="0 9 * * *",
+        schedule_timezone="UTC",
+        active=True,
+        max_concurrency=None,
+        per_host_delay_ms=None,
+        retry_policy_json=json.dumps({}),
+        output_prefs_json=json.dumps({}),
+    )
+
+    class _BrokenScheduledTasksDb:
+        def list_definitions(self, **kwargs):
+            raise RuntimeError("automation_definitions_unavailable")
+
+    monkeypatch.setattr(
+        ScheduledTasksControlPlaneService,
+        "_scheduled_tasks_db",
+        staticmethod(lambda user_id: _BrokenScheduledTasksDb()),
+    )
+
+    response = scheduled_tasks_client.get("/api/v1/scheduled-tasks", headers=auth_headers)
+
+    assert response.status_code == 200, response.text  # nosec B101
+    body = response.json()
+    assert body["partial"] is True  # nosec B101
+    assert "automation_definitions_unavailable" in body["errors"]  # nosec B101
+    primitives = {item["primitive"] for item in body["items"]}
+    assert {"reminder_task", "watchlist_job"} <= primitives  # nosec B101
+    assert any(item["source_ref"].get("task_id") == reminder_task_id for item in body["items"])  # nosec B101
+    assert any(item["source_ref"].get("job_id") == watchlist_job.id for item in body["items"])  # nosec B101
 
 
 def test_scheduled_tasks_reminder_mutations_proxy_native_crud(scheduled_tasks_client, auth_headers):


### PR DESCRIPTION
## Summary

- Adds the Scheduled Tasks Phase 4B API foundation for automation definitions: capabilities, previews, definitions, lifecycle actions, audit, idempotency, and control-plane projection.
- Wires the WebUI reference client for preview/create/edit/inspect/pause/resume/archive/duplicate flows while preserving Watchlists as a separate workflow and keeping execution unavailable.
- Enables the scheduled-tasks control-plane route in default config so the main API exposes the new paths without manual route-policy setup.

## Test Plan

- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_task_automation_db.py tldw_Server_API/tests/Notifications/test_scheduled_task_automation_service.py tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py tldw_Server_API/tests/Notifications/test_scheduled_tasks_control_plane.py -q` (`82 passed`)
- [x] `bunx vitest run src/components/Option/ScheduledTasks/__tests__/scheduled-task-automation-status.test.ts src/components/Option/ScheduledTasks/__tests__/ScheduledTaskAutomationDefinitionEditor.test.tsx src/components/Option/ScheduledTasks/__tests__/ScheduledTaskCreatePanel.test.tsx src/components/Option/ScheduledTasks/__tests__/ScheduledTaskDetailDrawer.test.tsx src/components/Option/ScheduledTasks/__tests__/ScheduledTasksPage.test.tsx src/components/Option/ScheduledTasks/__tests__/scheduled-task-results.test.ts` (`102 passed`)
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py tldw_Server_API/app/api/v1/schemas/scheduled_tasks_automation_schemas.py tldw_Server_API/app/core/DB_Management/Scheduled_Tasks_DB.py tldw_Server_API/app/services/scheduled_task_automation_service.py -f json -o /tmp/bandit_scheduled_tasks_phase4b.json` (`0 findings`)
- [x] OpenAPI import check confirmed `/api/v1/scheduled-tasks/capabilities`, `/api/v1/scheduled-tasks/previews`, and `/api/v1/scheduled-tasks/definitions` are present.
- [x] No-execution scan found no Jobs enqueueing, Scheduler registration, RAG execution, ACP dispatch, notifications, fake runs/results, or fake Home surfacing.

## Change Summary

Required before merge: human requester must replace this section with a human-written summary explaining what changed and why these implementation choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Scheduled Tasks Phase 4B API foundation for automation definitions (recurring questions and agent tasks) and wires the WebUI to create, edit, inspect, and manage them. Definitions are projected into the control‑plane as `automation_definition`; execution stays off.

- **New Features**
  - Backend
    - Adds `/api/v1/scheduled-tasks` endpoints for capabilities, previews (create/list), definitions (create/get/update), lifecycle (pause/resume/archive/duplicate), and audit; create/update are idempotent and atomic.
    - Projects definitions into the control‑plane list as `automation_definition`; watchlists unchanged.
    - Introduces a per-user SQLite store for previews/definitions/audit/idempotency; validates inputs and redacts sensitive agent text.
    - Enables the `scheduled-tasks` route in default config so these paths are exposed without extra policy.
  - Frontend
    - Adds `ScheduledTaskAutomationDefinitionEditor` and wires the reference client for preview/create/edit/inspect and lifecycle actions.
    - Extends the control‑plane client with capabilities/previews/definitions/audit endpoints and status helpers; results view ignores non-result automation lifecycle states.
  - Quality and safety
    - Backend/UI tests added and updated; OpenAPI import confirms new routes; Bandit reports 0 findings.
    - No execution paths added (no jobs, scheduler hooks, RAG, ACP, notifications, or fake runs/results).

- **Migration**
  - No action needed. New endpoints are enabled by default; execution is off. Existing watchlists and reminders are unaffected.

<sup>Written for commit 72cf62d66a1fa702060f51f63289931bace03647. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

