### PR TITLE
Verify Workspace Phase 2 single-user loop evidence

### DIFF
--- a/Docs/Design/Workspace_Container_Contract_2026_06.md
+++ b/Docs/Design/Workspace_Container_Contract_2026_06.md
@@ -192,18 +192,20 @@ Phase 2 names these resource types and membership expectations:
 | Media and sources | `media`, `workspace_source` | Media DB and Workspaces source selection | `media` links global media records; `workspace_source` links workspace source rows that own ordering, selection, and readiness projection. |
 | Artifacts | `workspace_artifact` | Workspaces artifact store | Workspace-owned generated or promoted artifact; includes lineage/review/export metadata. |
 | Chats | `chat` | Chat/ChaChaNotes | Conversation resource. Global chats may be linked; workspace-scoped chats belong to exactly one workspace. Moving a chat across workspaces is a fork/copy with provenance, not silent reassignment. |
-| Prompts | `prompt` (future) | Prompt Library | Prompt record stays globally browsable; workspace membership gates active use in the selected context. |
-| Workflows | `workflow` (future) | Workflows/Scheduler | Workflow definition or launch context; launch requires active workspace and runtime readiness when applicable. |
-| Watchlists | `watchlist` (future) | Watchlists/Jobs or Scheduler | Watchlist definition or run context; run requires active workspace and runtime readiness when applicable. |
-| ACP sessions/runs | `acp_session` (future) | ACP/Agent Orchestration | Links canonical workspace to ACP execution workspace, project, task, run, or session metadata. ACP remains execution owner. |
-| Sandbox sessions/runs | `sandbox_session` (future) | Sandbox | Links workspace to sandbox root/session diagnostics. Sandbox remains runtime/admission owner. |
+| Prompts | `prompt` | Prompt Library | Prompt record stays globally browsable; workspace membership gates active use in the selected context. |
+| Workflows | `workflow` | Workflows/Scheduler | Workflow definition or launch context; launch requires active workspace and runtime readiness when applicable. |
+| Watchlists | `watchlist` | Watchlists/Jobs or Scheduler | Watchlist definition or run context; run requires active workspace and runtime readiness when applicable. |
+| ACP sessions | `acp_session` | ACP/Agent Orchestration | Links canonical workspace to ACP session metadata through a Workspace runtime binding. ACP remains execution owner. |
+| ACP runs | `acp_run` (future) | ACP/Agent Orchestration | Reserved for run-level metadata after ACP run descriptors have a stable owning-domain contract. |
+| Sandbox sessions | `sandbox_session` | Sandbox | Links workspace to sandbox session diagnostics through a Workspace runtime binding. Sandbox remains runtime/admission owner. |
 | Project files | `project_file` (future) | Workspaces file inventory | Metadata-only path entry under a Workspace-owned root. Not source content and not a trust grant. |
 
 The current backend supports `workspace_note`, `media`, `workspace_source`,
-`workspace_artifact`, and `chat`. `membership_models.py` already reserves
-future values for `note`, `prompt`, `workflow`, `watchlist`, `acp_session`,
-`sandbox_session`, `project_file`, and study-related resources. Child issues
-must add owning-domain adapters before those future values become writable.
+`workspace_artifact`, `chat`, `prompt`, `workflow`, `watchlist`,
+`acp_session`, and `sandbox_session`. `membership_models.py` still reserves
+future values for `note`, `acp_run`, `project_file`, `study_deck`, `quiz`, and
+`study_pack`. Future child issues must add owning-domain adapters before those
+reserved values become writable.
 
 ## Transfer Policies
 
@@ -343,6 +345,7 @@ Secret handling:
 | `/api/v1/workspace-eligibility/check` | Shared active-context eligibility contract. |
 | `/api/v1/workspaces/{id}/memberships` | Generic association table for supported resource types. |
 | `/api/v1/workspaces/{id}/context` | Read model for Workspace Core shell state, source summary, capabilities, active operations, and membership summary. |
+| `/api/v1/workspaces/{id}/runtime-bindings` | Secret-safe runtime binding descriptor list/create/read/archive routes for repo/path/ACP/Sandbox/MCP-adjacent state. |
 | `/api/v1/workspaces/{id}/roots` | Workspace-owned project root read model with redacted path hints. |
 | `/api/v1/workspaces/{id}/file-inventory/*` | Metadata-only project-root inventory. Not source content indexing and not a trust grant. |
 | Sharing | Out of Phase 2 scope. Future sharing must consume the same `workspace_id` and membership model rather than inventing a parallel shared workspace identity. |
@@ -384,8 +387,8 @@ All known open implementation questions are assigned to child issues:
 
 | Question | Owner issue |
 | --- | --- |
-| Exact runtime binding descriptor schema, statuses, portability fields, and redaction behavior | [#1991](https://github.com/rmusser01/tldw_server/issues/1991) |
-| Owning-domain adapters for prompts, workflows, watchlists, ACP sessions/runs, sandbox sessions/runs, and remaining resource types | [#2378](https://github.com/rmusser01/tldw_server/issues/2378) |
+| Runtime consumer resume/import semantics beyond the descriptor read model | Follow-up after [#1991](https://github.com/rmusser01/tldw_server/issues/1991) evidence |
+| Owning-domain adapters for global notes, ACP runs, project files, and study-related resource types | Follow-up after [#1995](https://github.com/rmusser01/tldw_server/issues/1995) evidence |
 | Frontend route/store contract for active workspace context, global browsing labels, and eligibility UX | [#1993](https://github.com/rmusser01/tldw_server/issues/1993) |
 | Workspace activity/index contract and inspection UI | [#1994](https://github.com/rmusser01/tldw_server/issues/1994) |
 | End-to-end single-user evidence across create/import, attach, runtime context, activity, and recovery | [#1995](https://github.com/rmusser01/tldw_server/issues/1995) |

--- a/Docs/Validation/workspace-phase2-single-user-container-evidence.md
+++ b/Docs/Validation/workspace-phase2-single-user-container-evidence.md
@@ -1,0 +1,109 @@
+# Workspace Phase 2 Single-User Container Evidence
+
+Date: 2026-06-18
+Status: Complete for #1995 branch evidence
+Tracking: [#1995](https://github.com/rmusser01/tldw_server/issues/1995), [#1984](https://github.com/rmusser01/tldw_server/issues/1984)
+
+This matrix consolidates the final release evidence for the single-user
+Workspace Phase 2 container loop. It extends the narrower
+`workspaces-manager-uat-matrix.md` with the full resource set from #1995:
+workspace notes, media/sources, artifacts, chats, prompts, workflows,
+watchlists, ACP sessions, Sandbox sessions, runtime bindings, active-context
+eligibility, and global visibility invariants.
+
+## Current Evidence Snapshot
+
+- Backend baseline before contract repair:
+  `python -m pytest tldw_Server_API/tests/Workspaces -q` produced
+  `459 passed, 1 failed`. The failure was a stale eligibility expectation:
+  `acp_session` is now a supported membership adapter, so unsupported coverage
+  must use a still-future type such as `acp_run`.
+- Focused contract repair verification:
+  `python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_eligibility.py -q`
+  passed with `16 passed, 6 warnings`.
+- Backend consolidated verification:
+  `python -m pytest tldw_Server_API/tests/Workspaces -q` passed with
+  `461 passed, 8 warnings`.
+- Frontend focused contract verification:
+  `./node_modules/.bin/vitest run ...workspace focused suite...` passed with
+  `10 passed (10 files), 79 passed (79 tests)`. The initial run exposed a
+  stale `WorkspaceHeader` expectation that clicked the modal-closing ACP
+  footer action before asserting the diagnostics action; the test now verifies
+  diagnostics first and then the Agent Tasks handoff.
+- Browser evidence:
+  `TLDW_WEB_CMD='bun run dev:webpack -- -p 8080' TLDW_SERVER_URL=http://127.0.0.1:18001 TLDW_E2E_SERVER_URL=http://127.0.0.1:18001 TLDW_E2E_API_KEY=tldw-test-api-key-1995 ./node_modules/.bin/playwright test e2e/workflows/workspaces-manager.spec.ts --reporter=line --workers=1`
+  passed with `2 passed`. The local API server used
+  `AUTH_MODE=single_user`, `SINGLE_USER_API_KEY=tldw-test-api-key-1995`,
+  `CHAT_FORCE_MOCK=1`, and `STREAMS_UNIFIED=1`.
+
+## Scope And Deferrals
+
+Covered by this matrix:
+
+- Workspace lifecycle, archive/delete, profile/context, roots, file inventory,
+  source status, capabilities, memberships, runtime bindings, and eligibility.
+- Resource memberships for `workspace_note`, `media`, `workspace_source`,
+  `workspace_artifact`, `chat`, `prompt`, `workflow`, `watchlist`,
+  `acp_session`, and `sandbox_session`.
+- Visibility and recovery invariants: global browse/search/open/edit remains
+  domain-owned; active-context operations require an eligible active workspace.
+
+Deferred from the agreed Phase 2 evidence set:
+
+- Global reusable `note` adapter. Current covered notes are Workspace-owned
+  `workspace_note` rows.
+- `acp_run`, `project_file`, `study_deck`, `quiz`, and `study_pack` membership
+  adapters. These remain reserved/future fail-closed resource types.
+- Multi-user sharing/collaboration and long-lived preview hosting.
+
+## Scenario Matrix
+
+| ID | Requirement | Expected Result | Backend Evidence | Frontend/Browser Evidence | Status |
+| --- | --- | --- | --- | --- | --- |
+| W2E-001 | Create workspace from scratch | New `research` or `project` workspace has stable `workspace_id`, versioning, lifecycle timestamps, and context payload | `test_workspaces_api.py`, `test_workspace_core_context.py`, `test_workspace_core_models.py`; backend suite `461 passed` | `WorkspacesManagerPage.test.tsx`; `/workspaces` smoke passed in `workspaces-manager.spec.ts` | Verified |
+| W2E-002 | Import/reconcile existing workspace metadata | Existing local/reconciled workspace can map to canonical server metadata without rewriting local payloads | `test_workspace_migration_api.py`; backend suite `461 passed` | `workspace-local-reconciliation.test.ts`, `WorkspaceReconciliationPanel.test.tsx`; focused Vitest `79 passed` | Verified |
+| W2E-003 | Attach existing repo/project root | Project workspace can bind a host-local or Sandbox-managed primary root without duplicate primary roots | `test_workspace_project_roots_db.py`, `test_workspace_root_binding_service.py`, `test_workspace_sandbox_root_provisioning.py`; backend suite `461 passed` | `WorkspaceProjectRootPanel.test.tsx`; focused Vitest `79 passed` | Verified |
+| W2E-004 | File inventory and root status | File inventory is metadata-only, Jobs-backed, and reports scan/status/items without becoming source content or trust | `test_workspace_file_inventory_*`; backend suite `461 passed` | Root/status surfaced by focused manager/project-root tests; browser manager smoke passed | Verified |
+| W2E-005 | Workspace notes membership | Workspace-owned notes attach/list/update/remove and participate in generic membership summary | `test_workspace_sub_resources_api.py`, `test_workspace_membership_adapters.py`, `test_workspace_memberships_api.py`; backend suite `461 passed` | Research Workspace local note/store browser flow not rerun in this slice | Backend verified; frontend gap noted |
+| W2E-006 | Media and workspace sources membership | Global media links remain globally visible; workspace sources own selection/order/readiness inside Research Workspace | `test_workspace_source_status_api.py`, `test_workspace_source_preview_context_api.py`, `test_workspace_membership_adapters.py`, `test_workspace_memberships_api.py`; backend suite `461 passed` | Research Workspace source E2E/parity specs not rerun in this slice | Backend verified; frontend gap noted |
+| W2E-007 | Workspace artifacts membership | Workspace artifacts attach/list/update/remove/export with lineage and review-state constraints | `test_workspace_sub_resources_api.py`, `test_workspace_membership_adapters.py`, `test_workspace_memberships_api.py`; backend suite `461 passed` | Research Workspace Studio artifact E2E not rerun in this slice | Backend verified; frontend gap noted |
+| W2E-008 | Chat membership | Chat/conversation membership gates active-context use without hiding global chat visibility | `test_workspace_membership_adapters.py`, `test_workspace_memberships_api.py`, `test_workspace_context_membership_summary.py`; backend suite `461 passed` | Research Workspace grounded chat/search E2E not rerun in this slice | Backend verified; frontend gap noted |
+| W2E-009 | Prompt membership | Prompt adapter canonicalizes allowed prompt identifiers and exposes safe summaries without prompt bodies | `test_workspace_membership_adapters.py`, `test_workspace_memberships_api.py`; backend suite `461 passed` | Route metadata coverage included in focused Vitest; Prompt Workspace E2E not rerun | Backend verified; frontend partial |
+| W2E-010 | Workflow membership | Workflow adapter enforces tenant/owner/admin visibility and safe summaries | `test_workspace_membership_adapters.py`, `test_workspace_memberships_api.py`; backend suite `461 passed` | No dedicated Workflows workspace frontend contract in this slice; evidence is backend/API only | Backend verified; frontend gap noted |
+| W2E-011 | Watchlist membership | Watchlist adapter validates current-user watchlists and safe summaries for active/deleted state | `test_workspace_membership_adapters.py`, `test_workspace_memberships_api.py`; backend suite `461 passed` | No dedicated Watchlists workspace frontend contract in this slice; evidence is backend/API only | Backend verified; frontend gap noted |
+| W2E-012 | ACP session membership | ACP session adapter validates active Workspace runtime binding descriptors and does not grant execution/path trust | `test_workspace_runtime_bindings.py`, `test_workspace_runtime_bindings_api.py`, `test_workspace_membership_adapters.py`, `test_workspace_memberships_api.py`; backend suite `461 passed` | `ACPWorkspacePanel.test.tsx`, `WorkspaceHeader.test.tsx`, route metadata focused Vitest `79 passed` | Verified |
+| W2E-013 | Sandbox session membership | Sandbox session adapter validates active Workspace runtime binding descriptors and leaves admission to Sandbox | `test_workspace_runtime_bindings.py`, `test_workspace_runtime_bindings_api.py`, `test_workspace_membership_adapters.py`, `test_workspace_memberships_api.py`; backend suite `461 passed` | Sandbox-owned visible loop not covered by current frontend matrix | Backend verified; frontend gap noted |
+| W2E-014 | Active workspace selection and active-context gates | Visibility operations pass after domain permissions; active operations fail closed for no workspace, missing/archived workspace, unsupported type, unlinked/cross-workspace resource, missing runtime, or permission denial | `test_workspace_eligibility.py`, `test_workspace_eligibility_api.py`; backend suite `461 passed` | Frontend eligibility UX contract pending future/client-specific coverage | Backend verified; frontend gap noted |
+| W2E-015 | Global browse/search/open remains visible | Workspace selection does not hard-filter Library, Notes, Artifact, Chat, Prompt, Workflow, or Watchlist owner surfaces | Eligibility visibility tests; membership adapter/API tests confirm association-only model; backend suite `461 passed` | Research Workspace global search and owner-surface UI checks pending rerun/manual evidence | Backend verified; manual/frontend pending |
+| W2E-016 | Cross-workspace/unlinked recovery | Cross-workspace resource returns copy/switch recovery; unlinked resource returns link recovery with stable reason codes | `test_workspace_eligibility.py`, `test_workspace_eligibility_api.py`; backend suite `461 passed` | Recovery copy in UI pending client-specific evidence | Backend verified; frontend pending |
+| W2E-017 | Missing runtime and archived workspace behavior | Runtime-bound operations require `runtime_state="ready"`; archived workspaces block active operations and membership mutation | `test_workspace_eligibility.py`, `test_workspace_runtime_bindings.py`, `test_workspaces_api.py`; backend suite `461 passed` | Manager/project-root focused Vitest `79 passed`; detailed archive browser flow not rerun | Backend verified; frontend partial |
+| W2E-018 | Docs/API/frontend contracts match implementation | Canonical contract lists current supported adapters and public API routes; matrix names current deferrals | This document plus `Workspace_Container_Contract_2026_06.md`; `git diff --check` passed | Focused Vitest `79 passed`; browser manager smoke `2 passed` | Verified |
+| W2E-019 | Visible single-user loop | User can open manager, move to Research Workspace, and return to manager in single-user mode | Backend suite `461 passed`; local API server single-user mode passed health/auth-dependent UI calls during browser smoke | `workspaces-manager.spec.ts` passed with `2 passed`; create/select specifics are covered by focused manager tests and backend API tests | Verified for branch smoke |
+| W2E-020 | Final epic evidence | Final evidence summary with limitations is posted to #1984 and #1995 | Not applicable | Not applicable | Pending issue comments |
+
+## Verification Commands
+
+- Frontend dependencies: `bun install --frozen-lockfile` from `apps/`.
+- Focused frontend contract suites:
+  - `apps/packages/ui/src/components/Option/Workspaces/__tests__/WorkspacesManagerPage.test.tsx`
+  - `apps/packages/ui/src/components/Option/Workspaces/__tests__/WorkspaceProjectRootPanel.test.tsx`
+  - `apps/packages/ui/src/components/Option/Workspaces/__tests__/WorkspaceReconciliationPanel.test.tsx`
+  - `apps/packages/ui/src/components/Option/Workspaces/__tests__/workspace-local-reconciliation.test.ts`
+  - `apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx`
+  - `apps/packages/ui/src/components/Option/MCPHub/__tests__/SharedWorkspacesTab.test.tsx`
+  - `apps/packages/ui/src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx`
+  - `apps/packages/ui/src/routes/__tests__/option-workspaces.route.test.tsx`
+  - `apps/packages/ui/src/routes/__tests__/route-metadata.coverage.test.ts`
+  - `apps/tldw-frontend/__tests__/navigation/workspaces-page-wrapper.test.ts`
+- Focused browser evidence:
+  - `apps/tldw-frontend/e2e/workflows/workspaces-manager.spec.ts`
+- `git diff --check`.
+
+## Remaining Explicit Gaps
+
+- `research-workspace.spec.ts` and `research-workspace.parity.spec.ts` were not
+  rerun in this branch after the manager smoke passed. Their source/chat/studio
+  browser flows remain useful follow-up evidence, but the release-blocking
+  backend/API contracts and route/manager handoffs are covered above.
+- No production backend code was changed in this branch. Bandit is recorded as
+  not applicable for this evidence/test/docs-only change set.

--- a/Docs/Validation/workspace-phase2-single-user-container-evidence.md
+++ b/Docs/Validation/workspace-phase2-single-user-container-evidence.md
@@ -79,7 +79,7 @@ Deferred from the agreed Phase 2 evidence set:
 | W2E-017 | Missing runtime and archived workspace behavior | Runtime-bound operations require `runtime_state="ready"`; archived workspaces block active operations and membership mutation | `test_workspace_eligibility.py`, `test_workspace_runtime_bindings.py`, `test_workspaces_api.py`; backend suite `461 passed` | Manager/project-root focused Vitest `79 passed`; detailed archive browser flow not rerun | Backend verified; frontend partial |
 | W2E-018 | Docs/API/frontend contracts match implementation | Canonical contract lists current supported adapters and public API routes; matrix names current deferrals | This document plus `Workspace_Container_Contract_2026_06.md`; `git diff --check` passed | Focused Vitest `79 passed`; browser manager smoke `2 passed` | Verified |
 | W2E-019 | Visible single-user loop | User can open manager, move to Research Workspace, and return to manager in single-user mode | Backend suite `461 passed`; local API server single-user mode passed health/auth-dependent UI calls during browser smoke | `workspaces-manager.spec.ts` passed with `2 passed`; create/select specifics are covered by focused manager tests and backend API tests | Verified for branch smoke |
-| W2E-020 | Final epic evidence | Final evidence summary with limitations is posted to #1984 and #1995 | Not applicable | Not applicable | Pending issue comments |
+| W2E-020 | Final epic evidence | Final evidence summary with limitations is posted to #1984 and #1995 | [#1995 evidence comment](https://github.com/rmusser01/tldw_server/issues/1995#issuecomment-4738013294) | [#1984 evidence comment](https://github.com/rmusser01/tldw_server/issues/1984#issuecomment-4738013358) | Verified |
 
 ## Verification Commands
 

--- a/Docs/superpowers/plans/2026-06-18-workspace-phase2-e2e-verification-plan.md
+++ b/Docs/superpowers/plans/2026-06-18-workspace-phase2-e2e-verification-plan.md
@@ -1,0 +1,43 @@
+# Workspace Phase 2 E2E Verification Plan
+
+Task: `TASK-2384`
+
+GitHub: [#1995](https://github.com/rmusser01/tldw_server/issues/1995)
+
+## Stage 1: Baseline Reconciliation
+**Goal**: Reconcile the current `dev` implementation against the Phase 2 issue requirements and existing Workspace evidence.
+**Success Criteria**: Existing docs, tests, and prior UAT evidence are mapped to #1995 scope; baseline failures are identified with root cause.
+**Tests**:
+- `python -m pytest tldw_Server_API/tests/Workspaces -q`
+**Status**: Complete
+
+## Stage 2: Contract Repair
+**Goal**: Fix stale or missing verification contracts exposed by the baseline run without broadening product behavior.
+**Success Criteria**: Eligibility/resource membership tests reflect the current supported adapter set and still fail closed for future resource types.
+**Tests**:
+- `python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_eligibility.py -q`
+- `python -m pytest tldw_Server_API/tests/Workspaces -q`
+**Status**: Complete
+
+## Stage 3: Scenario Matrix
+**Goal**: Create the full Phase 2 single-user workspace loop matrix required by #1995.
+**Success Criteria**: Matrix covers workspace lifecycle/import, notes, media/sources, artifacts, chats, prompts, workflows, watchlists, ACP sessions, sandbox sessions, active-context gates, global visibility, cross-workspace recovery, runtime bindings, archived workspace behavior, API contracts, and frontend contracts.
+**Tests**:
+- Documentation review against #1995 acceptance criteria.
+**Status**: Complete
+
+## Stage 4: Focused Verification
+**Goal**: Run backend, frontend/client, and browser/manual evidence checks that map to the matrix.
+**Success Criteria**: Focused backend suites pass, focused frontend Workspace contract suites pass or documented blockers are filed, and visible single-user loop evidence is captured.
+**Tests**:
+- Backend Workspace pytest suite.
+- Focused frontend Vitest Workspace suites.
+- Focused Playwright Workspace manager/research Workspace suites where local services are available.
+**Status**: Complete
+
+## Stage 5: Release Evidence Closeout
+**Goal**: Update tracking records and post final evidence back to the Workspace epic.
+**Success Criteria**: Backlog task includes verification results and limitations, #1995 has a PR/evidence comment, and #1984 receives the final evidence summary required by #1995.
+**Tests**:
+- Bandit on touched backend paths, or document non-code/touched-test-only scope.
+**Status**: In Progress

--- a/Docs/superpowers/plans/2026-06-18-workspace-phase2-e2e-verification-plan.md
+++ b/Docs/superpowers/plans/2026-06-18-workspace-phase2-e2e-verification-plan.md
@@ -40,4 +40,4 @@ GitHub: [#1995](https://github.com/rmusser01/tldw_server/issues/1995)
 **Success Criteria**: Backlog task includes verification results and limitations, #1995 has a PR/evidence comment, and #1984 receives the final evidence summary required by #1995.
 **Tests**:
 - Bandit on touched backend paths, or document non-code/touched-test-only scope.
-**Status**: In Progress
+**Status**: Complete

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
@@ -1557,13 +1557,13 @@ describe("WorkspaceHeader workspace browser modal", () => {
       within(modal).getByText("Identified two release blockers.")
     ).toBeInTheDocument()
 
-    fireEvent.click(within(modal).getByRole("button", { name: "Open Agent Tasks" }))
-    expect(mockNavigate).toHaveBeenCalledWith("/agent-tasks?workspace=workspace-alpha")
-
     fireEvent.click(within(modal).getByRole("button", { name: "Open diagnostics" }))
     expect(mockNavigate).toHaveBeenCalledWith(
       "/acp-playground?session=sess-alpha&view=diagnostics"
     )
+
+    fireEvent.click(within(modal).getByRole("button", { name: "Open Agent Tasks" }))
+    expect(mockNavigate).toHaveBeenCalledWith("/agent-tasks?workspace=workspace-alpha")
   })
 
   it("shows direct workspace ACP sessions when Agent Tasks history has no runs", async () => {

--- a/backlog/completed/task-2384 - Verify-single-user-Workspace-Phase-2-container-loop-end-to-end.md
+++ b/backlog/completed/task-2384 - Verify-single-user-Workspace-Phase-2-container-loop-end-to-end.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2384
 title: Verify single-user Workspace Phase 2 container loop end-to-end
-status: In Progress
+status: Done
 labels:
 - workspace
 - phase2
@@ -12,6 +12,9 @@ priority: High
 references:
 - https://github.com/rmusser01/tldw_server/issues/1995
 - https://github.com/rmusser01/tldw_server/issues/1984
+- https://github.com/rmusser01/tldw_server/pull/2387
+- https://github.com/rmusser01/tldw_server/issues/1995#issuecomment-4738013294
+- https://github.com/rmusser01/tldw_server/issues/1984#issuecomment-4738013358
 ---
 
 ## Description
@@ -26,7 +29,7 @@ Track #1995 release evidence for the single-user Workspace Phase 2 container loo
 - [x] #2 Backend Workspace suite passes after reconciling stale ACP session eligibility expectations.
 - [x] #3 Focused frontend Workspace/ACP/route contract tests pass.
 - [x] #4 Live browser smoke verifies the canonical Workspaces manager and Research Workspace handoff in single-user mode.
-- [ ] #5 Final evidence is posted to GitHub issues #1995 and #1984.
+- [x] #5 Final evidence is posted to GitHub issues #1995 and #1984.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -45,12 +48,13 @@ Track #1995 release evidence for the single-user Workspace Phase 2 container loo
 - Backend verification: `python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_eligibility.py -q` passed with `16 passed, 6 warnings`; `python -m pytest tldw_Server_API/tests/Workspaces -q` passed with `461 passed, 8 warnings`.
 - Frontend verification: focused Vitest Workspace/Research Workspace/MCPHub/ACP/route suite passed with `10 passed (10 files), 79 passed (79 tests)`.
 - Browser verification: `workspaces-manager.spec.ts` passed against a local single-user API server with `2 passed`.
+- GitHub evidence comments posted to #1995 and #1984, and PR #2387 opened for review.
 - Remaining gaps are explicitly documented: Research Workspace source/chat/studio browser E2E and parity specs were not rerun in this slice; workflow/watchlist/sandbox frontend evidence remains backend/API-only or partial.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
+- [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
 - [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip

--- a/backlog/tasks/task-2384 - Verify-single-user-Workspace-Phase-2-container-loop-end-to-end.md
+++ b/backlog/tasks/task-2384 - Verify-single-user-Workspace-Phase-2-container-loop-end-to-end.md
@@ -1,0 +1,59 @@
+---
+id: TASK-2384
+title: Verify single-user Workspace Phase 2 container loop end-to-end
+status: In Progress
+labels:
+- workspace
+- phase2
+- verification
+- backend
+- frontend
+priority: High
+references:
+- https://github.com/rmusser01/tldw_server/issues/1995
+- https://github.com/rmusser01/tldw_server/issues/1984
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track #1995 release evidence for the single-user Workspace Phase 2 container loop. Build the scenario matrix, verify backend/API/client/manual/browser evidence across the agreed resource set, document limitations/deferrals, and post final evidence back to #1984.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Scenario matrix covers #1995 single-user Workspace Phase 2 loop requirements and identifies explicit deferrals.
+- [x] #2 Backend Workspace suite passes after reconciling stale ACP session eligibility expectations.
+- [x] #3 Focused frontend Workspace/ACP/route contract tests pass.
+- [x] #4 Live browser smoke verifies the canonical Workspaces manager and Research Workspace handoff in single-user mode.
+- [ ] #5 Final evidence is posted to GitHub issues #1995 and #1984.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Plan: `Docs/superpowers/plans/2026-06-18-workspace-phase2-e2e-verification-plan.md`.
+- Evidence matrix: `Docs/Validation/workspace-phase2-single-user-container-evidence.md`.
+- Baseline found one stale backend expectation: `acp_session` is currently supported by the membership/runtime binding adapters, so unsupported-type coverage now uses reserved future type `acp_run`.
+- Frontend focused run found one stale ACP history test ordering issue: the test clicked a modal-closing footer action before checking diagnostics. It now verifies diagnostics first, then Agent Tasks handoff.
+- Production backend code was not changed. Bandit is not applicable for this docs/test-only branch.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+- Backend verification: `python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_eligibility.py -q` passed with `16 passed, 6 warnings`; `python -m pytest tldw_Server_API/tests/Workspaces -q` passed with `461 passed, 8 warnings`.
+- Frontend verification: focused Vitest Workspace/Research Workspace/MCPHub/ACP/route suite passed with `10 passed (10 files), 79 passed (79 tests)`.
+- Browser verification: `workspaces-manager.spec.ts` passed against a local single-user API server with `2 passed`.
+- Remaining gaps are explicitly documented: Research Workspace source/chat/studio browser E2E and parity specs were not rerun in this slice; workflow/watchlist/sandbox frontend evidence remains backend/API-only or partial.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/tests/Workspaces/test_workspace_eligibility.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_eligibility.py
@@ -178,7 +178,7 @@ def test_active_operation_rejects_unlinked_resource(service: WorkspaceEligibilit
     assert {action.action for action in result.recovery_actions} == {"link_to_active_workspace"}
 
 
-def test_active_operation_rejects_unsupported_resource_type(
+def test_active_operation_rejects_unlinked_supported_runtime_session_resource(
     service: WorkspaceEligibilityService,
 ) -> None:
     result = service.check(
@@ -191,8 +191,27 @@ def test_active_operation_rejects_unsupported_resource_type(
     )
 
     assert result.allowed is False
-    assert result.reason_code == "unsupported_resource_type"
+    assert result.reason_code == "resource_not_linked"
     assert result.resource_type == "acp_session"
+    assert result.resource_workspace_ids == []
+    assert {action.action for action in result.recovery_actions} == {"link_to_active_workspace"}
+
+
+def test_active_operation_rejects_unsupported_resource_type(
+    service: WorkspaceEligibilityService,
+) -> None:
+    result = service.check(
+        _request(
+            "acp_run",
+            resource_type=" acp_run ",
+            resource_id="run-1",
+            runtime_state="ready",
+        )
+    )
+
+    assert result.allowed is False
+    assert result.reason_code == "unsupported_resource_type"
+    assert result.resource_type == "acp_run"
     assert {action.action for action in result.recovery_actions} == {"wait_for_adapter"}
 
 


### PR DESCRIPTION
## Change summary

AI-generated draft: this PR closes out #1995 branch evidence by reconciling the Workspace Phase 2 contract with the currently supported adapters, adding a release evidence matrix, and fixing stale backend/frontend test expectations exposed by the verification run. Per project policy, a human-authored change summary confirming the rationale is required before merge.

## What changed

- Added `Docs/Validation/workspace-phase2-single-user-container-evidence.md` with the #1995 scenario matrix, verification results, explicit deferrals, and remaining frontend gaps.
- Updated `Workspace_Container_Contract_2026_06.md` so `prompt`, `workflow`, `watchlist`, `acp_session`, and `sandbox_session` reflect current support, while `acp_run` and other reserved types remain future/fail-closed.
- Updated eligibility coverage so `acp_session` is treated as a supported runtime-bound type and unsupported coverage uses reserved `acp_run`.
- Fixed stale `WorkspaceHeader` ACP history test ordering by asserting diagnostics before clicking the modal-closing Agent Tasks action.
- Added Backlog.md task `TASK-2384` and a task-specific implementation plan.

## Verification

- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_eligibility.py -q` -> `16 passed, 6 warnings`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Workspaces -q` -> `461 passed, 8 warnings`
- `./node_modules/.bin/vitest run` with the focused Workspace/Research Workspace/MCPHub/ACP/route suite -> `10 passed (10 files), 79 passed (79 tests)`
- `TLDW_WEB_CMD='bun run dev:webpack -- -p 8080' TLDW_SERVER_URL=http://127.0.0.1:18001 TLDW_E2E_SERVER_URL=http://127.0.0.1:18001 TLDW_E2E_API_KEY=tldw-test-api-key-1995 ./node_modules/.bin/playwright test e2e/workflows/workspaces-manager.spec.ts --reporter=line --workers=1` -> `2 passed`
- `git diff --check` -> passed

## Notes

- Bandit is not applicable for this branch because it changes docs and tests, not production backend code.
- The evidence matrix explicitly records remaining non-blocking gaps: Research Workspace source/chat/studio browser E2E and parity specs were not rerun in this branch; workflow/watchlist/sandbox frontend evidence remains backend/API-only or partial.

Refs #1995
Refs #1984

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Workspace Phase 2 contract with current support, completes #1995 single‑user loop evidence closeout, and fixes stale eligibility and ACP header tests. Documents the runtime bindings API and finalizes the scenario matrix and verification plan.

- **New Features**
  - Marked `prompt`, `workflow`, `watchlist`, `acp_session`, and `sandbox_session` as supported; reserved `acp_run`.
  - Documented `/api/v1/workspaces/{id}/runtime-bindings` list/create/read/archive routes in the contract.
  - Added the release evidence matrix and E2E verification plan; completed `TASK-2384` closeout with posted evidence.

- **Bug Fixes**
  - Eligibility tests now treat `acp_session` as supported and use `acp_run` for unsupported coverage; updated reason codes and recovery actions.
  - Fixed `WorkspaceHeader` modal test by asserting diagnostics before clicking “Open Agent Tasks”.
  - Verification passed: backend `461 passed`, focused Vitest `79 passed`, Playwright manager smoke `2 passed`.

<sup>Written for commit 0ebf00dc3488b0a33ce971e3dc5be23acf8be0e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

