### PR TITLE
Add citation metadata to MCP web.research sources

### DIFF
--- a/backlog/tasks/task-2360 - Add-citation-metadata-to-MCP-web-research-sources.md
+++ b/backlog/tasks/task-2360 - Add-citation-metadata-to-MCP-web-research-sources.md
@@ -1,0 +1,39 @@
+---
+id: TASK-2360
+title: Add citation metadata to MCP web.research sources
+status: Done
+updated_date: '2026-06-14'
+labels:
+- mcp
+- tools
+- web
+- research
+dependencies:
+- TASK-2356
+references:
+- Docs/Design/MCP_Web_Research_Tool_Design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Enrich each web.research source with citation-oriented metadata: a 1-based rank, the domain, the search provider's own per-result metadata (author/date/source/...), and, when fetched, the final URL, content type, and a retrieval timestamp.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Every source carries `rank` (1-based, sequential over search results), `domain` (host of the result url), and `search_metadata` (the provider's per-result metadata dict, `{}` when absent) — available whether or not the source was fetched.
+- [x] #2 Fetched sources additionally carry `final_url` (post-redirect), `content_type`, and `retrieved_at` (ISO-8601 UTC); unfetched sources omit those retrieval fields.
+- [x] #3 The enrichment is additive (existing source fields and bundle shape unchanged); all existing web.research tests stay green.
+- [x] #4 New tests cover citation fields present, 1-based sequential rank, and that unfetched sources omit retrieval fields; ruff/compileall/bandit clean.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+`WebResearchModule._assemble_sources` now emits, per source: `rank` (incremented over dict entries), `domain` (`_safe_host(url)`), and `search_metadata` (carried through from the search result's `metadata`, previously dropped). When the sub-fetch succeeded it also sets `final_url` (fetch `final_url` or url), `content_type`, and `retrieved_at` (`datetime.now(UTC).isoformat()`); unfetched/denied sources keep `reason_code` and omit the retrieval fields. Purely additive — existing keys (title/url/snippet/fetched/status_code/content) unchanged.
+
+Tests: +3 (citation fields present incl. passed-through provider metadata; 1-based sequential rank; unfetched omits retrieval fields); 30 web.research tests green. ruff/compileall/bandit clean.
+
+This completes the deferred web-tools follow-ups (per-domain rate limiting #2357, response caching #2358, citation metadata). Remaining nice-to-haves: optional shared/process-global limiter+cache from gateway settings; conditional revalidation (ETag/Last-Modified).
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_research_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_research_module.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any, Protocol
 from urllib.parse import urlsplit
 
@@ -260,12 +260,17 @@ class WebResearchModule(WebToolBase):
                 fetch_args["max_bytes"] = params["max_bytes"]
             async with semaphore:
                 try:
-                    return url, await self._fetch.execute_tool("web.fetch", fetch_args, context)
+                    fetch_result = await self._fetch.execute_tool("web.fetch", fetch_args, context)
                 except Exception as exc:  # noqa: BLE001 - a fetch crash must not fail the bundle.
                     logger.bind(stage="web.research", host=_safe_host(url)).opt(exception=exc).warning(
                         "web.research sub-fetch raised"
                     )
                     return url, {"ok": False, "reason_code": "fetch_failed"}
+            # Stamp the retrieval time once per fetched URL so deduplicated
+            # duplicates share a single, consistent retrieved_at.
+            if isinstance(fetch_result, dict) and fetch_result.get("ok"):
+                fetch_result["retrieved_at"] = datetime.now(timezone.utc).isoformat()
+            return url, fetch_result
 
         pairs = await asyncio.gather(*(_fetch_one(url) for url in to_fetch))
         results.update(dict(pairs))
@@ -287,6 +292,16 @@ class WebResearchModule(WebToolBase):
     def _assemble_sources(
         self, results: list[Any], fetched: dict[str, dict[str, Any]]
     ) -> tuple[list[dict[str, Any]], int, bool]:
+        """Build the citation-oriented source list from search results + fetches.
+
+        Each source always carries ``rank`` (1-based), ``title``, ``url``,
+        ``domain``, ``snippet`` (search excerpt), ``search_metadata`` (the
+        provider's per-result metadata), and ``fetched``. A successfully fetched
+        source also carries ``final_url``, ``status_code``, ``content_type``,
+        ``content``, and ``retrieved_at`` (ISO-8601 UTC, stamped once per URL);
+        an unfetched/denied source carries ``reason_code`` instead. Returns
+        ``(sources, fetched_count, any_truncated)``.
+        """
         sources: list[dict[str, Any]] = []
         fetched_count = 0
         any_truncated = False
@@ -318,7 +333,7 @@ class WebResearchModule(WebToolBase):
                     source["status_code"] = fetch_result.get("status_code")
                     source["content_type"] = fetch_result.get("content_type")
                     source["content"] = fetch_result.get("content")
-                    source["retrieved_at"] = datetime.now(UTC).isoformat()
+                    source["retrieved_at"] = fetch_result.get("retrieved_at")
                     if fetch_result.get("truncated"):
                         any_truncated = True
                     fetched_count += 1

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_research_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/web_research_module.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
+from datetime import UTC, datetime
 from typing import Any, Protocol
 from urllib.parse import urlsplit
 
@@ -289,23 +290,35 @@ class WebResearchModule(WebToolBase):
         sources: list[dict[str, Any]] = []
         fetched_count = 0
         any_truncated = False
+        rank = 0
         for entry in results:
             if not isinstance(entry, dict):
                 continue
+            rank += 1
             url = entry.get("url")
             url = url.strip() if isinstance(url, str) else ""
+            metadata = entry.get("metadata")
             source: dict[str, Any] = {
+                # Citation-oriented fields: rank for ordering, domain for
+                # attribution, and the search provider's own metadata
+                # (author/date/source/...) carried through for the caller.
+                "rank": rank,
                 "title": entry.get("title"),
                 "url": url,
+                "domain": _safe_host(url) if url else None,
                 "snippet": entry.get("content"),
+                "search_metadata": metadata if isinstance(metadata, dict) else {},
                 "fetched": False,
             }
             fetch_result = fetched.get(url) if url else None
             if isinstance(fetch_result, dict):
                 if fetch_result.get("ok"):
                     source["fetched"] = True
+                    source["final_url"] = fetch_result.get("final_url") or url
                     source["status_code"] = fetch_result.get("status_code")
+                    source["content_type"] = fetch_result.get("content_type")
                     source["content"] = fetch_result.get("content")
+                    source["retrieved_at"] = datetime.now(UTC).isoformat()
                     if fetch_result.get("truncated"):
                         any_truncated = True
                     fetched_count += 1

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_research_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_research_module.py
@@ -376,15 +376,19 @@ async def test_sources_carry_citation_fields() -> None:
         }
     ]
     search = _FakeSearchModule(_search_ok(results=results))
+    # Use by_url so the fake does not override final_url — verifying that a
+    # redirected final_url propagates into the source.
     fetch = _FakeFetchModule(
-        default={
-            "ok": True,
-            "final_url": "https://example.com/one-final",
-            "status_code": 200,
-            "content_type": "text/html",
-            "content": "page",
-            "truncated": False,
-            "eval": {},
+        by_url={
+            "https://example.com/one": {
+                "ok": True,
+                "final_url": "https://example.com/one-final",
+                "status_code": 200,
+                "content_type": "text/html",
+                "content": "page",
+                "truncated": False,
+                "eval": {},
+            }
         }
     )
     module = _module(search, fetch)
@@ -393,7 +397,7 @@ async def test_sources_carry_citation_fields() -> None:
     assert src["rank"] == 1  # nosec B101
     assert src["domain"] == "example.com"  # nosec B101
     assert src["search_metadata"]["author"] == "A. Writer"  # nosec B101
-    assert src["final_url"] == "https://example.com/one"  # nosec B101 - fake echoes url
+    assert src["final_url"] == "https://example.com/one-final"  # nosec B101 - propagated
     assert src["content_type"] == "text/html"  # nosec B101
     assert isinstance(src["retrieved_at"], str) and src["retrieved_at"]  # nosec B101
 
@@ -418,3 +422,18 @@ async def test_unfetched_source_omits_retrieval_fields() -> None:
     # citation fields available even without a fetch
     assert unfetched["rank"] == 3  # nosec B101
     assert unfetched["domain"] == "example.net"  # nosec B101
+
+
+async def test_duplicate_urls_share_one_retrieved_at() -> None:
+    dup = [
+        {"title": "A", "url": "https://example.com/x", "content": "s", "metadata": {}},
+        {"title": "B", "url": "https://example.com/x", "content": "s", "metadata": {}},
+    ]
+    search = _FakeSearchModule(_search_ok(results=dup))
+    fetch = _FakeFetchModule(default=_fetch_ok())
+    module = _module(search, fetch)
+    result = await module.execute_tool("web.research", {"query": "q", "fetch_top_n": 2})
+    stamps = [s["retrieved_at"] for s in result["sources"]]
+    # Deduplicated fetch -> both duplicate sources share one retrieved_at.
+    assert stamps[0] == stamps[1]  # nosec B101
+    assert isinstance(stamps[0], str) and stamps[0]  # nosec B101

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_web_research_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_web_research_module.py
@@ -364,3 +364,57 @@ async def test_permission_check_failure_denies() -> None:
     result = await module.execute_tool("web.research", {"query": "q", "fetch_top_n": 1})
     assert fetch.calls == []  # nosec B101 - fail closed
     assert result["sources"][0]["reason_code"] == "permission_denied"  # nosec B101
+
+
+async def test_sources_carry_citation_fields() -> None:
+    results = [
+        {
+            "title": "Doc One",
+            "url": "https://example.com/one",
+            "content": "snippet one",
+            "metadata": {"author": "A. Writer", "date_published": "2026-01-02", "source": "example.com"},
+        }
+    ]
+    search = _FakeSearchModule(_search_ok(results=results))
+    fetch = _FakeFetchModule(
+        default={
+            "ok": True,
+            "final_url": "https://example.com/one-final",
+            "status_code": 200,
+            "content_type": "text/html",
+            "content": "page",
+            "truncated": False,
+            "eval": {},
+        }
+    )
+    module = _module(search, fetch)
+    result = await module.execute_tool("web.research", {"query": "q", "fetch_top_n": 1})
+    src = result["sources"][0]
+    assert src["rank"] == 1  # nosec B101
+    assert src["domain"] == "example.com"  # nosec B101
+    assert src["search_metadata"]["author"] == "A. Writer"  # nosec B101
+    assert src["final_url"] == "https://example.com/one"  # nosec B101 - fake echoes url
+    assert src["content_type"] == "text/html"  # nosec B101
+    assert isinstance(src["retrieved_at"], str) and src["retrieved_at"]  # nosec B101
+
+
+async def test_source_rank_is_one_based_and_sequential() -> None:
+    search = _FakeSearchModule(_search_ok())  # 3 results
+    fetch = _FakeFetchModule(default=_fetch_ok())
+    module = _module(search, fetch)
+    result = await module.execute_tool("web.research", {"query": "q", "fetch_top_n": 3})
+    assert [s["rank"] for s in result["sources"]] == [1, 2, 3]  # nosec B101
+
+
+async def test_unfetched_source_omits_retrieval_fields() -> None:
+    search = _FakeSearchModule(_search_ok())  # 3 results
+    fetch = _FakeFetchModule(default=_fetch_ok())
+    module = _module(search, fetch)
+    result = await module.execute_tool("web.research", {"query": "q", "fetch_top_n": 1})
+    unfetched = result["sources"][2]
+    assert unfetched["fetched"] is False  # nosec B101
+    assert "retrieved_at" not in unfetched  # nosec B101
+    assert "final_url" not in unfetched  # nosec B101
+    # citation fields available even without a fetch
+    assert unfetched["rank"] == 3  # nosec B101
+    assert unfetched["domain"] == "example.net"  # nosec B101


### PR DESCRIPTION
## Summary

Enriches each `web.research` source with citation-oriented metadata so callers can attribute and cite results properly. Purely additive — existing source keys and the bundle shape are unchanged.

## New per-source fields

Always present (fetched or not):
- **`rank`** — 1-based, sequential over the search results.
- **`domain`** — host of the result url.
- **`search_metadata`** — the search provider's own per-result metadata dict (author / date_published / source / language / relevance_score / ...), which was previously **dropped**; now carried through (`{}` when absent).

Added when the sub-fetch succeeded:
- **`final_url`** — the post-redirect URL (the canonical thing to cite).
- **`content_type`** — the fetched MIME type.
- **`retrieved_at`** — ISO-8601 UTC timestamp of retrieval ("accessed on").

Unfetched / denied sources keep their `reason_code` and omit the retrieval fields.

## Tests

- `test_web_research_module.py` (+3) — citation fields present (incl. passed-through provider metadata), 1-based sequential `rank`, unfetched sources omit retrieval fields.
- 30 web.research tests green; ruff/compileall/bandit clean.

backlog: task-2360

> Completes the deferred web-tools follow-ups (rate limiting #2357, response caching #2358, citation metadata). Remaining nice-to-haves noted: optional shared/process-global limiter+cache from gateway settings, conditional revalidation (ETag/Last-Modified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds citation metadata to `web.research` sources so callers can attribute and cite results correctly, per task-2360. Purely additive; existing fields and bundle shape are unchanged.

- **New Features**
  - Per source: rank (1-based), domain (host), and search_metadata (provider metadata dict, {} when absent).
  - When fetched: final_url (post-redirect), content_type, and retrieved_at (ISO-8601 UTC). Unfetched/denied omit these and keep reason_code.

- **Bug Fixes**
  - Python 3.10 compat: use datetime.now(timezone.utc) instead of `UTC`.
  - Consistent timestamps: stamp retrieved_at once per fetched URL so duplicate URLs share one value.

<sup>Written for commit d0bb210d652df8912419bbef8156c2fbcda92538. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

