### PR TITLE
Harden ACP client spec conformance

### DIFF
--- a/Docs/superpowers/plans/2026-06-16-acp-client-spec-conformance.md
+++ b/Docs/superpowers/plans/2026-06-16-acp-client-spec-conformance.md
@@ -1,0 +1,23 @@
+## Stage 1: Standard Session Close
+**Goal**: Move ACP teardown to the v1 `session/close` method while preserving compatibility with existing private runner builds.
+**Success Criteria**: Python clients call `session/close` first, fall back to `_tldw/session/close` only on method-not-found style failures, and the Go runner accepts standard `session/close`.
+**Tests**: Focused pytest coverage for standard and fallback close paths; Go runner coverage for standard close routing.
+**Status**: Complete
+
+## Stage 2: MCP Transport Capability Gates
+**Goal**: Prevent unsupported HTTP/SSE MCP server transports from being forwarded to downstream agents that did not advertise the required ACP `mcpCapabilities`.
+**Success Criteria**: The runner preserves supported MCP server configs and returns invalid params for unsupported HTTP/SSE transports after downstream initialization.
+**Tests**: Go runner tests for supported HTTP transport forwarding and unsupported SSE/HTTP rejection.
+**Status**: Complete
+
+## Stage 3: API Session Setup Validation
+**Goal**: Align public ACP session setup schemas with ACP v1 transport shapes and reject malformed requests before they reach the runner.
+**Success Criteria**: `cwd` must be absolute; MCP server configs support `stdio`, `http`, `sse`, and legacy `websocket`; stdio requires an absolute command; URL-based transports require a URL; dict env is normalized to ACP name/value pairs for compatibility.
+**Tests**: Focused schema tests for cwd, stdio, HTTP/SSE, env normalization, and endpoint request preservation.
+**Status**: Complete
+
+## Stage 4: Verification
+**Goal**: Prove the touched ACP scope works and record any residual risks.
+**Success Criteria**: Focused pytest suite, Go runner tests, and Bandit touched-scope run complete; Backlog task has verification notes.
+**Tests**: `python -m pytest ...`, `go test ./tools/tldw-agent/internal/acp`, and Bandit on touched Python files.
+**Status**: Complete

--- a/backlog/tasks/task-2367 - Harden-ACP-client-spec-conformance-for-downstream-agents.md
+++ b/backlog/tasks/task-2367 - Harden-ACP-client-spec-conformance-for-downstream-agents.md
@@ -1,0 +1,63 @@
+---
+id: TASK-2367
+title: Harden ACP client spec conformance for downstream agents
+status: Done
+labels:
+- ACP
+- protocol
+- backend
+priority: High
+modified_files:
+- Docs/superpowers/plans/2026-06-16-acp-client-spec-conformance.md
+- tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
+- tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py
+- tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py
+- tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py
+- tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py
+- tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_request_schema.py
+- tools/tldw-agent/internal/acp/runner.go
+- tools/tldw-agent/internal/acp/runner_test.go
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the first ACP protocol-hardening slice from the spec audit: standard session close support, stricter session setup validation, and MCP server transport/schema handling for downstream agents.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 ACP runner and Python clients use standard session/close where supported, with compatibility fallback for older runner private close method.
+- [ ] #2 Runner forwards or rejects MCP server transports according to ACP mcpCapabilities instead of silently passing unsupported HTTP/SSE transports downstream.
+- [ ] #3 API session setup rejects invalid cwd and malformed MCP server configs with clear 4xx validation errors.
+- [ ] #4 Focused Python and Go tests cover the new close and validation behavior.
+- [ ] #5 Touched scope passes focused tests and Bandit.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-16-acp-client-spec-conformance.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Verification completed: `python -m compileall -q ...` on touched Python modules passed; `python -m pytest -q tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_request_schema.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py::test_acp_session_new_preserves_explicit_empty_mcp_servers tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py::test_acp_session_new_rejects_relative_cwd tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py::test_acp_session_new_rejects_relative_stdio_mcp_command tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_new_records_sanitized_audit_event` passed with 38 tests; `go test ./internal/acp -count=1` passed from tools/tldw-agent; Bandit touched-scope run wrote /tmp/bandit_acp_client_spec_conformance.json with zero results/errors; `git diff --check` passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented ACP client spec-conformance hardening slice. Python standard and sandbox clients now call standard session/close first and fall back to private _tldw/session/close only for method-not-found compatibility. The Go ACP runner accepts standard session/close, stores downstream capabilities per session, forwards close when advertised, and rejects HTTP/SSE MCP server transports unless the downstream agent advertised the matching mcpCapabilities. Public ACP session setup schemas now validate absolute cwd, support stdio/http/sse/websocket MCP transport shapes, require absolute stdio commands and URL-based transport URLs, and normalize env/header dicts to ACP name/value arrays. Added focused Python and Go tests plus endpoint validation tests.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2367 - Harden-ACP-client-spec-conformance-for-downstream-agents.md
+++ b/backlog/tasks/task-2367 - Harden-ACP-client-spec-conformance-for-downstream-agents.md
@@ -12,6 +12,8 @@ modified_files:
 - tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
 - tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py
 - tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py
+- tldw_Server_API/app/core/Agent_Client_Protocol/stdio_client.py
+- tldw_Server_API/app/core/Agent_Client_Protocol/stream_client.py
 - tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py
 - tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py
 - tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_request_schema.py
@@ -27,11 +29,11 @@ Implement the first ACP protocol-hardening slice from the spec audit: standard s
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 ACP runner and Python clients use standard session/close where supported, with compatibility fallback for older runner private close method.
-- [ ] #2 Runner forwards or rejects MCP server transports according to ACP mcpCapabilities instead of silently passing unsupported HTTP/SSE transports downstream.
-- [ ] #3 API session setup rejects invalid cwd and malformed MCP server configs with clear 4xx validation errors.
-- [ ] #4 Focused Python and Go tests cover the new close and validation behavior.
-- [ ] #5 Touched scope passes focused tests and Bandit.
+- [x] #1 ACP runner and Python clients use standard session/close where supported, with compatibility fallback for older runner private close method.
+- [x] #2 Runner forwards or rejects MCP server transports according to ACP mcpCapabilities instead of silently passing unsupported HTTP/SSE transports downstream.
+- [x] #3 API session setup rejects invalid cwd and malformed MCP server configs with clear 4xx validation errors.
+- [x] #4 Focused Python and Go tests cover the new close and validation behavior.
+- [x] #5 Touched Python and Go scope passes focused tests (>38 tests) and Bandit security analysis with zero findings.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -43,21 +45,25 @@ Docs/superpowers/plans/2026-06-16-acp-client-spec-conformance.md
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Verification completed: `python -m compileall -q ...` on touched Python modules passed; `python -m pytest -q tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_request_schema.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py::test_acp_session_new_preserves_explicit_empty_mcp_servers tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py::test_acp_session_new_rejects_relative_cwd tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py::test_acp_session_new_rejects_relative_stdio_mcp_command tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_new_records_sanitized_audit_event` passed with 38 tests; `go test ./internal/acp -count=1` passed from tools/tldw-agent; Bandit touched-scope run wrote /tmp/bandit_acp_client_spec_conformance.json with zero results/errors; `git diff --check` passed.
+- Reopened to address PR #2372 review comments after rebasing the branch onto latest dev.
+- Fixed schema path/url normalization and env/header null handling review findings.
+- Fixed runner MCP type validation and Backlog readability review findings.
+- Stabilized an ACP audit endpoint test whose fixed timestamp had aged outside the default retention window.
+- Verification completed: `python -m compileall -q ...` on touched Python modules passed; `python -m pytest -q tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_request_schema.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py` passed with 73 tests; `go test ./internal/acp -count=1` passed from `tools/tldw-agent`; Bandit touched-scope run wrote `/tmp/bandit_acp_client_spec_conformance_review.json` with zero results/errors; `git diff --check` passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented ACP client spec-conformance hardening slice. Python standard and sandbox clients now call standard session/close first and fall back to private _tldw/session/close only for method-not-found compatibility. The Go ACP runner accepts standard session/close, stores downstream capabilities per session, forwards close when advertised, and rejects HTTP/SSE MCP server transports unless the downstream agent advertised the matching mcpCapabilities. Public ACP session setup schemas now validate absolute cwd, support stdio/http/sse/websocket MCP transport shapes, require absolute stdio commands and URL-based transport URLs, and normalize env/header dicts to ACP name/value arrays. Added focused Python and Go tests plus endpoint validation tests.
+Implemented ACP client spec-conformance hardening slice. Python standard and sandbox clients now call standard session/close first and fall back to private _tldw/session/close only for method-not-found compatibility. The Go ACP runner accepts standard session/close, stores downstream capabilities per session, forwards close when supported, and rejects HTTP/SSE MCP server transports unless the downstream agent explicitly advertises matching mcpCapabilities. Public ACP session setup schemas now validate absolute cwd, support stdio/http/sse/websocket MCP transport shapes, require absolute stdio commands and URL-based transport URLs, and normalize env/header dicts to ACP name/value arrays. Added focused Python and Go tests plus endpoint validation tests.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from enum import Enum
+from pathlib import PurePosixPath, PureWindowsPath
 from typing import Any, ClassVar, Literal, Union
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 
 
@@ -63,6 +64,11 @@ _LEGACY_ENTRYPOINT_STRATEGY_ALIASES = {
 def _coerce_entrypoint_strategy(value: Any) -> Any:
     """Import legacy ACP strategy aliases before public schema validation."""
     return _LEGACY_ENTRYPOINT_STRATEGY_ALIASES.get(str(value), value)
+
+
+def _is_absolute_cross_platform_path(value: str) -> bool:
+    candidate = str(value or "").strip()
+    return PurePosixPath(candidate).is_absolute() or PureWindowsPath(candidate).is_absolute()
 
 
 class ACPAgentEntrypointStatus(BaseModel):
@@ -332,16 +338,60 @@ class ACPMCPServerType(str, Enum):
     """MCP server connection types."""
     WEBSOCKET = "websocket"
     STDIO = "stdio"
+    HTTP = "http"
+    SSE = "sse"
+
+
+class ACPNameValuePair(BaseModel):
+    """ACP name/value pair used by env and header arrays."""
+    name: str = Field(..., min_length=1)
+    value: str = Field(...)
 
 
 class ACPMCPServerConfig(BaseModel):
     """Configuration for an MCP server."""
+    model_config = ConfigDict(use_enum_values=True)
+
     name: str = Field(..., description="Server identifier/name")
     type: ACPMCPServerType = Field(..., description="Connection type")
-    url: str | None = Field(default=None, description="WebSocket URL (for websocket type)")
+    url: str | None = Field(default=None, description="URL (for websocket, http, or sse type)")
     command: str | None = Field(default=None, description="Command to execute (for stdio type)")
     args: list[str] | None = Field(default=None, description="Command arguments (for stdio type)")
-    env: dict[str, str] | None = Field(default=None, description="Environment variables")
+    env: list[ACPNameValuePair] | None = Field(
+        default=None,
+        description="Environment variables as ACP name/value pairs",
+    )
+    headers: list[ACPNameValuePair] | None = Field(
+        default=None,
+        description="HTTP headers as ACP name/value pairs",
+    )
+
+    @field_validator("env", "headers", mode="before")
+    @classmethod
+    def normalize_name_value_pairs(cls, value: Any) -> Any:
+        if isinstance(value, dict):
+            return [
+                {"name": str(name), "value": str(raw_value)}
+                for name, raw_value in value.items()
+            ]
+        return value
+
+    @model_validator(mode="after")
+    def validate_transport_shape(self) -> "ACPMCPServerConfig":
+        transport = self.type.value if isinstance(self.type, ACPMCPServerType) else str(self.type)
+        if transport == ACPMCPServerType.STDIO.value:
+            if not self.command or not _is_absolute_cross_platform_path(self.command):
+                raise ValueError("stdio MCP server command must be an absolute path")
+            return self
+        if transport in {
+            ACPMCPServerType.WEBSOCKET.value,
+            ACPMCPServerType.HTTP.value,
+            ACPMCPServerType.SSE.value,
+        }:
+            if not self.url:
+                raise ValueError(f"{transport} MCP server url is required")
+            return self
+        return self
 
 
 # -----------------------------------------------------------------------------
@@ -519,6 +569,13 @@ class ACPSessionNewRequest(BaseModel):
         default=None,
         description="Optional materialized scope snapshot identifier for sandbox tenancy metadata",
     )
+
+    @field_validator("cwd")
+    @classmethod
+    def validate_cwd_absolute(cls, value: str) -> str:
+        if not _is_absolute_cross_platform_path(value):
+            raise ValueError("cwd must be an absolute path")
+        return value
 
 
 class ACPSessionNewResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from enum import Enum
 from pathlib import PurePosixPath, PureWindowsPath
 from typing import Any, ClassVar, Literal, Union
+from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
@@ -69,6 +70,10 @@ def _coerce_entrypoint_strategy(value: Any) -> Any:
 def _is_absolute_cross_platform_path(value: str) -> bool:
     candidate = str(value or "").strip()
     return PurePosixPath(candidate).is_absolute() or PureWindowsPath(candidate).is_absolute()
+
+
+def _normalize_required_string(value: Any) -> str:
+    return str(value or "").strip()
 
 
 class ACPAgentEntrypointStatus(BaseModel):
@@ -371,7 +376,10 @@ class ACPMCPServerConfig(BaseModel):
     def normalize_name_value_pairs(cls, value: Any) -> Any:
         if isinstance(value, dict):
             return [
-                {"name": str(name), "value": str(raw_value)}
+                {
+                    "name": str(name) if name is not None else None,
+                    "value": str(raw_value) if raw_value is not None else None,
+                }
                 for name, raw_value in value.items()
             ]
         return value
@@ -380,16 +388,27 @@ class ACPMCPServerConfig(BaseModel):
     def validate_transport_shape(self) -> "ACPMCPServerConfig":
         transport = self.type.value if isinstance(self.type, ACPMCPServerType) else str(self.type)
         if transport == ACPMCPServerType.STDIO.value:
-            if not self.command or not _is_absolute_cross_platform_path(self.command):
+            command = _normalize_required_string(self.command)
+            if not command or not _is_absolute_cross_platform_path(command):
                 raise ValueError("stdio MCP server command must be an absolute path")
+            self.command = command
             return self
         if transport in {
             ACPMCPServerType.WEBSOCKET.value,
             ACPMCPServerType.HTTP.value,
             ACPMCPServerType.SSE.value,
         }:
-            if not self.url:
-                raise ValueError(f"{transport} MCP server url is required")
+            url = _normalize_required_string(self.url)
+            parsed_url = urlparse(url)
+            allowed_schemes = (
+                {"ws", "wss"}
+                if transport == ACPMCPServerType.WEBSOCKET.value
+                else {"http", "https"}
+            )
+            if not url or parsed_url.scheme not in allowed_schemes or not parsed_url.netloc:
+                allowed = "/".join(sorted(allowed_schemes))
+                raise ValueError(f"{transport} MCP server url must use {allowed}")
+            self.url = url
             return self
         return self
 
@@ -573,9 +592,10 @@ class ACPSessionNewRequest(BaseModel):
     @field_validator("cwd")
     @classmethod
     def validate_cwd_absolute(cls, value: str) -> str:
-        if not _is_absolute_cross_platform_path(value):
+        normalized = _normalize_required_string(value)
+        if not normalized or not _is_absolute_cross_platform_path(normalized):
             raise ValueError("cwd must be an absolute path")
-        return value
+        return normalized
 
 
 class ACPSessionNewResponse(BaseModel):

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py
@@ -49,6 +49,8 @@ _ACP_GOVERNANCE_NONCRITICAL_EXCEPTIONS = (
 
 
 def _is_method_not_found_error(exc: ACPResponseError, method: str) -> bool:
+    if getattr(exc, "code", None) == -32601:
+        return True
     message = str(exc).lower()
     return (
         "method not found" in message

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py
@@ -48,6 +48,25 @@ _ACP_GOVERNANCE_NONCRITICAL_EXCEPTIONS = (
 )
 
 
+def _is_method_not_found_error(exc: ACPResponseError, method: str) -> bool:
+    message = str(exc).lower()
+    return (
+        "method not found" in message
+        or "-32601" in message
+        or ("not supported" in message and method.lower() in message)
+    )
+
+
+async def _call_session_close_with_fallback(client: Any, session_id: str) -> None:
+    params = {"sessionId": session_id}
+    try:
+        await client.call("session/close", params)
+    except ACPResponseError as exc:
+        if not _is_method_not_found_error(exc, "session/close"):
+            raise
+        await client.call("_tldw/session/close", params)
+
+
 def _policy_match_patterns(policy_document: dict[str, Any], *keys: str) -> list[str]:
     patterns: list[str] = []
     for key in keys:
@@ -809,7 +828,7 @@ class ACPRunnerClient(ACPRuntimePolicySupportMixin):
         await self._client.notify("session/cancel", {"sessionId": session_id})
 
     async def close_session(self, session_id: str) -> None:
-        await self._client.call("_tldw/session/close", {"sessionId": session_id})
+        await _call_session_close_with_fallback(self._client, session_id)
         self._updates.pop(session_id, None)
         self._session_owners.pop(str(session_id), None)
         self._clear_runtime_policy_session_state(session_id)

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py
@@ -24,6 +24,7 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.runner_client import (
     PERMISSION_TIMEOUT_SECONDS,
     PendingPermission,
     SessionWebSocketRegistry,
+    _call_session_close_with_fallback,
     _merge_runtime_and_governance_permission_outcome,
     _resolve_runtime_permission_outcome,
 )
@@ -717,7 +718,7 @@ class ACPSandboxRunnerManager(ACPRuntimePolicySupportMixin):
             return
         if sess:
             with contextlib.suppress(_ACP_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                await sess.client.call("_tldw/session/close", {"sessionId": session_id})
+                await _call_session_close_with_fallback(sess.client, session_id)
             try:
                 if sess.reader_task:
                     sess.reader_task.cancel()

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/stdio_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/stdio_client.py
@@ -11,7 +11,16 @@ from loguru import logger
 
 
 class ACPResponseError(RuntimeError):
-    pass
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: int | None = None,
+        error: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.error = error or {}
 
 
 @dataclass
@@ -112,7 +121,11 @@ class ACPStdioClient:
         await self._send(payload)
         resp = await future
         if resp.error:
-            raise ACPResponseError(resp.error.get("message", "ACP error"))
+            raise ACPResponseError(
+                resp.error.get("message", "ACP error"),
+                code=resp.error.get("code"),
+                error=resp.error,
+            )
         return resp
 
     async def notify(self, method: str, params: Any | None = None) -> None:
@@ -137,9 +150,11 @@ class ACPStdioClient:
             await self._proc.stdin.drain()
 
     async def _read_loop(self) -> None:
-        assert self._proc is not None
-        assert self._proc.stdout is not None
-        reader = self._proc.stdout
+        proc = self._proc
+        if proc is None or proc.stdout is None:
+            self._drain_pending("ACP stdout not available")
+            return
+        reader = proc.stdout
         while True:
             line = await reader.readline()
             if not line:
@@ -210,10 +225,11 @@ class ACPStdioClient:
         await self._send(payload)
 
     async def _stderr_loop(self) -> None:
-        assert self._proc is not None
-        assert self._proc.stderr is not None
+        proc = self._proc
+        if proc is None or proc.stderr is None:
+            return
         while True:
-            line = await self._proc.stderr.readline()
+            line = await proc.stderr.readline()
             if not line:
                 break
             logger.debug("ACP runner stderr: {}", line.decode("utf-8", errors="ignore").rstrip())

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/stream_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/stream_client.py
@@ -67,7 +67,11 @@ class ACPStreamClient:
         await self._send(payload)
         resp = await future
         if resp.error:
-            raise ACPResponseError(resp.error.get("message", "ACP error"))
+            raise ACPResponseError(
+                resp.error.get("message", "ACP error"),
+                code=resp.error.get("code"),
+                error=resp.error,
+            )
         return resp
 
     async def notify(self, method: str, params: Any | None = None) -> None:

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py
@@ -410,6 +410,46 @@ def test_acp_session_new_preserves_explicit_empty_mcp_servers(
     assert call["mcp_servers"] == []
 
 
+def test_acp_session_new_rejects_relative_cwd(
+    client_user_only,
+    stub_runner_client,
+):
+    resp = client_user_only.post(
+        "/api/v1/acp/sessions/new",
+        json={
+            "cwd": "relative/project",
+        },
+    )
+
+    assert resp.status_code == 422
+    assert stub_runner_client.create_session_calls == []
+    assert "absolute" in resp.text
+
+
+def test_acp_session_new_rejects_relative_stdio_mcp_command(
+    client_user_only,
+    stub_runner_client,
+    tmp_path,
+):
+    resp = client_user_only.post(
+        "/api/v1/acp/sessions/new",
+        json={
+            "cwd": str(tmp_path),
+            "mcp_servers": [
+                {
+                    "name": "workspace",
+                    "type": "stdio",
+                    "command": "mcp-filesystem",
+                }
+            ],
+        },
+    )
+
+    assert resp.status_code == 422
+    assert stub_runner_client.create_session_calls == []
+    assert "absolute" in resp.text
+
+
 def test_acp_session_new_records_sanitized_audit_event(
     client_user_only,
     stub_runner_client,

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py
@@ -692,7 +692,7 @@ def test_agent_audit_scope_is_admin_readable_without_runner_session(
         acp_endpoints._ACP_AUDIT_EVENTS.clear()
         acp_endpoints._ACP_AUDIT_EVENTS.append(
             {
-                "timestamp": "2026-05-10T00:00:00+00:00",
+                "timestamp": "2999-01-01T00:00:00+00:00",
                 "action": "agent_registered",
                 "user_id": 1,
                 "session_id": "agent:audit_agent",

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py
@@ -385,6 +385,39 @@ async def test_standard_runner_close_session_falls_back_to_private_runner_close(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_standard_runner_close_session_falls_back_on_json_rpc_method_not_found_code() -> None:
+    class _CallResult:
+        def __init__(self, result: dict[str, object]) -> None:
+            self.result = result
+
+    class _FakeClient:
+        is_running = True
+
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict[str, object]]] = []
+
+        async def call(self, method: str, payload: dict[str, object]):
+            self.calls.append((method, payload))
+            if method == "session/close":
+                raise ACPResponseError("unsupported", code=-32601)
+            if method == "_tldw/session/close":
+                return _CallResult({})
+            raise AssertionError(f"unexpected method: {method}")
+
+    runner = ACPRunnerClient(ACPRunnerConfig(command="echo"))
+    fake_client = _FakeClient()
+    runner._client = fake_client
+
+    await runner.close_session("session-close-code")
+
+    assert fake_client.calls == [
+        ("session/close", {"sessionId": "session-close-code"}),
+        ("_tldw/session/close", {"sessionId": "session-close-code"}),
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_create_session_rejects_unavailable_vz_macos_runtime(monkeypatch) -> None:
     manager = ACPSandboxRunnerManager(
         ACPSandboxConfig(

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py
@@ -318,6 +318,73 @@ async def test_standard_runner_create_session_retries_without_agent_type_then_mc
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_standard_runner_close_session_uses_standard_acp_close() -> None:
+    class _CallResult:
+        def __init__(self, result: dict[str, object]) -> None:
+            self.result = result
+
+    class _FakeClient:
+        is_running = True
+
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict[str, object]]] = []
+
+        async def call(self, method: str, payload: dict[str, object]):
+            self.calls.append((method, payload))
+            if method == "session/close":
+                return _CallResult({})
+            raise AssertionError(f"unexpected method: {method}")
+
+    runner = ACPRunnerClient(ACPRunnerConfig(command="echo"))
+    fake_client = _FakeClient()
+    runner._client = fake_client
+    runner._updates["session-close"] = asyncio.Queue()
+    runner._session_owners["session-close"] = 7
+
+    await runner.close_session("session-close")
+
+    assert fake_client.calls == [
+        ("session/close", {"sessionId": "session-close"}),
+    ]
+    assert "session-close" not in runner._updates
+    assert "session-close" not in runner._session_owners
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_standard_runner_close_session_falls_back_to_private_runner_close() -> None:
+    class _CallResult:
+        def __init__(self, result: dict[str, object]) -> None:
+            self.result = result
+
+    class _FakeClient:
+        is_running = True
+
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict[str, object]]] = []
+
+        async def call(self, method: str, payload: dict[str, object]):
+            self.calls.append((method, payload))
+            if method == "session/close":
+                raise ACPResponseError("method not found")
+            if method == "_tldw/session/close":
+                return _CallResult({})
+            raise AssertionError(f"unexpected method: {method}")
+
+    runner = ACPRunnerClient(ACPRunnerConfig(command="echo"))
+    fake_client = _FakeClient()
+    runner._client = fake_client
+
+    await runner.close_session("session-close-legacy")
+
+    assert fake_client.calls == [
+        ("session/close", {"sessionId": "session-close-legacy"}),
+        ("_tldw/session/close", {"sessionId": "session-close-legacy"}),
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_create_session_rejects_unavailable_vz_macos_runtime(monkeypatch) -> None:
     manager = ACPSandboxRunnerManager(
         ACPSandboxConfig(

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_request_schema.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_request_schema.py
@@ -16,6 +16,13 @@ def test_session_new_requires_absolute_cwd() -> None:
 
 
 @pytest.mark.unit
+def test_session_new_normalizes_absolute_cwd_whitespace() -> None:
+    request = ACPSessionNewRequest.model_validate({"cwd": " /repo "})
+
+    assert request.cwd == "/repo"
+
+
+@pytest.mark.unit
 def test_stdio_mcp_server_requires_absolute_command() -> None:
     with pytest.raises(ValidationError, match="absolute"):
         ACPMCPServerConfig.model_validate(
@@ -28,12 +35,61 @@ def test_stdio_mcp_server_requires_absolute_command() -> None:
 
 
 @pytest.mark.unit
+def test_stdio_mcp_server_normalizes_absolute_command_whitespace() -> None:
+    server = ACPMCPServerConfig.model_validate(
+        {
+            "name": "workspace",
+            "type": "stdio",
+            "command": " /usr/local/bin/mcp-filesystem ",
+        }
+    )
+
+    assert server.command == "/usr/local/bin/mcp-filesystem"
+
+
+@pytest.mark.unit
 def test_http_mcp_server_requires_url() -> None:
     with pytest.raises(ValidationError, match="url"):
         ACPMCPServerConfig.model_validate(
             {
                 "name": "remote",
                 "type": "http",
+            }
+        )
+
+
+@pytest.mark.unit
+def test_http_mcp_server_normalizes_url_whitespace() -> None:
+    server = ACPMCPServerConfig.model_validate(
+        {
+            "name": "remote",
+            "type": "http",
+            "url": " https://mcp.example.com ",
+        }
+    )
+
+    assert server.url == "https://mcp.example.com"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("transport", "url"),
+    [
+        ("http", "ftp://mcp.example.com"),
+        ("sse", "ws://mcp.example.com/events"),
+        ("websocket", "https://mcp.example.com/ws"),
+    ],
+)
+def test_remote_mcp_server_requires_transport_specific_url_scheme(
+    transport: str,
+    url: str,
+) -> None:
+    with pytest.raises(ValidationError, match="url"):
+        ACPMCPServerConfig.model_validate(
+            {
+                "name": "remote",
+                "type": transport,
+                "url": url,
             }
         )
 
@@ -93,3 +149,17 @@ def test_mcp_server_env_dict_is_normalized_to_name_value_pairs() -> None:
         {"name": "WORKSPACE_TOKEN", "value": "token-value"},
         {"name": "TRACE", "value": "1"},
     ]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("field_name", ["env", "headers"])
+def test_mcp_server_name_value_dict_rejects_null_values(field_name: str) -> None:
+    with pytest.raises(ValidationError):
+        ACPMCPServerConfig.model_validate(
+            {
+                "name": "workspace",
+                "type": "stdio",
+                "command": "/usr/local/bin/mcp-filesystem",
+                field_name: {"TOKEN": None},
+            }
+        )

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_request_schema.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_request_schema.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
+    ACPMCPServerConfig,
+    ACPSessionNewRequest,
+)
+
+
+@pytest.mark.unit
+def test_session_new_requires_absolute_cwd() -> None:
+    with pytest.raises(ValidationError, match="absolute"):
+        ACPSessionNewRequest.model_validate({"cwd": "relative/path"})
+
+
+@pytest.mark.unit
+def test_stdio_mcp_server_requires_absolute_command() -> None:
+    with pytest.raises(ValidationError, match="absolute"):
+        ACPMCPServerConfig.model_validate(
+            {
+                "name": "workspace",
+                "type": "stdio",
+                "command": "mcp-filesystem",
+            }
+        )
+
+
+@pytest.mark.unit
+def test_http_mcp_server_requires_url() -> None:
+    with pytest.raises(ValidationError, match="url"):
+        ACPMCPServerConfig.model_validate(
+            {
+                "name": "remote",
+                "type": "http",
+            }
+        )
+
+
+@pytest.mark.unit
+def test_http_and_sse_mcp_server_configs_are_valid() -> None:
+    request = ACPSessionNewRequest.model_validate(
+        {
+            "cwd": "/repo",
+            "mcp_servers": [
+                {
+                    "name": "remote-http",
+                    "type": "http",
+                    "url": "https://mcp.example.com",
+                    "headers": [{"name": "Authorization", "value": "Bearer token"}],
+                },
+                {
+                    "name": "remote-sse",
+                    "type": "sse",
+                    "url": "https://mcp.example.com/sse",
+                },
+            ],
+        }
+    )
+
+    dumped = request.model_dump(exclude_none=True)
+    assert dumped["mcp_servers"] == [
+        {
+            "name": "remote-http",
+            "type": "http",
+            "url": "https://mcp.example.com",
+            "headers": [{"name": "Authorization", "value": "Bearer token"}],
+        },
+        {
+            "name": "remote-sse",
+            "type": "sse",
+            "url": "https://mcp.example.com/sse",
+        },
+    ]
+
+
+@pytest.mark.unit
+def test_mcp_server_env_dict_is_normalized_to_name_value_pairs() -> None:
+    server = ACPMCPServerConfig.model_validate(
+        {
+            "name": "workspace",
+            "type": "stdio",
+            "command": "/usr/local/bin/mcp-filesystem",
+            "env": {
+                "WORKSPACE_TOKEN": "token-value",
+                "TRACE": "1",
+            },
+        }
+    )
+
+    assert server.model_dump(exclude_none=True)["env"] == [
+        {"name": "WORKSPACE_TOKEN", "value": "token-value"},
+        {"name": "TRACE", "value": "1"},
+    ]

--- a/tools/tldw-agent/internal/acp/runner.go
+++ b/tools/tldw-agent/internal/acp/runner.go
@@ -39,15 +39,16 @@ type Runner struct {
 }
 
 type Session struct {
-	id          string
-	downstream  *Conn
-	process     *exec.Cmd
-	workspace   *workspace.Session
-	fsTools     *tools.FSTools
-	searchTools *tools.SearchTools
-	gitTools    *tools.GitTools
-	terminal    *TerminalManager
-	runErr      <-chan error
+	id           string
+	downstream   *Conn
+	process      *exec.Cmd
+	capabilities map[string]interface{}
+	workspace    *workspace.Session
+	fsTools      *tools.FSTools
+	searchTools  *tools.SearchTools
+	gitTools     *tools.GitTools
+	terminal     *TerminalManager
+	runErr       <-chan error
 }
 
 func NewRunner(cfg *config.Config) *Runner {
@@ -98,7 +99,7 @@ func (r *Runner) handleUpstreamRequest(msg *RPCMessage) (*RPCResponse, error) {
 		return r.handleSessionPrompt(msg)
 	case "session/cancel":
 		return r.handleSessionCancel(msg)
-	case "_tldw/session/close":
+	case "session/close", "_tldw/session/close":
 		return r.handleSessionClose(msg)
 	case "session/load":
 		return NewErrorResponse(msg.ID, ErrMethodNotFound, "session/load not supported"), nil
@@ -268,7 +269,15 @@ func (r *Runner) handleSessionNew(msg *RPCMessage) (*RPCResponse, error) {
 		return &RPCResponse{JSONRPC: JSONRPCVersion, ID: msg.ID, Error: initResp.Error}, nil
 	}
 	if initResp != nil && initResp.Result != nil {
-		r.updateCachedCapabilities(initResp.Result)
+		session.capabilities = parseAgentCapabilities(initResp.Result)
+		if session.capabilities != nil {
+			r.setCachedCapabilities(session.capabilities)
+		}
+	}
+
+	if err := validateSessionNewMCPTransports(msg.Params, session.capabilities); err != nil {
+		r.terminateProcess(cmd)
+		return NewErrorResponse(msg.ID, ErrInvalidParams, err.Error()), nil
 	}
 
 	downstreamParams, err := stripSessionRoutingParams(msg.Params)
@@ -359,6 +368,22 @@ func (r *Runner) handleSessionClose(msg *RPCMessage) (*RPCResponse, error) {
 		return NewErrorResponse(msg.ID, ErrInvalidParams, "invalid session/close params"), nil
 	}
 
+	session := r.getSession(params.SessionID)
+	if session != nil {
+		if capabilityEnabled(session.capabilities, "sessionCapabilities", "close") {
+			resp, err := session.downstream.CallRaw(context.Background(), "session/close", msg.Params)
+			if err != nil {
+				r.cleanupSession(params.SessionID)
+				return NewErrorResponse(msg.ID, ErrInternal, fmt.Sprintf("downstream session/close failed: %v", err)), nil
+			}
+			if resp != nil && resp.Error != nil && resp.Error.Code != ErrMethodNotFound {
+				r.cleanupSession(params.SessionID)
+				return &RPCResponse{JSONRPC: JSONRPCVersion, ID: msg.ID, Error: resp.Error}, nil
+			}
+		} else {
+			_ = session.downstream.NotifyRaw("session/cancel", msg.Params)
+		}
+	}
 	r.cleanupSession(params.SessionID)
 	return NewResultResponse(msg.ID, nil), nil
 }
@@ -676,9 +701,81 @@ func (r *Runner) updateCachedCapabilities(raw json.RawMessage) {
 	if caps == nil {
 		return
 	}
+	r.setCachedCapabilities(caps)
+}
+
+func (r *Runner) setCachedCapabilities(caps map[string]interface{}) {
 	r.capsMu.Lock()
-	r.cachedCaps = caps
+	r.cachedCaps = copyMap(caps)
 	r.capsMu.Unlock()
+}
+
+func validateSessionNewMCPTransports(raw json.RawMessage, caps map[string]interface{}) error {
+	if raw == nil {
+		return nil
+	}
+	var params map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return fmt.Errorf("invalid session/new params")
+	}
+	rawServers, ok := params["mcpServers"]
+	if !ok || len(rawServers) == 0 || string(rawServers) == "null" {
+		return nil
+	}
+	var servers []map[string]interface{}
+	if err := json.Unmarshal(rawServers, &servers); err != nil {
+		return fmt.Errorf("mcpServers must be an array")
+	}
+	for _, server := range servers {
+		transport, _ := server["type"].(string)
+		switch strings.ToLower(strings.TrimSpace(transport)) {
+		case "http":
+			if !capabilityEnabled(caps, "mcpCapabilities", "http") {
+				return fmt.Errorf("mcpServers transport http requires agentCapabilities.mcpCapabilities.http")
+			}
+		case "sse":
+			if !capabilityEnabled(caps, "mcpCapabilities", "sse") {
+				return fmt.Errorf("mcpServers transport sse requires agentCapabilities.mcpCapabilities.sse")
+			}
+		}
+	}
+	return nil
+}
+
+func capabilityEnabled(caps map[string]interface{}, section string, capability string) bool {
+	if caps == nil {
+		return false
+	}
+	rawSection, ok := caps[section]
+	if !ok {
+		return false
+	}
+	switch typedSection := rawSection.(type) {
+	case map[string]interface{}:
+		rawValue, ok := typedSection[capability]
+		if !ok {
+			return false
+		}
+		return capabilityValueEnabled(rawValue)
+	case map[string]bool:
+		return typedSection[capability]
+	case map[string]map[string]interface{}:
+		_, ok := typedSection[capability]
+		return ok
+	default:
+		return false
+	}
+}
+
+func capabilityValueEnabled(value interface{}) bool {
+	switch typedValue := value.(type) {
+	case bool:
+		return typedValue
+	case nil:
+		return false
+	default:
+		return true
+	}
 }
 
 func (r *Runner) refreshCapabilities() map[string]interface{} {

--- a/tools/tldw-agent/internal/acp/runner.go
+++ b/tools/tldw-agent/internal/acp/runner.go
@@ -726,9 +726,22 @@ func validateSessionNewMCPTransports(raw json.RawMessage, caps map[string]interf
 	if err := json.Unmarshal(rawServers, &servers); err != nil {
 		return fmt.Errorf("mcpServers must be an array")
 	}
-	for _, server := range servers {
-		transport, _ := server["type"].(string)
-		switch strings.ToLower(strings.TrimSpace(transport)) {
+	for idx, server := range servers {
+		rawTransport, ok := server["type"]
+		if !ok {
+			return fmt.Errorf("mcpServers[%d].type must be a string", idx)
+		}
+		transport, ok := rawTransport.(string)
+		if !ok {
+			return fmt.Errorf("mcpServers[%d].type must be a string", idx)
+		}
+		normalizedTransport := strings.ToLower(strings.TrimSpace(transport))
+		if normalizedTransport == "" {
+			return fmt.Errorf("mcpServers[%d].type must not be empty", idx)
+		}
+		switch normalizedTransport {
+		case "stdio", "websocket":
+			continue
 		case "http":
 			if !capabilityEnabled(caps, "mcpCapabilities", "http") {
 				return fmt.Errorf("mcpServers transport http requires agentCapabilities.mcpCapabilities.http")
@@ -737,6 +750,8 @@ func validateSessionNewMCPTransports(raw json.RawMessage, caps map[string]interf
 			if !capabilityEnabled(caps, "mcpCapabilities", "sse") {
 				return fmt.Errorf("mcpServers transport sse requires agentCapabilities.mcpCapabilities.sse")
 			}
+		default:
+			return fmt.Errorf("mcpServers[%d].type %q is not supported", idx, transport)
 		}
 	}
 	return nil

--- a/tools/tldw-agent/internal/acp/runner_test.go
+++ b/tools/tldw-agent/internal/acp/runner_test.go
@@ -658,6 +658,59 @@ func TestRunnerAcceptsStandardSessionCloseAndForwardsWhenAdvertised(t *testing.T
 	}
 }
 
+func TestValidateSessionNewMCPTransportsRejectsMalformedTypes(t *testing.T) {
+	caps := map[string]interface{}{
+		"mcpCapabilities": map[string]bool{
+			"http": true,
+			"sse":  true,
+		},
+	}
+
+	tests := []struct {
+		name    string
+		server  map[string]interface{}
+		wantErr string
+	}{
+		{
+			name:    "missing type",
+			server:  map[string]interface{}{"name": "missing"},
+			wantErr: "mcpServers[0].type must be a string",
+		},
+		{
+			name:    "non string type",
+			server:  map[string]interface{}{"name": "bad", "type": 123},
+			wantErr: "mcpServers[0].type must be a string",
+		},
+		{
+			name:    "empty type",
+			server:  map[string]interface{}{"name": "empty", "type": "  "},
+			wantErr: "mcpServers[0].type must not be empty",
+		},
+		{
+			name:    "unknown type",
+			server:  map[string]interface{}{"name": "unknown", "type": "grpc"},
+			wantErr: "mcpServers[0].type \"grpc\" is not supported",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(map[string]interface{}{
+				"cwd":        t.TempDir(),
+				"mcpServers": []map[string]interface{}{tc.server},
+			})
+			if err != nil {
+				t.Fatalf("marshal session/new params: %v", err)
+			}
+
+			err = validateSessionNewMCPTransports(raw, caps)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("validateSessionNewMCPTransports error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestRunnerRejectsUnsupportedHTTPMCPServerTransport(t *testing.T) {
 	cfg := config.Default()
 	cfg.Agent.Command = "stub-agent"

--- a/tools/tldw-agent/internal/acp/runner_test.go
+++ b/tools/tldw-agent/internal/acp/runner_test.go
@@ -20,6 +20,7 @@ type stubAgent struct {
 	caps         map[string]interface{}
 	sessionNewCh chan map[string]interface{}
 	promptCh     chan promptParams
+	closeCh      chan string
 }
 
 type promptParams struct {
@@ -281,6 +282,7 @@ func newStubAgent(conn *Conn, sessionID string, caps map[string]interface{}) *st
 		caps:         caps,
 		sessionNewCh: make(chan map[string]interface{}, 1),
 		promptCh:     make(chan promptParams, 1),
+		closeCh:      make(chan string, 1),
 	}
 
 	conn.SetHandler(func(msg *RPCMessage) (*RPCResponse, error) {
@@ -315,6 +317,14 @@ func newStubAgent(conn *Conn, sessionID string, caps map[string]interface{}) *st
 			return NewResultResponse(msg.ID, map[string]interface{}{
 				"stopReason": "end",
 			}), nil
+		case "session/close":
+			var params struct {
+				SessionID string `json:"sessionId"`
+			}
+			if err := json.Unmarshal(msg.Params, &params); err == nil {
+				agent.closeCh <- params.SessionID
+			}
+			return NewResultResponse(msg.ID, nil), nil
 		default:
 			return NewErrorResponse(msg.ID, ErrMethodNotFound, "method not found"), nil
 		}
@@ -543,6 +553,300 @@ func TestRunnerStripsAgentTypeBeforeForwardingSessionNew(t *testing.T) {
 		}
 		if _, ok := params["mcpServers"]; !ok {
 			t.Fatalf("mcpServers should be preserved for downstream session/new: %#v", params)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("session/new was not forwarded to downstream")
+	}
+}
+
+func TestRunnerAcceptsStandardSessionCloseAndForwardsWhenAdvertised(t *testing.T) {
+	cfg := config.Default()
+	cfg.Agent.Command = "stub-agent"
+	runner := NewRunner(cfg)
+
+	caps := map[string]interface{}{
+		"sessionCapabilities": map[string]interface{}{
+			"close": true,
+		},
+	}
+
+	var (
+		mu                sync.Mutex
+		stubAgentInstance *stubAgent
+		spawnedConns      []net.Conn
+	)
+
+	runner.SetSpawnFunc(func(_ config.AgentConfig) (*Conn, *exec.Cmd, error) {
+		clientConn, serverConn := net.Pipe()
+
+		stubConn := NewConn(serverConn, serverConn)
+		mu.Lock()
+		spawnedConns = append(spawnedConns, clientConn, serverConn)
+		stubAgentInstance = newStubAgent(stubConn, "session_close", caps)
+		mu.Unlock()
+		go func() {
+			_ = stubConn.Run()
+		}()
+
+		return NewConn(clientConn, clientConn), nil, nil
+	})
+
+	upstreamConn, runnerConn := net.Pipe()
+	upstream := NewConn(upstreamConn, upstreamConn)
+	go func() {
+		_ = upstream.Run()
+	}()
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- runner.Run(runnerConn, runnerConn)
+	}()
+
+	t.Cleanup(func() {
+		_ = upstreamConn.Close()
+		_ = runnerConn.Close()
+		mu.Lock()
+		conns := append([]net.Conn(nil), spawnedConns...)
+		mu.Unlock()
+		for _, conn := range conns {
+			_ = conn.Close()
+		}
+		select {
+		case <-runErr:
+		case <-time.After(time.Second):
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	newResp, err := upstream.Call(ctx, "session/new", map[string]interface{}{
+		"cwd": t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("session/new failed: %v", err)
+	}
+	if newResp.Error != nil {
+		t.Fatalf("session/new returned RPC error: %#v", newResp.Error)
+	}
+	sessionID := extractSessionID(t, newResp.Result)
+
+	closeResp, err := upstream.Call(ctx, "session/close", map[string]interface{}{
+		"sessionId": sessionID,
+	})
+	if err != nil {
+		t.Fatalf("session/close failed: %v", err)
+	}
+	if closeResp.Error != nil {
+		t.Fatalf("session/close returned RPC error: %#v", closeResp.Error)
+	}
+
+	mu.Lock()
+	instance := stubAgentInstance
+	mu.Unlock()
+	if instance == nil {
+		t.Fatalf("stub agent was not spawned")
+	}
+
+	select {
+	case closedSessionID := <-instance.closeCh:
+		if closedSessionID != sessionID {
+			t.Fatalf("closed session = %q, want %q", closedSessionID, sessionID)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("downstream session/close was not forwarded")
+	}
+}
+
+func TestRunnerRejectsUnsupportedHTTPMCPServerTransport(t *testing.T) {
+	cfg := config.Default()
+	cfg.Agent.Command = "stub-agent"
+	runner := NewRunner(cfg)
+
+	caps := map[string]interface{}{
+		"mcpCapabilities": map[string]bool{
+			"http": false,
+			"sse":  false,
+		},
+	}
+
+	var (
+		mu                sync.Mutex
+		stubAgentInstance *stubAgent
+		spawnedConns      []net.Conn
+	)
+
+	runner.SetSpawnFunc(func(_ config.AgentConfig) (*Conn, *exec.Cmd, error) {
+		clientConn, serverConn := net.Pipe()
+
+		stubConn := NewConn(serverConn, serverConn)
+		mu.Lock()
+		spawnedConns = append(spawnedConns, clientConn, serverConn)
+		stubAgentInstance = newStubAgent(stubConn, "session_mcp_rejected", caps)
+		mu.Unlock()
+		go func() {
+			_ = stubConn.Run()
+		}()
+
+		return NewConn(clientConn, clientConn), nil, nil
+	})
+
+	upstreamConn, runnerConn := net.Pipe()
+	upstream := NewConn(upstreamConn, upstreamConn)
+	go func() {
+		_ = upstream.Run()
+	}()
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- runner.Run(runnerConn, runnerConn)
+	}()
+
+	t.Cleanup(func() {
+		_ = upstreamConn.Close()
+		_ = runnerConn.Close()
+		mu.Lock()
+		conns := append([]net.Conn(nil), spawnedConns...)
+		mu.Unlock()
+		for _, conn := range conns {
+			_ = conn.Close()
+		}
+		select {
+		case <-runErr:
+		case <-time.After(time.Second):
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resp, err := upstream.Call(ctx, "session/new", map[string]interface{}{
+		"cwd": t.TempDir(),
+		"mcpServers": []map[string]interface{}{
+			{
+				"name": "remote",
+				"type": "http",
+				"url":  "https://mcp.example.com",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("session/new transport rejection should return RPC error response: %v", err)
+	}
+	if resp.Error == nil {
+		t.Fatalf("session/new should reject unsupported http MCP transport")
+	}
+	if resp.Error.Code != ErrInvalidParams || !strings.Contains(resp.Error.Message, "mcpCapabilities.http") {
+		t.Fatalf("unexpected MCP transport rejection: %#v", resp.Error)
+	}
+
+	mu.Lock()
+	instance := stubAgentInstance
+	mu.Unlock()
+	if instance == nil {
+		t.Fatalf("stub agent was not spawned")
+	}
+	select {
+	case params := <-instance.sessionNewCh:
+		t.Fatalf("unsupported MCP transport should not reach downstream session/new: %#v", params)
+	default:
+	}
+}
+
+func TestRunnerPreservesSupportedHTTPMCPServerTransport(t *testing.T) {
+	cfg := config.Default()
+	cfg.Agent.Command = "stub-agent"
+	runner := NewRunner(cfg)
+
+	caps := map[string]interface{}{
+		"mcpCapabilities": map[string]bool{
+			"http": true,
+			"sse":  false,
+		},
+	}
+
+	var (
+		mu                sync.Mutex
+		stubAgentInstance *stubAgent
+		spawnedConns      []net.Conn
+	)
+
+	runner.SetSpawnFunc(func(_ config.AgentConfig) (*Conn, *exec.Cmd, error) {
+		clientConn, serverConn := net.Pipe()
+
+		stubConn := NewConn(serverConn, serverConn)
+		mu.Lock()
+		spawnedConns = append(spawnedConns, clientConn, serverConn)
+		stubAgentInstance = newStubAgent(stubConn, "session_mcp_supported", caps)
+		mu.Unlock()
+		go func() {
+			_ = stubConn.Run()
+		}()
+
+		return NewConn(clientConn, clientConn), nil, nil
+	})
+
+	upstreamConn, runnerConn := net.Pipe()
+	upstream := NewConn(upstreamConn, upstreamConn)
+	go func() {
+		_ = upstream.Run()
+	}()
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- runner.Run(runnerConn, runnerConn)
+	}()
+
+	t.Cleanup(func() {
+		_ = upstreamConn.Close()
+		_ = runnerConn.Close()
+		mu.Lock()
+		conns := append([]net.Conn(nil), spawnedConns...)
+		mu.Unlock()
+		for _, conn := range conns {
+			_ = conn.Close()
+		}
+		select {
+		case <-runErr:
+		case <-time.After(time.Second):
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resp, err := upstream.Call(ctx, "session/new", map[string]interface{}{
+		"cwd": t.TempDir(),
+		"mcpServers": []map[string]interface{}{
+			{
+				"name": "remote",
+				"type": "http",
+				"url":  "https://mcp.example.com",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("session/new failed: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("session/new returned RPC error: %#v", resp.Error)
+	}
+
+	mu.Lock()
+	instance := stubAgentInstance
+	mu.Unlock()
+	if instance == nil {
+		t.Fatalf("stub agent was not spawned")
+	}
+	select {
+	case params := <-instance.sessionNewCh:
+		servers, ok := params["mcpServers"].([]interface{})
+		if !ok || len(servers) != 1 {
+			t.Fatalf("mcpServers not preserved: %#v", params["mcpServers"])
+		}
+		server, ok := servers[0].(map[string]interface{})
+		if !ok || server["type"] != "http" || server["url"] != "https://mcp.example.com" {
+			t.Fatalf("unexpected forwarded MCP server: %#v", servers[0])
 		}
 	case <-time.After(time.Second):
 		t.Fatalf("session/new was not forwarded to downstream")


### PR DESCRIPTION
## Summary
- Move ACP close handling to standard `session/close` first, with `_tldw/session/close` fallback for older runner builds.
- Store downstream ACP capabilities per runner session and reject HTTP/SSE MCP server transports unless the agent advertises the matching `mcpCapabilities`.
- Tighten ACP session setup validation for absolute `cwd`, MCP transport shape, absolute stdio commands, URL-backed transports, and env/header name-value normalization.

## Change summary
AI-generated draft: a human maintainer must replace this section before merge with their own explanation of what changed and why these implementation choices were made, per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

## Test Plan
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && PYTHONPATH=/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/acp-client-spec-conformance python -m compileall -q tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && PYTHONPATH=/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/acp-client-spec-conformance python -m pytest -q tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_request_schema.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py::test_acp_session_new_preserves_explicit_empty_mcp_servers tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py::test_acp_session_new_rejects_relative_cwd tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py::test_acp_session_new_rejects_relative_stdio_mcp_command tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_new_records_sanitized_audit_event`
- [x] `cd tools/tldw-agent && go test ./internal/acp -count=1`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py -f json -o /tmp/bandit_acp_client_spec_conformance.json` (`0` results/errors)
- [x] `git diff --check`

## Backlog
- TASK-2367

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened ACP client spec conformance by prioritizing standard `session/close`, tightening session setup validation, and gating HTTP/SSE MCP transports by downstream capabilities. Addresses TASK-2367 and blocks invalid configs from reaching agents.

- **New Features**
  - Use `session/close` with `_tldw/session/close` fallback; Go runner forwards when advertised (else cancels) and caches capabilities per session.
  - Validate session setup: absolute `cwd`; MCP transports `stdio` (absolute command), `http`, `sse`, `websocket` with strict URL schemes; normalize `env`/`headers` dicts to ACP name/value arrays.
  - Gate MCP servers: reject `http`/`sse` unless agent `mcpCapabilities` advertise support; preserve supported configs.

- **Bug Fixes**
  - Propagate JSON-RPC error codes via `ACPResponseError`; harden stdio/stream clients against missing pipes.
  - Fix env/header null handling and trim whitespace for `cwd`, commands, and URLs.

<sup>Written for commit 1b85c60a531a7a09bc81abcf9633ec9c9aa8bb6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

