### PR TITLE
Add Workspace membership adapters for ACP-adjacent domains

### DIFF
--- a/Docs/superpowers/plans/2026-06-17-workspace-membership-adapters-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-17-workspace-membership-adapters-implementation-plan.md
@@ -1,0 +1,132 @@
+# Workspace Membership Adapters Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add tested Workspace membership adapters for prompt, workflow, watchlist, ACP session, and sandbox session resources while explicitly deferring global note and ACP run.
+
+**Architecture:** Extend the existing registry-based membership service. Add optional domain DB handles to `WorkspaceMembershipContext` and endpoint dependencies, keep adapter validation domain-owned, and use Workspace runtime binding descriptors for ACP/Sandbox session membership summaries.
+
+**Tech Stack:** Python, FastAPI dependencies, Pydantic schemas, pytest, Loguru, SQLite/Postgres-safe DB helper methods, Bandit.
+
+---
+
+### Task 1: Resource Registry And Context Contract
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Workspaces/membership_models.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/workspace_schemas.py`
+- Modify: `tldw_Server_API/app/core/Workspaces/membership_adapters.py`
+- Modify: `tldw_Server_API/app/core/Workspaces/membership_service.py`
+- Test: `tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py`
+
+- [x] **Step 1: Write failing registry/context tests**
+
+Add tests that expect `prompt`, `workflow`, `watchlist`, `acp_session`, and `sandbox_session` to be supported resource types, while `note` and `acp_run` still fail closed.
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q`
+
+Expected: FAIL because new resource types are unsupported.
+
+- [x] **Step 3: Implement minimal registry/context plumbing**
+
+Extend resource-type literals and `WorkspaceMembershipContext` with optional `prompts_db`, `workflows_db`, `watchlists_db`, and request metadata fields used for workflow tenant/admin checks.
+
+- [x] **Step 4: Run test to verify it passes**
+
+Run the same focused pytest command. Expected: PASS for registry/context tests, or progress to adapter-specific missing method failures in later tests.
+
+### Task 2: Prompt, Workflow, And Watchlist Adapters
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Workspaces/membership_adapters.py`
+- Modify: `tldw_Server_API/app/core/Workspaces/membership_service.py`
+- Test: `tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py`
+
+- [x] **Step 1: Write failing adapter tests**
+
+Add tests for prompt canonical ID resolution, prompt DB unavailable, workflow tenant/owner denial, workflow admin allowance, watchlist active lookup, and deleted summaries.
+
+- [x] **Step 2: Run tests to verify failure**
+
+Run focused adapter tests and confirm they fail because adapter classes/logic are missing.
+
+- [x] **Step 3: Implement minimal adapters**
+
+Add `PromptMembershipAdapter`, `WorkflowMembershipAdapter`, and `WatchlistMembershipAdapter`. Summaries must avoid prompt text, workflow definitions, and watchlist objective/body content.
+
+- [x] **Step 4: Run focused tests**
+
+Run `python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q`.
+
+### Task 3: ACP And Sandbox Session Adapters
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Workspaces/membership_adapters.py`
+- Test: `tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py`
+
+- [x] **Step 1: Write failing runtime binding adapter tests**
+
+Add tests for active ACP session and Sandbox session runtime binding validation, archived binding summary state, wrong binding kind/domain denial, and missing binding denial.
+
+- [x] **Step 2: Run tests to verify failure**
+
+Expected: FAIL because runtime binding membership adapters are missing.
+
+- [x] **Step 3: Implement runtime binding session adapters**
+
+Use `context.chacha_db.get_workspace_runtime_binding(workspace_id, binding_id, include_deleted=...)` and validate expected kind/domain. Summary metadata must use already-redacted descriptor fields.
+
+- [x] **Step 4: Run focused tests**
+
+Run the Workspace membership adapter tests and confirm green.
+
+### Task 4: API Dependency Wiring
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/API_Deps/Prompts_DB_Deps.py`
+- Modify: `tldw_Server_API/app/api/v1/API_Deps/Watchlists_DB_Deps.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/workspaces.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py`
+- Test: `tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py`
+
+- [x] **Step 1: Write failing API tests**
+
+Add tests proving membership create/list paths pass optional prompt/workflow/watchlist handles and workflow request metadata, and that unrelated resource calls still work when optional dependencies are unavailable.
+
+- [x] **Step 2: Run API tests to verify failure**
+
+Run: `python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py -q`
+
+- [x] **Step 3: Implement dependency wiring**
+
+Add optional prompt/watchlist dependency helpers and a workflow DB optional helper local to Workspace endpoints if no shared helper exists. Pass handles and workflow metadata into membership service calls.
+
+- [x] **Step 4: Run API tests**
+
+Run membership API tests and adapter tests.
+
+### Task 5: Docs, Backlog, And Verification
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Workspaces/README.md`
+- Modify: `backlog/tasks/task-2383 - Add-remaining-Workspace-membership-adapters-for-ACP-adjacent-resource-domains.md`
+
+- [x] **Step 1: Update docs**
+
+Document supported/deferred resource types, runtime binding session semantics, and the invariant that membership is not a trust source.
+
+- [x] **Step 2: Run focused verification**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py -q
+python -m bandit -r tldw_Server_API/app/core/Workspaces tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py tldw_Server_API/app/api/v1/API_Deps/Prompts_DB_Deps.py tldw_Server_API/app/api/v1/API_Deps/Watchlists_DB_Deps.py -f json -o /tmp/bandit_workspace_membership_adapters.json
+```
+
+- [x] **Step 3: Finalize Backlog task**
+
+Record touched files, verification results, known deferrals, and final summary.

--- a/Docs/superpowers/specs/2026-06-17-workspace-membership-adapters-design.md
+++ b/Docs/superpowers/specs/2026-06-17-workspace-membership-adapters-design.md
@@ -1,0 +1,71 @@
+# Workspace Membership Adapters Design
+
+## Goal
+
+Complete the next backend slice for GitHub issue #2378 by adding stable Workspace membership adapters for remaining ACP-adjacent resource domains without making membership a trust source for execution, file access, or runtime admission.
+
+## Scope
+
+Implement concrete adapters for:
+
+- `prompt`
+- `workflow`
+- `watchlist`
+- `acp_session`
+- `sandbox_session`
+
+Explicitly defer:
+
+- `note`, because the global note ownership/lifecycle boundary is not clear enough from the current membership adapter surface.
+- `acp_run`, because #2378 asks for ACP sessions and sandbox sessions, and no stable ACP run descriptor writer is assumed for this slice.
+
+Unsupported/deferred types must continue to fail closed with `unsupported_resource_type`.
+
+## Architecture
+
+The existing Workspace membership service stays registry-driven. New adapters validate through their owning domain stores before a membership row is written, then return a canonical `WorkspaceResourceRef` for persistence and summary rendering.
+
+`WorkspaceMembershipContext` will carry optional handles for prompt, workflow, and watchlist databases, plus request metadata needed for workflow ownership checks. Endpoint dependencies should follow the existing optional `media_db` pattern: unrelated membership calls must not fail when one optional subsystem DB is unavailable.
+
+ACP and Sandbox session adapters validate against `workspace_runtime_bindings` rows in the ChaChaNotes DB. Runtime binding descriptors are metadata-only references. They do not grant trust, path access, ACP execution permission, Sandbox admission, or MCP file access.
+
+## Resource Contracts
+
+### Prompt
+
+Validate through `PromptsDatabase.fetch_prompt_details()`. Accept ID, UUID, or name on input, but store the canonical numeric prompt ID. Summaries may expose name, author, timestamps, and compact format metadata, but must not expose prompt text, details, structured definition bodies, or other prompt content.
+
+### Workflow
+
+Validate through `WorkflowsDatabase.get_definition()`. Require same tenant and owner, unless the request context says the current user is a workflows admin. Store canonical numeric workflow ID. Summaries may expose name, version, description, tags, and active/deleted state, but not `definition_json` or run inputs/outputs.
+
+### Watchlist
+
+Validate through the current user's `WatchlistsDatabase.get_watchlist()`. Store canonical numeric watchlist ID. Summaries may expose name, domain, status, priority, tags, timestamps, and deleted/archived state, but not long objective/body-like fields.
+
+### ACP And Sandbox Sessions
+
+Validate against active `workspace_runtime_bindings` for the current workspace. `acp_session` requires `binding_kind="acp_session"` and `owner_domain="acp"`. `sandbox_session` requires `binding_kind="sandbox_session"` and `owner_domain="sandbox"`. Summaries use the already-normalized/redacted descriptor fields only.
+
+Reverse lookup for runtime-bound resources remains row-based. Runtime binding IDs are workspace-scoped, so resolving summaries must use each membership row's workspace context instead of treating the resource ID as globally authoritative.
+
+## Error Handling
+
+Missing optional domain DB handles return adapter-specific 503 errors only when that adapter is used.
+
+Missing, deleted, cross-workspace, wrong-kind, or wrong-owner resources return `resource_not_found` style failures and must not disclose that a resource exists outside the caller's valid scope.
+
+Summary resolution failures remain non-fatal for list/read paths and produce unresolved summaries with safe messages.
+
+## Testing
+
+Add tests before implementation for:
+
+- Registry support for the new resource types and fail-closed behavior for `note` and `acp_run`.
+- Prompt ID/UUID/name canonicalization and deleted/missing resource handling.
+- Workflow tenant/owner/admin validation and inactive summaries.
+- Watchlist active/deleted handling.
+- ACP/Sandbox session validation through runtime bindings, including wrong kind/domain and archived bindings.
+- Existing membership API behavior for pilot adapters remains stable.
+
+Run focused Workspace tests and Bandit on touched backend paths before completion.

--- a/backlog/tasks/task-2383 - Add-remaining-Workspace-membership-adapters-for-ACP-adjacent-resource-domains.md
+++ b/backlog/tasks/task-2383 - Add-remaining-Workspace-membership-adapters-for-ACP-adjacent-resource-domains.md
@@ -4,7 +4,7 @@ title: Add remaining Workspace membership adapters for ACP-adjacent resource dom
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-18 03:34'
+updated_date: '2026-06-18 03:50'
 labels:
   - workspace
   - acp
@@ -49,12 +49,27 @@ Optional Prompts/Workflows/Watchlists DB handles now flow through forward and re
 Runtime session adapters validate Workspace runtime binding kind/domain and expose only redacted descriptor metadata.
 
 Deferred note and acp_run support remains fail-closed.
+
+PR #2385 review pass:
+- Rebased on origin/dev; branch was already up to date.
+- Moved workflow admin/tenant metadata derivation into core Workspaces helper and normalized missing tenant_id to an empty string.
+- Replaced per-request WorkflowsDatabase construction with a cached optional dependency and shutdown cleanup hook.
+- Switched ACP/Sandbox session adapters from concrete inheritance to composition.
+- Made unlink cleanup independent of live prompt/workflow/watchlist domain adapter availability, with best-effort prompt canonicalization when Prompts DB is available.
+- Addressed Gemini status-code comments with raw 401/403 checks despite existing imports.
+
+Review-pass verification:
+- RED tests failed for the expected review issues before implementation.
+- Focused suite: 125 passed, 6 warnings.
+- compileall on touched modules passed.
+- git diff --check passed.
+- Bandit touched scope: 0 findings.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Supported ACP-adjacent Workspace membership adapters are implemented and documented. Focused verification passed: 119 Workspace membership/context tests, plus Bandit on touched backend/API scope with 0 findings.
+Supported ACP-adjacent Workspace membership adapters are implemented, documented, and updated for PR #2385 review feedback. Focused verification passed: 125 Workspace membership/context tests, compileall on touched modules, git diff --check, and Bandit on touched backend/API/service scope with 0 findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2383 - Add-remaining-Workspace-membership-adapters-for-ACP-adjacent-resource-domains.md
+++ b/backlog/tasks/task-2383 - Add-remaining-Workspace-membership-adapters-for-ACP-adjacent-resource-domains.md
@@ -1,0 +1,68 @@
+---
+id: TASK-2383
+title: Add remaining Workspace membership adapters for ACP-adjacent resource domains
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-18 03:34'
+labels:
+  - workspace
+  - acp
+  - backend
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/2378'
+documentation:
+  - Docs/superpowers/specs/2026-06-17-workspace-membership-adapters-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track implementation for GitHub issue #2378. Add or explicitly defer remaining Workspace membership resource adapters for prompt/workflow/watchlist and ACP/sandbox runtime-binding domains while preserving fail-closed unsupported types and the invariant that membership is not a trust source for ACP, Sandbox, MCP, or file access.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 prompt/workflow/watchlist/acp_session/sandbox_session are accepted resource types and resolve through domain-owned adapters
+- [x] #2 note and acp_run remain fail-closed as deferred resource types
+- [x] #3 prompt summaries do not expose prompt content, workflow summaries do not expose definitions, and watchlist summaries do not expose objectives
+- [x] #4 runtime session memberships validate against workspace runtime binding descriptors and do not grant ACP/Sandbox/MCP/file trust
+- [x] #5 forward and reverse API membership routes pass optional domain DB handles and workflow tenant/admin metadata
+- [x] #6 focused tests and Bandit verification are recorded
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-17-workspace-membership-adapters-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Workspace membership adapters for prompt, workflow, watchlist, acp_session, and sandbox_session.
+
+Optional Prompts/Workflows/Watchlists DB handles now flow through forward and reverse membership API routes. Workflow resolution receives tenant/admin request metadata.
+
+Runtime session adapters validate Workspace runtime binding kind/domain and expose only redacted descriptor metadata.
+
+Deferred note and acp_run support remains fail-closed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Supported ACP-adjacent Workspace membership adapters are implemented and documented. Focused verification passed: 119 Workspace membership/context tests, plus Bandit on touched backend/API scope with 0 findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/API_Deps/Prompts_DB_Deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/Prompts_DB_Deps.py
@@ -413,6 +413,23 @@ async def get_prompts_db_for_user(
         user_specific_lock.release()
 
 
+async def try_get_prompts_db_for_user(
+        request: Request,
+        current_user: User = Depends(get_request_user),
+) -> Optional[PromptsDatabase]:
+    """Optional Prompts DB dependency for routes that support mixed resource types."""
+    try:
+        return await get_prompts_db_for_user(request, current_user)
+    except HTTPException as exc:
+        if exc.status_code in {status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN}:
+            raise
+        logger.warning("Optional Prompts DB unavailable (status_code={})", exc.status_code)
+        return None
+    except (DatabaseError, SchemaError, InputError, ConflictError, OSError, RuntimeError, TypeError, ValueError) as exc:
+        logger.warning("Optional Prompts DB unexpected error ({})", type(exc).__name__)
+        return None
+
+
 async def close_all_cached_prompts_db_instances() -> None:
     """Closes all cached PromptsDatabase connections. Useful for application shutdown."""
     if _user_db_instances is None or _user_db_locks is None:

--- a/tldw_Server_API/app/api/v1/API_Deps/Prompts_DB_Deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/Prompts_DB_Deps.py
@@ -421,7 +421,7 @@ async def try_get_prompts_db_for_user(
     try:
         return await get_prompts_db_for_user(request, current_user)
     except HTTPException as exc:
-        if exc.status_code in {status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN}:
+        if exc.status_code in {401, 403}:
             raise
         logger.warning("Optional Prompts DB unavailable (status_code={})", exc.status_code)
         return None

--- a/tldw_Server_API/app/api/v1/API_Deps/Watchlists_DB_Deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/Watchlists_DB_Deps.py
@@ -43,3 +43,19 @@ async def get_watchlists_db_for_user(
             type(e).__name__,
         )
         raise HTTPException(status_code=500, detail="Watchlists DB unavailable") from e
+
+
+async def try_get_watchlists_db_for_user(
+    current_user: User = Depends(get_request_user)
+) -> WatchlistsDatabase | None:
+    """Optional Watchlists DB dependency for routes that support mixed resource types."""
+    try:
+        return await get_watchlists_db_for_user(current_user)
+    except HTTPException as exc:
+        if exc.status_code in {status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN}:
+            raise
+        logger.warning("Optional Watchlists DB unavailable (status_code={})", exc.status_code)
+        return None
+    except (DatabaseError, OSError, RuntimeError, TypeError, ValueError) as exc:
+        logger.warning("Optional Watchlists DB unexpected error ({})", type(exc).__name__)
+        return None

--- a/tldw_Server_API/app/api/v1/API_Deps/Watchlists_DB_Deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/Watchlists_DB_Deps.py
@@ -52,7 +52,7 @@ async def try_get_watchlists_db_for_user(
     try:
         return await get_watchlists_db_for_user(current_user)
     except HTTPException as exc:
-        if exc.status_code in {status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN}:
+        if exc.status_code in {401, 403}:
             raise
         logger.warning("Optional Watchlists DB unavailable (status_code={})", exc.status_code)
         return None

--- a/tldw_Server_API/app/api/v1/API_Deps/Workflows_DB_Deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/Workflows_DB_Deps.py
@@ -1,0 +1,58 @@
+"""FastAPI dependencies for optional Workflows database access."""
+from __future__ import annotations
+
+import sqlite3
+from threading import RLock
+
+from loguru import logger
+
+from tldw_Server_API.app.core.DB_Management.backends.base import DatabaseError as BackendDatabaseError
+from tldw_Server_API.app.core.DB_Management.DB_Manager import (
+    create_workflows_database,
+    get_content_backend_instance,
+)
+from tldw_Server_API.app.core.DB_Management.Workflows_DB import WorkflowsDatabase
+
+_WORKFLOWS_DB_DEPENDENCY_EXCEPTIONS = (
+    OSError,
+    RuntimeError,
+    TypeError,
+    ValueError,
+    sqlite3.Error,
+    BackendDatabaseError,
+)
+
+_cached_workflows_db: WorkflowsDatabase | None = None
+_cached_workflows_db_lock = RLock()
+
+
+def _get_cached_workflows_db_for_user() -> WorkflowsDatabase:
+    global _cached_workflows_db
+    if _cached_workflows_db is not None:
+        return _cached_workflows_db
+    with _cached_workflows_db_lock:
+        if _cached_workflows_db is None:
+            _cached_workflows_db = create_workflows_database(backend=get_content_backend_instance())
+        return _cached_workflows_db
+
+
+def try_get_workflows_db_for_user() -> WorkflowsDatabase | None:
+    """Optional Workflows DB dependency for routes that support mixed resource types."""
+    try:
+        return _get_cached_workflows_db_for_user()
+    except _WORKFLOWS_DB_DEPENDENCY_EXCEPTIONS as exc:
+        logger.warning("Optional Workflows DB unavailable ({})", type(exc).__name__)
+        return None
+
+
+def close_cached_workflows_db_for_user() -> None:
+    """Close and clear the cached optional Workflows DB dependency instance."""
+    global _cached_workflows_db
+    with _cached_workflows_db_lock:
+        db = _cached_workflows_db
+        _cached_workflows_db = None
+    if db is None:
+        return
+    close = getattr(db, "close", None) or getattr(db, "close_connection", None)
+    if callable(close):
+        close()

--- a/tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py
@@ -10,10 +10,7 @@ from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import try_get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.Prompts_DB_Deps import try_get_prompts_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.Watchlists_DB_Deps import try_get_watchlists_db_for_user
-from tldw_Server_API.app.api.v1.endpoints.workspaces import (
-    _membership_request_metadata,
-    try_get_workflows_db_for_user,
-)
+from tldw_Server_API.app.api.v1.API_Deps.Workflows_DB_Deps import try_get_workflows_db_for_user
 from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import WORKSPACES_READ_RATE_LIMIT
 from tldw_Server_API.app.api.v1.schemas.workspace_schemas import WorkspaceResourceMembershipListResponse
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
@@ -26,6 +23,9 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
 from tldw_Server_API.app.core.Workspaces.membership_service import (
     WorkspaceMembershipService,
     WorkspaceMembershipServiceError,
+)
+from tldw_Server_API.app.core.Workspaces.membership_request_metadata import (
+    build_workspace_membership_request_metadata,
 )
 
 router = APIRouter()
@@ -84,7 +84,7 @@ async def list_resource_workspace_memberships(
             workflows_db=workflows_db,
             watchlists_db=watchlists_db,
             user_id=_request_user_id(current_user),
-            request_metadata=_membership_request_metadata(current_user),
+            request_metadata=build_workspace_membership_request_metadata(current_user),
         )
     except WorkspaceMembershipServiceError as exc:
         raise _membership_service_error_to_http(exc) from exc

--- a/tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py
@@ -8,6 +8,12 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import try_get_media_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.Prompts_DB_Deps import try_get_prompts_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.Watchlists_DB_Deps import try_get_watchlists_db_for_user
+from tldw_Server_API.app.api.v1.endpoints.workspaces import (
+    _membership_request_metadata,
+    try_get_workflows_db_for_user,
+)
 from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import WORKSPACES_READ_RATE_LIMIT
 from tldw_Server_API.app.api.v1.schemas.workspace_schemas import WorkspaceResourceMembershipListResponse
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
@@ -59,6 +65,9 @@ async def list_resource_workspace_memberships(
     cursor: str | None = Query(default=None),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
     media_db: Any | None = Depends(try_get_media_db_for_user),
+    prompts_db: Any | None = Depends(try_get_prompts_db_for_user),
+    workflows_db: Any | None = Depends(try_get_workflows_db_for_user),
+    watchlists_db: Any | None = Depends(try_get_watchlists_db_for_user),
     current_user: User = Depends(get_request_user),
 ) -> WorkspaceResourceMembershipListResponse:
     """List memberships that connect the current user's workspaces to one resource."""
@@ -71,7 +80,11 @@ async def list_resource_workspace_memberships(
             limit=limit,
             cursor=cursor,
             media_db=media_db,
+            prompts_db=prompts_db,
+            workflows_db=workflows_db,
+            watchlists_db=watchlists_db,
             user_id=_request_user_id(current_user),
+            request_metadata=_membership_request_metadata(current_user),
         )
     except WorkspaceMembershipServiceError as exc:
         raise _membership_service_error_to_http(exc) from exc

--- a/tldw_Server_API/app/api/v1/endpoints/workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspaces.py
@@ -15,6 +15,8 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import try_get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import try_get_job_manager
+from tldw_Server_API.app.api.v1.API_Deps.Prompts_DB_Deps import try_get_prompts_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.Watchlists_DB_Deps import try_get_watchlists_db_for_user
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import (
     WORKSPACES_DELETE_RATE_LIMIT,
@@ -67,6 +69,12 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     ConflictError,
     InputError,
 )
+from tldw_Server_API.app.core.AuthNZ.permissions import WORKFLOWS_ADMIN
+from tldw_Server_API.app.core.DB_Management.DB_Manager import (
+    create_workflows_database,
+    get_content_backend_instance,
+)
+from tldw_Server_API.app.core.DB_Management.Workflows_DB import WorkflowsDatabase
 from tldw_Server_API.app.core.DB_Management.media_db import api as media_db_api
 from tldw_Server_API.app.core.DB_Management.media_db.errors import DatabaseError
 from tldw_Server_API.app.core.Jobs.manager import JobManager
@@ -490,6 +498,46 @@ def _membership_service(db: CharactersRAGDB) -> WorkspaceMembershipService:
 
 def _request_user_id(current_user: User) -> str:
     return str(current_user.id)
+
+
+def _normalize_claim_values(values: Any) -> list[str]:
+    raw_values = values if isinstance(values, (list, tuple, set)) else ([values] if values is not None else [])
+    normalized: list[str] = []
+    for value in raw_values:
+        text = str(value).strip().lower()
+        if text:
+            normalized.append(text)
+    return normalized
+
+
+def _is_workflows_admin_user(current_user: User) -> bool:
+    try:
+        if "admin" in _normalize_claim_values(getattr(current_user, "roles", [])):
+            return True
+        permission_values = _normalize_claim_values(getattr(current_user, "permissions", []))
+        return (
+            WORKFLOWS_ADMIN.lower() in permission_values
+            or "*" in permission_values
+            or "system.configure" in permission_values
+        )
+    except (AttributeError, TypeError, ValueError):
+        return False
+
+
+def _membership_request_metadata(current_user: User) -> dict[str, Any]:
+    return {
+        "tenant_id": str(getattr(current_user, "tenant_id", "default")),
+        "is_workflows_admin": _is_workflows_admin_user(current_user),
+    }
+
+
+async def try_get_workflows_db_for_user() -> WorkflowsDatabase | None:
+    """Optional Workflows DB dependency for routes that support mixed resource types."""
+    try:
+        return create_workflows_database(backend=get_content_backend_instance())
+    except (OSError, RuntimeError, TypeError, ValueError) as exc:
+        logger.warning("Optional Workflows DB unavailable ({})", type(exc).__name__)
+        return None
 
 
 def _membership_service_error_to_http(exc: WorkspaceMembershipServiceError) -> HTTPException:
@@ -1173,6 +1221,9 @@ async def list_workspace_memberships(
     cursor: str | None = Query(default=None),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
     media_db: Any | None = Depends(try_get_media_db_for_user),
+    prompts_db: Any | None = Depends(try_get_prompts_db_for_user),
+    workflows_db: WorkflowsDatabase | None = Depends(try_get_workflows_db_for_user),
+    watchlists_db: Any | None = Depends(try_get_watchlists_db_for_user),
     current_user: User = Depends(get_request_user),
 ) -> WorkspaceMembershipListResponse:
     """List memberships for one workspace."""
@@ -1186,7 +1237,11 @@ async def list_workspace_memberships(
             limit=limit,
             cursor=cursor,
             media_db=media_db,
+            prompts_db=prompts_db,
+            workflows_db=workflows_db,
+            watchlists_db=watchlists_db,
             user_id=_request_user_id(current_user),
+            request_metadata=_membership_request_metadata(current_user),
         )
     except WorkspaceMembershipServiceError as exc:
         raise _membership_service_error_to_http(exc) from exc
@@ -1207,6 +1262,9 @@ async def create_workspace_membership(
     body: WorkspaceMembershipCreateRequest,
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
     media_db: Any | None = Depends(try_get_media_db_for_user),
+    prompts_db: Any | None = Depends(try_get_prompts_db_for_user),
+    workflows_db: WorkflowsDatabase | None = Depends(try_get_workflows_db_for_user),
+    watchlists_db: Any | None = Depends(try_get_watchlists_db_for_user),
     current_user: User = Depends(get_request_user),
 ) -> WorkspaceMembershipResponse:
     """Link a resource to a workspace, idempotently for matching active rows."""
@@ -1215,7 +1273,11 @@ async def create_workspace_membership(
             workspace_id,
             body,
             media_db=media_db,
+            prompts_db=prompts_db,
+            workflows_db=workflows_db,
+            watchlists_db=watchlists_db,
             user_id=_request_user_id(current_user),
+            request_metadata=_membership_request_metadata(current_user),
             resolve=True,
         )
     except WorkspaceMembershipServiceError as exc:
@@ -1238,6 +1300,9 @@ async def get_workspace_membership(
     resolve: bool = Query(default=True),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
     media_db: Any | None = Depends(try_get_media_db_for_user),
+    prompts_db: Any | None = Depends(try_get_prompts_db_for_user),
+    workflows_db: WorkflowsDatabase | None = Depends(try_get_workflows_db_for_user),
+    watchlists_db: Any | None = Depends(try_get_watchlists_db_for_user),
     current_user: User = Depends(get_request_user),
 ) -> WorkspaceMembershipResponse:
     """Fetch one active workspace membership by resource."""
@@ -1247,7 +1312,11 @@ async def get_workspace_membership(
             resource_type,
             resource_id,
             media_db=media_db,
+            prompts_db=prompts_db,
+            workflows_db=workflows_db,
+            watchlists_db=watchlists_db,
             user_id=_request_user_id(current_user),
+            request_metadata=_membership_request_metadata(current_user),
             resolve=resolve,
         )
     except WorkspaceMembershipServiceError as exc:
@@ -1271,6 +1340,9 @@ async def delete_workspace_membership(
     resource_id: str,
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
     media_db: Any | None = Depends(try_get_media_db_for_user),
+    prompts_db: Any | None = Depends(try_get_prompts_db_for_user),
+    workflows_db: WorkflowsDatabase | None = Depends(try_get_workflows_db_for_user),
+    watchlists_db: Any | None = Depends(try_get_watchlists_db_for_user),
     current_user: User = Depends(get_request_user),
 ) -> Response:
     """Soft-delete a workspace membership; missing rows are idempotent no-ops."""
@@ -1280,7 +1352,11 @@ async def delete_workspace_membership(
             resource_type,
             resource_id,
             media_db=media_db,
+            prompts_db=prompts_db,
+            workflows_db=workflows_db,
+            watchlists_db=watchlists_db,
             user_id=_request_user_id(current_user),
+            request_metadata=_membership_request_metadata(current_user),
         )
     except WorkspaceMembershipServiceError as exc:
         raise _membership_service_error_to_http(exc) from exc

--- a/tldw_Server_API/app/api/v1/endpoints/workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspaces.py
@@ -17,6 +17,7 @@ from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import try_get_media_db_for_use
 from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import try_get_job_manager
 from tldw_Server_API.app.api.v1.API_Deps.Prompts_DB_Deps import try_get_prompts_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.Watchlists_DB_Deps import try_get_watchlists_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.Workflows_DB_Deps import try_get_workflows_db_for_user
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import (
     WORKSPACES_DELETE_RATE_LIMIT,
@@ -69,11 +70,6 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     ConflictError,
     InputError,
 )
-from tldw_Server_API.app.core.AuthNZ.permissions import WORKFLOWS_ADMIN
-from tldw_Server_API.app.core.DB_Management.DB_Manager import (
-    create_workflows_database,
-    get_content_backend_instance,
-)
 from tldw_Server_API.app.core.DB_Management.Workflows_DB import WorkflowsDatabase
 from tldw_Server_API.app.core.DB_Management.media_db import api as media_db_api
 from tldw_Server_API.app.core.DB_Management.media_db.errors import DatabaseError
@@ -86,6 +82,9 @@ from tldw_Server_API.app.core.Workspaces.file_inventory_jobs import (
     enqueue_workspace_file_inventory_scan_job,
 )
 from tldw_Server_API.app.core.Workspaces.context import build_workspace_core_context
+from tldw_Server_API.app.core.Workspaces.membership_request_metadata import (
+    build_workspace_membership_request_metadata,
+)
 from tldw_Server_API.app.core.Workspaces.membership_service import (
     WorkspaceMembershipService,
     WorkspaceMembershipServiceError,
@@ -498,46 +497,6 @@ def _membership_service(db: CharactersRAGDB) -> WorkspaceMembershipService:
 
 def _request_user_id(current_user: User) -> str:
     return str(current_user.id)
-
-
-def _normalize_claim_values(values: Any) -> list[str]:
-    raw_values = values if isinstance(values, (list, tuple, set)) else ([values] if values is not None else [])
-    normalized: list[str] = []
-    for value in raw_values:
-        text = str(value).strip().lower()
-        if text:
-            normalized.append(text)
-    return normalized
-
-
-def _is_workflows_admin_user(current_user: User) -> bool:
-    try:
-        if "admin" in _normalize_claim_values(getattr(current_user, "roles", [])):
-            return True
-        permission_values = _normalize_claim_values(getattr(current_user, "permissions", []))
-        return (
-            WORKFLOWS_ADMIN.lower() in permission_values
-            or "*" in permission_values
-            or "system.configure" in permission_values
-        )
-    except (AttributeError, TypeError, ValueError):
-        return False
-
-
-def _membership_request_metadata(current_user: User) -> dict[str, Any]:
-    return {
-        "tenant_id": str(getattr(current_user, "tenant_id", "default")),
-        "is_workflows_admin": _is_workflows_admin_user(current_user),
-    }
-
-
-async def try_get_workflows_db_for_user() -> WorkflowsDatabase | None:
-    """Optional Workflows DB dependency for routes that support mixed resource types."""
-    try:
-        return create_workflows_database(backend=get_content_backend_instance())
-    except (OSError, RuntimeError, TypeError, ValueError) as exc:
-        logger.warning("Optional Workflows DB unavailable ({})", type(exc).__name__)
-        return None
 
 
 def _membership_service_error_to_http(exc: WorkspaceMembershipServiceError) -> HTTPException:
@@ -1241,7 +1200,7 @@ async def list_workspace_memberships(
             workflows_db=workflows_db,
             watchlists_db=watchlists_db,
             user_id=_request_user_id(current_user),
-            request_metadata=_membership_request_metadata(current_user),
+            request_metadata=build_workspace_membership_request_metadata(current_user),
         )
     except WorkspaceMembershipServiceError as exc:
         raise _membership_service_error_to_http(exc) from exc
@@ -1277,7 +1236,7 @@ async def create_workspace_membership(
             workflows_db=workflows_db,
             watchlists_db=watchlists_db,
             user_id=_request_user_id(current_user),
-            request_metadata=_membership_request_metadata(current_user),
+            request_metadata=build_workspace_membership_request_metadata(current_user),
             resolve=True,
         )
     except WorkspaceMembershipServiceError as exc:
@@ -1316,7 +1275,7 @@ async def get_workspace_membership(
             workflows_db=workflows_db,
             watchlists_db=watchlists_db,
             user_id=_request_user_id(current_user),
-            request_metadata=_membership_request_metadata(current_user),
+            request_metadata=build_workspace_membership_request_metadata(current_user),
             resolve=resolve,
         )
     except WorkspaceMembershipServiceError as exc:
@@ -1356,7 +1315,7 @@ async def delete_workspace_membership(
             workflows_db=workflows_db,
             watchlists_db=watchlists_db,
             user_id=_request_user_id(current_user),
-            request_metadata=_membership_request_metadata(current_user),
+            request_metadata=build_workspace_membership_request_metadata(current_user),
         )
     except WorkspaceMembershipServiceError as exc:
         raise _membership_service_error_to_http(exc) from exc

--- a/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
@@ -71,6 +71,11 @@ WorkspaceMembershipResourceType = Literal[
     "workspace_source",
     "workspace_artifact",
     "chat",
+    "prompt",
+    "workflow",
+    "watchlist",
+    "acp_session",
+    "sandbox_session",
 ]
 WorkspaceMembershipRole = Literal[
     "member",

--- a/tldw_Server_API/app/core/Workspaces/README.md
+++ b/tldw_Server_API/app/core/Workspaces/README.md
@@ -59,7 +59,8 @@ context work should start from that contract.
 does not transfer ownership, hide or move global records, or make `/workspaces`
 the global filter for Library, Notes, Chat, or search surfaces. The first slice
 supports explicit links for `workspace_note`, `media`, `workspace_source`,
-`workspace_artifact`, and `chat`.
+`workspace_artifact`, `chat`, `prompt`, `workflow`, `watchlist`,
+`acp_session`, and `sandbox_session`.
 
 `workspace_sources` remains the Research Workspace source-selection and
 readiness table. A `workspace_source` membership can associate that source row
@@ -74,11 +75,14 @@ they want existing rows represented in the generic membership table.
 MCP effective permission preview and path admission continue to use MCP policy
 and root bindings. Generic Workspace membership is not a trust source for MCP
 tool execution, file access, ACP execution, or Sandbox path admission.
+`acp_session` and `sandbox_session` memberships validate against Workspace
+runtime binding descriptors and expose only redacted descriptor metadata.
 
-Future membership adapters must validate access through the owning domain
-adapter before linking or resolving a resource. Unsupported resource types must
-fail closed, and summaries/provenance should avoid exposing secrets, absolute
-paths, sandbox mount paths, prompts, model output contents, or file contents.
+Future membership adapters, including deferred `note` and `acp_run` support,
+must validate access through the owning domain adapter before linking or
+resolving a resource. Unsupported resource types must fail closed, and
+summaries/provenance should avoid exposing secrets, absolute paths, sandbox
+mount paths, prompts, model output contents, or file contents.
 
 ## Runtime Bindings
 

--- a/tldw_Server_API/app/core/Workspaces/membership_adapters.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_adapters.py
@@ -2,13 +2,50 @@
 from __future__ import annotations
 
 import inspect
+import json
+import sqlite3
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDBError
+from tldw_Server_API.app.core.DB_Management.backends.base import DatabaseError as BackendDatabaseError
 from tldw_Server_API.app.core.DB_Management.media_db import api as media_db_api
+from tldw_Server_API.app.core.DB_Management.media_db.errors import DatabaseError as MediaDatabaseError
+from tldw_Server_API.app.core.DB_Management.Prompts_DB import (
+    ConflictError as PromptsConflictError,
+    DatabaseError as PromptsDatabaseError,
+    InputError as PromptsInputError,
+    SchemaError as PromptsSchemaError,
+)
 from tldw_Server_API.app.core.Workspaces.membership_models import WorkspaceResourceRef
 from tldw_Server_API.app.core.exceptions import WorkspaceMembershipAdapterError
+
+_LOOKUP_EXCEPTIONS = (
+    AttributeError,
+    ConnectionError,
+    FileNotFoundError,
+    KeyError,
+    LookupError,
+    OSError,
+    PermissionError,
+    RuntimeError,
+    TimeoutError,
+    TypeError,
+    ValueError,
+    UnicodeDecodeError,
+    json.JSONDecodeError,
+    sqlite3.Error,
+    BackendDatabaseError,
+)
+_MEDIA_LOOKUP_EXCEPTIONS = _LOOKUP_EXCEPTIONS + (MediaDatabaseError,)
+_PROMPT_LOOKUP_EXCEPTIONS = _LOOKUP_EXCEPTIONS + (
+    PromptsConflictError,
+    PromptsDatabaseError,
+    PromptsInputError,
+    PromptsSchemaError,
+)
+_RUNTIME_BINDING_LOOKUP_EXCEPTIONS = _LOOKUP_EXCEPTIONS + (CharactersRAGDBError,)
 
 
 @dataclass(frozen=True)
@@ -19,6 +56,9 @@ class WorkspaceMembershipContext:
     user_id: str | None
     chacha_db: Any
     media_db: Any | None = None
+    prompts_db: Any | None = None
+    workflows_db: Any | None = None
+    watchlists_db: Any | None = None
     request_metadata: Mapping[str, Any] = field(default_factory=dict)
 
 
@@ -183,7 +223,7 @@ class MediaMembershipAdapter:
                 include_deleted=False,
                 include_trash=False,
             )
-        except Exception as exc:  # pragma: no cover - defensive adapter boundary.
+        except _MEDIA_LOOKUP_EXCEPTIONS as exc:  # pragma: no cover - defensive adapter boundary.
             raise WorkspaceMembershipAdapterError(
                 "media_lookup_failed",
                 "Media lookup failed while validating workspace membership.",
@@ -208,7 +248,7 @@ class MediaMembershipAdapter:
                 include_deleted=True,
                 include_trash=True,
             )
-        except Exception as exc:  # pragma: no cover - defensive adapter boundary.
+        except _MEDIA_LOOKUP_EXCEPTIONS as exc:  # pragma: no cover - defensive adapter boundary.
             raise WorkspaceMembershipAdapterError(
                 "media_lookup_failed",
                 "Media lookup failed while summarizing workspace membership.",
@@ -297,6 +337,298 @@ class ChatMembershipAdapter:
         return None
 
 
+class PromptMembershipAdapter:
+    resource_type = "prompt"
+
+    def validate_access(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        row = self._get_prompt(resource_id, context, include_deleted=False)
+        if not row or _is_deleted(row):
+            raise _resource_not_found(self.resource_type, _require_resource_id(resource_id))
+        return self._ref(row)
+
+    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        row = self._get_prompt(resource_id, context, include_deleted=True)
+        if not row:
+            raise _resource_not_found(self.resource_type, _require_resource_id(resource_id))
+        return self._ref(row, state=_resource_state(row))
+
+    def _get_prompt(
+        self,
+        resource_id: str,
+        context: WorkspaceMembershipContext,
+        *,
+        include_deleted: bool,
+    ) -> Mapping[str, Any] | None:
+        if context.prompts_db is None:
+            raise WorkspaceMembershipAdapterError(
+                "prompts_db_unavailable",
+                "Prompts DB is required to validate prompt workspace membership.",
+                status_code=503,
+            )
+        try:
+            row = context.prompts_db.fetch_prompt_details(resource_id, include_deleted=include_deleted)
+        except _PROMPT_LOOKUP_EXCEPTIONS as exc:  # pragma: no cover - defensive adapter boundary.
+            raise WorkspaceMembershipAdapterError(
+                "prompt_lookup_failed",
+                "Prompt lookup failed while validating workspace membership.",
+                status_code=503,
+            ) from exc
+        return _as_mapping(row)
+
+    def _ref(self, row: Mapping[str, Any], *, state: str = "available") -> WorkspaceResourceRef:
+        prompt_id = str(row.get("id") or "")
+        if not prompt_id:
+            raise _resource_not_found(self.resource_type, "unknown")
+        metadata = _compact_metadata(row, "author", "prompt_format", "prompt_schema_version")
+        return WorkspaceResourceRef(
+            resource_type=self.resource_type,
+            resource_id=prompt_id,
+            title=_first_non_empty(row, "name") or f"Prompt {prompt_id}",
+            subtitle=_first_non_empty(row, "prompt_format") or "prompt",
+            updated_at=_first_non_empty(row, "last_modified", "updated_at", "created_at"),
+            metadata=metadata,
+            state=state,
+        )
+
+    def on_link(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        return None
+
+    def on_unlink(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        return None
+
+
+class WorkflowMembershipAdapter:
+    resource_type = "workflow"
+
+    def validate_access(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        workflow_id = _parse_int_resource_id(resource_id, resource_type=self.resource_type)
+        row = self._get_workflow(workflow_id, context)
+        if not row or not self._is_visible(row, context) or not _workflow_is_active(row):
+            raise _resource_not_found(self.resource_type, str(workflow_id))
+        return self._ref(row, workflow_id)
+
+    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        workflow_id = _parse_int_resource_id(resource_id, resource_type=self.resource_type)
+        row = self._get_workflow(workflow_id, context)
+        if not row or not self._is_visible(row, context):
+            raise _resource_not_found(self.resource_type, str(workflow_id))
+        state = "available" if _workflow_is_active(row) else "archived"
+        return self._ref(row, workflow_id, state=state)
+
+    def _get_workflow(self, workflow_id: int, context: WorkspaceMembershipContext) -> Mapping[str, Any] | None:
+        if context.workflows_db is None:
+            raise WorkspaceMembershipAdapterError(
+                "workflows_db_unavailable",
+                "Workflows DB is required to validate workflow workspace membership.",
+                status_code=503,
+            )
+        try:
+            return _as_mapping(context.workflows_db.get_definition(workflow_id))
+        except _LOOKUP_EXCEPTIONS as exc:  # pragma: no cover - defensive adapter boundary.
+            raise WorkspaceMembershipAdapterError(
+                "workflow_lookup_failed",
+                "Workflow lookup failed while validating workspace membership.",
+                status_code=503,
+            ) from exc
+
+    def _is_visible(self, row: Mapping[str, Any], context: WorkspaceMembershipContext) -> bool:
+        tenant_id = str(context.request_metadata.get("tenant_id") or "").strip()
+        if tenant_id and str(row.get("tenant_id") or "") != tenant_id:
+            return False
+        if context.request_metadata.get("is_workflows_admin") is True:
+            return True
+        return bool(context.user_id) and str(row.get("owner_id") or "") == str(context.user_id)
+
+    def _ref(
+        self,
+        row: Mapping[str, Any],
+        workflow_id: int,
+        *,
+        state: str = "available",
+    ) -> WorkspaceResourceRef:
+        metadata = {
+            "version": row.get("version"),
+            "tags": _metadata_tags(row.get("tags")),
+        }
+        metadata = {key: value for key, value in metadata.items() if value not in (None, [], "")}
+        return WorkspaceResourceRef(
+            resource_type=self.resource_type,
+            resource_id=str(row.get("id") or workflow_id),
+            title=_first_non_empty(row, "name") or f"Workflow {workflow_id}",
+            subtitle="workflow",
+            updated_at=_first_non_empty(row, "updated_at", "created_at"),
+            metadata=metadata,
+            state=state,
+        )
+
+    def on_link(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        return None
+
+    def on_unlink(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        return None
+
+
+class WatchlistMembershipAdapter:
+    resource_type = "watchlist"
+
+    def validate_access(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        watchlist_id = _parse_int_resource_id(resource_id, resource_type=self.resource_type)
+        row = self._get_watchlist(watchlist_id, context, include_deleted=False)
+        if not row or _is_deleted(row):
+            raise _resource_not_found(self.resource_type, str(watchlist_id))
+        return self._ref(row, watchlist_id)
+
+    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        watchlist_id = _parse_int_resource_id(resource_id, resource_type=self.resource_type)
+        row = self._get_watchlist(watchlist_id, context, include_deleted=True)
+        if not row:
+            raise _resource_not_found(self.resource_type, str(watchlist_id))
+        return self._ref(row, watchlist_id, state=_resource_state(row))
+
+    def _get_watchlist(
+        self,
+        watchlist_id: int,
+        context: WorkspaceMembershipContext,
+        *,
+        include_deleted: bool,
+    ) -> Mapping[str, Any] | None:
+        if context.watchlists_db is None:
+            raise WorkspaceMembershipAdapterError(
+                "watchlists_db_unavailable",
+                "Watchlists DB is required to validate watchlist workspace membership.",
+                status_code=503,
+            )
+        try:
+            return _as_mapping(context.watchlists_db.get_watchlist(watchlist_id, include_deleted=include_deleted))
+        except KeyError:
+            return None
+        except _LOOKUP_EXCEPTIONS as exc:  # pragma: no cover - defensive adapter boundary.
+            raise WorkspaceMembershipAdapterError(
+                "watchlist_lookup_failed",
+                "Watchlist lookup failed while validating workspace membership.",
+                status_code=503,
+            ) from exc
+
+    def _ref(
+        self,
+        row: Mapping[str, Any],
+        watchlist_id: int,
+        *,
+        state: str = "available",
+    ) -> WorkspaceResourceRef:
+        metadata = _compact_metadata(row, "domain", "status", "priority")
+        tags = _metadata_tags(row.get("tags", row.get("tags_json")))
+        if tags:
+            metadata["tags"] = tags
+        return WorkspaceResourceRef(
+            resource_type=self.resource_type,
+            resource_id=str(row.get("id") or watchlist_id),
+            title=_first_non_empty(row, "name") or f"Watchlist {watchlist_id}",
+            subtitle=_first_non_empty(row, "domain") or "watchlist",
+            updated_at=_first_non_empty(row, "updated_at", "created_at"),
+            metadata=metadata,
+            state=state,
+        )
+
+    def on_link(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        return None
+
+    def on_unlink(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        return None
+
+
+class RuntimeBindingSessionMembershipAdapter:
+    resource_type = ""
+    binding_kind = ""
+    owner_domain = ""
+
+    def validate_access(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        binding_id = _require_resource_id(resource_id)
+        row = self._get_binding(binding_id, context, include_deleted=False)
+        if not row or self._binding_mismatch(row) or _is_deleted(row) or row.get("status") == "archived":
+            raise _resource_not_found(self.resource_type, binding_id)
+        return self._ref(row, binding_id)
+
+    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        binding_id = _require_resource_id(resource_id)
+        row = self._get_binding(binding_id, context, include_deleted=True)
+        if not row or self._binding_mismatch(row):
+            raise _resource_not_found(self.resource_type, binding_id)
+        state = "archived" if _is_deleted(row) or row.get("status") == "archived" else "available"
+        return self._ref(row, binding_id, state=state)
+
+    def _get_binding(
+        self,
+        binding_id: str,
+        context: WorkspaceMembershipContext,
+        *,
+        include_deleted: bool,
+    ) -> Mapping[str, Any] | None:
+        try:
+            row = context.chacha_db.get_workspace_runtime_binding(
+                context.workspace_id,
+                binding_id,
+                include_deleted=include_deleted,
+            )
+        except _RUNTIME_BINDING_LOOKUP_EXCEPTIONS as exc:  # pragma: no cover - defensive adapter boundary.
+            raise WorkspaceMembershipAdapterError(
+                "runtime_binding_lookup_failed",
+                "Runtime binding lookup failed while validating workspace membership.",
+                status_code=503,
+            ) from exc
+        return _as_mapping(row)
+
+    def _binding_mismatch(self, row: Mapping[str, Any]) -> bool:
+        return row.get("binding_kind") != self.binding_kind or row.get("owner_domain") != self.owner_domain
+
+    def _ref(
+        self,
+        row: Mapping[str, Any],
+        binding_id: str,
+        *,
+        state: str = "available",
+    ) -> WorkspaceResourceRef:
+        metadata = _compact_metadata(
+            row,
+            "binding_kind",
+            "owner_domain",
+            "status",
+            "portability",
+            "path_hint",
+            "redaction_report",
+        )
+        descriptor_metadata = row.get("metadata")
+        if isinstance(descriptor_metadata, Mapping):
+            metadata["descriptor"] = dict(descriptor_metadata)
+        return WorkspaceResourceRef(
+            resource_type=self.resource_type,
+            resource_id=str(row.get("binding_id") or binding_id),
+            title=_first_non_empty(row, "label") or f"{self.resource_type} {binding_id}",
+            subtitle=self.binding_kind,
+            updated_at=_first_non_empty(row, "updated_at", "created_at"),
+            metadata=metadata,
+            state=state,
+        )
+
+    def on_link(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        return None
+
+    def on_unlink(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        return None
+
+
+class AcpSessionMembershipAdapter(RuntimeBindingSessionMembershipAdapter):
+    resource_type = "acp_session"
+    binding_kind = "acp_session"
+    owner_domain = "acp"
+
+
+class SandboxSessionMembershipAdapter(RuntimeBindingSessionMembershipAdapter):
+    resource_type = "sandbox_session"
+    binding_kind = "sandbox_session"
+    owner_domain = "sandbox"
+
+
 def default_workspace_membership_adapters() -> dict[str, WorkspaceMembershipAdapter]:
     adapters: tuple[WorkspaceMembershipAdapter, ...] = (
         WorkspaceNoteMembershipAdapter(),
@@ -304,6 +636,11 @@ def default_workspace_membership_adapters() -> dict[str, WorkspaceMembershipAdap
         WorkspaceSourceMembershipAdapter(),
         WorkspaceArtifactMembershipAdapter(),
         ChatMembershipAdapter(),
+        PromptMembershipAdapter(),
+        WorkflowMembershipAdapter(),
+        WatchlistMembershipAdapter(),
+        AcpSessionMembershipAdapter(),
+        SandboxSessionMembershipAdapter(),
     )
     return {adapter.resource_type: adapter for adapter in adapters}
 
@@ -371,7 +708,7 @@ def _resource_not_found(resource_type: str, resource_id: str) -> WorkspaceMember
 
 
 def _is_deleted(row: Mapping[str, Any]) -> bool:
-    return row.get("deleted") in (True, 1, "1", "true", "True")
+    return row.get("deleted") in (True, 1, "1", "true", "True") or bool(row.get("deleted_at"))
 
 
 def _row_workspace_mismatch(row: Mapping[str, Any], workspace_id: str) -> bool:
@@ -380,7 +717,7 @@ def _row_workspace_mismatch(row: Mapping[str, Any], workspace_id: str) -> bool:
 
 
 def _is_archived(row: Mapping[str, Any]) -> bool:
-    return row.get("archived") in (True, 1, "1", "true", "True")
+    return row.get("archived") in (True, 1, "1", "true", "True") or bool(row.get("archived_at"))
 
 
 def _is_trash(row: Mapping[str, Any]) -> bool:
@@ -421,6 +758,46 @@ def _first_non_empty(row: Mapping[str, Any], *keys: str) -> str | None:
 
 def _compact_metadata(row: Mapping[str, Any], *keys: str) -> dict[str, Any]:
     return {key: row[key] for key in keys if row.get(key) is not None}
+
+
+def _as_mapping(row: Any) -> Mapping[str, Any] | None:
+    if row is None:
+        return None
+    if isinstance(row, Mapping):
+        return row
+    if hasattr(row, "to_dict"):
+        mapped = row.to_dict()
+        return mapped if isinstance(mapped, Mapping) else None
+    try:
+        return vars(row)
+    except TypeError:
+        return None
+
+
+def _workflow_is_active(row: Mapping[str, Any]) -> bool:
+    return row.get("is_active") not in (False, 0, "0", "false", "False")
+
+
+def _metadata_tags(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return []
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return [raw]
+        value = parsed
+    if isinstance(value, (list, tuple, set)):
+        result: list[str] = []
+        for item in value:
+            normalized = str(item or "").strip()
+            if normalized and normalized not in result:
+                result.append(normalized)
+        return result
+    return []
 
 
 def _media_href(media_id: str) -> str:

--- a/tldw_Server_API/app/core/Workspaces/membership_adapters.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_adapters.py
@@ -537,10 +537,11 @@ class WatchlistMembershipAdapter:
         return None
 
 
-class RuntimeBindingSessionMembershipAdapter:
-    resource_type = ""
-    binding_kind = ""
-    owner_domain = ""
+@dataclass(frozen=True)
+class _RuntimeBindingSessionResolver:
+    resource_type: str
+    binding_kind: str
+    owner_domain: str
 
     def validate_access(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
         binding_id = _require_resource_id(resource_id)
@@ -610,6 +611,23 @@ class RuntimeBindingSessionMembershipAdapter:
             state=state,
         )
 
+
+class AcpSessionMembershipAdapter:
+    resource_type = "acp_session"
+
+    def __init__(self, resolver: _RuntimeBindingSessionResolver | None = None) -> None:
+        self._resolver = resolver or _RuntimeBindingSessionResolver(
+            resource_type=self.resource_type,
+            binding_kind="acp_session",
+            owner_domain="acp",
+        )
+
+    def validate_access(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        return self._resolver.validate_access(resource_id, context)
+
+    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        return self._resolver.summarize(resource_id, context)
+
     def on_link(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
         return None
 
@@ -617,16 +635,27 @@ class RuntimeBindingSessionMembershipAdapter:
         return None
 
 
-class AcpSessionMembershipAdapter(RuntimeBindingSessionMembershipAdapter):
-    resource_type = "acp_session"
-    binding_kind = "acp_session"
-    owner_domain = "acp"
-
-
-class SandboxSessionMembershipAdapter(RuntimeBindingSessionMembershipAdapter):
+class SandboxSessionMembershipAdapter:
     resource_type = "sandbox_session"
-    binding_kind = "sandbox_session"
-    owner_domain = "sandbox"
+
+    def __init__(self, resolver: _RuntimeBindingSessionResolver | None = None) -> None:
+        self._resolver = resolver or _RuntimeBindingSessionResolver(
+            resource_type=self.resource_type,
+            binding_kind="sandbox_session",
+            owner_domain="sandbox",
+        )
+
+    def validate_access(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        return self._resolver.validate_access(resource_id, context)
+
+    def summarize(self, resource_id: str, context: WorkspaceMembershipContext) -> WorkspaceResourceRef:
+        return self._resolver.summarize(resource_id, context)
+
+    def on_link(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        return None
+
+    def on_unlink(self, membership: Mapping[str, Any], context: WorkspaceMembershipContext) -> None:
+        return None
 
 
 def default_workspace_membership_adapters() -> dict[str, WorkspaceMembershipAdapter]:

--- a/tldw_Server_API/app/core/Workspaces/membership_models.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_models.py
@@ -10,16 +10,23 @@ from typing import Any
 
 
 WORKSPACE_MEMBERSHIP_RESOURCE_TYPES = frozenset(
-    {"workspace_note", "media", "workspace_source", "workspace_artifact", "chat"}
-)
-WORKSPACE_MEMBERSHIP_FUTURE_RESOURCE_TYPES = frozenset(
     {
-        "note",
+        "workspace_note",
+        "media",
+        "workspace_source",
+        "workspace_artifact",
+        "chat",
         "prompt",
         "workflow",
         "watchlist",
         "acp_session",
         "sandbox_session",
+    }
+)
+WORKSPACE_MEMBERSHIP_FUTURE_RESOURCE_TYPES = frozenset(
+    {
+        "note",
+        "acp_run",
         "project_file",
         "study_deck",
         "quiz",

--- a/tldw_Server_API/app/core/Workspaces/membership_request_metadata.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_request_metadata.py
@@ -1,0 +1,42 @@
+"""Workspace membership request metadata helpers."""
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_Server_API.app.core.AuthNZ.permissions import WORKFLOWS_ADMIN
+
+
+def normalize_claim_values(values: Any) -> list[str]:
+    """Normalize role/permission claims to lowercase strings."""
+    raw_values = values if isinstance(values, (list, tuple, set)) else ([values] if values is not None else [])
+    normalized: list[str] = []
+    for value in raw_values:
+        text = str(value).strip().lower()
+        if text:
+            normalized.append(text)
+    return normalized
+
+
+def is_workflows_admin_user(current_user: Any) -> bool:
+    """Return whether explicit role/permission claims grant workflow-admin access."""
+    try:
+        if "admin" in normalize_claim_values(getattr(current_user, "roles", [])):
+            return True
+        permission_values = normalize_claim_values(getattr(current_user, "permissions", []))
+        return (
+            WORKFLOWS_ADMIN.lower() in permission_values
+            or "*" in permission_values
+            or "system.configure" in permission_values
+        )
+    except (AttributeError, TypeError, ValueError):
+        return False
+
+
+def build_workspace_membership_request_metadata(current_user: Any) -> dict[str, Any]:
+    """Build request metadata consumed by domain-owned membership adapters."""
+    raw_tenant_id = getattr(current_user, "tenant_id", None)
+    tenant_id = str(raw_tenant_id).strip() if raw_tenant_id is not None else ""
+    return {
+        "tenant_id": tenant_id,
+        "is_workflows_admin": is_workflows_admin_user(current_user),
+    }

--- a/tldw_Server_API/app/core/Workspaces/membership_service.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_service.py
@@ -57,6 +57,9 @@ class WorkspaceMembershipService:
         *,
         user_id: str | None = None,
         media_db: Any | None = None,
+        prompts_db: Any | None = None,
+        workflows_db: Any | None = None,
+        watchlists_db: Any | None = None,
         request_metadata: Mapping[str, Any] | None = None,
         resolve: bool = True,
     ) -> dict[str, Any]:
@@ -69,6 +72,9 @@ class WorkspaceMembershipService:
             workspace_id,
             user_id=user_id,
             media_db=media_db,
+            prompts_db=prompts_db,
+            workflows_db=workflows_db,
+            watchlists_db=watchlists_db,
             request_metadata=request_metadata,
         )
         ref = self._validate_access(adapter, data["resource_id"], context)
@@ -103,6 +109,10 @@ class WorkspaceMembershipService:
         *,
         user_id: str | None = None,
         media_db: Any | None = None,
+        prompts_db: Any | None = None,
+        workflows_db: Any | None = None,
+        watchlists_db: Any | None = None,
+        request_metadata: Mapping[str, Any] | None = None,
         resolve: bool = True,
     ) -> dict[str, Any] | None:
         """Fetch one active membership row for a Workspace."""
@@ -116,8 +126,11 @@ class WorkspaceMembershipService:
             workspace_id=workspace_id,
             user_id=user_id,
             media_db=media_db,
-            request_metadata=None,
-            validate=False,
+            prompts_db=prompts_db,
+            workflows_db=workflows_db,
+            watchlists_db=watchlists_db,
+            request_metadata=request_metadata,
+            validate=canonical_resource_type in {"prompt", "workflow", "watchlist"},
         )
         row = self.chacha_db.get_workspace_resource_membership(
             workspace_id,
@@ -127,7 +140,15 @@ class WorkspaceMembershipService:
         )
         if row is None:
             return None
-        context = self._context(workspace_id, user_id=user_id, media_db=media_db)
+        context = self._context(
+            workspace_id,
+            user_id=user_id,
+            media_db=media_db,
+            prompts_db=prompts_db,
+            workflows_db=workflows_db,
+            watchlists_db=watchlists_db,
+            request_metadata=request_metadata,
+        )
         return self._serialize_membership(row, context=context, resolve=resolve)
 
     def list_workspace_memberships(
@@ -141,6 +162,10 @@ class WorkspaceMembershipService:
         cursor: str | WorkspaceMembershipCursor | tuple[str, str, str] | None = None,
         user_id: str | None = None,
         media_db: Any | None = None,
+        prompts_db: Any | None = None,
+        workflows_db: Any | None = None,
+        watchlists_db: Any | None = None,
+        request_metadata: Mapping[str, Any] | None = None,
         resolve: bool = True,
     ) -> dict[str, Any]:
         """List memberships for one Workspace."""
@@ -159,7 +184,15 @@ class WorkspaceMembershipService:
             cursor=normalized_cursor,
         )
         page_rows, next_cursor = self._trim_workspace_page(rows, normalized_limit)
-        context = self._context(workspace_id, user_id=user_id, media_db=media_db)
+        context = self._context(
+            workspace_id,
+            user_id=user_id,
+            media_db=media_db,
+            prompts_db=prompts_db,
+            workflows_db=workflows_db,
+            watchlists_db=watchlists_db,
+            request_metadata=request_metadata,
+        )
         items = [self._serialize_membership(row, context=context, resolve=resolve) for row in page_rows]
         return {
             "workspace_id": workspace_id,
@@ -179,6 +212,10 @@ class WorkspaceMembershipService:
         cursor: str | WorkspaceResourceMembershipCursor | tuple[str, str] | None = None,
         user_id: str | None = None,
         media_db: Any | None = None,
+        prompts_db: Any | None = None,
+        workflows_db: Any | None = None,
+        watchlists_db: Any | None = None,
+        request_metadata: Mapping[str, Any] | None = None,
         resolve: bool = True,
     ) -> dict[str, Any]:
         """List Workspace memberships for one canonical resource."""
@@ -191,8 +228,11 @@ class WorkspaceMembershipService:
             workspace_id="",
             user_id=user_id,
             media_db=media_db,
-            request_metadata=None,
-            validate=canonical_resource_type == "media",
+            prompts_db=prompts_db,
+            workflows_db=workflows_db,
+            watchlists_db=watchlists_db,
+            request_metadata=request_metadata,
+            validate=canonical_resource_type in {"media", "prompt", "workflow", "watchlist"},
         )
         normalized_limit = self._normalize_limit(limit)
         normalized_cursor = self._resource_cursor_tuple(cursor)
@@ -207,7 +247,15 @@ class WorkspaceMembershipService:
         items = [
             self._serialize_membership(
                 row,
-                context=self._context(str(row.get("workspace_id") or ""), user_id=user_id, media_db=media_db),
+                context=self._context(
+                    str(row.get("workspace_id") or ""),
+                    user_id=user_id,
+                    media_db=media_db,
+                    prompts_db=prompts_db,
+                    workflows_db=workflows_db,
+                    watchlists_db=watchlists_db,
+                    request_metadata=request_metadata,
+                ),
                 resolve=resolve,
             )
             for row in page_rows
@@ -229,12 +277,24 @@ class WorkspaceMembershipService:
         *,
         user_id: str | None = None,
         media_db: Any | None = None,
+        prompts_db: Any | None = None,
+        workflows_db: Any | None = None,
+        watchlists_db: Any | None = None,
+        request_metadata: Mapping[str, Any] | None = None,
     ) -> dict[str, Any] | None:
         """Soft-delete one Workspace membership."""
         workspace = self._require_workspace(workspace_id)
         self._require_writable_workspace(workspace)
         adapter = self._get_adapter(resource_type)
-        context = self._context(workspace_id, user_id=user_id, media_db=media_db)
+        context = self._context(
+            workspace_id,
+            user_id=user_id,
+            media_db=media_db,
+            prompts_db=prompts_db,
+            workflows_db=workflows_db,
+            watchlists_db=watchlists_db,
+            request_metadata=request_metadata,
+        )
         canonical_resource_id = self._canonical_resource_id(
             adapter,
             adapter.resource_type,
@@ -242,8 +302,11 @@ class WorkspaceMembershipService:
             workspace_id=workspace_id,
             user_id=user_id,
             media_db=media_db,
-            request_metadata=None,
-            validate=False,
+            prompts_db=prompts_db,
+            workflows_db=workflows_db,
+            watchlists_db=watchlists_db,
+            request_metadata=request_metadata,
+            validate=adapter.resource_type in {"prompt", "workflow", "watchlist"},
         )
         row = self.chacha_db.delete_workspace_resource_membership(
             workspace_id,
@@ -368,6 +431,9 @@ class WorkspaceMembershipService:
         *,
         user_id: str | None,
         media_db: Any | None,
+        prompts_db: Any | None = None,
+        workflows_db: Any | None = None,
+        watchlists_db: Any | None = None,
         request_metadata: Mapping[str, Any] | None = None,
     ) -> WorkspaceMembershipContext:
         return WorkspaceMembershipContext(
@@ -375,6 +441,9 @@ class WorkspaceMembershipService:
             user_id=user_id,
             chacha_db=self.chacha_db,
             media_db=media_db,
+            prompts_db=prompts_db,
+            workflows_db=workflows_db,
+            watchlists_db=watchlists_db,
             request_metadata=dict(request_metadata or {}),
         )
 
@@ -609,6 +678,9 @@ class WorkspaceMembershipService:
         workspace_id: str,
         user_id: str | None,
         media_db: Any | None,
+        prompts_db: Any | None,
+        workflows_db: Any | None,
+        watchlists_db: Any | None,
         request_metadata: Mapping[str, Any] | None,
         validate: bool,
     ) -> str:
@@ -617,11 +689,14 @@ class WorkspaceMembershipService:
                 workspace_id,
                 user_id=user_id,
                 media_db=media_db,
+                prompts_db=prompts_db,
+                workflows_db=workflows_db,
+                watchlists_db=watchlists_db,
                 request_metadata=request_metadata,
             )
             return self._validate_access(adapter, resource_id, context).resource_id
         normalized_resource_id = self._non_empty_string(resource_id, "resource_id")
-        if resource_type in {"media", "workspace_note"}:
+        if resource_type in {"media", "workspace_note", "workflow", "watchlist"}:
             try:
                 parsed = int(normalized_resource_id)
             except (TypeError, ValueError) as exc:

--- a/tldw_Server_API/app/core/Workspaces/membership_service.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_service.py
@@ -306,8 +306,25 @@ class WorkspaceMembershipService:
             workflows_db=workflows_db,
             watchlists_db=watchlists_db,
             request_metadata=request_metadata,
-            validate=adapter.resource_type in {"prompt", "workflow", "watchlist"},
+            validate=False,
         )
+        if adapter.resource_type == "prompt" and prompts_db is not None:
+            try:
+                canonical_resource_id = self._canonical_resource_id(
+                    adapter,
+                    adapter.resource_type,
+                    resource_id,
+                    workspace_id=workspace_id,
+                    user_id=user_id,
+                    media_db=media_db,
+                    prompts_db=prompts_db,
+                    workflows_db=workflows_db,
+                    watchlists_db=watchlists_db,
+                    request_metadata=request_metadata,
+                    validate=True,
+                )
+            except WorkspaceMembershipServiceError:
+                canonical_resource_id = self._non_empty_string(resource_id, "resource_id")
         row = self.chacha_db.delete_workspace_resource_membership(
             workspace_id,
             adapter.resource_type,

--- a/tldw_Server_API/app/services/shutdown_post_worker_services.py
+++ b/tldw_Server_API/app/services/shutdown_post_worker_services.py
@@ -25,7 +25,13 @@ async def run_shutdown_post_worker_non_worker_cleanup(
         )
     except guard_exceptions as exc:
         logger.bind(error_type=type(exc).__name__).debug(
-            "Post-worker non-worker cleanup skipped after guarded exception"
+            "Post-worker personalization cleanup skipped after guarded exception"
+        )
+    try:
+        _close_cached_optional_workflows_db()
+    except guard_exceptions as exc:
+        logger.bind(error_type=type(exc).__name__).debug(
+            "Post-worker optional Workflows DB cleanup skipped after guarded exception"
         )
     return PostWorkerNonWorkerCleanupHandles()
 
@@ -36,3 +42,11 @@ async def _shutdown_personalization_consolidation(**kwargs):
     )
 
     await shutdown_personalization_consolidation(**kwargs)
+
+
+def _close_cached_optional_workflows_db() -> None:
+    from tldw_Server_API.app.api.v1.API_Deps.Workflows_DB_Deps import (
+        close_cached_workflows_db_for_user,
+    )
+
+    close_cached_workflows_db_for_user()

--- a/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+from types import SimpleNamespace
 
 import pytest
 from pydantic import ValidationError
@@ -365,6 +366,7 @@ class FakeChaChaDB:
         self.sources: dict[tuple[str, str], dict[str, object]] = {}
         self.artifacts: dict[tuple[str, str], dict[str, object]] = {}
         self.conversations: dict[str, dict[str, object]] = {}
+        self.runtime_bindings: dict[tuple[str, str], dict[str, object]] = {}
         self.memberships: dict[tuple[str, str, str], dict[str, object]] = {}
         self.last_add_data: dict[str, object] | None = None
         self.last_list_resource_key: tuple[str, str] | None = None
@@ -413,6 +415,18 @@ class FakeChaChaDB:
         include_deleted: bool = False,
     ) -> dict[str, object] | None:
         return self.conversations.get(conversation_id)
+
+    def get_workspace_runtime_binding(
+        self,
+        workspace_id: str,
+        binding_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, object] | None:
+        row = self.runtime_bindings.get((workspace_id, binding_id))
+        if row is None or (row.get("deleted") and not include_deleted):
+            return None
+        return dict(row)
 
     def add_workspace_resource_membership(
         self,
@@ -588,6 +602,39 @@ def _context(db: FakeChaChaDB, *, media_db: object | None = None) -> WorkspaceMe
     )
 
 
+class FakePromptsDB:
+    def __init__(self) -> None:
+        self.prompts: dict[int, dict[str, object]] = {}
+
+    def fetch_prompt_details(self, prompt_id_or_name_or_uuid: object, include_deleted: bool = False) -> dict[str, object] | None:
+        identifier = str(prompt_id_or_name_or_uuid)
+        for row in self.prompts.values():
+            if not include_deleted and row.get("deleted"):
+                continue
+            if identifier in {str(row.get("id")), str(row.get("uuid")), str(row.get("name"))}:
+                return dict(row)
+        return None
+
+
+class FakeWorkflowsDB:
+    def __init__(self) -> None:
+        self.definitions: dict[int, SimpleNamespace] = {}
+
+    def get_definition(self, workflow_id: int) -> SimpleNamespace | None:
+        return self.definitions.get(workflow_id)
+
+
+class FakeWatchlistsDB:
+    def __init__(self) -> None:
+        self.watchlists: dict[int, SimpleNamespace] = {}
+
+    def get_watchlist(self, watchlist_id: int, include_deleted: bool = False) -> SimpleNamespace:
+        row = self.watchlists.get(watchlist_id)
+        if row is None or (getattr(row, "deleted_at", None) and not include_deleted):
+            raise KeyError("watchlist_not_found")
+        return row
+
+
 def test_unsupported_resource_type_fails_closed() -> None:
     service = WorkspaceMembershipService(FakeChaChaDB())
 
@@ -602,6 +649,19 @@ def test_unsupported_resource_type_fails_closed() -> None:
     assert exc_info.value.status_code == 400
     with pytest.raises(WorkspaceMembershipAdapterError):
         get_workspace_membership_adapter("note")
+
+
+@pytest.mark.parametrize("resource_type", ["prompt", "workflow", "watchlist", "acp_session", "sandbox_session"])
+def test_remaining_phase2_resource_types_have_membership_adapters(resource_type: str) -> None:
+    assert get_workspace_membership_adapter(resource_type).resource_type == resource_type
+
+
+@pytest.mark.parametrize("resource_type", ["note", "acp_run"])
+def test_explicitly_deferred_resource_types_still_fail_closed(resource_type: str) -> None:
+    with pytest.raises(WorkspaceMembershipAdapterError) as exc_info:
+        get_workspace_membership_adapter(resource_type)
+
+    assert exc_info.value.code == "unsupported_resource_type"
 
 
 def test_workspace_note_adapter_validates_same_workspace_note() -> None:
@@ -966,6 +1026,193 @@ def test_deleted_media_summary_reports_deleted_state(monkeypatch: pytest.MonkeyP
     assert summary["state"] == "deleted"
     assert summary["title"] == "Deleted media"
     assert calls == [(42, True, True)]
+
+
+def test_prompt_membership_canonicalizes_to_numeric_id_and_omits_prompt_content() -> None:
+    db = FakeChaChaDB()
+    prompts_db = FakePromptsDB()
+    prompts_db.prompts[7] = {
+        "id": 7,
+        "uuid": "11111111-1111-4111-8111-111111111111",
+        "name": "Research Prompt",
+        "author": "analyst",
+        "details": "secret prompt body",
+        "system_prompt": "hidden system prompt",
+        "last_modified": "2026-06-07T12:05:00Z",
+        "deleted": 0,
+    }
+    service = WorkspaceMembershipService(db)
+
+    payload = service.link_membership(
+        "workspace-1",
+        {"resource_type": "prompt", "resource_id": "11111111-1111-4111-8111-111111111111"},
+        user_id="user-1",
+        prompts_db=prompts_db,
+    )
+
+    assert payload["resource_type"] == "prompt"
+    assert payload["resource_id"] == "7"
+    assert payload["summary"]["title"] == "Research Prompt"
+    assert payload["summary"]["metadata"]["author"] == "analyst"
+    assert "secret prompt body" not in json.dumps(payload)
+    assert "hidden system prompt" not in json.dumps(payload)
+
+
+def test_prompt_membership_requires_prompts_db() -> None:
+    service = WorkspaceMembershipService(FakeChaChaDB())
+
+    with pytest.raises(WorkspaceMembershipServiceError) as exc_info:
+        service.link_membership(
+            "workspace-1",
+            {"resource_type": "prompt", "resource_id": "7"},
+            user_id="user-1",
+        )
+
+    assert exc_info.value.code == "prompts_db_unavailable"
+    assert exc_info.value.status_code == 503
+
+
+def test_workflow_membership_requires_same_tenant_and_owner_unless_admin() -> None:
+    db = FakeChaChaDB()
+    workflows_db = FakeWorkflowsDB()
+    workflows_db.definitions[9] = SimpleNamespace(
+        id=9,
+        tenant_id="tenant-a",
+        owner_id="user-2",
+        name="Investigation",
+        version=3,
+        description="Runnable workflow",
+        tags='["research"]',
+        is_active=1,
+        updated_at="2026-06-07T12:05:00Z",
+        definition_json='{"secret":"do not expose"}',
+    )
+    service = WorkspaceMembershipService(db)
+
+    with pytest.raises(WorkspaceMembershipServiceError) as exc_info:
+        service.link_membership(
+            "workspace-1",
+            {"resource_type": "workflow", "resource_id": "9"},
+            user_id="user-1",
+            workflows_db=workflows_db,
+            request_metadata={"tenant_id": "tenant-a", "is_workflows_admin": False},
+        )
+
+    assert exc_info.value.code == "resource_not_found"
+
+    payload = service.link_membership(
+        "workspace-1",
+        {"resource_type": "workflow", "resource_id": "9"},
+        user_id="user-1",
+        workflows_db=workflows_db,
+        request_metadata={"tenant_id": "tenant-a", "is_workflows_admin": True},
+    )
+
+    assert payload["resource_id"] == "9"
+    assert payload["summary"]["title"] == "Investigation"
+    assert payload["summary"]["metadata"]["version"] == 3
+    assert "do not expose" not in json.dumps(payload)
+
+
+def test_watchlist_membership_validates_current_user_watchlist_and_deleted_summary() -> None:
+    db = FakeChaChaDB()
+    watchlists_db = FakeWatchlistsDB()
+    watchlists_db.watchlists[12] = SimpleNamespace(
+        id=12,
+        name="Claims Monitor",
+        domain="claims",
+        status="active",
+        priority="high",
+        tags=["claims", "policy"],
+        objective="long private objective",
+        deleted_at=None,
+        archived_at=None,
+        updated_at="2026-06-07T12:05:00Z",
+    )
+    service = WorkspaceMembershipService(db)
+
+    payload = service.link_membership(
+        "workspace-1",
+        {"resource_type": "watchlist", "resource_id": "12"},
+        user_id="user-1",
+        watchlists_db=watchlists_db,
+    )
+
+    assert payload["resource_id"] == "12"
+    assert payload["summary"]["title"] == "Claims Monitor"
+    assert payload["summary"]["metadata"]["priority"] == "high"
+    assert "long private objective" not in json.dumps(payload)
+
+    watchlists_db.watchlists[12].deleted_at = "2026-06-07T12:30:00Z"
+    listed = service.list_workspace_memberships("workspace-1", watchlists_db=watchlists_db)
+
+    assert listed["items"][0]["summary"]["state"] == "deleted"
+
+
+@pytest.mark.parametrize(
+    "resource_type,binding_kind,owner_domain",
+    [
+        ("acp_session", "acp_session", "acp"),
+        ("sandbox_session", "sandbox_session", "sandbox"),
+    ],
+)
+def test_runtime_session_membership_validates_workspace_runtime_binding(
+    resource_type: str,
+    binding_kind: str,
+    owner_domain: str,
+) -> None:
+    db = FakeChaChaDB()
+    db.runtime_bindings[("workspace-1", "session-1")] = {
+        "workspace_id": "workspace-1",
+        "binding_id": "session-1",
+        "binding_kind": binding_kind,
+        "owner_domain": owner_domain,
+        "locator_ref": "opaque-runtime-ref",
+        "label": "Runtime Session",
+        "status": "ready",
+        "path_hint": "repo",
+        "portability": "metadata-only",
+        "metadata": {"safe": "value", "absolute_root": "repo"},
+        "redaction_report": {"redacted": True, "redacted_fields": ["path_hint"], "rejected_fields": []},
+        "updated_at": "2026-06-07T12:05:00Z",
+        "deleted": False,
+    }
+    service = WorkspaceMembershipService(db)
+
+    payload = service.link_membership(
+        "workspace-1",
+        {"resource_type": resource_type, "resource_id": "session-1", "role": "runtime"},
+        user_id="user-1",
+    )
+
+    assert payload["resource_id"] == "session-1"
+    assert payload["summary"]["title"] == "Runtime Session"
+    assert payload["summary"]["metadata"]["binding_kind"] == binding_kind
+    assert payload["summary"]["metadata"]["status"] == "ready"
+
+
+def test_runtime_session_membership_rejects_wrong_binding_kind_or_domain() -> None:
+    db = FakeChaChaDB()
+    db.runtime_bindings[("workspace-1", "session-1")] = {
+        "workspace_id": "workspace-1",
+        "binding_id": "session-1",
+        "binding_kind": "sandbox_session",
+        "owner_domain": "sandbox",
+        "locator_ref": "opaque-runtime-ref",
+        "label": "Wrong Runtime Session",
+        "status": "ready",
+        "deleted": False,
+    }
+    service = WorkspaceMembershipService(db)
+
+    with pytest.raises(WorkspaceMembershipServiceError) as exc_info:
+        service.link_membership(
+            "workspace-1",
+            {"resource_type": "acp_session", "resource_id": "session-1", "role": "runtime"},
+            user_id="user-1",
+        )
+
+    assert exc_info.value.code == "resource_not_found"
 
 
 class RecordingAdapter:

--- a/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
@@ -656,6 +656,11 @@ def test_remaining_phase2_resource_types_have_membership_adapters(resource_type:
     assert get_workspace_membership_adapter(resource_type).resource_type == resource_type
 
 
+def test_runtime_session_adapters_use_composition_not_concrete_inheritance() -> None:
+    assert membership_adapters.AcpSessionMembershipAdapter.__bases__ == (object,)
+    assert membership_adapters.SandboxSessionMembershipAdapter.__bases__ == (object,)
+
+
 @pytest.mark.parametrize("resource_type", ["note", "acp_run"])
 def test_explicitly_deferred_resource_types_still_fail_closed(resource_type: str) -> None:
     with pytest.raises(WorkspaceMembershipAdapterError) as exc_info:
@@ -1361,6 +1366,26 @@ def test_unlink_membership_returns_deleted_row_when_adapter_hook_fails() -> None
     assert payload is not None
     assert payload["deleted"] is True
     assert db.memberships[("workspace-1", "media", "42")]["deleted"] is True
+
+
+@pytest.mark.parametrize(
+    "resource_type,resource_id",
+    [("prompt", "7"), ("workflow", "9"), ("watchlist", "12")],
+)
+def test_unlink_membership_does_not_require_live_domain_adapter(resource_type: str, resource_id: str) -> None:
+    db = FakeChaChaDB()
+    db.memberships[("workspace-1", resource_type, resource_id)] = _membership_row(
+        resource_type=resource_type,
+        resource_id=resource_id,
+        role="reference",
+    )
+    service = WorkspaceMembershipService(db)
+
+    payload = service.unlink_membership("workspace-1", resource_type, resource_id, user_id="user-1")
+
+    assert payload is not None
+    assert payload["deleted"] is True
+    assert db.memberships[("workspace-1", resource_type, resource_id)]["deleted"] is True
 
 
 def test_workspace_membership_summary_uses_db_aggregate_for_active_compact_totals() -> None:

--- a/tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py
@@ -9,6 +9,8 @@ from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import try_get_media_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.Prompts_DB_Deps import try_get_prompts_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.Watchlists_DB_Deps import try_get_watchlists_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user
 from tldw_Server_API.app.api.v1.endpoints import workspace_memberships as workspace_memberships_endpoint
 from tldw_Server_API.app.api.v1.endpoints import workspaces as workspaces_endpoint
@@ -185,6 +187,66 @@ class FakeMembershipDB:
         return dict(row)
 
 
+class FakePromptsDB:
+    def __init__(self) -> None:
+        self.prompts = {
+            7: {
+                "id": 7,
+                "uuid": "11111111-1111-4111-8111-111111111111",
+                "name": "Research Prompt",
+                "author": "analyst",
+                "details": "do not expose",
+                "last_modified": "2026-06-07T12:00:00Z",
+                "deleted": 0,
+            }
+        }
+
+    def fetch_prompt_details(self, prompt_id_or_name_or_uuid: object, include_deleted: bool = False) -> dict[str, object] | None:
+        identifier = str(prompt_id_or_name_or_uuid)
+        for row in self.prompts.values():
+            if not include_deleted and row.get("deleted"):
+                continue
+            if identifier in {str(row["id"]), str(row["uuid"]), str(row["name"])}:
+                return dict(row)
+        return None
+
+
+class FakeWorkflowsDB:
+    def get_definition(self, workflow_id: int) -> SimpleNamespace | None:
+        if workflow_id != 9:
+            return None
+        return SimpleNamespace(
+            id=9,
+            tenant_id="tenant-a",
+            owner_id="user-1",
+            name="Investigation",
+            version=2,
+            description="Workflow description",
+            tags='["research"]',
+            definition_json='{"secret":"do not expose"}',
+            is_active=1,
+            updated_at="2026-06-07T12:00:00Z",
+        )
+
+
+class FakeWatchlistsDB:
+    def get_watchlist(self, watchlist_id: int, include_deleted: bool = False) -> SimpleNamespace:
+        if watchlist_id != 12:
+            raise KeyError("watchlist_not_found")
+        return SimpleNamespace(
+            id=12,
+            name="Claims Monitor",
+            domain="claims",
+            status="active",
+            priority="high",
+            tags=["claims"],
+            objective="do not expose",
+            deleted_at=None,
+            archived_at=None,
+            updated_at="2026-06-07T12:00:00Z",
+        )
+
+
 @pytest.fixture
 def db() -> FakeMembershipDB:
     return FakeMembershipDB()
@@ -199,9 +261,13 @@ def membership_app(db: FakeMembershipDB) -> FastAPI:
     async def _allow_rate_limit() -> None:
         return None
 
-    app.dependency_overrides[get_request_user] = lambda: SimpleNamespace(id="user-1")
+    app.dependency_overrides[get_request_user] = lambda: SimpleNamespace(id="user-1", tenant_id="tenant-a")
     app.dependency_overrides[get_chacha_db_for_user] = lambda: db
     app.dependency_overrides[try_get_media_db_for_user] = lambda: object()
+    app.dependency_overrides[try_get_prompts_db_for_user] = lambda: FakePromptsDB()
+    app.dependency_overrides[try_get_watchlists_db_for_user] = lambda: FakeWatchlistsDB()
+    app.dependency_overrides[workspaces_endpoint.try_get_workflows_db_for_user] = lambda: FakeWorkflowsDB()
+    app.dependency_overrides[workspace_memberships_endpoint.try_get_workflows_db_for_user] = lambda: FakeWorkflowsDB()
     app.dependency_overrides[WORKSPACES_READ_RATE_LIMIT] = _allow_rate_limit
     app.dependency_overrides[WORKSPACES_WRITE_RATE_LIMIT] = _allow_rate_limit
     app.dependency_overrides[WORKSPACES_DELETE_RATE_LIMIT] = _allow_rate_limit
@@ -375,6 +441,81 @@ def test_reverse_resource_route_default_omits_resolved_summaries(client: TestCli
     body = response.json()
     assert body["total"] == 1
     assert body["items"][0]["summary"] is None
+
+
+def test_prompt_membership_route_uses_optional_prompts_db(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/workspaces/workspace-1/memberships",
+        json=_membership_payload(
+            resource_type="prompt",
+            resource_id="11111111-1111-4111-8111-111111111111",
+            role="reference",
+        ),
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["resource_type"] == "prompt"
+    assert body["resource_id"] == "7"
+    assert body["summary"]["title"] == "Research Prompt"
+    assert "do not expose" not in response.text
+
+
+def test_workflow_membership_route_passes_request_tenant_metadata(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/workspaces/workspace-1/memberships",
+        json=_membership_payload(resource_type="workflow", resource_id="9", role="runtime"),
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["resource_type"] == "workflow"
+    assert body["summary"]["title"] == "Investigation"
+    assert body["summary"]["metadata"]["version"] == 2
+    assert "do not expose" not in response.text
+
+
+def test_watchlist_membership_route_uses_optional_watchlists_db(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/workspaces/workspace-1/memberships",
+        json=_membership_payload(resource_type="watchlist", resource_id="12", role="runtime"),
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["resource_type"] == "watchlist"
+    assert body["summary"]["title"] == "Claims Monitor"
+    assert body["summary"]["metadata"]["priority"] == "high"
+    assert "do not expose" not in response.text
+
+
+def test_reverse_prompt_route_canonicalizes_with_optional_prompts_db(client: TestClient) -> None:
+    client.post(
+        "/api/v1/workspaces/workspace-1/memberships",
+        json=_membership_payload(resource_type="prompt", resource_id="Research Prompt", role="reference"),
+    )
+
+    response = client.get(
+        "/api/v1/workspace-memberships/resources/prompt/11111111-1111-4111-8111-111111111111",
+        params={"resolve": "false"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["resource_type"] == "prompt"
+    assert body["resource_id"] == "7"
+    assert body["total"] == 1
+
+
+def test_unrelated_chat_membership_does_not_require_optional_domain_dbs(membership_app: FastAPI) -> None:
+    membership_app.dependency_overrides[try_get_prompts_db_for_user] = lambda: None
+    membership_app.dependency_overrides[try_get_watchlists_db_for_user] = lambda: None
+    membership_app.dependency_overrides[workspaces_endpoint.try_get_workflows_db_for_user] = lambda: None
+    with TestClient(membership_app, raise_server_exceptions=False) as test_client:
+        response = test_client.post("/api/v1/workspaces/workspace-1/memberships", json=_membership_payload())
+
+    assert response.status_code == 201
+    assert response.json()["resource_type"] == "chat"
 
 
 def test_unsupported_resource_type_returns_stable_400_code(client: TestClient) -> None:

--- a/tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from types import SimpleNamespace
 from typing import Any
 
@@ -473,6 +474,52 @@ def test_workflow_membership_route_passes_request_tenant_metadata(client: TestCl
     assert body["summary"]["title"] == "Investigation"
     assert body["summary"]["metadata"]["version"] == 2
     assert "do not expose" not in response.text
+
+
+def test_workflow_membership_route_allows_owner_without_tenant_id(membership_app: FastAPI) -> None:
+    membership_app.dependency_overrides[get_request_user] = lambda: SimpleNamespace(id="user-1", tenant_id=None)
+    with TestClient(membership_app, raise_server_exceptions=False) as test_client:
+        response = test_client.post(
+            "/api/v1/workspaces/workspace-1/memberships",
+            json=_membership_payload(resource_type="workflow", resource_id="9", role="runtime"),
+        )
+
+    assert response.status_code == 201
+    assert response.json()["resource_id"] == "9"
+
+
+def test_optional_workflows_db_dependency_is_sync_and_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tldw_Server_API.app.api.v1.API_Deps import Workflows_DB_Deps as workflows_db_deps
+
+    class FakeWorkflowsDependencyDB:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    created: list[FakeWorkflowsDependencyDB] = []
+
+    def _create_workflows_database(*, backend: object | None = None) -> FakeWorkflowsDependencyDB:
+        _ = backend
+        db = FakeWorkflowsDependencyDB()
+        created.append(db)
+        return db
+
+    workflows_db_deps.close_cached_workflows_db_for_user()
+    monkeypatch.setattr(workflows_db_deps, "get_content_backend_instance", lambda: object())
+    monkeypatch.setattr(workflows_db_deps, "create_workflows_database", _create_workflows_database)
+
+    try:
+        first = workflows_db_deps.try_get_workflows_db_for_user()
+        second = workflows_db_deps.try_get_workflows_db_for_user()
+
+        assert not inspect.isawaitable(first)
+        assert first is second
+        assert len(created) == 1
+    finally:
+        workflows_db_deps.close_cached_workflows_db_for_user()
+    assert created[0].closed is True
 
 
 def test_watchlist_membership_route_uses_optional_watchlists_db(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- Adds Workspace membership adapters for prompt, workflow, watchlist, acp_session, and sandbox_session resources.
- Wires optional Prompts/Workflows/Watchlists DB dependencies through forward and reverse membership APIs, including workflow tenant/admin context.
- Documents supported/deferred resource types and preserves the boundary that membership is not a trust source for ACP, Sandbox, MCP, or file access.

## Change summary
Human requester must replace this section before merge per the AI-generated PR policy. The implementation adds fail-closed domain adapters, redacted summaries, and API dependency wiring so ACP-adjacent resources can participate in Workspace membership without broadening trust decisions.

## Verification
- `python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py tldw_Server_API/tests/Workspaces/test_workspace_context_membership_summary.py -q`
- `python -m bandit -r tldw_Server_API/app/core/Workspaces tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/api/v1/endpoints/workspace_memberships.py tldw_Server_API/app/api/v1/API_Deps/Prompts_DB_Deps.py tldw_Server_API/app/api/v1/API_Deps/Watchlists_DB_Deps.py -f json -o /tmp/bandit_workspace_membership_adapters.json`

## Tracking
- Closes #2378
- Backlog: TASK-2383

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Workspace membership adapters for `prompt`, `workflow`, `watchlist`, `acp_session`, and `sandbox_session` so ACP-adjacent resources can link to Workspaces without expanding trust. Wires optional Prompts/Workflows/Watchlists DBs and workflow tenant/admin metadata into membership APIs; `note` and `acp_run` remain fail-closed (aligns with #2378).

- **New Features**
  - Safe adapters with redacted summaries; prompt UUID/name → numeric ID; workflow/watchlist IDs canonicalized.
  - `acp_session`/`sandbox_session` validate Workspace runtime bindings; adapters use composition.
  - APIs pass optional domain handles and request metadata from a new helper; reverse routes canonicalize resource IDs.
  - Unlink works without live prompt/workflow/watchlist adapters; best-effort prompt canonicalization when available.
  - Tests cover new types, fail-closed behavior, and API wiring; docs updated.

- **Dependencies**
  - Added optional deps: `try_get_prompts_db_for_user`, `try_get_workflows_db_for_user`, `try_get_watchlists_db_for_user`; propagate 401/403, return None otherwise.
  - Cached optional `WorkflowsDatabase` with shutdown cleanup hook; unrelated routes continue to work when optional deps are unavailable.

<sup>Written for commit 6a61fee4b81be9fc94d1b2c450e75c0cbe06286d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

