### PR TITLE
docs: reconcile Claude ACP setup status

### DIFF
--- a/Docs/User_Guides/Integrations_Experiments/Anthropic_ClaudeCode_ClaudeSDK_Setup.md
+++ b/Docs/User_Guides/Integrations_Experiments/Anthropic_ClaudeCode_ClaudeSDK_Setup.md
@@ -2,16 +2,13 @@
 
 This guide is the Anthropic equivalent of first-time provider setup for `tldw_server`, with focus on Claude Code and Claude SDK workflows.
 
-## Support Status (As of June 3, 2026)
+## Support Status (As of June 17, 2026)
 
 Currently supported:
 
 - Anthropic via API key (`ANTHROPIC_API_KEY`) for server-side model calls
 - Anthropic BYOK API-key storage in multi-user mode
-
-Documented but not live-certified:
-
-- Claude Code through ACP is a documented external-adapter candidate using pinned `@agentclientprotocol/claude-agent-acp@0.40.0`; it is not live-E2E certified yet.
+- Claude Code through ACP is supported with caveats through the pinned external `@agentclientprotocol/claude-agent-acp@0.40.0` adapter on the verified macOS host runner profile. Sandbox, artifact-producing workflows, non-empty MCP injection, reviewer-loop behavior, and other host profiles remain unverified.
 
 Not yet supported:
 
@@ -116,7 +113,7 @@ Validate:
 curl -s http://127.0.0.1:8000/api/v1/acp/agents -H "X-API-KEY: <api-key>"
 ```
 
-You should see `claude_code` listed with `documented_unverified` support until the adapter is installed and live ACP initialize/session/prompt verification passes.
+You should see `claude_code` listed with `supported_with_caveats` support on the verified macOS host profile. Runtime status can still block on missing `claude`, missing `claude-agent-acp`, or missing/failed Claude Code or adapter auth in the same environment used by `tldw_server` and the runner.
 
 ## Path C: Claude SDK in Custom Agent Mode
 

--- a/backlog/tasks/task-2378 - Reconcile-stale-Claude-ACP-docs-after-live-certification-merge.md
+++ b/backlog/tasks/task-2378 - Reconcile-stale-Claude-ACP-docs-after-live-certification-merge.md
@@ -1,0 +1,52 @@
+---
+id: TASK-2378
+title: Reconcile stale Claude ACP docs after live certification merge
+status: Done
+labels:
+- ACP
+- docs
+priority: High
+references:
+- https://github.com/rmusser01/tldw_server/pull/2374
+- https://github.com/rmusser01/tldw_server/pull/2376
+- https://github.com/rmusser01/tldw_server/issues/1564
+- https://github.com/rmusser01/tldw_server/issues/1532
+modified_files:
+- Docs/User_Guides/Integrations_Experiments/Anthropic_ClaudeCode_ClaudeSDK_Setup.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Update duplicate/non-canonical Claude ACP setup wording that still reports claude_code as documented_unverified after PR #2374 merged, then reconcile or leave open the relevant ACP tracker issues based on whether this follow-up has landed.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 No current docs/setup surface claims claude_code is documented_unverified after live E2E certification.
+- [x] #2 Issue #1564 remains open with this PR linked until the docs reconciliation lands.
+- [x] #3 Issue #1532 remains open until #1564 is reconciled/closed after this follow-up lands.
+- [x] #4 Verification includes targeted grep and git diff checks.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Updated the duplicate Claude Code setup guide under Docs/User_Guides to match the live-E2E certification state merged in PR #2374. Verified no current user-facing setup/matrix surfaces still claim claude_code is documented_unverified/documented_only, ran git diff --check, opened PR #2376, and linked #1564/#1532 with comments. Bandit skipped because the PR is documentation-only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary

This follow-up updates the duplicate Claude Code setup guide under `Docs/User_Guides` so it matches the merged live-certification state from PR #2374. The current setup surfaces now describe Claude Code ACP as `supported_with_caveats` on the verified macOS host runner profile instead of the older documented-only candidate state.

The change is deliberately narrow because #1564 should not close until this stale user-facing wording lands. #1532 should remain open until #1564 is reconciled after this follow-up merges.

## Verification

- `git grep -n "Claude Code.*documented_unverified\|Claude Code.*documented-only\|claude_code.*documented_unverified\|claude_code.*documented_only" -- Docs/User_Guides Docs/Published/User_Guides Docs/Development/ACP_Compatibility_Matrix.md tldw_Server_API/Config_Files/agents.yaml || true`
- `git diff --check`

Bandit was skipped because this PR only changes Markdown/Backlog documentation.

Refs #1564
Refs #1532

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Claude Code ACP setup guide to live certification: `claude_code` is `supported_with_caveats` on the verified macOS host via `@agentclientprotocol/claude-agent-acp@0.40.0` (status date June 17, 2026).
Notes now call out unverified areas (sandbox, artifact flows, non-empty MCP injection, reviewer loop, other hosts), update the API agents listing to expect `supported_with_caveats`, and document runtime blockers (`claude`, `claude-agent-acp`, and auth in the `tldw_server`/runner env); adds a backlog task and aligns docs to close out #1564 while keeping #1532 open.

<sup>Written for commit 8538cf121f22de11fbb4f1ad2b794f19e88dadd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

