### PR TITLE
Add MCP policy explain and profile tool preview

### DIFF
--- a/Docs/superpowers/plans/2026-06-17-mcp-effective-permission-explain-preview-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-17-mcp-effective-permission-explain-preview-implementation-plan.md
@@ -1,0 +1,914 @@
+# MCP Effective Permission Explain And Preview Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a read-only MCP gateway policy explanation and profile tool-preview surface for admin API and CLI users.
+
+**Architecture:** Add one package-owned `policy_explain` service that assembles redacted response models, strict audit events, and degraded-state metadata while delegating decisions to existing policy primitives. Keep model-facing tool discovery filtered, but add a public admin catalog provider for unfiltered preview rows. Expose the service through optional standalone gateway admin routes, remote admin client methods, and CLI commands.
+
+**Tech Stack:** Python 3.10+, Pydantic v2-compatible models, FastAPI optional gateway routes, argparse CLI, stdlib `urllib`, pytest.
+
+---
+
+## Reference Documents
+
+- Spec: `Docs/superpowers/specs/2026-06-16-mcp-effective-permission-explain-preview-design.md`
+- Backlog: `TASK-2369`
+
+## File Map
+
+Create:
+
+- `mcp_unified/gateway/policy_explain.py`
+  - Request/response models.
+  - Public service class.
+  - Strict audit append helper.
+  - Redaction helpers.
+  - Public `GatewayPolicyExplainError`.
+
+- `tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py`
+  - Unit coverage for service outcomes, audit, redaction, static/runtime mode, and degraded states.
+
+- `tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py`
+  - FastAPI route coverage for auth, permission, audit failure, validation, and success responses.
+
+- `tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py`
+  - CLI and remote admin client coverage.
+
+Modify:
+
+- `mcp_unified/gateway/tool_discovery.py`
+  - Add a public unfiltered admin catalog provider.
+  - Preserve current model-facing `list_profile_tools`, `search_profile_tools`, and direct-call behavior.
+
+- `mcp_unified/gateway/admin_auth.py`
+  - Add `GatewayAdminIdentity`.
+  - Add `GatewayAdminPermissionChecker` protocol and `DefaultGatewayAdminPermissionChecker`.
+  - Add an identity-producing dependency while preserving existing auth error responses.
+
+- `mcp_unified/gateway/fastapi.py`
+  - Add optional policy explain route mounting.
+  - Add route request/response schemas or import them from `policy_explain.py`.
+  - Use strict audit and stable error envelope.
+
+- `mcp_unified/gateway/remote_admin.py`
+  - Add `explain_policy` and `preview_profile_tools` client methods.
+  - Allow POST request bodies in `_request_json`.
+
+- `mcp_unified/gateway/cli.py`
+  - Add `explain-policy` and `preview-profile-tools`.
+  - Support local and remote modes.
+  - Support `--args-json`, `--args-json-file`, and `--args-stdin`.
+  - Leave `simulate-policy` unchanged.
+
+- `mcp_unified/gateway/__init__.py`
+  - Export the new service and admin auth types only if exports are useful to embedders.
+
+- `mcp_unified/README.md`
+  - Add a short admin policy explain section.
+
+- `mcp_unified/USER_GUIDE.md`
+  - Add user-facing examples for API and CLI usage.
+
+## Implementation Notes
+
+- Tests should live in `tldw_Server_API/tests/MCP_unified` because this checkout does not currently have a standalone `mcp_unified/tests` tree.
+- Activate the repo virtual environment before running Python commands:
+
+```bash
+source .venv/bin/activate
+```
+
+- Prefer small commits after each task if executing inline. If using subagent-driven execution, review and commit each task result before dispatching the next task.
+- Do not implement model-facing MCP permission explanation tools in this plan.
+- Do not change the behavior of `simulate-policy`.
+- Service dependency callables such as profile resolvers and catalog providers should accept either sync or async implementations. Normalize them inside `policy_explain.py` so CLI, tests, and FastAPI wiring do not need duplicate adapters.
+
+---
+
+### Task 1: Add Policy Explain Service Models, Redaction, And Strict Audit
+
+**Files:**
+- Create: `mcp_unified/gateway/policy_explain.py`
+- Create: `tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py`
+
+- [ ] **Step 1: Write failing service tests**
+
+Create `tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py` with tests for:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from mcp_unified.gateway.policy_explain import (
+    GatewayPolicyExplainError,
+    GatewayPolicyExplainService,
+    PolicyExplainRequest,
+    ProfileToolPreviewRequest,
+)
+from mcp_unified.profiles import MCPProfile, ProfilePolicy
+from mcp_unified.storage.models import AuditEvent
+
+
+class _MemoryAuditStore:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.events: list[AuditEvent] = []
+
+    async def append_event(self, event: AuditEvent) -> None:
+        if self.fail:
+            raise RuntimeError("audit backend failed")
+        self.events.append(event)
+
+
+def _profile() -> MCPProfile:
+    return MCPProfile(
+        id="backend-engineer",
+        name="Backend Engineer",
+        policy_document=ProfilePolicy(
+            allowed_tools=["fs.patch"],
+            denied_tools=["shell.exec"],
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_explain_tool_call_redacts_subjects_and_audits() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    response = await service.explain_tool_call(
+        PolicyExplainRequest(
+            profile_id="backend-engineer",
+            tool_name="fs.patch",
+            arguments={"path": "/Users/example/project/src/app.py"},
+        )
+    )
+
+    assert response.ok is True
+    assert response.final_outcome == "allow"
+    assert response.subjects[0].redaction_state in {"sanitized", "redacted"}
+    rendered = response.model_dump_json()
+    assert "/Users/example" not in rendered
+    assert audit.events[0].event_type == "policy.explain.requested"
+    assert "/Users/example" not in str(audit.events[0].payload)
+
+
+@pytest.mark.asyncio
+async def test_explain_tool_call_fails_closed_when_audit_append_fails() -> None:
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=_MemoryAuditStore(fail=True),
+        actor_id="operator-1",
+    )
+
+    with pytest.raises(GatewayPolicyExplainError) as exc_info:
+        await service.explain_tool_call(
+            PolicyExplainRequest(profile_id="backend-engineer", tool_name="fs.patch")
+        )
+
+    assert exc_info.value.reason_code == "audit_store_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_preview_requires_catalog_for_complete_denied_counts() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    response = await service.preview_profile_tools(
+        ProfileToolPreviewRequest(profile_id="backend-engineer")
+    )
+
+    assert response.degraded is True
+    assert "catalog_unavailable" in response.degraded_reasons
+    assert response.redacted is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py -v
+```
+
+Expected: FAIL because `mcp_unified.gateway.policy_explain` does not exist.
+
+- [ ] **Step 3: Implement minimal service module**
+
+Create `mcp_unified/gateway/policy_explain.py` with:
+
+- Pydantic models:
+  - `PolicyExplainMode`
+  - `PolicyExplainRequest`
+  - `ProfileToolPreviewRequest`
+  - `PolicyExplainSubject`
+  - `PolicyExplainResponse`
+  - `ProfileToolPreviewEntry`
+  - `ProfileToolPreviewSummary`
+  - `ProfileToolPreviewResponse`
+  - `PolicyExplainErrorResponse`
+- `GatewayPolicyExplainError`.
+- `GatewayPolicyExplainService`.
+- `_append_audit_event_strict`.
+- `_redact_subject_value`.
+
+Implementation rules:
+
+- `mode` defaults to `runtime_effective`.
+- `arguments` defaults to `{}` and is never stored directly.
+- Enforce a conservative serialized argument size cap, for example `64 * 1024` bytes.
+- Call `simulate_tool_call_policy` for single-call explain.
+- Call `explain_profile_tool_decision` to derive final tool-level outcome and visibility.
+- Convert simulator subject values to `PolicyExplainSubject` with `redaction_state`.
+- Build audit payload from redacted response data only.
+- Raise `GatewayPolicyExplainError(reason_code="audit_store_unavailable")` if `audit_store` is missing or append fails.
+
+- [ ] **Step 4: Run service tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_unified/gateway/policy_explain.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
+git commit -m "feat: add MCP policy explain service"
+```
+
+---
+
+### Task 2: Add Public Admin Tool Catalog Provider
+
+**Files:**
+- Modify: `mcp_unified/gateway/tool_discovery.py`
+- Modify: `tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py`
+
+- [ ] **Step 1: Add failing catalog/preview tests**
+
+Extend `test_standalone_policy_explain_service.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_preview_includes_denied_installed_tools_from_admin_catalog() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=audit,
+        actor_id="operator-1",
+        installed_tool_catalog=lambda: [
+            {
+                "name": "fs.patch",
+                "description": "Patch file",
+                "metadata": {"category": "filesystem"},
+            },
+            {
+                "name": "shell.exec",
+                "description": "Shell",
+                "metadata": {"category": "process"},
+            },
+        ],
+    )
+
+    response = await service.preview_profile_tools(
+        ProfileToolPreviewRequest(profile_id="backend-engineer")
+    )
+
+    by_name = {entry.tool_name: entry for entry in response.tools}
+    assert by_name["fs.patch"].outcome == "allow"
+    assert by_name["shell.exec"].outcome == "deny"
+    assert by_name["shell.exec"].visibility == "hidden"
+    assert response.degraded is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py::test_preview_includes_denied_installed_tools_from_admin_catalog -v
+```
+
+Expected: FAIL because the service/catalog hook does not yet produce unfiltered rows.
+
+- [ ] **Step 3: Add public catalog helpers**
+
+Modify `mcp_unified/gateway/tool_discovery.py`:
+
+- Add a public dataclass, for example `AdminToolCatalogEntry`.
+- Add `list_admin_tool_catalog(profile, backend_tools, *, include_recommendations=True)`.
+- Reuse existing normalization/sorting helpers where possible.
+- Do not call `_visible_entries` for the admin catalog if doing so would hide denied tools.
+- Keep existing exports and model-facing functions stable.
+
+- [ ] **Step 4: Wire service preview to the catalog provider**
+
+Modify `GatewayPolicyExplainService.preview_profile_tools`:
+
+- Prefer an injected `admin_tool_catalog_provider`.
+- Fall back to an injected `installed_tool_catalog` plus `list_admin_tool_catalog`.
+- Mark preview degraded with `catalog_unavailable` when neither is available.
+- Include denied installed tools by default.
+- Apply `limit`, `include_denied`, `include_recommendations`, and `category`.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_unified/gateway/tool_discovery.py mcp_unified/gateway/policy_explain.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
+git commit -m "feat: add admin tool preview catalog"
+```
+
+---
+
+### Task 3: Add Admin Identity And Permission Seam
+
+**Files:**
+- Modify: `mcp_unified/gateway/admin_auth.py`
+- Create: `tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py`
+
+- [ ] **Step 1: Write failing auth seam tests**
+
+Create `test_standalone_policy_explain_api.py` with tests that directly exercise the auth helpers first:
+
+```python
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from mcp_unified.gateway.admin_auth import (
+    DefaultGatewayAdminPermissionChecker,
+    GatewayAdminAuthConfig,
+    GatewayAdminIdentity,
+    GatewayAdminPermissionError,
+    GatewayAdminPermissionChecker,
+)
+
+
+def test_default_admin_identity_has_policy_explain_permission_when_auth_disabled() -> None:
+    identity = GatewayAdminIdentity.local_admin()
+
+    assert identity.actor_id == "local-admin"
+    assert "mcp.policy.explain" in identity.permissions
+
+
+@pytest.mark.asyncio
+async def test_permission_checker_denies_missing_policy_explain_permission() -> None:
+    checker = DefaultGatewayAdminPermissionChecker()
+    identity = GatewayAdminIdentity(actor_id="viewer", permissions=frozenset())
+
+    with pytest.raises(GatewayAdminPermissionError) as exc_info:
+        await checker.require_permission(identity, "mcp.policy.explain")
+
+    assert exc_info.value.reason_code == "admin_permission_denied"
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py -v
+```
+
+Expected: FAIL because the new identity and permission checker do not exist.
+
+- [ ] **Step 3: Implement auth seam**
+
+Modify `mcp_unified/gateway/admin_auth.py`:
+
+- Add `GatewayAdminIdentity`.
+- Add `GatewayAdminPermissionError`.
+- Add `GatewayAdminPermissionChecker` as a protocol.
+- Add `DefaultGatewayAdminPermissionChecker` as the concrete default implementation.
+- Add a default local admin identity helper.
+- Add an identity-producing dependency helper, for example `gateway_admin_identity_dependency(config)`.
+- Preserve `GatewayAdminAuthError`, `gateway_admin_auth_dependencies`, and current auth error response payloads.
+- Add a permission error response helper with the stable error envelope.
+
+- [ ] **Step 4: Run auth tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py -v
+```
+
+Expected: PASS for the auth seam tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_unified/gateway/admin_auth.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
+git commit -m "feat: add gateway admin permission seam"
+```
+
+---
+
+### Task 4: Mount Policy Explain Admin API Routes
+
+**Files:**
+- Modify: `mcp_unified/gateway/fastapi.py`
+- Modify: `mcp_unified/gateway/policy_explain.py`
+- Modify: `tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py`
+
+- [ ] **Step 1: Add failing API route tests**
+
+Extend `test_standalone_policy_explain_api.py` with:
+
+```python
+from mcp_unified.gateway.fastapi import create_gateway_app
+from mcp_unified.gateway.runtime import GatewayRequestContext
+from mcp_unified.profiles import MCPProfile, ProfilePolicy
+from mcp_unified.storage.models import AuditEvent
+
+
+class _Runtime:
+    name = "test-runtime"
+    version = "0.1"
+
+    async def list_tools(self, context: GatewayRequestContext) -> list[dict]:
+        return [
+            {"name": "fs.patch", "description": "Patch file", "metadata": {"category": "filesystem"}},
+            {"name": "shell.exec", "description": "Shell", "metadata": {"category": "process"}},
+        ]
+
+    async def call_tool(self, name: str, arguments: dict, context: GatewayRequestContext) -> dict:
+        raise AssertionError("policy explain must not execute tools")
+
+
+class _Audit:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.events: list[AuditEvent] = []
+
+    async def append_event(self, event: AuditEvent) -> None:
+        if self.fail:
+            raise RuntimeError("audit failed")
+        self.events.append(event)
+
+
+def _profile() -> MCPProfile:
+    return MCPProfile(
+        id="backend-engineer",
+        name="Backend Engineer",
+        policy_document=ProfilePolicy(allowed_tools=["fs.patch"], denied_tools=["shell.exec"]),
+    )
+
+
+def test_policy_explain_route_requires_admin_key() -> None:
+    app = create_gateway_app(
+        _Runtime(),
+        enable_policy_explain_management=True,
+        policy_explain_profile_resolver=lambda profile_id: _profile(),
+        policy_explain_audit_store=_Audit(),
+        admin_auth=GatewayAdminAuthConfig(enabled=True, api_key="secret"),
+    )
+    client = TestClient(app)
+
+    response = client.post("/mcp/policy/explain", json={"profile_id": "backend-engineer", "tool_name": "fs.patch"})
+
+    assert response.status_code == 401
+    assert response.json()["reason_code"] == "admin_auth_required"
+
+
+def test_policy_explain_route_success_audits() -> None:
+    audit = _Audit()
+    app = create_gateway_app(
+        _Runtime(),
+        enable_policy_explain_management=True,
+        policy_explain_profile_resolver=lambda profile_id: _profile(),
+        policy_explain_audit_store=audit,
+        admin_auth=GatewayAdminAuthConfig(enabled=True, api_key="secret"),
+    )
+    client = TestClient(app)
+
+    response = client.post(
+        "/mcp/policy/explain",
+        headers={"X-MCP-Gateway-Admin-Key": "secret"},
+        json={"profile_id": "backend-engineer", "tool_name": "fs.patch", "arguments": {"path": "src/app.py"}},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["final_outcome"] == "allow"
+    assert audit.events[0].event_type == "policy.explain.requested"
+
+
+def test_policy_preview_route_includes_denied_tool() -> None:
+    audit = _Audit()
+    app = create_gateway_app(
+        _Runtime(),
+        enable_policy_explain_management=True,
+        policy_explain_profile_resolver=lambda profile_id: _profile(),
+        policy_explain_audit_store=audit,
+    )
+    client = TestClient(app)
+
+    response = client.post("/mcp/profiles/backend-engineer/tool-preview", json={})
+
+    assert response.status_code == 200
+    by_name = {tool["tool_name"]: tool for tool in response.json()["tools"]}
+    assert by_name["shell.exec"]["outcome"] == "deny"
+```
+
+- [ ] **Step 2: Run route tests to verify failure**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py -v
+```
+
+Expected: FAIL because `create_gateway_app` does not accept policy explain args and routes are not mounted.
+
+- [ ] **Step 3: Add route mounting and service resolution**
+
+Modify `mcp_unified/gateway/fastapi.py`:
+
+- Add optional args to `create_gateway_router` and `create_gateway_app`:
+  - `enable_policy_explain_management: bool = False`
+  - `policy_explain_service: GatewayPolicyExplainService | None = None`
+  - `policy_explain_profile_resolver: Callable[[str], MCPProfile | Awaitable[MCPProfile | None]] | None = None`
+  - `policy_explain_audit_store: AuditStore | None = None`
+  - `policy_explain_permission_checker: GatewayAdminPermissionChecker | None = None`
+- Add `_mount_policy_explain_routes`.
+- Use POST `/policy/explain`.
+- Use POST `/profiles/{profile_id}/tool-preview`.
+- Use `runtime.list_tools` with a neutral `GatewayRequestContext` as the installed tool catalog provider.
+- Return the stable policy explain error envelope for `GatewayPolicyExplainError` and permission errors.
+- Preserve existing `GatewayAdminAuthError` behavior.
+
+- [ ] **Step 4: Run API tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_unified/gateway/fastapi.py mcp_unified/gateway/policy_explain.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
+git commit -m "feat: expose MCP policy explain admin API"
+```
+
+---
+
+### Task 5: Add Remote Admin Client And CLI Commands
+
+**Files:**
+- Modify: `mcp_unified/gateway/remote_admin.py`
+- Modify: `mcp_unified/gateway/cli.py`
+- Modify: `tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py`
+
+- [ ] **Step 1: Write failing remote client and CLI tests**
+
+Create `test_standalone_policy_explain_cli.py`:
+
+```python
+from __future__ import annotations
+
+import io
+import json
+from argparse import Namespace
+from pathlib import Path
+from typing import Any
+
+from mcp_unified.gateway import cli as gateway_cli
+from mcp_unified.gateway.remote_admin import RemoteGatewayAdminClient, RemoteGatewayAdminConfig
+
+
+class _Response:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self) -> "_Response":
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.payload
+
+
+def test_remote_admin_client_posts_policy_explain_body() -> None:
+    seen: dict[str, Any] = {}
+
+    def opener(request: Any, timeout: float) -> _Response:
+        seen["url"] = request.full_url
+        seen["method"] = request.get_method()
+        seen["data"] = json.loads(request.data.decode("utf-8"))
+        return _Response({"ok": True})
+
+    client = RemoteGatewayAdminClient(
+        RemoteGatewayAdminConfig(gateway_url="http://localhost/mcp", admin_key="secret"),
+        opener=opener,
+    )
+
+    assert client.explain_policy({"profile_id": "backend-engineer", "tool_name": "fs.patch"}) == {"ok": True}
+    assert seen["url"].endswith("/policy/explain")
+    assert seen["method"] == "POST"
+    assert seen["data"]["tool_name"] == "fs.patch"
+
+
+def test_cli_args_json_file_avoids_command_line_json(tmp_path: Path) -> None:
+    args_path = tmp_path / "args.json"
+    args_path.write_text('{"path":"src/app.py"}', encoding="utf-8")
+
+    parsed = gateway_cli._policy_explain_arguments_from_args(
+        Namespace(args_json=None, args_json_file=str(args_path), args_stdin=False)
+    )
+
+    assert parsed == {"path": "src/app.py"}
+```
+
+- [ ] **Step 2: Run CLI tests to verify failure**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py -v
+```
+
+Expected: FAIL because remote methods and CLI parsing helpers do not exist.
+
+- [ ] **Step 3: Extend remote admin client**
+
+Modify `mcp_unified/gateway/remote_admin.py`:
+
+- Change `_request_json` to accept optional `payload: Mapping[str, Any] | None = None`.
+- Serialize provided payload for POST requests.
+- Add:
+  - `def explain_policy(self, payload: Mapping[str, Any]) -> dict[str, Any]`
+  - `def preview_profile_tools(self, profile_id: str, payload: Mapping[str, Any]) -> dict[str, Any]`
+
+- [ ] **Step 4: Add CLI subcommands**
+
+Modify `mcp_unified/gateway/cli.py`:
+
+- Register:
+  - `explain-policy`
+  - `preview-profile-tools`
+- Add shared args:
+  - `--profile`
+  - `--gateway-url`
+  - `--admin-key`
+  - `--admin-header-name`
+  - `--static-policy-only`
+  - `--session-id`
+- Add explain args:
+  - `--tool`
+  - `--args-json`
+  - `--args-json-file`
+  - `--args-stdin`
+  - `--capability`
+- Add preview args:
+  - `--category`
+  - `--include-recommendations`
+  - `--exclude-recommendations`
+  - `--include-denied`
+  - `--exclude-denied`
+  - `--limit`
+- Local mode should build `GatewayPolicyExplainService` from the same config/storage helpers used by `simulate-policy`.
+- Remote mode should call `RemoteGatewayAdminClient`.
+- Emit JSON to stdout on success and stderr on errors.
+
+- [ ] **Step 5: Run CLI tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_unified/gateway/remote_admin.py mcp_unified/gateway/cli.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py
+git commit -m "feat: add MCP policy explain CLI"
+```
+
+---
+
+### Task 6: Export Public Types And Update Package Docs
+
+**Files:**
+- Modify: `mcp_unified/gateway/__init__.py`
+- Modify: `mcp_unified/README.md`
+- Modify: `mcp_unified/USER_GUIDE.md`
+
+- [ ] **Step 1: Add minimal export smoke test**
+
+Add to `test_standalone_policy_explain_service.py`:
+
+```python
+def test_policy_explain_public_exports() -> None:
+    from mcp_unified.gateway import GatewayPolicyExplainService, PolicyExplainRequest
+
+    assert GatewayPolicyExplainService is not None
+    assert PolicyExplainRequest is not None
+```
+
+- [ ] **Step 2: Run export test to verify failure if exports are missing**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py::test_policy_explain_public_exports -v
+```
+
+Expected: FAIL if exports are not present.
+
+- [ ] **Step 3: Add exports**
+
+Modify `mcp_unified/gateway/__init__.py`:
+
+- Export `GatewayPolicyExplainService`.
+- Export `PolicyExplainRequest`.
+- Export `ProfileToolPreviewRequest`.
+- Export `GatewayPolicyExplainError`.
+- Keep lazy import style if adding direct imports would create optional dependency problems.
+
+- [ ] **Step 4: Update docs**
+
+Modify `mcp_unified/README.md` and `mcp_unified/USER_GUIDE.md` with:
+
+- What `explain-policy` does.
+- What `preview-profile-tools` does.
+- Local CLI example.
+- Remote CLI example.
+- Admin API examples.
+- Security notes: audited, redacted, no raw arguments echoed, `--args-json-file` or `--args-stdin` preferred for sensitive arguments.
+
+- [ ] **Step 5: Run export test**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py::test_policy_explain_public_exports -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_unified/gateway/__init__.py mcp_unified/README.md mcp_unified/USER_GUIDE.md tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
+git commit -m "docs: document MCP policy explain surface"
+```
+
+---
+
+### Task 7: Full Verification And Security Scan
+
+**Files:**
+- No new source files expected.
+- May update tests or docs only if verification reveals issues.
+
+- [ ] **Step 1: Run focused standalone policy explain tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py \
+  tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py \
+  tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py \
+  -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run related gateway regression tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/MCP_unified/test_mcp_http_auth_paths.py \
+  tldw_Server_API/tests/MCP_unified/test_mcp_config_sanitization.py \
+  -v
+```
+
+Expected: PASS or only pre-existing unrelated failures documented with exact failure names.
+
+- [ ] **Step 3: Run package import smoke**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python - <<'PY'
+from mcp_unified.gateway import GatewayPolicyExplainService, PolicyExplainRequest
+print(GatewayPolicyExplainService.__name__, PolicyExplainRequest.__name__)
+PY
+```
+
+Expected output:
+
+```text
+GatewayPolicyExplainService PolicyExplainRequest
+```
+
+- [ ] **Step 4: Run Bandit on touched package scope**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r \
+  mcp_unified/gateway/policy_explain.py \
+  mcp_unified/gateway/tool_discovery.py \
+  mcp_unified/gateway/admin_auth.py \
+  mcp_unified/gateway/fastapi.py \
+  mcp_unified/gateway/remote_admin.py \
+  mcp_unified/gateway/cli.py \
+  -f json -o /tmp/bandit_mcp_policy_explain.json
+```
+
+Expected: no new findings in touched code. If Bandit reports findings, fix changed-code findings before finishing.
+
+- [ ] **Step 5: Run diff checks**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors. Status should show only intended changes before final commit or be clean after commits.
+
+- [ ] **Step 6: Final commit if verification required fixes**
+
+If verification caused edits:
+
+```bash
+git add mcp_unified/gateway tldw_Server_API/tests/MCP_unified mcp_unified/README.md mcp_unified/USER_GUIDE.md
+git commit -m "test: verify MCP policy explain surface"
+```
+
+If no edits were needed, do not create an empty commit.
+
+---
+
+## Execution Handoff
+
+Recommended execution mode: **Subagent-Driven**. The tasks have clear boundaries and can be reviewed one at a time:
+
+1. Service and strict audit.
+2. Admin catalog provider.
+3. Auth permission seam.
+4. FastAPI routes.
+5. Remote client and CLI.
+6. Docs and exports.
+7. Verification.
+
+Use inline execution only if the current session needs to keep all edits local.

--- a/Docs/superpowers/specs/2026-06-16-mcp-effective-permission-explain-preview-design.md
+++ b/Docs/superpowers/specs/2026-06-16-mcp-effective-permission-explain-preview-design.md
@@ -1,0 +1,705 @@
+# MCP Effective Permission Explain And Preview Design
+
+Date: 2026-06-16
+Status: Draft for spec review
+Owner: Codex brainstorming session
+Backlog: TASK-2368
+
+## Summary
+
+Add a read-only policy explanation surface for the standalone MCP gateway so operators can answer two questions before exposing tools to models:
+
+1. Why would this specific profile, tool, and argument set be denied, require approval, or be allowed?
+2. Which tools would a profile see by default, including tools hidden by policy and tools recommended but not installed?
+
+The first implementation should provide an admin API and CLI, backed by a shared `mcp_unified.gateway.policy_explain` service. The service should reuse the existing policy simulation, decision, session grant, and discovery primitives instead of creating a second enforcement engine.
+
+The output is for operators and automation, not for model context by default. It must be redacted, audit every request, support runtime-effective and static-policy-only views, and degrade explicitly when a complete tool catalog or runtime state cannot be resolved.
+
+## User-Approved Decisions
+
+- First surface: admin API plus CLI.
+- Explain scope: both a single attempted tool call and profile-wide preview.
+- Profile-wide preview depth for V1: tool visibility only.
+- Runtime mode: runtime-effective by default, with optional static-policy-only mode.
+- CLI modes: local config/store mode and remote running-gateway admin API mode.
+- Authorization boundary: dedicated permission for policy explanation, separate from mutation admin.
+- Audit behavior: always audit policy explanation and preview requests.
+- Denied tools in profile preview: included by default because this is an admin/operator surface.
+- Architecture approach: shared `policy_explain` service used by API and CLI.
+
+## Goals
+
+- Provide a reliable answer for effective permission decisions without changing runtime enforcement semantics.
+- Make profile debugging practical by showing matched rule sources, normalized subjects, transient grant participation, install state, runtime availability, and final decision.
+- Keep the policy core executable and flat, while leaving room for authored hierarchical policies to compile into effective grants later.
+- Allow tldw_server and standalone gateway deployments to delegate policy explanation without granting full admin mutation rights.
+- Preserve compatibility with the existing `simulate-policy` CLI command.
+- Avoid leaking file contents, raw arguments, secrets, absolute host paths, or sensitive URL parts through responses or audit events.
+- Make degraded and partial answers explicit enough for CI, operators, and UI surfaces to reason about.
+
+## Non-Goals
+
+- Do not implement model-facing MCP tools for permission explanation in the first slice.
+- Do not add a web UI in the first slice.
+- Do not replace runtime policy enforcement, permission rules, session grants, approval leases, or hook enforcement.
+- Do not add hierarchical policy authoring in this slice.
+- Do not add shell alias parsing in this slice.
+- Do not expose raw tool arguments, raw shell commands, file contents, diffs, credential values, or host-absolute paths.
+- Do not require semantic search for preview or ranking.
+
+## Current Repo Foundation
+
+The current MCP unified module already has most of the policy primitives needed for an explain surface:
+
+- `mcp_unified.gateway.policy_simulation.simulate_tool_call_policy` provides read-only simulation for a candidate tool call.
+- `mcp_unified.profiles.decisions.PolicyDecisionOutcome` defines `deny`, `ask`, and `allow`.
+- `mcp_unified.profiles.decisions.explain_profile_tool_decision` explains static profile tool policy decisions.
+- `mcp_unified.profiles.subjects.extract_permission_rule_subjects` extracts policy subjects from tool arguments.
+- `mcp_unified.profiles.effective_policy.build_effective_policy_result` builds effective profile policy state.
+- Existing gateway storage bundles can include an `AuditStore`.
+- Existing gateway CLI has local profile storage and remote gateway admin client patterns.
+- Existing tool discovery surfaces filter denied or hidden tools for model-facing use.
+- Existing standalone admin auth validates API keys but does not yet expose an identity or permission result to route handlers.
+- Several existing gateway managers treat audit as best-effort. This feature must use a stricter audit path because the user-approved contract requires every explain or preview request to be audited.
+
+The important design consequence is that admin preview cannot rely only on model-facing `list_profile_tools` output. That API intentionally hides denied tools, while this feature must explain both visible and denied tools. A complete admin preview needs an unfiltered tool catalog input. When that catalog is unavailable, the preview must return a degraded response rather than pretending the filtered model-facing catalog is complete.
+
+## Design Review Hardening Incorporated
+
+The design includes the following hardening points from review:
+
+- Explicit outcome precedence: `deny` wins over `ask`, and `ask` wins over `allow`.
+- Separate permission modes are represented by the effective policy state rather than by new explain-only semantics.
+- Path subjects are normalized and redacted before response or audit.
+- Symlink, path grant, hook, sandbox, and shell parsing enforcement are outside this slice, but explain output must leave room to display those decision contributors once implemented.
+- Hook decisions, when present in future runtime traces, must not bypass explicit deny rules.
+- Dedicated tools remain preferred over shell escape hatches.
+- MCP server and tool wildcard subjects should be explainable using existing profile subject forms.
+- The response contract must answer why a tool, path, domain, or other subject is allowed or denied, including rule source, hook result when applicable, and final decision.
+
+## Proposed Architecture
+
+Add a shared read-only service module:
+
+```text
+mcp_unified/gateway/policy_explain.py
+```
+
+The service owns response model assembly, redaction, degraded-state reporting, and audit event emission. It delegates policy decisions to existing policy primitives.
+
+```mermaid
+flowchart LR
+    CLI["CLI local or remote"] --> Service["policy_explain service"]
+    API["Admin API routes"] --> Service
+    Service --> Sim["simulate_tool_call_policy"]
+    Service --> Decisions["profile decision helpers"]
+    Service --> Grants["policy grant/session stores"]
+    Service --> Catalog["unfiltered tool catalog"]
+    Service --> Audit["AuditStore"]
+    RemoteCLI["Remote CLI mode"] --> AdminAPI["Gateway admin API"]
+```
+
+The service should be dependency-injected with:
+
+- Profile store or resolved profile.
+- Optional policy grant store.
+- Optional approval/session grant resolver.
+- Optional unfiltered tool catalog provider.
+- Optional runtime status provider.
+- Required audit store for API mode and local CLI V1.
+- Strict audit helper that returns success or raises a public policy-explain error.
+- Actor/request metadata.
+
+The service should not execute tools, mutate profile state, install packages, or make network calls other than through explicitly provided runtime/admin clients.
+
+The implementation should add a public unfiltered catalog provider for admin use instead of calling private discovery helpers such as `_visible_entries`. Model-facing discovery should remain filtered.
+
+## Service Contract
+
+V1 service operations:
+
+```python
+async def explain_tool_call(request: PolicyExplainRequest) -> PolicyExplainResponse:
+    raise NotImplementedError
+
+async def preview_profile_tools(request: ProfileToolPreviewRequest) -> ProfileToolPreviewResponse:
+    raise NotImplementedError
+```
+
+### `PolicyExplainRequest`
+
+Required fields:
+
+- `profile_id`
+- `tool_name`
+
+Optional fields:
+
+- `arguments`: accepted only for transient subject extraction.
+- `capability`: optional capability override when the caller already knows it.
+- `session_id`: used for runtime-effective session grants.
+- `mode`: `runtime_effective` by default or `static_policy_only`.
+- `include_degraded_details`: defaults to true for admin surfaces.
+
+Argument handling:
+
+- Request argument payloads should have a conservative byte-size cap.
+- Oversized argument payloads should fail before policy evaluation with a structured validation error.
+- Raw arguments should be discarded immediately after subject extraction.
+
+### `ProfileToolPreviewRequest`
+
+Required fields:
+
+- `profile_id`
+
+Optional fields:
+
+- `mode`: `runtime_effective` by default or `static_policy_only`.
+- `session_id`
+- `category`
+- `include_recommendations`: defaults to true.
+- `include_denied`: defaults to true.
+- `limit`: defaults to 200.
+- `cursor`
+
+Hard cap:
+
+- `limit` must be capped by configuration, with a recommended V1 hard cap of 1000.
+
+## Admin API Surface
+
+Add admin API endpoints under the existing gateway admin router:
+
+```http
+POST /policy/explain
+POST /profiles/{profile_id}/tool-preview
+```
+
+The concrete mount path follows the existing gateway router prefix. The endpoint names should avoid implying mutation. The preview endpoint uses `POST` even though it is read-only because request bodies are safer for `session_id`, filters, and future policy subjects than query strings that are commonly logged.
+
+### `POST /policy/explain`
+
+Request body:
+
+```json
+{
+  "profile_id": "backend-engineer",
+  "tool_name": "fs.patch",
+  "arguments": {
+    "path": "src/app.py"
+  },
+  "session_id": "optional-session",
+  "mode": "runtime_effective"
+}
+```
+
+Response:
+
+```json
+{
+  "ok": true,
+  "mode": "runtime_effective",
+  "evaluated_at": "2026-06-16T20:00:00Z",
+  "profile_id": "backend-engineer",
+  "tool_name": "fs.patch",
+  "final_outcome": "allow",
+  "visibility": "visible",
+  "reason_code": "allowed_by_profile_rule",
+  "subjects": [
+    {
+      "kind": "path",
+      "value": "src/app.py",
+      "redaction_state": "sanitized",
+      "decision": "allow",
+      "matched_rules": [
+        {
+          "source": "profile.path_grant",
+          "outcome": "allow",
+          "pattern": "src/**"
+        }
+      ]
+    }
+  ],
+  "installation_status": "installed",
+  "runtime_availability": "available",
+  "transient_grants_evaluated": true,
+  "degraded": false,
+  "degraded_reasons": [],
+  "skipped_contributors": [],
+  "redacted": true,
+  "truncated": false
+}
+```
+
+### `POST /profiles/{profile_id}/tool-preview`
+
+Path parameters:
+
+- `profile_id`
+
+Request body:
+
+- `mode`
+- `session_id`
+- `category`
+- `include_recommendations`
+- `include_denied`
+- `limit`
+- `cursor`
+
+The path `profile_id` is canonical. If a future body schema also accepts `profile_id`, a conflicting value must fail validation instead of silently selecting one.
+
+Response:
+
+```json
+{
+  "ok": true,
+  "mode": "runtime_effective",
+  "evaluated_at": "2026-06-16T20:00:00Z",
+  "profile_id": "backend-engineer",
+  "summary": {
+    "visible": 42,
+    "hidden": 8,
+    "deferred": 3,
+    "allow": 38,
+    "ask": 4,
+    "deny": 8,
+    "not_installed": 3
+  },
+  "tools": [
+    {
+      "tool_name": "fs.patch",
+      "display_name": "Patch file",
+      "category": "filesystem",
+      "outcome": "allow",
+      "visibility": "visible",
+      "reason_code": "allowed_by_profile_rule",
+      "installation_status": "installed",
+      "runtime_availability": "available"
+    },
+    {
+      "tool_name": "shell.exec",
+      "display_name": "Shell",
+      "category": "process",
+      "outcome": "deny",
+      "visibility": "hidden",
+      "reason_code": "denied_by_profile_rule",
+      "installation_status": "installed",
+      "runtime_availability": "available"
+    },
+    {
+      "tool_name": "mcp__chrome-devtools__navigate",
+      "display_name": "Chrome DevTools navigate",
+      "category": "browser",
+      "outcome": "ask",
+      "visibility": "deferred",
+      "reason_code": "recommended_not_installed",
+      "installation_status": "not_installed",
+      "runtime_availability": "unknown"
+    }
+  ],
+  "degraded": false,
+  "degraded_reasons": [],
+  "skipped_contributors": [],
+  "redacted": true,
+  "truncated": false,
+  "next_cursor": null
+}
+```
+
+## CLI Surface
+
+Add CLI commands that call the same service in local mode and call the admin API in remote mode:
+
+```bash
+mcp-unified explain-policy --profile backend-engineer --tool fs.patch --args-json '{"path":"src/app.py"}'
+mcp-unified preview-profile-tools --profile backend-engineer --include-denied
+```
+
+Remote mode:
+
+```bash
+mcp-unified explain-policy \
+  --gateway-url http://127.0.0.1:8000 \
+  --admin-key "$MCP_GATEWAY_ADMIN_KEY" \
+  --profile backend-engineer \
+  --tool fs.patch \
+  --args-json '{"path":"src/app.py"}'
+```
+
+CLI requirements:
+
+- JSON output is the only required V1 format.
+- Remote mode should extend `RemoteGatewayAdminClient`.
+- Local mode should reuse the same storage bundle loading patterns as existing gateway CLI commands.
+- `--static-policy-only` maps to `mode=static_policy_only`.
+- `--session-id` enables runtime-effective transient grant checks where configured.
+- `--args-json` is acceptable for low-sensitivity examples, but the CLI should also support `--args-json-file` and `--args-stdin` so sensitive arguments do not have to appear in shell history or process listings.
+- Existing `simulate-policy` remains unchanged for backwards compatibility.
+
+## Authorization Model
+
+Add a dedicated permission seam for admin policy explanation:
+
+```text
+mcp.policy.explain
+```
+
+Standalone default:
+
+- If admin auth is enabled and the provided admin credential is valid, grant `mcp.policy.explain` unless a custom permission checker is configured.
+- If admin auth is disabled, the default standalone identity is an explicit local admin identity so audit records still have a stable actor source.
+
+tldw_server integration:
+
+- The host should be able to map `mcp.policy.explain` to its AuthNZ/RBAC model without granting broader profile, credential, install, or runtime mutation permissions.
+
+Recommended implementation shape:
+
+```python
+class GatewayAdminIdentity(BaseModel):
+    actor_id: str
+    permissions: frozenset[str] = frozenset()
+    source: str = "gateway_admin_auth"
+
+class GatewayAdminPermissionChecker(Protocol):
+    async def require_permission(
+        self,
+        identity: GatewayAdminIdentity,
+        permission: str,
+        *,
+        resource: str | None = None,
+    ) -> None:
+        raise NotImplementedError
+```
+
+Policy explanation routes should require both:
+
+- Successful gateway admin authentication.
+- `mcp.policy.explain`.
+
+This seam should not relax existing mutation admin authorization. It exists so hosted deployments can delegate read-only permission debugging to operators without granting full mutation power.
+
+The current `gateway_admin_auth_dependencies` shape returns route dependencies that only validate credentials. The implementation should add an identity-producing dependency or request-state adapter for policy-explain routes, while preserving the current auth error payloads and `create_gateway_router` exception handling.
+
+## Audit Model
+
+Policy explanation and preview requests must always be audited.
+
+Use the existing `AuditStore` and `AuditEvent` model rather than adding a separate audit writer.
+
+Do not reuse best-effort audit helpers that swallow append failures. Policy explanation must use a strict append helper because audit failure is a hard failure for this surface.
+
+Event types:
+
+- `policy.explain.requested`
+- `policy.preview_tools.requested`
+
+Required audit fields:
+
+- `actor_id`: admin identity if known, otherwise a stable local CLI actor marker.
+- `profile_id`
+- `target_type`: `tool` for single explain, `profile` for preview.
+- `target_id`: tool name or profile id.
+- `payload`: redacted metadata only.
+- `created_at`: store through existing audit store behavior.
+
+Allowed payload fields:
+
+- request mode.
+- session id hash or presence marker, not raw session id if considered sensitive by host policy.
+- requested tool name.
+- normalized subject kinds and redacted values.
+- final outcome.
+- reason code.
+- degraded flag and degraded reason codes.
+- result counts for preview.
+- truncation flag.
+
+Disallowed audit payload fields:
+
+- raw arguments.
+- file contents.
+- diffs.
+- credential values.
+- environment variables.
+- raw shell commands.
+- absolute host paths.
+- URL query strings or fragments.
+- request bodies from remote MCP tools.
+
+Fail-closed behavior:
+
+- Admin API requests fail with a structured `audit_store_unavailable` error if no audit store is configured.
+- Local CLI V1 also fails with `audit_store_unavailable` when no audit store can be resolved.
+- Failed audit writes prevent returning a successful response with policy details.
+- No unsafe unaudited override is included in V1.
+
+## Decision Semantics
+
+The service must report the final decision using existing policy precedence:
+
+```text
+deny > ask > allow
+```
+
+Runtime-effective mode includes:
+
+- Static profile tool grants and deny rules.
+- Permission rules and extracted subjects from supplied arguments.
+- Session-scoped TTL path grants.
+- Active approval leases for ask subjects, if currently represented by the runtime.
+- Install status where available.
+- Runtime availability where available.
+
+Static-policy-only mode includes:
+
+- Static profile tool grants and deny rules.
+- Static permission rules.
+- Extracted subjects from supplied arguments.
+
+Static-policy-only mode excludes:
+
+- Session-scoped TTL grants.
+- Runtime approval leases.
+- Live upstream process availability.
+
+The response must state which contributors were skipped in static mode.
+
+Static-policy-only mode is not inherently degraded. It should set `degraded=false` when the static answer is complete and include a `skipped_contributors` list to make the intentionally omitted runtime contributors explicit.
+
+Missing tool behavior:
+
+- A single-call explain request for an unknown tool should still return an explanation with `installation_status=not_installed` or `unknown`, depending on catalog data.
+- The policy decision should be reported separately from installation state so operators can see whether a tool would be allowed if installed.
+
+## Response Contract
+
+All response models should include:
+
+- `ok`
+- `mode`
+- `evaluated_at`
+- `profile_id`
+- `degraded`
+- `degraded_reasons`
+- `skipped_contributors`
+- `redacted`
+- `truncated`
+
+Single-call responses should include:
+
+- `tool_name`
+- `final_outcome`
+- `visibility`
+- `reason_code`
+- `subjects`
+- `installation_status`
+- `runtime_availability`
+- `transient_grants_evaluated`
+- `matched_rules`
+- `approval_context`, when applicable and safe.
+
+Profile preview responses should include:
+
+- `summary`
+- `tools`
+- `next_cursor`
+
+Tool preview entries should include:
+
+- `tool_name`
+- `display_name`, when safe and known.
+- `category`, when known.
+- `outcome`
+- `visibility`
+- `reason_code`
+- `installation_status`
+- `runtime_availability`
+- `recommendation_source`, when the row comes from recommendation metadata.
+
+Allowed enum values:
+
+```text
+mode: runtime_effective | static_policy_only
+outcome: deny | ask | allow
+visibility: visible | hidden | deferred
+installation_status: installed | not_installed | unknown
+runtime_availability: available | unavailable | unknown | not_applicable
+redaction_state: raw_safe | sanitized | redacted | omitted
+```
+
+Recommended reason codes:
+
+```text
+allowed_by_profile_rule
+allowed_by_session_grant
+allowed_by_approval_lease
+ask_by_profile_rule
+ask_by_permission_rule
+denied_by_profile_rule
+denied_by_permission_rule
+denied_by_hook
+denied_by_missing_grant
+hidden_by_policy
+recommended_not_installed
+tool_not_found
+catalog_unavailable
+filtered_catalog_only
+argument_required
+arguments_too_large
+runtime_state_unavailable
+audit_store_unavailable
+```
+
+Reason codes should remain stable because they will be used by tests, dashboards, CI policy checks, and future UI affordances.
+
+Error responses should use the same stable envelope across API and CLI:
+
+```json
+{
+  "ok": false,
+  "reason_code": "audit_store_unavailable",
+  "message": "Policy explanation requires an audit store.",
+  "details": {
+    "profile_id": "backend-engineer"
+  }
+}
+```
+
+Error details must follow the same redaction rules as successful responses.
+
+## Profile Tool Preview Semantics
+
+Profile-wide preview is an admin/operator view. It should include denied and hidden tools by default, with a flag to suppress them for compact output.
+
+Tool rows should be assembled from:
+
+- Installed internal tools.
+- Installed external MCP tools.
+- Profile recommendation catalog entries.
+- Category metadata where available.
+
+Ordering:
+
+1. Installed tools before not-installed recommendations.
+2. Category filter applied before text filtering if text filtering is later added.
+3. Stable lexical sort by category and tool name for deterministic CLI output.
+
+Completeness rules:
+
+- If an unfiltered installed-tool catalog is available, preview can be complete.
+- If only the model-facing filtered discovery surface is available, preview is degraded with `catalog_unavailable` or `filtered_catalog_only`.
+- Degraded preview must not claim denied count accuracy.
+
+V1 should not evaluate every possible path, URL, or argument-sensitive rule for profile-wide preview. Argument-sensitive tools should be marked as `deferred` when a final answer requires call arguments.
+
+## Degraded State Handling
+
+Degraded responses are allowed only when the answer is still useful and safely bounded.
+
+Examples:
+
+- Runtime status provider unavailable.
+- External MCP server state unavailable.
+- Installed tool catalog unavailable for profile-wide preview.
+- Recommendation catalog unavailable.
+- Arguments omitted for an argument-sensitive rule.
+
+Each degraded response must include:
+
+- `degraded=true`
+- machine-readable `degraded_reasons`
+- safe human-readable detail if available.
+
+Hard failures:
+
+- Profile not found.
+- Invalid JSON arguments.
+- Argument payload over the configured byte-size cap.
+- Unauthorized or missing `mcp.policy.explain`.
+- Missing audit store.
+- Limit above hard cap after normalization.
+
+## Security And Redaction Rules
+
+Raw arguments are toxic. The service may accept arguments for subject extraction, but must not persist them or echo them.
+
+Redaction requirements:
+
+- Host-absolute paths are normalized to workspace-relative or policy-subject paths where possible.
+- Paths outside known workspaces are redacted to a stable marker.
+- URL query strings and fragments are removed.
+- Shell command strings are never returned in V1.
+- Credential, token, cookie, key, password, and secret-like fields are replaced with redaction markers.
+- File content, diffs, receipts, and hashes are not included.
+- Environment variable values are not included.
+- Subject entries should use `redaction_state` rather than a boolean flag so callers can distinguish safe raw values, sanitized values, redacted values, and omitted values.
+
+Audit events must follow the same redaction contract as responses.
+
+The explain surface should not become a side channel for enumerating host filesystem paths or credentials. Operators can see tool names and policy subjects, but not sensitive values.
+
+## Testing Strategy
+
+Unit tests:
+
+- `deny > ask > allow` precedence is preserved.
+- Static-policy-only mode skips transient grants and reports skipped contributors.
+- Runtime-effective mode includes session-scoped grants when configured.
+- Argument-sensitive path subjects are extracted, normalized, and redacted.
+- Raw arguments are not present in responses or audit payloads.
+- Unknown tool responses distinguish policy decision from installation state.
+- Profile preview includes denied tools by default.
+- Profile preview marks argument-sensitive rows as `deferred`.
+- Degraded catalog state does not report denied counts as complete.
+- Limit normalization and hard-cap errors are deterministic.
+
+FastAPI route tests:
+
+- Admin auth failure returns intended auth payload.
+- Authenticated identity without `mcp.policy.explain` is denied.
+- Successful explain request writes `policy.explain.requested`.
+- Successful preview request writes `policy.preview_tools.requested`.
+- Missing audit store fails closed.
+- Audit append exceptions fail closed and do not return successful policy details.
+- Preview accepts body parameters without requiring sensitive session data in query strings.
+- Preview rejects conflicting path/body profile ids if body profile ids are later supported.
+
+CLI tests:
+
+- Local `explain-policy` prints JSON.
+- Local `preview-profile-tools` prints JSON with denied rows by default.
+- Remote mode calls `RemoteGatewayAdminClient`.
+- `--static-policy-only` maps to the correct mode.
+- `--args-json-file` and `--args-stdin` avoid requiring sensitive argument values on the command line.
+- Invalid `--args-json` fails without audit content leakage.
+- Existing `simulate-policy` command remains compatible.
+
+Regression tests:
+
+- A denied and hidden tool does not appear in model-facing discovery but does appear in admin preview.
+- A recommendation for a not-installed external MCP tool appears with `installation_status=not_installed`.
+- A redacted path outside the workspace does not expose an absolute path in response or audit.
+- Admin preview uses a public unfiltered catalog provider and does not depend on private model-facing discovery internals.
+
+## Rollout
+
+Recommended implementation slices:
+
+1. Add response models and shared `policy_explain` service with unit tests.
+2. Add admin API endpoints, dedicated permission seam, and audit behavior.
+3. Add local and remote CLI commands.
+4. Add documentation examples after the contracts stabilize.
+
+Each slice should preserve existing gateway behavior and keep `simulate-policy` intact.
+
+## Open Questions And Deferred Work
+
+- MCP/model-facing permission explanation tools can be considered later, but should be separately gated because they expose policy structure to models.
+- A web admin UI can consume the same API after the API and CLI contracts are stable.
+- Hierarchical policy authoring should compile into the flat executable grants used by this service.
+- Shell alias parsing and shell wrapper explanation should be handled in the shell alias work item, then surfaced through this explanation contract.
+- Hook, sandbox, file-lock, and temporary grant contributors should be displayed once their runtime decision metadata is available.

--- a/backlog/tasks/task-2368 - Design-MCP-effective-permission-explain-and-preview-surface.md
+++ b/backlog/tasks/task-2368 - Design-MCP-effective-permission-explain-and-preview-surface.md
@@ -1,0 +1,59 @@
+---
+id: TASK-2368
+title: Design MCP effective permission explain and preview surface
+status: Done
+assignee: []
+created_date: '2026-06-17 03:25'
+updated_date: '2026-06-17 03:28'
+labels:
+  - mcp
+  - policy
+  - design
+  - observability
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-06-16-mcp-effective-permission-explain-preview-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a design spec for a read-only MCP policy explain and profile tool-preview surface. The design should cover the shared policy_explain service, admin API, local and remote CLI modes, dedicated admin permission seam, required audit behavior, redacted response contract, degraded states, bounds, and test strategy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Design spec exists under Docs/superpowers/specs with the approved scope and decisions recorded.
+- [x] #2 Spec covers shared policy_explain service, admin API, CLI local/remote modes, authorization seam, audit requirements, redaction rules, degraded states, response contracts, preview semantics, tests, and rollout.
+- [x] #3 Spec is reviewed for issues and updated before handoff to implementation planning.
+- [x] #4 Doc-only validation is recorded, including diff checks and Bandit skip rationale.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created a design-only spec for the MCP effective permission explain and profile tool-preview surface. This task intentionally does not implement runtime code; implementation planning should wait for user approval of the reviewed spec.
+
+Local spec review incorporated fixes: corrected the subject extraction module path, changed profile preview to POST to avoid leaking session data in URL logs, clarified static-policy-only is not inherently degraded, added evaluated_at/skipped_contributors response fields, added argument payload size caps, added CLI --args-json-file/--args-stdin guidance, removed an unrelated FastAPI initialize test note, and required audit failures to prevent successful policy-detail responses.
+
+Second design-review pass incorporated fixes: documented the admin identity gap in the current API-key auth dependency, required a strict audit helper rather than existing best-effort audit helpers, required a public unfiltered admin catalog provider instead of private discovery internals, replaced subject-level boolean redaction with redaction_state, added a stable error envelope, and documented profile-id conflict validation for preview requests.
+
+Verification after second review: git diff --check passed; placeholder-marker scan passed; non-ASCII scan passed. Bandit remains skipped because this is documentation and Backlog metadata only.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the MCP Effective Permission Explain And Preview design spec and task record. The spec covers the shared policy_explain service, admin API, local/remote CLI behavior, dedicated mcp.policy.explain authorization, fail-closed audit behavior, redacted response contracts, degraded state handling, preview completeness semantics, tests, and rollout slices. Review fixes were incorporated before handoff. No runtime code was changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2369 - Plan-MCP-effective-permission-explain-implementation.md
+++ b/backlog/tasks/task-2369 - Plan-MCP-effective-permission-explain-implementation.md
@@ -1,0 +1,59 @@
+---
+id: TASK-2369
+title: Plan MCP effective permission explain implementation
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-17 03:40'
+labels:
+  - mcp
+  - policy
+  - planning
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create an implementation plan for the MCP effective permission explain and profile tool-preview surface based on the approved design spec.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Implementation plan exists under Docs/superpowers/plans with concrete task-by-task steps.
+- [x] #2 Plan maps expected files, tests, commands, and rollout order for the policy explain service, admin API, CLI, auth, audit, catalog provider, and docs.
+- [x] #3 Plan is reviewed for issues and updated before execution handoff.
+- [x] #4 Doc-only validation is recorded, including diff checks and Bandit skip rationale.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Plan created from approved spec TASK-2368. Local plan review incorporated fixes: replaced protocol instantiation with DefaultGatewayAdminPermissionChecker, added sync/async service dependency normalization, and removed a generic changed-files placeholder from the final verification step.
+
+Plan review note: the writing-plans workflow normally dispatches a plan-document-reviewer subagent, but the available multi-agent tool contract only permits spawning when the user explicitly asks for subagents. Per that higher-priority tool constraint, this pass used local review instead.
+
+Verification: git diff --check passed; implementation-plan placeholder scan passed; non-ASCII scan passed. Bandit skipped because this task only adds documentation and Backlog metadata.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the implementation plan for the MCP effective permission explain and profile tool-preview surface. The plan covers service models, strict audit, redaction, admin catalog provider, admin identity/permission seam, FastAPI routes, remote admin client methods, CLI commands, package docs, tests, and final verification. No runtime code was changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2370 - Implement-MCP-policy-explain-service-foundation.md
+++ b/backlog/tasks/task-2370 - Implement-MCP-policy-explain-service-foundation.md
@@ -1,0 +1,60 @@
+---
+id: TASK-2370
+title: Implement MCP policy explain service foundation
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-17 05:09'
+labels:
+  - mcp
+  - policy
+  - implementation
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 1 from the MCP effective permission explain implementation plan: service request/response models, redaction helpers, strict audit behavior, and focused unit tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 mcp_unified/gateway/policy_explain.py exists with service models, GatewayPolicyExplainService, GatewayPolicyExplainError, redaction helpers, and strict audit append behavior.
+- [x] #2 Focused service tests cover allow explanation, redacted/sanitized subjects, audit event writing, fail-closed audit append failure, and degraded preview without catalog.
+- [x] #3 Task 1 focused pytest command passes or failures are documented with blockers.
+- [x] #4 Changes are committed separately for Task 1.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the Task 1 service foundation in mcp_unified/gateway/policy_explain.py with typed request/response models, GatewayPolicyExplainService, GatewayPolicyExplainError, subject redaction helpers, effective decision handling, strict audit append behavior, and bounded preview pagination.
+
+Focused tests in tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py cover allow/ask/deny explanations, redaction/sanitization states, audit writes, audit fail-closed behavior, resolver failure auditing, degraded previews, validation error redaction, and preview pagination.
+
+Subagent review results: latest spec compliance review passed with no gaps; latest code-quality review found no Critical or Important issues. Minor follow-up candidates were cursor length hardening, async catalog_provider edge coverage, and richer install metadata in the later catalog task.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Task 1 added the standalone MCP policy explain service foundation and focused regression tests. Verification from this worktree using the root checkout virtualenv:
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py -v -> 34 passed, 7 warnings
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway/policy_explain.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py -s B101 -f json -o /tmp/bandit_task2370.json -> 0 findings
+- git diff --check -> exit 0
+
+Known non-blocking follow-ups: cap oversized cursor tokens, add explicit audit_store=None and async catalog_provider tests, and preserve installation metadata in the Task 2 catalog provider.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2371 - Implement-MCP-admin-tool-preview-catalog-provider.md
+++ b/backlog/tasks/task-2371 - Implement-MCP-admin-tool-preview-catalog-provider.md
@@ -4,7 +4,7 @@ title: Implement MCP admin tool preview catalog provider
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-06-17 05:16'
+updated_date: '2026-06-17 05:27'
 labels:
   - mcp
   - policy
@@ -33,6 +33,10 @@ Implement Task 2 from the MCP effective permission explain implementation plan: 
 Started Task 2 implementation under the approved subagent-driven workflow.
 
 Implemented Task 2 preview catalog wiring. Added AdminToolCatalogEntry and list_admin_tool_catalog without model-facing visibility filtering, wired GatewayPolicyExplainService to prefer admin_tool_catalog_provider and fall back to installed_tool_catalog/list_admin_tool_catalog, and added denied-installed admin catalog preview coverage. Verification so far: focused pytest passed (35 passed), Bandit passed with no issues, git diff --check passed.
+
+Code-quality review follow-up: added installed_tool_catalog fallback coverage, model-facing discovery exclusion assertions, preview filter coverage for include_denied/include_recommendations/category, and pagination-after-filtering coverage. The new pagination test exposed a row-ordering bug in preview catalog normalization; fixed by preserving catalog/provider order while de-duplicating.
+
+Verification caveat: requested command for tldw_Server_API/tests/MCP_unified/test_gateway_tool_discovery.py returned pytest exit 4 because that file does not exist in this worktree; no new test file was created because the review follow-up kept the owned-file scope unchanged.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2371 - Implement-MCP-admin-tool-preview-catalog-provider.md
+++ b/backlog/tasks/task-2371 - Implement-MCP-admin-tool-preview-catalog-provider.md
@@ -1,0 +1,46 @@
+---
+id: TASK-2371
+title: Implement MCP admin tool preview catalog provider
+status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-06-17 05:16'
+labels:
+  - mcp
+  - policy
+  - implementation
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 2 from the MCP effective permission explain implementation plan: add an unfiltered admin tool catalog provider and wire policy preview to include denied installed tools without changing model-facing tool discovery.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Admin catalog preview tests cover denied installed tools from the admin catalog.
+- [ ] #2 mcp_unified/gateway/tool_discovery.py exposes a public admin catalog entry/helper that does not hide denied tools.
+- [ ] #3 GatewayPolicyExplainService.preview_profile_tools uses admin_tool_catalog_provider or installed_tool_catalog fallback and preserves degraded behavior when no catalog is available.
+- [ ] #4 Focused policy explain service pytest passes or blockers are documented.
+- [ ] #5 Changes are committed separately for Task 2.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Started Task 2 implementation under the approved subagent-driven workflow.
+
+Implemented Task 2 preview catalog wiring. Added AdminToolCatalogEntry and list_admin_tool_catalog without model-facing visibility filtering, wired GatewayPolicyExplainService to prefer admin_tool_catalog_provider and fall back to installed_tool_catalog/list_admin_tool_catalog, and added denied-installed admin catalog preview coverage. Verification so far: focused pytest passed (35 passed), Bandit passed with no issues, git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2371 - Implement-MCP-admin-tool-preview-catalog-provider.md
+++ b/backlog/tasks/task-2371 - Implement-MCP-admin-tool-preview-catalog-provider.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-2371
 title: Implement MCP admin tool preview catalog provider
-status: In Progress
+status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-17 05:27'
+updated_date: '2026-06-17 05:35'
 labels:
   - mcp
   - policy
@@ -20,11 +20,11 @@ Implement Task 2 from the MCP effective permission explain implementation plan: 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Admin catalog preview tests cover denied installed tools from the admin catalog.
-- [ ] #2 mcp_unified/gateway/tool_discovery.py exposes a public admin catalog entry/helper that does not hide denied tools.
-- [ ] #3 GatewayPolicyExplainService.preview_profile_tools uses admin_tool_catalog_provider or installed_tool_catalog fallback and preserves degraded behavior when no catalog is available.
-- [ ] #4 Focused policy explain service pytest passes or blockers are documented.
-- [ ] #5 Changes are committed separately for Task 2.
+- [x] #1 Admin catalog preview tests cover denied installed tools from the admin catalog.
+- [x] #2 mcp_unified/gateway/tool_discovery.py exposes a public admin catalog entry/helper that does not hide denied tools.
+- [x] #3 GatewayPolicyExplainService.preview_profile_tools uses admin_tool_catalog_provider or installed_tool_catalog fallback and preserves degraded behavior when no catalog is available.
+- [x] #4 Focused policy explain service pytest passes or blockers are documented.
+- [x] #5 Changes are committed separately for Task 2.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -37,14 +37,29 @@ Implemented Task 2 preview catalog wiring. Added AdminToolCatalogEntry and list_
 Code-quality review follow-up: added installed_tool_catalog fallback coverage, model-facing discovery exclusion assertions, preview filter coverage for include_denied/include_recommendations/category, and pagination-after-filtering coverage. The new pagination test exposed a row-ordering bug in preview catalog normalization; fixed by preserving catalog/provider order while de-duplicating.
 
 Verification caveat: requested command for tldw_Server_API/tests/MCP_unified/test_gateway_tool_discovery.py returned pytest exit 4 because that file does not exist in this worktree; no new test file was created because the review follow-up kept the owned-file scope unchanged.
+
+Final review results: latest spec compliance review passed; latest code-quality review found no Critical or Important issues. The only reviewer note was final task bookkeeping, addressed here.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Task 2 added an unfiltered admin tool catalog provider and wired policy preview to include denied installed tools for admin-only previews while preserving model-facing filtering. It added AdminToolCatalogEntry/list_admin_tool_catalog, installed-catalog fallback wiring, install-status preservation, filter handling, and regression coverage for denied installed tools, model-facing denied-tool hiding, include_denied/include_recommendations/category filters, and cursor pagination after filtering.
+
+Verification from current HEAD using the root checkout virtualenv:
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py -v -> 38 passed, 7 warnings
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway/tool_discovery.py mcp_unified/gateway/policy_explain.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py -s B101 -f json -o /tmp/bandit_task2371.json -> 0 findings
+- git diff --check HEAD~2..HEAD -> exit 0
+
+Known caveat: tldw_Server_API/tests/MCP_unified/test_gateway_tool_discovery.py does not exist in this worktree, so that reviewer-suggested command is not a valid local gate.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2372 - Implement-MCP-gateway-admin-permission-seam.md
+++ b/backlog/tasks/task-2372 - Implement-MCP-gateway-admin-permission-seam.md
@@ -1,0 +1,51 @@
+---
+id: TASK-2372
+title: Implement MCP gateway admin permission seam
+status: In Progress
+labels:
+- mcp
+- policy
+- implementation
+- admin-auth
+modified_files:
+- mcp_unified/gateway/admin_auth.py
+- tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 3 from the MCP effective permission explain implementation plan: add GatewayAdminIdentity, a permission checker seam, permission errors/responses, and focused auth seam tests without mounting policy explain API routes yet.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 GatewayAdminIdentity exists with a local_admin helper that includes mcp.policy.explain permission when auth is disabled/local.
+- [ ] #2 GatewayAdminPermissionError, GatewayAdminPermissionChecker protocol, and DefaultGatewayAdminPermissionChecker are implemented with stable reason codes.
+- [ ] #3 An identity-producing admin dependency helper exists while preserving existing GatewayAdminAuthError, gateway_admin_auth_dependencies, and auth error responses.
+- [ ] #4 Focused tests cover local admin identity permission and missing-permission denial.
+- [ ] #5 Task 3 focused pytest passes or blockers are documented.
+- [ ] #6 Changes are committed separately for Task 3.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Task 3 seam implemented in mcp_unified/gateway/admin_auth.py with GatewayAdminIdentity, GatewayAdminPermissionError, GatewayAdminPermissionChecker protocol, DefaultGatewayAdminPermissionChecker, default local identity/dependency helper, and permission error response helper. Focused auth seam tests added in tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py. Verification passed: focused pytest (4 tests), existing app/core gateway admin auth pytest (7 tests), Bandit touched scope with B101 skipped, and git diff --check. Requested tldw_Server_API/tests/MCP_unified/test_standalone_gateway_admin_auth.py path does not exist. Awaiting controller review; task status remains In Progress.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2372 - Implement-MCP-gateway-admin-permission-seam.md
+++ b/backlog/tasks/task-2372 - Implement-MCP-gateway-admin-permission-seam.md
@@ -1,15 +1,16 @@
 ---
 id: TASK-2372
 title: Implement MCP gateway admin permission seam
-status: In Progress
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-17 05:54'
 labels:
-- mcp
-- policy
-- implementation
-- admin-auth
-modified_files:
-- mcp_unified/gateway/admin_auth.py
-- tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
+  - mcp
+  - policy
+  - implementation
+  - admin-auth
+dependencies: []
 ---
 
 ## Description
@@ -20,32 +21,44 @@ Implement Task 3 from the MCP effective permission explain implementation plan: 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 GatewayAdminIdentity exists with a local_admin helper that includes mcp.policy.explain permission when auth is disabled/local.
-- [ ] #2 GatewayAdminPermissionError, GatewayAdminPermissionChecker protocol, and DefaultGatewayAdminPermissionChecker are implemented with stable reason codes.
-- [ ] #3 An identity-producing admin dependency helper exists while preserving existing GatewayAdminAuthError, gateway_admin_auth_dependencies, and auth error responses.
-- [ ] #4 Focused tests cover local admin identity permission and missing-permission denial.
-- [ ] #5 Task 3 focused pytest passes or blockers are documented.
-- [ ] #6 Changes are committed separately for Task 3.
+- [x] #1 GatewayAdminIdentity exists with a local_admin helper that includes mcp.policy.explain permission when auth is disabled/local.
+- [x] #2 GatewayAdminPermissionError, GatewayAdminPermissionChecker protocol, and DefaultGatewayAdminPermissionChecker are implemented with stable reason codes.
+- [x] #3 An identity-producing admin dependency helper exists while preserving existing GatewayAdminAuthError, gateway_admin_auth_dependencies, and auth error responses.
+- [x] #4 Focused tests cover local admin identity permission and missing-permission denial.
+- [x] #5 Task 3 focused pytest passes or blockers are documented.
+- [x] #6 Changes are committed separately for Task 3.
 <!-- AC:END -->
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Task 3 quality-review fix: _gateway_admin_identity_dependency now preserves local identity only for disabled admin auth and returns a distinct generic authenticated gateway admin identity (actor_id=gateway-admin, source=gateway_admin_auth) after successful enabled admin auth without deriving from the credential. Added focused async test coverage for valid enabled auth identity plus missing/invalid GatewayAdminAuthError reason codes. Verification for review fix passed: focused policy explain API seam pytest (5 passed), existing app/core gateway admin auth pytest (7 passed), Bandit touched scope with B101 skipped (no issues), and git diff --check. Awaiting controller review; task status remains In Progress.
+Task 3 quality-review fix: _gateway_admin_identity_dependency now preserves local identity only for disabled admin auth and returns a distinct generic authenticated gateway admin identity (actor_id=gateway-admin, source=gateway_admin_auth) after successful enabled admin auth without deriving from the credential. Added focused async test coverage for valid enabled auth identity plus missing/invalid GatewayAdminAuthError reason codes. Verification for review fix passed: focused policy explain API seam pytest (5 passed), existing app/core gateway admin auth pytest (7 passed), Bandit touched scope with B101 skipped (no issues), and git diff --check.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Final review results: latest spec compliance review passed; latest code-quality review found no Critical or Important issues. The only reviewer note was final task bookkeeping, addressed here.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Task 3 added the standalone gateway admin permission seam. It introduced GatewayAdminIdentity, GatewayAdminPermissionError, GatewayAdminPermissionChecker, DefaultGatewayAdminPermissionChecker, identity-producing admin dependency helpers, stable permission-denied responses, and focused tests. A review fix now distinguishes disabled local admin identity from enabled authenticated gateway admin identity without exposing credential material.
 
+Verification from current HEAD using the root checkout virtualenv:
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py -v -> 5 passed, 7 warnings
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_admin_auth.py -v -> 7 passed, 5 warnings
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway/admin_auth.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py -s B101 -f json -o /tmp/bandit_task2372.json -> 0 findings
+- git diff --check HEAD~2..HEAD -> exit 0
+
+Known caveat: tldw_Server_API/tests/MCP_unified/test_standalone_gateway_admin_auth.py does not exist in this worktree; the existing package-level admin auth regression test was run instead.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2372 - Implement-MCP-gateway-admin-permission-seam.md
+++ b/backlog/tasks/task-2372 - Implement-MCP-gateway-admin-permission-seam.md
@@ -31,7 +31,7 @@ Implement Task 3 from the MCP effective permission explain implementation plan: 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Task 3 seam implemented in mcp_unified/gateway/admin_auth.py with GatewayAdminIdentity, GatewayAdminPermissionError, GatewayAdminPermissionChecker protocol, DefaultGatewayAdminPermissionChecker, default local identity/dependency helper, and permission error response helper. Focused auth seam tests added in tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py. Verification passed: focused pytest (4 tests), existing app/core gateway admin auth pytest (7 tests), Bandit touched scope with B101 skipped, and git diff --check. Requested tldw_Server_API/tests/MCP_unified/test_standalone_gateway_admin_auth.py path does not exist. Awaiting controller review; task status remains In Progress.
+Task 3 quality-review fix: _gateway_admin_identity_dependency now preserves local identity only for disabled admin auth and returns a distinct generic authenticated gateway admin identity (actor_id=gateway-admin, source=gateway_admin_auth) after successful enabled admin auth without deriving from the credential. Added focused async test coverage for valid enabled auth identity plus missing/invalid GatewayAdminAuthError reason codes. Verification for review fix passed: focused policy explain API seam pytest (5 passed), existing app/core gateway admin auth pytest (7 passed), Bandit touched scope with B101 skipped (no issues), and git diff --check. Awaiting controller review; task status remains In Progress.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2373 - Expose-MCP-policy-explain-admin-API-routes.md
+++ b/backlog/tasks/task-2373 - Expose-MCP-policy-explain-admin-API-routes.md
@@ -10,6 +10,8 @@ labels:
 modified_files:
 - mcp_unified/gateway/fastapi.py
 - mcp_unified/gateway/policy_explain.py
+- mcp_unified/gateway/profile_runtime.py
+- mcp_unified/gateway/tool_use_reporting.py
 - tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
 ---
 
@@ -33,7 +35,7 @@ Implement Task 4 from the MCP effective permission explain implementation plan: 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-Task 4 implemented with opt-in FastAPI route mounting in mcp_unified/gateway/fastapi.py. Added route tests for admin-auth enforcement, valid admin-key audit, runtime catalog denied-tool preview, GatewayPolicyExplainError stable envelope mapping, review-gap coverage for injected GatewayAdminPermissionError route-level 403 mapping, conflicting preview profile_id validation, and injected-service route actor/runtime catalog binding. Verification run before commit: focused policy explain API pytest passed; gateway admin auth pytest passed; Bandit initially found a test-only hardcoded /tmp path, then passed after changing fixture data; git diff --check passed.
+Task 4 implemented with opt-in FastAPI route mounting in mcp_unified/gateway/fastapi.py. Added route tests for admin-auth enforcement, valid admin-key audit, runtime catalog denied-tool preview, GatewayPolicyExplainError stable envelope mapping, review-gap coverage for injected GatewayAdminPermissionError route-level 403 mapping, conflicting preview profile_id validation, injected-service route actor/runtime catalog binding, and profile-aware runtime unfiltered admin catalog discovery. Verification run before commit: focused policy explain API pytest passed; gateway admin auth pytest passed; Bandit initially found a test-only hardcoded /tmp path, then passed after changing fixture data; git diff --check passed.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-2373 - Expose-MCP-policy-explain-admin-API-routes.md
+++ b/backlog/tasks/task-2373 - Expose-MCP-policy-explain-admin-API-routes.md
@@ -35,7 +35,7 @@ Implement Task 4 from the MCP effective permission explain implementation plan: 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-Task 4 implemented with opt-in FastAPI route mounting in mcp_unified/gateway/fastapi.py. Added route tests for admin-auth enforcement, valid admin-key audit, runtime catalog denied-tool preview, GatewayPolicyExplainError stable envelope mapping, review-gap coverage for injected GatewayAdminPermissionError route-level 403 mapping, conflicting preview profile_id validation, injected-service route actor/runtime catalog binding, and profile-aware runtime unfiltered admin catalog discovery. Verification run before commit: focused policy explain API pytest passed; gateway admin auth pytest passed; Bandit initially found a test-only hardcoded /tmp path, then passed after changing fixture data; git diff --check passed.
+Task 4 implemented with opt-in FastAPI route mounting in mcp_unified/gateway/fastapi.py. Added route tests for admin-auth enforcement, valid admin-key audit, runtime catalog denied-tool preview, GatewayPolicyExplainError stable envelope mapping, review-gap coverage for injected GatewayAdminPermissionError route-level 403 mapping, route-level audit_store_unavailable mapping, conflicting preview profile_id validation, injected-service route actor/runtime catalog binding, and profile-aware runtime unfiltered admin catalog discovery. Verification run before commit: focused policy explain API pytest passed; gateway admin auth pytest passed; Bandit initially found a test-only hardcoded /tmp path, then passed after changing fixture data; git diff --check passed.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-2373 - Expose-MCP-policy-explain-admin-API-routes.md
+++ b/backlog/tasks/task-2373 - Expose-MCP-policy-explain-admin-API-routes.md
@@ -1,18 +1,22 @@
 ---
 id: TASK-2373
 title: Expose MCP policy explain admin API routes
-status: In Progress
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-17 07:02'
 labels:
-- mcp
-- policy
-- implementation
-- admin-api
+  - mcp
+  - policy
+  - implementation
+  - admin-api
 modified_files:
-- mcp_unified/gateway/fastapi.py
-- mcp_unified/gateway/policy_explain.py
-- mcp_unified/gateway/profile_runtime.py
-- mcp_unified/gateway/tool_use_reporting.py
-- tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
+  - mcp_unified/gateway/fastapi.py
+  - mcp_unified/gateway/policy_explain.py
+  - mcp_unified/gateway/profile_runtime.py
+  - mcp_unified/gateway/tool_use_reporting.py
+  - tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
+dependencies: []
 ---
 
 ## Description
@@ -23,13 +27,13 @@ Implement Task 4 from the MCP effective permission explain implementation plan: 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 create_gateway_router/create_gateway_app accept optional policy explain management dependencies without changing default behavior.
-- [ ] #2 POST /mcp/policy/explain requires admin auth when enabled, checks mcp.policy.explain permission, returns stable policy explain responses, and audits successful requests.
-- [ ] #3 POST /mcp/profiles/{profile_id}/tool-preview returns preview rows including denied installed tools through the runtime catalog provider.
-- [ ] #4 GatewayPolicyExplainError and GatewayAdminPermissionError map to stable JSON error envelopes without becoming 500s.
-- [ ] #5 Focused admin API tests cover auth required, success audit, denied tool preview, and at least one permission/audit failure path.
-- [ ] #6 Task 4 focused pytest passes or blockers are documented.
-- [ ] #7 Changes are committed separately for Task 4.
+- [x] #1 create_gateway_router/create_gateway_app accept optional policy explain management dependencies without changing default behavior.
+- [x] #2 POST /mcp/policy/explain requires admin auth when enabled, checks mcp.policy.explain permission, returns stable policy explain responses, and audits successful requests.
+- [x] #3 POST /mcp/profiles/{profile_id}/tool-preview returns preview rows including denied installed tools through the runtime catalog provider.
+- [x] #4 GatewayPolicyExplainError and GatewayAdminPermissionError map to stable JSON error envelopes without becoming 500s.
+- [x] #5 Focused admin API tests cover auth required, success audit, denied tool preview, and at least one permission/audit failure path.
+- [x] #6 Task 4 focused pytest passes or blockers are documented.
+- [x] #7 Changes are committed separately for Task 4.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -40,22 +44,34 @@ Task 4 implemented with opt-in FastAPI route mounting in mcp_unified/gateway/fas
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Started Task 4 implementation under the approved subagent-driven workflow.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
+Final review results: latest spec compliance review passed; latest code-quality review found no Critical runtime/security issues. The remaining Important reviewer note was Backlog closeout, addressed here. Expanded Task 4 touched scope includes mcp_unified/gateway/profile_runtime.py and mcp_unified/gateway/tool_use_reporting.py for the explicit unfiltered admin catalog path.
+<!-- SECTION:NOTES:END -->
+
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Task 4 exposed opt-in MCP policy explain admin API routes. It added POST /mcp/policy/explain and POST /mcp/profiles/{profile_id}/tool-preview, wired admin identity plus mcp.policy.explain permission checks, stable policy/permission/audit error envelopes, route-bound service actor/catalog context, body/path profile_id conflict validation, and unfiltered admin catalog discovery for profile-aware and tool-use-reporting runtimes so denied installed tools remain visible in admin previews.
 
+Verification from current HEAD using the root checkout virtualenv:
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py -v -> 14 passed, 7 warnings
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_admin_auth.py -v -> 7 passed, 5 warnings
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway/fastapi.py mcp_unified/gateway/policy_explain.py mcp_unified/gateway/profile_runtime.py mcp_unified/gateway/tool_use_reporting.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py -s B101 -f json -o /tmp/bandit_task2373_final.json -> 0 findings
+- git diff --check HEAD~5..HEAD -> exit 0
+
+Known non-blocking follow-up: add an explicit disabled-route 404 regression test if this surface is touched again.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2373 - Expose-MCP-policy-explain-admin-API-routes.md
+++ b/backlog/tasks/task-2373 - Expose-MCP-policy-explain-admin-API-routes.md
@@ -33,7 +33,7 @@ Implement Task 4 from the MCP effective permission explain implementation plan: 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-Task 4 implemented with opt-in FastAPI route mounting in mcp_unified/gateway/fastapi.py. Added route tests for admin-auth enforcement, valid admin-key audit, runtime catalog denied-tool preview, GatewayPolicyExplainError stable envelope mapping, and review-gap coverage for injected GatewayAdminPermissionError route-level 403 mapping. Verification run before commit: focused policy explain API pytest passed; gateway admin auth pytest passed; Bandit initially found a test-only hardcoded /tmp path, then passed after changing fixture data; git diff --check passed.
+Task 4 implemented with opt-in FastAPI route mounting in mcp_unified/gateway/fastapi.py. Added route tests for admin-auth enforcement, valid admin-key audit, runtime catalog denied-tool preview, GatewayPolicyExplainError stable envelope mapping, review-gap coverage for injected GatewayAdminPermissionError route-level 403 mapping, conflicting preview profile_id validation, and injected-service route actor/runtime catalog binding. Verification run before commit: focused policy explain API pytest passed; gateway admin auth pytest passed; Bandit initially found a test-only hardcoded /tmp path, then passed after changing fixture data; git diff --check passed.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-2373 - Expose-MCP-policy-explain-admin-API-routes.md
+++ b/backlog/tasks/task-2373 - Expose-MCP-policy-explain-admin-API-routes.md
@@ -33,7 +33,7 @@ Implement Task 4 from the MCP effective permission explain implementation plan: 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-Task 4 implemented with opt-in FastAPI route mounting in mcp_unified/gateway/fastapi.py. Added route tests for admin-auth enforcement, valid admin-key audit, runtime catalog denied-tool preview, and GatewayPolicyExplainError stable envelope mapping. Verification run before commit: focused policy explain API pytest passed; gateway admin auth pytest passed; Bandit initially found a test-only hardcoded /tmp path, then passed after changing fixture data; git diff --check passed.
+Task 4 implemented with opt-in FastAPI route mounting in mcp_unified/gateway/fastapi.py. Added route tests for admin-auth enforcement, valid admin-key audit, runtime catalog denied-tool preview, GatewayPolicyExplainError stable envelope mapping, and review-gap coverage for injected GatewayAdminPermissionError route-level 403 mapping. Verification run before commit: focused policy explain API pytest passed; gateway admin auth pytest passed; Bandit initially found a test-only hardcoded /tmp path, then passed after changing fixture data; git diff --check passed.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-2373 - Expose-MCP-policy-explain-admin-API-routes.md
+++ b/backlog/tasks/task-2373 - Expose-MCP-policy-explain-admin-API-routes.md
@@ -1,0 +1,59 @@
+---
+id: TASK-2373
+title: Expose MCP policy explain admin API routes
+status: In Progress
+labels:
+- mcp
+- policy
+- implementation
+- admin-api
+modified_files:
+- mcp_unified/gateway/fastapi.py
+- mcp_unified/gateway/policy_explain.py
+- tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 4 from the MCP effective permission explain implementation plan: mount optional standalone gateway admin API routes for policy explain and profile tool preview using the policy explain service and admin permission seam.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 create_gateway_router/create_gateway_app accept optional policy explain management dependencies without changing default behavior.
+- [ ] #2 POST /mcp/policy/explain requires admin auth when enabled, checks mcp.policy.explain permission, returns stable policy explain responses, and audits successful requests.
+- [ ] #3 POST /mcp/profiles/{profile_id}/tool-preview returns preview rows including denied installed tools through the runtime catalog provider.
+- [ ] #4 GatewayPolicyExplainError and GatewayAdminPermissionError map to stable JSON error envelopes without becoming 500s.
+- [ ] #5 Focused admin API tests cover auth required, success audit, denied tool preview, and at least one permission/audit failure path.
+- [ ] #6 Task 4 focused pytest passes or blockers are documented.
+- [ ] #7 Changes are committed separately for Task 4.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Task 4 implemented with opt-in FastAPI route mounting in mcp_unified/gateway/fastapi.py. Added route tests for admin-auth enforcement, valid admin-key audit, runtime catalog denied-tool preview, and GatewayPolicyExplainError stable envelope mapping. Verification run before commit: focused policy explain API pytest passed; gateway admin auth pytest passed; Bandit initially found a test-only hardcoded /tmp path, then passed after changing fixture data; git diff --check passed.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Started Task 4 implementation under the approved subagent-driven workflow.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2374 - Add-MCP-policy-explain-remote-admin-client-and-CLI.md
+++ b/backlog/tasks/task-2374 - Add-MCP-policy-explain-remote-admin-client-and-CLI.md
@@ -1,16 +1,20 @@
 ---
 id: TASK-2374
 title: Add MCP policy explain remote admin client and CLI
-status: In Progress
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-17 07:32'
 labels:
-- mcp
-- policy
-- implementation
-- cli
+  - mcp
+  - policy
+  - implementation
+  - cli
 modified_files:
-- mcp_unified/gateway/remote_admin.py
-- mcp_unified/gateway/cli.py
-- tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py
+  - mcp_unified/gateway/remote_admin.py
+  - mcp_unified/gateway/cli.py
+  - tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py
+dependencies: []
 ---
 
 ## Description
@@ -21,35 +25,43 @@ Implement Task 5 from the MCP effective permission explain implementation plan: 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 RemoteGatewayAdminClient supports POST request bodies and exposes explain_policy plus preview_profile_tools methods.
-- [ ] #2 CLI registers explain-policy and preview-profile-tools commands with local and remote modes.
-- [ ] #3 CLI supports --args-json, --args-json-file, and --args-stdin for explain-policy without requiring sensitive JSON on the command line.
-- [ ] #4 Preview CLI supports category, include/exclude recommendations, include/exclude denied, and limit options.
-- [ ] #5 Focused CLI/remote client tests cover POST body handling and args-json-file parsing.
-- [ ] #6 Task 5 focused pytest passes or blockers are documented.
-- [ ] #7 Changes are committed separately for Task 5.
+- [x] #1 RemoteGatewayAdminClient supports POST request bodies and exposes explain_policy plus preview_profile_tools methods.
+- [x] #2 CLI registers explain-policy and preview-profile-tools commands with local and remote modes.
+- [x] #3 CLI supports --args-json, --args-json-file, and --args-stdin for explain-policy without requiring sensitive JSON on the command line.
+- [x] #4 Preview CLI supports category, include/exclude recommendations, include/exclude denied, and limit options.
+- [x] #5 Focused CLI/remote client tests cover POST body handling and args-json-file parsing.
+- [x] #6 Task 5 focused pytest passes or blockers are documented.
+- [x] #7 Changes are committed separately for Task 5.
 <!-- AC:END -->
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Started Task 5 implementation under the approved subagent-driven workflow.
 
 Task 5 added remote policy explain/preview POST client methods and CLI commands. Local preview uses `GatewayPolicyExplainService` with local config/profile storage; a standalone CLI runtime catalog helper is not currently available, so local preview relies on the service's profile/policy fallback and may report degraded runtime catalog state.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
+Controller follow-up addressed code-quality review findings: policy explain CLI remote mode is now explicit via --gateway-url or --remote, ambient MCP_UNIFIED_GATEWAY_URL no longer silently forces remote mode, --admin-key was removed from policy commands, admin keys are read only from MCP_UNIFIED_GATEWAY_ADMIN_KEY, explicit empty --args-json is rejected, and remote error payloads preserve message fields. Added regression coverage for env/local precedence, env-backed remote mode, empty args JSON, local plus gateway-url rejection, admin-key argument rejection, and message preservation.
+
+Reviews: spec follow-up reported no Critical/Important/Minor issues and marked spec ready; code-quality follow-up reported no Critical/Important issues, prior blockers resolved, and ready to merge.
+
+Verification: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py -v -> 10 passed, 7 warnings; /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_remote_runtime_cli.py -v -> 26 passed, 5 warnings; /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -k simulate_policy -v -> 4 passed, 90 deselected, 5 warnings; /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway/remote_admin.py mcp_unified/gateway/cli.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py -s B101 -f json -o /tmp/bandit_task2374.json -> 0 results; git diff --check -> clean.
+<!-- SECTION:NOTES:END -->
+
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Task 5 added remote admin POST methods and standalone CLI commands for policy explain and profile tool preview in both local and explicit remote modes. Review follow-up hardened mode selection and secret handling so local remains the default, remote is selected with --gateway-url or --remote, command-line admin secrets are rejected, and gateway error messages are preserved. Focused tests and Bandit passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2374 - Add-MCP-policy-explain-remote-admin-client-and-CLI.md
+++ b/backlog/tasks/task-2374 - Add-MCP-policy-explain-remote-admin-client-and-CLI.md
@@ -1,0 +1,55 @@
+---
+id: TASK-2374
+title: Add MCP policy explain remote admin client and CLI
+status: In Progress
+labels:
+- mcp
+- policy
+- implementation
+- cli
+modified_files:
+- mcp_unified/gateway/remote_admin.py
+- mcp_unified/gateway/cli.py
+- tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 5 from the MCP effective permission explain implementation plan: add remote admin client POST methods and local/remote CLI commands for explain-policy and preview-profile-tools.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 RemoteGatewayAdminClient supports POST request bodies and exposes explain_policy plus preview_profile_tools methods.
+- [ ] #2 CLI registers explain-policy and preview-profile-tools commands with local and remote modes.
+- [ ] #3 CLI supports --args-json, --args-json-file, and --args-stdin for explain-policy without requiring sensitive JSON on the command line.
+- [ ] #4 Preview CLI supports category, include/exclude recommendations, include/exclude denied, and limit options.
+- [ ] #5 Focused CLI/remote client tests cover POST body handling and args-json-file parsing.
+- [ ] #6 Task 5 focused pytest passes or blockers are documented.
+- [ ] #7 Changes are committed separately for Task 5.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Started Task 5 implementation under the approved subagent-driven workflow.
+
+Task 5 added remote policy explain/preview POST client methods and CLI commands. Local preview uses `GatewayPolicyExplainService` with local config/profile storage; a standalone CLI runtime catalog helper is not currently available, so local preview relies on the service's profile/policy fallback and may report degraded runtime catalog state.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2375 - Document-MCP-policy-explain-surface-and-exports.md
+++ b/backlog/tasks/task-2375 - Document-MCP-policy-explain-surface-and-exports.md
@@ -2,16 +2,20 @@
 id: TASK-2375
 title: Document MCP policy explain surface and exports
 status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-17 07:49'
 labels:
-- mcp
-- policy
-- implementation
-- docs
+  - mcp
+  - policy
+  - implementation
+  - docs
 modified_files:
-- mcp_unified/gateway/__init__.py
-- mcp_unified/README.md
-- mcp_unified/USER_GUIDE.md
-- tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
+  - mcp_unified/gateway/__init__.py
+  - mcp_unified/README.md
+  - mcp_unified/USER_GUIDE.md
+  - tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
+dependencies: []
 ---
 
 ## Description
@@ -22,20 +26,28 @@ Implement Task 6 from the MCP effective permission explain implementation plan: 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 mcp_unified.gateway exports GatewayPolicyExplainService, PolicyExplainRequest, ProfileToolPreviewRequest, and GatewayPolicyExplainError without breaking optional dependency behavior.
-- [ ] #2 A minimal public export smoke test covers the new gateway exports.
-- [ ] #3 mcp_unified/README.md documents explain-policy and preview-profile-tools purpose, local CLI usage, remote CLI usage, admin API examples, and security notes.
-- [ ] #4 mcp_unified/USER_GUIDE.md includes the same user-facing policy explain guidance where packaged users can find it.
-- [ ] #5 Focused export/docs tests pass or blockers are documented.
-- [ ] #6 Bandit is run for touched code where applicable or a docs-only skip is recorded.
-- [ ] #7 Changes are committed separately for Task 6.
+- [x] #1 mcp_unified.gateway exports GatewayPolicyExplainService, PolicyExplainRequest, ProfileToolPreviewRequest, and GatewayPolicyExplainError without breaking optional dependency behavior.
+- [x] #2 A minimal public export smoke test covers the new gateway exports.
+- [x] #3 mcp_unified/README.md documents explain-policy and preview-profile-tools purpose, local CLI usage, remote CLI usage, admin API examples, and security notes.
+- [x] #4 mcp_unified/USER_GUIDE.md includes the same user-facing policy explain guidance where packaged users can find it.
+- [x] #5 Focused export/docs tests pass or blockers are documented.
+- [x] #6 Bandit is run for touched code where applicable or a docs-only skip is recorded.
+- [x] #7 Changes are committed separately for Task 6.
 <!-- AC:END -->
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Started Task 6 implementation under the approved subagent-driven workflow. Scope: public gateway exports, minimal smoke test, and packaged README/user-guide documentation for the policy explain and profile tool preview surfaces.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Review follow-up addressed the remaining spec gap by documenting remote CLI preview-profile-tools usage in both packaged docs and tightened the public export smoke test to assert gateway.__all__ includes the policy explain API exports.
+
+Reviews: final spec follow-up reported no Critical or Important issues and marked spec ready; final code-quality follow-up reported no Critical or Important issues and ready-to-merge.
+
+Verification: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py -v -> 39 passed, 7 warnings; /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -v -> 34 passed, 5 warnings; /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway/__init__.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py -s B101 -f json -o /tmp/bandit_task2375.json -> 0 results; git diff --check -> clean.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
@@ -45,10 +57,10 @@ Implemented Task 6. Exported GatewayPolicyExplainService, PolicyExplainRequest, 
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2375 - Document-MCP-policy-explain-surface-and-exports.md
+++ b/backlog/tasks/task-2375 - Document-MCP-policy-explain-surface-and-exports.md
@@ -1,0 +1,54 @@
+---
+id: TASK-2375
+title: Document MCP policy explain surface and exports
+status: Done
+labels:
+- mcp
+- policy
+- implementation
+- docs
+modified_files:
+- mcp_unified/gateway/__init__.py
+- mcp_unified/README.md
+- mcp_unified/USER_GUIDE.md
+- tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 6 from the MCP effective permission explain implementation plan: export the policy explain public API from mcp_unified.gateway, add a minimal export smoke test, and document the explain-policy and preview-profile-tools local/remote/admin surfaces in the packaged README and user guide.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 mcp_unified.gateway exports GatewayPolicyExplainService, PolicyExplainRequest, ProfileToolPreviewRequest, and GatewayPolicyExplainError without breaking optional dependency behavior.
+- [ ] #2 A minimal public export smoke test covers the new gateway exports.
+- [ ] #3 mcp_unified/README.md documents explain-policy and preview-profile-tools purpose, local CLI usage, remote CLI usage, admin API examples, and security notes.
+- [ ] #4 mcp_unified/USER_GUIDE.md includes the same user-facing policy explain guidance where packaged users can find it.
+- [ ] #5 Focused export/docs tests pass or blockers are documented.
+- [ ] #6 Bandit is run for touched code where applicable or a docs-only skip is recorded.
+- [ ] #7 Changes are committed separately for Task 6.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Started Task 6 implementation under the approved subagent-driven workflow. Scope: public gateway exports, minimal smoke test, and packaged README/user-guide documentation for the policy explain and profile tool preview surfaces.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Task 6. Exported GatewayPolicyExplainService, PolicyExplainRequest, ProfileToolPreviewRequest, and GatewayPolicyExplainError from mcp_unified.gateway; added a public export smoke test to the standalone policy explain service tests; documented explain-policy and preview-profile-tools purpose, local CLI use, remote CLI use, admin API calls, and audit/redaction/security guidance in mcp_unified/README.md and mcp_unified/USER_GUIDE.md. Verification: pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py -v passed 39 tests; pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -v passed 34 tests; git diff --check passed. Bandit full touched-file scan was run and reported only pre-existing B101 pytest assert findings in the touched test file, with the new smoke test not flagged; Bandit with B101 skipped reported 0 results and 0 errors.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2376 - Run-MCP-policy-explain-full-verification-and-security-scan.md
+++ b/backlog/tasks/task-2376 - Run-MCP-policy-explain-full-verification-and-security-scan.md
@@ -1,0 +1,69 @@
+---
+id: TASK-2376
+title: Run MCP policy explain full verification and security scan
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-17 07:51'
+labels:
+  - mcp
+  - policy
+  - verification
+modified_files:
+  - backlog/tasks/task-2376 - Run-MCP-policy-explain-full-verification-and-security-scan.md
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement Task 7 from the MCP effective permission explain implementation plan: run the focused service, admin API, CLI, package-boundary, Bandit, and diff verification suite for the completed policy explain/profile preview surface; record blockers or close the plan if clean.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Focused policy explain service pytest passes or blockers are documented.
+- [x] #2 Focused policy explain admin API pytest passes or blockers are documented.
+- [x] #3 Focused policy explain CLI pytest passes or blockers are documented.
+- [x] #4 Package-boundary/runtime verification relevant to new exports passes or blockers are documented.
+- [x] #5 Bandit runs over the touched MCP policy explain/API/CLI scope and reports no new findings, or known pre-existing skips are documented.
+- [x] #6 git diff --check passes.
+- [x] #7 Final verification results are recorded and committed separately.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Started Task 7 final verification. This task is verification-only unless the focused suite exposes a still-valid defect.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Final verification completed with no blockers.
+
+Verification commands and results:
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py -v -> 39 passed, 7 warnings.
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py -v -> 14 passed, 7 warnings.
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py -v -> 10 passed, 7 warnings.
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -v -> 34 passed, 5 warnings.
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py -k simulate_policy -v -> 4 passed, 90 deselected, 5 warnings.
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway/policy_explain.py mcp_unified/gateway/tool_discovery.py mcp_unified/gateway/admin_auth.py mcp_unified/gateway/fastapi.py mcp_unified/gateway/remote_admin.py mcp_unified/gateway/cli.py mcp_unified/gateway/__init__.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py -s B101 -f json -o /tmp/bandit_task2376.json -> 0 results, 0 errors. B101 was skipped for pytest assert usage.
+- git diff --check -> clean.
+
+Known note: branch remains behind origin/dev by 3 commits; no rebase was requested during this verification task.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Task 7 completed the final focused verification and security scan for the MCP policy explain/profile preview surface. Service, admin API, CLI, package-boundary, adjacent simulate-policy CLI tests, Bandit, and diff checks all passed with no blockers. The only known follow-up is repository integration/rebase when requested, because this branch is still behind origin/dev by 3 commits.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2376 - Run-MCP-policy-explain-full-verification-and-security-scan.md
+++ b/backlog/tasks/task-2376 - Run-MCP-policy-explain-full-verification-and-security-scan.md
@@ -4,7 +4,7 @@ title: Run MCP policy explain full verification and security scan
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-17 07:51'
+updated_date: '2026-06-17 07:52'
 labels:
   - mcp
   - policy
@@ -50,6 +50,11 @@ Verification commands and results:
 - git diff --check -> clean.
 
 Known note: branch remains behind origin/dev by 3 commits; no rebase was requested during this verification task.
+
+Supplemental verification for the explicit plan Task 7 steps also passed:
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_http_auth_paths.py tldw_Server_API/tests/MCP_unified/test_mcp_config_sanitization.py -v -> 22 passed, 3 warnings. The command emitted expected test telemetry for invalid media.search requests while tests passed.
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python import smoke for from mcp_unified.gateway import GatewayPolicyExplainService, PolicyExplainRequest -> printed GatewayPolicyExplainService PolicyExplainRequest.
+- git status --short remained clean before appending this verification note.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2377 - Address-PR-2373-MCP-policy-explain-review-comments.md
+++ b/backlog/tasks/task-2377 - Address-PR-2373-MCP-policy-explain-review-comments.md
@@ -1,0 +1,64 @@
+---
+id: TASK-2377
+title: Address PR 2373 MCP policy explain review comments
+status: Done
+labels:
+- mcp
+- policy
+- review
+modified_files:
+- mcp_unified/README.md
+- mcp_unified/USER_GUIDE.md
+- mcp_unified/gateway/cli.py
+- mcp_unified/gateway/policy_explain.py
+- mcp_unified/gateway/fastapi.py
+- tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
+- tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
+- tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address still-valid PR review comments on the MCP policy explain/profile preview surface after rebasing on latest dev: test markers/docstrings, preview catalog exception diagnostics, admin route rate limiting, preview mode semantics, CLI session-id propagation, event-loop offloading, fallback hardening, and command-shaped redaction.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 New policy explain test modules include module docstrings and a single accepted test marker without relying on unsupported asyncio markers.
+- [x] #2 Preview catalog fallback records diagnostics instead of silently swallowing exceptions.
+- [x] #3 Admin policy explain routes have explicit finite rate limiting or an existing rate limit integration is correctly applied.
+- [x] #4 Profile tool preview mode semantics are corrected so response metadata does not misrepresent runtime-effective behavior.
+- [x] #5 CLI preview propagates session_id, grant-store simulation is offloaded, missing policy fallback is guarded, and command-shaped tool redaction handles spacing/case variants.
+- [x] #6 Focused policy explain service/API/CLI tests pass.
+- [x] #7 Bandit and diff checks pass for touched scope.
+- [x] #8 Review feedback outcome is recorded and committed.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Verified all nine current inline comments against the rebased branch. Still-valid findings addressed: missing module docstrings and accepted markers in new test modules; broad preview catalog fallback lacked diagnostics; admin policy explain routes lacked visible route-level rate limiting; preview mode exposed runtime/static metadata without differing computation semantics; preview CLI dropped session_id; runtime-effective policy simulation ran inline in async service methods; missing policy documents broke fallback tool-name extraction; command-shaped tool identifiers with spacing/case variants were not redacted.
+
+Verification:
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m compileall -q mcp_unified/gateway/policy_explain.py mcp_unified/gateway/fastapi.py mcp_unified/gateway/cli.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py`
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py -v` (68 passed)
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r mcp_unified/gateway/policy_explain.py mcp_unified/gateway/fastapi.py mcp_unified/gateway/cli.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py -s B101 -f json -o /tmp/bandit_task2377.json` (0 findings)
+- `git diff --check`
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR 2373 review feedback with scoped fixes for policy explain tests, diagnostics, rate limiting, runtime preview semantics, CLI session propagation, offloaded simulation, fallback guards, and redaction hardening. Added focused regression coverage and updated policy explain docs for session-scoped preview grants.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/README.md
+++ b/mcp_unified/README.md
@@ -101,7 +101,9 @@ policy state, and redacted subjects for a hypothetical tool call.
 
 `preview-profile-tools` previews a profile's effective tool surface across
 installed tools and profile recommendations so operators can see which tools are
-visible, deferred, blocked, or unavailable before assigning a profile.
+visible, deferred, blocked, or unavailable before assigning a profile. Pass a
+`session_id` when previewing runtime-effective state that includes session-bound
+approval grants.
 
 Local CLI examples:
 
@@ -123,7 +125,7 @@ printf '{"path":"src/app.py"}' | mcp-unified-gateway explain-policy \
   --remote --profile researcher --tool fs.read --args-stdin
 
 mcp-unified-gateway preview-profile-tools --remote --profile researcher \
-  --category filesystem --exclude-denied
+  --category filesystem --session-id "$MCP_SESSION_ID" --exclude-denied
 ```
 
 Admin API examples:
@@ -137,7 +139,7 @@ curl -sS -X POST "$MCP_UNIFIED_GATEWAY_URL/policy/explain" \
 curl -sS -X POST "$MCP_UNIFIED_GATEWAY_URL/profiles/researcher/tool-preview" \
   -H "X-MCP-Gateway-Admin-Key: $MCP_UNIFIED_GATEWAY_ADMIN_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"category":"filesystem","include_denied":true}'
+  -d '{"category":"filesystem","include_denied":true,"session_id":"session-1"}'
 ```
 
 Policy explanation and preview calls are audited when audit storage is

--- a/mcp_unified/README.md
+++ b/mcp_unified/README.md
@@ -121,6 +121,9 @@ export MCP_UNIFIED_GATEWAY_ADMIN_KEY=replace-with-admin-key
 
 printf '{"path":"src/app.py"}' | mcp-unified-gateway explain-policy \
   --remote --profile researcher --tool fs.read --args-stdin
+
+mcp-unified-gateway preview-profile-tools --remote --profile researcher \
+  --category filesystem --exclude-denied
 ```
 
 Admin API examples:

--- a/mcp_unified/README.md
+++ b/mcp_unified/README.md
@@ -93,6 +93,56 @@ Build an aggregate tool-use report when reporting is enabled:
 mcp-unified-gateway tool-events report --group-by profile --config ./gateway.json
 ```
 
+## Policy Explanation
+
+`explain-policy` explains one profile/tool decision before execution. It reports
+the effective `allow`, `ask`, or `deny` outcome, reason code, contributing
+policy state, and redacted subjects for a hypothetical tool call.
+
+`preview-profile-tools` previews a profile's effective tool surface across
+installed tools and profile recommendations so operators can see which tools are
+visible, deferred, blocked, or unavailable before assigning a profile.
+
+Local CLI examples:
+
+```bash
+mcp-unified-gateway explain-policy --profile researcher --tool fs.patch \
+  --args-json-file ./patch-args.json --config ./gateway.json
+
+mcp-unified-gateway preview-profile-tools --profile researcher \
+  --category filesystem --config ./gateway.json
+```
+
+Remote CLI example:
+
+```bash
+export MCP_UNIFIED_GATEWAY_URL=http://127.0.0.1:8000/mcp
+export MCP_UNIFIED_GATEWAY_ADMIN_KEY=replace-with-admin-key
+
+printf '{"path":"src/app.py"}' | mcp-unified-gateway explain-policy \
+  --remote --profile researcher --tool fs.read --args-stdin
+```
+
+Admin API examples:
+
+```bash
+curl -sS -X POST "$MCP_UNIFIED_GATEWAY_URL/policy/explain" \
+  -H "X-MCP-Gateway-Admin-Key: $MCP_UNIFIED_GATEWAY_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"profile_id":"researcher","tool_name":"fs.read","arguments":{"path":"src/app.py"}}'
+
+curl -sS -X POST "$MCP_UNIFIED_GATEWAY_URL/profiles/researcher/tool-preview" \
+  -H "X-MCP-Gateway-Admin-Key: $MCP_UNIFIED_GATEWAY_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"category":"filesystem","include_denied":true}'
+```
+
+Policy explanation and preview calls are audited when audit storage is
+configured, and responses redact or sanitize sensitive subjects. Raw tool
+arguments are not echoed back. Prefer `--args-json-file` or `--args-stdin` over
+inline `--args-json` for sensitive arguments so values are not exposed in shell
+history or process listings.
+
 ## Minimal Gateway Config
 
 ```json

--- a/mcp_unified/USER_GUIDE.md
+++ b/mcp_unified/USER_GUIDE.md
@@ -351,6 +351,9 @@ export MCP_UNIFIED_GATEWAY_ADMIN_KEY=replace-with-admin-key
 
 printf '{"path":"src/app.py"}' | mcp-unified-gateway explain-policy \
   --remote --profile researcher --tool fs.read --args-stdin
+
+mcp-unified-gateway preview-profile-tools --remote --profile researcher \
+  --category filesystem --exclude-denied
 ```
 
 Direct admin API examples:

--- a/mcp_unified/USER_GUIDE.md
+++ b/mcp_unified/USER_GUIDE.md
@@ -331,7 +331,9 @@ redacted subjects for the hypothetical call.
 
 Use `preview-profile-tools` when you need to review a profile's effective tool
 surface. It previews installed tools and profile recommendations, including
-whether tools are visible, deferred, denied, or unavailable.
+whether tools are visible, deferred, denied, or unavailable. Include a
+`session_id` when runtime-effective preview should account for session-scoped
+approval grants.
 
 Local CLI examples:
 
@@ -353,7 +355,7 @@ printf '{"path":"src/app.py"}' | mcp-unified-gateway explain-policy \
   --remote --profile researcher --tool fs.read --args-stdin
 
 mcp-unified-gateway preview-profile-tools --remote --profile researcher \
-  --category filesystem --exclude-denied
+  --category filesystem --session-id "$MCP_SESSION_ID" --exclude-denied
 ```
 
 Direct admin API examples:
@@ -367,7 +369,7 @@ curl -sS -X POST "$MCP_UNIFIED_GATEWAY_URL/policy/explain" \
 curl -sS -X POST "$MCP_UNIFIED_GATEWAY_URL/profiles/researcher/tool-preview" \
   -H "X-MCP-Gateway-Admin-Key: $MCP_UNIFIED_GATEWAY_ADMIN_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"category":"filesystem","include_denied":true}'
+  -d '{"category":"filesystem","include_denied":true,"session_id":"session-1"}'
 ```
 
 Security notes:

--- a/mcp_unified/USER_GUIDE.md
+++ b/mcp_unified/USER_GUIDE.md
@@ -322,6 +322,60 @@ runtime approvals. Runtime integrations for governed shell execution, WebFetch,
 WebSearch, LSP diagnostics, hooks, and admin policy simulation are separate
 follow-up tasks.
 
+### Explain Policy Decisions And Tool Previews
+
+Use `explain-policy` when you need to understand one effective profile/tool
+decision before execution. It returns the final `allow`, `ask`, or `deny`
+outcome, reason code, visibility, call state, relevant policy contributors, and
+redacted subjects for the hypothetical call.
+
+Use `preview-profile-tools` when you need to review a profile's effective tool
+surface. It previews installed tools and profile recommendations, including
+whether tools are visible, deferred, denied, or unavailable.
+
+Local CLI examples:
+
+```bash
+mcp-unified-gateway explain-policy --profile researcher --tool fs.patch \
+  --args-json-file ./patch-args.json --config ./gateway.json
+
+mcp-unified-gateway preview-profile-tools --profile researcher \
+  --category filesystem --config ./gateway.json
+```
+
+Remote CLI example:
+
+```bash
+export MCP_UNIFIED_GATEWAY_URL=http://127.0.0.1:8000/mcp
+export MCP_UNIFIED_GATEWAY_ADMIN_KEY=replace-with-admin-key
+
+printf '{"path":"src/app.py"}' | mcp-unified-gateway explain-policy \
+  --remote --profile researcher --tool fs.read --args-stdin
+```
+
+Direct admin API examples:
+
+```bash
+curl -sS -X POST "$MCP_UNIFIED_GATEWAY_URL/policy/explain" \
+  -H "X-MCP-Gateway-Admin-Key: $MCP_UNIFIED_GATEWAY_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"profile_id":"researcher","tool_name":"fs.read","arguments":{"path":"src/app.py"}}'
+
+curl -sS -X POST "$MCP_UNIFIED_GATEWAY_URL/profiles/researcher/tool-preview" \
+  -H "X-MCP-Gateway-Admin-Key: $MCP_UNIFIED_GATEWAY_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"category":"filesystem","include_denied":true}'
+```
+
+Security notes:
+
+- These calls require the gateway admin policy-explain permission remotely.
+- Calls are audited when audit storage is configured.
+- Responses redact or sanitize sensitive subjects and do not echo raw arguments.
+- Prefer `--args-json-file` or `--args-stdin` over inline `--args-json` for
+  sensitive arguments so values are not exposed in shell history or process
+  listings.
+
 ### Git Inspection Tools
 
 The `tldw-server` MCP host can expose optional native Git inspection tools when

--- a/mcp_unified/gateway/__init__.py
+++ b/mcp_unified/gateway/__init__.py
@@ -35,6 +35,12 @@ from .profile_governance import (
     PermissionChangeGovernor,
     PermissionChangeRequest,
 )
+from .policy_explain import (
+    GatewayPolicyExplainError,
+    GatewayPolicyExplainService,
+    PolicyExplainRequest,
+    ProfileToolPreviewRequest,
+)
 from .profiles import (
     GatewayProfileManagementError,
     GatewayProfileManager,
@@ -67,6 +73,8 @@ __all__ = [
     "GatewayExternalRuntimeManager",
     "ExternalRuntimeGatewayRuntime",
     "AllowPermissionChangeGovernor",
+    "GatewayPolicyExplainError",
+    "GatewayPolicyExplainService",
     "GatewayProfileBootstrap",
     "GatewayProfileBootstrapConfig",
     "GatewayProfileManagementError",
@@ -83,6 +91,8 @@ __all__ = [
     "PermissionChangeDecision",
     "PermissionChangeGovernor",
     "PermissionChangeRequest",
+    "PolicyExplainRequest",
+    "ProfileToolPreviewRequest",
     "ToolUseReportingGatewayRuntime",
     "ProfileAwareGatewayRuntime",
     "bootstrap_profile_gateway",

--- a/mcp_unified/gateway/admin_auth.py
+++ b/mcp_unified/gateway/admin_auth.py
@@ -26,6 +26,12 @@ _INVALID_PAYLOAD = {
     "error": "Gateway admin authentication failed",
     "reason_code": "admin_auth_invalid",
 }
+_PERMISSION_DENIED_PAYLOAD = {
+    "ok": False,
+    "error": "Gateway admin permission denied",
+    "reason_code": "admin_permission_denied",
+}
+_LOCAL_ADMIN_POLICY_EXPLAIN_PERMISSION = "mcp.policy.explain"
 
 
 class GatewayAdminAuthConfigLike(Protocol):
@@ -51,6 +57,22 @@ class GatewayAdminAuthError(Exception):
             self.payload = dict(_INVALID_PAYLOAD)
         else:
             raise ValueError(f"Unsupported gateway admin auth reason: {reason_code!r}")
+        self.reason_code = reason_code
+        super().__init__(self.payload["error"])
+
+
+class GatewayAdminPermissionError(Exception):
+    """Raised when an admin identity lacks a required gateway permission."""
+
+    def __init__(self, *, reason_code: str) -> None:
+        """Build a permission failure with a stable public reason code."""
+
+        if reason_code != "admin_permission_denied":
+            raise ValueError(
+                f"Unsupported gateway admin permission reason: {reason_code!r}"
+            )
+        self.status_code = 403
+        self.payload = dict(_PERMISSION_DENIED_PAYLOAD)
         self.reason_code = reason_code
         super().__init__(self.payload["error"])
 
@@ -99,6 +121,70 @@ class GatewayAdminAuthConfig:
         return secrets.compare_digest(credential, self.api_key)
 
 
+@dataclass(frozen=True, slots=True)
+class GatewayAdminIdentity:
+    """Authenticated gateway administrator identity and effective permissions."""
+
+    actor_id: str
+    permissions: frozenset[str]
+    source: str = "gateway_admin_auth"
+
+    def __post_init__(self) -> None:
+        """Normalize identity fields for stable permission checks."""
+
+        actor_id = str(self.actor_id).strip()
+        if not actor_id:
+            raise ValueError("gateway admin identity actor_id must be non-blank")
+        object.__setattr__(self, "actor_id", actor_id)
+        object.__setattr__(self, "permissions", frozenset(self.permissions))
+
+        source = str(self.source).strip()
+        if not source:
+            raise ValueError("gateway admin identity source must be non-blank")
+        object.__setattr__(self, "source", source)
+
+    @classmethod
+    def local_admin(cls) -> "GatewayAdminIdentity":
+        """Return the default local administrator identity."""
+
+        return cls(
+            actor_id="local-admin",
+            permissions=frozenset({_LOCAL_ADMIN_POLICY_EXPLAIN_PERMISSION}),
+            source="local",
+        )
+
+
+class GatewayAdminPermissionChecker(Protocol):
+    """Protocol for checking gateway admin effective permissions."""
+
+    async def require_permission(
+        self,
+        identity: GatewayAdminIdentity,
+        permission: str,
+    ) -> None:
+        """Raise when the identity lacks the required permission."""
+
+
+class DefaultGatewayAdminPermissionChecker:
+    """Default in-memory gateway admin permission checker."""
+
+    async def require_permission(
+        self,
+        identity: GatewayAdminIdentity,
+        permission: str,
+    ) -> None:
+        """Require one permission from the identity's effective permissions."""
+
+        if permission not in identity.permissions:
+            raise GatewayAdminPermissionError(reason_code="admin_permission_denied")
+
+
+def default_gateway_admin_identity() -> GatewayAdminIdentity:
+    """Return the default local gateway admin identity."""
+
+    return GatewayAdminIdentity.local_admin()
+
+
 def normalize_gateway_admin_auth_config(
     config: GatewayAdminAuthConfig | Mapping[str, Any] | None,
 ) -> GatewayAdminAuthConfig:
@@ -124,11 +210,33 @@ def gateway_admin_auth_dependencies(
     return [Depends(_gateway_admin_auth_dependency(resolved))]
 
 
+def gateway_admin_identity_dependency(
+    config: GatewayAdminAuthConfig | Mapping[str, Any] | None,
+) -> Callable[[Request], Awaitable[GatewayAdminIdentity]]:
+    """Return a FastAPI dependency that authenticates and yields an identity."""
+
+    return _gateway_admin_identity_dependency(
+        normalize_gateway_admin_auth_config(config)
+    )
+
+
 def gateway_admin_auth_error_response(
     request: Request,
     exc: GatewayAdminAuthError,
 ) -> Any:
     """Return the package-owned direct JSON error response for admin auth failures."""
+
+    from fastapi.responses import JSONResponse
+
+    del request
+    return JSONResponse(status_code=exc.status_code, content=exc.payload)
+
+
+def gateway_admin_permission_error_response(
+    request: Request,
+    exc: GatewayAdminPermissionError,
+) -> Any:
+    """Return the package-owned direct JSON error response for permission failures."""
 
     from fastapi.responses import JSONResponse
 
@@ -154,12 +262,40 @@ def _gateway_admin_auth_dependency(
     return require_gateway_admin
 
 
+def _gateway_admin_identity_dependency(
+    config: GatewayAdminAuthConfig,
+) -> Callable[[Request], Awaitable[GatewayAdminIdentity]]:
+    """Build an identity-producing request dependency."""
+
+    from fastapi import Request as FastAPIRequest
+
+    async def require_gateway_admin_identity(request: Any) -> GatewayAdminIdentity:
+        if not config.enabled:
+            return default_gateway_admin_identity()
+        credential = request.headers.get(config.header_name)
+        if credential is None or not credential.strip():
+            raise GatewayAdminAuthError(reason_code="admin_auth_required")
+        if not await config.verify(credential, request):
+            raise GatewayAdminAuthError(reason_code="admin_auth_invalid")
+        return default_gateway_admin_identity()
+
+    require_gateway_admin_identity.__annotations__["request"] = FastAPIRequest
+    return require_gateway_admin_identity
+
+
 __all__ = [
+    "DefaultGatewayAdminPermissionChecker",
     "GatewayAdminAuthConfig",
     "GatewayAdminAuthConfigLike",
     "GatewayAdminAuthError",
+    "GatewayAdminIdentity",
+    "GatewayAdminPermissionChecker",
+    "GatewayAdminPermissionError",
     "GatewayAdminVerifier",
+    "default_gateway_admin_identity",
     "gateway_admin_auth_dependencies",
     "gateway_admin_auth_error_response",
+    "gateway_admin_identity_dependency",
+    "gateway_admin_permission_error_response",
     "normalize_gateway_admin_auth_config",
 ]

--- a/mcp_unified/gateway/admin_auth.py
+++ b/mcp_unified/gateway/admin_auth.py
@@ -153,6 +153,15 @@ class GatewayAdminIdentity:
             source="local",
         )
 
+    @classmethod
+    def authenticated_admin(cls) -> "GatewayAdminIdentity":
+        """Return the generic authenticated gateway administrator identity."""
+
+        return cls(
+            actor_id="gateway-admin",
+            permissions=frozenset({_LOCAL_ADMIN_POLICY_EXPLAIN_PERMISSION}),
+        )
+
 
 class GatewayAdminPermissionChecker(Protocol):
     """Protocol for checking gateway admin effective permissions."""
@@ -183,6 +192,12 @@ def default_gateway_admin_identity() -> GatewayAdminIdentity:
     """Return the default local gateway admin identity."""
 
     return GatewayAdminIdentity.local_admin()
+
+
+def authenticated_gateway_admin_identity() -> GatewayAdminIdentity:
+    """Return the default authenticated gateway admin identity."""
+
+    return GatewayAdminIdentity.authenticated_admin()
 
 
 def normalize_gateway_admin_auth_config(
@@ -277,7 +292,7 @@ def _gateway_admin_identity_dependency(
             raise GatewayAdminAuthError(reason_code="admin_auth_required")
         if not await config.verify(credential, request):
             raise GatewayAdminAuthError(reason_code="admin_auth_invalid")
-        return default_gateway_admin_identity()
+        return authenticated_gateway_admin_identity()
 
     require_gateway_admin_identity.__annotations__["request"] = FastAPIRequest
     return require_gateway_admin_identity
@@ -292,6 +307,7 @@ __all__ = [
     "GatewayAdminPermissionChecker",
     "GatewayAdminPermissionError",
     "GatewayAdminVerifier",
+    "authenticated_gateway_admin_identity",
     "default_gateway_admin_identity",
     "gateway_admin_auth_dependencies",
     "gateway_admin_auth_error_response",

--- a/mcp_unified/gateway/cli.py
+++ b/mcp_unified/gateway/cli.py
@@ -55,6 +55,12 @@ from .policy_grants import (
     GatewayPolicyGrantManagementError,
     GatewayPolicyGrantManager,
 )
+from .policy_explain import (
+    GatewayPolicyExplainError,
+    GatewayPolicyExplainService,
+    PolicyExplainRequest,
+    ProfileToolPreviewRequest,
+)
 from .policy_simulation import simulate_tool_call_policy
 from .profiles import GatewayProfileManagementError, GatewayProfileManager
 from .remote_admin import (
@@ -88,6 +94,7 @@ _ToolEventsOperation = Callable[
     Coroutine[Any, Any, Mapping[str, Any]],
 ]
 _RemoteRuntimeOperation = Callable[[RemoteGatewayAdminClient], dict[str, Any]]
+_RemotePolicyOperation = Callable[[RemoteGatewayAdminClient], dict[str, Any]]
 
 
 class _CliArgumentError(ValueError):
@@ -560,6 +567,81 @@ def _build_parser() -> _JsonArgumentParser:
     _add_profile_config_argument(simulate_policy)
     simulate_policy.set_defaults(handler=_handle_simulate_policy)
 
+    explain_policy = subparsers.add_parser(
+        "explain-policy",
+        help="Explain one effective profile policy decision for a tool call.",
+    )
+    _add_policy_explain_common_arguments(explain_policy)
+    explain_policy.add_argument(
+        "--tool",
+        required=True,
+        help="Tool name for the policy explanation.",
+    )
+    explain_args_group = explain_policy.add_mutually_exclusive_group()
+    explain_args_group.add_argument(
+        "--args-json",
+        help="JSON object of tool arguments for the policy explanation.",
+    )
+    explain_args_group.add_argument(
+        "--args-json-file",
+        type=Path,
+        help="Path to a JSON object of tool arguments, or '-' to read from stdin.",
+    )
+    explain_args_group.add_argument(
+        "--args-stdin",
+        action="store_true",
+        help="Read a JSON object of tool arguments from stdin.",
+    )
+    explain_policy.add_argument(
+        "--capability",
+        help="Optional advertised tool capability for capability-based profiles.",
+    )
+    explain_policy.set_defaults(handler=_handle_explain_policy)
+
+    preview_profile_tools = subparsers.add_parser(
+        "preview-profile-tools",
+        help="Preview one profile's effective tool visibility.",
+    )
+    _add_policy_explain_common_arguments(preview_profile_tools)
+    preview_profile_tools.add_argument(
+        "--category",
+        help="Optional tool category filter.",
+    )
+    recommendations_group = preview_profile_tools.add_mutually_exclusive_group()
+    recommendations_group.add_argument(
+        "--include-recommendations",
+        action="store_true",
+        dest="include_recommendations",
+        default=True,
+        help="Include profile recommendations in preview results.",
+    )
+    recommendations_group.add_argument(
+        "--exclude-recommendations",
+        action="store_false",
+        dest="include_recommendations",
+        help="Exclude profile recommendations from preview results.",
+    )
+    denied_group = preview_profile_tools.add_mutually_exclusive_group()
+    denied_group.add_argument(
+        "--include-denied",
+        action="store_true",
+        dest="include_denied",
+        default=True,
+        help="Include denied or hidden tools in preview results.",
+    )
+    denied_group.add_argument(
+        "--exclude-denied",
+        action="store_false",
+        dest="include_denied",
+        help="Exclude denied or hidden tools from preview results.",
+    )
+    preview_profile_tools.add_argument(
+        "--limit",
+        type=int,
+        help="Maximum preview entries to return.",
+    )
+    preview_profile_tools.set_defaults(handler=_handle_preview_profile_tools)
+
     export_config = subparsers.add_parser(
         "export-config",
         help="Export a persistent gateway config snapshot.",
@@ -830,6 +912,51 @@ def _add_remote_runtime_arguments(parser: argparse.ArgumentParser) -> None:
         type=float,
         default=30.0,
         help="Remote gateway request timeout in seconds.",
+    )
+
+
+def _add_policy_explain_common_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add common local/remote policy explanation options."""
+
+    parser.add_argument(
+        "--profile",
+        required=True,
+        help="Profile id to evaluate.",
+    )
+    _add_profile_config_argument(parser)
+    parser.add_argument(
+        "--gateway-url",
+        help=(
+            "Mounted gateway base URL for remote mode. "
+            "Falls back to MCP_UNIFIED_GATEWAY_URL."
+        ),
+    )
+    parser.add_argument(
+        "--admin-key",
+        help=(
+            "Admin auth key for remote mode. "
+            "Falls back to MCP_UNIFIED_GATEWAY_ADMIN_KEY."
+        ),
+    )
+    parser.add_argument(
+        "--admin-header-name",
+        default="X-MCP-Gateway-Admin-Key",
+        help="Admin auth header name for remote mode.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=30.0,
+        help="Remote gateway request timeout in seconds.",
+    )
+    parser.add_argument(
+        "--static-policy-only",
+        action="store_true",
+        help="Ignore runtime/session contributors and explain static policy only.",
+    )
+    parser.add_argument(
+        "--session-id",
+        help="Optional session id for session-scoped policy grants.",
     )
 
 
@@ -1249,6 +1376,274 @@ def _simulation_arguments_from_args(args: argparse.Namespace) -> dict[str, Any]:
             raise ValueError("argv-json must be a JSON array of strings")
         arguments["argv"] = argv
     return arguments
+
+
+def _handle_explain_policy(args: argparse.Namespace) -> int:
+    """Explain one profile policy decision locally or through a gateway."""
+
+    try:
+        payload = _explain_policy_payload_from_args(args)
+    except _CliArgumentError:
+        raise
+    except ValueError as exc:
+        _emit_json(
+            {
+                "error": str(exc),
+                "ok": False,
+                "reason_code": "invalid_policy_explain_arguments",
+            },
+            sys.stderr,
+        )
+        return 1
+
+    if _policy_explain_remote_requested(args):
+        return _handle_remote_policy_explain_command(
+            args,
+            lambda client: client.explain_policy(payload),
+        )
+
+    return _handle_local_policy_explain_command(
+        args,
+        lambda service: service.explain_tool_call(
+            PolicyExplainRequest.model_validate(payload)
+        ),
+    )
+
+
+def _handle_preview_profile_tools(args: argparse.Namespace) -> int:
+    """Preview profile tool visibility locally or through a gateway."""
+
+    payload = _preview_profile_tools_payload_from_args(args)
+    profile_id = _require_cli_text(args.profile, field="profile")
+
+    if _policy_explain_remote_requested(args):
+        return _handle_remote_policy_explain_command(
+            args,
+            lambda client: client.preview_profile_tools(profile_id, payload),
+        )
+
+    return _handle_local_policy_explain_command(
+        args,
+        lambda service: service.preview_profile_tools(
+            ProfileToolPreviewRequest.model_validate(payload)
+        ),
+    )
+
+
+def _explain_policy_payload_from_args(args: argparse.Namespace) -> dict[str, Any]:
+    """Build an explain-policy request payload from CLI flags."""
+
+    payload: dict[str, Any] = {
+        "arguments": _policy_explain_arguments_from_args(args),
+        "mode": _policy_explain_mode_from_args(args),
+        "profile_id": _require_cli_text(args.profile, field="profile"),
+        "tool_name": _require_cli_text(args.tool, field="tool"),
+    }
+    capability = _optional_cli_text(args.capability, field="capability")
+    if capability is not None:
+        payload["capability"] = capability
+    session_id = _optional_cli_text(args.session_id, field="session_id")
+    if session_id is not None:
+        payload["session_id"] = session_id
+    return payload
+
+
+def _preview_profile_tools_payload_from_args(args: argparse.Namespace) -> dict[str, Any]:
+    """Build a preview-profile-tools request payload from CLI flags."""
+
+    payload: dict[str, Any] = {
+        "include_denied": bool(args.include_denied),
+        "include_recommendations": bool(args.include_recommendations),
+        "mode": _policy_explain_mode_from_args(args),
+        "profile_id": _require_cli_text(args.profile, field="profile"),
+    }
+    category = _optional_cli_text(args.category, field="category")
+    if category is not None:
+        payload["category"] = category
+    if args.limit is not None:
+        payload["limit"] = args.limit
+    return payload
+
+
+def _policy_explain_mode_from_args(args: argparse.Namespace) -> str:
+    """Return the policy explain mode encoded by shared CLI flags."""
+
+    if args.static_policy_only:
+        return "static_policy_only"
+    return "runtime_effective"
+
+
+def _policy_explain_arguments_from_args(args: argparse.Namespace) -> dict[str, Any]:
+    """Load the explain-policy tool arguments from one selected source."""
+
+    if args.args_json:
+        return _load_json_argument_text(args.args_json, label="args")
+    if args.args_json_file is not None:
+        return _load_json_argument_file(args.args_json_file, label="args")
+    if args.args_stdin:
+        return _load_json_argument_text(sys.stdin.read(), label="args")
+    return {}
+
+
+def _handle_remote_policy_explain_command(
+    args: argparse.Namespace,
+    operation: _RemotePolicyOperation,
+) -> int:
+    """Run one policy explain command against an already-running gateway."""
+
+    try:
+        config = _remote_policy_explain_config_from_args(args)
+        payload = operation(RemoteGatewayAdminClient(config))
+    except _CliArgumentError:
+        raise
+    except RemoteGatewayAdminError as exc:
+        _emit_json(exc.to_payload(), sys.stderr)
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        _emit_json(
+            {
+                "error": "Remote gateway command failed",
+                "error_type": exc.__class__.__name__,
+                "ok": False,
+                "reason_code": "remote_gateway_command_failed",
+            },
+            sys.stderr,
+        )
+        return 1
+
+    _emit_json(payload, sys.stdout)
+    return 0
+
+
+def _handle_local_policy_explain_command(
+    args: argparse.Namespace,
+    operation: Callable[
+        [GatewayPolicyExplainService],
+        Coroutine[Any, Any, Any],
+    ],
+) -> int:
+    """Run one policy explain command against local config/profile storage."""
+
+    config_path = _config_path_from_args(args)
+    profile_bundle: GatewayProfileStorageBundle | None = None
+    grant_store: Any = None
+    try:
+        try:
+            config = load_gateway_profile_bootstrap_config(config_path)
+            profile_bundle = build_gateway_profile_storage(config.store)
+            if not profile_bundle.metadata.persistent:
+                _run_async(_seed_readonly_memory_store(profile_bundle, config))
+            grant_store = build_gateway_policy_grant_store(config.policy_grants)
+            service = GatewayPolicyExplainService(
+                profile_resolver=_profile_resolver_for_policy_explain(
+                    profile_bundle,
+                    config,
+                ),
+                audit_store=profile_bundle.audit_store,
+                policy_grant_store=grant_store,
+            )
+        except _CliArgumentError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            _emit_json(
+                {
+                    "error": str(exc),
+                    "ok": False,
+                    "path": str(config_path),
+                },
+                sys.stderr,
+            )
+            return 1
+
+        try:
+            response = _run_async(operation(service))
+        except _CliArgumentError:
+            raise
+        except GatewayPolicyExplainError as exc:
+            _emit_json(exc.to_payload().model_dump(mode="json"), sys.stderr)
+            return 1
+        except Exception as exc:  # noqa: BLE001
+            _emit_json(
+                {
+                    "error": "Policy explain command failed",
+                    "error_type": exc.__class__.__name__,
+                    "ok": False,
+                    "reason_code": "policy_explain_command_failed",
+                },
+                sys.stderr,
+            )
+            return 1
+
+        _emit_json(response.model_dump(mode="json", exclude_none=True), sys.stdout)
+        return 0
+    finally:
+        if profile_bundle is not None:
+            _run_async(_close_storage_bundle(profile_bundle))
+        _close_policy_grant_store(grant_store)
+
+
+def _policy_explain_remote_requested(args: argparse.Namespace) -> bool:
+    """Return whether policy explain commands should use remote mode."""
+
+    gateway_url = _optional_cli_text(args.gateway_url, field="gateway_url")
+    if gateway_url is not None:
+        return True
+    env_gateway_url = _optional_cli_text(
+        os.environ.get("MCP_UNIFIED_GATEWAY_URL"),
+        field="MCP_UNIFIED_GATEWAY_URL",
+    )
+    return env_gateway_url is not None
+
+
+def _remote_policy_explain_config_from_args(
+    args: argparse.Namespace,
+) -> RemoteGatewayAdminConfig:
+    """Build a remote admin config for policy explain commands."""
+
+    gateway_url = _optional_cli_text(args.gateway_url, field="gateway_url")
+    if gateway_url is None:
+        gateway_url = _optional_cli_text(
+            os.environ.get("MCP_UNIFIED_GATEWAY_URL"),
+            field="MCP_UNIFIED_GATEWAY_URL",
+        )
+    if gateway_url is None:
+        raise _CliArgumentError(
+            "--gateway-url is required unless MCP_UNIFIED_GATEWAY_URL is set"
+        )
+
+    admin_key = _optional_cli_text(args.admin_key, field="admin_key")
+    if admin_key is None:
+        admin_key = _optional_cli_text(
+            os.environ.get("MCP_UNIFIED_GATEWAY_ADMIN_KEY"),
+            field="MCP_UNIFIED_GATEWAY_ADMIN_KEY",
+        )
+    try:
+        return RemoteGatewayAdminConfig(
+            gateway_url=gateway_url,
+            admin_header_name=args.admin_header_name,
+            admin_key=admin_key,
+            timeout_seconds=args.timeout_seconds,
+        )
+    except ValueError as exc:
+        raise _CliArgumentError(str(exc)) from exc
+
+
+def _profile_resolver_for_policy_explain(
+    bundle: GatewayProfileStorageBundle,
+    config: GatewayProfileBootstrapConfig,
+) -> Callable[[str], Coroutine[Any, Any, Any]]:
+    """Resolve profiles from configured storage with config-document fallback."""
+
+    async def _resolve(profile_id: str) -> Any:
+        profile = await bundle.profile_store.get_profile(profile_id)
+        if profile is not None:
+            return profile
+        for config_profile in config.profiles:
+            if config_profile.id == profile_id:
+                return config_profile.model_copy(deep=True)
+        return None
+
+    return _resolve
 
 
 def _handle_policy_grant_command(
@@ -2284,6 +2679,19 @@ def _load_json_argument_file(path: Path, *, label: str) -> dict[str, Any]:
             payload_text = path.read_text(encoding="utf-8")
     except OSError as exc:
         raise _CliArgumentError(f"Unable to read {label} JSON: {exc}") from exc
+
+    try:
+        payload = json.loads(payload_text)
+    except json.JSONDecodeError as exc:
+        raise _CliArgumentError(f"Invalid {label} JSON: {exc.msg}") from exc
+
+    if not isinstance(payload, dict):
+        raise _CliArgumentError(f"{label} JSON must be an object")
+    return payload
+
+
+def _load_json_argument_text(payload_text: str, *, label: str) -> dict[str, Any]:
+    """Load one JSON object payload from already-read text."""
 
     try:
         payload = json.loads(payload_text)

--- a/mcp_unified/gateway/cli.py
+++ b/mcp_unified/gateway/cli.py
@@ -1467,6 +1467,9 @@ def _preview_profile_tools_payload_from_args(args: argparse.Namespace) -> dict[s
     category = _optional_cli_text(args.category, field="category")
     if category is not None:
         payload["category"] = category
+    session_id = _optional_cli_text(args.session_id, field="session_id")
+    if session_id is not None:
+        payload["session_id"] = session_id
     if args.limit is not None:
         payload["limit"] = args.limit
     return payload

--- a/mcp_unified/gateway/cli.py
+++ b/mcp_unified/gateway/cli.py
@@ -927,21 +927,28 @@ def _add_policy_explain_common_arguments(parser: argparse.ArgumentParser) -> Non
     parser.add_argument(
         "--gateway-url",
         help=(
-            "Mounted gateway base URL for remote mode. "
-            "Falls back to MCP_UNIFIED_GATEWAY_URL."
+            "Mounted gateway base URL for remote mode. Providing this selects "
+            "remote mode."
         ),
     )
-    parser.add_argument(
-        "--admin-key",
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
+        "--local",
+        action="store_true",
+        help="Force local config/profile storage mode.",
+    )
+    mode_group.add_argument(
+        "--remote",
+        action="store_true",
         help=(
-            "Admin auth key for remote mode. "
-            "Falls back to MCP_UNIFIED_GATEWAY_ADMIN_KEY."
+            "Use a running gateway. Requires --gateway-url unless "
+            "MCP_UNIFIED_GATEWAY_URL is set."
         ),
     )
     parser.add_argument(
         "--admin-header-name",
         default="X-MCP-Gateway-Admin-Key",
-        help="Admin auth header name for remote mode.",
+        help="Admin auth header name used with MCP_UNIFIED_GATEWAY_ADMIN_KEY.",
     )
     parser.add_argument(
         "--timeout-seconds",
@@ -1476,7 +1483,7 @@ def _policy_explain_mode_from_args(args: argparse.Namespace) -> str:
 def _policy_explain_arguments_from_args(args: argparse.Namespace) -> dict[str, Any]:
     """Load the explain-policy tool arguments from one selected source."""
 
-    if args.args_json:
+    if args.args_json is not None:
         return _load_json_argument_text(args.args_json, label="args")
     if args.args_json_file is not None:
         return _load_json_argument_file(args.args_json_file, label="args")
@@ -1586,13 +1593,13 @@ def _policy_explain_remote_requested(args: argparse.Namespace) -> bool:
     """Return whether policy explain commands should use remote mode."""
 
     gateway_url = _optional_cli_text(args.gateway_url, field="gateway_url")
+    if args.local:
+        if gateway_url is not None:
+            raise _CliArgumentError("--local cannot be combined with --gateway-url")
+        return False
     if gateway_url is not None:
         return True
-    env_gateway_url = _optional_cli_text(
-        os.environ.get("MCP_UNIFIED_GATEWAY_URL"),
-        field="MCP_UNIFIED_GATEWAY_URL",
-    )
-    return env_gateway_url is not None
+    return bool(args.remote)
 
 
 def _remote_policy_explain_config_from_args(
@@ -1611,12 +1618,10 @@ def _remote_policy_explain_config_from_args(
             "--gateway-url is required unless MCP_UNIFIED_GATEWAY_URL is set"
         )
 
-    admin_key = _optional_cli_text(args.admin_key, field="admin_key")
-    if admin_key is None:
-        admin_key = _optional_cli_text(
-            os.environ.get("MCP_UNIFIED_GATEWAY_ADMIN_KEY"),
-            field="MCP_UNIFIED_GATEWAY_ADMIN_KEY",
-        )
+    admin_key = _optional_cli_text(
+        os.environ.get("MCP_UNIFIED_GATEWAY_ADMIN_KEY"),
+        field="MCP_UNIFIED_GATEWAY_ADMIN_KEY",
+    )
     try:
         return RemoteGatewayAdminConfig(
             gateway_url=gateway_url,

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -570,6 +570,26 @@ def _policy_explain_permission_error_response(
     )
 
 
+def _profile_tool_preview_payload_for_path(
+    payload: Any,
+    *,
+    profile_id: str,
+) -> Any:
+    """Return preview payload with a validated path-canonical profile id."""
+
+    if not isinstance(payload, Mapping):
+        return payload
+    body_profile_id = payload.get("profile_id")
+    if body_profile_id is None:
+        return {**payload, "profile_id": profile_id}
+    if body_profile_id == profile_id:
+        return payload
+    raise GatewayPolicyExplainError(
+        "Invalid policy preview request",
+        reason_code="invalid_policy_preview_request",
+    )
+
+
 def _profile_management_error_payload(exc: GatewayProfileManagementError) -> dict[str, Any]:
     """Return a public profile-management error payload without raw exception text."""
 
@@ -1391,7 +1411,10 @@ def _mount_policy_explain_routes(
         identity: GatewayAdminIdentity,
     ) -> GatewayPolicyExplainService:
         if policy_explain_service is not None:
-            return policy_explain_service
+            return policy_explain_service.with_request_context(
+                actor_id=identity.actor_id,
+                installed_tool_catalog=installed_tool_catalog,
+            )
         return GatewayPolicyExplainService(
             profile_resolver=policy_explain_profile_resolver,
             audit_store=policy_explain_audit_store,
@@ -1448,8 +1471,10 @@ def _mount_policy_explain_routes(
                 request,
                 reason_code="invalid_policy_preview_request",
             )
-            if isinstance(payload, Mapping):
-                payload = {**payload, "profile_id": profile_id}
+            payload = _profile_tool_preview_payload_for_path(
+                payload,
+                profile_id=profile_id,
+            )
             return await service_for_identity(identity).preview_profile_tools(
                 parse_profile_tool_preview_request(payload)
             )

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -1403,9 +1403,15 @@ def _mount_policy_explain_routes(
     )
 
     async def installed_tool_catalog() -> list[dict[str, Any]]:
-        return await runtime.list_tools(
-            GatewayRequestContext(request_id="policy-explain-tool-catalog")
+        context = GatewayRequestContext(request_id="policy-explain-tool-catalog")
+        admin_catalog = getattr(
+            runtime,
+            "list_backend_tools_for_admin_catalog",
+            None,
         )
+        if callable(admin_catalog):
+            return await admin_catalog(context)
+        return await runtime.list_tools(context)
 
     def service_for_identity(
         identity: GatewayAdminIdentity,

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Callable, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from contextlib import asynccontextmanager
 from typing import Any, Literal
 
@@ -13,12 +13,19 @@ from loguru import logger
 from pydantic import BaseModel, ConfigDict
 
 from mcp_unified.storage.models import CredentialGrant, ExternalServerDefinition
+from mcp_unified.interfaces.storage import AuditStore
+from mcp_unified.profiles import MCPProfile
 
 from .admin_auth import (
+    DefaultGatewayAdminPermissionChecker,
     GatewayAdminAuthConfig,
     GatewayAdminAuthError,
+    GatewayAdminIdentity,
+    GatewayAdminPermissionChecker,
+    GatewayAdminPermissionError,
     gateway_admin_auth_dependencies,
     gateway_admin_auth_error_response,
+    gateway_admin_identity_dependency,
     normalize_gateway_admin_auth_config,
 )
 from .bootstrap import GatewayProfileBootstrap
@@ -68,7 +75,16 @@ from .lifecycle import (
     normalize_external_runtime_lifecycle_config,
 )
 from .profiles import GatewayProfileManagementError, GatewayProfileManager
-from .runtime import GatewayRuntime
+from .policy_explain import (
+    GatewayPolicyExplainError,
+    GatewayPolicyExplainService,
+    PolicyExplainErrorResponse,
+    PolicyExplainResponse,
+    ProfileToolPreviewResponse,
+    parse_policy_explain_request,
+    parse_profile_tool_preview_request,
+)
+from .runtime import GatewayRequestContext, GatewayRuntime
 
 _PROFILE_HEADER_NAMES = ("x-mcp-profile", "x-mcp-profile-id")
 _PROFILE_QUERY_NAMES = ("profile_id", "profileId")
@@ -122,6 +138,14 @@ _CREDENTIAL_GRANT_STATUS_CODES = {
     "invalid_credential_grant_request": 422,
     "invalid_credential_grant_patch": 422,
     CREDENTIAL_GRANT_SENSITIVE_MATERIAL_REJECTED_REASON: 422,
+}
+_POLICY_EXPLAIN_STATUS_CODES = {
+    "profile_not_found": 404,
+    "invalid_policy_explain_request": 422,
+    "invalid_policy_preview_request": 422,
+    "audit_store_unavailable": 503,
+    "profile_resolution_failed": 503,
+    "policy_evaluation_failed": 422,
 }
 _EXTERNAL_SERVER_RESERVED_IDS = frozenset({"runtime", "refresh", "reconcile"})
 _PROFILE_MANAGEMENT_PUBLIC_ERRORS = {
@@ -388,6 +412,22 @@ async def _parse_json_body(request: Request) -> Any:
     return _parse_json_payload(await request.body())
 
 
+async def _parse_policy_explain_json_body(
+    request: Request,
+    *,
+    reason_code: str,
+) -> Any:
+    """Parse a policy-explain JSON body without exposing raw invalid input."""
+
+    try:
+        return await request.json()
+    except ValueError:
+        raise GatewayPolicyExplainError(
+            "Invalid JSON request",
+            reason_code=reason_code,
+        ) from None
+
+
 def _client_host(request: Request | WebSocket) -> str | None:
     """Return the peer host when the transport exposes one."""
 
@@ -503,6 +543,30 @@ def _credential_grant_error_response(
     return JSONResponse(
         status_code=_CREDENTIAL_GRANT_STATUS_CODES.get(exc.reason_code, 500),
         content=_credential_grant_error_payload(exc),
+    )
+
+
+def _policy_explain_error_response(exc: GatewayPolicyExplainError) -> JSONResponse:
+    """Translate expected policy-explain errors into HTTP JSON responses."""
+
+    return JSONResponse(
+        status_code=_POLICY_EXPLAIN_STATUS_CODES.get(exc.reason_code, 500),
+        content=exc.to_payload().model_dump(mode="json"),
+    )
+
+
+def _policy_explain_permission_error_response(
+    exc: GatewayAdminPermissionError,
+) -> JSONResponse:
+    """Return the policy-explain error envelope for admin permission failures."""
+
+    payload = PolicyExplainErrorResponse(
+        message=exc.payload["error"],
+        reason_code=exc.reason_code,
+    )
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=payload.model_dump(mode="json"),
     )
 
 
@@ -1292,6 +1356,109 @@ def _mount_credential_grant_routes(
             return _credential_grant_error_response(exc)
 
 
+def _mount_policy_explain_routes(
+    router: APIRouter,
+    runtime: GatewayRuntime,
+    *,
+    admin_auth: GatewayAdminAuthConfig,
+    policy_explain_service: GatewayPolicyExplainService | None = None,
+    policy_explain_profile_resolver: (
+        Callable[[str], MCPProfile | Awaitable[MCPProfile | None]] | None
+    ) = None,
+    policy_explain_audit_store: AuditStore | None = None,
+    policy_explain_permission_checker: GatewayAdminPermissionChecker | None = None,
+) -> None:
+    """Mount read-only policy explanation endpoints on the gateway router."""
+
+    if policy_explain_service is None and policy_explain_profile_resolver is None:
+        raise ValueError(
+            "policy explain management requires policy_explain_service "
+            "or policy_explain_profile_resolver"
+        )
+
+    identity_dependency = gateway_admin_identity_dependency(admin_auth)
+    permission_checker = (
+        policy_explain_permission_checker
+        or DefaultGatewayAdminPermissionChecker()
+    )
+
+    async def installed_tool_catalog() -> list[dict[str, Any]]:
+        return await runtime.list_tools(
+            GatewayRequestContext(request_id="policy-explain-tool-catalog")
+        )
+
+    def service_for_identity(
+        identity: GatewayAdminIdentity,
+    ) -> GatewayPolicyExplainService:
+        if policy_explain_service is not None:
+            return policy_explain_service
+        return GatewayPolicyExplainService(
+            profile_resolver=policy_explain_profile_resolver,
+            audit_store=policy_explain_audit_store,
+            actor_id=identity.actor_id,
+            installed_tool_catalog=installed_tool_catalog,
+        )
+
+    @router.post(
+        "/policy/explain",
+        response_model=PolicyExplainResponse,
+        response_model_exclude_none=True,
+    )
+    async def explain_policy(
+        request: Request,
+        identity: GatewayAdminIdentity = Depends(identity_dependency),
+    ) -> PolicyExplainResponse | JSONResponse:
+        """Return a redacted explanation for one profile/tool policy decision."""
+
+        try:
+            await permission_checker.require_permission(
+                identity,
+                "mcp.policy.explain",
+            )
+            payload = await _parse_policy_explain_json_body(
+                request,
+                reason_code="invalid_policy_explain_request",
+            )
+            return await service_for_identity(identity).explain_tool_call(
+                parse_policy_explain_request(payload)
+            )
+        except GatewayAdminPermissionError as exc:
+            return _policy_explain_permission_error_response(exc)
+        except GatewayPolicyExplainError as exc:
+            return _policy_explain_error_response(exc)
+
+    @router.post(
+        "/profiles/{profile_id}/tool-preview",
+        response_model=ProfileToolPreviewResponse,
+        response_model_exclude_none=True,
+    )
+    async def preview_profile_tools(
+        profile_id: str,
+        request: Request,
+        identity: GatewayAdminIdentity = Depends(identity_dependency),
+    ) -> ProfileToolPreviewResponse | JSONResponse:
+        """Return a redacted profile preview across installed gateway tools."""
+
+        try:
+            await permission_checker.require_permission(
+                identity,
+                "mcp.policy.explain",
+            )
+            payload = await _parse_policy_explain_json_body(
+                request,
+                reason_code="invalid_policy_preview_request",
+            )
+            if isinstance(payload, Mapping):
+                payload = {**payload, "profile_id": profile_id}
+            return await service_for_identity(identity).preview_profile_tools(
+                parse_profile_tool_preview_request(payload)
+            )
+        except GatewayAdminPermissionError as exc:
+            return _policy_explain_permission_error_response(exc)
+        except GatewayPolicyExplainError as exc:
+            return _policy_explain_error_response(exc)
+
+
 def create_gateway_router(
     runtime: GatewayRuntime,
     *,
@@ -1305,6 +1472,13 @@ def create_gateway_router(
     admin_auth: GatewayAdminAuthConfig | Mapping[str, Any] | None = None,
     credential_grant_manager: GatewayCredentialGrantManager | None = None,
     enable_credential_grant_management: bool = False,
+    enable_policy_explain_management: bool = False,
+    policy_explain_service: GatewayPolicyExplainService | None = None,
+    policy_explain_profile_resolver: (
+        Callable[[str], MCPProfile | Awaitable[MCPProfile | None]] | None
+    ) = None,
+    policy_explain_audit_store: AuditStore | None = None,
+    policy_explain_permission_checker: GatewayAdminPermissionChecker | None = None,
 ) -> APIRouter:
     """Create a package-owned FastAPI router for a standalone MCP runtime."""
 
@@ -1357,6 +1531,16 @@ def create_gateway_router(
             router,
             resolved_credential_grant_manager,
             admin_dependencies=admin_dependencies,
+        )
+    if enable_policy_explain_management:
+        _mount_policy_explain_routes(
+            router,
+            runtime,
+            admin_auth=resolved_admin_auth,
+            policy_explain_service=policy_explain_service,
+            policy_explain_profile_resolver=policy_explain_profile_resolver,
+            policy_explain_audit_store=policy_explain_audit_store,
+            policy_explain_permission_checker=policy_explain_permission_checker,
         )
 
     @router.get("/status")
@@ -1437,6 +1621,13 @@ def create_gateway_app(
     admin_auth: GatewayAdminAuthConfig | Mapping[str, Any] | None = None,
     credential_grant_manager: GatewayCredentialGrantManager | None = None,
     enable_credential_grant_management: bool = False,
+    enable_policy_explain_management: bool = False,
+    policy_explain_service: GatewayPolicyExplainService | None = None,
+    policy_explain_profile_resolver: (
+        Callable[[str], MCPProfile | Awaitable[MCPProfile | None]] | None
+    ) = None,
+    policy_explain_audit_store: AuditStore | None = None,
+    policy_explain_permission_checker: GatewayAdminPermissionChecker | None = None,
 ) -> FastAPI:
     """Create a minimal FastAPI app exposing the standalone MCP gateway router."""
 
@@ -1480,6 +1671,11 @@ def create_gateway_app(
             admin_auth=admin_auth,
             credential_grant_manager=credential_grant_manager,
             enable_credential_grant_management=enable_credential_grant_management,
+            enable_policy_explain_management=enable_policy_explain_management,
+            policy_explain_service=policy_explain_service,
+            policy_explain_profile_resolver=policy_explain_profile_resolver,
+            policy_explain_audit_store=policy_explain_audit_store,
+            policy_explain_permission_checker=policy_explain_permission_checker,
         ),
         prefix=prefix,
     )

--- a/mcp_unified/gateway/fastapi.py
+++ b/mcp_unified/gateway/fastapi.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
+from collections import deque
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from contextlib import asynccontextmanager
 from typing import Any, Literal
@@ -147,6 +150,9 @@ _POLICY_EXPLAIN_STATUS_CODES = {
     "profile_resolution_failed": 503,
     "policy_evaluation_failed": 422,
 }
+POLICY_EXPLAIN_RATE_LIMIT_MAX_REQUESTS = 120
+POLICY_EXPLAIN_RATE_LIMIT_WINDOW_SECONDS = 60.0
+_POLICY_EXPLAIN_RATE_LIMIT_MAX_KEYS = 2048
 _EXTERNAL_SERVER_RESERVED_IDS = frozenset({"runtime", "refresh", "reconcile"})
 _PROFILE_MANAGEMENT_PUBLIC_ERRORS = {
     "permission_change_denied": "Permission change denied",
@@ -406,6 +412,63 @@ class _GatewayAdminAuthHandlingRoute(APIRoute):
         return route_handler
 
 
+class _GatewayAdminRouteRateLimiter:
+    """Small in-memory rate limiter for standalone admin route surfaces."""
+
+    def __init__(
+        self,
+        *,
+        max_requests: int,
+        window_seconds: float,
+        max_keys: int = _POLICY_EXPLAIN_RATE_LIMIT_MAX_KEYS,
+    ) -> None:
+        self.max_requests = max(1, int(max_requests))
+        self.window_seconds = max(1.0, float(window_seconds))
+        self.max_keys = max(1, int(max_keys))
+        self._hits_by_key: dict[str, deque[float]] = {}
+        self._lock = asyncio.Lock()
+
+    async def allow(self, key: str) -> bool:
+        """Return whether one request is within this limiter's window."""
+
+        now = time.monotonic()
+        cutoff = now - self.window_seconds
+        async with self._lock:
+            self._prune_locked(cutoff)
+            hits = self._hits_by_key.setdefault(key, deque())
+            while hits and hits[0] <= cutoff:
+                hits.popleft()
+            if len(hits) >= self.max_requests:
+                return False
+            hits.append(now)
+            if len(self._hits_by_key) > self.max_keys:
+                self._prune_oldest_key_locked()
+            return True
+
+    def _prune_locked(self, cutoff: float) -> None:
+        empty_keys: list[str] = []
+        for key, hits in self._hits_by_key.items():
+            while hits and hits[0] <= cutoff:
+                hits.popleft()
+            if not hits:
+                empty_keys.append(key)
+        for key in empty_keys:
+            del self._hits_by_key[key]
+
+    def _prune_oldest_key_locked(self) -> None:
+        oldest_key: str | None = None
+        oldest_hit: float | None = None
+        for key, hits in self._hits_by_key.items():
+            if not hits:
+                oldest_key = key
+                break
+            if oldest_hit is None or hits[0] < oldest_hit:
+                oldest_key = key
+                oldest_hit = hits[0]
+        if oldest_key is not None:
+            del self._hits_by_key[oldest_key]
+
+
 async def _parse_json_body(request: Request) -> Any:
     """Parse raw JSON so malformed bodies return JSON-RPC parse errors."""
 
@@ -434,6 +497,15 @@ def _client_host(request: Request | WebSocket) -> str | None:
     if request.client is None:
         return None
     return request.client.host
+
+
+def _policy_explain_rate_limit_key(
+    request: Request,
+    identity: GatewayAdminIdentity,
+) -> str:
+    """Return the admin identity/IP key used for policy explain throttling."""
+
+    return f"{identity.actor_id}:{_client_host(request) or 'unknown'}"
 
 
 def _request_metadata(request: Request | WebSocket) -> dict[str, Any]:
@@ -566,6 +638,19 @@ def _policy_explain_permission_error_response(
     )
     return JSONResponse(
         status_code=exc.status_code,
+        content=payload.model_dump(mode="json"),
+    )
+
+
+def _policy_explain_rate_limit_error_response() -> JSONResponse:
+    """Return the policy-explain error envelope for rate-limit denials."""
+
+    payload = PolicyExplainErrorResponse(
+        message="Policy explain rate limit exceeded",
+        reason_code="policy_explain_rate_limited",
+    )
+    return JSONResponse(
+        status_code=429,
         content=payload.model_dump(mode="json"),
     )
 
@@ -1428,6 +1513,26 @@ def _mount_policy_explain_routes(
             installed_tool_catalog=installed_tool_catalog,
         )
 
+    route_rate_limiter = _GatewayAdminRouteRateLimiter(
+        max_requests=POLICY_EXPLAIN_RATE_LIMIT_MAX_REQUESTS,
+        window_seconds=POLICY_EXPLAIN_RATE_LIMIT_WINDOW_SECONDS,
+    )
+
+    async def policy_explain_rate_limit_response(
+        request: Request,
+        identity: GatewayAdminIdentity,
+    ) -> JSONResponse | None:
+        key = _policy_explain_rate_limit_key(request, identity)
+        if await route_rate_limiter.allow(key):
+            return None
+        logger.warning(
+            "Gateway policy explain route rate limit exceeded "
+            "(actor_id={}, client_host={})",
+            identity.actor_id,
+            _client_host(request) or "unknown",
+        )
+        return _policy_explain_rate_limit_error_response()
+
     @router.post(
         "/policy/explain",
         response_model=PolicyExplainResponse,
@@ -1444,6 +1549,12 @@ def _mount_policy_explain_routes(
                 identity,
                 "mcp.policy.explain",
             )
+            rate_limit_response = await policy_explain_rate_limit_response(
+                request,
+                identity,
+            )
+            if rate_limit_response is not None:
+                return rate_limit_response
             payload = await _parse_policy_explain_json_body(
                 request,
                 reason_code="invalid_policy_explain_request",
@@ -1473,6 +1584,12 @@ def _mount_policy_explain_routes(
                 identity,
                 "mcp.policy.explain",
             )
+            rate_limit_response = await policy_explain_rate_limit_response(
+                request,
+                identity,
+            )
+            if rate_limit_response is not None:
+                return rate_limit_response
             payload = await _parse_policy_explain_json_body(
                 request,
                 reason_code="invalid_policy_preview_request",

--- a/mcp_unified/gateway/policy_explain.py
+++ b/mcp_unified/gateway/policy_explain.py
@@ -933,7 +933,7 @@ def _preview_rows_from_catalog(catalog: Any) -> list[_PreviewCatalogRow]:
         if row is None:
             continue
         rows_by_name.setdefault(row.tool_name, row)
-    return [rows_by_name[tool_name] for tool_name in sorted(rows_by_name)]
+    return list(rows_by_name.values())
 
 
 def _preview_row_from_catalog_item(item: Any) -> _PreviewCatalogRow | None:

--- a/mcp_unified/gateway/policy_explain.py
+++ b/mcp_unified/gateway/policy_explain.py
@@ -1,0 +1,632 @@
+"""Redacted policy explanation service for the standalone MCP gateway."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import re
+from collections.abc import Awaitable, Callable, Iterable, Mapping
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Literal
+from urllib.parse import urlsplit
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from mcp_unified.interfaces.storage import AuditStore
+from mcp_unified.profiles import MCPProfile, explain_profile_tool_decision
+from mcp_unified.profiles.subjects import (
+    PermissionSubjectLimitError,
+    extract_permission_rule_subjects,
+)
+from mcp_unified.storage.models import AuditEvent
+
+from .policy_simulation import simulate_tool_call_policy
+
+MAX_POLICY_EXPLAIN_ARGUMENT_BYTES = 64 * 1024
+
+PolicyExplainOutcome = Literal["deny", "ask", "allow"]
+PolicyExplainRedactionState = Literal["plain", "sanitized", "redacted"]
+
+
+class PolicyExplainMode(str, Enum):
+    """How closely an explanation should mirror runtime policy state."""
+
+    RUNTIME_EFFECTIVE = "runtime_effective"
+    STATIC_PROFILE = "static_profile"
+
+
+class PolicyExplainRequest(BaseModel):
+    """Request to explain one profile/tool policy decision."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    profile_id: str
+    tool_name: str
+    arguments: dict[str, Any] = Field(default_factory=dict)
+    capability: str | None = None
+    session_id: str | None = None
+    mode: PolicyExplainMode = PolicyExplainMode.RUNTIME_EFFECTIVE
+
+    @field_validator("profile_id", "tool_name")
+    @classmethod
+    def _validate_required_text(cls, value: str) -> str:
+        return _required_text(value)
+
+    @field_validator("capability", "session_id")
+    @classmethod
+    def _normalize_optional_text(cls, value: str | None) -> str | None:
+        return _optional_text(value)
+
+    @field_validator("arguments", mode="before")
+    @classmethod
+    def _coerce_arguments(cls, value: Any) -> dict[str, Any]:
+        if value is None:
+            return {}
+        if not isinstance(value, Mapping):
+            raise ValueError("arguments must be an object")
+        return dict(value)
+
+    @model_validator(mode="after")
+    def _validate_argument_size(self) -> PolicyExplainRequest:
+        _validate_serialized_argument_size(self.arguments)
+        return self
+
+
+class ProfileToolPreviewRequest(BaseModel):
+    """Request to preview profile decisions across a tool catalog."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    profile_id: str
+    capability: str | None = None
+    mode: PolicyExplainMode = PolicyExplainMode.RUNTIME_EFFECTIVE
+
+    @field_validator("profile_id")
+    @classmethod
+    def _validate_profile_id(cls, value: str) -> str:
+        return _required_text(value)
+
+    @field_validator("capability")
+    @classmethod
+    def _normalize_capability(cls, value: str | None) -> str | None:
+        return _optional_text(value)
+
+
+class PolicyExplainSubject(BaseModel):
+    """One redacted subject considered by runtime permission rules."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: str
+    value: str
+    redaction_state: PolicyExplainRedactionState
+    outcome: str | None = None
+    reason_code: str | None = None
+    matched_rules: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class PolicyExplainResponse(BaseModel):
+    """Redacted explanation for one profile/tool policy decision."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ok: bool = True
+    profile_id: str
+    tool_name: str
+    mode: PolicyExplainMode
+    final_outcome: PolicyExplainOutcome
+    reason_code: str
+    visibility: str
+    call_state: str
+    requires_approval: bool
+    runtime_status: str | None = None
+    runtime_reason_code: str | None = None
+    subjects: list[PolicyExplainSubject] = Field(default_factory=list)
+    degraded: bool = False
+    degraded_reasons: list[str] = Field(default_factory=list)
+    redacted: bool = True
+
+
+class ProfileToolPreviewEntry(BaseModel):
+    """Redacted profile decision for one catalog or policy-listed tool."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    tool_name: str
+    final_outcome: PolicyExplainOutcome
+    reason_code: str
+    visibility: str
+    call_state: str
+    requires_approval: bool
+    redacted: bool = True
+
+
+class ProfileToolPreviewSummary(BaseModel):
+    """Count summary for profile tool preview entries."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    total: int = 0
+    allow: int = 0
+    ask: int = 0
+    deny: int = 0
+
+
+class ProfileToolPreviewResponse(BaseModel):
+    """Redacted preview of effective profile tool decisions."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ok: bool = True
+    profile_id: str
+    mode: PolicyExplainMode
+    entries: list[ProfileToolPreviewEntry] = Field(default_factory=list)
+    summary: ProfileToolPreviewSummary = Field(default_factory=ProfileToolPreviewSummary)
+    degraded: bool = False
+    degraded_reasons: list[str] = Field(default_factory=list)
+    redacted: bool = True
+
+
+class PolicyExplainErrorResponse(BaseModel):
+    """Stable error envelope for policy explanation failures."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ok: bool = False
+    error: str
+    reason_code: str
+
+
+class GatewayPolicyExplainError(RuntimeError):
+    """Expected policy explanation service failure."""
+
+    def __init__(self, message: str, *, reason_code: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+
+    def to_payload(self) -> PolicyExplainErrorResponse:
+        """Return a stable redacted error payload."""
+
+        return PolicyExplainErrorResponse(error=str(self), reason_code=self.reason_code)
+
+
+class GatewayPolicyExplainService:
+    """Assemble redacted policy explanations with strict audit events."""
+
+    def __init__(
+        self,
+        *,
+        profile_resolver: Callable[[str], MCPProfile | Awaitable[MCPProfile | None] | None],
+        audit_store: AuditStore | None,
+        actor_id: str | None = None,
+        catalog_provider: Callable[[], Iterable[Any] | Awaitable[Iterable[Any]]] | None = None,
+        policy_grant_store: Any | None = None,
+    ) -> None:
+        self.profile_resolver = profile_resolver
+        self.audit_store = audit_store
+        self.actor_id = actor_id
+        self.catalog_provider = catalog_provider
+        self.policy_grant_store = policy_grant_store
+
+    async def explain_tool_call(
+        self,
+        request: PolicyExplainRequest,
+    ) -> PolicyExplainResponse:
+        """Return a redacted explanation for one tool call policy check."""
+
+        profile = await self._resolve_profile(request.profile_id)
+        simulator_result = simulate_tool_call_policy(
+            profile,
+            request.tool_name,
+            request.arguments,
+            capability=request.capability,
+            policy_grant_store=self.policy_grant_store,
+            session_id=request.session_id,
+        )
+        tool_explanation = explain_profile_tool_decision(
+            profile,
+            request.tool_name,
+            capability=request.capability,
+        )
+        subjects, degraded_reasons = _policy_subjects_from_simulation(
+            simulator_result,
+            tool_name=request.tool_name,
+            arguments=request.arguments,
+        )
+        overall = _mapping_value(simulator_result, "overall")
+        response = PolicyExplainResponse(
+            profile_id=profile.id,
+            tool_name=request.tool_name,
+            mode=request.mode,
+            final_outcome=tool_explanation.final_outcome,
+            reason_code=tool_explanation.reason_code,
+            visibility=tool_explanation.visibility,
+            call_state=tool_explanation.call_state,
+            requires_approval=tool_explanation.requires_approval,
+            runtime_status=(
+                _mapping_value(overall, "status")
+                if isinstance(overall, Mapping)
+                else None
+            ),
+            runtime_reason_code=(
+                _mapping_value(overall, "reason_code")
+                if isinstance(overall, Mapping)
+                else None
+            ),
+            subjects=subjects,
+            degraded=bool(degraded_reasons),
+            degraded_reasons=degraded_reasons,
+        )
+        await _append_audit_event_strict(
+            self.audit_store,
+            event_type="policy.explain.requested",
+            actor_id=self.actor_id,
+            profile_id=profile.id,
+            target_type="tool",
+            target_id=request.tool_name,
+            payload=response.model_dump(mode="json", exclude_none=True),
+        )
+        return response
+
+    async def preview_profile_tools(
+        self,
+        request: ProfileToolPreviewRequest,
+    ) -> ProfileToolPreviewResponse:
+        """Return a redacted profile tool preview, degrading without a catalog."""
+
+        profile = await self._resolve_profile(request.profile_id)
+        degraded_reasons: list[str] = []
+        tool_names = await self._preview_tool_names(profile)
+        if self.catalog_provider is None:
+            degraded_reasons.append("catalog_unavailable")
+
+        entries = [
+            _profile_tool_preview_entry(profile, tool_name, capability=request.capability)
+            for tool_name in tool_names
+        ]
+        response = ProfileToolPreviewResponse(
+            profile_id=profile.id,
+            mode=request.mode,
+            entries=entries,
+            summary=_preview_summary(entries),
+            degraded=bool(degraded_reasons),
+            degraded_reasons=degraded_reasons,
+        )
+        await _append_audit_event_strict(
+            self.audit_store,
+            event_type="policy.preview.requested",
+            actor_id=self.actor_id,
+            profile_id=profile.id,
+            target_type="profile",
+            target_id=profile.id,
+            payload=response.model_dump(mode="json", exclude_none=True),
+        )
+        return response
+
+    async def _resolve_profile(self, profile_id: str) -> MCPProfile:
+        profile = await _maybe_await(self.profile_resolver(profile_id))
+        if profile is None:
+            raise GatewayPolicyExplainError(
+                "Profile not found",
+                reason_code="profile_not_found",
+            )
+        return profile
+
+    async def _preview_tool_names(self, profile: MCPProfile) -> list[str]:
+        if self.catalog_provider is not None:
+            catalog = await _maybe_await(self.catalog_provider())
+            return sorted(_tool_names_from_catalog(catalog))
+
+        policy_document = profile.policy_document
+        policy_tools = set(policy_document.allowed_tools or [])
+        policy_tools.update(policy_document.denied_tools or [])
+        return sorted(tool_name for tool_name in policy_tools if isinstance(tool_name, str))
+
+
+async def _append_audit_event_strict(
+    audit_store: AuditStore | None,
+    *,
+    event_type: str,
+    actor_id: str | None,
+    profile_id: str | None,
+    target_type: str | None,
+    target_id: str | None,
+    payload: Mapping[str, Any],
+) -> None:
+    """Append an audit event or fail closed when audit is unavailable."""
+
+    if audit_store is None:
+        raise GatewayPolicyExplainError(
+            "Audit store unavailable",
+            reason_code="audit_store_unavailable",
+        )
+    event = AuditEvent(
+        id=f"policy-explain-{uuid4().hex}",
+        event_type=event_type,
+        actor_id=actor_id,
+        profile_id=profile_id,
+        target_type=target_type,
+        target_id=target_id,
+        payload=dict(payload),
+        provenance={"source": "gateway_policy_explain_service"},
+        created_at=datetime.now(timezone.utc),
+    )
+    try:
+        await audit_store.append_event(event)
+    except Exception as exc:  # noqa: BLE001
+        raise GatewayPolicyExplainError(
+            "Audit store unavailable",
+            reason_code="audit_store_unavailable",
+        ) from exc
+
+
+def _redact_subject_value(
+    subject_type: str,
+    value: Any,
+) -> tuple[str, PolicyExplainRedactionState]:
+    """Return a safe subject value and its redaction state."""
+
+    if not isinstance(value, str):
+        return "[redacted]", "redacted"
+
+    subject = subject_type.strip().lower()
+    text = value.strip()
+    if not text:
+        return "", "plain"
+    if subject == "path":
+        return _redact_path(text)
+    if subject == "command":
+        return "[redacted-command]", "redacted"
+    if subject == "domain":
+        return _redact_domain(text)
+    if subject in {"tool", "mcp", "skill", "agent", "capability", "risk_class"}:
+        return text, "plain"
+    return "[redacted]", "redacted"
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def _policy_subjects_from_simulation(
+    simulator_result: Mapping[str, Any],
+    *,
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> tuple[list[PolicyExplainSubject], list[str]]:
+    degraded_reasons: list[str] = []
+    raw_subjects = [
+        item
+        for item in _sequence_value(simulator_result, "subjects")
+        if _mapping_value(item, "subject_type") != "tool"
+    ]
+    if not raw_subjects:
+        try:
+            raw_subjects = [
+                {
+                    "subject_type": subject_type,
+                    "value": value,
+                    "outcome": None,
+                    "reason_code": None,
+                    "matched_rules": [],
+                }
+                for subject_type, value, _argv in extract_permission_rule_subjects(
+                    tool_name,
+                    arguments,
+                )
+                if subject_type != "tool"
+            ]
+        except PermissionSubjectLimitError:
+            degraded_reasons.append("subject_limit_exceeded")
+
+    subjects: list[PolicyExplainSubject] = []
+    seen: set[tuple[str, str]] = set()
+    for raw_subject in raw_subjects:
+        subject_type = _mapping_value(raw_subject, "subject_type")
+        raw_value = _mapping_value(raw_subject, "value")
+        if not isinstance(subject_type, str):
+            continue
+        value, redaction_state = _redact_subject_value(subject_type, raw_value)
+        key = (subject_type, value)
+        if key in seen:
+            continue
+        seen.add(key)
+        subjects.append(
+            PolicyExplainSubject(
+                type=subject_type,
+                value=value,
+                redaction_state=redaction_state,
+                outcome=_optional_string(_mapping_value(raw_subject, "outcome")),
+                reason_code=_optional_string(_mapping_value(raw_subject, "reason_code")),
+                matched_rules=[
+                    _redacted_rule(rule)
+                    for rule in _sequence_value(raw_subject, "matched_rules")
+                    if isinstance(rule, Mapping)
+                ],
+            )
+        )
+    return subjects, degraded_reasons
+
+
+def _redacted_rule(rule: Mapping[str, Any]) -> dict[str, Any]:
+    rule_type = _optional_string(rule.get("rule_type"))
+    payload: dict[str, Any] = {}
+    for key in ("source", "rule_type", "outcome", "reason_code"):
+        value = _optional_string(rule.get(key))
+        if value is not None:
+            payload[key] = value
+    pattern = _optional_string(rule.get("pattern"))
+    if pattern is not None:
+        if rule_type is None:
+            payload["pattern"] = "[redacted]"
+        else:
+            payload["pattern"] = _redact_subject_value(rule_type, pattern)[0]
+    return payload
+
+
+def _profile_tool_preview_entry(
+    profile: MCPProfile,
+    tool_name: str,
+    *,
+    capability: str | None,
+) -> ProfileToolPreviewEntry:
+    explanation = explain_profile_tool_decision(
+        profile,
+        tool_name,
+        capability=capability,
+    )
+    return ProfileToolPreviewEntry(
+        tool_name=_redact_tool_identifier(tool_name),
+        final_outcome=explanation.final_outcome,
+        reason_code=explanation.reason_code,
+        visibility=explanation.visibility,
+        call_state=explanation.call_state,
+        requires_approval=explanation.requires_approval,
+    )
+
+
+def _preview_summary(
+    entries: Iterable[ProfileToolPreviewEntry],
+) -> ProfileToolPreviewSummary:
+    entry_list = list(entries)
+    summary = ProfileToolPreviewSummary(total=len(entry_list))
+    for entry in entry_list:
+        if entry.final_outcome == "allow":
+            summary.allow += 1
+        elif entry.final_outcome == "ask":
+            summary.ask += 1
+        elif entry.final_outcome == "deny":
+            summary.deny += 1
+    return summary
+
+
+def _tool_names_from_catalog(catalog: Iterable[Any]) -> set[str]:
+    tool_names: set[str] = set()
+    for item in catalog:
+        tool_name: Any
+        if isinstance(item, str):
+            tool_name = item
+        elif isinstance(item, Mapping):
+            tool_name = item.get("name") or item.get("tool_name")
+        else:
+            tool_name = getattr(item, "name", None) or getattr(item, "tool_name", None)
+        if isinstance(tool_name, str) and tool_name.strip():
+            tool_names.add(tool_name.strip())
+    return tool_names
+
+
+def _redact_path(value: str) -> tuple[str, PolicyExplainRedactionState]:
+    normalized = value.replace("\\", "/")
+    if "\n" in normalized or "\r" in normalized:
+        return "[redacted-path]", "redacted"
+    if _is_absolute_path(normalized):
+        filename = normalized.rstrip("/").rsplit("/", 1)[-1]
+        return (f".../{filename}" if filename else "[path]"), "sanitized"
+    return normalized, "plain"
+
+
+def _redact_domain(value: str) -> tuple[str, PolicyExplainRedactionState]:
+    parsed = urlsplit(value)
+    if parsed.scheme and parsed.netloc:
+        host = parsed.hostname or "[domain]"
+        try:
+            port = parsed.port
+        except ValueError:
+            port = None
+        if port is not None:
+            host = f"{host}:{port}"
+        return f"{parsed.scheme}://{host}", "sanitized"
+    sanitized = value.split("?", 1)[0].split("#", 1)[0]
+    if "@" in sanitized:
+        sanitized = sanitized.rsplit("@", 1)[-1]
+    state: PolicyExplainRedactionState = "sanitized" if sanitized != value else "plain"
+    return sanitized, state
+
+
+def _is_absolute_path(value: str) -> bool:
+    return bool(
+        value.startswith("/")
+        or value.startswith("~")
+        or re.match(r"^[A-Za-z]:/", value)
+    )
+
+
+def _redact_tool_identifier(tool_name: str) -> str:
+    stripped = tool_name.strip()
+    if "\n" in stripped or "\r" in stripped:
+        return "[redacted-tool]"
+    for command_tool in ("Bash", "Shell", "PowerShell", "Monitor"):
+        if stripped.startswith(f"{command_tool}(") and stripped.endswith(")"):
+            return f"{command_tool}([redacted-command])"
+    return stripped
+
+
+def _validate_serialized_argument_size(arguments: Mapping[str, Any]) -> None:
+    serialized = json.dumps(
+        arguments,
+        default=lambda _value: "[non-json-value]",
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    if len(serialized.encode("utf-8")) > MAX_POLICY_EXPLAIN_ARGUMENT_BYTES:
+        raise ValueError("arguments exceed maximum serialized size")
+
+
+def _sequence_value(value: Mapping[str, Any], key: str) -> list[Any]:
+    item = value.get(key)
+    if isinstance(item, list):
+        return item
+    if isinstance(item, tuple):
+        return list(item)
+    return []
+
+
+def _mapping_value(value: Any, key: str) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(key)
+    return None
+
+
+def _required_text(value: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError("value must be a string")
+    text = value.strip()
+    if not text:
+        raise ValueError("value cannot be blank")
+    return text
+
+
+def _optional_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return _optional_string(value)
+
+
+def _optional_string(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+__all__ = [
+    "GatewayPolicyExplainError",
+    "GatewayPolicyExplainService",
+    "MAX_POLICY_EXPLAIN_ARGUMENT_BYTES",
+    "PolicyExplainErrorResponse",
+    "PolicyExplainMode",
+    "PolicyExplainRequest",
+    "PolicyExplainResponse",
+    "PolicyExplainSubject",
+    "ProfileToolPreviewEntry",
+    "ProfileToolPreviewRequest",
+    "ProfileToolPreviewResponse",
+    "ProfileToolPreviewSummary",
+    "_append_audit_event_strict",
+    "_redact_subject_value",
+]

--- a/mcp_unified/gateway/policy_explain.py
+++ b/mcp_unified/gateway/policy_explain.py
@@ -30,6 +30,7 @@ POLICY_PREVIEW_TOOLS_AUDIT_EVENT_TYPE = "policy.preview_tools.requested"
 
 PolicyExplainOutcome = Literal["deny", "ask", "allow"]
 PolicyExplainRedactionState = Literal["raw_safe", "sanitized", "redacted", "omitted"]
+PolicyExplainVisibility = Literal["visible", "hidden", "deferred"]
 STATIC_POLICY_ONLY_SKIPPED_CONTRIBUTORS = [
     "session_grants",
     "approval_grants",
@@ -43,12 +44,12 @@ _DEFAULTS_BY_OUTCOME: dict[str, dict[str, Any]] = {
         "requires_approval": False,
     },
     "ask": {
-        "visibility": "direct",
+        "visibility": "visible",
         "call_state": "approval_required",
         "requires_approval": True,
     },
     "allow": {
-        "visibility": "direct",
+        "visibility": "visible",
         "call_state": "callable",
         "requires_approval": False,
     },
@@ -141,14 +142,18 @@ class PolicyExplainResponse(BaseModel):
     profile_id: str
     tool_name: str
     mode: PolicyExplainMode
+    evaluated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    truncated: bool = False
     final_outcome: PolicyExplainOutcome
     reason_code: str
-    visibility: str
+    visibility: PolicyExplainVisibility
     call_state: str
     requires_approval: bool
+    installation_status: str = "unknown"
+    runtime_availability: str = "unknown"
     tool_policy_outcome: PolicyExplainOutcome | None = None
     tool_policy_reason_code: str | None = None
-    tool_policy_visibility: str | None = None
+    tool_policy_visibility: PolicyExplainVisibility | None = None
     tool_policy_call_state: str | None = None
     tool_policy_requires_approval: bool | None = None
     runtime_status: str | None = None
@@ -168,7 +173,7 @@ class ProfileToolPreviewEntry(BaseModel):
     tool_name: str
     final_outcome: PolicyExplainOutcome
     reason_code: str
-    visibility: str
+    visibility: PolicyExplainVisibility
     call_state: str
     requires_approval: bool
     redacted: bool = True
@@ -193,7 +198,9 @@ class ProfileToolPreviewResponse(BaseModel):
     ok: bool = True
     profile_id: str
     mode: PolicyExplainMode
-    entries: list[ProfileToolPreviewEntry] = Field(default_factory=list)
+    evaluated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    truncated: bool = False
+    tools: list[ProfileToolPreviewEntry] = Field(default_factory=list)
     summary: ProfileToolPreviewSummary = Field(default_factory=ProfileToolPreviewSummary)
     degraded: bool = False
     degraded_reasons: list[str] = Field(default_factory=list)
@@ -207,8 +214,9 @@ class PolicyExplainErrorResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     ok: bool = False
-    error: str
+    message: str
     reason_code: str
+    details: dict[str, Any] = Field(default_factory=dict)
 
 
 class GatewayPolicyExplainError(RuntimeError):
@@ -221,7 +229,10 @@ class GatewayPolicyExplainError(RuntimeError):
     def to_payload(self) -> PolicyExplainErrorResponse:
         """Return a stable redacted error payload."""
 
-        return PolicyExplainErrorResponse(error=str(self), reason_code=self.reason_code)
+        return PolicyExplainErrorResponse(
+            message=str(self),
+            reason_code=self.reason_code,
+        )
 
 
 class GatewayPolicyExplainService:
@@ -264,63 +275,76 @@ class GatewayPolicyExplainService:
             if request.mode == PolicyExplainMode.RUNTIME_EFFECTIVE
             else None
         )
-        simulator_result = simulate_tool_call_policy(
-            profile,
-            request.tool_name,
-            request.arguments,
-            capability=request.capability,
-            policy_grant_store=policy_grant_store,
-            session_id=session_id,
-        )
-        tool_explanation = explain_profile_tool_decision(
-            profile,
-            request.tool_name,
-            capability=request.capability,
-        )
-        subjects, degraded_reasons = _policy_subjects_from_simulation(
-            simulator_result,
-            tool_name=request.tool_name,
-            arguments=request.arguments,
-        )
-        overall = _mapping_value(simulator_result, "overall")
-        effective_decision = _effective_decision_from_simulation(
-            simulator_result,
-            tool_policy_outcome=tool_explanation.final_outcome,
-            tool_policy_reason_code=tool_explanation.reason_code,
-        )
-        if effective_decision["degraded_reason"] is not None:
-            degraded_reasons.append(effective_decision["degraded_reason"])
         safe_tool_name = _redact_tool_identifier(request.tool_name)
-        skipped_contributors = _skipped_contributors_for_mode(request.mode)
-        response = PolicyExplainResponse(
-            profile_id=profile.id,
-            tool_name=safe_tool_name,
-            mode=request.mode,
-            final_outcome=effective_decision["final_outcome"],
-            reason_code=effective_decision["reason_code"],
-            visibility=effective_decision["visibility"],
-            call_state=effective_decision["call_state"],
-            requires_approval=effective_decision["requires_approval"],
-            tool_policy_outcome=tool_explanation.final_outcome,
-            tool_policy_reason_code=tool_explanation.reason_code,
-            tool_policy_visibility=tool_explanation.visibility,
-            tool_policy_call_state=tool_explanation.call_state,
-            tool_policy_requires_approval=tool_explanation.requires_approval,
-            runtime_status=(
-                _mapping_value(overall, "status")
-                if isinstance(overall, Mapping)
-                else None
-            ),
-            runtime_reason_code=(
-                _mapping_value(overall, "reason_code")
-                if isinstance(overall, Mapping)
-                else None
-            ),
-            subjects=subjects,
-            degraded=bool(degraded_reasons),
-            degraded_reasons=degraded_reasons,
-            skipped_contributors=skipped_contributors,
-        )
+        try:
+            simulator_result = simulate_tool_call_policy(
+                profile,
+                request.tool_name,
+                request.arguments,
+                capability=request.capability,
+                policy_grant_store=policy_grant_store,
+                session_id=session_id,
+            )
+            tool_explanation = explain_profile_tool_decision(
+                profile,
+                request.tool_name,
+                capability=request.capability,
+            )
+            subjects, degraded_reasons = _policy_subjects_from_simulation(
+                simulator_result,
+                tool_name=request.tool_name,
+                arguments=request.arguments,
+            )
+            overall = _mapping_value(simulator_result, "overall")
+            effective_decision = _effective_decision_from_simulation(
+                simulator_result,
+                tool_policy_outcome=tool_explanation.final_outcome,
+                tool_policy_reason_code=tool_explanation.reason_code,
+            )
+            if effective_decision["degraded_reason"] is not None:
+                degraded_reasons.append(effective_decision["degraded_reason"])
+            response = PolicyExplainResponse(
+                profile_id=profile.id,
+                tool_name=safe_tool_name,
+                mode=request.mode,
+                final_outcome=effective_decision["final_outcome"],
+                reason_code=effective_decision["reason_code"],
+                visibility=effective_decision["visibility"],
+                call_state=effective_decision["call_state"],
+                requires_approval=effective_decision["requires_approval"],
+                tool_policy_outcome=tool_explanation.final_outcome,
+                tool_policy_reason_code=tool_explanation.reason_code,
+                tool_policy_visibility=_approved_visibility(
+                    tool_explanation.visibility,
+                    outcome=tool_explanation.final_outcome,
+                ),
+                tool_policy_call_state=tool_explanation.call_state,
+                tool_policy_requires_approval=tool_explanation.requires_approval,
+                runtime_status=(
+                    _mapping_value(overall, "status")
+                    if isinstance(overall, Mapping)
+                    else None
+                ),
+                runtime_reason_code=(
+                    _mapping_value(overall, "reason_code")
+                    if isinstance(overall, Mapping)
+                    else None
+                ),
+                subjects=subjects,
+                degraded=bool(degraded_reasons),
+                degraded_reasons=degraded_reasons,
+                truncated="subject_limit_exceeded" in degraded_reasons,
+                skipped_contributors=_skipped_contributors_for_mode(request.mode),
+            )
+        except GatewayPolicyExplainError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            failure = GatewayPolicyExplainError(
+                "Policy evaluation failed",
+                reason_code="policy_evaluation_failed",
+            )
+            await self._audit_explain_failure(request, failure, profile_id=profile.id)
+            raise failure from exc
         await _append_audit_event_strict(
             self.audit_store,
             event_type=POLICY_EXPLAIN_AUDIT_EVENT_TYPE,
@@ -345,23 +369,42 @@ class GatewayPolicyExplainService:
                 await self._audit_preview_failure(request, exc)
             raise
         degraded_reasons: list[str] = []
-        tool_names = await self._preview_tool_names(profile)
-        if self.catalog_provider is None:
+        try:
+            tool_names = await self._preview_tool_names(profile)
+        except Exception:  # noqa: BLE001
             degraded_reasons.append("catalog_unavailable")
+            tool_names = _policy_tool_names_from_profile(profile)
+        else:
+            if self.catalog_provider is None:
+                degraded_reasons.append("catalog_unavailable")
 
-        entries = [
-            _profile_tool_preview_entry(profile, tool_name, capability=request.capability)
-            for tool_name in tool_names
-        ]
-        response = ProfileToolPreviewResponse(
-            profile_id=profile.id,
-            mode=request.mode,
-            entries=entries,
-            summary=_preview_summary(entries),
-            degraded=bool(degraded_reasons),
-            degraded_reasons=degraded_reasons,
-            skipped_contributors=_skipped_contributors_for_mode(request.mode),
-        )
+        try:
+            tools = [
+                _profile_tool_preview_entry(
+                    profile,
+                    tool_name,
+                    capability=request.capability,
+                )
+                for tool_name in tool_names
+            ]
+            response = ProfileToolPreviewResponse(
+                profile_id=profile.id,
+                mode=request.mode,
+                tools=tools,
+                summary=_preview_summary(tools),
+                degraded=bool(degraded_reasons),
+                degraded_reasons=degraded_reasons,
+                skipped_contributors=_skipped_contributors_for_mode(request.mode),
+            )
+        except GatewayPolicyExplainError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            failure = GatewayPolicyExplainError(
+                "Policy evaluation failed",
+                reason_code="policy_evaluation_failed",
+            )
+            await self._audit_preview_failure(request, failure, profile_id=profile.id)
+            raise failure from exc
         await _append_audit_event_strict(
             self.audit_store,
             event_type=POLICY_PREVIEW_TOOLS_AUDIT_EVENT_TYPE,
@@ -387,23 +430,23 @@ class GatewayPolicyExplainService:
             catalog = await _maybe_await(self.catalog_provider())
             return sorted(_tool_names_from_catalog(catalog))
 
-        policy_document = profile.policy_document
-        policy_tools = set(policy_document.allowed_tools or [])
-        policy_tools.update(policy_document.denied_tools or [])
-        return sorted(tool_name for tool_name in policy_tools if isinstance(tool_name, str))
+        return _policy_tool_names_from_profile(profile)
 
     async def _audit_explain_failure(
         self,
         request: PolicyExplainRequest,
         exc: GatewayPolicyExplainError,
+        *,
+        profile_id: str | None = None,
     ) -> None:
+        event_profile_id = profile_id or request.profile_id
         safe_tool_name = _redact_tool_identifier(request.tool_name)
         payload = {
             "ok": False,
-            "profile_id": request.profile_id,
+            "profile_id": event_profile_id,
             "tool_name": safe_tool_name,
             "mode": request.mode.value,
-            "error": str(exc),
+            "message": str(exc),
             "reason_code": exc.reason_code,
             "redacted": True,
         }
@@ -411,7 +454,7 @@ class GatewayPolicyExplainService:
             self.audit_store,
             event_type=POLICY_EXPLAIN_AUDIT_EVENT_TYPE,
             actor_id=self.actor_id,
-            profile_id=request.profile_id,
+            profile_id=event_profile_id,
             target_type="tool",
             target_id=safe_tool_name,
             payload=payload,
@@ -421,12 +464,15 @@ class GatewayPolicyExplainService:
         self,
         request: ProfileToolPreviewRequest,
         exc: GatewayPolicyExplainError,
+        *,
+        profile_id: str | None = None,
     ) -> None:
+        event_profile_id = profile_id or request.profile_id
         payload = {
             "ok": False,
-            "profile_id": request.profile_id,
+            "profile_id": event_profile_id,
             "mode": request.mode.value,
-            "error": str(exc),
+            "message": str(exc),
             "reason_code": exc.reason_code,
             "redacted": True,
         }
@@ -434,9 +480,9 @@ class GatewayPolicyExplainService:
             self.audit_store,
             event_type=POLICY_PREVIEW_TOOLS_AUDIT_EVENT_TYPE,
             actor_id=self.actor_id,
-            profile_id=request.profile_id,
+            profile_id=event_profile_id,
             target_type="profile",
-            target_id=request.profile_id,
+            target_id=event_profile_id,
             payload=payload,
         )
 
@@ -599,7 +645,10 @@ def _profile_tool_preview_entry(
         tool_name=_redact_tool_identifier(tool_name),
         final_outcome=explanation.final_outcome,
         reason_code=explanation.reason_code,
-        visibility=explanation.visibility,
+        visibility=_approved_visibility(
+            explanation.visibility,
+            outcome=explanation.final_outcome,
+        ),
         call_state=explanation.call_state,
         requires_approval=explanation.requires_approval,
     )
@@ -675,19 +724,45 @@ def _preview_summary(
     return summary
 
 
-def _tool_names_from_catalog(catalog: Iterable[Any]) -> set[str]:
+def _tool_names_from_catalog(catalog: Any) -> set[str]:
     tool_names: set[str] = set()
-    for item in catalog:
+    for item in _catalog_items(catalog):
         tool_name: Any
         if isinstance(item, str):
             tool_name = item
         elif isinstance(item, Mapping):
-            tool_name = item.get("name") or item.get("tool_name")
+            tool_name = item.get("tool_id") or item.get("name") or item.get("tool_name")
         else:
-            tool_name = getattr(item, "name", None) or getattr(item, "tool_name", None)
+            tool_name = (
+                getattr(item, "tool_id", None)
+                or getattr(item, "name", None)
+                or getattr(item, "tool_name", None)
+            )
         if isinstance(tool_name, str) and tool_name.strip():
             tool_names.add(tool_name.strip())
     return tool_names
+
+
+def _catalog_items(catalog: Any) -> Iterable[Any]:
+    if isinstance(catalog, Mapping):
+        tools = catalog.get("tools")
+        if tools is not None and not isinstance(tools, str):
+            if isinstance(tools, Iterable):
+                return tools
+            return []
+        return [catalog]
+    if isinstance(catalog, str):
+        return [catalog]
+    if isinstance(catalog, Iterable):
+        return catalog
+    return []
+
+
+def _policy_tool_names_from_profile(profile: MCPProfile) -> list[str]:
+    policy_document = profile.policy_document
+    policy_tools = set(policy_document.allowed_tools or [])
+    policy_tools.update(policy_document.denied_tools or [])
+    return sorted(tool_name for tool_name in policy_tools if isinstance(tool_name, str))
 
 
 def _redact_path(value: str) -> tuple[str, PolicyExplainRedactionState]:
@@ -709,16 +784,21 @@ def _redact_path(value: str) -> tuple[str, PolicyExplainRedactionState]:
 
 
 def _redact_domain(value: str) -> tuple[str, PolicyExplainRedactionState]:
-    parsed = urlsplit(value)
+    normalized = value.replace("\\", "/")
+    if "\n" in normalized or "\r" in normalized:
+        return "[redacted-domain]", "redacted"
+    if _is_absolute_path(normalized):
+        return _redact_path(normalized)
+    parsed = urlsplit(normalized)
     if parsed.scheme.lower() == "file":
-        return _redact_path(value)
+        return _redact_path(normalized)
     if parsed.scheme and parsed.netloc:
         return _redacted_url_origin(parsed), "sanitized"
-    sanitized = value.split("?", 1)[0].split("#", 1)[0]
+    sanitized = normalized.split("?", 1)[0].split("#", 1)[0]
     if "@" in sanitized:
         sanitized = sanitized.rsplit("@", 1)[-1]
     state: PolicyExplainRedactionState = (
-        "sanitized" if sanitized != value else "raw_safe"
+        "sanitized" if sanitized != normalized else "raw_safe"
     )
     return sanitized, state
 
@@ -738,6 +818,20 @@ def _skipped_contributors_for_mode(mode: PolicyExplainMode) -> list[str]:
     if mode != PolicyExplainMode.STATIC_POLICY_ONLY:
         return []
     return list(STATIC_POLICY_ONLY_SKIPPED_CONTRIBUTORS)
+
+
+def _approved_visibility(
+    value: Any,
+    *,
+    outcome: str | None = None,
+) -> PolicyExplainVisibility:
+    if value == "hidden":
+        return "hidden"
+    if value == "deferred":
+        return "deferred"
+    if outcome == "deny":
+        return "hidden"
+    return "visible"
 
 
 def _is_absolute_path(value: str) -> bool:
@@ -816,6 +910,7 @@ __all__ = [
     "PolicyExplainRequest",
     "PolicyExplainResponse",
     "PolicyExplainSubject",
+    "PolicyExplainVisibility",
     "ProfileToolPreviewEntry",
     "ProfileToolPreviewRequest",
     "ProfileToolPreviewResponse",

--- a/mcp_unified/gateway/policy_explain.py
+++ b/mcp_unified/gateway/policy_explain.py
@@ -273,8 +273,11 @@ class GatewayPolicyExplainService:
         overall = _mapping_value(simulator_result, "overall")
         effective_decision = _effective_decision_from_simulation(
             simulator_result,
+            tool_policy_outcome=tool_explanation.final_outcome,
             tool_policy_reason_code=tool_explanation.reason_code,
         )
+        if effective_decision["degraded_reason"] is not None:
+            degraded_reasons.append(effective_decision["degraded_reason"])
         safe_tool_name = _redact_tool_identifier(request.tool_name)
         response = PolicyExplainResponse(
             profile_id=profile.id,
@@ -537,9 +540,11 @@ def _profile_tool_preview_entry(
 def _effective_decision_from_simulation(
     simulator_result: Mapping[str, Any],
     *,
+    tool_policy_outcome: str,
     tool_policy_reason_code: str,
 ) -> dict[str, Any]:
     overall = _mapping_value(simulator_result, "overall")
+    legacy_policy = _mapping_value(simulator_result, "legacy_policy")
     status = (
         _optional_string(_mapping_value(overall, "status"))
         if isinstance(overall, Mapping)
@@ -550,20 +555,40 @@ def _effective_decision_from_simulation(
         if isinstance(overall, Mapping)
         else None
     )
-    if status == "denied":
+    legacy_status = (
+        _optional_string(_mapping_value(legacy_policy, "status"))
+        if isinstance(legacy_policy, Mapping)
+        else None
+    )
+    degraded_reason: str | None = None
+    if (
+        status == "denied"
+        and tool_policy_outcome == "ask"
+        and (legacy_status == "approval_required" or reason_code == "approval_required")
+    ):
+        outcome: PolicyExplainOutcome = "ask"
+    elif status == "denied":
         outcome: PolicyExplainOutcome = "deny"
     elif status == "approval_required":
         outcome = "ask"
-    else:
+    elif status == "allowed":
         outcome = "allow"
+    else:
+        outcome = "deny"
+        degraded_reason = "unknown_policy_status"
 
     defaults = _DEFAULTS_BY_OUTCOME[outcome]
     return {
         "final_outcome": outcome,
-        "reason_code": reason_code or tool_policy_reason_code,
+        "reason_code": (
+            "policy_status_unknown"
+            if degraded_reason is not None
+            else reason_code or tool_policy_reason_code
+        ),
         "visibility": defaults["visibility"],
         "call_state": defaults["call_state"],
         "requires_approval": defaults["requires_approval"],
+        "degraded_reason": degraded_reason,
     }
 
 
@@ -615,6 +640,8 @@ def _redact_path(value: str) -> tuple[str, PolicyExplainRedactionState]:
 
 def _redact_domain(value: str) -> tuple[str, PolicyExplainRedactionState]:
     parsed = urlsplit(value)
+    if parsed.scheme.lower() == "file":
+        return _redact_path(value)
     if parsed.scheme and parsed.netloc:
         host = parsed.hostname or "[domain]"
         try:

--- a/mcp_unified/gateway/policy_explain.py
+++ b/mcp_unified/gateway/policy_explain.py
@@ -9,7 +9,7 @@ from collections.abc import Awaitable, Callable, Iterable, Mapping
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Literal
-from urllib.parse import urlsplit
+from urllib.parse import unquote, urlsplit
 from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -25,16 +25,36 @@ from mcp_unified.storage.models import AuditEvent
 from .policy_simulation import simulate_tool_call_policy
 
 MAX_POLICY_EXPLAIN_ARGUMENT_BYTES = 64 * 1024
+POLICY_EXPLAIN_AUDIT_EVENT_TYPE = "policy.explain.requested"
+POLICY_PREVIEW_TOOLS_AUDIT_EVENT_TYPE = "policy.preview_tools.requested"
 
 PolicyExplainOutcome = Literal["deny", "ask", "allow"]
 PolicyExplainRedactionState = Literal["plain", "sanitized", "redacted"]
+
+_DEFAULTS_BY_OUTCOME: dict[str, dict[str, Any]] = {
+    "deny": {
+        "visibility": "hidden",
+        "call_state": "blocked",
+        "requires_approval": False,
+    },
+    "ask": {
+        "visibility": "direct",
+        "call_state": "approval_required",
+        "requires_approval": True,
+    },
+    "allow": {
+        "visibility": "direct",
+        "call_state": "callable",
+        "requires_approval": False,
+    },
+}
 
 
 class PolicyExplainMode(str, Enum):
     """How closely an explanation should mirror runtime policy state."""
 
     RUNTIME_EFFECTIVE = "runtime_effective"
-    STATIC_PROFILE = "static_profile"
+    STATIC_POLICY_ONLY = "static_policy_only"
 
 
 class PolicyExplainRequest(BaseModel):
@@ -121,6 +141,11 @@ class PolicyExplainResponse(BaseModel):
     visibility: str
     call_state: str
     requires_approval: bool
+    tool_policy_outcome: PolicyExplainOutcome | None = None
+    tool_policy_reason_code: str | None = None
+    tool_policy_visibility: str | None = None
+    tool_policy_call_state: str | None = None
+    tool_policy_requires_approval: bool | None = None
     runtime_status: str | None = None
     runtime_reason_code: str | None = None
     subjects: list[PolicyExplainSubject] = Field(default_factory=list)
@@ -217,13 +242,23 @@ class GatewayPolicyExplainService:
         """Return a redacted explanation for one tool call policy check."""
 
         profile = await self._resolve_profile(request.profile_id)
+        policy_grant_store = (
+            self.policy_grant_store
+            if request.mode == PolicyExplainMode.RUNTIME_EFFECTIVE
+            else None
+        )
+        session_id = (
+            request.session_id
+            if request.mode == PolicyExplainMode.RUNTIME_EFFECTIVE
+            else None
+        )
         simulator_result = simulate_tool_call_policy(
             profile,
             request.tool_name,
             request.arguments,
             capability=request.capability,
-            policy_grant_store=self.policy_grant_store,
-            session_id=request.session_id,
+            policy_grant_store=policy_grant_store,
+            session_id=session_id,
         )
         tool_explanation = explain_profile_tool_decision(
             profile,
@@ -236,15 +271,25 @@ class GatewayPolicyExplainService:
             arguments=request.arguments,
         )
         overall = _mapping_value(simulator_result, "overall")
+        effective_decision = _effective_decision_from_simulation(
+            simulator_result,
+            tool_policy_reason_code=tool_explanation.reason_code,
+        )
+        safe_tool_name = _redact_tool_identifier(request.tool_name)
         response = PolicyExplainResponse(
             profile_id=profile.id,
-            tool_name=request.tool_name,
+            tool_name=safe_tool_name,
             mode=request.mode,
-            final_outcome=tool_explanation.final_outcome,
-            reason_code=tool_explanation.reason_code,
-            visibility=tool_explanation.visibility,
-            call_state=tool_explanation.call_state,
-            requires_approval=tool_explanation.requires_approval,
+            final_outcome=effective_decision["final_outcome"],
+            reason_code=effective_decision["reason_code"],
+            visibility=effective_decision["visibility"],
+            call_state=effective_decision["call_state"],
+            requires_approval=effective_decision["requires_approval"],
+            tool_policy_outcome=tool_explanation.final_outcome,
+            tool_policy_reason_code=tool_explanation.reason_code,
+            tool_policy_visibility=tool_explanation.visibility,
+            tool_policy_call_state=tool_explanation.call_state,
+            tool_policy_requires_approval=tool_explanation.requires_approval,
             runtime_status=(
                 _mapping_value(overall, "status")
                 if isinstance(overall, Mapping)
@@ -261,11 +306,11 @@ class GatewayPolicyExplainService:
         )
         await _append_audit_event_strict(
             self.audit_store,
-            event_type="policy.explain.requested",
+            event_type=POLICY_EXPLAIN_AUDIT_EVENT_TYPE,
             actor_id=self.actor_id,
             profile_id=profile.id,
             target_type="tool",
-            target_id=request.tool_name,
+            target_id=safe_tool_name,
             payload=response.model_dump(mode="json", exclude_none=True),
         )
         return response
@@ -296,7 +341,7 @@ class GatewayPolicyExplainService:
         )
         await _append_audit_event_strict(
             self.audit_store,
-            event_type="policy.preview.requested",
+            event_type=POLICY_PREVIEW_TOOLS_AUDIT_EVENT_TYPE,
             actor_id=self.actor_id,
             profile_id=profile.id,
             target_type="profile",
@@ -489,6 +534,39 @@ def _profile_tool_preview_entry(
     )
 
 
+def _effective_decision_from_simulation(
+    simulator_result: Mapping[str, Any],
+    *,
+    tool_policy_reason_code: str,
+) -> dict[str, Any]:
+    overall = _mapping_value(simulator_result, "overall")
+    status = (
+        _optional_string(_mapping_value(overall, "status"))
+        if isinstance(overall, Mapping)
+        else None
+    )
+    reason_code = (
+        _optional_string(_mapping_value(overall, "reason_code"))
+        if isinstance(overall, Mapping)
+        else None
+    )
+    if status == "denied":
+        outcome: PolicyExplainOutcome = "deny"
+    elif status == "approval_required":
+        outcome = "ask"
+    else:
+        outcome = "allow"
+
+    defaults = _DEFAULTS_BY_OUTCOME[outcome]
+    return {
+        "final_outcome": outcome,
+        "reason_code": reason_code or tool_policy_reason_code,
+        "visibility": defaults["visibility"],
+        "call_state": defaults["call_state"],
+        "requires_approval": defaults["requires_approval"],
+    }
+
+
 def _preview_summary(
     entries: Iterable[ProfileToolPreviewEntry],
 ) -> ProfileToolPreviewSummary:
@@ -523,6 +601,12 @@ def _redact_path(value: str) -> tuple[str, PolicyExplainRedactionState]:
     normalized = value.replace("\\", "/")
     if "\n" in normalized or "\r" in normalized:
         return "[redacted-path]", "redacted"
+    parsed = urlsplit(normalized)
+    if parsed.scheme.lower() == "file":
+        file_path = unquote(parsed.path or "")
+        if not file_path:
+            return "file://[redacted-path]", "redacted"
+        return _redact_path(file_path)
     if _is_absolute_path(normalized):
         filename = normalized.rstrip("/").rsplit("/", 1)[-1]
         return (f".../{filename}" if filename else "[path]"), "sanitized"

--- a/mcp_unified/gateway/policy_explain.py
+++ b/mcp_unified/gateway/policy_explain.py
@@ -12,7 +12,14 @@ from typing import Any, Literal
 from urllib.parse import unquote, urlsplit
 from uuid import uuid4
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 
 from mcp_unified.interfaces.storage import AuditStore
 from mcp_unified.profiles import MCPProfile, explain_profile_tool_decision
@@ -68,7 +75,7 @@ class PolicyExplainMode(str, Enum):
 class PolicyExplainRequest(BaseModel):
     """Request to explain one profile/tool policy decision."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
 
     profile_id: str
     tool_name: str
@@ -105,11 +112,13 @@ class PolicyExplainRequest(BaseModel):
 class ProfileToolPreviewRequest(BaseModel):
     """Request to preview profile decisions across a tool catalog."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
 
     profile_id: str
     capability: str | None = None
     mode: PolicyExplainMode = PolicyExplainMode.RUNTIME_EFFECTIVE
+    limit: int = Field(default=200, ge=1, le=1000)
+    cursor: str | None = None
 
     @field_validator("profile_id")
     @classmethod
@@ -120,6 +129,16 @@ class ProfileToolPreviewRequest(BaseModel):
     @classmethod
     def _normalize_capability(cls, value: str | None) -> str | None:
         return _optional_text(value)
+
+    @field_validator("cursor")
+    @classmethod
+    def _normalize_cursor(cls, value: str | None) -> str | None:
+        cursor = _optional_text(value)
+        if cursor is None:
+            return None
+        if not cursor.isdigit():
+            raise ValueError("cursor must be a non-negative integer offset")
+        return cursor
 
 
 class PolicyExplainSubject(BaseModel):
@@ -192,6 +211,12 @@ class ProfileToolPreviewSummary(BaseModel):
     allow: int = 0
     ask: int = 0
     deny: int = 0
+    visible: int = 0
+    hidden: int = 0
+    deferred: int = 0
+    installed: int = 0
+    not_installed: int = 0
+    unknown_installation: int = 0
 
 
 class ProfileToolPreviewResponse(BaseModel):
@@ -204,6 +229,7 @@ class ProfileToolPreviewResponse(BaseModel):
     mode: PolicyExplainMode
     evaluated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     truncated: bool = False
+    next_cursor: str | None = None
     tools: list[ProfileToolPreviewEntry] = Field(default_factory=list)
     summary: ProfileToolPreviewSummary = Field(default_factory=ProfileToolPreviewSummary)
     degraded: bool = False
@@ -237,6 +263,30 @@ class GatewayPolicyExplainError(RuntimeError):
             message=str(self),
             reason_code=self.reason_code,
         )
+
+
+def parse_policy_explain_request(payload: Any) -> PolicyExplainRequest:
+    """Parse a policy explain request without leaking invalid input in errors."""
+
+    try:
+        return PolicyExplainRequest.model_validate(payload)
+    except ValidationError:
+        raise GatewayPolicyExplainError(
+            "Invalid policy explain request",
+            reason_code="invalid_policy_explain_request",
+        ) from None
+
+
+def parse_profile_tool_preview_request(payload: Any) -> ProfileToolPreviewRequest:
+    """Parse a profile tool preview request without leaking invalid input in errors."""
+
+    try:
+        return ProfileToolPreviewRequest.model_validate(payload)
+    except ValidationError:
+        raise GatewayPolicyExplainError(
+            "Invalid policy preview request",
+            reason_code="invalid_policy_preview_request",
+        ) from None
 
 
 class GatewayPolicyExplainService:
@@ -396,6 +446,11 @@ class GatewayPolicyExplainService:
 
         try:
             argument_sensitive = _has_argument_sensitive_permission_rules(profile)
+            page_tool_names, next_cursor = _preview_page(
+                tool_names,
+                limit=request.limit,
+                cursor=request.cursor,
+            )
             tools = [
                 _profile_tool_preview_entry(
                     profile,
@@ -403,11 +458,13 @@ class GatewayPolicyExplainService:
                     capability=request.capability,
                     argument_sensitive=argument_sensitive,
                 )
-                for tool_name in tool_names
+                for tool_name in page_tool_names
             ]
             response = ProfileToolPreviewResponse(
                 profile_id=profile.id,
                 mode=request.mode,
+                truncated=next_cursor is not None,
+                next_cursor=next_cursor,
                 tools=tools,
                 summary=_preview_summary(tools),
                 degraded=bool(degraded_reasons),
@@ -689,7 +746,6 @@ def _effective_decision_from_simulation(
     tool_policy_reason_code: str,
 ) -> dict[str, Any]:
     overall = _mapping_value(simulator_result, "overall")
-    legacy_policy = _mapping_value(simulator_result, "legacy_policy")
     status = (
         _optional_string(_mapping_value(overall, "status"))
         if isinstance(overall, Mapping)
@@ -700,16 +756,14 @@ def _effective_decision_from_simulation(
         if isinstance(overall, Mapping)
         else None
     )
-    legacy_status = (
-        _optional_string(_mapping_value(legacy_policy, "status"))
-        if isinstance(legacy_policy, Mapping)
-        else None
-    )
+    denial = _mapping_value(simulator_result, "denial")
+    has_explicit_denial = bool(denial)
     degraded_reason: str | None = None
     if (
         status == "denied"
         and tool_policy_outcome == "ask"
-        and (legacy_status == "approval_required" or reason_code == "approval_required")
+        and reason_code == "approval_required"
+        and not has_explicit_denial
     ):
         outcome: PolicyExplainOutcome = "ask"
     elif status == "denied":
@@ -749,7 +803,33 @@ def _preview_summary(
             summary.ask += 1
         elif entry.outcome == "deny":
             summary.deny += 1
+        if entry.visibility == "visible":
+            summary.visible += 1
+        elif entry.visibility == "hidden":
+            summary.hidden += 1
+        elif entry.visibility == "deferred":
+            summary.deferred += 1
+        if entry.installation_status == "installed":
+            summary.installed += 1
+        elif entry.installation_status == "not_installed":
+            summary.not_installed += 1
+        else:
+            summary.unknown_installation += 1
     return summary
+
+
+def _preview_page(
+    tool_names: list[str],
+    *,
+    limit: int,
+    cursor: str | None,
+) -> tuple[list[str], str | None]:
+    start = int(cursor) if cursor is not None else 0
+    if start >= len(tool_names):
+        return [], None
+    end = min(start + limit, len(tool_names))
+    next_cursor = str(end) if end < len(tool_names) else None
+    return tool_names[start:end], next_cursor
 
 
 def _preview_audit_payload(response: ProfileToolPreviewResponse) -> dict[str, Any]:
@@ -818,30 +898,40 @@ def _redact_path(value: str) -> tuple[str, PolicyExplainRedactionState]:
         return _redact_path(file_path)
     if parsed.scheme and parsed.netloc:
         return _redacted_url_origin(parsed), "sanitized"
-    if _is_absolute_path(normalized):
-        filename = normalized.rstrip("/").rsplit("/", 1)[-1]
+    sanitized = _strip_path_private_syntax(normalized)
+    if _is_absolute_path(sanitized):
+        filename = sanitized.rstrip("/").rsplit("/", 1)[-1]
         return (f".../{filename}" if filename else "[path]"), "sanitized"
-    return normalized, "raw_safe"
+    state: PolicyExplainRedactionState = (
+        "sanitized" if sanitized != normalized else "raw_safe"
+    )
+    return sanitized, state
 
 
 def _redact_domain(value: str) -> tuple[str, PolicyExplainRedactionState]:
     normalized = value.replace("\\", "/")
     if "\n" in normalized or "\r" in normalized:
         return "[redacted-domain]", "redacted"
-    if _is_absolute_path(normalized):
-        return _redact_path(normalized)
+    stripped = _strip_path_private_syntax(normalized)
+    if _is_absolute_path(stripped):
+        return _redact_path(stripped)
     parsed = urlsplit(normalized)
     if parsed.scheme.lower() == "file":
         return _redact_path(normalized)
     if parsed.scheme and parsed.netloc:
         return _redacted_url_origin(parsed), "sanitized"
-    sanitized = normalized.split("?", 1)[0].split("#", 1)[0]
-    if "@" in sanitized:
-        sanitized = sanitized.rsplit("@", 1)[-1]
+    sanitized = stripped
     state: PolicyExplainRedactionState = (
         "sanitized" if sanitized != normalized else "raw_safe"
     )
     return sanitized, state
+
+
+def _strip_path_private_syntax(value: str) -> str:
+    sanitized = value.split("?", 1)[0].split("#", 1)[0]
+    if "@" in sanitized:
+        sanitized = sanitized.rsplit("@", 1)[-1]
+    return sanitized
 
 
 def _redacted_url_origin(parsed: Any) -> str:
@@ -957,5 +1047,7 @@ __all__ = [
     "ProfileToolPreviewResponse",
     "ProfileToolPreviewSummary",
     "_append_audit_event_strict",
+    "parse_policy_explain_request",
+    "parse_profile_tool_preview_request",
     "_redact_subject_value",
 ]

--- a/mcp_unified/gateway/policy_explain.py
+++ b/mcp_unified/gateway/policy_explain.py
@@ -6,6 +6,7 @@ import inspect
 import json
 import re
 from collections.abc import Awaitable, Callable, Iterable, Mapping
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Literal
@@ -30,6 +31,7 @@ from mcp_unified.profiles.subjects import (
 )
 from mcp_unified.storage.models import AuditEvent
 
+from .tool_discovery import list_admin_tool_catalog
 from .policy_simulation import simulate_tool_call_policy
 
 MAX_POLICY_EXPLAIN_ARGUMENT_BYTES = 64 * 1024
@@ -119,6 +121,9 @@ class ProfileToolPreviewRequest(BaseModel):
     mode: PolicyExplainMode = PolicyExplainMode.RUNTIME_EFFECTIVE
     limit: int = Field(default=200, ge=1, le=1000)
     cursor: str | None = None
+    include_denied: bool = True
+    include_recommendations: bool = True
+    category: str | None = None
 
     @field_validator("profile_id")
     @classmethod
@@ -128,6 +133,11 @@ class ProfileToolPreviewRequest(BaseModel):
     @field_validator("capability")
     @classmethod
     def _normalize_capability(cls, value: str | None) -> str | None:
+        return _optional_text(value)
+
+    @field_validator("category")
+    @classmethod
+    def _normalize_category(cls, value: str | None) -> str | None:
         return _optional_text(value)
 
     @field_validator("cursor")
@@ -265,6 +275,15 @@ class GatewayPolicyExplainError(RuntimeError):
         )
 
 
+@dataclass(frozen=True, slots=True)
+class _PreviewCatalogRow:
+    """Internal catalog row with metadata needed for admin preview filtering."""
+
+    tool_name: str
+    installation_status: str = "unknown"
+    category: str | None = None
+
+
 def parse_policy_explain_request(payload: Any) -> PolicyExplainRequest:
     """Parse a policy explain request without leaking invalid input in errors."""
 
@@ -299,12 +318,19 @@ class GatewayPolicyExplainService:
         audit_store: AuditStore | None,
         actor_id: str | None = None,
         catalog_provider: Callable[[], Iterable[Any] | Awaitable[Iterable[Any]]] | None = None,
+        admin_tool_catalog_provider: Callable[
+            [MCPProfile],
+            Iterable[Any] | Awaitable[Iterable[Any]],
+        ] | None = None,
+        installed_tool_catalog: Any | None = None,
         policy_grant_store: Any | None = None,
     ) -> None:
         self.profile_resolver = profile_resolver
         self.audit_store = audit_store
         self.actor_id = actor_id or DEFAULT_AUDIT_ACTOR_ID
         self.catalog_provider = catalog_provider
+        self.admin_tool_catalog_provider = admin_tool_catalog_provider
+        self.installed_tool_catalog = installed_tool_catalog
         self.policy_grant_store = policy_grant_store
 
     async def explain_tool_call(
@@ -436,29 +462,45 @@ class GatewayPolicyExplainService:
             raise failure from exc
         degraded_reasons: list[str] = []
         try:
-            tool_names = await self._preview_tool_names(profile)
+            catalog_rows = await self._preview_catalog_rows(
+                profile,
+                include_recommendations=request.include_recommendations,
+            )
         except Exception:  # noqa: BLE001
             degraded_reasons.append("catalog_unavailable")
-            tool_names = _policy_tool_names_from_profile(profile)
+            catalog_rows = _policy_tool_rows_from_profile(profile)
         else:
-            if self.catalog_provider is None:
+            if (
+                self.admin_tool_catalog_provider is None
+                and self.installed_tool_catalog is None
+                and self.catalog_provider is None
+            ):
                 degraded_reasons.append("catalog_unavailable")
 
         try:
             argument_sensitive = _has_argument_sensitive_permission_rules(profile)
-            page_tool_names, next_cursor = _preview_page(
-                tool_names,
+            filtered_rows = _filter_preview_catalog_rows(
+                profile,
+                catalog_rows,
+                capability=request.capability,
+                include_denied=request.include_denied,
+                include_recommendations=request.include_recommendations,
+                category=request.category,
+            )
+            page_rows, next_cursor = _preview_page(
+                filtered_rows,
                 limit=request.limit,
                 cursor=request.cursor,
             )
             tools = [
                 _profile_tool_preview_entry(
                     profile,
-                    tool_name,
+                    row.tool_name,
                     capability=request.capability,
                     argument_sensitive=argument_sensitive,
+                    installation_status=row.installation_status,
                 )
-                for tool_name in page_tool_names
+                for row in page_rows
             ]
             response = ProfileToolPreviewResponse(
                 profile_id=profile.id,
@@ -500,12 +542,34 @@ class GatewayPolicyExplainService:
             )
         return profile
 
-    async def _preview_tool_names(self, profile: MCPProfile) -> list[str]:
+    async def _preview_catalog_rows(
+        self,
+        profile: MCPProfile,
+        *,
+        include_recommendations: bool,
+    ) -> list[_PreviewCatalogRow]:
+        if self.admin_tool_catalog_provider is not None:
+            catalog = await _maybe_await(self.admin_tool_catalog_provider(profile))
+            return _preview_rows_from_catalog(catalog)
+
+        if self.installed_tool_catalog is not None:
+            backend_tools = self.installed_tool_catalog
+            if callable(backend_tools):
+                backend_tools = backend_tools()
+            backend_tools = await _maybe_await(backend_tools)
+            return _preview_rows_from_catalog(
+                list_admin_tool_catalog(
+                    profile,
+                    backend_tools,
+                    include_recommendations=include_recommendations,
+                )
+            )
+
         if self.catalog_provider is not None:
             catalog = await _maybe_await(self.catalog_provider())
-            return sorted(_tool_names_from_catalog(catalog))
+            return _preview_rows_from_catalog(catalog)
 
-        return _policy_tool_names_from_profile(profile)
+        return _policy_tool_rows_from_profile(profile)
 
     async def _audit_explain_failure(
         self,
@@ -711,6 +775,7 @@ def _profile_tool_preview_entry(
     *,
     capability: str | None,
     argument_sensitive: bool,
+    installation_status: str = "unknown",
 ) -> ProfileToolPreviewEntry:
     explanation = explain_profile_tool_decision(
         profile,
@@ -725,6 +790,7 @@ def _profile_tool_preview_entry(
             visibility="deferred",
             call_state="deferred",
             requires_approval=False,
+            installation_status=installation_status,
         )
     return ProfileToolPreviewEntry(
         tool_name=_redact_tool_identifier(tool_name),
@@ -736,6 +802,7 @@ def _profile_tool_preview_entry(
         ),
         call_state=explanation.call_state,
         requires_approval=explanation.requires_approval,
+        installation_status=installation_status,
     )
 
 
@@ -819,17 +886,17 @@ def _preview_summary(
 
 
 def _preview_page(
-    tool_names: list[str],
+    rows: list[_PreviewCatalogRow],
     *,
     limit: int,
     cursor: str | None,
-) -> tuple[list[str], str | None]:
+) -> tuple[list[_PreviewCatalogRow], str | None]:
     start = int(cursor) if cursor is not None else 0
-    if start >= len(tool_names):
+    if start >= len(rows):
         return [], None
-    end = min(start + limit, len(tool_names))
-    next_cursor = str(end) if end < len(tool_names) else None
-    return tool_names[start:end], next_cursor
+    end = min(start + limit, len(rows))
+    next_cursor = str(end) if end < len(rows) else None
+    return rows[start:end], next_cursor
 
 
 def _preview_audit_payload(response: ProfileToolPreviewResponse) -> dict[str, Any]:
@@ -859,6 +926,94 @@ def _tool_names_from_catalog(catalog: Any) -> set[str]:
     return tool_names
 
 
+def _preview_rows_from_catalog(catalog: Any) -> list[_PreviewCatalogRow]:
+    rows_by_name: dict[str, _PreviewCatalogRow] = {}
+    for item in _catalog_items(catalog):
+        row = _preview_row_from_catalog_item(item)
+        if row is None:
+            continue
+        rows_by_name.setdefault(row.tool_name, row)
+    return [rows_by_name[tool_name] for tool_name in sorted(rows_by_name)]
+
+
+def _preview_row_from_catalog_item(item: Any) -> _PreviewCatalogRow | None:
+    if isinstance(item, str):
+        tool_name = item
+        installation_status = "unknown"
+        category = None
+    elif isinstance(item, Mapping):
+        tool_name = item.get("tool_id") or item.get("name") or item.get("tool_name")
+        installation_status = item.get("installation_status")
+        category = item.get("category")
+        metadata = item.get("metadata")
+        if category is None and isinstance(metadata, Mapping):
+            category = metadata.get("category")
+    else:
+        tool_name = (
+            getattr(item, "tool_id", None)
+            or getattr(item, "name", None)
+            or getattr(item, "tool_name", None)
+        )
+        installation_status = getattr(item, "installation_status", None)
+        category = getattr(item, "category", None)
+        metadata = getattr(item, "metadata", None)
+        if category is None and isinstance(metadata, Mapping):
+            category = metadata.get("category")
+
+    tool_text = _optional_string(tool_name)
+    if tool_text is None:
+        return None
+    return _PreviewCatalogRow(
+        tool_name=tool_text,
+        installation_status=_preview_installation_status(installation_status),
+        category=_optional_string(category),
+    )
+
+
+def _filter_preview_catalog_rows(
+    profile: MCPProfile,
+    rows: list[_PreviewCatalogRow],
+    *,
+    capability: str | None,
+    include_denied: bool,
+    include_recommendations: bool,
+    category: str | None,
+) -> list[_PreviewCatalogRow]:
+    normalized_category = _normalize_preview_category(category)
+    filtered: list[_PreviewCatalogRow] = []
+    for row in rows:
+        if (
+            normalized_category is not None
+            and _normalize_preview_category(row.category) != normalized_category
+        ):
+            continue
+        if not include_recommendations and row.installation_status == "not_installed":
+            continue
+        explanation = explain_profile_tool_decision(
+            profile,
+            row.tool_name,
+            capability=capability,
+        )
+        if not include_denied and explanation.final_outcome == "deny":
+            continue
+        filtered.append(row)
+    return filtered
+
+
+def _preview_installation_status(value: Any) -> str:
+    status = _optional_string(value)
+    if status in {"installed", "not_installed"}:
+        return status
+    if status in {"recommended_unavailable", "unavailable"}:
+        return "not_installed"
+    return "unknown"
+
+
+def _normalize_preview_category(value: str | None) -> str | None:
+    text = _optional_string(value)
+    return text.casefold() if text is not None else None
+
+
 def _catalog_items(catalog: Any) -> Iterable[Any]:
     if isinstance(catalog, Mapping):
         tools = catalog.get("tools")
@@ -879,6 +1034,13 @@ def _policy_tool_names_from_profile(profile: MCPProfile) -> list[str]:
     policy_tools = set(policy_document.allowed_tools or [])
     policy_tools.update(policy_document.denied_tools or [])
     return sorted(tool_name for tool_name in policy_tools if isinstance(tool_name, str))
+
+
+def _policy_tool_rows_from_profile(profile: MCPProfile) -> list[_PreviewCatalogRow]:
+    return [
+        _PreviewCatalogRow(tool_name=tool_name)
+        for tool_name in _policy_tool_names_from_profile(profile)
+    ]
 
 
 def _has_argument_sensitive_permission_rules(profile: MCPProfile) -> bool:

--- a/mcp_unified/gateway/policy_explain.py
+++ b/mcp_unified/gateway/policy_explain.py
@@ -171,11 +171,13 @@ class ProfileToolPreviewEntry(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     tool_name: str
-    final_outcome: PolicyExplainOutcome
+    outcome: PolicyExplainOutcome
     reason_code: str
     visibility: PolicyExplainVisibility
     call_state: str
     requires_approval: bool
+    installation_status: str = "unknown"
+    runtime_availability: str = "unknown"
     redacted: bool = True
 
 
@@ -643,7 +645,7 @@ def _profile_tool_preview_entry(
     )
     return ProfileToolPreviewEntry(
         tool_name=_redact_tool_identifier(tool_name),
-        final_outcome=explanation.final_outcome,
+        outcome=explanation.final_outcome,
         reason_code=explanation.reason_code,
         visibility=_approved_visibility(
             explanation.visibility,
@@ -715,11 +717,11 @@ def _preview_summary(
     entry_list = list(entries)
     summary = ProfileToolPreviewSummary(total=len(entry_list))
     for entry in entry_list:
-        if entry.final_outcome == "allow":
+        if entry.outcome == "allow":
             summary.allow += 1
-        elif entry.final_outcome == "ask":
+        elif entry.outcome == "ask":
             summary.ask += 1
-        elif entry.final_outcome == "deny":
+        elif entry.outcome == "deny":
             summary.deny += 1
     return summary
 

--- a/mcp_unified/gateway/policy_explain.py
+++ b/mcp_unified/gateway/policy_explain.py
@@ -333,6 +333,36 @@ class GatewayPolicyExplainService:
         self.installed_tool_catalog = installed_tool_catalog
         self.policy_grant_store = policy_grant_store
 
+    def with_request_context(
+        self,
+        *,
+        actor_id: str,
+        installed_tool_catalog: Any | None = None,
+    ) -> "GatewayPolicyExplainService":
+        """Return a request-bound copy without mutating this service instance.
+
+        Explicit service catalog providers keep precedence. The route runtime
+        installed catalog is only applied when the injected service has no
+        admin, installed, or generic catalog provider of its own.
+        """
+
+        effective_installed_tool_catalog = self.installed_tool_catalog
+        if (
+            effective_installed_tool_catalog is None
+            and self.admin_tool_catalog_provider is None
+            and self.catalog_provider is None
+        ):
+            effective_installed_tool_catalog = installed_tool_catalog
+        return GatewayPolicyExplainService(
+            profile_resolver=self.profile_resolver,
+            audit_store=self.audit_store,
+            actor_id=actor_id,
+            catalog_provider=self.catalog_provider,
+            admin_tool_catalog_provider=self.admin_tool_catalog_provider,
+            installed_tool_catalog=effective_installed_tool_catalog,
+            policy_grant_store=self.policy_grant_store,
+        )
+
     async def explain_tool_call(
         self,
         request: PolicyExplainRequest,

--- a/mcp_unified/gateway/policy_explain.py
+++ b/mcp_unified/gateway/policy_explain.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import json
 import re
@@ -9,10 +10,11 @@ from collections.abc import Awaitable, Callable, Iterable, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Literal
+from typing import Any, Literal, TypeVar
 from urllib.parse import unquote, urlsplit
 from uuid import uuid4
 
+from loguru import logger
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -31,8 +33,8 @@ from mcp_unified.profiles.subjects import (
 )
 from mcp_unified.storage.models import AuditEvent
 
-from .tool_discovery import list_admin_tool_catalog
 from .policy_simulation import simulate_tool_call_policy
+from .tool_discovery import list_admin_tool_catalog
 
 MAX_POLICY_EXPLAIN_ARGUMENT_BYTES = 64 * 1024
 POLICY_EXPLAIN_AUDIT_EVENT_TYPE = "policy.explain.requested"
@@ -47,6 +49,10 @@ STATIC_POLICY_ONLY_SKIPPED_CONTRIBUTORS = [
     "approval_grants",
     "runtime_availability",
 ]
+_COMMAND_TOOL_IDENTIFIER_PATTERN = re.compile(
+    r"^(Bash|Shell|PowerShell|Monitor)\s*\(.*\)$",
+    re.IGNORECASE,
+)
 
 _DEFAULTS_BY_OUTCOME: dict[str, dict[str, Any]] = {
     "deny": {
@@ -65,6 +71,7 @@ _DEFAULTS_BY_OUTCOME: dict[str, dict[str, Any]] = {
         "requires_approval": False,
     },
 }
+_TPreviewItem = TypeVar("_TPreviewItem")
 
 
 class PolicyExplainMode(str, Enum):
@@ -118,6 +125,7 @@ class ProfileToolPreviewRequest(BaseModel):
 
     profile_id: str
     capability: str | None = None
+    session_id: str | None = None
     mode: PolicyExplainMode = PolicyExplainMode.RUNTIME_EFFECTIVE
     limit: int = Field(default=200, ge=1, le=1000)
     cursor: str | None = None
@@ -130,7 +138,7 @@ class ProfileToolPreviewRequest(BaseModel):
     def _validate_profile_id(cls, value: str) -> str:
         return _required_text(value)
 
-    @field_validator("capability")
+    @field_validator("capability", "session_id")
     @classmethod
     def _normalize_capability(cls, value: str | None) -> str | None:
         return _optional_text(value)
@@ -393,7 +401,7 @@ class GatewayPolicyExplainService:
         )
         safe_tool_name = _redact_tool_identifier(request.tool_name)
         try:
-            simulator_result = simulate_tool_call_policy(
+            simulator_result = await _simulate_tool_call_policy_async(
                 profile,
                 request.tool_name,
                 request.arguments,
@@ -498,6 +506,11 @@ class GatewayPolicyExplainService:
             )
         except Exception:  # noqa: BLE001
             degraded_reasons.append("catalog_unavailable")
+            logger.opt(exception=True).warning(
+                "Policy preview catalog lookup failed for profile {}; "
+                "falling back to profile policy rows",
+                profile.id,
+            )
             catalog_rows = _policy_tool_rows_from_profile(profile)
         else:
             if (
@@ -510,35 +523,41 @@ class GatewayPolicyExplainService:
         try:
             argument_sensitive = _has_argument_sensitive_permission_rules(profile)
             filtered_rows = _filter_preview_catalog_rows(
-                profile,
                 catalog_rows,
-                capability=request.capability,
-                include_denied=request.include_denied,
                 include_recommendations=request.include_recommendations,
                 category=request.category,
             )
-            page_rows, next_cursor = _preview_page(
-                filtered_rows,
-                limit=request.limit,
-                cursor=request.cursor,
-            )
-            tools = [
-                _profile_tool_preview_entry(
+            runtime_effective = request.mode == PolicyExplainMode.RUNTIME_EFFECTIVE
+            preview_entries: list[ProfileToolPreviewEntry] = []
+            for row in filtered_rows:
+                entry, entry_degraded_reasons = await _profile_tool_preview_entry(
                     profile,
                     row.tool_name,
                     capability=request.capability,
                     argument_sensitive=argument_sensitive,
                     installation_status=row.installation_status,
+                    runtime_effective=runtime_effective,
+                    policy_grant_store=(
+                        self.policy_grant_store if runtime_effective else None
+                    ),
+                    session_id=request.session_id if runtime_effective else None,
                 )
-                for row in page_rows
-            ]
+                for degraded_reason in entry_degraded_reasons:
+                    _append_degraded_reason(degraded_reasons, degraded_reason)
+                if request.include_denied or entry.outcome != "deny":
+                    preview_entries.append(entry)
+            page_tools, next_cursor = _preview_page(
+                preview_entries,
+                limit=request.limit,
+                cursor=request.cursor,
+            )
             response = ProfileToolPreviewResponse(
                 profile_id=profile.id,
                 mode=request.mode,
                 truncated=next_cursor is not None,
                 next_cursor=next_cursor,
-                tools=tools,
-                summary=_preview_summary(tools),
+                tools=page_tools,
+                summary=_preview_summary(page_tools),
                 degraded=bool(degraded_reasons),
                 degraded_reasons=degraded_reasons,
                 skipped_contributors=_skipped_contributors_for_mode(request.mode),
@@ -799,40 +818,99 @@ def _redacted_rule(rule: Mapping[str, Any]) -> dict[str, Any]:
     return payload
 
 
-def _profile_tool_preview_entry(
+async def _simulate_tool_call_policy_async(
+    profile: MCPProfile,
+    tool_name: str,
+    arguments: dict[str, Any],
+    *,
+    capability: str | None,
+    policy_grant_store: Any | None,
+    session_id: str | None,
+) -> Mapping[str, Any]:
+    return await asyncio.to_thread(
+        simulate_tool_call_policy,
+        profile,
+        tool_name,
+        arguments,
+        capability=capability,
+        policy_grant_store=policy_grant_store,
+        session_id=session_id,
+    )
+
+
+async def _profile_tool_preview_entry(
     profile: MCPProfile,
     tool_name: str,
     *,
     capability: str | None,
     argument_sensitive: bool,
     installation_status: str = "unknown",
-) -> ProfileToolPreviewEntry:
+    runtime_effective: bool,
+    policy_grant_store: Any | None,
+    session_id: str | None,
+) -> tuple[ProfileToolPreviewEntry, list[str]]:
     explanation = explain_profile_tool_decision(
         profile,
         tool_name,
         capability=capability,
     )
-    if argument_sensitive and explanation.final_outcome == "allow":
-        return ProfileToolPreviewEntry(
-            tool_name=_redact_tool_identifier(tool_name),
-            outcome="ask",
-            reason_code="argument_sensitive_policy",
-            visibility="deferred",
-            call_state="deferred",
-            requires_approval=False,
-            installation_status=installation_status,
+    degraded_reasons: list[str] = []
+    if runtime_effective:
+        simulator_result = await _simulate_tool_call_policy_async(
+            profile,
+            tool_name,
+            {},
+            capability=capability,
+            policy_grant_store=policy_grant_store,
+            session_id=session_id,
         )
-    return ProfileToolPreviewEntry(
-        tool_name=_redact_tool_identifier(tool_name),
-        outcome=explanation.final_outcome,
-        reason_code=explanation.reason_code,
-        visibility=_approved_visibility(
+        effective_decision = _effective_decision_from_simulation(
+            simulator_result,
+            tool_policy_outcome=explanation.final_outcome,
+            tool_policy_reason_code=explanation.reason_code,
+        )
+        degraded_reason = effective_decision["degraded_reason"]
+        if degraded_reason is not None:
+            degraded_reasons.append(degraded_reason)
+        outcome = effective_decision["final_outcome"]
+        reason_code = effective_decision["reason_code"]
+        visibility = effective_decision["visibility"]
+        call_state = effective_decision["call_state"]
+        requires_approval = effective_decision["requires_approval"]
+    else:
+        outcome = explanation.final_outcome
+        reason_code = explanation.reason_code
+        visibility = _approved_visibility(
             explanation.visibility,
             outcome=explanation.final_outcome,
+        )
+        call_state = explanation.call_state
+        requires_approval = explanation.requires_approval
+
+    if argument_sensitive and outcome == "allow":
+        return (
+            ProfileToolPreviewEntry(
+                tool_name=_redact_tool_identifier(tool_name),
+                outcome="ask",
+                reason_code="argument_sensitive_policy",
+                visibility="deferred",
+                call_state="deferred",
+                requires_approval=False,
+                installation_status=installation_status,
+            ),
+            degraded_reasons,
+        )
+    return (
+        ProfileToolPreviewEntry(
+            tool_name=_redact_tool_identifier(tool_name),
+            outcome=outcome,
+            reason_code=reason_code,
+            visibility=visibility,
+            call_state=call_state,
+            requires_approval=requires_approval,
+            installation_status=installation_status,
         ),
-        call_state=explanation.call_state,
-        requires_approval=explanation.requires_approval,
-        installation_status=installation_status,
+        degraded_reasons,
     )
 
 
@@ -916,11 +994,11 @@ def _preview_summary(
 
 
 def _preview_page(
-    rows: list[_PreviewCatalogRow],
+    rows: list[_TPreviewItem],
     *,
     limit: int,
     cursor: str | None,
-) -> tuple[list[_PreviewCatalogRow], str | None]:
+) -> tuple[list[_TPreviewItem], str | None]:
     start = int(cursor) if cursor is not None else 0
     if start >= len(rows):
         return [], None
@@ -1001,11 +1079,8 @@ def _preview_row_from_catalog_item(item: Any) -> _PreviewCatalogRow | None:
 
 
 def _filter_preview_catalog_rows(
-    profile: MCPProfile,
     rows: list[_PreviewCatalogRow],
     *,
-    capability: str | None,
-    include_denied: bool,
     include_recommendations: bool,
     category: str | None,
 ) -> list[_PreviewCatalogRow]:
@@ -1018,13 +1093,6 @@ def _filter_preview_catalog_rows(
         ):
             continue
         if not include_recommendations and row.installation_status == "not_installed":
-            continue
-        explanation = explain_profile_tool_decision(
-            profile,
-            row.tool_name,
-            capability=capability,
-        )
-        if not include_denied and explanation.final_outcome == "deny":
             continue
         filtered.append(row)
     return filtered
@@ -1061,6 +1129,8 @@ def _catalog_items(catalog: Any) -> Iterable[Any]:
 
 def _policy_tool_names_from_profile(profile: MCPProfile) -> list[str]:
     policy_document = profile.policy_document
+    if policy_document is None:
+        return []
     policy_tools = set(policy_document.allowed_tools or [])
     policy_tools.update(policy_document.denied_tools or [])
     return sorted(tool_name for tool_name in policy_tools if isinstance(tool_name, str))
@@ -1143,6 +1213,11 @@ def _skipped_contributors_for_mode(mode: PolicyExplainMode) -> list[str]:
     return list(STATIC_POLICY_ONLY_SKIPPED_CONTRIBUTORS)
 
 
+def _append_degraded_reason(reasons: list[str], reason: str | None) -> None:
+    if reason is not None and reason not in reasons:
+        reasons.append(reason)
+
+
 def _approved_visibility(
     value: Any,
     *,
@@ -1169,9 +1244,9 @@ def _redact_tool_identifier(tool_name: str) -> str:
     stripped = tool_name.strip()
     if "\n" in stripped or "\r" in stripped:
         return "[redacted-tool]"
-    for command_tool in ("Bash", "Shell", "PowerShell", "Monitor"):
-        if stripped.startswith(f"{command_tool}(") and stripped.endswith(")"):
-            return f"{command_tool}([redacted-command])"
+    command_match = _COMMAND_TOOL_IDENTIFIER_PATTERN.match(stripped)
+    if command_match is not None:
+        return f"{command_match.group(1)}([redacted-command])"
     return stripped
 
 

--- a/mcp_unified/gateway/policy_explain.py
+++ b/mcp_unified/gateway/policy_explain.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from mcp_unified.interfaces.storage import AuditStore
 from mcp_unified.profiles import MCPProfile, explain_profile_tool_decision
+from mcp_unified.profiles.permission_rules import compile_permission_rules
 from mcp_unified.profiles.subjects import (
     PermissionSubjectLimitError,
     extract_permission_rule_subjects,
@@ -27,6 +28,7 @@ from .policy_simulation import simulate_tool_call_policy
 MAX_POLICY_EXPLAIN_ARGUMENT_BYTES = 64 * 1024
 POLICY_EXPLAIN_AUDIT_EVENT_TYPE = "policy.explain.requested"
 POLICY_PREVIEW_TOOLS_AUDIT_EVENT_TYPE = "policy.preview_tools.requested"
+DEFAULT_AUDIT_ACTOR_ID = "local-cli"
 
 PolicyExplainOutcome = Literal["deny", "ask", "allow"]
 PolicyExplainRedactionState = Literal["raw_safe", "sanitized", "redacted", "omitted"]
@@ -251,7 +253,7 @@ class GatewayPolicyExplainService:
     ) -> None:
         self.profile_resolver = profile_resolver
         self.audit_store = audit_store
-        self.actor_id = actor_id
+        self.actor_id = actor_id or DEFAULT_AUDIT_ACTOR_ID
         self.catalog_provider = catalog_provider
         self.policy_grant_store = policy_grant_store
 
@@ -264,9 +266,15 @@ class GatewayPolicyExplainService:
         try:
             profile = await self._resolve_profile(request.profile_id)
         except GatewayPolicyExplainError as exc:
-            if exc.reason_code == "profile_not_found":
-                await self._audit_explain_failure(request, exc)
+            await self._audit_explain_failure(request, exc)
             raise
+        except Exception as exc:  # noqa: BLE001
+            failure = GatewayPolicyExplainError(
+                "Profile resolution failed",
+                reason_code="profile_resolution_failed",
+            )
+            await self._audit_explain_failure(request, failure)
+            raise failure from exc
         policy_grant_store = (
             self.policy_grant_store
             if request.mode == PolicyExplainMode.RUNTIME_EFFECTIVE
@@ -367,9 +375,15 @@ class GatewayPolicyExplainService:
         try:
             profile = await self._resolve_profile(request.profile_id)
         except GatewayPolicyExplainError as exc:
-            if exc.reason_code == "profile_not_found":
-                await self._audit_preview_failure(request, exc)
+            await self._audit_preview_failure(request, exc)
             raise
+        except Exception as exc:  # noqa: BLE001
+            failure = GatewayPolicyExplainError(
+                "Profile resolution failed",
+                reason_code="profile_resolution_failed",
+            )
+            await self._audit_preview_failure(request, failure)
+            raise failure from exc
         degraded_reasons: list[str] = []
         try:
             tool_names = await self._preview_tool_names(profile)
@@ -381,11 +395,13 @@ class GatewayPolicyExplainService:
                 degraded_reasons.append("catalog_unavailable")
 
         try:
+            argument_sensitive = _has_argument_sensitive_permission_rules(profile)
             tools = [
                 _profile_tool_preview_entry(
                     profile,
                     tool_name,
                     capability=request.capability,
+                    argument_sensitive=argument_sensitive,
                 )
                 for tool_name in tool_names
             ]
@@ -414,7 +430,7 @@ class GatewayPolicyExplainService:
             profile_id=profile.id,
             target_type="profile",
             target_id=profile.id,
-            payload=response.model_dump(mode="json", exclude_none=True),
+            payload=_preview_audit_payload(response),
         )
         return response
 
@@ -637,12 +653,22 @@ def _profile_tool_preview_entry(
     tool_name: str,
     *,
     capability: str | None,
+    argument_sensitive: bool,
 ) -> ProfileToolPreviewEntry:
     explanation = explain_profile_tool_decision(
         profile,
         tool_name,
         capability=capability,
     )
+    if argument_sensitive and explanation.final_outcome == "allow":
+        return ProfileToolPreviewEntry(
+            tool_name=_redact_tool_identifier(tool_name),
+            outcome="ask",
+            reason_code="argument_sensitive_policy",
+            visibility="deferred",
+            call_state="deferred",
+            requires_approval=False,
+        )
     return ProfileToolPreviewEntry(
         tool_name=_redact_tool_identifier(tool_name),
         outcome=explanation.final_outcome,
@@ -726,6 +752,14 @@ def _preview_summary(
     return summary
 
 
+def _preview_audit_payload(response: ProfileToolPreviewResponse) -> dict[str, Any]:
+    return response.model_dump(
+        mode="json",
+        exclude={"tools"},
+        exclude_none=True,
+    )
+
+
 def _tool_names_from_catalog(catalog: Any) -> set[str]:
     tool_names: set[str] = set()
     for item in _catalog_items(catalog):
@@ -765,6 +799,11 @@ def _policy_tool_names_from_profile(profile: MCPProfile) -> list[str]:
     policy_tools = set(policy_document.allowed_tools or [])
     policy_tools.update(policy_document.denied_tools or [])
     return sorted(tool_name for tool_name in policy_tools if isinstance(tool_name, str))
+
+
+def _has_argument_sensitive_permission_rules(profile: MCPProfile) -> bool:
+    rules = compile_permission_rules(profile.policy_document)
+    return any(rule.rule_type in {"command", "domain", "path"} for rule in rules)
 
 
 def _redact_path(value: str) -> tuple[str, PolicyExplainRedactionState]:

--- a/mcp_unified/gateway/policy_explain.py
+++ b/mcp_unified/gateway/policy_explain.py
@@ -29,7 +29,12 @@ POLICY_EXPLAIN_AUDIT_EVENT_TYPE = "policy.explain.requested"
 POLICY_PREVIEW_TOOLS_AUDIT_EVENT_TYPE = "policy.preview_tools.requested"
 
 PolicyExplainOutcome = Literal["deny", "ask", "allow"]
-PolicyExplainRedactionState = Literal["plain", "sanitized", "redacted"]
+PolicyExplainRedactionState = Literal["raw_safe", "sanitized", "redacted", "omitted"]
+STATIC_POLICY_ONLY_SKIPPED_CONTRIBUTORS = [
+    "session_grants",
+    "approval_grants",
+    "runtime_availability",
+]
 
 _DEFAULTS_BY_OUTCOME: dict[str, dict[str, Any]] = {
     "deny": {
@@ -151,6 +156,7 @@ class PolicyExplainResponse(BaseModel):
     subjects: list[PolicyExplainSubject] = Field(default_factory=list)
     degraded: bool = False
     degraded_reasons: list[str] = Field(default_factory=list)
+    skipped_contributors: list[str] = Field(default_factory=list)
     redacted: bool = True
 
 
@@ -191,6 +197,7 @@ class ProfileToolPreviewResponse(BaseModel):
     summary: ProfileToolPreviewSummary = Field(default_factory=ProfileToolPreviewSummary)
     degraded: bool = False
     degraded_reasons: list[str] = Field(default_factory=list)
+    skipped_contributors: list[str] = Field(default_factory=list)
     redacted: bool = True
 
 
@@ -241,7 +248,12 @@ class GatewayPolicyExplainService:
     ) -> PolicyExplainResponse:
         """Return a redacted explanation for one tool call policy check."""
 
-        profile = await self._resolve_profile(request.profile_id)
+        try:
+            profile = await self._resolve_profile(request.profile_id)
+        except GatewayPolicyExplainError as exc:
+            if exc.reason_code == "profile_not_found":
+                await self._audit_explain_failure(request, exc)
+            raise
         policy_grant_store = (
             self.policy_grant_store
             if request.mode == PolicyExplainMode.RUNTIME_EFFECTIVE
@@ -279,6 +291,7 @@ class GatewayPolicyExplainService:
         if effective_decision["degraded_reason"] is not None:
             degraded_reasons.append(effective_decision["degraded_reason"])
         safe_tool_name = _redact_tool_identifier(request.tool_name)
+        skipped_contributors = _skipped_contributors_for_mode(request.mode)
         response = PolicyExplainResponse(
             profile_id=profile.id,
             tool_name=safe_tool_name,
@@ -306,6 +319,7 @@ class GatewayPolicyExplainService:
             subjects=subjects,
             degraded=bool(degraded_reasons),
             degraded_reasons=degraded_reasons,
+            skipped_contributors=skipped_contributors,
         )
         await _append_audit_event_strict(
             self.audit_store,
@@ -324,7 +338,12 @@ class GatewayPolicyExplainService:
     ) -> ProfileToolPreviewResponse:
         """Return a redacted profile tool preview, degrading without a catalog."""
 
-        profile = await self._resolve_profile(request.profile_id)
+        try:
+            profile = await self._resolve_profile(request.profile_id)
+        except GatewayPolicyExplainError as exc:
+            if exc.reason_code == "profile_not_found":
+                await self._audit_preview_failure(request, exc)
+            raise
         degraded_reasons: list[str] = []
         tool_names = await self._preview_tool_names(profile)
         if self.catalog_provider is None:
@@ -341,6 +360,7 @@ class GatewayPolicyExplainService:
             summary=_preview_summary(entries),
             degraded=bool(degraded_reasons),
             degraded_reasons=degraded_reasons,
+            skipped_contributors=_skipped_contributors_for_mode(request.mode),
         )
         await _append_audit_event_strict(
             self.audit_store,
@@ -371,6 +391,54 @@ class GatewayPolicyExplainService:
         policy_tools = set(policy_document.allowed_tools or [])
         policy_tools.update(policy_document.denied_tools or [])
         return sorted(tool_name for tool_name in policy_tools if isinstance(tool_name, str))
+
+    async def _audit_explain_failure(
+        self,
+        request: PolicyExplainRequest,
+        exc: GatewayPolicyExplainError,
+    ) -> None:
+        safe_tool_name = _redact_tool_identifier(request.tool_name)
+        payload = {
+            "ok": False,
+            "profile_id": request.profile_id,
+            "tool_name": safe_tool_name,
+            "mode": request.mode.value,
+            "error": str(exc),
+            "reason_code": exc.reason_code,
+            "redacted": True,
+        }
+        await _append_audit_event_strict(
+            self.audit_store,
+            event_type=POLICY_EXPLAIN_AUDIT_EVENT_TYPE,
+            actor_id=self.actor_id,
+            profile_id=request.profile_id,
+            target_type="tool",
+            target_id=safe_tool_name,
+            payload=payload,
+        )
+
+    async def _audit_preview_failure(
+        self,
+        request: ProfileToolPreviewRequest,
+        exc: GatewayPolicyExplainError,
+    ) -> None:
+        payload = {
+            "ok": False,
+            "profile_id": request.profile_id,
+            "mode": request.mode.value,
+            "error": str(exc),
+            "reason_code": exc.reason_code,
+            "redacted": True,
+        }
+        await _append_audit_event_strict(
+            self.audit_store,
+            event_type=POLICY_PREVIEW_TOOLS_AUDIT_EVENT_TYPE,
+            actor_id=self.actor_id,
+            profile_id=request.profile_id,
+            target_type="profile",
+            target_id=request.profile_id,
+            payload=payload,
+        )
 
 
 async def _append_audit_event_strict(
@@ -422,7 +490,7 @@ def _redact_subject_value(
     subject = subject_type.strip().lower()
     text = value.strip()
     if not text:
-        return "", "plain"
+        return "", "omitted"
     if subject == "path":
         return _redact_path(text)
     if subject == "command":
@@ -430,7 +498,7 @@ def _redact_subject_value(
     if subject == "domain":
         return _redact_domain(text)
     if subject in {"tool", "mcp", "skill", "agent", "capability", "risk_class"}:
-        return text, "plain"
+        return text, "raw_safe"
     return "[redacted]", "redacted"
 
 
@@ -632,10 +700,12 @@ def _redact_path(value: str) -> tuple[str, PolicyExplainRedactionState]:
         if not file_path:
             return "file://[redacted-path]", "redacted"
         return _redact_path(file_path)
+    if parsed.scheme and parsed.netloc:
+        return _redacted_url_origin(parsed), "sanitized"
     if _is_absolute_path(normalized):
         filename = normalized.rstrip("/").rsplit("/", 1)[-1]
         return (f".../{filename}" if filename else "[path]"), "sanitized"
-    return normalized, "plain"
+    return normalized, "raw_safe"
 
 
 def _redact_domain(value: str) -> tuple[str, PolicyExplainRedactionState]:
@@ -643,19 +713,31 @@ def _redact_domain(value: str) -> tuple[str, PolicyExplainRedactionState]:
     if parsed.scheme.lower() == "file":
         return _redact_path(value)
     if parsed.scheme and parsed.netloc:
-        host = parsed.hostname or "[domain]"
-        try:
-            port = parsed.port
-        except ValueError:
-            port = None
-        if port is not None:
-            host = f"{host}:{port}"
-        return f"{parsed.scheme}://{host}", "sanitized"
+        return _redacted_url_origin(parsed), "sanitized"
     sanitized = value.split("?", 1)[0].split("#", 1)[0]
     if "@" in sanitized:
         sanitized = sanitized.rsplit("@", 1)[-1]
-    state: PolicyExplainRedactionState = "sanitized" if sanitized != value else "plain"
+    state: PolicyExplainRedactionState = (
+        "sanitized" if sanitized != value else "raw_safe"
+    )
     return sanitized, state
+
+
+def _redacted_url_origin(parsed: Any) -> str:
+    host = parsed.hostname or "[domain]"
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    if port is not None:
+        host = f"{host}:{port}"
+    return f"{parsed.scheme}://{host}"
+
+
+def _skipped_contributors_for_mode(mode: PolicyExplainMode) -> list[str]:
+    if mode != PolicyExplainMode.STATIC_POLICY_ONLY:
+        return []
+    return list(STATIC_POLICY_ONLY_SKIPPED_CONTRIBUTORS)
 
 
 def _is_absolute_path(value: str) -> bool:

--- a/mcp_unified/gateway/profile_runtime.py
+++ b/mcp_unified/gateway/profile_runtime.py
@@ -235,6 +235,14 @@ class ProfileAwareGatewayRuntime:
             ),
         ]
 
+    async def list_backend_tools_for_admin_catalog(
+        self,
+        context: GatewayRequestContext,
+    ) -> list[Any]:
+        """Return unfiltered backend discovery data for admin policy preview."""
+
+        return await self._safe_backend_tools(context)
+
     async def call_tool(
         self,
         name: str,

--- a/mcp_unified/gateway/remote_admin.py
+++ b/mcp_unified/gateway/remote_admin.py
@@ -196,12 +196,41 @@ class RemoteGatewayAdminClient:
             f"/external-servers/{_quote_server_id(server_id)}/update",
         )
 
-    def _request_json(self, method: str, path: str) -> dict[str, Any]:
+    def explain_policy(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        """Explain one profile policy decision through the running gateway."""
+
+        return self._request_json("POST", "/policy/explain", payload=payload)
+
+    def preview_profile_tools(
+        self,
+        profile_id: str,
+        payload: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Preview profile tool visibility through the running gateway."""
+
+        return self._request_json(
+            "POST",
+            f"/profiles/{_quote_path_segment(profile_id, field='profile_id')}/tool-preview",
+            payload=payload,
+        )
+
+    def _request_json(
+        self,
+        method: str,
+        path: str,
+        payload: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
         """Send one request and return a JSON object response."""
 
+        request_body = None
+        if method == "POST":
+            request_body = json.dumps(
+                dict(payload) if payload is not None else {},
+                sort_keys=True,
+            ).encode("utf-8")
         request = urllib.request.Request(
             self.endpoint_url(path),
-            data=b"{}" if method == "POST" else None,
+            data=request_body,
             headers=self._headers(method),
             method=method,
         )
@@ -232,9 +261,15 @@ class RemoteGatewayAdminClient:
 def _quote_server_id(server_id: str) -> str:
     """Quote a server id for safe use in one path segment."""
 
-    normalized = server_id.strip()
+    return _quote_path_segment(server_id, field="server_id")
+
+
+def _quote_path_segment(value: str, *, field: str) -> str:
+    """Quote a required value for safe use in one path segment."""
+
+    normalized = value.strip()
     if not normalized:
-        raise ValueError("server_id is required")
+        raise ValueError(f"{field} is required")
     return urllib.parse.quote(normalized, safe="")
 
 

--- a/mcp_unified/gateway/remote_admin.py
+++ b/mcp_unified/gateway/remote_admin.py
@@ -93,7 +93,13 @@ class RemoteGatewayAdminError(RuntimeError):
         """Build an error from a public gateway JSON error payload."""
 
         error = payload.get("error")
-        message = error if isinstance(error, str) and error else "Remote gateway error"
+        payload_message = payload.get("message")
+        if isinstance(error, str) and error:
+            message = error
+        elif isinstance(payload_message, str) and payload_message:
+            message = payload_message
+        else:
+            message = "Remote gateway error"
         reason_code = payload.get("reason_code")
         return cls(
             message,

--- a/mcp_unified/gateway/tool_discovery.py
+++ b/mcp_unified/gateway/tool_discovery.py
@@ -74,6 +74,21 @@ class ProfileToolAvailability:
     has_recommended_unavailable_tools: bool
 
 
+@dataclass(frozen=True, slots=True)
+class AdminToolCatalogEntry:
+    """Policy-preview catalog row that is not filtered by model-facing visibility."""
+
+    tool_id: str
+    tool_name: str | None = None
+    display_name: str | None = None
+    description: str = ""
+    category: str = _DEFAULT_CATEGORY
+    capabilities: tuple[str, ...] = ()
+    installation_status: str = "unknown"
+    source: str = "backend"
+    metadata: dict[str, Any] | None = None
+
+
 def list_profile_tools(profile: MCPProfile, backend_tools: Any) -> dict[str, Any]:
     """Return all tools visible to a profile with deterministic category metadata."""
 
@@ -109,6 +124,47 @@ def search_profile_tools(
     return [
         _entry_payload(entry, score=scores.get(entry.tool_id, 0.0))
         for entry in ordered[:limit]
+    ]
+
+
+def list_admin_tool_catalog(
+    profile: MCPProfile,
+    backend_tools: Any,
+    *,
+    include_recommendations: bool = True,
+) -> list[AdminToolCatalogEntry]:
+    """Return installed and recommended tools for admin policy preview.
+
+    Unlike model-facing discovery, this catalog intentionally does not filter
+    installed backend tools through profile policy visibility. Denied installed
+    tools must remain present so admins can preview their effective decisions.
+    """
+
+    if not getattr(profile, "enabled", False):
+        return []
+    if build_effective_policy_result(profile).status != "resolved":
+        return []
+
+    entries: list[_ToolEntry] = []
+    seen: set[str] = set()
+    for tool in _backend_tool_sequence(backend_tools):
+        entry = _admin_installed_entry(profile, tool)
+        if entry is None or entry.tool_id in seen:
+            continue
+        entries.append(entry)
+        seen.add(entry.tool_id)
+
+    if include_recommendations:
+        for recommendation in _recommended_tool_sequence(profile):
+            entry = _recommended_entry(profile, recommendation)
+            if entry is None or entry.tool_id in seen:
+                continue
+            entries.append(entry)
+            seen.add(entry.tool_id)
+
+    return [
+        _admin_catalog_entry(entry)
+        for entry in _sort_entries(profile, entries, scores={})
     ]
 
 
@@ -275,6 +331,19 @@ def _installed_entry(profile: MCPProfile, tool: Any) -> _ToolEntry | None:
 
     if not isinstance(tool, dict) or not _installed_tool_allowed(profile, tool):
         return None
+    return _installed_backend_entry(profile, tool)
+
+
+def _admin_installed_entry(profile: MCPProfile, tool: Any) -> _ToolEntry | None:
+    """Normalize one installed backend descriptor without policy visibility checks."""
+
+    if not isinstance(tool, dict):
+        return None
+    return _installed_backend_entry(profile, tool)
+
+
+def _installed_backend_entry(profile: MCPProfile, tool: dict[str, Any]) -> _ToolEntry | None:
+    """Normalize one installed backend descriptor."""
 
     tool_id = _tool_name(tool)
     if tool_id is None:
@@ -672,6 +741,29 @@ def _entry_payload(entry: _ToolEntry, *, score: float) -> dict[str, Any]:
     return payload
 
 
+def _admin_catalog_entry(entry: _ToolEntry) -> AdminToolCatalogEntry:
+    """Return a public admin catalog row from a normalized discovery entry."""
+
+    installation_status = (
+        "installed"
+        if entry.installation_status == _INSTALLED
+        else "not_installed"
+        if entry.installation_status == _RECOMMENDED_UNAVAILABLE
+        else entry.installation_status
+    )
+    return AdminToolCatalogEntry(
+        tool_id=entry.tool_id,
+        tool_name=entry.tool_name,
+        display_name=entry.display_name,
+        description=entry.description,
+        category=entry.category,
+        capabilities=entry.capabilities,
+        installation_status=installation_status,
+        source=entry.source,
+        metadata=deepcopy(entry.metadata) if entry.metadata is not None else None,
+    )
+
+
 def _exposure_priority(entry: _ToolEntry) -> int:
     """Return stable sort priority for direct, deferred, and unavailable tools."""
 
@@ -805,8 +897,10 @@ def _normalize_sort_text(value: str) -> str:
 
 
 __all__ = [
+    "AdminToolCatalogEntry",
     "describe_profile_tool",
     "find_direct_profile_backend_tool",
+    "list_admin_tool_catalog",
     "list_direct_profile_backend_tools",
     "list_profile_tools",
     "profile_has_deferred_installed_tools",

--- a/mcp_unified/gateway/tool_use_reporting.py
+++ b/mcp_unified/gateway/tool_use_reporting.py
@@ -72,6 +72,21 @@ class ToolUseReportingGatewayRuntime:
 
         return await self._runtime.list_tools(context)
 
+    async def list_backend_tools_for_admin_catalog(
+        self,
+        context: GatewayRequestContext,
+    ) -> list[Any]:
+        """Delegate unfiltered admin catalog discovery when supported."""
+
+        admin_catalog = getattr(
+            self._runtime,
+            "list_backend_tools_for_admin_catalog",
+            None,
+        )
+        if callable(admin_catalog):
+            return await admin_catalog(context)
+        return await self._runtime.list_tools(context)
+
     async def call_tool(
         self,
         name: str,

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import pytest
+from fastapi.testclient import TestClient
 
 from mcp_unified.gateway.admin_auth import (
     DefaultGatewayAdminPermissionChecker,
@@ -13,11 +15,54 @@ from mcp_unified.gateway.admin_auth import (
     gateway_admin_identity_dependency,
     gateway_admin_permission_error_response,
 )
+from mcp_unified.gateway.fastapi import create_gateway_app
+from mcp_unified.profiles import MCPProfile, ProfilePolicy
+from mcp_unified.storage.models import AuditEvent
 
 
 class _RequestStub:
     def __init__(self, headers: dict[str, str] | None = None) -> None:
         self.headers = headers or {}
+
+
+class _MemoryAuditStore:
+    def __init__(self) -> None:
+        self.events: list[AuditEvent] = []
+
+    async def append_event(self, event: AuditEvent) -> None:
+        self.events.append(event)
+
+
+class _PolicyExplainRuntime:
+    name = "policy-explain-test"
+    version = "0.0-test"
+
+    async def list_tools(self, context: Any) -> list[dict[str, Any]]:
+        assert context.client_id is None
+        assert context.user_id is None
+        return [
+            {
+                "name": "fs.patch",
+                "description": "Patch files",
+                "metadata": {"category": "filesystem"},
+            },
+            {
+                "name": "shell.exec",
+                "description": "Execute shell commands",
+                "metadata": {"category": "shell"},
+            },
+        ]
+
+
+def _policy_profile() -> MCPProfile:
+    return MCPProfile(
+        id="backend-engineer",
+        name="Backend Engineer",
+        policy_document=ProfilePolicy(
+            allowed_tools=["fs.patch"],
+            denied_tools=["shell.exec"],
+        ),
+    )
 
 
 def test_default_admin_identity_has_policy_explain_permission_when_auth_disabled() -> None:
@@ -83,4 +128,109 @@ def test_permission_error_response_uses_stable_error_envelope() -> None:
         "ok": False,
         "error": "Gateway admin permission denied",
         "reason_code": "admin_permission_denied",
+    }
+
+
+def test_policy_explain_route_requires_admin_key_when_admin_auth_enabled() -> None:
+    app = create_gateway_app(
+        _PolicyExplainRuntime(),
+        enable_policy_explain_management=True,
+        policy_explain_profile_resolver=lambda profile_id: _policy_profile(),
+        policy_explain_audit_store=_MemoryAuditStore(),
+        admin_auth=GatewayAdminAuthConfig(enabled=True, api_key="secret"),
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp/policy/explain",
+            json={"profile_id": "backend-engineer", "tool_name": "fs.patch"},
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {
+        "ok": False,
+        "error": "Gateway admin authentication required",
+        "reason_code": "admin_auth_required",
+    }
+
+
+def test_policy_explain_route_succeeds_and_audits_with_valid_admin_key() -> None:
+    audit = _MemoryAuditStore()
+    app = create_gateway_app(
+        _PolicyExplainRuntime(),
+        enable_policy_explain_management=True,
+        policy_explain_profile_resolver=lambda profile_id: _policy_profile(),
+        policy_explain_audit_store=audit,
+        admin_auth=GatewayAdminAuthConfig(enabled=True, api_key="secret"),
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp/policy/explain",
+            headers={"X-MCP-Gateway-Admin-Key": "secret"},
+            json={
+                "profile_id": "backend-engineer",
+                "tool_name": "fs.patch",
+                "arguments": {"path": "workspace/example.py"},
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["profile_id"] == "backend-engineer"
+    assert payload["tool_name"] == "fs.patch"
+    assert payload["final_outcome"] == "allow"
+    assert audit.events[0].event_type == "policy.explain.requested"
+    assert audit.events[0].actor_id == "gateway-admin"
+    assert audit.events[0].target_id == "fs.patch"
+
+
+def test_profile_tool_preview_route_includes_denied_installed_runtime_tool() -> None:
+    audit = _MemoryAuditStore()
+    app = create_gateway_app(
+        _PolicyExplainRuntime(),
+        enable_policy_explain_management=True,
+        policy_explain_profile_resolver=lambda profile_id: _policy_profile(),
+        policy_explain_audit_store=audit,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp/profiles/backend-engineer/tool-preview",
+            json={},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    tools_by_name = {tool["tool_name"]: tool for tool in payload["tools"]}
+    assert tools_by_name["fs.patch"]["outcome"] == "allow"
+    assert tools_by_name["fs.patch"]["installation_status"] == "installed"
+    assert tools_by_name["shell.exec"]["outcome"] == "deny"
+    assert tools_by_name["shell.exec"]["visibility"] == "hidden"
+    assert tools_by_name["shell.exec"]["installation_status"] == "installed"
+    assert audit.events[0].event_type == "policy.preview_tools.requested"
+
+
+def test_policy_explain_route_maps_policy_errors_to_stable_json_envelope() -> None:
+    audit = _MemoryAuditStore()
+    app = create_gateway_app(
+        _PolicyExplainRuntime(),
+        enable_policy_explain_management=True,
+        policy_explain_profile_resolver=lambda profile_id: None,
+        policy_explain_audit_store=audit,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp/policy/explain",
+            json={"profile_id": "missing-profile", "tool_name": "fs.patch"},
+        )
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "ok": False,
+        "message": "Profile not found",
+        "reason_code": "profile_not_found",
+        "details": {},
     }

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
@@ -35,6 +35,11 @@ class _MemoryAuditStore:
         self.events.append(event)
 
 
+class _FailingAuditStore:
+    async def append_event(self, event: AuditEvent) -> None:
+        raise RuntimeError("audit backend failed for workspace/private-token.txt")
+
+
 class _PolicyExplainRuntime:
     name = "policy-explain-test"
     version = "0.0-test"
@@ -341,6 +346,35 @@ def test_policy_explain_route_maps_permission_denial_to_stable_json_envelope() -
         "details": {},
     }
     assert audit.events == []
+
+
+def test_policy_explain_route_maps_audit_failure_to_stable_json_envelope() -> None:
+    app = create_gateway_app(
+        _PolicyExplainRuntime(),
+        enable_policy_explain_management=True,
+        policy_explain_profile_resolver=lambda profile_id: _policy_profile(),
+        policy_explain_audit_store=_FailingAuditStore(),
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp/policy/explain",
+            json={
+                "profile_id": "backend-engineer",
+                "tool_name": "fs.patch",
+                "arguments": {"path": "workspace/private-token.txt"},
+            },
+        )
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "ok": False,
+        "message": "Audit store unavailable",
+        "reason_code": "audit_store_unavailable",
+        "details": {},
+    }
+    assert "private-token" not in response.text
+    assert "fs.patch" not in response.text
 
 
 def test_policy_explain_route_maps_policy_errors_to_stable_json_envelope() -> None:

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
@@ -54,6 +54,17 @@ class _PolicyExplainRuntime:
         ]
 
 
+class _DenyingPermissionChecker:
+    async def require_permission(
+        self,
+        identity: GatewayAdminIdentity,
+        permission: str,
+    ) -> None:
+        assert identity.actor_id == "local-admin"
+        assert permission == "mcp.policy.explain"
+        raise GatewayAdminPermissionError(reason_code="admin_permission_denied")
+
+
 def _policy_profile() -> MCPProfile:
     return MCPProfile(
         id="backend-engineer",
@@ -210,6 +221,32 @@ def test_profile_tool_preview_route_includes_denied_installed_runtime_tool() -> 
     assert tools_by_name["shell.exec"]["visibility"] == "hidden"
     assert tools_by_name["shell.exec"]["installation_status"] == "installed"
     assert audit.events[0].event_type == "policy.preview_tools.requested"
+
+
+def test_policy_explain_route_maps_permission_denial_to_stable_json_envelope() -> None:
+    audit = _MemoryAuditStore()
+    app = create_gateway_app(
+        _PolicyExplainRuntime(),
+        enable_policy_explain_management=True,
+        policy_explain_profile_resolver=lambda profile_id: _policy_profile(),
+        policy_explain_audit_store=audit,
+        policy_explain_permission_checker=_DenyingPermissionChecker(),
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp/policy/explain",
+            json={"profile_id": "backend-engineer", "tool_name": "fs.patch"},
+        )
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "ok": False,
+        "message": "Gateway admin permission denied",
+        "reason_code": "admin_permission_denied",
+        "details": {},
+    }
+    assert audit.events == []
 
 
 def test_policy_explain_route_maps_policy_errors_to_stable_json_envelope() -> None:

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
@@ -16,6 +16,7 @@ from mcp_unified.gateway.admin_auth import (
     gateway_admin_permission_error_response,
 )
 from mcp_unified.gateway.fastapi import create_gateway_app
+from mcp_unified.gateway.policy_explain import GatewayPolicyExplainService
 from mcp_unified.profiles import MCPProfile, ProfilePolicy
 from mcp_unified.storage.models import AuditEvent
 
@@ -221,6 +222,68 @@ def test_profile_tool_preview_route_includes_denied_installed_runtime_tool() -> 
     assert tools_by_name["shell.exec"]["visibility"] == "hidden"
     assert tools_by_name["shell.exec"]["installation_status"] == "installed"
     assert audit.events[0].event_type == "policy.preview_tools.requested"
+
+
+def test_profile_tool_preview_route_rejects_conflicting_body_profile_id() -> None:
+    audit = _MemoryAuditStore()
+    app = create_gateway_app(
+        _PolicyExplainRuntime(),
+        enable_policy_explain_management=True,
+        policy_explain_profile_resolver=lambda profile_id: _policy_profile(),
+        policy_explain_audit_store=audit,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp/profiles/backend-engineer/tool-preview",
+            json={"profile_id": "frontend-engineer"},
+        )
+
+    assert response.status_code == 422
+    assert response.json() == {
+        "ok": False,
+        "message": "Invalid policy preview request",
+        "reason_code": "invalid_policy_preview_request",
+        "details": {},
+    }
+    assert audit.events == []
+
+
+def test_injected_policy_explain_service_uses_route_identity_and_runtime_catalog() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _policy_profile(),
+        audit_store=audit,
+    )
+    app = create_gateway_app(
+        _PolicyExplainRuntime(),
+        enable_policy_explain_management=True,
+        policy_explain_service=service,
+        admin_auth=GatewayAdminAuthConfig(enabled=True, api_key="secret"),
+    )
+
+    with TestClient(app) as client:
+        explain_response = client.post(
+            "/mcp/policy/explain",
+            headers={"X-MCP-Gateway-Admin-Key": "secret"},
+            json={"profile_id": "backend-engineer", "tool_name": "fs.patch"},
+        )
+        preview_response = client.post(
+            "/mcp/profiles/backend-engineer/tool-preview",
+            headers={"X-MCP-Gateway-Admin-Key": "secret"},
+            json={},
+        )
+
+    assert explain_response.status_code == 200
+    assert audit.events[0].event_type == "policy.explain.requested"
+    assert audit.events[0].actor_id == "gateway-admin"
+    assert preview_response.status_code == 200
+    preview_payload = preview_response.json()
+    tools_by_name = {tool["tool_name"]: tool for tool in preview_payload["tools"]}
+    assert preview_payload["degraded"] is False
+    assert tools_by_name["shell.exec"]["installation_status"] == "installed"
+    assert audit.events[1].event_type == "policy.preview_tools.requested"
+    assert audit.events[1].actor_id == "gateway-admin"
 
 
 def test_policy_explain_route_maps_permission_denial_to_stable_json_envelope() -> None:

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
@@ -7,11 +7,17 @@ import pytest
 from mcp_unified.gateway.admin_auth import (
     DefaultGatewayAdminPermissionChecker,
     GatewayAdminAuthConfig,
+    GatewayAdminAuthError,
     GatewayAdminIdentity,
     GatewayAdminPermissionError,
     gateway_admin_identity_dependency,
     gateway_admin_permission_error_response,
 )
+
+
+class _RequestStub:
+    def __init__(self, headers: dict[str, str] | None = None) -> None:
+        self.headers = headers or {}
 
 
 def test_default_admin_identity_has_policy_explain_permission_when_auth_disabled() -> None:
@@ -28,6 +34,31 @@ async def test_gateway_admin_identity_dependency_returns_local_admin_when_auth_d
     identity = await dependency(None)
 
     assert identity == GatewayAdminIdentity.local_admin()
+
+
+@pytest.mark.asyncio
+async def test_gateway_admin_identity_dependency_distinguishes_authenticated_admin() -> None:
+    dependency = gateway_admin_identity_dependency(
+        GatewayAdminAuthConfig(enabled=True, api_key="secret")
+    )
+
+    identity = await dependency(
+        _RequestStub(headers={"X-MCP-Gateway-Admin-Key": "secret"})
+    )
+
+    assert identity.actor_id == "gateway-admin"
+    assert identity.source == "gateway_admin_auth"
+    assert "mcp.policy.explain" in identity.permissions
+
+    with pytest.raises(GatewayAdminAuthError) as missing:
+        await dependency(_RequestStub())
+    assert missing.value.reason_code == "admin_auth_required"
+
+    with pytest.raises(GatewayAdminAuthError) as invalid:
+        await dependency(
+            _RequestStub(headers={"X-MCP-Gateway-Admin-Key": "wrong"})
+        )
+    assert invalid.value.reason_code == "admin_auth_invalid"
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
@@ -15,6 +15,7 @@ from mcp_unified.gateway.admin_auth import (
     gateway_admin_identity_dependency,
     gateway_admin_permission_error_response,
 )
+from mcp_unified.gateway.bootstrap import bootstrap_profile_gateway
 from mcp_unified.gateway.fastapi import create_gateway_app
 from mcp_unified.gateway.policy_explain import GatewayPolicyExplainService
 from mcp_unified.profiles import MCPProfile, ProfilePolicy
@@ -222,6 +223,36 @@ def test_profile_tool_preview_route_includes_denied_installed_runtime_tool() -> 
     assert tools_by_name["shell.exec"]["visibility"] == "hidden"
     assert tools_by_name["shell.exec"]["installation_status"] == "installed"
     assert audit.events[0].event_type == "policy.preview_tools.requested"
+
+
+@pytest.mark.asyncio
+async def test_profile_tool_preview_route_uses_unfiltered_profile_runtime_catalog() -> None:
+    audit = _MemoryAuditStore()
+    bootstrap = await bootstrap_profile_gateway(
+        _PolicyExplainRuntime(),
+        profiles=[_policy_profile()],
+        default_profile_id="backend-engineer",
+    )
+    app = create_gateway_app(
+        bootstrap.runtime,
+        enable_policy_explain_management=True,
+        policy_explain_profile_resolver=lambda profile_id: _policy_profile(),
+        policy_explain_audit_store=audit,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp/profiles/backend-engineer/tool-preview",
+            json={},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    tools_by_name = {tool["tool_name"]: tool for tool in payload["tools"]}
+    assert tools_by_name["fs.patch"]["installation_status"] == "installed"
+    assert tools_by_name["shell.exec"]["outcome"] == "deny"
+    assert tools_by_name["shell.exec"]["visibility"] == "hidden"
+    assert tools_by_name["shell.exec"]["installation_status"] == "installed"
 
 
 def test_profile_tool_preview_route_rejects_conflicting_body_profile_id() -> None:

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
@@ -1,3 +1,5 @@
+"""Tests for the standalone MCP gateway policy explain admin API."""
+
 from __future__ import annotations
 
 import json
@@ -6,6 +8,7 @@ from typing import Any
 import pytest
 from fastapi.testclient import TestClient
 
+import mcp_unified.gateway.fastapi as gateway_fastapi
 from mcp_unified.gateway.admin_auth import (
     DefaultGatewayAdminPermissionChecker,
     GatewayAdminAuthConfig,
@@ -20,6 +23,8 @@ from mcp_unified.gateway.fastapi import create_gateway_app
 from mcp_unified.gateway.policy_explain import GatewayPolicyExplainService
 from mcp_unified.profiles import MCPProfile, ProfilePolicy
 from mcp_unified.storage.models import AuditEvent
+
+pytestmark = pytest.mark.unit
 
 
 class _RequestStub:
@@ -90,7 +95,6 @@ def test_default_admin_identity_has_policy_explain_permission_when_auth_disabled
     assert "mcp.policy.explain" in identity.permissions
 
 
-@pytest.mark.asyncio
 async def test_gateway_admin_identity_dependency_returns_local_admin_when_auth_disabled() -> None:
     dependency = gateway_admin_identity_dependency(GatewayAdminAuthConfig())
 
@@ -99,7 +103,6 @@ async def test_gateway_admin_identity_dependency_returns_local_admin_when_auth_d
     assert identity == GatewayAdminIdentity.local_admin()
 
 
-@pytest.mark.asyncio
 async def test_gateway_admin_identity_dependency_distinguishes_authenticated_admin() -> None:
     dependency = gateway_admin_identity_dependency(
         GatewayAdminAuthConfig(enabled=True, api_key="secret")
@@ -124,7 +127,6 @@ async def test_gateway_admin_identity_dependency_distinguishes_authenticated_adm
     assert invalid.value.reason_code == "admin_auth_invalid"
 
 
-@pytest.mark.asyncio
 async def test_permission_checker_denies_missing_policy_explain_permission() -> None:
     checker = DefaultGatewayAdminPermissionChecker()
     identity = GatewayAdminIdentity(actor_id="viewer", permissions=frozenset())
@@ -204,6 +206,44 @@ def test_policy_explain_route_succeeds_and_audits_with_valid_admin_key() -> None
     assert audit.events[0].target_id == "fs.patch"
 
 
+def test_profile_tool_preview_route_applies_rate_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(gateway_fastapi, "POLICY_EXPLAIN_RATE_LIMIT_MAX_REQUESTS", 1)
+    monkeypatch.setattr(
+        gateway_fastapi,
+        "POLICY_EXPLAIN_RATE_LIMIT_WINDOW_SECONDS",
+        60.0,
+    )
+    audit = _MemoryAuditStore()
+    app = create_gateway_app(
+        _PolicyExplainRuntime(),
+        enable_policy_explain_management=True,
+        policy_explain_profile_resolver=lambda profile_id: _policy_profile(),
+        policy_explain_audit_store=audit,
+    )
+
+    with TestClient(app) as client:
+        first_response = client.post(
+            "/mcp/profiles/backend-engineer/tool-preview",
+            json={},
+        )
+        second_response = client.post(
+            "/mcp/profiles/backend-engineer/tool-preview",
+            json={},
+        )
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 429
+    assert second_response.json() == {
+        "ok": False,
+        "message": "Policy explain rate limit exceeded",
+        "reason_code": "policy_explain_rate_limited",
+        "details": {},
+    }
+    assert len(audit.events) == 1
+
+
 def test_profile_tool_preview_route_includes_denied_installed_runtime_tool() -> None:
     audit = _MemoryAuditStore()
     app = create_gateway_app(
@@ -230,7 +270,6 @@ def test_profile_tool_preview_route_includes_denied_installed_runtime_tool() -> 
     assert audit.events[0].event_type == "policy.preview_tools.requested"
 
 
-@pytest.mark.asyncio
 async def test_profile_tool_preview_route_uses_unfiltered_profile_runtime_catalog() -> None:
     audit = _MemoryAuditStore()
     bootstrap = await bootstrap_profile_gateway(

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mcp_unified.gateway.admin_auth import (
+    DefaultGatewayAdminPermissionChecker,
+    GatewayAdminAuthConfig,
+    GatewayAdminIdentity,
+    GatewayAdminPermissionError,
+    gateway_admin_identity_dependency,
+    gateway_admin_permission_error_response,
+)
+
+
+def test_default_admin_identity_has_policy_explain_permission_when_auth_disabled() -> None:
+    identity = GatewayAdminIdentity.local_admin()
+
+    assert identity.actor_id == "local-admin"
+    assert "mcp.policy.explain" in identity.permissions
+
+
+@pytest.mark.asyncio
+async def test_gateway_admin_identity_dependency_returns_local_admin_when_auth_disabled() -> None:
+    dependency = gateway_admin_identity_dependency(GatewayAdminAuthConfig())
+
+    identity = await dependency(None)
+
+    assert identity == GatewayAdminIdentity.local_admin()
+
+
+@pytest.mark.asyncio
+async def test_permission_checker_denies_missing_policy_explain_permission() -> None:
+    checker = DefaultGatewayAdminPermissionChecker()
+    identity = GatewayAdminIdentity(actor_id="viewer", permissions=frozenset())
+
+    with pytest.raises(GatewayAdminPermissionError) as exc_info:
+        await checker.require_permission(identity, "mcp.policy.explain")
+
+    assert exc_info.value.reason_code == "admin_permission_denied"
+
+
+def test_permission_error_response_uses_stable_error_envelope() -> None:
+    response = gateway_admin_permission_error_response(
+        None,
+        GatewayAdminPermissionError(reason_code="admin_permission_denied"),
+    )
+
+    assert response.status_code == 403
+    assert json.loads(response.body) == {
+        "ok": False,
+        "error": "Gateway admin permission denied",
+        "reason_code": "admin_permission_denied",
+    }

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py
@@ -10,6 +10,7 @@ from mcp_unified.gateway import cli as gateway_cli
 from mcp_unified.gateway.remote_admin import (
     RemoteGatewayAdminClient,
     RemoteGatewayAdminConfig,
+    RemoteGatewayAdminError,
 )
 
 
@@ -119,6 +120,23 @@ def test_remote_gateway_admin_client_preview_profile_tools_posts_json_body() -> 
     ]
 
 
+def test_remote_gateway_admin_error_preserves_message_payload() -> None:
+    """Remote admin errors preserve gateway message fields for CLI stderr."""
+
+    error = RemoteGatewayAdminError.from_payload(
+        {"message": "Policy explanation failed", "reason_code": "policy_failed"},
+        status_code=403,
+    )
+
+    assert error.to_payload() == {
+        "error": "Policy explanation failed",
+        "message": "Policy explanation failed",
+        "ok": False,
+        "reason_code": "policy_failed",
+        "status_code": 403,
+    }
+
+
 def test_gateway_cli_explain_policy_reads_args_json_file_for_remote_payload(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
@@ -140,14 +158,13 @@ def test_gateway_cli_explain_policy_reads_args_json_file_for_remote_payload(
             return {"ok": True, "payload": payload}
 
     monkeypatch.setattr(gateway_cli, "RemoteGatewayAdminClient", _Client)
+    monkeypatch.setenv("MCP_UNIFIED_GATEWAY_ADMIN_KEY", "admin-secret")
 
     exit_code = gateway_cli.main(
         [
             "explain-policy",
             "--gateway-url",
             "http://127.0.0.1:8000/mcp",
-            "--admin-key",
-            "admin-secret",
             "--admin-header-name",
             "X-Admin",
             "--profile",
@@ -191,6 +208,177 @@ def test_gateway_cli_explain_policy_reads_args_json_file_for_remote_payload(
     assert configs[0].gateway_url == "http://127.0.0.1:8000/mcp"
     assert configs[0].admin_header_name == "X-Admin"
     assert configs[0].admin_key == "admin-secret"
+
+
+def test_gateway_cli_explain_policy_defaults_to_local_when_gateway_env_is_set(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ambient gateway env does not silently switch policy explain to remote mode."""
+
+    calls: list[tuple[str, str]] = []
+
+    def local_handler(args: Any, operation: Any) -> int:
+        del operation
+        calls.append((args.profile, args.tool))
+        print(json.dumps({"ok": True, "mode": "local"}))
+        return 0
+
+    monkeypatch.setenv("MCP_UNIFIED_GATEWAY_URL", "http://127.0.0.1:8000/mcp")
+    monkeypatch.setattr(
+        gateway_cli,
+        "_handle_local_policy_explain_command",
+        local_handler,
+    )
+
+    exit_code = gateway_cli.main(
+        [
+            "explain-policy",
+            "--profile",
+            "backend-engineer",
+            "--tool",
+            "fs.patch",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.err == ""
+    assert json.loads(captured.out) == {"ok": True, "mode": "local"}
+    assert calls == [("backend-engineer", "fs.patch")]
+
+
+def test_gateway_cli_preview_profile_tools_remote_flag_uses_gateway_env(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--remote explicitly selects env-backed remote gateway mode."""
+
+    configs: list[RemoteGatewayAdminConfig] = []
+
+    class _Client:
+        def __init__(self, config: RemoteGatewayAdminConfig) -> None:
+            configs.append(config)
+
+        def preview_profile_tools(
+            self,
+            profile_id: str,
+            payload: dict[str, Any],
+        ) -> dict[str, Any]:
+            return {"ok": True, "profile_id": profile_id, "payload": payload}
+
+    monkeypatch.setenv("MCP_UNIFIED_GATEWAY_URL", "http://127.0.0.1:8000/mcp")
+    monkeypatch.setenv("MCP_UNIFIED_GATEWAY_ADMIN_KEY", "admin-secret")
+    monkeypatch.setattr(gateway_cli, "RemoteGatewayAdminClient", _Client)
+
+    exit_code = gateway_cli.main(
+        [
+            "preview-profile-tools",
+            "--remote",
+            "--profile",
+            "backend-engineer",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.err == ""
+    assert json.loads(captured.out) == {
+        "ok": True,
+        "payload": {
+            "include_denied": True,
+            "include_recommendations": True,
+            "mode": "runtime_effective",
+            "profile_id": "backend-engineer",
+        },
+        "profile_id": "backend-engineer",
+    }
+    assert configs == [
+        RemoteGatewayAdminConfig(
+            gateway_url="http://127.0.0.1:8000/mcp",
+            admin_key="admin-secret",
+        )
+    ]
+
+
+def test_gateway_cli_explain_policy_rejects_empty_args_json(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Explicit empty --args-json is invalid instead of being ignored."""
+
+    exit_code = gateway_cli.main(
+        [
+            "explain-policy",
+            "--profile",
+            "backend-engineer",
+            "--tool",
+            "fs.patch",
+            "--args-json",
+            "",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert captured.out == ""
+    assert json.loads(captured.err) == {
+        "error": "Invalid args JSON: Expecting value",
+        "ok": False,
+    }
+
+
+def test_gateway_cli_explain_policy_rejects_local_with_gateway_url(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Local mode cannot be combined with an explicit remote URL."""
+
+    exit_code = gateway_cli.main(
+        [
+            "explain-policy",
+            "--local",
+            "--gateway-url",
+            "http://127.0.0.1:8000/mcp",
+            "--profile",
+            "backend-engineer",
+            "--tool",
+            "fs.patch",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert captured.out == ""
+    assert json.loads(captured.err) == {
+        "error": "--local cannot be combined with --gateway-url",
+        "ok": False,
+    }
+
+
+def test_gateway_cli_explain_policy_rejects_admin_key_argument(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Policy explain commands do not accept command-line admin secrets."""
+
+    exit_code = gateway_cli.main(
+        [
+            "explain-policy",
+            "--gateway-url",
+            "http://127.0.0.1:8000/mcp",
+            "--admin-key",
+            "admin-secret",
+            "--profile",
+            "backend-engineer",
+            "--tool",
+            "fs.patch",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert captured.out == ""
+    payload = json.loads(captured.err)
+    assert payload["ok"] is False
+    assert "--admin-key" in payload["error"]
 
 
 def test_gateway_cli_preview_profile_tools_maps_remote_payload_flags(

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py
@@ -1,3 +1,5 @@
+"""Tests for the standalone MCP gateway policy explain CLI."""
+
 from __future__ import annotations
 
 import json
@@ -12,6 +14,8 @@ from mcp_unified.gateway.remote_admin import (
     RemoteGatewayAdminConfig,
     RemoteGatewayAdminError,
 )
+
+pytestmark = pytest.mark.unit
 
 
 class _Response:
@@ -416,6 +420,8 @@ def test_gateway_cli_preview_profile_tools_maps_remote_payload_flags(
             "--exclude-denied",
             "--limit",
             "25",
+            "--session-id",
+            "session-1",
             "--static-policy-only",
         ]
     )
@@ -432,6 +438,7 @@ def test_gateway_cli_preview_profile_tools_maps_remote_payload_flags(
             "limit": 25,
             "mode": "static_policy_only",
             "profile_id": "backend-engineer",
+            "session_id": "session-1",
         },
         "profile_id": "backend-engineer",
     }
@@ -445,6 +452,7 @@ def test_gateway_cli_preview_profile_tools_maps_remote_payload_flags(
                 "limit": 25,
                 "mode": "static_policy_only",
                 "profile_id": "backend-engineer",
+                "session_id": "session-1",
             },
         )
     ]

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mcp_unified.gateway import cli as gateway_cli
+from mcp_unified.gateway.remote_admin import (
+    RemoteGatewayAdminClient,
+    RemoteGatewayAdminConfig,
+)
+
+
+class _Response:
+    """Small stdlib urlopen-compatible response double."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload
+
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+def test_remote_gateway_admin_client_explain_policy_posts_json_body() -> None:
+    """Policy explain remote calls POST the supplied JSON body."""
+
+    seen: list[tuple[str, str, dict[str, str], dict[str, Any]]] = []
+
+    def opener(request: Any, *, timeout: float) -> _Response:
+        del timeout
+        seen.append(
+            (
+                request.full_url,
+                request.get_method(),
+                {key.lower(): value for key, value in request.header_items()},
+                json.loads(request.data.decode("utf-8")),
+            )
+        )
+        return _Response(b'{"ok": true, "final_outcome": "allow"}')
+
+    client = RemoteGatewayAdminClient(
+        RemoteGatewayAdminConfig(gateway_url="http://example.test/mcp"),
+        opener=opener,
+    )
+
+    assert client.explain_policy(
+        {
+            "profile_id": "backend-engineer",
+            "tool_name": "fs.patch",
+            "arguments": {"path": "workspace/app.py"},
+        }
+    ) == {"ok": True, "final_outcome": "allow"}
+    assert seen == [
+        (
+            "http://example.test/mcp/policy/explain",
+            "POST",
+            {
+                "accept": "application/json",
+                "content-type": "application/json",
+            },
+            {
+                "profile_id": "backend-engineer",
+                "tool_name": "fs.patch",
+                "arguments": {"path": "workspace/app.py"},
+            },
+        )
+    ]
+
+
+def test_remote_gateway_admin_client_preview_profile_tools_posts_json_body() -> None:
+    """Profile tool preview remote calls POST the supplied JSON body."""
+
+    seen: list[tuple[str, str, dict[str, Any]]] = []
+
+    def opener(request: Any, *, timeout: float) -> _Response:
+        del timeout
+        seen.append(
+            (
+                request.full_url,
+                request.get_method(),
+                json.loads(request.data.decode("utf-8")),
+            )
+        )
+        return _Response(b'{"ok": true, "tools": []}')
+
+    client = RemoteGatewayAdminClient(
+        RemoteGatewayAdminConfig(gateway_url="http://example.test/mcp"),
+        opener=opener,
+    )
+
+    assert client.preview_profile_tools(
+        "backend engineer",
+        {
+            "category": "filesystem",
+            "include_denied": False,
+            "include_recommendations": False,
+            "limit": 25,
+        },
+    ) == {"ok": True, "tools": []}
+    assert seen == [
+        (
+            "http://example.test/mcp/profiles/backend%20engineer/tool-preview",
+            "POST",
+            {
+                "category": "filesystem",
+                "include_denied": False,
+                "include_recommendations": False,
+                "limit": 25,
+            },
+        )
+    ]
+
+
+def test_gateway_cli_explain_policy_reads_args_json_file_for_remote_payload(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """--args-json-file supplies tool arguments without command-line JSON."""
+
+    args_file = tmp_path / "tool-args.json"
+    args_file.write_text('{"path": "workspace/app.py"}', encoding="utf-8")
+    configs: list[RemoteGatewayAdminConfig] = []
+    calls: list[dict[str, Any]] = []
+
+    class _Client:
+        def __init__(self, config: RemoteGatewayAdminConfig) -> None:
+            configs.append(config)
+
+        def explain_policy(self, payload: dict[str, Any]) -> dict[str, Any]:
+            calls.append(payload)
+            return {"ok": True, "payload": payload}
+
+    monkeypatch.setattr(gateway_cli, "RemoteGatewayAdminClient", _Client)
+
+    exit_code = gateway_cli.main(
+        [
+            "explain-policy",
+            "--gateway-url",
+            "http://127.0.0.1:8000/mcp",
+            "--admin-key",
+            "admin-secret",
+            "--admin-header-name",
+            "X-Admin",
+            "--profile",
+            "backend-engineer",
+            "--tool",
+            "fs.patch",
+            "--args-json-file",
+            str(args_file),
+            "--capability",
+            "filesystem",
+            "--session-id",
+            "session-1",
+            "--static-policy-only",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.err == ""
+    assert json.loads(captured.out) == {
+        "ok": True,
+        "payload": {
+            "arguments": {"path": "workspace/app.py"},
+            "capability": "filesystem",
+            "mode": "static_policy_only",
+            "profile_id": "backend-engineer",
+            "session_id": "session-1",
+            "tool_name": "fs.patch",
+        },
+    }
+    assert calls == [
+        {
+            "arguments": {"path": "workspace/app.py"},
+            "capability": "filesystem",
+            "mode": "static_policy_only",
+            "profile_id": "backend-engineer",
+            "session_id": "session-1",
+            "tool_name": "fs.patch",
+        }
+    ]
+    assert configs[0].gateway_url == "http://127.0.0.1:8000/mcp"
+    assert configs[0].admin_header_name == "X-Admin"
+    assert configs[0].admin_key == "admin-secret"
+
+
+def test_gateway_cli_preview_profile_tools_maps_remote_payload_flags(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preview command registration maps payload flags to the remote client."""
+
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    class _Client:
+        def __init__(self, config: RemoteGatewayAdminConfig) -> None:
+            del config
+
+        def preview_profile_tools(
+            self,
+            profile_id: str,
+            payload: dict[str, Any],
+        ) -> dict[str, Any]:
+            calls.append((profile_id, payload))
+            return {"ok": True, "payload": payload, "profile_id": profile_id}
+
+    monkeypatch.setattr(gateway_cli, "RemoteGatewayAdminClient", _Client)
+
+    exit_code = gateway_cli.main(
+        [
+            "preview-profile-tools",
+            "--gateway-url",
+            "http://127.0.0.1:8000/mcp",
+            "--profile",
+            "backend-engineer",
+            "--category",
+            "filesystem",
+            "--exclude-recommendations",
+            "--exclude-denied",
+            "--limit",
+            "25",
+            "--static-policy-only",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.err == ""
+    assert json.loads(captured.out) == {
+        "ok": True,
+        "payload": {
+            "category": "filesystem",
+            "include_denied": False,
+            "include_recommendations": False,
+            "limit": 25,
+            "mode": "static_policy_only",
+            "profile_id": "backend-engineer",
+        },
+        "profile_id": "backend-engineer",
+    }
+    assert calls == [
+        (
+            "backend-engineer",
+            {
+                "category": "filesystem",
+                "include_denied": False,
+                "include_recommendations": False,
+                "limit": 25,
+                "mode": "static_policy_only",
+                "profile_id": "backend-engineer",
+            },
+        )
+    ]

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+import mcp_unified.gateway.policy_explain as policy_explain
 from mcp_unified.gateway.policy_explain import (
     GatewayPolicyExplainError,
     GatewayPolicyExplainService,
@@ -98,6 +99,33 @@ async def test_explain_tool_call_uses_runtime_permission_rule_denial_as_final_ou
     assert response.visibility == "hidden"
     assert response.call_state == "blocked"
     assert audit.events[0].payload["final_outcome"] == "deny"
+
+
+@pytest.mark.asyncio
+async def test_explain_tool_call_preserves_tool_level_ask_as_final_outcome() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: MCPProfile(
+            id="backend-engineer",
+            name="Backend Engineer",
+            policy_document=ProfilePolicy(
+                tool_rules=[{"pattern": "fs.patch", "outcome": "ask"}],
+            ),
+        ),
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    response = await service.explain_tool_call(
+        PolicyExplainRequest(profile_id="backend-engineer", tool_name="fs.patch")
+    )
+
+    assert response.final_outcome == "ask"
+    assert response.reason_code == "approval_required"
+    assert response.visibility == "direct"
+    assert response.call_state == "approval_required"
+    assert response.tool_policy_outcome == "ask"
+    assert audit.events[0].payload["final_outcome"] == "ask"
 
 
 @pytest.mark.asyncio
@@ -200,6 +228,110 @@ async def test_explain_tool_call_redacts_file_uri_paths() -> None:
     assert "token=secret" not in rendered
     assert "fragment" not in rendered
     assert response.subjects[0].value == ".../app.py"
+
+
+@pytest.mark.asyncio
+async def test_explain_tool_call_redacts_file_uri_domain_subject() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    response = await service.explain_tool_call(
+        PolicyExplainRequest(
+            profile_id="backend-engineer",
+            tool_name="fs.patch",
+            arguments={
+                "uri": "file:///Users/example/project/src/app.py?token=secret#fragment",
+            },
+        )
+    )
+
+    rendered = response.model_dump_json()
+    audit_payload = str(audit.events[0].payload)
+    assert "/Users/example" not in rendered
+    assert "/Users/example" not in audit_payload
+    assert "token=secret" not in rendered
+    assert "token=secret" not in audit_payload
+    assert "fragment" not in rendered
+    assert "fragment" not in audit_payload
+    assert response.subjects[0].type == "domain"
+    assert response.subjects[0].value == ".../app.py"
+
+
+@pytest.mark.asyncio
+async def test_explain_tool_call_redacts_file_uri_domain_list_subjects() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    response = await service.explain_tool_call(
+        PolicyExplainRequest(
+            profile_id="backend-engineer",
+            tool_name="fs.patch",
+            arguments={
+                "uris": [
+                    "file:///Users/example/project/src/app.py?token=secret#fragment",
+                ],
+            },
+        )
+    )
+
+    rendered = response.model_dump_json()
+    audit_payload = str(audit.events[0].payload)
+    assert "/Users/example" not in rendered
+    assert "/Users/example" not in audit_payload
+    assert "token=secret" not in rendered
+    assert "token=secret" not in audit_payload
+    assert "fragment" not in rendered
+    assert "fragment" not in audit_payload
+    assert response.subjects[0].type == "domain"
+    assert response.subjects[0].value == ".../app.py"
+
+
+@pytest.mark.asyncio
+async def test_explain_tool_call_unknown_simulator_status_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    def _unknown_policy_status(*_args: object, **_kwargs: object) -> dict[str, object]:
+        return {
+            "profile_id": "backend-engineer",
+            "tool_name": "fs.patch",
+            "legacy_policy": {"status": "resolved", "reason_code": "resolved"},
+            "subjects": [],
+            "approval_grant_markers": [],
+            "path_scopes": [],
+            "denial": None,
+            "overall": {"status": "mystery", "reason_code": "mystery_status"},
+        }
+
+    monkeypatch.setattr(
+        policy_explain,
+        "simulate_tool_call_policy",
+        _unknown_policy_status,
+    )
+
+    response = await service.explain_tool_call(
+        PolicyExplainRequest(profile_id="backend-engineer", tool_name="fs.patch")
+    )
+
+    assert response.final_outcome == "deny"
+    assert response.reason_code == "policy_status_unknown"
+    assert response.degraded is True
+    assert "unknown_policy_status" in response.degraded_reasons
+    assert audit.events[0].payload["final_outcome"] == "deny"
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
@@ -6,6 +6,7 @@ import mcp_unified.gateway.policy_explain as policy_explain
 from mcp_unified.gateway.policy_explain import (
     GatewayPolicyExplainError,
     GatewayPolicyExplainService,
+    PolicyExplainErrorResponse,
     PolicyExplainRequest,
     ProfileToolPreviewRequest,
     _redact_subject_value,
@@ -53,6 +54,38 @@ def test_subject_redaction_states_use_approved_contract() -> None:
     assert _redact_subject_value("path", "")[1] == "omitted"
 
 
+def test_error_response_uses_message_and_details_contract() -> None:
+    payload = PolicyExplainErrorResponse(
+        message="Policy evaluation failed",
+        reason_code="policy_evaluation_failed",
+        details={"field": "safe"},
+    ).model_dump()
+
+    assert payload["ok"] is False
+    assert payload["message"] == "Policy evaluation failed"
+    assert payload["reason_code"] == "policy_evaluation_failed"
+    assert payload["details"] == {"field": "safe"}
+    assert "error" not in payload
+
+
+def test_tool_names_from_catalog_reads_tool_id_and_mapping_payload() -> None:
+    catalog = {
+        "tools": [
+            {"tool_id": "fs.patch"},
+            {"name": "shell.exec"},
+            {"tool_name": "db.query"},
+            "cache.clear",
+        ],
+    }
+
+    assert policy_explain._tool_names_from_catalog(catalog) == {
+        "fs.patch",
+        "shell.exec",
+        "db.query",
+        "cache.clear",
+    }
+
+
 @pytest.mark.asyncio
 async def test_explain_tool_call_redacts_subjects_and_audits() -> None:
     audit = _MemoryAuditStore()
@@ -72,11 +105,17 @@ async def test_explain_tool_call_redacts_subjects_and_audits() -> None:
 
     assert response.ok is True
     assert response.final_outcome == "allow"
+    assert response.visibility == "visible"
     assert response.subjects[0].redaction_state in {"sanitized", "redacted"}
     rendered = response.model_dump_json()
     assert "/Users/example" not in rendered
     assert audit.events[0].event_type == "policy.explain.requested"
     assert "/Users/example" not in str(audit.events[0].payload)
+    dumped = response.model_dump(mode="json")
+    assert dumped["evaluated_at"]
+    assert dumped["truncated"] is False
+    assert dumped["installation_status"] == "unknown"
+    assert dumped["runtime_availability"] == "unknown"
 
 
 @pytest.mark.asyncio
@@ -128,7 +167,7 @@ async def test_explain_tool_call_preserves_tool_level_ask_as_final_outcome() -> 
 
     assert response.final_outcome == "ask"
     assert response.reason_code == "approval_required"
-    assert response.visibility == "direct"
+    assert response.visibility == "visible"
     assert response.call_state == "approval_required"
     assert response.tool_policy_outcome == "ask"
     assert audit.events[0].payload["final_outcome"] == "ask"
@@ -336,6 +375,59 @@ async def test_explain_tool_call_redacts_file_uri_domain_list_subjects() -> None
 
 
 @pytest.mark.asyncio
+async def test_explain_tool_call_redacts_absolute_uri_path_like_domain_subject() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    response = await service.explain_tool_call(
+        PolicyExplainRequest(
+            profile_id="backend-engineer",
+            tool_name="fs.patch",
+            arguments={"uri": "/Users/example/project/src/app.py"},
+        )
+    )
+
+    rendered = response.model_dump_json()
+    audit_payload = str(audit.events[0].payload)
+    assert "/Users/example" not in rendered
+    assert "/Users/example" not in audit_payload
+    assert response.subjects[0].type == "domain"
+    assert response.subjects[0].value == ".../app.py"
+
+
+@pytest.mark.asyncio
+async def test_explain_tool_call_redacts_windows_uri_path_like_domain_subject() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    raw_path = r"C:\Users\example\project\src\app.py"
+    response = await service.explain_tool_call(
+        PolicyExplainRequest(
+            profile_id="backend-engineer",
+            tool_name="fs.patch",
+            arguments={"uri": raw_path},
+        )
+    )
+
+    rendered = response.model_dump_json()
+    audit_payload = str(audit.events[0].payload)
+    assert "C:/Users/example" not in rendered
+    assert "C:/Users/example" not in audit_payload
+    assert raw_path not in rendered
+    assert raw_path not in audit_payload
+    assert response.subjects[0].type == "domain"
+    assert response.subjects[0].value == ".../app.py"
+
+
+@pytest.mark.asyncio
 async def test_explain_tool_call_unknown_simulator_status_fails_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -373,6 +465,42 @@ async def test_explain_tool_call_unknown_simulator_status_fails_closed(
     assert response.degraded is True
     assert "unknown_policy_status" in response.degraded_reasons
     assert audit.events[0].payload["final_outcome"] == "deny"
+
+
+@pytest.mark.asyncio
+async def test_explain_tool_call_audits_policy_evaluation_failure_before_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    def _raise_policy_error(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise RuntimeError("invalid policy internals")
+
+    monkeypatch.setattr(
+        policy_explain,
+        "simulate_tool_call_policy",
+        _raise_policy_error,
+    )
+
+    with pytest.raises(GatewayPolicyExplainError) as exc_info:
+        await service.explain_tool_call(
+            PolicyExplainRequest(
+                profile_id="backend-engineer",
+                tool_name="Bash(echo TOPSECRET)",
+                arguments={"path": "/Users/example/project/src/app.py"},
+            )
+        )
+
+    assert exc_info.value.reason_code == "policy_evaluation_failed"
+    assert audit.events[0].event_type == "policy.explain.requested"
+    assert audit.events[0].payload["reason_code"] == "policy_evaluation_failed"
+    assert "TOPSECRET" not in str(audit.events[0].payload)
+    assert "/Users/example" not in str(audit.events[0].payload)
 
 
 @pytest.mark.asyncio
@@ -453,3 +581,34 @@ async def test_preview_requires_catalog_for_complete_denied_counts() -> None:
     assert "catalog_unavailable" in response.degraded_reasons
     assert response.redacted is True
     assert audit.events[0].event_type == "policy.preview_tools.requested"
+    dumped = response.model_dump(mode="json")
+    assert "tools" in dumped
+    assert "entries" not in dumped
+    assert dumped["evaluated_at"]
+    assert dumped["truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_preview_catalog_provider_failure_degrades_and_audits() -> None:
+    audit = _MemoryAuditStore()
+
+    def _broken_catalog() -> list[str]:
+        raise RuntimeError("catalog backend failed")
+
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=audit,
+        actor_id="operator-1",
+        catalog_provider=_broken_catalog,
+    )
+
+    response = await service.preview_profile_tools(
+        ProfileToolPreviewRequest(profile_id="backend-engineer")
+    )
+
+    assert response.degraded is True
+    assert "catalog_unavailable" in response.degraded_reasons
+    assert [entry.tool_name for entry in response.tools] == ["fs.patch", "shell.exec"]
+    assert audit.events[0].event_type == "policy.preview_tools.requested"
+    assert audit.events[0].payload["degraded"] is True
+    assert "catalog_unavailable" in audit.events[0].payload["degraded_reasons"]

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import mcp_unified.gateway.policy_explain as policy_explain
+from mcp_unified.gateway.tool_discovery import AdminToolCatalogEntry
 from mcp_unified.gateway.policy_explain import (
     GatewayPolicyExplainError,
     GatewayPolicyExplainService,
@@ -834,6 +835,45 @@ async def test_preview_requires_catalog_for_complete_denied_counts() -> None:
         "not_installed": 0,
         "unknown_installation": 2,
     }
+
+
+@pytest.mark.asyncio
+async def test_preview_admin_catalog_includes_denied_installed_tools() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=audit,
+        actor_id="operator-1",
+        admin_tool_catalog_provider=lambda profile: [
+            AdminToolCatalogEntry(
+                tool_id="fs.patch",
+                category="filesystem",
+                installation_status="installed",
+            ),
+            AdminToolCatalogEntry(
+                tool_id="shell.exec",
+                category="shell",
+                installation_status="installed",
+            ),
+        ],
+    )
+
+    response = await service.preview_profile_tools(
+        ProfileToolPreviewRequest(profile_id="backend-engineer")
+    )
+
+    tools_by_name = {entry.tool_name: entry for entry in response.tools}
+    assert response.degraded is False
+    assert tools_by_name["fs.patch"].outcome == "allow"
+    assert tools_by_name["fs.patch"].visibility == "visible"
+    assert tools_by_name["fs.patch"].installation_status == "installed"
+    assert tools_by_name["shell.exec"].outcome == "deny"
+    assert tools_by_name["shell.exec"].visibility == "hidden"
+    assert tools_by_name["shell.exec"].installation_status == "installed"
+    assert response.summary.total == 2
+    assert response.summary.installed == 2
+    assert response.summary.deny == 1
+    assert response.summary.hidden == 1
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
@@ -49,6 +49,14 @@ def _profile_with_rules(*, permission_rules: list[dict[str, str]]) -> MCPProfile
     )
 
 
+def _raise_resolver_failure(_profile_id: str) -> MCPProfile:
+    raise RuntimeError("resolver backend failed")
+
+
+async def _raise_async_resolver_failure(_profile_id: str) -> MCPProfile:
+    raise RuntimeError("async resolver backend failed")
+
+
 def test_subject_redaction_states_use_approved_contract() -> None:
     assert _redact_subject_value("tool", "fs.patch")[1] == "raw_safe"
     assert _redact_subject_value("path", "")[1] == "omitted"
@@ -116,6 +124,21 @@ async def test_explain_tool_call_redacts_subjects_and_audits() -> None:
     assert dumped["truncated"] is False
     assert dumped["installation_status"] == "unknown"
     assert dumped["runtime_availability"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_explain_tool_call_uses_default_audit_actor() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=audit,
+    )
+
+    await service.explain_tool_call(
+        PolicyExplainRequest(profile_id="backend-engineer", tool_name="fs.patch")
+    )
+
+    assert audit.events[0].actor_id == "local-cli"
 
 
 @pytest.mark.asyncio
@@ -529,6 +552,63 @@ async def test_explain_tool_call_audits_profile_not_found_before_raising() -> No
 
 
 @pytest.mark.asyncio
+async def test_explain_tool_call_audits_sync_profile_resolver_failure() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=_raise_resolver_failure,
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    with pytest.raises(GatewayPolicyExplainError) as exc_info:
+        await service.explain_tool_call(
+            PolicyExplainRequest(
+                profile_id="backend-engineer",
+                tool_name="Bash(echo TOPSECRET)",
+            )
+        )
+
+    assert exc_info.value.reason_code == "profile_resolution_failed"
+    assert audit.events[0].event_type == "policy.explain.requested"
+    assert audit.events[0].payload["reason_code"] == "profile_resolution_failed"
+    assert "TOPSECRET" not in str(audit.events[0].payload)
+
+
+@pytest.mark.asyncio
+async def test_explain_tool_call_audits_async_profile_resolver_failure() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=_raise_async_resolver_failure,
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    with pytest.raises(GatewayPolicyExplainError) as exc_info:
+        await service.explain_tool_call(
+            PolicyExplainRequest(profile_id="backend-engineer", tool_name="fs.patch")
+        )
+
+    assert exc_info.value.reason_code == "profile_resolution_failed"
+    assert audit.events[0].payload["reason_code"] == "profile_resolution_failed"
+
+
+@pytest.mark.asyncio
+async def test_explain_tool_call_resolver_failure_preserves_audit_store_failure() -> None:
+    service = GatewayPolicyExplainService(
+        profile_resolver=_raise_resolver_failure,
+        audit_store=_MemoryAuditStore(fail=True),
+        actor_id="operator-1",
+    )
+
+    with pytest.raises(GatewayPolicyExplainError) as exc_info:
+        await service.explain_tool_call(
+            PolicyExplainRequest(profile_id="backend-engineer", tool_name="fs.patch")
+        )
+
+    assert exc_info.value.reason_code == "audit_store_unavailable"
+
+
+@pytest.mark.asyncio
 async def test_preview_profile_tools_audits_profile_not_found_before_raising() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -546,6 +626,43 @@ async def test_preview_profile_tools_audits_profile_not_found_before_raising() -
     assert audit.events[0].event_type == "policy.preview_tools.requested"
     assert audit.events[0].payload["reason_code"] == "profile_not_found"
     assert audit.events[0].payload["profile_id"] == "missing-profile"
+
+
+@pytest.mark.asyncio
+async def test_preview_profile_tools_audits_sync_profile_resolver_failure() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=_raise_resolver_failure,
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    with pytest.raises(GatewayPolicyExplainError) as exc_info:
+        await service.preview_profile_tools(
+            ProfileToolPreviewRequest(profile_id="backend-engineer")
+        )
+
+    assert exc_info.value.reason_code == "profile_resolution_failed"
+    assert audit.events[0].event_type == "policy.preview_tools.requested"
+    assert audit.events[0].payload["reason_code"] == "profile_resolution_failed"
+
+
+@pytest.mark.asyncio
+async def test_preview_profile_tools_audits_async_profile_resolver_failure() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=_raise_async_resolver_failure,
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    with pytest.raises(GatewayPolicyExplainError) as exc_info:
+        await service.preview_profile_tools(
+            ProfileToolPreviewRequest(profile_id="backend-engineer")
+        )
+
+    assert exc_info.value.reason_code == "profile_resolution_failed"
+    assert audit.events[0].payload["reason_code"] == "profile_resolution_failed"
 
 
 @pytest.mark.asyncio
@@ -590,6 +707,38 @@ async def test_preview_requires_catalog_for_complete_denied_counts() -> None:
     assert dumped["tools"][0]["installation_status"] == "unknown"
     assert dumped["tools"][0]["runtime_availability"] == "unknown"
     assert "final_outcome" not in dumped["tools"][0]
+    assert "tools" not in audit.events[0].payload
+    assert audit.events[0].payload["summary"] == {
+        "total": 2,
+        "allow": 1,
+        "ask": 0,
+        "deny": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_preview_defers_argument_sensitive_permission_rules() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile_with_rules(
+            permission_rules=[
+                {"pattern": "Edit(/Users/example/**)", "outcome": "deny"},
+            ]
+        ),
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    response = await service.preview_profile_tools(
+        ProfileToolPreviewRequest(profile_id="backend-engineer")
+    )
+
+    entry = next(tool for tool in response.tools if tool.tool_name == "fs.patch")
+    assert entry.outcome == "ask"
+    assert entry.visibility == "deferred"
+    assert entry.call_state == "deferred"
+    assert entry.reason_code == "argument_sensitive_policy"
+    assert response.summary.ask == 1
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
@@ -334,6 +334,33 @@ async def test_explain_tool_call_redacts_url_shaped_path_subjects() -> None:
 
 
 @pytest.mark.asyncio
+async def test_explain_tool_call_redacts_path_subject_query_fragment_and_userinfo() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    response = await service.explain_tool_call(
+        PolicyExplainRequest(
+            profile_id="backend-engineer",
+            tool_name="fs.patch",
+            arguments={
+                "path": "user:pass@/Users/example/project/src/app.py?token=secret#frag",
+            },
+        )
+    )
+
+    rendered = response.model_dump_json()
+    audit_payload = str(audit.events[0].payload)
+    for leaked_value in ("token=secret", "frag", "user:pass", "/Users/example"):
+        assert leaked_value not in rendered
+        assert leaked_value not in audit_payload
+    assert response.subjects[0].value == ".../app.py"
+
+
+@pytest.mark.asyncio
 async def test_explain_tool_call_redacts_file_uri_domain_subject() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -488,6 +515,93 @@ async def test_explain_tool_call_unknown_simulator_status_fails_closed(
     assert response.degraded is True
     assert "unknown_policy_status" in response.degraded_reasons
     assert audit.events[0].payload["final_outcome"] == "deny"
+
+
+def test_effective_decision_keeps_explicit_denial_over_legacy_approval_status() -> None:
+    decision = policy_explain._effective_decision_from_simulation(
+        {
+            "legacy_policy": {
+                "status": "approval_required",
+                "reason_code": "approval_required",
+            },
+            "overall": {
+                "status": "denied",
+                "reason_code": "denied_by_hook",
+            },
+            "denial": {
+                "reason_code": "denied_by_hook",
+            },
+        },
+        tool_policy_outcome="ask",
+        tool_policy_reason_code="approval_required",
+    )
+
+    assert decision["final_outcome"] == "deny"
+    assert decision["reason_code"] == "denied_by_hook"
+    assert decision["visibility"] == "hidden"
+    assert decision["call_state"] == "blocked"
+
+
+def test_effective_decision_preserves_approval_required_without_denial_payload() -> None:
+    decision = policy_explain._effective_decision_from_simulation(
+        {
+            "legacy_policy": {
+                "status": "approval_required",
+                "reason_code": "approval_required",
+            },
+            "overall": {
+                "status": "denied",
+                "reason_code": "approval_required",
+            },
+            "denial": None,
+        },
+        tool_policy_outcome="ask",
+        tool_policy_reason_code="approval_required",
+    )
+
+    assert decision["final_outcome"] == "ask"
+    assert decision["reason_code"] == "approval_required"
+    assert decision["visibility"] == "visible"
+    assert decision["call_state"] == "approval_required"
+
+
+def test_parse_policy_explain_request_redacts_validation_errors() -> None:
+    raw_path = "/Users/example/project/src/app.py?token=secret#frag"
+
+    with pytest.raises(GatewayPolicyExplainError) as exc_info:
+        policy_explain.parse_policy_explain_request(
+            {
+                "profile_id": "backend-engineer",
+                "tool_name": "fs.patch",
+                "arguments": {
+                    "path": raw_path,
+                    "blob": "x"
+                    * (policy_explain.MAX_POLICY_EXPLAIN_ARGUMENT_BYTES + 1),
+                },
+            }
+        )
+
+    assert exc_info.value.reason_code == "invalid_policy_explain_request"
+    rendered = exc_info.value.to_payload().model_dump_json()
+    for leaked_value in ("/Users/example", "token=secret", "frag"):
+        assert leaked_value not in str(exc_info.value)
+        assert leaked_value not in rendered
+
+
+def test_parse_profile_tool_preview_request_redacts_validation_errors() -> None:
+    with pytest.raises(GatewayPolicyExplainError) as exc_info:
+        policy_explain.parse_profile_tool_preview_request(
+            {
+                "profile_id": "/Users/example/project?token=secret#frag",
+                "limit": 1001,
+            }
+        )
+
+    assert exc_info.value.reason_code == "invalid_policy_preview_request"
+    rendered = exc_info.value.to_payload().model_dump_json()
+    for leaked_value in ("/Users/example", "token=secret", "frag"):
+        assert leaked_value not in str(exc_info.value)
+        assert leaked_value not in rendered
 
 
 @pytest.mark.asyncio
@@ -713,6 +827,12 @@ async def test_preview_requires_catalog_for_complete_denied_counts() -> None:
         "allow": 1,
         "ask": 0,
         "deny": 1,
+        "visible": 1,
+        "hidden": 1,
+        "deferred": 0,
+        "installed": 0,
+        "not_installed": 0,
+        "unknown_installation": 2,
     }
 
 
@@ -739,6 +859,42 @@ async def test_preview_defers_argument_sensitive_permission_rules() -> None:
     assert entry.call_state == "deferred"
     assert entry.reason_code == "argument_sensitive_policy"
     assert response.summary.ask == 1
+    assert response.summary.deferred == 1
+    assert response.summary.unknown_installation == 1
+
+
+@pytest.mark.asyncio
+async def test_preview_profile_tools_paginates_and_reports_next_cursor() -> None:
+    audit = _MemoryAuditStore()
+    tool_names = [f"tool.{index:03d}" for index in range(5)]
+    profile = MCPProfile(
+        id="catalog-profile",
+        name="Catalog Profile",
+        policy_document=ProfilePolicy(allowed_tools=tool_names),
+    )
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: profile,
+        audit_store=audit,
+        actor_id="operator-1",
+        catalog_provider=lambda: [{"tool_id": tool_name} for tool_name in tool_names],
+    )
+
+    response = await service.preview_profile_tools(
+        ProfileToolPreviewRequest(
+            profile_id="catalog-profile",
+            limit=2,
+            cursor="2",
+        )
+    )
+
+    assert [tool.tool_name for tool in response.tools] == ["tool.002", "tool.003"]
+    assert response.summary.total == 2
+    assert response.summary.visible == 2
+    assert response.summary.unknown_installation == 2
+    assert response.truncated is True
+    assert response.next_cursor == "4"
+    assert audit.events[0].payload["truncated"] is True
+    assert audit.events[0].payload["next_cursor"] == "4"
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
@@ -586,6 +586,10 @@ async def test_preview_requires_catalog_for_complete_denied_counts() -> None:
     assert "entries" not in dumped
     assert dumped["evaluated_at"]
     assert dumped["truncated"] is False
+    assert dumped["tools"][0]["outcome"] == "allow"
+    assert dumped["tools"][0]["installation_status"] == "unknown"
+    assert dumped["tools"][0]["runtime_availability"] == "unknown"
+    assert "final_outcome" not in dumped["tools"][0]
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
@@ -1,4 +1,8 @@
+"""Tests for the standalone MCP gateway policy explain service."""
+
 from __future__ import annotations
+
+import threading
 
 import pytest
 
@@ -20,6 +24,8 @@ from mcp_unified.gateway.policy_explain import (
 from mcp_unified.policy_grants import InMemoryPolicyGrantStore
 from mcp_unified.profiles import MCPProfile, ProfilePolicy
 from mcp_unified.storage.models import AuditEvent
+
+pytestmark = pytest.mark.unit
 
 
 class _MemoryAuditStore:
@@ -175,7 +181,23 @@ def test_tool_names_from_catalog_reads_tool_id_and_mapping_payload() -> None:
     }
 
 
-@pytest.mark.asyncio
+def test_redact_tool_identifier_handles_command_case_and_spacing() -> None:
+    assert (
+        policy_explain._redact_tool_identifier("bash (echo TOPSECRET)")
+        == "bash([redacted-command])"
+    )
+    assert (
+        policy_explain._redact_tool_identifier("PowerShell (Get-Secret)")
+        == "PowerShell([redacted-command])"
+    )
+
+
+def test_policy_tool_names_from_profile_handles_missing_policy_document() -> None:
+    profile = MCPProfile(id="empty", name="Empty", policy_document=None)
+
+    assert policy_explain._policy_tool_names_from_profile(profile) == []
+
+
 async def test_explain_tool_call_redacts_subjects_and_audits() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -207,7 +229,6 @@ async def test_explain_tool_call_redacts_subjects_and_audits() -> None:
     assert dumped["runtime_availability"] == "unknown"
 
 
-@pytest.mark.asyncio
 async def test_explain_tool_call_uses_default_audit_actor() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -222,7 +243,37 @@ async def test_explain_tool_call_uses_default_audit_actor() -> None:
     assert audit.events[0].actor_id == "local-cli"
 
 
-@pytest.mark.asyncio
+async def test_explain_tool_call_offloads_policy_simulation_from_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=audit,
+    )
+    original_simulator = policy_explain.simulate_tool_call_policy
+    event_loop_thread = threading.get_ident()
+    simulator_threads: list[int] = []
+
+    def _record_thread(*args: object, **kwargs: object) -> dict[str, object]:
+        simulator_threads.append(threading.get_ident())
+        return original_simulator(*args, **kwargs)
+
+    monkeypatch.setattr(
+        policy_explain,
+        "simulate_tool_call_policy",
+        _record_thread,
+    )
+
+    response = await service.explain_tool_call(
+        PolicyExplainRequest(profile_id="backend-engineer", tool_name="fs.patch")
+    )
+
+    assert response.final_outcome == "allow"
+    assert simulator_threads
+    assert simulator_threads[0] != event_loop_thread
+
+
 async def test_explain_tool_call_uses_runtime_permission_rule_denial_as_final_outcome() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -250,7 +301,6 @@ async def test_explain_tool_call_uses_runtime_permission_rule_denial_as_final_ou
     assert audit.events[0].payload["final_outcome"] == "deny"
 
 
-@pytest.mark.asyncio
 async def test_explain_tool_call_preserves_tool_level_ask_as_final_outcome() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -277,7 +327,6 @@ async def test_explain_tool_call_preserves_tool_level_ask_as_final_outcome() -> 
     assert audit.events[0].payload["final_outcome"] == "ask"
 
 
-@pytest.mark.asyncio
 async def test_explain_tool_call_redacts_shell_shaped_tool_name_from_response_and_audit() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -305,7 +354,6 @@ async def test_explain_tool_call_redacts_shell_shaped_tool_name_from_response_an
     assert response.tool_name == "Bash([redacted-command])"
 
 
-@pytest.mark.asyncio
 async def test_explain_tool_call_static_policy_only_ignores_runtime_approval_grants() -> None:
     grant_store = InMemoryPolicyGrantStore()
     grant_store.create_grant(
@@ -358,7 +406,61 @@ async def test_explain_tool_call_static_policy_only_ignores_runtime_approval_gra
     }
 
 
-@pytest.mark.asyncio
+async def test_preview_profile_tools_runtime_mode_applies_session_approval_grants() -> None:
+    grant_store = InMemoryPolicyGrantStore()
+    grant_store.create_grant(
+        profile_id="backend-engineer",
+        grant_type="approval",
+        subject_type="tool",
+        value="fs.patch",
+        ttl_seconds=300,
+        session_id="session-1",
+    )
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile_with_rules(
+            permission_rules=[
+                {"pattern": "fs.patch", "outcome": "ask"},
+            ]
+        ),
+        audit_store=audit,
+        actor_id="operator-1",
+        policy_grant_store=grant_store,
+    )
+
+    runtime_response = await service.preview_profile_tools(
+        ProfileToolPreviewRequest(
+            profile_id="backend-engineer",
+            session_id="session-1",
+        )
+    )
+    no_session_response = await service.preview_profile_tools(
+        ProfileToolPreviewRequest(profile_id="backend-engineer")
+    )
+    static_response = await service.preview_profile_tools(
+        ProfileToolPreviewRequest(
+            profile_id="backend-engineer",
+            session_id="session-1",
+            mode="static_policy_only",
+        )
+    )
+
+    runtime_entry = next(
+        tool for tool in runtime_response.tools if tool.tool_name == "fs.patch"
+    )
+    no_session_entry = next(
+        tool for tool in no_session_response.tools if tool.tool_name == "fs.patch"
+    )
+    static_entry = next(
+        tool for tool in static_response.tools if tool.tool_name == "fs.patch"
+    )
+    assert runtime_entry.outcome == "allow"
+    assert no_session_entry.outcome == "ask"
+    assert no_session_entry.reason_code == "approval_required"
+    assert static_entry.outcome == "allow"
+    assert "session_grants" in static_response.skipped_contributors
+
+
 async def test_explain_tool_call_redacts_file_uri_paths() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -384,7 +486,6 @@ async def test_explain_tool_call_redacts_file_uri_paths() -> None:
     assert response.subjects[0].value == ".../app.py"
 
 
-@pytest.mark.asyncio
 async def test_explain_tool_call_redacts_url_shaped_path_subjects() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -414,7 +515,6 @@ async def test_explain_tool_call_redacts_url_shaped_path_subjects() -> None:
     assert response.subjects[0].value == "https://api.example.test"
 
 
-@pytest.mark.asyncio
 async def test_explain_tool_call_redacts_path_subject_query_fragment_and_userinfo() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -441,7 +541,6 @@ async def test_explain_tool_call_redacts_path_subject_query_fragment_and_userinf
     assert response.subjects[0].value == ".../app.py"
 
 
-@pytest.mark.asyncio
 async def test_explain_tool_call_redacts_file_uri_domain_subject() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -472,7 +571,6 @@ async def test_explain_tool_call_redacts_file_uri_domain_subject() -> None:
     assert response.subjects[0].value == ".../app.py"
 
 
-@pytest.mark.asyncio
 async def test_explain_tool_call_redacts_file_uri_domain_list_subjects() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -505,7 +603,6 @@ async def test_explain_tool_call_redacts_file_uri_domain_list_subjects() -> None
     assert response.subjects[0].value == ".../app.py"
 
 
-@pytest.mark.asyncio
 async def test_explain_tool_call_redacts_absolute_uri_path_like_domain_subject() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -530,7 +627,6 @@ async def test_explain_tool_call_redacts_absolute_uri_path_like_domain_subject()
     assert response.subjects[0].value == ".../app.py"
 
 
-@pytest.mark.asyncio
 async def test_explain_tool_call_redacts_windows_uri_path_like_domain_subject() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -558,7 +654,6 @@ async def test_explain_tool_call_redacts_windows_uri_path_like_domain_subject() 
     assert response.subjects[0].value == ".../app.py"
 
 
-@pytest.mark.asyncio
 async def test_explain_tool_call_unknown_simulator_status_fails_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -685,7 +780,6 @@ def test_parse_profile_tool_preview_request_redacts_validation_errors() -> None:
         assert leaked_value not in rendered
 
 
-@pytest.mark.asyncio
 async def test_explain_tool_call_audits_policy_evaluation_failure_before_raising(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -721,7 +815,6 @@ async def test_explain_tool_call_audits_policy_evaluation_failure_before_raising
     assert "/Users/example" not in str(audit.events[0].payload)
 
 
-@pytest.mark.asyncio
 async def test_explain_tool_call_audits_profile_not_found_before_raising() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -746,7 +839,6 @@ async def test_explain_tool_call_audits_profile_not_found_before_raising() -> No
     assert "/Users/example" not in str(audit.events[0].payload)
 
 
-@pytest.mark.asyncio
 async def test_explain_tool_call_audits_sync_profile_resolver_failure() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -769,7 +861,6 @@ async def test_explain_tool_call_audits_sync_profile_resolver_failure() -> None:
     assert "TOPSECRET" not in str(audit.events[0].payload)
 
 
-@pytest.mark.asyncio
 async def test_explain_tool_call_audits_async_profile_resolver_failure() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -787,7 +878,6 @@ async def test_explain_tool_call_audits_async_profile_resolver_failure() -> None
     assert audit.events[0].payload["reason_code"] == "profile_resolution_failed"
 
 
-@pytest.mark.asyncio
 async def test_explain_tool_call_resolver_failure_preserves_audit_store_failure() -> None:
     service = GatewayPolicyExplainService(
         profile_resolver=_raise_resolver_failure,
@@ -803,7 +893,6 @@ async def test_explain_tool_call_resolver_failure_preserves_audit_store_failure(
     assert exc_info.value.reason_code == "audit_store_unavailable"
 
 
-@pytest.mark.asyncio
 async def test_preview_profile_tools_audits_profile_not_found_before_raising() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -823,7 +912,6 @@ async def test_preview_profile_tools_audits_profile_not_found_before_raising() -
     assert audit.events[0].payload["profile_id"] == "missing-profile"
 
 
-@pytest.mark.asyncio
 async def test_preview_profile_tools_audits_sync_profile_resolver_failure() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -842,7 +930,6 @@ async def test_preview_profile_tools_audits_sync_profile_resolver_failure() -> N
     assert audit.events[0].payload["reason_code"] == "profile_resolution_failed"
 
 
-@pytest.mark.asyncio
 async def test_preview_profile_tools_audits_async_profile_resolver_failure() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -860,7 +947,6 @@ async def test_preview_profile_tools_audits_async_profile_resolver_failure() -> 
     assert audit.events[0].payload["reason_code"] == "profile_resolution_failed"
 
 
-@pytest.mark.asyncio
 async def test_explain_tool_call_fails_closed_when_audit_append_fails() -> None:
     service = GatewayPolicyExplainService(
         profile_resolver=lambda profile_id: _profile(),
@@ -876,7 +962,6 @@ async def test_explain_tool_call_fails_closed_when_audit_append_fails() -> None:
     assert exc_info.value.reason_code == "audit_store_unavailable"
 
 
-@pytest.mark.asyncio
 async def test_preview_requires_catalog_for_complete_denied_counts() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -917,7 +1002,6 @@ async def test_preview_requires_catalog_for_complete_denied_counts() -> None:
     }
 
 
-@pytest.mark.asyncio
 async def test_preview_admin_catalog_includes_denied_installed_tools() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -956,7 +1040,6 @@ async def test_preview_admin_catalog_includes_denied_installed_tools() -> None:
     assert response.summary.hidden == 1
 
 
-@pytest.mark.asyncio
 async def test_preview_installed_catalog_fallback_includes_denied_installed_tools() -> None:
     audit = _MemoryAuditStore()
     backend_tools = _installed_preview_backend_tools()
@@ -995,7 +1078,6 @@ async def test_preview_installed_catalog_fallback_includes_denied_installed_tool
     assert "shell.exec" not in search_tool_ids
 
 
-@pytest.mark.asyncio
 async def test_preview_filters_denied_and_recommendation_rows() -> None:
     audit = _MemoryAuditStore()
     profile = _profile_with_preview_recommendations()
@@ -1027,7 +1109,6 @@ async def test_preview_filters_denied_and_recommendation_rows() -> None:
     )
 
 
-@pytest.mark.asyncio
 async def test_preview_category_filter_paginates_after_filtering() -> None:
     audit = _MemoryAuditStore()
     profile = _profile_with_preview_recommendations()
@@ -1074,7 +1155,6 @@ async def test_preview_category_filter_paginates_after_filtering() -> None:
     ]
 
 
-@pytest.mark.asyncio
 async def test_preview_defers_argument_sensitive_permission_rules() -> None:
     audit = _MemoryAuditStore()
     service = GatewayPolicyExplainService(
@@ -1101,7 +1181,6 @@ async def test_preview_defers_argument_sensitive_permission_rules() -> None:
     assert response.summary.unknown_installation == 1
 
 
-@pytest.mark.asyncio
 async def test_preview_profile_tools_paginates_and_reports_next_cursor() -> None:
     audit = _MemoryAuditStore()
     tool_names = [f"tool.{index:03d}" for index in range(5)]
@@ -1135,7 +1214,6 @@ async def test_preview_profile_tools_paginates_and_reports_next_cursor() -> None
     assert audit.events[0].payload["next_cursor"] == "4"
 
 
-@pytest.mark.asyncio
 async def test_preview_catalog_provider_failure_degrades_and_audits() -> None:
     audit = _MemoryAuditStore()
 

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+
+from mcp_unified.gateway.policy_explain import (
+    GatewayPolicyExplainError,
+    GatewayPolicyExplainService,
+    PolicyExplainRequest,
+    ProfileToolPreviewRequest,
+)
+from mcp_unified.profiles import MCPProfile, ProfilePolicy
+from mcp_unified.storage.models import AuditEvent
+
+
+class _MemoryAuditStore:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.events: list[AuditEvent] = []
+
+    async def append_event(self, event: AuditEvent) -> None:
+        if self.fail:
+            raise RuntimeError("audit backend failed")
+        self.events.append(event)
+
+
+def _profile() -> MCPProfile:
+    return MCPProfile(
+        id="backend-engineer",
+        name="Backend Engineer",
+        policy_document=ProfilePolicy(
+            allowed_tools=["fs.patch"],
+            denied_tools=["shell.exec"],
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_explain_tool_call_redacts_subjects_and_audits() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    response = await service.explain_tool_call(
+        PolicyExplainRequest(
+            profile_id="backend-engineer",
+            tool_name="fs.patch",
+            arguments={"path": "/Users/example/project/src/app.py"},
+        )
+    )
+
+    assert response.ok is True
+    assert response.final_outcome == "allow"
+    assert response.subjects[0].redaction_state in {"sanitized", "redacted"}
+    rendered = response.model_dump_json()
+    assert "/Users/example" not in rendered
+    assert audit.events[0].event_type == "policy.explain.requested"
+    assert "/Users/example" not in str(audit.events[0].payload)
+
+
+@pytest.mark.asyncio
+async def test_explain_tool_call_fails_closed_when_audit_append_fails() -> None:
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=_MemoryAuditStore(fail=True),
+        actor_id="operator-1",
+    )
+
+    with pytest.raises(GatewayPolicyExplainError) as exc_info:
+        await service.explain_tool_call(
+            PolicyExplainRequest(profile_id="backend-engineer", tool_name="fs.patch")
+        )
+
+    assert exc_info.value.reason_code == "audit_store_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_preview_requires_catalog_for_complete_denied_counts() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    response = await service.preview_profile_tools(
+        ProfileToolPreviewRequest(profile_id="backend-engineer")
+    )
+
+    assert response.degraded is True
+    assert "catalog_unavailable" in response.degraded_reasons
+    assert response.redacted is True

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import pytest
 
 import mcp_unified.gateway.policy_explain as policy_explain
-from mcp_unified.gateway.tool_discovery import AdminToolCatalogEntry
+from mcp_unified.gateway.tool_discovery import (
+    AdminToolCatalogEntry,
+    list_profile_tools,
+    search_profile_tools,
+)
 from mcp_unified.gateway.policy_explain import (
     GatewayPolicyExplainError,
     GatewayPolicyExplainService,
@@ -37,6 +41,68 @@ def _profile() -> MCPProfile:
             denied_tools=["shell.exec"],
         ),
     )
+
+
+def _profile_with_preview_recommendations() -> MCPProfile:
+    return MCPProfile(
+        id="backend-engineer",
+        name="Backend Engineer",
+        policy_document=ProfilePolicy(
+            allowed_tools=["cache.clear", "fs.patch", "fs.read"],
+            denied_tools=["shell.exec"],
+        ),
+        metadata={
+            "tooling": {
+                "recommended_tools": [
+                    {
+                        "id": "fs.inspect",
+                        "display_name": "Inspect Files",
+                        "category": "filesystem",
+                    },
+                ],
+            },
+        },
+    )
+
+
+def _installed_preview_backend_tools() -> list[dict[str, object]]:
+    return [
+        {
+            "name": "fs.patch",
+            "description": "Patch files",
+            "metadata": {"category": "filesystem"},
+        },
+        {
+            "name": "shell.exec",
+            "description": "Execute shell commands",
+            "metadata": {"category": "shell"},
+        },
+    ]
+
+
+def _filter_preview_backend_tools() -> list[dict[str, object]]:
+    return [
+        {
+            "name": "cache.clear",
+            "description": "Clear cache entries",
+            "metadata": {"category": "cache"},
+        },
+        {
+            "name": "fs.patch",
+            "description": "Patch files",
+            "metadata": {"category": "filesystem"},
+        },
+        {
+            "name": "fs.read",
+            "description": "Read files",
+            "metadata": {"category": "filesystem"},
+        },
+        {
+            "name": "shell.exec",
+            "description": "Execute shell commands",
+            "metadata": {"category": "shell"},
+        },
+    ]
 
 
 def _profile_with_rules(*, permission_rules: list[dict[str, str]]) -> MCPProfile:
@@ -874,6 +940,124 @@ async def test_preview_admin_catalog_includes_denied_installed_tools() -> None:
     assert response.summary.installed == 2
     assert response.summary.deny == 1
     assert response.summary.hidden == 1
+
+
+@pytest.mark.asyncio
+async def test_preview_installed_catalog_fallback_includes_denied_installed_tools() -> None:
+    audit = _MemoryAuditStore()
+    backend_tools = _installed_preview_backend_tools()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=audit,
+        actor_id="operator-1",
+        installed_tool_catalog=backend_tools,
+    )
+
+    response = await service.preview_profile_tools(
+        ProfileToolPreviewRequest(profile_id="backend-engineer")
+    )
+
+    tools_by_name = {entry.tool_name: entry for entry in response.tools}
+    assert response.degraded is False
+    assert tools_by_name["fs.patch"].outcome == "allow"
+    assert tools_by_name["fs.patch"].visibility == "visible"
+    assert tools_by_name["fs.patch"].installation_status == "installed"
+    assert tools_by_name["shell.exec"].outcome == "deny"
+    assert tools_by_name["shell.exec"].visibility == "hidden"
+    assert tools_by_name["shell.exec"].installation_status == "installed"
+
+    model_catalog = list_profile_tools(_profile(), backend_tools)
+    model_tool_ids = {tool["tool_id"] for tool in model_catalog["tools"]}
+    assert model_tool_ids == {"fs.patch"}
+    search_tool_ids = {
+        tool["tool_id"]
+        for tool in search_profile_tools(
+            _profile(),
+            backend_tools,
+            query="shell",
+            limit=10,
+        )
+    }
+    assert "shell.exec" not in search_tool_ids
+
+
+@pytest.mark.asyncio
+async def test_preview_filters_denied_and_recommendation_rows() -> None:
+    audit = _MemoryAuditStore()
+    profile = _profile_with_preview_recommendations()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: profile,
+        audit_store=audit,
+        actor_id="operator-1",
+        installed_tool_catalog=_filter_preview_backend_tools(),
+    )
+
+    allowed_response = await service.preview_profile_tools(
+        ProfileToolPreviewRequest(
+            profile_id="backend-engineer",
+            include_denied=False,
+        )
+    )
+    assert "shell.exec" not in {entry.tool_name for entry in allowed_response.tools}
+
+    installed_response = await service.preview_profile_tools(
+        ProfileToolPreviewRequest(
+            profile_id="backend-engineer",
+            include_recommendations=False,
+        )
+    )
+    assert "fs.inspect" not in {entry.tool_name for entry in installed_response.tools}
+    assert all(
+        entry.installation_status == "installed"
+        for entry in installed_response.tools
+    )
+
+
+@pytest.mark.asyncio
+async def test_preview_category_filter_paginates_after_filtering() -> None:
+    audit = _MemoryAuditStore()
+    profile = _profile_with_preview_recommendations()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: profile,
+        audit_store=audit,
+        actor_id="operator-1",
+        installed_tool_catalog=_filter_preview_backend_tools(),
+    )
+
+    first_page = await service.preview_profile_tools(
+        ProfileToolPreviewRequest(
+            profile_id="backend-engineer",
+            category="filesystem",
+            limit=1,
+        )
+    )
+    second_page = await service.preview_profile_tools(
+        ProfileToolPreviewRequest(
+            profile_id="backend-engineer",
+            category="filesystem",
+            limit=1,
+            cursor=first_page.next_cursor,
+        )
+    )
+
+    assert [entry.tool_name for entry in first_page.tools] == ["fs.patch"]
+    assert first_page.next_cursor == "1"
+    assert first_page.truncated is True
+    assert [entry.tool_name for entry in second_page.tools] == ["fs.read"]
+    assert second_page.next_cursor == "2"
+    assert second_page.truncated is True
+
+    all_filesystem = await service.preview_profile_tools(
+        ProfileToolPreviewRequest(
+            profile_id="backend-engineer",
+            category="filesystem",
+        )
+    )
+    assert [entry.tool_name for entry in all_filesystem.tools] == [
+        "fs.patch",
+        "fs.read",
+        "fs.inspect",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
@@ -8,6 +8,7 @@ from mcp_unified.gateway.policy_explain import (
     PolicyExplainRequest,
     ProfileToolPreviewRequest,
 )
+from mcp_unified.policy_grants import InMemoryPolicyGrantStore
 from mcp_unified.profiles import MCPProfile, ProfilePolicy
 from mcp_unified.storage.models import AuditEvent
 
@@ -30,6 +31,17 @@ def _profile() -> MCPProfile:
         policy_document=ProfilePolicy(
             allowed_tools=["fs.patch"],
             denied_tools=["shell.exec"],
+        ),
+    )
+
+
+def _profile_with_rules(*, permission_rules: list[dict[str, str]]) -> MCPProfile:
+    return MCPProfile(
+        id="backend-engineer",
+        name="Backend Engineer",
+        policy_document=ProfilePolicy(
+            allowed_tools=["fs.patch"],
+            permission_rules=permission_rules,
         ),
     )
 
@@ -58,6 +70,136 @@ async def test_explain_tool_call_redacts_subjects_and_audits() -> None:
     assert "/Users/example" not in rendered
     assert audit.events[0].event_type == "policy.explain.requested"
     assert "/Users/example" not in str(audit.events[0].payload)
+
+
+@pytest.mark.asyncio
+async def test_explain_tool_call_uses_runtime_permission_rule_denial_as_final_outcome() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile_with_rules(
+            permission_rules=[
+                {"pattern": "Edit(/Users/example/**)", "outcome": "deny"},
+            ]
+        ),
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    response = await service.explain_tool_call(
+        PolicyExplainRequest(
+            profile_id="backend-engineer",
+            tool_name="fs.patch",
+            arguments={"path": "/Users/example/project/src/app.py"},
+        )
+    )
+
+    assert response.final_outcome == "deny"
+    assert response.reason_code == "permission_rule_denied"
+    assert response.visibility == "hidden"
+    assert response.call_state == "blocked"
+    assert audit.events[0].payload["final_outcome"] == "deny"
+
+
+@pytest.mark.asyncio
+async def test_explain_tool_call_redacts_shell_shaped_tool_name_from_response_and_audit() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: MCPProfile(
+            id="shell-profile",
+            name="Shell Profile",
+            policy_document=ProfilePolicy(
+                allowed_tools=["Bash(echo TOPSECRET)"],
+            ),
+        ),
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    response = await service.explain_tool_call(
+        PolicyExplainRequest(
+            profile_id="shell-profile",
+            tool_name="Bash(echo TOPSECRET)",
+        )
+    )
+
+    assert "TOPSECRET" not in response.model_dump_json()
+    assert "TOPSECRET" not in str(audit.events[0].payload)
+    assert "TOPSECRET" not in str(audit.events[0].target_id)
+    assert response.tool_name == "Bash([redacted-command])"
+
+
+@pytest.mark.asyncio
+async def test_explain_tool_call_static_policy_only_ignores_runtime_approval_grants() -> None:
+    grant_store = InMemoryPolicyGrantStore()
+    grant_store.create_grant(
+        profile_id="backend-engineer",
+        grant_type="approval",
+        subject_type="path",
+        value="/Users/example/project/src/app.py",
+        ttl_seconds=300,
+        session_id="session-1",
+    )
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile_with_rules(
+            permission_rules=[
+                {"pattern": "Edit(/Users/example/**)", "outcome": "ask"},
+            ]
+        ),
+        audit_store=audit,
+        actor_id="operator-1",
+        policy_grant_store=grant_store,
+    )
+
+    runtime_response = await service.explain_tool_call(
+        PolicyExplainRequest(
+            profile_id="backend-engineer",
+            tool_name="fs.patch",
+            arguments={"path": "/Users/example/project/src/app.py"},
+            session_id="session-1",
+        )
+    )
+    static_response = await service.explain_tool_call(
+        PolicyExplainRequest(
+            profile_id="backend-engineer",
+            tool_name="fs.patch",
+            arguments={"path": "/Users/example/project/src/app.py"},
+            session_id="session-1",
+            mode="static_policy_only",
+        )
+    )
+
+    assert runtime_response.final_outcome == "allow"
+    assert static_response.mode == "static_policy_only"
+    assert static_response.final_outcome == "ask"
+    assert static_response.reason_code == "approval_required"
+    assert static_response.call_state == "approval_required"
+
+
+@pytest.mark.asyncio
+async def test_explain_tool_call_redacts_file_uri_paths() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    response = await service.explain_tool_call(
+        PolicyExplainRequest(
+            profile_id="backend-engineer",
+            tool_name="fs.patch",
+            arguments={
+                "path": "file:///Users/example/project/src/app.py?token=secret#fragment",
+            },
+        )
+    )
+
+    rendered = response.model_dump_json()
+    assert "/Users/example" not in rendered
+    assert "token=secret" not in rendered
+    assert "fragment" not in rendered
+    assert response.subjects[0].value == ".../app.py"
 
 
 @pytest.mark.asyncio
@@ -92,3 +234,4 @@ async def test_preview_requires_catalog_for_complete_denied_counts() -> None:
     assert response.degraded is True
     assert "catalog_unavailable" in response.degraded_reasons
     assert response.redacted is True
+    assert audit.events[0].event_type == "policy.preview_tools.requested"

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+import mcp_unified.gateway as gateway
 import mcp_unified.gateway.policy_explain as policy_explain
 from mcp_unified.gateway.tool_discovery import (
     AdminToolCatalogEntry,
@@ -122,6 +123,18 @@ def _raise_resolver_failure(_profile_id: str) -> MCPProfile:
 
 async def _raise_async_resolver_failure(_profile_id: str) -> MCPProfile:
     raise RuntimeError("async resolver backend failed")
+
+
+def test_gateway_package_exports_policy_explain_public_api() -> None:
+    expected_exports = {
+        "GatewayPolicyExplainService": GatewayPolicyExplainService,
+        "PolicyExplainRequest": PolicyExplainRequest,
+        "ProfileToolPreviewRequest": ProfileToolPreviewRequest,
+        "GatewayPolicyExplainError": GatewayPolicyExplainError,
+    }
+    for export_name, expected_obj in expected_exports.items():
+        if getattr(gateway, export_name) is not expected_obj:
+            pytest.fail(f"{export_name} does not resolve to the public service API")
 
 
 def test_subject_redaction_states_use_approved_contract() -> None:

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
@@ -135,6 +135,7 @@ def test_gateway_package_exports_policy_explain_public_api() -> None:
     for export_name, expected_obj in expected_exports.items():
         if getattr(gateway, export_name) is not expected_obj:
             pytest.fail(f"{export_name} does not resolve to the public service API")
+        assert export_name in gateway.__all__
 
 
 def test_subject_redaction_states_use_approved_contract() -> None:

--- a/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py
@@ -8,6 +8,7 @@ from mcp_unified.gateway.policy_explain import (
     GatewayPolicyExplainService,
     PolicyExplainRequest,
     ProfileToolPreviewRequest,
+    _redact_subject_value,
 )
 from mcp_unified.policy_grants import InMemoryPolicyGrantStore
 from mcp_unified.profiles import MCPProfile, ProfilePolicy
@@ -45,6 +46,11 @@ def _profile_with_rules(*, permission_rules: list[dict[str, str]]) -> MCPProfile
             permission_rules=permission_rules,
         ),
     )
+
+
+def test_subject_redaction_states_use_approved_contract() -> None:
+    assert _redact_subject_value("tool", "fs.patch")[1] == "raw_safe"
+    assert _redact_subject_value("path", "")[1] == "omitted"
 
 
 @pytest.mark.asyncio
@@ -202,6 +208,11 @@ async def test_explain_tool_call_static_policy_only_ignores_runtime_approval_gra
     assert static_response.final_outcome == "ask"
     assert static_response.reason_code == "approval_required"
     assert static_response.call_state == "approval_required"
+    assert set(static_response.skipped_contributors) >= {
+        "session_grants",
+        "approval_grants",
+        "runtime_availability",
+    }
 
 
 @pytest.mark.asyncio
@@ -228,6 +239,36 @@ async def test_explain_tool_call_redacts_file_uri_paths() -> None:
     assert "token=secret" not in rendered
     assert "fragment" not in rendered
     assert response.subjects[0].value == ".../app.py"
+
+
+@pytest.mark.asyncio
+async def test_explain_tool_call_redacts_url_shaped_path_subjects() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: _profile(),
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    response = await service.explain_tool_call(
+        PolicyExplainRequest(
+            profile_id="backend-engineer",
+            tool_name="fs.patch",
+            arguments={
+                "path": "https://user:pass@api.example.test/path?token=secret#frag",
+            },
+        )
+    )
+
+    rendered = response.model_dump_json()
+    audit_payload = str(audit.events[0].payload)
+    assert "token=secret" not in rendered
+    assert "token=secret" not in audit_payload
+    assert "frag" not in rendered
+    assert "frag" not in audit_payload
+    assert "user:pass" not in rendered
+    assert "user:pass" not in audit_payload
+    assert response.subjects[0].value == "https://api.example.test"
 
 
 @pytest.mark.asyncio
@@ -332,6 +373,51 @@ async def test_explain_tool_call_unknown_simulator_status_fails_closed(
     assert response.degraded is True
     assert "unknown_policy_status" in response.degraded_reasons
     assert audit.events[0].payload["final_outcome"] == "deny"
+
+
+@pytest.mark.asyncio
+async def test_explain_tool_call_audits_profile_not_found_before_raising() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: None,
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    with pytest.raises(GatewayPolicyExplainError) as exc_info:
+        await service.explain_tool_call(
+            PolicyExplainRequest(
+                profile_id="missing-profile",
+                tool_name="Bash(echo TOPSECRET)",
+                arguments={"path": "/Users/example/project/src/app.py"},
+            )
+        )
+
+    assert exc_info.value.reason_code == "profile_not_found"
+    assert audit.events[0].event_type == "policy.explain.requested"
+    assert audit.events[0].payload["reason_code"] == "profile_not_found"
+    assert "TOPSECRET" not in str(audit.events[0].payload)
+    assert "/Users/example" not in str(audit.events[0].payload)
+
+
+@pytest.mark.asyncio
+async def test_preview_profile_tools_audits_profile_not_found_before_raising() -> None:
+    audit = _MemoryAuditStore()
+    service = GatewayPolicyExplainService(
+        profile_resolver=lambda profile_id: None,
+        audit_store=audit,
+        actor_id="operator-1",
+    )
+
+    with pytest.raises(GatewayPolicyExplainError) as exc_info:
+        await service.preview_profile_tools(
+            ProfileToolPreviewRequest(profile_id="missing-profile")
+        )
+
+    assert exc_info.value.reason_code == "profile_not_found"
+    assert audit.events[0].event_type == "policy.preview_tools.requested"
+    assert audit.events[0].payload["reason_code"] == "profile_not_found"
+    assert audit.events[0].payload["profile_id"] == "missing-profile"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add a read-only MCP gateway policy explanation service with redacted responses and strict audit behavior.
- Add admin API routes, remote admin client methods, and CLI commands for `explain-policy` and `preview-profile-tools`.
- Document the packaged policy explain surface and export the public gateway types.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_service.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_api.py tldw_Server_API/tests/MCP_unified/test_standalone_policy_explain_cli.py -q` -> 63 passed
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q` -> 34 passed
- [x] `git diff --check` -> clean

## Security
- [x] Bandit over the touched policy/API/CLI scope with pytest asserts skipped (`-s B101`) -> 0 findings

## Change summary
This PR adds an admin/operator-facing way to explain effective profile policy decisions and preview profile tool visibility without exposing raw tool arguments. The implementation keeps model-facing discovery filtered, routes the preview surface through admin-only APIs/CLI, and records redacted audit events so operators can debug profile policy without widening tool access.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an admin-only policy explanation and profile tool preview to the MCP gateway so operators can understand profile decisions and tool visibility without changing model-facing access. Responses are redacted, audited, rate-limited, and can account for session-scoped grants.

- **New Features**
  - `mcp_unified.gateway.policy_explain`: read-only service with redacted outputs, stable reason codes, degraded-state metadata, and strict `AuditStore` writes that fail closed; hardened command-shaped redaction and clearer preview semantics.
  - Admin API: optional `explain-policy` and `preview-profile-tools` routes in `create_gateway_app`, guarded by a dedicated admin seam and the `mcp.policy.explain` permission, with lightweight rate limiting.
  - CLI and remote client: `explain-policy` and `preview-profile-tools` commands and POST methods; supports `--session-id` propagation, non-blocking remote calls, and improved error messages; docs updated; public exports added (`GatewayPolicyExplainService`, `PolicyExplainRequest`, `ProfileToolPreviewRequest`).
  - Admin catalog: unfiltered preview provider in `tool_discovery` and runtime support to show denied installed tools and recommendations, with graceful fallbacks and diagnostics; model-facing discovery stays filtered.

<sup>Written for commit 6145b9039b6b3821ee25c27f8f77fe8b21ea452d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

