### PR TITLE
Add MCP approval lease flow for ask permission decisions

### DIFF
--- a/backlog/tasks/task-2351 - Add-MCP-approval-lease-flow-for-ask-permission-decisions.md
+++ b/backlog/tasks/task-2351 - Add-MCP-approval-lease-flow-for-ask-permission-decisions.md
@@ -1,0 +1,73 @@
+---
+id: TASK-2351
+title: Add MCP approval lease flow for ask permission decisions
+status: Done
+assignee: []
+created_date: '2026-06-11'
+updated_date: '2026-06-11'
+labels:
+  - mcp
+  - policy
+  - security
+  - approvals
+  - followup
+dependencies:
+  - TASK-2349
+  - TASK-2350
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the top deferred item from TASK-2349: an approval lease flow so matched `ask` permission-rule decisions can be satisfied by a TTL-bound operator-issued grant instead of being hard-blocked. Operators grant a short-lived approval for one (profile, subject_type, normalized value) tuple, optionally scoped to a session; the gateway runtime converts matching `ask` decisions to allow until expiry. `deny` outcomes are never overridden.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A reusable TTL-bound policy grant store exists with memory and SQLite backends, exact-match on normalized subject values, session scoping, expiry, and periodic cleanup.
+- [x] #2 The gateway runtime consults active approval leases for matched ask decisions before raising approval_required; deny rules are never overridden; expired or session-mismatched leases do not apply.
+- [x] #3 Ask denials report redacted approval availability metadata; approved calls carry a redacted lease marker (not the raw grant id) in delegated context metadata.
+- [x] #4 Operators can create, list, and revoke approval leases through the gateway CLI against a persistent (sqlite) grant store configured via the gateway config `policy_grants` section, with TTL clamps and audit events.
+- [x] #5 Bootstrap wiring exposes the grant store on bootstrap results and config-driven bootstrap builds it from `policy_grants`.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+New `mcp_unified/policy_grants/` package modeled on `filesystem_locks/`: frozen `PolicyGrant` dataclass (grant_id, profile_id, grant_type approval|path, subject_type, value, actions, effect, session_id, user_id, granted_by, reason, expires_at, ttl_seconds, safe_payload), `InMemoryPolicyGrantStore` (RLock + periodic sweep), `SQLitePolicyGrantStore` (SQLAlchemy, epoch_us expiry, batched cleanup, secrets.token_urlsafe ids), and `create_policy_grant_store()` factory (grant_store_backend memory|sqlite). The schema includes `actions`/`effect` now so TASK-2301 path grants need no migration. Subject values are normalized at grant and lookup time via the new public `normalize_permission_subject_value()` wrapper in `profiles/permission_rules.py`, so a grant for `https://Example.com/x` and a runtime subject `example.com` agree. Session semantics: grant with session_id=None applies profile-wide; a session-scoped grant matches only its session and wins over a global grant when both match.
+
+Runtime hookup in `gateway/profile_runtime.py`: `ProfileAwareGatewayRuntime` accepts optional `policy_grant_store` (absent preserves the previous hard-block behavior). On a matched ask decision, `_active_approval_lease_marker()` consults `find_active_grant`; store failures fail closed to denial (noqa BLE001 documented inline). Approved subjects contribute a redacted SHA256[:16] marker of the grant id, attached to the delegated context metadata under `mcp_policy_approval_grants` so tool-use reporting can record it without leaking the revocation token. Ask denials gain `provenance.approval = {available, grant_type, subject_type}`.
+
+Management surface: `gateway/policy_grants.py` `GatewayPolicyGrantManager` (TTL clamped to [60, 86400], default 900; audit events policy_grant.approval.created / policy_grant.revoked via the AuditStore pattern from credential grants). CLI verbs `create-approval-grant`, `list-approval-grants`, `revoke-approval-grant` in `gateway/cli.py`, requiring a persistent sqlite `policy_grants` store from the gateway config (reason_code policy_grant_store_unavailable otherwise). Config: `GatewayPolicyGrantStoreConfig` + `policy_grants` field on `GatewayProfileBootstrapConfig` + `build_gateway_policy_grant_store()`; `bootstrap_profile_gateway` passes the store to the runtime and exposes it on `GatewayProfileBootstrap`.
+
+TDD evidence:
+- Store red: 13 tests in new test_policy_grant_stores.py failed with ModuleNotFoundError before the package existed; green after.
+- Runtime red: 5 tests in test_gateway_fastapi_package.py failed with TypeError (unexpected policy_grant_store kwarg); green after hookup.
+- Manager/config/bootstrap red: 7 tests in new test_gateway_policy_grant_manager.py failed on missing modules/fields; green after.
+- CLI red: 3 tests in test_gateway_cli_package.py failed on unknown subcommands; green after.
+
+Verification:
+- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_policy_grant_stores.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_grant_manager.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py -q` passed with 383 tests.
+- Ruff over all touched modules and tests passed (fixed one pre-existing F821 missing Mapping import in test_gateway_cli_package.py).
+- `python -m compileall -q` over touched modules passed.
+- Bandit over mcp_unified/policy_grants/ and gateway/policy_grants.py reported no findings.
+- `git diff --check` passed.
+
+Deferred: pattern-valued approval grants (exact normalized match only); REST admin endpoints for grants (CLI only); CLI audit events currently use the profile storage bundle's audit store; consuming/limiting lease use counts.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a TTL-bound policy grant store (memory + SQLite) and wired approval leases into gateway runtime permission-rule enforcement so operator-granted, optionally session-scoped leases convert matched ask decisions to allow until expiry, never overriding deny. Includes CLI grant/list/revoke management with TTL clamps and audit events, config/bootstrap wiring, and redacted lease markers in delegated context metadata.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/gateway/bootstrap.py
+++ b/mcp_unified/gateway/bootstrap.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, cast
 from mcp_unified.gateway.lifecycle import GatewayExternalRuntimeLifecycleConfig
 from mcp_unified.gateway.profiles import GatewayProfileManager, GatewayProfileStoreMetadata
 from mcp_unified.interfaces.storage import AuditStore, ProfileAssignmentStore, ProfileStore
+from mcp_unified.policy_grants import PolicyGrantStore
 from mcp_unified.profiles.models import MCPProfile
 from mcp_unified.profiles.presets import duplicate_builtin_preset
 from mcp_unified.profiles.resolver import AssignmentBackedProfileResolver
@@ -41,6 +42,7 @@ class GatewayProfileBootstrap:
     external_runtime_lifecycle: GatewayExternalRuntimeLifecycleConfig | None = None
     credential_grant_manager: GatewayCredentialGrantManager | None = None
     admin_auth: GatewayAdminAuthConfig | None = None
+    policy_grant_store: PolicyGrantStore | None = None
 
 
 async def bootstrap_profile_gateway(
@@ -58,6 +60,7 @@ async def bootstrap_profile_gateway(
     external_runtime_lifecycle: GatewayExternalRuntimeLifecycleConfig | None = None,
     credential_grant_manager: GatewayCredentialGrantManager | None = None,
     admin_auth: GatewayAdminAuthConfig | None = None,
+    policy_grant_store: PolicyGrantStore | None = None,
 ) -> GatewayProfileBootstrap:
     """Seed profile data and return a profile-aware gateway runtime."""
 
@@ -99,6 +102,7 @@ async def bootstrap_profile_gateway(
     runtime = ProfileAwareGatewayRuntime(
         backend,
         profile_resolver=resolver,
+        policy_grant_store=policy_grant_store,
     )
     profile_manager = GatewayProfileManager(
         profile_store=store,
@@ -121,6 +125,7 @@ async def bootstrap_profile_gateway(
         external_runtime_lifecycle=external_runtime_lifecycle,
         credential_grant_manager=credential_grant_manager,
         admin_auth=admin_auth,
+        policy_grant_store=policy_grant_store,
     )
 
 

--- a/mcp_unified/gateway/cli.py
+++ b/mcp_unified/gateway/cli.py
@@ -33,6 +33,7 @@ from .config import (
     GatewayProfileStorageBundle,
     GatewayToolUseReportingConfig,
     build_gateway_external_registry_storage,
+    build_gateway_policy_grant_store,
     build_gateway_profile_storage,
     build_gateway_tool_use_event_store,
     credential_grant_manager_from_storage,
@@ -47,6 +48,11 @@ from .credential_grants import (
 from .external_registry import (
     GatewayExternalRegistryManagementError,
     GatewayExternalRegistryManager,
+)
+from .policy_grants import (
+    APPROVAL_GRANT_DEFAULT_TTL_SECONDS,
+    GatewayPolicyGrantManagementError,
+    GatewayPolicyGrantManager,
 )
 from .profiles import GatewayProfileManagementError, GatewayProfileManager
 from .remote_admin import (
@@ -396,6 +402,69 @@ def _build_parser() -> _JsonArgumentParser:
     )
     _add_profile_config_argument(delete_credential_grant)
     delete_credential_grant.set_defaults(handler=_handle_delete_credential_grant)
+
+    create_approval_grant = subparsers.add_parser(
+        "create-approval-grant",
+        help="Create a TTL-bound approval lease for one ask permission subject.",
+    )
+    create_approval_grant.add_argument(
+        "--profile",
+        required=True,
+        help="Profile id the approval lease applies to.",
+    )
+    create_approval_grant.add_argument(
+        "--subject-type",
+        required=True,
+        choices=("tool", "path", "domain", "command", "mcp"),
+        help="Permission subject family the lease approves.",
+    )
+    create_approval_grant.add_argument(
+        "--value",
+        required=True,
+        help="Subject value to approve (normalized before storage).",
+    )
+    create_approval_grant.add_argument(
+        "--ttl-seconds",
+        type=int,
+        default=None,
+        help="Lease lifetime in seconds (clamped to safe bounds).",
+    )
+    create_approval_grant.add_argument(
+        "--session-id",
+        help="Optional session id restricting where the lease applies.",
+    )
+    create_approval_grant.add_argument(
+        "--granted-by",
+        help="Optional operator identity recorded with the lease.",
+    )
+    create_approval_grant.add_argument(
+        "--reason",
+        help="Optional human-readable reason recorded with the lease.",
+    )
+    _add_profile_config_argument(create_approval_grant)
+    create_approval_grant.set_defaults(handler=_handle_create_approval_grant)
+
+    list_approval_grants = subparsers.add_parser(
+        "list-approval-grants",
+        help="List active policy grants from a configured grant store.",
+    )
+    list_approval_grants.add_argument(
+        "--profile",
+        help="Optional profile id filter.",
+    )
+    _add_profile_config_argument(list_approval_grants)
+    list_approval_grants.set_defaults(handler=_handle_list_approval_grants)
+
+    revoke_approval_grant = subparsers.add_parser(
+        "revoke-approval-grant",
+        help="Revoke one active policy grant by id.",
+    )
+    revoke_approval_grant.add_argument(
+        "grant_id",
+        help="Policy grant id to revoke.",
+    )
+    _add_profile_config_argument(revoke_approval_grant)
+    revoke_approval_grant.set_defaults(handler=_handle_revoke_approval_grant)
 
     export_config = subparsers.add_parser(
         "export-config",
@@ -892,6 +961,118 @@ def _handle_delete_credential_grant(args: argparse.Namespace) -> int:
         args,
         lambda manager: manager.delete_grant(grant_id),
     )
+
+
+def _handle_create_approval_grant(args: argparse.Namespace) -> int:
+    """Create one TTL-bound approval lease in a configured grant store."""
+
+    profile_id = _require_cli_text(args.profile, field="profile")
+    value = _require_cli_text(args.value, field="value")
+    ttl_seconds = (
+        args.ttl_seconds
+        if args.ttl_seconds is not None
+        else APPROVAL_GRANT_DEFAULT_TTL_SECONDS
+    )
+    session_id = _optional_cli_text(args.session_id, field="session_id")
+    granted_by = _optional_cli_text(args.granted_by, field="granted_by")
+    reason = _optional_cli_text(args.reason, field="reason")
+    return _handle_policy_grant_command(
+        args,
+        lambda manager: manager.grant_approval(
+            profile_id=profile_id,
+            subject_type=args.subject_type,
+            value=value,
+            ttl_seconds=ttl_seconds,
+            session_id=session_id,
+            granted_by=granted_by,
+            reason=reason,
+        ),
+    )
+
+
+def _handle_list_approval_grants(args: argparse.Namespace) -> int:
+    """List active policy grants from a configured grant store."""
+
+    profile_id = _optional_cli_text(args.profile, field="profile")
+    return _handle_policy_grant_command(
+        args,
+        lambda manager: manager.list_grants(profile_id=profile_id),
+    )
+
+
+def _handle_revoke_approval_grant(args: argparse.Namespace) -> int:
+    """Revoke one active policy grant by id."""
+
+    grant_id = _require_cli_text(args.grant_id, field="grant_id")
+    return _handle_policy_grant_command(
+        args,
+        lambda manager: manager.revoke_grant(grant_id),
+    )
+
+
+def _handle_policy_grant_command(
+    args: argparse.Namespace,
+    operation: Callable[[GatewayPolicyGrantManager], Coroutine[Any, Any, Any]],
+) -> int:
+    """Run a policy-grant command against the configured grant store."""
+
+    config_path = _config_path_from_args(args)
+    profile_bundle: GatewayProfileStorageBundle | None = None
+    grant_store: Any = None
+    try:
+        try:
+            config = load_gateway_profile_bootstrap_config(config_path)
+            if config.policy_grants is None or config.policy_grants.kind != "sqlite":
+                raise GatewayPolicyGrantManagementError(
+                    "Policy grant management requires a persistent (sqlite) "
+                    "policy_grants store in the gateway config",
+                    reason_code="policy_grant_store_unavailable",
+                )
+            grant_store = build_gateway_policy_grant_store(config.policy_grants)
+            profile_bundle = build_gateway_profile_storage(config.store)
+            manager = GatewayPolicyGrantManager(
+                policy_grant_store=grant_store,
+                audit_store=profile_bundle.audit_store,
+            )
+        except _CliArgumentError:
+            raise
+        except GatewayPolicyGrantManagementError as exc:
+            _emit_json(exc.to_payload(), sys.stderr)
+            return 1
+        except Exception as exc:  # noqa: BLE001
+            _emit_json(
+                {
+                    "error": str(exc),
+                    "ok": False,
+                    "path": str(config_path),
+                },
+                sys.stderr,
+            )
+            return 1
+
+        try:
+            payload = _run_async(operation(manager))
+        except _CliArgumentError:
+            raise
+        except GatewayPolicyGrantManagementError as exc:
+            _emit_json(exc.to_payload(), sys.stderr)
+            return 1
+        except Exception:  # noqa: BLE001
+            unavailable_error = GatewayPolicyGrantManagementError(
+                "Policy grant store unavailable",
+                reason_code="policy_grant_store_unavailable",
+            )
+            _emit_json(unavailable_error.to_payload(), sys.stderr)
+            return 1
+
+        _emit_json(_cli_payload(payload), sys.stdout)
+        return 0
+    finally:
+        if profile_bundle is not None:
+            _run_async(_close_storage_bundle(profile_bundle))
+        close_grant_store = getattr(grant_store, "close", None)
+        if callable(close_grant_store):
+            close_grant_store()
 
 
 def _handle_export_config(args: argparse.Namespace) -> int:

--- a/mcp_unified/gateway/config.py
+++ b/mcp_unified/gateway/config.py
@@ -21,14 +21,15 @@ from mcp_unified.interfaces.storage import (
     ProfileAssignmentStore,
     ProfileStore,
 )
+from mcp_unified.policy_grants import PolicyGrantStore, create_policy_grant_store
 from mcp_unified.profiles.models import MCPProfile
 from mcp_unified.profiles.store import (
     InMemoryProfileAssignmentStore,
     InMemoryProfileStore,
 )
 
-from .bootstrap import GatewayProfileBootstrap, bootstrap_profile_gateway
 from .admin_auth import GatewayAdminAuthConfig
+from .bootstrap import GatewayProfileBootstrap, bootstrap_profile_gateway
 from .credential_grants import GatewayCredentialGrantManager
 from .external_registry import GatewayExternalRegistryManager, GatewayStoreMetadata
 from .lifecycle import GatewayExternalRuntimeLifecycleConfig
@@ -118,6 +119,29 @@ class GatewayProfileStoreConfig:
         if normalized_kind == "sqlite":
             if self.sqlite_path is None:
                 raise ValueError("sqlite_path is required for sqlite profile store")
+            if not str(self.sqlite_path).strip():
+                raise ValueError("sqlite_path cannot be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayPolicyGrantStoreConfig:
+    """Policy grant store selection for TTL-bound approval leases."""
+
+    kind: str = "memory"
+    sqlite_path: str | Path | None = None
+
+    def __post_init__(self) -> None:
+        """Validate and normalize the configured policy grant store kind."""
+
+        normalized_kind = str(self.kind).strip().lower()
+        if normalized_kind not in {"memory", "sqlite"}:
+            raise ValueError(
+                f"Unsupported gateway policy grant store kind: {self.kind!r}"
+            )
+        object.__setattr__(self, "kind", normalized_kind)
+        if normalized_kind == "sqlite":
+            if self.sqlite_path is None:
+                raise ValueError("sqlite_path is required for sqlite policy grant store")
             if not str(self.sqlite_path).strip():
                 raise ValueError("sqlite_path cannot be empty")
 
@@ -303,6 +327,7 @@ class GatewayProfileBootstrapConfig:
     tool_use_reporting: GatewayToolUseReportingConfig | Mapping[str, Any] = field(
         default_factory=GatewayToolUseReportingConfig
     )
+    policy_grants: GatewayPolicyGrantStoreConfig | Mapping[str, Any] | None = None
 
     def __post_init__(self) -> None:
         """Normalize nested config values into copy-isolated profile data."""
@@ -312,6 +337,17 @@ class GatewayProfileBootstrapConfig:
             store = GatewayProfileStoreConfig(**store)
         elif not isinstance(store, GatewayProfileStoreConfig):
             raise TypeError("store must be a GatewayProfileStoreConfig or mapping")
+
+        policy_grants = self.policy_grants
+        if isinstance(policy_grants, Mapping):
+            policy_grants = GatewayPolicyGrantStoreConfig(**policy_grants)
+        elif policy_grants is not None and not isinstance(
+            policy_grants, GatewayPolicyGrantStoreConfig
+        ):
+            raise TypeError(
+                "policy_grants must be a GatewayPolicyGrantStoreConfig, mapping, or None"
+            )
+        object.__setattr__(self, "policy_grants", policy_grants)
 
         external_runtime = self.external_runtime
         if isinstance(external_runtime, Mapping):
@@ -463,11 +499,25 @@ async def bootstrap_profile_gateway_from_config(
         external_runtime_lifecycle=resolved_config.external_runtime.lifecycle_config(),
         credential_grant_manager=credential_grant_manager,
         admin_auth=resolved_config.admin_auth.runtime_config(),
+        policy_grant_store=build_gateway_policy_grant_store(resolved_config.policy_grants),
     )
     return _wrap_bootstrap_tool_use_reporting(
         bootstrap,
         resolved_config.tool_use_reporting,
     )
+
+
+def build_gateway_policy_grant_store(
+    config: GatewayPolicyGrantStoreConfig | None,
+) -> PolicyGrantStore | None:
+    """Build the configured policy grant store, or None when not configured."""
+
+    if config is None:
+        return None
+    settings: dict[str, Any] = {"grant_store_backend": config.kind}
+    if config.sqlite_path is not None:
+        settings["grant_store_sqlite_path"] = str(config.sqlite_path)
+    return create_policy_grant_store(settings)
 
 
 def build_gateway_profile_storage(
@@ -1022,6 +1072,7 @@ __all__ = [
     "GatewayExternalRuntimeBootstrapConfig",
     "GatewayExternalRuntimeFactoryKind",
     "GatewayExternalRegistryStorageBundle",
+    "GatewayPolicyGrantStoreConfig",
     "GatewayProfileBootstrapConfig",
     "GatewayProfileStoreConfig",
     "GatewayProfileStoreKind",
@@ -1031,6 +1082,7 @@ __all__ = [
     "GatewayToolUseReportingStoreKind",
     "bootstrap_profile_gateway_from_config",
     "build_gateway_external_registry_storage",
+    "build_gateway_policy_grant_store",
     "build_gateway_profile_storage",
     "build_gateway_tool_use_event_store",
     "build_gateway_tool_use_recorder",

--- a/mcp_unified/gateway/policy_grants.py
+++ b/mcp_unified/gateway/policy_grants.py
@@ -1,0 +1,167 @@
+"""Gateway management surface for TTL-bound policy grants (approval leases)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from loguru import logger
+
+from mcp_unified.interfaces.storage import AuditStore
+from mcp_unified.policy_grants import PolicyGrant, PolicyGrantStore
+from mcp_unified.storage.models import AuditEvent
+
+APPROVAL_GRANT_MIN_TTL_SECONDS = 60
+APPROVAL_GRANT_DEFAULT_TTL_SECONDS = 900
+APPROVAL_GRANT_MAX_TTL_SECONDS = 86_400
+
+
+class GatewayPolicyGrantManagementError(RuntimeError):
+    """Domain error for expected gateway policy-grant failures."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason_code: str,
+        grant_id: str | None = None,
+        profile_id: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.grant_id = grant_id
+        self.profile_id = profile_id
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a deterministic JSON-safe error payload."""
+
+        payload: dict[str, Any] = {
+            "ok": False,
+            "error": str(self),
+            "reason_code": self.reason_code,
+        }
+        if self.grant_id is not None:
+            payload["grant_id"] = self.grant_id
+        if self.profile_id is not None:
+            payload["profile_id"] = self.profile_id
+        return payload
+
+
+class GatewayPolicyGrantManager:
+    """Manage TTL-bound policy grants for the standalone gateway."""
+
+    def __init__(
+        self,
+        *,
+        policy_grant_store: PolicyGrantStore,
+        audit_store: AuditStore | None = None,
+    ) -> None:
+        self.policy_grant_store = policy_grant_store
+        self.audit_store = audit_store
+
+    async def grant_approval(
+        self,
+        *,
+        profile_id: str,
+        subject_type: str,
+        value: str,
+        ttl_seconds: int = APPROVAL_GRANT_DEFAULT_TTL_SECONDS,
+        session_id: str | None = None,
+        granted_by: str | None = None,
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        """Create one approval lease with clamped TTL and audit provenance."""
+
+        ttl = min(
+            APPROVAL_GRANT_MAX_TTL_SECONDS,
+            max(APPROVAL_GRANT_MIN_TTL_SECONDS, int(ttl_seconds)),
+        )
+        try:
+            grant = self.policy_grant_store.create_grant(
+                profile_id=profile_id,
+                grant_type="approval",
+                subject_type=subject_type,
+                value=value,
+                ttl_seconds=ttl,
+                session_id=session_id,
+                granted_by=granted_by,
+                reason=reason,
+            )
+        except ValueError as exc:
+            raise GatewayPolicyGrantManagementError(
+                f"Invalid policy grant request: {exc}",
+                reason_code="invalid_policy_grant",
+                profile_id=profile_id if isinstance(profile_id, str) else None,
+            ) from exc
+        await self._append_audit_event(
+            "policy_grant.approval.created",
+            grant=grant,
+        )
+        return {"grant": grant.safe_payload()}
+
+    async def list_grants(
+        self,
+        *,
+        profile_id: str | None = None,
+        grant_type: str | None = None,
+    ) -> dict[str, Any]:
+        """Return active grants, optionally filtered by profile and type."""
+
+        grants = self.policy_grant_store.list_active_grants(
+            profile_id=profile_id,
+            grant_type=grant_type,
+        )
+        return {"grants": [grant.safe_payload() for grant in grants]}
+
+    async def revoke_grant(self, grant_id: str) -> dict[str, Any]:
+        """Revoke one active grant by id."""
+
+        grant = self.policy_grant_store.revoke_grant(grant_id)
+        if grant is None:
+            raise GatewayPolicyGrantManagementError(
+                "Policy grant not found or already expired",
+                reason_code="policy_grant_not_found",
+                grant_id=grant_id,
+            )
+        await self._append_audit_event("policy_grant.revoked", grant=grant)
+        return {"grant": grant.safe_payload()}
+
+    async def _append_audit_event(
+        self,
+        event_type: str,
+        *,
+        grant: PolicyGrant,
+        payload: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Append an audit event when an audit store is configured."""
+
+        if self.audit_store is None:
+            return
+        event = AuditEvent(
+            id=str(uuid4()),
+            event_type=event_type,
+            profile_id=grant.profile_id,
+            target_type="policy_grant",
+            target_id=grant.grant_id,
+            payload=dict(payload or grant.safe_payload()),
+            provenance={"source": "gateway_policy_grant_manager"},
+            created_at=datetime.now(timezone.utc),
+        )
+        try:
+            await self.audit_store.append_event(event)
+        except Exception:  # noqa: BLE001
+            logger.opt(exception=True).warning(
+                "Failed to append policy grant audit event {event_type}",
+                event_type=event_type,
+            )
+
+
+__all__ = [
+    "APPROVAL_GRANT_DEFAULT_TTL_SECONDS",
+    "APPROVAL_GRANT_MAX_TTL_SECONDS",
+    "APPROVAL_GRANT_MIN_TTL_SECONDS",
+    "GatewayPolicyGrantManagementError",
+    "GatewayPolicyGrantManager",
+]

--- a/mcp_unified/gateway/profile_runtime.py
+++ b/mcp_unified/gateway/profile_runtime.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import hashlib
 from collections import OrderedDict
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from typing import Any, Protocol
 
 from mcp_unified.interfaces.storage import ProfileStore
+from mcp_unified.policy_grants import PolicyGrantStore
 from mcp_unified.profiles.decisions import PolicyDecisionRule
 from mcp_unified.profiles.models import MCPProfile
 from mcp_unified.profiles.permission_rules import (
@@ -194,6 +196,7 @@ class ProfileAwareGatewayRuntime:
         profile_store: ProfileStore | None = None,
         profile_resolver: GatewayProfileResolver | None = None,
         default_profile_id: str | None = None,
+        policy_grant_store: PolicyGrantStore | None = None,
     ) -> None:
         if profile_resolver is None:
             if profile_store is None:
@@ -204,6 +207,7 @@ class ProfileAwareGatewayRuntime:
             )
         self._backend = backend
         self._profile_resolver = profile_resolver
+        self._policy_grant_store = policy_grant_store
         self._permission_rule_cache: OrderedDict[
             tuple[str, Any], tuple[PolicyDecisionRule, ...]
         ] = OrderedDict()
@@ -515,16 +519,25 @@ class ProfileAwareGatewayRuntime:
                 policy_result,
                 message=f"Gateway profile denied tool execution: {policy_result.reason_code}",
             )
-        _enforce_permission_rules_for_tool_call(
+        approval_grant_markers = _enforce_permission_rules_for_tool_call(
             profile,
             name,
             arguments,
             self._compiled_permission_rules(profile, tool_name=name),
+            policy_grant_store=self._policy_grant_store,
+            session_id=_context_session_id(context),
         )
+        delegated_context = _context_with_effective_policy(context, policy_result.policy)
+        if approval_grant_markers:
+            delegated_context = _context_with_metadata_value(
+                delegated_context,
+                "mcp_policy_approval_grants",
+                approval_grant_markers,
+            )
         return await self._backend.call_tool(
             name,
             arguments,
-            _context_with_effective_policy(context, policy_result.policy),
+            delegated_context,
         )
 
     def _compiled_permission_rules(
@@ -840,6 +853,17 @@ def _context_profile_id(context: GatewayRequestContext) -> str | None:
     return None
 
 
+def _context_session_id(context: GatewayRequestContext) -> str | None:
+    """Return an explicit session id from transport metadata, if present."""
+
+    metadata = context.metadata or {}
+    for key in ("session_id", "sessionId", "mcp_session", "mcp-session"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
 def _context_with_effective_policy(
     context: GatewayRequestContext,
     policy: Any,
@@ -850,6 +874,23 @@ def _context_with_effective_policy(
         return context
     metadata = dict(context.metadata or {})
     metadata[EFFECTIVE_POLICY_METADATA_KEY] = _json_safe_model(policy)
+    return GatewayRequestContext(
+        request_id=context.request_id,
+        client_id=context.client_id,
+        user_id=context.user_id,
+        metadata=metadata,
+    )
+
+
+def _context_with_metadata_value(
+    context: GatewayRequestContext,
+    key: str,
+    value: Any,
+) -> GatewayRequestContext:
+    """Return a copy of the context with one extra metadata entry."""
+
+    metadata = dict(context.metadata or {})
+    metadata[key] = value
     return GatewayRequestContext(
         request_id=context.request_id,
         client_id=context.client_id,
@@ -1021,12 +1062,19 @@ def _enforce_permission_rules_for_tool_call(
     tool_name: str,
     arguments: dict[str, Any],
     rules: Sequence[PolicyDecisionRule],
-) -> None:
-    """Apply matching non-grant permission rules to one allowed runtime call."""
+    *,
+    policy_grant_store: PolicyGrantStore | None = None,
+    session_id: str | None = None,
+) -> list[str]:
+    """Apply matching non-grant permission rules to one allowed runtime call.
+
+    Returns redacted markers for approval leases that satisfied ask decisions.
+    """
 
     if not rules:
-        return
+        return []
 
+    approval_grant_markers: list[str] = []
     try:
         subjects = _permission_rule_subjects_for_tool_call(tool_name, arguments)
     except _PermissionSubjectLimitError as exc:
@@ -1061,21 +1109,67 @@ def _enforce_permission_rules_for_tool_call(
             ) from exc
         if not decision.matched_rules or decision.outcome == "allow":
             continue
+        if decision.outcome == "ask":
+            lease_marker = _active_approval_lease_marker(
+                policy_grant_store,
+                profile_id=profile.id,
+                subject_type=subject_type,
+                value=value,
+                session_id=session_id,
+            )
+            if lease_marker is not None:
+                approval_grant_markers.append(lease_marker)
+                continue
         status = "approval_required" if decision.outcome == "ask" else "denied"
+        provenance: dict[str, Any] = {
+            "profile_id": profile.id,
+            "tool_name": tool_name,
+            "subject_type": subject_type,
+            "matched_rules": [
+                matched_rule.model_dump(mode="json", exclude_none=True)
+                for matched_rule in decision.matched_rules
+            ],
+        }
+        if decision.outcome == "ask":
+            provenance["approval"] = {
+                "available": policy_grant_store is not None,
+                "grant_type": "approval",
+                "subject_type": subject_type,
+            }
         raise GatewayPolicyDenied(
             f"Gateway profile denied tool execution: {decision.reason_code}",
             status=status,
             reason_code=decision.reason_code,
-            provenance={
-                "profile_id": profile.id,
-                "tool_name": tool_name,
-                "subject_type": subject_type,
-                "matched_rules": [
-                    matched_rule.model_dump(mode="json", exclude_none=True)
-                    for matched_rule in decision.matched_rules
-                ],
-            },
+            provenance=provenance,
         )
+    return approval_grant_markers
+
+
+def _active_approval_lease_marker(
+    policy_grant_store: PolicyGrantStore | None,
+    *,
+    profile_id: str,
+    subject_type: str,
+    value: str,
+    session_id: str | None,
+) -> str | None:
+    """Return a redacted marker when an active approval lease covers one subject."""
+
+    if policy_grant_store is None:
+        return None
+    try:
+        lease = policy_grant_store.find_active_grant(
+            profile_id=profile_id,
+            grant_type="approval",
+            subject_type=subject_type,
+            value=value,
+            session_id=session_id,
+        )
+    except Exception:  # noqa: BLE001 - store failures must fail closed to denial
+        return None
+    if lease is None:
+        return None
+    return hashlib.sha256(lease.grant_id.encode("utf-8")).hexdigest()[:16]
 
 
 def _permission_rule_subjects_for_tool_call(

--- a/mcp_unified/gateway/profile_runtime.py
+++ b/mcp_unified/gateway/profile_runtime.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 from collections import OrderedDict
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from typing import Any, Protocol
+
+from loguru import logger
 
 from mcp_unified.interfaces.storage import ProfileStore
 from mcp_unified.policy_grants import PolicyGrantStore
@@ -519,14 +522,25 @@ class ProfileAwareGatewayRuntime:
                 policy_result,
                 message=f"Gateway profile denied tool execution: {policy_result.reason_code}",
             )
-        approval_grant_markers = _enforce_permission_rules_for_tool_call(
-            profile,
-            name,
-            arguments,
-            self._compiled_permission_rules(profile, tool_name=name),
-            policy_grant_store=self._policy_grant_store,
-            session_id=_context_session_id(context),
-        )
+        compiled_rules = self._compiled_permission_rules(profile, tool_name=name)
+        if self._policy_grant_store is None:
+            approval_grant_markers = _enforce_permission_rules_for_tool_call(
+                profile,
+                name,
+                arguments,
+                compiled_rules,
+            )
+        else:
+            # Grant-store lookups may hit SQLite; keep them off the event loop.
+            approval_grant_markers = await asyncio.to_thread(
+                _enforce_permission_rules_for_tool_call,
+                profile,
+                name,
+                arguments,
+                compiled_rules,
+                policy_grant_store=self._policy_grant_store,
+                session_id=_context_session_id(context),
+            )
         delegated_context = _context_with_effective_policy(context, policy_result.policy)
         if approval_grant_markers:
             delegated_context = _context_with_metadata_value(
@@ -1166,6 +1180,12 @@ def _active_approval_lease_marker(
             session_id=session_id,
         )
     except Exception:  # noqa: BLE001 - store failures must fail closed to denial
+        logger.opt(exception=True).warning(
+            "Policy grant store lookup failed; treating ask decision as unapproved "
+            "(profile_id={profile_id}, subject_type={subject_type})",
+            profile_id=profile_id,
+            subject_type=subject_type,
+        )
         return None
     if lease is None:
         return None

--- a/mcp_unified/policy_grants/__init__.py
+++ b/mcp_unified/policy_grants/__init__.py
@@ -1,0 +1,20 @@
+"""TTL-bound policy grants (approval leases and path grants) for the MCP gateway."""
+
+from .memory import InMemoryPolicyGrantStore, create_policy_grant_store
+from .models import (
+    APPROVAL_SUBJECT_TYPES,
+    POLICY_GRANT_TYPES,
+    PolicyGrant,
+    PolicyGrantStore,
+    validate_grant_request,
+)
+
+__all__ = [
+    "APPROVAL_SUBJECT_TYPES",
+    "POLICY_GRANT_TYPES",
+    "InMemoryPolicyGrantStore",
+    "PolicyGrant",
+    "PolicyGrantStore",
+    "create_policy_grant_store",
+    "validate_grant_request",
+]

--- a/mcp_unified/policy_grants/memory.py
+++ b/mcp_unified/policy_grants/memory.py
@@ -1,0 +1,198 @@
+"""Process-local TTL-bound policy grant store for the standalone MCP gateway."""
+
+from __future__ import annotations
+
+import secrets
+import threading
+import time
+from collections.abc import Mapping
+from typing import Any
+
+from .models import PolicyGrant, PolicyGrantStore, validate_grant_request
+
+
+class InMemoryPolicyGrantStore:
+    """Thread-safe, process-local TTL-bound policy grant store."""
+
+    def __init__(
+        self,
+        *,
+        token_bytes: int = 24,
+        sweep_interval: int = 64,
+        max_sweep_entries: int = 512,
+    ) -> None:
+        self._token_bytes = max(16, token_bytes)
+        self._sweep_interval = max(1, sweep_interval)
+        self._max_sweep_entries = max(1, max_sweep_entries)
+        self._operation_count = 0
+        self._grants: dict[str, PolicyGrant] = {}
+        self._lock = threading.RLock()
+
+    def create_grant(
+        self,
+        *,
+        profile_id: str,
+        grant_type: str,
+        subject_type: str,
+        value: str,
+        ttl_seconds: int,
+        actions: tuple[str, ...] = (),
+        effect: str = "allow",
+        session_id: str | None = None,
+        user_id: str | None = None,
+        granted_by: str | None = None,
+        reason: str | None = None,
+    ) -> PolicyGrant:
+        """Create one validated grant with a generated opaque id."""
+
+        normalized_profile_id, grant_type, subject_type, normalized_value = validate_grant_request(
+            profile_id=profile_id,
+            grant_type=grant_type,
+            subject_type=subject_type,
+            value=value,
+        )
+        now = time.time()
+        ttl = max(1, int(ttl_seconds))
+        grant = PolicyGrant(
+            grant_id=secrets.token_urlsafe(self._token_bytes),
+            profile_id=normalized_profile_id,
+            grant_type=grant_type,
+            subject_type=subject_type,
+            value=normalized_value,
+            expires_at=now + ttl,
+            ttl_seconds=ttl,
+            actions=tuple(actions),
+            effect=effect,
+            session_id=session_id,
+            user_id=user_id,
+            granted_by=granted_by,
+            reason=reason,
+        )
+        with self._lock:
+            self._maybe_sweep_expired_locked(now=now)
+            self._grants[grant.grant_id] = grant
+        return grant
+
+    def list_active_grants(
+        self,
+        *,
+        profile_id: str | None = None,
+        grant_type: str | None = None,
+    ) -> list[PolicyGrant]:
+        """Return active grants filtered by profile and grant type."""
+
+        now = time.time()
+        with self._lock:
+            self._maybe_sweep_expired_locked(now=now)
+            return [
+                grant
+                for grant in self._grants.values()
+                if grant.is_active(now)
+                and (profile_id is None or grant.profile_id == profile_id)
+                and (grant_type is None or grant.grant_type == grant_type)
+            ]
+
+    def revoke_grant(self, grant_id: str) -> PolicyGrant | None:
+        """Remove one grant by id, returning it when it was still active."""
+
+        now = time.time()
+        with self._lock:
+            grant = self._grants.pop(grant_id, None)
+        if grant is None or not grant.is_active(now):
+            return None
+        return grant
+
+    def find_active_grant(
+        self,
+        *,
+        profile_id: str,
+        grant_type: str,
+        subject_type: str,
+        value: str,
+        session_id: str | None = None,
+    ) -> PolicyGrant | None:
+        """Return one active grant matching the normalized subject, if any."""
+
+        try:
+            _, _, _, normalized_value = validate_grant_request(
+                profile_id=profile_id,
+                grant_type=grant_type,
+                subject_type=subject_type,
+                value=value,
+            )
+        except ValueError:
+            return None
+        now = time.time()
+        best: PolicyGrant | None = None
+        with self._lock:
+            self._maybe_sweep_expired_locked(now=now)
+            for grant in self._grants.values():
+                if not grant.is_active(now):
+                    continue
+                if (
+                    grant.profile_id != profile_id.strip()
+                    or grant.grant_type != grant_type
+                    or grant.subject_type != subject_type
+                    or grant.value != normalized_value
+                ):
+                    continue
+                if not grant.matches_session(session_id):
+                    continue
+                if best is None or (best.session_id is None and grant.session_id is not None):
+                    best = grant
+        return best
+
+    def _maybe_sweep_expired_locked(self, *, now: float) -> None:
+        self._operation_count += 1
+        if self._operation_count % self._sweep_interval != 0 and len(self._grants) <= self._max_sweep_entries:
+            return
+        expired = [
+            grant_id
+            for grant_id, grant in list(self._grants.items())[: self._max_sweep_entries]
+            if not grant.is_active(now)
+        ]
+        for grant_id in expired:
+            del self._grants[grant_id]
+
+
+def create_policy_grant_store(settings: Mapping[str, Any] | None = None) -> PolicyGrantStore:
+    """Create the configured policy grant store backend.
+
+    Defaults to the process-local memory store. Unsupported backends fail
+    closed so future persistent backends cannot silently downgrade operator
+    intent.
+    """
+
+    raw_backend = (settings or {}).get("grant_store_backend")
+    if raw_backend is None:
+        return InMemoryPolicyGrantStore()
+    backend = str(raw_backend).strip().lower()
+    if backend in {"memory", "in_memory"}:
+        return InMemoryPolicyGrantStore()
+    if backend == "sqlite":
+        sqlite_path = (settings or {}).get("grant_store_sqlite_path")
+        if sqlite_path is None or not str(sqlite_path).strip():
+            raise ValueError("grant_store_sqlite_path is required for sqlite policy grant store")
+        try:
+            from .sqlite import SQLitePolicyGrantStore
+        except ModuleNotFoundError as exc:
+            if exc.name == "sqlalchemy":
+                raise ImportError(
+                    "SQLitePolicyGrantStore requires the mcp-unified sqlite extra. "
+                    "Install mcp-unified[sqlite] or mcp-unified[gateway]."
+                ) from exc
+            raise
+
+        return SQLitePolicyGrantStore(
+            str(sqlite_path).strip(),
+            timeout_seconds=float((settings or {}).get("grant_store_sqlite_timeout_seconds", 30.0)),
+            cleanup_interval=int((settings or {}).get("grant_store_cleanup_interval", 64)),
+            cleanup_limit=int((settings or {}).get("grant_store_cleanup_limit", 512)),
+        )
+    raise ValueError(f"unsupported policy grant_store_backend: {raw_backend!r}")
+
+
+__all__ = [
+    "InMemoryPolicyGrantStore",
+    "create_policy_grant_store",
+]

--- a/mcp_unified/policy_grants/memory.py
+++ b/mcp_unified/policy_grants/memory.py
@@ -114,7 +114,7 @@ class InMemoryPolicyGrantStore:
         """Return one active grant matching the normalized subject, if any."""
 
         try:
-            _, _, _, normalized_value = validate_grant_request(
+            normalized_profile_id, _, _, normalized_value = validate_grant_request(
                 profile_id=profile_id,
                 grant_type=grant_type,
                 subject_type=subject_type,
@@ -130,7 +130,7 @@ class InMemoryPolicyGrantStore:
                 if not grant.is_active(now):
                     continue
                 if (
-                    grant.profile_id != profile_id.strip()
+                    grant.profile_id != normalized_profile_id
                     or grant.grant_type != grant_type
                     or grant.subject_type != subject_type
                     or grant.value != normalized_value
@@ -146,13 +146,15 @@ class InMemoryPolicyGrantStore:
         self._operation_count += 1
         if self._operation_count % self._sweep_interval != 0 and len(self._grants) <= self._max_sweep_entries:
             return
-        expired = [
-            grant_id
-            for grant_id, grant in list(self._grants.items())[: self._max_sweep_entries]
-            if not grant.is_active(now)
-        ]
-        for grant_id in expired:
-            del self._grants[grant_id]
+        # Rotate visited entries to the end so successive bounded sweeps
+        # eventually visit every entry, not just the head of the dict.
+        for _ in range(min(self._max_sweep_entries, len(self._grants))):
+            grant_id, grant = next(iter(self._grants.items()))
+            if grant.is_active(now):
+                self._grants.pop(grant_id)
+                self._grants[grant_id] = grant
+            else:
+                del self._grants[grant_id]
 
 
 def create_policy_grant_store(settings: Mapping[str, Any] | None = None) -> PolicyGrantStore:

--- a/mcp_unified/policy_grants/models.py
+++ b/mcp_unified/policy_grants/models.py
@@ -1,0 +1,147 @@
+"""Shared TTL-bound policy grant models for the standalone MCP gateway."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+from mcp_unified.profiles.permission_rules import normalize_permission_subject_value
+
+POLICY_GRANT_TYPES = frozenset({"approval", "path"})
+APPROVAL_SUBJECT_TYPES = frozenset({"tool", "path", "domain", "command", "mcp"})
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyGrant:
+    """One TTL-bound operator-issued policy grant (approval lease or path grant)."""
+
+    grant_id: str
+    profile_id: str
+    grant_type: str
+    subject_type: str
+    value: str
+    expires_at: float
+    ttl_seconds: int
+    actions: tuple[str, ...] = ()
+    effect: str = "allow"
+    session_id: str | None = None
+    user_id: str | None = None
+    granted_by: str | None = None
+    reason: str | None = None
+
+    def expires_at_iso(self) -> str:
+        """Return the grant expiry timestamp in UTC ISO-8601 form."""
+
+        return datetime.fromtimestamp(self.expires_at, tz=timezone.utc).isoformat()
+
+    def is_active(self, now: float) -> bool:
+        """Return whether the grant is still active at the supplied time."""
+
+        return self.expires_at > now
+
+    def matches_session(self, session_id: str | None) -> bool:
+        """Return whether the grant applies to the supplied session scope."""
+
+        return self.session_id is None or self.session_id == session_id
+
+    def safe_payload(self) -> dict[str, Any]:
+        """Return grant metadata safe for operator-facing responses."""
+
+        return {
+            "grant_id": self.grant_id,
+            "profile_id": self.profile_id,
+            "grant_type": self.grant_type,
+            "subject_type": self.subject_type,
+            "value": self.value,
+            "actions": list(self.actions),
+            "effect": self.effect,
+            "session_id": self.session_id,
+            "granted_by": self.granted_by,
+            "reason": self.reason,
+            "expires_at": self.expires_at_iso(),
+            "ttl_seconds": self.ttl_seconds,
+        }
+
+
+class PolicyGrantStore(Protocol):
+    """Backend contract for TTL-bound policy grants."""
+
+    def create_grant(
+        self,
+        *,
+        profile_id: str,
+        grant_type: str,
+        subject_type: str,
+        value: str,
+        ttl_seconds: int,
+        actions: tuple[str, ...] = (),
+        effect: str = "allow",
+        session_id: str | None = None,
+        user_id: str | None = None,
+        granted_by: str | None = None,
+        reason: str | None = None,
+    ) -> PolicyGrant:
+        """Create one validated grant and return it."""
+        ...
+
+    def list_active_grants(
+        self,
+        *,
+        profile_id: str | None = None,
+        grant_type: str | None = None,
+    ) -> list[PolicyGrant]:
+        """Return active grants, optionally filtered by profile and type."""
+        ...
+
+    def revoke_grant(self, grant_id: str) -> PolicyGrant | None:
+        """Revoke one grant by id, returning it when it was active."""
+        ...
+
+    def find_active_grant(
+        self,
+        *,
+        profile_id: str,
+        grant_type: str,
+        subject_type: str,
+        value: str,
+        session_id: str | None = None,
+    ) -> PolicyGrant | None:
+        """Return one active grant matching the normalized subject, if any."""
+        ...
+
+
+def validate_grant_request(
+    *,
+    profile_id: str,
+    grant_type: str,
+    subject_type: str,
+    value: str,
+) -> tuple[str, str, str, str]:
+    """Validate and normalize one grant request's identity dimensions."""
+
+    normalized_profile_id = profile_id.strip() if isinstance(profile_id, str) else ""
+    if not normalized_profile_id:
+        raise ValueError("policy grant requires a non-empty profile_id")
+    if grant_type not in POLICY_GRANT_TYPES:
+        raise ValueError(f"unsupported policy grant_type: {grant_type!r}")
+    if grant_type == "approval":
+        if subject_type not in APPROVAL_SUBJECT_TYPES:
+            raise ValueError(f"unsupported approval subject_type: {subject_type!r}")
+        normalized_value = normalize_permission_subject_value(subject_type, value)  # type: ignore[arg-type]
+    else:
+        if subject_type != "path":
+            raise ValueError("path policy grants require subject_type 'path'")
+        normalized_value = value.strip() if isinstance(value, str) else ""
+        if not normalized_value:
+            raise ValueError("policy grant requires a non-empty value")
+    return normalized_profile_id, grant_type, subject_type, normalized_value
+
+
+__all__ = [
+    "APPROVAL_SUBJECT_TYPES",
+    "POLICY_GRANT_TYPES",
+    "PolicyGrant",
+    "PolicyGrantStore",
+    "validate_grant_request",
+]

--- a/mcp_unified/policy_grants/sqlite.py
+++ b/mcp_unified/policy_grants/sqlite.py
@@ -1,0 +1,282 @@
+"""SQLite-backed TTL-bound policy grant store for the standalone MCP gateway."""
+
+from __future__ import annotations
+
+import json
+import secrets
+import time
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import (
+    URL,
+    Column,
+    Engine,
+    Index,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    create_engine,
+    delete,
+    select,
+)
+
+from .models import PolicyGrant, validate_grant_request
+
+
+class SQLitePolicyGrantStore:
+    """SQLite-backed TTL-bound policy grant store for cooperating local processes."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        timeout_seconds: float = 30.0,
+        token_bytes: int = 24,
+        cleanup_interval: int = 64,
+        cleanup_limit: int = 512,
+    ) -> None:
+        raw_path = str(path).strip()
+        if not raw_path:
+            raise ValueError("SQLite policy grant store requires a database path")
+        if raw_path == ":memory:":
+            raise ValueError("SQLite policy grant store requires a file-backed database path")
+
+        db_path = Path(raw_path).expanduser()
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.path = str(db_path)
+        self._token_bytes = max(16, token_bytes)
+        self._cleanup_interval = max(1, int(cleanup_interval))
+        self._cleanup_limit = max(1, int(cleanup_limit))
+        self._operation_count = 0
+        self._metadata = MetaData()
+        self._table = Table(
+            "mcp_policy_grants",
+            self._metadata,
+            Column("grant_id", String, primary_key=True),
+            Column("profile_id", String, nullable=False),
+            Column("grant_type", String, nullable=False),
+            Column("subject_type", String, nullable=False),
+            Column("value", String, nullable=False),
+            Column("actions_json", String, nullable=False),
+            Column("effect", String, nullable=False),
+            Column("session_id", String),
+            Column("user_id", String),
+            Column("granted_by", String),
+            Column("reason", String),
+            Column("expires_at_epoch_us", Integer, nullable=False),
+            Column("ttl_seconds", Integer, nullable=False),
+            Column("created_at_epoch_us", Integer, nullable=False),
+        )
+        Index(
+            "idx_mcp_policy_grants_lookup",
+            self._table.c.profile_id,
+            self._table.c.grant_type,
+            self._table.c.expires_at_epoch_us,
+        )
+        self._engine: Engine = create_engine(
+            URL.create("sqlite", database=self.path),
+            connect_args={"timeout": timeout_seconds, "check_same_thread": False},
+            future=True,
+        )
+        self._metadata.create_all(self._engine)
+
+    def create_grant(
+        self,
+        *,
+        profile_id: str,
+        grant_type: str,
+        subject_type: str,
+        value: str,
+        ttl_seconds: int,
+        actions: tuple[str, ...] = (),
+        effect: str = "allow",
+        session_id: str | None = None,
+        user_id: str | None = None,
+        granted_by: str | None = None,
+        reason: str | None = None,
+    ) -> PolicyGrant:
+        """Create one validated grant with a generated opaque id."""
+
+        normalized_profile_id, grant_type, subject_type, normalized_value = validate_grant_request(
+            profile_id=profile_id,
+            grant_type=grant_type,
+            subject_type=subject_type,
+            value=value,
+        )
+        now_us = _now_us()
+        ttl = max(1, int(ttl_seconds))
+        grant = PolicyGrant(
+            grant_id=secrets.token_urlsafe(self._token_bytes),
+            profile_id=normalized_profile_id,
+            grant_type=grant_type,
+            subject_type=subject_type,
+            value=normalized_value,
+            expires_at=(now_us + ttl * 1_000_000) / 1_000_000,
+            ttl_seconds=ttl,
+            actions=tuple(actions),
+            effect=effect,
+            session_id=session_id,
+            user_id=user_id,
+            granted_by=granted_by,
+            reason=reason,
+        )
+        with self._engine.begin() as connection:
+            self._maybe_cleanup_expired(connection, now_us=now_us)
+            connection.execute(
+                self._table.insert().values(
+                    grant_id=grant.grant_id,
+                    profile_id=grant.profile_id,
+                    grant_type=grant.grant_type,
+                    subject_type=grant.subject_type,
+                    value=grant.value,
+                    actions_json=json.dumps(list(grant.actions)),
+                    effect=grant.effect,
+                    session_id=grant.session_id,
+                    user_id=grant.user_id,
+                    granted_by=grant.granted_by,
+                    reason=grant.reason,
+                    expires_at_epoch_us=now_us + ttl * 1_000_000,
+                    ttl_seconds=ttl,
+                    created_at_epoch_us=now_us,
+                )
+            )
+        return grant
+
+    def list_active_grants(
+        self,
+        *,
+        profile_id: str | None = None,
+        grant_type: str | None = None,
+    ) -> list[PolicyGrant]:
+        """Return active grants filtered by profile and grant type."""
+
+        now_us = _now_us()
+        conditions = [self._table.c.expires_at_epoch_us > now_us]
+        if profile_id is not None:
+            conditions.append(self._table.c.profile_id == profile_id)
+        if grant_type is not None:
+            conditions.append(self._table.c.grant_type == grant_type)
+        with self._engine.begin() as connection:
+            self._maybe_cleanup_expired(connection, now_us=now_us)
+            rows = connection.execute(select(self._table).where(*conditions)).mappings().all()
+        return [_grant_from_row(row) for row in rows]
+
+    def revoke_grant(self, grant_id: str) -> PolicyGrant | None:
+        """Remove one grant by id, returning it when it was still active."""
+
+        now_us = _now_us()
+        with self._engine.begin() as connection:
+            row = (
+                connection.execute(
+                    select(self._table).where(self._table.c.grant_id == grant_id)
+                )
+                .mappings()
+                .first()
+            )
+            if row is None:
+                return None
+            connection.execute(delete(self._table).where(self._table.c.grant_id == grant_id))
+        if int(row["expires_at_epoch_us"]) <= now_us:
+            return None
+        return _grant_from_row(row)
+
+    def find_active_grant(
+        self,
+        *,
+        profile_id: str,
+        grant_type: str,
+        subject_type: str,
+        value: str,
+        session_id: str | None = None,
+    ) -> PolicyGrant | None:
+        """Return one active grant matching the normalized subject, if any."""
+
+        try:
+            _, _, _, normalized_value = validate_grant_request(
+                profile_id=profile_id,
+                grant_type=grant_type,
+                subject_type=subject_type,
+                value=value,
+            )
+        except ValueError:
+            return None
+        now_us = _now_us()
+        with self._engine.begin() as connection:
+            self._maybe_cleanup_expired(connection, now_us=now_us)
+            rows = (
+                connection.execute(
+                    select(self._table).where(
+                        self._table.c.profile_id == profile_id.strip(),
+                        self._table.c.grant_type == grant_type,
+                        self._table.c.subject_type == subject_type,
+                        self._table.c.value == normalized_value,
+                        self._table.c.expires_at_epoch_us > now_us,
+                    )
+                )
+                .mappings()
+                .all()
+            )
+        best: PolicyGrant | None = None
+        for row in rows:
+            grant = _grant_from_row(row)
+            if not grant.matches_session(session_id):
+                continue
+            if best is None or (best.session_id is None and grant.session_id is not None):
+                best = grant
+        return best
+
+    def close(self) -> None:
+        """Dispose the underlying SQLAlchemy engine."""
+
+        self._engine.dispose()
+
+    def _maybe_cleanup_expired(self, connection: Any, *, now_us: int) -> None:
+        self._operation_count += 1
+        if self._operation_count % self._cleanup_interval != 0:
+            return
+        expired_ids = (
+            connection.execute(
+                select(self._table.c.grant_id)
+                .where(self._table.c.expires_at_epoch_us <= now_us)
+                .limit(self._cleanup_limit)
+            )
+            .scalars()
+            .all()
+        )
+        if not expired_ids:
+            return
+        connection.execute(
+            delete(self._table).where(
+                self._table.c.expires_at_epoch_us <= now_us,
+                self._table.c.grant_id.in_(expired_ids),
+            )
+        )
+
+
+def _now_us() -> int:
+    return int(time.time() * 1_000_000)
+
+
+def _grant_from_row(row: Mapping[str, Any]) -> PolicyGrant:
+    raw_actions = json.loads(str(row["actions_json"]))
+    return PolicyGrant(
+        grant_id=str(row["grant_id"]),
+        profile_id=str(row["profile_id"]),
+        grant_type=str(row["grant_type"]),
+        subject_type=str(row["subject_type"]),
+        value=str(row["value"]),
+        expires_at=int(row["expires_at_epoch_us"]) / 1_000_000,
+        ttl_seconds=int(row["ttl_seconds"]),
+        actions=tuple(str(action) for action in raw_actions),
+        effect=str(row["effect"]),
+        session_id=row["session_id"],
+        user_id=row["user_id"],
+        granted_by=row["granted_by"],
+        reason=row["reason"],
+    )
+
+
+__all__ = ["SQLitePolicyGrantStore"]

--- a/mcp_unified/policy_grants/sqlite.py
+++ b/mcp_unified/policy_grants/sqlite.py
@@ -44,7 +44,7 @@ class SQLitePolicyGrantStore:
         if raw_path == ":memory:":
             raise ValueError("SQLite policy grant store requires a file-backed database path")
 
-        db_path = Path(raw_path).expanduser()
+        db_path = Path(raw_path).expanduser().resolve()
         db_path.parent.mkdir(parents=True, exist_ok=True)
         self.path = str(db_path)
         self._token_bytes = max(16, token_bytes)
@@ -159,8 +159,9 @@ class SQLitePolicyGrantStore:
             conditions.append(self._table.c.profile_id == profile_id)
         if grant_type is not None:
             conditions.append(self._table.c.grant_type == grant_type)
+        # Read paths never delete expired rows; cleanup runs on writes so
+        # read transactions keep shared locks under concurrent load.
         with self._engine.begin() as connection:
-            self._maybe_cleanup_expired(connection, now_us=now_us)
             rows = connection.execute(select(self._table).where(*conditions)).mappings().all()
         return [_grant_from_row(row) for row in rows]
 
@@ -169,6 +170,7 @@ class SQLitePolicyGrantStore:
 
         now_us = _now_us()
         with self._engine.begin() as connection:
+            self._maybe_cleanup_expired(connection, now_us=now_us)
             row = (
                 connection.execute(
                     select(self._table).where(self._table.c.grant_id == grant_id)
@@ -195,7 +197,7 @@ class SQLitePolicyGrantStore:
         """Return one active grant matching the normalized subject, if any."""
 
         try:
-            _, _, _, normalized_value = validate_grant_request(
+            normalized_profile_id, _, _, normalized_value = validate_grant_request(
                 profile_id=profile_id,
                 grant_type=grant_type,
                 subject_type=subject_type,
@@ -205,11 +207,10 @@ class SQLitePolicyGrantStore:
             return None
         now_us = _now_us()
         with self._engine.begin() as connection:
-            self._maybe_cleanup_expired(connection, now_us=now_us)
             rows = (
                 connection.execute(
                     select(self._table).where(
-                        self._table.c.profile_id == profile_id.strip(),
+                        self._table.c.profile_id == normalized_profile_id,
                         self._table.c.grant_type == grant_type,
                         self._table.c.subject_type == subject_type,
                         self._table.c.value == normalized_value,

--- a/mcp_unified/profiles/permission_rules.py
+++ b/mcp_unified/profiles/permission_rules.py
@@ -364,6 +364,12 @@ def _normalize_domain_pattern(pattern: str) -> str:
     return host
 
 
+def normalize_permission_subject_value(subject_type: PermissionRuleSubject, value: str) -> str:
+    """Normalize a requested subject value for permission matching and grants."""
+
+    return _normalize_subject_value(subject_type, value)
+
+
 def _normalize_subject_value(subject_type: PermissionRuleSubject, value: str) -> str:
     """Normalize a requested subject for permission matching."""
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -8,6 +8,7 @@ import json
 import os
 import subprocess
 import sys
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -2727,3 +2728,112 @@ def _seed_sqlite_tool_use_events(
             await store.aclose()
 
     asyncio.run(_seed())
+
+
+def test_gateway_cli_approval_grant_lifecycle(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Create, list, and revoke an approval grant through the CLI."""
+
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "store": {"kind": "memory"},
+                "policy_grants": {
+                    "kind": "sqlite",
+                    "sqlite_path": str(tmp_path / "grants.db"),
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = gateway_cli.main(
+        [
+            "create-approval-grant",
+            "--config",
+            str(config_path),
+            "--profile",
+            "researcher",
+            "--subject-type",
+            "domain",
+            "--value",
+            "https://Example.com/private",
+            "--ttl-seconds",
+            "900",
+            "--granted-by",
+            "operator",
+        ]
+    )
+    created = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    grant_payload = created["grant"]
+    assert grant_payload["value"] == "example.com"
+    assert grant_payload["profile_id"] == "researcher"
+    grant_id = grant_payload["grant_id"]
+
+    exit_code = gateway_cli.main(
+        ["list-approval-grants", "--config", str(config_path)]
+    )
+    listed = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert [grant["grant_id"] for grant in listed["grants"]] == [grant_id]
+
+    exit_code = gateway_cli.main(
+        ["revoke-approval-grant", grant_id, "--config", str(config_path)]
+    )
+    revoked = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert revoked["grant"]["grant_id"] == grant_id
+
+    exit_code = gateway_cli.main(
+        ["list-approval-grants", "--config", str(config_path)]
+    )
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out)["grants"] == []
+
+
+def test_gateway_cli_approval_grant_requires_configured_store(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Fail closed when no policy grant store is configured."""
+
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text(json.dumps({"store": {"kind": "memory"}}), encoding="utf-8")
+
+    exit_code = gateway_cli.main(
+        ["list-approval-grants", "--config", str(config_path)]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    payload = json.loads(captured.err)
+    assert payload["reason_code"] == "policy_grant_store_unavailable"
+
+
+def test_gateway_cli_approval_grant_requires_persistent_store(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Reject CLI grant management against a process-local memory store."""
+
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "store": {"kind": "memory"},
+                "policy_grants": {"kind": "memory"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = gateway_cli.main(
+        ["list-approval-grants", "--config", str(config_path)]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    payload = json.loads(captured.err)
+    assert payload["reason_code"] == "policy_grant_store_unavailable"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -3017,6 +3017,203 @@ def test_gateway_profile_runtime_allows_oversized_arguments_without_permission_r
     assert len(backend.call_requests) == 1
 
 
+def _web_fetch_tool_descriptor() -> dict[str, Any]:
+    return {
+        "name": "web.fetch",
+        "description": "Fetch a URL.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"url": {"type": "string"}},
+            "required": ["url"],
+        },
+        "metadata": {"category": "web", "capability": "network.fetch"},
+    }
+
+
+def _ask_rule_runtime_with_grant_store() -> tuple[Any, Any, Any]:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime([_web_fetch_tool_descriptor()])
+    profile = _profile_with_allowed_tools_and_permission_rules(
+        "researcher",
+        allowed_tools=["web.fetch"],
+        permission_rules=[{"pattern": "WebFetch(example.com)", "outcome": "ask"}],
+    )
+    grant_store = InMemoryPolicyGrantStore()
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="researcher",
+        policy_grant_store=grant_store,
+    )
+    return runtime, backend, grant_store
+
+
+def test_gateway_profile_runtime_ask_denial_reports_approval_availability() -> None:
+    runtime, backend, _grant_store = _ask_rule_runtime_with_grant_store()
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        denied = _post_tool_call(
+            client,
+            "web.fetch",
+            {"url": "https://example.com/private", "query": "private"},
+            "ask-no-lease",
+        )
+
+    body = denied.json()
+    _assert_jsonrpc_error(body, code=-32001, request_id="ask-no-lease")
+    error_data = body["error"]["data"]
+    assert error_data["status"] == "approval_required"
+    approval = error_data["provenance"]["approval"]
+    assert approval["available"] is True
+    assert approval["subject_type"] == "domain"
+    assert "example.com/private" not in json.dumps(error_data)
+    assert backend.call_requests == []
+
+
+def test_gateway_profile_runtime_active_approval_lease_allows_ask_decision() -> None:
+    runtime, backend, grant_store = _ask_rule_runtime_with_grant_store()
+    grant = grant_store.create_grant(
+        profile_id="researcher",
+        grant_type="approval",
+        subject_type="domain",
+        value="example.com",
+        ttl_seconds=900,
+        granted_by="operator",
+    )
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        allowed = _post_tool_call(
+            client,
+            "web.fetch",
+            {"url": "https://example.com/private", "query": "private"},
+            "ask-with-lease",
+        )
+
+    assert allowed.json().get("error") is None
+    assert len(backend.call_requests) == 1
+    delegated_context = backend.call_requests[-1][2]
+    markers = delegated_context.metadata.get("mcp_policy_approval_grants")
+    assert markers
+    assert grant.grant_id not in json.dumps(markers)
+
+
+def test_gateway_profile_runtime_expired_approval_lease_blocks_again(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import mcp_unified.policy_grants.memory as memory_grants
+
+    runtime, backend, grant_store = _ask_rule_runtime_with_grant_store()
+    monkeypatch.setattr(memory_grants.time, "time", lambda: 1_000.0)
+    grant_store.create_grant(
+        profile_id="researcher",
+        grant_type="approval",
+        subject_type="domain",
+        value="example.com",
+        ttl_seconds=10,
+    )
+    monkeypatch.setattr(memory_grants.time, "time", lambda: 1_011.0)
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        denied = _post_tool_call(
+            client,
+            "web.fetch",
+            {"url": "https://example.com/private", "query": "private"},
+            "ask-expired-lease",
+        )
+
+    body = denied.json()
+    _assert_jsonrpc_error(body, code=-32001, request_id="ask-expired-lease")
+    assert body["error"]["data"]["status"] == "approval_required"
+    assert backend.call_requests == []
+
+
+def test_gateway_profile_runtime_approval_lease_never_overrides_deny_rule() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime([_read_text_tool_descriptor()])
+    profile = _profile_with_allowed_tools_and_permission_rules(
+        "reviewer",
+        allowed_tools=["fs.read_text"],
+        permission_rules=[
+            {
+                "pattern": "Read(docs/private/**)",
+                "outcome": "deny",
+                "reason_code": "private_docs_denied",
+            }
+        ],
+    )
+    grant_store = InMemoryPolicyGrantStore()
+    grant_store.create_grant(
+        profile_id="reviewer",
+        grant_type="approval",
+        subject_type="path",
+        value="docs/private/secret.txt",
+        ttl_seconds=900,
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="reviewer",
+        policy_grant_store=grant_store,
+    )
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        denied = _post_tool_call(
+            client,
+            "fs.read_text",
+            {"path": "docs/private/secret.txt", "query": "secret"},
+            "deny-with-lease",
+        )
+
+    body = denied.json()
+    _assert_jsonrpc_error(body, code=-32001, request_id="deny-with-lease")
+    assert body["error"]["data"]["reason_code"] == "private_docs_denied"
+    assert body["error"]["data"]["status"] == "denied"
+    assert backend.call_requests == []
+
+
+def test_gateway_profile_runtime_session_scoped_lease_only_matches_its_session() -> None:
+    import asyncio
+
+    from mcp_unified.gateway.runtime import GatewayPolicyDenied, GatewayRequestContext
+
+    runtime, backend, grant_store = _ask_rule_runtime_with_grant_store()
+    grant_store.create_grant(
+        profile_id="researcher",
+        grant_type="approval",
+        subject_type="domain",
+        value="example.com",
+        ttl_seconds=900,
+        session_id="session-1",
+    )
+    arguments = {"url": "https://example.com/private", "query": "private"}
+
+    matching_context = GatewayRequestContext(
+        request_id="session-match",
+        metadata={"session_id": "session-1"},
+    )
+    result = asyncio.run(runtime.call_tool("web.fetch", arguments, matching_context))
+    assert result is not None
+    assert len(backend.call_requests) == 1
+
+    mismatched_context = GatewayRequestContext(
+        request_id="session-mismatch",
+        metadata={"session_id": "session-2"},
+    )
+    with pytest.raises(GatewayPolicyDenied):
+        asyncio.run(runtime.call_tool("web.fetch", arguments, mismatched_context))
+    assert len(backend.call_requests) == 1
+
+
 def test_gateway_profile_runtime_denies_explicit_tool_before_backend_discovery() -> None:
     from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
     from mcp_unified.profiles.store import InMemoryProfileStore

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -5830,3 +5830,39 @@ def test_gateway_batch_omits_notification_runtime_errors() -> None:
 
     assert response.status_code == 200
     assert response.json() == [{"jsonrpc": "2.0", "result": {"pong": True}, "id": "ok"}]
+
+
+def test_gateway_profile_runtime_failing_grant_store_fails_closed_to_denial() -> None:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    class _FailingGrantStore:
+        def find_active_grant(self, **kwargs: Any) -> Any:
+            raise RuntimeError("grant store unavailable")
+
+    backend = _CustomToolListGatewayRuntime([_web_fetch_tool_descriptor()])
+    profile = _profile_with_allowed_tools_and_permission_rules(
+        "researcher",
+        allowed_tools=["web.fetch"],
+        permission_rules=[{"pattern": "WebFetch(example.com)", "outcome": "ask"}],
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="researcher",
+        policy_grant_store=_FailingGrantStore(),
+    )
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        denied = _post_tool_call(
+            client,
+            "web.fetch",
+            {"url": "https://example.com/private", "query": "private"},
+            "ask-store-failure",
+        )
+
+    body = denied.json()
+    _assert_jsonrpc_error(body, code=-32001, request_id="ask-store-failure")
+    assert body["error"]["data"]["status"] == "approval_required"
+    assert backend.call_requests == []

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_grant_manager.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_grant_manager.py
@@ -1,0 +1,238 @@
+"""Tests for the gateway policy grant manager, config, and bootstrap wiring."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+class _RecordingAuditStore:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def append_event(self, event: Any) -> None:
+        self.events.append(event)
+
+
+def test_policy_grant_manager_grant_list_revoke_lifecycle_with_audit() -> None:
+    from mcp_unified.gateway.policy_grants import GatewayPolicyGrantManager
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    audit_store = _RecordingAuditStore()
+    manager = GatewayPolicyGrantManager(
+        policy_grant_store=InMemoryPolicyGrantStore(),
+        audit_store=audit_store,
+    )
+
+    created = asyncio.run(
+        manager.grant_approval(
+            profile_id="researcher",
+            subject_type="domain",
+            value="https://Example.com/private",
+            ttl_seconds=900,
+            granted_by="operator",
+            reason="one-off fetch",
+        )
+    )
+    grant_payload = created["grant"]
+    assert grant_payload["value"] == "example.com"
+    assert grant_payload["grant_type"] == "approval"
+    assert grant_payload["ttl_seconds"] == 900
+
+    listed = asyncio.run(manager.list_grants(profile_id="researcher"))
+    assert len(listed["grants"]) == 1
+    assert listed["grants"][0]["grant_id"] == grant_payload["grant_id"]
+
+    revoked = asyncio.run(manager.revoke_grant(grant_payload["grant_id"]))
+    assert revoked["grant"]["grant_id"] == grant_payload["grant_id"]
+    assert asyncio.run(manager.list_grants(profile_id="researcher"))["grants"] == []
+
+    event_types = [event.event_type for event in audit_store.events]
+    assert "policy_grant.approval.created" in event_types
+    assert "policy_grant.revoked" in event_types
+
+
+def test_policy_grant_manager_clamps_ttl_to_bounds() -> None:
+    from mcp_unified.gateway.policy_grants import (
+        APPROVAL_GRANT_MAX_TTL_SECONDS,
+        APPROVAL_GRANT_MIN_TTL_SECONDS,
+        GatewayPolicyGrantManager,
+    )
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    manager = GatewayPolicyGrantManager(policy_grant_store=InMemoryPolicyGrantStore())
+
+    oversized = asyncio.run(
+        manager.grant_approval(
+            profile_id="researcher",
+            subject_type="tool",
+            value="web.fetch",
+            ttl_seconds=10_000_000,
+        )
+    )
+    assert oversized["grant"]["ttl_seconds"] == APPROVAL_GRANT_MAX_TTL_SECONDS
+
+    undersized = asyncio.run(
+        manager.grant_approval(
+            profile_id="researcher",
+            subject_type="tool",
+            value="web.search",
+            ttl_seconds=1,
+        )
+    )
+    assert undersized["grant"]["ttl_seconds"] == APPROVAL_GRANT_MIN_TTL_SECONDS
+
+
+def test_policy_grant_manager_rejects_invalid_requests() -> None:
+    from mcp_unified.gateway.policy_grants import (
+        GatewayPolicyGrantManagementError,
+        GatewayPolicyGrantManager,
+    )
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    manager = GatewayPolicyGrantManager(policy_grant_store=InMemoryPolicyGrantStore())
+
+    with pytest.raises(GatewayPolicyGrantManagementError) as excinfo:
+        asyncio.run(
+            manager.grant_approval(
+                profile_id="researcher",
+                subject_type="skill",
+                value="anything",
+            )
+        )
+    assert excinfo.value.reason_code == "invalid_policy_grant"
+    assert excinfo.value.to_payload()["ok"] is False
+
+
+def test_policy_grant_manager_revoke_missing_grant_raises_not_found() -> None:
+    from mcp_unified.gateway.policy_grants import (
+        GatewayPolicyGrantManagementError,
+        GatewayPolicyGrantManager,
+    )
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    manager = GatewayPolicyGrantManager(policy_grant_store=InMemoryPolicyGrantStore())
+
+    with pytest.raises(GatewayPolicyGrantManagementError) as excinfo:
+        asyncio.run(manager.revoke_grant("missing-grant"))
+    assert excinfo.value.reason_code == "policy_grant_not_found"
+
+
+def test_bootstrap_config_accepts_policy_grants_section(tmp_path: Path) -> None:
+    from mcp_unified.gateway.config import (
+        GatewayPolicyGrantStoreConfig,
+        GatewayProfileBootstrapConfig,
+    )
+
+    config = GatewayProfileBootstrapConfig(
+        policy_grants={"kind": "sqlite", "sqlite_path": str(tmp_path / "grants.db")}
+    )
+    assert isinstance(config.policy_grants, GatewayPolicyGrantStoreConfig)
+    assert config.policy_grants.kind == "sqlite"
+
+    default_config = GatewayProfileBootstrapConfig()
+    assert default_config.policy_grants is None
+
+    with pytest.raises(ValueError):
+        GatewayProfileBootstrapConfig(policy_grants={"kind": "sqlite"})
+    with pytest.raises(ValueError):
+        GatewayProfileBootstrapConfig(policy_grants={"kind": "redis"})
+
+
+def test_build_gateway_policy_grant_store_backend_selection(tmp_path: Path) -> None:
+    from mcp_unified.gateway.config import (
+        GatewayPolicyGrantStoreConfig,
+        build_gateway_policy_grant_store,
+    )
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+    from mcp_unified.policy_grants.sqlite import SQLitePolicyGrantStore
+
+    assert build_gateway_policy_grant_store(None) is None
+    assert isinstance(
+        build_gateway_policy_grant_store(GatewayPolicyGrantStoreConfig(kind="memory")),
+        InMemoryPolicyGrantStore,
+    )
+
+    sqlite_store = build_gateway_policy_grant_store(
+        GatewayPolicyGrantStoreConfig(
+            kind="sqlite",
+            sqlite_path=tmp_path / "grants.db",
+        )
+    )
+    assert isinstance(sqlite_store, SQLitePolicyGrantStore)
+    sqlite_store.close()
+
+
+def test_bootstrap_profile_gateway_wires_policy_grant_store() -> None:
+    from mcp_unified.gateway.bootstrap import bootstrap_profile_gateway
+    from mcp_unified.gateway.runtime import GatewayRequestContext
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    class _StaticBackend:
+        name = "unit-backend"
+        version = "0.0-test"
+
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        async def list_tools(self, context: Any) -> list[dict[str, Any]]:
+            return [
+                {
+                    "name": "web.fetch",
+                    "description": "Fetch a URL.",
+                    "inputSchema": {"type": "object", "properties": {"url": {"type": "string"}}},
+                    "metadata": {"category": "web", "capability": "network.fetch"},
+                }
+            ]
+
+        async def call_tool(
+            self,
+            name: str,
+            arguments: dict[str, Any],
+            context: Any,
+        ) -> dict[str, Any]:
+            self.calls.append(name)
+            return {"content": [{"type": "text", "text": "ok"}]}
+
+    backend = _StaticBackend()
+    grant_store = InMemoryPolicyGrantStore()
+    grant_store.create_grant(
+        profile_id="researcher",
+        grant_type="approval",
+        subject_type="domain",
+        value="example.com",
+        ttl_seconds=900,
+    )
+
+    async def _exercise() -> dict[str, Any]:
+        bootstrap = await bootstrap_profile_gateway(
+            backend,
+            profiles=[
+                {
+                    "id": "researcher",
+                    "name": "Researcher",
+                    "policy_document": {
+                        "allowed_tools": ["web.fetch"],
+                        "permission_rules": [
+                            {"pattern": "WebFetch(example.com)", "outcome": "ask"}
+                        ],
+                    },
+                }
+            ],
+            default_profile_id="researcher",
+            policy_grant_store=grant_store,
+        )
+        assert bootstrap.policy_grant_store is grant_store
+        context = GatewayRequestContext(request_id="bootstrap-lease")
+        return await bootstrap.runtime.call_tool(
+            "web.fetch",
+            {"url": "https://example.com/private"},
+            context,
+        )
+
+    result = asyncio.run(_exercise())
+    assert result is not None
+    assert backend.calls == ["web.fetch"]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_policy_grant_stores.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_policy_grant_stores.py
@@ -1,0 +1,416 @@
+"""Tests for the standalone MCP policy grant stores (approval leases + TTL grants)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_policy_grant_package_exposes_models_and_factory() -> None:
+    from mcp_unified.policy_grants import (
+        InMemoryPolicyGrantStore,
+        PolicyGrant,
+        PolicyGrantStore,
+        create_policy_grant_store,
+    )
+
+    assert PolicyGrant is not None
+    assert PolicyGrantStore is not None
+    assert InMemoryPolicyGrantStore is not None
+    assert callable(create_policy_grant_store)
+
+
+def test_memory_store_creates_and_finds_normalized_approval_grant() -> None:
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    store = InMemoryPolicyGrantStore()
+    grant = store.create_grant(
+        profile_id="researcher",
+        grant_type="approval",
+        subject_type="domain",
+        value="https://Example.com/private",
+        ttl_seconds=900,
+        granted_by="operator",
+        reason="one-off research fetch",
+    )
+
+    assert grant.grant_id
+    assert grant.value == "example.com"
+    assert grant.effect == "allow"
+    assert grant.ttl_seconds == 900
+
+    found = store.find_active_grant(
+        profile_id="researcher",
+        grant_type="approval",
+        subject_type="domain",
+        value="example.com",
+    )
+    assert found is not None
+    assert found.grant_id == grant.grant_id
+
+
+def test_memory_store_find_misses_on_mismatched_dimensions() -> None:
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    store = InMemoryPolicyGrantStore()
+    store.create_grant(
+        profile_id="researcher",
+        grant_type="approval",
+        subject_type="domain",
+        value="example.com",
+        ttl_seconds=900,
+    )
+
+    assert (
+        store.find_active_grant(
+            profile_id="other-profile",
+            grant_type="approval",
+            subject_type="domain",
+            value="example.com",
+        )
+        is None
+    )
+    assert (
+        store.find_active_grant(
+            profile_id="researcher",
+            grant_type="path",
+            subject_type="path",
+            value="example.com",
+        )
+        is None
+    )
+    assert (
+        store.find_active_grant(
+            profile_id="researcher",
+            grant_type="approval",
+            subject_type="domain",
+            value="other.example.org",
+        )
+        is None
+    )
+
+
+def test_memory_store_expired_grant_is_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    import mcp_unified.policy_grants.memory as memory_grants
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    store = InMemoryPolicyGrantStore()
+    monkeypatch.setattr(memory_grants.time, "time", lambda: 1_000.0)
+    store.create_grant(
+        profile_id="researcher",
+        grant_type="approval",
+        subject_type="domain",
+        value="example.com",
+        ttl_seconds=10,
+    )
+
+    monkeypatch.setattr(memory_grants.time, "time", lambda: 1_011.0)
+    assert (
+        store.find_active_grant(
+            profile_id="researcher",
+            grant_type="approval",
+            subject_type="domain",
+            value="example.com",
+        )
+        is None
+    )
+    assert store.list_active_grants(profile_id="researcher") == []
+
+
+def test_memory_store_session_scoped_grant_only_matches_its_session() -> None:
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    store = InMemoryPolicyGrantStore()
+    store.create_grant(
+        profile_id="researcher",
+        grant_type="approval",
+        subject_type="domain",
+        value="example.com",
+        ttl_seconds=900,
+        session_id="session-1",
+    )
+
+    assert (
+        store.find_active_grant(
+            profile_id="researcher",
+            grant_type="approval",
+            subject_type="domain",
+            value="example.com",
+            session_id="session-1",
+        )
+        is not None
+    )
+    assert (
+        store.find_active_grant(
+            profile_id="researcher",
+            grant_type="approval",
+            subject_type="domain",
+            value="example.com",
+            session_id="session-2",
+        )
+        is None
+    )
+    assert (
+        store.find_active_grant(
+            profile_id="researcher",
+            grant_type="approval",
+            subject_type="domain",
+            value="example.com",
+        )
+        is None
+    )
+
+
+def test_memory_store_global_grant_matches_any_session() -> None:
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    store = InMemoryPolicyGrantStore()
+    store.create_grant(
+        profile_id="researcher",
+        grant_type="approval",
+        subject_type="tool",
+        value="web.fetch",
+        ttl_seconds=900,
+    )
+
+    for session_id in (None, "session-1", "session-2"):
+        found = store.find_active_grant(
+            profile_id="researcher",
+            grant_type="approval",
+            subject_type="tool",
+            value="web.fetch",
+            session_id=session_id,
+        )
+        assert found is not None
+
+
+def test_memory_store_revoke_deactivates_grant() -> None:
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    store = InMemoryPolicyGrantStore()
+    grant = store.create_grant(
+        profile_id="researcher",
+        grant_type="approval",
+        subject_type="domain",
+        value="example.com",
+        ttl_seconds=900,
+    )
+
+    revoked = store.revoke_grant(grant.grant_id)
+    assert revoked is not None
+    assert revoked.grant_id == grant.grant_id
+    assert (
+        store.find_active_grant(
+            profile_id="researcher",
+            grant_type="approval",
+            subject_type="domain",
+            value="example.com",
+        )
+        is None
+    )
+    assert store.revoke_grant("missing-grant-id") is None
+
+
+def test_memory_store_list_active_grants_filters() -> None:
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    store = InMemoryPolicyGrantStore()
+    store.create_grant(
+        profile_id="researcher",
+        grant_type="approval",
+        subject_type="domain",
+        value="example.com",
+        ttl_seconds=900,
+    )
+    store.create_grant(
+        profile_id="researcher",
+        grant_type="path",
+        subject_type="path",
+        value="docs/scratch",
+        actions=("read", "write"),
+        ttl_seconds=900,
+    )
+    store.create_grant(
+        profile_id="backend",
+        grant_type="approval",
+        subject_type="tool",
+        value="web.fetch",
+        ttl_seconds=900,
+    )
+
+    assert len(store.list_active_grants()) == 3
+    assert len(store.list_active_grants(profile_id="researcher")) == 2
+    approvals = store.list_active_grants(profile_id="researcher", grant_type="approval")
+    assert len(approvals) == 1
+    assert approvals[0].subject_type == "domain"
+
+
+def test_memory_store_rejects_invalid_grants() -> None:
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    store = InMemoryPolicyGrantStore()
+    with pytest.raises(ValueError):
+        store.create_grant(
+            profile_id="researcher",
+            grant_type="unknown",
+            subject_type="domain",
+            value="example.com",
+            ttl_seconds=900,
+        )
+    with pytest.raises(ValueError):
+        store.create_grant(
+            profile_id="researcher",
+            grant_type="approval",
+            subject_type="skill",
+            value="anything",
+            ttl_seconds=900,
+        )
+    with pytest.raises(ValueError):
+        store.create_grant(
+            profile_id="   ",
+            grant_type="approval",
+            subject_type="domain",
+            value="example.com",
+            ttl_seconds=900,
+        )
+    with pytest.raises(ValueError):
+        store.create_grant(
+            profile_id="researcher",
+            grant_type="path",
+            subject_type="domain",
+            value="docs/scratch",
+            ttl_seconds=900,
+        )
+
+
+def test_policy_grant_safe_payload_includes_expiry_metadata() -> None:
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    store = InMemoryPolicyGrantStore()
+    grant = store.create_grant(
+        profile_id="researcher",
+        grant_type="approval",
+        subject_type="domain",
+        value="example.com",
+        ttl_seconds=900,
+        session_id="session-1",
+        granted_by="operator",
+    )
+
+    payload = grant.safe_payload()
+    assert payload["grant_id"] == grant.grant_id
+    assert payload["profile_id"] == "researcher"
+    assert payload["grant_type"] == "approval"
+    assert payload["subject_type"] == "domain"
+    assert payload["value"] == "example.com"
+    assert payload["session_id"] == "session-1"
+    assert payload["ttl_seconds"] == 900
+    assert payload["expires_at"].endswith("+00:00")
+
+
+def test_sqlite_store_persists_grants_across_instances(tmp_path: Path) -> None:
+    from mcp_unified.policy_grants.sqlite import SQLitePolicyGrantStore
+
+    db_path = tmp_path / "grants.db"
+    first = SQLitePolicyGrantStore(db_path)
+    try:
+        grant = first.create_grant(
+            profile_id="researcher",
+            grant_type="approval",
+            subject_type="domain",
+            value="https://Example.com/private",
+            ttl_seconds=900,
+            session_id="session-1",
+            granted_by="operator",
+            reason="one-off research fetch",
+        )
+        assert grant.value == "example.com"
+    finally:
+        first.close()
+
+    second = SQLitePolicyGrantStore(db_path)
+    try:
+        found = second.find_active_grant(
+            profile_id="researcher",
+            grant_type="approval",
+            subject_type="domain",
+            value="example.com",
+            session_id="session-1",
+        )
+        assert found is not None
+        assert found.grant_id == grant.grant_id
+        assert found.granted_by == "operator"
+
+        revoked = second.revoke_grant(grant.grant_id)
+        assert revoked is not None
+        assert (
+            second.find_active_grant(
+                profile_id="researcher",
+                grant_type="approval",
+                subject_type="domain",
+                value="example.com",
+                session_id="session-1",
+            )
+            is None
+        )
+    finally:
+        second.close()
+
+
+def test_sqlite_store_expired_grant_is_not_found(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import mcp_unified.policy_grants.sqlite as sqlite_grants
+    from mcp_unified.policy_grants.sqlite import SQLitePolicyGrantStore
+
+    store = SQLitePolicyGrantStore(tmp_path / "grants.db")
+    try:
+        monkeypatch.setattr(sqlite_grants.time, "time", lambda: 1_000.0)
+        store.create_grant(
+            profile_id="researcher",
+            grant_type="approval",
+            subject_type="domain",
+            value="example.com",
+            ttl_seconds=10,
+        )
+
+        monkeypatch.setattr(sqlite_grants.time, "time", lambda: 1_011.0)
+        assert (
+            store.find_active_grant(
+                profile_id="researcher",
+                grant_type="approval",
+                subject_type="domain",
+                value="example.com",
+            )
+            is None
+        )
+        assert store.list_active_grants(profile_id="researcher") == []
+    finally:
+        store.close()
+
+
+def test_policy_grant_store_factory_backend_selection(tmp_path: Path) -> None:
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore, create_policy_grant_store
+    from mcp_unified.policy_grants.sqlite import SQLitePolicyGrantStore
+
+    assert isinstance(create_policy_grant_store(None), InMemoryPolicyGrantStore)
+    assert isinstance(
+        create_policy_grant_store({"grant_store_backend": "memory"}),
+        InMemoryPolicyGrantStore,
+    )
+
+    sqlite_store = create_policy_grant_store(
+        {
+            "grant_store_backend": "sqlite",
+            "grant_store_sqlite_path": str(tmp_path / "grants.db"),
+        }
+    )
+    assert isinstance(sqlite_store, SQLitePolicyGrantStore)
+    sqlite_store.close()
+
+    with pytest.raises(ValueError):
+        create_policy_grant_store({"grant_store_backend": "sqlite"})
+    with pytest.raises(ValueError):
+        create_policy_grant_store({"grant_store_backend": "redis"})

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_policy_grant_stores.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_policy_grant_stores.py
@@ -414,3 +414,85 @@ def test_policy_grant_store_factory_backend_selection(tmp_path: Path) -> None:
         create_policy_grant_store({"grant_store_backend": "sqlite"})
     with pytest.raises(ValueError):
         create_policy_grant_store({"grant_store_backend": "redis"})
+
+
+def test_memory_store_sweep_eventually_removes_late_expired_grants(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import mcp_unified.policy_grants.memory as memory_grants
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    store = InMemoryPolicyGrantStore(sweep_interval=1, max_sweep_entries=2)
+    monkeypatch.setattr(memory_grants.time, "time", lambda: 1_000.0)
+    for index in range(3):
+        store.create_grant(
+            profile_id=f"profile-{index}",
+            grant_type="approval",
+            subject_type="tool",
+            value="web.fetch",
+            ttl_seconds=10_000,
+        )
+    expiring = store.create_grant(
+        profile_id="expiring",
+        grant_type="approval",
+        subject_type="tool",
+        value="web.fetch",
+        ttl_seconds=10,
+    )
+
+    monkeypatch.setattr(memory_grants.time, "time", lambda: 1_050.0)
+    for _ in range(4):
+        store.list_active_grants()
+
+    assert expiring.grant_id not in store._grants
+    assert len(store._grants) == 3
+
+
+def test_sqlite_store_read_paths_do_not_delete_expired_rows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import mcp_unified.policy_grants.sqlite as sqlite_grants
+    from mcp_unified.policy_grants.sqlite import SQLitePolicyGrantStore
+    from sqlalchemy import func, select
+
+    store = SQLitePolicyGrantStore(tmp_path / "grants.db", cleanup_interval=1)
+
+    def _row_count() -> int:
+        with store._engine.begin() as connection:
+            return int(connection.execute(select(func.count()).select_from(store._table)).scalar_one())
+
+    try:
+        monkeypatch.setattr(sqlite_grants.time, "time", lambda: 1_000.0)
+        store.create_grant(
+            profile_id="researcher",
+            grant_type="approval",
+            subject_type="domain",
+            value="example.com",
+            ttl_seconds=10,
+        )
+
+        monkeypatch.setattr(sqlite_grants.time, "time", lambda: 1_050.0)
+        for _ in range(3):
+            assert store.list_active_grants(profile_id="researcher") == []
+        assert (
+            store.find_active_grant(
+                profile_id="researcher",
+                grant_type="approval",
+                subject_type="domain",
+                value="example.com",
+            )
+            is None
+        )
+        assert _row_count() == 1
+
+        store.create_grant(
+            profile_id="researcher",
+            grant_type="approval",
+            subject_type="tool",
+            value="web.fetch",
+            ttl_seconds=900,
+        )
+        assert _row_count() == 1
+    finally:
+        store.close()


### PR DESCRIPTION
## Summary
- Add a reusable TTL-bound policy grant store (`mcp_unified/policy_grants/`) with memory and SQLite backends, modeled on the filesystem lock leases (epoch-µs expiry, periodic batched cleanup, opaque token ids).
- Consult active approval leases in gateway runtime permission-rule enforcement: an operator-granted, optionally session-scoped lease converts a matched `ask` decision to allow until expiry. `deny` rules are never overridden; expired or session-mismatched leases do not apply; store failures fail closed to denial.
- Approved calls carry a redacted SHA-256 lease marker (not the raw grant token) in delegated context metadata; `ask` denials gain redacted `approval: {available, grant_type, subject_type}` provenance.
- Operator surface: `GatewayPolicyGrantManager` (TTL clamped to 60s–24h, default 15m, audit events) plus CLI verbs `create-approval-grant` / `list-approval-grants` / `revoke-approval-grant`, requiring a persistent sqlite `policy_grants` config section (fails closed with `policy_grant_store_unavailable`). Config + bootstrap wiring included.

Implements the top deferred item from TASK-2349 (approval prompt/lease flow). Backlog: TASK-2351.

## Test Plan
- [x] `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_policy_grant_stores.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_grant_manager.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_permission_rules.py tldw_Server_API/app/core/MCP_unified/tests/test_profile_policy_decisions.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_lock_managers.py -q` (383 passed, re-verified after rebase onto dev)
- [x] `python -m ruff check` over touched modules and tests
- [x] `python -m compileall -q` over touched modules
- [x] `python -m bandit -r mcp_unified/policy_grants/ mcp_unified/gateway/policy_grants.py -q` (no findings)
- [x] `git diff --check`

## Deferred
- Pattern-valued approval grants (exact normalized-subject match only).
- REST admin endpoints for grants (CLI only).
- Lease use-count limits / consumption semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds short-lived approval leases that turn matched ask permission decisions into allow until expiry, with CLI management and runtime wiring that never overrides deny. Also improves performance and reliability of grant lookups and cleanup. Implements the top deferred item from TASK-2349.

- New Features
  - `mcp_unified/policy_grants/`: TTL-bound grant store with memory and SQLite backends, exact normalized-subject match, optional session scoping, periodic cleanup.
  - Gateway runtime: consults approval leases for ask outcomes; store failures fail closed; approved calls include redacted SHA-256 markers in `mcp_policy_approval_grants`; ask denials add redacted `approval` provenance.
  - Operator tools: `GatewayPolicyGrantManager` (TTL clamp 60s–24h, default 15m, audit events) and CLI verbs `create-approval-grant`, `list-approval-grants`, `revoke-approval-grant`.
  - Config/bootstrap: `GatewayPolicyGrantStoreConfig`, `build_gateway_policy_grant_store`, and runtime wiring via `policy_grants`.

- Refactors
  - Offload grant-store-backed enforcement to a worker thread to keep SQLite lookups off the event loop.
  - In-memory sweep now rotates entries so bounded sweeps cover all; SQLite read paths no longer delete expired rows (cleanup runs on create/revoke) to keep shared locks.
  - Normalize and reuse profile id from validation; resolve SQLite DB path to an absolute path; log redacted warnings on grant-store failures.

<sup>Written for commit fd09d28cff8dc58a0afd783a423ccf96393d7360. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

