### PR TITLE
Add response caching to MCP web.fetch

### DIFF
--- a/Docs/Design/MCP_Web_Fetch_Response_Cache.md
+++ b/Docs/Design/MCP_Web_Fetch_Response_Cache.md
@@ -1,0 +1,57 @@
+# MCP `web.fetch` Response Cache
+
+Status: Implementing (June 2026)
+Owner: standalone MCP gateway backlog
+Companion: `MCP_Web_Tools_Rate_Limiting.md`
+
+## Goal
+
+Cache successful `web.fetch` results so repeated fetches of the same resource —
+common inside a `web.research` bundle or across closely-spaced calls — skip the
+network. Opt-in (off unless a cache is supplied), since caching trades content
+freshness.
+
+## `ResponseCache` (`web_cache.py`)
+
+In-memory, thread-safe **TTL + LRU** cache:
+
+- `make_cache_key(url, fmt, max_bytes)` — the request inputs that determine the
+  output. Different format or byte cap is a distinct entry.
+- `get(key)` returns the value or `None` (miss/expired; expired entries are
+  dropped on access); a hit is moved to most-recently-used.
+- `put(key, value)` stores with the configured TTL and evicts the
+  least-recently-used entry (`OrderedDict.popitem(last=False)`) past `max_entries`.
+- `ttl_seconds <= 0` or `max_entries <= 0` disables the cache (`enabled` False).
+- Injectable `clock` for deterministic tests. Defaults: 300 s TTL, 256 entries.
+
+## Integration
+
+`WebFetchModule.__init__` gains `response_cache: ResponseCache | None` (default
+`None` → no caching). In `execute_tool`, after validation:
+
+- **Lookup** by `(requested_url, format, max_bytes)`. A hit returns the stored
+  result with `cached: true` and performs **no** network request. This is safe:
+  the gateway already enforced the call's permission rules before `execute_tool`,
+  and a cache hit hits no network (so SSRF/egress is moot).
+- **Store** only successful results (`ok: true`), tagged `cached: false` when
+  fresh. Errors are never cached.
+
+`web.research` composes a `WebFetchModule`; supplying it a cache transparently
+de-dupes repeated sub-fetches across a bundle.
+
+## Result
+
+Successful results now carry a `cached: bool` field. To enable in a deployment,
+wire `WebFetchModule(..., response_cache=ResponseCache(...))`.
+
+## Tests
+
+- `test_web_cache.py` (6) — put/get, miss, key distinguishes format/max_bytes,
+  TTL expiry (fake clock), LRU eviction, disabled.
+- `test_web_fetch_module.py` — second identical fetch served from cache (client
+  not called, `cached: true`); different format is a miss; errors not cached.
+
+## Deferred
+
+Richer citation metadata on `web.research`; an optional process-global / shared
+cache wired from gateway settings; conditional revalidation (ETag/Last-Modified).

--- a/backlog/tasks/task-2359 - Add-response-caching-to-MCP-web-fetch.md
+++ b/backlog/tasks/task-2359 - Add-response-caching-to-MCP-web-fetch.md
@@ -1,0 +1,44 @@
+---
+id: TASK-2359
+title: Add response caching to MCP web.fetch
+status: Done
+updated_date: '2026-06-14'
+labels:
+- mcp
+- tools
+- web
+- performance
+references:
+- Docs/Design/MCP_Web_Fetch_Response_Cache.md
+dependencies:
+- TASK-2354
+- TASK-2358
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add an opt-in in-memory TTL+LRU response cache to web.fetch so repeated fetches of the same resource (common inside a web.research bundle or across closely-spaced calls) skip the network.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A `ResponseCache` provides thread-safe TTL + LRU get/put keyed via `make_cache_key(url, format, max_bytes)`, with injectable clock; `ttl_seconds<=0` or `max_entries<=0` disables it.
+- [x] #2 `WebFetchModule` (opt-in `response_cache=None`) returns a cache hit as `{...cached: true}` with no network request; fresh successful results are tagged `cached: false` and stored; errors are never cached.
+- [x] #3 The cache key distinguishes format and max_bytes; expired entries miss and are dropped; LRU eviction past `max_entries`. web.research can de-dupe sub-fetches by supplying its WebFetchModule a cache.
+- [x] #4 Unit tests for the cache (put/get, miss, key fields, TTL expiry, LRU, disabled) and web.fetch integration (2nd fetch served from cache, format miss, errors not cached); existing web suites stay green.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+New `web_cache.py`: `ResponseCache` (OrderedDict TTL+LRU, threading.Lock, injectable clock, default 300s/256 entries; `enabled` False when ttl/max<=0) + `make_cache_key(url, fmt, max_bytes)`.
+
+`WebFetchModule.__init__` takes `response_cache=None` (opt-in, off by default since caching trades freshness). In `execute_tool` after validation: lookup by `(requested_url, fmt, max_bytes)` → hit returns `{**cached, "cached": True}` with no network (gateway already enforced permission rules; a hit hits no network so SSRF/egress is moot). Fresh successes are tagged `cached: False` and `put` into the cache; errors are not cached.
+
+web.research composes a WebFetchModule, so passing it a cache de-dupes repeated sub-fetches across a bundle (no web.research change needed).
+
+Tests: `test_web_cache.py` (6) + 3 web.fetch integration; 96 web tests green. ruff/compileall/bandit clean.
+
+Deferred: web.research citation metadata; optional shared/process-global cache from gateway settings; conditional revalidation (ETag/Last-Modified).
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_cache.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_cache.py
@@ -1,0 +1,79 @@
+"""In-memory TTL + LRU response cache for the ``web.fetch`` MCP tool.
+
+Caches successful fetch results keyed by the request inputs (url, format,
+max_bytes) so repeated fetches of the same resource — common inside a
+``web.research`` bundle or across closely-spaced calls — skip the network. It is
+opt-in: ``WebFetchModule`` only uses it when a cache instance is supplied.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import OrderedDict
+from collections.abc import Callable
+from typing import Any
+
+_DEFAULT_TTL_SECONDS = 300.0
+_DEFAULT_MAX_ENTRIES = 256
+
+
+def make_cache_key(url: str, fmt: str, max_bytes: int) -> tuple[str, str, int]:
+    """Build the cache key from the request inputs that determine the output."""
+    return (url, fmt, int(max_bytes))
+
+
+class ResponseCache:
+    """Thread-safe in-memory TTL cache with LRU eviction.
+
+    ``ttl_seconds <= 0`` or ``max_entries <= 0`` disables caching (``enabled`` is
+    ``False``); ``get`` always misses and ``put`` is a no-op.
+    """
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float = _DEFAULT_TTL_SECONDS,
+        max_entries: int = _DEFAULT_MAX_ENTRIES,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self._ttl_seconds = ttl_seconds
+        self._max_entries = max_entries
+        self._clock = clock or time.monotonic
+        self._lock = threading.Lock()
+        # key -> (expires_at, value); ordered for LRU eviction.
+        self._entries: OrderedDict[Any, tuple[float, Any]] = OrderedDict()
+
+    @property
+    def enabled(self) -> bool:
+        return self._ttl_seconds > 0 and self._max_entries > 0
+
+    def get(self, key: Any) -> Any | None:
+        """Return the cached value for ``key`` or ``None`` if missing/expired."""
+        if not self.enabled:
+            return None
+        now = self._clock()
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                return None
+            expires_at, value = entry
+            if expires_at <= now:
+                del self._entries[key]
+                return None
+            self._entries.move_to_end(key)
+            return value
+
+    def put(self, key: Any, value: Any) -> None:
+        """Store ``value`` for ``key`` with the configured TTL, evicting LRU as needed."""
+        if not self.enabled:
+            return
+        expires_at = self._clock() + self._ttl_seconds
+        with self._lock:
+            self._entries[key] = (expires_at, value)
+            self._entries.move_to_end(key)
+            while len(self._entries) > self._max_entries:
+                self._entries.popitem(last=False)
+
+
+__all__ = ["ResponseCache", "make_cache_key"]

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_cache.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_cache.py
@@ -8,6 +8,7 @@ opt-in: ``WebFetchModule`` only uses it when a cache instance is supplied.
 
 from __future__ import annotations
 
+import copy
 import threading
 import time
 from collections import OrderedDict
@@ -18,9 +19,15 @@ _DEFAULT_TTL_SECONDS = 300.0
 _DEFAULT_MAX_ENTRIES = 256
 
 
-def make_cache_key(url: str, fmt: str, max_bytes: int) -> tuple[str, str, int]:
-    """Build the cache key from the request inputs that determine the output."""
-    return (url, fmt, int(max_bytes))
+def make_cache_key(
+    url: str, fmt: str, max_bytes: int, respect_robots: bool
+) -> tuple[str, str, int, bool]:
+    """Build the cache key from the request inputs that determine the output.
+
+    ``respect_robots`` is policy-relevant, so requests with different robots
+    modes never share a cached entry.
+    """
+    return (url, fmt, int(max_bytes), bool(respect_robots))
 
 
 class ResponseCache:
@@ -49,7 +56,11 @@ class ResponseCache:
         return self._ttl_seconds > 0 and self._max_entries > 0
 
     def get(self, key: Any) -> Any | None:
-        """Return the cached value for ``key`` or ``None`` if missing/expired."""
+        """Return a copy of the cached value for ``key`` or ``None`` if missing/expired.
+
+        A copy is returned so callers can mutate the result without corrupting the
+        cached entry (and vice versa).
+        """
         if not self.enabled:
             return None
         now = self._clock()
@@ -62,15 +73,16 @@ class ResponseCache:
                 del self._entries[key]
                 return None
             self._entries.move_to_end(key)
-            return value
+            return copy.deepcopy(value)
 
     def put(self, key: Any, value: Any) -> None:
-        """Store ``value`` for ``key`` with the configured TTL, evicting LRU as needed."""
+        """Store a copy of ``value`` for ``key`` with the configured TTL, evicting LRU."""
         if not self.enabled:
             return
         expires_at = self._clock() + self._ttl_seconds
+        stored = copy.deepcopy(value)
         with self._lock:
-            self._entries[key] = (expires_at, value)
+            self._entries[key] = (expires_at, stored)
             self._entries.move_to_end(key)
             while len(self._entries) > self._max_entries:
                 self._entries.popitem(last=False)

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_fetch_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_fetch_module.py
@@ -26,6 +26,7 @@ from tldw_Server_API.app.core.Web_Scraping.outbound_policy import (
 )
 
 from ..base import ModuleConfig, create_tool_definition
+from .web_cache import ResponseCache, make_cache_key
 from .web_rate_limit import DomainRateLimiter
 from .web_tool_base import CONTROL_CHARS_RE, WebToolBase, WebToolError
 
@@ -201,12 +202,15 @@ class WebFetchModule(WebToolBase):
         *,
         client: WebFetchHttpClient | None = None,
         rate_limiter: DomainRateLimiter | None = None,
+        response_cache: ResponseCache | None = None,
     ) -> None:
         super().__init__(config)
         self._client: WebFetchHttpClient = client or HttpxWebFetchClient()
         # A default, generously-bounded per-domain limiter is on unless the caller
         # supplies one (pass DomainRateLimiter(max_requests=0) to disable).
         self._rate_limiter: DomainRateLimiter = rate_limiter or DomainRateLimiter()
+        # Response caching is opt-in (None = no caching) since it trades freshness.
+        self._response_cache: ResponseCache | None = response_cache
 
     async def on_initialize(self) -> None:
         return None
@@ -290,6 +294,14 @@ class WebFetchModule(WebToolBase):
             )
         except WebToolError as exc:
             return self._structured_error(tool_name, exc.reason_code, exc.message, context=context)
+
+        # Cache hit: return the stored result (the gateway already enforced the
+        # call's permission rules, and a cache hit performs no network request).
+        cache_key = make_cache_key(requested_url, fmt, max_bytes)
+        if self._response_cache is not None:
+            cached = self._response_cache.get(cache_key)
+            if cached is not None:
+                return {**cached, "cached": True}
 
         # Follow redirects manually, re-applying the outbound policy to every hop
         # so a permitted URL cannot redirect into denied/private address space.
@@ -385,7 +397,7 @@ class WebFetchModule(WebToolBase):
                 context=context,
             )
 
-        return {
+        result = {
             "ok": True,
             "url": requested_url,
             "final_url": response.final_url,
@@ -396,6 +408,7 @@ class WebFetchModule(WebToolBase):
             "content": content,
             "bytes_fetched": len(response.body),
             "truncated": bool(response.truncated),
+            "cached": False,
             "eval": self._eval_metadata(
                 _TOOL_FETCH,
                 reason_code=None,
@@ -403,6 +416,9 @@ class WebFetchModule(WebToolBase):
                 context=context,
             ),
         }
+        if self._response_cache is not None:
+            self._response_cache.put(cache_key, result)
+        return result
 
     # ---- validation ----------------------------------------------------
 

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_fetch_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_fetch_module.py
@@ -295,13 +295,38 @@ class WebFetchModule(WebToolBase):
         except WebToolError as exc:
             return self._structured_error(tool_name, exc.reason_code, exc.message, context=context)
 
-        # Cache hit: return the stored result (the gateway already enforced the
-        # call's permission rules, and a cache hit performs no network request).
-        cache_key = make_cache_key(requested_url, fmt, max_bytes)
+        # Cache lookup. A hit still re-applies the outbound policy to the requested
+        # URL (cheap; no body download) so a newly-denied domain or robots rule is
+        # honored, and the eval metadata is rebuilt from the current call context.
+        cache_key = None
         if self._response_cache is not None:
+            cache_key = make_cache_key(requested_url, fmt, max_bytes, respect_robots)
             cached = self._response_cache.get(cache_key)
             if cached is not None:
-                return {**cached, "cached": True}
+                decision = await decide_web_outbound_policy(
+                    requested_url,
+                    respect_robots=respect_robots,
+                    user_agent=_DEFAULT_USER_AGENT,
+                    source="mcp.web_fetch",
+                    stage="web.fetch",
+                )
+                if not getattr(decision, "allowed", False):
+                    return self._structured_error(
+                        tool_name,
+                        "outbound_policy_denied",
+                        f"Outbound policy denied the request ({getattr(decision, 'reason', 'denied')}).",
+                        context=context,
+                    )
+                return {
+                    **cached,
+                    "cached": True,
+                    "eval": self._eval_metadata(
+                        _TOOL_FETCH,
+                        reason_code=None,
+                        truncated=bool(cached.get("truncated")),
+                        context=context,
+                    ),
+                }
 
         # Follow redirects manually, re-applying the outbound policy to every hop
         # so a permitted URL cannot redirect into denied/private address space.
@@ -416,7 +441,7 @@ class WebFetchModule(WebToolBase):
                 context=context,
             ),
         }
-        if self._response_cache is not None:
+        if self._response_cache is not None and cache_key is not None:
             self._response_cache.put(cache_key, result)
         return result
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_cache.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_cache.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.web_cache import (
+    ResponseCache,
+    make_cache_key,
+)
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def test_put_then_get_returns_value() -> None:
+    cache = ResponseCache(ttl_seconds=100, max_entries=8)
+    cache.put(make_cache_key("https://example.com", "markdown", 1000), {"ok": True})
+    assert cache.get(make_cache_key("https://example.com", "markdown", 1000)) == {"ok": True}  # nosec B101
+
+
+def test_missing_key_returns_none() -> None:
+    cache = ResponseCache(ttl_seconds=100, max_entries=8)
+    assert cache.get(make_cache_key("https://example.com", "markdown", 1000)) is None  # nosec B101
+
+
+def test_key_distinguishes_format_and_max_bytes() -> None:
+    cache = ResponseCache(ttl_seconds=100, max_entries=8)
+    cache.put(make_cache_key("https://example.com", "markdown", 1000), {"v": 1})
+    assert cache.get(make_cache_key("https://example.com", "text", 1000)) is None  # nosec B101
+    assert cache.get(make_cache_key("https://example.com", "markdown", 2000)) is None  # nosec B101
+
+
+def test_entry_expires_after_ttl() -> None:
+    clock = _FakeClock()
+    cache = ResponseCache(ttl_seconds=100, max_entries=8, clock=clock)
+    key = make_cache_key("https://example.com", "markdown", 1000)
+    cache.put(key, {"ok": True})
+    clock.now += 101
+    assert cache.get(key) is None  # nosec B101
+
+
+def test_lru_eviction_when_over_capacity() -> None:
+    cache = ResponseCache(ttl_seconds=1000, max_entries=2)
+    a = make_cache_key("https://a.example", "markdown", 1)
+    b = make_cache_key("https://b.example", "markdown", 1)
+    c = make_cache_key("https://c.example", "markdown", 1)
+    cache.put(a, 1)
+    cache.put(b, 2)
+    cache.get(a)  # touch a -> most recently used; b is now LRU
+    cache.put(c, 3)  # evicts b
+    assert cache.get(a) == 1  # nosec B101
+    assert cache.get(b) is None  # nosec B101
+    assert cache.get(c) == 3  # nosec B101
+
+
+def test_disabled_cache_never_stores() -> None:
+    cache = ResponseCache(ttl_seconds=0)
+    assert cache.enabled is False  # nosec B101
+    key = make_cache_key("https://example.com", "markdown", 1000)
+    cache.put(key, {"ok": True})
+    assert cache.get(key) is None  # nosec B101

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_cache.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_cache.py
@@ -16,26 +16,26 @@ class _FakeClock:
 
 def test_put_then_get_returns_value() -> None:
     cache = ResponseCache(ttl_seconds=100, max_entries=8)
-    cache.put(make_cache_key("https://example.com", "markdown", 1000), {"ok": True})
-    assert cache.get(make_cache_key("https://example.com", "markdown", 1000)) == {"ok": True}  # nosec B101
+    cache.put(make_cache_key("https://example.com", "markdown", 1000, False), {"ok": True})
+    assert cache.get(make_cache_key("https://example.com", "markdown", 1000, False)) == {"ok": True}  # nosec B101
 
 
 def test_missing_key_returns_none() -> None:
     cache = ResponseCache(ttl_seconds=100, max_entries=8)
-    assert cache.get(make_cache_key("https://example.com", "markdown", 1000)) is None  # nosec B101
+    assert cache.get(make_cache_key("https://example.com", "markdown", 1000, False)) is None  # nosec B101
 
 
 def test_key_distinguishes_format_and_max_bytes() -> None:
     cache = ResponseCache(ttl_seconds=100, max_entries=8)
-    cache.put(make_cache_key("https://example.com", "markdown", 1000), {"v": 1})
-    assert cache.get(make_cache_key("https://example.com", "text", 1000)) is None  # nosec B101
-    assert cache.get(make_cache_key("https://example.com", "markdown", 2000)) is None  # nosec B101
+    cache.put(make_cache_key("https://example.com", "markdown", 1000, False), {"v": 1})
+    assert cache.get(make_cache_key("https://example.com", "text", 1000, False)) is None  # nosec B101
+    assert cache.get(make_cache_key("https://example.com", "markdown", 2000, False)) is None  # nosec B101
 
 
 def test_entry_expires_after_ttl() -> None:
     clock = _FakeClock()
     cache = ResponseCache(ttl_seconds=100, max_entries=8, clock=clock)
-    key = make_cache_key("https://example.com", "markdown", 1000)
+    key = make_cache_key("https://example.com", "markdown", 1000, False)
     cache.put(key, {"ok": True})
     clock.now += 101
     assert cache.get(key) is None  # nosec B101
@@ -43,9 +43,9 @@ def test_entry_expires_after_ttl() -> None:
 
 def test_lru_eviction_when_over_capacity() -> None:
     cache = ResponseCache(ttl_seconds=1000, max_entries=2)
-    a = make_cache_key("https://a.example", "markdown", 1)
-    b = make_cache_key("https://b.example", "markdown", 1)
-    c = make_cache_key("https://c.example", "markdown", 1)
+    a = make_cache_key("https://a.example", "markdown", 1, False)
+    b = make_cache_key("https://b.example", "markdown", 1, False)
+    c = make_cache_key("https://c.example", "markdown", 1, False)
     cache.put(a, 1)
     cache.put(b, 2)
     cache.get(a)  # touch a -> most recently used; b is now LRU
@@ -58,6 +58,23 @@ def test_lru_eviction_when_over_capacity() -> None:
 def test_disabled_cache_never_stores() -> None:
     cache = ResponseCache(ttl_seconds=0)
     assert cache.enabled is False  # nosec B101
-    key = make_cache_key("https://example.com", "markdown", 1000)
+    key = make_cache_key("https://example.com", "markdown", 1000, False)
     cache.put(key, {"ok": True})
     assert cache.get(key) is None  # nosec B101
+
+
+def test_respect_robots_is_part_of_key() -> None:
+    cache = ResponseCache(ttl_seconds=100, max_entries=8)
+    cache.put(make_cache_key("https://example.com", "markdown", 1000, False), {"v": 1})
+    # A different respect_robots mode must not collide.
+    assert cache.get(make_cache_key("https://example.com", "markdown", 1000, True)) is None  # nosec B101
+
+
+def test_returned_value_is_isolated_copy() -> None:
+    cache = ResponseCache(ttl_seconds=100, max_entries=8)
+    key = make_cache_key("https://example.com", "markdown", 1000, False)
+    cache.put(key, {"nested": {"x": 1}})
+    got = cache.get(key)
+    got["nested"]["x"] = 999  # mutate the returned copy
+    again = cache.get(key)
+    assert again["nested"]["x"] == 1  # nosec B101 - cache entry unaffected

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_fetch_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_fetch_module.py
@@ -517,3 +517,62 @@ async def test_rate_limit_disabled_allows_many(monkeypatch: pytest.MonkeyPatch) 
     for _ in range(5):
         result = await module.execute_tool("web.fetch", {"url": "https://example.com/a"})
         assert result["ok"] is True  # nosec B101
+
+
+async def test_response_cache_serves_second_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tldw_Server_API.app.core.MCP_unified.modules.implementations.web_cache import (
+        ResponseCache,
+    )
+
+    _allow_policy(monkeypatch)
+    client = _FakeClient(_html_response(_RICH_HTML))
+    module = WebFetchModule(
+        ModuleConfig(name="WebFetch"), client=client, response_cache=ResponseCache(ttl_seconds=300)
+    )
+
+    first = await module.execute_tool("web.fetch", {"url": "https://example.com/post"})
+    assert first["ok"] is True  # nosec B101
+    assert first["cached"] is False  # nosec B101
+    assert len(client.calls) == 1  # nosec B101
+
+    second = await module.execute_tool("web.fetch", {"url": "https://example.com/post"})
+    assert second["ok"] is True  # nosec B101
+    assert second["cached"] is True  # nosec B101
+    assert second["content"] == first["content"]  # nosec B101
+    # Served from cache: the client was not called again.
+    assert len(client.calls) == 1  # nosec B101
+
+
+async def test_response_cache_key_includes_format(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tldw_Server_API.app.core.MCP_unified.modules.implementations.web_cache import (
+        ResponseCache,
+    )
+
+    _allow_policy(monkeypatch)
+    client = _FakeClient(_html_response(_RICH_HTML))
+    module = WebFetchModule(
+        ModuleConfig(name="WebFetch"), client=client, response_cache=ResponseCache(ttl_seconds=300)
+    )
+    await module.execute_tool("web.fetch", {"url": "https://example.com/post", "format": "markdown"})
+    # A different format is a cache miss -> the client is called again.
+    result = await module.execute_tool("web.fetch", {"url": "https://example.com/post", "format": "text"})
+    assert result["cached"] is False  # nosec B101
+    assert len(client.calls) == 2  # nosec B101
+
+
+async def test_response_cache_does_not_store_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tldw_Server_API.app.core.MCP_unified.modules.implementations.web_cache import (
+        ResponseCache,
+    )
+
+    _allow_policy(monkeypatch)
+    client = _FakeClient(_html_response(b"missing", status_code=404, content_type="text/html"))
+    module = WebFetchModule(
+        ModuleConfig(name="WebFetch"), client=client, response_cache=ResponseCache(ttl_seconds=300)
+    )
+    first = await module.execute_tool("web.fetch", {"url": "https://example.com/missing"})
+    assert first["ok"] is False  # nosec B101
+    second = await module.execute_tool("web.fetch", {"url": "https://example.com/missing"})
+    # Errors are not cached -> the client is retried.
+    assert second["ok"] is False  # nosec B101
+    assert len(client.calls) == 2  # nosec B101

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_fetch_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_fetch_module.py
@@ -576,3 +576,45 @@ async def test_response_cache_does_not_store_errors(monkeypatch: pytest.MonkeyPa
     # Errors are not cached -> the client is retried.
     assert second["ok"] is False  # nosec B101
     assert len(client.calls) == 2  # nosec B101
+
+
+async def test_cache_hit_uses_current_context_for_eval(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tldw_Server_API.app.core.MCP_unified.modules.implementations.web_cache import (
+        ResponseCache,
+    )
+
+    _allow_policy(monkeypatch)
+    client = _FakeClient(_html_response(_RICH_HTML))
+    module = WebFetchModule(
+        ModuleConfig(name="WebFetch"), client=client, response_cache=ResponseCache(ttl_seconds=300)
+    )
+    ctx_a = RequestContext(request_id="r1", metadata={"profile_id": "alpha"})
+    ctx_b = RequestContext(request_id="r2", metadata={"profile_id": "beta"})
+
+    first = await module.execute_tool("web.fetch", {"url": "https://example.com/post"}, ctx_a)
+    assert first["eval"]["profile_id"] == "alpha"  # nosec B101
+
+    second = await module.execute_tool("web.fetch", {"url": "https://example.com/post"}, ctx_b)
+    assert second["cached"] is True  # nosec B101
+    # eval is rebuilt from the current request context, not the cached one.
+    assert second["eval"]["profile_id"] == "beta"  # nosec B101
+
+
+async def test_cache_hit_re_enforces_outbound_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tldw_Server_API.app.core.MCP_unified.modules.implementations.web_cache import (
+        ResponseCache,
+    )
+
+    _allow_policy(monkeypatch)
+    client = _FakeClient(_html_response(_RICH_HTML))
+    module = WebFetchModule(
+        ModuleConfig(name="WebFetch"), client=client, response_cache=ResponseCache(ttl_seconds=300)
+    )
+    first = await module.execute_tool("web.fetch", {"url": "https://example.com/post"})
+    assert first["ok"] is True  # nosec B101
+
+    # The domain becomes denied; a cache hit must NOT serve the stored content.
+    _deny_policy(monkeypatch)
+    second = await module.execute_tool("web.fetch", {"url": "https://example.com/post"})
+    assert second["ok"] is False  # nosec B101
+    assert second["reason_code"] == "outbound_policy_denied"  # nosec B101


### PR DESCRIPTION
## Summary

Adds an **opt-in in-memory TTL+LRU response cache** to `web.fetch` so repeated fetches of the same resource — common inside a `web.research` bundle or across closely-spaced calls — skip the network. Off by default since caching trades content freshness.

## `ResponseCache` (`web_cache.py`)

Thread-safe TTL + LRU:
- `make_cache_key(url, format, max_bytes)` — the request inputs that determine the output (a different format or byte cap is a distinct entry).
- `get` returns the value or `None` (miss/expired; expired dropped on access; hit → MRU); `put` stores with TTL and evicts LRU (`OrderedDict.popitem(last=False)`) past `max_entries`.
- `ttl_seconds<=0` / `max_entries<=0` → disabled. Injectable `clock`. Defaults 300 s / 256 entries.

## Integration

`WebFetchModule.__init__` gains `response_cache` (default `None` → no caching). In `execute_tool`, after validation:
- **Lookup** by `(requested_url, format, max_bytes)` → a hit returns `{...cached: true}` with **no network request**. Safe: the gateway already enforced the call's permission rules before `execute_tool`, and a hit hits no network (so SSRF/egress is moot).
- **Store** only successful results, tagged `cached: false` when fresh; errors are never cached.

`web.research` composes a `WebFetchModule`, so supplying it a cache transparently de-dupes repeated sub-fetches across a bundle — no `web.research` change required.

## Tests

- `test_web_cache.py` (6) — put/get, miss, key distinguishes format/max_bytes, TTL expiry (fake clock), LRU eviction, disabled.
- `test_web_fetch_module.py` (+3) — 2nd identical fetch served from cache (client not called, `cached: true`), different format is a miss, errors not cached.
- 96 web tests green; ruff/compileall/bandit clean. Injectable clock + cache → deterministic, no network.

backlog: task-2359 · design: `Docs/Design/MCP_Web_Fetch_Response_Cache.md`

> Remaining deferred: richer citation metadata on `web.research` (next PR), optional shared/process-global cache from gateway settings, conditional revalidation (ETag/Last-Modified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in in-memory TTL+LRU response cache to `web.fetch` so repeat requests skip the network and return faster. Implements TASK-2359; off by default, and cache hits re-run outbound policy and return with `cached: true`.

- **New Features**
  - `ResponseCache`: thread-safe TTL+LRU; deep-copies on get/put; defaults 300s/256 entries; disabled when `ttl_seconds<=0` or `max_entries<=0`; injectable clock.
  - `WebFetchModule`: new `response_cache` option; cache key is `(url, format, max_bytes, respect_robots)`; stores only successful results with `cached: false`; never caches errors; cache hits re-validate outbound policy and rebuild `eval` from the current call context.
  - `web.research`: de-duplicates by supplying a shared cache to its composed fetcher; no API changes.

- **Migration**
  - To enable caching, pass `response_cache=ResponseCache(...)` when constructing `WebFetchModule`.

<sup>Written for commit 36122df25515ad0a9c29187585856282dc6d4112. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

