### PR TITLE
Add MCP web.fetch tool with domain policy controls

### DIFF
--- a/Docs/Design/MCP_Web_Fetch_Tool_Design.md
+++ b/Docs/Design/MCP_Web_Fetch_Tool_Design.md
@@ -1,0 +1,103 @@
+# MCP `web.fetch` Tool Design
+
+Status: Implementing (June 2026)
+Owner: standalone MCP gateway backlog
+
+## Goal
+
+Add a built-in MCP tool, `web.fetch`, that retrieves a single user-specified
+URL, applies the centralized outbound (SSRF/egress) policy, and returns bounded,
+extracted page content (markdown/text/html). The tool is gated by the gateway's
+existing **domain** permission subjects so profile authors can allow/deny/ask on
+`WebFetch(<domain>)` rules without any new policy plumbing.
+
+## Why this shape
+
+- **In-server module, not standalone-package code.** Built-in tool
+  *implementations* live in
+  `tldw_Server_API/app/core/MCP_unified/modules/implementations/` (e.g.
+  `git_module.py`, `filesystem_module.py`). They may import server internals
+  (`Web_Scraping/`), which keeps the standalone `mcp_unified/` gateway package
+  free of heavy web deps (httpx/trafilatura). The gateway only learns the tool
+  exists via `mcp_unified/profiles/presets.py`.
+- **Domain policy is already wired.** `mcp_unified/profiles/subjects.py` extracts
+  a `domain` subject from any `url`/`uri`/`domain` argument, and
+  `permission_rules.py` compiles `WebFetch(<pattern>)` rule specifiers into
+  `domain` rules. A tool that takes a `url` argument therefore gets
+  allow/deny/ask enforcement for free at the gateway runtime. The module does not
+  re-implement domain policy — it only enforces the always-on SSRF/egress guard.
+
+## Tool: `web.fetch`
+
+Read-only. Arguments (additionalProperties: false):
+
+| arg | type | default | bounds |
+|---|---|---|---|
+| `url` | string (required) | — | http/https only |
+| `format` | enum `markdown`\|`text`\|`html` | `markdown` | — |
+| `max_bytes` | integer | 1_000_000 | 1 .. 5_000_000 |
+| `timeout_seconds` | integer | 15 | 1 .. 30 |
+| `respect_robots` | boolean | `false` | explicit fetch defaults off |
+
+Success result:
+
+```
+{
+  "ok": true,
+  "url": "<requested>",
+  "final_url": "<after redirects>",
+  "status_code": 200,
+  "content_type": "text/html; charset=utf-8",
+  "title": "<extracted or null>",
+  "format": "markdown",
+  "content": "<bounded extracted text>",
+  "bytes_fetched": 12345,
+  "truncated": false,
+  "eval": { ... }
+}
+```
+
+Error result: `{ ok: false, reason_code, message, eval }`.
+
+Reason codes: `invalid_url` (bad/unsupported scheme), `outbound_policy_denied`
+(SSRF/egress/robots), `fetch_failed` (network/timeout/status), `empty_content`,
+`unknown_tool`.
+
+## Security & bounds
+
+1. Validate scheme is `http`/`https`; reject everything else (`invalid_url`).
+2. `decide_web_outbound_policy(url, respect_robots=..., user_agent=...,
+   source="mcp.web_fetch", stage="web.fetch")` — denies private/loopback/link-local
+   targets and (optionally) robots-disallowed paths. Denial → `outbound_policy_denied`.
+3. Bounded streaming download: stop after `max_bytes`; set `truncated=true`.
+4. `timeout_seconds` hard cap (30s).
+5. HTML extracted with `trafilatura.extract(..., output_format=...)`; text/plain,
+   text/markdown, application/json returned as decoded bounded body; other
+   content types rejected with `empty_content`.
+
+## Testability
+
+`WebFetchHttpClient` Protocol + `WebFetchResponse` dataclass so tests inject a
+fake fetcher (no network). Default `HttpxWebFetchClient` uses
+`httpx.AsyncClient` with streaming + byte cap. Outbound policy is monkeypatched
+in tests via `evaluate_url_policy` (same hook `Web_Scraping` tests use).
+
+## Registration
+
+`server.py`: optional block gated by `MCP_ENABLE_WEB_FETCH_MODULE` (disabled by
+default, mirroring git/sandbox), id `web_fetch`, department `research`.
+
+## Gateway presets
+
+Add `_WEB_READ_TOOLS = ["web.fetch"]` in `presets.py`; wire into the
+`deep-researcher` preset (the only preset carrying the `external_network` risk
+class and `research.web` capability) via a `tooling_metadata_document`.
+
+## Tests
+
+- `test_web_fetch_module.py`: invalid scheme; outbound denial; happy-path html→
+  markdown extraction with injected client; byte cap → truncated; text/plain
+  passthrough; unsupported content type; arg validation (unknown arg, bad bounds);
+  fetch failure mapping.
+- `test_web_fetch_module_registration.py`: registered when flag set, absent when unset.
+- preset assertion: `deep-researcher` enables `web.fetch`.

--- a/backlog/tasks/task-2354 - Add-MCP-web-fetch-tool-with-domain-policy-controls.md
+++ b/backlog/tasks/task-2354 - Add-MCP-web-fetch-tool-with-domain-policy-controls.md
@@ -1,0 +1,49 @@
+---
+id: TASK-2354
+title: Add MCP web.fetch tool with domain policy controls
+status: Done
+updated_date: '2026-06-12'
+labels:
+- mcp
+- tools
+- web
+- policy
+references:
+- Docs/Design/MCP_Web_Fetch_Tool_Design.md
+dependencies:
+- TASK-2344
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a built-in MCP `web.fetch` tool that retrieves a single user-specified URL, applies the centralized outbound (SSRF/egress) policy, and returns bounded extracted content. The tool takes a `url` argument so it is automatically governed by the gateway's existing domain permission subjects (`WebFetch(<domain>)` allow/deny/ask rules) without new policy plumbing.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A `web.fetch` MCP tool fetches an http/https URL and returns `{ok, url, final_url, status_code, content_type, title, format, content, bytes_fetched, truncated, eval}`; non-http(s) schemes return a structured `invalid_url` error.
+- [x] #2 Every fetch passes through `decide_web_outbound_policy` (SSRF/egress, optional robots); a denied target returns `outbound_policy_denied` and performs no network request beyond policy evaluation.
+- [x] #3 Responses are bounded by `max_bytes` (truncation flagged) and `timeout_seconds`, both clamped to safe maxima; HTML is extracted to markdown/text via trafilatura, text/plain and json pass through, other content types return `empty_content`.
+- [x] #4 The module is registered only when `MCP_ENABLE_WEB_FETCH_MODULE` is set, the HTTP client is injectable for tests (no network in unit tests), and the `deep-researcher` gateway preset enables `web.fetch`.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+In-server module `tldw_Server_API/app/core/MCP_unified/modules/implementations/web_fetch_module.py` (`WebFetchModule(BaseModule)`, single `web.fetch` tool). The implementation lives in-server (not the standalone `mcp_unified/` package) so it may import `Web_Scraping.outbound_policy.decide_web_outbound_policy` and trafilatura without adding heavy deps to the standalone gateway. Domain allow/deny/ask is NOT re-implemented: the gateway already extracts a `domain` subject from the `url` argument (`mcp_unified/profiles/subjects.py`) and compiles Claude-style `WebFetch(<domain>)` rule specifiers into domain rules (`permission_rules.py`), so runtime domain policy applies automatically.
+
+Security/bounds: scheme allow-list (http/https → else `invalid_url`); mandatory `decide_web_outbound_policy(... source="mcp.web_fetch", stage="web.fetch")` SSRF/egress gate before any fetch (denied → `outbound_policy_denied`, no network call); `max_bytes` (default 1MB, max 5MB) with `truncated` flag; `timeout_seconds` (default 15, max 30); HTML → trafilatura markdown/txt with a regex tag-strip fallback so extraction is deterministic; text/plain·markdown·json·xml pass through; other content types → `empty_content`; status ≥400 → `fetch_failed`; client exceptions → `fetch_failed`.
+
+Testability via injectable `WebFetchHttpClient` Protocol + `WebFetchResponse` dataclass (default `HttpxWebFetchClient` streams with a byte cap); outbound policy monkeypatched at the module reference in tests — no network in unit tests.
+
+Registration: optional env-flag block in `server.py` gated by `MCP_ENABLE_WEB_FETCH_MODULE` (disabled by default, mirroring git/sandbox), id `web_fetch`, department `research`. Gateway preset: `_WEB_READ_TOOLS = ["web.fetch"]` wired into the `deep-researcher` preset's new tooling_metadata_document (the only preset carrying `external_network`/`research.web`).
+
+TDD evidence:
+- RED: `pytest test_web_fetch_module.py` → collection error (module absent), then 16/17 (one test-harness `RequestContext` arg bug) before module existed.
+- GREEN: `test_web_fetch_module.py` 17 passed; `test_web_fetch_module_registration.py` 2 passed; `test_profile_presets.py` 27 passed (incl. new `test_deep_researcher_enables_web_fetch`).
+- Regression: `test_federation_shell_contracts.py`, `test_storage_contracts.py`, `test_profile_permission_rules.py`, `test_profile_policy_decisions.py` → 91 passed.
+- ruff (new files) clean; `compileall` rc=0; `bandit -r web_fetch_module.py` no findings; `git diff --check` clean. (Pre-existing SIM300 findings in `test_profile_presets.py` left at dev baseline.)
+
+Deferred: streaming/range fetch, per-domain rate limiting, caching, and a companion `web.search` tool (separate backlog item).
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/mcp_unified/profiles/presets.py
+++ b/mcp_unified/profiles/presets.py
@@ -203,6 +203,7 @@ _GIT_READ_TOOLS = [
     "git.conflicts.list",
     "git.conflicts.read",
 ]
+_WEB_READ_TOOLS = ["web.fetch"]
 _TEST_READ_TOOLS = ["tests.results.read", "tests.logs.read"]
 _TEST_REQUEST_TOOLS = [*_TEST_READ_TOOLS, "tests.request"]
 _BROWSER_READ_TOOLS = [
@@ -452,6 +453,26 @@ _BUILTIN_PRESETS: tuple[ProfilePreset, ...] = (
             },
         },
         requires_workspace_binding=True,
+        tooling_metadata_document=tooling_metadata(
+            enabled_tools=[
+                *_TOOL_DISCOVERY_TOOLS,
+                *_WEB_READ_TOOLS,
+            ],
+            enabled_capabilities=["research.web", "external.network"],
+            direct_categories=["web", "tool_discovery"],
+            deferred_categories=["web_search", "citations", "browser"],
+            recommended_tools=[
+                recommended_tool(
+                    "citations.collect",
+                    category="citations",
+                    description="Collect citation candidates from fetched sources for later review.",
+                ),
+            ],
+            recommended_servers=[
+                web_search_server_recommendation(),
+                browser_server_recommendation(),
+            ],
+        ),
     ),
     _preset(
         preset_id="code-reviewer",

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_fetch_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_fetch_module.py
@@ -1,0 +1,440 @@
+"""Read-only ``web.fetch`` MCP tool with centralized outbound policy controls.
+
+The tool retrieves a single user-specified URL, enforces the always-on
+SSRF/egress outbound policy, and returns bounded extracted page content. Because
+the tool takes a ``url`` argument, the gateway runtime automatically governs it
+with the existing domain permission subjects (Claude-style ``WebFetch(<domain>)``
+allow/deny/ask rules) — this module does not re-implement domain policy.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from loguru import logger
+
+from tldw_Server_API.app.core.MCP_unified.tool_observability import (
+    build_execution_eval_metadata,
+    build_tool_eval_metadata,
+)
+from tldw_Server_API.app.core.Web_Scraping.outbound_policy import (
+    decide_web_outbound_policy,
+)
+
+from ..base import BaseModule, ModuleConfig, create_tool_definition
+
+_TOOL_FETCH = "web.fetch"
+_TOOL_PROMPT_VERSION = "2026.06.12"
+
+_ALLOWED_ARGS = {"url", "format", "max_bytes", "timeout_seconds", "respect_robots"}
+_FORMATS = {"markdown", "text", "html"}
+
+_DEFAULT_MAX_BYTES = 1_000_000
+_MAX_MAX_BYTES = 5_000_000
+_DEFAULT_TIMEOUT_SECONDS = 15
+_MAX_TIMEOUT_SECONDS = 30
+_DEFAULT_USER_AGENT = "tldw-mcp-web-fetch/1.0"
+
+# Content types we will surface as text. Anything else is rejected so the tool
+# never returns binary blobs through the JSON tool contract.
+_HTML_TYPES = {"text/html", "application/xhtml+xml"}
+_PLAIN_TYPES = {
+    "text/plain",
+    "text/markdown",
+    "application/json",
+    "application/xml",
+    "text/xml",
+    "application/ld+json",
+}
+
+_SCRIPT_STYLE_RE = re.compile(r"<(script|style)[^>]*>.*?</\1>", re.IGNORECASE | re.DOTALL)
+_TAG_RE = re.compile(r"<[^>]+>")
+_TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+_WS_RE = re.compile(r"[ \t ]+")
+_BLANKLINES_RE = re.compile(r"\n{3,}")
+
+
+@dataclass(frozen=True, slots=True)
+class WebFetchResponse:
+    """Normalized HTTP response consumed by :class:`WebFetchModule`."""
+
+    final_url: str
+    status_code: int
+    content_type: str
+    body: bytes
+    truncated: bool
+
+
+class WebFetchHttpClient(Protocol):
+    """Injectable fetcher so the module is unit-testable without the network."""
+
+    async def fetch(
+        self,
+        url: str,
+        *,
+        timeout_seconds: float,
+        max_bytes: int,
+        user_agent: str,
+    ) -> WebFetchResponse: ...
+
+
+class HttpxWebFetchClient:
+    """Default :class:`WebFetchHttpClient` backed by ``httpx`` with a byte cap."""
+
+    async def fetch(
+        self,
+        url: str,
+        *,
+        timeout_seconds: float,
+        max_bytes: int,
+        user_agent: str,
+    ) -> WebFetchResponse:
+        import httpx  # Local import: keeps module import cheap and httpx optional at import time.
+
+        chunks: list[bytes] = []
+        downloaded = 0
+        truncated = False
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout_seconds,
+            headers={"User-Agent": user_agent},
+        ) as client:
+            async with client.stream("GET", url) as response:
+                content_type = response.headers.get("content-type", "")
+                async for chunk in response.aiter_bytes():
+                    remaining = max_bytes - downloaded
+                    if remaining <= 0:
+                        truncated = True
+                        break
+                    if len(chunk) > remaining:
+                        chunks.append(chunk[:remaining])
+                        downloaded += remaining
+                        truncated = True
+                        break
+                    chunks.append(chunk)
+                    downloaded += len(chunk)
+                return WebFetchResponse(
+                    final_url=str(response.url),
+                    status_code=response.status_code,
+                    content_type=content_type,
+                    body=b"".join(chunks),
+                    truncated=truncated,
+                )
+
+
+class _WebFetchError(Exception):
+    """Internal control-flow error carrying a structured reason code."""
+
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.message = message
+
+
+class WebFetchModule(BaseModule):
+    """Single read-only ``web.fetch`` tool governed by outbound + domain policy."""
+
+    def __init__(
+        self,
+        config: ModuleConfig,
+        *,
+        client: WebFetchHttpClient | None = None,
+    ) -> None:
+        super().__init__(config)
+        self._client: WebFetchHttpClient = client or HttpxWebFetchClient()
+
+    async def on_initialize(self) -> None:
+        return None
+
+    async def on_shutdown(self) -> None:
+        return None
+
+    async def check_health(self) -> dict[str, bool]:
+        return {"initialized": True, "client": self._client is not None}
+
+    async def get_tools(self) -> list[dict[str, Any]]:
+        tool = create_tool_definition(
+            name=_TOOL_FETCH,
+            description=(
+                "Fetch a single http(s) URL and return bounded, extracted page "
+                "content. Subject to outbound (SSRF/egress) policy and domain "
+                "permission rules."
+            ),
+            parameters={
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "description": "The http(s) URL to fetch.",
+                    },
+                    "format": {
+                        "type": "string",
+                        "enum": sorted(_FORMATS),
+                        "description": "Extraction format for HTML content.",
+                    },
+                    "max_bytes": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": _MAX_MAX_BYTES,
+                    },
+                    "timeout_seconds": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": _MAX_TIMEOUT_SECONDS,
+                    },
+                    "respect_robots": {"type": "boolean"},
+                },
+                "required": ["url"],
+            },
+            metadata={
+                "category": "web",
+                "readOnlyHint": True,
+                "uses_network": True,
+                "capabilities": ["research.web", "external.network"],
+                **build_tool_eval_metadata(
+                    tool_prompt_id=f"mcp.{_TOOL_FETCH}.v1",
+                    tool_prompt_version=_TOOL_PROMPT_VERSION,
+                    task_families=["web_research", "citation_collection"],
+                    expected_result_kind="bounded_web_document",
+                    success_signals=[
+                        "enforced_outbound_policy",
+                        "bounded_response",
+                        "extracted_readable_content",
+                    ],
+                ),
+            },
+        )
+        tool["inputSchema"]["additionalProperties"] = False
+        return [tool]
+
+    async def execute_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: Any | None = None,
+    ) -> Any:
+        if tool_name != _TOOL_FETCH:
+            return self._error(tool_name, "unknown_tool", "Unknown web tool.", context=context)
+
+        args = self.sanitize_input(arguments or {})
+        try:
+            url, fmt, max_bytes, timeout_seconds, respect_robots = self._validate(args)
+        except _WebFetchError as exc:
+            return self._error(tool_name, exc.reason_code, exc.message, context=context)
+
+        decision = await decide_web_outbound_policy(
+            url,
+            respect_robots=respect_robots,
+            user_agent=_DEFAULT_USER_AGENT,
+            source="mcp.web_fetch",
+            stage="web.fetch",
+        )
+        if not getattr(decision, "allowed", False):
+            return self._error(
+                tool_name,
+                "outbound_policy_denied",
+                f"Outbound policy denied the request ({getattr(decision, 'reason', 'denied')}).",
+                context=context,
+            )
+
+        try:
+            response = await self._client.fetch(
+                url,
+                timeout_seconds=timeout_seconds,
+                max_bytes=max_bytes,
+                user_agent=_DEFAULT_USER_AGENT,
+            )
+        except Exception as exc:  # noqa: BLE001 - network/client errors are expected and mapped.
+            logger.bind(stage="web.fetch", error_type=exc.__class__.__name__).debug(
+                "web.fetch client error"
+            )
+            return self._error(tool_name, "fetch_failed", "Failed to fetch the URL.", context=context)
+
+        if response.status_code >= 400:
+            return self._error(
+                tool_name,
+                "fetch_failed",
+                f"Upstream returned status {response.status_code}.",
+                status_code=response.status_code,
+                context=context,
+            )
+
+        try:
+            content, title = self._extract(response, fmt)
+        except _WebFetchError as exc:
+            return self._error(
+                tool_name,
+                exc.reason_code,
+                exc.message,
+                status_code=response.status_code,
+                context=context,
+            )
+
+        return {
+            "ok": True,
+            "url": url,
+            "final_url": response.final_url,
+            "status_code": response.status_code,
+            "content_type": response.content_type,
+            "title": title,
+            "format": fmt,
+            "content": content,
+            "bytes_fetched": len(response.body),
+            "truncated": bool(response.truncated),
+            "eval": self._eval_metadata(
+                _TOOL_FETCH,
+                reason_code=None,
+                truncated=bool(response.truncated),
+                context=context,
+            ),
+        }
+
+    # ---- validation ----------------------------------------------------
+
+    def _validate(self, args: dict[str, Any]) -> tuple[str, str, int, int, bool]:
+        unknown = sorted(set(args) - _ALLOWED_ARGS)
+        if unknown:
+            raise _WebFetchError("invalid_arguments", f"unknown arguments: {', '.join(unknown)}")
+
+        url = args.get("url")
+        if not isinstance(url, str) or not url.strip():
+            raise _WebFetchError("invalid_arguments", "url is required")
+        url = url.strip()
+        if not re.match(r"^https?://", url, re.IGNORECASE):
+            raise _WebFetchError("invalid_url", "url must use the http or https scheme")
+
+        fmt = args.get("format", "markdown")
+        if fmt not in _FORMATS:
+            raise _WebFetchError("invalid_arguments", "format must be one of markdown, text, html")
+
+        max_bytes = self._bounded_int(
+            args, "max_bytes", default=_DEFAULT_MAX_BYTES, maximum=_MAX_MAX_BYTES
+        )
+        timeout_seconds = self._bounded_int(
+            args, "timeout_seconds", default=_DEFAULT_TIMEOUT_SECONDS, maximum=_MAX_TIMEOUT_SECONDS
+        )
+
+        respect_robots = args.get("respect_robots", False)
+        if not isinstance(respect_robots, bool):
+            raise _WebFetchError("invalid_arguments", "respect_robots must be a boolean")
+
+        return url, fmt, max_bytes, timeout_seconds, respect_robots
+
+    @staticmethod
+    def _bounded_int(args: dict[str, Any], name: str, *, default: int, maximum: int) -> int:
+        value = args.get(name)
+        if value is None:
+            return default
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            raise _WebFetchError("invalid_arguments", f"{name} must be a positive integer")
+        if value > maximum:
+            raise _WebFetchError("invalid_arguments", f"{name} exceeds maximum ({maximum})")
+        return value
+
+    # ---- extraction ----------------------------------------------------
+
+    def _extract(self, response: WebFetchResponse, fmt: str) -> tuple[str, str | None]:
+        main_type = response.content_type.split(";", 1)[0].strip().lower()
+        text = response.body.decode("utf-8", errors="replace")
+
+        if main_type in _HTML_TYPES or (not main_type and "<html" in text.lower()):
+            if fmt == "html":
+                return text, self._html_title(text)
+            content = self._extract_html(text, fmt)
+            if not content:
+                raise _WebFetchError("empty_content", "No readable content could be extracted.")
+            return content, self._html_title(text)
+
+        if main_type in _PLAIN_TYPES:
+            cleaned = text.strip()
+            if not cleaned:
+                raise _WebFetchError("empty_content", "Response body was empty.")
+            return cleaned, None
+
+        raise _WebFetchError(
+            "empty_content", f"Unsupported content type for extraction: {main_type or 'unknown'}"
+        )
+
+    def _extract_html(self, html: str, fmt: str) -> str:
+        output_format = "markdown" if fmt == "markdown" else "txt"
+        try:
+            import trafilatura
+
+            extracted = trafilatura.extract(html, output_format=output_format)
+            if extracted and extracted.strip():
+                return extracted.strip()
+        except Exception as exc:  # noqa: BLE001 - extractor failures fall back to tag strip.
+            logger.bind(error_type=exc.__class__.__name__).debug("trafilatura extraction failed")
+        return self._strip_tags(html)
+
+    @staticmethod
+    def _strip_tags(html: str) -> str:
+        without_scripts = _SCRIPT_STYLE_RE.sub(" ", html)
+        text = _TAG_RE.sub(" ", without_scripts)
+        text = _WS_RE.sub(" ", text)
+        text = "\n".join(line.strip() for line in text.splitlines())
+        text = _BLANKLINES_RE.sub("\n\n", text)
+        return text.strip()
+
+    @staticmethod
+    def _html_title(html: str) -> str | None:
+        match = _TITLE_RE.search(html)
+        if not match:
+            return None
+        title = _WS_RE.sub(" ", _TAG_RE.sub(" ", match.group(1))).strip()
+        return title or None
+
+    # ---- result helpers ------------------------------------------------
+
+    def _error(
+        self,
+        tool_name: str,
+        reason_code: str,
+        message: str,
+        *,
+        status_code: int | None = None,
+        context: Any | None = None,
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "ok": False,
+            "reason_code": reason_code,
+            "message": message,
+            "eval": self._eval_metadata(
+                tool_name, reason_code=reason_code, truncated=False, context=context
+            ),
+        }
+        if status_code is not None:
+            result["status_code"] = status_code
+        return result
+
+    def _eval_metadata(
+        self,
+        tool_name: str,
+        *,
+        reason_code: str | None,
+        truncated: bool,
+        context: Any | None,
+    ) -> dict[str, Any]:
+        return build_execution_eval_metadata(
+            tool_name=tool_name,
+            tool_prompt_id=f"mcp.{tool_name}.v1",
+            tool_prompt_version=_TOOL_PROMPT_VERSION,
+            action_family="web_fetch",
+            result_kind="bounded_web_document",
+            profile_id=self._profile_id_from_context_metadata(context),
+            path_filter_used=False,
+            truncated=truncated,
+            reason_code=reason_code,
+        )
+
+    @staticmethod
+    def _profile_id_from_context_metadata(context: Any | None) -> str | None:
+        metadata = getattr(context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return None
+        for key in ("profile_id", "selected_profile_id"):
+            value = metadata.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_fetch_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_fetch_module.py
@@ -9,9 +9,12 @@ allow/deny/ask rules) — this module does not re-implement domain policy.
 
 from __future__ import annotations
 
+import codecs
+import html as html_lib
 import re
 from dataclasses import dataclass
 from typing import Any, Protocol
+from urllib.parse import urljoin, urlsplit
 
 from loguru import logger
 
@@ -37,6 +40,13 @@ _DEFAULT_TIMEOUT_SECONDS = 15
 _MAX_TIMEOUT_SECONDS = 30
 _DEFAULT_USER_AGENT = "tldw-mcp-web-fetch/1.0"
 
+# Redirects are followed manually so the outbound policy is re-checked before
+# each hop (auto-following would let a permitted URL redirect into denied
+# address space and bypass SSRF/egress protection).
+_REDIRECT_STATUS = {301, 302, 303, 307, 308}
+_MAX_REDIRECTS = 5
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
 # Content types we will surface as text. Anything else is rejected so the tool
 # never returns binary blobs through the JSON tool contract.
 _HTML_TYPES = {"text/html", "application/xhtml+xml"}
@@ -58,13 +68,19 @@ _BLANKLINES_RE = re.compile(r"\n{3,}")
 
 @dataclass(frozen=True, slots=True)
 class WebFetchResponse:
-    """Normalized HTTP response consumed by :class:`WebFetchModule`."""
+    """Normalized HTTP response consumed by :class:`WebFetchModule`.
+
+    ``location`` carries the absolute redirect target when ``status_code`` is a
+    redirect; the module re-checks the outbound policy against it before
+    following, so the client never follows redirects on its own.
+    """
 
     final_url: str
     status_code: int
     content_type: str
     body: bytes
     truncated: bool
+    location: str | None = None
 
 
 class WebFetchHttpClient(Protocol):
@@ -80,8 +96,32 @@ class WebFetchHttpClient(Protocol):
     ) -> WebFetchResponse: ...
 
 
+def _is_supported_content_type(content_type: str) -> bool:
+    main_type = content_type.split(";", 1)[0].strip().lower()
+    return (not main_type) or main_type in _HTML_TYPES or main_type in _PLAIN_TYPES
+
+
+def _safe_host(url: str) -> str:
+    """Return just the host for log context, never the path/query (may hold secrets)."""
+    try:
+        return urlsplit(url).hostname or "unknown"
+    except ValueError:
+        return "unknown"
+
+
 class HttpxWebFetchClient:
-    """Default :class:`WebFetchHttpClient` backed by ``httpx`` with a byte cap."""
+    """Default :class:`WebFetchHttpClient` backed by ``httpx`` with a byte cap.
+
+    Redirects are NOT auto-followed: a redirect response is returned with its
+    resolved ``location`` so the caller can re-apply the outbound policy. The
+    body is only downloaded for terminal responses with a supported content
+    type, avoiding fetching binary payloads (images/video/PDF) just to reject
+    them later.
+    """
+
+    def __init__(self, *, transport: Any | None = None) -> None:
+        # ``transport`` is an injection seam for tests (e.g. httpx.MockTransport).
+        self._transport = transport
 
     async def fetch(
         self,
@@ -93,16 +133,40 @@ class HttpxWebFetchClient:
     ) -> WebFetchResponse:
         import httpx  # Local import: keeps module import cheap and httpx optional at import time.
 
-        chunks: list[bytes] = []
-        downloaded = 0
-        truncated = False
         async with httpx.AsyncClient(
-            follow_redirects=True,
+            follow_redirects=False,
             timeout=timeout_seconds,
             headers={"User-Agent": user_agent},
+            transport=self._transport,
         ) as client:
             async with client.stream("GET", url) as response:
                 content_type = response.headers.get("content-type", "")
+
+                if response.status_code in _REDIRECT_STATUS:
+                    location_header = response.headers.get("location")
+                    location = urljoin(url, location_header) if location_header else None
+                    return WebFetchResponse(
+                        final_url=str(response.url),
+                        status_code=response.status_code,
+                        content_type=content_type,
+                        body=b"",
+                        truncated=False,
+                        location=location,
+                    )
+
+                if not _is_supported_content_type(content_type):
+                    # Reject unsupported (binary) payloads without downloading them.
+                    return WebFetchResponse(
+                        final_url=str(response.url),
+                        status_code=response.status_code,
+                        content_type=content_type,
+                        body=b"",
+                        truncated=False,
+                    )
+
+                chunks: list[bytes] = []
+                downloaded = 0
+                truncated = False
                 async for chunk in response.aiter_bytes():
                     remaining = max_bytes - downloaded
                     if remaining <= 0:
@@ -217,39 +281,74 @@ class WebFetchModule(BaseModule):
         if tool_name != _TOOL_FETCH:
             return self._error(tool_name, "unknown_tool", "Unknown web tool.", context=context)
 
-        args = self.sanitize_input(arguments or {})
+        # Note: the inherited SQL-oriented sanitize_input() is intentionally NOT
+        # applied to the raw URL — legitimate URLs commonly contain substrings
+        # such as ``--`` or ``/*`` that it would reject. Inputs are validated
+        # explicitly below instead.
         try:
-            url, fmt, max_bytes, timeout_seconds, respect_robots = self._validate(args)
+            requested_url, fmt, max_bytes, timeout_seconds, respect_robots = self._validate(
+                arguments or {}
+            )
         except _WebFetchError as exc:
             return self._error(tool_name, exc.reason_code, exc.message, context=context)
 
-        decision = await decide_web_outbound_policy(
-            url,
-            respect_robots=respect_robots,
-            user_agent=_DEFAULT_USER_AGENT,
-            source="mcp.web_fetch",
-            stage="web.fetch",
-        )
-        if not getattr(decision, "allowed", False):
+        # Follow redirects manually, re-applying the outbound policy to every hop
+        # so a permitted URL cannot redirect into denied/private address space.
+        current_url = requested_url
+        for _hop in range(_MAX_REDIRECTS + 1):
+            decision = await decide_web_outbound_policy(
+                current_url,
+                respect_robots=respect_robots,
+                user_agent=_DEFAULT_USER_AGENT,
+                source="mcp.web_fetch",
+                stage="web.fetch",
+            )
+            if not getattr(decision, "allowed", False):
+                return self._error(
+                    tool_name,
+                    "outbound_policy_denied",
+                    f"Outbound policy denied the request ({getattr(decision, 'reason', 'denied')}).",
+                    context=context,
+                )
+
+            try:
+                response = await self._client.fetch(
+                    current_url,
+                    timeout_seconds=timeout_seconds,
+                    max_bytes=max_bytes,
+                    user_agent=_DEFAULT_USER_AGENT,
+                )
+            except Exception as exc:  # noqa: BLE001 - network/client errors are expected and mapped.
+                logger.bind(stage="web.fetch", host=_safe_host(current_url)).opt(exception=exc).warning(
+                    "web.fetch client error"
+                )
+                return self._error(tool_name, "fetch_failed", "Failed to fetch the URL.", context=context)
+
+            if response.status_code in _REDIRECT_STATUS:
+                if not response.location:
+                    logger.bind(stage="web.fetch", host=_safe_host(current_url)).warning(
+                        "web.fetch redirect without a Location header"
+                    )
+                    return self._error(
+                        tool_name,
+                        "fetch_failed",
+                        "Upstream returned a redirect without a Location header.",
+                        status_code=response.status_code,
+                        context=context,
+                    )
+                current_url = response.location
+                continue
+            break
+        else:
+            logger.bind(stage="web.fetch", host=_safe_host(requested_url)).warning(
+                "web.fetch exceeded the redirect limit"
+            )
             return self._error(
                 tool_name,
-                "outbound_policy_denied",
-                f"Outbound policy denied the request ({getattr(decision, 'reason', 'denied')}).",
+                "fetch_failed",
+                f"Exceeded the redirect limit ({_MAX_REDIRECTS}).",
                 context=context,
             )
-
-        try:
-            response = await self._client.fetch(
-                url,
-                timeout_seconds=timeout_seconds,
-                max_bytes=max_bytes,
-                user_agent=_DEFAULT_USER_AGENT,
-            )
-        except Exception as exc:  # noqa: BLE001 - network/client errors are expected and mapped.
-            logger.bind(stage="web.fetch", error_type=exc.__class__.__name__).debug(
-                "web.fetch client error"
-            )
-            return self._error(tool_name, "fetch_failed", "Failed to fetch the URL.", context=context)
 
         if response.status_code >= 400:
             return self._error(
@@ -263,6 +362,12 @@ class WebFetchModule(BaseModule):
         try:
             content, title = self._extract(response, fmt)
         except _WebFetchError as exc:
+            logger.bind(
+                stage="web.fetch",
+                host=_safe_host(response.final_url),
+                reason_code=exc.reason_code,
+                content_type=response.content_type,
+            ).debug("web.fetch extraction rejected the response")
             return self._error(
                 tool_name,
                 exc.reason_code,
@@ -273,7 +378,7 @@ class WebFetchModule(BaseModule):
 
         return {
             "ok": True,
-            "url": url,
+            "url": requested_url,
             "final_url": response.final_url,
             "status_code": response.status_code,
             "content_type": response.content_type,
@@ -301,6 +406,8 @@ class WebFetchModule(BaseModule):
         if not isinstance(url, str) or not url.strip():
             raise _WebFetchError("invalid_arguments", "url is required")
         url = url.strip()
+        if _CONTROL_CHARS_RE.search(url):
+            raise _WebFetchError("invalid_url", "url must not contain control characters")
         if not re.match(r"^https?://", url, re.IGNORECASE):
             raise _WebFetchError("invalid_url", "url must use the http or https scheme")
 
@@ -336,7 +443,7 @@ class WebFetchModule(BaseModule):
 
     def _extract(self, response: WebFetchResponse, fmt: str) -> tuple[str, str | None]:
         main_type = response.content_type.split(";", 1)[0].strip().lower()
-        text = response.body.decode("utf-8", errors="replace")
+        text = self._decode_body(response.body, response.content_type)
 
         if main_type in _HTML_TYPES or (not main_type and "<html" in text.lower()):
             if fmt == "html":
@@ -346,15 +453,30 @@ class WebFetchModule(BaseModule):
                 raise _WebFetchError("empty_content", "No readable content could be extracted.")
             return content, self._html_title(text)
 
-        if main_type in _PLAIN_TYPES:
+        # Plain text, or an absent/misconfigured content type that did not look
+        # like HTML: surface the decoded body directly.
+        if main_type in _PLAIN_TYPES or not main_type:
             cleaned = text.strip()
             if not cleaned:
                 raise _WebFetchError("empty_content", "Response body was empty.")
             return cleaned, None
 
         raise _WebFetchError(
-            "empty_content", f"Unsupported content type for extraction: {main_type or 'unknown'}"
+            "empty_content", f"Unsupported content type for extraction: {main_type}"
         )
+
+    @staticmethod
+    def _decode_body(body: bytes, content_type: str) -> str:
+        """Decode the response body using the charset advertised in the header."""
+        charset = "utf-8"
+        if "charset=" in content_type.lower():
+            candidate = content_type.lower().split("charset=", 1)[1].split(";", 1)[0].strip().strip('"')
+            try:
+                codecs.lookup(candidate)
+                charset = candidate
+            except (LookupError, ValueError):
+                charset = "utf-8"
+        return body.decode(charset, errors="replace")
 
     def _extract_html(self, html: str, fmt: str) -> str:
         output_format = "markdown" if fmt == "markdown" else "txt"
@@ -365,13 +487,16 @@ class WebFetchModule(BaseModule):
             if extracted and extracted.strip():
                 return extracted.strip()
         except Exception as exc:  # noqa: BLE001 - extractor failures fall back to tag strip.
-            logger.bind(error_type=exc.__class__.__name__).debug("trafilatura extraction failed")
+            logger.bind(stage="web.fetch").opt(exception=exc).debug(
+                "trafilatura extraction failed; falling back to tag strip"
+            )
         return self._strip_tags(html)
 
     @staticmethod
     def _strip_tags(html: str) -> str:
         without_scripts = _SCRIPT_STYLE_RE.sub(" ", html)
         text = _TAG_RE.sub(" ", without_scripts)
+        text = html_lib.unescape(text)
         text = _WS_RE.sub(" ", text)
         text = "\n".join(line.strip() for line in text.splitlines())
         text = _BLANKLINES_RE.sub("\n\n", text)
@@ -382,7 +507,7 @@ class WebFetchModule(BaseModule):
         match = _TITLE_RE.search(html)
         if not match:
             return None
-        title = _WS_RE.sub(" ", _TAG_RE.sub(" ", match.group(1))).strip()
+        title = html_lib.unescape(_WS_RE.sub(" ", _TAG_RE.sub(" ", match.group(1)))).strip()
         return title or None
 
     # ---- result helpers ------------------------------------------------

--- a/tldw_Server_API/app/core/MCP_unified/server.py
+++ b/tldw_Server_API/app/core/MCP_unified/server.py
@@ -587,6 +587,20 @@ class MCPServer:
                     })
                     logger.info("MCP_ENABLE_GIT_MODULE=true; queuing GitModule for registration")
 
+            # 6b) Optional: Web fetch module - disabled by default (external network).
+            if self._env_flag_enabled("MCP_ENABLE_WEB_FETCH_MODULE"):
+                if not any(m.get("id") == "web_fetch" for m in modules_to_load if isinstance(m, dict)):
+                    modules_to_load.append({
+                        "id": "web_fetch",
+                        "class": "tldw_Server_API.app.core.MCP_unified.modules.implementations.web_fetch_module:WebFetchModule",
+                        "enabled": True,
+                        "name": "WebFetch",
+                        "version": "1.0.0",
+                        "department": "research",
+                        "settings": {},
+                    })
+                    logger.info("MCP_ENABLE_WEB_FETCH_MODULE=true; queuing WebFetchModule for registration")
+
             # 7) Optional: Sandbox module (code interpreter) - disabled by default
             if self._env_flag_enabled("MCP_ENABLE_SANDBOX_MODULE"):
                 modules_to_load.append({

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
@@ -45,6 +45,7 @@ TOOLING_PRESET_IDS = {
     "merge-conflict-resolver",
     "documentation-writer",
     "project-researcher",
+    "deep-researcher",
     "code-reviewer",
     "devops-engineer",
     "backend-engineer",
@@ -74,6 +75,7 @@ TOOL_CATEGORY_BY_PREFIX = {
     "tool_describe": "tool_discovery",
     "tool_search": "tool_discovery",
     "ui": "frontend",
+    "web": "web",
 }
 
 
@@ -237,6 +239,16 @@ def test_web_search_is_recommended_unavailable_not_enabled() -> None:
     assert "web_search" not in progressive_disclosure["deferred_categories"]
     assert web_search_recommendations
     assert all(item["required"] is False for item in web_search_recommendations)
+
+
+def test_deep_researcher_enables_web_fetch() -> None:
+    deep_researcher = presets.get_builtin_preset("deep-researcher")
+    assert deep_researcher is not None  # nosec B101
+
+    tooling = deep_researcher.profile.metadata["tooling"]
+    assert "web.fetch" in tooling["enabled_tools"]  # nosec B101
+    assert "research.web" in tooling["enabled_capabilities"]  # nosec B101
+    assert "web" in tooling["progressive_disclosure"]["direct_categories"]  # nosec B101
 
 
 def test_cdp_browser_exact_target_is_documented() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_fetch_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_fetch_module.py
@@ -10,6 +10,7 @@ from tldw_Server_API.app.core.MCP_unified.modules.implementations import (
     web_fetch_module as wfm,
 )
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.web_fetch_module import (
+    HttpxWebFetchClient,
     WebFetchModule,
     WebFetchResponse,
 )
@@ -99,6 +100,60 @@ def _html_response(
         body=body,
         truncated=truncated,
     )
+
+
+def _redirect_response(*, location: str | None, final_url: str = "https://example.com/start") -> WebFetchResponse:
+    return WebFetchResponse(
+        final_url=final_url,
+        status_code=302,
+        content_type="text/html",
+        body=b"",
+        truncated=False,
+        location=location,
+    )
+
+
+class _SequenceClient:
+    """Fake client that returns one response per call, recording fetched URLs."""
+
+    def __init__(self, responses: list[WebFetchResponse]) -> None:
+        self._responses = list(responses)
+        self.calls: list[str] = []
+
+    async def fetch(
+        self,
+        url: str,
+        *,
+        timeout_seconds: float,
+        max_bytes: int,
+        user_agent: str,
+    ) -> WebFetchResponse:
+        self.calls.append(url)
+        if not self._responses:
+            raise AssertionError(f"unexpected extra fetch: {url}")
+        return self._responses.pop(0)
+
+
+def _policy_allowing(monkeypatch: pytest.MonkeyPatch, allowed_hosts: set[str]) -> list[str]:
+    """Policy mock that allows only the given hosts; records every checked URL."""
+    from urllib.parse import urlsplit
+
+    checked: list[str] = []
+
+    async def _decide(url: str, **kwargs: Any) -> Any:
+        checked.append(url)
+        host = urlsplit(url).hostname or ""
+        return SimpleNamespace(
+            allowed=host in allowed_hosts,
+            reason="allowed" if host in allowed_hosts else "ssrf_private_ip",
+            mode="strict",
+            stage=kwargs.get("stage", ""),
+            source=kwargs.get("source", ""),
+            details=None,
+        )
+
+    monkeypatch.setattr(wfm, "decide_web_outbound_policy", _decide)
+    return checked
 
 
 _RICH_HTML = (
@@ -261,3 +316,143 @@ async def test_eval_metadata_records_profile_from_context(monkeypatch: pytest.Mo
     )
     assert result["ok"] is True  # nosec B101
     assert result["eval"]["profile_id"] == "deep-researcher"  # nosec B101
+
+
+async def test_redirect_into_denied_host_is_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    checked = _policy_allowing(monkeypatch, {"example.com"})
+    client = _SequenceClient(
+        [_redirect_response(location="https://169.254.169.254/latest/meta-data")]
+    )
+    module = _module(client)
+    result = await module.execute_tool("web.fetch", {"url": "https://example.com/start"})
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "outbound_policy_denied"  # nosec B101
+    # Only the first hop was fetched; the denied redirect target was never requested.
+    assert client.calls == ["https://example.com/start"]  # nosec B101
+    assert "https://169.254.169.254/latest/meta-data" in checked  # nosec B101
+
+
+async def test_redirect_to_allowed_host_is_followed(monkeypatch: pytest.MonkeyPatch) -> None:
+    _policy_allowing(monkeypatch, {"example.com", "example.org"})
+    client = _SequenceClient(
+        [
+            _redirect_response(location="https://example.org/final"),
+            _html_response(_RICH_HTML, final_url="https://example.org/final"),
+        ]
+    )
+    module = _module(client)
+    result = await module.execute_tool("web.fetch", {"url": "https://example.com/start"})
+    assert result["ok"] is True  # nosec B101
+    assert result["final_url"] == "https://example.org/final"  # nosec B101
+    assert client.calls == ["https://example.com/start", "https://example.org/final"]  # nosec B101
+
+
+async def test_redirect_without_location_is_fetch_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    _policy_allowing(monkeypatch, {"example.com"})
+    client = _SequenceClient([_redirect_response(location=None)])
+    module = _module(client)
+    result = await module.execute_tool("web.fetch", {"url": "https://example.com/start"})
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "fetch_failed"  # nosec B101
+
+
+async def test_redirect_limit_is_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    _policy_allowing(monkeypatch, {"example.com"})
+    client = _SequenceClient(
+        [_redirect_response(location=f"https://example.com/hop{i}") for i in range(10)]
+    )
+    module = _module(client)
+    result = await module.execute_tool("web.fetch", {"url": "https://example.com/start"})
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "fetch_failed"  # nosec B101
+
+
+async def test_url_with_sql_like_substrings_is_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
+    _allow_policy(monkeypatch)
+    client = _FakeClient(_html_response(_RICH_HTML))
+    module = _module(client)
+    # URLs commonly contain '--' and '/*'; sanitize_input must not reject them.
+    result = await module.execute_tool(
+        "web.fetch", {"url": "https://example.com/a--b/c?x=1/*y*/&z=--q"}
+    )
+    assert result["ok"] is True  # nosec B101
+
+
+async def test_non_utf8_charset_is_decoded(monkeypatch: pytest.MonkeyPatch) -> None:
+    _allow_policy(monkeypatch)
+    body = "café déjà vu".encode("latin-1")
+    client = _FakeClient(
+        _html_response(body, content_type="text/plain; charset=ISO-8859-1")
+    )
+    module = _module(client)
+    result = await module.execute_tool("web.fetch", {"url": "https://example.com/raw"})
+    assert result["ok"] is True  # nosec B101
+    assert "café" in result["content"]  # nosec B101
+
+
+async def test_missing_content_type_falls_back_to_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    _allow_policy(monkeypatch)
+    client = _FakeClient(_html_response(b"just some text", content_type=""))
+    module = _module(client)
+    result = await module.execute_tool("web.fetch", {"url": "https://example.com/raw"})
+    assert result["ok"] is True  # nosec B101
+    assert result["content"] == "just some text"  # nosec B101
+
+
+async def test_html_entities_are_unescaped(monkeypatch: pytest.MonkeyPatch) -> None:
+    _allow_policy(monkeypatch)
+    body = (
+        b"<html><head><title>Tom &amp; Jerry</title></head>"
+        b"<body><p>Cats &amp; dogs &lt;3 &gt; rocks</p></body></html>"
+    )
+    client = _FakeClient(_html_response(body))
+    module = _module(client)
+    result = await module.execute_tool(
+        "web.fetch", {"url": "https://example.com/post", "format": "text"}
+    )
+    assert result["ok"] is True  # nosec B101
+    assert result["title"] == "Tom & Jerry"  # nosec B101
+    assert "&amp;" not in result["content"]  # nosec B101
+
+
+async def test_httpx_client_does_not_auto_follow_redirects() -> None:
+    import httpx
+
+    requested: list[str] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        requested.append(str(request.url))
+        return httpx.Response(302, headers={"Location": "/next"})
+
+    client = HttpxWebFetchClient(transport=httpx.MockTransport(_handler))
+    response = await client.fetch(
+        "https://example.com/start",
+        timeout_seconds=5,
+        max_bytes=1000,
+        user_agent="test",
+    )
+    assert response.status_code == 302  # nosec B101
+    assert response.location == "https://example.com/next"  # nosec B101
+    # The redirect target was never requested by the client.
+    assert requested == ["https://example.com/start"]  # nosec B101
+
+
+async def test_httpx_client_skips_body_for_unsupported_content_type() -> None:
+    import httpx
+
+    body_chunks_sent = {"n": 0}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        body_chunks_sent["n"] += 1
+        return httpx.Response(200, headers={"Content-Type": "image/png"}, content=b"\x89PNG" * 100)
+
+    client = HttpxWebFetchClient(transport=httpx.MockTransport(_handler))
+    response = await client.fetch(
+        "https://example.com/logo.png",
+        timeout_seconds=5,
+        max_bytes=1000,
+        user_agent="test",
+    )
+    assert response.status_code == 200  # nosec B101
+    assert response.content_type == "image/png"  # nosec B101
+    assert response.body == b""  # nosec B101 - unsupported type not downloaded

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_fetch_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_fetch_module.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
+from tldw_Server_API.app.core.MCP_unified.modules.implementations import (
+    web_fetch_module as wfm,
+)
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.web_fetch_module import (
+    WebFetchModule,
+    WebFetchResponse,
+)
+from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeClient:
+    """Injectable fetcher so unit tests never touch the network."""
+
+    def __init__(self, response: WebFetchResponse | None = None, exc: BaseException | None = None) -> None:
+        self.response = response
+        self.exc = exc
+        self.calls: list[dict[str, Any]] = []
+
+    async def fetch(
+        self,
+        url: str,
+        *,
+        timeout_seconds: float,
+        max_bytes: int,
+        user_agent: str,
+    ) -> WebFetchResponse:
+        self.calls.append(
+            {
+                "url": url,
+                "timeout_seconds": timeout_seconds,
+                "max_bytes": max_bytes,
+                "user_agent": user_agent,
+            }
+        )
+        if self.exc is not None:
+            raise self.exc
+        assert self.response is not None  # nosec B101
+        return self.response
+
+
+def _module(client: _FakeClient) -> WebFetchModule:
+    return WebFetchModule(ModuleConfig(name="WebFetch"), client=client)
+
+
+def _allow_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _decide(url: str, **kwargs: Any) -> Any:
+        return SimpleNamespace(
+            allowed=True,
+            reason="allowed",
+            mode="compat",
+            stage=kwargs.get("stage", ""),
+            source=kwargs.get("source", ""),
+            details=None,
+        )
+
+    monkeypatch.setattr(wfm, "decide_web_outbound_policy", _decide)
+
+
+def _deny_policy(monkeypatch: pytest.MonkeyPatch, *, reason: str = "ssrf_private_ip") -> list[str]:
+    seen: list[str] = []
+
+    async def _decide(url: str, **kwargs: Any) -> Any:
+        seen.append(url)
+        return SimpleNamespace(
+            allowed=False,
+            reason=reason,
+            mode="strict",
+            stage=kwargs.get("stage", ""),
+            source=kwargs.get("source", ""),
+            details=None,
+        )
+
+    monkeypatch.setattr(wfm, "decide_web_outbound_policy", _decide)
+    return seen
+
+
+def _html_response(
+    body: bytes = b"",
+    *,
+    final_url: str = "https://example.com/post",
+    status_code: int = 200,
+    content_type: str = "text/html; charset=utf-8",
+    truncated: bool = False,
+) -> WebFetchResponse:
+    return WebFetchResponse(
+        final_url=final_url,
+        status_code=status_code,
+        content_type=content_type,
+        body=body,
+        truncated=truncated,
+    )
+
+
+_RICH_HTML = (
+    b"<html><head><title>Example Title</title></head>"
+    b"<body><article><h1>Heading</h1>"
+    b"<p>Example article body paragraph one with enough text to extract.</p>"
+    b"<p>Example article body paragraph two continuing the readable content.</p>"
+    b"</article></body></html>"
+)
+
+
+async def test_get_tools_exposes_web_fetch_contract() -> None:
+    module = _module(_FakeClient())
+    tools = await module.get_tools()
+    assert [tool["name"] for tool in tools] == ["web.fetch"]  # nosec B101
+    tool = tools[0]
+    assert tool["inputSchema"]["required"] == ["url"]  # nosec B101
+    assert tool["inputSchema"]["additionalProperties"] is False  # nosec B101
+    assert tool["metadata"]["readOnlyHint"] is True  # nosec B101
+
+
+async def test_invalid_scheme_returns_invalid_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    _allow_policy(monkeypatch)
+    client = _FakeClient()
+    module = _module(client)
+    result = await module.execute_tool("web.fetch", {"url": "ftp://example.com/x"})
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "invalid_url"  # nosec B101
+    assert client.calls == []  # nosec B101
+
+
+async def test_outbound_policy_denial_blocks_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _deny_policy(monkeypatch)
+    client = _FakeClient()
+    module = _module(client)
+    result = await module.execute_tool("web.fetch", {"url": "https://169.254.169.254/latest"})
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "outbound_policy_denied"  # nosec B101
+    assert seen == ["https://169.254.169.254/latest"]  # nosec B101
+    assert client.calls == []  # nosec B101
+
+
+async def test_happy_path_html_extracted_to_markdown(monkeypatch: pytest.MonkeyPatch) -> None:
+    _allow_policy(monkeypatch)
+    client = _FakeClient(_html_response(_RICH_HTML))
+    module = _module(client)
+    result = await module.execute_tool(
+        "web.fetch",
+        {"url": "https://example.com/post", "format": "markdown"},
+    )
+    assert result["ok"] is True  # nosec B101
+    assert result["status_code"] == 200  # nosec B101
+    assert result["final_url"] == "https://example.com/post"  # nosec B101
+    assert result["format"] == "markdown"  # nosec B101
+    assert "Example article body" in result["content"]  # nosec B101
+    assert result["title"] == "Example Title"  # nosec B101
+    assert result["bytes_fetched"] == len(_RICH_HTML)  # nosec B101
+    assert result["truncated"] is False  # nosec B101
+    assert client.calls and client.calls[0]["url"] == "https://example.com/post"  # nosec B101
+
+
+async def test_byte_cap_truncation_is_flagged(monkeypatch: pytest.MonkeyPatch) -> None:
+    _allow_policy(monkeypatch)
+    client = _FakeClient(_html_response(_RICH_HTML, truncated=True))
+    module = _module(client)
+    result = await module.execute_tool(
+        "web.fetch",
+        {"url": "https://example.com/post", "max_bytes": 16},
+    )
+    assert result["ok"] is True  # nosec B101
+    assert result["truncated"] is True  # nosec B101
+    assert client.calls[0]["max_bytes"] == 16  # nosec B101
+
+
+async def test_text_plain_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    _allow_policy(monkeypatch)
+    body = b"plain readable body content"
+    client = _FakeClient(
+        _html_response(body, content_type="text/plain; charset=utf-8")
+    )
+    module = _module(client)
+    result = await module.execute_tool("web.fetch", {"url": "https://example.com/raw.txt"})
+    assert result["ok"] is True  # nosec B101
+    assert result["content"] == "plain readable body content"  # nosec B101
+
+
+async def test_unsupported_content_type_returns_empty_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    _allow_policy(monkeypatch)
+    client = _FakeClient(_html_response(b"\x89PNG\r\n", content_type="image/png"))
+    module = _module(client)
+    result = await module.execute_tool("web.fetch", {"url": "https://example.com/logo.png"})
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "empty_content"  # nosec B101
+
+
+async def test_client_exception_maps_to_fetch_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    _allow_policy(monkeypatch)
+    client = _FakeClient(exc=TimeoutError("boom"))
+    module = _module(client)
+    result = await module.execute_tool("web.fetch", {"url": "https://example.com/slow"})
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "fetch_failed"  # nosec B101
+
+
+async def test_http_error_status_maps_to_fetch_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    _allow_policy(monkeypatch)
+    client = _FakeClient(_html_response(b"not found", status_code=404, content_type="text/html"))
+    module = _module(client)
+    result = await module.execute_tool("web.fetch", {"url": "https://example.com/missing"})
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "fetch_failed"  # nosec B101
+    assert result["status_code"] == 404  # nosec B101
+
+
+async def test_unknown_argument_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    _allow_policy(monkeypatch)
+    module = _module(_FakeClient())
+    result = await module.execute_tool(
+        "web.fetch", {"url": "https://example.com", "depth": 3}
+    )
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "invalid_arguments"  # nosec B101
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {"url": "https://example.com", "max_bytes": -1},
+        {"url": "https://example.com", "timeout_seconds": 0},
+        {"url": "https://example.com", "max_bytes": 10**9},
+        {"url": "https://example.com", "format": "pdf"},
+        {"url": 123},
+    ],
+)
+async def test_bad_bounds_are_rejected(
+    monkeypatch: pytest.MonkeyPatch, arguments: dict[str, Any]
+) -> None:
+    _allow_policy(monkeypatch)
+    module = _module(_FakeClient())
+    result = await module.execute_tool("web.fetch", arguments)
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "invalid_arguments"  # nosec B101
+
+
+async def test_unknown_tool_returns_structured_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _allow_policy(monkeypatch)
+    module = _module(_FakeClient())
+    result = await module.execute_tool("web.other", {"url": "https://example.com"})
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "unknown_tool"  # nosec B101
+
+
+async def test_eval_metadata_records_profile_from_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    _allow_policy(monkeypatch)
+    client = _FakeClient(_html_response(_RICH_HTML))
+    module = _module(client)
+    context = RequestContext(request_id="req-web", metadata={"profile_id": "deep-researcher"})
+    result = await module.execute_tool(
+        "web.fetch", {"url": "https://example.com/post"}, context
+    )
+    assert result["ok"] is True  # nosec B101
+    assert result["eval"]["profile_id"] == "deep-researcher"  # nosec B101

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_fetch_module_registration.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_fetch_module_registration.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+async def _capture_default_registrations(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> list[dict[str, Any]]:
+    from tldw_Server_API.app.core.MCP_unified.server import MCPServer
+
+    server = MCPServer()
+    registrations: list[dict[str, Any]] = []
+
+    async def _capture_registration(module_id: str, module_type: type[Any], config: Any) -> None:
+        registrations.append(
+            {"module_id": module_id, "module_type": module_type, "config": config}
+        )
+
+    monkeypatch.setattr(server.module_registry, "register_module", _capture_registration)
+    monkeypatch.setenv("MCP_MODULES_CONFIG", str(tmp_path / "missing-modules.yaml"))
+    monkeypatch.delenv("MCP_MODULES", raising=False)
+    monkeypatch.setenv("MCP_ENABLE_MEDIA_MODULE", "0")
+    monkeypatch.setenv("MCP_ENABLE_FILESYSTEM_MODULE", "0")
+    monkeypatch.setenv("MCP_ENABLE_BROWSER_CDP_MODULE", "0")
+    monkeypatch.delenv("MCP_BROWSER_CDP_URL", raising=False)
+
+    await server._register_default_modules()
+    return registrations
+
+
+@pytest.mark.asyncio
+async def test_server_registers_web_fetch_module_when_enabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("MCP_ENABLE_WEB_FETCH_MODULE", "1")
+
+    registrations = await _capture_default_registrations(monkeypatch, tmp_path)
+
+    registration = next(item for item in registrations if item["module_id"] == "web_fetch")
+    assert registration["module_type"].__name__ == "WebFetchModule"  # nosec B101
+    assert registration["config"].name == "WebFetch"  # nosec B101
+    assert registration["config"].department == "research"  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_server_does_not_register_web_fetch_module_when_flag_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("MCP_ENABLE_WEB_FETCH_MODULE", raising=False)
+
+    registrations = await _capture_default_registrations(monkeypatch, tmp_path)
+
+    assert "web_fetch" not in {item["module_id"] for item in registrations}  # nosec B101


### PR DESCRIPTION
## Summary

Adds a built-in, read-only **`web.fetch`** MCP tool that retrieves a single http(s) URL, enforces the centralized SSRF/egress outbound policy, and returns bounded extracted content (markdown/text/html).

Because the tool takes a `url` argument, it is automatically governed by the gateway's existing **domain** permission subjects — Claude-style `WebFetch(<domain>)` allow/deny/ask rules — with no new policy plumbing. The module only adds the always-on SSRF/egress safety gate.

## Why in-server (not the standalone `mcp_unified/` package)

Built-in tool *implementations* live in `tldw_Server_API/app/core/MCP_unified/modules/implementations/` (like `git_module.py`). Keeping `web.fetch` there lets it reuse `Web_Scraping.outbound_policy.decide_web_outbound_policy` and trafilatura without adding heavy web deps to the standalone gateway package. The gateway only learns about the tool via `mcp_unified/profiles/presets.py`.

## Behavior & bounds

- Scheme allow-list (http/https → else `invalid_url`).
- Mandatory `decide_web_outbound_policy(... source="mcp.web_fetch", stage="web.fetch")` before any fetch; denial → `outbound_policy_denied` with **no** network call.
- `max_bytes` (default 1 MB, max 5 MB) with `truncated` flag; `timeout_seconds` (default 15, max 30).
- HTML → trafilatura markdown/txt with a deterministic regex tag-strip fallback; text/plain·markdown·json·xml pass through; other content types → `empty_content`; status ≥400 / client errors → `fetch_failed`.
- Injectable `WebFetchHttpClient` Protocol + `WebFetchResponse` dataclass → network-free unit tests.

## Wiring

- Optional registration gated by `MCP_ENABLE_WEB_FETCH_MODULE` (off by default, mirroring git/sandbox), id `web_fetch`, department `research`.
- `web.fetch` enabled in the `deep-researcher` gateway preset (the `external_network` / `research.web` preset).

## Tests

- `test_web_fetch_module.py` (17) — contract, invalid scheme, outbound denial blocks fetch, html→markdown, truncation, text passthrough, unsupported type, fetch/status errors, arg validation, eval profile metadata.
- `test_web_fetch_module_registration.py` (2) — registered iff flag set.
- `test_profile_presets.py` — new `test_deep_researcher_enables_web_fetch`.
- Regression: federation/storage/permission-rule/policy-decision suites (91) pass.
- ruff (new files) clean; `compileall` rc=0; `bandit` no findings; `git diff --check` clean.

backlog: task-2354 · design: `Docs/Design/MCP_Web_Fetch_Tool_Design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a built-in, read-only `web.fetch` MCP tool to safely fetch a single http(s) URL and return bounded markdown/text/html, with manual redirect handling that re-applies outbound policy on each hop. It enforces the centralized SSRF/egress policy and existing domain rules, and is opt-in via `MCP_ENABLE_WEB_FETCH_MODULE` (enabled in the `deep-researcher` preset). Addresses TASK-2354.

- **New Features**
  - Security/policy: http/https only; redirects followed manually with the outbound policy re-checked on every hop; enforced via `decide_web_outbound_policy`; domain allow/deny/ask applies automatically.
  - Results/bounds: returns `{ok, url, final_url, status_code, content_type, title, format, content, bytes_fetched, truncated}`; defaults `max_bytes` 1 MB (max 5 MB) and `timeout_seconds` 15s (max 30s); HTML → `markdown`/`text`/`html`; unsupported types rejected and not downloaded; charset-aware decoding with entity unescape; absent/mis-set content types fall back to text.
  - Implementation: in-server `WebFetchModule` using `trafilatura` with a tag-strip fallback; injectable `WebFetchHttpClient` (default `httpx` with no auto-follow) for network-free tests; URL validation avoids generic sanitizers and rejects control chars.
  - Wiring: optional module behind `MCP_ENABLE_WEB_FETCH_MODULE`; added to `deep-researcher` tooling.

- **Migration**
  - Set `MCP_ENABLE_WEB_FETCH_MODULE=1` to register the module.
  - Use existing `WebFetch(<domain>)` rules to grant or prompt domains as needed.
  - For other presets, add `web.fetch` to enabled tools; `deep-researcher` includes it by default.

<sup>Written for commit 5d8e3e6bf8f0f67cd8b2acb34cbaffb34ed581cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

