### PR TITLE
fix: quote remaining Mermaid node labels containing periods

### DIFF
--- a/README.md
+++ b/README.md
@@ -935,8 +935,8 @@ flowchart LR
   end
 
   subgraph EXTERNAL [External Providers]
-    LLMCloud[LLM APIs (OpenAI, Anthropic, etc.)]:::ext
-    LLMOnPrem[Local LLMs (vLLM, Ollama, llama.cpp, ...)]:::ext
+    LLMCloud["LLM APIs (OpenAI, Anthropic, etc.)"]:::ext
+    LLMOnPrem["Local LLMs (vLLM, Ollama, llama.cpp, ...)"]:::ext
     AudioProv[STT/TTS Providers]:::ext
     OCRVLM[OCR/VLM (tesseract, dots, points)]:::ext
     MediaDL[yt-dlp / ffmpeg]:::ext


### PR DESCRIPTION
Follow-up to #2361 — two more node labels with periods were still causing Mermaid parse errors.

## Summary
- What changed: Added quotes around `LLMCloud` and `LLMOnPrem` node labels
- Why: `etc.` in LLMCloud and `llama.cpp` / `...` in LLMOnPrem contain periods, which Mermaid treats as special characters in unquoted labels

## Validation
- [ ] Tests added/updated — N/A (README-only change)
- [ ] Unit/integration tests pass — N/A
- [ ] Docs updated — N/A

## UX Audit Checklist / Watchlists Checklists
N/A — README-only change, no code or UI modified.

## Risk & Rollback
- Risk level: Low
- Rollback plan: Revert the two character changes to `README.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quoted the LLMCloud and LLMOnPrem labels in the README’s Mermaid diagram to fix parse errors from periods and restore proper rendering.

<sup>Written for commit 620ac00ec3ba27e08168ce3eb6e6dd4b74e6e8d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

