### PR TITLE
Add configurable MCP tool-call hook manager

### DIFF
--- a/Docs/superpowers/plans/2026-06-17-mcp-configurable-tool-call-hooks-plan.md
+++ b/Docs/superpowers/plans/2026-06-17-mcp-configurable-tool-call-hooks-plan.md
@@ -1,0 +1,56 @@
+# MCP Configurable Tool-Call Hooks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a host-neutral, configurable MCP tool-call hook manager that makes the existing hook seam usable without changing default runtime behavior.
+
+**Architecture:** Keep hook contracts in `mcp_unified.interfaces.runtime` and add concrete manager/config primitives under a new `mcp_unified.tool_hooks` package. The protocol remains the enforcement point; the concrete manager only orders hooks, normalizes results, captures safe hook metadata, and optionally records metadata-only hook events.
+
+**Tech Stack:** Python dataclasses/protocols, existing MCP runtime dependency injection, existing tool-use reporting models, pytest.
+
+---
+
+## Stage 1: Hook Manager Package
+**Goal**: Provide concrete host-neutral hook registration and deterministic execution.
+**Success Criteria**: A configured manager can run ordered pre/post hooks, return the first blocking pre-hook decision, and never require tldw_server imports.
+**Tests**: Unit tests for no hooks, ordering, deny/ask precedence, disabled hooks, and post-hook suppression.
+**Status**: Complete
+
+- [ ] Add failing tests in `tldw_Server_API/app/core/MCP_unified/tests/test_tool_hook_manager.py`.
+- [ ] Create `mcp_unified/tool_hooks/models.py` for hook configs, callback protocols, and safe metadata result models.
+- [ ] Create `mcp_unified/tool_hooks/manager.py` for `ConfiguredToolCallHookManager`.
+- [ ] Export the package from `mcp_unified/tool_hooks/__init__.py`.
+- [ ] Run focused tests and keep the existing protocol hook tests green.
+
+## Stage 2: Reporting Metadata Contract
+**Goal**: Surface hook decisions/failures in metadata-only reporting without leaking tool arguments or raw exception messages.
+**Success Criteria**: Tool-use events can carry bounded hook metadata, and protocol events attach the hook summary when available.
+**Tests**: Model validation tests plus protocol/tool-use tests for hook-denied and hook-post-failure summaries.
+**Status**: Complete
+
+- [ ] Add failing model tests for bounded hook decision metadata.
+- [ ] Extend `mcp_unified/tool_use_reporting/models.py` with safe hook metadata fields.
+- [ ] Update protocol event construction to read hook summaries from request metadata.
+- [ ] Run reporting and protocol hook tests.
+
+## Stage 3: Runtime Injection And Defaults
+**Goal**: Let embedders opt into the configured manager while preserving no-op defaults.
+**Success Criteria**: `MCPRuntimeDependencies` defaults remain no-op, and package callers can build a configured manager directly.
+**Tests**: Extraction contract tests and manager tests verify default no-op behavior and explicit injection behavior.
+**Status**: Complete
+
+- [ ] Add tests proving default runtime dependencies still use `NoopToolCallHookManager`.
+- [ ] Add tests proving `MCPProtocol` accepts the configured manager via dependencies.
+- [ ] Keep tldw default dependency builder unchanged unless tests reveal a required package-level hook config.
+
+## Stage 4: Docs And Verification
+**Goal**: Document the new package-level hook manager and complete validation.
+**Success Criteria**: User guide explains how to configure hooks, failure behavior, ordering, and reporting metadata.
+**Tests**: Focused pytest suite and Bandit on touched Python paths.
+**Status**: Complete
+
+- [ ] Update `mcp_unified/USER_GUIDE.md` with the hook manager integration.
+- [ ] Update `mcp_unified/README.md` if the package API surface needs a short mention.
+- [ ] Run focused pytest commands.
+- [ ] Run Bandit on touched Python package/test files.
+- [ ] Update `TASK-2379` with verification and final summary.

--- a/backlog/tasks/task-2379 - Implement-MCP-configurable-tool-call-hook-manager-integration.md
+++ b/backlog/tasks/task-2379 - Implement-MCP-configurable-tool-call-hook-manager-integration.md
@@ -31,12 +31,12 @@ Add the first implementation slice after the MCP tool-call hook seam: a configur
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Runtime can be constructed with a concrete hook manager/registry without requiring host-specific code.
-- [ ] #2 Configured hooks execute in deterministic order for pre and post tool-call phases.
-- [ ] #3 Pre-hook failures fail closed with governance errors and do not execute the tool.
-- [ ] #4 Post-hook failures are observed/audited without changing the original tool result or error.
-- [ ] #5 Hook decisions and failures surface in existing tool-call audit/reporting metadata without logging sensitive payloads.
-- [ ] #6 Focused tests cover default no-op behavior, ordering, deny/failure handling, and post-hook non-interference.
+- [x] #1 Runtime can be constructed with a concrete hook manager/registry without requiring host-specific code.
+- [x] #2 Configured hooks execute in deterministic order for pre and post tool-call phases.
+- [x] #3 Pre-hook failures fail closed with governance errors and do not execute the tool.
+- [x] #4 Post-hook failures are observed/audited without changing the original tool result or error.
+- [x] #5 Hook decisions and failures surface in existing tool-call audit/reporting metadata without logging sensitive payloads.
+- [x] #6 Focused tests cover default no-op behavior, ordering, deny/failure handling, and post-hook non-interference.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -54,15 +54,15 @@ Docs/superpowers/plans/2026-06-17-mcp-configurable-tool-call-hooks-plan.md
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented a package-level configurable MCP tool-call hook manager with ordered pre/post registrations, first-blocking pre-hook behavior, pre-hook fail-closed errors, and post-hook failure continuation. Added metadata-only hook result rows to tool-use reporting and wired protocol hook decisions/failures into tool-use events without raw hook messages, callback metadata, tool arguments, or absolute paths. Updated package docs and manifest entries for the new hook package and reporting package. Validation after rebasing onto latest origin/dev: 212 focused MCP package/reporting/protocol tests passed; production Bandit passed with zero findings; full touched-scope Bandit only reported pytest B101 assert warnings; wheel build succeeded with a pre-existing setuptools license deprecation warning.
+Implemented a package-level configurable MCP tool-call hook manager with ordered pre/post registrations, first-blocking pre-hook behavior, pre-hook fail-closed errors, and post-hook failure continuation. Added metadata-only hook result rows to tool-use reporting and wired protocol hook decisions/failures into tool-use events without raw hook messages, callback metadata, tool arguments, or absolute paths. Review remediation added fail-closed normalization for malformed hook actions, authoritative manager hook provenance, hook_order on pre-hook execution failures, empty-phase registration rejection, approval_required-to-ask reporting normalization, and per-event hook result consumption. The Qodo exception-centralization suggestion was skipped because this is a standalone mcp_unified package exception and moving it into tldw_Server_API.app.core would break the package boundary; existing mcp_unified modules already use package-local exceptions. Validation after rebasing onto latest origin/dev: 245 focused MCP package/reporting/protocol tests passed; Ruff passed on modified Python files; production Bandit passed with zero findings; wheel build succeeded with a pre-existing setuptools license deprecation warning.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2379 - Implement-MCP-configurable-tool-call-hook-manager-integration.md
+++ b/backlog/tasks/task-2379 - Implement-MCP-configurable-tool-call-hook-manager-integration.md
@@ -1,0 +1,68 @@
+---
+id: TASK-2379
+title: Implement MCP configurable tool-call hook manager integration
+status: Done
+labels:
+- mcp
+- gateway
+- hooks
+priority: medium
+modified_files:
+- mcp_unified/tool_hooks/__init__.py
+- mcp_unified/tool_hooks/manager.py
+- mcp_unified/tool_hooks/models.py
+- mcp_unified/tool_use_reporting/models.py
+- mcp_unified/tool_use_reporting/__init__.py
+- mcp_unified/pyproject.toml
+- tldw_Server_API/app/core/MCP_unified/protocol.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_tool_hook_manager.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_models.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py
+- mcp_unified/README.md
+- mcp_unified/USER_GUIDE.md
+- Docs/superpowers/plans/2026-06-17-mcp-configurable-tool-call-hooks-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the first implementation slice after the MCP tool-call hook seam: a configurable/runtime hook manager that can register ordered pre/post hooks, preserve fail-closed governance semantics, expose decisions to audit/reporting, and remain host-neutral for standalone gateway use.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Runtime can be constructed with a concrete hook manager/registry without requiring host-specific code.
+- [ ] #2 Configured hooks execute in deterministic order for pre and post tool-call phases.
+- [ ] #3 Pre-hook failures fail closed with governance errors and do not execute the tool.
+- [ ] #4 Post-hook failures are observed/audited without changing the original tool result or error.
+- [ ] #5 Hook decisions and failures surface in existing tool-call audit/reporting metadata without logging sensitive payloads.
+- [ ] #6 Focused tests cover default no-op behavior, ordering, deny/failure handling, and post-hook non-interference.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-17-mcp-configurable-tool-call-hooks-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented a package-level configurable MCP tool-call hook manager with ordered pre/post registrations, first-blocking pre-hook behavior, pre-hook fail-closed errors, and post-hook failure continuation. Added metadata-only hook result rows to tool-use reporting and wired protocol hook decisions/failures into tool-use events without raw hook messages, callback metadata, tool arguments, or absolute paths. Updated package docs and manifest entries for the new hook package and reporting package. Validation after rebasing onto latest origin/dev: 212 focused MCP package/reporting/protocol tests passed; production Bandit passed with zero findings; full touched-scope Bandit only reported pytest B101 assert warnings; wheel build succeeded with a pre-existing setuptools license deprecation warning.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/mcp_unified/README.md
+++ b/mcp_unified/README.md
@@ -23,6 +23,8 @@ surface for early standalone gateway work.
   helpers.
 - Metadata-only tool-use reporting for aggregate profile, model, tool, and
   prompt-version analysis.
+- Configurable package-level tool-call hook manager primitives for embedders
+  that need ordered pre/post policy, approval, or audit hooks.
 - Package-local filesystem advisory lock backends for coordinating
   read-before-mutate workflows. The memory backend is the default.
   An optional SQLite backend can coordinate cooperating processes that point at
@@ -198,6 +200,38 @@ store for CLI reporting, export, and cleanup commands.
 
 See [USER_GUIDE.md](USER_GUIDE.md) for report, export, cleanup, privacy, and
 future evaluation workflow details.
+
+## Tool-Call Hooks
+
+The package includes a host-neutral `ConfiguredToolCallHookManager` for
+embedding pre/post tool-call hooks through `MCPRuntimeDependencies`. Pre-hooks
+run in configured order and stop at the first `deny`, `ask`, or
+`approval_required` decision. Post-hooks run after tool completion and continue
+after individual post-hook failures so the original tool result or error is
+preserved.
+
+```python
+from mcp_unified.tool_hooks import (
+    ConfiguredToolCallHookManager,
+    ToolHookRegistration,
+)
+
+hook_manager = ConfiguredToolCallHookManager(
+    [
+        ToolHookRegistration(
+            hook_id="profile-policy",
+            before=check_profile_policy,
+            after=record_profile_observation,
+            order=10,
+        )
+    ]
+)
+```
+
+Hook summaries are metadata-only and can be attached to tool-use reporting
+events when reporting is enabled. Gateway JSON/admin configuration for hook
+registries is intentionally left to a later surface; this slice provides the
+package API and protocol/reporting integration.
 
 ## Documentation
 

--- a/mcp_unified/USER_GUIDE.md
+++ b/mcp_unified/USER_GUIDE.md
@@ -681,18 +681,63 @@ Each event is one attempted MCP tool call. The stored metadata can include:
   and action family.
 - Grant, approval, installation, runtime availability, path-filter, truncation,
   idempotency replay, and nested-call indicators.
+- Bounded tool-call hook summaries: phase, hook id, hook order, action, status,
+  sanitized reason code, and sanitized error type.
 - UTC timestamp and integer epoch microseconds for stable ordering.
 
 This lets operators compare, for example, whether one profile mode has a higher
 tool-call success rate, whether a model is repeatedly denied a tool, or whether
 a new tool prompt version changes latency or reason-code distribution.
 
+### Package-Level Tool-Call Hooks
+
+Embedders can provide ordered pre/post hooks by constructing a
+`ConfiguredToolCallHookManager` and passing it through `MCPRuntimeDependencies`
+as `tool_call_hook_manager`.
+
+```python
+from mcp_unified.tool_hooks import (
+    ConfiguredToolCallHookManager,
+    ToolHookRegistration,
+)
+
+hook_manager = ConfiguredToolCallHookManager(
+    [
+        ToolHookRegistration(
+            hook_id="profile-policy",
+            before=check_profile_policy,
+            after=record_profile_observation,
+            order=10,
+        ),
+        ToolHookRegistration(
+            hook_id="approval-gate",
+            before=request_approval_if_needed,
+            phases=("pre",),
+            order=20,
+        ),
+    ]
+)
+```
+
+Pre-hooks run in ascending `order` and then by `hook_id`. The first pre-hook
+decision with `deny`, `ask`, or `approval_required` stops evaluation and is
+enforced by the protocol. If a pre-hook raises, the protocol fails closed and
+the tool is not executed. Post-hooks run after success or failure; individual
+post-hook failures are recorded as hook metadata and do not suppress the
+original tool result or error.
+
+Hook reporting is metadata-only. Stored events do not include hook messages,
+raw callback metadata, tool arguments, result payloads, raw exception messages,
+or absolute paths. Gateway JSON/admin configuration for hook registries is a
+future surface; this slice exposes the package API for hosts and tests.
+
 ### What Reporting Does Not Capture
 
 The metadata-only recorder does not capture tool arguments, tool result payloads,
-secret values, raw exception text, conversation messages, files, screenshots, or
-browser/page contents. The `capture_ref` field is only a future-safe reference
-slot; this slice does not create or store raw captures.
+secret values, raw exception text, hook messages, raw hook metadata,
+conversation messages, files, screenshots, or browser/page contents. The
+`capture_ref` field is only a future-safe reference slot; this slice does not
+create or store raw captures.
 
 ### Privacy, Retention, And Evaluations
 

--- a/mcp_unified/pyproject.toml
+++ b/mcp_unified/pyproject.toml
@@ -61,6 +61,8 @@ packages = [
   "mcp_unified.interfaces",
   "mcp_unified.profiles",
   "mcp_unified.storage",
+  "mcp_unified.tool_hooks",
+  "mcp_unified.tool_use_reporting",
 ]
 
 [tool.setuptools.package-dir]
@@ -71,6 +73,8 @@ mcp_unified = "."
 "mcp_unified.interfaces" = "interfaces"
 "mcp_unified.profiles" = "profiles"
 "mcp_unified.storage" = "storage"
+"mcp_unified.tool_hooks" = "tool_hooks"
+"mcp_unified.tool_use_reporting" = "tool_use_reporting"
 
 [tool.setuptools.package-data]
 mcp_unified = ["py.typed", "README.md", "USER_GUIDE.md"]

--- a/mcp_unified/tool_hooks/__init__.py
+++ b/mcp_unified/tool_hooks/__init__.py
@@ -1,0 +1,17 @@
+"""Configurable MCP tool-call hook manager primitives."""
+
+from .manager import ConfiguredToolCallHookManager
+from .models import (
+    ToolHookCallback,
+    ToolHookExecutionError,
+    ToolHookRegistration,
+    ToolHookResult,
+)
+
+__all__ = [
+    "ConfiguredToolCallHookManager",
+    "ToolHookCallback",
+    "ToolHookExecutionError",
+    "ToolHookRegistration",
+    "ToolHookResult",
+]

--- a/mcp_unified/tool_hooks/manager.py
+++ b/mcp_unified/tool_hooks/manager.py
@@ -61,6 +61,7 @@ class ConfiguredToolCallHookManager:
             except Exception as exc:
                 raise ToolHookExecutionError(
                     hook_id=registration.hook_id,
+                    hook_order=registration.order,
                     phase="pre",
                     error_type=exc.__class__.__name__,
                 ) from exc
@@ -98,7 +99,7 @@ class ConfiguredToolCallHookManager:
                 raw_decision = await _maybe_await(callback(context))
             except asyncio.CancelledError:
                 raise
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001 - post hooks must not suppress tool outcomes.
                 logger.warning(
                     "MCP post-tool hook failed; continuing. hook_id={} error_type={}",
                     registration.hook_id,
@@ -163,7 +164,9 @@ async def _maybe_await(value: ToolHookResult | Any) -> ToolHookResult:
 def _normalized_action(action: Any) -> ToolHookAction:
     """Return a supported hook action, defaulting invalid values to deny."""
 
-    normalized = str(action or "allow").strip().lower()
+    if not action:
+        return "deny"
+    normalized = str(action).strip().lower()
     if normalized in _VALID_HOOK_ACTIONS:
         return cast(ToolHookAction, normalized)
     return "deny"
@@ -173,7 +176,12 @@ def _coerce_decision(decision: ToolHookResult) -> ToolHookDecision:
     """Normalize callback return values into a typed decision."""
 
     if isinstance(decision, ToolHookDecision):
-        return decision
+        return ToolHookDecision(
+            action=_normalized_action(decision.action),
+            reason_code=decision.reason_code,
+            message=decision.message,
+            metadata=dict(decision.metadata) if isinstance(decision.metadata, dict) else {},
+        )
     if decision is None:
         return ToolHookDecision(action="allow")
     if isinstance(decision, dict):
@@ -203,14 +211,14 @@ def _hook_result_payload(
 ) -> dict[str, Any]:
     """Return safe metadata for one hook result."""
 
-    action = _normalized_action(decision.action)
-    status = "ask" if action == "approval_required" else action
+    normalized_action = _normalized_action(decision.action)
+    action = "ask" if normalized_action == "approval_required" else normalized_action
     payload: dict[str, Any] = {
         "phase": phase,
         "hook_id": registration.hook_id,
         "hook_order": registration.order,
         "action": action,
-        "status": status,
+        "status": action,
     }
     if decision.reason_code:
         payload["reason_code"] = str(decision.reason_code)
@@ -245,11 +253,11 @@ def _decision_with_manager_metadata(
     """Attach manager provenance to a blocking pre-hook decision."""
 
     metadata = dict(decision.metadata) if isinstance(decision.metadata, dict) else {}
-    metadata.setdefault("hook_id", registration.hook_id)
-    metadata.setdefault("hook_order", registration.order)
+    metadata["hook_id"] = registration.hook_id
+    metadata["hook_order"] = registration.order
     metadata["hook_results"] = list(results)
     return ToolHookDecision(
-        action=decision.action,
+        action=_normalized_action(decision.action),
         reason_code=decision.reason_code,
         message=decision.message,
         metadata=metadata,

--- a/mcp_unified/tool_hooks/manager.py
+++ b/mcp_unified/tool_hooks/manager.py
@@ -1,0 +1,259 @@
+"""Configurable host-neutral MCP tool-call hook manager."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Iterable
+from typing import Any, cast
+
+from loguru import logger
+
+from mcp_unified.interfaces.runtime import (
+    ToolHookAction,
+    ToolHookCallContext,
+    ToolHookDecision,
+    ToolHookPhase,
+)
+
+from .models import (
+    ToolHookCallback,
+    ToolHookExecutionError,
+    ToolHookRegistration,
+    ToolHookResult,
+)
+
+_VALID_HOOK_ACTIONS = {"allow", "deny", "ask", "approval_required"}
+
+
+class ConfiguredToolCallHookManager:
+    """Run ordered tool-call hooks with protocol-compatible decisions."""
+
+    def __init__(self, registrations: Iterable[ToolHookRegistration] = ()) -> None:
+        self._registrations = tuple(
+            sorted(
+                registrations,
+                key=lambda registration: (registration.order, registration.hook_id),
+            )
+        )
+
+    @property
+    def registrations(self) -> tuple[ToolHookRegistration, ...]:
+        """Return configured registrations in execution order."""
+
+        return self._registrations
+
+    async def before_tool_call(
+        self,
+        context: ToolHookCallContext,
+    ) -> ToolHookDecision | None:
+        """Run pre-tool hooks and return the first blocking decision."""
+
+        results: list[dict[str, Any]] = []
+        for registration in self._iter_phase("pre"):
+            callback = self._before_callback(registration)
+            if callback is None:
+                continue
+            try:
+                raw_decision = await _maybe_await(callback(context))
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                raise ToolHookExecutionError(
+                    hook_id=registration.hook_id,
+                    phase="pre",
+                    error_type=exc.__class__.__name__,
+                ) from exc
+
+            decision = _coerce_decision(raw_decision)
+            result = _hook_result_payload(
+                decision,
+                registration=registration,
+                phase="pre",
+            )
+            results.append(result)
+            if _normalized_action(decision.action) != "allow":
+                return _decision_with_manager_metadata(
+                    decision,
+                    registration=registration,
+                    results=results,
+                )
+
+        if results:
+            return ToolHookDecision(action="allow", metadata={"hook_results": results})
+        return None
+
+    async def after_tool_call(
+        self,
+        context: ToolHookCallContext,
+    ) -> ToolHookDecision | None:
+        """Run post-tool hooks while preserving the original tool outcome."""
+
+        results: list[dict[str, Any]] = []
+        for registration in self._iter_phase("post"):
+            callback = self._after_callback(registration)
+            if callback is None:
+                continue
+            try:
+                raw_decision = await _maybe_await(callback(context))
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning(
+                    "MCP post-tool hook failed; continuing. hook_id={} error_type={}",
+                    registration.hook_id,
+                    exc.__class__.__name__,
+                )
+                results.append(
+                    _hook_error_payload(
+                        registration=registration,
+                        phase="post",
+                        error_type=exc.__class__.__name__,
+                    )
+                )
+                continue
+
+            decision = _coerce_decision(raw_decision)
+            results.append(
+                _hook_result_payload(
+                    decision,
+                    registration=registration,
+                    phase="post",
+                )
+            )
+
+        if results:
+            return ToolHookDecision(action="allow", metadata={"hook_results": results})
+        return None
+
+    def _iter_phase(self, phase: ToolHookPhase) -> Iterable[ToolHookRegistration]:
+        """Yield enabled registrations that apply to one phase."""
+
+        for registration in self._registrations:
+            if registration.enabled and phase in registration.phases:
+                yield registration
+
+    @staticmethod
+    def _before_callback(registration: ToolHookRegistration) -> ToolHookCallback | None:
+        """Return the callback for a pre-hook registration."""
+
+        if registration.before is not None:
+            return registration.before
+        before = getattr(registration.hook, "before_tool_call", None)
+        return cast(ToolHookCallback | None, before) if callable(before) else None
+
+    @staticmethod
+    def _after_callback(registration: ToolHookRegistration) -> ToolHookCallback | None:
+        """Return the callback for a post-hook registration."""
+
+        if registration.after is not None:
+            return registration.after
+        after = getattr(registration.hook, "after_tool_call", None)
+        return cast(ToolHookCallback | None, after) if callable(after) else None
+
+
+async def _maybe_await(value: ToolHookResult | Any) -> ToolHookResult:
+    """Await callback results when a hook returned an awaitable."""
+
+    if inspect.isawaitable(value):
+        return await value
+    return cast(ToolHookResult, value)
+
+
+def _normalized_action(action: Any) -> ToolHookAction:
+    """Return a supported hook action, defaulting invalid values to deny."""
+
+    normalized = str(action or "allow").strip().lower()
+    if normalized in _VALID_HOOK_ACTIONS:
+        return cast(ToolHookAction, normalized)
+    return "deny"
+
+
+def _coerce_decision(decision: ToolHookResult) -> ToolHookDecision:
+    """Normalize callback return values into a typed decision."""
+
+    if isinstance(decision, ToolHookDecision):
+        return decision
+    if decision is None:
+        return ToolHookDecision(action="allow")
+    if isinstance(decision, dict):
+        metadata = decision.get("metadata")
+        action = _normalized_action(decision.get("action") or decision.get("status"))
+        return ToolHookDecision(
+            action=action,
+            reason_code=(
+                str(decision.get("reason_code"))
+                if decision.get("reason_code") is not None
+                else None
+            ),
+            message=str(decision.get("message")) if decision.get("message") is not None else None,
+            metadata=dict(metadata) if isinstance(metadata, dict) else {},
+        )
+    return ToolHookDecision(
+        action="deny",
+        reason_code="invalid_tool_hook_decision",
+    )
+
+
+def _hook_result_payload(
+    decision: ToolHookDecision,
+    *,
+    registration: ToolHookRegistration,
+    phase: ToolHookPhase,
+) -> dict[str, Any]:
+    """Return safe metadata for one hook result."""
+
+    action = _normalized_action(decision.action)
+    status = "ask" if action == "approval_required" else action
+    payload: dict[str, Any] = {
+        "phase": phase,
+        "hook_id": registration.hook_id,
+        "hook_order": registration.order,
+        "action": action,
+        "status": status,
+    }
+    if decision.reason_code:
+        payload["reason_code"] = str(decision.reason_code)
+    return payload
+
+
+def _hook_error_payload(
+    *,
+    registration: ToolHookRegistration,
+    phase: ToolHookPhase,
+    error_type: str,
+) -> dict[str, Any]:
+    """Return safe metadata for one hook execution failure."""
+
+    return {
+        "phase": phase,
+        "hook_id": registration.hook_id,
+        "hook_order": registration.order,
+        "action": "deny",
+        "status": "error",
+        "reason_code": "tool_hook_unavailable",
+        "error_type": error_type,
+    }
+
+
+def _decision_with_manager_metadata(
+    decision: ToolHookDecision,
+    *,
+    registration: ToolHookRegistration,
+    results: list[dict[str, Any]],
+) -> ToolHookDecision:
+    """Attach manager provenance to a blocking pre-hook decision."""
+
+    metadata = dict(decision.metadata) if isinstance(decision.metadata, dict) else {}
+    metadata.setdefault("hook_id", registration.hook_id)
+    metadata.setdefault("hook_order", registration.order)
+    metadata["hook_results"] = list(results)
+    return ToolHookDecision(
+        action=decision.action,
+        reason_code=decision.reason_code,
+        message=decision.message,
+        metadata=metadata,
+    )
+
+
+__all__ = ["ConfiguredToolCallHookManager"]

--- a/mcp_unified/tool_hooks/models.py
+++ b/mcp_unified/tool_hooks/models.py
@@ -47,6 +47,10 @@ class ToolHookRegistration:
                 raise ValueError(f"Unsupported MCP tool hook phase: {phase!r}")
             if phase not in phases:
                 phases.append(phase)
+        if not phases:
+            raise ValueError(
+                "ToolHookRegistration.phases must include at least one of: 'pre', 'post'"
+            )
         object.__setattr__(self, "phases", tuple(phases))
 
         if self.hook is None and self.before is None and self.after is None:
@@ -60,11 +64,13 @@ class ToolHookExecutionError(RuntimeError):
         self,
         *,
         hook_id: str,
+        hook_order: int | None = None,
         phase: ToolHookPhase,
         error_type: str,
     ) -> None:
         super().__init__(f"MCP tool hook failed: {phase}:{hook_id}:{error_type}")
         self.hook_id = hook_id
+        self.hook_order = hook_order
         self.phase = phase
         self.error_type = error_type
 

--- a/mcp_unified/tool_hooks/models.py
+++ b/mcp_unified/tool_hooks/models.py
@@ -1,0 +1,77 @@
+"""Host-neutral models for configurable MCP tool-call hooks."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any, TypeAlias
+
+from mcp_unified.interfaces.runtime import (
+    ToolCallHookManager,
+    ToolHookCallContext,
+    ToolHookDecision,
+    ToolHookPhase,
+)
+
+ToolHookResult: TypeAlias = ToolHookDecision | dict[str, Any] | None
+ToolHookCallback: TypeAlias = Callable[
+    [ToolHookCallContext],
+    ToolHookResult | Awaitable[ToolHookResult],
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ToolHookRegistration:
+    """One configured hook registration for the package-level hook manager."""
+
+    hook_id: str
+    hook: ToolCallHookManager | None = None
+    before: ToolHookCallback | None = None
+    after: ToolHookCallback | None = None
+    order: int = 0
+    enabled: bool = True
+    phases: tuple[ToolHookPhase, ...] = field(default=("pre", "post"))
+
+    def __post_init__(self) -> None:
+        """Validate registration shape early for deterministic runtime behavior."""
+
+        hook_id = str(self.hook_id).strip()
+        if not hook_id:
+            raise ValueError("hook_id is required")
+        object.__setattr__(self, "hook_id", hook_id)
+        object.__setattr__(self, "order", int(self.order))
+
+        phases: list[ToolHookPhase] = []
+        for phase in self.phases:
+            if phase not in {"pre", "post"}:
+                raise ValueError(f"Unsupported MCP tool hook phase: {phase!r}")
+            if phase not in phases:
+                phases.append(phase)
+        object.__setattr__(self, "phases", tuple(phases))
+
+        if self.hook is None and self.before is None and self.after is None:
+            raise ValueError("ToolHookRegistration requires hook, before, or after")
+
+
+class ToolHookExecutionError(RuntimeError):
+    """Raised when a pre-tool hook fails and execution must fail closed."""
+
+    def __init__(
+        self,
+        *,
+        hook_id: str,
+        phase: ToolHookPhase,
+        error_type: str,
+    ) -> None:
+        super().__init__(f"MCP tool hook failed: {phase}:{hook_id}:{error_type}")
+        self.hook_id = hook_id
+        self.phase = phase
+        self.error_type = error_type
+
+
+__all__ = [
+    "ToolHookCallback",
+    "ToolHookExecutionError",
+    "ToolHookRegistration",
+    "ToolHookResult",
+]

--- a/mcp_unified/tool_use_reporting/__init__.py
+++ b/mcp_unified/tool_use_reporting/__init__.py
@@ -11,6 +11,7 @@ from mcp_unified.tool_use_reporting.models import (
     MAX_REPORT_EVENT_LIMIT,
     MAX_REPORT_GROUP_LIMIT,
     MAX_REPORT_REASON_CODE_LIMIT,
+    MAX_TOOL_HOOK_RESULTS,
     RuntimeSurface,
     SourceKind,
     ToolUseEvent,
@@ -21,6 +22,7 @@ from mcp_unified.tool_use_reporting.models import (
     ToolUseReportQuery,
     ToolUseReportRow,
     ToolUseStatus,
+    ToolHookResultMetadata,
 )
 from mcp_unified.tool_use_reporting.reporting import ToolUseReportService
 from mcp_unified.tool_use_reporting.recorder import (
@@ -50,6 +52,7 @@ __all__ = [
     "MAX_REPORT_EVENT_LIMIT",
     "MAX_REPORT_GROUP_LIMIT",
     "MAX_REPORT_REASON_CODE_LIMIT",
+    "MAX_TOOL_HOOK_RESULTS",
     "RuntimeSurface",
     "SourceKind",
     "NoopToolUseRecorder",
@@ -62,6 +65,7 @@ __all__ = [
     "ToolUseReportGroupBy",
     "ToolUseReportQuery",
     "ToolUseReportRow",
+    "ToolHookResultMetadata",
     "ToolUseReportService",
     "ToolUseRecorder",
     "ToolUseStatus",

--- a/mcp_unified/tool_use_reporting/models.py
+++ b/mcp_unified/tool_use_reporting/models.py
@@ -40,6 +40,7 @@ MAX_REPORT_EVENT_LIMIT = 5_000
 MAX_REPORT_GROUP_LIMIT = 500
 MAX_REPORT_REASON_CODE_LIMIT = 25
 MAX_FILE_POLICY_DECISIONS = 20
+MAX_TOOL_HOOK_RESULTS = 20
 MAX_FILE_POLICY_PATH_LENGTH = 512
 
 _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
@@ -163,6 +164,61 @@ class FilePolicyDecisionMetadata(BaseModel):
         return True
 
 
+class ToolHookResultMetadata(BaseModel):
+    """Safe metadata for one tool-call hook decision attached to a tool event."""
+
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    phase: str | None = None
+    hook_id: str | None = None
+    hook_order: int | None = None
+    action: str | None = None
+    status: str | None = None
+    reason_code: str | None = None
+    error_type: str | None = None
+    redacted: bool = True
+
+    @field_validator(
+        "phase",
+        "hook_id",
+        "action",
+        "status",
+        "error_type",
+        mode="before",
+    )
+    @classmethod
+    def _sanitize_optional_ids(cls, value: Any, info: Any) -> str | None:
+        """Sanitize bounded scalar hook fields."""
+
+        return _safe_optional_id(value, field=str(info.field_name))
+
+    @field_validator("reason_code", mode="before")
+    @classmethod
+    def _sanitize_hook_reason_code(cls, value: Any) -> str | None:
+        """Sanitize hook reason codes without preserving raw paths."""
+
+        return sanitize_reason_code(value)
+
+    @field_validator("hook_order", mode="before")
+    @classmethod
+    def _normalize_hook_order(cls, value: Any) -> int | None:
+        """Normalize hook order metadata when present."""
+
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @field_validator("redacted", mode="before")
+    @classmethod
+    def _force_redacted(cls, _value: Any) -> bool:
+        """Hook event metadata is always stored as redacted."""
+
+        return True
+
+
 class ToolUseEvent(BaseModel):
     """Immutable metadata-only record for one attempted MCP tool call."""
 
@@ -210,6 +266,7 @@ class ToolUseEvent(BaseModel):
     idempotency_replay: bool = False
     capture_ref: str | None = None
     file_policy_decisions: tuple[FilePolicyDecisionMetadata, ...] = ()
+    tool_hook_results: tuple[ToolHookResultMetadata, ...] = ()
     file_policy_sha256_before_present: bool | None = None
     file_policy_sha256_after_present: bool | None = None
     file_policy_lock_lease_present: bool | None = None
@@ -279,6 +336,17 @@ class ToolUseEvent(BaseModel):
         if not isinstance(value, list | tuple):
             return []
         return list(value[:MAX_FILE_POLICY_DECISIONS])
+
+    @field_validator("tool_hook_results", mode="before")
+    @classmethod
+    def _bound_tool_hook_results(cls, value: Any) -> list[Any]:
+        """Bound tool-hook result metadata cardinality."""
+
+        if value is None:
+            return []
+        if not isinstance(value, list | tuple):
+            return []
+        return list(value[:MAX_TOOL_HOOK_RESULTS])
 
     @field_validator("duration_ms", mode="before")
     @classmethod

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -44,6 +44,7 @@ from mcp_unified.tool_use_reporting.builders import (
 )
 from mcp_unified.tool_use_reporting.models import (
     MAX_FILE_POLICY_DECISIONS,
+    MAX_TOOL_HOOK_RESULTS,
     ToolUseEvent,
     ToolUseStatus,
 )
@@ -706,6 +707,68 @@ class MCPProtocol:
         return [dict(decision) for decision in bounded_decisions if isinstance(decision, dict)]
 
     @staticmethod
+    def _tool_use_hook_results(metadata: dict[str, Any] | None) -> list[dict[str, Any]]:
+        """Extract bounded tool-hook result metadata from request metadata."""
+
+        if not isinstance(metadata, dict):
+            return []
+        raw_results = metadata.get("mcp_tool_hook_results")
+        if not isinstance(raw_results, list):
+            return []
+        bounded_results = raw_results[:MAX_TOOL_HOOK_RESULTS]
+        return [dict(result) for result in bounded_results if isinstance(result, dict)]
+
+    @staticmethod
+    def _tool_hook_summary_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
+        """Return sanitized hook summary rows from a protocol hook payload."""
+
+        metadata = payload.get("metadata")
+        if isinstance(metadata, dict):
+            hook_results = metadata.get("hook_results")
+            if isinstance(hook_results, list):
+                return [
+                    dict(item)
+                    for item in hook_results[:MAX_TOOL_HOOK_RESULTS]
+                    if isinstance(item, dict)
+                ]
+
+        row: dict[str, Any] = {
+            "phase": payload.get("phase"),
+            "action": payload.get("action"),
+            "status": payload.get("status"),
+        }
+        if payload.get("reason_code") is not None:
+            row["reason_code"] = payload.get("reason_code")
+        if payload.get("error_type") is not None:
+            row["error_type"] = payload.get("error_type")
+        if isinstance(metadata, dict):
+            if metadata.get("hook_id") is not None:
+                row["hook_id"] = metadata.get("hook_id")
+            if metadata.get("hook_order") is not None:
+                row["hook_order"] = metadata.get("hook_order")
+        elif payload.get("hook_id") is not None:
+            row["hook_id"] = payload.get("hook_id")
+            if payload.get("hook_order") is not None:
+                row["hook_order"] = payload.get("hook_order")
+        return [row]
+
+    @staticmethod
+    def _append_tool_hook_summary(context: RequestContext, payload: dict[str, Any]) -> None:
+        """Append safe hook metadata for tool-use reporting."""
+
+        metadata = getattr(context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return
+        existing = metadata.get("mcp_tool_hook_results")
+        if not isinstance(existing, list):
+            existing = []
+            metadata["mcp_tool_hook_results"] = existing
+        remaining = max(0, MAX_TOOL_HOOK_RESULTS - len(existing))
+        if remaining <= 0:
+            return
+        existing.extend(MCPProtocol._tool_hook_summary_items(payload)[:remaining])
+
+    @staticmethod
     def _tool_use_decision_grant_outcome(file_policy_decisions: list[dict[str, Any]]) -> str | None:
         """Summarize path-decision grant outcomes with denial precedence."""
 
@@ -797,6 +860,7 @@ class MCPProtocol:
         """Build a metadata-only tool-use event."""
         metadata = getattr(context, "metadata", {})
         dimensions = extract_safe_context_dimensions(metadata if isinstance(metadata, dict) else None)
+        hook_results = self._tool_use_hook_results(metadata if isinstance(metadata, dict) else None)
         eval_metadata = self._tool_use_eval_metadata(payload=payload, tool_def=tool_def)
         safe_requested_name = self._safe_tool_use_name(requested_tool_name)
         safe_effective_name = self._safe_tool_use_name(effective_tool_name or safe_requested_name)
@@ -848,6 +912,7 @@ class MCPProtocol:
             grant_outcome=eval_metadata.get("grant_outcome") or decision_grant_outcome,
             truncated=eval_metadata.get("truncated"),
             file_policy_decisions=file_policy_decisions,
+            tool_hook_results=hook_results,
             file_policy_sha256_before_present=file_policy_sha256_before_present,
             file_policy_sha256_after_present=file_policy_sha256_after_present,
             file_policy_lock_lease_present=file_policy_lock_lease_present,
@@ -1698,6 +1763,13 @@ class MCPProtocol:
                 "reason_code": "tool_hook_unavailable",
                 "error_type": exc.__class__.__name__,
             }
+            hook_id = getattr(exc, "hook_id", None)
+            if hook_id is not None:
+                payload["hook_id"] = hook_id
+            hook_order = getattr(exc, "hook_order", None)
+            if hook_order is not None:
+                payload["hook_order"] = hook_order
+            self._append_tool_hook_summary(context, payload)
             raise GovernanceDeniedError(
                 "Permission denied by MCP tool hook",
                 governance={
@@ -1710,6 +1782,8 @@ class MCPProtocol:
 
         decision = self._coerce_tool_hook_decision(raw_decision)
         payload = self._tool_hook_payload(decision, phase="pre")
+        if raw_decision is not None:
+            self._append_tool_hook_summary(context, payload)
         action = str(payload.get("action") or "allow").strip().lower()
         if action == "allow":
             return payload
@@ -1774,7 +1848,7 @@ class MCPProtocol:
             error=error,
         )
         try:
-            await self._tool_call_hook_manager.after_tool_call(hook_context)
+            raw_decision = await self._tool_call_hook_manager.after_tool_call(hook_context)
         except asyncio.CancelledError:
             raise
         except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
@@ -1787,6 +1861,25 @@ class MCPProtocol:
                 status,
                 exc.__class__.__name__,
             )
+            payload = {
+                "phase": "post",
+                "action": "deny",
+                "status": "error",
+                "reason_code": "tool_hook_unavailable",
+                "error_type": exc.__class__.__name__,
+            }
+            hook_id = getattr(exc, "hook_id", None)
+            if hook_id is not None:
+                payload["hook_id"] = hook_id
+            hook_order = getattr(exc, "hook_order", None)
+            if hook_order is not None:
+                payload["hook_order"] = hook_order
+            self._append_tool_hook_summary(context, payload)
+            return
+        if raw_decision is not None:
+            decision = self._coerce_tool_hook_decision(raw_decision)
+            payload = self._tool_hook_payload(decision, phase="post")
+            self._append_tool_hook_summary(context, payload)
 
     async def process_request(
         self,

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -708,11 +708,11 @@ class MCPProtocol:
 
     @staticmethod
     def _tool_use_hook_results(metadata: dict[str, Any] | None) -> list[dict[str, Any]]:
-        """Extract bounded tool-hook result metadata from request metadata."""
+        """Consume bounded tool-hook result metadata from request metadata."""
 
         if not isinstance(metadata, dict):
             return []
-        raw_results = metadata.get("mcp_tool_hook_results")
+        raw_results = metadata.pop("mcp_tool_hook_results", None)
         if not isinstance(raw_results, list):
             return []
         bounded_results = raw_results[:MAX_TOOL_HOOK_RESULTS]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_tool_hook_manager.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_tool_hook_manager.py
@@ -1,0 +1,173 @@
+"""Tests for host-neutral MCP tool-call hook manager primitives."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mcp_unified.interfaces.runtime import ToolHookCallContext, ToolHookDecision
+from mcp_unified.tool_hooks import (
+    ConfiguredToolCallHookManager,
+    ToolHookExecutionError,
+    ToolHookRegistration,
+)
+
+
+def _context(*, phase: str = "pre") -> ToolHookCallContext:
+    return ToolHookCallContext(
+        phase="post" if phase == "post" else "pre",
+        tool_name="fs.patch",
+        module_id="filesystem",
+        is_write=True,
+        tool_category="management",
+        arguments_hash="abc123",
+        request_id="request-1",
+        user_id="user-1",
+        client_id="client-1",
+        session_id="session-1",
+        tool_args={"path": "docs/story.md"},
+        metadata={"profile_id": "backend-engineer"},
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_configured_manager_runs_pre_hooks_in_order_until_blocking_decision() -> None:
+    calls: list[str] = []
+
+    async def allow(_context: ToolHookCallContext) -> ToolHookDecision:
+        calls.append("allow")
+        return ToolHookDecision(action="allow", reason_code="first_clear")
+
+    async def deny(_context: ToolHookCallContext) -> ToolHookDecision:
+        calls.append("deny")
+        return ToolHookDecision(action="deny", reason_code="blocked_by_policy")
+
+    async def late(_context: ToolHookCallContext) -> ToolHookDecision:
+        calls.append("late")
+        return ToolHookDecision(action="allow")
+
+    manager = ConfiguredToolCallHookManager(
+        [
+            ToolHookRegistration(hook_id="late-hook", before=late, order=30),
+            ToolHookRegistration(hook_id="allow-hook", before=allow, order=10),
+            ToolHookRegistration(hook_id="deny-hook", before=deny, order=20),
+        ]
+    )
+
+    decision = await manager.before_tool_call(_context())
+
+    assert calls == ["allow", "deny"]
+    assert decision.action == "deny"
+    assert decision.reason_code == "blocked_by_policy"
+    assert decision.metadata["hook_id"] == "deny-hook"
+    assert decision.metadata["hook_order"] == 20
+    assert [item["hook_id"] for item in decision.metadata["hook_results"]] == [
+        "allow-hook",
+        "deny-hook",
+    ]
+    assert [item["action"] for item in decision.metadata["hook_results"]] == [
+        "allow",
+        "deny",
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_configured_manager_skips_disabled_and_wrong_phase_hooks() -> None:
+    calls: list[str] = []
+
+    async def record(context: ToolHookCallContext) -> ToolHookDecision:
+        calls.append(context.phase)
+        return ToolHookDecision(action="allow")
+
+    manager = ConfiguredToolCallHookManager(
+        [
+            ToolHookRegistration(hook_id="disabled", before=record, enabled=False),
+            ToolHookRegistration(hook_id="post-only", before=record, phases=("post",)),
+            ToolHookRegistration(hook_id="enabled", before=record, phases=("pre",)),
+        ]
+    )
+
+    decision = await manager.before_tool_call(_context())
+
+    assert calls == ["pre"]
+    assert decision.action == "allow"
+    assert [item["hook_id"] for item in decision.metadata["hook_results"]] == ["enabled"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_configured_manager_pre_hook_failure_identifies_failed_hook() -> None:
+    async def explode(_context: ToolHookCallContext) -> ToolHookDecision:
+        raise RuntimeError("hook backend unavailable")
+
+    manager = ConfiguredToolCallHookManager(
+        [ToolHookRegistration(hook_id="policy-service", before=explode)]
+    )
+
+    with pytest.raises(ToolHookExecutionError) as exc_info:
+        await manager.before_tool_call(_context())
+
+    assert exc_info.value.hook_id == "policy-service"
+    assert exc_info.value.phase == "pre"
+    assert exc_info.value.error_type == "RuntimeError"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_configured_manager_post_hooks_continue_after_failure_and_report_error() -> None:
+    calls: list[str] = []
+
+    async def first(_context: ToolHookCallContext) -> ToolHookDecision:
+        calls.append("first")
+        return ToolHookDecision(action="allow", reason_code="observed")
+
+    async def explode(_context: ToolHookCallContext) -> ToolHookDecision:
+        calls.append("explode")
+        raise RuntimeError("post hook backend unavailable")
+
+    async def last(_context: ToolHookCallContext) -> dict[str, Any]:
+        calls.append("last")
+        return {"action": "allow", "reason_code": "finished"}
+
+    manager = ConfiguredToolCallHookManager(
+        [
+            ToolHookRegistration(hook_id="first", after=first, order=10),
+            ToolHookRegistration(hook_id="explode", after=explode, order=20),
+            ToolHookRegistration(hook_id="last", after=last, order=30),
+        ]
+    )
+
+    decision = await manager.after_tool_call(_context(phase="post"))
+
+    assert calls == ["first", "explode", "last"]
+    assert decision.action == "allow"
+    assert decision.metadata["hook_results"] == [
+        {
+            "phase": "post",
+            "hook_id": "first",
+            "hook_order": 10,
+            "action": "allow",
+            "status": "allow",
+            "reason_code": "observed",
+        },
+        {
+            "phase": "post",
+            "hook_id": "explode",
+            "hook_order": 20,
+            "action": "deny",
+            "status": "error",
+            "reason_code": "tool_hook_unavailable",
+            "error_type": "RuntimeError",
+        },
+        {
+            "phase": "post",
+            "hook_id": "last",
+            "hook_order": 30,
+            "action": "allow",
+            "status": "allow",
+            "reason_code": "finished",
+        },
+    ]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_tool_hook_manager.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_tool_hook_manager.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-
 from mcp_unified.interfaces.runtime import ToolHookCallContext, ToolHookDecision
 from mcp_unified.tool_hooks import (
     ConfiguredToolCallHookManager,
@@ -98,21 +97,88 @@ async def test_configured_manager_skips_disabled_and_wrong_phase_hooks() -> None
 
 
 @pytest.mark.unit
+def test_configured_manager_rejects_empty_hook_phases() -> None:
+    async def record(_context: ToolHookCallContext) -> ToolHookDecision:
+        return ToolHookDecision(action="allow")
+
+    with pytest.raises(ValueError, match="phases must include at least one"):
+        ToolHookRegistration(hook_id="no-phases", before=record, phases=())
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_configured_manager_pre_hook_failure_identifies_failed_hook() -> None:
     async def explode(_context: ToolHookCallContext) -> ToolHookDecision:
         raise RuntimeError("hook backend unavailable")
 
     manager = ConfiguredToolCallHookManager(
-        [ToolHookRegistration(hook_id="policy-service", before=explode)]
+        [ToolHookRegistration(hook_id="policy-service", before=explode, order=15)]
     )
 
     with pytest.raises(ToolHookExecutionError) as exc_info:
         await manager.before_tool_call(_context())
 
     assert exc_info.value.hook_id == "policy-service"
+    assert exc_info.value.hook_order == 15
     assert exc_info.value.phase == "pre"
     assert exc_info.value.error_type == "RuntimeError"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_configured_manager_fails_closed_and_overwrites_spoofed_provenance() -> None:
+    async def malformed(_context: ToolHookCallContext) -> ToolHookDecision:
+        return ToolHookDecision(
+            action=False,  # type: ignore[arg-type]
+            reason_code="malformed_action",
+            metadata={"hook_id": "spoofed", "hook_order": 999},
+        )
+
+    manager = ConfiguredToolCallHookManager(
+        [ToolHookRegistration(hook_id="real-hook", before=malformed, order=7)]
+    )
+
+    decision = await manager.before_tool_call(_context())
+
+    assert decision.action == "deny"
+    assert decision.reason_code == "malformed_action"
+    assert decision.metadata["hook_id"] == "real-hook"
+    assert decision.metadata["hook_order"] == 7
+    assert decision.metadata["hook_results"] == [
+        {
+            "phase": "pre",
+            "hook_id": "real-hook",
+            "hook_order": 7,
+            "action": "deny",
+            "status": "deny",
+            "reason_code": "malformed_action",
+        }
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_configured_manager_reports_approval_required_as_ask() -> None:
+    async def approval_required(_context: ToolHookCallContext) -> ToolHookDecision:
+        return ToolHookDecision(action="approval_required", reason_code="needs_approval")
+
+    manager = ConfiguredToolCallHookManager(
+        [ToolHookRegistration(hook_id="approval-hook", before=approval_required, order=5)]
+    )
+
+    decision = await manager.before_tool_call(_context())
+
+    assert decision.action == "approval_required"
+    assert decision.metadata["hook_results"] == [
+        {
+            "phase": "pre",
+            "hook_id": "approval-hook",
+            "hook_order": 5,
+            "action": "ask",
+            "status": "ask",
+            "reason_code": "needs_approval",
+        }
+    ]
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_models.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_models.py
@@ -10,7 +10,7 @@ from mcp_unified.tool_use_reporting.builders import (
     classify_tool_use_exception,
     extract_safe_context_dimensions,
 )
-from mcp_unified.tool_use_reporting.models import ToolUseEvent
+from mcp_unified.tool_use_reporting.models import MAX_TOOL_HOOK_RESULTS, ToolUseEvent
 from mcp_unified.tool_use_reporting.recorder import NoopToolUseRecorder
 from mcp_unified.tool_use_reporting.sanitization import sanitize_safe_id
 
@@ -97,6 +97,76 @@ def test_tool_use_event_sanitizes_file_policy_decisions() -> None:
     assert event.file_policy_sha256_before_present is True
     assert event.file_policy_sha256_after_present is True
     assert event.file_policy_lock_lease_present is True
+
+
+def test_tool_use_event_sanitizes_tool_hook_results() -> None:
+    event = ToolUseEvent(
+        runtime_surface="protocol",
+        requested_tool_name="fs.patch",
+        status="denied",
+        tool_hook_results=[
+            {
+                "phase": "pre",
+                "hook_id": "profile-policy",
+                "hook_order": 10,
+                "action": "deny",
+                "status": "deny",
+                "reason_code": "blocked_by_policy",
+                "message": "do not persist /Users/example/private.txt",
+                "metadata": {"path": "/Users/example/private.txt"},
+                "redacted": False,
+            },
+            {
+                "phase": "post",
+                "hook_id": "person@example.com",
+                "hook_order": "20",
+                "action": "allow",
+                "status": "error",
+                "error_type": "RuntimeError",
+                "reason_code": "/Users/example/private.txt",
+            },
+        ],
+    )
+
+    assert len(event.tool_hook_results) == 2
+    first = event.tool_hook_results[0]
+    assert first.phase == "pre"
+    assert first.hook_id == "profile-policy"
+    assert first.hook_order == 10
+    assert first.action == "deny"
+    assert first.status == "deny"
+    assert first.reason_code == "blocked_by_policy"
+    assert first.error_type is None
+    assert first.redacted is True
+
+    second = event.tool_hook_results[1]
+    assert second.phase == "post"
+    assert second.hook_id is None
+    assert second.hook_order == 20
+    assert second.action == "allow"
+    assert second.status == "error"
+    assert second.reason_code == "unknown"
+    assert second.error_type == "RuntimeError"
+
+    dumped = event.model_dump_json()
+    assert "/Users/example" not in dumped
+    assert "do not persist" not in dumped
+    assert "metadata" not in dumped
+
+
+def test_tool_use_event_bounds_tool_hook_results() -> None:
+    event = ToolUseEvent(
+        runtime_surface="protocol",
+        requested_tool_name="fs.patch",
+        status="success",
+        tool_hook_results=[
+            {"phase": "pre", "hook_id": f"hook-{index}", "action": "allow"}
+            for index in range(MAX_TOOL_HOOK_RESULTS + 3)
+        ],
+    )
+
+    assert len(event.tool_hook_results) == MAX_TOOL_HOOK_RESULTS
+    assert event.tool_hook_results[-1].hook_id == f"hook-{MAX_TOOL_HOOK_RESULTS - 1}"
 
 
 def test_tool_use_event_rejects_uri_like_file_policy_paths_before_normalization() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py
@@ -7,9 +7,9 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
-
-from mcp_unified.tool_use_reporting.models import MAX_FILE_POLICY_DECISIONS, ToolUseEvent
 from mcp_unified.interfaces.runtime import ToolHookCallContext, ToolHookDecision
+from mcp_unified.tool_hooks import ConfiguredToolCallHookManager, ToolHookRegistration
+from mcp_unified.tool_use_reporting.models import MAX_FILE_POLICY_DECISIONS, ToolUseEvent
 
 from tldw_Server_API.app.core.MCP_unified.auth.rate_limiter import RateLimitExceeded
 from tldw_Server_API.app.core.MCP_unified.protocol import (
@@ -449,6 +449,44 @@ def test_protocol_file_policy_presence_ignores_empty_containers() -> None:
     assert event.file_policy_lock_lease_present is False
 
 
+def test_protocol_consumes_hook_results_per_tool_use_event() -> None:
+    protocol, _ = _protocol()
+    context = _request_context(
+        metadata={
+            "mcp_tool_hook_results": [
+                {
+                    "phase": "pre",
+                    "hook_id": "policy-hook",
+                    "hook_order": 4,
+                    "action": "deny",
+                    "status": "deny",
+                    "reason_code": "blocked",
+                }
+            ]
+        }
+    )
+
+    first_event = protocol._build_tool_use_event(
+        context=context,
+        requested_tool_name="test.read",
+        status="denied",
+        execution_origin="failed_before_execution",
+        duration_ms=0,
+    )
+    second_event = protocol._build_tool_use_event(
+        context=context,
+        requested_tool_name="test.read",
+        status="success",
+        execution_origin="executed",
+        duration_ms=0,
+    )
+
+    assert len(first_event.tool_hook_results) == 1
+    assert first_event.tool_hook_results[0].hook_id == "policy-hook"
+    assert "mcp_tool_hook_results" not in context.metadata
+    assert len(second_event.tool_hook_results) == 0
+
+
 @pytest.mark.asyncio
 async def test_protocol_records_successful_tool_use_event() -> None:
     protocol, recorder = _protocol()
@@ -649,6 +687,38 @@ async def test_protocol_records_pre_hook_denial_metadata_without_raw_payload() -
 
 
 @pytest.mark.asyncio
+async def test_protocol_records_pre_hook_failure_order_without_executing_tool() -> None:
+    async def fail_pre_hook(_context: ToolHookCallContext) -> ToolHookDecision:
+        raise RuntimeError("policy backend failed")
+
+    hook_manager = ConfiguredToolCallHookManager(
+        [ToolHookRegistration(hook_id="policy-backend", before=fail_pre_hook, order=12)]
+    )
+    module = _ToolModule()
+    protocol, recorder = _protocol(module=module, hook_manager=hook_manager)
+
+    with pytest.raises(GovernanceDeniedError):
+        await protocol._handle_tools_call(
+            {"name": "test.read", "arguments": {"value": "ok"}},
+            _request_context(metadata={"profile_id": "backend-engineer"}),
+        )
+
+    assert module.calls == 0
+    event = recorder.events[-1]
+    assert event.execution_origin == "failed_before_execution"
+    assert event.status == "denied"
+    assert event.reason_code == "tool_hook_unavailable"
+    assert len(event.tool_hook_results) == 1
+    hook_result = event.tool_hook_results[0]
+    assert hook_result.phase == "pre"
+    assert hook_result.hook_id == "policy-backend"
+    assert hook_result.hook_order == 12
+    assert hook_result.status == "deny"
+    assert hook_result.reason_code == "tool_hook_unavailable"
+    assert hook_result.error_type == "ToolHookExecutionError"
+
+
+@pytest.mark.asyncio
 async def test_protocol_records_post_hook_failure_without_changing_success() -> None:
     protocol, recorder = _protocol(hook_manager=_FailingPostToolHookManager())
 
@@ -809,7 +879,7 @@ async def test_protocol_skips_when_tool_use_already_observed() -> None:
 async def test_protocol_records_execution_failure_without_raw_arguments() -> None:
     protocol, recorder = _protocol(module=_ToolModule(fail=ValueError("bad /Users/me/secret.txt")))
 
-    with pytest.raises(Exception):
+    with pytest.raises(InvalidParamsException):
         await protocol._handle_tools_call(
             {"name": "test.read", "arguments": {"path": "/Users/me/secret.txt"}},
             _request_context(),
@@ -825,7 +895,7 @@ async def test_protocol_records_execution_failure_without_raw_arguments() -> Non
 async def test_protocol_records_unavailable_failure_origin_as_unavailable() -> None:
     protocol, recorder = _protocol(module=_ToolModule(fail=LookupError("missing tool")))
 
-    with pytest.raises(Exception):
+    with pytest.raises(LookupError):
         await protocol._handle_tools_call(
             {"name": "test.read", "arguments": {}},
             _request_context(),

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 
 from mcp_unified.tool_use_reporting.models import MAX_FILE_POLICY_DECISIONS, ToolUseEvent
+from mcp_unified.interfaces.runtime import ToolHookCallContext, ToolHookDecision
 
 from tldw_Server_API.app.core.MCP_unified.auth.rate_limiter import RateLimitExceeded
 from tldw_Server_API.app.core.MCP_unified.protocol import (
@@ -35,6 +36,31 @@ class _FailingToolUseRecorder:
     async def record_tool_use(self, event: ToolUseEvent) -> None:
         self.called = True
         raise RuntimeError(f"do not leak {event.requested_tool_name}")
+
+
+class _DenyingToolHookManager:
+    async def before_tool_call(self, _context: ToolHookCallContext) -> ToolHookDecision:
+        return ToolHookDecision(
+            action="deny",
+            reason_code="blocked_by_profile_hook",
+            message="blocked by hook",
+            metadata={
+                "hook_id": "profile-policy",
+                "hook_order": 10,
+                "path": "/Users/example/private.txt",
+            },
+        )
+
+    async def after_tool_call(self, _context: ToolHookCallContext) -> None:
+        return None
+
+
+class _FailingPostToolHookManager:
+    async def before_tool_call(self, _context: ToolHookCallContext) -> None:
+        return None
+
+    async def after_tool_call(self, _context: ToolHookCallContext) -> None:
+        raise RuntimeError("post hook failed for /Users/example/private.txt")
 
 
 class _AllowAllRbac:
@@ -290,6 +316,7 @@ def _protocol(
     rate_limiter: Any | None = None,
     effective_policy: dict[str, Any] | None = None,
     path_scope_enforcer: Any | None = None,
+    hook_manager: Any | None = None,
 ) -> tuple[MCPProtocol, Any]:
     recorder = recorder or _RecordingToolUseRecorder()
     module = module or _ToolModule()
@@ -305,6 +332,7 @@ def _protocol(
         path_scope_enforcer=path_scope_enforcer or _FilePolicyPathScopeEnforcer(),
         redis_client_factory=lambda **kwargs: None,
         tool_use_recorder=recorder,
+        tool_call_hook_manager=hook_manager,
     )
     protocol = MCPProtocol(dependencies=deps)
     return protocol, recorder
@@ -591,6 +619,55 @@ async def test_protocol_records_prepare_denial_without_raw_error() -> None:
     assert event.status == "denied"
     assert event.reason_code == "permission_denied"
     assert "/Users/me" not in event.model_dump_json()
+
+
+@pytest.mark.asyncio
+async def test_protocol_records_pre_hook_denial_metadata_without_raw_payload() -> None:
+    protocol, recorder = _protocol(hook_manager=_DenyingToolHookManager())
+
+    with pytest.raises(GovernanceDeniedError):
+        await protocol._handle_tools_call(
+            {"name": "test.read", "arguments": {"path": "/Users/example/private.txt"}},
+            _request_context(metadata={"profile_id": "backend-engineer"}),
+        )
+
+    event = recorder.events[-1]
+    assert event.execution_origin == "failed_before_execution"
+    assert event.status == "denied"
+    assert event.reason_code == "blocked_by_profile_hook"
+    assert len(event.tool_hook_results) == 1
+    hook_result = event.tool_hook_results[0]
+    assert hook_result.phase == "pre"
+    assert hook_result.hook_id == "profile-policy"
+    assert hook_result.hook_order == 10
+    assert hook_result.action == "deny"
+    assert hook_result.status == "deny"
+    assert hook_result.reason_code == "blocked_by_profile_hook"
+    dumped = event.model_dump_json()
+    assert "/Users/example" not in dumped
+    assert "blocked by hook" not in dumped
+
+
+@pytest.mark.asyncio
+async def test_protocol_records_post_hook_failure_without_changing_success() -> None:
+    protocol, recorder = _protocol(hook_manager=_FailingPostToolHookManager())
+
+    response = await protocol._handle_tools_call(
+        {"name": "test.read", "arguments": {"value": "ok"}},
+        _request_context(metadata={"profile_id": "backend-engineer"}),
+    )
+
+    assert response["tool"] == "test.read"
+    event = recorder.events[-1]
+    assert event.status == "success"
+    assert len(event.tool_hook_results) == 1
+    hook_result = event.tool_hook_results[0]
+    assert hook_result.phase == "post"
+    assert hook_result.status == "error"
+    assert hook_result.action == "deny"
+    assert hook_result.reason_code == "tool_hook_unavailable"
+    assert hook_result.error_type == "RuntimeError"
+    assert "/Users/example" not in event.model_dump_json()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add a package-level `mcp_unified.tool_hooks` API with ordered `ToolHookRegistration` entries and a `ConfiguredToolCallHookManager`.
- Surface sanitized hook decision/failure summaries in metadata-only tool-use events.
- Document hook-manager usage and include the new package/reporting modules in the standalone package manifest.

## Test Plan
- [x] `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_tool_hook_manager.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_tool_hooks.py tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_models.py tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q`
- [x] `python -m bandit -r mcp_unified/tool_hooks mcp_unified/tool_use_reporting tldw_Server_API/app/core/MCP_unified/protocol.py -f json -o /tmp/bandit_mcp_hook_manager_production_rebased.json`
- [x] `python -m build --wheel mcp_unified --outdir /tmp/mcp_hook_manager_dist_rebased`

## Change summary
AI-authored draft. Per project policy, a human requester must replace this section with a human-written change summary before this PR is merge-ready.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a host-neutral, configurable tool-call hook manager with ordered pre/post execution and sanitized hook summaries in tool-use reporting. Defaults are unchanged; includes review-driven normalization and per-event hook-summary handling. Satisfies TASK-2379.

- **New Features**
  - New `mcp_unified.tool_hooks` with `ConfiguredToolCallHookManager` and `ToolHookRegistration` for ordered pre/post hooks. Pre-hooks fail closed on errors and stop at the first blocking decision; post-hook failures are recorded and do not change the tool result.
  - Protocol attaches bounded, sanitized hook summaries to tool-use events as `tool_hook_results` (max 20) via `mcp_unified.tool_use_reporting` models and consumes them per event from `context.metadata["mcp_tool_hook_results"]`.
  - Review updates: invalid actions normalize to `deny`; `approval_required` appears as `ask` in summaries; manager sets authoritative `hook_id`/`hook_order` on blocking/failure decisions; empty-phase registrations are rejected; all fields are bounded and sanitized.
  - No raw hook messages, tool args, or absolute paths are captured; only safe fields like `phase`, `hook_id`, `hook_order`, `action/status`, `reason_code`, and `error_type`. Docs updated in `README.md` and `USER_GUIDE.md`.

- **Migration**
  - No changes required; defaults remain no-op.
  - To adopt: construct `ConfiguredToolCallHookManager` with your `ToolHookRegistration` list and pass it via `MCPRuntimeDependencies.tool_call_hook_manager` for `MCPProtocol`.

<sup>Written for commit 6024002dfd505379fad185e1573ba3212f33d88d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

