### PR TITLE
Add advisory VZ host smoke evidence summary

### DIFF
--- a/.github/workflows/vz-linux-host-gated.yml
+++ b/.github/workflows/vz-linux-host-gated.yml
@@ -145,7 +145,11 @@ jobs:
             exit 0
           fi
 
-          "${python_bin}" "${summary_script}" --evidence-dir "${evidence_dir}" || true
+          "${python_bin}" "${summary_script}" --evidence-dir "${evidence_dir}"
+          summary_status=$?
+          if [[ ${summary_status} -ne 0 ]]; then
+            append_summary_warning "evidence summary failed with exit ${summary_status}; inspect uploaded artifacts/logs when present"
+          fi
           exit 0
 
       - name: Upload smoke evidence

--- a/.github/workflows/vz-linux-host-gated.yml
+++ b/.github/workflows/vz-linux-host-gated.yml
@@ -108,6 +108,46 @@ jobs:
 
           bash tools/vz-linux-image/scripts/run-host-e2e-smoke.sh "${args[@]}"
 
+      - name: Summarize smoke evidence
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          evidence_dir="${RUNNER_TEMP}/tldw-vz-helper-ci/evidence"
+          summary_script="tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py"
+          append_summary_warning() {
+            local message="$1"
+            if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+              {
+                echo "# VZ Linux Host Smoke Evidence Summary"
+                echo
+                echo "> Advisory only: ${message}"
+              } >> "${GITHUB_STEP_SUMMARY}" 2>/dev/null || true
+            fi
+            echo "warning: ${message}" >&2
+          }
+
+          python_bin=""
+          if command -v python >/dev/null 2>&1; then
+            python_bin="$(command -v python)"
+          elif command -v python3 >/dev/null 2>&1; then
+            python_bin="$(command -v python3)"
+          fi
+
+          if [[ -f "${summary_script}" ]]; then
+            :
+          else
+            append_summary_warning "evidence summary script is unavailable; inspect uploaded artifacts when present"
+            exit 0
+          fi
+          if [[ -z "${python_bin}" ]]; then
+            append_summary_warning "python interpreter is unavailable; inspect uploaded artifacts when present"
+            exit 0
+          fi
+
+          "${python_bin}" "${summary_script}" --evidence-dir "${evidence_dir}" || true
+          exit 0
+
       - name: Upload smoke evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+++ b/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
@@ -223,6 +223,13 @@ bundle contract.
 
 ## Artifact And Log Expectations
 
+The workflow writes an advisory GitHub step summary after the smoke wrapper has
+had a chance to finalize evidence. Inspect the GitHub step summary first for a
+quick overview of evidence availability, final exit code, phase outcomes,
+cleanup state, and artifact pointers. The summary is advisory: missing or
+malformed summary output in this first slice should not replace the smoke step
+result and does not replace artifacts.
+
 The workflow must upload structured smoke evidence from:
 
 ```text

--- a/Docs/superpowers/plans/2026-06-17-vz-host-gated-evidence-summary-advisory.md
+++ b/Docs/superpowers/plans/2026-06-17-vz-host-gated-evidence-summary-advisory.md
@@ -1,0 +1,669 @@
+# VZ Host-Gated Evidence Summary Advisory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an advisory GitHub step-summary report for VZ Linux host-gated smoke evidence without changing VM execution, artifact upload semantics, or host-gated pass/fail behavior.
+
+**Architecture:** Add a small standard-library Python summarizer under `tools/vz-linux-image/scripts` that reads only known direct child evidence files, renders sanitized Markdown, and exits `0` for all advisory failure modes. Wire the host-gated workflow to run the summarizer with `if: always()` after the smoke wrapper and before artifact uploads, with shell guards for missing checkout/script/interpreter cases. Keep validation portable through focused pytest coverage and workflow contract tests.
+
+**Tech Stack:** Python 3 standard library, pytest, GitHub Actions YAML, Bash workflow shell, Markdown operator docs, Backlog.md task tracking.
+
+---
+
+## File Structure
+
+- Create `tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py`
+  - Owns evidence probing, JSON parsing, Markdown rendering, output fallback, and advisory CLI exit behavior.
+  - Must not import project modules or require the repo package to be installed.
+- Create `tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py`
+  - Owns portable unit/CLI tests for complete, missing, malformed, unsafe, and fallback evidence cases.
+- Modify `.github/workflows/vz-linux-host-gated.yml`
+  - Adds the always-run summary step between smoke execution and artifact uploads.
+- Modify `tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py`
+  - Adds workflow contract tests for summary step ordering, guarded invocation, advisory behavior, and evidence path.
+- Modify `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`
+  - Documents the GitHub step summary as the first inline diagnostic surface and preserves artifact inspection order.
+- Modify `backlog/tasks/task-2381 - Add-advisory-VZ-host-smoke-evidence-summary.md`
+  - Tracks plan path, touched files, verification, known skips, and final status.
+
+Do not modify `tools/vz-linux-image/scripts/run-host-e2e-smoke.sh` in this slice unless an implementation issue proves the evidence contract is wrong. The summarizer consumes existing evidence; it does not generate evidence.
+
+---
+
+### Task 1: Add Failing Summarizer Tests
+
+**Files:**
+- Create: `tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py`
+- Read: `tools/vz-linux-image/scripts/run-host-e2e-smoke.sh`
+- Read: `Docs/superpowers/specs/2026-06-17-vz-host-gated-evidence-summary-advisory-design.md`
+
+- [ ] **Step 1: Create test scaffolding**
+
+Create the test file with helpers that run the future script through `subprocess.run`:
+
+```python
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+IMAGE_DIR = Path(__file__).resolve().parents[1]
+SUMMARY_SCRIPT = IMAGE_DIR / "scripts" / "summarize-host-e2e-evidence.py"
+EXPECTED_EVIDENCE_FILES = {
+    "host-smoke-evidence.json",
+    "source-bundle-hashes-before.txt",
+    "source-bundle-hashes-after.txt",
+    "run-bundle-hashes.txt",
+    "runtime-paths.txt",
+    "cleanup-status.txt",
+}
+
+
+def _run_summary(
+    evidence_dir: Path,
+    *,
+    summary_path: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    if summary_path is not None:
+        env["GITHUB_STEP_SUMMARY"] = str(summary_path)
+    else:
+        env.pop("GITHUB_STEP_SUMMARY", None)
+    return subprocess.run(
+        [sys.executable, str(SUMMARY_SCRIPT), "--evidence-dir", str(evidence_dir)],
+        cwd=IMAGE_DIR,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+```
+
+- [ ] **Step 2: Add complete evidence test**
+
+Add a test that creates all expected files and writes representative JSON:
+
+```python
+def test_summary_reports_complete_evidence(tmp_path: Path) -> None:
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir()
+    for evidence_file in EXPECTED_EVIDENCE_FILES - {"host-smoke-evidence.json"}:
+        (evidence_dir / evidence_file).write_text(f"{evidence_file}\n", encoding="utf-8")
+    (evidence_dir / "host-smoke-evidence.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "created_at": "2026-06-17T00:00:00Z",
+                "source_bundle_path": "/private/source/bundle",
+                "run_bundle_path": "/private/run/bundle",
+                "image_store_root": "/private/image-store",
+                "smoke_run_id": "ci-123",
+                "socket_path": "/private/runtime/helper.sock",
+                "serial_log_dir": "/private/runtime/serial",
+                "evidence_dir": str(evidence_dir),
+                "helper_path": "/private/helper",
+                "helper_pid_file": "/private/helper.pid",
+                "skip_build": False,
+                "skip_sign": False,
+                "include_failure_drills": False,
+                "final_exit_code": 7,
+                "phases": {
+                    "real_host_smoke": {
+                        "status": "failed",
+                        "exit_code": 7,
+                        "timestamp": "2026-06-17T00:00:01Z",
+                    },
+                    "cleanup": {
+                        "status": "ok",
+                        "exit_code": 0,
+                        "timestamp": "2026-06-17T00:00:02Z",
+                    },
+                },
+                "cleanup": {
+                    "status": 0,
+                    "helper_pid": "123",
+                    "helper_running_after_cleanup": False,
+                    "socket_present_after_cleanup": False,
+                },
+                "evidence_files": {
+                    evidence_file: str(evidence_dir / evidence_file)
+                    for evidence_file in EXPECTED_EVIDENCE_FILES
+                },
+                "log_artifacts": [
+                    {
+                        "path": "/private/runtime/serial/vm.log",
+                        "size_bytes": 128,
+                        "sha256": "a" * 64,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run_summary(evidence_dir)
+
+    assert result.returncode == 0, result.stderr
+    assert "VZ Linux Host Smoke Evidence Summary" in result.stdout
+    assert "Advisory only" in result.stdout
+    assert "final_exit_code" in result.stdout
+    assert "7" in result.stdout
+    assert "real_host_smoke" in result.stdout
+    assert "cleanup" in result.stdout
+    assert "vz-linux-host-gated-evidence" in result.stdout
+    for evidence_file in EXPECTED_EVIDENCE_FILES:
+        assert evidence_file in result.stdout
+```
+
+- [ ] **Step 3: Add missing and partial evidence tests**
+
+Add tests for:
+
+- nonexistent evidence directory
+- evidence path that exists but is a regular file
+- evidence directory with only `cleanup-status.txt`
+
+Expected assertions:
+
+- return code is `0`
+- output contains `warning`
+- output contains expected file names
+- no traceback is printed
+
+- [ ] **Step 4: Add malformed, oversized, and symlink tests**
+
+Add tests for:
+
+- malformed `host-smoke-evidence.json`
+- JSON larger than `1 MiB`
+- `host-smoke-evidence.json` symlink to another file
+- expected evidence file that is a directory
+
+Expected assertions:
+
+- return code is `0`
+- output warns about the specific unsafe/unavailable file
+- symlink target content is not included in output
+- no traceback is printed
+
+- [ ] **Step 5: Add summary output fallback tests**
+
+Add tests for:
+
+- valid `GITHUB_STEP_SUMMARY` path appends Markdown to the file and keeps stdout minimal or empty
+- invalid/unwritable `GITHUB_STEP_SUMMARY` falls back to stdout or stderr and exits `0`
+
+Use a directory path as `GITHUB_STEP_SUMMARY` for the unwritable target case, because opening a directory for append should fail portably.
+
+- [ ] **Step 6: Run tests to verify RED**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py -q
+```
+
+Expected: FAIL because `tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py` does not exist yet.
+
+---
+
+### Task 2: Implement Advisory Evidence Summarizer
+
+**Files:**
+- Create: `tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py`
+- Test: `tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py`
+
+- [ ] **Step 1: Add constants and dataclasses**
+
+Create the script with standard-library-only imports:
+
+```python
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import stat
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+EXPECTED_EVIDENCE_FILES = (
+    "host-smoke-evidence.json",
+    "source-bundle-hashes-before.txt",
+    "source-bundle-hashes-after.txt",
+    "run-bundle-hashes.txt",
+    "runtime-paths.txt",
+    "cleanup-status.txt",
+)
+JSON_MAX_BYTES = 1024 * 1024
+DISPLAY_MAX_CHARS = 240
+
+
+@dataclass(frozen=True)
+class EvidenceFileStatus:
+    name: str
+    present: bool
+    readable: bool
+    reason: str
+    size_bytes: int | None = None
+```
+
+- [ ] **Step 2: Implement safe rendering helpers**
+
+Add helpers:
+
+```python
+def _display(value: object, *, max_chars: int = DISPLAY_MAX_CHARS) -> str:
+    text = "" if value is None else str(value)
+    text = " ".join(text.replace("\r", "\n").splitlines())
+    text = html.escape(text, quote=False)
+    text = text.replace("|", "\\|")
+    if len(text) > max_chars:
+        return text[: max_chars - 1] + "..."
+    return text
+```
+
+Also add a helper that renders Markdown tables from rows and applies `_display` to every cell.
+
+- [ ] **Step 3: Implement direct-child evidence probing**
+
+Implement:
+
+```python
+def _probe_evidence_dir(evidence_dir: Path) -> tuple[bool, list[str]]:
+    try:
+        metadata = evidence_dir.lstat()
+    except FileNotFoundError:
+        return False, [f"warning: evidence directory is missing: {evidence_dir}"]
+    except OSError as exc:
+        return False, [f"warning: evidence directory cannot be inspected: {type(exc).__name__}: {exc}"]
+    if stat.S_ISLNK(metadata.st_mode):
+        return False, [f"warning: evidence directory is a symlink and was not read: {evidence_dir}"]
+    if not stat.S_ISDIR(metadata.st_mode):
+        return False, [f"warning: evidence path is not a directory and was not read: {evidence_dir}"]
+    return True, []
+
+def _probe_expected_file(evidence_dir: Path, name: str) -> EvidenceFileStatus:
+    path = evidence_dir / name
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return EvidenceFileStatus(name=name, present=False, readable=False, reason="missing")
+    except OSError as exc:
+        return EvidenceFileStatus(name=name, present=False, readable=False, reason=type(exc).__name__)
+    if stat.S_ISLNK(metadata.st_mode):
+        return EvidenceFileStatus(name=name, present=True, readable=False, reason="symlink skipped")
+    if not stat.S_ISREG(metadata.st_mode):
+        return EvidenceFileStatus(name=name, present=True, readable=False, reason="non-regular file skipped")
+    return EvidenceFileStatus(
+        name=name,
+        present=True,
+        readable=True,
+        reason="ok",
+        size_bytes=metadata.st_size,
+    )
+```
+
+If `_probe_evidence_dir` returns `False`, render the warning plus a missing
+checklist for all expected files and do not call `_probe_expected_file`. Use
+`lstat`; do not use recursive globbing; do not resolve or read through symlinks.
+
+- [ ] **Step 4: Implement bounded JSON loading**
+
+Implement:
+
+```python
+def _load_evidence_json(
+    evidence_dir: Path,
+    file_statuses: dict[str, EvidenceFileStatus],
+) -> tuple[dict[str, Any] | None, list[str]]:
+    json_status = file_statuses["host-smoke-evidence.json"]
+    if not json_status.readable:
+        return None, [f"structured metadata unavailable: {json_status.reason}"]
+    if json_status.size_bytes is not None and json_status.size_bytes > JSON_MAX_BYTES:
+        return None, [f"structured metadata skipped: exceeds {JSON_MAX_BYTES} bytes"]
+    try:
+        raw_text = (evidence_dir / "host-smoke-evidence.json").read_text(encoding="utf-8")
+        payload = json.loads(raw_text)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return None, [f"structured metadata parse failed: {type(exc).__name__}: {exc}"]
+    if not isinstance(payload, dict):
+        return None, ["structured metadata parse failed: top-level JSON is not an object"]
+    return payload, []
+```
+
+Do not include raw JSON content in warnings.
+
+- [ ] **Step 5: Implement Markdown report generation**
+
+Build `render_summary(evidence_dir: Path) -> str` with these sections:
+
+- `# VZ Linux Host Smoke Evidence Summary`
+- advisory notice
+- evidence directory path
+- warning block when any warnings exist
+- final exit code and smoke run id when JSON exists
+- expected files checklist table with `present/readable/reason/size`
+- phase outcomes table when `phases` is a dict
+- cleanup table when `cleanup` is a dict
+- runtime/artifact pointers table for known JSON keys:
+  - `source_bundle_path`
+  - `run_bundle_path`
+  - `image_store_root`
+  - `socket_path`
+  - `serial_log_dir`
+  - `helper_pid_file`
+  - `evidence_dir`
+- log artifact table from `log_artifacts` when it is a list of dicts
+- footer that names `vz-linux-host-gated-evidence` as the primary artifact and `vz-linux-host-gated-helper-logs` as the raw-log fallback
+
+Every dynamic value must pass through `_display`.
+
+- [ ] **Step 6: Implement output and advisory CLI boundary**
+
+Implement:
+
+```python
+def _write_summary(markdown: str, summary_path: str | None) -> None:
+    if not summary_path:
+        sys.stdout.write(markdown)
+        if not markdown.endswith("\n"):
+            sys.stdout.write("\n")
+        return
+    try:
+        with Path(summary_path).open("a", encoding="utf-8") as handle:
+            handle.write(markdown)
+            if not markdown.endswith("\n"):
+                handle.write("\n")
+    except OSError as exc:
+        print(
+            f"warning: unable to append to GITHUB_STEP_SUMMARY: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        sys.stdout.write(markdown)
+        if not markdown.endswith("\n"):
+            sys.stdout.write("\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(...)
+    parser.add_argument("--evidence-dir", required=True)
+    args = parser.parse_args(argv)
+    try:
+        markdown = render_summary(Path(args.evidence_dir))
+        _write_summary(markdown, os.environ.get("GITHUB_STEP_SUMMARY"))
+    except Exception as exc:  # advisory CLI boundary; do not mask smoke failures
+        print(f"warning: evidence summary unavailable: {type(exc).__name__}: {exc}", file=sys.stderr)
+    return 0
+```
+
+Keep the broad `Exception` catch only at the CLI boundary. Do not use broad catches inside core helpers when narrower exceptions are available.
+
+- [ ] **Step 7: Run focused GREEN tests**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py -q
+python tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py --evidence-dir /tmp/does-not-exist >/tmp/vz-summary.md
+```
+
+Expected: tests pass; the CLI exits `0` and writes an advisory missing-evidence summary.
+
+- [ ] **Step 8: Commit summarizer and tests**
+
+```bash
+git add tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py \
+  tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py
+git commit -m "tools: summarize VZ host smoke evidence"
+```
+
+---
+
+### Task 3: Wire Host-Gated Workflow Summary Step
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py`
+- Modify: `.github/workflows/vz-linux-host-gated.yml`
+
+- [ ] **Step 1: Add failing workflow contract tests**
+
+Add helper if needed:
+
+```python
+def _workflow_step_names(steps: list[dict[str, Any]]) -> list[str]:
+    return [str(step.get("name", "")) for step in steps]
+```
+
+Add a test:
+
+```python
+def test_vz_linux_host_gated_workflow_summarizes_evidence_before_uploads() -> None:
+    workflow = _load_workflow()
+    steps = workflow["jobs"]["vz-linux-host-gated-smoke"]["steps"]
+    names = _workflow_step_names(steps)
+
+    assert "Run managed host smoke" in names
+    assert "Summarize smoke evidence" in names
+    assert "Upload smoke evidence" in names
+    assert names.index("Run managed host smoke") < names.index("Summarize smoke evidence")
+    assert names.index("Summarize smoke evidence") < names.index("Upload smoke evidence")
+
+    summary_step = steps[names.index("Summarize smoke evidence")]
+    assert summary_step["if"] == "always()"
+    assert summary_step["shell"] == "bash"
+    run_block = summary_step["run"]
+    assert "summarize-host-e2e-evidence.py" in run_block
+    assert '${RUNNER_TEMP}/tldw-vz-helper-ci/evidence' in run_block
+    assert "GITHUB_STEP_SUMMARY" in run_block
+```
+
+Add a second test:
+
+```python
+def test_vz_linux_host_gated_workflow_summary_step_is_guarded() -> None:
+    workflow = _load_workflow()
+    steps = workflow["jobs"]["vz-linux-host-gated-smoke"]["steps"]
+    run_block = _workflow_step_run(steps, "Summarize smoke evidence")
+
+    assert "command -v python" in run_block
+    assert "command -v python3" in run_block
+    assert "[[ -f" in run_block
+    assert "exit 0" in run_block
+    assert "pip install" not in run_block
+    assert "${{ runner.temp }}/tldw-vz-helper-ci/**" not in run_block
+```
+
+- [ ] **Step 2: Run workflow tests to verify RED**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q
+```
+
+Expected: FAIL because the workflow has no summary step yet.
+
+- [ ] **Step 3: Add workflow step**
+
+Insert after `Run managed host smoke` and before `Upload smoke evidence`:
+
+```yaml
+      - name: Summarize smoke evidence
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          evidence_dir="${RUNNER_TEMP}/tldw-vz-helper-ci/evidence"
+          summary_script="tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py"
+          append_summary_warning() {
+            local message="$1"
+            if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+              {
+                echo "# VZ Linux Host Smoke Evidence Summary"
+                echo
+                echo "> Advisory only: ${message}"
+              } >> "${GITHUB_STEP_SUMMARY}" 2>/dev/null || true
+            fi
+            echo "warning: ${message}" >&2
+          }
+
+          python_bin=""
+          if command -v python >/dev/null 2>&1; then
+            python_bin="$(command -v python)"
+          elif command -v python3 >/dev/null 2>&1; then
+            python_bin="$(command -v python3)"
+          fi
+
+          if [[ ! -f "${summary_script}" ]]; then
+            append_summary_warning "evidence summary script is unavailable; inspect uploaded artifacts when present"
+            exit 0
+          fi
+          if [[ -z "${python_bin}" ]]; then
+            append_summary_warning "python interpreter is unavailable; inspect uploaded artifacts when present"
+            exit 0
+          fi
+
+          "${python_bin}" "${summary_script}" --evidence-dir "${evidence_dir}" || true
+          exit 0
+```
+
+Do not install dependencies. Keep `set +e`, explicit `exit 0`, and `|| true` so this advisory step cannot become the job's primary failure.
+
+- [ ] **Step 4: Run workflow GREEN tests**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit workflow wiring**
+
+```bash
+git add .github/workflows/vz-linux-host-gated.yml \
+  tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+git commit -m "ci: summarize VZ host smoke evidence"
+```
+
+---
+
+### Task 4: Update Docs, Backlog, And Final Verification
+
+**Files:**
+- Modify: `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`
+- Modify: `backlog/tasks/task-2381 - Add-advisory-VZ-host-smoke-evidence-summary.md`
+- Read: `Docs/superpowers/specs/2026-06-17-vz-host-gated-evidence-summary-advisory-design.md`
+- Read: `Docs/superpowers/plans/2026-06-17-vz-host-gated-evidence-summary-advisory.md`
+
+- [ ] **Step 1: Add policy docs test if not already covered**
+
+If the existing workflow policy tests do not cover the summary, add an assertion to `test_vz_linux_host_gated_policy_prioritizes_evidence_artifact` or a new focused test requiring:
+
+- `GitHub step summary`
+- `advisory`
+- `vz-linux-host-gated-evidence`
+- `vz-linux-host-gated-helper-logs`
+- evidence summary does not replace artifacts
+
+- [ ] **Step 2: Update host-gated policy**
+
+In `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`, document the operator order:
+
+1. Inspect the GitHub Actions step summary for an advisory run overview.
+2. Inspect `vz-linux-host-gated-evidence` for structured evidence files.
+3. Inspect `vz-linux-host-gated-helper-logs` for raw serial/helper logs only when needed.
+
+State that missing/malformed summary output in this first slice is advisory and should not change the smoke step result.
+
+- [ ] **Step 3: Run focused verification**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py \
+  tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q
+bash -n tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+python tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py --evidence-dir /tmp/does-not-exist >/tmp/tldw-vz-evidence-summary-smoke.md
+git diff --check
+```
+
+Expected:
+
+- summarizer tests pass
+- workflow/doc contract tests pass
+- smoke wrapper shell syntax remains valid
+- missing evidence CLI smoke exits `0`
+- diff check is clean
+
+- [ ] **Step 4: Run Bandit on touched production Python**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m bandit -r tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py -f json -o /tmp/bandit_vz_evidence_summary.json
+```
+
+Expected: no new security findings in the touched script. If Bandit is not installed, install/use the repo dev environment only if that is already the project pattern; otherwise record the exact skip reason in Backlog.
+
+- [ ] **Step 5: Update Backlog task**
+
+Update `TASK-2381`:
+
+- mark acceptance criteria complete when satisfied
+- record touched files
+- record exact verification commands and results
+- record Bandit result or skip reason
+- record real VZ smoke as not run because this is host-independent workflow/reporting only
+- add final summary
+
+- [ ] **Step 6: Commit docs/backlog/final verification**
+
+```bash
+git add Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md \
+  tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py \
+  Docs/superpowers/plans/2026-06-17-vz-host-gated-evidence-summary-advisory.md \
+  "backlog/tasks/task-2381 - Add-advisory-VZ-host-smoke-evidence-summary.md"
+git commit -m "docs: document VZ evidence summary workflow"
+```
+
+- [ ] **Step 7: Final branch review**
+
+Run:
+
+```bash
+git status --short
+git log --oneline dev..HEAD
+```
+
+Expected: clean worktree with a small stack of commits for spec, plan, tests/implementation, workflow, and docs/backlog.
+
+---
+
+## PR Checklist
+
+- Keep the PR scoped to advisory evidence summary only.
+- Do not run real VZ VM smoke as part of normal local verification unless the user explicitly asks for prepared-host validation.
+- Do not change host-gated triggers, self-hosted runner labels, artifact upload paths, helper lifecycle, image-store clone behavior, or evidence generation schema.
+- Include a human-owned `Change summary` placeholder in the PR body because AI-generated PRs are merge-blocked without a human-written rationale.

--- a/Docs/superpowers/plans/2026-06-17-vz-host-gated-evidence-summary-advisory.md
+++ b/Docs/superpowers/plans/2026-06-17-vz-host-gated-evidence-summary-advisory.md
@@ -8,6 +8,8 @@
 
 **Tech Stack:** Python 3 standard library, pytest, GitHub Actions YAML, Bash workflow shell, Markdown operator docs, Backlog.md task tracking.
 
+**Status:** Complete. Implemented, reviewed, verified, and recorded in `TASK-2381`.
+
 ---
 
 ## File Structure
@@ -37,7 +39,7 @@ Do not modify `tools/vz-linux-image/scripts/run-host-e2e-smoke.sh` in this slice
 - Read: `tools/vz-linux-image/scripts/run-host-e2e-smoke.sh`
 - Read: `Docs/superpowers/specs/2026-06-17-vz-host-gated-evidence-summary-advisory-design.md`
 
-- [ ] **Step 1: Create test scaffolding**
+- [x] **Step 1: Create test scaffolding**
 
 Create the test file with helpers that run the future script through `subprocess.run`:
 
@@ -87,7 +89,7 @@ def _run_summary(
     )
 ```
 
-- [ ] **Step 2: Add complete evidence test**
+- [x] **Step 2: Add complete evidence test**
 
 Add a test that creates all expected files and writes representative JSON:
 
@@ -163,7 +165,7 @@ def test_summary_reports_complete_evidence(tmp_path: Path) -> None:
         assert evidence_file in result.stdout
 ```
 
-- [ ] **Step 3: Add missing and partial evidence tests**
+- [x] **Step 3: Add missing and partial evidence tests**
 
 Add tests for:
 
@@ -178,7 +180,7 @@ Expected assertions:
 - output contains expected file names
 - no traceback is printed
 
-- [ ] **Step 4: Add malformed, oversized, and symlink tests**
+- [x] **Step 4: Add malformed, oversized, and symlink tests**
 
 Add tests for:
 
@@ -194,7 +196,7 @@ Expected assertions:
 - symlink target content is not included in output
 - no traceback is printed
 
-- [ ] **Step 5: Add summary output fallback tests**
+- [x] **Step 5: Add summary output fallback tests**
 
 Add tests for:
 
@@ -203,7 +205,7 @@ Add tests for:
 
 Use a directory path as `GITHUB_STEP_SUMMARY` for the unwritable target case, because opening a directory for append should fail portably.
 
-- [ ] **Step 6: Run tests to verify RED**
+- [x] **Step 6: Run tests to verify RED**
 
 Run:
 
@@ -222,7 +224,7 @@ Expected: FAIL because `tools/vz-linux-image/scripts/summarize-host-e2e-evidence
 - Create: `tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py`
 - Test: `tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py`
 
-- [ ] **Step 1: Add constants and dataclasses**
+- [x] **Step 1: Add constants and dataclasses**
 
 Create the script with standard-library-only imports:
 
@@ -262,7 +264,7 @@ class EvidenceFileStatus:
     size_bytes: int | None = None
 ```
 
-- [ ] **Step 2: Implement safe rendering helpers**
+- [x] **Step 2: Implement safe rendering helpers**
 
 Add helpers:
 
@@ -279,7 +281,7 @@ def _display(value: object, *, max_chars: int = DISPLAY_MAX_CHARS) -> str:
 
 Also add a helper that renders Markdown tables from rows and applies `_display` to every cell.
 
-- [ ] **Step 3: Implement direct-child evidence probing**
+- [x] **Step 3: Implement direct-child evidence probing**
 
 Implement:
 
@@ -322,7 +324,7 @@ If `_probe_evidence_dir` returns `False`, render the warning plus a missing
 checklist for all expected files and do not call `_probe_expected_file`. Use
 `lstat`; do not use recursive globbing; do not resolve or read through symlinks.
 
-- [ ] **Step 4: Implement bounded JSON loading**
+- [x] **Step 4: Implement bounded JSON loading**
 
 Implement:
 
@@ -348,7 +350,7 @@ def _load_evidence_json(
 
 Do not include raw JSON content in warnings.
 
-- [ ] **Step 5: Implement Markdown report generation**
+- [x] **Step 5: Implement Markdown report generation**
 
 Build `render_summary(evidence_dir: Path) -> str` with these sections:
 
@@ -373,7 +375,7 @@ Build `render_summary(evidence_dir: Path) -> str` with these sections:
 
 Every dynamic value must pass through `_display`.
 
-- [ ] **Step 6: Implement output and advisory CLI boundary**
+- [x] **Step 6: Implement output and advisory CLI boundary**
 
 Implement:
 
@@ -413,7 +415,7 @@ def main(argv: list[str] | None = None) -> int:
 
 Keep the broad `Exception` catch only at the CLI boundary. Do not use broad catches inside core helpers when narrower exceptions are available.
 
-- [ ] **Step 7: Run focused GREEN tests**
+- [x] **Step 7: Run focused GREEN tests**
 
 Run:
 
@@ -425,7 +427,7 @@ python tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py --evidence-di
 
 Expected: tests pass; the CLI exits `0` and writes an advisory missing-evidence summary.
 
-- [ ] **Step 8: Commit summarizer and tests**
+- [x] **Step 8: Commit summarizer and tests**
 
 ```bash
 git add tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py \
@@ -441,7 +443,7 @@ git commit -m "tools: summarize VZ host smoke evidence"
 - Modify: `tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py`
 - Modify: `.github/workflows/vz-linux-host-gated.yml`
 
-- [ ] **Step 1: Add failing workflow contract tests**
+- [x] **Step 1: Add failing workflow contract tests**
 
 Add helper if needed:
 
@@ -489,7 +491,7 @@ def test_vz_linux_host_gated_workflow_summary_step_is_guarded() -> None:
     assert "${{ runner.temp }}/tldw-vz-helper-ci/**" not in run_block
 ```
 
-- [ ] **Step 2: Run workflow tests to verify RED**
+- [x] **Step 2: Run workflow tests to verify RED**
 
 Run:
 
@@ -500,7 +502,7 @@ python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_w
 
 Expected: FAIL because the workflow has no summary step yet.
 
-- [ ] **Step 3: Add workflow step**
+- [x] **Step 3: Add workflow step**
 
 Insert after `Run managed host smoke` and before `Upload smoke evidence`:
 
@@ -546,7 +548,7 @@ Insert after `Run managed host smoke` and before `Upload smoke evidence`:
 
 Do not install dependencies. Keep `set +e`, explicit `exit 0`, and `|| true` so this advisory step cannot become the job's primary failure.
 
-- [ ] **Step 4: Run workflow GREEN tests**
+- [x] **Step 4: Run workflow GREEN tests**
 
 Run:
 
@@ -557,7 +559,7 @@ python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_w
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit workflow wiring**
+- [x] **Step 5: Commit workflow wiring**
 
 ```bash
 git add .github/workflows/vz-linux-host-gated.yml \
@@ -575,7 +577,7 @@ git commit -m "ci: summarize VZ host smoke evidence"
 - Read: `Docs/superpowers/specs/2026-06-17-vz-host-gated-evidence-summary-advisory-design.md`
 - Read: `Docs/superpowers/plans/2026-06-17-vz-host-gated-evidence-summary-advisory.md`
 
-- [ ] **Step 1: Add policy docs test if not already covered**
+- [x] **Step 1: Add policy docs test if not already covered**
 
 If the existing workflow policy tests do not cover the summary, add an assertion to `test_vz_linux_host_gated_policy_prioritizes_evidence_artifact` or a new focused test requiring:
 
@@ -585,7 +587,7 @@ If the existing workflow policy tests do not cover the summary, add an assertion
 - `vz-linux-host-gated-helper-logs`
 - evidence summary does not replace artifacts
 
-- [ ] **Step 2: Update host-gated policy**
+- [x] **Step 2: Update host-gated policy**
 
 In `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`, document the operator order:
 
@@ -595,7 +597,7 @@ In `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`, document the oper
 
 State that missing/malformed summary output in this first slice is advisory and should not change the smoke step result.
 
-- [ ] **Step 3: Run focused verification**
+- [x] **Step 3: Run focused verification**
 
 Run:
 
@@ -616,7 +618,7 @@ Expected:
 - missing evidence CLI smoke exits `0`
 - diff check is clean
 
-- [ ] **Step 4: Run Bandit on touched production Python**
+- [x] **Step 4: Run Bandit on touched production Python**
 
 Run:
 
@@ -627,7 +629,7 @@ python -m bandit -r tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py 
 
 Expected: no new security findings in the touched script. If Bandit is not installed, install/use the repo dev environment only if that is already the project pattern; otherwise record the exact skip reason in Backlog.
 
-- [ ] **Step 5: Update Backlog task**
+- [x] **Step 5: Update Backlog task**
 
 Update `TASK-2381`:
 
@@ -638,7 +640,7 @@ Update `TASK-2381`:
 - record real VZ smoke as not run because this is host-independent workflow/reporting only
 - add final summary
 
-- [ ] **Step 6: Commit docs/backlog/final verification**
+- [x] **Step 6: Commit docs/backlog/final verification**
 
 ```bash
 git add Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md \
@@ -648,7 +650,7 @@ git add Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md \
 git commit -m "docs: document VZ evidence summary workflow"
 ```
 
-- [ ] **Step 7: Final branch review**
+- [x] **Step 7: Final branch review**
 
 Run:
 

--- a/Docs/superpowers/specs/2026-06-17-vz-host-gated-evidence-summary-advisory-design.md
+++ b/Docs/superpowers/specs/2026-06-17-vz-host-gated-evidence-summary-advisory-design.md
@@ -1,0 +1,187 @@
+# VZ Host-Gated Evidence Summary Advisory Design
+
+**Date:** 2026-06-17
+**Status:** Design slice
+**Task:** `TASK-2381`
+
+## Goal
+
+Add an advisory, host-independent summary step for VZ Linux host-gated smoke
+evidence. Operators should be able to open the GitHub Actions run and see a
+small Markdown summary of what evidence was produced, which files are missing,
+what the smoke wrapper reported as its final exit code, and where to look next.
+
+This is a reporting layer only. It must not change helper startup, VM
+execution, image-store cloning, evidence generation, artifact upload semantics,
+or the host-gated trust model.
+
+## Current State
+
+The smoke wrapper writes structured evidence under:
+
+```text
+<runtime-dir>/evidence
+```
+
+The host-gated workflow uploads that directory as
+`vz-linux-host-gated-evidence`, and uploads narrowed helper logs separately as
+`vz-linux-host-gated-helper-logs`.
+
+That gives operators the right artifacts, but the first diagnostic step is
+still manual: download the evidence artifact, inspect JSON/hash/status files,
+then decide whether raw helper logs are needed. A GitHub step summary can make
+the common case faster without changing any VZ execution path.
+
+## Design
+
+Add a portable evidence summarizer script that accepts an evidence directory and
+writes Markdown to the GitHub step summary file when available:
+
+```bash
+python tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py \
+  --evidence-dir "${RUNNER_TEMP}/tldw-vz-helper-ci/evidence"
+```
+
+The implementation should default to `$GITHUB_STEP_SUMMARY` when it is set and
+append to that file for GitHub Actions runs. It should fall back to stdout for
+local/operator runs. The script should be usable on any host with Python and
+must not require Virtualization.framework, a prepared VZ bundle, or a running
+helper.
+
+The summarizer is a read-only diagnostic tool. It must not create, modify, or
+delete the evidence directory or any evidence file.
+
+The workflow should run the summarizer with `if: always()` after the smoke
+wrapper has had a chance to finalize evidence and before or near the artifact
+upload steps. The summary step must exit `0` in this first advisory slice, even
+when the evidence directory is missing or malformed. GitHub Actions will still
+preserve the primary smoke failure because the failing smoke step remains the
+job's authoritative result.
+
+## Evidence Contract
+
+The summary should treat these files as expected evidence:
+
+- `host-smoke-evidence.json`
+- `source-bundle-hashes-before.txt`
+- `source-bundle-hashes-after.txt`
+- `run-bundle-hashes.txt`
+- `runtime-paths.txt`
+- `cleanup-status.txt`
+
+The implementation should inspect only these direct child paths under the
+configured evidence directory. It should use `lstat`-style checks, skip
+symlinks and non-regular files with warnings, and cap JSON reads so a corrupt
+or malicious file cannot exhaust memory in an operator diagnostic path.
+
+When `host-smoke-evidence.json` is present and valid, the summary should report:
+
+- evidence directory path
+- evidence file presence checklist
+- final smoke exit code when recorded
+- phase outcomes when recorded
+- cleanup status when recorded
+- run/source hash file presence
+- runtime path pointers when recorded
+- artifact/log pointers when recorded
+
+The summary should not parse or embed raw serial logs, helper stdout/stderr, or
+guest command output. It may mention paths, file names, sizes, and status values
+already present in the evidence bundle.
+
+## Error Handling
+
+Missing evidence directory:
+
+- write a warning summary that evidence is unavailable
+- list the expected evidence directory
+- explain that this may indicate an early setup/preflight failure
+- exit `0`
+
+Missing `host-smoke-evidence.json` with some files present:
+
+- write a warning summary that structured metadata is missing
+- still show the file presence checklist
+- point operators to the evidence artifact and helper-log artifact
+- exit `0`
+
+Malformed JSON:
+
+- write a warning summary that JSON could not be parsed
+- include only the parse error class/message, not raw file contents
+- still show the file presence checklist
+- exit `0`
+
+Unexpected filesystem errors while probing evidence:
+
+- degrade to a warning row for the affected file/path
+- avoid recursive directory traversal outside the configured evidence directory
+- treat symlinks, directories, devices, and oversized JSON as unavailable
+  evidence rather than reading through them
+- exit `0` in advisory mode
+
+## Workflow Contract
+
+The host-gated workflow should preserve this order:
+
+1. Run managed host smoke.
+2. Run advisory evidence summary with `if: always()`.
+3. Upload `vz-linux-host-gated-evidence` with `if: always()`.
+4. Upload `vz-linux-host-gated-helper-logs` with `if: always()`.
+
+The summary step must not use broad runtime globs and must not change the
+artifact paths. It should read only the configured evidence directory.
+
+## Risk Review
+
+- Advisory mode can hide defects if operators treat warnings as success.
+  Mitigation: label the summary clearly as advisory and keep the smoke step as
+  the only authoritative pass/fail result in this slice.
+- Summary output can leak sensitive data if it embeds logs. Mitigation: never
+  include raw log contents, helper stdout/stderr, guest output, or environment
+  variables.
+- A diagnostic reader can become a filesystem probe if it follows arbitrary
+  links. Mitigation: inspect only known direct child evidence files, skip
+  symlinks/non-regular files, and avoid recursive traversal.
+- Missing evidence after a smoke failure is still useful signal, but failing the
+  summary step would obscure the original failure. Mitigation: always exit `0`
+  for malformed/missing evidence until a later strict-mode design is approved.
+- Parsing too much evidence schema now would make future schema changes harder.
+  Mitigation: use optional reads with graceful fallbacks and treat unknown JSON
+  fields as ignored.
+- Running the summary before evidence finalization would produce false missing
+  warnings. Mitigation: place it after the smoke wrapper command, which owns
+  evidence finalization through its exit trap.
+
+## Tests
+
+Portable tests should cover:
+
+- complete evidence directory produces Markdown with final exit code, phase
+  outcomes, cleanup status, expected file checklist, and artifact/log pointers
+- missing evidence directory produces a warning summary and exits `0`
+- malformed `host-smoke-evidence.json` produces a warning summary, keeps the
+  file checklist, and exits `0`
+- partial evidence without JSON still summarizes present/missing files
+- workflow contract includes an always-run summary step pointed at
+  `${{ runner.temp }}/tldw-vz-helper-ci/evidence`
+
+Real VZ execution remains host-gated/manual and is not required for normal CI.
+
+## Non-Goals
+
+- Failing CI based on evidence summary quality.
+- Downloading or parsing GitHub artifacts through the GitHub API.
+- Parsing raw serial/helper logs.
+- Changing smoke evidence schema or wrapper evidence finalization.
+- Changing helper lifecycle, VM provisioning, image-store clone behavior, or
+  cleanup semantics.
+- Adding dashboards, PR comments, or automatic issue updates.
+
+## Future Work
+
+A later strict-mode slice can make missing or malformed evidence fail
+host-gated runs once prepared-host evidence quality is stable. Another later
+slice can aggregate evidence summaries into the prepared-host evidence tracker,
+but this advisory slice should stay limited to local files and GitHub step
+summary output.

--- a/Docs/superpowers/specs/2026-06-17-vz-host-gated-evidence-summary-advisory-design.md
+++ b/Docs/superpowers/specs/2026-06-17-vz-host-gated-evidence-summary-advisory-design.md
@@ -51,6 +51,10 @@ helper.
 The summarizer is a read-only diagnostic tool. It must not create, modify, or
 delete the evidence directory or any evidence file.
 
+Summary output is diagnostic, not authoritative. If appending to
+`$GITHUB_STEP_SUMMARY` fails, the script should write the same summary to stdout
+or stderr, emit a warning, and still exit `0` in advisory mode.
+
 The workflow should run the summarizer with `if: always()` after the smoke
 wrapper has had a chance to finalize evidence and before or near the artifact
 upload steps. The summary step must exit `0` in this first advisory slice, even
@@ -72,7 +76,9 @@ The summary should treat these files as expected evidence:
 The implementation should inspect only these direct child paths under the
 configured evidence directory. It should use `lstat`-style checks, skip
 symlinks and non-regular files with warnings, and cap JSON reads so a corrupt
-or malicious file cannot exhaust memory in an operator diagnostic path.
+or malicious file cannot exhaust memory in an operator diagnostic path. The JSON
+read cap should be explicit in code, with `1 MiB` as the initial ceiling because
+the current evidence schema is small.
 
 When `host-smoke-evidence.json` is present and valid, the summary should report:
 
@@ -89,6 +95,11 @@ The summary should not parse or embed raw serial logs, helper stdout/stderr, or
 guest command output. It may mention paths, file names, sizes, and status values
 already present in the evidence bundle.
 
+All values read from evidence JSON or filesystem metadata should be treated as
+external input for rendering purposes. The Markdown renderer should escape table
+cell separators, normalize newlines, cap displayed field lengths, and avoid
+passing raw HTML through to the GitHub summary.
+
 ## Error Handling
 
 Missing evidence directory:
@@ -96,6 +107,13 @@ Missing evidence directory:
 - write a warning summary that evidence is unavailable
 - list the expected evidence directory
 - explain that this may indicate an early setup/preflight failure
+- exit `0`
+
+Evidence path exists but is not a directory:
+
+- write a warning summary that the configured evidence path is unusable
+- do not descend into or read through symlinks, regular files, devices, or other
+  non-directory paths
 - exit `0`
 
 Missing `host-smoke-evidence.json` with some files present:
@@ -120,6 +138,13 @@ Unexpected filesystem errors while probing evidence:
   evidence rather than reading through them
 - exit `0` in advisory mode
 
+Unexpected implementation errors:
+
+- catch at the CLI boundary
+- print a concise advisory warning without a traceback by default
+- exit `0` in advisory mode so the summary step cannot mask the primary smoke
+  result
+
 ## Workflow Contract
 
 The host-gated workflow should preserve this order:
@@ -132,6 +157,16 @@ The host-gated workflow should preserve this order:
 The summary step must not use broad runtime globs and must not change the
 artifact paths. It should read only the configured evidence directory.
 
+Because the summary step uses `if: always()`, it can run after checkout or
+Python setup failures. The workflow shell should therefore guard the
+summarizer invocation:
+
+- if the summarizer script is present, run it with `python` or `python3`,
+  whichever is available
+- if the script or interpreter is unavailable, append a short advisory warning
+  directly to `$GITHUB_STEP_SUMMARY` when possible and exit `0`
+- do not install dependencies or run repository setup from the summary step
+
 ## Risk Review
 
 - Advisory mode can hide defects if operators treat warnings as success.
@@ -143,9 +178,15 @@ artifact paths. It should read only the configured evidence directory.
 - A diagnostic reader can become a filesystem probe if it follows arbitrary
   links. Mitigation: inspect only known direct child evidence files, skip
   symlinks/non-regular files, and avoid recursive traversal.
+- Markdown output can be shaped by evidence values. Mitigation: escape Markdown
+  table separators, normalize newlines, cap displayed values, and avoid raw HTML
+  passthrough.
 - Missing evidence after a smoke failure is still useful signal, but failing the
   summary step would obscure the original failure. Mitigation: always exit `0`
   for malformed/missing evidence until a later strict-mode design is approved.
+- Always-run workflow steps may execute after checkout or setup failures.
+  Mitigation: guard missing script/interpreter cases in shell and emit a direct
+  advisory summary without failing the job.
 - Parsing too much evidence schema now would make future schema changes harder.
   Mitigation: use optional reads with graceful fallbacks and treat unknown JSON
   fields as ignored.
@@ -162,9 +203,14 @@ Portable tests should cover:
 - missing evidence directory produces a warning summary and exits `0`
 - malformed `host-smoke-evidence.json` produces a warning summary, keeps the
   file checklist, and exits `0`
+- oversized JSON and symlink/non-regular evidence files are warned about and not
+  read through
+- unwritable or missing `$GITHUB_STEP_SUMMARY` falls back without a non-zero exit
 - partial evidence without JSON still summarizes present/missing files
 - workflow contract includes an always-run summary step pointed at
   `${{ runner.temp }}/tldw-vz-helper-ci/evidence`
+- workflow contract guards missing summarizer script or missing interpreter so
+  early checkout/setup failures are not masked
 
 Real VZ execution remains host-gated/manual and is not required for normal CI.
 

--- a/backlog/tasks/task-2381 - Add-advisory-VZ-host-smoke-evidence-summary.md
+++ b/backlog/tasks/task-2381 - Add-advisory-VZ-host-smoke-evidence-summary.md
@@ -9,6 +9,16 @@ labels:
 - ci
 - diagnostics
 priority: Medium
+documentation:
+- Docs/superpowers/specs/2026-06-17-vz-host-gated-evidence-summary-advisory-design.md
+- Docs/superpowers/plans/2026-06-17-vz-host-gated-evidence-summary-advisory.md
+- Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+modified_files:
+- .github/workflows/vz-linux-host-gated.yml
+- tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py
+- tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py
+- tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+- backlog/tasks/task-2381 - Add-advisory-VZ-host-smoke-evidence-summary.md
 ---
 
 ## Description
@@ -57,7 +67,7 @@ Add an advisory-first host-gated evidence summary path for VZ Linux smoke runs. 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added an advisory VZ host smoke evidence summarizer, wired it into the host-gated workflow, and documented the operator contract. The summarizer is read-only, exits 0 for missing/malformed evidence, appends to GitHub step summary when available, and uses descriptor-safe path handling plus allowlisted JSON rendering to avoid symlink traversal or raw log leakage.
+Added PR #2388 review follow-up fixes after rebasing onto origin/dev: concise summarizer docstrings, macOS root temp alias handling for /tmp and /var without allowing final/arbitrary symlink traversal, explicit workflow warning when the advisory summarizer exits non-zero, and focused regression tests for those cases. Verification: focused pytest suite passed with 42 tests; Bandit on the summarizer reported 0 findings; git diff --check passed; advisory missing-evidence smoke command succeeded with venv Python.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2381 - Add-advisory-VZ-host-smoke-evidence-summary.md
+++ b/backlog/tasks/task-2381 - Add-advisory-VZ-host-smoke-evidence-summary.md
@@ -40,6 +40,8 @@ Add an advisory-first host-gated evidence summary path for VZ Linux smoke runs. 
 - Follow-up spec review found and addressed two masking risks: `if: always()` can run after checkout/setup failure when the script or interpreter is missing, and `$GITHUB_STEP_SUMMARY` write failures could otherwise make the advisory step fail. The spec now requires shell guards, stdout/stderr fallback, advisory exit `0`, Markdown sanitization, non-directory evidence path handling, and tests for these cases.
 - Subagent spec review was not spawned because the available multi-agent tool requires explicit user authorization for delegation.
 - Planning verification: `git diff --check`; Bandit not run for the design-only docs/backlog commit.
+- Implementation plan drafted at `Docs/superpowers/plans/2026-06-17-vz-host-gated-evidence-summary-advisory.md`.
+- Local plan review tightened the handoff by replacing an implicit evidence-directory probe with exact `lstat` handling for missing, symlinked, non-directory, and unreadable evidence roots. Plan reviewer subagent was not spawned because delegation requires explicit user authorization in this environment.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2381 - Add-advisory-VZ-host-smoke-evidence-summary.md
+++ b/backlog/tasks/task-2381 - Add-advisory-VZ-host-smoke-evidence-summary.md
@@ -1,0 +1,58 @@
+---
+id: TASK-2381
+title: Add advisory VZ host smoke evidence summary
+status: In Progress
+labels:
+- sandbox
+- vz_linux
+- host-gated
+- ci
+- diagnostics
+priority: Medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add an advisory-first host-gated evidence summary path for VZ Linux smoke runs. The summary should read structured smoke evidence when available, write operator-friendly GitHub step-summary output, and never mask the primary smoke result in this first slice.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A design spec captures advisory-only summary behavior, malformed/missing evidence handling, and non-goals before implementation.
+- [ ] #2 The host-gated workflow can run an always-run advisory evidence summary step after smoke/evidence generation.
+- [ ] #3 The summary reports evidence present/missing, required file presence, phase outcomes, final exit code, cleanup status, and artifact/log pointers when available.
+- [ ] #4 Malformed or missing evidence produces warnings and exit 0 in this first advisory slice.
+- [ ] #5 Focused tests cover complete evidence, missing evidence, malformed JSON, and workflow wiring without requiring a real VZ host.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Write and commit the approved design spec. 2. Review the spec for issues before implementation planning. 3. After approval, create an implementation plan and implement TDD-first in a separate commit/PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Design spec drafted at `Docs/superpowers/specs/2026-06-17-vz-host-gated-evidence-summary-advisory-design.md`.
+- Local design review tightened the read-only contract: append-only GitHub step summary output, no evidence mutation, direct-child-only probes, symlink/non-regular-file skips, and bounded JSON reads.
+- Subagent spec review was not spawned because the available multi-agent tool requires explicit user authorization for delegation.
+- Planning verification: `git diff --check`; Bandit not run for the design-only docs/backlog commit.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2381 - Add-advisory-VZ-host-smoke-evidence-summary.md
+++ b/backlog/tasks/task-2381 - Add-advisory-VZ-host-smoke-evidence-summary.md
@@ -37,6 +37,7 @@ Add an advisory-first host-gated evidence summary path for VZ Linux smoke runs. 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 - Design spec drafted at `Docs/superpowers/specs/2026-06-17-vz-host-gated-evidence-summary-advisory-design.md`.
 - Local design review tightened the read-only contract: append-only GitHub step summary output, no evidence mutation, direct-child-only probes, symlink/non-regular-file skips, and bounded JSON reads.
+- Follow-up spec review found and addressed two masking risks: `if: always()` can run after checkout/setup failure when the script or interpreter is missing, and `$GITHUB_STEP_SUMMARY` write failures could otherwise make the advisory step fail. The spec now requires shell guards, stdout/stderr fallback, advisory exit `0`, Markdown sanitization, non-directory evidence path handling, and tests for these cases.
 - Subagent spec review was not spawned because the available multi-agent tool requires explicit user authorization for delegation.
 - Planning verification: `git diff --check`; Bandit not run for the design-only docs/backlog commit.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-2381 - Add-advisory-VZ-host-smoke-evidence-summary.md
+++ b/backlog/tasks/task-2381 - Add-advisory-VZ-host-smoke-evidence-summary.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2381
 title: Add advisory VZ host smoke evidence summary
-status: In Progress
+status: Done
 labels:
 - sandbox
 - vz_linux

--- a/backlog/tasks/task-2381 - Add-advisory-VZ-host-smoke-evidence-summary.md
+++ b/backlog/tasks/task-2381 - Add-advisory-VZ-host-smoke-evidence-summary.md
@@ -19,11 +19,11 @@ Add an advisory-first host-gated evidence summary path for VZ Linux smoke runs. 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A design spec captures advisory-only summary behavior, malformed/missing evidence handling, and non-goals before implementation.
-- [ ] #2 The host-gated workflow can run an always-run advisory evidence summary step after smoke/evidence generation.
-- [ ] #3 The summary reports evidence present/missing, required file presence, phase outcomes, final exit code, cleanup status, and artifact/log pointers when available.
-- [ ] #4 Malformed or missing evidence produces warnings and exit 0 in this first advisory slice.
-- [ ] #5 Focused tests cover complete evidence, missing evidence, malformed JSON, and workflow wiring without requiring a real VZ host.
+- [x] #1 A design spec captures advisory-only summary behavior, malformed/missing evidence handling, and non-goals before implementation.
+- [x] #2 The host-gated workflow can run an always-run advisory evidence summary step after smoke/evidence generation.
+- [x] #3 The summary reports evidence present/missing, required file presence, phase outcomes, final exit code, cleanup status, and artifact/log pointers when available.
+- [x] #4 Malformed or missing evidence produces warnings and exit 0 in this first advisory slice.
+- [x] #5 Focused tests cover complete evidence, missing evidence, malformed JSON, and workflow wiring without requiring a real VZ host.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -42,20 +42,30 @@ Add an advisory-first host-gated evidence summary path for VZ Linux smoke runs. 
 - Planning verification: `git diff --check`; Bandit not run for the design-only docs/backlog commit.
 - Implementation plan drafted at `Docs/superpowers/plans/2026-06-17-vz-host-gated-evidence-summary-advisory.md`.
 - Local plan review tightened the handoff by replacing an implicit evidence-directory probe with exact `lstat` handling for missing, symlinked, non-directory, and unreadable evidence roots. Plan reviewer subagent was not spawned because delegation requires explicit user authorization in this environment.
+- Implemented `tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py` and `tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py`. Review loops hardened descriptor-safe evidence reads, intermediate symlink handling, malformed nested metadata filtering, and scalar-only JSON rendering.
+- Wired `.github/workflows/vz-linux-host-gated.yml` to run `Summarize smoke evidence` with `if: always()` after managed smoke and before artifact uploads. Updated `tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py` to cover ordering, guards, advisory behavior, and docs policy terms.
+- Updated `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md` to document the advisory GitHub step summary as the first inline diagnostic surface without replacing smoke results or artifacts.
+- Verification: `python -m pytest tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q` passed with 40 tests and 6 existing warnings.
+- Verification: `bash -n tools/vz-linux-image/scripts/run-host-e2e-smoke.sh` passed.
+- Verification: `python tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py --evidence-dir /private/tmp/tldw-vz-evidence-missing >/tmp/tldw-vz-evidence-summary-smoke.md` exited 0 and wrote the advisory missing-evidence summary.
+- Verification: `python -m bandit -r tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py -f json -o /tmp/bandit_vz_evidence_summary_final_docs.json` completed with 0 findings.
+- Verification: `git diff --check` passed.
+- Discarded check: `bash -n .github/workflows/vz-linux-host-gated.yml` is not a valid YAML validation command and failed on workflow syntax; workflow YAML is parsed by the contract tests.
+- Real VZ VM smoke was not run for this slice because the change is host-independent advisory reporting and workflow contract wiring.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Added an advisory VZ host smoke evidence summarizer, wired it into the host-gated workflow, and documented the operator contract. The summarizer is read-only, exits 0 for missing/malformed evidence, appends to GitHub step summary when available, and uses descriptor-safe path handling plus allowlisted JSON rendering to avoid symlink traversal or raw log leakage.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+++ b/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
@@ -56,6 +56,11 @@ def _workflow_step_run(steps: list[dict[str, Any]], step_name: str) -> str:
     pytest.fail(f"Workflow step not found: {step_name}")
 
 
+def _workflow_step_names(steps: list[dict[str, Any]]) -> list[str]:
+    """Return workflow step names as strings for ordering assertions."""
+    return [str(step.get("name", "")) for step in steps]
+
+
 def _workflow_run_blocks(steps: list[dict[str, Any]]) -> str:
     """Return all non-empty workflow run blocks joined for broad contract assertions."""
     return "\n".join(
@@ -162,6 +167,42 @@ def test_vz_linux_host_gated_workflow_passes_explicit_evidence_dir() -> None:
 
     assert 'evidence_dir="${runtime_dir}/evidence"' in smoke_step_run  # nosec B101
     assert '--evidence-dir "${evidence_dir}"' in smoke_step_run  # nosec B101
+
+
+def test_vz_linux_host_gated_workflow_summarizes_evidence_before_uploads() -> None:
+    """The advisory summary should run after smoke finalization and before upload."""
+    workflow = _load_workflow()
+    steps = workflow["jobs"]["vz-linux-host-gated-smoke"]["steps"]
+    names = _workflow_step_names(steps)
+
+    assert "Run managed host smoke" in names  # nosec B101
+    assert "Summarize smoke evidence" in names  # nosec B101
+    assert "Upload smoke evidence" in names  # nosec B101
+    assert names.index("Run managed host smoke") < names.index("Summarize smoke evidence")  # nosec B101
+    assert names.index("Summarize smoke evidence") < names.index("Upload smoke evidence")  # nosec B101
+
+    summary_step = steps[names.index("Summarize smoke evidence")]
+    assert summary_step["if"] == "always()"  # nosec B101
+    assert summary_step["shell"] == "bash"  # nosec B101
+    run_block = summary_step["run"]
+    assert "tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py" in run_block  # nosec B101
+    assert '${RUNNER_TEMP}/tldw-vz-helper-ci/evidence' in run_block  # nosec B101
+    assert "GITHUB_STEP_SUMMARY" in run_block  # nosec B101
+
+
+def test_vz_linux_host_gated_workflow_summary_step_is_guarded() -> None:
+    """The advisory summary should degrade to warnings without changing job failure."""
+    workflow = _load_workflow()
+    steps = workflow["jobs"]["vz-linux-host-gated-smoke"]["steps"]
+    run_block = _workflow_step_run(steps, "Summarize smoke evidence")
+
+    assert "command -v python" in run_block  # nosec B101
+    assert "command -v python3" in run_block  # nosec B101
+    assert "[[ -f" in run_block  # nosec B101
+    assert "exit 0" in run_block  # nosec B101
+    assert "|| true" in run_block  # nosec B101
+    assert "pip install" not in run_block  # nosec B101
+    assert "${{ runner.temp }}/tldw-vz-helper-ci/**" not in run_block  # nosec B101
 
 
 def test_vz_linux_host_gated_workflow_failure_drills_are_manual_opt_in() -> None:

--- a/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+++ b/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
@@ -200,7 +200,9 @@ def test_vz_linux_host_gated_workflow_summary_step_is_guarded() -> None:
     assert "command -v python3" in run_block  # nosec B101
     assert "[[ -f" in run_block  # nosec B101
     assert "exit 0" in run_block  # nosec B101
-    assert "|| true" in run_block  # nosec B101
+    assert '"${python_bin}" "${summary_script}" --evidence-dir "${evidence_dir}" || true' not in run_block  # nosec B101
+    assert "summary_status=$?" in run_block  # nosec B101
+    assert "append_summary_warning \"evidence summary failed" in run_block  # nosec B101
     assert "pip install" not in run_block  # nosec B101
     assert "${{ runner.temp }}/tldw-vz-helper-ci/**" not in run_block  # nosec B101
 

--- a/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+++ b/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
@@ -305,8 +305,11 @@ def test_vz_linux_host_gated_policy_prioritizes_evidence_artifact() -> None:
     policy = _normalized_text(POLICY_PATH)
 
     for required_term in (
+        "GitHub step summary",
+        "advisory",
         "vz-linux-host-gated-evidence",
         "vz-linux-host-gated-helper-logs",
+        "does not replace artifacts",
         "Inspect `vz-linux-host-gated-evidence` first",
         "raw helper logs",
         "must not include disposable image-store bundles or rootfs clones",

--- a/tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py
+++ b/tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import html
 import json
 import os
@@ -31,6 +32,7 @@ RUNTIME_POINTER_KEYS = (
     "helper_pid_file",
     "evidence_dir",
 )
+MARKDOWN_ESCAPE_CHARS = frozenset("\\`[]()!|")
 
 
 @dataclass(frozen=True)
@@ -46,7 +48,10 @@ def _display(value: object, *, max_chars: int = DISPLAY_MAX_CHARS) -> str:
     text = "" if value is None else str(value)
     text = " ".join(text.replace("\r", "\n").splitlines())
     text = html.escape(text, quote=False)
-    text = text.replace("|", "\\|")
+    text = "".join(
+        f"\\{character}" if character in MARKDOWN_ESCAPE_CHARS else character
+        for character in text
+    )
     if len(text) > max_chars:
         return text[: max_chars - 1] + "..."
     return text
@@ -146,6 +151,41 @@ def _probe_expected_files(evidence_dir: Path) -> dict[str, EvidenceFileStatus]:
     return {name: _probe_expected_file(evidence_dir, name) for name in EXPECTED_EVIDENCE_FILES}
 
 
+def _open_json_flags() -> int:
+    flags = os.O_RDONLY
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    return flags
+
+
+def _read_json_bytes_from_descriptor(path: Path) -> tuple[bytes | None, list[str]]:
+    fd: int | None = None
+    try:
+        fd = os.open(path, _open_json_flags())
+        metadata = os.fstat(fd)
+        if not stat.S_ISREG(metadata.st_mode):
+            return None, ["warning: structured metadata skipped: opened path is not a regular file"]
+        if metadata.st_size > JSON_MAX_BYTES:
+            return None, [f"warning: structured metadata skipped: exceeds {JSON_MAX_BYTES} bytes"]
+        with os.fdopen(fd, "rb") as handle:
+            fd = None
+            raw_bytes = handle.read(JSON_MAX_BYTES + 1)
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            return None, ["warning: structured metadata open failed: symlink skipped"]
+        return None, [f"warning: structured metadata open/read failed: {type(exc).__name__}: {exc}"]
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+    if len(raw_bytes) > JSON_MAX_BYTES:
+        return None, [f"warning: structured metadata skipped: exceeds {JSON_MAX_BYTES} bytes"]
+    return raw_bytes, []
+
+
 def _load_evidence_json(
     evidence_dir: Path,
     file_statuses: dict[str, EvidenceFileStatus],
@@ -156,14 +196,16 @@ def _load_evidence_json(
     if json_status.size_bytes is not None and json_status.size_bytes > JSON_MAX_BYTES:
         return None, [f"warning: structured metadata skipped: exceeds {JSON_MAX_BYTES} bytes"]
 
+    raw_bytes, read_warnings = _read_json_bytes_from_descriptor(evidence_dir / "host-smoke-evidence.json")
+    if read_warnings:
+        return None, read_warnings
+    if raw_bytes is None:
+        return None, ["warning: structured metadata unavailable: descriptor read returned no data"]
+
     try:
-        with (evidence_dir / "host-smoke-evidence.json").open("rb") as handle:
-            raw_bytes = handle.read(JSON_MAX_BYTES + 1)
-        if len(raw_bytes) > JSON_MAX_BYTES:
-            return None, [f"warning: structured metadata skipped: exceeds {JSON_MAX_BYTES} bytes"]
         raw_text = raw_bytes.decode("utf-8")
         payload = json.loads(raw_text)
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         return None, [f"warning: structured metadata parse failed: {type(exc).__name__}: {exc}"]
     if not isinstance(payload, dict):
         return None, ["warning: structured metadata parse failed: top-level JSON is not an object"]

--- a/tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py
+++ b/tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py
@@ -33,6 +33,12 @@ RUNTIME_POINTER_KEYS = (
     "evidence_dir",
 )
 MARKDOWN_ESCAPE_CHARS = frozenset("\\`[]()!|")
+CLEANUP_KEYS = (
+    "status",
+    "helper_pid",
+    "helper_running_after_cleanup",
+    "socket_present_after_cleanup",
+)
 
 
 @dataclass(frozen=True)
@@ -277,7 +283,7 @@ def _render_phase_outcomes(payload: dict[str, Any] | None) -> str:
                 )
             )
         else:
-            rows.append((phase, details, "", ""))
+            rows.append((phase, "invalid or unavailable", "", ""))
     return "## Phase Outcomes\n\n" + _table(("Phase", "Status", "Exit code", "Timestamp"), rows)
 
 
@@ -287,7 +293,9 @@ def _render_cleanup(payload: dict[str, Any] | None) -> str:
     cleanup = payload.get("cleanup")
     if not isinstance(cleanup, dict) or not cleanup:
         return ""
-    rows = [(key, value) for key, value in cleanup.items()]
+    rows = [(key, cleanup[key]) for key in CLEANUP_KEYS if key in cleanup]
+    if not rows:
+        return ""
     return "## Cleanup Status\n\n" + _table(("Field", "Value"), rows)
 
 
@@ -329,8 +337,8 @@ def _render_log_artifacts(payload: dict[str, Any] | None) -> str:
                     artifact.get("sha256", ""),
                 )
             )
-        else:
-            rows.append((artifact, "", ""))
+    if not rows:
+        return ""
     return "## Log Artifact Metadata\n\n" + _table(("Path", "Size bytes", "SHA-256"), rows)
 
 

--- a/tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py
+++ b/tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py
@@ -23,6 +23,7 @@ EXPECTED_EVIDENCE_FILES = (
 )
 JSON_MAX_BYTES = 1024 * 1024
 DISPLAY_MAX_CHARS = 240
+INVALID_METADATA_VALUE = "invalid or unavailable"
 RUNTIME_POINTER_KEYS = (
     "source_bundle_path",
     "run_bundle_path",
@@ -81,6 +82,12 @@ def _display(value: object, *, max_chars: int = DISPLAY_MAX_CHARS) -> str:
     if len(text) > max_chars:
         return text[: max_chars - 1] + "..."
     return text
+
+
+def _metadata_scalar(value: Any) -> object:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return INVALID_METADATA_VALUE
 
 
 def _table(headers: tuple[str, ...], rows: list[tuple[object, ...]]) -> str:
@@ -431,7 +438,7 @@ def _render_run_overview(payload: dict[str, Any] | None) -> str:
     rows: list[tuple[object, object]] = []
     for key in ("smoke_run_id", "final_exit_code", "created_at", "schema_version"):
         if key in payload:
-            rows.append((key, payload[key]))
+            rows.append((key, _metadata_scalar(payload[key])))
     if not rows:
         return "## Structured Run Metadata\n\nStructured metadata was parsed, but no known run overview fields were present."
     return "## Structured Run Metadata\n\n" + _table(("Field", "Value"), rows)
@@ -450,13 +457,13 @@ def _render_phase_outcomes(payload: dict[str, Any] | None) -> str:
             rows.append(
                 (
                     phase,
-                    details.get("status", ""),
-                    details.get("exit_code", ""),
-                    details.get("timestamp", ""),
+                    _metadata_scalar(details.get("status", "")),
+                    _metadata_scalar(details.get("exit_code", "")),
+                    _metadata_scalar(details.get("timestamp", "")),
                 )
             )
         else:
-            rows.append((phase, "invalid or unavailable", "", ""))
+            rows.append((phase, INVALID_METADATA_VALUE, "", ""))
     return "## Phase Outcomes\n\n" + _table(("Phase", "Status", "Exit code", "Timestamp"), rows)
 
 
@@ -466,7 +473,7 @@ def _render_cleanup(payload: dict[str, Any] | None) -> str:
     cleanup = payload.get("cleanup")
     if not isinstance(cleanup, dict) or not cleanup:
         return ""
-    rows = [(key, cleanup[key]) for key in CLEANUP_KEYS if key in cleanup]
+    rows = [(key, _metadata_scalar(cleanup[key])) for key in CLEANUP_KEYS if key in cleanup]
     if not rows:
         return ""
     return "## Cleanup Status\n\n" + _table(("Field", "Value"), rows)
@@ -475,7 +482,7 @@ def _render_cleanup(payload: dict[str, Any] | None) -> str:
 def _render_runtime_pointers(payload: dict[str, Any] | None) -> str:
     if not payload:
         return ""
-    rows = [(key, payload[key]) for key in RUNTIME_POINTER_KEYS if key in payload]
+    rows = [(key, _metadata_scalar(payload[key])) for key in RUNTIME_POINTER_KEYS if key in payload]
     if not rows:
         return ""
     return "## Runtime And Artifact Pointers\n\n" + _table(("Field", "Value"), rows)
@@ -487,7 +494,11 @@ def _render_recorded_evidence_paths(payload: dict[str, Any] | None) -> str:
     evidence_files = payload.get("evidence_files")
     if not isinstance(evidence_files, dict) or not evidence_files:
         return ""
-    rows = [(name, evidence_files.get(name, "")) for name in EXPECTED_EVIDENCE_FILES if name in evidence_files]
+    rows = [
+        (name, _metadata_scalar(evidence_files.get(name, "")))
+        for name in EXPECTED_EVIDENCE_FILES
+        if name in evidence_files
+    ]
     if not rows:
         return ""
     return "## Recorded Evidence File Paths\n\n" + _table(("File", "Recorded path"), rows)
@@ -505,9 +516,9 @@ def _render_log_artifacts(payload: dict[str, Any] | None) -> str:
         if isinstance(artifact, dict):
             rows.append(
                 (
-                    artifact.get("path", ""),
-                    artifact.get("size_bytes", ""),
-                    artifact.get("sha256", ""),
+                    _metadata_scalar(artifact.get("path", "")),
+                    _metadata_scalar(artifact.get("size_bytes", "")),
+                    _metadata_scalar(artifact.get("sha256", "")),
                 )
             )
     if not rows:

--- a/tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py
+++ b/tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py
@@ -127,24 +127,53 @@ def _missing_evidence_dir_warning(evidence_dir: Path) -> str:
     )
 
 
-def _classify_evidence_dir_open_error(evidence_dir: Path, exc: OSError) -> str:
-    if isinstance(exc, FileNotFoundError):
+def _classify_evidence_dir_open_error(
+    evidence_dir: Path,
+    exc: OSError,
+    *,
+    parent_fd: int | None = None,
+    component: str | None = None,
+) -> str:
+    if parent_fd is not None and component is not None:
+        try:
+            metadata = os.stat(component, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            return _missing_evidence_dir_warning(evidence_dir)
+        except OSError:
+            pass
+        else:
+            if stat.S_ISLNK(metadata.st_mode):
+                return f"warning: evidence directory is a symlink or contains a symlink and was not read: {evidence_dir}"
+            if not stat.S_ISDIR(metadata.st_mode):
+                return f"warning: evidence path is not a directory and was not read: {evidence_dir}"
+    if isinstance(exc, FileNotFoundError) or exc.errno == errno.ENOENT:
         return _missing_evidence_dir_warning(evidence_dir)
     if exc.errno == errno.ELOOP:
-        return f"warning: evidence directory is a symlink and was not read: {evidence_dir}"
-    try:
-        metadata = evidence_dir.lstat()
-    except FileNotFoundError:
-        return _missing_evidence_dir_warning(evidence_dir)
-    except OSError:
-        return f"warning: evidence directory cannot be safely opened: {type(exc).__name__}: {exc}"
-    if stat.S_ISLNK(metadata.st_mode):
-        return f"warning: evidence directory is a symlink and was not read: {evidence_dir}"
-    if not stat.S_ISDIR(metadata.st_mode):
+        return f"warning: evidence directory is a symlink or contains a symlink and was not read: {evidence_dir}"
+    if exc.errno == errno.ENOTDIR:
         return f"warning: evidence path is not a directory and was not read: {evidence_dir}"
     if exc.errno in {errno.EACCES, errno.EPERM}:
         return f"warning: evidence directory is unreadable and was not read: {evidence_dir}"
-    return f"warning: evidence directory cannot be safely opened: {type(exc).__name__}: {exc}"
+    return f"warning: evidence directory path is unsafe or unavailable: {type(exc).__name__}: {exc}"
+
+
+def _evidence_dir_components(evidence_dir: Path) -> tuple[str, list[str], str | None]:
+    parts = evidence_dir.parts
+    if evidence_dir.is_absolute():
+        start_path = os.sep
+        raw_components = list(parts[1:])
+    else:
+        start_path = "."
+        raw_components = list(parts)
+
+    components: list[str] = []
+    for component in raw_components:
+        if component in ("", "."):
+            continue
+        if component == "..":
+            return start_path, [], "warning: evidence directory path contains unsafe '..' component and was not read"
+        components.append(component)
+    return start_path, components, None
 
 
 def _open_evidence_dir(evidence_dir: Path) -> EvidenceDirHandle:
@@ -160,9 +189,13 @@ def _open_evidence_dir(evidence_dir: Path) -> EvidenceDirHandle:
             ],
         )
 
+    start_path, components, component_warning = _evidence_dir_components(evidence_dir)
+    if component_warning is not None:
+        return EvidenceDirHandle(path=evidence_dir, fd=None, warnings=[component_warning])
+
     fd: int | None = None
     try:
-        fd = os.open(evidence_dir, _open_dir_flags())
+        fd = os.open(start_path, _open_dir_flags())
         metadata = os.fstat(fd)
     except OSError as exc:
         if fd is not None:
@@ -179,6 +212,41 @@ def _open_evidence_dir(evidence_dir: Path) -> EvidenceDirHandle:
             fd=None,
             warnings=[f"warning: evidence path is not a directory and was not read: {evidence_dir}"],
         )
+    for component in components:
+        next_fd: int | None = None
+        try:
+            next_fd = os.open(component, _open_dir_flags(), dir_fd=fd)
+        except OSError as exc:
+            warning = _classify_evidence_dir_open_error(
+                evidence_dir,
+                exc,
+                parent_fd=fd,
+                component=component,
+            )
+            os.close(fd)
+            return EvidenceDirHandle(
+                path=evidence_dir,
+                fd=None,
+                warnings=[warning],
+            )
+        os.close(fd)
+        fd = next_fd
+        try:
+            metadata = os.fstat(fd)
+        except OSError as exc:
+            os.close(fd)
+            return EvidenceDirHandle(
+                path=evidence_dir,
+                fd=None,
+                warnings=[f"warning: evidence directory cannot be safely opened: {type(exc).__name__}: {exc}"],
+            )
+        if not stat.S_ISDIR(metadata.st_mode):
+            os.close(fd)
+            return EvidenceDirHandle(
+                path=evidence_dir,
+                fd=None,
+                warnings=[f"warning: evidence path is not a directory and was not read: {evidence_dir}"],
+            )
     return EvidenceDirHandle(path=evidence_dir, fd=fd, warnings=[])
 
 

--- a/tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py
+++ b/tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import stat
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+EXPECTED_EVIDENCE_FILES = (
+    "host-smoke-evidence.json",
+    "source-bundle-hashes-before.txt",
+    "source-bundle-hashes-after.txt",
+    "run-bundle-hashes.txt",
+    "runtime-paths.txt",
+    "cleanup-status.txt",
+)
+JSON_MAX_BYTES = 1024 * 1024
+DISPLAY_MAX_CHARS = 240
+RUNTIME_POINTER_KEYS = (
+    "source_bundle_path",
+    "run_bundle_path",
+    "image_store_root",
+    "socket_path",
+    "serial_log_dir",
+    "helper_pid_file",
+    "evidence_dir",
+)
+
+
+@dataclass(frozen=True)
+class EvidenceFileStatus:
+    name: str
+    present: bool
+    readable: bool
+    reason: str
+    size_bytes: int | None = None
+
+
+def _display(value: object, *, max_chars: int = DISPLAY_MAX_CHARS) -> str:
+    text = "" if value is None else str(value)
+    text = " ".join(text.replace("\r", "\n").splitlines())
+    text = html.escape(text, quote=False)
+    text = text.replace("|", "\\|")
+    if len(text) > max_chars:
+        return text[: max_chars - 1] + "..."
+    return text
+
+
+def _table(headers: tuple[str, ...], rows: list[tuple[object, ...]]) -> str:
+    rendered = [
+        "| " + " | ".join(_display(header) for header in headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+    ]
+    for row in rows:
+        padded = row + ("",) * (len(headers) - len(row))
+        rendered.append("| " + " | ".join(_display(cell) for cell in padded[: len(headers)]) + " |")
+    return "\n".join(rendered)
+
+
+def _probe_evidence_dir(evidence_dir: Path) -> tuple[bool, list[str]]:
+    try:
+        metadata = evidence_dir.lstat()
+    except FileNotFoundError:
+        return False, [f"warning: evidence directory is missing: {evidence_dir}"]
+    except OSError as exc:
+        return False, [f"warning: evidence directory cannot be inspected: {type(exc).__name__}: {exc}"]
+    if stat.S_ISLNK(metadata.st_mode):
+        return False, [f"warning: evidence directory is a symlink and was not read: {evidence_dir}"]
+    if not stat.S_ISDIR(metadata.st_mode):
+        return False, [f"warning: evidence path is not a directory and was not read: {evidence_dir}"]
+    if not os.access(evidence_dir, os.R_OK | os.X_OK):
+        return False, [f"warning: evidence directory is unreadable and was not read: {evidence_dir}"]
+    return True, []
+
+
+def _missing_file_statuses(reason: str) -> dict[str, EvidenceFileStatus]:
+    return {
+        name: EvidenceFileStatus(
+            name=name,
+            present=False,
+            readable=False,
+            reason=reason,
+        )
+        for name in EXPECTED_EVIDENCE_FILES
+    }
+
+
+def _probe_expected_file(evidence_dir: Path, name: str) -> EvidenceFileStatus:
+    path = evidence_dir / name
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return EvidenceFileStatus(name=name, present=False, readable=False, reason="missing")
+    except OSError as exc:
+        return EvidenceFileStatus(
+            name=name,
+            present=False,
+            readable=False,
+            reason=f"cannot inspect: {type(exc).__name__}",
+        )
+    if stat.S_ISLNK(metadata.st_mode):
+        return EvidenceFileStatus(
+            name=name,
+            present=True,
+            readable=False,
+            reason="symlink skipped",
+            size_bytes=metadata.st_size,
+        )
+    if not stat.S_ISREG(metadata.st_mode):
+        return EvidenceFileStatus(
+            name=name,
+            present=True,
+            readable=False,
+            reason="non-regular file skipped",
+            size_bytes=metadata.st_size,
+        )
+    if not os.access(path, os.R_OK):
+        return EvidenceFileStatus(
+            name=name,
+            present=True,
+            readable=False,
+            reason="unreadable",
+            size_bytes=metadata.st_size,
+        )
+    return EvidenceFileStatus(
+        name=name,
+        present=True,
+        readable=True,
+        reason="ok",
+        size_bytes=metadata.st_size,
+    )
+
+
+def _probe_expected_files(evidence_dir: Path) -> dict[str, EvidenceFileStatus]:
+    return {name: _probe_expected_file(evidence_dir, name) for name in EXPECTED_EVIDENCE_FILES}
+
+
+def _load_evidence_json(
+    evidence_dir: Path,
+    file_statuses: dict[str, EvidenceFileStatus],
+) -> tuple[dict[str, Any] | None, list[str]]:
+    json_status = file_statuses["host-smoke-evidence.json"]
+    if not json_status.readable:
+        return None, [f"warning: structured metadata unavailable: {json_status.reason}"]
+    if json_status.size_bytes is not None and json_status.size_bytes > JSON_MAX_BYTES:
+        return None, [f"warning: structured metadata skipped: exceeds {JSON_MAX_BYTES} bytes"]
+
+    try:
+        with (evidence_dir / "host-smoke-evidence.json").open("rb") as handle:
+            raw_bytes = handle.read(JSON_MAX_BYTES + 1)
+        if len(raw_bytes) > JSON_MAX_BYTES:
+            return None, [f"warning: structured metadata skipped: exceeds {JSON_MAX_BYTES} bytes"]
+        raw_text = raw_bytes.decode("utf-8")
+        payload = json.loads(raw_text)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return None, [f"warning: structured metadata parse failed: {type(exc).__name__}: {exc}"]
+    if not isinstance(payload, dict):
+        return None, ["warning: structured metadata parse failed: top-level JSON is not an object"]
+    return payload, []
+
+
+def _file_status_warnings(file_statuses: dict[str, EvidenceFileStatus]) -> list[str]:
+    warnings: list[str] = []
+    for status in file_statuses.values():
+        if status.present and not status.readable:
+            warnings.append(f"warning: {status.name} unavailable: {status.reason}")
+    return warnings
+
+
+def _render_warnings(warnings: list[str]) -> str:
+    if not warnings:
+        return ""
+    lines = ["## Warnings"]
+    lines.extend(f"- {_display(warning)}" for warning in warnings)
+    return "\n".join(lines)
+
+
+def _render_file_checklist(file_statuses: dict[str, EvidenceFileStatus]) -> str:
+    rows = [
+        (
+            status.name,
+            "yes" if status.present else "no",
+            "yes" if status.readable else "no",
+            status.reason,
+            status.size_bytes if status.size_bytes is not None else "-",
+        )
+        for status in file_statuses.values()
+    ]
+    return "## Expected File Checklist\n\n" + _table(
+        ("file", "present", "readable", "reason", "size bytes"),
+        rows,
+    )
+
+
+def _render_run_overview(payload: dict[str, Any] | None) -> str:
+    if payload is None:
+        return "## Structured Run Metadata\n\nStructured metadata was not parsed; inspect the checklist and uploaded artifacts."
+
+    rows: list[tuple[object, object]] = []
+    for key in ("smoke_run_id", "final_exit_code", "created_at", "schema_version"):
+        if key in payload:
+            rows.append((key, payload[key]))
+    if not rows:
+        return "## Structured Run Metadata\n\nStructured metadata was parsed, but no known run overview fields were present."
+    return "## Structured Run Metadata\n\n" + _table(("Field", "Value"), rows)
+
+
+def _render_phase_outcomes(payload: dict[str, Any] | None) -> str:
+    if not payload:
+        return ""
+    phases = payload.get("phases")
+    if not isinstance(phases, dict) or not phases:
+        return ""
+
+    rows: list[tuple[object, object, object, object]] = []
+    for phase, details in phases.items():
+        if isinstance(details, dict):
+            rows.append(
+                (
+                    phase,
+                    details.get("status", ""),
+                    details.get("exit_code", ""),
+                    details.get("timestamp", ""),
+                )
+            )
+        else:
+            rows.append((phase, details, "", ""))
+    return "## Phase Outcomes\n\n" + _table(("Phase", "Status", "Exit code", "Timestamp"), rows)
+
+
+def _render_cleanup(payload: dict[str, Any] | None) -> str:
+    if not payload:
+        return ""
+    cleanup = payload.get("cleanup")
+    if not isinstance(cleanup, dict) or not cleanup:
+        return ""
+    rows = [(key, value) for key, value in cleanup.items()]
+    return "## Cleanup Status\n\n" + _table(("Field", "Value"), rows)
+
+
+def _render_runtime_pointers(payload: dict[str, Any] | None) -> str:
+    if not payload:
+        return ""
+    rows = [(key, payload[key]) for key in RUNTIME_POINTER_KEYS if key in payload]
+    if not rows:
+        return ""
+    return "## Runtime And Artifact Pointers\n\n" + _table(("Field", "Value"), rows)
+
+
+def _render_recorded_evidence_paths(payload: dict[str, Any] | None) -> str:
+    if not payload:
+        return ""
+    evidence_files = payload.get("evidence_files")
+    if not isinstance(evidence_files, dict) or not evidence_files:
+        return ""
+    rows = [(name, evidence_files.get(name, "")) for name in EXPECTED_EVIDENCE_FILES if name in evidence_files]
+    if not rows:
+        return ""
+    return "## Recorded Evidence File Paths\n\n" + _table(("File", "Recorded path"), rows)
+
+
+def _render_log_artifacts(payload: dict[str, Any] | None) -> str:
+    if not payload:
+        return ""
+    log_artifacts = payload.get("log_artifacts")
+    if not isinstance(log_artifacts, list) or not log_artifacts:
+        return ""
+
+    rows: list[tuple[object, object, object]] = []
+    for artifact in log_artifacts:
+        if isinstance(artifact, dict):
+            rows.append(
+                (
+                    artifact.get("path", ""),
+                    artifact.get("size_bytes", ""),
+                    artifact.get("sha256", ""),
+                )
+            )
+        else:
+            rows.append((artifact, "", ""))
+    return "## Log Artifact Metadata\n\n" + _table(("Path", "Size bytes", "SHA-256"), rows)
+
+
+def render_summary(evidence_dir: Path) -> str:
+    warnings: list[str] = []
+    evidence_dir_ok, dir_warnings = _probe_evidence_dir(evidence_dir)
+    warnings.extend(dir_warnings)
+
+    if evidence_dir_ok:
+        file_statuses = _probe_expected_files(evidence_dir)
+        warnings.extend(_file_status_warnings(file_statuses))
+        payload, json_warnings = _load_evidence_json(evidence_dir, file_statuses)
+        warnings.extend(json_warnings)
+    else:
+        file_statuses = _missing_file_statuses("missing: evidence directory was not inspected")
+        payload = None
+
+    sections = [
+        "# VZ Linux Host Smoke Evidence Summary",
+        "> Advisory only: this summary is diagnostic and does not determine the host smoke job result.",
+        f"**Evidence directory:** `{_display(evidence_dir)}`",
+        _render_warnings(warnings),
+        _render_run_overview(payload),
+        _render_file_checklist(file_statuses),
+        _render_phase_outcomes(payload),
+        _render_cleanup(payload),
+        _render_runtime_pointers(payload),
+        _render_recorded_evidence_paths(payload),
+        _render_log_artifacts(payload),
+        (
+            "> Primary artifact: `vz-linux-host-gated-evidence`. "
+            "Raw-log fallback: `vz-linux-host-gated-helper-logs`."
+        ),
+    ]
+    return "\n\n".join(section for section in sections if section).rstrip() + "\n"
+
+
+def _write_summary(markdown: str, summary_path: str | None) -> None:
+    if not summary_path:
+        sys.stdout.write(markdown)
+        if not markdown.endswith("\n"):
+            sys.stdout.write("\n")
+        return
+    try:
+        with Path(summary_path).open("a", encoding="utf-8") as handle:
+            handle.write(markdown)
+            if not markdown.endswith("\n"):
+                handle.write("\n")
+    except OSError as exc:
+        print(
+            f"warning: unable to append to GITHUB_STEP_SUMMARY: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        sys.stdout.write(markdown)
+        if not markdown.endswith("\n"):
+            sys.stdout.write("\n")
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace | None:
+    parser = argparse.ArgumentParser(
+        description="Render an advisory Markdown summary for VZ Linux host smoke evidence.",
+    )
+    parser.add_argument("--evidence-dir", required=True, help="Path to the evidence directory to summarize.")
+    try:
+        return parser.parse_args(argv)
+    except SystemExit as exc:
+        if exc.code not in (0, None):
+            print("warning: invalid evidence summary arguments; no summary was rendered", file=sys.stderr)
+        return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        args = _parse_args(argv)
+        if args is None:
+            return 0
+        markdown = render_summary(Path(args.evidence_dir))
+        _write_summary(markdown, os.environ.get("GITHUB_STEP_SUMMARY"))
+    except Exception as exc:  # advisory CLI boundary; do not mask smoke failures
+        print(f"warning: evidence summary unavailable: {type(exc).__name__}: {exc}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py
+++ b/tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py
@@ -50,6 +50,26 @@ class EvidenceFileStatus:
     size_bytes: int | None = None
 
 
+@dataclass
+class EvidenceDirHandle:
+    path: Path
+    fd: int | None
+    warnings: list[str]
+
+    def __enter__(self) -> "EvidenceDirHandle":
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if self.fd is None:
+            return
+        fd = self.fd
+        self.fd = None
+        os.close(fd)
+
+
 def _display(value: object, *, max_chars: int = DISPLAY_MAX_CHARS) -> str:
     text = "" if value is None else str(value)
     text = " ".join(text.replace("\r", "\n").splitlines())
@@ -75,24 +95,91 @@ def _table(headers: tuple[str, ...], rows: list[tuple[object, ...]]) -> str:
 
 
 def _probe_evidence_dir(evidence_dir: Path) -> tuple[bool, list[str]]:
+    with _open_evidence_dir(evidence_dir) as evidence_root:
+        return evidence_root.fd is not None, evidence_root.warnings
+
+
+def _dir_fd_operations_available() -> bool:
+    supports_dir_fd = getattr(os, "supports_dir_fd", set())
+    supports_follow_symlinks = getattr(os, "supports_follow_symlinks", set())
+    return (
+        os.open in supports_dir_fd
+        and os.stat in supports_dir_fd
+        and os.access in supports_dir_fd
+        and os.stat in supports_follow_symlinks
+        and os.access in supports_follow_symlinks
+        and hasattr(os, "O_NOFOLLOW")
+    )
+
+
+def _open_dir_flags() -> int:
+    flags = os.O_RDONLY
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_DIRECTORY", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    return flags
+
+
+def _missing_evidence_dir_warning(evidence_dir: Path) -> str:
+    return (
+        f"warning: evidence directory is missing: {evidence_dir}. "
+        "This may indicate an early setup/preflight failure."
+    )
+
+
+def _classify_evidence_dir_open_error(evidence_dir: Path, exc: OSError) -> str:
+    if isinstance(exc, FileNotFoundError):
+        return _missing_evidence_dir_warning(evidence_dir)
+    if exc.errno == errno.ELOOP:
+        return f"warning: evidence directory is a symlink and was not read: {evidence_dir}"
     try:
         metadata = evidence_dir.lstat()
     except FileNotFoundError:
-        return False, [
-            (
-                f"warning: evidence directory is missing: {evidence_dir}. "
-                "This may indicate an early setup/preflight failure."
-            )
-        ]
-    except OSError as exc:
-        return False, [f"warning: evidence directory cannot be inspected: {type(exc).__name__}: {exc}"]
+        return _missing_evidence_dir_warning(evidence_dir)
+    except OSError:
+        return f"warning: evidence directory cannot be safely opened: {type(exc).__name__}: {exc}"
     if stat.S_ISLNK(metadata.st_mode):
-        return False, [f"warning: evidence directory is a symlink and was not read: {evidence_dir}"]
+        return f"warning: evidence directory is a symlink and was not read: {evidence_dir}"
     if not stat.S_ISDIR(metadata.st_mode):
-        return False, [f"warning: evidence path is not a directory and was not read: {evidence_dir}"]
-    if not os.access(evidence_dir, os.R_OK | os.X_OK):
-        return False, [f"warning: evidence directory is unreadable and was not read: {evidence_dir}"]
-    return True, []
+        return f"warning: evidence path is not a directory and was not read: {evidence_dir}"
+    if exc.errno in {errno.EACCES, errno.EPERM}:
+        return f"warning: evidence directory is unreadable and was not read: {evidence_dir}"
+    return f"warning: evidence directory cannot be safely opened: {type(exc).__name__}: {exc}"
+
+
+def _open_evidence_dir(evidence_dir: Path) -> EvidenceDirHandle:
+    if not _dir_fd_operations_available():
+        return EvidenceDirHandle(
+            path=evidence_dir,
+            fd=None,
+            warnings=[
+                (
+                    "warning: evidence directory was not read because safe directory "
+                    "file descriptor operations are unavailable on this platform"
+                )
+            ],
+        )
+
+    fd: int | None = None
+    try:
+        fd = os.open(evidence_dir, _open_dir_flags())
+        metadata = os.fstat(fd)
+    except OSError as exc:
+        if fd is not None:
+            os.close(fd)
+        return EvidenceDirHandle(
+            path=evidence_dir,
+            fd=None,
+            warnings=[_classify_evidence_dir_open_error(evidence_dir, exc)],
+        )
+    if not stat.S_ISDIR(metadata.st_mode):
+        os.close(fd)
+        return EvidenceDirHandle(
+            path=evidence_dir,
+            fd=None,
+            warnings=[f"warning: evidence path is not a directory and was not read: {evidence_dir}"],
+        )
+    return EvidenceDirHandle(path=evidence_dir, fd=fd, warnings=[])
 
 
 def _missing_file_statuses(reason: str) -> dict[str, EvidenceFileStatus]:
@@ -107,10 +194,16 @@ def _missing_file_statuses(reason: str) -> dict[str, EvidenceFileStatus]:
     }
 
 
-def _probe_expected_file(evidence_dir: Path, name: str) -> EvidenceFileStatus:
-    path = evidence_dir / name
+def _probe_expected_file(evidence_root: EvidenceDirHandle, name: str) -> EvidenceFileStatus:
+    if evidence_root.fd is None:
+        return EvidenceFileStatus(
+            name=name,
+            present=False,
+            readable=False,
+            reason="missing: evidence directory was not inspected",
+        )
     try:
-        metadata = path.lstat()
+        metadata = os.stat(name, dir_fd=evidence_root.fd, follow_symlinks=False)
     except FileNotFoundError:
         return EvidenceFileStatus(name=name, present=False, readable=False, reason="missing")
     except OSError as exc:
@@ -136,7 +229,7 @@ def _probe_expected_file(evidence_dir: Path, name: str) -> EvidenceFileStatus:
             reason="non-regular file skipped",
             size_bytes=metadata.st_size,
         )
-    if not os.access(path, os.R_OK):
+    if not _can_read_child(evidence_root, name):
         return EvidenceFileStatus(
             name=name,
             present=True,
@@ -153,21 +246,33 @@ def _probe_expected_file(evidence_dir: Path, name: str) -> EvidenceFileStatus:
     )
 
 
-def _probe_expected_files(evidence_dir: Path) -> dict[str, EvidenceFileStatus]:
-    return {name: _probe_expected_file(evidence_dir, name) for name in EXPECTED_EVIDENCE_FILES}
+def _probe_expected_files(evidence_root: EvidenceDirHandle) -> dict[str, EvidenceFileStatus]:
+    return {name: _probe_expected_file(evidence_root, name) for name in EXPECTED_EVIDENCE_FILES}
 
 
 def _open_json_flags() -> int:
     flags = os.O_RDONLY
     flags |= getattr(os, "O_CLOEXEC", 0)
     flags |= getattr(os, "O_NOFOLLOW", 0)
+    flags |= getattr(os, "O_NONBLOCK", 0)
     return flags
 
 
-def _read_json_bytes_from_descriptor(path: Path) -> tuple[bytes | None, list[str]]:
+def _can_read_child(evidence_root: EvidenceDirHandle, name: str) -> bool:
+    if evidence_root.fd is None:
+        return False
+    try:
+        return os.access(name, os.R_OK, dir_fd=evidence_root.fd, follow_symlinks=False)
+    except (NotImplementedError, OSError):
+        return False
+
+
+def _read_json_bytes_from_descriptor(evidence_root: EvidenceDirHandle) -> tuple[bytes | None, list[str]]:
+    if evidence_root.fd is None:
+        return None, ["warning: structured metadata unavailable: evidence directory was not inspected"]
     fd: int | None = None
     try:
-        fd = os.open(path, _open_json_flags())
+        fd = os.open("host-smoke-evidence.json", _open_json_flags(), dir_fd=evidence_root.fd)
         metadata = os.fstat(fd)
         if not stat.S_ISREG(metadata.st_mode):
             return None, ["warning: structured metadata skipped: opened path is not a regular file"]
@@ -193,7 +298,7 @@ def _read_json_bytes_from_descriptor(path: Path) -> tuple[bytes | None, list[str
 
 
 def _load_evidence_json(
-    evidence_dir: Path,
+    evidence_root: EvidenceDirHandle,
     file_statuses: dict[str, EvidenceFileStatus],
 ) -> tuple[dict[str, Any] | None, list[str]]:
     json_status = file_statuses["host-smoke-evidence.json"]
@@ -202,7 +307,7 @@ def _load_evidence_json(
     if json_status.size_bytes is not None and json_status.size_bytes > JSON_MAX_BYTES:
         return None, [f"warning: structured metadata skipped: exceeds {JSON_MAX_BYTES} bytes"]
 
-    raw_bytes, read_warnings = _read_json_bytes_from_descriptor(evidence_dir / "host-smoke-evidence.json")
+    raw_bytes, read_warnings = _read_json_bytes_from_descriptor(evidence_root)
     if read_warnings:
         return None, read_warnings
     if raw_bytes is None:
@@ -344,17 +449,16 @@ def _render_log_artifacts(payload: dict[str, Any] | None) -> str:
 
 def render_summary(evidence_dir: Path) -> str:
     warnings: list[str] = []
-    evidence_dir_ok, dir_warnings = _probe_evidence_dir(evidence_dir)
-    warnings.extend(dir_warnings)
-
-    if evidence_dir_ok:
-        file_statuses = _probe_expected_files(evidence_dir)
-        warnings.extend(_file_status_warnings(file_statuses))
-        payload, json_warnings = _load_evidence_json(evidence_dir, file_statuses)
-        warnings.extend(json_warnings)
-    else:
-        file_statuses = _missing_file_statuses("missing: evidence directory was not inspected")
-        payload = None
+    with _open_evidence_dir(evidence_dir) as evidence_root:
+        warnings.extend(evidence_root.warnings)
+        if evidence_root.fd is not None:
+            file_statuses = _probe_expected_files(evidence_root)
+            warnings.extend(_file_status_warnings(file_statuses))
+            payload, json_warnings = _load_evidence_json(evidence_root, file_statuses)
+            warnings.extend(json_warnings)
+        else:
+            file_statuses = _missing_file_statuses("missing: evidence directory was not inspected")
+            payload = None
 
     sections = [
         "# VZ Linux Host Smoke Evidence Summary",

--- a/tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py
+++ b/tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py
@@ -67,7 +67,12 @@ def _probe_evidence_dir(evidence_dir: Path) -> tuple[bool, list[str]]:
     try:
         metadata = evidence_dir.lstat()
     except FileNotFoundError:
-        return False, [f"warning: evidence directory is missing: {evidence_dir}"]
+        return False, [
+            (
+                f"warning: evidence directory is missing: {evidence_dir}. "
+                "This may indicate an early setup/preflight failure."
+            )
+        ]
     except OSError as exc:
         return False, [f"warning: evidence directory cannot be inspected: {type(exc).__name__}: {exc}"]
     if stat.S_ISLNK(metadata.st_mode):

--- a/tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py
+++ b/tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+"""Render advisory GitHub summaries for VZ Linux host smoke evidence."""
+
 from __future__ import annotations
 
 import argparse
@@ -44,6 +46,8 @@ CLEANUP_KEYS = (
 
 @dataclass(frozen=True)
 class EvidenceFileStatus:
+    """Readability status for one expected smoke evidence file."""
+
     name: str
     present: bool
     readable: bool
@@ -53,17 +57,22 @@ class EvidenceFileStatus:
 
 @dataclass
 class EvidenceDirHandle:
+    """Descriptor-pinned evidence directory handle plus advisory warnings."""
+
     path: Path
     fd: int | None
     warnings: list[str]
 
     def __enter__(self) -> "EvidenceDirHandle":
+        """Return this handle for context-manager use."""
         return self
 
     def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        """Close the descriptor when leaving a context-manager block."""
         self.close()
 
     def close(self) -> None:
+        """Close the pinned directory descriptor if it is still open."""
         if self.fd is None:
             return
         fd = self.fd
@@ -72,6 +81,7 @@ class EvidenceDirHandle:
 
 
 def _display(value: object, *, max_chars: int = DISPLAY_MAX_CHARS) -> str:
+    """Escape and truncate dynamic values before rendering Markdown."""
     text = "" if value is None else str(value)
     text = " ".join(text.replace("\r", "\n").splitlines())
     text = html.escape(text, quote=False)
@@ -85,12 +95,14 @@ def _display(value: object, *, max_chars: int = DISPLAY_MAX_CHARS) -> str:
 
 
 def _metadata_scalar(value: Any) -> object:
+    """Return only scalar metadata values that are safe for compact tables."""
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
     return INVALID_METADATA_VALUE
 
 
 def _table(headers: tuple[str, ...], rows: list[tuple[object, ...]]) -> str:
+    """Render a small Markdown table with escaped cells."""
     rendered = [
         "| " + " | ".join(_display(header) for header in headers) + " |",
         "| " + " | ".join("---" for _ in headers) + " |",
@@ -102,11 +114,13 @@ def _table(headers: tuple[str, ...], rows: list[tuple[object, ...]]) -> str:
 
 
 def _probe_evidence_dir(evidence_dir: Path) -> tuple[bool, list[str]]:
+    """Probe whether an evidence directory can be safely opened."""
     with _open_evidence_dir(evidence_dir) as evidence_root:
         return evidence_root.fd is not None, evidence_root.warnings
 
 
 def _dir_fd_operations_available() -> bool:
+    """Return whether this platform supports descriptor-relative safe reads."""
     supports_dir_fd = getattr(os, "supports_dir_fd", set())
     supports_follow_symlinks = getattr(os, "supports_follow_symlinks", set())
     return (
@@ -120,6 +134,7 @@ def _dir_fd_operations_available() -> bool:
 
 
 def _open_dir_flags() -> int:
+    """Build flags for opening directories without following symlinks."""
     flags = os.O_RDONLY
     flags |= getattr(os, "O_CLOEXEC", 0)
     flags |= getattr(os, "O_DIRECTORY", 0)
@@ -128,6 +143,7 @@ def _open_dir_flags() -> int:
 
 
 def _missing_evidence_dir_warning(evidence_dir: Path) -> str:
+    """Format the advisory warning used when the evidence directory is absent."""
     return (
         f"warning: evidence directory is missing: {evidence_dir}. "
         "This may indicate an early setup/preflight failure."
@@ -141,6 +157,7 @@ def _classify_evidence_dir_open_error(
     parent_fd: int | None = None,
     component: str | None = None,
 ) -> str:
+    """Classify descriptor-open failures without exposing evidence contents."""
     if parent_fd is not None and component is not None:
         try:
             metadata = os.stat(component, dir_fd=parent_fd, follow_symlinks=False)
@@ -165,6 +182,7 @@ def _classify_evidence_dir_open_error(
 
 
 def _evidence_dir_components(evidence_dir: Path) -> tuple[str, list[str], str | None]:
+    """Split an evidence path into safe directory-walk components."""
     parts = evidence_dir.parts
     if evidence_dir.is_absolute():
         start_path = os.sep
@@ -183,7 +201,34 @@ def _evidence_dir_components(evidence_dir: Path) -> tuple[str, list[str], str | 
     return start_path, components, None
 
 
+def _normalize_macos_temp_alias(evidence_dir: Path) -> Path:
+    """Rewrite macOS root temp aliases while preserving symlink rejection elsewhere."""
+    if not evidence_dir.is_absolute():
+        return evidence_dir
+    parts = evidence_dir.parts
+    if len(parts) < 3 or parts[1] not in {"tmp", "var"}:
+        return evidence_dir
+
+    alias_root = Path(os.sep) / parts[1]
+    try:
+        alias_metadata = os.lstat(alias_root)
+    except OSError:
+        return evidence_dir
+    if not stat.S_ISLNK(alias_metadata.st_mode):
+        return evidence_dir
+
+    expected_target = Path(os.sep) / "private" / parts[1]
+    try:
+        resolved_target = alias_root.resolve(strict=True)
+    except OSError:
+        return evidence_dir
+    if resolved_target != expected_target:
+        return evidence_dir
+    return resolved_target.joinpath(*parts[2:])
+
+
 def _open_evidence_dir(evidence_dir: Path) -> EvidenceDirHandle:
+    """Open the evidence directory with descriptor-pinned symlink-safe traversal."""
     if not _dir_fd_operations_available():
         return EvidenceDirHandle(
             path=evidence_dir,
@@ -196,7 +241,8 @@ def _open_evidence_dir(evidence_dir: Path) -> EvidenceDirHandle:
             ],
         )
 
-    start_path, components, component_warning = _evidence_dir_components(evidence_dir)
+    physical_evidence_dir = _normalize_macos_temp_alias(evidence_dir)
+    start_path, components, component_warning = _evidence_dir_components(physical_evidence_dir)
     if component_warning is not None:
         return EvidenceDirHandle(path=evidence_dir, fd=None, warnings=[component_warning])
 
@@ -258,6 +304,7 @@ def _open_evidence_dir(evidence_dir: Path) -> EvidenceDirHandle:
 
 
 def _missing_file_statuses(reason: str) -> dict[str, EvidenceFileStatus]:
+    """Return missing statuses for all expected evidence files."""
     return {
         name: EvidenceFileStatus(
             name=name,
@@ -270,6 +317,7 @@ def _missing_file_statuses(reason: str) -> dict[str, EvidenceFileStatus]:
 
 
 def _probe_expected_file(evidence_root: EvidenceDirHandle, name: str) -> EvidenceFileStatus:
+    """Inspect one expected evidence file without following symlinks."""
     if evidence_root.fd is None:
         return EvidenceFileStatus(
             name=name,
@@ -322,10 +370,12 @@ def _probe_expected_file(evidence_root: EvidenceDirHandle, name: str) -> Evidenc
 
 
 def _probe_expected_files(evidence_root: EvidenceDirHandle) -> dict[str, EvidenceFileStatus]:
+    """Inspect every expected evidence file in the pinned directory."""
     return {name: _probe_expected_file(evidence_root, name) for name in EXPECTED_EVIDENCE_FILES}
 
 
 def _open_json_flags() -> int:
+    """Build flags for opening structured metadata without following symlinks."""
     flags = os.O_RDONLY
     flags |= getattr(os, "O_CLOEXEC", 0)
     flags |= getattr(os, "O_NOFOLLOW", 0)
@@ -334,6 +384,7 @@ def _open_json_flags() -> int:
 
 
 def _can_read_child(evidence_root: EvidenceDirHandle, name: str) -> bool:
+    """Return whether a direct child is readable without following symlinks."""
     if evidence_root.fd is None:
         return False
     try:
@@ -343,6 +394,7 @@ def _can_read_child(evidence_root: EvidenceDirHandle, name: str) -> bool:
 
 
 def _read_json_bytes_from_descriptor(evidence_root: EvidenceDirHandle) -> tuple[bytes | None, list[str]]:
+    """Read bounded structured metadata bytes from the pinned evidence directory."""
     if evidence_root.fd is None:
         return None, ["warning: structured metadata unavailable: evidence directory was not inspected"]
     fd: int | None = None
@@ -376,6 +428,7 @@ def _load_evidence_json(
     evidence_root: EvidenceDirHandle,
     file_statuses: dict[str, EvidenceFileStatus],
 ) -> tuple[dict[str, Any] | None, list[str]]:
+    """Load and validate the structured smoke evidence JSON object."""
     json_status = file_statuses["host-smoke-evidence.json"]
     if not json_status.readable:
         return None, [f"warning: structured metadata unavailable: {json_status.reason}"]
@@ -399,6 +452,7 @@ def _load_evidence_json(
 
 
 def _file_status_warnings(file_statuses: dict[str, EvidenceFileStatus]) -> list[str]:
+    """Render advisory warning strings for present but unreadable files."""
     warnings: list[str] = []
     for status in file_statuses.values():
         if status.present and not status.readable:
@@ -407,6 +461,7 @@ def _file_status_warnings(file_statuses: dict[str, EvidenceFileStatus]) -> list[
 
 
 def _render_warnings(warnings: list[str]) -> str:
+    """Render warning lines for the summary."""
     if not warnings:
         return ""
     lines = ["## Warnings"]
@@ -415,6 +470,7 @@ def _render_warnings(warnings: list[str]) -> str:
 
 
 def _render_file_checklist(file_statuses: dict[str, EvidenceFileStatus]) -> str:
+    """Render expected evidence file status rows."""
     rows = [
         (
             status.name,
@@ -432,6 +488,7 @@ def _render_file_checklist(file_statuses: dict[str, EvidenceFileStatus]) -> str:
 
 
 def _render_run_overview(payload: dict[str, Any] | None) -> str:
+    """Render high-level structured smoke run metadata."""
     if payload is None:
         return "## Structured Run Metadata\n\nStructured metadata was not parsed; inspect the checklist and uploaded artifacts."
 
@@ -445,6 +502,7 @@ def _render_run_overview(payload: dict[str, Any] | None) -> str:
 
 
 def _render_phase_outcomes(payload: dict[str, Any] | None) -> str:
+    """Render per-phase smoke outcomes when available."""
     if not payload:
         return ""
     phases = payload.get("phases")
@@ -468,6 +526,7 @@ def _render_phase_outcomes(payload: dict[str, Any] | None) -> str:
 
 
 def _render_cleanup(payload: dict[str, Any] | None) -> str:
+    """Render helper cleanup status fields when available."""
     if not payload:
         return ""
     cleanup = payload.get("cleanup")
@@ -480,6 +539,7 @@ def _render_cleanup(payload: dict[str, Any] | None) -> str:
 
 
 def _render_runtime_pointers(payload: dict[str, Any] | None) -> str:
+    """Render runtime and artifact path pointers from structured metadata."""
     if not payload:
         return ""
     rows = [(key, _metadata_scalar(payload[key])) for key in RUNTIME_POINTER_KEYS if key in payload]
@@ -489,6 +549,7 @@ def _render_runtime_pointers(payload: dict[str, Any] | None) -> str:
 
 
 def _render_recorded_evidence_paths(payload: dict[str, Any] | None) -> str:
+    """Render evidence paths recorded by the smoke wrapper."""
     if not payload:
         return ""
     evidence_files = payload.get("evidence_files")
@@ -505,6 +566,7 @@ def _render_recorded_evidence_paths(payload: dict[str, Any] | None) -> str:
 
 
 def _render_log_artifacts(payload: dict[str, Any] | None) -> str:
+    """Render captured helper log artifact metadata."""
     if not payload:
         return ""
     log_artifacts = payload.get("log_artifacts")
@@ -527,6 +589,7 @@ def _render_log_artifacts(payload: dict[str, Any] | None) -> str:
 
 
 def render_summary(evidence_dir: Path) -> str:
+    """Build the complete advisory Markdown summary for an evidence directory."""
     warnings: list[str] = []
     with _open_evidence_dir(evidence_dir) as evidence_root:
         warnings.extend(evidence_root.warnings)
@@ -560,6 +623,7 @@ def render_summary(evidence_dir: Path) -> str:
 
 
 def _write_summary(markdown: str, summary_path: str | None) -> None:
+    """Append Markdown to GitHub step summary or fall back to stdout."""
     if not summary_path:
         sys.stdout.write(markdown)
         if not markdown.endswith("\n"):
@@ -581,6 +645,7 @@ def _write_summary(markdown: str, summary_path: str | None) -> None:
 
 
 def _parse_args(argv: list[str] | None) -> argparse.Namespace | None:
+    """Parse CLI arguments without allowing parser failures to fail smoke."""
     parser = argparse.ArgumentParser(
         description="Render an advisory Markdown summary for VZ Linux host smoke evidence.",
     )
@@ -594,6 +659,7 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace | None:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Run the advisory evidence summarizer CLI and always return success."""
     try:
         args = _parse_args(argv)
         if args is None:

--- a/tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py
+++ b/tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import subprocess
@@ -100,6 +101,17 @@ def _write_complete_evidence(evidence_dir: Path) -> None:
     )
 
 
+def _load_summary_module():
+    module_name = "vz_evidence_summary_under_test"
+    spec = importlib.util.spec_from_file_location(module_name, SUMMARY_SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 def _assert_advisory_success(result: subprocess.CompletedProcess[str]) -> None:
     assert result.returncode == 0, result.stderr
     assert "Traceback" not in result.stdout
@@ -152,6 +164,27 @@ def test_evidence_path_that_is_regular_file_warns_without_traceback(tmp_path: Pa
     _assert_advisory_success(result)
     assert "warning" in result.stdout.lower()
     assert "not a directory" in result.stdout
+    for evidence_file in EXPECTED_EVIDENCE_FILES:
+        assert evidence_file in result.stdout
+
+
+def test_evidence_directory_symlink_is_warned_and_target_is_not_read(tmp_path: Path) -> None:
+    target_dir = tmp_path / "target-evidence"
+    target_dir.mkdir()
+    target_secret = "evidence-root-symlink-target-should-not-appear"
+    (target_dir / "host-smoke-evidence.json").write_text(
+        json.dumps({"smoke_run_id": target_secret}),
+        encoding="utf-8",
+    )
+    evidence_link = tmp_path / "evidence-link"
+    evidence_link.symlink_to(target_dir, target_is_directory=True)
+
+    result = _run_summary(evidence_link)
+
+    _assert_advisory_success(result)
+    assert "warning" in result.stdout.lower()
+    assert "evidence directory is a symlink" in result.stdout
+    assert target_secret not in result.stdout
     for evidence_file in EXPECTED_EVIDENCE_FILES:
         assert evidence_file in result.stdout
 
@@ -222,6 +255,39 @@ def test_json_symlink_is_skipped_without_reading_target(tmp_path: Path) -> None:
     assert target_secret not in result.stdout
 
 
+def test_json_loader_rejects_path_swapped_to_symlink_after_probe(tmp_path: Path) -> None:
+    if not hasattr(os, "O_NOFOLLOW"):
+        pytest.skip("descriptor-level symlink rejection requires os.O_NOFOLLOW")
+    module = _load_summary_module()
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir()
+    json_path = evidence_dir / "host-smoke-evidence.json"
+    original_json = json.dumps({"smoke_run_id": "original"})
+    json_path.write_text(original_json, encoding="utf-8")
+    file_statuses = {
+        "host-smoke-evidence.json": module.EvidenceFileStatus(
+            name="host-smoke-evidence.json",
+            present=True,
+            readable=True,
+            reason="ok",
+            size_bytes=len(original_json.encode("utf-8")),
+        )
+    }
+    target_secret = "swapped-symlink-target-should-not-appear"
+    target = tmp_path / "target.json"
+    target.write_text(json.dumps({"smoke_run_id": target_secret}), encoding="utf-8")
+    json_path.unlink()
+    json_path.symlink_to(target)
+
+    payload, warnings = module._load_evidence_json(evidence_dir, file_statuses)
+
+    assert payload is None
+    warning_text = "\n".join(warnings)
+    assert "structured metadata" in warning_text
+    assert "symlink" in warning_text.lower() or "open" in warning_text.lower()
+    assert target_secret not in warning_text
+
+
 def test_expected_evidence_file_that_is_directory_is_warned_and_skipped(tmp_path: Path) -> None:
     evidence_dir = tmp_path / "evidence"
     evidence_dir.mkdir()
@@ -233,6 +299,46 @@ def test_expected_evidence_file_that_is_directory_is_warned_and_skipped(tmp_path
     assert "warning" in result.stdout.lower()
     assert "cleanup-status.txt" in result.stdout
     assert "non-regular file skipped" in result.stdout
+
+
+def test_summary_sanitizes_dynamic_markdown_metadata(tmp_path: Path) -> None:
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir()
+    for evidence_file in EXPECTED_EVIDENCE_FILES - {"host-smoke-evidence.json"}:
+        (evidence_dir / evidence_file).write_text(f"{evidence_file}\n", encoding="utf-8")
+    hostile_value = (
+        "line one|pipe\n"
+        "line two <b>tag</b>\n"
+        "[docs](https://example.test)\n"
+        "![alt](https://example.test/image.png)\n"
+        "`inline-code`"
+    )
+    (evidence_dir / "host-smoke-evidence.json").write_text(
+        json.dumps(
+            {
+                "smoke_run_id": hostile_value,
+                "final_exit_code": 0,
+                "phases": {
+                    "phase|one\nphase two": {
+                        "status": hostile_value,
+                        "exit_code": 0,
+                        "timestamp": "2026-06-17T00:00:01Z",
+                    }
+                },
+                "cleanup": {"status": hostile_value},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run_summary(evidence_dir)
+
+    _assert_advisory_success(result)
+    assert "line one\\|pipe line two &lt;b&gt;tag&lt;/b&gt;" in result.stdout
+    assert "<b>tag</b>" not in result.stdout
+    assert "[docs](https://example.test)" not in result.stdout
+    assert "![alt](https://example.test/image.png)" not in result.stdout
+    assert "`inline-code`" not in result.stdout
 
 
 def test_valid_github_step_summary_path_appends_markdown(tmp_path: Path) -> None:

--- a/tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py
+++ b/tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import importlib.util
+import inspect
 import json
 import os
+import shutil
 import subprocess
 import sys
+import uuid
 from pathlib import Path
 
 import pytest
@@ -142,6 +145,44 @@ def test_summary_reports_complete_evidence(tmp_path: Path) -> None:
     assert "vz-linux-host-gated-helper-logs" in result.stdout
     for evidence_file in EXPECTED_EVIDENCE_FILES:
         assert evidence_file in result.stdout
+
+
+def test_summary_module_defines_docstrings_for_helpers() -> None:
+    module = _load_summary_module()
+
+    assert inspect.getdoc(module)
+    for name, value in vars(module).items():
+        if name.startswith("__"):
+            continue
+        is_module_object = getattr(value, "__module__", None) == module.__name__
+        if (inspect.isclass(value) or inspect.isfunction(value)) and is_module_object:
+            assert inspect.getdoc(value), name
+
+
+def test_summary_reads_evidence_under_macos_tmp_symlink_prefix() -> None:
+    tmp_alias = Path("/tmp")
+    if not tmp_alias.is_symlink():
+        pytest.skip("/tmp is not a symlink on this host")
+    try:
+        physical_tmp = tmp_alias.resolve(strict=True)
+    except OSError as exc:
+        pytest.skip(f"/tmp cannot be resolved: {exc}")
+    if physical_tmp == tmp_alias:
+        pytest.skip("/tmp does not resolve to a distinct physical path")
+
+    evidence_dir = physical_tmp / f"tldw-vz-evidence-{uuid.uuid4().hex}"
+    try:
+        _write_complete_evidence(evidence_dir)
+        alias_evidence_dir = tmp_alias / evidence_dir.relative_to(physical_tmp)
+
+        result = _run_summary(alias_evidence_dir)
+    finally:
+        shutil.rmtree(evidence_dir, ignore_errors=True)
+
+    _assert_advisory_success(result)
+    assert "VZ Linux Host Smoke Evidence Summary" in result.stdout
+    assert "ci-123" in result.stdout
+    assert "evidence directory is a symlink" not in result.stdout
 
 
 def test_missing_evidence_directory_warns_and_lists_expected_files(tmp_path: Path) -> None:

--- a/tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py
+++ b/tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py
@@ -138,6 +138,7 @@ def test_missing_evidence_directory_warns_and_lists_expected_files(tmp_path: Pat
     _assert_advisory_success(result)
     assert "warning" in result.stdout.lower()
     assert "missing" in result.stdout.lower()
+    assert "early setup/preflight failure" in result.stdout
     for evidence_file in EXPECTED_EVIDENCE_FILES:
         assert evidence_file in result.stdout
 

--- a/tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py
+++ b/tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py
@@ -189,6 +189,32 @@ def test_evidence_directory_symlink_is_warned_and_target_is_not_read(tmp_path: P
         assert evidence_file in result.stdout
 
 
+def test_intermediate_parent_symlink_is_warned_and_target_is_not_read(tmp_path: Path) -> None:
+    target_dir = tmp_path / "target"
+    target_evidence_dir = target_dir / "evidence"
+    target_evidence_dir.mkdir(parents=True)
+    target_secret = "intermediate-parent-symlink-target-should-not-appear"
+    (target_evidence_dir / "host-smoke-evidence.json").write_text(
+        json.dumps({"smoke_run_id": target_secret}),
+        encoding="utf-8",
+    )
+    link_parent = tmp_path / "link-parent"
+    link_parent.symlink_to(target_dir, target_is_directory=True)
+
+    result = _run_summary(link_parent / "evidence")
+
+    _assert_advisory_success(result)
+    assert "warning" in result.stdout.lower()
+    assert (
+        "symlink" in result.stdout.lower()
+        or "unsafe" in result.stdout.lower()
+        or "unavailable" in result.stdout.lower()
+    )
+    assert target_secret not in result.stdout
+    for evidence_file in EXPECTED_EVIDENCE_FILES:
+        assert evidence_file in result.stdout
+
+
 def test_partial_evidence_without_json_warns_and_checks_files(tmp_path: Path) -> None:
     evidence_dir = tmp_path / "evidence"
     evidence_dir.mkdir()

--- a/tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py
+++ b/tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py
@@ -457,6 +457,67 @@ def test_summary_does_not_render_raw_nested_malformed_values(tmp_path: Path) -> 
     assert "128" in result.stdout
 
 
+def test_summary_replaces_container_values_in_expected_scalar_fields(tmp_path: Path) -> None:
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir()
+    for evidence_file in EXPECTED_EVIDENCE_FILES - {"host-smoke-evidence.json"}:
+        (evidence_dir / evidence_file).write_text(f"{evidence_file}\n", encoding="utf-8")
+    raw_sentinel = "RAW-SCALAR-CONTAINER-CONTENT-SHOULD-NOT-RENDER"
+    (evidence_dir / "host-smoke-evidence.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "created_at": "2026-06-17T00:00:00Z",
+                "smoke_run_id": {"raw_guest_output": raw_sentinel},
+                "final_exit_code": 0,
+                "source_bundle_path": ["raw", raw_sentinel],
+                "run_bundle_path": "/private/run/bundle",
+                "phases": {
+                    "real_host_smoke": {
+                        "status": {"raw_guest_output": raw_sentinel},
+                        "exit_code": 0,
+                        "timestamp": "2026-06-17T00:00:01Z",
+                    }
+                },
+                "cleanup": {
+                    "status": {"raw_guest_output": raw_sentinel},
+                    "helper_pid": "123",
+                    "helper_running_after_cleanup": False,
+                    "socket_present_after_cleanup": False,
+                },
+                "evidence_files": {
+                    "host-smoke-evidence.json": {"raw_guest_output": raw_sentinel},
+                    "cleanup-status.txt": str(evidence_dir / "cleanup-status.txt"),
+                },
+                "log_artifacts": [
+                    {
+                        "path": {"raw_guest_output": raw_sentinel},
+                        "size_bytes": 128,
+                        "sha256": "c" * 64,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run_summary(evidence_dir)
+
+    _assert_advisory_success(result)
+    assert raw_sentinel not in result.stdout
+    assert "invalid or unavailable" in result.stdout
+    assert "final_exit_code" in result.stdout
+    assert "0" in result.stdout
+    assert "created_at" in result.stdout
+    assert "2026-06-17T00:00:00Z" in result.stdout
+    assert "real_host_smoke" in result.stdout
+    assert "helper_pid" in result.stdout
+    assert "123" in result.stdout
+    assert "/private/run/bundle" in result.stdout
+    assert "cleanup-status.txt" in result.stdout
+    assert "128" in result.stdout
+
+
 def test_valid_github_step_summary_path_appends_markdown(tmp_path: Path) -> None:
     evidence_dir = tmp_path / "evidence"
     _write_complete_evidence(evidence_dir)

--- a/tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py
+++ b/tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py
@@ -341,6 +341,58 @@ def test_summary_sanitizes_dynamic_markdown_metadata(tmp_path: Path) -> None:
     assert "`inline-code`" not in result.stdout
 
 
+def test_summary_does_not_render_raw_nested_malformed_values(tmp_path: Path) -> None:
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir()
+    for evidence_file in EXPECTED_EVIDENCE_FILES - {"host-smoke-evidence.json"}:
+        (evidence_dir / evidence_file).write_text(f"{evidence_file}\n", encoding="utf-8")
+    raw_sentinel = "RAW-GUEST-LOG-CONTENT-SHOULD-NOT-RENDER"
+    (evidence_dir / "host-smoke-evidence.json").write_text(
+        json.dumps(
+            {
+                "smoke_run_id": "ci-valid",
+                "final_exit_code": 0,
+                "phases": {
+                    "real_host_smoke": {
+                        "status": "ok",
+                        "exit_code": 0,
+                        "timestamp": "2026-06-17T00:00:01Z",
+                    },
+                    "malformed_phase": raw_sentinel,
+                },
+                "cleanup": {
+                    "status": 0,
+                    "helper_pid": "123",
+                    "helper_running_after_cleanup": False,
+                    "socket_present_after_cleanup": False,
+                    "raw_guest_output": raw_sentinel,
+                },
+                "log_artifacts": [
+                    {
+                        "path": "/private/runtime/serial/vm.log",
+                        "size_bytes": 128,
+                        "sha256": "b" * 64,
+                    },
+                    raw_sentinel,
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run_summary(evidence_dir)
+
+    _assert_advisory_success(result)
+    assert raw_sentinel not in result.stdout
+    assert "real_host_smoke" in result.stdout
+    assert "ok" in result.stdout
+    assert "helper_pid" in result.stdout
+    assert "123" in result.stdout
+    assert "raw_guest_output" not in result.stdout
+    assert "/private/runtime/serial/vm.log" in result.stdout
+    assert "128" in result.stdout
+
+
 def test_valid_github_step_summary_path_appends_markdown(tmp_path: Path) -> None:
     evidence_dir = tmp_path / "evidence"
     _write_complete_evidence(evidence_dir)

--- a/tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py
+++ b/tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+IMAGE_DIR = Path(__file__).resolve().parents[1]
+SUMMARY_SCRIPT = IMAGE_DIR / "scripts" / "summarize-host-e2e-evidence.py"
+EXPECTED_EVIDENCE_FILES = {
+    "host-smoke-evidence.json",
+    "source-bundle-hashes-before.txt",
+    "source-bundle-hashes-after.txt",
+    "run-bundle-hashes.txt",
+    "runtime-paths.txt",
+    "cleanup-status.txt",
+}
+
+
+def _run_summary(
+    evidence_dir: Path,
+    *,
+    summary_path: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    if summary_path is not None:
+        env["GITHUB_STEP_SUMMARY"] = str(summary_path)
+    else:
+        env.pop("GITHUB_STEP_SUMMARY", None)
+    return subprocess.run(
+        [sys.executable, str(SUMMARY_SCRIPT), "--evidence-dir", str(evidence_dir)],
+        cwd=IMAGE_DIR,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _write_complete_evidence(evidence_dir: Path) -> None:
+    evidence_dir.mkdir()
+    for evidence_file in EXPECTED_EVIDENCE_FILES - {"host-smoke-evidence.json"}:
+        (evidence_dir / evidence_file).write_text(f"{evidence_file}\n", encoding="utf-8")
+    (evidence_dir / "host-smoke-evidence.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "created_at": "2026-06-17T00:00:00Z",
+                "source_bundle_path": "/private/source/bundle",
+                "run_bundle_path": "/private/run/bundle",
+                "image_store_root": "/private/image-store",
+                "smoke_run_id": "ci-123",
+                "socket_path": "/private/runtime/helper.sock",
+                "serial_log_dir": "/private/runtime/serial",
+                "evidence_dir": str(evidence_dir),
+                "helper_path": "/private/helper",
+                "helper_pid_file": "/private/helper.pid",
+                "skip_build": False,
+                "skip_sign": False,
+                "include_failure_drills": False,
+                "final_exit_code": 7,
+                "phases": {
+                    "real_host_smoke": {
+                        "status": "failed",
+                        "exit_code": 7,
+                        "timestamp": "2026-06-17T00:00:01Z",
+                    },
+                    "cleanup": {
+                        "status": "ok",
+                        "exit_code": 0,
+                        "timestamp": "2026-06-17T00:00:02Z",
+                    },
+                },
+                "cleanup": {
+                    "status": 0,
+                    "helper_pid": "123",
+                    "helper_running_after_cleanup": False,
+                    "socket_present_after_cleanup": False,
+                },
+                "evidence_files": {
+                    evidence_file: str(evidence_dir / evidence_file)
+                    for evidence_file in EXPECTED_EVIDENCE_FILES
+                },
+                "log_artifacts": [
+                    {
+                        "path": "/private/runtime/serial/vm.log",
+                        "size_bytes": 128,
+                        "sha256": "a" * 64,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _assert_advisory_success(result: subprocess.CompletedProcess[str]) -> None:
+    assert result.returncode == 0, result.stderr
+    assert "Traceback" not in result.stdout
+    assert "Traceback" not in result.stderr
+
+
+def test_summary_reports_complete_evidence(tmp_path: Path) -> None:
+    evidence_dir = tmp_path / "evidence"
+    _write_complete_evidence(evidence_dir)
+
+    result = _run_summary(evidence_dir)
+
+    _assert_advisory_success(result)
+    assert "VZ Linux Host Smoke Evidence Summary" in result.stdout
+    assert "Advisory only" in result.stdout
+    assert "final_exit_code" in result.stdout
+    assert "7" in result.stdout
+    assert "smoke_run_id" in result.stdout
+    assert "ci-123" in result.stdout
+    assert "real_host_smoke" in result.stdout
+    assert "cleanup" in result.stdout
+    assert "status" in result.stdout
+    assert "helper_running_after_cleanup" in result.stdout
+    assert "/private/run/bundle" in result.stdout
+    assert "/private/runtime/serial/vm.log" in result.stdout
+    assert "128" in result.stdout
+    assert "vz-linux-host-gated-evidence" in result.stdout
+    assert "vz-linux-host-gated-helper-logs" in result.stdout
+    for evidence_file in EXPECTED_EVIDENCE_FILES:
+        assert evidence_file in result.stdout
+
+
+def test_missing_evidence_directory_warns_and_lists_expected_files(tmp_path: Path) -> None:
+    result = _run_summary(tmp_path / "missing-evidence")
+
+    _assert_advisory_success(result)
+    assert "warning" in result.stdout.lower()
+    assert "missing" in result.stdout.lower()
+    for evidence_file in EXPECTED_EVIDENCE_FILES:
+        assert evidence_file in result.stdout
+
+
+def test_evidence_path_that_is_regular_file_warns_without_traceback(tmp_path: Path) -> None:
+    evidence_path = tmp_path / "evidence"
+    evidence_path.write_text("not a directory\n", encoding="utf-8")
+
+    result = _run_summary(evidence_path)
+
+    _assert_advisory_success(result)
+    assert "warning" in result.stdout.lower()
+    assert "not a directory" in result.stdout
+    for evidence_file in EXPECTED_EVIDENCE_FILES:
+        assert evidence_file in result.stdout
+
+
+def test_partial_evidence_without_json_warns_and_checks_files(tmp_path: Path) -> None:
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir()
+    (evidence_dir / "cleanup-status.txt").write_text("cleanup_status=0\n", encoding="utf-8")
+
+    result = _run_summary(evidence_dir)
+
+    _assert_advisory_success(result)
+    assert "warning" in result.stdout.lower()
+    assert "structured metadata" in result.stdout
+    assert "cleanup-status.txt" in result.stdout
+    assert "present" in result.stdout
+    assert "host-smoke-evidence.json" in result.stdout
+    assert "missing" in result.stdout
+
+
+def test_malformed_json_warns_without_raw_json_dump(tmp_path: Path) -> None:
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir()
+    raw_json = '{"secret_raw_json": "do not echo",'
+    (evidence_dir / "host-smoke-evidence.json").write_text(raw_json, encoding="utf-8")
+
+    result = _run_summary(evidence_dir)
+
+    _assert_advisory_success(result)
+    assert "warning" in result.stdout.lower()
+    assert "JSONDecodeError" in result.stdout
+    assert "host-smoke-evidence.json" in result.stdout
+    assert "secret_raw_json" not in result.stdout
+    assert raw_json not in result.stdout
+
+
+def test_oversized_json_warns_and_is_not_parsed(tmp_path: Path) -> None:
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir()
+    oversized_marker = "oversized-marker-should-not-appear"
+    (evidence_dir / "host-smoke-evidence.json").write_text(
+        json.dumps({"smoke_run_id": oversized_marker}) + (" " * (1024 * 1024)),
+        encoding="utf-8",
+    )
+
+    result = _run_summary(evidence_dir)
+
+    _assert_advisory_success(result)
+    assert "warning" in result.stdout.lower()
+    assert "exceeds" in result.stdout
+    assert oversized_marker not in result.stdout
+
+
+def test_json_symlink_is_skipped_without_reading_target(tmp_path: Path) -> None:
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir()
+    target = tmp_path / "target.json"
+    target_secret = "symlink-target-content-should-not-appear"
+    target.write_text(json.dumps({"smoke_run_id": target_secret}), encoding="utf-8")
+    (evidence_dir / "host-smoke-evidence.json").symlink_to(target)
+
+    result = _run_summary(evidence_dir)
+
+    _assert_advisory_success(result)
+    assert "warning" in result.stdout.lower()
+    assert "symlink" in result.stdout
+    assert "host-smoke-evidence.json" in result.stdout
+    assert target_secret not in result.stdout
+
+
+def test_expected_evidence_file_that_is_directory_is_warned_and_skipped(tmp_path: Path) -> None:
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir()
+    (evidence_dir / "cleanup-status.txt").mkdir()
+
+    result = _run_summary(evidence_dir)
+
+    _assert_advisory_success(result)
+    assert "warning" in result.stdout.lower()
+    assert "cleanup-status.txt" in result.stdout
+    assert "non-regular file skipped" in result.stdout
+
+
+def test_valid_github_step_summary_path_appends_markdown(tmp_path: Path) -> None:
+    evidence_dir = tmp_path / "evidence"
+    _write_complete_evidence(evidence_dir)
+    summary_path = tmp_path / "step-summary.md"
+    summary_path.write_text("existing summary\n", encoding="utf-8")
+
+    result = _run_summary(evidence_dir, summary_path=summary_path)
+
+    _assert_advisory_success(result)
+    assert result.stdout == ""
+    assert result.stderr == ""
+    summary = summary_path.read_text(encoding="utf-8")
+    assert summary.startswith("existing summary\n")
+    assert "VZ Linux Host Smoke Evidence Summary" in summary
+    assert "final_exit_code" in summary
+
+
+def test_invalid_github_step_summary_path_falls_back_to_stdout_and_stderr(tmp_path: Path) -> None:
+    evidence_dir = tmp_path / "evidence"
+    _write_complete_evidence(evidence_dir)
+    summary_path = tmp_path / "summary-directory"
+    summary_path.mkdir()
+
+    result = _run_summary(evidence_dir, summary_path=summary_path)
+
+    _assert_advisory_success(result)
+    assert "warning: unable to append to GITHUB_STEP_SUMMARY" in result.stderr
+    assert "VZ Linux Host Smoke Evidence Summary" in result.stdout
+    assert "final_exit_code" in result.stdout

--- a/tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py
+++ b/tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py
@@ -259,33 +259,71 @@ def test_json_loader_rejects_path_swapped_to_symlink_after_probe(tmp_path: Path)
     if not hasattr(os, "O_NOFOLLOW"):
         pytest.skip("descriptor-level symlink rejection requires os.O_NOFOLLOW")
     module = _load_summary_module()
+    if not module._dir_fd_operations_available():
+        pytest.skip("directory file descriptor operations are unavailable")
     evidence_dir = tmp_path / "evidence"
     evidence_dir.mkdir()
     json_path = evidence_dir / "host-smoke-evidence.json"
     original_json = json.dumps({"smoke_run_id": "original"})
     json_path.write_text(original_json, encoding="utf-8")
-    file_statuses = {
-        "host-smoke-evidence.json": module.EvidenceFileStatus(
-            name="host-smoke-evidence.json",
-            present=True,
-            readable=True,
-            reason="ok",
-            size_bytes=len(original_json.encode("utf-8")),
-        )
-    }
-    target_secret = "swapped-symlink-target-should-not-appear"
-    target = tmp_path / "target.json"
-    target.write_text(json.dumps({"smoke_run_id": target_secret}), encoding="utf-8")
-    json_path.unlink()
-    json_path.symlink_to(target)
+    with module._open_evidence_dir(evidence_dir) as evidence_root:
+        file_statuses = {
+            "host-smoke-evidence.json": module.EvidenceFileStatus(
+                name="host-smoke-evidence.json",
+                present=True,
+                readable=True,
+                reason="ok",
+                size_bytes=len(original_json.encode("utf-8")),
+            )
+        }
+        target_secret = "swapped-symlink-target-should-not-appear"
+        target = tmp_path / "target.json"
+        target.write_text(json.dumps({"smoke_run_id": target_secret}), encoding="utf-8")
+        json_path.unlink()
+        json_path.symlink_to(target)
 
-    payload, warnings = module._load_evidence_json(evidence_dir, file_statuses)
+        payload, warnings = module._load_evidence_json(evidence_root, file_statuses)
 
     assert payload is None
     warning_text = "\n".join(warnings)
     assert "structured metadata" in warning_text
     assert "symlink" in warning_text.lower() or "open" in warning_text.lower()
     assert target_secret not in warning_text
+
+
+def test_pinned_evidence_directory_fd_ignores_root_symlink_swap(tmp_path: Path) -> None:
+    module = _load_summary_module()
+    if not module._dir_fd_operations_available():
+        pytest.skip("directory file descriptor operations are unavailable")
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir()
+    original_marker = "original-pinned-evidence"
+    (evidence_dir / "host-smoke-evidence.json").write_text(
+        json.dumps({"smoke_run_id": original_marker}),
+        encoding="utf-8",
+    )
+    with module._open_evidence_dir(evidence_dir) as evidence_root:
+        pinned_fd = evidence_root.fd
+        assert pinned_fd is not None
+        moved_evidence_dir = tmp_path / "moved-evidence"
+        evidence_dir.rename(moved_evidence_dir)
+        target_dir = tmp_path / "target-evidence"
+        target_dir.mkdir()
+        target_secret = "swapped-root-symlink-target-should-not-render"
+        (target_dir / "host-smoke-evidence.json").write_text(
+            json.dumps({"smoke_run_id": target_secret}),
+            encoding="utf-8",
+        )
+        evidence_dir.symlink_to(target_dir, target_is_directory=True)
+
+        file_statuses = module._probe_expected_files(evidence_root)
+        payload, warnings = module._load_evidence_json(evidence_root, file_statuses)
+
+        assert warnings == []
+        assert payload == {"smoke_run_id": original_marker}
+        assert target_secret not in json.dumps(payload)
+    with pytest.raises(OSError):
+        os.fstat(pinned_fd)
 
 
 def test_expected_evidence_file_that_is_directory_is_warned_and_skipped(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Adds a host-independent VZ smoke evidence summarizer that renders advisory GitHub step summaries from structured evidence without mutating evidence files.
- Wires the host-gated VZ Linux workflow to run the summary after smoke finalization and before artifact uploads, while preserving smoke result authority.
- Documents the operator contract and records TASK-2381 completion.

## Test Plan
- [x] `python -m pytest tools/vz-linux-image/tests/test_summarize_host_e2e_evidence.py tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q`
- [x] `bash -n tools/vz-linux-image/scripts/run-host-e2e-smoke.sh`
- [x] `python -m bandit -r tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py -f json -o /tmp/bandit_vz_evidence_summary_final_review_controller.json`
- [x] `python tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py --evidence-dir /private/tmp/tldw-vz-evidence-missing >/tmp/tldw-vz-evidence-summary-smoke.md`

## Change summary
Human-authored rationale to be added before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an advisory, host‑independent summarizer for VZ Linux host‑gated smoke that writes a GitHub step summary after smoke to speed triage with a safe overview of evidence, exit code, phases, cleanup, and artifact pointers (TASK-2381).

- **New Features**
  - Adds `tools/vz-linux-image/scripts/summarize-host-e2e-evidence.py` (stdlib-only): descriptor‑pinned, symlink‑safe reads of direct child evidence; caps JSON at 1 MiB; escapes Markdown and coerces non‑scalars; handles macOS `/tmp`/`/var` aliases; always exits 0; writes to `$GITHUB_STEP_SUMMARY` with stdout fallback.
  - Wires `.github/workflows/vz-linux-host-gated.yml` to run “Summarize smoke evidence” with `if: always()` after smoke and before uploads; guarded for missing script/interpreter; appends a warning to the step summary on non‑zero script exit without failing the job.
  - Expands tests for complete/missing/partial/malformed/oversized/symlink evidence, sanitization, descriptor‑pinned reads, macOS aliasing, and workflow ordering/guards (`tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py`).
  - Updates docs to make the step summary the first diagnostic surface; adds design and implementation plan specs; records completion in TASK‑2381.

<sup>Written for commit f02428582883b153690c34859c2c3d4c225512c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

