### PR TITLE
Add per-domain rate limiting to MCP web tools

### DIFF
--- a/Docs/Design/MCP_Web_Tools_Rate_Limiting.md
+++ b/Docs/Design/MCP_Web_Tools_Rate_Limiting.md
@@ -1,0 +1,58 @@
+# MCP Web Tools — Per-Domain Rate Limiting
+
+Status: Implementing (June 2026)
+Owner: standalone MCP gateway backlog
+Companions: `MCP_Web_Fetch_Tool_Design.md`, `MCP_Web_Research_Tool_Design.md`
+
+## Goal
+
+Add a soft, per-domain request-rate control to the read-only web tools so a
+single `web.fetch` (and, transitively, `web.research`) instance cannot hammer one
+host. This is politeness / basic abuse protection — distinct from the always-on
+SSRF/egress outbound policy, which remains the hard security boundary.
+
+## `DomainRateLimiter`
+
+`web_rate_limit.py` — an in-memory, thread-safe **sliding-window** limiter keyed
+by destination host:
+
+- `try_acquire(domain) -> bool`: records a request; returns `False` when the host
+  already has `max_requests` hits inside the trailing `window_seconds`.
+- `max_requests <= 0` (or `None`) disables limiting (always allows) — the explicit
+  opt-out.
+- Injectable `clock` for deterministic tests; bounded domain tracking
+  (`_MAX_TRACKED_DOMAINS`, oldest-evicted) so a long-lived limiter can't grow
+  without bound.
+- Defaults: 60 requests / 60 s per domain — enough headroom for normal
+  research/redirect flows, low enough to curb a runaway loop.
+
+## Integration
+
+`WebFetchModule.__init__` gains `rate_limiter: DomainRateLimiter | None`; when
+`None` a default (enabled) limiter is constructed, so the control is **on by
+default**. In the redirect loop, after the outbound policy passes and **before**
+each `client.fetch`, the hop's host is checked: over-limit → structured
+`rate_limited` error (the request never goes out, and redirects count as hops).
+
+`web.research` composes a `WebFetchModule`, so its sub-fetches share that
+module's limiter and are throttled per-domain across the bundle automatically —
+no `web.research` change required.
+
+## Result / errors
+
+A throttled call returns the standard `{ ok: false, reason_code: "rate_limited",
+message, eval }`. To disable in a given deployment, wire
+`WebFetchModule(..., rate_limiter=DomainRateLimiter(max_requests=0))`.
+
+## Tests
+
+- `test_web_rate_limit.py` (7) — within/over limit, per-domain isolation, window
+  expiry (fake clock), case-insensitive host key, disabled via `0`/`None`.
+- `test_web_fetch_module.py` — rate limit blocks the second same-domain fetch
+  (client not called), different domains independent, disabled limiter allows many.
+
+## Deferred (next slices)
+
+- Response caching (TTL/LRU keyed by url+format+max_bytes) for `web.fetch`.
+- Richer citation metadata on `web.research` sources.
+- Optional shared/process-global limiter wired from gateway settings.

--- a/Docs/Design/MCP_Web_Tools_Rate_Limiting.md
+++ b/Docs/Design/MCP_Web_Tools_Rate_Limiting.md
@@ -21,7 +21,7 @@ by destination host:
 - `max_requests <= 0` (or `None`) disables limiting (always allows) — the explicit
   opt-out.
 - Injectable `clock` for deterministic tests; bounded domain tracking
-  (`_MAX_TRACKED_DOMAINS`, oldest-evicted) so a long-lived limiter can't grow
+  (`_MAX_TRACKED_DOMAINS`, LRU-evicted (OrderedDict)) so a long-lived limiter can't grow
   without bound.
 - Defaults: 60 requests / 60 s per domain — enough headroom for normal
   research/redirect flows, low enough to curb a runaway loop.

--- a/backlog/tasks/task-2358 - Add-per-domain-rate-limiting-to-MCP-web-tools.md
+++ b/backlog/tasks/task-2358 - Add-per-domain-rate-limiting-to-MCP-web-tools.md
@@ -32,7 +32,7 @@ Add a soft per-domain request-rate control to the read-only web MCP tools so a s
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-New `tldw_Server_API/app/core/MCP_unified/modules/implementations/web_rate_limit.py`: `DomainRateLimiter` — `dict[host] -> deque[timestamps]`, `threading.Lock`, `time.monotonic` (injectable `clock`), trailing-window eviction on each `try_acquire`, `_MAX_TRACKED_DOMAINS=1024` oldest-evicted cap, `enabled` property. Defaults 60 req / 60 s.
+New `tldw_Server_API/app/core/MCP_unified/modules/implementations/web_rate_limit.py`: `DomainRateLimiter` — `dict[host] -> deque[timestamps]`, `threading.Lock`, `time.monotonic` (injectable `clock`), trailing-window eviction on each `try_acquire`, `_MAX_TRACKED_DOMAINS=1024` LRU-evicted (OrderedDict) cap, `enabled` property. Defaults 60 req / 60 s.
 
 `WebFetchModule.__init__` takes `rate_limiter=None` → default-constructs an enabled limiter (on by default). In the redirect loop, after `decide_web_outbound_policy` passes and before `self._client.fetch`, `_safe_host(current_url)` is checked via `try_acquire`; over-limit → `_structured_error(... "rate_limited" ...)` (logged with host). web.research is unchanged: its composed `WebFetchModule` carries the limiter so sub-fetches throttle per-domain across a bundle.
 

--- a/backlog/tasks/task-2358 - Add-per-domain-rate-limiting-to-MCP-web-tools.md
+++ b/backlog/tasks/task-2358 - Add-per-domain-rate-limiting-to-MCP-web-tools.md
@@ -1,0 +1,44 @@
+---
+id: TASK-2358
+title: Add per-domain rate limiting to MCP web tools
+status: Done
+updated_date: '2026-06-14'
+labels:
+- mcp
+- tools
+- web
+- hardening
+references:
+- Docs/Design/MCP_Web_Tools_Rate_Limiting.md
+dependencies:
+- TASK-2354
+- TASK-2356
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a soft per-domain request-rate control to the read-only web MCP tools so a single web.fetch (and transitively web.research) instance cannot hammer one host. Distinct from the always-on SSRF/egress outbound policy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A `DomainRateLimiter` provides a thread-safe in-memory sliding-window `try_acquire(domain) -> bool` keyed by host, with injectable clock, bounded domain tracking, and case-insensitive host keys; `max_requests <= 0`/`None` disables it.
+- [x] #2 `WebFetchModule` consults the limiter per hop (after the outbound policy, before the client fetch); over-limit returns a structured `rate_limited` error and performs no network request; redirects count as hops.
+- [x] #3 The limiter is on by default (generous 60/60s) and injectable; passing `DomainRateLimiter(max_requests=0)` disables it. web.research's sub-fetches inherit throttling via the composed WebFetchModule.
+- [x] #4 Unit tests for the limiter (within/over limit, per-domain, window expiry, case-insensitive, disabled) and web.fetch integration tests (blocks 2nd same-domain fetch, per-domain independence, disabled allows many); existing web suites stay green.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+New `tldw_Server_API/app/core/MCP_unified/modules/implementations/web_rate_limit.py`: `DomainRateLimiter` — `dict[host] -> deque[timestamps]`, `threading.Lock`, `time.monotonic` (injectable `clock`), trailing-window eviction on each `try_acquire`, `_MAX_TRACKED_DOMAINS=1024` oldest-evicted cap, `enabled` property. Defaults 60 req / 60 s.
+
+`WebFetchModule.__init__` takes `rate_limiter=None` → default-constructs an enabled limiter (on by default). In the redirect loop, after `decide_web_outbound_policy` passes and before `self._client.fetch`, `_safe_host(current_url)` is checked via `try_acquire`; over-limit → `_structured_error(... "rate_limited" ...)` (logged with host). web.research is unchanged: its composed `WebFetchModule` carries the limiter so sub-fetches throttle per-domain across a bundle.
+
+To disable: `WebFetchModule(..., rate_limiter=DomainRateLimiter(max_requests=0))`.
+
+Tests: `test_web_rate_limit.py` (7) + 3 web.fetch integration tests; 136 web/preset tests green. ruff/compileall/bandit clean.
+
+Deferred: response caching (TTL/LRU) for web.fetch; richer citation metadata on web.research; optional process-global limiter wired from gateway settings.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_fetch_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_fetch_module.py
@@ -26,6 +26,7 @@ from tldw_Server_API.app.core.Web_Scraping.outbound_policy import (
 )
 
 from ..base import ModuleConfig, create_tool_definition
+from .web_rate_limit import DomainRateLimiter
 from .web_tool_base import CONTROL_CHARS_RE, WebToolBase, WebToolError
 
 _TOOL_FETCH = "web.fetch"
@@ -199,9 +200,13 @@ class WebFetchModule(WebToolBase):
         config: ModuleConfig,
         *,
         client: WebFetchHttpClient | None = None,
+        rate_limiter: DomainRateLimiter | None = None,
     ) -> None:
         super().__init__(config)
         self._client: WebFetchHttpClient = client or HttpxWebFetchClient()
+        # A default, generously-bounded per-domain limiter is on unless the caller
+        # supplies one (pass DomainRateLimiter(max_requests=0) to disable).
+        self._rate_limiter: DomainRateLimiter = rate_limiter or DomainRateLimiter()
 
     async def on_initialize(self) -> None:
         return None
@@ -302,6 +307,16 @@ class WebFetchModule(WebToolBase):
                     tool_name,
                     "outbound_policy_denied",
                     f"Outbound policy denied the request ({getattr(decision, 'reason', 'denied')}).",
+                    context=context,
+                )
+
+            host = _safe_host(current_url)
+            if not self._rate_limiter.try_acquire(host):
+                logger.bind(stage="web.fetch", host=host).warning("web.fetch per-domain rate limit exceeded")
+                return self._structured_error(
+                    tool_name,
+                    "rate_limited",
+                    "Per-domain request rate limit exceeded.",
                     context=context,
                 )
 

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_rate_limit.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_rate_limit.py
@@ -1,0 +1,80 @@
+"""Per-domain rate limiting for the read-only web MCP tools.
+
+A small in-memory sliding-window limiter keyed by destination host. It throttles
+how often a single ``web.fetch`` (and, transitively, ``web.research``) instance
+will hit one domain, for politeness and basic abuse protection. The actual
+SSRF/egress safety net lives in the outbound policy; this is a separate, softer
+control.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from collections.abc import Callable
+
+# Generous defaults: enough headroom for normal research/redirect flows, low
+# enough to curb a tool hammering a single host.
+_DEFAULT_MAX_REQUESTS = 60
+_DEFAULT_WINDOW_SECONDS = 60.0
+# Cap how many distinct domains we track so a long-lived limiter cannot grow
+# without bound; the least-recently-touched domain is evicted when exceeded.
+_MAX_TRACKED_DOMAINS = 1024
+
+
+class DomainRateLimiter:
+    """Thread-safe sliding-window request limiter keyed by domain.
+
+    ``max_requests <= 0`` (or ``None``) disables limiting entirely (always
+    allows), which is the explicit way to opt out.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_requests: int | None = _DEFAULT_MAX_REQUESTS,
+        window_seconds: float = _DEFAULT_WINDOW_SECONDS,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self._max_requests = max_requests if (max_requests is not None and max_requests > 0) else 0
+        self._window_seconds = max(0.0, window_seconds)
+        self._clock = clock or time.monotonic
+        self._lock = threading.Lock()
+        self._hits: dict[str, deque[float]] = {}
+
+    @property
+    def enabled(self) -> bool:
+        return self._max_requests > 0
+
+    def try_acquire(self, domain: str) -> bool:
+        """Record a request to ``domain``; return ``False`` if it exceeds the limit."""
+        if not self.enabled:
+            return True
+        key = (domain or "unknown").lower()
+        now = self._clock()
+        cutoff = now - self._window_seconds
+        with self._lock:
+            bucket = self._hits.get(key)
+            if bucket is None:
+                bucket = deque()
+                self._hits[key] = bucket
+                self._evict_if_needed(key)
+            while bucket and bucket[0] <= cutoff:
+                bucket.popleft()
+            if len(bucket) >= self._max_requests:
+                return False
+            bucket.append(now)
+            return True
+
+    def _evict_if_needed(self, just_added: str) -> None:
+        """Drop the oldest-tracked domain when over the tracking cap (caller holds lock)."""
+        if len(self._hits) <= _MAX_TRACKED_DOMAINS:
+            return
+        for key in list(self._hits):
+            if key != just_added:
+                del self._hits[key]
+                return
+
+
+__all__ = ["DomainRateLimiter"]

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_rate_limit.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_rate_limit.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import threading
 import time
-from collections import deque
+from collections import OrderedDict, deque
 from collections.abc import Callable
 
 # Generous defaults: enough headroom for normal research/redirect flows, low
@@ -36,12 +36,19 @@ class DomainRateLimiter:
         max_requests: int | None = _DEFAULT_MAX_REQUESTS,
         window_seconds: float = _DEFAULT_WINDOW_SECONDS,
         clock: Callable[[], float] | None = None,
+        max_tracked_domains: int = _MAX_TRACKED_DOMAINS,
     ) -> None:
-        self._max_requests = max_requests if (max_requests is not None and max_requests > 0) else 0
+        if max_requests is not None and max_requests > 0:
+            self._max_requests = max_requests
+        else:
+            self._max_requests = 0
         self._window_seconds = max(0.0, window_seconds)
         self._clock = clock or time.monotonic
+        self._max_tracked_domains = max(1, max_tracked_domains)
         self._lock = threading.Lock()
-        self._hits: dict[str, deque[float]] = {}
+        # OrderedDict gives O(1) LRU eviction: accessed domains move to the end,
+        # and the least-recently-used (front) entry is dropped when over the cap.
+        self._hits: OrderedDict[str, deque[float]] = OrderedDict()
 
     @property
     def enabled(self) -> bool:
@@ -59,7 +66,10 @@ class DomainRateLimiter:
             if bucket is None:
                 bucket = deque()
                 self._hits[key] = bucket
-                self._evict_if_needed(key)
+                self._evict_if_needed()
+            else:
+                # Mark this domain as most-recently-used for LRU eviction.
+                self._hits.move_to_end(key)
             while bucket and bucket[0] <= cutoff:
                 bucket.popleft()
             if len(bucket) >= self._max_requests:
@@ -67,14 +77,10 @@ class DomainRateLimiter:
             bucket.append(now)
             return True
 
-    def _evict_if_needed(self, just_added: str) -> None:
-        """Drop the oldest-tracked domain when over the tracking cap (caller holds lock)."""
-        if len(self._hits) <= _MAX_TRACKED_DOMAINS:
-            return
-        for key in list(self._hits):
-            if key != just_added:
-                del self._hits[key]
-                return
+    def _evict_if_needed(self) -> None:
+        """Drop the least-recently-used domain when over the cap (caller holds lock)."""
+        if len(self._hits) > self._max_tracked_domains:
+            self._hits.popitem(last=False)
 
 
 __all__ = ["DomainRateLimiter"]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_fetch_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_fetch_module.py
@@ -49,8 +49,8 @@ class _FakeClient:
         return self.response
 
 
-def _module(client: _FakeClient) -> WebFetchModule:
-    return WebFetchModule(ModuleConfig(name="WebFetch"), client=client)
+def _module(client: _FakeClient, *, rate_limiter: Any | None = None) -> WebFetchModule:
+    return WebFetchModule(ModuleConfig(name="WebFetch"), client=client, rate_limiter=rate_limiter)
 
 
 def _allow_policy(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -470,3 +470,50 @@ async def test_httpx_client_skips_body_for_unsupported_content_type() -> None:
     assert response.status_code == 200  # nosec B101
     assert response.content_type == "image/png"  # nosec B101
     assert response.body == b""  # nosec B101 - unsupported type not downloaded
+
+
+async def test_per_domain_rate_limit_blocks_second_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tldw_Server_API.app.core.MCP_unified.modules.implementations.web_rate_limit import (
+        DomainRateLimiter,
+    )
+
+    _allow_policy(monkeypatch)
+    client = _FakeClient(_html_response(_RICH_HTML))
+    module = _module(client, rate_limiter=DomainRateLimiter(max_requests=1, window_seconds=60))
+
+    first = await module.execute_tool("web.fetch", {"url": "https://example.com/a"})
+    assert first["ok"] is True  # nosec B101
+
+    second = await module.execute_tool("web.fetch", {"url": "https://example.com/b"})
+    assert second["ok"] is False  # nosec B101
+    assert second["reason_code"] == "rate_limited"  # nosec B101
+    # The blocked request never reached the client (one successful fetch only).
+    assert len(client.calls) == 1  # nosec B101
+
+
+async def test_rate_limit_is_per_domain(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tldw_Server_API.app.core.MCP_unified.modules.implementations.web_rate_limit import (
+        DomainRateLimiter,
+    )
+
+    _allow_policy(monkeypatch)
+    client = _FakeClient(_html_response(_RICH_HTML))
+    module = _module(client, rate_limiter=DomainRateLimiter(max_requests=1, window_seconds=60))
+
+    a = await module.execute_tool("web.fetch", {"url": "https://example.com/x"})
+    b = await module.execute_tool("web.fetch", {"url": "https://example.org/y"})
+    assert a["ok"] is True  # nosec B101
+    assert b["ok"] is True  # nosec B101 - different domain, independent budget
+
+
+async def test_rate_limit_disabled_allows_many(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tldw_Server_API.app.core.MCP_unified.modules.implementations.web_rate_limit import (
+        DomainRateLimiter,
+    )
+
+    _allow_policy(monkeypatch)
+    client = _FakeClient(_html_response(_RICH_HTML))
+    module = _module(client, rate_limiter=DomainRateLimiter(max_requests=0))
+    for _ in range(5):
+        result = await module.execute_tool("web.fetch", {"url": "https://example.com/a"})
+        assert result["ok"] is True  # nosec B101

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_rate_limit.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_rate_limit.py
@@ -57,3 +57,24 @@ def test_disabled_when_max_requests_none() -> None:
     limiter = DomainRateLimiter(max_requests=None)
     assert limiter.enabled is False  # nosec B101
     assert limiter.try_acquire("example.com") is True  # nosec B101
+
+
+def test_active_domain_survives_lru_eviction() -> None:
+    # Cap tracking at 2 domains. Keep "active" recently-used while churning others;
+    # it must not be evicted (which would reset its history and let it bypass).
+    limiter = DomainRateLimiter(max_requests=1, window_seconds=1000, max_tracked_domains=2)
+    assert limiter.try_acquire("active.example") is True  # consume active's single token
+    for i in range(5):
+        limiter.try_acquire("active.example")  # refresh recency (already blocked, but touches LRU)
+        limiter.try_acquire(f"churn-{i}.example")  # evicts the least-recently-used (a churn host)
+    # active.example was kept, so its budget is still exhausted.
+    assert limiter.try_acquire("active.example") is False  # nosec B101
+
+
+def test_least_recently_used_domain_is_evicted() -> None:
+    limiter = DomainRateLimiter(max_requests=1, window_seconds=1000, max_tracked_domains=1)
+    assert limiter.try_acquire("first.example") is True
+    assert limiter.try_acquire("first.example") is False  # budget used
+    # Tracking a second host evicts "first" (LRU); its history resets.
+    limiter.try_acquire("second.example")
+    assert limiter.try_acquire("first.example") is True  # nosec B101 - history was evicted

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_rate_limit.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_rate_limit.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.web_rate_limit import (
+    DomainRateLimiter,
+)
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def test_allows_requests_within_limit() -> None:
+    limiter = DomainRateLimiter(max_requests=3, window_seconds=10)
+    assert [limiter.try_acquire("example.com") for _ in range(3)] == [True, True, True]  # nosec B101
+
+
+def test_blocks_request_over_limit() -> None:
+    limiter = DomainRateLimiter(max_requests=2, window_seconds=10)
+    limiter.try_acquire("example.com")
+    limiter.try_acquire("example.com")
+    assert limiter.try_acquire("example.com") is False  # nosec B101
+
+
+def test_limit_is_per_domain() -> None:
+    limiter = DomainRateLimiter(max_requests=1, window_seconds=10)
+    assert limiter.try_acquire("a.example") is True  # nosec B101
+    assert limiter.try_acquire("b.example") is True  # nosec B101
+    assert limiter.try_acquire("a.example") is False  # nosec B101
+
+
+def test_window_expiry_allows_again() -> None:
+    clock = _FakeClock()
+    limiter = DomainRateLimiter(max_requests=1, window_seconds=10, clock=clock)
+    assert limiter.try_acquire("example.com") is True  # nosec B101
+    assert limiter.try_acquire("example.com") is False  # nosec B101
+    clock.now += 11  # advance past the window
+    assert limiter.try_acquire("example.com") is True  # nosec B101
+
+
+def test_domain_key_is_case_insensitive() -> None:
+    limiter = DomainRateLimiter(max_requests=1, window_seconds=10)
+    assert limiter.try_acquire("Example.COM") is True  # nosec B101
+    assert limiter.try_acquire("example.com") is False  # nosec B101
+
+
+def test_disabled_when_max_requests_non_positive() -> None:
+    limiter = DomainRateLimiter(max_requests=0)
+    assert limiter.enabled is False  # nosec B101
+    assert all(limiter.try_acquire("example.com") for _ in range(100))  # nosec B101
+
+
+def test_disabled_when_max_requests_none() -> None:
+    limiter = DomainRateLimiter(max_requests=None)
+    assert limiter.enabled is False  # nosec B101
+    assert limiter.try_acquire("example.com") is True  # nosec B101


### PR DESCRIPTION
## Summary

Step (b) of the web-tools hardening follow-up. Adds a soft, **per-domain request-rate control** to the read-only web tools so a single `web.fetch` (and transitively `web.research`) instance can't hammer one host. This is politeness / basic abuse protection — separate from the always-on SSRF/egress outbound policy, which stays the hard boundary.

## `DomainRateLimiter` (`web_rate_limit.py`)

In-memory, thread-safe **sliding-window** limiter keyed by host:
- `try_acquire(domain) -> bool` — records a request; `False` once the host has `max_requests` hits within the trailing `window_seconds`.
- `max_requests <= 0` / `None` → disabled (always allows) — explicit opt-out.
- Injectable `clock` for deterministic tests; bounded domain tracking (oldest-evicted); case-insensitive host key.
- Defaults: **60 req / 60 s** per domain.

## Integration

- `WebFetchModule.__init__` gains `rate_limiter` (default-constructs an enabled limiter → **on by default**). In the redirect loop, after the outbound policy passes and **before** each `client.fetch`, the hop host is checked; over-limit → structured `rate_limited` error with **no network request** (redirects count as hops).
- `web.research` is unchanged — its composed `WebFetchModule` carries the limiter, so sub-fetches are throttled per-domain across a bundle.
- Disable in a deployment via `WebFetchModule(..., rate_limiter=DomainRateLimiter(max_requests=0))`.

## Tests

- `test_web_rate_limit.py` (7) — within/over limit, per-domain isolation, window expiry (fake clock), case-insensitive key, disabled via `0`/`None`.
- `test_web_fetch_module.py` (+3) — blocks the 2nd same-domain fetch (client not called), different domains independent, disabled limiter allows many.
- 136 web/preset tests green; ruff/compileall/bandit clean. Injectable clock + limiter → deterministic, no network.

backlog: task-2358 · design: `Docs/Design/MCP_Web_Tools_Rate_Limiting.md`

> Deferred follow-ups: response caching (TTL/LRU) for `web.fetch`, richer citation metadata on `web.research`, and an optional process-global limiter wired from gateway settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-domain sliding-window rate limiting to `web.fetch` (and transitively `web.research`) to prevent hammering a single host. Enabled by default, blocks over-limit domains before any network call, and now uses true LRU eviction to safely bound memory.

- **New Features**
  - `DomainRateLimiter`: thread-safe in-memory limiter with `try_acquire(domain)`, case-insensitive hosts, LRU-evicted bounded tracking with configurable `max_tracked_domains`, and injectable clock; `max_requests <= 0`/`None` disables.
  - Integrated in `WebFetchModule` after outbound policy and before the client call; redirects count as hops and are checked; returns `rate_limited` without sending a request.
  - Tests and design docs added, including LRU eviction behavior; matches TASK-2358 acceptance criteria.

- **Migration**
  - No action needed; limiter is on by default.
  - To disable or tune, pass `WebFetchModule(..., rate_limiter=DomainRateLimiter(max_requests=0 | custom))`. `web.research` inherits the limiter automatically.

<sup>Written for commit 8b6e74abb56ebea9d0917c293b30e640ed0474d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

