### PR TITLE
Add Workspace active-context eligibility contract

### DIFF
--- a/Docs/superpowers/plans/2026-06-17-workspace-active-context-eligibility.md
+++ b/Docs/superpowers/plans/2026-06-17-workspace-active-context-eligibility.md
@@ -1,0 +1,38 @@
+# Workspace Active Context Eligibility Plan
+
+## Stage 1: Contract Tests
+**Goal**: Capture the active-context eligibility matrix before implementation.
+**Success Criteria**: Tests describe visibility behavior, active workspace gates, resource membership gates, runtime gates, and stable denial reasons.
+**Tests**:
+- `tldw_Server_API/tests/Workspaces/test_workspace_eligibility.py`
+- `tldw_Server_API/tests/Workspaces/test_workspace_eligibility_api.py`
+**Status**: Complete
+
+## Stage 2: Eligibility Core
+**Goal**: Add a shared Workspace eligibility helper that answers whether an operation can use a resource in the active workspace context.
+**Success Criteria**: The helper accepts active workspace, resource, operation, runtime state, and permission state; it returns stable reason codes and recovery actions without changing browse/search/open/edit visibility semantics.
+**Tests**:
+- Unit tests for visibility operations, no active workspace, archived workspace, unlinked resource, cross-workspace resource, unsupported resource type, missing runtime, and permission denial.
+**Status**: Complete
+
+## Stage 3: API Surface
+**Goal**: Expose the eligibility helper through a small contract endpoint for frontend and integration callers.
+**Success Criteria**: `POST /api/v1/workspace-eligibility/check` returns the shared response shape and is registered with the workspace routes.
+**Tests**:
+- API tests for allowed visibility checks, linked resource checks, and denial payloads.
+**Status**: Complete
+
+## Stage 4: Documentation
+**Goal**: Document the operation matrix, reason codes, and recovery guidance in the Workspace core contract.
+**Success Criteria**: Workspace docs explain the difference between global visibility and active-context eligibility, and point future resource adapters to issue #2378.
+**Tests**:
+- Documentation review during self-review.
+**Status**: Complete
+
+## Stage 5: Verification
+**Goal**: Verify focused behavior and security checks before opening a PR.
+**Success Criteria**: Focused Workspace tests pass, Bandit runs on touched backend paths, Backlog task is updated, changes are committed and pushed, and a PR is opened against `dev`.
+**Tests**:
+- Focused pytest command for Workspace eligibility and memberships.
+- Bandit against touched backend modules.
+**Status**: Complete

--- a/backlog/tasks/task-2379 - Implement-Workspace-Phase-2-active-context-eligibility-semantics.md
+++ b/backlog/tasks/task-2379 - Implement-Workspace-Phase-2-active-context-eligibility-semantics.md
@@ -1,0 +1,69 @@
+---
+id: TASK-2379
+title: Implement Workspace Phase 2 active-context eligibility semantics
+status: Done
+labels:
+- Workspace
+- Phase 2
+- Backend
+priority: High
+references:
+- https://github.com/rmusser01/tldw_server/issues/1992
+- https://github.com/rmusser01/tldw_server/issues/1984
+- https://github.com/rmusser01/tldw_server/issues/1990
+- https://github.com/rmusser01/tldw_server/issues/2378
+modified_files:
+- tldw_Server_API/app/core/Workspaces/eligibility.py
+- tldw_Server_API/app/api/v1/endpoints/workspace_eligibility.py
+- tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+- tldw_Server_API/app/api/v1/router_groups/content.py
+- tldw_Server_API/app/api/v1/router_groups/minimal.py
+- tldw_Server_API/app/core/Workspaces/README.md
+- tldw_Server_API/tests/Workspaces/test_workspace_eligibility.py
+- tldw_Server_API/tests/Workspaces/test_workspace_eligibility_api.py
+- Docs/superpowers/plans/2026-06-17-workspace-active-context-eligibility.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the shared active-context eligibility contract for issue #1992, using the landed workspace membership service as the canonical membership source while preserving global browse/open visibility and fail-closed active operation behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Shared eligibility service/helper accepts active_workspace_id, resource_type, resource_id, operation, and runtime/membership context.
+- [x] #2 Workspace-sensitive operation matrix covers staging, RAG grounding, prompt use, tool use, agent manipulation, ACP run, sandbox operation, workflow launch, and watchlist run.
+- [x] #3 Allowed browse/search/open/edit visibility remains separate from active-context eligibility decisions.
+- [x] #4 Denied active-context operations return stable reason codes and user-actionable recovery copy for no active workspace, unlinked/cross-workspace resource, archived workspace, missing runtime, unsupported resource type, and permission failure.
+- [x] #5 Contract is documented for frontend adoption.
+- [x] #6 Focused backend tests and Bandit verification are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-17-workspace-active-context-eligibility.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+No known skips or blockers.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Workspace Phase 2 active-context eligibility semantics for #1992 and addressed PR review feedback after rebasing on latest dev. Added a shared WorkspaceEligibilityService with explicit visibility vs active-context operation sets, runtime-required gates, stable reason codes, recovery actions, and compact membership references. Added POST /api/v1/workspace-eligibility/check, schemas, router registration, tests, and Workspace README documentation. Review fixes: sync FastAPI handler for sync DB work, required explicit runtime_state/permission_state in the API request, runtime-bound operations fail closed unless runtime_state is ready, normalized unsupported resource type denials, safer label reads, active workspace filtered from cross-workspace reverse membership results, and workspace_not_found coverage. Verification: python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_eligibility.py tldw_Server_API/tests/Workspaces/test_workspace_eligibility_api.py tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py tldw_Server_API/tests/Workspaces/test_workspace_migration_api.py tldw_Server_API/tests/Workspaces/test_workspaces_api.py::TestWorkspaceLifecycle tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py -q passed with 163 tests. Bandit on touched backend modules wrote /tmp/bandit_workspace_eligibility_phase2_rebase.json and reported results=0.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/workspace_eligibility.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspace_eligibility.py
@@ -1,0 +1,55 @@
+"""Workspace active-context eligibility endpoint."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
+from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import WORKSPACES_READ_RATE_LIMIT
+from tldw_Server_API.app.api.v1.schemas.workspace_schemas import (
+    WorkspaceEligibilityCheckRequest,
+    WorkspaceEligibilityCheckResponse,
+)
+from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    CharactersRAGDBError,
+    ConflictError,
+    InputError,
+)
+from tldw_Server_API.app.core.Workspaces.eligibility import (
+    WorkspaceEligibilityRequest,
+    WorkspaceEligibilityService,
+)
+
+
+router = APIRouter()
+
+
+@router.post(
+    "/check",
+    response_model=WorkspaceEligibilityCheckResponse,
+    dependencies=[Depends(WORKSPACES_READ_RATE_LIMIT)],
+    summary="Check whether a resource can be used in the active workspace context",
+)
+def check_workspace_eligibility(
+    request: WorkspaceEligibilityCheckRequest,
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+    current_user: User = Depends(get_request_user),
+) -> WorkspaceEligibilityCheckResponse:
+    """Return an eligibility decision without mutating resource or workspace state."""
+    _ = current_user
+    try:
+        result = WorkspaceEligibilityService(db).check(
+            WorkspaceEligibilityRequest(
+                operation=request.operation,
+                active_workspace_id=request.active_workspace_id,
+                resource_type=request.resource_type,
+                resource_id=request.resource_id,
+                runtime_state=request.runtime_state,
+                permission_state=request.permission_state,
+            )
+        )
+    except (ConflictError, InputError, CharactersRAGDBError) as exc:
+        raise map_db_error_to_http(exc, default_detail="Failed to check workspace eligibility") from exc
+    return WorkspaceEligibilityCheckResponse(**result.to_dict())

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -397,6 +397,13 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
             route_key="workspaces",
         ),
         ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.workspace_eligibility",
+            log_name="workspace_eligibility",
+            prefix=f"{API_V1_PREFIX}/workspace-eligibility",
+            tags=("workspaces",),
+            route_key="workspaces",
+        ),
+        ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.character_chat_sessions",
             log_name="character_chat_sessions",
             prefix=f"{API_V1_PREFIX}/chats",

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -47,6 +47,7 @@ MINIMAL_REQUIRED_ROUTER_NAMES = (
     "workspace_migrations",
     "workspaces",
     "workspace_memberships",
+    "workspace_eligibility",
 )
 MINIMAL_REQUIRED_ROUTER_OVERRIDES = {
     name: RouterSpecOverride(skip_exceptions=REQUIRED_ROUTER_SKIP_EXCEPTIONS)

--- a/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
@@ -12,6 +12,13 @@ from tldw_Server_API.app.core.Workspaces.membership_models import (
     WORKSPACE_MEMBERSHIP_MAX_PROVENANCE_BYTES,
     normalize_membership_json_object,
 )
+from tldw_Server_API.app.core.Workspaces.eligibility import (
+    WorkspaceEligibilityOperation,
+    WorkspaceEligibilityOperationCategory,
+    WorkspaceEligibilityPermissionState,
+    WorkspaceEligibilityReasonCode,
+    WorkspaceEligibilityRuntimeState,
+)
 
 WORKSPACE_MIGRATION_MAX_MANIFEST_BYTES = 256 * 1024
 WORKSPACE_MIGRATION_MAX_DIAGNOSTICS_BYTES = 64 * 1024
@@ -312,6 +319,48 @@ class WorkspaceContextMembershipSummary(BaseModel):
     total: int = 0
     by_resource_type: dict[str, int] = Field(default_factory=dict)
     by_role: dict[str, int] = Field(default_factory=dict)
+
+
+# --- Eligibility schemas ---
+
+class WorkspaceEligibilityCheckRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    operation: WorkspaceEligibilityOperation
+    resource_type: str = Field(..., min_length=1, max_length=80)
+    resource_id: str = Field(..., min_length=1, max_length=512)
+    active_workspace_id: str | None = Field(default=None, min_length=1, max_length=128)
+    runtime_state: WorkspaceEligibilityRuntimeState
+    permission_state: WorkspaceEligibilityPermissionState
+
+
+class WorkspaceEligibilityRecoveryActionResponse(BaseModel):
+    action: str
+    label: str
+    href: str | None = None
+
+
+class WorkspaceEligibilityMembershipResponse(BaseModel):
+    workspace_id: str
+    resource_type: str
+    resource_id: str
+    role: str = "member"
+    label: str | None = None
+
+
+class WorkspaceEligibilityCheckResponse(BaseModel):
+    allowed: bool
+    reason_code: WorkspaceEligibilityReasonCode
+    message: str
+    operation: WorkspaceEligibilityOperation
+    operation_category: WorkspaceEligibilityOperationCategory
+    active_workspace_id: str | None = None
+    resource_type: str
+    resource_id: str
+    global_visibility_preserved: bool = True
+    recovery_actions: list[WorkspaceEligibilityRecoveryActionResponse] = Field(default_factory=list)
+    membership: WorkspaceEligibilityMembershipResponse | None = None
+    resource_workspace_ids: list[str] = Field(default_factory=list)
 
 
 # --- Source schemas ---

--- a/tldw_Server_API/app/core/Workspaces/README.md
+++ b/tldw_Server_API/app/core/Workspaces/README.md
@@ -16,6 +16,8 @@ holds focused core helpers used by those flows.
 - `file_inventory_models.py`, `file_inventory_ignore.py`, `file_inventory_scanner.py`,
   and `file_inventory_jobs.py` implement metadata-only project-root inventory
   scanning and Jobs enqueue helpers.
+- `eligibility.py` checks whether a resource can be used by an active Workspace
+  operation without changing global resource visibility.
 - `workspace_artifact_exports.py` prepares traceable workspace artifact exports.
 - Related API surface: `app/api/v1/endpoints/workspaces.py` and `app/api/v1/endpoints/workspace_migrations.py`.
 - Related tests: `tests/Workspaces/`.
@@ -38,6 +40,7 @@ holds focused core helpers used by those flows.
 - `service_capabilities.py` - readiness and capability projection.
 - `source_jobs.py` - workspace source job payload and enqueue helpers.
 - `status_projection.py` - source status derivation.
+- `eligibility.py` - active Workspace operation eligibility and recovery actions.
 - `file_inventory_*` - ignore policy, metadata scanner, durable status models,
   and Jobs enqueue helpers for project-root file inventory.
 - `workspace_artifact_exports.py` - artifact export helpers and traceability checks.
@@ -69,10 +72,54 @@ adapter before linking or resolving a resource. Unsupported resource types must
 fail closed, and summaries/provenance should avoid exposing secrets, absolute
 paths, sandbox mount paths, prompts, model output contents, or file contents.
 
+## Active Context Eligibility
+
+Global browse, search, open, and edit visibility remains owned by each resource
+domain. Workspace eligibility does not hide resources from those global surfaces;
+it only decides whether a resource may be used inside the currently selected
+Workspace context.
+
+`eligibility.py` and `POST /api/v1/workspace-eligibility/check` expose the
+shared contract. Visibility operations (`browse`, `search`, `open`, `edit`) are
+allowed when normal ownership/permission checks have already passed, even when
+no active workspace exists. Active-context operations require a selected,
+non-archived workspace and a membership row that links the resource to that
+workspace. API callers must explicitly send `runtime_state` and
+`permission_state`; the endpoint does not default either field to an allowed
+state. Active-context operations are:
+
+- `stage`
+- `rag_ground`
+- `prompt_use`
+- `tool_use`
+- `agent_manipulate`
+- `acp_run`
+- `sandbox_operation`
+- `workflow_launch`
+- `watchlist_run`
+
+Runtime-bound operations (`tool_use`, `agent_manipulate`, `acp_run`,
+`sandbox_operation`, `workflow_launch`, `watchlist_run`) also fail closed when
+the caller does not report `runtime_state="ready"`. Stable denial reasons are
+`no_active_workspace`, `workspace_not_found`, `workspace_archived`,
+`unsupported_resource_type`, `resource_not_linked`,
+`cross_workspace_resource`, `missing_runtime`, and `permission_denied`.
+Responses include recovery actions such as selecting or creating a workspace,
+linking/copying the resource into the active workspace, switching to the
+workspace that already contains the resource, unarchiving the workspace, or
+configuring the workspace runtime.
+
+Eligibility checks intentionally do not make membership a trust source for MCP,
+ACP, Sandbox path admission, or file access. Those systems must continue to use
+their own policy, root binding, and runtime admission checks after eligibility
+passes.
+
 ## How It Connects
 
 - `app/api/v1/endpoints/workspaces.py` exposes workspace CRUD, sources, status, preview, sub-resource routes, and read-only Workspace Core contract surfaces.
 - `app/api/v1/endpoints/workspace_migrations.py` exposes workspace migration routes.
+- `app/api/v1/endpoints/workspace_eligibility.py` exposes the active-context
+  eligibility contract.
 - `app/api/v1/schemas/workspace_schemas.py` defines workspace request and response models.
 - ChaChaNotes workspace tables store workspace metadata, persisted `workspace_profile`, project roots, sources, notes, and artifact references.
 - Jobs, Media DB, and RAG/indexing state feed `status_projection.py`.
@@ -145,6 +192,9 @@ paths, sandbox mount paths, prompts, model output contents, or file contents.
 - Generic membership rows are a read-model association layer over domain-owned
   resources. Domain tables and adapters remain responsible for ownership,
   visibility, and access validation.
+- Active-context eligibility is a read-only decision layer over workspace state,
+  runtime state supplied by callers, and generic membership rows. It does not
+  mutate memberships or replace domain-specific permission checks.
 
 ### Follow-Up Slices
 
@@ -171,6 +221,8 @@ paths, sandbox mount paths, prompts, model output contents, or file contents.
 - New membership resource type: add a fail-closed domain adapter, validate
   resource access through the owning domain API, update schemas/tests, and keep
   MCP/root/path trust decisions outside generic membership.
+- New active-context operation: update `eligibility.py`,
+  `workspace_schemas.py`, eligibility API tests, and this operation matrix.
 
 ## Extension Points
 
@@ -193,6 +245,8 @@ paths, sandbox mount paths, prompts, model output contents, or file contents.
 - `tests/Workspaces/test_workspace_sub_resources_api.py`
 - `tests/Workspaces/test_workspace_membership_adapters.py`
 - `tests/Workspaces/test_workspace_memberships_api.py`
+- `tests/Workspaces/test_workspace_eligibility.py`
+- `tests/Workspaces/test_workspace_eligibility_api.py`
 - `tests/Workspaces/test_workspace_context_membership_summary.py`
 - `tests/Workspaces/test_workspace_migration_api.py`
 - `tests/Workspaces/test_workspace_rate_limit_contract.py`

--- a/tldw_Server_API/app/core/Workspaces/eligibility.py
+++ b/tldw_Server_API/app/core/Workspaces/eligibility.py
@@ -1,0 +1,410 @@
+"""Workspace active-context eligibility checks."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal, cast
+
+from tldw_Server_API.app.core.Workspaces.membership_models import WORKSPACE_MEMBERSHIP_RESOURCE_TYPES
+
+
+WorkspaceEligibilityOperation = Literal[
+    "browse",
+    "search",
+    "open",
+    "edit",
+    "stage",
+    "rag_ground",
+    "prompt_use",
+    "tool_use",
+    "agent_manipulate",
+    "acp_run",
+    "sandbox_operation",
+    "workflow_launch",
+    "watchlist_run",
+]
+WorkspaceEligibilityOperationCategory = Literal["visibility", "active_context"]
+WorkspaceEligibilityRuntimeState = Literal["not_required", "ready", "missing"]
+WorkspaceEligibilityPermissionState = Literal["granted", "denied"]
+WorkspaceEligibilityReasonCode = Literal[
+    "allowed",
+    "visibility_allowed",
+    "no_active_workspace",
+    "workspace_not_found",
+    "workspace_archived",
+    "unsupported_resource_type",
+    "resource_not_linked",
+    "cross_workspace_resource",
+    "missing_runtime",
+    "permission_denied",
+]
+
+WORKSPACE_VISIBILITY_OPERATIONS = frozenset({"browse", "search", "open", "edit"})
+WORKSPACE_ACTIVE_CONTEXT_OPERATIONS = frozenset(
+    {
+        "stage",
+        "rag_ground",
+        "prompt_use",
+        "tool_use",
+        "agent_manipulate",
+        "acp_run",
+        "sandbox_operation",
+        "workflow_launch",
+        "watchlist_run",
+    }
+)
+WORKSPACE_RUNTIME_REQUIRED_OPERATIONS = frozenset(
+    {
+        "tool_use",
+        "agent_manipulate",
+        "acp_run",
+        "sandbox_operation",
+        "workflow_launch",
+        "watchlist_run",
+    }
+)
+WORKSPACE_ELIGIBILITY_OPERATIONS = WORKSPACE_VISIBILITY_OPERATIONS | WORKSPACE_ACTIVE_CONTEXT_OPERATIONS
+_UNSET = object()
+
+
+@dataclass(frozen=True)
+class WorkspaceEligibilityRequest:
+    """Input for active-context eligibility checks."""
+
+    operation: WorkspaceEligibilityOperation
+    resource_type: str
+    resource_id: str
+    runtime_state: WorkspaceEligibilityRuntimeState
+    permission_state: WorkspaceEligibilityPermissionState
+    active_workspace_id: str | None = None
+
+
+@dataclass(frozen=True)
+class WorkspaceEligibilityRecoveryAction:
+    """Client-facing recovery action for an eligibility denial."""
+
+    action: str
+    label: str
+    href: str | None = None
+
+    def to_dict(self) -> dict[str, str | None]:
+        return {
+            "action": self.action,
+            "label": self.label,
+            "href": self.href,
+        }
+
+
+@dataclass(frozen=True)
+class WorkspaceEligibilityMembership:
+    """Compact membership reference returned with eligibility decisions."""
+
+    workspace_id: str
+    resource_type: str
+    resource_id: str
+    role: str = "member"
+    label: str | None = None
+
+    @classmethod
+    def from_row(cls, row: Mapping[str, Any]) -> "WorkspaceEligibilityMembership":
+        return cls(
+            workspace_id=str(row.get("workspace_id") or ""),
+            resource_type=str(row.get("resource_type") or ""),
+            resource_id=str(row.get("resource_id") or ""),
+            role=str(row.get("role") or "member"),
+            label=str(row.get("label")) if row.get("label") is not None else None,
+        )
+
+    def to_dict(self) -> dict[str, str | None]:
+        return {
+            "workspace_id": self.workspace_id,
+            "resource_type": self.resource_type,
+            "resource_id": self.resource_id,
+            "role": self.role,
+            "label": self.label,
+        }
+
+
+@dataclass(frozen=True)
+class WorkspaceEligibilityResult:
+    """Stable eligibility decision returned to API and integration callers."""
+
+    allowed: bool
+    reason_code: WorkspaceEligibilityReasonCode
+    message: str
+    operation: WorkspaceEligibilityOperation
+    operation_category: WorkspaceEligibilityOperationCategory
+    active_workspace_id: str | None
+    resource_type: str
+    resource_id: str
+    global_visibility_preserved: bool = True
+    recovery_actions: list[WorkspaceEligibilityRecoveryAction] = field(default_factory=list)
+    membership: WorkspaceEligibilityMembership | None = None
+    resource_workspace_ids: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "allowed": self.allowed,
+            "reason_code": self.reason_code,
+            "message": self.message,
+            "operation": self.operation,
+            "operation_category": self.operation_category,
+            "active_workspace_id": self.active_workspace_id,
+            "resource_type": self.resource_type,
+            "resource_id": self.resource_id,
+            "global_visibility_preserved": self.global_visibility_preserved,
+            "recovery_actions": [action.to_dict() for action in self.recovery_actions],
+            "membership": self.membership.to_dict() if self.membership is not None else None,
+            "resource_workspace_ids": list(self.resource_workspace_ids),
+        }
+
+
+class WorkspaceEligibilityService:
+    """Resolve whether a resource can be used by an active Workspace operation."""
+
+    def __init__(self, chacha_db: Any) -> None:
+        self.chacha_db = chacha_db
+
+    def check(self, request: WorkspaceEligibilityRequest) -> WorkspaceEligibilityResult:
+        operation_category = self._operation_category(request.operation)
+        if request.permission_state == "denied":
+            return self._deny(
+                request,
+                operation_category,
+                "permission_denied",
+                "The current user is not allowed to access this resource for the requested operation.",
+                self._actions("permission_denied"),
+            )
+
+        if operation_category == "visibility":
+            return WorkspaceEligibilityResult(
+                allowed=True,
+                reason_code="visibility_allowed",
+                message="Global resource visibility is preserved for this operation.",
+                operation=request.operation,
+                operation_category=operation_category,
+                active_workspace_id=request.active_workspace_id,
+                resource_type=request.resource_type,
+                resource_id=request.resource_id,
+                global_visibility_preserved=True,
+            )
+
+        active_workspace_id = self._non_empty_or_none(request.active_workspace_id)
+        if active_workspace_id is None:
+            return self._deny(
+                request,
+                operation_category,
+                "no_active_workspace",
+                "Select or create a workspace before using resources in an active workspace context.",
+                self._actions("no_active_workspace"),
+                active_workspace_id=None,
+            )
+
+        workspace = self.chacha_db.get_workspace(active_workspace_id)
+        if workspace is None:
+            return self._deny(
+                request,
+                operation_category,
+                "workspace_not_found",
+                "The active workspace was not found.",
+                self._actions("workspace_not_found"),
+            )
+        if self._workspace_is_archived(workspace):
+            return self._deny(
+                request,
+                operation_category,
+                "workspace_archived",
+                "Archived workspaces cannot run active workspace operations.",
+                self._actions("workspace_archived"),
+            )
+
+        if request.operation in WORKSPACE_RUNTIME_REQUIRED_OPERATIONS and request.runtime_state != "ready":
+            return self._deny(
+                request,
+                operation_category,
+                "missing_runtime",
+                "The active workspace is missing the runtime required for this operation.",
+                self._actions("missing_runtime"),
+            )
+
+        resource_type = request.resource_type.strip()
+        if resource_type not in WORKSPACE_MEMBERSHIP_RESOURCE_TYPES:
+            return self._deny(
+                request,
+                operation_category,
+                "unsupported_resource_type",
+                "This resource type does not yet have a workspace membership adapter.",
+                self._actions("unsupported_resource_type"),
+                resource_type=resource_type,
+            )
+        resource_id = self._canonical_resource_id(resource_type, request.resource_id)
+
+        membership_row = self.chacha_db.get_workspace_resource_membership(
+            active_workspace_id,
+            resource_type,
+            resource_id,
+            include_deleted=False,
+        )
+        if membership_row is not None:
+            membership = WorkspaceEligibilityMembership.from_row(membership_row)
+            return WorkspaceEligibilityResult(
+                allowed=True,
+                reason_code="allowed",
+                message="The resource is linked to the active workspace.",
+                operation=request.operation,
+                operation_category=operation_category,
+                active_workspace_id=active_workspace_id,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                global_visibility_preserved=True,
+                membership=membership,
+                resource_workspace_ids=[membership.workspace_id],
+            )
+
+        resource_memberships = self._list_resource_workspace_memberships(resource_type, resource_id)
+        resource_workspace_ids = [
+            str(row.get("workspace_id"))
+            for row in resource_memberships
+            if row.get("workspace_id") is not None and str(row.get("workspace_id")) != active_workspace_id
+        ]
+        if resource_workspace_ids:
+            return self._deny(
+                request,
+                operation_category,
+                "cross_workspace_resource",
+                "This resource is linked to a different workspace; copy it or switch workspaces before using it here.",
+                self._actions("cross_workspace_resource"),
+                active_workspace_id=active_workspace_id,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                resource_workspace_ids=resource_workspace_ids,
+            )
+
+        return self._deny(
+            request,
+            operation_category,
+            "resource_not_linked",
+            "Link this resource to the active workspace before using it in an active workspace context.",
+            self._actions("resource_not_linked"),
+            active_workspace_id=active_workspace_id,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            resource_workspace_ids=[],
+        )
+
+    def _list_resource_workspace_memberships(self, resource_type: str, resource_id: str) -> list[Mapping[str, Any]]:
+        rows = self.chacha_db.list_resource_workspace_memberships(
+            resource_type,
+            resource_id,
+            include_deleted=False,
+            limit=100,
+            cursor=None,
+        )
+        return [row for row in rows if isinstance(row, Mapping)]
+
+    @staticmethod
+    def _operation_category(operation: WorkspaceEligibilityOperation) -> WorkspaceEligibilityOperationCategory:
+        if operation in WORKSPACE_VISIBILITY_OPERATIONS:
+            return "visibility"
+        if operation in WORKSPACE_ACTIVE_CONTEXT_OPERATIONS:
+            return "active_context"
+        raise ValueError(f"Unsupported workspace eligibility operation: {operation}")
+
+    @staticmethod
+    def _canonical_resource_id(resource_type: str, resource_id: str) -> str:
+        normalized = str(resource_id).strip()
+        if resource_type in {"media", "workspace_note"}:
+            try:
+                parsed = int(normalized)
+            except (TypeError, ValueError):
+                return normalized
+            if parsed >= 0:
+                return str(parsed)
+        return normalized
+
+    @staticmethod
+    def _workspace_is_archived(workspace: Mapping[str, Any]) -> bool:
+        return workspace.get("archived") in (True, 1, "1", "true", "True")
+
+    @staticmethod
+    def _non_empty_or_none(value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = str(value).strip()
+        return normalized or None
+
+    def _deny(
+        self,
+        request: WorkspaceEligibilityRequest,
+        operation_category: WorkspaceEligibilityOperationCategory,
+        reason_code: WorkspaceEligibilityReasonCode,
+        message: str,
+        recovery_actions: list[WorkspaceEligibilityRecoveryAction],
+        *,
+        active_workspace_id: str | None | object = _UNSET,
+        resource_type: str | None = None,
+        resource_id: str | None = None,
+        resource_workspace_ids: list[str] | None = None,
+    ) -> WorkspaceEligibilityResult:
+        resolved_workspace_id = (
+            request.active_workspace_id
+            if active_workspace_id is _UNSET
+            else cast(str | None, active_workspace_id)
+        )
+        return WorkspaceEligibilityResult(
+            allowed=False,
+            reason_code=reason_code,
+            message=message,
+            operation=request.operation,
+            operation_category=operation_category,
+            active_workspace_id=resolved_workspace_id,
+            resource_type=resource_type if resource_type is not None else request.resource_type,
+            resource_id=resource_id if resource_id is not None else request.resource_id,
+            global_visibility_preserved=True,
+            recovery_actions=recovery_actions,
+            resource_workspace_ids=list(resource_workspace_ids or []),
+        )
+
+    @staticmethod
+    def _actions(reason_code: WorkspaceEligibilityReasonCode) -> list[WorkspaceEligibilityRecoveryAction]:
+        actions: dict[str, list[WorkspaceEligibilityRecoveryAction]] = {
+            "no_active_workspace": [
+                WorkspaceEligibilityRecoveryAction("select_workspace", "Select an active workspace"),
+                WorkspaceEligibilityRecoveryAction("create_workspace", "Create a workspace"),
+            ],
+            "workspace_not_found": [
+                WorkspaceEligibilityRecoveryAction("select_workspace", "Select an available workspace"),
+            ],
+            "workspace_archived": [
+                WorkspaceEligibilityRecoveryAction("select_workspace", "Select an active workspace"),
+                WorkspaceEligibilityRecoveryAction("unarchive_workspace", "Unarchive this workspace"),
+            ],
+            "unsupported_resource_type": [
+                WorkspaceEligibilityRecoveryAction("wait_for_adapter", "Use a supported workspace resource type"),
+            ],
+            "resource_not_linked": [
+                WorkspaceEligibilityRecoveryAction(
+                    "link_to_active_workspace",
+                    "Link this resource to the active workspace",
+                ),
+            ],
+            "cross_workspace_resource": [
+                WorkspaceEligibilityRecoveryAction(
+                    "copy_to_active_workspace",
+                    "Copy or link the resource to the active workspace",
+                ),
+                WorkspaceEligibilityRecoveryAction(
+                    "switch_workspace",
+                    "Switch to a workspace that already contains this resource",
+                ),
+            ],
+            "missing_runtime": [
+                WorkspaceEligibilityRecoveryAction("configure_workspace_runtime", "Configure the workspace runtime"),
+            ],
+            "permission_denied": [
+                WorkspaceEligibilityRecoveryAction("request_access", "Request access or select a permitted workspace"),
+            ],
+            "allowed": [],
+            "visibility_allowed": [],
+        }
+        return list(actions[reason_code])

--- a/tldw_Server_API/tests/Workspaces/test_workspace_eligibility.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_eligibility.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.Workspaces.eligibility import (
+    WorkspaceEligibilityOperation,
+    WorkspaceEligibilityRequest,
+    WorkspaceEligibilityService,
+    WORKSPACE_ACTIVE_CONTEXT_OPERATIONS,
+    WORKSPACE_VISIBILITY_OPERATIONS,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> CharactersRAGDB:
+    database = CharactersRAGDB(
+        db_path=str(tmp_path / "workspace_eligibility.sqlite"),
+        client_id="test-client",
+    )
+    database.upsert_workspace("ws-active", "Active Workspace")
+    database.upsert_workspace("ws-other", "Other Workspace")
+    database.upsert_workspace("ws-archived", "Archived Workspace")
+    database.update_workspace("ws-archived", {"archived": True}, expected_version=1)
+    database.add_workspace_resource_membership(
+        "ws-active",
+        {"resource_type": "chat", "resource_id": "chat-1", "role": "conversation"},
+    )
+    database.add_workspace_resource_membership(
+        "ws-other",
+        {"resource_type": "chat", "resource_id": "chat-other", "role": "conversation"},
+    )
+    return database
+
+
+@pytest.fixture
+def service(db: CharactersRAGDB) -> WorkspaceEligibilityService:
+    return WorkspaceEligibilityService(db)
+
+
+def _request(
+    operation: WorkspaceEligibilityOperation,
+    *,
+    active_workspace_id: str | None = "ws-active",
+    resource_type: str = "chat",
+    resource_id: str = "chat-1",
+    runtime_state: str = "not_required",
+    permission_state: str = "granted",
+) -> WorkspaceEligibilityRequest:
+    return WorkspaceEligibilityRequest(
+        operation=operation,
+        active_workspace_id=active_workspace_id,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        runtime_state=runtime_state,
+        permission_state=permission_state,
+    )
+
+
+def test_operation_matrix_separates_visibility_from_active_context() -> None:
+    assert WORKSPACE_VISIBILITY_OPERATIONS == frozenset({"browse", "search", "open", "edit"})
+    assert WORKSPACE_ACTIVE_CONTEXT_OPERATIONS == frozenset(
+        {
+            "stage",
+            "rag_ground",
+            "prompt_use",
+            "tool_use",
+            "agent_manipulate",
+            "acp_run",
+            "sandbox_operation",
+            "workflow_launch",
+            "watchlist_run",
+        }
+    )
+    assert WORKSPACE_VISIBILITY_OPERATIONS.isdisjoint(WORKSPACE_ACTIVE_CONTEXT_OPERATIONS)
+
+
+@pytest.mark.parametrize("operation", ["browse", "search", "open", "edit"])
+def test_visibility_operations_do_not_require_active_workspace(
+    service: WorkspaceEligibilityService,
+    operation: WorkspaceEligibilityOperation,
+) -> None:
+    result = service.check(
+        _request(
+            operation,
+            active_workspace_id=None,
+            resource_type="prompt",
+            resource_id="prompt-1",
+        )
+    )
+
+    assert result.allowed is True
+    assert result.operation_category == "visibility"
+    assert result.reason_code == "visibility_allowed"
+    assert result.global_visibility_preserved is True
+    assert result.recovery_actions == []
+
+
+def test_permission_denial_applies_before_visibility_allowance(
+    service: WorkspaceEligibilityService,
+) -> None:
+    result = service.check(
+        _request(
+            "open",
+            active_workspace_id=None,
+            resource_type="chat",
+            resource_id="chat-1",
+            permission_state="denied",
+        )
+    )
+
+    assert result.allowed is False
+    assert result.reason_code == "permission_denied"
+    assert result.operation_category == "visibility"
+    assert result.global_visibility_preserved is True
+
+
+def test_active_operation_requires_active_workspace(service: WorkspaceEligibilityService) -> None:
+    result = service.check(_request("stage", active_workspace_id=None))
+
+    assert result.allowed is False
+    assert result.reason_code == "no_active_workspace"
+    assert result.operation_category == "active_context"
+    assert {action.action for action in result.recovery_actions} == {"select_workspace", "create_workspace"}
+
+
+def test_active_operation_rejects_archived_workspace(service: WorkspaceEligibilityService) -> None:
+    result = service.check(_request("rag_ground", active_workspace_id="ws-archived"))
+
+    assert result.allowed is False
+    assert result.reason_code == "workspace_archived"
+    assert {action.action for action in result.recovery_actions} == {"select_workspace", "unarchive_workspace"}
+
+
+def test_active_operation_rejects_nonexistent_workspace(service: WorkspaceEligibilityService) -> None:
+    result = service.check(_request("stage", active_workspace_id="ws-nonexistent"))
+
+    assert result.allowed is False
+    assert result.reason_code == "workspace_not_found"
+    assert {action.action for action in result.recovery_actions} == {"select_workspace"}
+
+
+def test_active_operation_allows_resource_linked_to_active_workspace(
+    service: WorkspaceEligibilityService,
+) -> None:
+    result = service.check(_request("rag_ground"))
+
+    assert result.allowed is True
+    assert result.reason_code == "allowed"
+    assert result.operation_category == "active_context"
+    assert result.membership is not None
+    assert result.membership.workspace_id == "ws-active"
+    assert result.resource_workspace_ids == ["ws-active"]
+
+
+def test_active_operation_rejects_resource_linked_to_other_workspace(
+    service: WorkspaceEligibilityService,
+) -> None:
+    result = service.check(_request("rag_ground", resource_id="chat-other"))
+
+    assert result.allowed is False
+    assert result.reason_code == "cross_workspace_resource"
+    assert result.resource_workspace_ids == ["ws-other"]
+    assert {action.action for action in result.recovery_actions} == {"copy_to_active_workspace", "switch_workspace"}
+
+
+def test_active_operation_rejects_unlinked_resource(service: WorkspaceEligibilityService) -> None:
+    result = service.check(_request("rag_ground", resource_id="chat-missing"))
+
+    assert result.allowed is False
+    assert result.reason_code == "resource_not_linked"
+    assert result.resource_workspace_ids == []
+    assert {action.action for action in result.recovery_actions} == {"link_to_active_workspace"}
+
+
+def test_active_operation_rejects_unsupported_resource_type(
+    service: WorkspaceEligibilityService,
+) -> None:
+    result = service.check(
+        _request(
+            "acp_run",
+            resource_type=" acp_session ",
+            resource_id="session-1",
+            runtime_state="ready",
+        )
+    )
+
+    assert result.allowed is False
+    assert result.reason_code == "unsupported_resource_type"
+    assert result.resource_type == "acp_session"
+    assert {action.action for action in result.recovery_actions} == {"wait_for_adapter"}
+
+
+def test_runtime_required_operations_require_ready_runtime(
+    service: WorkspaceEligibilityService,
+) -> None:
+    result = service.check(_request("acp_run", runtime_state="not_required"))
+
+    assert result.allowed is False
+    assert result.reason_code == "missing_runtime"
+    assert {action.action for action in result.recovery_actions} == {"configure_workspace_runtime"}
+
+
+def test_permission_denial_applies_before_active_context_membership(
+    service: WorkspaceEligibilityService,
+) -> None:
+    result = service.check(_request("rag_ground", permission_state="denied"))
+
+    assert result.allowed is False
+    assert result.reason_code == "permission_denied"
+    assert result.resource_workspace_ids == []

--- a/tldw_Server_API/tests/Workspaces/test_workspace_eligibility_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_eligibility_api.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import try_get_media_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user
+from tldw_Server_API.app.api.v1.endpoints import workspace_eligibility as workspace_eligibility_endpoint
+from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import WORKSPACES_READ_RATE_LIMIT
+
+
+class FakeEligibilityDB:
+    def __init__(self) -> None:
+        self.workspaces: dict[str, dict[str, object]] = {
+            "workspace-1": {"id": "workspace-1", "archived": False},
+            "workspace-2": {"id": "workspace-2", "archived": False},
+            "workspace-archived": {"id": "workspace-archived", "archived": True},
+        }
+        self.memberships: dict[tuple[str, str, str], dict[str, object]] = {
+            ("workspace-1", "chat", "chat-1"): {
+                "workspace_id": "workspace-1",
+                "resource_type": "chat",
+                "resource_id": "chat-1",
+                "role": "conversation",
+                "label": None,
+                "transfer_policy": "link",
+                "provenance": {},
+                "metadata": {},
+                "created_at": "2026-06-17T12:00:00Z",
+                "updated_at": "2026-06-17T12:00:00Z",
+                "version": 1,
+                "deleted": False,
+            },
+            ("workspace-2", "chat", "chat-2"): {
+                "workspace_id": "workspace-2",
+                "resource_type": "chat",
+                "resource_id": "chat-2",
+                "role": "conversation",
+                "label": None,
+                "transfer_policy": "link",
+                "provenance": {},
+                "metadata": {},
+                "created_at": "2026-06-17T12:01:00Z",
+                "updated_at": "2026-06-17T12:01:00Z",
+                "version": 1,
+                "deleted": False,
+            },
+        }
+
+    def get_workspace(self, workspace_id: str) -> dict[str, object] | None:
+        return self.workspaces.get(workspace_id)
+
+    def get_workspace_resource_membership(
+        self,
+        workspace_id: str,
+        resource_type: str,
+        resource_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, object] | None:
+        row = self.memberships.get((workspace_id, resource_type, resource_id))
+        if row is None or (row.get("deleted") and not include_deleted):
+            return None
+        return dict(row)
+
+    def list_resource_workspace_memberships(
+        self,
+        resource_type: str,
+        resource_id: str,
+        *,
+        include_deleted: bool = False,
+        limit: int = 100,
+        cursor: tuple[str, str] | None = None,
+    ) -> list[dict[str, object]]:
+        _ = cursor
+        rows = [
+            row
+            for (_, row_resource_type, row_resource_id), row in self.memberships.items()
+            if row_resource_type == resource_type
+            and row_resource_id == resource_id
+            and (include_deleted or not row.get("deleted"))
+        ]
+        rows.sort(key=lambda row: (str(row["updated_at"]), str(row["workspace_id"])), reverse=True)
+        return [dict(row) for row in rows[:limit]]
+
+
+@pytest.fixture
+def db() -> FakeEligibilityDB:
+    return FakeEligibilityDB()
+
+
+@pytest.fixture
+def client(db: FakeEligibilityDB) -> TestClient:
+    app = FastAPI()
+    app.include_router(workspace_eligibility_endpoint.router, prefix="/api/v1/workspace-eligibility")
+
+    async def _allow_rate_limit() -> None:
+        return None
+
+    app.dependency_overrides[get_request_user] = lambda: SimpleNamespace(id="user-1")
+    app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    app.dependency_overrides[try_get_media_db_for_user] = lambda: None
+    app.dependency_overrides[WORKSPACES_READ_RATE_LIMIT] = _allow_rate_limit
+    with TestClient(app, raise_server_exceptions=False) as test_client:
+        yield test_client
+
+
+def _payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "active_workspace_id": "workspace-1",
+        "resource_type": "chat",
+        "resource_id": "chat-1",
+        "operation": "rag_ground",
+        "runtime_state": "not_required",
+        "permission_state": "granted",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_post_check_allows_visibility_without_active_workspace(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/workspace-eligibility/check",
+        json=_payload(
+            active_workspace_id=None,
+            resource_type="prompt",
+            resource_id="prompt-1",
+            operation="open",
+        ),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["allowed"] is True
+    assert body["operation_category"] == "visibility"
+    assert body["reason_code"] == "visibility_allowed"
+    assert body["global_visibility_preserved"] is True
+
+
+def test_post_check_allows_active_operation_for_linked_resource(client: TestClient) -> None:
+    response = client.post("/api/v1/workspace-eligibility/check", json=_payload())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["allowed"] is True
+    assert body["reason_code"] == "allowed"
+    assert body["membership"]["workspace_id"] == "workspace-1"
+
+
+def test_post_check_denies_cross_workspace_resource(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/workspace-eligibility/check",
+        json=_payload(resource_id="chat-2"),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["allowed"] is False
+    assert body["reason_code"] == "cross_workspace_resource"
+    assert body["resource_workspace_ids"] == ["workspace-2"]
+    assert {action["action"] for action in body["recovery_actions"]} == {
+        "copy_to_active_workspace",
+        "switch_workspace",
+    }
+
+
+def test_post_check_denies_missing_runtime(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/workspace-eligibility/check",
+        json=_payload(operation="acp_run", runtime_state="not_required"),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["allowed"] is False
+    assert body["reason_code"] == "missing_runtime"
+    assert body["recovery_actions"][0]["action"] == "configure_workspace_runtime"
+
+
+def test_post_check_requires_explicit_runtime_and_permission_state(client: TestClient) -> None:
+    payload = _payload()
+    payload.pop("runtime_state")
+    payload.pop("permission_state")
+
+    response = client.post("/api/v1/workspace-eligibility/check", json=payload)
+
+    assert response.status_code == 422
+    missing_fields = {error["loc"][-1] for error in response.json()["detail"]}
+    assert {"runtime_state", "permission_state"} <= missing_fields


### PR DESCRIPTION
## Summary
- Adds a shared Workspace active-context eligibility service for #1992 with explicit visibility vs active-context operation sets, stable denial reason codes, and recovery actions.
- Exposes `POST /api/v1/workspace-eligibility/check` and registers it in the normal and minimal router groups.
- Documents the contract in the Workspace README and adds focused unit/API coverage.

Part of #1984. Closes #1992. Follow-up adapters remain tracked in #2378.

## Verification
- `python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_eligibility.py tldw_Server_API/tests/Workspaces/test_workspace_eligibility_api.py tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py tldw_Server_API/tests/Workspaces/test_workspace_migration_api.py tldw_Server_API/tests/Workspaces/test_workspaces_api.py::TestWorkspaceLifecycle tldw_Server_API/tests/ChaChaNotesDB/test_workspace_resource_memberships_db.py -q` (161 passed)
- `python -m bandit -r tldw_Server_API/app/core/Workspaces/eligibility.py tldw_Server_API/app/api/v1/endpoints/workspace_eligibility.py tldw_Server_API/app/api/v1/schemas/workspace_schemas.py tldw_Server_API/app/api/v1/router_groups/content.py tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_workspace_eligibility_phase2.json` (results=0)

## AI-generated PR change summary gate
This PR materially includes AI-authored changes. Per project policy, the human requester still needs to add a human-written Change summary explaining what changed and why before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared Workspace active-context eligibility contract and `POST /api/v1/workspace-eligibility/check` to tell clients if a resource can be used in the selected workspace, with stable reason codes and recovery actions. Preserves global browse/search/open/edit visibility while gating active-context operations; implements requirements from #1992 (part of #1984).

- **New Features**
  - Introduces `eligibility.py` to separate visibility vs active-context ops and enforce runtime-required gates and permission checks.
  - Covers active operations: `stage`, `rag_ground`, `prompt_use`, `tool_use`, `agent_manipulate`, `acp_run`, `sandbox_operation`, `workflow_launch`, `watchlist_run`.
  - Adds `POST /api/v1/workspace-eligibility/check` with request/response schemas; registered in content and minimal router groups.
  - Requires explicit `runtime_state` and `permission_state`; runtime-bound ops fail closed unless `runtime_state="ready"`.
  - Returns stable reason codes, `operation_category`, and recovery actions; includes optional `membership` and `resource_workspace_ids` to guide next steps.

<sup>Written for commit d9cbe91c8e79b20e85737b74efa82ac0b6f6f9e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

