### PR TITLE
Harden MCP web tools: shared WebToolBase

### DIFF
--- a/backlog/tasks/task-2357 - Harden-MCP-web-tools-shared-base.md
+++ b/backlog/tasks/task-2357 - Harden-MCP-web-tools-shared-base.md
@@ -1,0 +1,50 @@
+---
+id: TASK-2357
+title: Harden MCP web tools with a shared WebToolBase
+status: Done
+updated_date: '2026-06-14'
+labels:
+- mcp
+- tools
+- web
+- refactor
+dependencies:
+- TASK-2354
+- TASK-2355
+- TASK-2356
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Extract a shared `WebToolBase` for the three read-only web MCP tools (web.fetch, web.search, web.research) to remove the duplicated `sanitize_input` override, execution eval metadata, structured error-result shape, profile-id context reader, and domain-list validator. Behavior-preserving refactor guarded by the existing web-tool test suites.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A `web_tool_base.py` provides `WebToolBase(BaseModule)` + shared `WebToolError`, with one implementation each of the permissive `sanitize_input` override, `_structured_error`, `_eval_metadata`, `_profile_id_from_context_metadata`, and `_validate_domain_list`.
+- [x] #2 web.fetch, web.search, and web.research extend `WebToolBase`, set the `_ACTION_FAMILY`/`_RESULT_KIND`/`_TOOL_PROMPT_VERSION` class attributes, and drop their per-module copies of the shared helpers (incl. the three private `_WebXError` classes, now unified as `WebToolError`).
+- [x] #3 The refactor is behavior-preserving: all existing web-tool, registration, and preset tests stay green (111) and a new `test_web_tool_base.py` (6) directly covers the base.
+- [x] #4 ruff/compileall/bandit clean; no public result-shape or error-code changes.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+New `tldw_Server_API/app/core/MCP_unified/modules/implementations/web_tool_base.py`:
+- `WebToolError(reason_code, message)` — single control-flow error replacing `_WebFetchError`/`_WebSearchError`/`_WebResearchError`.
+- `WebToolBase(BaseModule)`:
+  - `sanitize_input` permissive override (strip NUL/control chars only via shared `CONTROL_CHARS_RE`, depth guard) — the MCP protocol sanitizes every tool call before execute, so the SQL denylist would otherwise reject `--`/`/*`/punycode.
+  - `_structured_error(tool_name, reason_code, message, *, context, truncated=False, **extra)` — extra non-None fields (e.g. web.fetch `status_code`) merge into the result.
+  - `_eval_metadata` driven by class attrs `_ACTION_FAMILY` / `_RESULT_KIND` / `_TOOL_PROMPT_VERSION` (lazy import of `build_execution_eval_metadata`).
+  - `_profile_id_from_context_metadata`, `_validate_domain_list` (empty list → None).
+  - Exports `CONTROL_CHARS_RE` so web.fetch reuses it for URL control-char rejection.
+
+Each module now: extends `WebToolBase`, sets the three class attrs, deletes its duplicated helpers + private error class + control-char/depth constants, and uses `WebToolError` / `self._structured_error`. web.fetch keeps its fetch/redirect/extraction logic; web.search keeps normalization; web.research keeps orchestration.
+
+Net: ~150 lines of duplication removed; eval metadata, sanitize semantics, and error shape now have a single source of truth.
+
+Tests: 117 green (6 new base + 29 fetch + 28 search + 21 research + 2×3 registration + 27 presets, overlapping). ruff/compileall/bandit clean; `git diff --check` clean.
+
+Deferred (next web-tools hardening slice): per-domain rate limiting (shared limiter consulted in web.fetch per hop), response caching, and richer citation metadata on web.research sources.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_fetch_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_fetch_module.py
@@ -19,14 +19,14 @@ from urllib.parse import urljoin, urlsplit
 from loguru import logger
 
 from tldw_Server_API.app.core.MCP_unified.tool_observability import (
-    build_execution_eval_metadata,
     build_tool_eval_metadata,
 )
 from tldw_Server_API.app.core.Web_Scraping.outbound_policy import (
     decide_web_outbound_policy,
 )
 
-from ..base import BaseModule, ModuleConfig, create_tool_definition
+from ..base import ModuleConfig, create_tool_definition
+from .web_tool_base import CONTROL_CHARS_RE, WebToolBase, WebToolError
 
 _TOOL_FETCH = "web.fetch"
 _TOOL_PROMPT_VERSION = "2026.06.12"
@@ -45,8 +45,6 @@ _DEFAULT_USER_AGENT = "tldw-mcp-web-fetch/1.0"
 # address space and bypass SSRF/egress protection).
 _REDIRECT_STATUS = {301, 302, 303, 307, 308}
 _MAX_REDIRECTS = 5
-_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
-_MAX_SANITIZE_DEPTH = 20
 
 # Content types we will surface as text. Anything else is rejected so the tool
 # never returns binary blobs through the JSON tool contract.
@@ -189,17 +187,12 @@ class HttpxWebFetchClient:
                 )
 
 
-class _WebFetchError(Exception):
-    """Internal control-flow error carrying a structured reason code."""
-
-    def __init__(self, reason_code: str, message: str) -> None:
-        super().__init__(message)
-        self.reason_code = reason_code
-        self.message = message
-
-
-class WebFetchModule(BaseModule):
+class WebFetchModule(WebToolBase):
     """Single read-only ``web.fetch`` tool governed by outbound + domain policy."""
+
+    _ACTION_FAMILY = "web_fetch"
+    _RESULT_KIND = "bounded_web_document"
+    _TOOL_PROMPT_VERSION = _TOOL_PROMPT_VERSION
 
     def __init__(
         self,
@@ -273,27 +266,6 @@ class WebFetchModule(BaseModule):
         tool["inputSchema"]["additionalProperties"] = False
         return [tool]
 
-    def sanitize_input(self, input_data: Any, _depth: int = 0) -> Any:
-        """Permissive sanitizer for web fetch inputs.
-
-        The MCP protocol layer runs ``module.sanitize_input`` on every tool call
-        before execution. The base implementation rejects strings containing
-        SQL-injection substrings such as ``--``, ``/*`` and ``*/`` — which appear
-        constantly in legitimate URLs and query strings — and would turn them
-        into a protocol ``InvalidParams`` error before this tool's own validation
-        can run. We therefore strip only NUL/control characters and keep a depth
-        guard.
-        """
-        if _depth > _MAX_SANITIZE_DEPTH:
-            raise ValueError("Input too deeply nested")
-        if isinstance(input_data, str):
-            return _CONTROL_CHARS_RE.sub("", input_data)
-        if isinstance(input_data, dict):
-            return {key: self.sanitize_input(value, _depth + 1) for key, value in input_data.items()}
-        if isinstance(input_data, list):
-            return [self.sanitize_input(value, _depth + 1) for value in input_data]
-        return input_data
-
     async def execute_tool(
         self,
         tool_name: str,
@@ -301,7 +273,7 @@ class WebFetchModule(BaseModule):
         context: Any | None = None,
     ) -> Any:
         if tool_name != _TOOL_FETCH:
-            return self._error(tool_name, "unknown_tool", "Unknown web tool.", context=context)
+            return self._structured_error(tool_name, "unknown_tool", "Unknown web tool.", context=context)
 
         # Note: the inherited SQL-oriented sanitize_input() is intentionally NOT
         # applied to the raw URL — legitimate URLs commonly contain substrings
@@ -311,8 +283,8 @@ class WebFetchModule(BaseModule):
             requested_url, fmt, max_bytes, timeout_seconds, respect_robots = self._validate(
                 arguments or {}
             )
-        except _WebFetchError as exc:
-            return self._error(tool_name, exc.reason_code, exc.message, context=context)
+        except WebToolError as exc:
+            return self._structured_error(tool_name, exc.reason_code, exc.message, context=context)
 
         # Follow redirects manually, re-applying the outbound policy to every hop
         # so a permitted URL cannot redirect into denied/private address space.
@@ -326,7 +298,7 @@ class WebFetchModule(BaseModule):
                 stage="web.fetch",
             )
             if not getattr(decision, "allowed", False):
-                return self._error(
+                return self._structured_error(
                     tool_name,
                     "outbound_policy_denied",
                     f"Outbound policy denied the request ({getattr(decision, 'reason', 'denied')}).",
@@ -344,14 +316,14 @@ class WebFetchModule(BaseModule):
                 logger.bind(stage="web.fetch", host=_safe_host(current_url)).opt(exception=exc).warning(
                     "web.fetch client error"
                 )
-                return self._error(tool_name, "fetch_failed", "Failed to fetch the URL.", context=context)
+                return self._structured_error(tool_name, "fetch_failed", "Failed to fetch the URL.", context=context)
 
             if response.status_code in _REDIRECT_STATUS:
                 if not response.location:
                     logger.bind(stage="web.fetch", host=_safe_host(current_url)).warning(
                         "web.fetch redirect without a Location header"
                     )
-                    return self._error(
+                    return self._structured_error(
                         tool_name,
                         "fetch_failed",
                         "Upstream returned a redirect without a Location header.",
@@ -365,7 +337,7 @@ class WebFetchModule(BaseModule):
             logger.bind(stage="web.fetch", host=_safe_host(requested_url)).warning(
                 "web.fetch exceeded the redirect limit"
             )
-            return self._error(
+            return self._structured_error(
                 tool_name,
                 "fetch_failed",
                 f"Exceeded the redirect limit ({_MAX_REDIRECTS}).",
@@ -373,7 +345,7 @@ class WebFetchModule(BaseModule):
             )
 
         if response.status_code >= 400:
-            return self._error(
+            return self._structured_error(
                 tool_name,
                 "fetch_failed",
                 f"Upstream returned status {response.status_code}.",
@@ -383,14 +355,14 @@ class WebFetchModule(BaseModule):
 
         try:
             content, title = self._extract(response, fmt)
-        except _WebFetchError as exc:
+        except WebToolError as exc:
             logger.bind(
                 stage="web.fetch",
                 host=_safe_host(response.final_url),
                 reason_code=exc.reason_code,
                 content_type=response.content_type,
             ).debug("web.fetch extraction rejected the response")
-            return self._error(
+            return self._structured_error(
                 tool_name,
                 exc.reason_code,
                 exc.message,
@@ -422,20 +394,20 @@ class WebFetchModule(BaseModule):
     def _validate(self, args: dict[str, Any]) -> tuple[str, str, int, int, bool]:
         unknown = sorted(set(args) - _ALLOWED_ARGS)
         if unknown:
-            raise _WebFetchError("invalid_arguments", f"unknown arguments: {', '.join(unknown)}")
+            raise WebToolError("invalid_arguments", f"unknown arguments: {', '.join(unknown)}")
 
         url = args.get("url")
         if not isinstance(url, str) or not url.strip():
-            raise _WebFetchError("invalid_arguments", "url is required")
+            raise WebToolError("invalid_arguments", "url is required")
         url = url.strip()
-        if _CONTROL_CHARS_RE.search(url):
-            raise _WebFetchError("invalid_url", "url must not contain control characters")
+        if CONTROL_CHARS_RE.search(url):
+            raise WebToolError("invalid_url", "url must not contain control characters")
         if not re.match(r"^https?://", url, re.IGNORECASE):
-            raise _WebFetchError("invalid_url", "url must use the http or https scheme")
+            raise WebToolError("invalid_url", "url must use the http or https scheme")
 
         fmt = args.get("format", "markdown")
         if fmt not in _FORMATS:
-            raise _WebFetchError("invalid_arguments", "format must be one of markdown, text, html")
+            raise WebToolError("invalid_arguments", "format must be one of markdown, text, html")
 
         max_bytes = self._bounded_int(
             args, "max_bytes", default=_DEFAULT_MAX_BYTES, maximum=_MAX_MAX_BYTES
@@ -446,7 +418,7 @@ class WebFetchModule(BaseModule):
 
         respect_robots = args.get("respect_robots", False)
         if not isinstance(respect_robots, bool):
-            raise _WebFetchError("invalid_arguments", "respect_robots must be a boolean")
+            raise WebToolError("invalid_arguments", "respect_robots must be a boolean")
 
         return url, fmt, max_bytes, timeout_seconds, respect_robots
 
@@ -456,9 +428,9 @@ class WebFetchModule(BaseModule):
         if value is None:
             return default
         if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
-            raise _WebFetchError("invalid_arguments", f"{name} must be a positive integer")
+            raise WebToolError("invalid_arguments", f"{name} must be a positive integer")
         if value > maximum:
-            raise _WebFetchError("invalid_arguments", f"{name} exceeds maximum ({maximum})")
+            raise WebToolError("invalid_arguments", f"{name} exceeds maximum ({maximum})")
         return value
 
     # ---- extraction ----------------------------------------------------
@@ -472,7 +444,7 @@ class WebFetchModule(BaseModule):
                 return text, self._html_title(text)
             content = self._extract_html(text, fmt)
             if not content:
-                raise _WebFetchError("empty_content", "No readable content could be extracted.")
+                raise WebToolError("empty_content", "No readable content could be extracted.")
             return content, self._html_title(text)
 
         # Plain text, or an absent/misconfigured content type that did not look
@@ -480,10 +452,10 @@ class WebFetchModule(BaseModule):
         if main_type in _PLAIN_TYPES or not main_type:
             cleaned = text.strip()
             if not cleaned:
-                raise _WebFetchError("empty_content", "Response body was empty.")
+                raise WebToolError("empty_content", "Response body was empty.")
             return cleaned, None
 
-        raise _WebFetchError(
+        raise WebToolError(
             "empty_content", f"Unsupported content type for extraction: {main_type}"
         )
 
@@ -531,57 +503,3 @@ class WebFetchModule(BaseModule):
             return None
         title = html_lib.unescape(_WS_RE.sub(" ", _TAG_RE.sub(" ", match.group(1)))).strip()
         return title or None
-
-    # ---- result helpers ------------------------------------------------
-
-    def _error(
-        self,
-        tool_name: str,
-        reason_code: str,
-        message: str,
-        *,
-        status_code: int | None = None,
-        context: Any | None = None,
-    ) -> dict[str, Any]:
-        result: dict[str, Any] = {
-            "ok": False,
-            "reason_code": reason_code,
-            "message": message,
-            "eval": self._eval_metadata(
-                tool_name, reason_code=reason_code, truncated=False, context=context
-            ),
-        }
-        if status_code is not None:
-            result["status_code"] = status_code
-        return result
-
-    def _eval_metadata(
-        self,
-        tool_name: str,
-        *,
-        reason_code: str | None,
-        truncated: bool,
-        context: Any | None,
-    ) -> dict[str, Any]:
-        return build_execution_eval_metadata(
-            tool_name=tool_name,
-            tool_prompt_id=f"mcp.{tool_name}.v1",
-            tool_prompt_version=_TOOL_PROMPT_VERSION,
-            action_family="web_fetch",
-            result_kind="bounded_web_document",
-            profile_id=self._profile_id_from_context_metadata(context),
-            path_filter_used=False,
-            truncated=truncated,
-            reason_code=reason_code,
-        )
-
-    @staticmethod
-    def _profile_id_from_context_metadata(context: Any | None) -> str | None:
-        metadata = getattr(context, "metadata", None)
-        if not isinstance(metadata, dict):
-            return None
-        for key in ("profile_id", "selected_profile_id"):
-            value = metadata.get(key)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-        return None

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_research_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_research_module.py
@@ -11,7 +11,6 @@ inherited. Individual fetch failures are tolerated and recorded per source.
 from __future__ import annotations
 
 import asyncio
-import re
 from collections.abc import Callable
 from typing import Any, Protocol
 from urllib.parse import urlsplit
@@ -19,11 +18,11 @@ from urllib.parse import urlsplit
 from loguru import logger
 
 from tldw_Server_API.app.core.MCP_unified.tool_observability import (
-    build_execution_eval_metadata,
     build_tool_eval_metadata,
 )
 
-from ..base import BaseModule, ModuleConfig, create_tool_definition
+from ..base import ModuleConfig, create_tool_definition
+from .web_tool_base import WebToolBase, WebToolError
 
 _TOOL_RESEARCH = "web.research"
 _TOOL_PROMPT_VERSION = "2026.06.14"
@@ -45,9 +44,6 @@ _MAX_MAX_RESULTS = 25
 _DEFAULT_FETCH_TOP_N = 3
 _MAX_FETCH_TOP_N = 10
 _FETCH_CONCURRENCY = 3
-
-_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
-_MAX_SANITIZE_DEPTH = 20
 
 
 class WebToolModule(Protocol):
@@ -74,17 +70,12 @@ def _safe_host(url: str) -> str:
         return "unknown"
 
 
-class _WebResearchError(Exception):
-    """Internal control-flow error carrying a structured reason code."""
-
-    def __init__(self, reason_code: str, message: str) -> None:
-        super().__init__(message)
-        self.reason_code = reason_code
-        self.message = message
-
-
-class WebResearchModule(BaseModule):
+class WebResearchModule(WebToolBase):
     """Single read-only ``web.research`` tool composing search + fetch."""
+
+    _ACTION_FAMILY = "web_research"
+    _RESULT_KIND = "bounded_web_research_bundle"
+    _TOOL_PROMPT_VERSION = _TOOL_PROMPT_VERSION
 
     def __init__(
         self,
@@ -167,23 +158,6 @@ class WebResearchModule(BaseModule):
         tool["inputSchema"]["additionalProperties"] = False
         return [tool]
 
-    def sanitize_input(self, input_data: Any, _depth: int = 0) -> Any:
-        """Permissive sanitizer (strip only NUL/control chars).
-
-        See ``WebSearchModule.sanitize_input`` — the MCP protocol sanitizes every
-        tool call before execution, and the base SQL denylist would reject
-        legitimate research queries containing ``--``/``/*``.
-        """
-        if _depth > _MAX_SANITIZE_DEPTH:
-            raise ValueError("Input too deeply nested")
-        if isinstance(input_data, str):
-            return _CONTROL_CHARS_RE.sub("", input_data)
-        if isinstance(input_data, dict):
-            return {key: self.sanitize_input(value, _depth + 1) for key, value in input_data.items()}
-        if isinstance(input_data, list):
-            return [self.sanitize_input(value, _depth + 1) for value in input_data]
-        return input_data
-
     async def execute_tool(
         self,
         tool_name: str,
@@ -191,12 +165,12 @@ class WebResearchModule(BaseModule):
         context: Any | None = None,
     ) -> Any:
         if tool_name != _TOOL_RESEARCH:
-            return self._error(tool_name, "unknown_tool", "Unknown web tool.", context=context)
+            return self._structured_error(tool_name, "unknown_tool", "Unknown web tool.", context=context)
 
         try:
-            params = self._validate(arguments or {})
-        except _WebResearchError as exc:
-            return self._error(tool_name, exc.reason_code, exc.message, context=context)
+            params = self._validate(self.sanitize_input(arguments or {}))
+        except WebToolError as exc:
+            return self._structured_error(tool_name, exc.reason_code, exc.message, context=context)
 
         search_args: dict[str, Any] = {
             "query": params["query"],
@@ -213,11 +187,11 @@ class WebResearchModule(BaseModule):
             search_result = await self._search.execute_tool("web.search", search_args, context)
         except Exception as exc:  # noqa: BLE001 - a search crash maps to a structured error.
             logger.bind(stage="web.research").opt(exception=exc).error("web.research search stage failed")
-            return self._error(tool_name, "search_failed", "Web search stage failed.", context=context)
+            return self._structured_error(tool_name, "search_failed", "Web search stage failed.", context=context)
 
         if not isinstance(search_result, dict) or not search_result.get("ok"):
             reason_code, message = self._delegated_error(search_result, "search_failed")
-            return self._error(tool_name, reason_code, message, context=context)
+            return self._structured_error(tool_name, reason_code, message, context=context)
 
         results = search_result.get("results")
         if not isinstance(results, list):
@@ -352,16 +326,16 @@ class WebResearchModule(BaseModule):
     def _validate(self, args: dict[str, Any]) -> dict[str, Any]:
         unknown = sorted(set(args) - _ALLOWED_ARGS)
         if unknown:
-            raise _WebResearchError("invalid_arguments", f"unknown arguments: {', '.join(unknown)}")
+            raise WebToolError("invalid_arguments", f"unknown arguments: {', '.join(unknown)}")
 
         query = args.get("query")
         if not isinstance(query, str) or not query.strip():
-            raise _WebResearchError("invalid_arguments", "query is required")
+            raise WebToolError("invalid_arguments", "query is required")
         query = query.strip()
 
         engine = args.get("engine")
         if engine is not None and (not isinstance(engine, str) or not engine.strip()):
-            raise _WebResearchError("invalid_arguments", "engine must be a non-empty string")
+            raise WebToolError("invalid_arguments", "engine must be a non-empty string")
 
         max_results = self._bounded_int(
             args, "max_results", default=_DEFAULT_MAX_RESULTS, minimum=1, maximum=_MAX_MAX_RESULTS
@@ -374,12 +348,12 @@ class WebResearchModule(BaseModule):
 
         fmt = args.get("format", "markdown")
         if fmt not in _FORMATS:
-            raise _WebResearchError("invalid_arguments", "format must be one of markdown, text, html")
+            raise WebToolError("invalid_arguments", "format must be one of markdown, text, html")
 
         max_bytes = args.get("max_bytes")
         if max_bytes is not None:
             if not isinstance(max_bytes, int) or isinstance(max_bytes, bool) or max_bytes <= 0:
-                raise _WebResearchError("invalid_arguments", "max_bytes must be a positive integer")
+                raise WebToolError("invalid_arguments", "max_bytes must be a positive integer")
 
         site_whitelist = self._validate_domain_list(args, "site_whitelist")
         site_blacklist = self._validate_domain_list(args, "site_blacklist")
@@ -401,65 +375,7 @@ class WebResearchModule(BaseModule):
         if value is None:
             return default
         if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
-            raise _WebResearchError("invalid_arguments", f"{name} must be an integer >= {minimum}")
+            raise WebToolError("invalid_arguments", f"{name} must be an integer >= {minimum}")
         if value > maximum:
-            raise _WebResearchError("invalid_arguments", f"{name} exceeds maximum ({maximum})")
+            raise WebToolError("invalid_arguments", f"{name} exceeds maximum ({maximum})")
         return value
-
-    @staticmethod
-    def _validate_domain_list(args: dict[str, Any], name: str) -> list[str] | None:
-        value = args.get(name)
-        if value is None:
-            return None
-        if not isinstance(value, list) or not all(isinstance(item, str) and item.strip() for item in value):
-            raise _WebResearchError("invalid_arguments", f"{name} must be a list of non-empty strings")
-        stripped = [item.strip() for item in value]
-        return stripped or None
-
-    # ---- result helpers ------------------------------------------------
-
-    def _error(
-        self,
-        tool_name: str,
-        reason_code: str,
-        message: str,
-        *,
-        context: Any | None = None,
-    ) -> dict[str, Any]:
-        return {
-            "ok": False,
-            "reason_code": reason_code,
-            "message": message,
-            "eval": self._eval_metadata(tool_name, reason_code=reason_code, context=context),
-        }
-
-    def _eval_metadata(
-        self,
-        tool_name: str,
-        *,
-        reason_code: str | None,
-        truncated: bool = False,
-        context: Any | None,
-    ) -> dict[str, Any]:
-        return build_execution_eval_metadata(
-            tool_name=tool_name,
-            tool_prompt_id=f"mcp.{tool_name}.v1",
-            tool_prompt_version=_TOOL_PROMPT_VERSION,
-            action_family="web_research",
-            result_kind="bounded_web_research_bundle",
-            profile_id=self._profile_id_from_context_metadata(context),
-            path_filter_used=False,
-            truncated=truncated,
-            reason_code=reason_code,
-        )
-
-    @staticmethod
-    def _profile_id_from_context_metadata(context: Any | None) -> str | None:
-        metadata = getattr(context, "metadata", None)
-        if not isinstance(metadata, dict):
-            return None
-        for key in ("profile_id", "selected_profile_id"):
-            value = metadata.get(key)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-        return None

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_research_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_research_module.py
@@ -167,8 +167,10 @@ class WebResearchModule(WebToolBase):
         if tool_name != _TOOL_RESEARCH:
             return self._structured_error(tool_name, "unknown_tool", "Unknown web tool.", context=context)
 
+        # The MCP protocol layer already runs sanitize_input on arguments before
+        # execute_tool, so we do not re-sanitize here.
         try:
-            params = self._validate(self.sanitize_input(arguments or {}))
+            params = self._validate(arguments or {})
         except WebToolError as exc:
             return self._structured_error(tool_name, exc.reason_code, exc.message, context=context)
 

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_search_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_search_module.py
@@ -9,17 +9,16 @@ module adds argument validation, result bounding, and structured error mapping.
 from __future__ import annotations
 
 import asyncio
-import re
 from typing import Any, Protocol
 
 from loguru import logger
 
 from tldw_Server_API.app.core.MCP_unified.tool_observability import (
-    build_execution_eval_metadata,
     build_tool_eval_metadata,
 )
 
-from ..base import BaseModule, ModuleConfig, create_tool_definition
+from ..base import ModuleConfig, create_tool_definition
+from .web_tool_base import WebToolBase, WebToolError
 
 _TOOL_SEARCH = "web.search"
 _TOOL_PROMPT_VERSION = "2026.06.12"
@@ -60,9 +59,6 @@ _DEFAULT_RESULT_COUNT = 10
 _MAX_RESULT_COUNT = 25
 _MAX_RESULT_CONTENT_CHARS = 4000
 
-_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
-_MAX_SANITIZE_DEPTH = 20
-
 
 class WebSearchBackend(Protocol):
     """Injectable search backend so the module is unit-testable without network."""
@@ -92,17 +88,12 @@ class PerformWebSearchBackend:
         )
 
 
-class _WebSearchError(Exception):
-    """Internal control-flow error carrying a structured reason code."""
-
-    def __init__(self, reason_code: str, message: str) -> None:
-        super().__init__(message)
-        self.reason_code = reason_code
-        self.message = message
-
-
-class WebSearchModule(BaseModule):
+class WebSearchModule(WebToolBase):
     """Single read-only ``web.search`` tool over the multi-provider search API."""
+
+    _ACTION_FAMILY = "web_search"
+    _RESULT_KIND = "bounded_web_search_results"
+    _TOOL_PROMPT_VERSION = _TOOL_PROMPT_VERSION
 
     def __init__(
         self,
@@ -174,28 +165,6 @@ class WebSearchModule(BaseModule):
         tool["inputSchema"]["additionalProperties"] = False
         return [tool]
 
-    def sanitize_input(self, input_data: Any, _depth: int = 0) -> Any:
-        """Permissive sanitizer for web search inputs.
-
-        The base implementation rejects strings containing SQL-injection
-        substrings such as ``--``, ``/*`` and ``*/``. Those appear in legitimate
-        search queries (e.g. ``pip install --no-cache-dir``) and punycode domain
-        filters (e.g. ``xn--...``). The MCP protocol layer runs
-        ``module.sanitize_input`` on every tool call before execution, so without
-        this override such inputs would be rejected with a protocol
-        ``InvalidParams`` error instead of being searched. We therefore strip
-        only NUL/control characters and keep a depth guard.
-        """
-        if _depth > _MAX_SANITIZE_DEPTH:
-            raise ValueError("Input too deeply nested")
-        if isinstance(input_data, str):
-            return _CONTROL_CHARS_RE.sub("", input_data)
-        if isinstance(input_data, dict):
-            return {key: self.sanitize_input(value, _depth + 1) for key, value in input_data.items()}
-        if isinstance(input_data, list):
-            return [self.sanitize_input(value, _depth + 1) for value in input_data]
-        return input_data
-
     async def execute_tool(
         self,
         tool_name: str,
@@ -203,13 +172,13 @@ class WebSearchModule(BaseModule):
         context: Any | None = None,
     ) -> Any:
         if tool_name != _TOOL_SEARCH:
-            return self._error(tool_name, "unknown_tool", "Unknown web tool.", context=context)
+            return self._structured_error(tool_name, "unknown_tool", "Unknown web tool.", context=context)
 
         args = self.sanitize_input(arguments or {})
         try:
             params = self._validate(args)
-        except _WebSearchError as exc:
-            return self._error(tool_name, exc.reason_code, exc.message, context=context)
+        except WebToolError as exc:
+            return self._structured_error(tool_name, exc.reason_code, exc.message, context=context)
 
         try:
             payload = await asyncio.to_thread(self._backend.search, **params)
@@ -217,12 +186,12 @@ class WebSearchModule(BaseModule):
             logger.bind(stage="web.search", engine=params["engine"]).opt(exception=exc).warning(
                 "web.search backend error"
             )
-            return self._error(tool_name, "search_failed", "Web search failed.", context=context)
+            return self._structured_error(tool_name, "search_failed", "Web search failed.", context=context)
 
         try:
             results, total, truncated = self._normalize(payload, params["result_count"])
-        except _WebSearchError as exc:
-            return self._error(tool_name, exc.reason_code, exc.message, context=context)
+        except WebToolError as exc:
+            return self._structured_error(tool_name, exc.reason_code, exc.message, context=context)
 
         return {
             "ok": True,
@@ -242,18 +211,18 @@ class WebSearchModule(BaseModule):
     def _validate(self, args: dict[str, Any]) -> dict[str, Any]:
         unknown = sorted(set(args) - _ALLOWED_ARGS)
         if unknown:
-            raise _WebSearchError("invalid_arguments", f"unknown arguments: {', '.join(unknown)}")
+            raise WebToolError("invalid_arguments", f"unknown arguments: {', '.join(unknown)}")
 
         query = args.get("query")
         if not isinstance(query, str) or not query.strip():
-            raise _WebSearchError("invalid_arguments", "query is required")
+            raise WebToolError("invalid_arguments", "query is required")
         query = query.strip()
 
         engine = args.get("engine")
         if engine is None:
             engine = _DEFAULT_ENGINE
         elif not isinstance(engine, str) or engine.lower() not in _ALLOWED_ENGINES:
-            raise _WebSearchError("invalid_engine", "engine is not a supported provider")
+            raise WebToolError("invalid_engine", "engine is not a supported provider")
         else:
             engine = engine.lower()
 
@@ -261,9 +230,9 @@ class WebSearchModule(BaseModule):
         if result_count is None:
             result_count = _DEFAULT_RESULT_COUNT
         elif not isinstance(result_count, int) or isinstance(result_count, bool) or result_count <= 0:
-            raise _WebSearchError("invalid_arguments", "result_count must be a positive integer")
+            raise WebToolError("invalid_arguments", "result_count must be a positive integer")
         elif result_count > _MAX_RESULT_COUNT:
-            raise _WebSearchError("invalid_arguments", f"result_count exceeds maximum ({_MAX_RESULT_COUNT})")
+            raise WebToolError("invalid_arguments", f"result_count exceeds maximum ({_MAX_RESULT_COUNT})")
 
         # Strip optional string fields; normalize empty/whitespace to None so the
         # backend applies its own defaults instead of receiving blank values.
@@ -274,7 +243,7 @@ class WebSearchModule(BaseModule):
                 str_fields[str_field] = None
                 continue
             if not isinstance(value, str):
-                raise _WebSearchError("invalid_arguments", f"{str_field} must be a string")
+                raise WebToolError("invalid_arguments", f"{str_field} must be a string")
             stripped = value.strip()
             str_fields[str_field] = stripped or None
 
@@ -294,35 +263,23 @@ class WebSearchModule(BaseModule):
             "date_range": str_fields["date_range"],
         }
 
-    @staticmethod
-    def _validate_domain_list(args: dict[str, Any], name: str) -> list[str] | None:
-        value = args.get(name)
-        if value is None:
-            return None
-        if not isinstance(value, list) or not all(isinstance(item, str) and item.strip() for item in value):
-            raise _WebSearchError("invalid_arguments", f"{name} must be a list of non-empty strings")
-        # An empty (or all-whitespace) list would be read by some providers as
-        # "exclude everything"; normalize it to None instead.
-        stripped = [item.strip() for item in value]
-        return stripped or None
-
     # ---- normalization -------------------------------------------------
 
     def _normalize(
         self, payload: Any, result_count: int
     ) -> tuple[list[dict[str, Any]], int, bool]:
         if not isinstance(payload, dict):
-            raise _WebSearchError("search_failed", "Search backend returned an unexpected payload.")
+            raise WebToolError("search_failed", "Search backend returned an unexpected payload.")
 
         error_text = payload.get("processing_error") or payload.get("error")
         if error_text:
             if "outbound policy" in str(error_text).lower():
-                raise _WebSearchError("outbound_policy_denied", "Outbound policy denied the search provider.")
-            raise _WebSearchError("search_failed", "Web search failed.")
+                raise WebToolError("outbound_policy_denied", "Outbound policy denied the search provider.")
+            raise WebToolError("search_failed", "Web search failed.")
 
         raw_results = payload.get("results") or []
         if not isinstance(raw_results, list):
-            raise _WebSearchError("search_failed", "Search backend returned malformed results.")
+            raise WebToolError("search_failed", "Search backend returned malformed results.")
 
         # The response is bounded when the provider returned more results than
         # requested or any single result's content had to be clipped.
@@ -363,51 +320,3 @@ class WebSearchModule(BaseModule):
         if isinstance(value, str):
             return value
         return "" if value is None else str(value)
-
-    # ---- result helpers ------------------------------------------------
-
-    def _error(
-        self,
-        tool_name: str,
-        reason_code: str,
-        message: str,
-        *,
-        context: Any | None = None,
-    ) -> dict[str, Any]:
-        return {
-            "ok": False,
-            "reason_code": reason_code,
-            "message": message,
-            "eval": self._eval_metadata(tool_name, reason_code=reason_code, context=context),
-        }
-
-    def _eval_metadata(
-        self,
-        tool_name: str,
-        *,
-        reason_code: str | None,
-        truncated: bool = False,
-        context: Any | None,
-    ) -> dict[str, Any]:
-        return build_execution_eval_metadata(
-            tool_name=tool_name,
-            tool_prompt_id=f"mcp.{tool_name}.v1",
-            tool_prompt_version=_TOOL_PROMPT_VERSION,
-            action_family="web_search",
-            result_kind="bounded_web_search_results",
-            profile_id=self._profile_id_from_context_metadata(context),
-            path_filter_used=False,
-            truncated=truncated,
-            reason_code=reason_code,
-        )
-
-    @staticmethod
-    def _profile_id_from_context_metadata(context: Any | None) -> str | None:
-        metadata = getattr(context, "metadata", None)
-        if not isinstance(metadata, dict):
-            return None
-        for key in ("profile_id", "selected_profile_id"):
-            value = metadata.get(key)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-        return None

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_search_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_search_module.py
@@ -174,9 +174,10 @@ class WebSearchModule(WebToolBase):
         if tool_name != _TOOL_SEARCH:
             return self._structured_error(tool_name, "unknown_tool", "Unknown web tool.", context=context)
 
-        args = self.sanitize_input(arguments or {})
+        # The MCP protocol layer already runs sanitize_input on arguments before
+        # execute_tool, so we do not re-sanitize here.
         try:
-            params = self._validate(args)
+            params = self._validate(arguments or {})
         except WebToolError as exc:
             return self._structured_error(tool_name, exc.reason_code, exc.message, context=context)
 

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_tool_base.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_tool_base.py
@@ -92,7 +92,8 @@ class WebToolBase(BaseModule):
             ),
         }
         for key, value in extra.items():
-            if value is not None:
+            # Never let caller-supplied extras overwrite the core error fields.
+            if value is not None and key not in result:
                 result[key] = value
         return result
 
@@ -104,7 +105,9 @@ class WebToolBase(BaseModule):
         truncated: bool = False,
         context: Any | None = None,
     ) -> dict[str, Any]:
-        from ...tool_observability import build_execution_eval_metadata
+        from tldw_Server_API.app.core.MCP_unified.tool_observability import (
+            build_execution_eval_metadata,
+        )
 
         return build_execution_eval_metadata(
             tool_name=tool_name,

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_tool_base.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_tool_base.py
@@ -1,0 +1,146 @@
+"""Shared base for the read-only web MCP tools (web.fetch / web.search / web.research).
+
+Centralizes the behavior these tools had duplicated: a permissive
+``sanitize_input`` override (the MCP protocol sanitizes every tool call before
+execution, and the base SQL denylist wrongly rejects legitimate URLs/queries
+containing ``--``/``/*``/punycode), execution eval metadata, the structured
+error-result shape, the profile-id context reader, and the domain-list
+validator.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from ..base import BaseModule, create_tool_definition  # re-exported for module convenience
+
+__all__ = ["CONTROL_CHARS_RE", "WebToolBase", "WebToolError", "create_tool_definition"]
+
+# Shared across the web tools: stripped from sanitized inputs, and rejected
+# outright in URL validation.
+CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+_MAX_SANITIZE_DEPTH = 20
+
+
+class WebToolError(Exception):
+    """Internal control-flow error carrying a structured reason code.
+
+    Shared by all web tools so the domain-list validator and per-tool validation
+    can raise a single type that ``execute_tool`` maps to a structured result.
+    """
+
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.message = message
+
+
+class WebToolBase(BaseModule):
+    """Base class with the shared plumbing for read-only web tools.
+
+    Subclasses set the three eval-metadata class attributes and use
+    :meth:`_structured_error` / :meth:`_eval_metadata` / :meth:`_validate_domain_list`.
+    """
+
+    # Eval-metadata identity; subclasses override.
+    _ACTION_FAMILY: str = "web"
+    _RESULT_KIND: str = "web_result"
+    _TOOL_PROMPT_VERSION: str = "2026.06.14"
+
+    def sanitize_input(self, input_data: Any, _depth: int = 0) -> Any:
+        """Permissive sanitizer that strips only NUL/control characters.
+
+        The base ``sanitize_input`` rejects strings containing SQL-injection
+        substrings (``--``, ``/*``, ``*/``), but those appear constantly in
+        legitimate URLs, search queries (``pip install --no-cache-dir``), and
+        punycode domains (``xn--...``). The MCP protocol runs this on every tool
+        call before execution, so without the override such inputs would be
+        rejected with a protocol ``InvalidParams`` error. We keep only the NUL/
+        control-char stripping and a depth guard.
+        """
+        if _depth > _MAX_SANITIZE_DEPTH:
+            raise ValueError("Input too deeply nested")
+        if isinstance(input_data, str):
+            return CONTROL_CHARS_RE.sub("", input_data)
+        if isinstance(input_data, dict):
+            return {key: self.sanitize_input(value, _depth + 1) for key, value in input_data.items()}
+        if isinstance(input_data, list):
+            return [self.sanitize_input(value, _depth + 1) for value in input_data]
+        return input_data
+
+    def _structured_error(
+        self,
+        tool_name: str,
+        reason_code: str,
+        message: str,
+        *,
+        context: Any | None = None,
+        truncated: bool = False,
+        **extra: Any,
+    ) -> dict[str, Any]:
+        """Return the shared ``{ok: false, reason_code, message, eval}`` payload.
+
+        Extra keyword fields (e.g. ``status_code``) are merged into the result.
+        """
+        result: dict[str, Any] = {
+            "ok": False,
+            "reason_code": reason_code,
+            "message": message,
+            "eval": self._eval_metadata(
+                tool_name, reason_code=reason_code, truncated=truncated, context=context
+            ),
+        }
+        for key, value in extra.items():
+            if value is not None:
+                result[key] = value
+        return result
+
+    def _eval_metadata(
+        self,
+        tool_name: str,
+        *,
+        reason_code: str | None,
+        truncated: bool = False,
+        context: Any | None = None,
+    ) -> dict[str, Any]:
+        from ...tool_observability import build_execution_eval_metadata
+
+        return build_execution_eval_metadata(
+            tool_name=tool_name,
+            tool_prompt_id=f"mcp.{tool_name}.v1",
+            tool_prompt_version=self._TOOL_PROMPT_VERSION,
+            action_family=self._ACTION_FAMILY,
+            result_kind=self._RESULT_KIND,
+            profile_id=self._profile_id_from_context_metadata(context),
+            path_filter_used=False,
+            truncated=truncated,
+            reason_code=reason_code,
+        )
+
+    @staticmethod
+    def _profile_id_from_context_metadata(context: Any | None) -> str | None:
+        metadata = getattr(context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return None
+        for key in ("profile_id", "selected_profile_id"):
+            value = metadata.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
+    @staticmethod
+    def _validate_domain_list(args: dict[str, Any], name: str) -> list[str] | None:
+        """Validate an optional list-of-domains argument.
+
+        Returns ``None`` for absent or empty/whitespace lists (so providers do
+        not read an empty list as "exclude everything"); raises
+        :class:`WebToolError` for malformed input.
+        """
+        value = args.get(name)
+        if value is None:
+            return None
+        if not isinstance(value, list) or not all(isinstance(item, str) and item.strip() for item in value):
+            raise WebToolError("invalid_arguments", f"{name} must be a list of non-empty strings")
+        stripped = [item.strip() for item in value]
+        return stripped or None

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_tool_base.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_tool_base.py
@@ -39,53 +39,80 @@ def _tool() -> _SampleWebTool:
     return _SampleWebTool(ModuleConfig(name="Sample"))
 
 
-async def test_sanitize_input_allows_sql_like_and_punycode_strips_control() -> None:
-    tool = _tool()
-    cleaned = tool.sanitize_input(
-        {"query": "pip install --no-cache-dir", "domains": ["xn--80ak6aa92e.com"], "ctl": "a\x00b\x07c"}
-    )
+async def test_sanitize_input_allows_sql_like_substrings() -> None:
+    cleaned = _tool().sanitize_input({"query": "pip install --no-cache-dir"})
     assert cleaned["query"] == "pip install --no-cache-dir"  # nosec B101
+
+
+async def test_sanitize_input_preserves_punycode_in_lists() -> None:
+    cleaned = _tool().sanitize_input({"domains": ["xn--80ak6aa92e.com"]})
     assert cleaned["domains"] == ["xn--80ak6aa92e.com"]  # nosec B101
+
+
+async def test_sanitize_input_strips_control_characters() -> None:
+    cleaned = _tool().sanitize_input({"ctl": "a\x00b\x07c"})
     assert cleaned["ctl"] == "abc"  # nosec B101
 
 
 async def test_sanitize_input_depth_guard() -> None:
-    tool = _tool()
     deep: Any = "x"
     for _ in range(25):
         deep = {"k": deep}
     with pytest.raises(ValueError):
-        tool.sanitize_input(deep)
+        _tool().sanitize_input(deep)
 
 
-async def test_structured_error_shape_and_extra_fields() -> None:
-    tool = _tool()
-    err = tool._structured_error("sample.tool", "bad_thing", "it broke", status_code=503)
+async def test_structured_error_is_not_ok() -> None:
+    err = _tool()._structured_error("sample.tool", "bad_thing", "it broke")
     assert err["ok"] is False  # nosec B101
-    assert err["reason_code"] == "bad_thing"  # nosec B101
-    assert err["message"] == "it broke"  # nosec B101
+
+
+async def test_structured_error_carries_reason_and_message() -> None:
+    err = _tool()._structured_error("sample.tool", "bad_thing", "it broke")
+    assert (err["reason_code"], err["message"]) == ("bad_thing", "it broke")  # nosec B101
+
+
+async def test_structured_error_merges_extra_fields() -> None:
+    err = _tool()._structured_error("sample.tool", "bad", "msg", status_code=503)
     assert err["status_code"] == 503  # nosec B101
-    assert err["eval"]["reason_code"] == "bad_thing"  # nosec B101
 
 
 async def test_structured_error_omits_none_extras() -> None:
-    tool = _tool()
-    err = tool._structured_error("sample.tool", "bad", "msg", status_code=None)
+    err = _tool()._structured_error("sample.tool", "bad", "msg", status_code=None)
     assert "status_code" not in err  # nosec B101
 
 
-async def test_eval_metadata_uses_class_identity_and_profile() -> None:
-    tool = _tool()
+async def test_structured_error_extra_cannot_overwrite_core_fields() -> None:
+    # ``ok`` and ``eval`` are the result keys reachable via **extra; the guard
+    # must keep the caller from clobbering them.
+    err = _tool()._structured_error("sample.tool", "bad", "msg", ok=True, eval="HIJACKED")
+    assert err["ok"] is False  # nosec B101
+    assert err["eval"] != "HIJACKED"  # nosec B101
+
+
+async def test_eval_metadata_reads_profile_from_context() -> None:
     context = RequestContext(request_id="r", metadata={"profile_id": "deep-researcher"})
-    meta = tool._eval_metadata("sample.tool", reason_code=None, truncated=True, context=context)
+    meta = _tool()._eval_metadata("sample.tool", reason_code=None, truncated=False, context=context)
     assert meta["profile_id"] == "deep-researcher"  # nosec B101
+
+
+async def test_eval_metadata_propagates_truncated() -> None:
+    meta = _tool()._eval_metadata("sample.tool", reason_code=None, truncated=True, context=None)
     assert meta["truncated"] is True  # nosec B101
 
 
-async def test_validate_domain_list() -> None:
-    tool = _tool()
-    assert tool._validate_domain_list({}, "site_whitelist") is None  # nosec B101
-    assert tool._validate_domain_list({"site_whitelist": []}, "site_whitelist") is None  # nosec B101
-    assert tool._validate_domain_list({"site_whitelist": ["  a.com "]}, "site_whitelist") == ["a.com"]  # nosec B101
+async def test_validate_domain_list_absent_is_none() -> None:
+    assert _tool()._validate_domain_list({}, "site_whitelist") is None  # nosec B101
+
+
+async def test_validate_domain_list_empty_is_none() -> None:
+    assert _tool()._validate_domain_list({"site_whitelist": []}, "site_whitelist") is None  # nosec B101
+
+
+async def test_validate_domain_list_strips_entries() -> None:
+    assert _tool()._validate_domain_list({"site_whitelist": ["  a.com "]}, "site_whitelist") == ["a.com"]  # nosec B101
+
+
+async def test_validate_domain_list_rejects_non_strings() -> None:
     with pytest.raises(WebToolError):
-        tool._validate_domain_list({"site_whitelist": ["ok", 5]}, "site_whitelist")
+        _tool()._validate_domain_list({"site_whitelist": ["ok", 5]}, "site_whitelist")

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_tool_base.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_tool_base.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.web_tool_base import (
+    WebToolBase,
+    WebToolError,
+)
+from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+
+pytestmark = pytest.mark.asyncio
+
+
+class _SampleWebTool(WebToolBase):
+    _ACTION_FAMILY = "sample_web"
+    _RESULT_KIND = "sample_result"
+    _TOOL_PROMPT_VERSION = "2026.01.01"
+
+    async def on_initialize(self) -> None:
+        return None
+
+    async def on_shutdown(self) -> None:
+        return None
+
+    async def check_health(self) -> dict[str, bool]:
+        return {"initialized": True}
+
+    async def get_tools(self) -> list[dict[str, Any]]:
+        return []
+
+    async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context: Any | None = None) -> Any:
+        return None
+
+
+def _tool() -> _SampleWebTool:
+    return _SampleWebTool(ModuleConfig(name="Sample"))
+
+
+async def test_sanitize_input_allows_sql_like_and_punycode_strips_control() -> None:
+    tool = _tool()
+    cleaned = tool.sanitize_input(
+        {"query": "pip install --no-cache-dir", "domains": ["xn--80ak6aa92e.com"], "ctl": "a\x00b\x07c"}
+    )
+    assert cleaned["query"] == "pip install --no-cache-dir"  # nosec B101
+    assert cleaned["domains"] == ["xn--80ak6aa92e.com"]  # nosec B101
+    assert cleaned["ctl"] == "abc"  # nosec B101
+
+
+async def test_sanitize_input_depth_guard() -> None:
+    tool = _tool()
+    deep: Any = "x"
+    for _ in range(25):
+        deep = {"k": deep}
+    with pytest.raises(ValueError):
+        tool.sanitize_input(deep)
+
+
+async def test_structured_error_shape_and_extra_fields() -> None:
+    tool = _tool()
+    err = tool._structured_error("sample.tool", "bad_thing", "it broke", status_code=503)
+    assert err["ok"] is False  # nosec B101
+    assert err["reason_code"] == "bad_thing"  # nosec B101
+    assert err["message"] == "it broke"  # nosec B101
+    assert err["status_code"] == 503  # nosec B101
+    assert err["eval"]["reason_code"] == "bad_thing"  # nosec B101
+
+
+async def test_structured_error_omits_none_extras() -> None:
+    tool = _tool()
+    err = tool._structured_error("sample.tool", "bad", "msg", status_code=None)
+    assert "status_code" not in err  # nosec B101
+
+
+async def test_eval_metadata_uses_class_identity_and_profile() -> None:
+    tool = _tool()
+    context = RequestContext(request_id="r", metadata={"profile_id": "deep-researcher"})
+    meta = tool._eval_metadata("sample.tool", reason_code=None, truncated=True, context=context)
+    assert meta["profile_id"] == "deep-researcher"  # nosec B101
+    assert meta["truncated"] is True  # nosec B101
+
+
+async def test_validate_domain_list() -> None:
+    tool = _tool()
+    assert tool._validate_domain_list({}, "site_whitelist") is None  # nosec B101
+    assert tool._validate_domain_list({"site_whitelist": []}, "site_whitelist") is None  # nosec B101
+    assert tool._validate_domain_list({"site_whitelist": ["  a.com "]}, "site_whitelist") == ["a.com"]  # nosec B101
+    with pytest.raises(WebToolError):
+        tool._validate_domain_list({"site_whitelist": ["ok", 5]}, "site_whitelist")


### PR DESCRIPTION
## Summary

Slice 2 of the "research chain + harden web tools" pair. Extracts a shared **`WebToolBase`** for the three read-only web MCP tools (`web.fetch`, `web.search`, `web.research`), removing ~150 lines of duplicated plumbing and giving the cross-cutting behavior a single source of truth.

> **Stacked on #2355** (`codex/mcp-web-research-tool`) since it refactors `web.research` too. **Retarget to `dev` after #2355 merges.** The hardening-only diff is the second commit.

## What moved into `web_tool_base.py`

- **`WebToolError`** — one control-flow error replacing the three private `_WebFetchError` / `_WebSearchError` / `_WebResearchError`.
- **`WebToolBase(BaseModule)`**:
  - permissive `sanitize_input` override (strip NUL/control chars only via shared `CONTROL_CHARS_RE` + depth guard) — the MCP protocol sanitizes every tool call before execute, so the base SQL denylist would otherwise reject `--`/`/*`/punycode;
  - `_structured_error(..., **extra)` — extra non-None fields (e.g. web.fetch `status_code`) merge into the result;
  - `_eval_metadata` driven by class attrs `_ACTION_FAMILY` / `_RESULT_KIND` / `_TOOL_PROMPT_VERSION`;
  - `_profile_id_from_context_metadata`, `_validate_domain_list` (empty list → `None`).

Each module now extends `WebToolBase`, sets the three class attributes, and deletes its copies. web.fetch keeps its fetch/redirect/extraction logic; web.search keeps normalization; web.research keeps orchestration.

## Behavior-preserving

No public result-shape or error-code changes — this is a pure dedup refactor guarded by the existing suites.

## Tests

- New `test_web_tool_base.py` (6) directly covers the base: sanitize allows `--`/punycode + strips control chars, depth guard, `_structured_error` shape + extras + None-omission, eval class-identity/profile, domain-list validation.
- All existing web-tool + registration + preset tests stay green (111).
- ruff/compileall/bandit clean; `git diff --check` clean.

backlog: task-2357

> Deferred to a follow-up hardening slice: per-domain rate limiting (shared limiter consulted in web.fetch per hop), response caching, and richer citation metadata on web.research sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared `WebToolBase` for `web.fetch`, `web.search`, and `web.research` to remove duplicated plumbing and centralize behavior. Public behavior is unchanged; result shapes and error codes stay the same. Implements task-2357.

- **Refactors**
  - Unified `WebToolError` and shared helpers: `_structured_error` (merges extras without overwriting core fields), `_eval_metadata` (absolute import), `_profile_id_from_context_metadata`, `_validate_domain_list`.
  - Moved permissive `sanitize_input` to the base (strip control chars; depth guard) and exported `CONTROL_CHARS_RE`; dropped redundant per-tool sanitizing in `web.search` and `web.research`.
  - `web.fetch`, `web.search`, `web.research` now extend `WebToolBase` and set `_ACTION_FAMILY`, `_RESULT_KIND`, `_TOOL_PROMPT_VERSION`; removed private `_WebXError` classes and duplicate helpers.
  - Added focused base tests; all web-tool tests pass.

<sup>Written for commit 627eceab6490e407ba27827738eba78345aeca1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

