### PR TITLE
Add MCP web.research tool (composes web.search + web.fetch)

### DIFF
--- a/Docs/Design/MCP_Web_Research_Tool_Design.md
+++ b/Docs/Design/MCP_Web_Research_Tool_Design.md
@@ -85,6 +85,24 @@ source with `fetched: false` and the fetch's `reason_code`.
 5. Assemble `sources` preserving search order; `fetched_count` = number of ok
    fetches; `truncated` = search truncated OR any fetched source truncated.
 
+## Per-URL permission enforcement
+
+`web.research` takes a `query` (no `url`), so the gateway runtime extracts no
+per-call domain subject for it, and its internal `web.fetch` calls do not pass
+through `_enforce_permission_rules_for_tool_call`. The always-on outbound
+(SSRF/egress) policy inside `web.fetch` still applies, but profile-authored
+`WebFetch(<domain>)` ask/deny rules would otherwise be bypassed for the fetched
+URLs.
+
+To close that gap, `WebResearchModule` accepts an optional injected
+`permission_check: (url, context) -> "allow" | "ask" | "deny"`. When wired by the
+gateway, it is consulted (fail-closed on error) before each sub-fetch: `deny` →
+the source is marked `fetched: false, reason_code: "permission_denied"`; `ask` →
+`"permission_required"`; only `allow` URLs are fetched. Absent a check (default /
+tests), behavior is unchanged and SSRF/egress remains enforced. The longer-term
+design is to compose `web.research` at the gateway layer so each `web.fetch(url=)`
+is a real, individually-enforced tool call.
+
 ## Testability
 
 `WebResearchModule(config, *, search_module=None, fetch_module=None)` — tests

--- a/Docs/Design/MCP_Web_Research_Tool_Design.md
+++ b/Docs/Design/MCP_Web_Research_Tool_Design.md
@@ -1,0 +1,110 @@
+# MCP `web.research` Tool Design
+
+Status: Implementing (June 2026)
+Owner: standalone MCP gateway backlog
+Companions: `MCP_Web_Fetch_Tool_Design.md`, `MCP_Web_Search_Tool_Design.md`
+
+## Goal
+
+Add a built-in, read-only MCP tool, `web.research`, that **composes** the
+already-merged `web.search` and `web.fetch` tools into one call: run a search
+query, then fetch + extract the top N results into a single bounded research
+bundle. It is the natural "do my web research" primitive for the
+`deep-researcher` preset.
+
+## Why composition (not a new pipeline)
+
+`web.research` does not re-implement search or fetch. It instantiates a
+`WebSearchModule` and a `WebFetchModule` (injectable for tests) and drives them
+via their existing `execute_tool` contracts. This means:
+
+- Every fetched URL re-runs the per-hop outbound (SSRF/egress) policy inside
+  `web.fetch`, including redirect re-checks — no new egress surface.
+- Search provider egress is enforced inside `web.search`.
+- Bounds (byte caps, content truncation, result caps) and structured error
+  codes are inherited from the two tools.
+
+## Tool: `web.research`
+
+Read-only. Arguments (additionalProperties: false):
+
+| arg | type | default | bounds |
+|---|---|---|---|
+| `query` | string (required) | — | non-empty |
+| `engine` | string | search default | search engine allow-list |
+| `max_results` | integer | 5 | 1 .. 25 (search `result_count`) |
+| `fetch_top_n` | integer | 3 | 0 .. 10, clamped to `max_results` |
+| `format` | enum markdown\|text\|html | markdown | fetch format |
+| `max_bytes` | integer | — | per-fetch byte cap (fetch bounds) |
+| `site_whitelist` | string[] | — | forwarded to search |
+| `site_blacklist` | string[] | — | forwarded to search |
+
+Success result:
+
+```
+{
+  "ok": true,
+  "query": "...",
+  "engine": "duckduckgo",
+  "result_count": 5,        // results returned by search
+  "fetched_count": 3,       // sources actually fetched+extracted ok
+  "truncated": false,       // search truncated OR any source clipped
+  "sources": [
+    {
+      "title": "...",
+      "url": "https://...",
+      "snippet": "<search result content>",
+      "fetched": true,
+      "status_code": 200,
+      "content": "<extracted, bounded>"
+    },
+    { "title": "...", "url": "https://...", "snippet": "...",
+      "fetched": false, "reason_code": "outbound_policy_denied" }
+  ],
+  "eval": { ... }
+}
+```
+
+Error result: `{ ok: false, reason_code, message, eval }`.
+
+Top-level reason codes (search stage): `invalid_arguments`, `invalid_engine`,
+`outbound_policy_denied`, `search_failed`, `unknown_tool`. A search failure fails
+the whole call; **individual fetch failures do not** — they are recorded on the
+source with `fetched: false` and the fetch's `reason_code`.
+
+## Behavior
+
+1. Permissive `sanitize_input` override (strip control chars only; queries
+   contain `--`/punycode), mirroring `web.search`/`web.fetch`.
+2. Validate + clamp (`fetch_top_n` ≤ `max_results` ≤ 25; `fetch_top_n` ≤ 10).
+3. `web.search` with `{query, engine, result_count: max_results, site_*}`. On
+   error → return it as the tool error.
+4. Take the first `fetch_top_n` results that carry a `url`; fetch them with
+   **bounded concurrency** (semaphore = 3) via `web.fetch`
+   `{url, format, max_bytes}`. Partial-failure tolerant.
+5. Assemble `sources` preserving search order; `fetched_count` = number of ok
+   fetches; `truncated` = search truncated OR any fetched source truncated.
+
+## Testability
+
+`WebResearchModule(config, *, search_module=None, fetch_module=None)` — tests
+inject fakes exposing `async execute_tool(name, args, context)` that return
+canned `web.search` / `web.fetch` dicts. No network, no provider config.
+
+## Registration & presets
+
+- `server.py`: optional block gated by `MCP_ENABLE_WEB_RESEARCH_MODULE` (off by
+  default), id `web_research`, department `research`.
+- `presets.py`: add `web.research` to `_WEB_READ_TOOLS`; enabled in the
+  `deep-researcher` preset.
+
+## Tests
+
+- `test_web_research_module.py`: contract; happy path (search → top-N fetch →
+  bundle with order preserved); search error short-circuits; one fetch failing
+  is tolerated (`fetched: false` + reason_code); `fetch_top_n` clamped to
+  results/max; `fetch_top_n: 0` returns search-only sources; truncated flag from
+  search or fetch; results without a url skipped; sanitize override allows `--`;
+  arg validation; unknown tool; eval profile metadata.
+- `test_web_research_module_registration.py`: registered iff flag set.
+- `test_profile_presets.py`: `deep-researcher` enables `web.research`.

--- a/backlog/tasks/task-2356 - Add-MCP-web-research-tool.md
+++ b/backlog/tasks/task-2356 - Add-MCP-web-research-tool.md
@@ -1,0 +1,44 @@
+---
+id: TASK-2356
+title: Add MCP web.research tool
+status: Done
+updated_date: '2026-06-14'
+labels:
+- mcp
+- tools
+- web
+- research
+references:
+- Docs/Design/MCP_Web_Research_Tool_Design.md
+dependencies:
+- TASK-2354
+- TASK-2355
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a built-in read-only MCP `web.research` tool that composes the merged `web.search` and `web.fetch` tools: run one search query, then fetch + extract the top N results into a single bounded research bundle. Per-result fetches inherit web.fetch's per-hop outbound policy; individual fetch failures are tolerated and recorded per source.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A `web.research` MCP tool searches a query then fetches the top `fetch_top_n` results, returning `{ok, query, engine, result_count, fetched_count, truncated, sources:[{title,url,snippet,fetched,status_code?,content?,reason_code?}], eval}` with sources in search order.
+- [x] #2 It composes WebSearchModule + WebFetchModule via their execute_tool contracts (no re-implemented search/fetch/egress); a search-stage failure surfaces as the tool error, while individual fetch failures are tolerated (`fetched: false` + the fetch reason_code) and do not fail the call.
+- [x] #3 Bounds: `max_results` 1..25 (search result_count), `fetch_top_n` 0..10 clamped to max_results, bounded fetch concurrency (3); `truncated` is true when search truncated OR any fetched source was clipped; results without a url are skipped for fetching.
+- [x] #4 The module is registered only when `MCP_ENABLE_WEB_RESEARCH_MODULE` is set, the composed modules are injectable for tests (no network/config), a permissive `sanitize_input` override allows `--`/punycode queries, and the `deep-researcher` preset enables `web.research`.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+In-server module `tldw_Server_API/app/core/MCP_unified/modules/implementations/web_research_module.py` (`WebResearchModule(BaseModule)`, single `web.research` tool). Composition over re-implementation: holds a `WebSearchModule` + `WebFetchModule` (injectable via `search_module`/`fetch_module` ctor kwargs; defaults lazily construct the real modules) and drives them through `execute_tool`. So every fetched URL re-runs web.fetch's per-hop SSRF/egress + redirect policy, and search provider egress runs inside web.search — no new egress surface.
+
+Flow: validate/clamp → `web.search {query, result_count: max_results, engine?, site_*}` → on error surface its reason_code/message → take first `fetch_top_n` results with a url → `asyncio.gather` fetch with `Semaphore(3)` → assemble sources in search order. Engine-value validation is DELEGATED to web.search (web.research only checks structural types/bounds), so an invalid engine surfaces as web.search's `invalid_engine`. Permissive `sanitize_input` override (strip control chars only) mirrors web.search/web.fetch since the protocol sanitizes before execute.
+
+Registration: optional env-flag block in `server.py` gated by `MCP_ENABLE_WEB_RESEARCH_MODULE` (off by default), id `web_research`, department `research`. Preset: `_WEB_READ_TOOLS = ["web.fetch", "web.search", "web.research"]`, enabled in `deep-researcher`.
+
+TDD: RED `pytest test_web_research_module.py` → collection error (module absent). GREEN: 21 module + 2 registration tests; 107 with web search/fetch/preset regression. ruff/compileall/bandit clean.
+
+Deferred to the web-tools hardening slice (task TBD): extract a shared `_WebToolBase` (sanitize_input override, eval helpers, control-char constants, domain-list validator) across web.fetch/web.search/web.research; per-domain rate limiting; response caching; richer citation metadata.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/mcp_unified/profiles/presets.py
+++ b/mcp_unified/profiles/presets.py
@@ -203,7 +203,7 @@ _GIT_READ_TOOLS = [
     "git.conflicts.list",
     "git.conflicts.read",
 ]
-_WEB_READ_TOOLS = ["web.fetch", "web.search"]
+_WEB_READ_TOOLS = ["web.fetch", "web.search", "web.research"]
 _TEST_READ_TOOLS = ["tests.results.read", "tests.logs.read"]
 _TEST_REQUEST_TOOLS = [*_TEST_READ_TOOLS, "tests.request"]
 _BROWSER_READ_TOOLS = [

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_research_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_research_module.py
@@ -1,0 +1,409 @@
+"""Read-only ``web.research`` MCP tool composing ``web.search`` + ``web.fetch``.
+
+The tool runs one search query and then fetches + extracts the top N results
+into a single bounded research bundle. It does not re-implement search or fetch:
+it drives a :class:`WebSearchModule` and :class:`WebFetchModule` through their
+existing ``execute_tool`` contracts, so the per-provider and per-hop outbound
+(SSRF/egress) policies, byte/content bounds, and structured error codes are all
+inherited. Individual fetch failures are tolerated and recorded per source.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from typing import Any, Protocol
+
+from loguru import logger
+
+from tldw_Server_API.app.core.MCP_unified.tool_observability import (
+    build_execution_eval_metadata,
+    build_tool_eval_metadata,
+)
+
+from ..base import BaseModule, ModuleConfig, create_tool_definition
+
+_TOOL_RESEARCH = "web.research"
+_TOOL_PROMPT_VERSION = "2026.06.14"
+
+_ALLOWED_ARGS = {
+    "query",
+    "engine",
+    "max_results",
+    "fetch_top_n",
+    "format",
+    "max_bytes",
+    "site_whitelist",
+    "site_blacklist",
+}
+_FORMATS = {"markdown", "text", "html"}
+
+_DEFAULT_MAX_RESULTS = 5
+_MAX_MAX_RESULTS = 25
+_DEFAULT_FETCH_TOP_N = 3
+_MAX_FETCH_TOP_N = 10
+_FETCH_CONCURRENCY = 3
+
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+_MAX_SANITIZE_DEPTH = 20
+
+
+class WebToolModule(Protocol):
+    """Minimal surface needed from the composed search/fetch modules."""
+
+    async def execute_tool(
+        self, tool_name: str, arguments: dict[str, Any], context: Any | None = ...
+    ) -> Any: ...
+
+
+class _WebResearchError(Exception):
+    """Internal control-flow error carrying a structured reason code."""
+
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.message = message
+
+
+class WebResearchModule(BaseModule):
+    """Single read-only ``web.research`` tool composing search + fetch."""
+
+    def __init__(
+        self,
+        config: ModuleConfig,
+        *,
+        search_module: WebToolModule | None = None,
+        fetch_module: WebToolModule | None = None,
+    ) -> None:
+        super().__init__(config)
+        self._search = search_module or self._default_search_module()
+        self._fetch = fetch_module or self._default_fetch_module()
+
+    @staticmethod
+    def _default_search_module() -> WebToolModule:
+        from .web_search_module import WebSearchModule
+
+        return WebSearchModule(ModuleConfig(name="WebSearch"))
+
+    @staticmethod
+    def _default_fetch_module() -> WebToolModule:
+        from .web_fetch_module import WebFetchModule
+
+        return WebFetchModule(ModuleConfig(name="WebFetch"))
+
+    async def on_initialize(self) -> None:
+        return None
+
+    async def on_shutdown(self) -> None:
+        return None
+
+    async def check_health(self) -> dict[str, bool]:
+        return {
+            "initialized": True,
+            "search_module": self._search is not None,
+            "fetch_module": self._fetch is not None,
+        }
+
+    async def get_tools(self) -> list[dict[str, Any]]:
+        tool = create_tool_definition(
+            name=_TOOL_RESEARCH,
+            description=(
+                "Search the web and fetch + extract the top results into one "
+                "bounded research bundle. Composes web.search and web.fetch; "
+                "subject to outbound (SSRF/egress) policy and external-network "
+                "permission."
+            ),
+            parameters={
+                "properties": {
+                    "query": {"type": "string", "description": "The research query."},
+                    "engine": {"type": "string", "description": "Search provider; defaults to configured."},
+                    "max_results": {"type": "integer", "minimum": 1, "maximum": _MAX_MAX_RESULTS},
+                    "fetch_top_n": {"type": "integer", "minimum": 0, "maximum": _MAX_FETCH_TOP_N},
+                    "format": {"type": "string", "enum": sorted(_FORMATS)},
+                    "max_bytes": {"type": "integer", "minimum": 1},
+                    "site_whitelist": {"type": "array", "items": {"type": "string"}},
+                    "site_blacklist": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["query"],
+            },
+            metadata={
+                "category": "web",
+                "readOnlyHint": True,
+                "uses_network": True,
+                "capabilities": ["research.web", "external.network"],
+                **build_tool_eval_metadata(
+                    tool_prompt_id=f"mcp.{_TOOL_RESEARCH}.v1",
+                    tool_prompt_version=_TOOL_PROMPT_VERSION,
+                    task_families=["web_research", "citation_collection"],
+                    expected_result_kind="bounded_web_research_bundle",
+                    success_signals=[
+                        "enforced_outbound_policy",
+                        "bounded_sources",
+                        "tolerated_partial_fetch_failures",
+                    ],
+                ),
+            },
+        )
+        tool["inputSchema"]["additionalProperties"] = False
+        return [tool]
+
+    def sanitize_input(self, input_data: Any, _depth: int = 0) -> Any:
+        """Permissive sanitizer (strip only NUL/control chars).
+
+        See ``WebSearchModule.sanitize_input`` — the MCP protocol sanitizes every
+        tool call before execution, and the base SQL denylist would reject
+        legitimate research queries containing ``--``/``/*``.
+        """
+        if _depth > _MAX_SANITIZE_DEPTH:
+            raise ValueError("Input too deeply nested")
+        if isinstance(input_data, str):
+            return _CONTROL_CHARS_RE.sub("", input_data)
+        if isinstance(input_data, dict):
+            return {key: self.sanitize_input(value, _depth + 1) for key, value in input_data.items()}
+        if isinstance(input_data, list):
+            return [self.sanitize_input(value, _depth + 1) for value in input_data]
+        return input_data
+
+    async def execute_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: Any | None = None,
+    ) -> Any:
+        if tool_name != _TOOL_RESEARCH:
+            return self._error(tool_name, "unknown_tool", "Unknown web tool.", context=context)
+
+        try:
+            params = self._validate(arguments or {})
+        except _WebResearchError as exc:
+            return self._error(tool_name, exc.reason_code, exc.message, context=context)
+
+        search_args: dict[str, Any] = {
+            "query": params["query"],
+            "result_count": params["max_results"],
+        }
+        if params["engine"] is not None:
+            search_args["engine"] = params["engine"]
+        if params["site_whitelist"] is not None:
+            search_args["site_whitelist"] = params["site_whitelist"]
+        if params["site_blacklist"] is not None:
+            search_args["site_blacklist"] = params["site_blacklist"]
+
+        search_result = await self._search.execute_tool("web.search", search_args, context)
+        if not isinstance(search_result, dict) or not search_result.get("ok"):
+            reason_code, message = self._delegated_error(search_result, "search_failed")
+            return self._error(tool_name, reason_code, message, context=context)
+
+        results = search_result.get("results") or []
+        fetch_targets = self._fetch_targets(results, params["fetch_top_n"])
+        fetched = await self._fetch_sources(fetch_targets, params, context)
+
+        sources, fetched_count, any_fetch_truncated = self._assemble_sources(results, fetched)
+        truncated = bool(search_result.get("truncated")) or any_fetch_truncated
+
+        return {
+            "ok": True,
+            "query": params["query"],
+            "engine": search_result.get("engine"),
+            "result_count": len(results),
+            "fetched_count": fetched_count,
+            "truncated": truncated,
+            "sources": sources,
+            "eval": self._eval_metadata(
+                _TOOL_RESEARCH, reason_code=None, truncated=truncated, context=context
+            ),
+        }
+
+    # ---- orchestration -------------------------------------------------
+
+    @staticmethod
+    def _fetch_targets(results: list[Any], fetch_top_n: int) -> list[str]:
+        targets: list[str] = []
+        for entry in results:
+            if len(targets) >= fetch_top_n:
+                break
+            if not isinstance(entry, dict):
+                continue
+            url = entry.get("url")
+            if isinstance(url, str) and url.strip():
+                targets.append(url.strip())
+        return targets
+
+    async def _fetch_sources(
+        self, urls: list[str], params: dict[str, Any], context: Any | None
+    ) -> dict[str, dict[str, Any]]:
+        if not urls:
+            return {}
+        semaphore = asyncio.Semaphore(_FETCH_CONCURRENCY)
+
+        async def _fetch_one(url: str) -> tuple[str, Any]:
+            fetch_args: dict[str, Any] = {"url": url, "format": params["format"]}
+            if params["max_bytes"] is not None:
+                fetch_args["max_bytes"] = params["max_bytes"]
+            async with semaphore:
+                try:
+                    return url, await self._fetch.execute_tool("web.fetch", fetch_args, context)
+                except Exception as exc:  # noqa: BLE001 - a fetch crash must not fail the bundle.
+                    logger.bind(stage="web.research").opt(exception=exc).warning(
+                        "web.research sub-fetch raised"
+                    )
+                    return url, {"ok": False, "reason_code": "fetch_failed"}
+
+        pairs = await asyncio.gather(*(_fetch_one(url) for url in urls))
+        return dict(pairs)
+
+    def _assemble_sources(
+        self, results: list[Any], fetched: dict[str, dict[str, Any]]
+    ) -> tuple[list[dict[str, Any]], int, bool]:
+        sources: list[dict[str, Any]] = []
+        fetched_count = 0
+        any_truncated = False
+        for entry in results:
+            if not isinstance(entry, dict):
+                continue
+            url = entry.get("url")
+            url = url.strip() if isinstance(url, str) else ""
+            source: dict[str, Any] = {
+                "title": entry.get("title"),
+                "url": url,
+                "snippet": entry.get("content"),
+                "fetched": False,
+            }
+            fetch_result = fetched.get(url) if url else None
+            if isinstance(fetch_result, dict):
+                if fetch_result.get("ok"):
+                    source["fetched"] = True
+                    source["status_code"] = fetch_result.get("status_code")
+                    source["content"] = fetch_result.get("content")
+                    if fetch_result.get("truncated"):
+                        any_truncated = True
+                    fetched_count += 1
+                else:
+                    source["reason_code"] = fetch_result.get("reason_code", "fetch_failed")
+            sources.append(source)
+        return sources, fetched_count, any_truncated
+
+    @staticmethod
+    def _delegated_error(result: Any, fallback: str) -> tuple[str, str]:
+        if isinstance(result, dict):
+            return (
+                str(result.get("reason_code") or fallback),
+                str(result.get("message") or "Delegated web tool failed."),
+            )
+        return fallback, "Delegated web tool returned an unexpected payload."
+
+    # ---- validation ----------------------------------------------------
+
+    def _validate(self, args: dict[str, Any]) -> dict[str, Any]:
+        unknown = sorted(set(args) - _ALLOWED_ARGS)
+        if unknown:
+            raise _WebResearchError("invalid_arguments", f"unknown arguments: {', '.join(unknown)}")
+
+        query = args.get("query")
+        if not isinstance(query, str) or not query.strip():
+            raise _WebResearchError("invalid_arguments", "query is required")
+        query = query.strip()
+
+        engine = args.get("engine")
+        if engine is not None and (not isinstance(engine, str) or not engine.strip()):
+            raise _WebResearchError("invalid_arguments", "engine must be a non-empty string")
+
+        max_results = self._bounded_int(
+            args, "max_results", default=_DEFAULT_MAX_RESULTS, minimum=1, maximum=_MAX_MAX_RESULTS
+        )
+        fetch_top_n = self._bounded_int(
+            args, "fetch_top_n", default=_DEFAULT_FETCH_TOP_N, minimum=0, maximum=_MAX_FETCH_TOP_N
+        )
+        # Never fetch more than the search will return.
+        fetch_top_n = min(fetch_top_n, max_results)
+
+        fmt = args.get("format", "markdown")
+        if fmt not in _FORMATS:
+            raise _WebResearchError("invalid_arguments", "format must be one of markdown, text, html")
+
+        max_bytes = args.get("max_bytes")
+        if max_bytes is not None and (not isinstance(max_bytes, int) or isinstance(max_bytes, bool) or max_bytes <= 0):
+            raise _WebResearchError("invalid_arguments", "max_bytes must be a positive integer")
+
+        site_whitelist = self._validate_domain_list(args, "site_whitelist")
+        site_blacklist = self._validate_domain_list(args, "site_blacklist")
+
+        return {
+            "query": query,
+            "engine": engine.strip() if isinstance(engine, str) else None,
+            "max_results": max_results,
+            "fetch_top_n": fetch_top_n,
+            "format": fmt,
+            "max_bytes": max_bytes,
+            "site_whitelist": site_whitelist,
+            "site_blacklist": site_blacklist,
+        }
+
+    @staticmethod
+    def _bounded_int(args: dict[str, Any], name: str, *, default: int, minimum: int, maximum: int) -> int:
+        value = args.get(name)
+        if value is None:
+            return default
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise _WebResearchError("invalid_arguments", f"{name} must be an integer >= {minimum}")
+        if value > maximum:
+            raise _WebResearchError("invalid_arguments", f"{name} exceeds maximum ({maximum})")
+        return value
+
+    @staticmethod
+    def _validate_domain_list(args: dict[str, Any], name: str) -> list[str] | None:
+        value = args.get(name)
+        if value is None:
+            return None
+        if not isinstance(value, list) or not all(isinstance(item, str) and item.strip() for item in value):
+            raise _WebResearchError("invalid_arguments", f"{name} must be a list of non-empty strings")
+        stripped = [item.strip() for item in value]
+        return stripped or None
+
+    # ---- result helpers ------------------------------------------------
+
+    def _error(
+        self,
+        tool_name: str,
+        reason_code: str,
+        message: str,
+        *,
+        context: Any | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "reason_code": reason_code,
+            "message": message,
+            "eval": self._eval_metadata(tool_name, reason_code=reason_code, context=context),
+        }
+
+    def _eval_metadata(
+        self,
+        tool_name: str,
+        *,
+        reason_code: str | None,
+        truncated: bool = False,
+        context: Any | None,
+    ) -> dict[str, Any]:
+        return build_execution_eval_metadata(
+            tool_name=tool_name,
+            tool_prompt_id=f"mcp.{tool_name}.v1",
+            tool_prompt_version=_TOOL_PROMPT_VERSION,
+            action_family="web_research",
+            result_kind="bounded_web_research_bundle",
+            profile_id=self._profile_id_from_context_metadata(context),
+            path_filter_used=False,
+            truncated=truncated,
+            reason_code=reason_code,
+        )
+
+    @staticmethod
+    def _profile_id_from_context_metadata(context: Any | None) -> str | None:
+        metadata = getattr(context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return None
+        for key in ("profile_id", "selected_profile_id"):
+            value = metadata.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_research_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_research_module.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 
 import asyncio
 import re
+from collections.abc import Callable
 from typing import Any, Protocol
+from urllib.parse import urlsplit
 
 from loguru import logger
 
@@ -56,6 +58,22 @@ class WebToolModule(Protocol):
     ) -> Any: ...
 
 
+# (url, context) -> "allow" | "ask" | "deny". When wired by the gateway, this lets
+# web.research honor the profile's WebFetch(<domain>) permission rules for each
+# sub-fetched URL — which the gateway cannot enforce itself because the top-level
+# web.research call carries no per-URL `url` subject. Absent a check, the
+# always-on outbound (SSRF/egress) policy inside web.fetch still applies.
+PermissionCheck = Callable[[str, Any], str]
+
+
+def _safe_host(url: str) -> str:
+    """Return just the host for log context, never the path/query (may hold secrets)."""
+    try:
+        return urlsplit(url).hostname or "unknown"
+    except ValueError:
+        return "unknown"
+
+
 class _WebResearchError(Exception):
     """Internal control-flow error carrying a structured reason code."""
 
@@ -74,10 +92,12 @@ class WebResearchModule(BaseModule):
         *,
         search_module: WebToolModule | None = None,
         fetch_module: WebToolModule | None = None,
+        permission_check: PermissionCheck | None = None,
     ) -> None:
         super().__init__(config)
         self._search = search_module or self._default_search_module()
         self._fetch = fetch_module or self._default_fetch_module()
+        self._permission_check = permission_check
 
     @staticmethod
     def _default_search_module() -> WebToolModule:
@@ -189,12 +209,19 @@ class WebResearchModule(BaseModule):
         if params["site_blacklist"] is not None:
             search_args["site_blacklist"] = params["site_blacklist"]
 
-        search_result = await self._search.execute_tool("web.search", search_args, context)
+        try:
+            search_result = await self._search.execute_tool("web.search", search_args, context)
+        except Exception as exc:  # noqa: BLE001 - a search crash maps to a structured error.
+            logger.bind(stage="web.research").opt(exception=exc).error("web.research search stage failed")
+            return self._error(tool_name, "search_failed", "Web search stage failed.", context=context)
+
         if not isinstance(search_result, dict) or not search_result.get("ok"):
             reason_code, message = self._delegated_error(search_result, "search_failed")
             return self._error(tool_name, reason_code, message, context=context)
 
-        results = search_result.get("results") or []
+        results = search_result.get("results")
+        if not isinstance(results, list):
+            results = []
         fetch_targets = self._fetch_targets(results, params["fetch_top_n"])
         fetched = await self._fetch_sources(fetch_targets, params, context)
 
@@ -234,6 +261,20 @@ class WebResearchModule(BaseModule):
     ) -> dict[str, dict[str, Any]]:
         if not urls:
             return {}
+        # Deduplicate so a repeated URL is fetched (and policy-checked) once.
+        unique_urls = list(dict.fromkeys(urls))
+
+        results: dict[str, dict[str, Any]] = {}
+        to_fetch: list[str] = []
+        for url in unique_urls:
+            decision = self._check_permission(url, context)
+            if decision == "deny":
+                results[url] = {"ok": False, "reason_code": "permission_denied"}
+            elif decision == "ask":
+                results[url] = {"ok": False, "reason_code": "permission_required"}
+            else:
+                to_fetch.append(url)
+
         semaphore = asyncio.Semaphore(_FETCH_CONCURRENCY)
 
         async def _fetch_one(url: str) -> tuple[str, Any]:
@@ -244,13 +285,27 @@ class WebResearchModule(BaseModule):
                 try:
                     return url, await self._fetch.execute_tool("web.fetch", fetch_args, context)
                 except Exception as exc:  # noqa: BLE001 - a fetch crash must not fail the bundle.
-                    logger.bind(stage="web.research").opt(exception=exc).warning(
+                    logger.bind(stage="web.research", host=_safe_host(url)).opt(exception=exc).warning(
                         "web.research sub-fetch raised"
                     )
                     return url, {"ok": False, "reason_code": "fetch_failed"}
 
-        pairs = await asyncio.gather(*(_fetch_one(url) for url in urls))
-        return dict(pairs)
+        pairs = await asyncio.gather(*(_fetch_one(url) for url in to_fetch))
+        results.update(dict(pairs))
+        return results
+
+    def _check_permission(self, url: str, context: Any | None) -> str:
+        """Evaluate the optional per-URL permission hook, failing closed on error."""
+        if self._permission_check is None:
+            return "allow"
+        try:
+            decision = self._permission_check(url, context)
+        except Exception as exc:  # noqa: BLE001 - a check error must not silently allow.
+            logger.bind(stage="web.research", host=_safe_host(url)).opt(exception=exc).warning(
+                "web.research permission check raised; denying"
+            )
+            return "deny"
+        return decision if decision in {"allow", "ask", "deny"} else "allow"
 
     def _assemble_sources(
         self, results: list[Any], fetched: dict[str, dict[str, Any]]
@@ -322,8 +377,9 @@ class WebResearchModule(BaseModule):
             raise _WebResearchError("invalid_arguments", "format must be one of markdown, text, html")
 
         max_bytes = args.get("max_bytes")
-        if max_bytes is not None and (not isinstance(max_bytes, int) or isinstance(max_bytes, bool) or max_bytes <= 0):
-            raise _WebResearchError("invalid_arguments", "max_bytes must be a positive integer")
+        if max_bytes is not None:
+            if not isinstance(max_bytes, int) or isinstance(max_bytes, bool) or max_bytes <= 0:
+                raise _WebResearchError("invalid_arguments", "max_bytes must be a positive integer")
 
         site_whitelist = self._validate_domain_list(args, "site_whitelist")
         site_blacklist = self._validate_domain_list(args, "site_blacklist")

--- a/tldw_Server_API/app/core/MCP_unified/server.py
+++ b/tldw_Server_API/app/core/MCP_unified/server.py
@@ -615,6 +615,20 @@ class MCPServer:
                     })
                     logger.info("MCP_ENABLE_WEB_SEARCH_MODULE=true; queuing WebSearchModule for registration")
 
+            # 6d) Optional: Web research module - disabled by default (composes search + fetch).
+            if self._env_flag_enabled("MCP_ENABLE_WEB_RESEARCH_MODULE"):
+                if not any(m.get("id") == "web_research" for m in modules_to_load if isinstance(m, dict)):
+                    modules_to_load.append({
+                        "id": "web_research",
+                        "class": "tldw_Server_API.app.core.MCP_unified.modules.implementations.web_research_module:WebResearchModule",
+                        "enabled": True,
+                        "name": "WebResearch",
+                        "version": "1.0.0",
+                        "department": "research",
+                        "settings": {},
+                    })
+                    logger.info("MCP_ENABLE_WEB_RESEARCH_MODULE=true; queuing WebResearchModule for registration")
+
             # 7) Optional: Sandbox module (code interpreter) - disabled by default
             if self._env_flag_enabled("MCP_ENABLE_SANDBOX_MODULE"):
                 modules_to_load.append({

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_profile_presets.py
@@ -248,6 +248,7 @@ def test_deep_researcher_enables_web_tools() -> None:
     tooling = deep_researcher.profile.metadata["tooling"]
     assert "web.fetch" in tooling["enabled_tools"]  # nosec B101
     assert "web.search" in tooling["enabled_tools"]  # nosec B101
+    assert "web.research" in tooling["enabled_tools"]  # nosec B101
     assert "research.web" in tooling["enabled_capabilities"]  # nosec B101
     assert "web" in tooling["progressive_disclosure"]["direct_categories"]  # nosec B101
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_research_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_research_module.py
@@ -43,9 +43,17 @@ class _FakeFetchModule:
         raise AssertionError(f"unexpected fetch url: {url}")
 
 
-def _module(search: _FakeSearchModule, fetch: _FakeFetchModule) -> WebResearchModule:
+def _module(
+    search: _FakeSearchModule,
+    fetch: _FakeFetchModule,
+    *,
+    permission_check: Any | None = None,
+) -> WebResearchModule:
     return WebResearchModule(
-        ModuleConfig(name="WebResearch"), search_module=search, fetch_module=fetch
+        ModuleConfig(name="WebResearch"),
+        search_module=search,
+        fetch_module=fetch,
+        permission_check=permission_check,
     )
 
 
@@ -273,3 +281,86 @@ async def test_eval_metadata_records_profile_from_context() -> None:
     result = await module.execute_tool("web.research", {"query": "q", "fetch_top_n": 1}, context)
     assert result["ok"] is True  # nosec B101
     assert result["eval"]["profile_id"] == "deep-researcher"  # nosec B101
+
+
+async def test_search_exception_maps_to_search_failed() -> None:
+    class _RaisingSearch:
+        calls: list[Any] = []
+
+        async def execute_tool(self, name: str, args: dict[str, Any], context: Any | None = None) -> Any:
+            raise RuntimeError("boom")
+
+    fetch = _FakeFetchModule(default=_fetch_ok())
+    module = WebResearchModule(
+        ModuleConfig(name="WebResearch"), search_module=_RaisingSearch(), fetch_module=fetch
+    )
+    result = await module.execute_tool("web.research", {"query": "q"})
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "search_failed"  # nosec B101
+    assert fetch.calls == []  # nosec B101
+
+
+async def test_non_list_results_handled() -> None:
+    search = _FakeSearchModule(
+        {"ok": True, "engine": "duckduckgo", "query": "q", "results": "not-a-list", "truncated": False, "eval": {}}
+    )
+    fetch = _FakeFetchModule(default=_fetch_ok())
+    module = _module(search, fetch)
+    result = await module.execute_tool("web.research", {"query": "q"})
+    assert result["ok"] is True  # nosec B101
+    assert result["result_count"] == 0  # nosec B101
+    assert fetch.calls == []  # nosec B101
+
+
+async def test_duplicate_urls_fetched_once() -> None:
+    dup = [
+        {"title": "A", "url": "https://example.com/x", "content": "s", "metadata": {}},
+        {"title": "B", "url": "https://example.com/x", "content": "s", "metadata": {}},
+    ]
+    search = _FakeSearchModule(_search_ok(results=dup))
+    fetch = _FakeFetchModule(default=_fetch_ok())
+    module = _module(search, fetch)
+    result = await module.execute_tool("web.research", {"query": "q", "fetch_top_n": 2})
+    assert fetch.calls == ["https://example.com/x"]  # nosec B101 - fetched once
+    assert result["ok"] is True  # nosec B101
+
+
+async def test_permission_check_denies_source_before_fetch() -> None:
+    def _check(url: str, context: Any) -> str:
+        return "deny" if "example.com" in url else "allow"
+
+    search = _FakeSearchModule(_search_ok())  # example.com/1, example.org/2, example.net/3
+    fetch = _FakeFetchModule(default=_fetch_ok())
+    module = _module(search, fetch, permission_check=_check)
+    result = await module.execute_tool("web.research", {"query": "q", "fetch_top_n": 3})
+    denied = next(s for s in result["sources"] if s["url"] == "https://example.com/1")
+    assert denied["fetched"] is False  # nosec B101
+    assert denied["reason_code"] == "permission_denied"  # nosec B101
+    # The denied URL was never fetched; the allowed ones were.
+    assert "https://example.com/1" not in fetch.calls  # nosec B101
+    assert "https://example.org/2" in fetch.calls  # nosec B101
+
+
+async def test_permission_check_ask_marks_required() -> None:
+    def _check(url: str, context: Any) -> str:
+        return "ask"
+
+    search = _FakeSearchModule(_search_ok())
+    fetch = _FakeFetchModule(default=_fetch_ok())
+    module = _module(search, fetch, permission_check=_check)
+    result = await module.execute_tool("web.research", {"query": "q", "fetch_top_n": 2})
+    assert fetch.calls == []  # nosec B101
+    assert all(s["fetched"] is False for s in result["sources"])  # nosec B101
+    assert result["sources"][0]["reason_code"] == "permission_required"  # nosec B101
+
+
+async def test_permission_check_failure_denies() -> None:
+    def _check(url: str, context: Any) -> str:
+        raise RuntimeError("policy backend down")
+
+    search = _FakeSearchModule(_search_ok())
+    fetch = _FakeFetchModule(default=_fetch_ok())
+    module = _module(search, fetch, permission_check=_check)
+    result = await module.execute_tool("web.research", {"query": "q", "fetch_top_n": 1})
+    assert fetch.calls == []  # nosec B101 - fail closed
+    assert result["sources"][0]["reason_code"] == "permission_denied"  # nosec B101

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_research_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_research_module.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.web_research_module import (
+    WebResearchModule,
+)
+from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeSearchModule:
+    """Stands in for WebSearchModule.execute_tool."""
+
+    def __init__(self, result: dict[str, Any]) -> None:
+        self.result = result
+        self.calls: list[dict[str, Any]] = []
+
+    async def execute_tool(self, name: str, args: dict[str, Any], context: Any | None = None) -> Any:
+        self.calls.append({"name": name, "args": dict(args)})
+        return self.result
+
+
+class _FakeFetchModule:
+    """Stands in for WebFetchModule.execute_tool; returns one canned result per url."""
+
+    def __init__(self, by_url: dict[str, dict[str, Any]] | None = None, default: dict[str, Any] | None = None) -> None:
+        self.by_url = by_url or {}
+        self.default = default
+        self.calls: list[str] = []
+
+    async def execute_tool(self, name: str, args: dict[str, Any], context: Any | None = None) -> Any:
+        url = args.get("url")
+        self.calls.append(url)
+        if url in self.by_url:
+            return self.by_url[url]
+        if self.default is not None:
+            return dict(self.default, url=url, final_url=url)
+        raise AssertionError(f"unexpected fetch url: {url}")
+
+
+def _module(search: _FakeSearchModule, fetch: _FakeFetchModule) -> WebResearchModule:
+    return WebResearchModule(
+        ModuleConfig(name="WebResearch"), search_module=search, fetch_module=fetch
+    )
+
+
+def _search_ok(
+    *,
+    engine: str = "duckduckgo",
+    query: str = "q",
+    results: list[dict[str, Any]] | None = None,
+    truncated: bool = False,
+) -> dict[str, Any]:
+    if results is None:
+        results = [
+            {"title": "One", "url": "https://example.com/1", "content": "snippet one", "metadata": {}},
+            {"title": "Two", "url": "https://example.org/2", "content": "snippet two", "metadata": {}},
+            {"title": "Three", "url": "https://example.net/3", "content": "snippet three", "metadata": {}},
+        ]
+    return {
+        "ok": True,
+        "engine": engine,
+        "query": query,
+        "result_count": len(results),
+        "total_results_found": len(results),
+        "truncated": truncated,
+        "results": results,
+        "eval": {"truncated": truncated},
+    }
+
+
+def _fetch_ok(*, content: str = "page content", status_code: int = 200, truncated: bool = False) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "url": "https://example.com/x",
+        "final_url": "https://example.com/x",
+        "status_code": status_code,
+        "content_type": "text/html",
+        "title": "Page",
+        "format": "markdown",
+        "content": content,
+        "bytes_fetched": len(content),
+        "truncated": truncated,
+        "eval": {},
+    }
+
+
+def _error(reason_code: str) -> dict[str, Any]:
+    return {"ok": False, "reason_code": reason_code, "message": "boom", "eval": {}}
+
+
+async def test_get_tools_exposes_web_research_contract() -> None:
+    module = _module(_FakeSearchModule(_search_ok()), _FakeFetchModule(default=_fetch_ok()))
+    tools = await module.get_tools()
+    assert [tool["name"] for tool in tools] == ["web.research"]  # nosec B101
+    tool = tools[0]
+    assert tool["inputSchema"]["required"] == ["query"]  # nosec B101
+    assert tool["inputSchema"]["additionalProperties"] is False  # nosec B101
+    assert tool["metadata"]["readOnlyHint"] is True  # nosec B101
+
+
+async def test_happy_path_searches_then_fetches_top_n() -> None:
+    search = _FakeSearchModule(_search_ok())
+    fetch = _FakeFetchModule(default=_fetch_ok())
+    module = _module(search, fetch)
+    result = await module.execute_tool(
+        "web.research", {"query": "python", "max_results": 3, "fetch_top_n": 2}
+    )
+    assert result["ok"] is True  # nosec B101
+    assert result["query"] == "python"  # nosec B101
+    assert result["engine"] == "duckduckgo"  # nosec B101
+    assert result["result_count"] == 3  # nosec B101
+    assert result["fetched_count"] == 2  # nosec B101
+    # search received result_count=max_results
+    assert search.calls[0]["args"]["result_count"] == 3  # nosec B101
+    # only the top 2 urls were fetched, in order
+    assert fetch.calls == ["https://example.com/1", "https://example.org/2"]  # nosec B101
+    # sources preserve search order; fetched ones carry content
+    assert [s["url"] for s in result["sources"]] == [
+        "https://example.com/1",
+        "https://example.org/2",
+        "https://example.net/3",
+    ]  # nosec B101
+    assert result["sources"][0]["fetched"] is True  # nosec B101
+    assert result["sources"][0]["snippet"] == "snippet one"  # nosec B101
+    assert result["sources"][0]["content"] == "page content"  # nosec B101
+    # the third result was not fetched (beyond fetch_top_n)
+    assert result["sources"][2]["fetched"] is False  # nosec B101
+
+
+async def test_search_error_short_circuits() -> None:
+    search = _FakeSearchModule(_error("search_failed"))
+    fetch = _FakeFetchModule(default=_fetch_ok())
+    module = _module(search, fetch)
+    result = await module.execute_tool("web.research", {"query": "q"})
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "search_failed"  # nosec B101
+    assert fetch.calls == []  # nosec B101
+
+
+async def test_individual_fetch_failure_is_tolerated() -> None:
+    search = _FakeSearchModule(_search_ok())
+    fetch = _FakeFetchModule(
+        by_url={
+            "https://example.com/1": _error("outbound_policy_denied"),
+            "https://example.org/2": _fetch_ok(content="ok two"),
+        }
+    )
+    module = _module(search, fetch)
+    result = await module.execute_tool(
+        "web.research", {"query": "q", "fetch_top_n": 2}
+    )
+    assert result["ok"] is True  # nosec B101
+    assert result["fetched_count"] == 1  # nosec B101
+    src0 = next(s for s in result["sources"] if s["url"] == "https://example.com/1")
+    assert src0["fetched"] is False  # nosec B101
+    assert src0["reason_code"] == "outbound_policy_denied"  # nosec B101
+    src1 = next(s for s in result["sources"] if s["url"] == "https://example.org/2")
+    assert src1["fetched"] is True  # nosec B101
+    assert src1["content"] == "ok two"  # nosec B101
+
+
+async def test_fetch_top_n_clamped_to_results() -> None:
+    search = _FakeSearchModule(_search_ok())  # 3 results
+    fetch = _FakeFetchModule(default=_fetch_ok())
+    module = _module(search, fetch)
+    result = await module.execute_tool(
+        "web.research", {"query": "q", "max_results": 3, "fetch_top_n": 9}
+    )
+    assert result["ok"] is True  # nosec B101
+    # fetch_top_n (9) clamped to the 3 available results
+    assert len(fetch.calls) == 3  # nosec B101
+    assert result["fetched_count"] == 3  # nosec B101
+
+
+async def test_fetch_top_n_zero_returns_search_only() -> None:
+    search = _FakeSearchModule(_search_ok())
+    fetch = _FakeFetchModule(default=_fetch_ok())
+    module = _module(search, fetch)
+    result = await module.execute_tool(
+        "web.research", {"query": "q", "fetch_top_n": 0}
+    )
+    assert result["ok"] is True  # nosec B101
+    assert fetch.calls == []  # nosec B101
+    assert result["fetched_count"] == 0  # nosec B101
+    assert all(s["fetched"] is False for s in result["sources"])  # nosec B101
+
+
+async def test_truncated_propagates_from_search() -> None:
+    search = _FakeSearchModule(_search_ok(truncated=True))
+    fetch = _FakeFetchModule(default=_fetch_ok())
+    module = _module(search, fetch)
+    result = await module.execute_tool("web.research", {"query": "q", "fetch_top_n": 1})
+    assert result["truncated"] is True  # nosec B101
+
+
+async def test_truncated_propagates_from_fetch() -> None:
+    search = _FakeSearchModule(_search_ok())
+    fetch = _FakeFetchModule(default=_fetch_ok(truncated=True))
+    module = _module(search, fetch)
+    result = await module.execute_tool("web.research", {"query": "q", "fetch_top_n": 1})
+    assert result["truncated"] is True  # nosec B101
+
+
+async def test_results_without_url_are_skipped_for_fetch() -> None:
+    results = [
+        {"title": "No URL", "url": "", "content": "snippet", "metadata": {}},
+        {"title": "Has URL", "url": "https://example.com/ok", "content": "snippet", "metadata": {}},
+    ]
+    search = _FakeSearchModule(_search_ok(results=results))
+    fetch = _FakeFetchModule(default=_fetch_ok())
+    module = _module(search, fetch)
+    result = await module.execute_tool("web.research", {"query": "q", "fetch_top_n": 2})
+    assert fetch.calls == ["https://example.com/ok"]  # nosec B101
+    assert result["fetched_count"] == 1  # nosec B101
+
+
+async def test_sanitize_input_allows_sql_like_query() -> None:
+    module = _module(_FakeSearchModule(_search_ok()), _FakeFetchModule(default=_fetch_ok()))
+    cleaned = module.sanitize_input({"query": "pip install --no-cache-dir"})
+    assert cleaned["query"] == "pip install --no-cache-dir"  # nosec B101
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {"query": "   "},
+        {"query": 123},
+        {"query": "q", "max_results": 0},
+        {"query": "q", "max_results": 1000},
+        {"query": "q", "fetch_top_n": -1},
+        {"query": "q", "fetch_top_n": 99},
+        {"query": "q", "format": "pdf"},
+        {"query": "q", "depth": 2},
+    ],
+)
+async def test_argument_validation(arguments: dict[str, Any]) -> None:
+    search = _FakeSearchModule(_search_ok())
+    fetch = _FakeFetchModule(default=_fetch_ok())
+    module = _module(search, fetch)
+    result = await module.execute_tool("web.research", arguments)
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "invalid_arguments"  # nosec B101
+    assert search.calls == []  # nosec B101
+
+
+async def test_invalid_engine_surfaces_from_search() -> None:
+    # Engine-value validation is delegated to web.search; its error is surfaced.
+    search = _FakeSearchModule(_error("invalid_engine"))
+    fetch = _FakeFetchModule(default=_fetch_ok())
+    module = _module(search, fetch)
+    result = await module.execute_tool("web.research", {"query": "q", "engine": "askjeeves"})
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "invalid_engine"  # nosec B101
+    assert fetch.calls == []  # nosec B101
+
+
+async def test_unknown_tool_returns_structured_error() -> None:
+    module = _module(_FakeSearchModule(_search_ok()), _FakeFetchModule(default=_fetch_ok()))
+    result = await module.execute_tool("web.other", {"query": "q"})
+    assert result["ok"] is False  # nosec B101
+    assert result["reason_code"] == "unknown_tool"  # nosec B101
+
+
+async def test_eval_metadata_records_profile_from_context() -> None:
+    module = _module(_FakeSearchModule(_search_ok()), _FakeFetchModule(default=_fetch_ok()))
+    context = RequestContext(request_id="req-research", metadata={"profile_id": "deep-researcher"})
+    result = await module.execute_tool("web.research", {"query": "q", "fetch_top_n": 1}, context)
+    assert result["ok"] is True  # nosec B101
+    assert result["eval"]["profile_id"] == "deep-researcher"  # nosec B101

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_research_module_registration.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_research_module_registration.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+async def _capture_default_registrations(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> list[dict[str, Any]]:
+    from tldw_Server_API.app.core.MCP_unified.server import MCPServer
+
+    server = MCPServer()
+    registrations: list[dict[str, Any]] = []
+
+    async def _capture_registration(module_id: str, module_type: type[Any], config: Any) -> None:
+        registrations.append(
+            {"module_id": module_id, "module_type": module_type, "config": config}
+        )
+
+    monkeypatch.setattr(server.module_registry, "register_module", _capture_registration)
+    monkeypatch.setenv("MCP_MODULES_CONFIG", str(tmp_path / "missing-modules.yaml"))
+    monkeypatch.delenv("MCP_MODULES", raising=False)
+    monkeypatch.setenv("MCP_ENABLE_MEDIA_MODULE", "0")
+    monkeypatch.setenv("MCP_ENABLE_FILESYSTEM_MODULE", "0")
+    monkeypatch.setenv("MCP_ENABLE_BROWSER_CDP_MODULE", "0")
+    monkeypatch.delenv("MCP_BROWSER_CDP_URL", raising=False)
+
+    await server._register_default_modules()
+    return registrations
+
+
+@pytest.mark.asyncio
+async def test_server_registers_web_research_module_when_enabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("MCP_ENABLE_WEB_RESEARCH_MODULE", "1")
+
+    registrations = await _capture_default_registrations(monkeypatch, tmp_path)
+
+    registration = next(item for item in registrations if item["module_id"] == "web_research")
+    assert registration["module_type"].__name__ == "WebResearchModule"  # nosec B101
+    assert registration["config"].name == "WebResearch"  # nosec B101
+    assert registration["config"].department == "research"  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_server_does_not_register_web_research_module_when_flag_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("MCP_ENABLE_WEB_RESEARCH_MODULE", raising=False)
+
+    registrations = await _capture_default_registrations(monkeypatch, tmp_path)
+
+    assert "web_research" not in {item["module_id"] for item in registrations}  # nosec B101


### PR DESCRIPTION
## Summary

Adds a built-in, read-only **`web.research`** MCP tool that **composes** the already-merged `web.search` (#2349) and `web.fetch` (#2348) tools: run one search query, then fetch + extract the top N results into a single bounded research bundle. It's the "do my web research" primitive for the `deep-researcher` preset.

## Composition, not re-implementation

`web.research` instantiates a `WebSearchModule` + `WebFetchModule` (injectable for tests) and drives them through their existing `execute_tool` contracts, so:
- Every fetched URL re-runs `web.fetch`'s **per-hop outbound (SSRF/egress) policy**, including redirect re-checks — no new egress surface.
- Search-provider egress is enforced inside `web.search`.
- Byte/content bounds, truncation, and structured error codes are inherited.

## Behavior

- Flow: validate/clamp → `web.search {query, result_count: max_results, engine?, site_*}` → on error surface its `reason_code`/`message` → take the first `fetch_top_n` results with a `url` → `asyncio.gather` fetch with `Semaphore(3)` → assemble `sources` in search order.
- **Partial-failure tolerant:** a search-stage failure fails the call; an individual fetch failure is recorded on the source (`fetched: false` + the fetch `reason_code`) and never fails the bundle.
- Engine-value validation is **delegated** to `web.search` (so an invalid engine surfaces as its `invalid_engine`); `web.research` only validates structural types/bounds.
- Bounds: `max_results` 1..25, `fetch_top_n` 0..10 clamped to `max_results`; `truncated` = search truncated OR any source clipped; url-less results skipped for fetch.
- Permissive `sanitize_input` override (allows `--`/punycode queries — the protocol sanitizes before execute).

Result shape:
```
{ ok, query, engine, result_count, fetched_count, truncated,
  sources: [ { title, url, snippet, fetched, status_code?, content?, reason_code? } ], eval }
```

## Wiring

- Optional registration gated by `MCP_ENABLE_WEB_RESEARCH_MODULE` (off by default), id `web_research`, department `research`.
- `_WEB_READ_TOOLS = ["web.fetch", "web.search", "web.research"]`; enabled in the `deep-researcher` preset.

## Tests

- `test_web_research_module.py` (21) — contract, happy path (top-N fetch, order preserved), search error short-circuits, fetch failure tolerated, `fetch_top_n` clamp, `fetch_top_n: 0`, truncation from search/fetch, url-less results skipped, delegated `invalid_engine`, sanitize override, arg validation, unknown tool, eval profile metadata.
- `test_web_research_module_registration.py` (2) — registered iff flag set.
- `test_profile_presets.py` — `deep-researcher` enables `web.research`.
- 107 combined with web search/fetch/preset suites. ruff/compileall/bandit clean. Injectable composed modules → no network/config in unit tests.

backlog: task-2356 · design: `Docs/Design/MCP_Web_Research_Tool_Design.md`

> Slice 1 of the user-requested "research chain + harden web tools" pair. Slice 2 (shared `_WebToolBase`, per-domain rate limiting, caching, richer citation metadata) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a built-in, read-only `web.research` tool that composes `web.search` and `web.fetch` to run one query and return a bounded bundle of top results with fetched content. Adds a fail-closed per-URL permission check so profile domain rules are honored. Meets TASK-2356.

- **New Features**
  - New `web.research` tool composed via `execute_tool` calls to `WebSearchModule` + `WebFetchModule` (injectable).
  - Behavior: `max_results` 1..25; `fetch_top_n` 0..10 (clamped); concurrency 3; preserves search order; aggregates `truncated`; skips url-less results.
  - Errors: search-stage errors fail the call; individual fetch errors recorded per source (`fetched: false` + `reason_code`).
  - Optional registration behind `MCP_ENABLE_WEB_RESEARCH_MODULE`; added to `_WEB_READ_TOOLS` and enabled in the `deep-researcher` preset.
  - Design doc added; tests cover contract, bounds, registration, and presets.

- **Bug Fixes**
  - Enforce per-URL profile rules via optional `permission_check(url, context) -> allow|ask|deny` (deny → `permission_denied`, ask → `permission_required`; default preserves prior behavior).
  - Wrap search exceptions → `search_failed`; coerce non-list `results` to `[]`; deduplicate URLs before fetching.
  - Improved logging with sanitized host on sub-fetch failures.

<sup>Written for commit 0145824b70e4a686dbf94166e57b80a66e54b1f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

