### PR TITLE
Add MCP web.search tool

### DIFF
--- a/Docs/Design/MCP_Web_Search_Tool_Design.md
+++ b/Docs/Design/MCP_Web_Search_Tool_Design.md
@@ -1,0 +1,102 @@
+# MCP `web.search` Tool Design
+
+Status: Implementing (June 2026)
+Owner: standalone MCP gateway backlog
+Companion: `Docs/Design/MCP_Web_Fetch_Tool_Design.md`
+
+## Goal
+
+Add a built-in, read-only MCP tool, `web.search`, that runs a query against a
+configured multi-provider web search backend and returns a bounded list of
+normalized results. It complements `web.fetch` (which retrieves one URL) and is
+the natural follow-up search primitive for the `deep-researcher` preset.
+
+## Why this shape
+
+- **In-server module.** Like `web.fetch`/`git`, the tool implementation lives in
+  `tldw_Server_API/app/core/MCP_unified/modules/implementations/web_search_module.py`
+  so it can call `Web_Scraping.WebSearch_APIs.perform_websearch` without pulling
+  provider SDKs into the standalone `mcp_unified/` gateway package.
+- **Outbound policy is enforced inside the provider call.** `perform_websearch`
+  runs each provider request through `_enforce_provider_outbound_policy`
+  (SSRF/egress). The module surfaces a denial as `outbound_policy_denied` rather
+  than re-implementing the gate.
+- **Governance.** `web.search` is gated as a whole tool via tool-level permission
+  rules and the `external_network` / `research.web` preset capability. Unlike
+  `web.fetch`, the input is a `query` (no `url`), so domain *subjects* are not
+  extracted from the call — domain rules don't apply per-result, by design. The
+  Claude-style `WebSearch(<domain>)` rule keyword remains available for authors
+  but only matches when a domain subject is present.
+
+## Tool: `web.search`
+
+Read-only. Arguments (additionalProperties: false):
+
+| arg | type | default | bounds |
+|---|---|---|---|
+| `query` | string (required) | — | non-empty |
+| `engine` | string | configured/`duckduckgo` | allow-list of supported providers |
+| `result_count` | integer | 10 | 1 .. 25 |
+| `content_country` | string | `US` | — |
+| `search_lang` | string | `en` | — |
+| `output_lang` | string | `en` | — |
+| `safesearch` | string | provider default | — |
+| `site_whitelist` | string[] | — | non-empty strings |
+| `site_blacklist` | string[] | — | non-empty strings |
+| `date_range` | string | — | — |
+
+Supported engines: google, duckduckgo, brave, kagi, serper, tavily, exa,
+firecrawl, searx, yandex, baidu.
+
+Success result:
+
+```
+{
+  "ok": true,
+  "engine": "duckduckgo",
+  "query": "python asyncio",
+  "result_count": 2,
+  "total_results_found": 2,
+  "results": [
+    {"title": "...", "url": "https://...", "content": "<<=4000 chars>>", "metadata": {...}}
+  ],
+  "eval": { ... }
+}
+```
+
+Error result: `{ ok: false, reason_code, message, eval }`.
+
+Reason codes: `invalid_arguments`, `invalid_engine`, `outbound_policy_denied`
+(provider blocked by egress policy), `search_failed` (provider/network/parse
+error), `unknown_tool`.
+
+## Bounds & normalization
+
+- `result_count` clamped to 25; the result list is also truncated to the
+  requested count defensively.
+- Per-result `content` truncated to 4000 chars.
+- `perform_websearch` is synchronous/blocking → run via `asyncio.to_thread`.
+- A `processing_error`/`error` field containing "outbound policy" maps to
+  `outbound_policy_denied`; any other error maps to `search_failed`.
+
+## Testability
+
+`WebSearchBackend` Protocol (default `PerformWebSearchBackend`) is injected so
+unit tests provide a fake returning a normalized `perform_websearch` payload —
+no provider config, no network.
+
+## Registration & presets
+
+- `server.py`: optional block gated by `MCP_ENABLE_WEB_SEARCH_MODULE` (off by
+  default), id `web_search`, department `research`.
+- `presets.py`: `_WEB_READ_TOOLS = ["web.fetch", "web.search"]`, wired into the
+  `deep-researcher` preset.
+
+## Tests
+
+- `test_web_search_module.py`: contract, happy path, content bounding, result
+  cap, empty query, invalid engine, argument validation, processing-error →
+  search_failed, outbound-policy → denied, backend exception → search_failed,
+  unknown tool, site-filter passthrough, eval profile metadata.
+- `test_web_search_module_registration.py`: registered iff flag set.
+- `test_profile_presets.py`: `deep-researcher` enables `web.search`.

--- a/backlog/tasks/task-2355 - Add-MCP-web-search-tool.md
+++ b/backlog/tasks/task-2355 - Add-MCP-web-search-tool.md
@@ -1,0 +1,50 @@
+---
+id: TASK-2355
+title: Add MCP web.search tool
+status: Done
+updated_date: '2026-06-12'
+labels:
+- mcp
+- tools
+- web
+- research
+references:
+- Docs/Design/MCP_Web_Search_Tool_Design.md
+dependencies:
+- TASK-2354
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a built-in read-only MCP `web.search` tool that runs a query against a configured multi-provider web search backend and returns a bounded list of normalized results, complementing `web.fetch`. The provider call enforces the centralized outbound (SSRF/egress) policy; the tool is gated by the `external_network`/`research.web` preset capability and tool-level permission rules.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A `web.search` MCP tool runs a query against a configured provider and returns `{ok, engine, query, result_count, total_results_found, results:[{title,url,content,metadata}], eval}`; empty query and unsupported engine return structured `invalid_arguments`/`invalid_engine` errors without calling the backend.
+- [x] #2 The provider call goes through `WebSearch_APIs.perform_websearch` (which enforces per-provider outbound policy); a `processing_error` mentioning the outbound policy maps to `outbound_policy_denied`, any other error/exception maps to `search_failed`.
+- [x] #3 Results are bounded: list truncated to `result_count` (clamped to 25, default 10) and per-result `content` truncated to 4000 chars; site_whitelist/site_blacklist accept only lists of non-empty strings and are forwarded to the backend.
+- [x] #4 The module is registered only when `MCP_ENABLE_WEB_SEARCH_MODULE` is set, the search backend is injectable for tests (no network/config in unit tests, blocking call offloaded via asyncio.to_thread), and the `deep-researcher` gateway preset enables `web.search`.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+In-server module `tldw_Server_API/app/core/MCP_unified/modules/implementations/web_search_module.py` (`WebSearchModule(BaseModule)`, single `web.search` tool), mirroring the `web.fetch` slice (task-2354). Default backend `PerformWebSearchBackend` delegates to `Web_Scraping.WebSearch_APIs.perform_websearch` (sync, multi-provider, returns a normalized `{results:[{title,url,content,metadata}], processing_error, error, total_results_found}` dict). Offloaded via `asyncio.to_thread`.
+
+Governance: `web.search` takes a `query` (no `url`), so domain *subjects* are not extracted from the call — it is gated as a whole tool via tool-level rules and the `external_network`/`research.web` capability. Outbound (SSRF/egress) policy is enforced inside `perform_websearch._enforce_provider_outbound_policy`; the module maps an "outbound policy" processing_error to `outbound_policy_denied`.
+
+Bounds: engine allow-list (google/duckduckgo/brave/kagi/serper/tavily/exa/firecrawl/searx/yandex/baidu), default `duckduckgo`; result_count default 10 / max 25 with defensive list truncation; per-result content capped at 4000 chars; site_whitelist/site_blacklist validated as list[str].
+
+Registration: optional env-flag block in `server.py` gated by `MCP_ENABLE_WEB_SEARCH_MODULE` (off by default), id `web_search`, department `research`. Preset wiring: `_WEB_READ_TOOLS = ["web.fetch", "web.search"]` in `presets.py`, enabled in the `deep-researcher` tooling_metadata_document.
+
+Stacked on the `web.fetch` branch (PR base = codex/mcp-webfetch-tool; retarget to dev after #2348 merges) because both touch `server.py` and `presets.py`.
+
+TDD evidence:
+- RED: `pytest test_web_search_module.py` → collection error (module absent).
+- GREEN: `test_web_search_module.py` 19 passed; `test_web_search_module_registration.py` 2 passed; `test_profile_presets.py` 27 passed (incl. updated `test_deep_researcher_enables_web_tools`); web.fetch suites still green (67 combined).
+- ruff (new/touched files) clean; `compileall` rc=0; `bandit -r web_search_module.py` no findings; `git diff --check` clean.
+
+Deferred: query sub-generation/aggregation (the heavier `generate_and_search`/`aggregate_results` pipeline), result re-ranking, and per-result fetch+extract chaining with `web.fetch`.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-2355 - Add-MCP-web-search-tool.md
+++ b/backlog/tasks/task-2355 - Add-MCP-web-search-tool.md
@@ -47,4 +47,10 @@ TDD evidence:
 - ruff (new/touched files) clean; `compileall` rc=0; `bandit -r web_search_module.py` no findings; `git diff --check` clean.
 
 Deferred: query sub-generation/aggregation (the heavier `generate_and_search`/`aggregate_results` pipeline), result re-ranking, and per-result fetch+extract chaining with `web.fetch`.
+
+Review fixes (PR #2349, rebased onto dev after #2348 merged):
+- Qodo "Action required" — search inputs over-sanitized: overrode `sanitize_input` in `WebSearchModule` to strip only NUL/control chars (no SQL denylist). The MCP protocol calls `module.sanitize_input` before execution, so without this a query like `pip install --no-cache-dir` or a punycode `xn--` domain filter was rejected with a protocol InvalidParams. The SAME override was added to `WebFetchModule` (the merged #2348 fix only removed the internal call but the protocol-level sanitize still rejected `--` URLs — incomplete; now corrected here).
+- Qodo — truncation not reported: `_normalize` now computes a `truncated` flag (list exceeded `result_count` OR any content clipped) and threads it into both the result payload and `eval.truncated`.
+- Gemini — normalize `title`/`url`/`content` to strings via `_coerce_str`; empty/whitespace site filter lists → None; blank optional string args (content_country/search_lang/output_lang/safesearch/date_range) stripped → None so backend defaults apply.
+- +11 web.search tests (sanitize override, control-char strip, sql-like query executes, truncation list/content/none, string coercion, empty site list, blank optional strings) and +2 web.fetch sanitize override tests. 86 web/preset tests green; ruff/compileall/bandit clean.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/mcp_unified/profiles/presets.py
+++ b/mcp_unified/profiles/presets.py
@@ -203,7 +203,7 @@ _GIT_READ_TOOLS = [
     "git.conflicts.list",
     "git.conflicts.read",
 ]
-_WEB_READ_TOOLS = ["web.fetch"]
+_WEB_READ_TOOLS = ["web.fetch", "web.search"]
 _TEST_READ_TOOLS = ["tests.results.read", "tests.logs.read"]
 _TEST_REQUEST_TOOLS = [*_TEST_READ_TOOLS, "tests.request"]
 _BROWSER_READ_TOOLS = [

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_fetch_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_fetch_module.py
@@ -46,6 +46,7 @@ _DEFAULT_USER_AGENT = "tldw-mcp-web-fetch/1.0"
 _REDIRECT_STATUS = {301, 302, 303, 307, 308}
 _MAX_REDIRECTS = 5
 _CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+_MAX_SANITIZE_DEPTH = 20
 
 # Content types we will surface as text. Anything else is rejected so the tool
 # never returns binary blobs through the JSON tool contract.
@@ -271,6 +272,27 @@ class WebFetchModule(BaseModule):
         )
         tool["inputSchema"]["additionalProperties"] = False
         return [tool]
+
+    def sanitize_input(self, input_data: Any, _depth: int = 0) -> Any:
+        """Permissive sanitizer for web fetch inputs.
+
+        The MCP protocol layer runs ``module.sanitize_input`` on every tool call
+        before execution. The base implementation rejects strings containing
+        SQL-injection substrings such as ``--``, ``/*`` and ``*/`` — which appear
+        constantly in legitimate URLs and query strings — and would turn them
+        into a protocol ``InvalidParams`` error before this tool's own validation
+        can run. We therefore strip only NUL/control characters and keep a depth
+        guard.
+        """
+        if _depth > _MAX_SANITIZE_DEPTH:
+            raise ValueError("Input too deeply nested")
+        if isinstance(input_data, str):
+            return _CONTROL_CHARS_RE.sub("", input_data)
+        if isinstance(input_data, dict):
+            return {key: self.sanitize_input(value, _depth + 1) for key, value in input_data.items()}
+        if isinstance(input_data, list):
+            return [self.sanitize_input(value, _depth + 1) for value in input_data]
+        return input_data
 
     async def execute_tool(
         self,

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_search_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_search_module.py
@@ -1,0 +1,353 @@
+"""Read-only ``web.search`` MCP tool wrapping the multi-provider web search API.
+
+The tool runs a query against a configured search provider and returns a bounded
+list of normalized results. The provider call itself enforces the centralized
+outbound (SSRF/egress) policy inside ``WebSearch_APIs.perform_websearch``; this
+module adds argument validation, result bounding, and structured error mapping.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Protocol
+
+from loguru import logger
+
+from tldw_Server_API.app.core.MCP_unified.tool_observability import (
+    build_execution_eval_metadata,
+    build_tool_eval_metadata,
+)
+
+from ..base import BaseModule, ModuleConfig, create_tool_definition
+
+_TOOL_SEARCH = "web.search"
+_TOOL_PROMPT_VERSION = "2026.06.12"
+
+_ALLOWED_ARGS = {
+    "query",
+    "engine",
+    "result_count",
+    "content_country",
+    "search_lang",
+    "output_lang",
+    "safesearch",
+    "site_whitelist",
+    "site_blacklist",
+    "date_range",
+}
+
+# Curated provider allow-list. Mirrors the engines dispatched by
+# ``WebSearch_APIs.perform_websearch`` that return normalized results.
+_ALLOWED_ENGINES = frozenset(
+    {
+        "google",
+        "duckduckgo",
+        "brave",
+        "kagi",
+        "serper",
+        "tavily",
+        "exa",
+        "firecrawl",
+        "searx",
+        "yandex",
+        "baidu",
+    }
+)
+_DEFAULT_ENGINE = "duckduckgo"
+
+_DEFAULT_RESULT_COUNT = 10
+_MAX_RESULT_COUNT = 25
+_MAX_RESULT_CONTENT_CHARS = 4000
+
+
+class WebSearchBackend(Protocol):
+    """Injectable search backend so the module is unit-testable without network."""
+
+    def search(self, **kwargs: Any) -> dict[str, Any]: ...
+
+
+class PerformWebSearchBackend:
+    """Default backend delegating to ``WebSearch_APIs.perform_websearch``."""
+
+    def search(self, **kwargs: Any) -> dict[str, Any]:
+        from tldw_Server_API.app.core.Web_Scraping.WebSearch_APIs import (
+            perform_websearch,
+        )
+
+        return perform_websearch(
+            kwargs["engine"],
+            kwargs["query"],
+            kwargs.get("content_country") or "US",
+            kwargs.get("search_lang") or "en",
+            kwargs.get("output_lang") or "en",
+            kwargs["result_count"],
+            date_range=kwargs.get("date_range"),
+            safesearch=kwargs.get("safesearch"),
+            site_whitelist=kwargs.get("site_whitelist"),
+            site_blacklist=kwargs.get("site_blacklist"),
+        )
+
+
+class _WebSearchError(Exception):
+    """Internal control-flow error carrying a structured reason code."""
+
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.message = message
+
+
+class WebSearchModule(BaseModule):
+    """Single read-only ``web.search`` tool over the multi-provider search API."""
+
+    def __init__(
+        self,
+        config: ModuleConfig,
+        *,
+        backend: WebSearchBackend | None = None,
+    ) -> None:
+        super().__init__(config)
+        self._backend: WebSearchBackend = backend or PerformWebSearchBackend()
+
+    async def on_initialize(self) -> None:
+        return None
+
+    async def on_shutdown(self) -> None:
+        return None
+
+    async def check_health(self) -> dict[str, bool]:
+        return {"initialized": True, "backend": self._backend is not None}
+
+    async def get_tools(self) -> list[dict[str, Any]]:
+        tool = create_tool_definition(
+            name=_TOOL_SEARCH,
+            description=(
+                "Search the web with a configured provider and return a bounded "
+                "list of normalized results. Subject to outbound (SSRF/egress) "
+                "policy and external-network permission."
+            ),
+            parameters={
+                "properties": {
+                    "query": {"type": "string", "description": "The search query."},
+                    "engine": {
+                        "type": "string",
+                        "enum": sorted(_ALLOWED_ENGINES),
+                        "description": "Search provider; defaults to the configured provider.",
+                    },
+                    "result_count": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": _MAX_RESULT_COUNT,
+                    },
+                    "content_country": {"type": "string"},
+                    "search_lang": {"type": "string"},
+                    "output_lang": {"type": "string"},
+                    "safesearch": {"type": "string"},
+                    "site_whitelist": {"type": "array", "items": {"type": "string"}},
+                    "site_blacklist": {"type": "array", "items": {"type": "string"}},
+                    "date_range": {"type": "string"},
+                },
+                "required": ["query"],
+            },
+            metadata={
+                "category": "web",
+                "readOnlyHint": True,
+                "uses_network": True,
+                "capabilities": ["research.web", "external.network"],
+                **build_tool_eval_metadata(
+                    tool_prompt_id=f"mcp.{_TOOL_SEARCH}.v1",
+                    tool_prompt_version=_TOOL_PROMPT_VERSION,
+                    task_families=["web_research", "citation_collection"],
+                    expected_result_kind="bounded_web_search_results",
+                    success_signals=[
+                        "enforced_outbound_policy",
+                        "bounded_results",
+                        "normalized_result_shape",
+                    ],
+                ),
+            },
+        )
+        tool["inputSchema"]["additionalProperties"] = False
+        return [tool]
+
+    async def execute_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: Any | None = None,
+    ) -> Any:
+        if tool_name != _TOOL_SEARCH:
+            return self._error(tool_name, "unknown_tool", "Unknown web tool.", context=context)
+
+        args = self.sanitize_input(arguments or {})
+        try:
+            params = self._validate(args)
+        except _WebSearchError as exc:
+            return self._error(tool_name, exc.reason_code, exc.message, context=context)
+
+        try:
+            payload = await asyncio.to_thread(self._backend.search, **params)
+        except Exception as exc:  # noqa: BLE001 - provider/network errors are mapped.
+            logger.bind(stage="web.search", error_type=exc.__class__.__name__).debug(
+                "web.search backend error"
+            )
+            return self._error(tool_name, "search_failed", "Web search failed.", context=context)
+
+        try:
+            results, total = self._normalize(payload, params["result_count"])
+        except _WebSearchError as exc:
+            return self._error(tool_name, exc.reason_code, exc.message, context=context)
+
+        return {
+            "ok": True,
+            "engine": params["engine"],
+            "query": params["query"],
+            "result_count": len(results),
+            "total_results_found": total,
+            "results": results,
+            "eval": self._eval_metadata(_TOOL_SEARCH, reason_code=None, context=context),
+        }
+
+    # ---- validation ----------------------------------------------------
+
+    def _validate(self, args: dict[str, Any]) -> dict[str, Any]:
+        unknown = sorted(set(args) - _ALLOWED_ARGS)
+        if unknown:
+            raise _WebSearchError("invalid_arguments", f"unknown arguments: {', '.join(unknown)}")
+
+        query = args.get("query")
+        if not isinstance(query, str) or not query.strip():
+            raise _WebSearchError("invalid_arguments", "query is required")
+        query = query.strip()
+
+        engine = args.get("engine")
+        if engine is None:
+            engine = _DEFAULT_ENGINE
+        elif not isinstance(engine, str) or engine.lower() not in _ALLOWED_ENGINES:
+            raise _WebSearchError("invalid_engine", "engine is not a supported provider")
+        else:
+            engine = engine.lower()
+
+        result_count = args.get("result_count")
+        if result_count is None:
+            result_count = _DEFAULT_RESULT_COUNT
+        elif not isinstance(result_count, int) or isinstance(result_count, bool) or result_count <= 0:
+            raise _WebSearchError("invalid_arguments", "result_count must be a positive integer")
+        elif result_count > _MAX_RESULT_COUNT:
+            raise _WebSearchError("invalid_arguments", f"result_count exceeds maximum ({_MAX_RESULT_COUNT})")
+
+        for str_field in ("content_country", "search_lang", "output_lang", "safesearch", "date_range"):
+            value = args.get(str_field)
+            if value is not None and not isinstance(value, str):
+                raise _WebSearchError("invalid_arguments", f"{str_field} must be a string")
+
+        site_whitelist = self._validate_domain_list(args, "site_whitelist")
+        site_blacklist = self._validate_domain_list(args, "site_blacklist")
+
+        return {
+            "engine": engine,
+            "query": query,
+            "result_count": result_count,
+            "content_country": args.get("content_country"),
+            "search_lang": args.get("search_lang"),
+            "output_lang": args.get("output_lang"),
+            "safesearch": args.get("safesearch"),
+            "site_whitelist": site_whitelist,
+            "site_blacklist": site_blacklist,
+            "date_range": args.get("date_range"),
+        }
+
+    @staticmethod
+    def _validate_domain_list(args: dict[str, Any], name: str) -> list[str] | None:
+        value = args.get(name)
+        if value is None:
+            return None
+        if not isinstance(value, list) or not all(isinstance(item, str) and item.strip() for item in value):
+            raise _WebSearchError("invalid_arguments", f"{name} must be a list of non-empty strings")
+        return [item.strip() for item in value]
+
+    # ---- normalization -------------------------------------------------
+
+    def _normalize(self, payload: Any, result_count: int) -> tuple[list[dict[str, Any]], int]:
+        if not isinstance(payload, dict):
+            raise _WebSearchError("search_failed", "Search backend returned an unexpected payload.")
+
+        error_text = payload.get("processing_error") or payload.get("error")
+        if error_text:
+            if "outbound policy" in str(error_text).lower():
+                raise _WebSearchError("outbound_policy_denied", "Outbound policy denied the search provider.")
+            raise _WebSearchError("search_failed", "Web search failed.")
+
+        raw_results = payload.get("results") or []
+        if not isinstance(raw_results, list):
+            raise _WebSearchError("search_failed", "Search backend returned malformed results.")
+
+        results: list[dict[str, Any]] = []
+        for entry in raw_results[:result_count]:
+            if not isinstance(entry, dict):
+                continue
+            results.append(self._normalize_entry(entry))
+
+        total = payload.get("total_results_found")
+        if not isinstance(total, int):
+            total = len(results)
+        return results, total
+
+    def _normalize_entry(self, entry: dict[str, Any]) -> dict[str, Any]:
+        content = entry.get("content")
+        if isinstance(content, str) and len(content) > _MAX_RESULT_CONTENT_CHARS:
+            content = content[:_MAX_RESULT_CONTENT_CHARS]
+        metadata = entry.get("metadata")
+        return {
+            "title": entry.get("title"),
+            "url": entry.get("url"),
+            "content": content,
+            "metadata": metadata if isinstance(metadata, dict) else {},
+        }
+
+    # ---- result helpers ------------------------------------------------
+
+    def _error(
+        self,
+        tool_name: str,
+        reason_code: str,
+        message: str,
+        *,
+        context: Any | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "reason_code": reason_code,
+            "message": message,
+            "eval": self._eval_metadata(tool_name, reason_code=reason_code, context=context),
+        }
+
+    def _eval_metadata(
+        self,
+        tool_name: str,
+        *,
+        reason_code: str | None,
+        context: Any | None,
+    ) -> dict[str, Any]:
+        return build_execution_eval_metadata(
+            tool_name=tool_name,
+            tool_prompt_id=f"mcp.{tool_name}.v1",
+            tool_prompt_version=_TOOL_PROMPT_VERSION,
+            action_family="web_search",
+            result_kind="bounded_web_search_results",
+            profile_id=self._profile_id_from_context_metadata(context),
+            path_filter_used=False,
+            truncated=False,
+            reason_code=reason_code,
+        )
+
+    @staticmethod
+    def _profile_id_from_context_metadata(context: Any | None) -> str | None:
+        metadata = getattr(context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return None
+        for key in ("profile_id", "selected_profile_id"):
+            value = metadata.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_search_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_search_module.py
@@ -9,6 +9,7 @@ module adds argument validation, result bounding, and structured error mapping.
 from __future__ import annotations
 
 import asyncio
+import re
 from typing import Any, Protocol
 
 from loguru import logger
@@ -58,6 +59,9 @@ _DEFAULT_ENGINE = "duckduckgo"
 _DEFAULT_RESULT_COUNT = 10
 _MAX_RESULT_COUNT = 25
 _MAX_RESULT_CONTENT_CHARS = 4000
+
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+_MAX_SANITIZE_DEPTH = 20
 
 
 class WebSearchBackend(Protocol):
@@ -170,6 +174,28 @@ class WebSearchModule(BaseModule):
         tool["inputSchema"]["additionalProperties"] = False
         return [tool]
 
+    def sanitize_input(self, input_data: Any, _depth: int = 0) -> Any:
+        """Permissive sanitizer for web search inputs.
+
+        The base implementation rejects strings containing SQL-injection
+        substrings such as ``--``, ``/*`` and ``*/``. Those appear in legitimate
+        search queries (e.g. ``pip install --no-cache-dir``) and punycode domain
+        filters (e.g. ``xn--...``). The MCP protocol layer runs
+        ``module.sanitize_input`` on every tool call before execution, so without
+        this override such inputs would be rejected with a protocol
+        ``InvalidParams`` error instead of being searched. We therefore strip
+        only NUL/control characters and keep a depth guard.
+        """
+        if _depth > _MAX_SANITIZE_DEPTH:
+            raise ValueError("Input too deeply nested")
+        if isinstance(input_data, str):
+            return _CONTROL_CHARS_RE.sub("", input_data)
+        if isinstance(input_data, dict):
+            return {key: self.sanitize_input(value, _depth + 1) for key, value in input_data.items()}
+        if isinstance(input_data, list):
+            return [self.sanitize_input(value, _depth + 1) for value in input_data]
+        return input_data
+
     async def execute_tool(
         self,
         tool_name: str,
@@ -188,13 +214,13 @@ class WebSearchModule(BaseModule):
         try:
             payload = await asyncio.to_thread(self._backend.search, **params)
         except Exception as exc:  # noqa: BLE001 - provider/network errors are mapped.
-            logger.bind(stage="web.search", error_type=exc.__class__.__name__).debug(
+            logger.bind(stage="web.search", engine=params["engine"]).opt(exception=exc).warning(
                 "web.search backend error"
             )
             return self._error(tool_name, "search_failed", "Web search failed.", context=context)
 
         try:
-            results, total = self._normalize(payload, params["result_count"])
+            results, total, truncated = self._normalize(payload, params["result_count"])
         except _WebSearchError as exc:
             return self._error(tool_name, exc.reason_code, exc.message, context=context)
 
@@ -204,8 +230,11 @@ class WebSearchModule(BaseModule):
             "query": params["query"],
             "result_count": len(results),
             "total_results_found": total,
+            "truncated": truncated,
             "results": results,
-            "eval": self._eval_metadata(_TOOL_SEARCH, reason_code=None, context=context),
+            "eval": self._eval_metadata(
+                _TOOL_SEARCH, reason_code=None, truncated=truncated, context=context
+            ),
         }
 
     # ---- validation ----------------------------------------------------
@@ -236,10 +265,18 @@ class WebSearchModule(BaseModule):
         elif result_count > _MAX_RESULT_COUNT:
             raise _WebSearchError("invalid_arguments", f"result_count exceeds maximum ({_MAX_RESULT_COUNT})")
 
+        # Strip optional string fields; normalize empty/whitespace to None so the
+        # backend applies its own defaults instead of receiving blank values.
+        str_fields: dict[str, str | None] = {}
         for str_field in ("content_country", "search_lang", "output_lang", "safesearch", "date_range"):
             value = args.get(str_field)
-            if value is not None and not isinstance(value, str):
+            if value is None:
+                str_fields[str_field] = None
+                continue
+            if not isinstance(value, str):
                 raise _WebSearchError("invalid_arguments", f"{str_field} must be a string")
+            stripped = value.strip()
+            str_fields[str_field] = stripped or None
 
         site_whitelist = self._validate_domain_list(args, "site_whitelist")
         site_blacklist = self._validate_domain_list(args, "site_blacklist")
@@ -248,13 +285,13 @@ class WebSearchModule(BaseModule):
             "engine": engine,
             "query": query,
             "result_count": result_count,
-            "content_country": args.get("content_country"),
-            "search_lang": args.get("search_lang"),
-            "output_lang": args.get("output_lang"),
-            "safesearch": args.get("safesearch"),
+            "content_country": str_fields["content_country"],
+            "search_lang": str_fields["search_lang"],
+            "output_lang": str_fields["output_lang"],
+            "safesearch": str_fields["safesearch"],
             "site_whitelist": site_whitelist,
             "site_blacklist": site_blacklist,
-            "date_range": args.get("date_range"),
+            "date_range": str_fields["date_range"],
         }
 
     @staticmethod
@@ -264,11 +301,16 @@ class WebSearchModule(BaseModule):
             return None
         if not isinstance(value, list) or not all(isinstance(item, str) and item.strip() for item in value):
             raise _WebSearchError("invalid_arguments", f"{name} must be a list of non-empty strings")
-        return [item.strip() for item in value]
+        # An empty (or all-whitespace) list would be read by some providers as
+        # "exclude everything"; normalize it to None instead.
+        stripped = [item.strip() for item in value]
+        return stripped or None
 
     # ---- normalization -------------------------------------------------
 
-    def _normalize(self, payload: Any, result_count: int) -> tuple[list[dict[str, Any]], int]:
+    def _normalize(
+        self, payload: Any, result_count: int
+    ) -> tuple[list[dict[str, Any]], int, bool]:
         if not isinstance(payload, dict):
             raise _WebSearchError("search_failed", "Search backend returned an unexpected payload.")
 
@@ -282,28 +324,45 @@ class WebSearchModule(BaseModule):
         if not isinstance(raw_results, list):
             raise _WebSearchError("search_failed", "Search backend returned malformed results.")
 
+        # The response is bounded when the provider returned more results than
+        # requested or any single result's content had to be clipped.
+        truncated = len(raw_results) > result_count
         results: list[dict[str, Any]] = []
         for entry in raw_results[:result_count]:
             if not isinstance(entry, dict):
                 continue
-            results.append(self._normalize_entry(entry))
+            normalized, content_clipped = self._normalize_entry(entry)
+            truncated = truncated or content_clipped
+            results.append(normalized)
 
         total = payload.get("total_results_found")
         if not isinstance(total, int):
             total = len(results)
-        return results, total
+        return results, total, truncated
 
-    def _normalize_entry(self, entry: dict[str, Any]) -> dict[str, Any]:
-        content = entry.get("content")
-        if isinstance(content, str) and len(content) > _MAX_RESULT_CONTENT_CHARS:
+    def _normalize_entry(self, entry: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+        title = self._coerce_str(entry.get("title"))
+        url = self._coerce_str(entry.get("url"))
+        content = self._coerce_str(entry.get("content"))
+        content_clipped = len(content) > _MAX_RESULT_CONTENT_CHARS
+        if content_clipped:
             content = content[:_MAX_RESULT_CONTENT_CHARS]
         metadata = entry.get("metadata")
-        return {
-            "title": entry.get("title"),
-            "url": entry.get("url"),
-            "content": content,
-            "metadata": metadata if isinstance(metadata, dict) else {},
-        }
+        return (
+            {
+                "title": title,
+                "url": url,
+                "content": content,
+                "metadata": metadata if isinstance(metadata, dict) else {},
+            },
+            content_clipped,
+        )
+
+    @staticmethod
+    def _coerce_str(value: Any) -> str:
+        if isinstance(value, str):
+            return value
+        return "" if value is None else str(value)
 
     # ---- result helpers ------------------------------------------------
 
@@ -327,6 +386,7 @@ class WebSearchModule(BaseModule):
         tool_name: str,
         *,
         reason_code: str | None,
+        truncated: bool = False,
         context: Any | None,
     ) -> dict[str, Any]:
         return build_execution_eval_metadata(
@@ -337,7 +397,7 @@ class WebSearchModule(BaseModule):
             result_kind="bounded_web_search_results",
             profile_id=self._profile_id_from_context_metadata(context),
             path_filter_used=False,
-            truncated=False,
+            truncated=truncated,
             reason_code=reason_code,
         )
 

--- a/tldw_Server_API/app/core/MCP_unified/server.py
+++ b/tldw_Server_API/app/core/MCP_unified/server.py
@@ -601,6 +601,20 @@ class MCPServer:
                     })
                     logger.info("MCP_ENABLE_WEB_FETCH_MODULE=true; queuing WebFetchModule for registration")
 
+            # 6c) Optional: Web search module - disabled by default (external network).
+            if self._env_flag_enabled("MCP_ENABLE_WEB_SEARCH_MODULE"):
+                if not any(m.get("id") == "web_search" for m in modules_to_load if isinstance(m, dict)):
+                    modules_to_load.append({
+                        "id": "web_search",
+                        "class": "tldw_Server_API.app.core.MCP_unified.modules.implementations.web_search_module:WebSearchModule",
+                        "enabled": True,
+                        "name": "WebSearch",
+                        "version": "1.0.0",
+                        "department": "research",
+                        "settings": {},
+                    })
+                    logger.info("MCP_ENABLE_WEB_SEARCH_MODULE=true; queuing WebSearchModule for registration")
+
             # 7) Optional: Sandbox module (code interpreter) - disabled by default
             if self._env_flag_enabled("MCP_ENABLE_SANDBOX_MODULE"):
                 modules_to_load.append({

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
@@ -241,12 +241,13 @@ def test_web_search_is_recommended_unavailable_not_enabled() -> None:
     assert all(item["required"] is False for item in web_search_recommendations)
 
 
-def test_deep_researcher_enables_web_fetch() -> None:
+def test_deep_researcher_enables_web_tools() -> None:
     deep_researcher = presets.get_builtin_preset("deep-researcher")
     assert deep_researcher is not None  # nosec B101
 
     tooling = deep_researcher.profile.metadata["tooling"]
     assert "web.fetch" in tooling["enabled_tools"]  # nosec B101
+    assert "web.search" in tooling["enabled_tools"]  # nosec B101
     assert "research.web" in tooling["enabled_capabilities"]  # nosec B101
     assert "web" in tooling["progressive_disclosure"]["direct_categories"]  # nosec B101
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_fetch_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_fetch_module.py
@@ -378,6 +378,20 @@ async def test_url_with_sql_like_substrings_is_accepted(monkeypatch: pytest.Monk
     assert result["ok"] is True  # nosec B101
 
 
+async def test_sanitize_input_allows_sql_like_url() -> None:
+    # The MCP protocol layer runs module.sanitize_input before execution; the
+    # override must not reject URLs containing '--' or '/*'.
+    module = _module(_FakeClient())
+    cleaned = module.sanitize_input({"url": "https://example.com/a--b?x=/*y*/"})
+    assert cleaned["url"] == "https://example.com/a--b?x=/*y*/"  # nosec B101
+
+
+async def test_sanitize_input_strips_control_characters() -> None:
+    module = _module(_FakeClient())
+    cleaned = module.sanitize_input({"url": "https://example.com/a\x00b"})
+    assert cleaned["url"] == "https://example.com/ab"  # nosec B101
+
+
 async def test_non_utf8_charset_is_decoded(monkeypatch: pytest.MonkeyPatch) -> None:
     _allow_policy(monkeypatch)
     body = "café déjà vu".encode("latin-1")

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_search_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_search_module.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.web_search_module import (
+    WebSearchModule,
+)
+from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeBackend:
+    """Injectable search backend so unit tests never hit a provider/network."""
+
+    def __init__(self, result: dict[str, Any] | None = None, exc: BaseException | None = None) -> None:
+        self.result = result
+        self.exc = exc
+        self.calls: list[dict[str, Any]] = []
+
+    def search(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(dict(kwargs))
+        if self.exc is not None:
+            raise self.exc
+        assert self.result is not None  # nosec B101
+        return self.result
+
+
+def _module(backend: _FakeBackend) -> WebSearchModule:
+    return WebSearchModule(ModuleConfig(name="WebSearch"), backend=backend)
+
+
+def _ok_payload(*, engine: str = "duckduckgo", query: str = "q", results: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    return {
+        "search_engine": engine,
+        "search_query": query,
+        "results": results
+        if results is not None
+        else [
+            {
+                "title": "Result One",
+                "url": "https://example.com/one",
+                "content": "First snippet of content.",
+                "metadata": {"source": "example.com"},
+            },
+            {
+                "title": "Result Two",
+                "url": "https://example.org/two",
+                "content": "Second snippet of content.",
+                "metadata": {"source": "example.org"},
+            },
+        ],
+        "total_results_found": 2,
+        "processing_error": None,
+        "error": None,
+    }
+
+
+async def test_get_tools_exposes_web_search_contract() -> None:
+    module = _module(_FakeBackend())
+    tools = await module.get_tools()
+    assert [tool["name"] for tool in tools] == ["web.search"]  # nosec B101
+    tool = tools[0]
+    assert tool["inputSchema"]["required"] == ["query"]  # nosec B101
+    assert tool["inputSchema"]["additionalProperties"] is False  # nosec B101
+    assert tool["metadata"]["readOnlyHint"] is True  # nosec B101
+
+
+async def test_happy_path_returns_normalized_results() -> None:
+    backend = _FakeBackend(_ok_payload(query="python asyncio"))
+    module = _module(backend)
+    result = await module.execute_tool(
+        "web.search", {"query": "python asyncio", "engine": "duckduckgo"}
+    )
+    assert result["ok"] is True  # nosec B101
+    assert result["engine"] == "duckduckgo"  # nosec B101
+    assert result["query"] == "python asyncio"  # nosec B101
+    assert result["result_count"] == 2  # nosec B101
+    assert result["total_results_found"] == 2  # nosec B101
+    assert [item["url"] for item in result["results"]] == [
+        "https://example.com/one",
+        "https://example.org/two",
+    ]  # nosec B101
+    assert backend.calls[0]["query"] == "python asyncio"  # nosec B101
+    assert backend.calls[0]["engine"] == "duckduckgo"  # nosec B101
+
+
+async def test_result_content_is_bounded() -> None:
+    long = "x" * 10_000
+    backend = _FakeBackend(
+        _ok_payload(
+            results=[
+                {"title": "T", "url": "https://example.com", "content": long, "metadata": {}}
+            ]
+        )
+    )
+    module = _module(backend)
+    result = await module.execute_tool("web.search", {"query": "q"})
+    assert result["ok"] is True  # nosec B101
+    assert len(result["results"][0]["content"]) < len(long)  # nosec B101
+
+
+async def test_results_capped_to_requested_count() -> None:
+    many = [
+        {"title": f"T{i}", "url": f"https://example.com/{i}", "content": "c", "metadata": {}}
+        for i in range(5)
+    ]
+    backend = _FakeBackend(_ok_payload(results=many))
+    module = _module(backend)
+    result = await module.execute_tool("web.search", {"query": "q", "result_count": 2})
+    assert result["ok"] is True  # nosec B101
+    assert result["result_count"] == 2  # nosec B101
+    assert len(result["results"]) == 2  # nosec B101
+
+
+async def test_empty_query_is_rejected() -> None:
+    backend = _FakeBackend()
+    module = _module(backend)
+    result = await module.execute_tool("web.search", {"query": "   "})
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "invalid_arguments"  # nosec B101
+    assert backend.calls == []  # nosec B101
+
+
+async def test_invalid_engine_is_rejected() -> None:
+    backend = _FakeBackend()
+    module = _module(backend)
+    result = await module.execute_tool("web.search", {"query": "q", "engine": "askjeeves"})
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "invalid_engine"  # nosec B101
+    assert backend.calls == []  # nosec B101
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {"query": "q", "result_count": 0},
+        {"query": "q", "result_count": -1},
+        {"query": "q", "result_count": 1000},
+        {"query": "q", "result_count": "five"},
+        {"query": 123},
+        {"query": "q", "site_whitelist": "example.com"},
+        {"query": "q", "depth": 2},
+    ],
+)
+async def test_argument_validation(arguments: dict[str, Any]) -> None:
+    backend = _FakeBackend()
+    module = _module(backend)
+    result = await module.execute_tool("web.search", arguments)
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "invalid_arguments"  # nosec B101
+    assert backend.calls == []  # nosec B101
+
+
+async def test_processing_error_maps_to_search_failed() -> None:
+    backend = _FakeBackend({"results": [], "processing_error": "Error performing web search"})
+    module = _module(backend)
+    result = await module.execute_tool("web.search", {"query": "q"})
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "search_failed"  # nosec B101
+
+
+async def test_outbound_policy_error_maps_to_denied() -> None:
+    backend = _FakeBackend(
+        {"results": [], "processing_error": "Error performing web search: Blocked by outbound policy: ssrf"}
+    )
+    module = _module(backend)
+    result = await module.execute_tool("web.search", {"query": "q"})
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "outbound_policy_denied"  # nosec B101
+
+
+async def test_backend_exception_maps_to_search_failed() -> None:
+    backend = _FakeBackend(exc=RuntimeError("boom"))
+    module = _module(backend)
+    result = await module.execute_tool("web.search", {"query": "q"})
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "search_failed"  # nosec B101
+
+
+async def test_unknown_tool_returns_structured_error() -> None:
+    backend = _FakeBackend()
+    module = _module(backend)
+    result = await module.execute_tool("web.other", {"query": "q"})
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "unknown_tool"  # nosec B101
+
+
+async def test_site_filters_passed_to_backend() -> None:
+    backend = _FakeBackend(_ok_payload())
+    module = _module(backend)
+    result = await module.execute_tool(
+        "web.search",
+        {
+            "query": "q",
+            "site_whitelist": ["example.com"],
+            "site_blacklist": ["spam.example"],
+        },
+    )
+    assert result["ok"] is True  # nosec B101
+    assert backend.calls[0]["site_whitelist"] == ["example.com"]  # nosec B101
+    assert backend.calls[0]["site_blacklist"] == ["spam.example"]  # nosec B101
+
+
+async def test_eval_metadata_records_profile_from_context() -> None:
+    backend = _FakeBackend(_ok_payload())
+    module = _module(backend)
+    context = RequestContext(request_id="req-search", metadata={"profile_id": "deep-researcher"})
+    result = await module.execute_tool("web.search", {"query": "q"}, context)
+    assert result["ok"] is True  # nosec B101
+    assert result["eval"]["profile_id"] == "deep-researcher"  # nosec B101

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_search_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_search_module.py
@@ -212,3 +212,105 @@ async def test_eval_metadata_records_profile_from_context() -> None:
     result = await module.execute_tool("web.search", {"query": "q"}, context)
     assert result["ok"] is True  # nosec B101
     assert result["eval"]["profile_id"] == "deep-researcher"  # nosec B101
+
+
+async def test_sanitize_input_allows_sql_like_query_and_punycode() -> None:
+    # The protocol layer runs module.sanitize_input before execution; it must not
+    # reject queries with '--' (CLI flags) or punycode 'xn--' domain filters.
+    module = _module(_FakeBackend())
+    cleaned = module.sanitize_input(
+        {
+            "query": "pip install --no-cache-dir",
+            "site_whitelist": ["xn--80ak6aa92e.com"],
+        }
+    )
+    assert cleaned["query"] == "pip install --no-cache-dir"  # nosec B101
+    assert cleaned["site_whitelist"] == ["xn--80ak6aa92e.com"]  # nosec B101
+
+
+async def test_sanitize_input_strips_control_characters() -> None:
+    module = _module(_FakeBackend())
+    cleaned = module.sanitize_input({"query": "a\x00b\x07c"})
+    assert cleaned["query"] == "abc"  # nosec B101
+
+
+async def test_sql_like_query_executes_successfully() -> None:
+    backend = _FakeBackend(_ok_payload(query="pip install --no-cache-dir"))
+    module = _module(backend)
+    result = await module.execute_tool(
+        "web.search", {"query": "pip install --no-cache-dir"}
+    )
+    assert result["ok"] is True  # nosec B101
+    assert backend.calls[0]["query"] == "pip install --no-cache-dir"  # nosec B101
+
+
+async def test_truncated_reported_when_results_exceed_count() -> None:
+    many = [
+        {"title": f"T{i}", "url": f"https://example.com/{i}", "content": "c", "metadata": {}}
+        for i in range(5)
+    ]
+    backend = _FakeBackend(_ok_payload(results=many))
+    module = _module(backend)
+    result = await module.execute_tool("web.search", {"query": "q", "result_count": 2})
+    assert result["truncated"] is True  # nosec B101
+    assert result["eval"]["truncated"] is True  # nosec B101
+
+
+async def test_truncated_reported_when_content_clipped() -> None:
+    backend = _FakeBackend(
+        _ok_payload(
+            results=[
+                {"title": "T", "url": "https://example.com", "content": "x" * 9000, "metadata": {}}
+            ]
+        )
+    )
+    module = _module(backend)
+    result = await module.execute_tool("web.search", {"query": "q"})
+    assert result["truncated"] is True  # nosec B101
+    assert result["eval"]["truncated"] is True  # nosec B101
+
+
+async def test_not_truncated_when_within_bounds() -> None:
+    backend = _FakeBackend(_ok_payload())
+    module = _module(backend)
+    result = await module.execute_tool("web.search", {"query": "q"})
+    assert result["truncated"] is False  # nosec B101
+    assert result["eval"]["truncated"] is False  # nosec B101
+
+
+async def test_result_fields_coerced_to_strings() -> None:
+    backend = _FakeBackend(
+        _ok_payload(
+            results=[
+                {"title": None, "url": 12345, "content": None, "metadata": "not-a-dict"}
+            ]
+        )
+    )
+    module = _module(backend)
+    result = await module.execute_tool("web.search", {"query": "q"})
+    entry = result["results"][0]
+    assert entry["title"] == ""  # nosec B101
+    assert entry["url"] == "12345"  # nosec B101
+    assert entry["content"] == ""  # nosec B101
+    assert entry["metadata"] == {}  # nosec B101
+
+
+async def test_empty_site_list_normalized_to_none() -> None:
+    backend = _FakeBackend(_ok_payload())
+    module = _module(backend)
+    result = await module.execute_tool(
+        "web.search", {"query": "q", "site_whitelist": []}
+    )
+    assert result["ok"] is True  # nosec B101
+    assert backend.calls[0]["site_whitelist"] is None  # nosec B101
+
+
+async def test_blank_optional_strings_normalized_to_none() -> None:
+    backend = _FakeBackend(_ok_payload())
+    module = _module(backend)
+    result = await module.execute_tool(
+        "web.search", {"query": "q", "content_country": "   ", "safesearch": ""}
+    )
+    assert result["ok"] is True  # nosec B101
+    assert backend.calls[0]["content_country"] is None  # nosec B101
+    assert backend.calls[0]["safesearch"] is None  # nosec B101

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_search_module_registration.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_search_module_registration.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+async def _capture_default_registrations(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> list[dict[str, Any]]:
+    from tldw_Server_API.app.core.MCP_unified.server import MCPServer
+
+    server = MCPServer()
+    registrations: list[dict[str, Any]] = []
+
+    async def _capture_registration(module_id: str, module_type: type[Any], config: Any) -> None:
+        registrations.append(
+            {"module_id": module_id, "module_type": module_type, "config": config}
+        )
+
+    monkeypatch.setattr(server.module_registry, "register_module", _capture_registration)
+    monkeypatch.setenv("MCP_MODULES_CONFIG", str(tmp_path / "missing-modules.yaml"))
+    monkeypatch.delenv("MCP_MODULES", raising=False)
+    monkeypatch.setenv("MCP_ENABLE_MEDIA_MODULE", "0")
+    monkeypatch.setenv("MCP_ENABLE_FILESYSTEM_MODULE", "0")
+    monkeypatch.setenv("MCP_ENABLE_BROWSER_CDP_MODULE", "0")
+    monkeypatch.delenv("MCP_BROWSER_CDP_URL", raising=False)
+
+    await server._register_default_modules()
+    return registrations
+
+
+@pytest.mark.asyncio
+async def test_server_registers_web_search_module_when_enabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("MCP_ENABLE_WEB_SEARCH_MODULE", "1")
+
+    registrations = await _capture_default_registrations(monkeypatch, tmp_path)
+
+    registration = next(item for item in registrations if item["module_id"] == "web_search")
+    assert registration["module_type"].__name__ == "WebSearchModule"  # nosec B101
+    assert registration["config"].name == "WebSearch"  # nosec B101
+    assert registration["config"].department == "research"  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_server_does_not_register_web_search_module_when_flag_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("MCP_ENABLE_WEB_SEARCH_MODULE", raising=False)
+
+    registrations = await _capture_default_registrations(monkeypatch, tmp_path)
+
+    assert "web_search" not in {item["module_id"] for item in registrations}  # nosec B101


### PR DESCRIPTION
## Summary

Adds a built-in, read-only **`web.search`** MCP tool that runs a query against a configured multi-provider search backend and returns a bounded list of normalized results — the natural companion to `web.fetch`.

> **Stacked on #2348** (`codex/mcp-webfetch-tool`). Both slices touch `server.py` and `presets.py`, so this PR is based on the web.fetch branch to avoid conflicts. **Retarget to `dev` after #2348 merges.** The web.search-only diff is the second commit.

## Behavior

- `WebSearchModule(BaseModule)` exposes one `web.search` tool over `Web_Scraping.WebSearch_APIs.perform_websearch` (sync/blocking → run via `asyncio.to_thread`).
- Engine allow-list (google/duckduckgo/brave/kagi/serper/tavily/exa/firecrawl/searx/yandex/baidu), default `duckduckgo`.
- `result_count` default 10 / max 25 with defensive list truncation; per-result `content` capped at 4000 chars; `site_whitelist`/`site_blacklist` validated as `list[str]` and forwarded.
- Result shape: `{ok, engine, query, result_count, total_results_found, results:[{title,url,content,metadata}], eval}`.
- Reason codes: `invalid_arguments`, `invalid_engine`, `outbound_policy_denied`, `search_failed`, `unknown_tool`.

## Governance

`web.search` takes a `query` (no `url`), so domain *subjects* aren't extracted from the call — it's gated as a whole tool via tool-level rules and the `external_network` / `research.web` capability. Outbound (SSRF/egress) policy is enforced **inside** `perform_websearch`'s per-provider gate; the module maps an "outbound policy" error to `outbound_policy_denied` rather than reimplementing it.

## Wiring

- Optional registration gated by `MCP_ENABLE_WEB_SEARCH_MODULE` (off by default), id `web_search`, department `research`.
- `_WEB_READ_TOOLS = ["web.fetch", "web.search"]`; enabled in the `deep-researcher` preset.

## Tests

- `test_web_search_module.py` (19) — contract, happy path, content bounding, result cap, empty query, invalid engine, arg validation, processing-error → search_failed, outbound-policy → denied, backend exception → search_failed, unknown tool, site-filter passthrough, eval profile metadata.
- `test_web_search_module_registration.py` (2) — registered iff flag set.
- `test_profile_presets.py` — `test_deep_researcher_enables_web_tools` now asserts both web tools.
- Injectable `WebSearchBackend` → no network/config in unit tests. 67 combined with web.fetch suites pass; ruff/compileall/bandit clean.

backlog: task-2355 · design: `Docs/Design/MCP_Web_Search_Tool_Design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a built-in, read-only `web.search` MCP tool that queries a multi-provider backend and returns a normalized, bounded list of results. Complements `web.fetch` and is enabled in the `deep-researcher` preset. Implements task-2355.

- **New Features**
  - Adds `WebSearchModule` exposing `web.search`, backed by `WebSearch_APIs.perform_websearch` (run via `asyncio.to_thread`).
  - Engine allow-list: google, duckduckgo, brave, kagi, serper, tavily, exa, firecrawl, searx, yandex, baidu; default `duckduckgo`.
  - Bounds: `result_count` default 10 (max 25); per-result `content` max 4000 chars; forwards validated `site_whitelist`/`site_blacklist`.
  - Errors: `invalid_arguments`, `invalid_engine`, `outbound_policy_denied`, `search_failed`.
  - Wiring: gated by `MCP_ENABLE_WEB_SEARCH_MODULE` (off by default); added to `_WEB_READ_TOOLS`; enabled for `deep-researcher`.

- **Bug Fixes**
  - Relaxed input sanitization for `web.search` and `web.fetch`: override to strip only control chars, allowing `--`, `/* */`, and punycode.
  - Better result normalization: coerce `title`/`url`/`content` to strings; normalize empty site filters and blank optional strings to `None`.
  - Report truncation: add `truncated` in the response and `eval.truncated` when list exceeds `result_count` or content is clipped.

<sup>Written for commit e8cdbb9231e109c3199c158e46842d0ca9c1b2c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

