### PR TITLE
Emit VZ host smoke evidence bundle

### DIFF
--- a/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+++ b/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
@@ -233,6 +233,23 @@ The upload step must run with `if: always()` and `if-no-files-found: ignore` so
 failed early setup still preserves available logs without creating noisy
 secondary failures.
 
+The delegated smoke wrapper writes structured evidence under the uploaded
+runtime directory's `evidence/` subdirectory by default. Expected evidence files
+are:
+
+```text
+host-smoke-evidence.json
+source-bundle-hashes-before.txt
+source-bundle-hashes-after.txt
+run-bundle-hashes.txt
+runtime-paths.txt
+cleanup-status.txt
+```
+
+The structured evidence should contain paths, sizes, hashes, phase outcomes,
+and cleanup state. It must not contain raw serial log contents, helper
+stdout/stderr contents, secrets, or raw user data.
+
 Uploaded logs are for operator debugging. They must not be treated as public API
 output and should not contain secrets or raw user data.
 

--- a/Docs/superpowers/plans/2026-06-17-vz-host-smoke-evidence-bundle.md
+++ b/Docs/superpowers/plans/2026-06-17-vz-host-smoke-evidence-bundle.md
@@ -1,0 +1,272 @@
+# VZ Host Smoke Evidence Bundle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add default-on structured evidence output to the VZ Linux host smoke wrapper.
+
+**Architecture:** Keep evidence capture inside `run-host-e2e-smoke.sh`, because both local operator runs and the host-gated workflow already delegate to it. The wrapper writes concise files under a private evidence directory and the existing workflow artifact upload retains them automatically.
+
+**Tech Stack:** Bash wrapper, Python/pytest wrapper tests, GitHub Actions workflow contract tests, Markdown policy docs.
+
+---
+
+## File Structure
+
+- Modify `tools/vz-linux-image/scripts/run-host-e2e-smoke.sh`: add `--evidence-dir`, safe directory preparation, phase tracking, evidence file generation, and exit-code-preserving trap behavior.
+- Modify `tools/vz-linux-image/tests/test_host_e2e_smoke_script.py`: add portable fake-helper tests for default evidence behavior, override behavior, unsafe evidence dir rejection, and failure exit-code preservation.
+- Modify `tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py`: assert host-gated upload covers evidence and policy mentions structured evidence.
+- Modify `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`: document structured evidence files under the runtime artifact upload.
+- Modify `backlog/tasks/task-2368 - Add-default-VZ-host-smoke-evidence-bundle.md`: keep task status and verification current.
+
+## Task 1: Add Tests For Wrapper Evidence Contract
+
+**Files:**
+- Modify: `tools/vz-linux-image/tests/test_host_e2e_smoke_script.py`
+
+- [x] **Step 1: Add dry-run default evidence test**
+
+Add a test that runs `run-host-e2e-smoke.sh --dry-run` with a fake bundle/helper and asserts stdout mentions:
+
+```text
+evidence directory:
+host-smoke-evidence.json
+source-bundle-hashes-before.txt
+source-bundle-hashes-after.txt
+run-bundle-hashes.txt
+runtime-paths.txt
+cleanup-status.txt
+```
+
+Also assert the default evidence path is under `/evidence` beside the default socket runtime dir and that no evidence directory is created.
+
+- [x] **Step 2: Add evidence-dir override dry-run test**
+
+Run dry-run with `--evidence-dir <tmp>/custom-evidence`; assert stdout mentions the override and does not create it.
+
+- [x] **Step 3: Add real fake-helper evidence creation test**
+
+Use the existing fake Python/fake helper pattern. Run a real wrapper execution with socket wait skipped. Assert these files exist in the evidence dir:
+
+```text
+host-smoke-evidence.json
+source-bundle-hashes-before.txt
+source-bundle-hashes-after.txt
+run-bundle-hashes.txt
+runtime-paths.txt
+cleanup-status.txt
+```
+
+Parse `host-smoke-evidence.json` and assert it records schema version, source bundle, run bundle, evidence dir, serial dir, helper pid file, `real_host_smoke` success, and cleanup socket absence.
+
+- [x] **Step 4: Add unsafe evidence directory rejection test**
+
+Create an evidence directory with mode `0755`; run the wrapper with `--evidence-dir`; assert non-zero and stderr includes `evidence directory must be owner-only`.
+
+- [x] **Step 5: Add late failure exit-code preservation test**
+
+Use fake Python that succeeds for helper daemon smoke but fails for `test_vz_linux_real_host_e2e.py`. Run the wrapper with `--evidence-dir`. Assert the wrapper exits with the fake pytest failure code and still writes `cleanup-status.txt` plus `host-smoke-evidence.json`.
+
+- [x] **Step 6: Run tests and verify RED**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tools/vz-linux-image/tests/test_host_e2e_smoke_script.py -q
+```
+
+Expected: new tests fail because `--evidence-dir` and evidence files do not exist yet.
+
+## Task 2: Implement Evidence Capture In Wrapper
+
+**Files:**
+- Modify: `tools/vz-linux-image/scripts/run-host-e2e-smoke.sh`
+
+- [x] **Step 1: Add CLI state and help**
+
+Add:
+
+```bash
+EVIDENCE_DIR=""
+EVIDENCE_FINALIZED=0
+declare -a PHASE_RECORDS=()
+```
+
+Add `--evidence-dir PATH` to usage and option parsing.
+
+- [x] **Step 2: Resolve default evidence directory**
+
+After default `IMAGE_STORE_ROOT` resolution, set:
+
+```bash
+if [[ -z "${EVIDENCE_DIR}" ]]; then
+  EVIDENCE_DIR="$(dirname "${SOCKET_PATH}")/evidence"
+fi
+```
+
+- [x] **Step 3: Add evidence directory safety helper**
+
+Implement `prepare_private_evidence_dir()` matching serial directory hardening:
+refuse symlink, refuse non-directory, create missing directory `0700`, require current owner and no group/world mode.
+
+Dry-run must not call the mutating helper.
+
+- [x] **Step 4: Add phase tracking helpers**
+
+Add `mark_phase_started`, `mark_phase_ok`, and `mark_phase_failed` helpers that append simple `phase|status|timestamp` records. Keep the format shell-safe and easy to serialize.
+
+- [x] **Step 5: Add hash and metadata helpers**
+
+Add helpers for:
+
+```bash
+hash_bundle_files SOURCE OUTPUT
+write_runtime_paths
+write_cleanup_status FINAL_EXIT
+write_json_evidence FINAL_EXIT
+```
+
+Use a standard-library Python interpreter for SHA-256 calculation and JSON
+serialization so paths are quoted safely and the wrapper does not depend on
+platform-specific `stat` or `shasum` behavior for evidence content. Do not use
+the fake pytest runner shim for evidence serialization in wrapper tests. Store
+log paths, sizes, and hashes only; never write raw log contents into JSON.
+
+- [x] **Step 6: Replace simple trap with exit-code-preserving finalize**
+
+Implement:
+
+```bash
+finalize() {
+  local status="$?"
+  set +e
+  cleanup
+  finalize_evidence "${status}"
+  local finalize_status="$?"
+  if [[ "${status}" -eq 0 && "${finalize_status}" -ne 0 ]]; then
+    exit "${finalize_status}"
+  fi
+  exit "${status}"
+}
+trap finalize EXIT INT TERM
+```
+
+Guard against double-finalization.
+
+- [x] **Step 7: Wrap phases with explicit status recording**
+
+Call each phase through a small runner helper so failures are recorded before `set -e` exits.
+
+- [x] **Step 8: Run wrapper tests and verify GREEN**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tools/vz-linux-image/tests/test_host_e2e_smoke_script.py -q
+```
+
+Expected: all wrapper tests pass.
+
+## Task 3: Update Host-Gated Contract And Policy Docs
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py`
+- Modify: `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`
+
+- [x] **Step 1: Add workflow contract expectation**
+
+Update the workflow contract test to assert the upload path still covers:
+
+```text
+${{ runner.temp }}/tldw-vz-helper-ci/**
+```
+
+and the policy text includes `host-smoke-evidence.json`.
+
+- [x] **Step 2: Verify RED if policy is not updated**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q
+```
+
+Expected: fails until policy doc mentions structured evidence files.
+
+- [x] **Step 3: Update policy docs**
+
+Add a short paragraph to `Artifact And Log Expectations` stating that the runtime upload includes an `evidence/` directory containing:
+
+```text
+host-smoke-evidence.json
+source-bundle-hashes-before.txt
+source-bundle-hashes-after.txt
+run-bundle-hashes.txt
+runtime-paths.txt
+cleanup-status.txt
+```
+
+- [x] **Step 4: Run contract tests and verify GREEN**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q
+```
+
+Expected: pass.
+
+## Task 4: Final Verification And Commit
+
+**Files:**
+- Modify: `backlog/tasks/task-2368 - Add-default-VZ-host-smoke-evidence-bundle.md`
+
+- [x] **Step 1: Run focused test suite**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tools/vz-linux-image/tests/test_prepare_smoke_bundle.py tools/vz-linux-image/tests/test_host_e2e_smoke_script.py tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q
+```
+
+Expected: pass.
+
+- [x] **Step 2: Run Bandit on touched executable scope**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m bandit -r tools/vz-linux-image/scripts -f json -o /tmp/bandit_vz_host_smoke_evidence.json
+```
+
+Expected: no new findings in touched script scope.
+
+- [x] **Step 3: Run whitespace validation**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [x] **Step 4: Update Backlog task**
+
+Mark acceptance criteria complete, record verification, document any skipped real VZ smoke, and add final summary.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add tools/vz-linux-image/scripts/run-host-e2e-smoke.sh \
+  tools/vz-linux-image/tests/test_host_e2e_smoke_script.py \
+  tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py \
+  Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md \
+  'backlog/tasks/task-2368 - Add-default-VZ-host-smoke-evidence-bundle.md'
+git commit -m "feat: emit VZ host smoke evidence bundle"
+```

--- a/Docs/superpowers/specs/2026-06-17-vz-host-smoke-evidence-bundle-design.md
+++ b/Docs/superpowers/specs/2026-06-17-vz-host-smoke-evidence-bundle-design.md
@@ -1,0 +1,110 @@
+# VZ Host Smoke Evidence Bundle Design
+
+**Date:** 2026-06-17
+**Status:** Implementation slice
+**Task:** `TASK-2368`
+
+## Goal
+
+Make prepared-host VZ Linux smoke evidence repeatable by having the operator
+wrapper write a small structured evidence bundle automatically. The bundle
+should be useful for local runs and host-gated workflow artifacts without
+requiring manual hash/stat collection after every smoke.
+
+## Scope
+
+This slice adds default-on evidence capture to
+`tools/vz-linux-image/scripts/run-host-e2e-smoke.sh`.
+
+Default evidence output is:
+
+```text
+<runtime-dir>/evidence
+```
+
+Operators may override it with:
+
+```bash
+--evidence-dir PATH
+```
+
+The current host-gated workflow already uploads
+`${{ runner.temp }}/tldw-vz-helper-ci/**`, so evidence under the runtime
+directory is retained without adding a new action or widening permissions.
+
+## Evidence Files
+
+The wrapper writes these files on real runs:
+
+- `host-smoke-evidence.json`: schema version, timestamps, source bundle,
+  image-store root, smoke run id, disposable run bundle, helper path, signing
+  flags, failure-drill flag, runtime paths, phase outcomes, cleanup state, and
+  log artifact pointers.
+- `source-bundle-hashes-before.txt` and `source-bundle-hashes-after.txt`:
+  SHA-256 hashes for source bundle files relevant to boot and provenance.
+- `run-bundle-hashes.txt`: SHA-256 hashes for the disposable run bundle after
+  materialization and smoke execution.
+- `runtime-paths.txt`: socket, serial directory, image-store root, evidence
+  directory, helper pid file, and owner/mode metadata.
+- `cleanup-status.txt`: helper PID status, accepted socket status, cleanup
+  result, and final smoke exit code.
+
+The JSON must not include raw helper stdout/stderr or serial log contents. It
+may include paths, sizes, and SHA-256 values for those files.
+
+## Path Safety
+
+Evidence directory handling follows the same trust-boundary posture as socket
+and serial directories:
+
+- refuse symlink paths
+- refuse existing non-directory paths
+- create missing directories with mode `0700`
+- require current-user ownership
+- require no group/world permissions
+
+Dry-run validates and prints the resolved evidence directory and planned file
+names, but it does not create files or directories.
+
+## Phase Tracking And Exit Semantics
+
+The wrapper records phase state incrementally:
+
+- `validate_inputs`
+- `prepare_runtime_paths`
+- `prepare_smoke_bundle`
+- `helper_daemon_smoke`
+- `start_helper`
+- `wait_for_helper_socket`
+- `real_host_smoke`
+- `failure_drills`
+- `cleanup`
+- `evidence_finalize`
+
+The `EXIT` trap must preserve the original smoke exit code. Cleanup and
+evidence finalization run after failure when possible, but they must not hide a
+real smoke failure. If the smoke succeeded and evidence finalization fails, the
+wrapper should exit non-zero because the host-gated acceptance policy treats
+missing artifacts as a regression.
+
+## Tests
+
+Portable tests should cover:
+
+- dry-run mentions the default evidence directory and planned evidence files
+  without creating them
+- `--evidence-dir PATH` override is propagated
+- fake-helper real run creates the expected evidence files
+- evidence directory hardening rejects unsafe paths
+- a late fake pytest failure preserves the failing exit code while still
+  writing cleanup/evidence status
+- workflow contract expects the runtime artifact upload to retain evidence
+
+Real VZ execution remains host-gated/manual and is not required for normal CI.
+
+## Non-Goals
+
+- Adding a separate upload-artifact action in this slice.
+- Parsing raw serial logs into JSON.
+- Changing VM provisioning, helper lifecycle, or image-store GC behavior.
+- Making host-gated VZ smoke part of normal PR CI.

--- a/Docs/superpowers/specs/2026-06-17-vz-host-smoke-evidence-bundle-design.md
+++ b/Docs/superpowers/specs/2026-06-17-vz-host-smoke-evidence-bundle-design.md
@@ -50,7 +50,9 @@ The wrapper writes these files on real runs:
   result, and final smoke exit code.
 
 The JSON must not include raw helper stdout/stderr or serial log contents. It
-may include paths, sizes, and SHA-256 values for those files.
+may include paths, sizes, and SHA-256 values for those files. Hash and JSON
+generation should use a standard-library Python interpreter rather than shell
+string assembly, so path quoting remains safe and portable.
 
 ## Path Safety
 

--- a/backlog/tasks/task-2368 - Add-default-VZ-host-smoke-evidence-bundle.md
+++ b/backlog/tasks/task-2368 - Add-default-VZ-host-smoke-evidence-bundle.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2368
 title: Add default VZ host smoke evidence bundle
-status: In Progress
+status: Done
 labels:
 - sandbox
 - vz_linux
@@ -27,14 +27,14 @@ Add default-on structured evidence capture to the VZ Linux host smoke wrapper so
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] `run-host-e2e-smoke.sh` defaults evidence output to the private runtime directory under `evidence/`.
-- [ ] Operators can override evidence output with `--evidence-dir PATH`.
-- [ ] Evidence directory preflight refuses symlinks, non-directories, wrong-owner directories, and group/world-accessible directories; missing directories are created `0700`.
-- [ ] Dry-run prints the resolved evidence directory and planned evidence files without creating them.
-- [ ] Real/fake-helper runs write structured evidence files including source hashes, run hashes, runtime paths, phase outcomes, and cleanup state.
-- [ ] Trap/cleanup/finalization preserves the original smoke exit code.
-- [ ] Evidence JSON stores log pointers, sizes, and hashes only, not raw serial/helper log content.
-- [ ] Host-gated workflow/docs/tests expect the evidence bundle to be retained by the existing runtime artifact upload.
+- [x] `run-host-e2e-smoke.sh` defaults evidence output to the private runtime directory under `evidence/`.
+- [x] Operators can override evidence output with `--evidence-dir PATH`.
+- [x] Evidence directory preflight refuses symlinks, non-directories, wrong-owner directories, and group/world-accessible directories; missing directories are created `0700`.
+- [x] Dry-run prints the resolved evidence directory and planned evidence files without creating them.
+- [x] Real/fake-helper runs write structured evidence files including source hashes, run hashes, runtime paths, phase outcomes, and cleanup state.
+- [x] Trap/cleanup/finalization preserves the original smoke exit code.
+- [x] Evidence JSON stores log pointers, sizes, and hashes only, not raw serial/helper log content.
+- [x] Host-gated workflow/docs/tests expect the evidence bundle to be retained by the existing runtime artifact upload.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -42,20 +42,28 @@ Add default-on structured evidence capture to the VZ Linux host smoke wrapper so
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Baseline verification before edits: `python -m pytest tools/vz-linux-image/tests/test_prepare_smoke_bundle.py tools/vz-linux-image/tests/test_host_e2e_smoke_script.py tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q` returned `45 passed, 6 warnings`.
 - Design spec: `Docs/superpowers/specs/2026-06-17-vz-host-smoke-evidence-bundle-design.md`.
+- Added implementation plan: `Docs/superpowers/plans/2026-06-17-vz-host-smoke-evidence-bundle.md`.
+- RED wrapper verification: new evidence tests failed before implementation because `--evidence-dir` and evidence outputs were not implemented.
+- RED host-gated policy verification: the policy contract test failed before docs mentioned `host-smoke-evidence.json`.
+- Final focused verification: `python -m pytest tools/vz-linux-image/tests/test_prepare_smoke_bundle.py tools/vz-linux-image/tests/test_host_e2e_smoke_script.py tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q` returned `51 passed, 6 warnings`.
+- Shell syntax verification: `bash -n tools/vz-linux-image/scripts/run-host-e2e-smoke.sh` exited `0`.
+- Whitespace verification: `git diff --check` exited `0`.
+- Security verification: `python -m bandit -r tools/vz-linux-image/scripts -f json -o /tmp/bandit_vz_host_smoke_evidence.json` exited `0` with `0` results and `0` errors.
+- Known skip: no real Apple Virtualization VM smoke was run for this local code slice; validation used the existing portable fake-helper wrapper tests plus the host-gated workflow contract tests.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Implemented default-on VZ host smoke evidence capture under the runtime `evidence/` directory, added `--evidence-dir PATH` override support, hardened evidence directory permissions, and preserved smoke exit codes through cleanup/finalization. Evidence now records streamed SHA-256 bundle hashes, runtime paths, phase outcomes, cleanup state, and log path/size/hash metadata without embedding raw log contents. Host-gated acceptance docs and workflow contract tests now require the structured evidence bundle to be retained by the existing runtime artifact upload.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2368 - Add-default-VZ-host-smoke-evidence-bundle.md
+++ b/backlog/tasks/task-2368 - Add-default-VZ-host-smoke-evidence-bundle.md
@@ -50,6 +50,13 @@ Add default-on structured evidence capture to the VZ Linux host smoke wrapper so
 - Whitespace verification: `git diff --check` exited `0`.
 - Security verification: `python -m bandit -r tools/vz-linux-image/scripts -f json -o /tmp/bandit_vz_host_smoke_evidence.json` exited `0` with `0` results and `0` errors.
 - Known skip: no real Apple Virtualization VM smoke was run for this local code slice; validation used the existing portable fake-helper wrapper tests plus the host-gated workflow contract tests.
+- Review fixes: rebased on latest `origin/dev`; addressed reviewer findings for empty run-bundle hash roots, best-effort unreadable log metadata, direct `mkdir -p -m 700` evidence directory creation, validated `--python` fallback for evidence serialization, owner-only evidence files, evidence finalize phase accuracy, exact dry-run evidence paths, and new evidence-test docstrings.
+- Review-fix RED verification: `python -m pytest tools/vz-linux-image/tests/test_host_e2e_smoke_script.py -q` failed before wrapper fixes on unreadable log metadata, empty run-bundle hashing, invalid PATH Python fallback, and exact evidence path assertions.
+- Review-fix final focused verification: `python -m pytest tools/vz-linux-image/tests/test_prepare_smoke_bundle.py tools/vz-linux-image/tests/test_host_e2e_smoke_script.py tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q` returned `53 passed, 6 warnings`.
+- Review-fix shell syntax verification: `bash -n tools/vz-linux-image/scripts/run-host-e2e-smoke.sh` exited `0`.
+- Review-fix whitespace verification: `git diff --check` exited `0`.
+- Review-fix security verification: `python -m bandit -r tools/vz-linux-image/scripts -f json -o /tmp/bandit_vz_host_smoke_evidence_review.json` exited `0` with `0` results and `0` errors.
+- CI note: PR check inspection found only canceled GitHub Actions runs for the old head SHA, with logs unavailable; no code failure was available to patch locally before pushing the review-fix commit.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2368 - Add-default-VZ-host-smoke-evidence-bundle.md
+++ b/backlog/tasks/task-2368 - Add-default-VZ-host-smoke-evidence-bundle.md
@@ -1,0 +1,61 @@
+---
+id: TASK-2368
+title: Add default VZ host smoke evidence bundle
+status: In Progress
+labels:
+- sandbox
+- vz_linux
+- evidence
+- host_gated
+references:
+- Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+- tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+- .github/workflows/vz-linux-host-gated.yml
+modified_files:
+- tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+- tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
+- tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+- Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+- Docs/superpowers/specs/2026-06-17-vz-host-smoke-evidence-bundle-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add default-on structured evidence capture to the VZ Linux host smoke wrapper so local operator runs and the host-gated workflow retain concise, redacted proof of source/run bundle hashes, runtime paths, phase outcomes, and cleanup state without manual ad hoc commands.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] `run-host-e2e-smoke.sh` defaults evidence output to the private runtime directory under `evidence/`.
+- [ ] Operators can override evidence output with `--evidence-dir PATH`.
+- [ ] Evidence directory preflight refuses symlinks, non-directories, wrong-owner directories, and group/world-accessible directories; missing directories are created `0700`.
+- [ ] Dry-run prints the resolved evidence directory and planned evidence files without creating them.
+- [ ] Real/fake-helper runs write structured evidence files including source hashes, run hashes, runtime paths, phase outcomes, and cleanup state.
+- [ ] Trap/cleanup/finalization preserves the original smoke exit code.
+- [ ] Evidence JSON stores log pointers, sizes, and hashes only, not raw serial/helper log content.
+- [ ] Host-gated workflow/docs/tests expect the evidence bundle to be retained by the existing runtime artifact upload.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Baseline verification before edits: `python -m pytest tools/vz-linux-image/tests/test_prepare_smoke_bundle.py tools/vz-linux-image/tests/test_host_e2e_smoke_script.py tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q` returned `45 passed, 6 warnings`.
+- Design spec: `Docs/superpowers/specs/2026-06-17-vz-host-smoke-evidence-bundle-design.md`.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+++ b/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
@@ -201,6 +201,21 @@ def test_vz_linux_host_gated_workflow_uses_minimal_permissions_and_uploads_logs(
     assert "${{ runner.temp }}/tldw-vz-helper-ci/**" in upload_steps[0]["with"]["path"]  # nosec B101
 
 
+def test_vz_linux_host_gated_policy_tracks_structured_evidence_bundle() -> None:
+    """The policy should describe the structured evidence retained by the runtime upload."""
+    policy = POLICY_PATH.read_text(encoding="utf-8")
+
+    for evidence_file in (
+        "host-smoke-evidence.json",
+        "source-bundle-hashes-before.txt",
+        "source-bundle-hashes-after.txt",
+        "run-bundle-hashes.txt",
+        "runtime-paths.txt",
+        "cleanup-status.txt",
+    ):
+        assert evidence_file in policy  # nosec B101
+
+
 def test_vz_linux_host_gated_acceptance_policy_doc_exists_and_references_workflow() -> None:
     """The host-gated workflow should have an operator-facing acceptance policy."""
     policy = POLICY_PATH.read_text(encoding="utf-8")

--- a/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+++ b/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
@@ -400,7 +400,7 @@ prepare_private_evidence_dir() {
     fi
     return 0
   fi
-  mkdir -p "${EVIDENCE_DIR}"
+  mkdir -p -m 700 "${EVIDENCE_DIR}"
   chmod 700 "${EVIDENCE_DIR}"
   if ! directory_is_owner_private "${EVIDENCE_DIR}"; then
     die "evidence directory must be owner-only: ${EVIDENCE_DIR}"
@@ -587,13 +587,26 @@ phase_records_text() {
   done
 }
 
+evidence_python_supports_stdlib() {
+  local candidate="$1"
+  [[ -n "${candidate}" && -x "${candidate}" ]] || return 1
+  "${candidate}" -c 'import hashlib, json, pathlib' >/dev/null 2>&1
+}
+
 evidence_python_bin() {
-  if command -v python3 >/dev/null 2>&1; then
-    command -v python3
+  local candidate
+  candidate="$(command -v python3 2>/dev/null || true)"
+  if evidence_python_supports_stdlib "${candidate}"; then
+    printf '%s\n' "${candidate}"
     return 0
   fi
-  if command -v python >/dev/null 2>&1; then
-    command -v python
+  candidate="$(command -v python 2>/dev/null || true)"
+  if evidence_python_supports_stdlib "${candidate}"; then
+    printf '%s\n' "${candidate}"
+    return 0
+  fi
+  if evidence_python_supports_stdlib "${PYTHON_BIN}"; then
+    printf '%s\n' "${PYTHON_BIN}"
     return 0
   fi
   return 1
@@ -606,6 +619,15 @@ hash_bundle_files() {
   local bundle_root="$1"
   local output_path="$2"
   local evidence_python
+  if [[ -z "${bundle_root}" ]]; then
+    mkdir -p -m 700 "$(dirname "${output_path}")"
+    {
+      printf '# sha256  relative_path\n'
+      printf '# missing: <empty bundle path>\n'
+    } > "${output_path}"
+    chmod 600 "${output_path}"
+    return 0
+  fi
   evidence_python="$(evidence_python_bin)" || return 1
   EVIDENCE_HASH_ROOT="${bundle_root}" \
     EVIDENCE_HASH_OUTPUT="${output_path}" \
@@ -636,6 +658,7 @@ with output.open("w", encoding="utf-8") as handle:
         digest = sha256_file(path)
         handle.write(f"{digest}  {path.relative_to(root)}\n")
 PY
+  chmod 600 "${output_path}"
 }
 
 write_runtime_paths() {
@@ -687,6 +710,7 @@ with output.open("w", encoding="utf-8") as handle:
         if value:
             handle.write(f"{key}_metadata={metadata(value)}\n")
 PY
+  chmod 600 "${EVIDENCE_DIR}/runtime-paths.txt"
 }
 
 CLEANUP_HELPER_PID=""
@@ -720,6 +744,7 @@ write_cleanup_status() {
     printf 'socket_path=%s\n' "${SOCKET_PATH}"
     printf 'socket_present_after_cleanup=%s\n' "${CLEANUP_SOCKET_PRESENT}"
   } > "${EVIDENCE_DIR}/cleanup-status.txt"
+  chmod 600 "${EVIDENCE_DIR}/cleanup-status.txt"
 }
 
 write_json_evidence() {
@@ -727,11 +752,12 @@ write_json_evidence() {
     return 0
   fi
   local final_exit="$1"
+  local phase_records="${2:-$(phase_records_text)}"
   local evidence_python
   evidence_python="$(evidence_python_bin)" || return 1
   EVIDENCE_JSON_OUTPUT="${EVIDENCE_DIR}/host-smoke-evidence.json" \
     EVIDENCE_CREATED_AT="$(timestamp_utc)" \
-    EVIDENCE_PHASE_RECORDS="$(phase_records_text)" \
+    EVIDENCE_PHASE_RECORDS="${phase_records}" \
     EVIDENCE_SOURCE_BUNDLE="${SOURCE_BUNDLE_PATH}" \
     EVIDENCE_RUN_BUNDLE="${BUNDLE_PATH}" \
     EVIDENCE_IMAGE_STORE_ROOT="${IMAGE_STORE_ROOT}" \
@@ -808,7 +834,10 @@ logs = []
 if serial_dir.is_dir():
     for path in sorted(serial_dir.glob("*.log")):
         if path.is_file() and not path.is_symlink():
-            logs.append(file_metadata(path))
+            try:
+                logs.append(file_metadata(path))
+            except OSError:
+                pass
 
 payload = {
     "schema_version": 1,
@@ -837,10 +866,14 @@ payload = {
     "log_artifacts": logs,
 }
 
-Path(os.environ["EVIDENCE_JSON_OUTPUT"]).write_text(
+output = Path(os.environ["EVIDENCE_JSON_OUTPUT"])
+temporary_output = output.with_name(f".{output.name}.{os.getpid()}.tmp")
+temporary_output.write_text(
     json.dumps(payload, indent=2, sort_keys=True) + "\n",
     encoding="utf-8",
 )
+temporary_output.chmod(0o600)
+os.replace(temporary_output, output)
 PY
 }
 
@@ -848,10 +881,13 @@ finalize_evidence() {
   local final_exit="$1"
   local cleanup_status="$2"
   local status=0
+  local old_umask
   if [[ "${DRY_RUN}" -eq 1 || "${EVIDENCE_FINALIZED}" -eq 1 ]]; then
     return 0
   fi
   EVIDENCE_FINALIZED=1
+  old_umask="$(umask)"
+  umask 077
   mark_phase_started "evidence_finalize"
   prepare_private_evidence_dir || status="$?"
   if [[ "${status}" -eq 0 ]]; then
@@ -867,13 +903,17 @@ finalize_evidence() {
     write_cleanup_status "${final_exit}" "${cleanup_status}" || status="$?"
   fi
   if [[ "${status}" -eq 0 ]]; then
-    mark_phase_ok "evidence_finalize"
-  else
+    local evidence_success_record
+    evidence_success_record="evidence_finalize|ok|0|$(timestamp_utc)"
+    write_json_evidence "${final_exit}" "$(phase_records_text; printf '%s\n' "${evidence_success_record}")" || status="$?"
+    if [[ "${status}" -eq 0 ]]; then
+      PHASE_RECORDS+=("${evidence_success_record}")
+    fi
+  fi
+  if [[ "${status}" -ne 0 ]]; then
     mark_phase_failed "evidence_finalize" "${status}"
   fi
-  if [[ "${status}" -eq 0 ]]; then
-    write_json_evidence "${final_exit}" || status="$?"
-  fi
+  umask "${old_umask}"
   return "${status}"
 }
 

--- a/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+++ b/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
@@ -13,6 +13,7 @@ SERIAL_LOG_DIR="${DEFAULT_RUNTIME_DIR}/serial"
 IMAGE_STORE_ROOT=""
 SMOKE_RUN_ID="host-smoke-$$"
 PREPARE_SMOKE_BUNDLE_SCRIPT="${SCRIPT_DIR}/prepare-smoke-bundle.py"
+EVIDENCE_DIR=""
 HELPER_PATH="${REPO_ROOT}/tools/macos-vz-helper/.build/debug/macos-vz-helper"
 ENTITLEMENTS_PATH=""
 PYTHON_BIN=""
@@ -22,6 +23,16 @@ SKIP_SIGN=0
 INCLUDE_FAILURE_DRILLS=0
 HELPER_PID=""
 HELPER_PID_FILE=""
+EVIDENCE_FINALIZED=0
+PHASE_RECORDS=()
+EVIDENCE_FILE_NAMES=(
+  "host-smoke-evidence.json"
+  "source-bundle-hashes-before.txt"
+  "source-bundle-hashes-after.txt"
+  "run-bundle-hashes.txt"
+  "runtime-paths.txt"
+  "cleanup-status.txt"
+)
 
 usage() {
   cat <<'EOF'
@@ -38,6 +49,8 @@ Options:
   --image-store-root PATH
                          Private image-store root for disposable smoke bundles
   --smoke-run-id ID      Image-store run id for the disposable smoke bundle
+  --evidence-dir PATH    Directory for structured smoke evidence
+                         (default: socket runtime directory/evidence)
   --socket PATH          Host-side helper AF_UNIX socket path
   --serial-log-dir PATH  Directory for helper VM serial logs
   --helper PATH          Helper binary path
@@ -118,6 +131,11 @@ while [[ "$#" -gt 0 ]]; do
       SMOKE_RUN_ID="$2"
       shift 2
       ;;
+    --evidence-dir)
+      require_value "$1" "${2:-}"
+      EVIDENCE_DIR="$2"
+      shift 2
+      ;;
     --socket)
       require_value "$1" "${2:-}"
       SOCKET_PATH="$2"
@@ -189,6 +207,10 @@ if [[ -z "${IMAGE_STORE_ROOT}" ]]; then
   IMAGE_STORE_ROOT="$(dirname "${SOCKET_PATH}")/image-store"
 fi
 
+if [[ -z "${EVIDENCE_DIR}" ]]; then
+  EVIDENCE_DIR="$(dirname "${SOCKET_PATH}")/evidence"
+fi
+
 validate_inputs() {
   [[ -d "${SOURCE_BUNDLE_PATH}" ]] || die "bundle directory does not exist: ${SOURCE_BUNDLE_PATH}"
   [[ -f "${SOURCE_BUNDLE_PATH}/kernel" ]] || die "bundle missing kernel: ${SOURCE_BUNDLE_PATH}/kernel"
@@ -205,12 +227,21 @@ prepare_smoke_bundle() {
     --store-root "${IMAGE_STORE_ROOT}" \
     --run-id "${SMOKE_RUN_ID}"
   )
+  local prepare_status
   print_cmd "${prepare_args[@]}"
   if [[ "${DRY_RUN}" -eq 1 ]]; then
     BUNDLE_PATH="$("${prepare_args[@]}" --print-path-only)"
+    prepare_status="$?"
+    if [[ "${prepare_status}" -ne 0 ]]; then
+      return "${prepare_status}"
+    fi
     return 0
   fi
   BUNDLE_PATH="$("${prepare_args[@]}")"
+  prepare_status="$?"
+  if [[ "${prepare_status}" -ne 0 ]]; then
+    return "${prepare_status}"
+  fi
   [[ -d "${BUNDLE_PATH}" ]] || die "prepared smoke bundle directory missing: ${BUNDLE_PATH}"
 }
 
@@ -344,6 +375,46 @@ prepare_private_serial_log_dir() {
   fi
 }
 
+prepare_private_evidence_dir() {
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    if [[ -L "${EVIDENCE_DIR}" ]]; then
+      die "evidence directory is a symlink: ${EVIDENCE_DIR}"
+    fi
+    if [[ -e "${EVIDENCE_DIR}" && ! -d "${EVIDENCE_DIR}" ]]; then
+      die "evidence path is not a directory: ${EVIDENCE_DIR}"
+    fi
+    if [[ -d "${EVIDENCE_DIR}" ]] && ! directory_is_owner_private "${EVIDENCE_DIR}"; then
+      die "evidence directory must be owner-only: ${EVIDENCE_DIR}"
+    fi
+    return 0
+  fi
+  if [[ -L "${EVIDENCE_DIR}" ]]; then
+    die "evidence directory is a symlink: ${EVIDENCE_DIR}"
+  fi
+  if [[ -e "${EVIDENCE_DIR}" && ! -d "${EVIDENCE_DIR}" ]]; then
+    die "evidence path is not a directory: ${EVIDENCE_DIR}"
+  fi
+  if [[ -d "${EVIDENCE_DIR}" ]]; then
+    if ! directory_is_owner_private "${EVIDENCE_DIR}"; then
+      die "evidence directory must be owner-only: ${EVIDENCE_DIR}"
+    fi
+    return 0
+  fi
+  mkdir -p "${EVIDENCE_DIR}"
+  chmod 700 "${EVIDENCE_DIR}"
+  if ! directory_is_owner_private "${EVIDENCE_DIR}"; then
+    die "evidence directory must be owner-only: ${EVIDENCE_DIR}"
+  fi
+}
+
+print_evidence_plan() {
+  echo "evidence directory: ${EVIDENCE_DIR}"
+  local evidence_file
+  for evidence_file in "${EVIDENCE_FILE_NAMES[@]}"; do
+    echo "evidence file: ${EVIDENCE_DIR}/${evidence_file}"
+  done
+}
+
 prepare_runtime_paths() {
   if [[ "${DRY_RUN}" -eq 1 ]]; then
     return 0
@@ -472,22 +543,385 @@ run_real_vz_linux_failure_drills() {
     -m vz_linux_host_failure_drill -q -rs
 }
 
+timestamp_utc() {
+  date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+mark_phase_started() {
+  local phase="$1"
+  PHASE_RECORDS+=("${phase}|started|0|$(timestamp_utc)")
+}
+
+mark_phase_ok() {
+  local phase="$1"
+  PHASE_RECORDS+=("${phase}|ok|0|$(timestamp_utc)")
+}
+
+mark_phase_failed() {
+  local phase="$1"
+  local status="$2"
+  PHASE_RECORDS+=("${phase}|failed|${status}|$(timestamp_utc)")
+}
+
+run_phase() {
+  local phase="$1"
+  shift
+  local status
+  mark_phase_started "${phase}"
+  set +e
+  "$@"
+  status="$?"
+  set -e
+  if [[ "${status}" -eq 0 ]]; then
+    mark_phase_ok "${phase}"
+  else
+    mark_phase_failed "${phase}" "${status}"
+  fi
+  return "${status}"
+}
+
+phase_records_text() {
+  local record
+  for record in "${PHASE_RECORDS[@]}"; do
+    printf '%s\n' "${record}"
+  done
+}
+
+evidence_python_bin() {
+  if command -v python3 >/dev/null 2>&1; then
+    command -v python3
+    return 0
+  fi
+  if command -v python >/dev/null 2>&1; then
+    command -v python
+    return 0
+  fi
+  return 1
+}
+
+hash_bundle_files() {
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    return 0
+  fi
+  local bundle_root="$1"
+  local output_path="$2"
+  local evidence_python
+  evidence_python="$(evidence_python_bin)" || return 1
+  EVIDENCE_HASH_ROOT="${bundle_root}" \
+    EVIDENCE_HASH_OUTPUT="${output_path}" \
+    "${evidence_python}" - <<'PY'
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+root = Path(os.environ["EVIDENCE_HASH_ROOT"])
+output = Path(os.environ["EVIDENCE_HASH_OUTPUT"])
+output.parent.mkdir(parents=True, exist_ok=True)
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+with output.open("w", encoding="utf-8") as handle:
+    handle.write("# sha256  relative_path\n")
+    if not root.is_dir():
+        handle.write(f"# missing: {root}\n")
+        raise SystemExit(0)
+    for path in sorted(p for p in root.rglob("*") if p.is_file() and not p.is_symlink()):
+        digest = sha256_file(path)
+        handle.write(f"{digest}  {path.relative_to(root)}\n")
+PY
+}
+
+write_runtime_paths() {
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    return 0
+  fi
+  local evidence_python
+  evidence_python="$(evidence_python_bin)" || return 1
+  EVIDENCE_RUNTIME_OUTPUT="${EVIDENCE_DIR}/runtime-paths.txt" \
+    EVIDENCE_SOURCE_BUNDLE="${SOURCE_BUNDLE_PATH}" \
+    EVIDENCE_RUN_BUNDLE="${BUNDLE_PATH}" \
+    EVIDENCE_IMAGE_STORE_ROOT="${IMAGE_STORE_ROOT}" \
+    EVIDENCE_SOCKET_PATH="${SOCKET_PATH}" \
+    EVIDENCE_SERIAL_LOG_DIR="${SERIAL_LOG_DIR}" \
+    EVIDENCE_DIR_PATH="${EVIDENCE_DIR}" \
+    EVIDENCE_HELPER_PATH="${HELPER_PATH}" \
+    EVIDENCE_HELPER_PID_FILE="${HELPER_PID_FILE:-$(helper_pid_file_path)}" \
+    "${evidence_python}" - <<'PY'
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+output = Path(os.environ["EVIDENCE_RUNTIME_OUTPUT"])
+paths = {
+    "source_bundle_path": os.environ["EVIDENCE_SOURCE_BUNDLE"],
+    "run_bundle_path": os.environ["EVIDENCE_RUN_BUNDLE"],
+    "image_store_root": os.environ["EVIDENCE_IMAGE_STORE_ROOT"],
+    "socket_path": os.environ["EVIDENCE_SOCKET_PATH"],
+    "serial_log_dir": os.environ["EVIDENCE_SERIAL_LOG_DIR"],
+    "evidence_dir": os.environ["EVIDENCE_DIR_PATH"],
+    "helper_path": os.environ["EVIDENCE_HELPER_PATH"],
+    "helper_pid_file": os.environ["EVIDENCE_HELPER_PID_FILE"],
+}
+
+def metadata(path_text: str) -> str:
+    path = Path(path_text)
+    try:
+        st = path.lstat()
+    except OSError:
+        return "exists=false"
+    mode = stat.S_IMODE(st.st_mode)
+    return f"exists=true owner={st.st_uid} mode={mode:o} size={st.st_size}"
+
+with output.open("w", encoding="utf-8") as handle:
+    for key, value in paths.items():
+        handle.write(f"{key}={value}\n")
+        if value:
+            handle.write(f"{key}_metadata={metadata(value)}\n")
+PY
+}
+
+CLEANUP_HELPER_PID=""
+CLEANUP_HELPER_RUNNING="false"
+CLEANUP_SOCKET_PRESENT="false"
+CLEANUP_STATUS="0"
+
+write_cleanup_status() {
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    return 0
+  fi
+  local final_exit="$1"
+  local cleanup_status="$2"
+  local pid
+  pid="$(current_helper_pid)"
+  CLEANUP_HELPER_PID="${pid}"
+  CLEANUP_STATUS="${cleanup_status}"
+  CLEANUP_HELPER_RUNNING="false"
+  CLEANUP_SOCKET_PRESENT="false"
+  if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+    CLEANUP_HELPER_RUNNING="true"
+  fi
+  if [[ -S "${SOCKET_PATH}" ]]; then
+    CLEANUP_SOCKET_PRESENT="true"
+  fi
+  {
+    printf 'final_exit_code=%s\n' "${final_exit}"
+    printf 'cleanup_status=%s\n' "${cleanup_status}"
+    printf 'helper_pid=%s\n' "${pid}"
+    printf 'helper_running_after_cleanup=%s\n' "${CLEANUP_HELPER_RUNNING}"
+    printf 'socket_path=%s\n' "${SOCKET_PATH}"
+    printf 'socket_present_after_cleanup=%s\n' "${CLEANUP_SOCKET_PRESENT}"
+  } > "${EVIDENCE_DIR}/cleanup-status.txt"
+}
+
+write_json_evidence() {
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    return 0
+  fi
+  local final_exit="$1"
+  local evidence_python
+  evidence_python="$(evidence_python_bin)" || return 1
+  EVIDENCE_JSON_OUTPUT="${EVIDENCE_DIR}/host-smoke-evidence.json" \
+    EVIDENCE_CREATED_AT="$(timestamp_utc)" \
+    EVIDENCE_PHASE_RECORDS="$(phase_records_text)" \
+    EVIDENCE_SOURCE_BUNDLE="${SOURCE_BUNDLE_PATH}" \
+    EVIDENCE_RUN_BUNDLE="${BUNDLE_PATH}" \
+    EVIDENCE_IMAGE_STORE_ROOT="${IMAGE_STORE_ROOT}" \
+    EVIDENCE_SMOKE_RUN_ID="${SMOKE_RUN_ID}" \
+    EVIDENCE_SOCKET_PATH="${SOCKET_PATH}" \
+    EVIDENCE_SERIAL_LOG_DIR="${SERIAL_LOG_DIR}" \
+    EVIDENCE_DIR_PATH="${EVIDENCE_DIR}" \
+    EVIDENCE_HELPER_PATH="${HELPER_PATH}" \
+    EVIDENCE_HELPER_PID_FILE="${HELPER_PID_FILE:-$(helper_pid_file_path)}" \
+    EVIDENCE_SKIP_BUILD="${SKIP_BUILD}" \
+    EVIDENCE_SKIP_SIGN="${SKIP_SIGN}" \
+    EVIDENCE_INCLUDE_FAILURE_DRILLS="${INCLUDE_FAILURE_DRILLS}" \
+    EVIDENCE_FINAL_EXIT="${final_exit}" \
+    EVIDENCE_CLEANUP_STATUS="${CLEANUP_STATUS}" \
+    EVIDENCE_CLEANUP_HELPER_PID="${CLEANUP_HELPER_PID}" \
+    EVIDENCE_CLEANUP_HELPER_RUNNING="${CLEANUP_HELPER_RUNNING}" \
+    EVIDENCE_CLEANUP_SOCKET_PRESENT="${CLEANUP_SOCKET_PRESENT}" \
+    "${evidence_python}" - <<'PY'
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+def bool_from_flag(value: str) -> bool:
+    return value in {"1", "true", "TRUE", "True", "yes", "YES", "Yes"}
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def file_metadata(path: Path) -> dict[str, Any]:
+    digest = sha256_file(path)
+    return {"path": str(path), "size_bytes": path.stat().st_size, "sha256": digest}
+
+
+def phase_payload(records_text: str) -> dict[str, dict[str, Any]]:
+    phases: dict[str, dict[str, Any]] = {}
+    for record in records_text.splitlines():
+        parts = record.split("|", 3)
+        if len(parts) != 4:
+            continue
+        phase, status, exit_code, timestamp = parts
+        try:
+            parsed_exit = int(exit_code)
+        except ValueError:
+            parsed_exit = 0
+        phases[phase] = {"status": status, "exit_code": parsed_exit, "timestamp": timestamp}
+    return phases
+
+
+evidence_dir = Path(os.environ["EVIDENCE_DIR_PATH"])
+serial_dir = Path(os.environ["EVIDENCE_SERIAL_LOG_DIR"])
+evidence_files = {
+    name: str(evidence_dir / name)
+    for name in (
+        "host-smoke-evidence.json",
+        "source-bundle-hashes-before.txt",
+        "source-bundle-hashes-after.txt",
+        "run-bundle-hashes.txt",
+        "runtime-paths.txt",
+        "cleanup-status.txt",
+    )
+}
+logs = []
+if serial_dir.is_dir():
+    for path in sorted(serial_dir.glob("*.log")):
+        if path.is_file() and not path.is_symlink():
+            logs.append(file_metadata(path))
+
+payload = {
+    "schema_version": 1,
+    "created_at": os.environ["EVIDENCE_CREATED_AT"],
+    "source_bundle_path": os.environ["EVIDENCE_SOURCE_BUNDLE"],
+    "run_bundle_path": os.environ["EVIDENCE_RUN_BUNDLE"],
+    "image_store_root": os.environ["EVIDENCE_IMAGE_STORE_ROOT"],
+    "smoke_run_id": os.environ["EVIDENCE_SMOKE_RUN_ID"],
+    "socket_path": os.environ["EVIDENCE_SOCKET_PATH"],
+    "serial_log_dir": os.environ["EVIDENCE_SERIAL_LOG_DIR"],
+    "evidence_dir": os.environ["EVIDENCE_DIR_PATH"],
+    "helper_path": os.environ["EVIDENCE_HELPER_PATH"],
+    "helper_pid_file": os.environ["EVIDENCE_HELPER_PID_FILE"],
+    "skip_build": bool_from_flag(os.environ["EVIDENCE_SKIP_BUILD"]),
+    "skip_sign": bool_from_flag(os.environ["EVIDENCE_SKIP_SIGN"]),
+    "include_failure_drills": bool_from_flag(os.environ["EVIDENCE_INCLUDE_FAILURE_DRILLS"]),
+    "final_exit_code": int(os.environ["EVIDENCE_FINAL_EXIT"]),
+    "phases": phase_payload(os.environ.get("EVIDENCE_PHASE_RECORDS", "")),
+    "cleanup": {
+        "status": int(os.environ["EVIDENCE_CLEANUP_STATUS"]),
+        "helper_pid": os.environ["EVIDENCE_CLEANUP_HELPER_PID"],
+        "helper_running_after_cleanup": bool_from_flag(os.environ["EVIDENCE_CLEANUP_HELPER_RUNNING"]),
+        "socket_present_after_cleanup": bool_from_flag(os.environ["EVIDENCE_CLEANUP_SOCKET_PRESENT"]),
+    },
+    "evidence_files": evidence_files,
+    "log_artifacts": logs,
+}
+
+Path(os.environ["EVIDENCE_JSON_OUTPUT"]).write_text(
+    json.dumps(payload, indent=2, sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+PY
+}
+
+finalize_evidence() {
+  local final_exit="$1"
+  local cleanup_status="$2"
+  local status=0
+  if [[ "${DRY_RUN}" -eq 1 || "${EVIDENCE_FINALIZED}" -eq 1 ]]; then
+    return 0
+  fi
+  EVIDENCE_FINALIZED=1
+  mark_phase_started "evidence_finalize"
+  prepare_private_evidence_dir || status="$?"
+  if [[ "${status}" -eq 0 ]]; then
+    hash_bundle_files "${SOURCE_BUNDLE_PATH}" "${EVIDENCE_DIR}/source-bundle-hashes-after.txt" || status="$?"
+  fi
+  if [[ "${status}" -eq 0 ]]; then
+    hash_bundle_files "${BUNDLE_PATH}" "${EVIDENCE_DIR}/run-bundle-hashes.txt" || status="$?"
+  fi
+  if [[ "${status}" -eq 0 ]]; then
+    write_runtime_paths || status="$?"
+  fi
+  if [[ "${status}" -eq 0 ]]; then
+    write_cleanup_status "${final_exit}" "${cleanup_status}" || status="$?"
+  fi
+  if [[ "${status}" -eq 0 ]]; then
+    mark_phase_ok "evidence_finalize"
+  else
+    mark_phase_failed "evidence_finalize" "${status}"
+  fi
+  if [[ "${status}" -eq 0 ]]; then
+    write_json_evidence "${final_exit}" || status="$?"
+  fi
+  return "${status}"
+}
+
+finalize() {
+  local status="$?"
+  local cleanup_status=0
+  local evidence_status=0
+  trap - EXIT INT TERM
+  set +e
+  mark_phase_started "cleanup"
+  cleanup
+  cleanup_status="$?"
+  if [[ "${cleanup_status}" -eq 0 ]]; then
+    mark_phase_ok "cleanup"
+  else
+    mark_phase_failed "cleanup" "${cleanup_status}"
+  fi
+  finalize_evidence "${status}" "${cleanup_status}"
+  evidence_status="$?"
+  if [[ "${status}" -eq 0 && "${evidence_status}" -ne 0 ]]; then
+    exit "${evidence_status}"
+  fi
+  exit "${status}"
+}
+
 if [[ "${DRY_RUN}" -eq 1 ]]; then
   echo "dry-run: printing host smoke commands without starting helper or VMs"
 fi
 
-trap cleanup EXIT INT TERM
-validate_inputs
+trap finalize EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+run_phase validate_inputs validate_inputs
 cd "${REPO_ROOT}"
-build_helper_if_needed
-sign_helper_if_requested
-require_helper_binary
-prepare_runtime_paths
-prepare_smoke_bundle
-run_helper_daemon_smoke
-start_helper_for_real_e2e
-wait_for_helper_socket
-run_real_vz_linux_host_smoke
+run_phase build_helper build_helper_if_needed
+run_phase sign_helper sign_helper_if_requested
+run_phase require_helper_binary require_helper_binary
+run_phase prepare_runtime_paths prepare_runtime_paths
+run_phase prepare_evidence_dir prepare_private_evidence_dir
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+  print_evidence_plan
+fi
+run_phase source_hash_before hash_bundle_files "${SOURCE_BUNDLE_PATH}" "${EVIDENCE_DIR}/source-bundle-hashes-before.txt"
+run_phase prepare_smoke_bundle prepare_smoke_bundle
+run_phase helper_daemon_smoke run_helper_daemon_smoke
+run_phase start_helper start_helper_for_real_e2e
+run_phase wait_for_helper_socket wait_for_helper_socket
+run_phase real_host_smoke run_real_vz_linux_host_smoke
 if [[ "${INCLUDE_FAILURE_DRILLS}" -eq 1 ]]; then
-  run_real_vz_linux_failure_drills
+  run_phase failure_drills run_real_vz_linux_failure_drills
 fi

--- a/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
+++ b/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import re
 import signal
@@ -15,6 +16,14 @@ import pytest
 IMAGE_DIR = Path(__file__).resolve().parents[1]
 REPO_ROOT = IMAGE_DIR.parents[1]
 SMOKE_SCRIPT = IMAGE_DIR / "scripts" / "run-host-e2e-smoke.sh"
+EVIDENCE_FILES = {
+    "host-smoke-evidence.json",
+    "source-bundle-hashes-before.txt",
+    "source-bundle-hashes-after.txt",
+    "run-bundle-hashes.txt",
+    "runtime-paths.txt",
+    "cleanup-status.txt",
+}
 
 
 def _run_smoke_script(*args: str, env_overrides: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
@@ -126,6 +135,61 @@ def test_host_e2e_smoke_script_dry_run_uses_disposable_run_bundle(tmp_path: Path
     assert run_bundle != str(bundle)
     assert f"TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH={run_bundle}" in result.stdout
     assert f"TLDW_SANDBOX_VZ_LINUX_E2E_BASE_IMAGE={bundle}" not in result.stdout
+
+
+def test_host_e2e_smoke_script_dry_run_prints_default_evidence_bundle(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "kernel").write_bytes(b"kernel")
+    (bundle / "rootfs.img").write_bytes(b"rootfs")
+    helper = tmp_path / "macos-vz-helper"
+
+    result = _run_smoke_script(
+        "--dry-run",
+        "--bundle",
+        str(bundle),
+        "--helper",
+        str(helper),
+        "--python",
+        sys.executable,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "evidence directory:" in result.stdout
+    evidence_match = re.search(r"evidence directory: ([^\n]+/evidence)", result.stdout)
+    assert evidence_match is not None
+    evidence_dir = Path(evidence_match.group(1))
+    assert evidence_dir.name == "evidence"
+    assert not evidence_dir.exists()
+    for evidence_file in EVIDENCE_FILES:
+        assert evidence_file in result.stdout
+
+
+def test_host_e2e_smoke_script_dry_run_accepts_evidence_dir_override(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "kernel").write_bytes(b"kernel")
+    (bundle / "rootfs.img").write_bytes(b"rootfs")
+    helper = tmp_path / "macos-vz-helper"
+    evidence_dir = tmp_path / "custom-evidence"
+
+    result = _run_smoke_script(
+        "--dry-run",
+        "--bundle",
+        str(bundle),
+        "--helper",
+        str(helper),
+        "--evidence-dir",
+        str(evidence_dir),
+        "--python",
+        sys.executable,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"evidence directory: {evidence_dir}" in result.stdout
+    assert not evidence_dir.exists()
+    for evidence_file in EVIDENCE_FILES:
+        assert f"{evidence_dir}/{evidence_file}" in result.stdout
 
 
 def test_host_e2e_smoke_script_dry_run_uses_materializer_normalized_path(tmp_path: Path) -> None:
@@ -248,6 +312,190 @@ def test_host_e2e_smoke_script_real_run_passes_disposable_bundle_to_pytest(tmp_p
     assert all(path.endswith("/bundle") for path in recorded_paths)
     assert all((Path(path) / "rootfs.img").is_file() for path in recorded_paths)
     assert source_rootfs.read_bytes() == source_before
+
+
+def test_host_e2e_smoke_script_real_run_writes_evidence_bundle(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "kernel").write_bytes(b"kernel")
+    (bundle / "rootfs.img").write_bytes(b"rootfs")
+    (bundle / "manifest.json").write_text(
+        '{"bundle_version":"1","kernel":"kernel","rootfs":"rootfs.img"}',
+        encoding="utf-8",
+    )
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    evidence_dir = tmp_path / "evidence"
+    fake_python = tmp_path / "fake-python"
+    fake_helper = tmp_path / "fake-helper"
+    fake_python.write_text(
+        "#!/usr/bin/env python3\n"
+        "import os\n"
+        "import sys\n"
+        f"real_python = {str(sys.executable)!r}\n"
+        "if len(sys.argv) > 1 and sys.argv[1].endswith('prepare-smoke-bundle.py'):\n"
+        "    os.execv(real_python, [real_python, *sys.argv[1:]])\n"
+        "if sys.argv[1:3] != ['-m', 'pytest']:\n"
+        "    sys.exit(2)\n"
+        "sys.exit(0)\n",
+        encoding="utf-8",
+    )
+    fake_helper.write_text(
+        "#!/usr/bin/env python3\n"
+        "import signal\n"
+        "import sys\n"
+        "import time\n"
+        "signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))\n"
+        "while True:\n"
+        "    time.sleep(0.1)\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+    fake_helper.chmod(0o755)
+
+    result = _run_smoke_script(
+        "--bundle",
+        str(bundle),
+        "--helper",
+        str(fake_helper),
+        "--evidence-dir",
+        str(evidence_dir),
+        "--python",
+        str(fake_python),
+        "--skip-build",
+        "--skip-sign",
+        env_overrides={
+            "TMPDIR": str(tmp_dir),
+            "TLDW_HOST_E2E_SMOKE_SKIP_SOCKET_WAIT": "1",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert {path.name for path in evidence_dir.iterdir()} >= EVIDENCE_FILES
+    evidence = json.loads((evidence_dir / "host-smoke-evidence.json").read_text(encoding="utf-8"))
+    assert evidence["schema_version"] == 1
+    assert evidence["source_bundle_path"] == str(bundle)
+    assert evidence["evidence_dir"] == str(evidence_dir)
+    assert evidence["serial_log_dir"].endswith("/serial")
+    assert evidence["helper_pid_file"].endswith("/helper.pid")
+    assert evidence["final_exit_code"] == 0
+    assert evidence["phases"]["real_host_smoke"]["status"] == "ok"
+    assert evidence["cleanup"]["socket_present_after_cleanup"] is False
+    assert Path(evidence["run_bundle_path"]).name == "bundle"
+    assert "raw_log_contents" not in evidence
+
+
+def test_host_e2e_smoke_script_refuses_non_private_evidence_directory(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "kernel").write_bytes(b"kernel")
+    (bundle / "rootfs.img").write_bytes(b"rootfs")
+    socket_dir = tmp_path / "private-runtime"
+    socket_dir.mkdir(mode=0o700)
+    socket_dir.chmod(0o700)
+    serial_log_dir = tmp_path / "serial"
+    evidence_dir = tmp_path / "public-evidence"
+    evidence_dir.mkdir(mode=0o755)
+    evidence_dir.chmod(0o755)
+    fake_python = tmp_path / "fake-python"
+    fake_helper = tmp_path / "fake-helper"
+    fake_python.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "sys.exit(0 if sys.argv[1:3] == ['-m', 'pytest'] else 2)\n",
+        encoding="utf-8",
+    )
+    fake_helper.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    fake_python.chmod(0o755)
+    fake_helper.chmod(0o755)
+
+    result = _run_smoke_script(
+        "--bundle",
+        str(bundle),
+        "--helper",
+        str(fake_helper),
+        "--socket",
+        str(socket_dir / "helper.sock"),
+        "--serial-log-dir",
+        str(serial_log_dir),
+        "--evidence-dir",
+        str(evidence_dir),
+        "--python",
+        str(fake_python),
+        "--skip-build",
+        "--skip-sign",
+        env_overrides={"TLDW_HOST_E2E_SMOKE_SKIP_SOCKET_WAIT": "1"},
+    )
+
+    assert result.returncode != 0
+    assert "evidence directory must be owner-only" in result.stderr
+
+
+def test_host_e2e_smoke_script_late_failure_preserves_exit_and_writes_evidence(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "kernel").write_bytes(b"kernel")
+    (bundle / "rootfs.img").write_bytes(b"rootfs")
+    (bundle / "manifest.json").write_text(
+        '{"bundle_version":"1","kernel":"kernel","rootfs":"rootfs.img"}',
+        encoding="utf-8",
+    )
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    evidence_dir = tmp_path / "evidence"
+    fake_python = tmp_path / "fake-python"
+    fake_helper = tmp_path / "fake-helper"
+    fake_python.write_text(
+        "#!/usr/bin/env python3\n"
+        "import os\n"
+        "import sys\n"
+        f"real_python = {str(sys.executable)!r}\n"
+        "if len(sys.argv) > 1 and sys.argv[1].endswith('prepare-smoke-bundle.py'):\n"
+        "    os.execv(real_python, [real_python, *sys.argv[1:]])\n"
+        "if sys.argv[1:3] != ['-m', 'pytest']:\n"
+        "    sys.exit(2)\n"
+        "if any(arg.endswith('test_vz_linux_real_host_e2e.py') for arg in sys.argv):\n"
+        "    sys.exit(7)\n"
+        "sys.exit(0)\n",
+        encoding="utf-8",
+    )
+    fake_helper.write_text(
+        "#!/usr/bin/env python3\n"
+        "import signal\n"
+        "import sys\n"
+        "import time\n"
+        "signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))\n"
+        "while True:\n"
+        "    time.sleep(0.1)\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+    fake_helper.chmod(0o755)
+
+    result = _run_smoke_script(
+        "--bundle",
+        str(bundle),
+        "--helper",
+        str(fake_helper),
+        "--evidence-dir",
+        str(evidence_dir),
+        "--python",
+        str(fake_python),
+        "--skip-build",
+        "--skip-sign",
+        env_overrides={
+            "TMPDIR": str(tmp_dir),
+            "TLDW_HOST_E2E_SMOKE_SKIP_SOCKET_WAIT": "1",
+        },
+    )
+
+    assert result.returncode == 7
+    assert (evidence_dir / "cleanup-status.txt").is_file()
+    evidence = json.loads((evidence_dir / "host-smoke-evidence.json").read_text(encoding="utf-8"))
+    assert evidence["final_exit_code"] == 7
+    assert evidence["phases"]["real_host_smoke"]["status"] == "failed"
+    assert evidence["phases"]["real_host_smoke"]["exit_code"] == 7
+    assert evidence["cleanup"]["socket_present_after_cleanup"] is False
 
 
 def test_host_e2e_smoke_script_dry_run_includes_failure_drills_when_requested(tmp_path: Path) -> None:

--- a/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
+++ b/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -24,6 +25,37 @@ EVIDENCE_FILES = {
     "runtime-paths.txt",
     "cleanup-status.txt",
 }
+SHA256_RE = re.compile(r"^[0-9a-f]{64}  .+$", re.MULTILINE)
+
+
+def _sha256_file(path: Path) -> str:
+    """Return the SHA-256 digest for a test fixture file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _planned_evidence_files(stdout: str) -> set[str]:
+    """Extract evidence file paths printed by a dry-run plan."""
+    return {
+        line.removeprefix("evidence file: ")
+        for line in stdout.splitlines()
+        if line.startswith("evidence file: ")
+    }
+
+
+def _assert_owner_only(path: Path) -> None:
+    """Assert that a path is not group/world accessible."""
+    assert path.stat().st_mode & 0o077 == 0
+
+
+def _read_hash_file(path: Path) -> str:
+    """Read an evidence hash artifact and verify it contains SHA-256 rows."""
+    text = path.read_text(encoding="utf-8")
+    assert SHA256_RE.search(text)
+    return text
 
 
 def _run_smoke_script(*args: str, env_overrides: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
@@ -138,6 +170,7 @@ def test_host_e2e_smoke_script_dry_run_uses_disposable_run_bundle(tmp_path: Path
 
 
 def test_host_e2e_smoke_script_dry_run_prints_default_evidence_bundle(tmp_path: Path) -> None:
+    """Dry-run prints every evidence file under the default evidence directory."""
     bundle = tmp_path / "bundle"
     bundle.mkdir()
     (bundle / "kernel").write_bytes(b"kernel")
@@ -158,14 +191,16 @@ def test_host_e2e_smoke_script_dry_run_prints_default_evidence_bundle(tmp_path: 
     assert "evidence directory:" in result.stdout
     evidence_match = re.search(r"evidence directory: ([^\n]+/evidence)", result.stdout)
     assert evidence_match is not None
-    evidence_dir = Path(evidence_match.group(1))
+    evidence_dir_text = evidence_match.group(1)
+    evidence_dir = Path(evidence_dir_text)
     assert evidence_dir.name == "evidence"
     assert not evidence_dir.exists()
-    for evidence_file in EVIDENCE_FILES:
-        assert evidence_file in result.stdout
+    expected_paths = {f"{evidence_dir_text}/{evidence_file}" for evidence_file in EVIDENCE_FILES}
+    assert expected_paths <= _planned_evidence_files(result.stdout)
 
 
 def test_host_e2e_smoke_script_dry_run_accepts_evidence_dir_override(tmp_path: Path) -> None:
+    """Dry-run accepts a custom evidence directory without creating it."""
     bundle = tmp_path / "bundle"
     bundle.mkdir()
     (bundle / "kernel").write_bytes(b"kernel")
@@ -188,8 +223,8 @@ def test_host_e2e_smoke_script_dry_run_accepts_evidence_dir_override(tmp_path: P
     assert result.returncode == 0, result.stderr
     assert f"evidence directory: {evidence_dir}" in result.stdout
     assert not evidence_dir.exists()
-    for evidence_file in EVIDENCE_FILES:
-        assert f"{evidence_dir}/{evidence_file}" in result.stdout
+    expected_paths = {str(evidence_dir / evidence_file) for evidence_file in EVIDENCE_FILES}
+    assert expected_paths <= _planned_evidence_files(result.stdout)
 
 
 def test_host_e2e_smoke_script_dry_run_uses_materializer_normalized_path(tmp_path: Path) -> None:
@@ -315,10 +350,13 @@ def test_host_e2e_smoke_script_real_run_passes_disposable_bundle_to_pytest(tmp_p
 
 
 def test_host_e2e_smoke_script_real_run_writes_evidence_bundle(tmp_path: Path) -> None:
+    """Real fake-helper runs write private, hashed, redacted evidence artifacts."""
     bundle = tmp_path / "bundle"
     bundle.mkdir()
-    (bundle / "kernel").write_bytes(b"kernel")
-    (bundle / "rootfs.img").write_bytes(b"rootfs")
+    kernel = bundle / "kernel"
+    rootfs = bundle / "rootfs.img"
+    kernel.write_bytes(b"kernel")
+    rootfs.write_bytes(b"rootfs")
     (bundle / "manifest.json").write_text(
         '{"bundle_version":"1","kernel":"kernel","rootfs":"rootfs.img"}',
         encoding="utf-8",
@@ -337,6 +375,15 @@ def test_host_e2e_smoke_script_real_run_writes_evidence_bundle(tmp_path: Path) -
         "    os.execv(real_python, [real_python, *sys.argv[1:]])\n"
         "if sys.argv[1:3] != ['-m', 'pytest']:\n"
         "    sys.exit(2)\n"
+        "serial_dir = os.environ.get('TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR')\n"
+        "if serial_dir:\n"
+        "    os.makedirs(serial_dir, exist_ok=True)\n"
+        "    with open(os.path.join(serial_dir, 'guest.log'), 'w', encoding='utf-8') as handle:\n"
+        "        handle.write('raw serial log should stay out of evidence')\n"
+        "    unreadable = os.path.join(serial_dir, 'unreadable.log')\n"
+        "    with open(unreadable, 'w', encoding='utf-8') as handle:\n"
+        "        handle.write('unreadable raw serial log should stay out of evidence')\n"
+        "    os.chmod(unreadable, 0)\n"
         "sys.exit(0)\n",
         encoding="utf-8",
     )
@@ -370,9 +417,22 @@ def test_host_e2e_smoke_script_real_run_writes_evidence_bundle(tmp_path: Path) -
         },
     )
 
-    assert result.returncode == 0, result.stderr
-    assert {path.name for path in evidence_dir.iterdir()} >= EVIDENCE_FILES
-    evidence = json.loads((evidence_dir / "host-smoke-evidence.json").read_text(encoding="utf-8"))
+    try:
+        assert result.returncode == 0, result.stderr
+        assert {path.name for path in evidence_dir.iterdir()} >= EVIDENCE_FILES
+        _assert_owner_only(evidence_dir)
+        for evidence_file in EVIDENCE_FILES:
+            _assert_owner_only(evidence_dir / evidence_file)
+        source_before_hashes = _read_hash_file(evidence_dir / "source-bundle-hashes-before.txt")
+        source_after_hashes = _read_hash_file(evidence_dir / "source-bundle-hashes-after.txt")
+        run_hashes = _read_hash_file(evidence_dir / "run-bundle-hashes.txt")
+        assert f"{_sha256_file(kernel)}  kernel" in source_before_hashes
+        assert f"{_sha256_file(rootfs)}  rootfs.img" in source_after_hashes
+        assert f"{_sha256_file(rootfs)}  rootfs.img" in run_hashes
+        evidence = json.loads((evidence_dir / "host-smoke-evidence.json").read_text(encoding="utf-8"))
+    finally:
+        for unreadable_log in tmp_dir.glob("**/unreadable.log"):
+            unreadable_log.chmod(0o600)
     assert evidence["schema_version"] == 1
     assert evidence["source_bundle_path"] == str(bundle)
     assert evidence["evidence_dir"] == str(evidence_dir)
@@ -383,9 +443,15 @@ def test_host_e2e_smoke_script_real_run_writes_evidence_bundle(tmp_path: Path) -
     assert evidence["cleanup"]["socket_present_after_cleanup"] is False
     assert Path(evidence["run_bundle_path"]).name == "bundle"
     assert "raw_log_contents" not in evidence
+    guest_log = next(item for item in evidence["log_artifacts"] if Path(item["path"]).name == "guest.log")
+    assert guest_log["size_bytes"] > 0
+    assert guest_log["sha256"] == _sha256_file(Path(guest_log["path"]))
+    assert "raw serial log should stay out of evidence" not in json.dumps(evidence)
+    assert all(Path(item["path"]).name != "unreadable.log" for item in evidence["log_artifacts"])
 
 
 def test_host_e2e_smoke_script_refuses_non_private_evidence_directory(tmp_path: Path) -> None:
+    """Real runs reject pre-existing evidence directories that are not private."""
     bundle = tmp_path / "bundle"
     bundle.mkdir()
     (bundle / "kernel").write_bytes(b"kernel")
@@ -431,7 +497,94 @@ def test_host_e2e_smoke_script_refuses_non_private_evidence_directory(tmp_path: 
     assert "evidence directory must be owner-only" in result.stderr
 
 
+def test_host_e2e_smoke_script_prepare_failure_does_not_hash_repo_as_run_bundle(tmp_path: Path) -> None:
+    """Early failures write a missing run-bundle hash artifact instead of hashing the cwd."""
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    evidence_dir = tmp_path / "evidence"
+
+    result = _run_smoke_script(
+        "--bundle",
+        str(bundle),
+        "--evidence-dir",
+        str(evidence_dir),
+        "--skip-build",
+        "--skip-sign",
+    )
+
+    assert result.returncode != 0
+    run_hashes = (evidence_dir / "run-bundle-hashes.txt").read_text(encoding="utf-8")
+    assert "# missing: <empty bundle path>" in run_hashes
+    assert "run-host-e2e-smoke.sh" not in run_hashes
+
+
+def test_host_e2e_smoke_script_evidence_falls_back_to_valid_python_bin(tmp_path: Path) -> None:
+    """Evidence generation skips invalid PATH Python shims and uses a valid --python."""
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "kernel").write_bytes(b"kernel")
+    (bundle / "rootfs.img").write_bytes(b"rootfs")
+    (bundle / "manifest.json").write_text(
+        '{"bundle_version":"1","kernel":"kernel","rootfs":"rootfs.img"}',
+        encoding="utf-8",
+    )
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    evidence_dir = tmp_path / "evidence"
+    fake_path = tmp_path / "fake-path"
+    fake_path.mkdir()
+    failing_python3 = fake_path / "python3"
+    fake_python = tmp_path / "fake-python"
+    fake_helper = tmp_path / "fake-helper"
+    failing_python3.write_text("#!/bin/sh\nexit 9\n", encoding="utf-8")
+    fake_python.write_text(
+        f"#!{sys.executable}\n"
+        "import os\n"
+        "import sys\n"
+        f"real_python = {str(sys.executable)!r}\n"
+        "if sys.argv[1:2] == ['-c']:\n"
+        "    os.execv(real_python, [real_python, *sys.argv[1:]])\n"
+        "if len(sys.argv) > 1 and sys.argv[1].endswith('prepare-smoke-bundle.py'):\n"
+        "    os.execv(real_python, [real_python, *sys.argv[1:]])\n"
+        "if sys.argv[1:3] != ['-m', 'pytest']:\n"
+        "    sys.exit(2)\n"
+        "sys.exit(0)\n",
+        encoding="utf-8",
+    )
+    fake_helper.write_text(
+        "#!/bin/sh\n"
+        "trap 'exit 0' TERM\n"
+        "while true; do sleep 1; done\n",
+        encoding="utf-8",
+    )
+    failing_python3.chmod(0o755)
+    fake_python.chmod(0o755)
+    fake_helper.chmod(0o755)
+
+    result = _run_smoke_script(
+        "--bundle",
+        str(bundle),
+        "--helper",
+        str(fake_helper),
+        "--evidence-dir",
+        str(evidence_dir),
+        "--python",
+        str(fake_python),
+        "--skip-build",
+        "--skip-sign",
+        env_overrides={
+            "PATH": f"{fake_path}:{os.environ['PATH']}",
+            "TMPDIR": str(tmp_dir),
+            "TLDW_HOST_E2E_SMOKE_SKIP_SOCKET_WAIT": "1",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (evidence_dir / "host-smoke-evidence.json").is_file()
+
+
 def test_host_e2e_smoke_script_late_failure_preserves_exit_and_writes_evidence(tmp_path: Path) -> None:
+    """Late pytest failures preserve the pytest exit code and still write evidence."""
     bundle = tmp_path / "bundle"
     bundle.mkdir()
     (bundle / "kernel").write_bytes(b"kernel")


### PR DESCRIPTION
## Summary
- Adds default-on structured VZ host smoke evidence under the runtime `evidence/` directory, with `--evidence-dir PATH` override support.
- Records streamed SHA-256 bundle hashes, runtime paths, phase outcomes, cleanup state, and log path/size/hash metadata without embedding raw log contents.
- Updates host-gated acceptance docs, workflow contract tests, implementation plan, and Backlog task `TASK-2368`.
- Review fixes harden empty run-bundle failures, unreadable log metadata, evidence file permissions, evidence Python fallback, and evidence-finalize phase reporting.

## Risk Level
Low. This affects the host-side VZ Linux smoke wrapper and associated tests/docs, not production sandbox execution paths.

## Rollback Plan
Revert this PR. The prior smoke wrapper behavior did not depend on persisted structured evidence, so rollback returns to the previous runtime artifact contents without data migration.

## Validation Checklist
- [x] `source .venv/bin/activate && python -m pytest tools/vz-linux-image/tests/test_prepare_smoke_bundle.py tools/vz-linux-image/tests/test_host_e2e_smoke_script.py tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q` -> `53 passed, 6 warnings`
- [x] `bash -n tools/vz-linux-image/scripts/run-host-e2e-smoke.sh`
- [x] `git diff --check`
- [x] `source .venv/bin/activate && python -m bandit -r tools/vz-linux-image/scripts -f json -o /tmp/bandit_vz_host_smoke_evidence_review.json` -> `0` results, `0` errors
- [x] PR rebased on latest `origin/dev`

## Change Summary
Human-authored change summary required before merge.

## Known Skips
- No real Apple Virtualization VM smoke was run for this local code slice; validation used portable fake-helper wrapper tests plus host-gated workflow contract tests.
- CodeRabbit's docstring coverage warning is repo-wide (`8.82%` vs `80%`) and not scoped to this PR; this PR adds docstrings to the new evidence tests/helpers it introduces.
