### PR TITLE
Add TTL-bound MCP session path grants

### DIFF
--- a/backlog/tasks/task-2301 - Add-TTL-bound-MCP-session-path-grants.md
+++ b/backlog/tasks/task-2301 - Add-TTL-bound-MCP-session-path-grants.md
@@ -1,7 +1,8 @@
 ---
 id: TASK-2301
 title: Add TTL-bound MCP session path grants
-status: To Do
+status: Done
+updated_date: '2026-06-11'
 labels:
 - mcp
 - policy
@@ -10,6 +11,8 @@ labels:
 - followup
 references:
 - Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+dependencies:
+- TASK-2351
 ---
 
 ## Description
@@ -20,26 +23,49 @@ Add temporary path grants scoped to a session, run, or short TTL so operators ca
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 Operators can create TTL-bound path grants (profile, workspace-relative prefix, file-policy actions, optional session scope) without editing the profile document.
+- [x] #2 Path grant prefixes are normalized and validated like authored path grants (no absolute paths, drive prefixes, or '..' segments); actions are validated against the file-policy action taxonomy.
+- [x] #3 Active applicable grants are merged into the delegated effective policy's path_scopes with source/grant_id/expiry provenance; expired and session-mismatched grants are excluded; base profile scopes are preserved.
+- [x] #4 Grants expire automatically and can be listed and revoked through the gateway CLI, with audit events on create and revoke.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Built on the TASK-2351 `mcp_unified/policy_grants/` store using `grant_type="path"` (schema already carried `actions`/`effect`, so no migration was needed). Validation lives in `policy_grants/models.py`: `validate_grant_request` now normalizes path-grant values through the new public `normalize_path_grant_prefix()` wrapper in `profiles/path_grants.py` (rejecting absolute paths, Windows drive prefixes, and `..` segments), and the new `validate_grant_actions()` requires at least one action and checks each against `PATH_GRANT_ACTIONS`. Both memory and SQLite stores call it in `create_grant`.
 
+Runtime merge in `gateway/profile_runtime.py`: `_policy_with_ttl_path_grants()` runs in `_call_backend_tool_through_policy` after policy resolution and before `_context_with_effective_policy`, keeping `build_effective_policy_result()` pure. It lists active `path` grants for the profile, filters by `matches_session(_context_session_id(context))`, and appends flat scopes `{prefix, actions, effect, source: "ttl_grant", grant_id, expires_at}` to `policy.path_scopes` via `model_copy`. Store failures leave the base policy unchanged (never widen on error); no applicable grants means the policy object passes through untouched.
+
+Management: `GatewayPolicyGrantManager.grant_path()` with the same TTL clamps as approval leases ([60, 86400], default 900) and `policy_grant.path.created` audit events. CLI verb `create-path-grant` (--profile, --prefix, --actions CSV, --ttl-seconds, --session-id, --granted-by, --reason); `list-approval-grants` gained a `--grant-type` filter; `revoke-approval-grant` works for both grant types.
+
+TDD evidence:
+- Store red: 3 new tests (prefix normalization, unsafe values, invalid actions) failed against the permissive TASK-2351 validation; green after.
+- Manager red: 2 grant_path tests failed with AttributeError (method missing); green after.
+- Runtime red: merge test failed (no ttl_grant scopes in delegated effective policy); green after. The inapplicable-grants test (expired + session mismatch) pins that such grants stay excluded.
+- CLI red: 2 tests failed on unknown create-path-grant subcommand; green after.
+
+Verification:
+- `python -m pytest` over test_gateway_fastapi_package.py, test_gateway_cli_package.py, test_policy_grant_stores.py, test_gateway_policy_grant_manager.py, test_profile_permission_rules.py, test_profile_policy_decisions.py, test_filesystem_lock_managers.py passed with 392 tests.
+- Ruff over all touched modules and tests passed.
+- `python -m compileall -q` over touched modules passed.
+- Bandit over mcp_unified/policy_grants/ and gateway modules reported no findings.
+- `git diff --check` passed.
+
+Deferred: temporary deny-effect grants (permanent deny belongs in the profile); pattern-valued prefixes beyond prefix semantics; surfacing TTL grants in the effective permission preview endpoint; ToolUseEvent marker when a merged grant was actually consulted by the downstream path enforcer.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Added TTL-bound, optionally session-scoped path grants on the shared policy grant store: validated workspace-relative prefixes and file-policy actions, runtime merge of active applicable grants into delegated effective policy path_scopes with ttl_grant provenance, and CLI create/list/revoke management with audit events and TTL clamps.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/mcp_unified/gateway/cli.py
+++ b/mcp_unified/gateway/cli.py
@@ -444,6 +444,46 @@ def _build_parser() -> _JsonArgumentParser:
     _add_profile_config_argument(create_approval_grant)
     create_approval_grant.set_defaults(handler=_handle_create_approval_grant)
 
+    create_path_grant = subparsers.add_parser(
+        "create-path-grant",
+        help="Create a TTL-bound temporary path grant for one profile.",
+    )
+    create_path_grant.add_argument(
+        "--profile",
+        required=True,
+        help="Profile id the path grant applies to.",
+    )
+    create_path_grant.add_argument(
+        "--prefix",
+        required=True,
+        help="Workspace-relative path prefix to grant (normalized before storage).",
+    )
+    create_path_grant.add_argument(
+        "--actions",
+        required=True,
+        help="Comma-separated file policy actions the grant allows (e.g. read,write).",
+    )
+    create_path_grant.add_argument(
+        "--ttl-seconds",
+        type=int,
+        default=None,
+        help="Grant lifetime in seconds (clamped to safe bounds).",
+    )
+    create_path_grant.add_argument(
+        "--session-id",
+        help="Optional session id restricting where the grant applies.",
+    )
+    create_path_grant.add_argument(
+        "--granted-by",
+        help="Optional operator identity recorded with the grant.",
+    )
+    create_path_grant.add_argument(
+        "--reason",
+        help="Optional human-readable reason recorded with the grant.",
+    )
+    _add_profile_config_argument(create_path_grant)
+    create_path_grant.set_defaults(handler=_handle_create_path_grant)
+
     list_approval_grants = subparsers.add_parser(
         "list-approval-grants",
         help="List active policy grants from a configured grant store.",
@@ -451,6 +491,11 @@ def _build_parser() -> _JsonArgumentParser:
     list_approval_grants.add_argument(
         "--profile",
         help="Optional profile id filter.",
+    )
+    list_approval_grants.add_argument(
+        "--grant-type",
+        choices=("approval", "path"),
+        help="Optional grant type filter.",
     )
     _add_profile_config_argument(list_approval_grants)
     list_approval_grants.set_defaults(handler=_handle_list_approval_grants)
@@ -990,13 +1035,43 @@ def _handle_create_approval_grant(args: argparse.Namespace) -> int:
     )
 
 
+def _handle_create_path_grant(args: argparse.Namespace) -> int:
+    """Create one TTL-bound path grant in a configured grant store."""
+
+    profile_id = _require_cli_text(args.profile, field="profile")
+    prefix = _require_cli_text(args.prefix, field="prefix")
+    raw_actions = _require_cli_text(args.actions, field="actions")
+    actions = tuple(action.strip() for action in raw_actions.split(",") if action.strip())
+    ttl_seconds = (
+        args.ttl_seconds
+        if args.ttl_seconds is not None
+        else APPROVAL_GRANT_DEFAULT_TTL_SECONDS
+    )
+    session_id = _optional_cli_text(args.session_id, field="session_id")
+    granted_by = _optional_cli_text(args.granted_by, field="granted_by")
+    reason = _optional_cli_text(args.reason, field="reason")
+    return _handle_policy_grant_command(
+        args,
+        lambda manager: manager.grant_path(
+            profile_id=profile_id,
+            prefix=prefix,
+            actions=actions,
+            ttl_seconds=ttl_seconds,
+            session_id=session_id,
+            granted_by=granted_by,
+            reason=reason,
+        ),
+    )
+
+
 def _handle_list_approval_grants(args: argparse.Namespace) -> int:
     """List active policy grants from a configured grant store."""
 
     profile_id = _optional_cli_text(args.profile, field="profile")
+    grant_type = _optional_cli_text(args.grant_type, field="grant_type")
     return _handle_policy_grant_command(
         args,
-        lambda manager: manager.list_grants(profile_id=profile_id),
+        lambda manager: manager.list_grants(profile_id=profile_id, grant_type=grant_type),
     )
 
 

--- a/mcp_unified/gateway/policy_grants.py
+++ b/mcp_unified/gateway/policy_grants.py
@@ -101,6 +101,44 @@ class GatewayPolicyGrantManager:
         )
         return {"grant": grant.safe_payload()}
 
+    async def grant_path(
+        self,
+        *,
+        profile_id: str,
+        prefix: str,
+        actions: tuple[str, ...],
+        ttl_seconds: int = APPROVAL_GRANT_DEFAULT_TTL_SECONDS,
+        session_id: str | None = None,
+        granted_by: str | None = None,
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        """Create one TTL-bound path grant with clamped TTL and audit provenance."""
+
+        ttl = min(
+            APPROVAL_GRANT_MAX_TTL_SECONDS,
+            max(APPROVAL_GRANT_MIN_TTL_SECONDS, int(ttl_seconds)),
+        )
+        try:
+            grant = self.policy_grant_store.create_grant(
+                profile_id=profile_id,
+                grant_type="path",
+                subject_type="path",
+                value=prefix,
+                ttl_seconds=ttl,
+                actions=actions,
+                session_id=session_id,
+                granted_by=granted_by,
+                reason=reason,
+            )
+        except ValueError as exc:
+            raise GatewayPolicyGrantManagementError(
+                f"Invalid policy grant request: {exc}",
+                reason_code="invalid_policy_grant",
+                profile_id=profile_id if isinstance(profile_id, str) else None,
+            ) from exc
+        await self._append_audit_event("policy_grant.path.created", grant=grant)
+        return {"grant": grant.safe_payload()}
+
     async def list_grants(
         self,
         *,

--- a/mcp_unified/gateway/profile_runtime.py
+++ b/mcp_unified/gateway/profile_runtime.py
@@ -914,7 +914,7 @@ def _policy_with_ttl_path_grants(
 ) -> Any:
     """Return the effective policy with active TTL path grants merged in."""
 
-    if policy is None or policy_grant_store is None:
+    if policy is None or policy_grant_store is None or not hasattr(policy, "path_scopes"):
         return policy
     try:
         grants = policy_grant_store.list_active_grants(
@@ -922,6 +922,11 @@ def _policy_with_ttl_path_grants(
             grant_type="path",
         )
     except Exception:  # noqa: BLE001 - grant store failures must not alter base policy
+        logger.opt(exception=True).warning(
+            "Policy grant store listing failed; delegating base policy without "
+            "TTL path grants (profile_id={profile_id})",
+            profile_id=profile_id,
+        )
         return policy
     merged_scopes = [
         {

--- a/mcp_unified/gateway/profile_runtime.py
+++ b/mcp_unified/gateway/profile_runtime.py
@@ -522,6 +522,7 @@ class ProfileAwareGatewayRuntime:
                 policy_result,
                 message=f"Gateway profile denied tool execution: {policy_result.reason_code}",
             )
+        session_id = _context_session_id(context)
         compiled_rules = self._compiled_permission_rules(profile, tool_name=name)
         if self._policy_grant_store is None:
             approval_grant_markers = _enforce_permission_rules_for_tool_call(
@@ -530,6 +531,7 @@ class ProfileAwareGatewayRuntime:
                 arguments,
                 compiled_rules,
             )
+            delegated_policy = policy_result.policy
         else:
             # Grant-store lookups may hit SQLite; keep them off the event loop.
             approval_grant_markers = await asyncio.to_thread(
@@ -539,9 +541,16 @@ class ProfileAwareGatewayRuntime:
                 arguments,
                 compiled_rules,
                 policy_grant_store=self._policy_grant_store,
-                session_id=_context_session_id(context),
+                session_id=session_id,
             )
-        delegated_context = _context_with_effective_policy(context, policy_result.policy)
+            delegated_policy = await asyncio.to_thread(
+                _policy_with_ttl_path_grants,
+                policy_result.policy,
+                self._policy_grant_store,
+                profile_id=profile.id,
+                session_id=session_id,
+            )
+        delegated_context = _context_with_effective_policy(context, delegated_policy)
         if approval_grant_markers:
             delegated_context = _context_with_metadata_value(
                 delegated_context,
@@ -893,6 +902,43 @@ def _context_with_effective_policy(
         client_id=context.client_id,
         user_id=context.user_id,
         metadata=metadata,
+    )
+
+
+def _policy_with_ttl_path_grants(
+    policy: Any,
+    policy_grant_store: PolicyGrantStore | None,
+    *,
+    profile_id: str,
+    session_id: str | None,
+) -> Any:
+    """Return the effective policy with active TTL path grants merged in."""
+
+    if policy is None or policy_grant_store is None:
+        return policy
+    try:
+        grants = policy_grant_store.list_active_grants(
+            profile_id=profile_id,
+            grant_type="path",
+        )
+    except Exception:  # noqa: BLE001 - grant store failures must not alter base policy
+        return policy
+    merged_scopes = [
+        {
+            "prefix": grant.value,
+            "actions": list(grant.actions),
+            "effect": grant.effect,
+            "source": "ttl_grant",
+            "grant_id": grant.grant_id,
+            "expires_at": grant.expires_at_iso(),
+        }
+        for grant in grants
+        if grant.matches_session(session_id)
+    ]
+    if not merged_scopes:
+        return policy
+    return policy.model_copy(
+        update={"path_scopes": [*(policy.path_scopes or []), *merged_scopes]}
     )
 
 

--- a/mcp_unified/policy_grants/__init__.py
+++ b/mcp_unified/policy_grants/__init__.py
@@ -6,6 +6,7 @@ from .models import (
     POLICY_GRANT_TYPES,
     PolicyGrant,
     PolicyGrantStore,
+    validate_grant_actions,
     validate_grant_request,
 )
 
@@ -16,5 +17,6 @@ __all__ = [
     "PolicyGrant",
     "PolicyGrantStore",
     "create_policy_grant_store",
+    "validate_grant_actions",
     "validate_grant_request",
 ]

--- a/mcp_unified/policy_grants/__init__.py
+++ b/mcp_unified/policy_grants/__init__.py
@@ -7,6 +7,7 @@ from .models import (
     PolicyGrant,
     PolicyGrantStore,
     validate_grant_actions,
+    validate_grant_effect,
     validate_grant_request,
 )
 
@@ -18,5 +19,6 @@ __all__ = [
     "PolicyGrantStore",
     "create_policy_grant_store",
     "validate_grant_actions",
+    "validate_grant_effect",
     "validate_grant_request",
 ]

--- a/mcp_unified/policy_grants/memory.py
+++ b/mcp_unified/policy_grants/memory.py
@@ -12,6 +12,7 @@ from .models import (
     PolicyGrant,
     PolicyGrantStore,
     validate_grant_actions,
+    validate_grant_effect,
     validate_grant_request,
 )
 
@@ -57,6 +58,7 @@ class InMemoryPolicyGrantStore:
             value=value,
         )
         normalized_actions = validate_grant_actions(grant_type, actions)
+        normalized_effect = validate_grant_effect(effect)
         now = time.time()
         ttl = max(1, int(ttl_seconds))
         grant = PolicyGrant(
@@ -68,7 +70,7 @@ class InMemoryPolicyGrantStore:
             expires_at=now + ttl,
             ttl_seconds=ttl,
             actions=normalized_actions,
-            effect=effect,
+            effect=normalized_effect,
             session_id=session_id,
             user_id=user_id,
             granted_by=granted_by,

--- a/mcp_unified/policy_grants/memory.py
+++ b/mcp_unified/policy_grants/memory.py
@@ -8,7 +8,12 @@ import time
 from collections.abc import Mapping
 from typing import Any
 
-from .models import PolicyGrant, PolicyGrantStore, validate_grant_request
+from .models import (
+    PolicyGrant,
+    PolicyGrantStore,
+    validate_grant_actions,
+    validate_grant_request,
+)
 
 
 class InMemoryPolicyGrantStore:
@@ -51,6 +56,7 @@ class InMemoryPolicyGrantStore:
             subject_type=subject_type,
             value=value,
         )
+        normalized_actions = validate_grant_actions(grant_type, actions)
         now = time.time()
         ttl = max(1, int(ttl_seconds))
         grant = PolicyGrant(
@@ -61,7 +67,7 @@ class InMemoryPolicyGrantStore:
             value=normalized_value,
             expires_at=now + ttl,
             ttl_seconds=ttl,
-            actions=tuple(actions),
+            actions=normalized_actions,
             effect=effect,
             session_id=session_id,
             user_id=user_id,

--- a/mcp_unified/policy_grants/models.py
+++ b/mcp_unified/policy_grants/models.py
@@ -147,7 +147,9 @@ def validate_grant_actions(grant_type: str, actions: tuple[str, ...]) -> tuple[s
     """Validate and normalize one grant request's action list."""
 
     normalized = tuple(
-        str(action or "").strip() for action in actions or () if str(action or "").strip()
+        str(action or "").strip().lower()
+        for action in actions or ()
+        if str(action or "").strip()
     )
     if grant_type != "path":
         return normalized
@@ -159,11 +161,25 @@ def validate_grant_actions(grant_type: str, actions: tuple[str, ...]) -> tuple[s
     return normalized
 
 
+def validate_grant_effect(effect: str) -> str:
+    """Validate and normalize one grant request's effect.
+
+    TTL-bound grants can only widen policy temporarily; deny effects belong
+    in the profile document, so anything except "allow" is rejected.
+    """
+
+    normalized = str(effect or "").strip().lower()
+    if normalized != "allow":
+        raise ValueError("policy grants only support effect 'allow'")
+    return normalized
+
+
 __all__ = [
     "APPROVAL_SUBJECT_TYPES",
     "POLICY_GRANT_TYPES",
     "PolicyGrant",
     "PolicyGrantStore",
     "validate_grant_actions",
+    "validate_grant_effect",
     "validate_grant_request",
 ]

--- a/mcp_unified/policy_grants/models.py
+++ b/mcp_unified/policy_grants/models.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Protocol
 
+from mcp_unified.profiles.path_grants import PATH_GRANT_ACTIONS, normalize_path_grant_prefix
 from mcp_unified.profiles.permission_rules import normalize_permission_subject_value
 
 POLICY_GRANT_TYPES = frozenset({"approval", "path"})
@@ -132,10 +133,30 @@ def validate_grant_request(
     else:
         if subject_type != "path":
             raise ValueError("path policy grants require subject_type 'path'")
-        normalized_value = value.strip() if isinstance(value, str) else ""
-        if not normalized_value:
-            raise ValueError("policy grant requires a non-empty value")
+        normalized_prefix = normalize_path_grant_prefix(value)
+        if normalized_prefix is None:
+            raise ValueError(
+                "path policy grants require a workspace-relative prefix "
+                "without '..' or absolute segments"
+            )
+        normalized_value = normalized_prefix
     return normalized_profile_id, grant_type, subject_type, normalized_value
+
+
+def validate_grant_actions(grant_type: str, actions: tuple[str, ...]) -> tuple[str, ...]:
+    """Validate and normalize one grant request's action list."""
+
+    normalized = tuple(
+        str(action or "").strip() for action in actions or () if str(action or "").strip()
+    )
+    if grant_type != "path":
+        return normalized
+    if not normalized:
+        raise ValueError("path policy grants require at least one action")
+    invalid = sorted(action for action in normalized if action not in PATH_GRANT_ACTIONS)
+    if invalid:
+        raise ValueError(f"unsupported path grant actions: {', '.join(invalid)}")
+    return normalized
 
 
 __all__ = [
@@ -143,5 +164,6 @@ __all__ = [
     "POLICY_GRANT_TYPES",
     "PolicyGrant",
     "PolicyGrantStore",
+    "validate_grant_actions",
     "validate_grant_request",
 ]

--- a/mcp_unified/policy_grants/sqlite.py
+++ b/mcp_unified/policy_grants/sqlite.py
@@ -23,7 +23,12 @@ from sqlalchemy import (
     select,
 )
 
-from .models import PolicyGrant, validate_grant_actions, validate_grant_request
+from .models import (
+    PolicyGrant,
+    validate_grant_actions,
+    validate_grant_effect,
+    validate_grant_request,
+)
 
 
 class SQLitePolicyGrantStore:
@@ -107,6 +112,7 @@ class SQLitePolicyGrantStore:
             value=value,
         )
         normalized_actions = validate_grant_actions(grant_type, actions)
+        normalized_effect = validate_grant_effect(effect)
         now_us = _now_us()
         ttl = max(1, int(ttl_seconds))
         grant = PolicyGrant(
@@ -118,7 +124,7 @@ class SQLitePolicyGrantStore:
             expires_at=(now_us + ttl * 1_000_000) / 1_000_000,
             ttl_seconds=ttl,
             actions=normalized_actions,
-            effect=effect,
+            effect=normalized_effect,
             session_id=session_id,
             user_id=user_id,
             granted_by=granted_by,

--- a/mcp_unified/policy_grants/sqlite.py
+++ b/mcp_unified/policy_grants/sqlite.py
@@ -23,7 +23,7 @@ from sqlalchemy import (
     select,
 )
 
-from .models import PolicyGrant, validate_grant_request
+from .models import PolicyGrant, validate_grant_actions, validate_grant_request
 
 
 class SQLitePolicyGrantStore:
@@ -106,6 +106,7 @@ class SQLitePolicyGrantStore:
             subject_type=subject_type,
             value=value,
         )
+        normalized_actions = validate_grant_actions(grant_type, actions)
         now_us = _now_us()
         ttl = max(1, int(ttl_seconds))
         grant = PolicyGrant(
@@ -116,7 +117,7 @@ class SQLitePolicyGrantStore:
             value=normalized_value,
             expires_at=(now_us + ttl * 1_000_000) / 1_000_000,
             ttl_seconds=ttl,
-            actions=tuple(actions),
+            actions=normalized_actions,
             effect=effect,
             session_id=session_id,
             user_id=user_id,

--- a/mcp_unified/profiles/path_grants.py
+++ b/mcp_unified/profiles/path_grants.py
@@ -97,6 +97,12 @@ def _as_action_list(value: Any) -> list[str]:
     return sorted({str(item or "").strip().lower() for item in raw_items if str(item or "").strip()})
 
 
+def normalize_path_grant_prefix(raw_value: Any) -> str | None:
+    """Public wrapper normalizing a workspace-relative path-grant prefix."""
+
+    return _normalize_path_prefix(raw_value)
+
+
 def _normalize_path_prefix(raw_value: Any) -> str | None:
     """Normalize a workspace-relative path-grant prefix."""
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -2837,3 +2837,106 @@ def test_gateway_cli_approval_grant_requires_persistent_store(
     assert exit_code == 1
     payload = json.loads(captured.err)
     assert payload["reason_code"] == "policy_grant_store_unavailable"
+
+
+def test_gateway_cli_path_grant_lifecycle(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Create, list, and revoke a TTL path grant through the CLI."""
+
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "store": {"kind": "memory"},
+                "policy_grants": {
+                    "kind": "sqlite",
+                    "sqlite_path": str(tmp_path / "grants.db"),
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = gateway_cli.main(
+        [
+            "create-path-grant",
+            "--config",
+            str(config_path),
+            "--profile",
+            "reviewer",
+            "--prefix",
+            "docs\\scratch/./sub",
+            "--actions",
+            "read,write",
+            "--ttl-seconds",
+            "900",
+            "--session-id",
+            "session-1",
+        ]
+    )
+    created = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    grant_payload = created["grant"]
+    assert grant_payload["grant_type"] == "path"
+    assert grant_payload["value"] == "docs/scratch/sub"
+    assert grant_payload["actions"] == ["read", "write"]
+    grant_id = grant_payload["grant_id"]
+
+    exit_code = gateway_cli.main(
+        [
+            "list-approval-grants",
+            "--config",
+            str(config_path),
+            "--grant-type",
+            "path",
+        ]
+    )
+    listed = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert [grant["grant_id"] for grant in listed["grants"]] == [grant_id]
+
+    exit_code = gateway_cli.main(
+        ["revoke-approval-grant", grant_id, "--config", str(config_path)]
+    )
+    assert exit_code == 0
+    capsys.readouterr()
+
+
+def test_gateway_cli_path_grant_rejects_invalid_actions(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Fail closed on invalid path grant actions."""
+
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "store": {"kind": "memory"},
+                "policy_grants": {
+                    "kind": "sqlite",
+                    "sqlite_path": str(tmp_path / "grants.db"),
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = gateway_cli.main(
+        [
+            "create-path-grant",
+            "--config",
+            str(config_path),
+            "--profile",
+            "reviewer",
+            "--prefix",
+            "docs/scratch",
+            "--actions",
+            "read,launch_missiles",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert json.loads(captured.err)["reason_code"] == "invalid_policy_grant"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -5872,6 +5872,8 @@ def test_gateway_profile_runtime_failing_grant_store_fails_closed_to_denial() ->
 
 
 def _path_grant_runtime(profile_path_scopes: list[dict[str, Any]] | None = None) -> tuple[Any, Any, Any]:
+    """Build a grant-store-backed runtime around one fs.read_text reviewer profile."""
+
     from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
     from mcp_unified.policy_grants import InMemoryPolicyGrantStore
     from mcp_unified.profiles.models import MCPProfile, ProfilePolicy
@@ -5895,6 +5897,8 @@ def _path_grant_runtime(profile_path_scopes: list[dict[str, Any]] | None = None)
 
 
 def _delegated_path_scopes(backend: Any) -> list[dict[str, Any]]:
+    """Return the path scopes from the last delegated call's effective policy."""
+
     from mcp_unified.gateway.profile_runtime import EFFECTIVE_POLICY_METADATA_KEY
 
     delegated_context = backend.call_requests[-1][2]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py
@@ -5840,6 +5840,9 @@ def test_gateway_profile_runtime_failing_grant_store_fails_closed_to_denial() ->
         def find_active_grant(self, **kwargs: Any) -> Any:
             raise RuntimeError("grant store unavailable")
 
+        def list_active_grants(self, **kwargs: Any) -> Any:
+            raise RuntimeError("grant store unavailable")
+
     backend = _CustomToolListGatewayRuntime([_web_fetch_tool_descriptor()])
     profile = _profile_with_allowed_tools_and_permission_rules(
         "researcher",
@@ -5866,3 +5869,108 @@ def test_gateway_profile_runtime_failing_grant_store_fails_closed_to_denial() ->
     _assert_jsonrpc_error(body, code=-32001, request_id="ask-store-failure")
     assert body["error"]["data"]["status"] == "approval_required"
     assert backend.call_requests == []
+
+
+def _path_grant_runtime(profile_path_scopes: list[dict[str, Any]] | None = None) -> tuple[Any, Any, Any]:
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+    from mcp_unified.profiles.models import MCPProfile, ProfilePolicy
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    backend = _CustomToolListGatewayRuntime([_read_text_tool_descriptor()])
+    profile = MCPProfile(
+        id="reviewer",
+        name="Profile reviewer",
+        policy_document=ProfilePolicy(allowed_tools=["fs.read_text"]),
+        path_scopes=profile_path_scopes or [],
+    )
+    grant_store = InMemoryPolicyGrantStore()
+    runtime = ProfileAwareGatewayRuntime(
+        backend,
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="reviewer",
+        policy_grant_store=grant_store,
+    )
+    return runtime, backend, grant_store
+
+
+def _delegated_path_scopes(backend: Any) -> list[dict[str, Any]]:
+    from mcp_unified.gateway.profile_runtime import EFFECTIVE_POLICY_METADATA_KEY
+
+    delegated_context = backend.call_requests[-1][2]
+    effective_policy = delegated_context.metadata[EFFECTIVE_POLICY_METADATA_KEY]
+    return effective_policy["path_scopes"]
+
+
+def test_gateway_profile_runtime_merges_ttl_path_grants_into_effective_policy() -> None:
+    runtime, backend, grant_store = _path_grant_runtime(
+        profile_path_scopes=[{"prefix": "docs/manuals", "actions": ["read"], "effect": "allow"}]
+    )
+    grant = grant_store.create_grant(
+        profile_id="reviewer",
+        grant_type="path",
+        subject_type="path",
+        value="docs/scratch",
+        actions=("read", "write"),
+        ttl_seconds=900,
+    )
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        allowed = _post_tool_call(
+            client,
+            "fs.read_text",
+            {"path": "docs/scratch/notes.txt", "query": "notes"},
+            "ttl-path-grant-merged",
+        )
+
+    assert allowed.json().get("error") is None
+    path_scopes = _delegated_path_scopes(backend)
+    assert {"prefix": "docs/manuals", "actions": ["read"], "effect": "allow"} in path_scopes
+    merged = [scope for scope in path_scopes if scope.get("source") == "ttl_grant"]
+    assert len(merged) == 1
+    assert merged[0]["prefix"] == "docs/scratch"
+    assert merged[0]["actions"] == ["read", "write"]
+    assert merged[0]["effect"] == "allow"
+    assert merged[0]["grant_id"] == grant.grant_id
+    assert merged[0]["expires_at"] == grant.expires_at_iso()
+
+
+def test_gateway_profile_runtime_skips_inapplicable_ttl_path_grants(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import mcp_unified.policy_grants.memory as memory_grants
+
+    runtime, backend, grant_store = _path_grant_runtime()
+    grant_store.create_grant(
+        profile_id="reviewer",
+        grant_type="path",
+        subject_type="path",
+        value="docs/other-session",
+        actions=("read",),
+        ttl_seconds=900,
+        session_id="session-1",
+    )
+    monkeypatch.setattr(memory_grants.time, "time", lambda: 1_000.0)
+    grant_store.create_grant(
+        profile_id="reviewer",
+        grant_type="path",
+        subject_type="path",
+        value="docs/expired",
+        actions=("read",),
+        ttl_seconds=10,
+    )
+    monkeypatch.setattr(memory_grants.time, "time", lambda: 1_011.0)
+    app = create_gateway_app(runtime, prefix="/mcp")
+
+    with TestClient(app) as client:
+        allowed = _post_tool_call(
+            client,
+            "fs.read_text",
+            {"path": "docs/anything.txt", "query": "notes"},
+            "ttl-path-grant-skipped",
+        )
+
+    assert allowed.json().get("error") is None
+    path_scopes = _delegated_path_scopes(backend)
+    assert [scope for scope in path_scopes if scope.get("source") == "ttl_grant"] == []

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_grant_manager.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_grant_manager.py
@@ -236,3 +236,65 @@ def test_bootstrap_profile_gateway_wires_policy_grant_store() -> None:
     result = asyncio.run(_exercise())
     assert result is not None
     assert backend.calls == ["web.fetch"]
+
+
+def test_policy_grant_manager_grant_path_lifecycle_with_audit() -> None:
+    from mcp_unified.gateway.policy_grants import GatewayPolicyGrantManager
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    audit_store = _RecordingAuditStore()
+    manager = GatewayPolicyGrantManager(
+        policy_grant_store=InMemoryPolicyGrantStore(),
+        audit_store=audit_store,
+    )
+
+    created = asyncio.run(
+        manager.grant_path(
+            profile_id="reviewer",
+            prefix="docs\\scratch/./sub",
+            actions=("read", "write"),
+            ttl_seconds=900,
+            session_id="session-1",
+            granted_by="operator",
+            reason="one-off scratch access",
+        )
+    )
+    grant_payload = created["grant"]
+    assert grant_payload["grant_type"] == "path"
+    assert grant_payload["value"] == "docs/scratch/sub"
+    assert grant_payload["actions"] == ["read", "write"]
+    assert grant_payload["session_id"] == "session-1"
+
+    listed = asyncio.run(manager.list_grants(profile_id="reviewer", grant_type="path"))
+    assert [grant["grant_id"] for grant in listed["grants"]] == [grant_payload["grant_id"]]
+
+    assert "policy_grant.path.created" in [event.event_type for event in audit_store.events]
+
+
+def test_policy_grant_manager_grant_path_rejects_invalid_requests() -> None:
+    from mcp_unified.gateway.policy_grants import (
+        GatewayPolicyGrantManagementError,
+        GatewayPolicyGrantManager,
+    )
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    manager = GatewayPolicyGrantManager(policy_grant_store=InMemoryPolicyGrantStore())
+
+    with pytest.raises(GatewayPolicyGrantManagementError) as excinfo:
+        asyncio.run(
+            manager.grant_path(
+                profile_id="reviewer",
+                prefix="/etc/passwd",
+                actions=("read",),
+            )
+        )
+    assert excinfo.value.reason_code == "invalid_policy_grant"
+
+    with pytest.raises(GatewayPolicyGrantManagementError):
+        asyncio.run(
+            manager.grant_path(
+                profile_id="reviewer",
+                prefix="docs/scratch",
+                actions=("launch_missiles",),
+            )
+        )

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_policy_grant_stores.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_policy_grant_stores.py
@@ -558,3 +558,44 @@ def test_memory_store_rejects_invalid_path_grant_actions() -> None:
             actions=(),
             ttl_seconds=900,
         )
+
+
+def test_memory_store_normalizes_action_case() -> None:
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    store = InMemoryPolicyGrantStore()
+    grant = store.create_grant(
+        profile_id="reviewer",
+        grant_type="path",
+        subject_type="path",
+        value="docs/scratch",
+        actions=("READ", " Write "),
+        ttl_seconds=900,
+    )
+    assert grant.actions == ("read", "write")
+
+
+def test_memory_store_rejects_non_allow_effects() -> None:
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    store = InMemoryPolicyGrantStore()
+    for invalid_effect in ("deny", "bogus", ""):
+        with pytest.raises(ValueError):
+            store.create_grant(
+                profile_id="reviewer",
+                grant_type="path",
+                subject_type="path",
+                value="docs/scratch",
+                actions=("read",),
+                effect=invalid_effect,
+                ttl_seconds=900,
+            )
+    allowed = store.create_grant(
+        profile_id="reviewer",
+        grant_type="approval",
+        subject_type="tool",
+        value="web.fetch",
+        effect="Allow",
+        ttl_seconds=900,
+    )
+    assert allowed.effect == "allow"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_policy_grant_stores.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_policy_grant_stores.py
@@ -496,3 +496,65 @@ def test_sqlite_store_read_paths_do_not_delete_expired_rows(
         assert _row_count() == 1
     finally:
         store.close()
+def test_memory_store_normalizes_path_grant_prefix() -> None:
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    store = InMemoryPolicyGrantStore()
+    grant = store.create_grant(
+        profile_id="reviewer",
+        grant_type="path",
+        subject_type="path",
+        value="docs\\scratch/./sub/",
+        actions=("read", "write"),
+        ttl_seconds=900,
+    )
+    assert grant.value == "docs/scratch/sub"
+    assert grant.actions == ("read", "write")
+
+    found = store.find_active_grant(
+        profile_id="reviewer",
+        grant_type="path",
+        subject_type="path",
+        value="docs/scratch/sub",
+    )
+    assert found is not None
+
+
+def test_memory_store_rejects_unsafe_path_grant_values() -> None:
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    store = InMemoryPolicyGrantStore()
+    for unsafe_value in ("/etc/passwd", "../outside", "C:/windows", "  "):
+        with pytest.raises(ValueError):
+            store.create_grant(
+                profile_id="reviewer",
+                grant_type="path",
+                subject_type="path",
+                value=unsafe_value,
+                actions=("read",),
+                ttl_seconds=900,
+            )
+
+
+def test_memory_store_rejects_invalid_path_grant_actions() -> None:
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    store = InMemoryPolicyGrantStore()
+    with pytest.raises(ValueError):
+        store.create_grant(
+            profile_id="reviewer",
+            grant_type="path",
+            subject_type="path",
+            value="docs/scratch",
+            actions=("read", "launch_missiles"),
+            ttl_seconds=900,
+        )
+    with pytest.raises(ValueError):
+        store.create_grant(
+            profile_id="reviewer",
+            grant_type="path",
+            subject_type="path",
+            value="docs/scratch",
+            actions=(),
+            ttl_seconds=900,
+        )


### PR DESCRIPTION
## Summary
- Reuse the policy grant store from #2345 with `grant_type="path"` so operators can issue temporary, optionally session-scoped filesystem access without editing profiles (backlog TASK-2301).
- Prefixes are normalized and validated like authored path grants via the new public `normalize_path_grant_prefix()` (rejecting absolute paths, Windows drive prefixes, and `..`); actions are validated against the file-policy action taxonomy and at least one is required.
- The gateway runtime merges active applicable grants into the delegated effective policy's `path_scopes` as `{prefix, actions, effect, source: "ttl_grant", grant_id, expires_at}` after policy resolution, keeping `build_effective_policy_result()` pure. Expired and session-mismatched grants are excluded; store failures never widen the base policy.
- CLI: new `create-path-grant` verb (profile, prefix, comma-separated actions, TTL, session scope) plus a `--grant-type` filter on `list-approval-grants`; `revoke-approval-grant` works for both grant types. Audit events on create and revoke.

**Stacked on #2345** (shares the `mcp_unified/policy_grants/` store); GitHub will retarget to `dev` when that merges.

## Test Plan
- [x] Combined MCP gateway suite (392 passed, re-verified after rebase)
- [x] `python -m ruff check` over touched modules and tests
- [x] `python -m compileall -q` over touched modules
- [x] `python -m bandit -r mcp_unified/policy_grants/ mcp_unified/gateway/policy_grants.py mcp_unified/gateway/profile_runtime.py -q` (no findings)
- [x] `git diff --check`

## Deferred
- Temporary deny-effect grants (permanent deny belongs in the profile).
- Surfacing TTL grants in the effective permission preview endpoint.
- ToolUseEvent marker when a merged grant is consulted by the downstream path enforcer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds TTL-bound, optionally session-scoped path grants that merge into the effective policy at runtime so operators can grant temporary filesystem access without editing profiles. Implements TASK-2301 using the shared store from TASK-2351.

- **New Features**
  - Store: reuse `mcp_unified/policy_grants/` with `grant_type="path"`; prefixes validated via `normalize_path_grant_prefix()`; actions validated via `validate_grant_actions()` against `PATH_GRANT_ACTIONS`.
  - Runtime: merge active applicable path grants into `path_scopes` as `{prefix, actions, effect, source: "ttl_grant", grant_id, expires_at}` after policy resolution; expired/session-mismatched skipped; store failures never widen policy.
  - CLI: `create-path-grant` (profile, prefix, `actions`, TTL, optional session); `list-approval-grants` adds `--grant-type`; `revoke-approval-grant` works for both types; audit events on create/revoke; TTL clamped to [60, 86400] seconds (default 900).

- **Bug Fixes**
  - Validation: effect must be `allow` via `validate_grant_effect()`; actions normalized to lowercase.
  - Runtime: guard merge when policy lacks `path_scopes`; on grant-store errors, log and delegate the base policy unchanged.

<sup>Written for commit 83987e1c2cc39bfa8f065984e980dabf83a921da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

