### PR TITLE
Harden WorkspaceHeader ACP navigation assertions

### DIFF
--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
@@ -1558,12 +1558,17 @@ describe("WorkspaceHeader workspace browser modal", () => {
     ).toBeInTheDocument()
 
     fireEvent.click(within(modal).getByRole("button", { name: "Open diagnostics" }))
-    expect(mockNavigate).toHaveBeenCalledWith(
+    expect(mockNavigate).toHaveBeenNthCalledWith(
+      1,
       "/acp-playground?session=sess-alpha&view=diagnostics"
     )
 
     fireEvent.click(within(modal).getByRole("button", { name: "Open Agent Tasks" }))
-    expect(mockNavigate).toHaveBeenCalledWith("/agent-tasks?workspace=workspace-alpha")
+    expect(mockNavigate).toHaveBeenNthCalledWith(
+      2,
+      "/agent-tasks?workspace=workspace-alpha"
+    )
+    expect(mockNavigate).toHaveBeenCalledTimes(2)
   })
 
   it("shows direct workspace ACP sessions when Agent Tasks history has no runs", async () => {

--- a/backlog/completed/task-2385 - Address-PR-2387-WorkspaceHeader-navigation-review-feedback.md
+++ b/backlog/completed/task-2385 - Address-PR-2387-WorkspaceHeader-navigation-review-feedback.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2385
 title: Address PR 2387 WorkspaceHeader navigation review feedback
-status: In Progress
+status: Done
 labels:
 - workspace
 - frontend
@@ -11,6 +11,9 @@ references:
 - https://github.com/rmusser01/tldw_server/pull/2387
 - https://github.com/rmusser01/tldw_server/pull/2387#issuecomment-4738026921
 - https://github.com/rmusser01/tldw_server/pull/2387#discussion_r3433030173
+- https://github.com/rmusser01/tldw_server/pull/2389
+- https://github.com/rmusser01/tldw_server/pull/2387#issuecomment-4742827932
+- https://github.com/rmusser01/tldw_server/pull/2387#discussion_r3436459284
 ---
 
 ## Description
@@ -23,7 +26,7 @@ Track follow-up work for review comments left on PR #2387 after it merged. Harde
 <!-- AC:BEGIN -->
 - [x] #1 WorkspaceHeader ACP history navigation assertions enforce call order and no extra navigation calls.
 - [x] #2 The focused WorkspaceHeader test passes.
-- [ ] #3 Gemini backlog filename comment is answered with repository convention context.
+- [x] #3 Gemini backlog filename comment is answered with repository convention context.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -39,15 +42,18 @@ Track follow-up work for review comments left on PR #2387 after it merged. Harde
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+- Hardened the ACP history navigation assertions in `WorkspaceHeader.test.tsx` by checking call order and total call count.
+- Opened follow-up PR #2389 because PR #2387 was already merged before review follow-up work began.
+- Replied to Qodo on #2387 with the follow-up PR and verification results.
+- Replied to the Gemini inline comment explaining that Backlog.md generated task filenames intentionally follow this repository's `task-<id> - <Title>.md` convention.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2385 - Address-PR-2387-WorkspaceHeader-navigation-review-feedback.md
+++ b/backlog/tasks/task-2385 - Address-PR-2387-WorkspaceHeader-navigation-review-feedback.md
@@ -1,0 +1,53 @@
+---
+id: TASK-2385
+title: Address PR 2387 WorkspaceHeader navigation review feedback
+status: In Progress
+labels:
+- workspace
+- frontend
+- review
+priority: High
+references:
+- https://github.com/rmusser01/tldw_server/pull/2387
+- https://github.com/rmusser01/tldw_server/pull/2387#issuecomment-4738026921
+- https://github.com/rmusser01/tldw_server/pull/2387#discussion_r3433030173
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track follow-up work for review comments left on PR #2387 after it merged. Harden WorkspaceHeader ACP history navigation assertions and respond to the backlog filename convention comment.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 WorkspaceHeader ACP history navigation assertions enforce call order and no extra navigation calls.
+- [x] #2 The focused WorkspaceHeader test passes.
+- [ ] #3 Gemini backlog filename comment is answered with repository convention context.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- PR #2387 was already merged, so this is a follow-up branch from latest `origin/dev` rather than an in-place PR rebase.
+- Qodo feedback is valid: `toHaveBeenCalledWith` does not enforce order or call exclusivity.
+- Gemini backlog filename feedback conflicts with existing Backlog.md generated filename convention in this repository; respond rather than rename generated Backlog records.
+- Verification: `./node_modules/.bin/vitest run ../packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx` passed with `43 passed`.
+- Bandit is not applicable because this branch only changes a frontend test and Backlog task metadata, not production backend code.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary

AI-generated draft: this follow-up addresses review feedback left on merged PR #2387. It tightens the WorkspaceHeader ACP run history test so the diagnostics and Agent Tasks clicks must navigate in the expected order and no extra navigations can occur.

## What changed

- Replaced broad `toHaveBeenCalledWith` assertions with `toHaveBeenNthCalledWith` for the ACP diagnostics and Agent Tasks actions.
- Added `toHaveBeenCalledTimes(2)` to catch accidental extra navigations.
- Added Backlog task `TASK-2385` for the PR #2387 review follow-up.

## Verification

- `./node_modules/.bin/vitest run ../packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx` -> `43 passed`
- `git diff --check` -> passed

## Notes

- PR #2387 was already merged, so this is a follow-up branch from latest `origin/dev` rather than an in-place rebase of the merged PR.
- Bandit is not applicable because this branch only changes a frontend test and Backlog task metadata, not production backend code.
- The Gemini backlog filename comment on #2387 conflicts with this repository's Backlog.md generated filename convention; I will respond on the original thread rather than rename generated task records.

Refs #2387

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the WorkspaceHeader ACP navigation test to enforce click order (Diagnostics → Agent Tasks) and fail on any extra navigations. Records completion of backlog task `TASK-2385` for the PR #2387 follow-up.

<sup>Written for commit eddd8acc673d6d6a6f7abb7daf9299267922d89e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

