### PR TITLE
TASK-2283: Add sandbox env-file support

### DIFF
--- a/backlog/tasks/task-2283 - Add-Claude-style-governed-Bash-and-PowerShell-runtime-tools.md
+++ b/backlog/tasks/task-2283 - Add-Claude-style-governed-Bash-and-PowerShell-runtime-tools.md
@@ -4,7 +4,7 @@ title: Add Claude-style governed Bash and PowerShell runtime tools
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-06-18 04:17'
+updated_date: '2026-06-18 04:45'
 labels:
   - mcp
   - command-runtime
@@ -55,6 +55,8 @@ PR review hardening implemented: addressed Qodo, Gemini, and CodeRabbit comments
 Sixth slice implemented: added envFile / env_file support for governed sandbox command steps. Env files are validated as workspace-relative paths, resolved under the active workspace root with symlink target containment, bounded to 65536 bytes, parsed as simple UTF-8 .env KEY=value entries without expansion, forwarded only to sandbox.run, and salted into nested idempotency scope by path/content digest without exposing secret values. Non-sandbox command chains fail closed instead of silently loading env files. Verification: focused run command pytest 69 passed; Ruff passed for touched Python files; py_compile passed for touched Python files; Bandit report /tmp/bandit_mcp_run_env_file.json had results=0 errors=0 skipped=0.
 
 Sixth-slice hardening added: sandbox.run env values are redacted from tool hook contexts while preserving the real prepared/executed sandbox arguments and argument hash behavior. Verification rerun after hardening: run-command plus protocol hook pytest 78 passed; Ruff passed for touched Python files; py_compile passed for touched Python files; Bandit report /tmp/bandit_mcp_run_env_file.json had results=0 errors=0 skipped=0.
+
+PR #2386 review pass: rebased branch onto latest origin/dev (already up to date) and addressed still-valid review items. Changes: introduced RunEnvFileValidationError for envFile failures, replaced path.stat/read_bytes with os.open/os.fstat/os.fdopen bounded descriptor reads using O_NOFOLLOW/O_CLOEXEC where available, accepted UTF-8 BOM via utf-8-sig, restricted env variable names to ASCII [A-Za-z_][A-Za-z0-9_]*, removed redundant env-file alias normalization, added docstrings to new sandbox hook test helpers, and added focused regression tests for BOM/unicode-key rejection, descriptor reads, and OSError mapping. The marker-policy finding was handled for the newly added env-file tests by marking them unit and relying on repo-configured pytest asyncio auto mode; existing pre-existing asyncio markers were left unchanged. Verification: run-command plus protocol hook pytest 81 passed; Ruff passed for touched Python files; py_compile passed for touched Python files; Bandit report /tmp/bandit_mcp_run_env_file_review.json had results=0 errors=0 skipped=0; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2283 - Add-Claude-style-governed-Bash-and-PowerShell-runtime-tools.md
+++ b/backlog/tasks/task-2283 - Add-Claude-style-governed-Bash-and-PowerShell-runtime-tools.md
@@ -4,7 +4,7 @@ title: Add Claude-style governed Bash and PowerShell runtime tools
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-06-18 01:07'
+updated_date: '2026-06-18 04:17'
 labels:
   - mcp
   - command-runtime
@@ -51,6 +51,10 @@ Fourth slice implemented: added opt-in retainOutputArtifacts / retain_output_art
 Fifth slice implemented: added sandboxSessionId / sandbox_session_id support for governed sandbox command steps. When set, sandbox steps call sandbox.run with session_id instead of the default base_image, validation rejects empty/non-string/conflicting aliases, and nested idempotency keys are salted by sandbox session scope. Remaining broader TASK-2283 areas include env-file, shell selection, and telemetry parity if desired in later slices. Verification: focused command runtime pytest 112 passed; Ruff passed for touched Python files; py_compile passed for touched Python files; Bandit report /tmp/bandit_mcp_shell_sandbox_session_2283.json had results=0 errors=0; git diff --check passed.
 
 PR review hardening implemented: addressed Qodo, Gemini, and CodeRabbit comments by adding docstrings to newly added helpers/tests, replacing the sleep-based timeout test with deterministic cancellation, preserving whitespace in cwd-rewritten file path tokens, hashing idempotency scope with structured JSON serialization, and using per-invocation spill directories so timeout cleanup removes spills even when execution is cancelled before a result is returned. Verification: focused command runtime pytest 115 passed; Ruff passed for touched Python files; py_compile passed for touched Python files; Bandit report /tmp/bandit_mcp_shell_pr2384_review.json had results=0 errors=0; git diff --check passed.
+
+Sixth slice implemented: added envFile / env_file support for governed sandbox command steps. Env files are validated as workspace-relative paths, resolved under the active workspace root with symlink target containment, bounded to 65536 bytes, parsed as simple UTF-8 .env KEY=value entries without expansion, forwarded only to sandbox.run, and salted into nested idempotency scope by path/content digest without exposing secret values. Non-sandbox command chains fail closed instead of silently loading env files. Verification: focused run command pytest 69 passed; Ruff passed for touched Python files; py_compile passed for touched Python files; Bandit report /tmp/bandit_mcp_run_env_file.json had results=0 errors=0 skipped=0.
+
+Sixth-slice hardening added: sandbox.run env values are redacted from tool hook contexts while preserving the real prepared/executed sandbox arguments and argument hash behavior. Verification rerun after hardening: run-command plus protocol hook pytest 78 passed; Ruff passed for touched Python files; py_compile passed for touched Python files; Bandit report /tmp/bandit_mcp_run_env_file.json had results=0 errors=0 skipped=0.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2283 - Add-Claude-style-governed-Bash-and-PowerShell-runtime-tools.md
+++ b/backlog/tasks/task-2283 - Add-Claude-style-governed-Bash-and-PowerShell-runtime-tools.md
@@ -4,7 +4,7 @@ title: Add Claude-style governed Bash and PowerShell runtime tools
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-06-18 04:45'
+updated_date: '2026-06-18 04:49'
 labels:
   - mcp
   - command-runtime
@@ -57,6 +57,8 @@ Sixth slice implemented: added envFile / env_file support for governed sandbox c
 Sixth-slice hardening added: sandbox.run env values are redacted from tool hook contexts while preserving the real prepared/executed sandbox arguments and argument hash behavior. Verification rerun after hardening: run-command plus protocol hook pytest 78 passed; Ruff passed for touched Python files; py_compile passed for touched Python files; Bandit report /tmp/bandit_mcp_run_env_file.json had results=0 errors=0 skipped=0.
 
 PR #2386 review pass: rebased branch onto latest origin/dev (already up to date) and addressed still-valid review items. Changes: introduced RunEnvFileValidationError for envFile failures, replaced path.stat/read_bytes with os.open/os.fstat/os.fdopen bounded descriptor reads using O_NOFOLLOW/O_CLOEXEC where available, accepted UTF-8 BOM via utf-8-sig, restricted env variable names to ASCII [A-Za-z_][A-Za-z0-9_]*, removed redundant env-file alias normalization, added docstrings to new sandbox hook test helpers, and added focused regression tests for BOM/unicode-key rejection, descriptor reads, and OSError mapping. The marker-policy finding was handled for the newly added env-file tests by marking them unit and relying on repo-configured pytest asyncio auto mode; existing pre-existing asyncio markers were left unchanged. Verification: run-command plus protocol hook pytest 81 passed; Ruff passed for touched Python files; py_compile passed for touched Python files; Bandit report /tmp/bandit_mcp_run_env_file_review.json had results=0 errors=0 skipped=0; git diff --check passed.
+
+PR #2386 follow-up refinement: changed RunEnvFileValidationError to inherit the project ValidationError base while preserving ValueError-compatible behavior through the existing exception hierarchy. Verification rerun after refinement: run-command plus protocol hook pytest 81 passed; Ruff passed for touched Python files; py_compile passed for touched Python files; Bandit report /tmp/bandit_mcp_run_env_file_review.json had results=0 errors=0 skipped=0; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/app/core/MCP_unified/README.md
+++ b/tldw_Server_API/app/core/MCP_unified/README.md
@@ -431,6 +431,8 @@ Phase-1 adds a governed virtual CLI foundation to MCP Unified.
 
 `sandboxSessionId` / `sandbox_session_id` may be set when a command chain uses the governed `sandbox` command. Sandbox steps then call `sandbox.run` with that session id instead of the default base image, so session ownership and sandbox policy still remain enforced by the backing sandbox module.
 
+`envFile` / `env_file` may be set when a command chain uses the governed `sandbox` command. The file must be UTF-8, workspace-relative, bounded in size, and remain inside the resolved workspace root after symlink resolution. Values are parsed as simple `.env` `KEY=value` entries without shell expansion and are forwarded only to `sandbox.run`; they are not injected into the host process environment or rendered back in command output.
+
 Phase-1 command families:
 
 - Pure transforms (no MCP backend call): `grep`, `head`, `tail`, `json`

--- a/tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py
+++ b/tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py
@@ -25,6 +25,7 @@ class AdapterContext:
     parent_idempotency_key: str | None = None
     cwd: str | None = None
     sandbox_session_id: str | None = None
+    sandbox_env: Mapping[str, str] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -334,6 +335,8 @@ class PhaseOneCommandAdapters:
             if len(argv) < 2:
                 return _UsageError("usage: sandbox <command...>")
             arguments: dict[str, Any] = {"command": argv[1:]}
+            if self.context.sandbox_env:
+                arguments["env"] = dict(self.context.sandbox_env)
             if self.context.sandbox_session_id:
                 arguments["session_id"] = self.context.sandbox_session_id
             else:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
@@ -40,6 +40,10 @@ _RUN_TOOL_NAMES = frozenset((_RUN_TOOL_NAME, *_RUN_TOOL_ALIASES))
 _RUN_ENV_FILE_MAX_BYTES = 64 * 1024
 
 
+class RunEnvFileValidationError(ValueError):
+    """Raised when run env-file input fails validation or safe loading."""
+
+
 class _AdapterBackend(CommandBackend):
     def __init__(self, adapters: PhaseOneCommandAdapters) -> None:
         self._adapters = adapters
@@ -149,7 +153,7 @@ class RunCommandModule(BaseModule):
                 visible=visible,
                 context=context,
             )
-        except ValueError as exc:
+        except RunEnvFileValidationError as exc:
             return present_command_execution_result(
                 CommandExecutionResult(
                     stdout="",
@@ -605,7 +609,7 @@ class RunCommandModule(BaseModule):
         if env_file is None:
             return None, None
         if not self._chain_includes_visible_sandbox(chain, visible):
-            raise ValueError("envFile is only supported for command chains that include sandbox")
+            raise RunEnvFileValidationError("envFile is only supported for command chains that include sandbox")
         relative_path = self._env_file_relative_path(env_file, cwd)
         env_file_path = await self._resolve_env_file_path(relative_path, context)
         payload = await asyncio.to_thread(self._read_env_file_bytes, env_file_path)
@@ -648,21 +652,21 @@ class RunCommandModule(BaseModule):
 
         workspace_root = await self._resolve_workspace_root(context)
         if workspace_root is None:
-            raise ValueError("envFile requires a resolved workspace root")
+            raise RunEnvFileValidationError("envFile requires a resolved workspace root")
         workspace_root = workspace_root.resolve(strict=False)
         lexical_path = workspace_root / relative_path
         if not self._path_is_relative_to(lexical_path, workspace_root):
-            raise ValueError("envFile must stay within the workspace root")
+            raise RunEnvFileValidationError("envFile must stay within the workspace root")
         try:
             resolved_path = await asyncio.to_thread(lexical_path.resolve, strict=True)
         except FileNotFoundError as exc:
-            raise ValueError("envFile was not found") from exc
+            raise RunEnvFileValidationError("envFile was not found") from exc
         except (OSError, RuntimeError) as exc:
-            raise ValueError("envFile could not be resolved") from exc
+            raise RunEnvFileValidationError("envFile could not be resolved") from exc
         if not self._path_is_relative_to(resolved_path, workspace_root):
-            raise ValueError("envFile symlink target must stay within the workspace root")
+            raise RunEnvFileValidationError("envFile symlink target must stay within the workspace root")
         if not await asyncio.to_thread(resolved_path.is_file):
-            raise ValueError("envFile must reference a regular file")
+            raise RunEnvFileValidationError("envFile must reference a regular file")
         return resolved_path
 
     @staticmethod
@@ -679,17 +683,30 @@ class RunCommandModule(BaseModule):
     def _read_env_file_bytes(path: Path) -> bytes:
         """Read a bounded env file payload."""
 
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        if hasattr(os, "O_CLOEXEC"):
+            flags |= os.O_CLOEXEC
+        fd: int | None = None
         try:
-            info = path.stat(follow_symlinks=False)
+            fd = os.open(path, flags)
+            info = os.fstat(fd)
+            if not stat.S_ISREG(info.st_mode):
+                raise RunEnvFileValidationError("envFile must reference a regular file")
+            if info.st_size > _RUN_ENV_FILE_MAX_BYTES:
+                raise RunEnvFileValidationError(f"envFile exceeds {_RUN_ENV_FILE_MAX_BYTES} bytes")
+            handle = os.fdopen(fd, "rb", closefd=True)
+            fd = None
+            with handle:
+                payload = handle.read(_RUN_ENV_FILE_MAX_BYTES + 1)
         except OSError as exc:
-            raise ValueError("envFile could not be inspected") from exc
-        if not stat.S_ISREG(info.st_mode):
-            raise ValueError("envFile must reference a regular file")
-        if info.st_size > _RUN_ENV_FILE_MAX_BYTES:
-            raise ValueError(f"envFile exceeds {_RUN_ENV_FILE_MAX_BYTES} bytes")
-        payload = path.read_bytes()
+            raise RunEnvFileValidationError("envFile could not be read") from exc
+        finally:
+            if fd is not None:
+                os.close(fd)
         if len(payload) > _RUN_ENV_FILE_MAX_BYTES:
-            raise ValueError(f"envFile exceeds {_RUN_ENV_FILE_MAX_BYTES} bytes")
+            raise RunEnvFileValidationError(f"envFile exceeds {_RUN_ENV_FILE_MAX_BYTES} bytes")
         return payload
 
     @staticmethod
@@ -697,9 +714,9 @@ class RunCommandModule(BaseModule):
         """Parse a minimal .env file without expansion or host environment access."""
 
         try:
-            text = payload.decode("utf-8")
+            text = payload.decode("utf-8-sig")
         except UnicodeDecodeError as exc:
-            raise ValueError("envFile must be UTF-8") from exc
+            raise RunEnvFileValidationError("envFile must be UTF-8") from exc
 
         env: dict[str, str] = {}
         for line_number, raw_line in enumerate(text.splitlines(), start=1):
@@ -709,11 +726,11 @@ class RunCommandModule(BaseModule):
             if line.startswith("export "):
                 line = line[len("export ") :].lstrip()
             if "=" not in line:
-                raise ValueError(f"envFile line {line_number} must be KEY=value")
+                raise RunEnvFileValidationError(f"envFile line {line_number} must be KEY=value")
             key, value = line.split("=", 1)
             key = key.strip()
             if not RunCommandModule._is_valid_env_key(key):
-                raise ValueError(f"envFile line {line_number} has invalid variable name")
+                raise RunEnvFileValidationError(f"envFile line {line_number} has invalid variable name")
             value = value.strip()
             if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
                 value = value[1:-1]
@@ -724,9 +741,21 @@ class RunCommandModule(BaseModule):
     def _is_valid_env_key(key: str) -> bool:
         """Return whether a key is a portable environment variable name."""
 
-        if not key or not (key[0] == "_" or key[0].isalpha()):
+        if not key or not (key[0] == "_" or RunCommandModule._is_ascii_alpha(key[0])):
             return False
-        return all(ch == "_" or ch.isalnum() for ch in key[1:])
+        return all(ch == "_" or RunCommandModule._is_ascii_alnum(ch) for ch in key[1:])
+
+    @staticmethod
+    def _is_ascii_alpha(char: str) -> bool:
+        """Return whether one character is in the ASCII alpha range."""
+
+        return ("A" <= char <= "Z") or ("a" <= char <= "z")
+
+    @staticmethod
+    def _is_ascii_alnum(char: str) -> bool:
+        """Return whether one character is in the ASCII alphanumeric range."""
+
+        return RunCommandModule._is_ascii_alpha(char) or ("0" <= char <= "9")
 
     @staticmethod
     def _first_nonempty(*values: Any) -> str | None:
@@ -915,15 +944,10 @@ class RunCommandModule(BaseModule):
 
         env_file = arguments.get("env_file")
         env_file_camel = arguments.get("envFile")
-        if env_file is not None:
-            cls._normalize_env_file(env_file, "env_file")
-        if env_file_camel is not None:
-            cls._normalize_env_file(env_file_camel, "envFile")
-        if env_file is not None and env_file_camel is not None:
-            legacy_value = cls._normalize_env_file(env_file, "env_file")
-            camel_value = cls._normalize_env_file(env_file_camel, "envFile")
-            if legacy_value != camel_value:
-                raise ValueError("envFile and env_file must match when both are provided")
+        legacy_value = cls._normalize_env_file(env_file, "env_file") if env_file is not None else None
+        camel_value = cls._normalize_env_file(env_file_camel, "envFile") if env_file_camel is not None else None
+        if legacy_value is not None and camel_value is not None and legacy_value != camel_value:
+            raise RunEnvFileValidationError("envFile and env_file must match when both are provided")
 
     @classmethod
     def _env_file(cls, arguments: dict[str, Any]) -> str | None:
@@ -940,20 +964,20 @@ class RunCommandModule(BaseModule):
         """Normalize env-file paths as workspace-relative file references."""
 
         if not isinstance(value, str) or not value.strip():
-            raise ValueError(f"{key} must be a non-empty workspace-relative path")
+            raise RunEnvFileValidationError(f"{key} must be a non-empty workspace-relative path")
         text = value.strip()
         if cls._is_anchored_path(text) or text.startswith("~"):
-            raise ValueError(f"{key} must be workspace-relative")
+            raise RunEnvFileValidationError(f"{key} must be workspace-relative")
         parts: list[str] = []
         for raw_part in text.replace("\\", "/").split("/"):
             part = raw_part.strip()
             if not part or part == ".":
                 continue
             if part == "..":
-                raise ValueError(f"{key} must not contain path traversal")
+                raise RunEnvFileValidationError(f"{key} must not contain path traversal")
             parts.append(part)
         if not parts:
-            raise ValueError(f"{key} must reference a workspace-relative file")
+            raise RunEnvFileValidationError(f"{key} must reference a workspace-relative file")
         return "/".join(parts)
 
     @classmethod

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
@@ -17,6 +17,8 @@ from typing import Any
 
 from loguru import logger
 
+from tldw_Server_API.app.core.exceptions import ValidationError
+
 from ...command_runtime.adapters import (
     AdapterContext,
     PhaseOneCommandAdapters,
@@ -40,7 +42,7 @@ _RUN_TOOL_NAMES = frozenset((_RUN_TOOL_NAME, *_RUN_TOOL_ALIASES))
 _RUN_ENV_FILE_MAX_BYTES = 64 * 1024
 
 
-class RunEnvFileValidationError(ValueError):
+class RunEnvFileValidationError(ValidationError):
     """Raised when run env-file input fails validation or safe loading."""
 
 

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
@@ -37,6 +37,7 @@ _RUN_WRITE_BACKEND_TOOLS = {"fs.write", "fs.write_text", "sandbox.run"}
 _RUN_TOOL_NAME = "run"
 _RUN_TOOL_ALIASES = ("bash", "shell", "powershell", "pwsh")
 _RUN_TOOL_NAMES = frozenset((_RUN_TOOL_NAME, *_RUN_TOOL_ALIASES))
+_RUN_ENV_FILE_MAX_BYTES = 64 * 1024
 
 
 class _AdapterBackend(CommandBackend):
@@ -105,6 +106,7 @@ class RunCommandModule(BaseModule):
         cwd = self._cwd(args)
         retain_output_artifacts = self._retain_output_artifacts(args)
         sandbox_session_id = self._sandbox_session_id(args)
+        env_file = self._env_file(args)
         visible = await self._visible_commands_for_context(context)
         if command_text in {"help", "--help"}:
             return present_command_execution_result(
@@ -139,6 +141,24 @@ class RunCommandModule(BaseModule):
                 )
             )
 
+        try:
+            sandbox_env, env_file_scope = await self._sandbox_env_for_chain(
+                env_file=env_file,
+                cwd=cwd,
+                chain=chain,
+                visible=visible,
+                context=context,
+            )
+        except ValueError as exc:
+            return present_command_execution_result(
+                CommandExecutionResult(
+                    stdout="",
+                    stderr=str(exc),
+                    exit_code=2,
+                    duration_ms=max(0.0, (time.perf_counter() - start) * 1000.0),
+                )
+            )
+
         protocol = await self._resolve_protocol()
         spill_parent_dir = await self._resolve_spill_dir(context)
         invocation_spill_dir = await self._create_invocation_spill_dir(spill_parent_dir, context)
@@ -153,9 +173,11 @@ class RunCommandModule(BaseModule):
                 self._parent_idempotency_key(context, arguments),
                 cwd,
                 sandbox_session_id,
+                env_file_scope,
             ),
             cwd=cwd,
             sandbox_session_id=sandbox_session_id,
+            sandbox_env=sandbox_env,
         )
         adapters = PhaseOneCommandAdapters(adapter_context)
         executor = CommandRuntimeExecutor(
@@ -221,6 +243,8 @@ class RunCommandModule(BaseModule):
             - {
                 "command",
                 "cwd",
+                "envFile",
+                "env_file",
                 "idempotencyKey",
                 "idempotency_key",
                 "retainOutputArtifacts",
@@ -255,6 +279,7 @@ class RunCommandModule(BaseModule):
         self._validate_cwd_arguments(arguments)
         self._validate_retain_output_artifact_arguments(arguments)
         self._validate_sandbox_session_arguments(arguments)
+        self._validate_env_file_arguments(arguments)
 
     def sanitize_input(self, input_data: Any, _depth: int = 0) -> Any:
         """Sanitize input while allowing CLI flags like `--help` and shell-like tokens."""
@@ -331,6 +356,16 @@ class RunCommandModule(BaseModule):
                     "idempotencyKey": {
                         "type": "string",
                         "description": "Optional parent idempotency key for nested governed steps.",
+                    },
+                    "env_file": {
+                        "type": "string",
+                        "description": "Legacy alias for envFile.",
+                    },
+                    "envFile": {
+                        "type": "string",
+                        "description": (
+                            "Workspace-relative .env-style file to pass only to governed sandbox steps."
+                        ),
                     },
                     "cwd": {
                         "type": "string",
@@ -556,6 +591,143 @@ class RunCommandModule(BaseModule):
             return None
         return Path(workspace_root_raw).expanduser().resolve(strict=False)
 
+    async def _sandbox_env_for_chain(
+        self,
+        *,
+        env_file: str | None,
+        cwd: str | None,
+        chain: Any,
+        visible: Mapping[str, CommandDescriptor],
+        context: Any | None,
+    ) -> tuple[dict[str, str] | None, str | None]:
+        """Load env-file values for sandbox-backed command chains only."""
+
+        if env_file is None:
+            return None, None
+        if not self._chain_includes_visible_sandbox(chain, visible):
+            raise ValueError("envFile is only supported for command chains that include sandbox")
+        relative_path = self._env_file_relative_path(env_file, cwd)
+        env_file_path = await self._resolve_env_file_path(relative_path, context)
+        payload = await asyncio.to_thread(self._read_env_file_bytes, env_file_path)
+        env = self._parse_env_file_bytes(payload)
+        env_file_digest = hashlib.sha256(payload).hexdigest()
+        scope = json.dumps(
+            {"path": relative_path, "sha256": env_file_digest},
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        return env, scope
+
+    @staticmethod
+    def _chain_includes_visible_sandbox(
+        chain: Any,
+        visible: Mapping[str, CommandDescriptor],
+    ) -> bool:
+        """Return True when the parsed chain contains a sandbox step visible in policy."""
+
+        if "sandbox" not in visible:
+            return False
+        for segment in getattr(chain, "segments", []) or []:
+            for invocation in getattr(segment, "commands", []) or []:
+                argv = list(getattr(invocation, "argv", []) or [])
+                if argv and argv[0] == "sandbox":
+                    return True
+        return False
+
+    @staticmethod
+    def _env_file_relative_path(env_file: str, cwd: str | None) -> str:
+        """Apply cwd to a normalized env-file path."""
+
+        if not cwd:
+            return env_file
+        return f"{cwd}/{env_file}"
+
+    async def _resolve_env_file_path(self, relative_path: str, context: Any | None) -> Path:
+        """Resolve an env file under the active workspace root with symlink containment."""
+
+        workspace_root = await self._resolve_workspace_root(context)
+        if workspace_root is None:
+            raise ValueError("envFile requires a resolved workspace root")
+        workspace_root = workspace_root.resolve(strict=False)
+        lexical_path = workspace_root / relative_path
+        if not self._path_is_relative_to(lexical_path, workspace_root):
+            raise ValueError("envFile must stay within the workspace root")
+        try:
+            resolved_path = await asyncio.to_thread(lexical_path.resolve, strict=True)
+        except FileNotFoundError as exc:
+            raise ValueError("envFile was not found") from exc
+        except (OSError, RuntimeError) as exc:
+            raise ValueError("envFile could not be resolved") from exc
+        if not self._path_is_relative_to(resolved_path, workspace_root):
+            raise ValueError("envFile symlink target must stay within the workspace root")
+        if not await asyncio.to_thread(resolved_path.is_file):
+            raise ValueError("envFile must reference a regular file")
+        return resolved_path
+
+    @staticmethod
+    def _path_is_relative_to(path: Path, parent: Path) -> bool:
+        """Compatibility wrapper for Path.relative_to containment checks."""
+
+        try:
+            path.relative_to(parent)
+        except ValueError:
+            return False
+        return True
+
+    @staticmethod
+    def _read_env_file_bytes(path: Path) -> bytes:
+        """Read a bounded env file payload."""
+
+        try:
+            info = path.stat(follow_symlinks=False)
+        except OSError as exc:
+            raise ValueError("envFile could not be inspected") from exc
+        if not stat.S_ISREG(info.st_mode):
+            raise ValueError("envFile must reference a regular file")
+        if info.st_size > _RUN_ENV_FILE_MAX_BYTES:
+            raise ValueError(f"envFile exceeds {_RUN_ENV_FILE_MAX_BYTES} bytes")
+        payload = path.read_bytes()
+        if len(payload) > _RUN_ENV_FILE_MAX_BYTES:
+            raise ValueError(f"envFile exceeds {_RUN_ENV_FILE_MAX_BYTES} bytes")
+        return payload
+
+    @staticmethod
+    def _parse_env_file_bytes(payload: bytes) -> dict[str, str]:
+        """Parse a minimal .env file without expansion or host environment access."""
+
+        try:
+            text = payload.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError("envFile must be UTF-8") from exc
+
+        env: dict[str, str] = {}
+        for line_number, raw_line in enumerate(text.splitlines(), start=1):
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("export "):
+                line = line[len("export ") :].lstrip()
+            if "=" not in line:
+                raise ValueError(f"envFile line {line_number} must be KEY=value")
+            key, value = line.split("=", 1)
+            key = key.strip()
+            if not RunCommandModule._is_valid_env_key(key):
+                raise ValueError(f"envFile line {line_number} has invalid variable name")
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+                value = value[1:-1]
+            env[key] = value
+        return env
+
+    @staticmethod
+    def _is_valid_env_key(key: str) -> bool:
+        """Return whether a key is a portable environment variable name."""
+
+        if not key or not (key[0] == "_" or key[0].isalpha()):
+            return False
+        return all(ch == "_" or ch.isalnum() for ch in key[1:])
+
     @staticmethod
     def _first_nonempty(*values: Any) -> str | None:
         for value in values:
@@ -679,6 +851,7 @@ class RunCommandModule(BaseModule):
         parent_key: str | None,
         cwd: str | None,
         sandbox_session_id: str | None,
+        env_file_scope: str | None = None,
     ) -> str | None:
         """Salt a parent idempotency key with unambiguous execution scope data."""
 
@@ -689,6 +862,8 @@ class RunCommandModule(BaseModule):
             scope_payload["cwd"] = cwd
         if sandbox_session_id:
             scope_payload["sandbox_session_id"] = sandbox_session_id
+        if env_file_scope:
+            scope_payload["env_file"] = env_file_scope
         if not scope_payload:
             return parent_key
         serialized_scope = json.dumps(
@@ -733,6 +908,53 @@ class RunCommandModule(BaseModule):
         if not isinstance(value, str) or not value.strip():
             raise ValueError(f"{key} must be a non-empty string")
         return value.strip()
+
+    @classmethod
+    def _validate_env_file_arguments(cls, arguments: dict[str, Any]) -> None:
+        """Validate env-file aliases before command execution starts."""
+
+        env_file = arguments.get("env_file")
+        env_file_camel = arguments.get("envFile")
+        if env_file is not None:
+            cls._normalize_env_file(env_file, "env_file")
+        if env_file_camel is not None:
+            cls._normalize_env_file(env_file_camel, "envFile")
+        if env_file is not None and env_file_camel is not None:
+            legacy_value = cls._normalize_env_file(env_file, "env_file")
+            camel_value = cls._normalize_env_file(env_file_camel, "envFile")
+            if legacy_value != camel_value:
+                raise ValueError("envFile and env_file must match when both are provided")
+
+    @classmethod
+    def _env_file(cls, arguments: dict[str, Any]) -> str | None:
+        """Return the normalized env-file path from either supported alias."""
+
+        for key in ("envFile", "env_file"):
+            value = arguments.get(key)
+            if value is not None:
+                return cls._normalize_env_file(value, key)
+        return None
+
+    @classmethod
+    def _normalize_env_file(cls, value: Any, key: str) -> str:
+        """Normalize env-file paths as workspace-relative file references."""
+
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"{key} must be a non-empty workspace-relative path")
+        text = value.strip()
+        if cls._is_anchored_path(text) or text.startswith("~"):
+            raise ValueError(f"{key} must be workspace-relative")
+        parts: list[str] = []
+        for raw_part in text.replace("\\", "/").split("/"):
+            part = raw_part.strip()
+            if not part or part == ".":
+                continue
+            if part == "..":
+                raise ValueError(f"{key} must not contain path traversal")
+            parts.append(part)
+        if not parts:
+            raise ValueError(f"{key} must reference a workspace-relative file")
+        return "/".join(parts)
 
     @classmethod
     def _validate_cwd_arguments(cls, arguments: dict[str, Any]) -> None:

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -1600,12 +1600,27 @@ class MCPProtocol:
         }
 
     @staticmethod
-    def _hook_safe_tool_args(tool_args: Any) -> dict[str, Any] | None:
+    def _hook_safe_tool_args(tool_args: Any, *, tool_name: str | None = None) -> dict[str, Any] | None:
         """Return detached sanitized tool arguments for hook evaluation."""
         if not isinstance(tool_args, dict):
             return None
         copied = MCPProtocol._hook_safe_copy(tool_args)
-        return copied if isinstance(copied, dict) else None
+        if not isinstance(copied, dict):
+            return None
+        return MCPProtocol._redact_hook_visible_tool_args(copied, tool_name=tool_name)
+
+    @staticmethod
+    def _redact_hook_visible_tool_args(tool_args: dict[str, Any], *, tool_name: str | None = None) -> dict[str, Any]:
+        """Redact secret-bearing argument values from hook-visible metadata."""
+
+        if str(tool_name or "") != "sandbox.run":
+            return tool_args
+        env = tool_args.get("env")
+        if not isinstance(env, dict):
+            return tool_args
+        redacted = dict(tool_args)
+        redacted["env"] = {str(key): "[redacted]" for key in env}
+        return redacted
 
     @staticmethod
     def _hook_safe_scope_payload(scope_payload: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -1644,7 +1659,7 @@ class MCPProtocol:
             client_id=context.client_id,
             session_id=context.session_id,
             metadata=self._hook_safe_metadata(context),
-            tool_args=self._hook_safe_tool_args(tool_args),
+            tool_args=self._hook_safe_tool_args(tool_args, tool_name=tool_name),
             status=status,
             duration_ms=duration_ms,
             error_type=error.__class__.__name__ if error is not None else None,

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_tool_hooks.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_tool_hooks.py
@@ -106,6 +106,30 @@ class _ToolModuleStub:
         return {"ok": True, "tool": tool_name, "arguments": arguments}
 
 
+class _SandboxModuleStub(_ToolModuleStub):
+    name = "sandbox"
+
+    async def get_tools(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "sandbox.run",
+                "description": "Run a sandbox command.",
+                "inputSchema": {"type": "object"},
+                "metadata": {"category": "write"},
+            }
+        ]
+
+    def is_write_tool_call(
+        self,
+        _tool_name: str,
+        _arguments: dict[str, Any],
+        *,
+        tool_def: dict[str, Any] | None = None,
+    ) -> bool:
+        del tool_def
+        return True
+
+
 class _RegistryStub:
     def __init__(self, module: _ToolModuleStub) -> None:
         self.module = module
@@ -238,6 +262,35 @@ async def test_hook_context_mutation_cannot_mutate_prepared_tool_arguments() -> 
     assert len(hooks.before_contexts) == 1
     assert hooks.before_contexts[0].tool_args == {"nested": {"value": "mutated-by-hook"}}
     assert hooks.before_contexts[0].metadata == {"nested": {"value": "mutated-by-hook"}}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sandbox_run_env_is_redacted_in_hook_context_but_preserved_for_execution() -> None:
+    hooks = _RecordingToolHookManager()
+    protocol, module, _ = _protocol(module=_SandboxModuleStub(), hook_manager=hooks)
+
+    result = await protocol._handle_tools_call(
+        {
+            "name": "sandbox.run",
+            "arguments": {
+                "command": ["python", "-V"],
+                "env": {"API_TOKEN": "super-secret", "PUBLIC_FLAG": "enabled"},
+            },
+        },
+        _context(),
+    )
+
+    assert module.executions == 1
+    assert result["content"][0]["json"]["arguments"]["env"] == {
+        "API_TOKEN": "super-secret",
+        "PUBLIC_FLAG": "enabled",
+    }
+    assert hooks.before_contexts[0].tool_args == {
+        "command": ["python", "-V"],
+        "env": {"API_TOKEN": "[redacted]", "PUBLIC_FLAG": "[redacted]"},
+    }
+    assert hooks.after_contexts[0].tool_args == hooks.before_contexts[0].tool_args
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_tool_hooks.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_tool_hooks.py
@@ -107,9 +107,13 @@ class _ToolModuleStub:
 
 
 class _SandboxModuleStub(_ToolModuleStub):
+    """Sandbox-like module stub used to verify secret-bearing hook metadata."""
+
     name = "sandbox"
 
     async def get_tools(self) -> list[dict[str, Any]]:
+        """Return a minimal sandbox.run tool definition."""
+
         return [
             {
                 "name": "sandbox.run",
@@ -126,6 +130,8 @@ class _SandboxModuleStub(_ToolModuleStub):
         *,
         tool_def: dict[str, Any] | None = None,
     ) -> bool:
+        """Classify sandbox.run as write-capable for protocol governance."""
+
         del tool_def
         return True
 
@@ -265,8 +271,9 @@ async def test_hook_context_mutation_cannot_mutate_prepared_tool_arguments() -> 
 
 
 @pytest.mark.unit
-@pytest.mark.asyncio
 async def test_sandbox_run_env_is_redacted_in_hook_context_but_preserved_for_execution() -> None:
+    """Hook contexts should redact sandbox env values without mutating execution args."""
+
     hooks = _RecordingToolHookManager()
     protocol, module, _ = _protocol(module=_SandboxModuleStub(), hook_manager=hooks)
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
@@ -213,6 +213,8 @@ async def test_run_module_exposes_governed_bash_and_shell_alias_tools() -> None:
         assert "retain_output_artifacts" in alias["inputSchema"]["properties"]
         assert "sandboxSessionId" in alias["inputSchema"]["properties"]
         assert "sandbox_session_id" in alias["inputSchema"]["properties"]
+        assert "envFile" in alias["inputSchema"]["properties"]
+        assert "env_file" in alias["inputSchema"]["properties"]
 
 
 @pytest.mark.asyncio
@@ -451,6 +453,239 @@ async def test_run_sandbox_session_id_uses_session_backed_sandbox_run() -> None:
         "session_id": "sandbox-session-1",
         "command": ["python", "-V"],
     }
+
+
+@pytest.mark.asyncio
+async def test_run_env_file_is_forwarded_only_to_sandbox_run_without_rendering_values(tmp_path: Path) -> None:
+    """envFile should load workspace env values into sandbox.run without rendering secrets."""
+
+    class _SandboxProtocolStub(_ProtocolStub):
+        async def _handle_tools_list(self, params: dict[str, Any], context: RequestContext) -> dict[str, Any]:
+            del params, context
+            return {"tools": [{"name": "sandbox.run", "module": "sandbox", "canExecute": True}]}
+
+        async def execute_prepared_tool_call(self, prepared: _PreparedCall) -> dict[str, Any]:
+            self.execute_calls.append(prepared)
+            return {"content": [{"type": "json", "json": {"status": "completed"}}], "tool": "sandbox.run"}
+
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    env_file = workspace_root / ".env.sandbox"
+    env_file.write_text(
+        "\n".join(
+            [
+                "# comment",
+                "API_TOKEN=super-secret",
+                "export FEATURE_FLAG=enabled",
+                "QUOTED=\"two words\"",
+                "SINGLE='single quoted'",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    protocol = _SandboxProtocolStub()
+    module = RunCommandModule(
+        ModuleConfig(
+            name="run",
+            settings={
+                "protocol": protocol,
+                "workspace_root_resolver": _WorkspaceRootResolverStub(workspace_root),
+            },
+        )
+    )
+    context = RequestContext(request_id="run-env-file", user_id="1", client_id="unit")
+
+    rendered = await module.execute_tool(
+        "run",
+        {"command": "sandbox python app.py", "envFile": ".env.sandbox"},
+        context=context,
+    )
+
+    assert "[exit:0 |" in rendered
+    assert "super-secret" not in rendered
+    assert protocol.prepare_calls[0].params["name"] == "sandbox.run"
+    assert protocol.prepare_calls[0].params["arguments"] == {
+        "base_image": "python:3.11",
+        "command": ["python", "app.py"],
+        "env": {
+            "API_TOKEN": "super-secret",
+            "FEATURE_FLAG": "enabled",
+            "QUOTED": "two words",
+            "SINGLE": "single quoted",
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_env_file_uses_cwd_to_resolve_workspace_relative_file(tmp_path: Path) -> None:
+    """envFile should resolve beneath cwd without escaping the workspace root."""
+
+    class _SandboxProtocolStub(_ProtocolStub):
+        async def _handle_tools_list(self, params: dict[str, Any], context: RequestContext) -> dict[str, Any]:
+            del params, context
+            return {"tools": [{"name": "sandbox.run", "module": "sandbox", "canExecute": True}]}
+
+        async def execute_prepared_tool_call(self, prepared: _PreparedCall) -> dict[str, Any]:
+            self.execute_calls.append(prepared)
+            return {"content": [{"type": "json", "json": {"ok": True}}], "tool": "sandbox.run"}
+
+    workspace_root = tmp_path / "workspace"
+    (workspace_root / "apps" / "api").mkdir(parents=True)
+    (workspace_root / "apps" / "api" / ".env").write_text("APP_ENV=test\n", encoding="utf-8")
+    protocol = _SandboxProtocolStub()
+    module = RunCommandModule(
+        ModuleConfig(
+            name="run",
+            settings={
+                "protocol": protocol,
+                "workspace_root_resolver": _WorkspaceRootResolverStub(workspace_root),
+            },
+        )
+    )
+    context = RequestContext(request_id="run-env-file-cwd", user_id="1", client_id="unit")
+
+    await module.execute_tool(
+        "run",
+        {"command": "sandbox python app.py", "cwd": "apps/api", "envFile": ".env"},
+        context=context,
+    )
+
+    assert protocol.prepare_calls[0].params["arguments"]["env"] == {"APP_ENV": "test"}
+
+
+@pytest.mark.asyncio
+async def test_run_env_file_participates_in_nested_idempotency_keys_without_secret_values(tmp_path: Path) -> None:
+    """Env-file content changes should alter nested idempotency without exposing values in keys."""
+
+    class _SandboxProtocolStub(_ProtocolStub):
+        async def _handle_tools_list(self, params: dict[str, Any], context: RequestContext) -> dict[str, Any]:
+            del params, context
+            return {"tools": [{"name": "sandbox.run", "module": "sandbox", "canExecute": True}]}
+
+        async def execute_prepared_tool_call(self, prepared: _PreparedCall) -> dict[str, Any]:
+            self.execute_calls.append(prepared)
+            return {"content": [{"type": "json", "json": {"ok": True}}], "tool": "sandbox.run"}
+
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    env_file = workspace_root / ".env"
+    env_file.write_text("TOKEN=first-secret\n", encoding="utf-8")
+    protocol = _SandboxProtocolStub()
+    module = RunCommandModule(
+        ModuleConfig(
+            name="run",
+            settings={
+                "protocol": protocol,
+                "workspace_root_resolver": _WorkspaceRootResolverStub(workspace_root),
+            },
+        )
+    )
+    context = RequestContext(request_id="run-env-file-idem", user_id="1", client_id="unit")
+
+    await module.execute_tool(
+        "run",
+        {"command": "sandbox python -V", "envFile": ".env", "idempotencyKey": "parent-idem-env"},
+        context=context,
+    )
+    env_file.write_text("TOKEN=second-secret\n", encoding="utf-8")
+    await module.execute_tool(
+        "run",
+        {"command": "sandbox python -V", "envFile": ".env", "idempotencyKey": "parent-idem-env"},
+        context=context,
+    )
+
+    first_key = protocol.prepare_calls[0].idempotency_key
+    second_key = protocol.prepare_calls[1].idempotency_key
+    assert first_key != second_key
+    assert first_key is not None and first_key.startswith("parent-idem-env:")
+    assert second_key is not None and second_key.startswith("parent-idem-env:")
+    assert "first-secret" not in first_key
+    assert "second-secret" not in second_key
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {"command": "sandbox python -V", "envFile": ""},
+        {"command": "sandbox python -V", "envFile": 123},
+        {"command": "sandbox python -V", "envFile": "/tmp/.env"},
+        {"command": "sandbox python -V", "envFile": "../.env"},
+        {"command": "sandbox python -V", "envFile": "~/.env"},
+        {"command": "sandbox python -V", "envFile": ".env", "env_file": "other.env"},
+    ],
+)
+async def test_run_rejects_invalid_env_file_arguments(arguments: dict[str, Any]) -> None:
+    """envFile aliases must be safe, relative, and consistent."""
+
+    protocol = _ProtocolStub()
+    module = _build_module(protocol)
+
+    with pytest.raises(ValueError, match="envFile|env_file"):
+        await module.execute_tool("run", arguments, context=RequestContext(request_id="run-env-file-invalid"))
+
+
+@pytest.mark.asyncio
+async def test_run_env_file_rejects_non_sandbox_command_chains(tmp_path: Path) -> None:
+    """envFile should fail closed instead of being silently ignored outside sandbox steps."""
+
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    (workspace_root / ".env").write_text("TOKEN=secret\n", encoding="utf-8")
+    protocol = _ProtocolStub()
+    module = RunCommandModule(
+        ModuleConfig(
+            name="run",
+            settings={
+                "protocol": protocol,
+                "workspace_root_resolver": _WorkspaceRootResolverStub(workspace_root),
+            },
+        )
+    )
+
+    rendered = await module.execute_tool(
+        "run",
+        {"command": "ls", "envFile": ".env"},
+        context=RequestContext(request_id="run-env-file-non-sandbox"),
+    )
+
+    assert "envFile is only supported for command chains that include sandbox" in rendered
+    assert protocol.prepare_calls == []
+    assert protocol.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_run_env_file_rejects_malformed_files(tmp_path: Path) -> None:
+    """Malformed env files should fail before any sandbox tool call is prepared."""
+
+    class _SandboxProtocolStub(_ProtocolStub):
+        async def _handle_tools_list(self, params: dict[str, Any], context: RequestContext) -> dict[str, Any]:
+            del params, context
+            return {"tools": [{"name": "sandbox.run", "module": "sandbox", "canExecute": True}]}
+
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    (workspace_root / ".env").write_text("GOOD=value\nNO_EQUALS\n", encoding="utf-8")
+    protocol = _SandboxProtocolStub()
+    module = RunCommandModule(
+        ModuleConfig(
+            name="run",
+            settings={
+                "protocol": protocol,
+                "workspace_root_resolver": _WorkspaceRootResolverStub(workspace_root),
+            },
+        )
+    )
+
+    rendered = await module.execute_tool(
+        "run",
+        {"command": "sandbox python -V", "envFile": ".env"},
+        context=RequestContext(request_id="run-env-file-malformed"),
+    )
+
+    assert "envFile line 2 must be KEY=value" in rendered
+    assert protocol.prepare_calls == []
+    assert protocol.execute_calls == []
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
@@ -455,7 +455,7 @@ async def test_run_sandbox_session_id_uses_session_backed_sandbox_run() -> None:
     }
 
 
-@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_run_env_file_is_forwarded_only_to_sandbox_run_without_rendering_values(tmp_path: Path) -> None:
     """envFile should load workspace env values into sandbox.run without rendering secrets."""
 
@@ -516,7 +516,7 @@ async def test_run_env_file_is_forwarded_only_to_sandbox_run_without_rendering_v
     }
 
 
-@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_run_env_file_uses_cwd_to_resolve_workspace_relative_file(tmp_path: Path) -> None:
     """envFile should resolve beneath cwd without escaping the workspace root."""
 
@@ -553,7 +553,7 @@ async def test_run_env_file_uses_cwd_to_resolve_workspace_relative_file(tmp_path
     assert protocol.prepare_calls[0].params["arguments"]["env"] == {"APP_ENV": "test"}
 
 
-@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_run_env_file_participates_in_nested_idempotency_keys_without_secret_values(tmp_path: Path) -> None:
     """Env-file content changes should alter nested idempotency without exposing values in keys."""
 
@@ -603,7 +603,6 @@ async def test_run_env_file_participates_in_nested_idempotency_keys_without_secr
     assert "second-secret" not in second_key
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "arguments",
     [
@@ -615,6 +614,7 @@ async def test_run_env_file_participates_in_nested_idempotency_keys_without_secr
         {"command": "sandbox python -V", "envFile": ".env", "env_file": "other.env"},
     ],
 )
+@pytest.mark.unit
 async def test_run_rejects_invalid_env_file_arguments(arguments: dict[str, Any]) -> None:
     """envFile aliases must be safe, relative, and consistent."""
 
@@ -625,7 +625,7 @@ async def test_run_rejects_invalid_env_file_arguments(arguments: dict[str, Any])
         await module.execute_tool("run", arguments, context=RequestContext(request_id="run-env-file-invalid"))
 
 
-@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_run_env_file_rejects_non_sandbox_command_chains(tmp_path: Path) -> None:
     """envFile should fail closed instead of being silently ignored outside sandbox steps."""
 
@@ -654,7 +654,7 @@ async def test_run_env_file_rejects_non_sandbox_command_chains(tmp_path: Path) -
     assert protocol.execute_calls == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_run_env_file_rejects_malformed_files(tmp_path: Path) -> None:
     """Malformed env files should fail before any sandbox tool call is prepared."""
 
@@ -686,6 +686,53 @@ async def test_run_env_file_rejects_malformed_files(tmp_path: Path) -> None:
     assert "envFile line 2 must be KEY=value" in rendered
     assert protocol.prepare_calls == []
     assert protocol.execute_calls == []
+
+
+@pytest.mark.unit
+def test_run_env_file_parser_accepts_bom_and_rejects_unicode_keys() -> None:
+    """Env parser should handle UTF-8 BOMs but enforce ASCII variable names."""
+
+    parsed = RunCommandModule._parse_env_file_bytes(b"\xef\xbb\xbfAPI_TOKEN=ok\n")
+
+    assert parsed == {"API_TOKEN": "ok"}
+    with pytest.raises(run_command_module_module.RunEnvFileValidationError, match="invalid variable name"):
+        RunCommandModule._parse_env_file_bytes("ÄPI_TOKEN=bad\n".encode())
+    with pytest.raises(run_command_module_module.RunEnvFileValidationError, match="invalid variable name"):
+        RunCommandModule._parse_env_file_bytes("ＡPI_TOKEN=bad\n".encode())
+
+
+@pytest.mark.unit
+def test_run_env_file_reader_uses_descriptor_read_without_path_read_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Env reader should not re-open the path after descriptor validation."""
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("API_TOKEN=ok\n", encoding="utf-8")
+
+    def _fail_read_bytes(_path: Path) -> bytes:
+        raise AssertionError("Path.read_bytes must not be used for envFile reads")
+
+    monkeypatch.setattr(Path, "read_bytes", _fail_read_bytes)
+
+    assert RunCommandModule._read_env_file_bytes(env_file) == b"API_TOKEN=ok\n"
+
+
+@pytest.mark.unit
+def test_run_env_file_reader_maps_open_errors(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Env reader should surface OSError as a structured env-file validation error."""
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("API_TOKEN=ok\n", encoding="utf-8")
+
+    def _raise_open(*_args: Any, **_kwargs: Any) -> int:
+        raise PermissionError("blocked")
+
+    monkeypatch.setattr(run_command_module_module.os, "open", _raise_open)
+
+    with pytest.raises(run_command_module_module.RunEnvFileValidationError, match="could not be read"):
+        RunCommandModule._read_env_file_bytes(env_file)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## AI-generated implementation summary

This slice adds `envFile` / `env_file` support to the governed `run`/shell facade for `sandbox` command steps. Env files are workspace-relative, resolved under the active workspace root with symlink target containment, bounded to 64 KiB, parsed as simple UTF-8 `.env` `KEY=value` entries without shell expansion, and forwarded only to `sandbox.run`.

It also redacts `sandbox.run.env` values from tool hook contexts while preserving the real prepared/executed sandbox arguments and argument hashes.

## Change summary

Human requester: please replace this section before merge with your own summary of what changed and why these implementation choices are acceptable.

## Verification

- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_tool_hooks.py -q` -> 78 passed
- `python -m ruff check tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_tool_hooks.py` -> passed
- `python -m py_compile tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_tool_hooks.py` -> passed
- `python -m bandit -r tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py tldw_Server_API/app/core/MCP_unified/protocol.py -f json -o /tmp/bandit_mcp_run_env_file.json` -> results=0 errors=0 skipped=0
- `git diff --check` -> passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `envFile`/`env_file` support to the governed `run` tool for sandbox command chains, securely loading workspace `.env` variables into `sandbox.run` while redacting secrets and salting idempotency with the env-file path and digest. Part of TASK-2283.

- **New Features**
  - Validation and parsing: workspace‑relative with symlink containment; UTF‑8 (BOM OK); ≤64 KiB; simple `KEY=value`; ASCII names `[A-Za-z_][A-Za-z0-9_]*`; no expansion.
  - Sandbox‑only: errors on non‑sandbox chains; forwards vars to `sandbox.run` as `env`; not injected into the host or rendered in output.
  - API/idempotency: adds `envFile`/`env_file` to `run` input (aliases must match); salts nested idempotency with path and SHA‑256 digest.
  - Safety/observability: redacts `sandbox.run.env` in tool hook contexts; execution uses real values; bounded descriptor reads with `O_NOFOLLOW`/`O_CLOEXEC`, regular‑file checks; errors surfaced as `RunEnvFileValidationError` (now extends project `ValidationError`).

<sup>Written for commit 67abd341dfa8fea5ae89753107c555ebd33043c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

