### PR TITLE
Add MCP policy simulation CLI and shared subject extraction

### DIFF
--- a/backlog/tasks/task-2303 - Add-MCP-policy-simulation-CLI-and-admin-harness.md
+++ b/backlog/tasks/task-2303 - Add-MCP-policy-simulation-CLI-and-admin-harness.md
@@ -1,7 +1,8 @@
 ---
 id: TASK-2303
 title: Add MCP policy simulation CLI and admin harness
-status: To Do
+status: Done
+updated_date: '2026-06-11'
 labels:
 - mcp
 - policy
@@ -10,6 +11,10 @@ labels:
 - followup
 references:
 - Docs/superpowers/specs/2026-06-07-mcp-fs-patch-write-safe-edit-tools-design.md
+dependencies:
+- TASK-2349
+- TASK-2351
+- TASK-2301
 ---
 
 ## Description
@@ -20,26 +25,47 @@ Add policy simulation tooling, for example `mcp policy simulate --profile backen
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 Operators can simulate one profile policy decision for a hypothetical tool call (tool, paths, urls, command/argv, raw arguments JSON) through the gateway CLI and receive a deterministic JSON verdict.
+- [x] #2 The simulation pipeline mirrors runtime ordering (legacy tool/capability decision, then permission-rule subjects, then approval-lease and TTL path-grant overlays) and reuses the same enforcement and merge code so verdicts cannot drift; a parity test asserts harness verdicts match actual runtime call outcomes.
+- [x] #3 Output reports overall status (allowed/denied/approval_required), legacy policy status, per-subject decisions with matched rules and reason codes, approval lease markers, and merged effective path scopes including TTL grants.
+- [x] #4 Simulation is read-only: it never writes audit events or consumes leases; unknown profiles produce a structured profile_not_found error.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Anti-drift extraction: moved the permission-rule subject extraction (subject key sets, bounds constants, limit error, and helpers) from `gateway/profile_runtime.py` into a new shared `mcp_unified/profiles/subjects.py` with public names (`extract_permission_rule_subjects`, `PermissionSubjectLimitError`, `MAX_PERMISSION_SUBJECTS` / `MAX_SUBJECT_VALUE_LENGTH` / `MAX_COMMAND_ARGV_TOKENS`). The runtime imports from there, so enforcement and simulation share one extractor. Refactor verified by the existing gateway suite staying green (191 tests) before the harness work continued.
 
+Harness: new `mcp_unified/gateway/policy_simulation.py` `simulate_tool_call_policy(profile, tool_name, arguments, *, capability, policy_grant_store, session_id)`. It runs `build_effective_policy_result()` for the legacy decision, compiles permission rules (compile failure simulates as denied/invalid_permission_rules), reports informational per-subject decisions via `evaluate_permission_rule_decision` (unmatched subjects shown as effective "allow"), then derives the actual verdict by calling the runtime's own `_enforce_permission_rules_for_tool_call` (catching `GatewayPolicyDenied` and surfacing its `to_error_data()` payload), and finally reports merged path scopes via the runtime's `_policy_with_ttl_path_grants`. The parity test runs five (tool, arguments) cases through both the harness and a real `ProfileAwareGatewayRuntime.call_tool` and asserts identical statuses, covering allow, path deny, ask without lease, ask satisfied by lease, and legacy tool denial.
+
+CLI: `simulate-policy --profile --tool [--path]... [--url]... [--command] [--argv-json] [--arguments-json] [--capability] [--session-id] --config`. The handler loads the gateway config, seeds `config.profiles` into the resolved profile store (so pure-JSON configs are simulatable), loads the profile (structured `profile_not_found` error otherwise), builds the optional policy grant store from `policy_grants`, and emits the harness payload as JSON. Simulation does not require a persistent grant store; without one, ask decisions simulate as approval_required.
+
+TDD evidence:
+- Red: 8 tests in new test_gateway_policy_simulation.py and 2 CLI tests failed with missing modules/subcommands; green after.
+- Refactor safety: test_gateway_fastapi_package.py (191 tests incl. all subject-bound and permission-rule cases) green after the subjects.py extraction.
+
+Verification:
+- Combined suite (test_gateway_fastapi_package, test_gateway_cli_package, test_policy_grant_stores, test_gateway_policy_grant_manager, test_gateway_policy_simulation, test_profile_permission_rules, test_profile_policy_decisions, test_filesystem_lock_managers) passed with 402 tests; re-run 5x green. One unreproducible single failure of test_gateway_cli_path_grant_lifecycle was observed in one combined run immediately after the slice landed (passed in isolation, file-level, and 8 subsequent attempts) — recorded here as a watch item.
+- Ruff over all touched modules and tests passed.
+- `python -m compileall -q` over touched modules passed.
+- Bandit over profiles/subjects.py and gateway/policy_simulation.py reported no findings.
+- `git diff --check` passed.
+
+Deferred: human-readable table output (CLI emits JSON like all other verbs); `--action` evaluation against merged path scopes (path scopes are reported for operator inspection; action-level path-enforcer simulation needs the downstream enforcer contract); remote admin endpoint for simulation.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Added a read-only policy simulation harness and simulate-policy CLI verb that mirror the gateway runtime decision pipeline by reusing the shared subject extractor (newly extracted to profiles/subjects.py), the runtime enforcement function, and the TTL path-grant merge, with a parity test pinning harness verdicts to actual runtime outcomes across allow/deny/ask/lease/legacy-denial cases.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/mcp_unified/gateway/cli.py
+++ b/mcp_unified/gateway/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import inspect
 import json
 import os
 import sys
@@ -1156,9 +1157,14 @@ def _handle_simulate_policy(args: argparse.Namespace) -> int:
         try:
             config = load_gateway_profile_bootstrap_config(config_path)
             profile_bundle = build_gateway_profile_storage(config.store)
-            for seeded_profile in config.profiles:
-                _run_async(profile_bundle.profile_store.upsert_profile(seeded_profile))
+            # Simulation is read-only: never write config profiles into the
+            # store; fall back to the config document in memory instead.
             profile = _run_async(profile_bundle.profile_store.get_profile(profile_id))
+            if profile is None:
+                for config_profile in config.profiles:
+                    if config_profile.id == profile_id:
+                        profile = config_profile.model_copy(deep=True)
+                        break
             if profile is None:
                 _emit_json(
                     {
@@ -1193,13 +1199,25 @@ def _handle_simulate_policy(args: argparse.Namespace) -> int:
     finally:
         if profile_bundle is not None:
             _run_async(_close_storage_bundle(profile_bundle))
-        close_grant_store = getattr(grant_store, "close", None)
-        if callable(close_grant_store):
-            close_grant_store()
+        _close_policy_grant_store(grant_store)
+
+
+def _close_policy_grant_store(grant_store: Any) -> None:
+    """Close a policy grant store, awaiting coroutine-style close methods."""
+
+    close_grant_store = getattr(grant_store, "close", None)
+    if not callable(close_grant_store):
+        return
+    result = close_grant_store()
+    if inspect.iscoroutine(result):
+        _run_async(result)
 
 
 def _simulation_arguments_from_args(args: argparse.Namespace) -> dict[str, Any]:
-    """Build the simulated tool-call arguments from CLI flags."""
+    """Build the simulated tool-call arguments from CLI flags.
+
+    Explicit convenience flags override keys supplied via --arguments-json.
+    """
 
     arguments: dict[str, Any] = {}
     if args.arguments_json:
@@ -1212,16 +1230,16 @@ def _simulation_arguments_from_args(args: argparse.Namespace) -> dict[str, Any]:
         arguments.update(parsed)
     paths = [path for path in (args.path or []) if path.strip()]
     if len(paths) == 1:
-        arguments.setdefault("path", paths[0])
+        arguments["path"] = paths[0]
     elif paths:
-        arguments.setdefault("paths", paths)
+        arguments["paths"] = paths
     urls = [url for url in (args.url or []) if url.strip()]
     if len(urls) == 1:
-        arguments.setdefault("url", urls[0])
+        arguments["url"] = urls[0]
     elif urls:
-        arguments.setdefault("urls", urls)
+        arguments["urls"] = urls
     if args.command and args.command.strip():
-        arguments.setdefault("command", args.command.strip())
+        arguments["command"] = args.command.strip()
     if args.argv_json:
         try:
             argv = json.loads(args.argv_json)
@@ -1229,7 +1247,7 @@ def _simulation_arguments_from_args(args: argparse.Namespace) -> dict[str, Any]:
             raise ValueError(f"argv-json is not valid JSON: {exc}") from exc
         if not isinstance(argv, list) or not all(isinstance(token, str) for token in argv):
             raise ValueError("argv-json must be a JSON array of strings")
-        arguments.setdefault("argv", argv)
+        arguments["argv"] = argv
     return arguments
 
 
@@ -1293,9 +1311,7 @@ def _handle_policy_grant_command(
     finally:
         if profile_bundle is not None:
             _run_async(_close_storage_bundle(profile_bundle))
-        close_grant_store = getattr(grant_store, "close", None)
-        if callable(close_grant_store):
-            close_grant_store()
+        _close_policy_grant_store(grant_store)
 
 
 def _handle_export_config(args: argparse.Namespace) -> int:

--- a/mcp_unified/gateway/cli.py
+++ b/mcp_unified/gateway/cli.py
@@ -54,6 +54,7 @@ from .policy_grants import (
     GatewayPolicyGrantManagementError,
     GatewayPolicyGrantManager,
 )
+from .policy_simulation import simulate_tool_call_policy
 from .profiles import GatewayProfileManagementError, GatewayProfileManager
 from .remote_admin import (
     RemoteGatewayAdminClient,
@@ -510,6 +511,53 @@ def _build_parser() -> _JsonArgumentParser:
     )
     _add_profile_config_argument(revoke_approval_grant)
     revoke_approval_grant.set_defaults(handler=_handle_revoke_approval_grant)
+
+    simulate_policy = subparsers.add_parser(
+        "simulate-policy",
+        help="Simulate one profile policy decision for a hypothetical tool call.",
+    )
+    simulate_policy.add_argument(
+        "--profile",
+        required=True,
+        help="Profile id to simulate against.",
+    )
+    simulate_policy.add_argument(
+        "--tool",
+        required=True,
+        help="Tool name for the simulated call.",
+    )
+    simulate_policy.add_argument(
+        "--path",
+        action="append",
+        help="Path argument for the simulated call (repeatable).",
+    )
+    simulate_policy.add_argument(
+        "--url",
+        action="append",
+        help="URL argument for the simulated call (repeatable).",
+    )
+    simulate_policy.add_argument(
+        "--command",
+        help="Shell command string argument for the simulated call.",
+    )
+    simulate_policy.add_argument(
+        "--argv-json",
+        help="JSON array of argv tokens for the simulated call.",
+    )
+    simulate_policy.add_argument(
+        "--arguments-json",
+        help="JSON object of raw tool arguments (merged with convenience flags).",
+    )
+    simulate_policy.add_argument(
+        "--capability",
+        help="Optional advertised tool capability for capability-based profiles.",
+    )
+    simulate_policy.add_argument(
+        "--session-id",
+        help="Optional session id for session-scoped grants.",
+    )
+    _add_profile_config_argument(simulate_policy)
+    simulate_policy.set_defaults(handler=_handle_simulate_policy)
 
     export_config = subparsers.add_parser(
         "export-config",
@@ -1083,6 +1131,106 @@ def _handle_revoke_approval_grant(args: argparse.Namespace) -> int:
         args,
         lambda manager: manager.revoke_grant(grant_id),
     )
+
+
+def _handle_simulate_policy(args: argparse.Namespace) -> int:
+    """Simulate one profile policy decision for a hypothetical tool call."""
+
+    profile_id = _require_cli_text(args.profile, field="profile")
+    tool_name = _require_cli_text(args.tool, field="tool")
+    capability = _optional_cli_text(args.capability, field="capability")
+    session_id = _optional_cli_text(args.session_id, field="session_id")
+    try:
+        arguments = _simulation_arguments_from_args(args)
+    except ValueError as exc:
+        _emit_json(
+            {"ok": False, "error": str(exc), "reason_code": "invalid_simulation_arguments"},
+            sys.stderr,
+        )
+        return 1
+
+    config_path = _config_path_from_args(args)
+    profile_bundle: GatewayProfileStorageBundle | None = None
+    grant_store: Any = None
+    try:
+        try:
+            config = load_gateway_profile_bootstrap_config(config_path)
+            profile_bundle = build_gateway_profile_storage(config.store)
+            for seeded_profile in config.profiles:
+                _run_async(profile_bundle.profile_store.upsert_profile(seeded_profile))
+            profile = _run_async(profile_bundle.profile_store.get_profile(profile_id))
+            if profile is None:
+                _emit_json(
+                    {
+                        "ok": False,
+                        "error": f"Profile not found: {profile_id}",
+                        "reason_code": "profile_not_found",
+                        "profile_id": profile_id,
+                    },
+                    sys.stderr,
+                )
+                return 1
+            grant_store = build_gateway_policy_grant_store(config.policy_grants)
+        except _CliArgumentError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            _emit_json(
+                {"error": str(exc), "ok": False, "path": str(config_path)},
+                sys.stderr,
+            )
+            return 1
+
+        payload = simulate_tool_call_policy(
+            profile,
+            tool_name,
+            arguments,
+            capability=capability,
+            policy_grant_store=grant_store,
+            session_id=session_id,
+        )
+        _emit_json(_cli_payload(payload), sys.stdout)
+        return 0
+    finally:
+        if profile_bundle is not None:
+            _run_async(_close_storage_bundle(profile_bundle))
+        close_grant_store = getattr(grant_store, "close", None)
+        if callable(close_grant_store):
+            close_grant_store()
+
+
+def _simulation_arguments_from_args(args: argparse.Namespace) -> dict[str, Any]:
+    """Build the simulated tool-call arguments from CLI flags."""
+
+    arguments: dict[str, Any] = {}
+    if args.arguments_json:
+        try:
+            parsed = json.loads(args.arguments_json)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"arguments-json is not valid JSON: {exc}") from exc
+        if not isinstance(parsed, dict):
+            raise ValueError("arguments-json must be a JSON object")
+        arguments.update(parsed)
+    paths = [path for path in (args.path or []) if path.strip()]
+    if len(paths) == 1:
+        arguments.setdefault("path", paths[0])
+    elif paths:
+        arguments.setdefault("paths", paths)
+    urls = [url for url in (args.url or []) if url.strip()]
+    if len(urls) == 1:
+        arguments.setdefault("url", urls[0])
+    elif urls:
+        arguments.setdefault("urls", urls)
+    if args.command and args.command.strip():
+        arguments.setdefault("command", args.command.strip())
+    if args.argv_json:
+        try:
+            argv = json.loads(args.argv_json)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"argv-json is not valid JSON: {exc}") from exc
+        if not isinstance(argv, list) or not all(isinstance(token, str) for token in argv):
+            raise ValueError("argv-json must be a JSON array of strings")
+        arguments.setdefault("argv", argv)
+    return arguments
 
 
 def _handle_policy_grant_command(

--- a/mcp_unified/gateway/policy_simulation.py
+++ b/mcp_unified/gateway/policy_simulation.py
@@ -146,7 +146,7 @@ def _subject_details(
                 "subject_type": subject_type,
                 "value": value,
                 "outcome": effective_outcome,
-                "reason_code": decision.reason_code,
+                "reason_code": decision.reason_code if decision.matched_rules else None,
                 "matched_rules": [
                     matched_rule.model_dump(mode="json", exclude_none=True)
                     for matched_rule in decision.matched_rules

--- a/mcp_unified/gateway/policy_simulation.py
+++ b/mcp_unified/gateway/policy_simulation.py
@@ -1,0 +1,159 @@
+"""Read-only policy simulation harness for the standalone MCP gateway.
+
+The harness mirrors the runtime tool-call decision pipeline by reusing the
+same legacy policy resolution, permission-rule enforcement, and TTL grant
+merge code the gateway executes, so simulated verdicts cannot drift from
+runtime behavior. It never writes audit events or consumes leases.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp_unified.policy_grants import PolicyGrantStore
+from mcp_unified.profiles.models import MCPProfile
+from mcp_unified.profiles.permission_rules import (
+    compile_permission_rules,
+    evaluate_permission_rule_decision,
+)
+from mcp_unified.profiles.resolution import build_effective_policy_result
+from mcp_unified.profiles.subjects import (
+    PermissionSubjectLimitError,
+    extract_permission_rule_subjects,
+)
+
+from .profile_runtime import (
+    _enforce_permission_rules_for_tool_call,
+    _policy_with_ttl_path_grants,
+)
+from .runtime import GatewayPolicyDenied
+
+
+def simulate_tool_call_policy(
+    profile: MCPProfile,
+    tool_name: str,
+    arguments: dict[str, Any],
+    *,
+    capability: str | None = None,
+    policy_grant_store: PolicyGrantStore | None = None,
+    session_id: str | None = None,
+) -> dict[str, Any]:
+    """Simulate one gateway tool-call policy decision without executing it."""
+
+    result: dict[str, Any] = {
+        "profile_id": profile.id,
+        "tool_name": tool_name,
+        "legacy_policy": None,
+        "subjects": [],
+        "approval_grant_markers": [],
+        "path_scopes": [],
+        "denial": None,
+        "overall": {"status": "allowed", "reason_code": None},
+    }
+
+    legacy_result = build_effective_policy_result(
+        profile,
+        tool_name=tool_name,
+        capability=capability,
+    )
+    result["legacy_policy"] = {
+        "status": legacy_result.status,
+        "reason_code": legacy_result.reason_code,
+    }
+    if legacy_result.status != "resolved":
+        result["overall"] = {
+            "status": "denied",
+            "reason_code": legacy_result.reason_code,
+        }
+        return result
+
+    try:
+        rules = (
+            tuple(compile_permission_rules(profile.policy_document))
+            if profile.policy_document is not None
+            else ()
+        )
+    except ValueError:
+        result["overall"] = {
+            "status": "denied",
+            "reason_code": "invalid_permission_rules",
+        }
+        return result
+
+    result["subjects"] = _subject_details(tool_name, arguments, rules)
+
+    try:
+        result["approval_grant_markers"] = _enforce_permission_rules_for_tool_call(
+            profile,
+            tool_name,
+            arguments,
+            rules,
+            policy_grant_store=policy_grant_store,
+            session_id=session_id,
+        )
+    except GatewayPolicyDenied as exc:
+        result["denial"] = exc.to_error_data()
+        result["overall"] = {"status": exc.status, "reason_code": exc.reason_code}
+
+    merged_policy = _policy_with_ttl_path_grants(
+        legacy_result.policy,
+        policy_grant_store,
+        profile_id=profile.id,
+        session_id=session_id,
+    )
+    if merged_policy is not None:
+        result["path_scopes"] = [dict(scope) for scope in merged_policy.path_scopes or []]
+    return result
+
+
+def _subject_details(
+    tool_name: str,
+    arguments: dict[str, Any],
+    rules: tuple[Any, ...],
+) -> list[dict[str, Any]]:
+    """Return per-subject decision detail for one simulated tool call."""
+
+    if not rules:
+        return []
+    try:
+        subjects = extract_permission_rule_subjects(tool_name, arguments)
+    except PermissionSubjectLimitError:
+        return []
+
+    details: list[dict[str, Any]] = []
+    for subject_type, value, argv in subjects:
+        try:
+            decision = evaluate_permission_rule_decision(
+                rules,
+                subject_type=subject_type,
+                value=value,
+                argv=argv,
+            )
+        except ValueError:
+            details.append(
+                {
+                    "subject_type": subject_type,
+                    "value": value,
+                    "outcome": "error",
+                    "reason_code": "invalid_permission_rule_subject",
+                    "matched_rules": [],
+                }
+            )
+            continue
+        effective_outcome = decision.outcome if decision.matched_rules else "allow"
+        details.append(
+            {
+                "subject_type": subject_type,
+                "value": value,
+                "outcome": effective_outcome,
+                "reason_code": decision.reason_code,
+                "matched_rules": [
+                    matched_rule.model_dump(mode="json", exclude_none=True)
+                    for matched_rule in decision.matched_rules
+                ],
+            }
+        )
+    return details
+
+
+__all__ = ["simulate_tool_call_policy"]

--- a/mcp_unified/gateway/profile_runtime.py
+++ b/mcp_unified/gateway/profile_runtime.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 from collections import OrderedDict
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from copy import deepcopy
 from typing import Any, Protocol
 
@@ -16,7 +16,6 @@ from mcp_unified.policy_grants import PolicyGrantStore
 from mcp_unified.profiles.decisions import PolicyDecisionRule
 from mcp_unified.profiles.models import MCPProfile
 from mcp_unified.profiles.permission_rules import (
-    PermissionRuleSubject,
     compile_permission_rules,
     evaluate_permission_rule_decision,
 )
@@ -26,6 +25,10 @@ from mcp_unified.profiles.resolution import (
     build_effective_policy_result,
 )
 from mcp_unified.profiles.resolver import StoreBackedProfileResolver
+from mcp_unified.profiles.subjects import (
+    PermissionSubjectLimitError,
+    extract_permission_rule_subjects,
+)
 from mcp_unified.tool_use_reporting.sanitization import sanitize_safe_id
 
 from .runtime import GatewayPolicyDenied, GatewayRequestContext, GatewayRuntime
@@ -64,30 +67,7 @@ _TOOL_CALL_ARGUMENT_KEYS = frozenset({"tool_id", "arguments"})
 _TOOL_SEARCH_ARGUMENT_KEYS = frozenset({"query", "category", "limit"})
 _TOOL_DESCRIBE_ARGUMENT_KEYS = frozenset({"tool_id"})
 _EMPTY_ARGUMENT_KEYS = frozenset()
-_PATH_ARGUMENT_KEYS = frozenset(
-    {
-        "path",
-        "file",
-        "file_path",
-        "filepath",
-        "filename",
-        "base_path",
-        "target_path",
-        "source_path",
-        "destination_path",
-        "new_path",
-        "old_path",
-    }
-)
-_PATH_ARGUMENT_LIST_KEYS = frozenset({"paths", "files", "file_paths"})
-_DOMAIN_ARGUMENT_KEYS = frozenset({"url", "uri", "domain", "host", "base_url"})
-_DOMAIN_ARGUMENT_LIST_KEYS = frozenset({"urls", "uris", "domains", "hosts"})
-_COMMAND_ARGUMENT_KEYS = frozenset({"command", "cmd", "shell_command"})
-_COMMAND_ARGV_KEYS = frozenset({"argv"})
 _PERMISSION_RULE_CACHE_MAX_ENTRIES = 64
-_MAX_PERMISSION_SUBJECTS = 128
-_MAX_SUBJECT_VALUE_LENGTH = 4096
-_MAX_COMMAND_ARGV_TOKENS = 256
 _BRIDGE_TOOL_DESCRIPTORS: dict[str, dict[str, Any]] = {
     _TOOL_CATEGORIES_LIST: {
         "name": _TOOL_CATEGORIES_LIST,
@@ -1114,14 +1094,6 @@ def _effective_policy_for_tool(
     )
 
 
-class _PermissionSubjectLimitError(Exception):
-    """Raised when one tool call exceeds permission-subject extraction limits."""
-
-    def __init__(self, limit: str) -> None:
-        super().__init__(limit)
-        self.limit = limit
-
-
 def _enforce_permission_rules_for_tool_call(
     profile: MCPProfile,
     tool_name: str,
@@ -1141,8 +1113,8 @@ def _enforce_permission_rules_for_tool_call(
 
     approval_grant_markers: list[str] = []
     try:
-        subjects = _permission_rule_subjects_for_tool_call(tool_name, arguments)
-    except _PermissionSubjectLimitError as exc:
+        subjects = extract_permission_rule_subjects(tool_name, arguments)
+    except PermissionSubjectLimitError as exc:
         raise GatewayPolicyDenied(
             "Gateway profile rejected oversized tool arguments for permission rules",
             reason_code="permission_subject_limits_exceeded",
@@ -1241,91 +1213,6 @@ def _active_approval_lease_marker(
     if lease is None:
         return None
     return hashlib.sha256(lease.grant_id.encode("utf-8")).hexdigest()[:16]
-
-
-def _permission_rule_subjects_for_tool_call(
-    tool_name: str,
-    arguments: dict[str, Any],
-) -> list[tuple[PermissionRuleSubject, str, Sequence[str] | None]]:
-    """Extract bounded permission-rule subjects from one gateway tool call."""
-
-    subjects: list[tuple[PermissionRuleSubject, str, Sequence[str] | None]] = []
-    _append_permission_subject(subjects, "tool", tool_name, None)
-    if tool_name.lower().startswith("mcp__"):
-        _append_permission_subject(subjects, "mcp", tool_name, None)
-    if not isinstance(arguments, Mapping):
-        return subjects
-
-    for key, value in arguments.items():
-        if not isinstance(key, str):
-            continue
-        normalized_key = key.strip().lower()
-        if normalized_key in _PATH_ARGUMENT_KEYS:
-            for item in _string_values(value):
-                _append_permission_subject(subjects, "path", item, None)
-        elif normalized_key in _PATH_ARGUMENT_LIST_KEYS:
-            for item in _nested_string_values(value):
-                _append_permission_subject(subjects, "path", item, None)
-        elif normalized_key in _DOMAIN_ARGUMENT_KEYS:
-            for item in _string_values(value):
-                _append_permission_subject(subjects, "domain", item, None)
-        elif normalized_key in _DOMAIN_ARGUMENT_LIST_KEYS:
-            for item in _nested_string_values(value):
-                _append_permission_subject(subjects, "domain", item, None)
-        elif normalized_key in _COMMAND_ARGUMENT_KEYS:
-            for item in _string_values(value):
-                _append_permission_subject(subjects, "command", item, None)
-        elif normalized_key in _COMMAND_ARGV_KEYS:
-            argv = _argv_argument(value)
-            if argv is not None:
-                if len(argv) > _MAX_COMMAND_ARGV_TOKENS:
-                    raise _PermissionSubjectLimitError("max_command_argv_tokens")
-                _append_permission_subject(subjects, "command", " ".join(argv), argv)
-    return subjects
-
-
-def _append_permission_subject(
-    subjects: list[tuple[PermissionRuleSubject, str, Sequence[str] | None]],
-    subject_type: PermissionRuleSubject,
-    value: str,
-    argv: Sequence[str] | None,
-) -> None:
-    """Append one extracted subject while enforcing extraction limits."""
-
-    if len(subjects) >= _MAX_PERMISSION_SUBJECTS:
-        raise _PermissionSubjectLimitError("max_permission_subjects")
-    if len(value) > _MAX_SUBJECT_VALUE_LENGTH:
-        raise _PermissionSubjectLimitError("max_subject_value_length")
-    subjects.append((subject_type, value, argv))
-
-
-def _string_values(value: Any) -> tuple[str, ...]:
-    """Return one non-empty string value or an empty tuple."""
-
-    if isinstance(value, str) and value.strip():
-        return (value.strip(),)
-    return ()
-
-
-def _nested_string_values(value: Any) -> tuple[str, ...]:
-    """Return non-empty string values from a scalar or shallow sequence."""
-
-    if isinstance(value, (str, bytes, Mapping)):
-        return _string_values(value)
-    if isinstance(value, Sequence):
-        return tuple(item.strip() for item in value if isinstance(item, str) and item.strip())
-    return ()
-
-
-def _argv_argument(value: Any) -> tuple[str, ...] | None:
-    """Return argv tokens when a tool call provides an argv-shaped argument."""
-
-    if isinstance(value, (str, bytes, Mapping)) or not isinstance(value, Sequence):
-        return None
-    argv = tuple(value)
-    if not argv or not all(isinstance(item, str) for item in argv):
-        return None
-    return argv
 
 
 def _primary_capability(tool: Any) -> str | None:

--- a/mcp_unified/profiles/subjects.py
+++ b/mcp_unified/profiles/subjects.py
@@ -1,0 +1,141 @@
+"""Shared permission-rule subject extraction for runtime enforcement and simulation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .permission_rules import PermissionRuleSubject
+
+MAX_PERMISSION_SUBJECTS = 128
+MAX_SUBJECT_VALUE_LENGTH = 4096
+MAX_COMMAND_ARGV_TOKENS = 256
+
+PATH_ARGUMENT_KEYS = frozenset(
+    {
+        "path",
+        "file",
+        "file_path",
+        "filepath",
+        "filename",
+        "base_path",
+        "target_path",
+        "source_path",
+        "destination_path",
+        "new_path",
+        "old_path",
+    }
+)
+PATH_ARGUMENT_LIST_KEYS = frozenset({"paths", "files", "file_paths"})
+DOMAIN_ARGUMENT_KEYS = frozenset({"url", "uri", "domain", "host", "base_url"})
+DOMAIN_ARGUMENT_LIST_KEYS = frozenset({"urls", "uris", "domains", "hosts"})
+COMMAND_ARGUMENT_KEYS = frozenset({"command", "cmd", "shell_command"})
+COMMAND_ARGV_KEYS = frozenset({"argv"})
+
+
+class PermissionSubjectLimitError(Exception):
+    """Raised when one tool call exceeds permission-subject extraction limits."""
+
+    def __init__(self, limit: str) -> None:
+        super().__init__(limit)
+        self.limit = limit
+
+
+def extract_permission_rule_subjects(
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> list[tuple[PermissionRuleSubject, str, Sequence[str] | None]]:
+    """Extract bounded permission-rule subjects from one gateway tool call."""
+
+    subjects: list[tuple[PermissionRuleSubject, str, Sequence[str] | None]] = []
+    _append_permission_subject(subjects, "tool", tool_name, None)
+    if tool_name.lower().startswith("mcp__"):
+        _append_permission_subject(subjects, "mcp", tool_name, None)
+    if not isinstance(arguments, Mapping):
+        return subjects
+
+    for key, value in arguments.items():
+        if not isinstance(key, str):
+            continue
+        normalized_key = key.strip().lower()
+        if normalized_key in PATH_ARGUMENT_KEYS:
+            for item in _string_values(value):
+                _append_permission_subject(subjects, "path", item, None)
+        elif normalized_key in PATH_ARGUMENT_LIST_KEYS:
+            for item in _nested_string_values(value):
+                _append_permission_subject(subjects, "path", item, None)
+        elif normalized_key in DOMAIN_ARGUMENT_KEYS:
+            for item in _string_values(value):
+                _append_permission_subject(subjects, "domain", item, None)
+        elif normalized_key in DOMAIN_ARGUMENT_LIST_KEYS:
+            for item in _nested_string_values(value):
+                _append_permission_subject(subjects, "domain", item, None)
+        elif normalized_key in COMMAND_ARGUMENT_KEYS:
+            for item in _string_values(value):
+                _append_permission_subject(subjects, "command", item, None)
+        elif normalized_key in COMMAND_ARGV_KEYS:
+            argv = _argv_argument(value)
+            if argv is not None:
+                if len(argv) > MAX_COMMAND_ARGV_TOKENS:
+                    raise PermissionSubjectLimitError("max_command_argv_tokens")
+                _append_permission_subject(subjects, "command", " ".join(argv), argv)
+    return subjects
+
+
+def _append_permission_subject(
+    subjects: list[tuple[PermissionRuleSubject, str, Sequence[str] | None]],
+    subject_type: PermissionRuleSubject,
+    value: str,
+    argv: Sequence[str] | None,
+) -> None:
+    """Append one extracted subject while enforcing extraction limits."""
+
+    if len(subjects) >= MAX_PERMISSION_SUBJECTS:
+        raise PermissionSubjectLimitError("max_permission_subjects")
+    if len(value) > MAX_SUBJECT_VALUE_LENGTH:
+        raise PermissionSubjectLimitError("max_subject_value_length")
+    subjects.append((subject_type, value, argv))
+
+
+def _string_values(value: Any) -> tuple[str, ...]:
+    """Return one non-empty string value or an empty tuple."""
+
+    if isinstance(value, str) and value.strip():
+        return (value.strip(),)
+    return ()
+
+
+def _nested_string_values(value: Any) -> tuple[str, ...]:
+    """Return non-empty string values from a scalar or shallow sequence."""
+
+    if isinstance(value, (str, bytes, Mapping)):
+        return _string_values(value)
+    if isinstance(value, Sequence):
+        return tuple(item.strip() for item in value if isinstance(item, str) and item.strip())
+    return ()
+
+
+def _argv_argument(value: Any) -> tuple[str, ...] | None:
+    """Return argv tokens when a tool call provides an argv-shaped argument."""
+
+    if isinstance(value, (str, bytes, Mapping)) or not isinstance(value, Sequence):
+        return None
+    argv = tuple(value)
+    if not argv or not all(isinstance(item, str) for item in argv):
+        return None
+    return argv
+
+
+__all__ = [
+    "COMMAND_ARGUMENT_KEYS",
+    "COMMAND_ARGV_KEYS",
+    "DOMAIN_ARGUMENT_KEYS",
+    "DOMAIN_ARGUMENT_LIST_KEYS",
+    "MAX_COMMAND_ARGV_TOKENS",
+    "MAX_PERMISSION_SUBJECTS",
+    "MAX_SUBJECT_VALUE_LENGTH",
+    "PATH_ARGUMENT_KEYS",
+    "PATH_ARGUMENT_LIST_KEYS",
+    "PermissionSubjectLimitError",
+    "extract_permission_rule_subjects",
+]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -3029,3 +3029,103 @@ def test_gateway_cli_simulate_policy_unknown_profile_errors(
     captured = capsys.readouterr()
     assert exit_code == 1
     assert json.loads(captured.err)["reason_code"] == "profile_not_found"
+
+
+def test_gateway_cli_simulate_policy_does_not_write_persistent_profile_store(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Simulation must stay read-only even against a persistent profile store."""
+
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "store": {"kind": "sqlite", "sqlite_path": str(tmp_path / "profiles.db")},
+                "profiles": [
+                    {
+                        "id": "researcher",
+                        "name": "Researcher",
+                        "policy_document": {"allowed_tools": ["web.fetch"]},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = gateway_cli.main(
+        [
+            "simulate-policy",
+            "--config",
+            str(config_path),
+            "--profile",
+            "researcher",
+            "--tool",
+            "web.fetch",
+            "--url",
+            "https://example.com/page",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["overall"]["status"] == "allowed"
+
+    exit_code = gateway_cli.main(
+        ["show-profile", "researcher", "--config", str(config_path)]
+    )
+    capsys.readouterr()
+    assert exit_code == 1
+
+
+def test_gateway_cli_simulate_policy_flags_override_arguments_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Explicit convenience flags must win over --arguments-json keys."""
+
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "store": {"kind": "memory"},
+                "profiles": [
+                    {
+                        "id": "reviewer",
+                        "name": "Reviewer",
+                        "policy_document": {
+                            "allowed_tools": ["fs.read_text"],
+                            "permission_rules": [
+                                {
+                                    "pattern": "Read(docs/private/**)",
+                                    "outcome": "deny",
+                                    "reason_code": "private_docs_denied",
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = gateway_cli.main(
+        [
+            "simulate-policy",
+            "--config",
+            str(config_path),
+            "--profile",
+            "reviewer",
+            "--tool",
+            "fs.read_text",
+            "--path",
+            "docs/private/secret.txt",
+            "--arguments-json",
+            json.dumps({"path": "docs/public/notes.txt"}),
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["overall"]["status"] == "denied"
+    assert payload["overall"]["reason_code"] == "private_docs_denied"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py
@@ -2940,3 +2940,92 @@ def test_gateway_cli_path_grant_rejects_invalid_actions(
     captured = capsys.readouterr()
     assert exit_code == 1
     assert json.loads(captured.err)["reason_code"] == "invalid_policy_grant"
+
+
+def test_gateway_cli_simulate_policy_reports_decision(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Simulate a profile policy decision for one hypothetical tool call."""
+
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "store": {"kind": "memory"},
+                "profiles": [
+                    {
+                        "id": "researcher",
+                        "name": "Researcher",
+                        "policy_document": {
+                            "allowed_tools": ["web.fetch"],
+                            "permission_rules": [
+                                {"pattern": "WebFetch(example.com)", "outcome": "ask"}
+                            ],
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = gateway_cli.main(
+        [
+            "simulate-policy",
+            "--config",
+            str(config_path),
+            "--profile",
+            "researcher",
+            "--tool",
+            "web.fetch",
+            "--url",
+            "https://example.com/private",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["overall"]["status"] == "approval_required"
+    assert payload["profile_id"] == "researcher"
+
+    exit_code = gateway_cli.main(
+        [
+            "simulate-policy",
+            "--config",
+            str(config_path),
+            "--profile",
+            "researcher",
+            "--tool",
+            "web.fetch",
+            "--url",
+            "https://other.example.org/page",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["overall"]["status"] == "allowed"
+
+
+def test_gateway_cli_simulate_policy_unknown_profile_errors(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Report a JSON error payload for an unknown profile id."""
+
+    config_path = tmp_path / "gateway.json"
+    config_path.write_text(json.dumps({"store": {"kind": "memory"}}), encoding="utf-8")
+
+    exit_code = gateway_cli.main(
+        [
+            "simulate-policy",
+            "--config",
+            str(config_path),
+            "--profile",
+            "missing",
+            "--tool",
+            "web.fetch",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert json.loads(captured.err)["reason_code"] == "profile_not_found"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_simulation.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_simulation.py
@@ -266,3 +266,23 @@ def test_simulation_matches_runtime_outcomes() -> None:
             f"parity mismatch for {tool_name} {arguments}: "
             f"simulated={simulated['overall']['status']} runtime={runtime_status}"
         )
+
+
+def test_simulation_unmatched_subjects_report_no_reason_code() -> None:
+    from mcp_unified.gateway.policy_simulation import simulate_tool_call_policy
+
+    profile = _profile(
+        "reviewer",
+        allowed_tools=["fs.read_text"],
+        permission_rules=[{"pattern": "Read(docs/private/**)", "outcome": "deny"}],
+    )
+    result = simulate_tool_call_policy(
+        profile,
+        "fs.read_text",
+        {"path": "docs/public/notes.txt"},
+    )
+    assert result["overall"]["status"] == "allowed"
+    for subject in result["subjects"]:
+        assert subject["outcome"] == "allow"
+        assert subject["reason_code"] is None
+        assert subject["matched_rules"] == []

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_simulation.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_policy_simulation.py
@@ -1,0 +1,268 @@
+"""Tests for the gateway policy simulation harness and shared subject extraction."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+
+def _profile(
+    profile_id: str,
+    *,
+    allowed_tools: list[str],
+    permission_rules: list[Any] | None = None,
+    path_scopes: list[dict[str, Any]] | None = None,
+) -> Any:
+    from mcp_unified.profiles.models import MCPProfile, ProfilePolicy
+
+    return MCPProfile(
+        id=profile_id,
+        name=f"Profile {profile_id}",
+        policy_document=ProfilePolicy(
+            allowed_tools=allowed_tools,
+            permission_rules=permission_rules or [],
+        ),
+        path_scopes=path_scopes or [],
+    )
+
+
+def test_subjects_module_extracts_permission_rule_subjects() -> None:
+    from mcp_unified.profiles.subjects import extract_permission_rule_subjects
+
+    subjects = extract_permission_rule_subjects(
+        "fs.read_text",
+        {
+            "path": "docs/a.txt",
+            "url": "https://example.com/x",
+            "argv": ["git", "status"],
+        },
+    )
+    pairs = {(subject_type, value) for subject_type, value, _argv in subjects}
+    assert ("tool", "fs.read_text") in pairs
+    assert ("path", "docs/a.txt") in pairs
+    assert ("domain", "https://example.com/x") in pairs
+    assert ("command", "git status") in pairs
+
+
+def test_subjects_module_enforces_extraction_limits() -> None:
+    from mcp_unified.profiles.subjects import (
+        MAX_PERMISSION_SUBJECTS,
+        PermissionSubjectLimitError,
+        extract_permission_rule_subjects,
+    )
+
+    with pytest.raises(PermissionSubjectLimitError):
+        extract_permission_rule_subjects(
+            "fs.read_text",
+            {"paths": [f"docs/file-{index}.txt" for index in range(MAX_PERMISSION_SUBJECTS + 1)]},
+        )
+
+
+def test_simulation_reports_allowed_call() -> None:
+    from mcp_unified.gateway.policy_simulation import simulate_tool_call_policy
+
+    profile = _profile(
+        "reviewer",
+        allowed_tools=["fs.read_text"],
+        permission_rules=[{"pattern": "Read(docs/private/**)", "outcome": "deny"}],
+    )
+    result = simulate_tool_call_policy(
+        profile,
+        "fs.read_text",
+        {"path": "docs/public/notes.txt"},
+    )
+    assert result["overall"]["status"] == "allowed"
+    assert result["legacy_policy"]["status"] == "resolved"
+    subject_types = {subject["subject_type"] for subject in result["subjects"]}
+    assert {"tool", "path"} <= subject_types
+
+
+def test_simulation_reports_denied_path_rule() -> None:
+    from mcp_unified.gateway.policy_simulation import simulate_tool_call_policy
+
+    profile = _profile(
+        "reviewer",
+        allowed_tools=["fs.read_text"],
+        permission_rules=[
+            {
+                "pattern": "Read(docs/private/**)",
+                "outcome": "deny",
+                "reason_code": "private_docs_denied",
+            }
+        ],
+    )
+    result = simulate_tool_call_policy(
+        profile,
+        "fs.read_text",
+        {"path": "docs/private/secret.txt"},
+    )
+    assert result["overall"]["status"] == "denied"
+    assert result["overall"]["reason_code"] == "private_docs_denied"
+    denied_subjects = [
+        subject for subject in result["subjects"] if subject["outcome"] == "deny"
+    ]
+    assert denied_subjects
+    assert denied_subjects[0]["subject_type"] == "path"
+    assert denied_subjects[0]["matched_rules"]
+
+
+def test_simulation_reports_legacy_tool_denial() -> None:
+    from mcp_unified.gateway.policy_simulation import simulate_tool_call_policy
+
+    profile = _profile("reviewer", allowed_tools=["fs.read_text"])
+    result = simulate_tool_call_policy(profile, "admin.delete", {})
+    assert result["overall"]["status"] == "denied"
+    assert result["legacy_policy"]["status"] != "resolved"
+
+
+def test_simulation_ask_rule_blocks_then_lease_allows() -> None:
+    from mcp_unified.gateway.policy_simulation import simulate_tool_call_policy
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    profile = _profile(
+        "researcher",
+        allowed_tools=["web.fetch"],
+        permission_rules=[{"pattern": "WebFetch(example.com)", "outcome": "ask"}],
+    )
+    grant_store = InMemoryPolicyGrantStore()
+    arguments = {"url": "https://example.com/private"}
+
+    blocked = simulate_tool_call_policy(
+        profile,
+        "web.fetch",
+        arguments,
+        policy_grant_store=grant_store,
+    )
+    assert blocked["overall"]["status"] == "approval_required"
+
+    grant_store.create_grant(
+        profile_id="researcher",
+        grant_type="approval",
+        subject_type="domain",
+        value="example.com",
+        ttl_seconds=900,
+    )
+    allowed = simulate_tool_call_policy(
+        profile,
+        "web.fetch",
+        arguments,
+        policy_grant_store=grant_store,
+    )
+    assert allowed["overall"]["status"] == "allowed"
+    assert allowed["approval_grant_markers"]
+
+
+def test_simulation_includes_merged_ttl_path_grants() -> None:
+    from mcp_unified.gateway.policy_simulation import simulate_tool_call_policy
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+
+    profile = _profile(
+        "reviewer",
+        allowed_tools=["fs.read_text"],
+        path_scopes=[{"prefix": "docs/manuals", "actions": ["read"], "effect": "allow"}],
+    )
+    grant_store = InMemoryPolicyGrantStore()
+    grant_store.create_grant(
+        profile_id="reviewer",
+        grant_type="path",
+        subject_type="path",
+        value="docs/scratch",
+        actions=("read", "write"),
+        ttl_seconds=900,
+    )
+
+    result = simulate_tool_call_policy(
+        profile,
+        "fs.read_text",
+        {"path": "docs/scratch/notes.txt"},
+        policy_grant_store=grant_store,
+    )
+    assert result["overall"]["status"] == "allowed"
+    sources = {scope.get("source") for scope in result["path_scopes"]}
+    assert "ttl_grant" in sources
+    prefixes = {scope["prefix"] for scope in result["path_scopes"]}
+    assert {"docs/manuals", "docs/scratch"} <= prefixes
+
+
+def test_simulation_matches_runtime_outcomes() -> None:
+    from mcp_unified.gateway.policy_simulation import simulate_tool_call_policy
+    from mcp_unified.gateway.profile_runtime import ProfileAwareGatewayRuntime
+    from mcp_unified.gateway.runtime import GatewayPolicyDenied, GatewayRequestContext
+    from mcp_unified.policy_grants import InMemoryPolicyGrantStore
+    from mcp_unified.profiles.store import InMemoryProfileStore
+
+    class _ParityBackend:
+        name = "parity-backend"
+        version = "0.0-test"
+
+        async def list_tools(self, context: Any) -> list[dict[str, Any]]:
+            return []
+
+        async def call_tool(
+            self,
+            name: str,
+            arguments: dict[str, Any],
+            context: Any,
+        ) -> dict[str, Any]:
+            return {"content": [{"type": "text", "text": "ok"}]}
+
+    profile = _profile(
+        "reviewer",
+        allowed_tools=["fs.read_text", "web.fetch"],
+        permission_rules=[
+            {
+                "pattern": "Read(docs/private/**)",
+                "outcome": "deny",
+                "reason_code": "private_docs_denied",
+            },
+            {"pattern": "WebFetch(example.com)", "outcome": "ask"},
+        ],
+    )
+    grant_store = InMemoryPolicyGrantStore()
+    grant_store.create_grant(
+        profile_id="reviewer",
+        grant_type="approval",
+        subject_type="domain",
+        value="approved.example.org",
+        ttl_seconds=900,
+    )
+    profile.policy_document.permission_rules.append(
+        {"pattern": "WebFetch(approved.example.org)", "outcome": "ask"}
+    )
+    runtime = ProfileAwareGatewayRuntime(
+        _ParityBackend(),
+        profile_store=InMemoryProfileStore([profile]),
+        default_profile_id="reviewer",
+        policy_grant_store=grant_store,
+    )
+
+    cases: list[tuple[str, dict[str, Any]]] = [
+        ("fs.read_text", {"path": "docs/public/notes.txt"}),
+        ("fs.read_text", {"path": "docs/private/secret.txt"}),
+        ("web.fetch", {"url": "https://example.com/private"}),
+        ("web.fetch", {"url": "https://approved.example.org/data"}),
+        ("admin.delete", {}),
+    ]
+
+    async def _runtime_status(tool_name: str, arguments: dict[str, Any]) -> str:
+        context = GatewayRequestContext(request_id=f"parity-{tool_name}")
+        try:
+            await runtime.call_tool(tool_name, arguments, context)
+        except GatewayPolicyDenied as exc:
+            return exc.status
+        return "allowed"
+
+    for tool_name, arguments in cases:
+        simulated = simulate_tool_call_policy(
+            profile,
+            tool_name,
+            arguments,
+            policy_grant_store=grant_store,
+        )
+        runtime_status = asyncio.run(_runtime_status(tool_name, arguments))
+        assert simulated["overall"]["status"] == runtime_status, (
+            f"parity mismatch for {tool_name} {arguments}: "
+            f"simulated={simulated['overall']['status']} runtime={runtime_status}"
+        )


### PR DESCRIPTION
## Summary
- Extract permission-rule subject extraction (key sets, bounds, limit error, helpers) from `gateway/profile_runtime.py` into a shared `mcp_unified/profiles/subjects.py` so runtime enforcement and simulation use one extractor and cannot drift (backlog TASK-2303).
- New read-only harness `gateway/policy_simulation.py::simulate_tool_call_policy()` mirrors the runtime pipeline by reusing the legacy policy resolution, the runtime's own enforcement function, and the TTL path-grant merge. A parity test runs five (tool, arguments) cases through both the harness and a real `ProfileAwareGatewayRuntime.call_tool` and asserts identical verdicts (allow, path deny, ask, lease-satisfied ask, legacy tool denial).
- New `simulate-policy` CLI verb: `simulate-policy --profile X --tool Y [--path]... [--url]... [--command] [--argv-json] [--arguments-json] [--capability] [--session-id]`. Loads profiles from gateway config (seeding `config.profiles` into the store so pure-JSON configs are simulatable), overlays approval leases and TTL path grants when a `policy_grants` store is configured, and emits a structured JSON decision with overall status, legacy decision, per-subject matched rules, lease markers, and merged path scopes. Simulation never writes audit events or consumes leases.

**Stacked on #2346** (and #2345); GitHub will retarget as the stack merges.

## Test Plan
- [x] Combined MCP gateway suite incl. new test_gateway_policy_simulation.py (402 passed, re-verified after rebase; previously re-run 5x green)
- [x] `python -m ruff check` over touched modules and tests
- [x] `python -m compileall -q` over touched modules
- [x] `python -m bandit -r mcp_unified/profiles/subjects.py mcp_unified/gateway/policy_simulation.py -q` (no findings)
- [x] `git diff --check`

## Deferred
- Human-readable table output (CLI emits JSON like all other gateway verbs).
- `--action` evaluation against merged path scopes (scopes are reported for operator inspection; action-level path-enforcer simulation needs the downstream enforcer contract).
- Remote admin endpoint for simulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only MCP policy simulation CLI and a shared subject extractor to keep simulation identical to runtime decisions. Satisfies TASK-2303 by letting operators simulate one tool-call decision and inspect structured JSON results without side effects.

- **New Features**
  - `simulate-policy` CLI: simulate one profile decision for a tool call; loads the profile from the store and falls back to in-memory `config.profiles` (never writes), overlays approval leases and TTL path grants when a `policy_grants` store is configured; supports `--path`, `--url`, `--command`, `--argv-json`, `--arguments-json`, `--capability`, `--session-id`.
  - Outputs JSON with overall status, legacy decision, per-subject matched rules, approval lease markers, and merged path scopes; harness in `mcp_unified/gateway/policy_simulation.py` reuses legacy policy resolution, runtime enforcement, and TTL path-grant merge, with a parity test to pin outcomes.

- **Bug Fixes**
  - Kept simulation strictly read-only: no seeding of config profiles into the profile store; reads store first, then falls back to the config document.
  - Convenience flags override `--arguments-json` keys.
  - Unmatched simulated subjects report a null `reason_code`.
  - Grant-store shutdown now handles coroutine-style `close()` via a shared helper used across grant CLI paths.

<sup>Written for commit 6c023ef0b86d218a535c1d2dfcfc93805247667a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

