### PR TITLE
Add Workspace runtime binding descriptors

### DIFF
--- a/Docs/superpowers/plans/2026-06-18-workspace-runtime-bindings.md
+++ b/Docs/superpowers/plans/2026-06-18-workspace-runtime-bindings.md
@@ -1,0 +1,502 @@
+# Workspace Runtime Bindings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement Workspace Phase 2 runtime binding descriptors for issue #1991 with durable persistence, secret-safe metadata handling, and focused API routes.
+
+**Architecture:** Add a Workspace-owned runtime binding descriptor layer separate from project roots and resource memberships. The new core helper normalizes binding vocabulary and redacts/rejects sensitive metadata before persistence; ChaChaNotes stores descriptor rows; the Workspaces API exposes read/write/archive routes using existing workspace lifecycle and error mapping patterns.
+
+**Tech Stack:** Python 3.11, FastAPI, Pydantic v2, SQLite/PostgreSQL-compatible ChaChaNotesDB helpers, pytest.
+
+---
+
+## Scope
+
+This is a backend-only first slice for GitHub issue #1991 and Backlog task `TASK-2381`.
+
+Implement:
+
+- Canonical binding vocabulary:
+  - `binding_kind`: `repo`, `git_worktree`, `local_path`, `workspace_project_root`, `acp_execution_workspace`, `acp_session`, `acp_run`, `sandbox_root`, `sandbox_session`, `mcp_workspace_set`, `remote_runtime`
+  - `owner_domain`: `workspaces`, `acp`, `sandbox`, `mcp`, `jobs`, `workflows`, `watchlists`, `external`
+  - `status`: `ready`, `missing`, `inspect-only`, `blocked`, `provisioning`, `unavailable`, `detached`, `conflict`, `runtime-missing`, `archived`, `unsupported`
+  - `portability`: `reference`, `metadata-only`, `local-only`, `copy`
+- Secret-safe metadata normalization:
+  - Reject sensitive metadata keys by default.
+  - Redact sensitive values in `path_hint` and descriptor metadata response paths.
+  - Persist `redaction_report` with omitted/rejected field names.
+  - Accept underscore status/portability aliases (`inspect_only`, `runtime_missing`, `metadata_only`, `local_only`) and normalize them to the contract's hyphenated wire values.
+- Durable descriptor persistence:
+  - Upsert one active descriptor by `(workspace_id, binding_id)`.
+  - List active descriptors, optionally filtered by `binding_kind` or `owner_domain`.
+  - Get one active descriptor.
+  - Archive one descriptor idempotently.
+- API routes:
+  - `POST /api/v1/workspaces/{workspace_id}/runtime-bindings`
+  - `GET /api/v1/workspaces/{workspace_id}/runtime-bindings`
+  - `GET /api/v1/workspaces/{workspace_id}/runtime-bindings/{binding_id}`
+  - `DELETE /api/v1/workspaces/{workspace_id}/runtime-bindings/{binding_id}`
+- Docs:
+  - Update `tldw_Server_API/app/core/Workspaces/README.md`.
+  - Keep the contract untouched unless implementation discovers ambiguity.
+
+Do not implement:
+
+- ACP or Sandbox runtime resume.
+- Secret storage.
+- Root/path trust admission.
+- Frontend UI.
+- Membership adapters for ACP/Sandbox. That remains #2378.
+
+## File Map
+
+- Create `tldw_Server_API/app/core/Workspaces/runtime_bindings.py`
+  - Runtime binding literals, normalization, path hint redaction, metadata sanitizer, and response payload shaping.
+- Modify `tldw_Server_API/app/core/Workspaces/models.py`
+  - Re-export or define literal types where core Workspace code already centralizes vocabulary.
+- Modify `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+  - Add schema table/indexes for SQLite and PostgreSQL.
+  - Add normalize/serialize/deserialize helpers.
+  - Add upsert/list/get/archive methods.
+- Modify `tldw_Server_API/app/api/v1/schemas/workspace_schemas.py`
+  - Add request/response schemas and enum literals.
+- Modify `tldw_Server_API/app/api/v1/endpoints/workspaces.py`
+  - Add route handlers and map DB/core errors to HTTP responses.
+- Create `tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py`
+  - Core sanitizer and DB persistence tests.
+- Create `tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py`
+  - FastAPI route tests.
+- Modify `tldw_Server_API/app/core/Workspaces/README.md`
+  - Document the runtime binding descriptor contract.
+- Modify `backlog/tasks/task-2381 - Implement-Workspace-runtime-binding-descriptors-for-issue-1991.md`
+  - Track plan path, implementation notes, verification, and closeout.
+
+## Task 1: Core Runtime Binding Normalizer
+
+**Files:**
+
+- Create: `tldw_Server_API/app/core/Workspaces/runtime_bindings.py`
+- Modify: `tldw_Server_API/app/core/Workspaces/models.py`
+- Test: `tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py`
+
+- [x] **Step 1: Write failing tests for descriptor normalization**
+
+Add tests like:
+
+```python
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import InputError
+from tldw_Server_API.app.core.Workspaces.runtime_bindings import (
+    normalize_runtime_binding_payload,
+)
+
+
+def test_runtime_binding_normalizer_redacts_path_and_preserves_safe_metadata():
+    payload = normalize_runtime_binding_payload(
+        {
+            "binding_id": "repo-main",
+            "binding_kind": "repo",
+            "owner_domain": "workspaces",
+            "locator_ref": "repo-123",
+            "label": "Main Repo",
+            "status": "ready",
+            "path_hint": "/Users/example/private/project",
+            "portability": "reference",
+            "metadata": {"branch": "main", "remote": "origin"},
+        }
+    )
+
+    assert payload["path_hint"] == "project"
+    assert payload["metadata"] == {"branch": "main", "remote": "origin"}
+    assert payload["redaction_report"]["redacted_fields"] == ["path_hint"]
+
+
+def test_runtime_binding_normalizer_normalizes_contract_aliases():
+    payload = normalize_runtime_binding_payload(
+        {
+            "binding_id": "sandbox-root",
+            "binding_kind": "sandbox_root",
+            "owner_domain": "sandbox",
+            "locator_ref": "sandbox-123",
+            "status": "inspect_only",
+            "portability": "metadata_only",
+        }
+    )
+
+    assert payload["status"] == "inspect-only"
+    assert payload["portability"] == "metadata-only"
+
+
+def test_runtime_binding_normalizer_rejects_secret_metadata_keys():
+    with pytest.raises(InputError):
+        normalize_runtime_binding_payload(
+            {
+                "binding_id": "acp-session",
+                "binding_kind": "acp_session",
+                "owner_domain": "acp",
+                "locator_ref": "session-123",
+                "label": "ACP Session",
+                "status": "ready",
+                "portability": "metadata-only",
+                "metadata": {"OPENAI_API_KEY": "sk-secret"},
+            }
+        )
+```
+
+- [x] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py -q
+```
+
+Expected: fail because `runtime_bindings.py` does not exist.
+
+- [x] **Step 3: Implement minimal normalizer**
+
+Create `runtime_bindings.py` with:
+
+- frozensets for allowed literals.
+- `_normalized_required_string(value, field_name, max_length)`.
+- `redacted_path_hint(value)` matching existing root redaction behavior.
+- `normalize_runtime_binding_payload(data)`.
+- `runtime_binding_response_payload(row)`.
+
+Use `InputError` for malformed values. Keep the first slice intentionally strict: secret-looking metadata keys cause `InputError`, while path hints are redacted to basename.
+
+- [x] **Step 4: Run tests to verify GREEN**
+
+Run the same pytest command. Expected: pass.
+
+- [x] **Step 5: Refactor**
+
+Remove duplicate path-hint logic only within the new module. Do not refactor existing root helpers in this task.
+
+## Task 2: Durable DB Persistence
+
+**Files:**
+
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+- Test: `tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py`
+
+- [x] **Step 1: Write failing DB CRUD/archive tests**
+
+Add tests:
+
+```python
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+
+def test_workspace_runtime_binding_upsert_list_get_and_archive(tmp_path):
+    db = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="user-1")
+    db.upsert_workspace("ws-1", "Workspace")
+
+    created = db.upsert_workspace_runtime_binding(
+        "ws-1",
+        {
+            "binding_id": "repo-main",
+            "binding_kind": "repo",
+            "owner_domain": "workspaces",
+            "locator_ref": "repo-123",
+            "label": "Main Repo",
+            "status": "ready",
+            "path_hint": "/Users/example/project",
+            "portability": "reference",
+            "metadata": {"branch": "main"},
+        },
+        user_id="user-1",
+    )
+
+    assert created["path_hint"] == "project"
+    assert created["metadata"] == {"branch": "main"}
+    assert db.get_workspace_runtime_binding("ws-1", "repo-main")["binding_id"] == "repo-main"
+    assert [item["binding_id"] for item in db.list_workspace_runtime_bindings("ws-1")] == ["repo-main"]
+
+    archived = db.archive_workspace_runtime_binding("ws-1", "repo-main", user_id="user-1")
+    assert archived["status"] == "archived"
+    assert archived["deleted"] in (True, 1)
+    assert db.get_workspace_runtime_binding("ws-1", "repo-main") is None
+    assert db.get_workspace_runtime_binding("ws-1", "repo-main", include_deleted=True)["status"] == "archived"
+```
+
+- [x] **Step 2: Run tests to verify RED**
+
+Expected: fail because DB methods/table do not exist.
+
+- [x] **Step 3: Add schema**
+
+In `_ensure_workspace_subresource_schema_sqlite`, create:
+
+```sql
+CREATE TABLE IF NOT EXISTS workspace_runtime_bindings (
+    workspace_id        TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    binding_id          TEXT NOT NULL,
+    binding_kind        TEXT NOT NULL,
+    owner_domain        TEXT NOT NULL,
+    locator_ref         TEXT NOT NULL,
+    label               TEXT,
+    status              TEXT NOT NULL,
+    path_hint           TEXT,
+    portability         TEXT NOT NULL,
+    metadata_json       TEXT NOT NULL DEFAULT '{}',
+    redaction_report_json TEXT NOT NULL DEFAULT '{}',
+    created_by_user_id  TEXT,
+    updated_by_user_id  TEXT,
+    created_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted             BOOLEAN NOT NULL DEFAULT 0,
+    client_id           TEXT NOT NULL DEFAULT 'unknown',
+    version             INTEGER NOT NULL DEFAULT 1,
+    PRIMARY KEY (workspace_id, binding_id)
+)
+```
+
+Add indexes:
+
+- `idx_ws_runtime_bindings_workspace ON workspace_runtime_bindings(workspace_id, deleted, binding_kind, owner_domain)`
+- `idx_ws_runtime_bindings_locator ON workspace_runtime_bindings(owner_domain, locator_ref, deleted)`
+- `idx_ws_runtime_bindings_updated ON workspace_runtime_bindings(workspace_id, updated_at)`
+
+Add PostgreSQL statements in `_ensure_workspace_subresource_schema_postgres` with `BOOLEAN DEFAULT false` and `TIMESTAMP`.
+
+- [x] **Step 4: Add DB methods**
+
+Add methods near membership methods:
+
+- `_normalize_workspace_runtime_binding_row`
+- `_workspace_runtime_binding_write_error`
+- `_get_workspace_runtime_binding_with_conn`
+- `upsert_workspace_runtime_binding`
+- `get_workspace_runtime_binding`
+- `list_workspace_runtime_bindings`
+- `archive_workspace_runtime_binding`
+
+Use `normalize_runtime_binding_payload()` from the core module. Follow membership methods for idempotency, soft delete, version increment, and BackendDatabaseError wrapping.
+
+- [x] **Step 5: Run tests to verify GREEN**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py -q
+```
+
+Expected: pass.
+
+## Task 3: API Schemas And Routes
+
+**Files:**
+
+- Modify: `tldw_Server_API/app/api/v1/schemas/workspace_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/workspaces.py`
+- Test: `tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py`
+
+- [x] **Step 1: Write failing API tests**
+
+Create tests using the existing FastAPI app fixture style from `test_workspaces_api.py`:
+
+```python
+def test_workspace_runtime_binding_api_upserts_lists_gets_and_archives(workspace_fastapi_app, db):
+    db.upsert_workspace("ws-runtime", "Runtime Workspace")
+    response = _post_runtime_binding(
+        workspace_fastapi_app,
+        db,
+        "ws-runtime",
+        {
+            "binding_id": "acp-session-1",
+            "binding_kind": "acp_session",
+            "owner_domain": "acp",
+            "locator_ref": "session-1",
+            "label": "ACP Session",
+            "status": "runtime-missing",
+            "path_hint": "/Users/example/agent-workspace",
+            "portability": "metadata-only",
+            "metadata": {"agent": "codex"},
+        },
+    )
+    assert response.status_code == 201
+    created = response.json()
+    assert created["path_hint"] == "agent-workspace"
+    assert "absolute_root" not in created
+
+    listed = _list_runtime_bindings(workspace_fastapi_app, db, "ws-runtime")
+    assert listed.status_code == 200
+    assert listed.json()["items"][0]["binding_id"] == "acp-session-1"
+
+    fetched = _get_runtime_binding(workspace_fastapi_app, db, "ws-runtime", "acp-session-1")
+    assert fetched.status_code == 200
+
+    deleted = _delete_runtime_binding(workspace_fastapi_app, db, "ws-runtime", "acp-session-1")
+    assert deleted.status_code == 204
+    assert _get_runtime_binding(workspace_fastapi_app, db, "ws-runtime", "acp-session-1").status_code == 404
+```
+
+Also test:
+
+- Unknown binding kind returns 422.
+- Secret-looking metadata key returns 422.
+- Missing workspace returns 404.
+- Archived workspace rejects upsert/archive with 409 or existing writable-workspace pattern.
+
+- [x] **Step 2: Run tests to verify RED**
+
+Expected: fail because schemas/routes do not exist.
+
+- [x] **Step 3: Add Pydantic schemas**
+
+Add literals and models:
+
+- `WorkspaceRuntimeBindingKind`
+- `WorkspaceRuntimeBindingOwnerDomain`
+- `WorkspaceRuntimeBindingStatus`
+- `WorkspaceRuntimeBindingPortability`
+- `WorkspaceRuntimeBindingUpsertRequest`
+- `WorkspaceRuntimeBindingRedactionReport`
+- `WorkspaceRuntimeBindingResponse`
+- `WorkspaceRuntimeBindingListResponse`
+
+Use `extra="forbid"`, field length bounds, bounded metadata validation, and pass values through `normalize_runtime_binding_payload` where possible.
+
+- [x] **Step 4: Add routes**
+
+In `workspaces.py`, import new schemas and add helpers:
+
+- `_runtime_binding_to_response(row)`
+- `_runtime_binding_not_found(binding_id)`
+- `_runtime_binding_write_forbidden(workspace)`
+
+Add routes after root routes or before membership routes:
+
+- POST upsert: require workspace exists and is not archived/deleted; return 201 for create and 200 for update is acceptable only if implementation can detect update. Prefer 201 for both unless tests enforce version behavior.
+- GET list: supports `binding_kind`, `owner_domain`, `include_archived=false`, `limit`.
+- GET one: 404 if absent/deleted.
+- DELETE/archive: 204, idempotent for missing active rows if existing endpoint patterns prefer no-op; otherwise 404. Choose 204 for idempotent archive if row already archived, 404 if never existed.
+
+- [x] **Step 5: Run tests to verify GREEN**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py -q
+```
+
+Expected: pass.
+
+## Task 4: Docs, Backlog, And Local Verification
+
+**Files:**
+
+- Modify: `tldw_Server_API/app/core/Workspaces/README.md`
+- Modify: `backlog/tasks/task-2381 - Implement-Workspace-runtime-binding-descriptors-for-issue-1991.md`
+
+- [x] **Step 1: Update README**
+
+Add a `Runtime Bindings` section that states:
+
+- Runtime bindings are descriptor metadata, not trust grants.
+- Public responses expose `path_hint` and `redaction_report`, not secrets or raw absolute paths.
+- ACP/Sandbox/MCP remain admission owners.
+- The API surface is under `/api/v1/workspaces/{workspace_id}/runtime-bindings`.
+
+- [x] **Step 2: Update Backlog task**
+
+Set `TASK-2381` to `In Progress`, add implementation plan path, touched files, and verification notes as commands are run.
+
+- [x] **Step 3: Run focused verification**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py \
+  tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py \
+  tldw_Server_API/tests/Workspaces/test_workspace_project_roots_db.py \
+  tldw_Server_API/tests/Workspaces/test_workspaces_api.py -q
+```
+
+- [x] **Step 4: Run Bandit on touched backend paths**
+
+Run:
+
+```bash
+python -m bandit -r \
+  tldw_Server_API/app/core/Workspaces/runtime_bindings.py \
+  tldw_Server_API/app/core/Workspaces/models.py \
+  tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py \
+  tldw_Server_API/app/api/v1/schemas/workspace_schemas.py \
+  tldw_Server_API/app/api/v1/endpoints/workspaces.py \
+  -f json -o /tmp/bandit_workspace_runtime_bindings.json
+```
+
+Expected: no new findings in changed code. If Bandit reports pre-existing findings in large touched files, document exact IDs and confirm whether changed lines are implicated.
+
+- [x] **Step 5: Run formatting/diff checks**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors; only intended files changed.
+
+## Task 5: Commit And PR
+
+**Files:**
+
+- All touched files from prior tasks.
+
+- [x] **Step 1: Final Backlog update**
+
+Mark acceptance criteria complete, add final summary, DoD, verification results, and known skips/blockers.
+
+- [x] **Step 2: Review diff**
+
+Run:
+
+```bash
+git diff --stat
+git diff -- tldw_Server_API/app/core/Workspaces/runtime_bindings.py
+git diff -- tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+git diff -- tldw_Server_API/app/api/v1/endpoints/workspaces.py
+```
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add \
+  "backlog/tasks/task-2381 - Implement-Workspace-runtime-binding-descriptors-for-issue-1991.md" \
+  Docs/superpowers/plans/2026-06-18-workspace-runtime-bindings.md \
+  tldw_Server_API/app/core/Workspaces/README.md \
+  tldw_Server_API/app/core/Workspaces/models.py \
+  tldw_Server_API/app/core/Workspaces/runtime_bindings.py \
+  tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py \
+  tldw_Server_API/app/api/v1/schemas/workspace_schemas.py \
+  tldw_Server_API/app/api/v1/endpoints/workspaces.py \
+  tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py \
+  tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py
+git commit -m "feat: add workspace runtime binding descriptors"
+```
+
+- [ ] **Step 4: Push and open PR**
+
+Run:
+
+```bash
+git push -u origin codex/workspace-runtime-bindings
+gh pr create --base dev --head codex/workspace-runtime-bindings --title "Add Workspace runtime binding descriptors" --body-file /tmp/workspace_runtime_bindings_pr.md
+```
+
+PR body must include:
+
+- Change summary with what changed and why.
+- Test plan with exact commands and outcomes.
+- Links to #1991, #1984, and `TASK-2381`.
+- Note that runtime bindings are descriptors only, not trust grants or secret stores.

--- a/backlog/tasks/task-2381 - Implement-Workspace-runtime-binding-descriptors-for-issue-1991.md
+++ b/backlog/tasks/task-2381 - Implement-Workspace-runtime-binding-descriptors-for-issue-1991.md
@@ -1,0 +1,72 @@
+---
+id: TASK-2381
+title: Implement Workspace runtime binding descriptors for issue 1991
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-18 01:20'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1991'
+  - 'https://github.com/rmusser01/tldw_server/issues/1984'
+  - Docs/Design/Workspace_Container_Contract_2026_06.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Backend-first Workspace Phase 2 slice for #1991: durable runtime binding descriptors with secret-safe metadata handling, focused API routes, tests, and documentation updates.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Runtime binding descriptor literals and secret-safe metadata rules are defined in the Workspace core layer.
+- [x] #2 Durable Workspace runtime binding persistence supports upsert/list/get/archive for a workspace.
+- [x] #3 Public runtime binding responses expose path hints and redaction reports but not raw secrets or private path payloads.
+- [x] #4 Workspace runtime binding API routes are available under /api/v1/workspaces/{workspace_id}/runtime-bindings.
+- [x] #5 Tests cover metadata redaction/rejection, DB CRUD/archive, API happy path and fail-closed errors.
+- [x] #6 Docs/plan/backlog references are updated and verification results are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-18-workspace-runtime-bindings.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation plan: Docs/superpowers/plans/2026-06-18-workspace-runtime-bindings.md
+
+Implemented runtime binding descriptor vocabulary and secret-safe normalizer, durable ChaChaNotes workspace_runtime_bindings persistence, Workspaces API schemas/routes, focused tests, and README documentation.
+
+Verification:
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py tldw_Server_API/tests/Workspaces/test_workspace_project_roots_db.py tldw_Server_API/tests/Workspaces/test_workspaces_api.py -q -> 110 passed, 6 warnings
+- python -m bandit -r touched backend files -f json -o /tmp/bandit_workspace_runtime_bindings.json -> 0 results, 0 errors
+- git diff --check -> clean
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Workspace runtime binding descriptors for #1991: centralized runtime binding vocabulary, secret-safe metadata/path redaction, durable ChaChaNotes workspace_runtime_bindings persistence, Workspaces API list/upsert/get/archive routes, focused unit/API coverage, and README documentation.
+
+Verification:
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py tldw_Server_API/tests/Workspaces/test_workspace_project_roots_db.py tldw_Server_API/tests/Workspaces/test_workspaces_api.py -q -> 110 passed, 6 warnings
+- python -m bandit -r touched backend files -f json -o /tmp/bandit_workspace_runtime_bindings.json -> 0 results, 0 errors
+- git diff --check -> clean
+
+Known skips/blockers: no known blockers; full repository test suite not run for this focused slice.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2382 - Rebase-and-address-PR-2383-review-feedback.md
+++ b/backlog/tasks/task-2382 - Rebase-and-address-PR-2383-review-feedback.md
@@ -1,0 +1,54 @@
+---
+id: TASK-2382
+title: Rebase and address PR 2383 review feedback
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-18 03:10'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2383'
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase codex/workspace-runtime-bindings onto the latest dev branch and address unresolved GitHub review comments or issues on PR #2383.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Branch is rebased onto latest origin/dev.
+- [x] #2 Unresolved actionable PR review comments are addressed or documented with rationale.
+- [x] #3 Focused tests and security checks are run for touched code.
+- [x] #4 PR branch is pushed after fixes.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Review-fix plan: keep the rebased PR branch isolated; evaluate each PR comment against the code; add regression tests for behavior/security findings; implement fixed SQL, safe logging, status semantics, schema contract, redaction behavior, JSON normalization, and threadpool wrapping; run focused workspace tests, Bandit, and diff checks; commit and force-push the rebased branch.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Rebased codex/workspace-runtime-bindings onto origin/dev and addressed PR #2383 review feedback. Added regressions for env metadata, nested path redaction, client redaction_report spoofing, unsafe JSON decode logging, and archived-status writes. Implemented safe logging, fixed runtime-binding SQL strings with bound params, threadpool-wrapped runtime-binding route DB calls, system-managed archived status, server-derived redaction reports, and normalized request model fields with raw persistence payload preservation.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR #2383 onto latest origin/dev and addressed all actionable review comments found from Qodo and Gemini. Verification: focused runtime-binding tests passed (18 passed); broader Workspace regression passed (117 passed, 6 warnings); touched-scope Bandit JSON showed 0 results and 0 errors; git diff --check and git diff --cached --check were clean.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Backlog task records final summary and verification.
+- [x] #2 Working tree is clean except intentional committed changes.
+- [x] #3 Relevant tests pass.
+- [x] #4 Bandit has no new findings in touched scope.
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspaces.py
@@ -46,6 +46,9 @@ from tldw_Server_API.app.api.v1.schemas.workspace_schemas import (
     WorkspaceResponse,
     WorkspaceRootResponse,
     WorkspaceRootsResponse,
+    WorkspaceRuntimeBindingDescriptorListResponse,
+    WorkspaceRuntimeBindingDescriptorResponse,
+    WorkspaceRuntimeBindingDescriptorUpsertRequest,
     WorkspaceSandboxRootProvisionRequest,
     WorkspaceSandboxRootProvisionResponse,
     WorkspaceSourceCreateRequest,
@@ -93,6 +96,11 @@ from tldw_Server_API.app.core.Workspaces.root_binding_service import (
     attach_primary_workspace_root,
 )
 from tldw_Server_API.app.core.Workspaces.operations import workspace_operation_response_payload
+from tldw_Server_API.app.core.Workspaces.runtime_bindings import (
+    WORKSPACE_RUNTIME_BINDING_KINDS,
+    WORKSPACE_RUNTIME_BINDING_OWNER_DOMAINS,
+    runtime_binding_response_payload,
+)
 from tldw_Server_API.app.core.Workspaces.sandbox_root_provisioning import (
     provision_and_attach_sandbox_root,
 )
@@ -196,6 +204,10 @@ def _workspace_roots_response(
 
 def _operation_to_response(operation: dict[str, Any]) -> WorkspaceOperationResponse:
     return WorkspaceOperationResponse(**workspace_operation_response_payload(operation))
+
+
+def _runtime_binding_to_response(binding: dict[str, Any]) -> WorkspaceRuntimeBindingDescriptorResponse:
+    return WorkspaceRuntimeBindingDescriptorResponse(**runtime_binding_response_payload(binding))
 
 
 def _root_path_hint(root: dict[str, Any]) -> str | None:
@@ -502,6 +514,51 @@ def _workspace_membership_not_found(resource_type: str, resource_id: str) -> HTT
             },
         },
     )
+
+
+def _workspace_runtime_binding_not_found(binding_id: str) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail={
+            "code": "workspace_runtime_binding_not_found",
+            "message": "Workspace runtime binding was not found.",
+            "details": {"binding_id": binding_id},
+        },
+    )
+
+
+def _workspace_runtime_binding_archived_conflict(workspace_id: str) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={
+            "code": "workspace_archived",
+            "message": "Archived workspaces cannot be modified.",
+            "details": {"workspace_id": workspace_id},
+        },
+    )
+
+
+def _validate_runtime_binding_query_filter(
+    value: str | None,
+    field_name: str,
+    allowed: frozenset[str],
+) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if normalized not in allowed:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "code": "workspace_runtime_binding_filter_invalid",
+                "message": f"{field_name} is not supported.",
+                "details": {
+                    "field": field_name,
+                    "allowed": sorted(allowed),
+                },
+            },
+        )
+    return normalized
 
 
 def _workspace_with_primary_root(
@@ -1156,6 +1213,165 @@ async def delete_workspace_membership(
         raise _membership_service_error_to_http(exc) from exc
     except (ConflictError, InputError, CharactersRAGDBError) as exc:
         raise map_db_error_to_http(exc, default_detail="Failed to delete workspace membership") from exc
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# ── Runtime Bindings ─────────────────────────────────────────────────
+
+@router.get(
+    "/{workspace_id}/runtime-bindings",
+    response_model=WorkspaceRuntimeBindingDescriptorListResponse,
+    dependencies=[Depends(WORKSPACES_READ_RATE_LIMIT)],
+    summary="List workspace runtime binding descriptors",
+)
+async def list_workspace_runtime_bindings(
+    workspace_id: str,
+    binding_kind: str | None = Query(default=None),
+    owner_domain: str | None = Query(default=None),
+    include_archived: bool = Query(default=False),
+    limit: int = Query(default=100, ge=1, le=1000),
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+    current_user: User = Depends(get_request_user),
+) -> WorkspaceRuntimeBindingDescriptorListResponse:
+    """List descriptor-only runtime bindings for a workspace."""
+    _ = current_user
+    try:
+        _require_workspace(db, workspace_id)
+        normalized_kind = _validate_runtime_binding_query_filter(
+            binding_kind,
+            "binding_kind",
+            WORKSPACE_RUNTIME_BINDING_KINDS,
+        )
+        normalized_owner = _validate_runtime_binding_query_filter(
+            owner_domain,
+            "owner_domain",
+            WORKSPACE_RUNTIME_BINDING_OWNER_DOMAINS,
+        )
+        bindings = db.list_workspace_runtime_bindings(
+            workspace_id,
+            binding_kind=normalized_kind,
+            owner_domain=normalized_owner,
+            include_deleted=include_archived,
+            limit=limit,
+        )
+    except HTTPException:
+        raise
+    except (ConflictError, InputError, CharactersRAGDBError) as exc:
+        raise map_db_error_to_http(
+            exc,
+            input_status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            default_detail="Failed to fetch workspace runtime bindings",
+        ) from exc
+    items = [_runtime_binding_to_response(binding) for binding in bindings]
+    return WorkspaceRuntimeBindingDescriptorListResponse(
+        workspace_id=workspace_id,
+        items=items,
+        total=len(items),
+    )
+
+
+@router.post(
+    "/{workspace_id}/runtime-bindings",
+    response_model=WorkspaceRuntimeBindingDescriptorResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(WORKSPACES_WRITE_RATE_LIMIT)],
+    summary="Create or update a workspace runtime binding descriptor",
+)
+async def upsert_workspace_runtime_binding(
+    workspace_id: str,
+    body: WorkspaceRuntimeBindingDescriptorUpsertRequest,
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+    current_user: User = Depends(get_request_user),
+) -> WorkspaceRuntimeBindingDescriptorResponse:
+    """Persist descriptor metadata for an external runtime binding."""
+    try:
+        workspace = _require_workspace(db, workspace_id)
+        if bool(workspace.get("archived", False)):
+            raise _workspace_runtime_binding_archived_conflict(workspace_id)
+        binding = db.upsert_workspace_runtime_binding(
+            workspace_id,
+            body.model_dump(),
+            user_id=_request_user_id(current_user),
+        )
+    except HTTPException:
+        raise
+    except (ConflictError, InputError, CharactersRAGDBError) as exc:
+        raise map_db_error_to_http(
+            exc,
+            input_status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            default_detail="Failed to create workspace runtime binding",
+        ) from exc
+    return _runtime_binding_to_response(binding)
+
+
+@router.get(
+    "/{workspace_id}/runtime-bindings/{binding_id}",
+    response_model=WorkspaceRuntimeBindingDescriptorResponse,
+    dependencies=[Depends(WORKSPACES_READ_RATE_LIMIT)],
+    summary="Get a workspace runtime binding descriptor",
+)
+async def get_workspace_runtime_binding(
+    workspace_id: str,
+    binding_id: str,
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+    current_user: User = Depends(get_request_user),
+) -> WorkspaceRuntimeBindingDescriptorResponse:
+    """Fetch one active runtime binding descriptor."""
+    _ = current_user
+    try:
+        _require_workspace(db, workspace_id)
+        binding = db.get_workspace_runtime_binding(workspace_id, binding_id)
+    except HTTPException:
+        raise
+    except (ConflictError, InputError, CharactersRAGDBError) as exc:
+        raise map_db_error_to_http(
+            exc,
+            input_status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            default_detail="Failed to fetch workspace runtime binding",
+        ) from exc
+    if binding is None:
+        raise _workspace_runtime_binding_not_found(binding_id)
+    return _runtime_binding_to_response(binding)
+
+
+@router.delete(
+    "/{workspace_id}/runtime-bindings/{binding_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(WORKSPACES_DELETE_RATE_LIMIT)],
+    summary="Archive a workspace runtime binding descriptor",
+)
+async def archive_workspace_runtime_binding(
+    workspace_id: str,
+    binding_id: str,
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+    current_user: User = Depends(get_request_user),
+) -> Response:
+    """Archive one runtime binding descriptor without affecting the runtime itself."""
+    try:
+        workspace = _require_workspace(db, workspace_id)
+        if bool(workspace.get("archived", False)):
+            raise _workspace_runtime_binding_archived_conflict(workspace_id)
+        archived = db.archive_workspace_runtime_binding(
+            workspace_id,
+            binding_id,
+            user_id=_request_user_id(current_user),
+        )
+    except HTTPException:
+        raise
+    except (ConflictError, InputError, CharactersRAGDBError) as exc:
+        raise map_db_error_to_http(
+            exc,
+            input_status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            default_detail="Failed to archive workspace runtime binding",
+        ) from exc
+    if archived is None:
+        existing = db.get_workspace_runtime_binding(
+            workspace_id,
+            binding_id,
+            include_deleted=True,
+        )
+        if existing is None:
+            raise _workspace_runtime_binding_not_found(binding_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspaces.py
@@ -9,6 +9,7 @@ from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
 from loguru import logger
+from starlette.concurrency import run_in_threadpool
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
@@ -559,6 +560,78 @@ def _validate_runtime_binding_query_filter(
             },
         )
     return normalized
+
+
+def _list_workspace_runtime_bindings_sync(
+    db: CharactersRAGDB,
+    workspace_id: str,
+    *,
+    binding_kind: str | None,
+    owner_domain: str | None,
+    include_archived: bool,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """List runtime bindings with synchronous DB work isolated for threadpool use."""
+    _require_workspace(db, workspace_id)
+    return db.list_workspace_runtime_bindings(
+        workspace_id,
+        binding_kind=binding_kind,
+        owner_domain=owner_domain,
+        include_deleted=include_archived,
+        limit=limit,
+    )
+
+
+def _upsert_workspace_runtime_binding_sync(
+    db: CharactersRAGDB,
+    workspace_id: str,
+    body: WorkspaceRuntimeBindingDescriptorUpsertRequest,
+    user_id: str,
+) -> dict[str, Any]:
+    """Create or update a runtime binding using synchronous DB APIs."""
+    workspace = _require_workspace(db, workspace_id)
+    if bool(workspace.get("archived", False)):
+        raise _workspace_runtime_binding_archived_conflict(workspace_id)
+    return db.upsert_workspace_runtime_binding(
+        workspace_id,
+        body.persistence_payload(),
+        user_id=user_id,
+    )
+
+
+def _get_workspace_runtime_binding_sync(
+    db: CharactersRAGDB,
+    workspace_id: str,
+    binding_id: str,
+) -> dict[str, Any] | None:
+    """Fetch one runtime binding using synchronous DB APIs."""
+    _require_workspace(db, workspace_id)
+    return db.get_workspace_runtime_binding(workspace_id, binding_id)
+
+
+def _archive_workspace_runtime_binding_sync(
+    db: CharactersRAGDB,
+    workspace_id: str,
+    binding_id: str,
+    user_id: str,
+) -> None:
+    """Archive one runtime binding using synchronous DB APIs."""
+    workspace = _require_workspace(db, workspace_id)
+    if bool(workspace.get("archived", False)):
+        raise _workspace_runtime_binding_archived_conflict(workspace_id)
+    archived = db.archive_workspace_runtime_binding(
+        workspace_id,
+        binding_id,
+        user_id=user_id,
+    )
+    if archived is None:
+        existing = db.get_workspace_runtime_binding(
+            workspace_id,
+            binding_id,
+            include_deleted=True,
+        )
+        if existing is None:
+            raise _workspace_runtime_binding_not_found(binding_id)
 
 
 def _workspace_with_primary_root(
@@ -1247,11 +1320,13 @@ async def list_workspace_runtime_bindings(
             "owner_domain",
             WORKSPACE_RUNTIME_BINDING_OWNER_DOMAINS,
         )
-        bindings = db.list_workspace_runtime_bindings(
+        bindings = await run_in_threadpool(
+            _list_workspace_runtime_bindings_sync,
+            db,
             workspace_id,
             binding_kind=normalized_kind,
             owner_domain=normalized_owner,
-            include_deleted=include_archived,
+            include_archived=include_archived,
             limit=limit,
         )
     except HTTPException:
@@ -1285,13 +1360,12 @@ async def upsert_workspace_runtime_binding(
 ) -> WorkspaceRuntimeBindingDescriptorResponse:
     """Persist descriptor metadata for an external runtime binding."""
     try:
-        workspace = _require_workspace(db, workspace_id)
-        if bool(workspace.get("archived", False)):
-            raise _workspace_runtime_binding_archived_conflict(workspace_id)
-        binding = db.upsert_workspace_runtime_binding(
+        binding = await run_in_threadpool(
+            _upsert_workspace_runtime_binding_sync,
+            db,
             workspace_id,
-            body.model_dump(),
-            user_id=_request_user_id(current_user),
+            body,
+            _request_user_id(current_user),
         )
     except HTTPException:
         raise
@@ -1319,8 +1393,12 @@ async def get_workspace_runtime_binding(
     """Fetch one active runtime binding descriptor."""
     _ = current_user
     try:
-        _require_workspace(db, workspace_id)
-        binding = db.get_workspace_runtime_binding(workspace_id, binding_id)
+        binding = await run_in_threadpool(
+            _get_workspace_runtime_binding_sync,
+            db,
+            workspace_id,
+            binding_id,
+        )
     except HTTPException:
         raise
     except (ConflictError, InputError, CharactersRAGDBError) as exc:
@@ -1348,13 +1426,12 @@ async def archive_workspace_runtime_binding(
 ) -> Response:
     """Archive one runtime binding descriptor without affecting the runtime itself."""
     try:
-        workspace = _require_workspace(db, workspace_id)
-        if bool(workspace.get("archived", False)):
-            raise _workspace_runtime_binding_archived_conflict(workspace_id)
-        archived = db.archive_workspace_runtime_binding(
+        await run_in_threadpool(
+            _archive_workspace_runtime_binding_sync,
+            db,
             workspace_id,
             binding_id,
-            user_id=_request_user_id(current_user),
+            _request_user_id(current_user),
         )
     except HTTPException:
         raise
@@ -1364,14 +1441,6 @@ async def archive_workspace_runtime_binding(
             input_status=status.HTTP_422_UNPROCESSABLE_ENTITY,
             default_detail="Failed to archive workspace runtime binding",
         ) from exc
-    if archived is None:
-        existing = db.get_workspace_runtime_binding(
-            workspace_id,
-            binding_id,
-            include_deleted=True,
-        )
-        if existing is None:
-            raise _workspace_runtime_binding_not_found(binding_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 

--- a/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
@@ -12,6 +12,9 @@ from tldw_Server_API.app.core.Workspaces.membership_models import (
     WORKSPACE_MEMBERSHIP_MAX_PROVENANCE_BYTES,
     normalize_membership_json_object,
 )
+from tldw_Server_API.app.core.Workspaces.runtime_bindings import (
+    normalize_runtime_binding_payload,
+)
 from tldw_Server_API.app.core.Workspaces.eligibility import (
     WorkspaceEligibilityOperation,
     WorkspaceEligibilityOperationCategory,
@@ -642,6 +645,107 @@ class WorkspaceRuntimeBinding(BaseModel):
     state: WorkspaceCapabilityServiceState
     reason_code: str | None = None
     management_surface: str | None = None
+
+
+WorkspaceRuntimeBindingKind = Literal[
+    "repo",
+    "git_worktree",
+    "local_path",
+    "workspace_project_root",
+    "acp_execution_workspace",
+    "acp_session",
+    "acp_run",
+    "sandbox_root",
+    "sandbox_session",
+    "mcp_workspace_set",
+    "remote_runtime",
+]
+WorkspaceRuntimeBindingOwnerDomain = Literal[
+    "workspaces",
+    "acp",
+    "sandbox",
+    "mcp",
+    "jobs",
+    "workflows",
+    "watchlists",
+    "external",
+]
+WorkspaceRuntimeBindingStatus = Literal[
+    "ready",
+    "missing",
+    "inspect-only",
+    "blocked",
+    "provisioning",
+    "unavailable",
+    "detached",
+    "conflict",
+    "runtime-missing",
+    "archived",
+    "unsupported",
+]
+WorkspaceRuntimeBindingPortability = Literal[
+    "reference",
+    "metadata-only",
+    "local-only",
+    "copy",
+]
+
+
+class WorkspaceRuntimeBindingRedactionReport(BaseModel):
+    redacted: bool = False
+    redacted_fields: list[str] = Field(default_factory=list)
+    rejected_fields: list[str] = Field(default_factory=list)
+
+
+class WorkspaceRuntimeBindingDescriptorUpsertRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    binding_id: str = Field(..., min_length=1, max_length=128)
+    binding_kind: str = Field(..., min_length=1, max_length=80)
+    owner_domain: str = Field(..., min_length=1, max_length=80)
+    locator_ref: str = Field(..., min_length=1, max_length=512)
+    label: str | None = Field(default=None, max_length=512)
+    status: str = Field(..., min_length=1, max_length=80)
+    path_hint: str | None = Field(default=None, max_length=1024)
+    portability: str = Field(..., min_length=1, max_length=80)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    redaction_report: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_runtime_binding_contract(self) -> "WorkspaceRuntimeBindingDescriptorUpsertRequest":
+        try:
+            normalize_runtime_binding_payload(self.model_dump())
+        except ValueError as exc:
+            raise ValueError(str(exc)) from exc
+        return self
+
+
+class WorkspaceRuntimeBindingDescriptorResponse(BaseModel):
+    workspace_id: str
+    binding_id: str
+    binding_kind: WorkspaceRuntimeBindingKind
+    owner_domain: WorkspaceRuntimeBindingOwnerDomain
+    locator_ref: str
+    label: str | None = None
+    status: WorkspaceRuntimeBindingStatus
+    path_hint: str | None = None
+    portability: WorkspaceRuntimeBindingPortability
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    redaction_report: WorkspaceRuntimeBindingRedactionReport = Field(
+        default_factory=WorkspaceRuntimeBindingRedactionReport
+    )
+    created_by_user_id: str | None = None
+    updated_by_user_id: str | None = None
+    created_at: str
+    updated_at: str
+    deleted: bool = False
+    version: int
+
+
+class WorkspaceRuntimeBindingDescriptorListResponse(BaseModel):
+    workspace_id: str
+    items: list[WorkspaceRuntimeBindingDescriptorResponse]
+    total: int
 
 
 WorkspaceOperationStatus = Literal[

--- a/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
@@ -5,7 +5,7 @@ import json
 import re
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, StrictBool, ValidationInfo, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, StrictBool, ValidationInfo, field_validator, model_validator
 
 from tldw_Server_API.app.core.Workspaces.membership_models import (
     WORKSPACE_MEMBERSHIP_MAX_METADATA_BYTES,
@@ -700,6 +700,9 @@ class WorkspaceRuntimeBindingRedactionReport(BaseModel):
 class WorkspaceRuntimeBindingDescriptorUpsertRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    _normalized_payload: dict[str, Any] = PrivateAttr(default_factory=dict)
+    _persistence_payload: dict[str, Any] = PrivateAttr(default_factory=dict)
+
     binding_id: str = Field(..., min_length=1, max_length=128)
     binding_kind: str = Field(..., min_length=1, max_length=80)
     owner_domain: str = Field(..., min_length=1, max_length=80)
@@ -709,15 +712,34 @@ class WorkspaceRuntimeBindingDescriptorUpsertRequest(BaseModel):
     path_hint: str | None = Field(default=None, max_length=1024)
     portability: str = Field(..., min_length=1, max_length=80)
     metadata: dict[str, Any] = Field(default_factory=dict)
-    redaction_report: dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def _validate_runtime_binding_contract(self) -> "WorkspaceRuntimeBindingDescriptorUpsertRequest":
+        persistence_payload = self.model_dump()
         try:
-            normalize_runtime_binding_payload(self.model_dump())
+            normalized = normalize_runtime_binding_payload(persistence_payload)
         except ValueError as exc:
             raise ValueError(str(exc)) from exc
+        self.binding_id = normalized["binding_id"]
+        self.binding_kind = normalized["binding_kind"]
+        self.owner_domain = normalized["owner_domain"]
+        self.locator_ref = normalized["locator_ref"]
+        self.label = normalized["label"]
+        self.status = normalized["status"]
+        self.path_hint = normalized["path_hint"]
+        self.portability = normalized["portability"]
+        self.metadata = normalized["metadata"]
+        self._normalized_payload = normalized
+        self._persistence_payload = persistence_payload
         return self
+
+    def normalized_payload(self) -> dict[str, Any]:
+        """Return the server-normalized runtime binding request fields."""
+        return dict(self._normalized_payload)
+
+    def persistence_payload(self) -> dict[str, Any]:
+        """Return the original validated payload so persistence can derive redactions."""
+        return dict(self._persistence_payload)
 
 
 class WorkspaceRuntimeBindingDescriptorResponse(BaseModel):

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -18521,17 +18521,21 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         *,
         include_deleted: bool,
     ) -> dict[str, Any] | None:
-        clauses = [
-            "workspace_id = ?",
-            "binding_id = ?",
-        ]
-        params: list[Any] = [workspace_id, binding_id]
-        if not include_deleted:
-            clauses.append("deleted = ?")
-            params.append(self._workspace_active_deleted_value())
+        include_deleted_flag = 1 if include_deleted else 0
         row = conn.execute(
-            f"SELECT * FROM workspace_runtime_bindings WHERE {' AND '.join(clauses)}",  # nosec B608
-            tuple(params),
+            """
+            SELECT *
+              FROM workspace_runtime_bindings
+             WHERE workspace_id = ?
+               AND binding_id = ?
+               AND (? = 1 OR deleted = ?)
+            """,
+            (
+                workspace_id,
+                binding_id,
+                include_deleted_flag,
+                self._workspace_active_deleted_value(),
+            ),
         ).fetchone()
         return self._normalize_workspace_runtime_binding_row(row)
 
@@ -18724,22 +18728,38 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             "workspace_id",
         )
         normalized_limit = self._normalize_runtime_binding_limit(limit)
-        clauses = ["workspace_id = ?"]
-        params: list[Any] = [normalized_workspace_id]
-        if binding_kind is not None:
-            clauses.append("binding_kind = ?")
-            params.append(self._workspace_runtime_binding_filter_value(binding_kind, "binding_kind"))
-        if owner_domain is not None:
-            clauses.append("owner_domain = ?")
-            params.append(self._workspace_runtime_binding_filter_value(owner_domain, "owner_domain"))
-        if not include_deleted:
-            clauses.append("deleted = ?")
-            params.append(self._workspace_active_deleted_value())
-        params.append(normalized_limit)
+        normalized_kind = (
+            self._workspace_runtime_binding_filter_value(binding_kind, "binding_kind")
+            if binding_kind is not None
+            else None
+        )
+        normalized_owner = (
+            self._workspace_runtime_binding_filter_value(owner_domain, "owner_domain")
+            if owner_domain is not None
+            else None
+        )
+        include_deleted_flag = 1 if include_deleted else 0
         cursor = self.execute_query(
-            f"SELECT * FROM workspace_runtime_bindings WHERE {' AND '.join(clauses)} "  # nosec B608
-            "ORDER BY updated_at DESC, binding_id ASC LIMIT ?",
-            tuple(params),
+            """
+            SELECT *
+              FROM workspace_runtime_bindings
+             WHERE workspace_id = ?
+               AND (? = 1 OR deleted = ?)
+               AND (? IS NULL OR binding_kind = ?)
+               AND (? IS NULL OR owner_domain = ?)
+             ORDER BY updated_at DESC, binding_id ASC
+             LIMIT ?
+            """,
+            (
+                normalized_workspace_id,
+                include_deleted_flag,
+                self._workspace_active_deleted_value(),
+                normalized_kind,
+                normalized_kind,
+                normalized_owner,
+                normalized_owner,
+                normalized_limit,
+            ),
         )
         return [
             normalized

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -9146,6 +9146,41 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 "CREATE INDEX IF NOT EXISTS idx_ws_resource_memberships_updated "
                 "ON workspace_resource_memberships(workspace_id, updated_at)"
             )
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS workspace_runtime_bindings (
+                    workspace_id          TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+                    binding_id            TEXT NOT NULL,
+                    binding_kind          TEXT NOT NULL,
+                    owner_domain          TEXT NOT NULL,
+                    locator_ref           TEXT NOT NULL,
+                    label                 TEXT,
+                    status                TEXT NOT NULL,
+                    path_hint             TEXT,
+                    portability           TEXT NOT NULL,
+                    metadata_json         TEXT NOT NULL DEFAULT '{}',
+                    redaction_report_json TEXT NOT NULL DEFAULT '{}',
+                    created_by_user_id    TEXT,
+                    updated_by_user_id    TEXT,
+                    created_at            DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    updated_at            DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    deleted               BOOLEAN NOT NULL DEFAULT 0,
+                    client_id             TEXT NOT NULL DEFAULT 'unknown',
+                    version               INTEGER NOT NULL DEFAULT 1,
+                    PRIMARY KEY (workspace_id, binding_id)
+                )
+            """)
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_ws_runtime_bindings_workspace "
+                "ON workspace_runtime_bindings(workspace_id, deleted, binding_kind, owner_domain)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_ws_runtime_bindings_locator "
+                "ON workspace_runtime_bindings(owner_domain, locator_ref, deleted)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_ws_runtime_bindings_updated "
+                "ON workspace_runtime_bindings(workspace_id, updated_at)"
+            )
         except sqlite3.Error as exc:
             raise SchemaError(f"Failed ensuring SQLite workspace sub-resource schema: {exc}") from exc  # noqa: TRY003
 
@@ -9353,6 +9388,35 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             "ON workspace_resource_memberships(resource_type, resource_id, deleted)",
             "CREATE INDEX IF NOT EXISTS idx_ws_resource_memberships_updated "
             "ON workspace_resource_memberships(workspace_id, updated_at)",
+            """
+            CREATE TABLE IF NOT EXISTS workspace_runtime_bindings (
+                workspace_id          TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+                binding_id            TEXT NOT NULL,
+                binding_kind          TEXT NOT NULL,
+                owner_domain          TEXT NOT NULL,
+                locator_ref           TEXT NOT NULL,
+                label                 TEXT,
+                status                TEXT NOT NULL,
+                path_hint             TEXT,
+                portability           TEXT NOT NULL,
+                metadata_json         TEXT NOT NULL DEFAULT '{}',
+                redaction_report_json TEXT NOT NULL DEFAULT '{}',
+                created_by_user_id    TEXT,
+                updated_by_user_id    TEXT,
+                created_at            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                deleted               BOOLEAN NOT NULL DEFAULT false,
+                client_id             TEXT NOT NULL DEFAULT 'unknown',
+                version               INTEGER NOT NULL DEFAULT 1,
+                PRIMARY KEY (workspace_id, binding_id)
+            )
+            """,
+            "CREATE INDEX IF NOT EXISTS idx_ws_runtime_bindings_workspace "
+            "ON workspace_runtime_bindings(workspace_id, deleted, binding_kind, owner_domain)",
+            "CREATE INDEX IF NOT EXISTS idx_ws_runtime_bindings_locator "
+            "ON workspace_runtime_bindings(owner_domain, locator_ref, deleted)",
+            "CREATE INDEX IF NOT EXISTS idx_ws_runtime_bindings_updated "
+            "ON workspace_runtime_bindings(workspace_id, updated_at)",
         ]
         for statement in statements:
             self.backend.execute(statement, connection=conn)
@@ -18344,6 +18408,416 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     "UPDATE workspace_sources SET position = ?, version = version + 1 WHERE workspace_id = ? AND id = ?",
                     (idx, workspace_id, source_id),
                 )
+
+    # --- Workspace Runtime Binding Methods ---
+
+    @staticmethod
+    def _normalize_workspace_runtime_binding_actor(user_id: str | None) -> str | None:
+        if user_id is None:
+            return None
+        normalized = str(user_id).strip()
+        return normalized or None
+
+    @staticmethod
+    def _workspace_runtime_binding_is_constraint_error(exc: Exception) -> bool:
+        message = str(exc).lower()
+        return any(
+            token in message
+            for token in (
+                "unique",
+                "duplicate",
+                "constraint",
+                "foreign key",
+            )
+        )
+
+    def _workspace_runtime_binding_write_error(self, exc: Exception) -> CharactersRAGDBError:
+        if self._workspace_runtime_binding_is_constraint_error(exc):
+            return ConflictError(
+                f"Workspace runtime binding write conflicted: {exc}",
+                entity="workspace_runtime_bindings",
+            )
+        return CharactersRAGDBError(f"Workspace runtime binding write failed: {exc}")  # noqa: TRY003
+
+    @staticmethod
+    def _normalize_runtime_binding_limit(limit: int) -> int:
+        if isinstance(limit, bool) or not isinstance(limit, int):
+            raise InputError("limit must be an integer.")  # noqa: TRY003
+        if limit < 1 or limit > 1000:
+            raise InputError("limit must be between 1 and 1000.")  # noqa: TRY003
+        return limit
+
+    @staticmethod
+    def _normalize_workspace_runtime_binding_required_string(value: Any, field_name: str) -> str:
+        normalized = str(value if value is not None else "").strip()
+        if not normalized:
+            raise InputError(f"{field_name} is required.")  # noqa: TRY003
+        return normalized
+
+    @staticmethod
+    def _workspace_runtime_binding_filter_value(value: Any, field_name: str) -> str:
+        normalized = str(value if value is not None else "").strip().lower()
+        if not normalized:
+            raise InputError(f"{field_name} is required.")  # noqa: TRY003
+        return normalized
+
+    def _normalize_workspace_runtime_binding_input(self, data: Mapping[str, Any]) -> dict[str, Any]:
+        from tldw_Server_API.app.core.Workspaces.runtime_bindings import (
+            normalize_runtime_binding_payload,
+        )
+
+        return normalize_runtime_binding_payload(data)
+
+    def _normalize_workspace_runtime_binding_row(self, row: Mapping[str, Any] | None) -> dict[str, Any] | None:
+        if not row:
+            return None
+        from tldw_Server_API.app.core.Workspaces.runtime_bindings import (
+            runtime_binding_response_payload,
+        )
+
+        return runtime_binding_response_payload(row)
+
+    @staticmethod
+    def _workspace_runtime_binding_fields_match(
+        existing: Mapping[str, Any],
+        requested: Mapping[str, Any],
+    ) -> bool:
+        return all(
+            existing.get(field_name) == requested.get(field_name)
+            for field_name in (
+                "binding_kind",
+                "owner_domain",
+                "locator_ref",
+                "label",
+                "status",
+                "path_hint",
+                "portability",
+                "metadata",
+                "redaction_report",
+            )
+        )
+
+    def _require_workspace_runtime_binding_workspace(
+        self,
+        conn: sqlite3.Connection | BackendConnectionWrapper,
+        workspace_id: str,
+    ) -> None:
+        row = conn.execute(
+            "SELECT id FROM workspaces WHERE id = ? AND deleted = ?",
+            (workspace_id, self._workspace_active_deleted_value()),
+        ).fetchone()
+        if row is None:
+            raise ConflictError(
+                "Workspace not found or deleted.",
+                entity="workspaces",
+                entity_id=workspace_id,
+            )
+
+    def _get_workspace_runtime_binding_with_conn(
+        self,
+        conn: sqlite3.Connection | BackendConnectionWrapper,
+        workspace_id: str,
+        binding_id: str,
+        *,
+        include_deleted: bool,
+    ) -> dict[str, Any] | None:
+        clauses = [
+            "workspace_id = ?",
+            "binding_id = ?",
+        ]
+        params: list[Any] = [workspace_id, binding_id]
+        if not include_deleted:
+            clauses.append("deleted = ?")
+            params.append(self._workspace_active_deleted_value())
+        row = conn.execute(
+            f"SELECT * FROM workspace_runtime_bindings WHERE {' AND '.join(clauses)}",  # nosec B608
+            tuple(params),
+        ).fetchone()
+        return self._normalize_workspace_runtime_binding_row(row)
+
+    def upsert_workspace_runtime_binding(
+        self,
+        workspace_id: str,
+        data: Mapping[str, Any],
+        *,
+        user_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Create, update, or restore a Workspace runtime binding descriptor."""
+        normalized_workspace_id = self._normalize_workspace_runtime_binding_required_string(
+            workspace_id,
+            "workspace_id",
+        )
+        values = self._normalize_workspace_runtime_binding_input(data)
+        actor = self._normalize_workspace_runtime_binding_actor(user_id)
+        now = self._get_current_utc_timestamp_iso()
+        active_deleted_value = self._workspace_active_deleted_value()
+
+        try:
+            with self.transaction() as conn:
+                self._require_workspace_runtime_binding_workspace(conn, normalized_workspace_id)
+                existing = self._get_workspace_runtime_binding_with_conn(
+                    conn,
+                    normalized_workspace_id,
+                    values["binding_id"],
+                    include_deleted=True,
+                )
+                if existing is not None:
+                    if (
+                        existing.get("deleted") not in (True, 1)
+                        and self._workspace_runtime_binding_fields_match(existing, values)
+                    ):
+                        return existing
+                    cursor = conn.execute(
+                        """
+                        UPDATE workspace_runtime_bindings
+                           SET binding_kind = ?,
+                               owner_domain = ?,
+                               locator_ref = ?,
+                               label = ?,
+                               status = ?,
+                               path_hint = ?,
+                               portability = ?,
+                               metadata_json = ?,
+                               redaction_report_json = ?,
+                               updated_by_user_id = ?,
+                               updated_at = ?,
+                               deleted = ?,
+                               client_id = ?,
+                               version = version + 1
+                         WHERE workspace_id = ?
+                           AND binding_id = ?
+                        """,
+                        (
+                            values["binding_kind"],
+                            values["owner_domain"],
+                            values["locator_ref"],
+                            values["label"],
+                            values["status"],
+                            values["path_hint"],
+                            values["portability"],
+                            values["metadata_json"],
+                            values["redaction_report_json"],
+                            actor,
+                            now,
+                            active_deleted_value,
+                            self.client_id or "unknown",
+                            normalized_workspace_id,
+                            values["binding_id"],
+                        ),
+                    )
+                    if cursor.rowcount == 1:
+                        updated = self._get_workspace_runtime_binding_with_conn(
+                            conn,
+                            normalized_workspace_id,
+                            values["binding_id"],
+                            include_deleted=False,
+                        )
+                        if updated is None:
+                            raise CharactersRAGDBError("Updated runtime binding row could not be reloaded.")  # noqa: TRY003
+                        return updated
+                    raise CharactersRAGDBError("Runtime binding update changed no rows.")  # noqa: TRY003
+
+                conn.execute(
+                    """
+                    INSERT INTO workspace_runtime_bindings (
+                        workspace_id,
+                        binding_id,
+                        binding_kind,
+                        owner_domain,
+                        locator_ref,
+                        label,
+                        status,
+                        path_hint,
+                        portability,
+                        metadata_json,
+                        redaction_report_json,
+                        created_by_user_id,
+                        updated_by_user_id,
+                        created_at,
+                        updated_at,
+                        deleted,
+                        client_id,
+                        version
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+                    """,
+                    (
+                        normalized_workspace_id,
+                        values["binding_id"],
+                        values["binding_kind"],
+                        values["owner_domain"],
+                        values["locator_ref"],
+                        values["label"],
+                        values["status"],
+                        values["path_hint"],
+                        values["portability"],
+                        values["metadata_json"],
+                        values["redaction_report_json"],
+                        actor,
+                        actor,
+                        now,
+                        now,
+                        active_deleted_value,
+                        self.client_id or "unknown",
+                    ),
+                )
+                created = self._get_workspace_runtime_binding_with_conn(
+                    conn,
+                    normalized_workspace_id,
+                    values["binding_id"],
+                    include_deleted=False,
+                )
+                if created is None:
+                    raise CharactersRAGDBError("Created runtime binding row could not be reloaded.")  # noqa: TRY003
+                return created
+        except ConflictError:
+            raise
+        except (sqlite3.IntegrityError, BackendDatabaseError) as exc:
+            raise self._workspace_runtime_binding_write_error(exc) from exc
+
+    def get_workspace_runtime_binding(
+        self,
+        workspace_id: str,
+        binding_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, Any] | None:
+        """Fetch one Workspace runtime binding descriptor."""
+        normalized_workspace_id = self._normalize_workspace_runtime_binding_required_string(
+            workspace_id,
+            "workspace_id",
+        )
+        normalized_binding_id = self._normalize_workspace_runtime_binding_required_string(
+            binding_id,
+            "binding_id",
+        )
+        try:
+            if include_deleted:
+                cursor = self.execute_query(
+                    "SELECT * FROM workspace_runtime_bindings WHERE workspace_id = ? AND binding_id = ?",
+                    (normalized_workspace_id, normalized_binding_id),
+                )
+                return self._normalize_workspace_runtime_binding_row(cursor.fetchone())
+            cursor = self.execute_query(
+                "SELECT * FROM workspace_runtime_bindings WHERE workspace_id = ? AND binding_id = ? AND deleted = ?",
+                (
+                    normalized_workspace_id,
+                    normalized_binding_id,
+                    self._workspace_active_deleted_value(),
+                ),
+            )
+            return self._normalize_workspace_runtime_binding_row(cursor.fetchone())
+        except BackendDatabaseError as exc:
+            raise CharactersRAGDBError(f"Failed fetching workspace runtime binding: {exc}") from exc  # noqa: TRY003
+
+    def list_workspace_runtime_bindings(
+        self,
+        workspace_id: str,
+        *,
+        binding_kind: str | None = None,
+        owner_domain: str | None = None,
+        include_deleted: bool = False,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """List runtime binding descriptors for one Workspace."""
+        normalized_workspace_id = self._normalize_workspace_runtime_binding_required_string(
+            workspace_id,
+            "workspace_id",
+        )
+        normalized_limit = self._normalize_runtime_binding_limit(limit)
+        clauses = ["workspace_id = ?"]
+        params: list[Any] = [normalized_workspace_id]
+        if binding_kind is not None:
+            clauses.append("binding_kind = ?")
+            params.append(self._workspace_runtime_binding_filter_value(binding_kind, "binding_kind"))
+        if owner_domain is not None:
+            clauses.append("owner_domain = ?")
+            params.append(self._workspace_runtime_binding_filter_value(owner_domain, "owner_domain"))
+        if not include_deleted:
+            clauses.append("deleted = ?")
+            params.append(self._workspace_active_deleted_value())
+        params.append(normalized_limit)
+        cursor = self.execute_query(
+            f"SELECT * FROM workspace_runtime_bindings WHERE {' AND '.join(clauses)} "  # nosec B608
+            "ORDER BY updated_at DESC, binding_id ASC LIMIT ?",
+            tuple(params),
+        )
+        return [
+            normalized
+            for row in cursor.fetchall()
+            if (normalized := self._normalize_workspace_runtime_binding_row(row)) is not None
+        ]
+
+    def archive_workspace_runtime_binding(
+        self,
+        workspace_id: str,
+        binding_id: str,
+        *,
+        user_id: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Soft-delete one Workspace runtime binding descriptor."""
+        normalized_workspace_id = self._normalize_workspace_runtime_binding_required_string(
+            workspace_id,
+            "workspace_id",
+        )
+        normalized_binding_id = self._normalize_workspace_runtime_binding_required_string(
+            binding_id,
+            "binding_id",
+        )
+        actor = self._normalize_workspace_runtime_binding_actor(user_id)
+        now = self._get_current_utc_timestamp_iso()
+        try:
+            with self.transaction() as conn:
+                existing = self._get_workspace_runtime_binding_with_conn(
+                    conn,
+                    normalized_workspace_id,
+                    normalized_binding_id,
+                    include_deleted=True,
+                )
+                if existing is None or existing.get("deleted") in (True, 1):
+                    return None
+                deleted_value = True if self.backend_type == BackendType.POSTGRESQL else 1
+                cursor = conn.execute(
+                    """
+                    UPDATE workspace_runtime_bindings
+                       SET deleted = ?,
+                           status = ?,
+                           updated_at = ?,
+                           updated_by_user_id = ?,
+                           client_id = ?,
+                           version = version + 1
+                     WHERE workspace_id = ?
+                       AND binding_id = ?
+                       AND deleted = ?
+                    """,
+                    (
+                        deleted_value,
+                        "archived",
+                        now,
+                        actor,
+                        self.client_id or "unknown",
+                        normalized_workspace_id,
+                        normalized_binding_id,
+                        self._workspace_active_deleted_value(),
+                    ),
+                )
+                if cursor.rowcount == 1:
+                    return self._get_workspace_runtime_binding_with_conn(
+                        conn,
+                        normalized_workspace_id,
+                        normalized_binding_id,
+                        include_deleted=True,
+                    )
+                raced = self._get_workspace_runtime_binding_with_conn(
+                    conn,
+                    normalized_workspace_id,
+                    normalized_binding_id,
+                    include_deleted=True,
+                )
+                if raced is None or raced.get("deleted") in (True, 1):
+                    return raced
+                raise CharactersRAGDBError("Archive race left runtime binding active.")  # noqa: TRY003
+        except (sqlite3.IntegrityError, BackendDatabaseError) as exc:
+            raise self._workspace_runtime_binding_write_error(exc) from exc
 
     # --- Workspace Resource Membership Methods ---
 

--- a/tldw_Server_API/app/core/Workspaces/README.md
+++ b/tldw_Server_API/app/core/Workspaces/README.md
@@ -42,6 +42,8 @@ context work should start from that contract.
 ## Module Map
 
 - `models.py` - canonical profiles, kinds, root states, and allowed-action helpers.
+- `runtime_bindings.py` - runtime binding descriptor normalization and
+  secret-safe metadata handling.
 - `context.py` - Workspace Core context and runtime capability envelope builder.
 - `service_capabilities.py` - readiness and capability projection.
 - `source_jobs.py` - workspace source job payload and enqueue helpers.
@@ -77,6 +79,29 @@ Future membership adapters must validate access through the owning domain
 adapter before linking or resolving a resource. Unsupported resource types must
 fail closed, and summaries/provenance should avoid exposing secrets, absolute
 paths, sandbox mount paths, prompts, model output contents, or file contents.
+
+## Runtime Bindings
+
+`workspace_runtime_bindings` stores descriptor metadata for runtimes associated
+with a workspace. Runtime bindings are not trust grants, root admissions,
+resumable sessions, or secret stores. ACP, Sandbox, MCP, Jobs, Workflows, and
+other owner domains remain responsible for their own runtime admission and
+lifecycle decisions.
+
+The public API surface is
+`/api/v1/workspaces/{workspace_id}/runtime-bindings`. Responses expose
+descriptor fields, normalized status, `path_hint`, metadata, and
+`redaction_report`. They must not expose raw absolute roots, environment
+variables, API keys, bearer tokens, credentials, prompt text, model output, or
+file contents. Path-like hints are reduced to display basenames before storage
+or response.
+
+Supported descriptor kinds include repository, worktree, local path,
+Workspace-owned project root, ACP session/run/workspace, Sandbox root/session,
+MCP workspace set, and remote-runtime placeholders. Missing or unavailable
+runtimes should be represented with explicit statuses such as `missing`,
+`runtime-missing`, `inspect-only`, `unavailable`, `blocked`, or `unsupported`
+instead of causing workspace reads to fail.
 
 ## Active Context Eligibility
 

--- a/tldw_Server_API/app/core/Workspaces/models.py
+++ b/tldw_Server_API/app/core/Workspaces/models.py
@@ -25,6 +25,48 @@ ProjectRootState = Literal[
     "archived",
 ]
 ResolutionStatus = Literal["complete", "partial", "failed"]
+RuntimeBindingKind = Literal[
+    "repo",
+    "git_worktree",
+    "local_path",
+    "workspace_project_root",
+    "acp_execution_workspace",
+    "acp_session",
+    "acp_run",
+    "sandbox_root",
+    "sandbox_session",
+    "mcp_workspace_set",
+    "remote_runtime",
+]
+RuntimeBindingOwnerDomain = Literal[
+    "workspaces",
+    "acp",
+    "sandbox",
+    "mcp",
+    "jobs",
+    "workflows",
+    "watchlists",
+    "external",
+]
+RuntimeBindingStatus = Literal[
+    "ready",
+    "missing",
+    "inspect-only",
+    "blocked",
+    "provisioning",
+    "unavailable",
+    "detached",
+    "conflict",
+    "runtime-missing",
+    "archived",
+    "unsupported",
+]
+RuntimeBindingPortability = Literal[
+    "reference",
+    "metadata-only",
+    "local-only",
+    "copy",
+]
 
 _WORKING_INVENTORY_STATES = frozenset(
     {
@@ -47,6 +89,56 @@ _SAFE_INVENTORY_STATES = frozenset(
 )
 _PROJECT_ROOT_BACKENDS = frozenset({"host_local", "sandbox_volume"})
 _READY_SANDBOX_MOUNT_STATES = frozenset({"ready", "mounted"})
+WORKSPACE_RUNTIME_BINDING_KINDS = frozenset(
+    {
+        "repo",
+        "git_worktree",
+        "local_path",
+        "workspace_project_root",
+        "acp_execution_workspace",
+        "acp_session",
+        "acp_run",
+        "sandbox_root",
+        "sandbox_session",
+        "mcp_workspace_set",
+        "remote_runtime",
+    }
+)
+WORKSPACE_RUNTIME_BINDING_OWNER_DOMAINS = frozenset(
+    {
+        "workspaces",
+        "acp",
+        "sandbox",
+        "mcp",
+        "jobs",
+        "workflows",
+        "watchlists",
+        "external",
+    }
+)
+WORKSPACE_RUNTIME_BINDING_STATUSES = frozenset(
+    {
+        "ready",
+        "missing",
+        "inspect-only",
+        "blocked",
+        "provisioning",
+        "unavailable",
+        "detached",
+        "conflict",
+        "runtime-missing",
+        "archived",
+        "unsupported",
+    }
+)
+WORKSPACE_RUNTIME_BINDING_PORTABILITY = frozenset(
+    {
+        "reference",
+        "metadata-only",
+        "local-only",
+        "copy",
+    }
+)
 
 
 class AllowedAction(TypedDict):

--- a/tldw_Server_API/app/core/Workspaces/runtime_bindings.py
+++ b/tldw_Server_API/app/core/Workspaces/runtime_bindings.py
@@ -32,7 +32,7 @@ _SECRET_KEY_RE = re.compile(
     r"(^|[_\-.])("
     r"api[_\-.]?key|access[_\-.]?key|secret|token|password|passwd|pwd|"
     r"credential|credentials|private[_\-.]?key|client[_\-.]?secret|"
-    r"bearer|authorization|auth[_\-.]?header|env|environment"
+    r"bearer|authorization|auth[_\-.]?header|env[_\-.]?vars?|environment[_\-.]?variables?"
     r")($|[_\-.])",
     re.IGNORECASE,
 )
@@ -49,9 +49,11 @@ _PATH_METADATA_KEY_RE = re.compile(
     r")($|[_\-.])",
     re.IGNORECASE,
 )
+_WRITE_STATUSES = WORKSPACE_RUNTIME_BINDING_STATUSES - {"archived"}
 
 
 def _input_error(message: str) -> ValueError:
+    """Return the DB-layer input exception without importing it at module load."""
     from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import InputError
 
     return InputError(message)
@@ -75,8 +77,9 @@ def normalize_runtime_binding_payload(data: Mapping[str, Any]) -> dict[str, Any]
     status = _enum_value(
         data.get("status"),
         "status",
-        WORKSPACE_RUNTIME_BINDING_STATUSES,
+        _WRITE_STATUSES,
         aliases=_STATUS_ALIASES,
+        extra_guidance="Use DELETE to archive a runtime binding.",
     )
     portability = _enum_value(
         data.get("portability"),
@@ -86,20 +89,20 @@ def normalize_runtime_binding_payload(data: Mapping[str, Any]) -> dict[str, Any]
     )
     raw_path_hint = _optional_string(data.get("path_hint"), "path_hint", max_length=1024)
     path_hint = redacted_path_hint(raw_path_hint) if raw_path_hint is not None else None
-    metadata = normalize_runtime_binding_json_object(
+    metadata, _metadata_json = normalize_runtime_binding_json_object(
         data.get("metadata", data.get("metadata_json")),
         field_name="metadata",
         max_bytes=WORKSPACE_RUNTIME_BINDING_MAX_METADATA_BYTES,
         reject_secrets=True,
     )
     metadata, metadata_redacted_fields = _redact_path_like_metadata(metadata, "metadata")
-    metadata, metadata_json = dump_runtime_binding_json_object(
+    metadata, metadata_json = normalize_runtime_binding_json_object(
         metadata,
         field_name="metadata",
         max_bytes=WORKSPACE_RUNTIME_BINDING_MAX_METADATA_BYTES,
         reject_secrets=True,
     )
-    redaction_report = _redaction_report(data.get("redaction_report", data.get("redaction_report_json")))
+    redaction_report = _default_redaction_report()
     redacted_fields = list(redaction_report.get("redacted_fields") or [])
     for field_name in metadata_redacted_fields:
         if field_name not in redacted_fields:
@@ -108,7 +111,7 @@ def normalize_runtime_binding_payload(data: Mapping[str, Any]) -> dict[str, Any]
         redacted_fields.append("path_hint")
     redaction_report["redacted_fields"] = redacted_fields
     redaction_report["redacted"] = bool(redacted_fields or redaction_report.get("rejected_fields"))
-    redaction_report, redaction_report_json = dump_runtime_binding_json_object(
+    redaction_report, redaction_report_json = normalize_runtime_binding_json_object(
         redaction_report,
         field_name="redaction_report",
         max_bytes=WORKSPACE_RUNTIME_BINDING_MAX_REDACTION_BYTES,
@@ -164,42 +167,14 @@ def redacted_path_hint(value: Any) -> str:
     return raw_value
 
 
-def dump_runtime_binding_json_object(
-    value: Any,
-    *,
-    field_name: str,
-    max_bytes: int,
-    reject_secrets: bool,
-) -> tuple[dict[str, Any], str]:
-    """Normalize, validate, and serialize a bounded descriptor JSON object."""
-    normalized = normalize_runtime_binding_json_object(
-        value,
-        field_name=field_name,
-        max_bytes=max_bytes,
-        reject_secrets=reject_secrets,
-    )
-    try:
-        dumped = json.dumps(
-            normalized,
-            ensure_ascii=True,
-            allow_nan=False,
-            separators=(",", ":"),
-            sort_keys=True,
-        )
-    except (TypeError, ValueError) as exc:
-        raise _input_error(f"{field_name} must be JSON serializable.") from exc
-    if len(dumped.encode("utf-8")) > max_bytes:
-        raise _input_error(f"{field_name} exceeds {max_bytes} bytes.")
-    return normalized, dumped
-
-
 def normalize_runtime_binding_json_object(
     value: Any,
     *,
     field_name: str,
     max_bytes: int,
     reject_secrets: bool,
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], str]:
+    """Normalize and serialize a bounded descriptor JSON object once."""
     if value is None:
         normalized: dict[str, Any] = {}
     elif isinstance(value, str):
@@ -232,7 +207,7 @@ def normalize_runtime_binding_json_object(
         raise _input_error(f"{field_name} must be JSON serializable.") from exc
     if len(dumped.encode("utf-8")) > max_bytes:
         raise _input_error(f"{field_name} exceeds {max_bytes} bytes.")
-    return normalized
+    return normalized, dumped
 
 
 def load_runtime_binding_json_object(raw: Any, *, field_name: str) -> dict[str, Any]:
@@ -247,12 +222,10 @@ def load_runtime_binding_json_object(raw: Any, *, field_name: str) -> dict[str, 
         try:
             parsed = json.loads(raw)
         except json.JSONDecodeError:
-            preview = raw[:120].replace("\n", "\\n")
             logger.warning(
-                "Failed to decode workspace runtime binding JSON field {} ({} chars): {}",
+                "Failed to decode workspace runtime binding JSON field {} ({} chars); raw value omitted.",
                 field_name,
                 len(raw),
-                preview,
             )
             return {}
         return dict(parsed) if isinstance(parsed, Mapping) else {}
@@ -260,7 +233,8 @@ def load_runtime_binding_json_object(raw: Any, *, field_name: str) -> dict[str, 
 
 
 def _redaction_report(value: Any) -> dict[str, Any]:
-    report = normalize_runtime_binding_json_object(
+    """Normalize a stored redaction report into the public report shape."""
+    report, _report_json = normalize_runtime_binding_json_object(
         value,
         field_name="redaction_report",
         max_bytes=WORKSPACE_RUNTIME_BINDING_MAX_REDACTION_BYTES,
@@ -276,10 +250,12 @@ def _redaction_report(value: Any) -> dict[str, Any]:
 
 
 def _default_redaction_report() -> dict[str, Any]:
+    """Return the default server-generated redaction report."""
     return {"redacted": False, "redacted_fields": [], "rejected_fields": []}
 
 
 def _string_list(value: Any) -> list[str]:
+    """Return a de-duplicated list of non-empty string values."""
     if value is None:
         return []
     if isinstance(value, str):
@@ -295,6 +271,7 @@ def _string_list(value: Any) -> list[str]:
 
 
 def _reject_secret_like_json(value: Any, field_path: str) -> None:
+    """Reject secret-looking keys or values in a JSON-like structure."""
     if isinstance(value, Mapping):
         for key, item in value.items():
             key_text = str(key)
@@ -317,16 +294,18 @@ def _redact_path_like_metadata(
     *,
     path_context: bool = False,
 ) -> tuple[Any, list[str]]:
+    """Redact path-like metadata values and report the fields changed."""
     if isinstance(value, Mapping):
         result: dict[str, Any] = {}
         redacted_fields: list[str] = []
         for key, item in value.items():
             key_text = str(key)
             child_path = f"{field_path}.{key_text}"
+            child_path_context = bool(_PATH_METADATA_KEY_RE.search(key_text))
             redacted_item, child_fields = _redact_path_like_metadata(
                 item,
                 child_path,
-                path_context=path_context or bool(_PATH_METADATA_KEY_RE.search(key_text)),
+                path_context=child_path_context,
             )
             result[key_text] = redacted_item
             redacted_fields.extend(child_fields)
@@ -351,6 +330,7 @@ def _redact_path_like_metadata(
 
 
 def _required_identifier(value: Any, field_name: str) -> str:
+    """Return a required bounded identifier or raise a contract error."""
     normalized = _required_string(value, field_name, max_length=128)
     if not _IDENTIFIER_RE.fullmatch(normalized):
         raise _input_error(f"{field_name} contains unsupported characters.")
@@ -358,6 +338,7 @@ def _required_identifier(value: Any, field_name: str) -> str:
 
 
 def _required_string(value: Any, field_name: str, *, max_length: int) -> str:
+    """Return a required bounded string or raise a contract error."""
     normalized = str(value if value is not None else "").strip()
     if not normalized:
         raise _input_error(f"{field_name} is required.")
@@ -367,6 +348,7 @@ def _required_string(value: Any, field_name: str, *, max_length: int) -> str:
 
 
 def _optional_string(value: Any, field_name: str, *, max_length: int) -> str | None:
+    """Return an optional bounded string or None."""
     if value is None:
         return None
     normalized = str(value).strip()
@@ -383,11 +365,16 @@ def _enum_value(
     allowed: frozenset[str],
     *,
     aliases: Mapping[str, str] | None = None,
+    extra_guidance: str | None = None,
 ) -> str:
+    """Normalize a string enum value, applying aliases before validation."""
     normalized = str(value if value is not None else "").strip().lower()
     if aliases:
         normalized = aliases.get(normalized, normalized)
     if normalized not in allowed:
         allowed_values = ", ".join(sorted(allowed))
-        raise _input_error(f"{field_name} must be one of: {allowed_values}.")
+        message = f"{field_name} must be one of: {allowed_values}."
+        if extra_guidance:
+            message = f"{message} {extra_guidance}"
+        raise _input_error(message)
     return normalized

--- a/tldw_Server_API/app/core/Workspaces/runtime_bindings.py
+++ b/tldw_Server_API/app/core/Workspaces/runtime_bindings.py
@@ -1,0 +1,393 @@
+"""Secret-safe Workspace runtime binding descriptor helpers."""
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping, Sequence
+from pathlib import PurePath, PureWindowsPath
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Workspaces.models import (
+    WORKSPACE_RUNTIME_BINDING_KINDS,
+    WORKSPACE_RUNTIME_BINDING_OWNER_DOMAINS,
+    WORKSPACE_RUNTIME_BINDING_PORTABILITY,
+    WORKSPACE_RUNTIME_BINDING_STATUSES,
+)
+
+WORKSPACE_RUNTIME_BINDING_MAX_METADATA_BYTES = 16 * 1024
+WORKSPACE_RUNTIME_BINDING_MAX_REDACTION_BYTES = 8 * 1024
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+_STATUS_ALIASES = {
+    "inspect_only": "inspect-only",
+    "runtime_missing": "runtime-missing",
+}
+_PORTABILITY_ALIASES = {
+    "metadata_only": "metadata-only",
+    "local_only": "local-only",
+}
+_SECRET_KEY_RE = re.compile(
+    r"(^|[_\-.])("
+    r"api[_\-.]?key|access[_\-.]?key|secret|token|password|passwd|pwd|"
+    r"credential|credentials|private[_\-.]?key|client[_\-.]?secret|"
+    r"bearer|authorization|auth[_\-.]?header|env|environment"
+    r")($|[_\-.])",
+    re.IGNORECASE,
+)
+_SECRET_VALUE_RE = re.compile(
+    r"(-----BEGIN [A-Z ]*PRIVATE KEY-----|"
+    r"\bsk-[A-Za-z0-9_\-]{12,}|"
+    r"\b(?:ghp|github_pat|xox[baprs])_[A-Za-z0-9_\-]{12,})",
+    re.IGNORECASE,
+)
+_PATH_METADATA_KEY_RE = re.compile(
+    r"(^|[_\-.])("
+    r"absolute[_\-.]?root|root|paths?|mount[_\-.]?path|workspace[_\-.]?path|"
+    r"repo[_\-.]?path|local[_\-.]?path|project[_\-.]?root|dir|directory"
+    r")($|[_\-.])",
+    re.IGNORECASE,
+)
+
+
+def _input_error(message: str) -> ValueError:
+    from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import InputError
+
+    return InputError(message)
+
+
+def normalize_runtime_binding_payload(data: Mapping[str, Any]) -> dict[str, Any]:
+    """Normalize and sanitize a runtime binding descriptor for storage or response."""
+    binding_id = _required_identifier(data.get("binding_id"), "binding_id")
+    binding_kind = _enum_value(
+        data.get("binding_kind"),
+        "binding_kind",
+        WORKSPACE_RUNTIME_BINDING_KINDS,
+    )
+    owner_domain = _enum_value(
+        data.get("owner_domain"),
+        "owner_domain",
+        WORKSPACE_RUNTIME_BINDING_OWNER_DOMAINS,
+    )
+    locator_ref = _required_string(data.get("locator_ref"), "locator_ref", max_length=512)
+    label = _optional_string(data.get("label"), "label", max_length=512)
+    status = _enum_value(
+        data.get("status"),
+        "status",
+        WORKSPACE_RUNTIME_BINDING_STATUSES,
+        aliases=_STATUS_ALIASES,
+    )
+    portability = _enum_value(
+        data.get("portability"),
+        "portability",
+        WORKSPACE_RUNTIME_BINDING_PORTABILITY,
+        aliases=_PORTABILITY_ALIASES,
+    )
+    raw_path_hint = _optional_string(data.get("path_hint"), "path_hint", max_length=1024)
+    path_hint = redacted_path_hint(raw_path_hint) if raw_path_hint is not None else None
+    metadata = normalize_runtime_binding_json_object(
+        data.get("metadata", data.get("metadata_json")),
+        field_name="metadata",
+        max_bytes=WORKSPACE_RUNTIME_BINDING_MAX_METADATA_BYTES,
+        reject_secrets=True,
+    )
+    metadata, metadata_redacted_fields = _redact_path_like_metadata(metadata, "metadata")
+    metadata, metadata_json = dump_runtime_binding_json_object(
+        metadata,
+        field_name="metadata",
+        max_bytes=WORKSPACE_RUNTIME_BINDING_MAX_METADATA_BYTES,
+        reject_secrets=True,
+    )
+    redaction_report = _redaction_report(data.get("redaction_report", data.get("redaction_report_json")))
+    redacted_fields = list(redaction_report.get("redacted_fields") or [])
+    for field_name in metadata_redacted_fields:
+        if field_name not in redacted_fields:
+            redacted_fields.append(field_name)
+    if raw_path_hint is not None and path_hint != raw_path_hint and "path_hint" not in redacted_fields:
+        redacted_fields.append("path_hint")
+    redaction_report["redacted_fields"] = redacted_fields
+    redaction_report["redacted"] = bool(redacted_fields or redaction_report.get("rejected_fields"))
+    redaction_report, redaction_report_json = dump_runtime_binding_json_object(
+        redaction_report,
+        field_name="redaction_report",
+        max_bytes=WORKSPACE_RUNTIME_BINDING_MAX_REDACTION_BYTES,
+        reject_secrets=True,
+    )
+
+    return {
+        "binding_id": binding_id,
+        "binding_kind": binding_kind,
+        "owner_domain": owner_domain,
+        "locator_ref": locator_ref,
+        "label": label,
+        "status": status,
+        "path_hint": path_hint,
+        "portability": portability,
+        "metadata": metadata,
+        "metadata_json": metadata_json,
+        "redaction_report": redaction_report,
+        "redaction_report_json": redaction_report_json,
+    }
+
+
+def runtime_binding_response_payload(row: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a public runtime binding response payload from a DB row-like mapping."""
+    item = dict(row)
+    item["metadata"] = load_runtime_binding_json_object(
+        item.get("metadata", item.get("metadata_json")),
+        field_name="metadata_json",
+    )
+    item["redaction_report"] = load_runtime_binding_json_object(
+        item.get("redaction_report", item.get("redaction_report_json")),
+        field_name="redaction_report_json",
+    ) or _default_redaction_report()
+    if item.get("path_hint"):
+        item["path_hint"] = redacted_path_hint(item["path_hint"])
+    item["deleted"] = bool(item.get("deleted", False))
+    item["version"] = int(item.get("version") or 1)
+    return item
+
+
+def redacted_path_hint(value: Any) -> str:
+    """Reduce absolute or segmented paths to a safe display hint."""
+    raw_value = str(value or "").strip()
+    if not raw_value:
+        return "project_root"
+    windows_path = PureWindowsPath(raw_value)
+    if raw_value.startswith(("/", "~", "\\\\")) or windows_path.is_absolute():
+        if windows_path.is_absolute() or raw_value.startswith("\\\\"):
+            return windows_path.name or "project_root"
+        return PurePath(raw_value).name or "project_root"
+    if "/" in raw_value or "\\" in raw_value:
+        return windows_path.name or PurePath(raw_value).name or "project_root"
+    return raw_value
+
+
+def dump_runtime_binding_json_object(
+    value: Any,
+    *,
+    field_name: str,
+    max_bytes: int,
+    reject_secrets: bool,
+) -> tuple[dict[str, Any], str]:
+    """Normalize, validate, and serialize a bounded descriptor JSON object."""
+    normalized = normalize_runtime_binding_json_object(
+        value,
+        field_name=field_name,
+        max_bytes=max_bytes,
+        reject_secrets=reject_secrets,
+    )
+    try:
+        dumped = json.dumps(
+            normalized,
+            ensure_ascii=True,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as exc:
+        raise _input_error(f"{field_name} must be JSON serializable.") from exc
+    if len(dumped.encode("utf-8")) > max_bytes:
+        raise _input_error(f"{field_name} exceeds {max_bytes} bytes.")
+    return normalized, dumped
+
+
+def normalize_runtime_binding_json_object(
+    value: Any,
+    *,
+    field_name: str,
+    max_bytes: int,
+    reject_secrets: bool,
+) -> dict[str, Any]:
+    if value is None:
+        normalized: dict[str, Any] = {}
+    elif isinstance(value, str):
+        if not value.strip():
+            normalized = {}
+        else:
+            try:
+                parsed = json.loads(value)
+            except json.JSONDecodeError as exc:
+                raise _input_error(f"{field_name} must be valid JSON.") from exc
+            if not isinstance(parsed, Mapping):
+                raise _input_error(f"{field_name} must be a JSON object.")
+            normalized = dict(parsed)
+    elif isinstance(value, Mapping):
+        normalized = dict(value)
+    else:
+        raise _input_error(f"{field_name} must be a JSON object.")
+
+    if reject_secrets:
+        _reject_secret_like_json(normalized, field_name)
+    try:
+        dumped = json.dumps(
+            normalized,
+            ensure_ascii=True,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as exc:
+        raise _input_error(f"{field_name} must be JSON serializable.") from exc
+    if len(dumped.encode("utf-8")) > max_bytes:
+        raise _input_error(f"{field_name} exceeds {max_bytes} bytes.")
+    return normalized
+
+
+def load_runtime_binding_json_object(raw: Any, *, field_name: str) -> dict[str, Any]:
+    """Load descriptor JSON with warning on corruption instead of silent loss."""
+    if raw is None:
+        return {}
+    if isinstance(raw, Mapping):
+        return dict(raw)
+    if isinstance(raw, str):
+        if not raw.strip():
+            return {}
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            preview = raw[:120].replace("\n", "\\n")
+            logger.warning(
+                "Failed to decode workspace runtime binding JSON field {} ({} chars): {}",
+                field_name,
+                len(raw),
+                preview,
+            )
+            return {}
+        return dict(parsed) if isinstance(parsed, Mapping) else {}
+    return {}
+
+
+def _redaction_report(value: Any) -> dict[str, Any]:
+    report = normalize_runtime_binding_json_object(
+        value,
+        field_name="redaction_report",
+        max_bytes=WORKSPACE_RUNTIME_BINDING_MAX_REDACTION_BYTES,
+        reject_secrets=True,
+    )
+    if not report:
+        return _default_redaction_report()
+    return {
+        "redacted": bool(report.get("redacted", False)),
+        "redacted_fields": _string_list(report.get("redacted_fields")),
+        "rejected_fields": _string_list(report.get("rejected_fields")),
+    }
+
+
+def _default_redaction_report() -> dict[str, Any]:
+    return {"redacted": False, "redacted_fields": [], "rejected_fields": []}
+
+
+def _string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        result: list[str] = []
+        for item in value:
+            normalized = str(item or "").strip()
+            if normalized and normalized not in result:
+                result.append(normalized)
+        return result
+    return []
+
+
+def _reject_secret_like_json(value: Any, field_path: str) -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            key_text = str(key)
+            child_path = f"{field_path}.{key_text}"
+            if _SECRET_KEY_RE.search(key_text):
+                raise _input_error(f"{field_path} contains secret-looking field '{child_path}'.")
+            _reject_secret_like_json(item, child_path)
+        return
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for index, item in enumerate(value):
+            _reject_secret_like_json(item, f"{field_path}[{index}]")
+        return
+    if isinstance(value, str) and _SECRET_VALUE_RE.search(value):
+        raise _input_error(f"{field_path} contains a secret-looking value.")
+
+
+def _redact_path_like_metadata(
+    value: Any,
+    field_path: str,
+    *,
+    path_context: bool = False,
+) -> tuple[Any, list[str]]:
+    if isinstance(value, Mapping):
+        result: dict[str, Any] = {}
+        redacted_fields: list[str] = []
+        for key, item in value.items():
+            key_text = str(key)
+            child_path = f"{field_path}.{key_text}"
+            redacted_item, child_fields = _redact_path_like_metadata(
+                item,
+                child_path,
+                path_context=path_context or bool(_PATH_METADATA_KEY_RE.search(key_text)),
+            )
+            result[key_text] = redacted_item
+            redacted_fields.extend(child_fields)
+        return result, redacted_fields
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        result_list: list[Any] = []
+        redacted_fields = []
+        for index, item in enumerate(value):
+            redacted_item, child_fields = _redact_path_like_metadata(
+                item,
+                f"{field_path}[{index}]",
+                path_context=path_context,
+            )
+            result_list.append(redacted_item)
+            redacted_fields.extend(child_fields)
+        return result_list, redacted_fields
+    if path_context and isinstance(value, str):
+        redacted = redacted_path_hint(value)
+        if redacted != value:
+            return redacted, [field_path]
+    return value, []
+
+
+def _required_identifier(value: Any, field_name: str) -> str:
+    normalized = _required_string(value, field_name, max_length=128)
+    if not _IDENTIFIER_RE.fullmatch(normalized):
+        raise _input_error(f"{field_name} contains unsupported characters.")
+    return normalized
+
+
+def _required_string(value: Any, field_name: str, *, max_length: int) -> str:
+    normalized = str(value if value is not None else "").strip()
+    if not normalized:
+        raise _input_error(f"{field_name} is required.")
+    if len(normalized) > max_length:
+        raise _input_error(f"{field_name} exceeds {max_length} characters.")
+    return normalized
+
+
+def _optional_string(value: Any, field_name: str, *, max_length: int) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    if not normalized:
+        return None
+    if len(normalized) > max_length:
+        raise _input_error(f"{field_name} exceeds {max_length} characters.")
+    return normalized
+
+
+def _enum_value(
+    value: Any,
+    field_name: str,
+    allowed: frozenset[str],
+    *,
+    aliases: Mapping[str, str] | None = None,
+) -> str:
+    normalized = str(value if value is not None else "").strip().lower()
+    if aliases:
+        normalized = aliases.get(normalized, normalized)
+    if normalized not in allowed:
+        allowed_values = ", ".join(sorted(allowed))
+        raise _input_error(f"{field_name} must be one of: {allowed_values}.")
+    return normalized

--- a/tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    InputError,
+)
+from tldw_Server_API.app.core.Workspaces.runtime_bindings import (
+    normalize_runtime_binding_payload,
+)
+
+
+def test_runtime_binding_normalizer_redacts_path_and_preserves_safe_metadata() -> None:
+    payload = normalize_runtime_binding_payload(
+        {
+            "binding_id": "repo-main",
+            "binding_kind": "repo",
+            "owner_domain": "workspaces",
+            "locator_ref": "repo-123",
+            "label": "Main Repo",
+            "status": "ready",
+            "path_hint": "/Users/example/private/project",
+            "portability": "reference",
+            "metadata": {"branch": "main", "remote": "origin"},
+        }
+    )
+
+    assert payload["path_hint"] == "project"
+    assert payload["metadata"] == {"branch": "main", "remote": "origin"}
+    assert payload["redaction_report"]["redacted_fields"] == ["path_hint"]
+
+
+def test_runtime_binding_normalizer_normalizes_contract_aliases() -> None:
+    payload = normalize_runtime_binding_payload(
+        {
+            "binding_id": "sandbox-root",
+            "binding_kind": "sandbox_root",
+            "owner_domain": "sandbox",
+            "locator_ref": "sandbox-123",
+            "status": "inspect_only",
+            "portability": "metadata_only",
+        }
+    )
+
+    assert payload["status"] == "inspect-only"
+    assert payload["portability"] == "metadata-only"
+
+
+def test_runtime_binding_normalizer_rejects_secret_metadata_keys() -> None:
+    with pytest.raises(InputError):
+        normalize_runtime_binding_payload(
+            {
+                "binding_id": "acp-session",
+                "binding_kind": "acp_session",
+                "owner_domain": "acp",
+                "locator_ref": "session-123",
+                "label": "ACP Session",
+                "status": "ready",
+                "portability": "metadata-only",
+                "metadata": {"OPENAI_API_KEY": "sk-secret"},
+            }
+        )
+
+
+def test_runtime_binding_normalizer_redacts_path_metadata_values() -> None:
+    payload = normalize_runtime_binding_payload(
+        {
+            "binding_id": "sandbox-root",
+            "binding_kind": "sandbox_root",
+            "owner_domain": "sandbox",
+            "locator_ref": "sandbox-123",
+            "status": "ready",
+            "portability": "metadata-only",
+            "metadata": {
+                "absolute_root": "/Users/example/private/project",
+                "nested": {"mount_path": "client/acme/repo"},
+            },
+        }
+    )
+
+    assert payload["metadata"]["absolute_root"] == "project"
+    assert payload["metadata"]["nested"]["mount_path"] == "repo"
+    assert payload["redaction_report"]["redacted_fields"] == [
+        "metadata.absolute_root",
+        "metadata.nested.mount_path",
+    ]
+
+
+def test_workspace_runtime_binding_upsert_list_get_and_archive(tmp_path: Path) -> None:
+    db = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="user-1")
+    try:
+        db.upsert_workspace("ws-1", "Workspace")
+
+        created = db.upsert_workspace_runtime_binding(
+            "ws-1",
+            {
+                "binding_id": "repo-main",
+                "binding_kind": "repo",
+                "owner_domain": "workspaces",
+                "locator_ref": "repo-123",
+                "label": "Main Repo",
+                "status": "ready",
+                "path_hint": "/Users/example/project",
+                "portability": "reference",
+                "metadata": {"branch": "main"},
+            },
+            user_id="user-1",
+        )
+
+        assert created["path_hint"] == "project"
+        assert created["metadata"] == {"branch": "main"}
+        assert db.get_workspace_runtime_binding("ws-1", "repo-main")["binding_id"] == "repo-main"
+        assert [item["binding_id"] for item in db.list_workspace_runtime_bindings("ws-1")] == [
+            "repo-main"
+        ]
+
+        updated = db.upsert_workspace_runtime_binding(
+            "ws-1",
+            {
+                "binding_id": "repo-main",
+                "binding_kind": "repo",
+                "owner_domain": "workspaces",
+                "locator_ref": "repo-123",
+                "label": "Main Repo",
+                "status": "missing",
+                "path_hint": "/Users/example/project",
+                "portability": "reference",
+                "metadata": {"branch": "dev"},
+            },
+            user_id="user-1",
+        )
+
+        assert updated["status"] == "missing"
+        assert updated["metadata"] == {"branch": "dev"}
+        assert updated["version"] == created["version"] + 1
+
+        archived = db.archive_workspace_runtime_binding("ws-1", "repo-main", user_id="user-1")
+        assert archived["status"] == "archived"
+        assert archived["deleted"] in (True, 1)
+        assert db.get_workspace_runtime_binding("ws-1", "repo-main") is None
+        assert (
+            db.get_workspace_runtime_binding("ws-1", "repo-main", include_deleted=True)["status"]
+            == "archived"
+        )
+    finally:
+        db.close_connection()
+
+
+def test_workspace_runtime_binding_filters_by_kind_and_owner(tmp_path: Path) -> None:
+    db = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="user-1")
+    try:
+        db.upsert_workspace("ws-1", "Workspace")
+        db.upsert_workspace_runtime_binding(
+            "ws-1",
+            {
+                "binding_id": "repo-main",
+                "binding_kind": "repo",
+                "owner_domain": "workspaces",
+                "locator_ref": "repo-123",
+                "status": "ready",
+                "portability": "reference",
+            },
+        )
+        db.upsert_workspace_runtime_binding(
+            "ws-1",
+            {
+                "binding_id": "acp-session",
+                "binding_kind": "acp_session",
+                "owner_domain": "acp",
+                "locator_ref": "session-123",
+                "status": "runtime_missing",
+                "portability": "metadata_only",
+            },
+        )
+
+        assert [
+            item["binding_id"]
+            for item in db.list_workspace_runtime_bindings("ws-1", binding_kind="repo")
+        ] == ["repo-main"]
+        assert [
+            item["binding_id"]
+            for item in db.list_workspace_runtime_bindings("ws-1", owner_domain="acp")
+        ] == ["acp-session"]
+    finally:
+        db.close_connection()

--- a/tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py
@@ -8,6 +8,7 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     CharactersRAGDB,
     InputError,
 )
+from tldw_Server_API.app.core.Workspaces import runtime_bindings as runtime_binding_helpers
 from tldw_Server_API.app.core.Workspaces.runtime_bindings import (
     normalize_runtime_binding_payload,
 )
@@ -65,6 +66,22 @@ def test_runtime_binding_normalizer_rejects_secret_metadata_keys() -> None:
         )
 
 
+def test_runtime_binding_normalizer_allows_environment_labels() -> None:
+    payload = normalize_runtime_binding_payload(
+        {
+            "binding_id": "repo-main",
+            "binding_kind": "repo",
+            "owner_domain": "workspaces",
+            "locator_ref": "repo-123",
+            "status": "ready",
+            "portability": "reference",
+            "metadata": {"env": "production", "environment": "staging"},
+        }
+    )
+
+    assert payload["metadata"] == {"env": "production", "environment": "staging"}
+
+
 def test_runtime_binding_normalizer_redacts_path_metadata_values() -> None:
     payload = normalize_runtime_binding_payload(
         {
@@ -87,6 +104,91 @@ def test_runtime_binding_normalizer_redacts_path_metadata_values() -> None:
         "metadata.absolute_root",
         "metadata.nested.mount_path",
     ]
+
+
+def test_runtime_binding_normalizer_does_not_redact_nested_non_path_values() -> None:
+    payload = normalize_runtime_binding_payload(
+        {
+            "binding_id": "repo-main",
+            "binding_kind": "repo",
+            "owner_domain": "workspaces",
+            "locator_ref": "repo-123",
+            "status": "ready",
+            "portability": "reference",
+            "metadata": {
+                "project_root": {
+                    "path": "/Users/example/private/project",
+                    "docs_url": "https://example.test/docs/runtime-bindings",
+                    "branch": "feature/runtime-bindings",
+                },
+            },
+        }
+    )
+
+    assert payload["metadata"]["project_root"]["path"] == "project"
+    assert payload["metadata"]["project_root"]["docs_url"] == "https://example.test/docs/runtime-bindings"
+    assert payload["metadata"]["project_root"]["branch"] == "feature/runtime-bindings"
+    assert payload["redaction_report"]["redacted_fields"] == [
+        "metadata.project_root.path",
+    ]
+
+
+def test_runtime_binding_normalizer_ignores_client_redaction_report() -> None:
+    payload = normalize_runtime_binding_payload(
+        {
+            "binding_id": "repo-main",
+            "binding_kind": "repo",
+            "owner_domain": "workspaces",
+            "locator_ref": "repo-123",
+            "status": "ready",
+            "portability": "reference",
+            "metadata": {"branch": "main"},
+            "redaction_report": {
+                "redacted": True,
+                "redacted_fields": ["metadata.branch"],
+                "rejected_fields": ["metadata.fake_secret"],
+            },
+        }
+    )
+
+    assert payload["redaction_report"] == {
+        "redacted": False,
+        "redacted_fields": [],
+        "rejected_fields": [],
+    }
+
+
+def test_runtime_binding_json_decode_warning_omits_raw_preview(monkeypatch: pytest.MonkeyPatch) -> None:
+    raw_payload = '{"api_key":"sk-should-not-appear",'
+    warnings: list[tuple[str, tuple[object, ...]]] = []
+
+    monkeypatch.setattr(
+        runtime_binding_helpers.logger,
+        "warning",
+        lambda message, *args: warnings.append((message, args)),
+    )
+
+    assert runtime_binding_helpers.load_runtime_binding_json_object(raw_payload, field_name="metadata_json") == {}
+
+    rendered = "\n".join(f"{message} {args}" for message, args in warnings)
+    assert "metadata_json" in rendered
+    assert str(len(raw_payload)) in rendered
+    assert "sk-should-not-appear" not in rendered
+    assert "api_key" not in rendered
+
+
+def test_runtime_binding_normalizer_rejects_archived_status_on_write() -> None:
+    with pytest.raises(InputError, match="DELETE"):
+        normalize_runtime_binding_payload(
+            {
+                "binding_id": "repo-main",
+                "binding_kind": "repo",
+                "owner_domain": "workspaces",
+                "locator_ref": "repo-123",
+                "status": "archived",
+                "portability": "reference",
+            }
+        )
 
 
 def test_workspace_runtime_binding_upsert_list_get_and_archive(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py
@@ -151,6 +151,36 @@ def test_workspace_runtime_binding_api_rejects_secret_metadata_key(
     assert response.status_code == 422
 
 
+def test_workspace_runtime_binding_api_rejects_client_redaction_report(
+    workspace_client: TestClient,
+    db: CharactersRAGDB,
+) -> None:
+    db.upsert_workspace("ws-runtime", "Runtime Workspace")
+
+    response = workspace_client.post(
+        "/api/v1/workspaces/ws-runtime/runtime-bindings",
+        json=_descriptor_payload(
+            redaction_report={"redacted": True, "redacted_fields": ["metadata.agent"]},
+        ),
+    )
+
+    assert response.status_code == 422
+
+
+def test_workspace_runtime_binding_api_rejects_archived_status_on_upsert(
+    workspace_client: TestClient,
+    db: CharactersRAGDB,
+) -> None:
+    db.upsert_workspace("ws-runtime", "Runtime Workspace")
+
+    response = workspace_client.post(
+        "/api/v1/workspaces/ws-runtime/runtime-bindings",
+        json=_descriptor_payload(status="archived"),
+    )
+
+    assert response.status_code == 422
+
+
 def test_workspace_runtime_binding_api_returns_404_for_missing_workspace(
     workspace_client: TestClient,
 ) -> None:

--- a/tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user
+from tldw_Server_API.app.api.v1.endpoints import workspaces as workspaces_endpoint
+from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import (
+    WORKSPACES_DELETE_RATE_LIMIT,
+    WORKSPACES_READ_RATE_LIMIT,
+    WORKSPACES_WRITE_RATE_LIMIT,
+)
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Iterator[CharactersRAGDB]:
+    database = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="user-1")
+    try:
+        yield database
+    finally:
+        database.close_connection()
+
+
+@pytest.fixture
+def workspace_fastapi_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(workspaces_endpoint.router, prefix="/api/v1/workspaces")
+    return app
+
+
+@pytest.fixture
+def workspace_client(workspace_fastapi_app: FastAPI, db: CharactersRAGDB) -> Iterator[TestClient]:
+    async def _allow_rate_limit() -> None:
+        return None
+
+    workspace_fastapi_app.dependency_overrides[get_request_user] = lambda: SimpleNamespace(id=1)
+    workspace_fastapi_app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    workspace_fastapi_app.dependency_overrides[WORKSPACES_READ_RATE_LIMIT] = _allow_rate_limit
+    workspace_fastapi_app.dependency_overrides[WORKSPACES_WRITE_RATE_LIMIT] = _allow_rate_limit
+    workspace_fastapi_app.dependency_overrides[WORKSPACES_DELETE_RATE_LIMIT] = _allow_rate_limit
+    try:
+        with TestClient(workspace_fastapi_app, raise_server_exceptions=False) as client:
+            yield client
+    finally:
+        workspace_fastapi_app.dependency_overrides.pop(get_request_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(get_chacha_db_for_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_READ_RATE_LIMIT, None)
+        workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_WRITE_RATE_LIMIT, None)
+        workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_DELETE_RATE_LIMIT, None)
+
+
+def _descriptor_payload(**overrides: Any) -> dict[str, Any]:
+    payload = {
+        "binding_id": "acp-session-1",
+        "binding_kind": "acp_session",
+        "owner_domain": "acp",
+        "locator_ref": "session-1",
+        "label": "ACP Session",
+        "status": "runtime_missing",
+        "path_hint": "/Users/example/agent-workspace",
+        "portability": "metadata_only",
+        "metadata": {
+            "agent": "codex",
+            "absolute_root": "/Users/example/private/agent-workspace",
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_workspace_runtime_binding_api_upserts_lists_gets_and_archives(
+    workspace_client: TestClient,
+    db: CharactersRAGDB,
+) -> None:
+    db.upsert_workspace("ws-runtime", "Runtime Workspace")
+
+    response = workspace_client.post(
+        "/api/v1/workspaces/ws-runtime/runtime-bindings",
+        json=_descriptor_payload(),
+    )
+    assert response.status_code == 201
+    created = response.json()
+    assert created["binding_id"] == "acp-session-1"
+    assert created["status"] == "runtime-missing"
+    assert created["path_hint"] == "agent-workspace"
+    assert created["metadata"] == {"agent": "codex", "absolute_root": "agent-workspace"}
+    assert created["redaction_report"]["redacted_fields"] == [
+        "metadata.absolute_root",
+        "path_hint",
+    ]
+    assert "absolute_root" not in created
+
+    listed = workspace_client.get(
+        "/api/v1/workspaces/ws-runtime/runtime-bindings?binding_kind=acp_session"
+    )
+    assert listed.status_code == 200
+    assert listed.json()["total"] == 1
+    assert listed.json()["items"][0]["binding_id"] == "acp-session-1"
+
+    fetched = workspace_client.get(
+        "/api/v1/workspaces/ws-runtime/runtime-bindings/acp-session-1"
+    )
+    assert fetched.status_code == 200
+    assert fetched.json()["owner_domain"] == "acp"
+
+    deleted = workspace_client.delete(
+        "/api/v1/workspaces/ws-runtime/runtime-bindings/acp-session-1"
+    )
+    assert deleted.status_code == 204
+    assert (
+        workspace_client.get(
+            "/api/v1/workspaces/ws-runtime/runtime-bindings/acp-session-1"
+        ).status_code
+        == 404
+    )
+
+
+def test_workspace_runtime_binding_api_rejects_unknown_binding_kind(
+    workspace_client: TestClient,
+    db: CharactersRAGDB,
+) -> None:
+    db.upsert_workspace("ws-runtime", "Runtime Workspace")
+
+    response = workspace_client.post(
+        "/api/v1/workspaces/ws-runtime/runtime-bindings",
+        json=_descriptor_payload(binding_kind="unknown_runtime"),
+    )
+
+    assert response.status_code == 422
+
+
+def test_workspace_runtime_binding_api_rejects_secret_metadata_key(
+    workspace_client: TestClient,
+    db: CharactersRAGDB,
+) -> None:
+    db.upsert_workspace("ws-runtime", "Runtime Workspace")
+
+    response = workspace_client.post(
+        "/api/v1/workspaces/ws-runtime/runtime-bindings",
+        json=_descriptor_payload(metadata={"OPENAI_API_KEY": "sk-secret"}),
+    )
+
+    assert response.status_code == 422
+
+
+def test_workspace_runtime_binding_api_returns_404_for_missing_workspace(
+    workspace_client: TestClient,
+) -> None:
+    response = workspace_client.post(
+        "/api/v1/workspaces/missing/runtime-bindings",
+        json=_descriptor_payload(),
+    )
+
+    assert response.status_code == 404
+
+
+def test_workspace_runtime_binding_api_rejects_writes_to_archived_workspace(
+    workspace_client: TestClient,
+    db: CharactersRAGDB,
+) -> None:
+    workspace = db.upsert_workspace("ws-archived", "Archived Workspace")
+    db.update_workspace("ws-archived", {"archived": True}, expected_version=workspace["version"])
+
+    response = workspace_client.post(
+        "/api/v1/workspaces/ws-archived/runtime-bindings",
+        json=_descriptor_payload(),
+    )
+
+    assert response.status_code == 409


### PR DESCRIPTION
## Change summary

This PR adds Workspace runtime binding descriptors for #1991 as descriptor-only metadata under the Workspace API. It defines the runtime binding vocabulary, stores descriptors durably in ChaChaNotes, exposes list/upsert/get/archive API routes, and redacts/rejects sensitive metadata before persistence and response.

The implementation keeps runtime bindings separate from project roots and resource memberships because bindings describe external runtime state; they are not trust grants, root admission, resumable sessions, or secret storage. Metadata and path hints are normalized centrally so ACP/Sandbox/MCP placeholders can be represented without leaking absolute paths, environment variables, credentials, prompts, model output, or file contents.

Note for merge gate: this PR is materially AI-authored. Per repo policy, the human requester should review/replace this Change summary with a human-owned summary before merge.

## Test plan

- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py tldw_Server_API/tests/Workspaces/test_workspace_project_roots_db.py tldw_Server_API/tests/Workspaces/test_workspaces_api.py -q` -> 110 passed, 6 warnings
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Workspaces/runtime_bindings.py tldw_Server_API/app/core/Workspaces/models.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/api/v1/schemas/workspace_schemas.py tldw_Server_API/app/api/v1/endpoints/workspaces.py -f json -o /tmp/bandit_workspace_runtime_bindings.json` -> 0 results, 0 errors
- `git diff --check` -> clean

## Links

- Closes #1991
- Part of #1984
- Backlog: TASK-2381

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds descriptor-only Workspace runtime binding support with secret-safe normalization and CRUD APIs, stored durably in `ChaChaNotes`. Implements #1991 (Phase 2) and aligns with TASK-2381; includes follow-up fixes for alias handling and stricter redaction.

- **New Features**
  - Runtime binding vocabulary with alias normalization; rejects secret-like keys and redacts path hints to basenames.
  - Durable storage via new `workspace_runtime_bindings` table and helpers (upsert/list/get/archive) for SQLite/Postgres in `ChaChaNotes`.
  - API routes under `/api/v1/workspaces/{workspace_id}/runtime-bindings`: `POST` create/update, `GET` list (filters: `binding_kind`, `owner_domain`), `GET` one, `DELETE` archive; writes blocked on archived workspaces.
  - Responses expose `path_hint`, `metadata`, and `redaction_report` only; no absolute paths, env vars, or credentials.

- **Bug Fixes**
  - Hardened secret-key detection, added status/portability alias handling, and offloaded DB calls via `run_in_threadpool`; updated docs and expanded unit/API tests.

<sup>Written for commit c2fb5b94e1d8a8e579e5072f65fad0f490df7fe2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

