### PR TITLE
TASK-2283 add governed run shell selection

### DIFF
--- a/backlog/tasks/task-2283 - Add-Claude-style-governed-Bash-and-PowerShell-runtime-tools.md
+++ b/backlog/tasks/task-2283 - Add-Claude-style-governed-Bash-and-PowerShell-runtime-tools.md
@@ -4,7 +4,7 @@ title: Add Claude-style governed Bash and PowerShell runtime tools
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-06-18 04:49'
+updated_date: '2026-06-18 14:12'
 labels:
   - mcp
   - command-runtime
@@ -59,6 +59,8 @@ Sixth-slice hardening added: sandbox.run env values are redacted from tool hook 
 PR #2386 review pass: rebased branch onto latest origin/dev (already up to date) and addressed still-valid review items. Changes: introduced RunEnvFileValidationError for envFile failures, replaced path.stat/read_bytes with os.open/os.fstat/os.fdopen bounded descriptor reads using O_NOFOLLOW/O_CLOEXEC where available, accepted UTF-8 BOM via utf-8-sig, restricted env variable names to ASCII [A-Za-z_][A-Za-z0-9_]*, removed redundant env-file alias normalization, added docstrings to new sandbox hook test helpers, and added focused regression tests for BOM/unicode-key rejection, descriptor reads, and OSError mapping. The marker-policy finding was handled for the newly added env-file tests by marking them unit and relying on repo-configured pytest asyncio auto mode; existing pre-existing asyncio markers were left unchanged. Verification: run-command plus protocol hook pytest 81 passed; Ruff passed for touched Python files; py_compile passed for touched Python files; Bandit report /tmp/bandit_mcp_run_env_file_review.json had results=0 errors=0 skipped=0; git diff --check passed.
 
 PR #2386 follow-up refinement: changed RunEnvFileValidationError to inherit the project ValidationError base while preserving ValueError-compatible behavior through the existing exception hierarchy. Verification rerun after refinement: run-command plus protocol hook pytest 81 passed; Ruff passed for touched Python files; py_compile passed for touched Python files; Bandit report /tmp/bandit_mcp_run_env_file_review.json had results=0 errors=0 skipped=0; git diff --check passed.
+
+Seventh slice implemented: added explicit shellName / shell_name selection for the governed virtual CLI. The selector accepts bash, shell, powershell, and pwsh labels, validates alias consistency, pins bash/powershell/pwsh tool aliases to their matching selector, carries the selected label in AdapterContext for future adapter behavior, and salts nested idempotency keys by shell selection without enabling raw host shell execution. Verification: focused run-command pytest 80 passed; Ruff passed for touched Python files; py_compile passed for touched Python files; Bandit report /tmp/bandit_mcp_run_shell_selection.json had results=0 errors=0 skipped=0; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/app/core/MCP_unified/README.md
+++ b/tldw_Server_API/app/core/MCP_unified/README.md
@@ -423,6 +423,8 @@ Phase-1 adds a governed virtual CLI foundation to MCP Unified.
 
 `bash`, `shell`, `powershell`, and `pwsh` may also appear as compatibility aliases for `run`. They use the same `command` argument and the same governed runtime; they are not host shell execution surfaces. Unsupported raw-shell features such as redirection, command substitution, environment expansion, environment assignment prefixes, and background execution fail before any backend MCP tool call is prepared.
 
+`shellName` / `shell_name` may be set to `bash`, `shell`, `powershell`, or `pwsh` to label the intended virtual shell dialect for a `run` invocation. The selector is validated, included in nested idempotency scope, and never enables raw host shell execution. The `bash`, `powershell`, and `pwsh` aliases are pinned to their matching `shellName` values; conflicting selectors fail before backend MCP calls are prepared.
+
 `run` and its shell-facing aliases also accept optional `timeoutSeconds` / `timeout_seconds` values. The timeout covers the governed command chain, including policy preflight and nested MCP tool execution, and returns exit code `124` when exceeded.
 
 `cwd` / `workingDirectory` may be set to a workspace-relative directory for a single governed command chain. Relative file paths and search base paths are evaluated beneath that cwd, while absolute paths and final read/write decisions still flow through the backing MCP tools and profile policy. The cwd value rejects absolute paths, Windows drive roots, home-relative paths, and `..` traversal.

--- a/tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py
+++ b/tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py
@@ -26,6 +26,7 @@ class AdapterContext:
     cwd: str | None = None
     sandbox_session_id: str | None = None
     sandbox_env: Mapping[str, str] | None = None
+    shell_name: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
@@ -40,6 +40,8 @@ _RUN_TOOL_NAME = "run"
 _RUN_TOOL_ALIASES = ("bash", "shell", "powershell", "pwsh")
 _RUN_TOOL_NAMES = frozenset((_RUN_TOOL_NAME, *_RUN_TOOL_ALIASES))
 _RUN_ENV_FILE_MAX_BYTES = 64 * 1024
+_RUN_SHELL_NAME_CHOICES = ("bash", "shell", "powershell", "pwsh")
+_RUN_PINNED_ALIAS_SHELLS = {"bash": "bash", "powershell": "powershell", "pwsh": "pwsh"}
 
 
 class RunEnvFileValidationError(ValidationError):
@@ -113,6 +115,7 @@ class RunCommandModule(BaseModule):
         retain_output_artifacts = self._retain_output_artifacts(args)
         sandbox_session_id = self._sandbox_session_id(args)
         env_file = self._env_file(args)
+        shell_name = self._shell_name(tool_name, args)
         visible = await self._visible_commands_for_context(context)
         if command_text in {"help", "--help"}:
             return present_command_execution_result(
@@ -180,10 +183,12 @@ class RunCommandModule(BaseModule):
                 cwd,
                 sandbox_session_id,
                 env_file_scope,
+                shell_name,
             ),
             cwd=cwd,
             sandbox_session_id=sandbox_session_id,
             sandbox_env=sandbox_env,
+            shell_name=shell_name,
         )
         adapters = PhaseOneCommandAdapters(adapter_context)
         executor = CommandRuntimeExecutor(
@@ -257,6 +262,8 @@ class RunCommandModule(BaseModule):
                 "retain_output_artifacts",
                 "sandboxSessionId",
                 "sandbox_session_id",
+                "shellName",
+                "shell_name",
                 "timeoutSeconds",
                 "timeout_seconds",
                 "workingDirectory",
@@ -286,6 +293,7 @@ class RunCommandModule(BaseModule):
         self._validate_retain_output_artifact_arguments(arguments)
         self._validate_sandbox_session_arguments(arguments)
         self._validate_env_file_arguments(arguments)
+        self._validate_shell_name_arguments(tool_name, arguments)
 
     def sanitize_input(self, input_data: Any, _depth: int = 0) -> Any:
         """Sanitize input while allowing CLI flags like `--help` and shell-like tokens."""
@@ -396,6 +404,18 @@ class RunCommandModule(BaseModule):
                     "sandboxSessionId": {
                         "type": "string",
                         "description": "Sandbox session id for governed sandbox command steps.",
+                    },
+                    "shell_name": {
+                        "type": "string",
+                        "enum": list(_RUN_SHELL_NAME_CHOICES),
+                        "description": "Legacy alias for shellName.",
+                    },
+                    "shellName": {
+                        "type": "string",
+                        "enum": list(_RUN_SHELL_NAME_CHOICES),
+                        "description": (
+                            "Optional virtual shell dialect label; does not enable raw host shell execution."
+                        ),
                     },
                     "timeout_seconds": {
                         "type": "number",
@@ -883,6 +903,7 @@ class RunCommandModule(BaseModule):
         cwd: str | None,
         sandbox_session_id: str | None,
         env_file_scope: str | None = None,
+        shell_name: str | None = None,
     ) -> str | None:
         """Salt a parent idempotency key with unambiguous execution scope data."""
 
@@ -895,6 +916,8 @@ class RunCommandModule(BaseModule):
             scope_payload["sandbox_session_id"] = sandbox_session_id
         if env_file_scope:
             scope_payload["env_file"] = env_file_scope
+        if shell_name:
+            scope_payload["shell_name"] = shell_name
         if not scope_payload:
             return parent_key
         serialized_scope = json.dumps(
@@ -939,6 +962,43 @@ class RunCommandModule(BaseModule):
         if not isinstance(value, str) or not value.strip():
             raise ValueError(f"{key} must be a non-empty string")
         return value.strip()
+
+    @classmethod
+    def _validate_shell_name_arguments(cls, tool_name: str, arguments: dict[str, Any]) -> None:
+        """Validate explicit shell selection aliases before execution starts."""
+
+        shell_name = arguments.get("shell_name")
+        shell_name_camel = arguments.get("shellName")
+        legacy_value = cls._normalize_shell_name(shell_name, "shell_name") if shell_name is not None else None
+        camel_value = cls._normalize_shell_name(shell_name_camel, "shellName") if shell_name_camel is not None else None
+        if legacy_value is not None and camel_value is not None and legacy_value != camel_value:
+            raise ValueError("shellName and shell_name must match when both are provided")
+
+        selected = camel_value if camel_value is not None else legacy_value
+        pinned = _RUN_PINNED_ALIAS_SHELLS.get(tool_name)
+        if selected is not None and pinned is not None and selected != pinned:
+            raise ValueError(f"{tool_name} alias requires shellName={pinned}")
+
+    @classmethod
+    def _shell_name(cls, tool_name: str, arguments: dict[str, Any]) -> str | None:
+        """Return the selected virtual shell label, including pinned aliases."""
+
+        for key in ("shellName", "shell_name"):
+            value = arguments.get(key)
+            if value is not None:
+                return cls._normalize_shell_name(value, key)
+        return _RUN_PINNED_ALIAS_SHELLS.get(tool_name)
+
+    @staticmethod
+    def _normalize_shell_name(value: Any, key: str) -> str:
+        """Normalize one virtual shell selection value."""
+
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"{key} must be one of: {', '.join(_RUN_SHELL_NAME_CHOICES)}")
+        normalized = value.strip().lower()
+        if normalized not in _RUN_SHELL_NAME_CHOICES:
+            raise ValueError(f"{key} must be one of: {', '.join(_RUN_SHELL_NAME_CHOICES)}")
+        return normalized
 
     @classmethod
     def _validate_env_file_arguments(cls, arguments: dict[str, Any]) -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
@@ -190,7 +190,7 @@ def _build_module(protocol: _ProtocolStub) -> RunCommandModule:
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_run_module_exposes_governed_bash_and_shell_alias_tools() -> None:
     protocol = _ProtocolStub()
     module = _build_module(protocol)
@@ -215,6 +215,8 @@ async def test_run_module_exposes_governed_bash_and_shell_alias_tools() -> None:
         assert "sandbox_session_id" in alias["inputSchema"]["properties"]
         assert "envFile" in alias["inputSchema"]["properties"]
         assert "env_file" in alias["inputSchema"]["properties"]
+        assert "shellName" in alias["inputSchema"]["properties"]
+        assert "shell_name" in alias["inputSchema"]["properties"]
 
 
 @pytest.mark.asyncio
@@ -411,6 +413,59 @@ def test_scoped_parent_idempotency_key_uses_unambiguous_scope_serialization() ->
     )
 
     assert newline_encoded_key != component_key
+
+
+@pytest.mark.unit
+async def test_run_shell_name_participates_in_nested_idempotency_scope() -> None:
+    """Explicit shell selection should scope nested idempotency without changing backend routing."""
+
+    protocol = _ProtocolStub()
+    module = _build_module(protocol)
+    context = RequestContext(request_id="run-shell-name-idem", user_id="1", client_id="unit")
+
+    await module.execute_tool(
+        "run",
+        {"command": "cat notes.txt", "shellName": "bash", "idempotencyKey": "parent-idem-shell"},
+        context=context,
+    )
+    await module.execute_tool(
+        "run",
+        {"command": "cat notes.txt", "shellName": "powershell", "idempotencyKey": "parent-idem-shell"},
+        context=context,
+    )
+
+    first_key = protocol.prepare_calls[0].idempotency_key
+    second_key = protocol.prepare_calls[1].idempotency_key
+    assert first_key != second_key
+    assert first_key is not None and first_key.startswith("parent-idem-shell:")
+    assert second_key is not None and second_key.startswith("parent-idem-shell:")
+    assert [call.params["name"] for call in protocol.prepare_calls] == ["fs.read", "fs.read"]
+
+
+@pytest.mark.parametrize(
+    "tool_name, arguments",
+    [
+        ("run", {"command": "ls", "shellName": ""}),
+        ("run", {"command": "ls", "shellName": "zsh"}),
+        ("run", {"command": "ls", "shellName": 123}),
+        ("run", {"command": "ls", "shellName": "bash", "shell_name": "powershell"}),
+        ("bash", {"command": "ls", "shellName": "powershell"}),
+        ("powershell", {"command": "ls", "shell_name": "bash"}),
+        ("pwsh", {"command": "ls", "shellName": "powershell"}),
+    ],
+)
+@pytest.mark.unit
+async def test_run_rejects_invalid_or_conflicting_shell_name_arguments(
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> None:
+    """Shell selection must be explicit, known, and compatible with pinned aliases."""
+
+    protocol = _ProtocolStub()
+    module = _build_module(protocol)
+
+    with pytest.raises(ValueError, match="shellName|shell_name"):
+        await module.execute_tool(tool_name, arguments, context=RequestContext(request_id="run-shell-name-invalid"))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add `shellName` / `shell_name` as an explicit virtual shell dialect selector for the governed `run` tool.
- Validate supported labels (`bash`, `shell`, `powershell`, `pwsh`) and reject conflicts with pinned aliases.
- Include shell selection in nested idempotency scope and document that it never enables raw host shell execution.

## Change summary
Human-authored summary required before merge: explain what changed and why the selected validation/idempotency behavior is acceptable.

## Risk & Rollback
Human-authored rollback assessment required before merge.

## Verification
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py -q` -> 80 passed, 4 warnings
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m ruff check tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py` -> passed
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m py_compile tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py` -> passed
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py -f json -o /tmp/bandit_mcp_run_shell_selection.json` -> results=0 errors=0 skipped=0
- `git diff --check` -> passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an explicit virtual shell selector to the governed `run` tool to label commands as `bash`, `shell`, `powershell`, or `pwsh`. Delivers part of TASK-2283 by validating selector values, pinning alias-shell consistency, and salting nested idempotency by shell without enabling raw host shell execution.

- **New Features**
  - Accepts `shellName`/`shell_name` with values: `bash`, `shell`, `powershell`, `pwsh`; mismatched or invalid values error.
  - Pins aliases `bash`, `powershell`, and `pwsh` to their matching selector; conflicting selector + alias now fails before backend calls.
  - Adds `shellName`/`shell_name` to the input schema and carries `shell_name` in `AdapterContext`.
  - Includes `shell_name` in the scoped parent idempotency key for nested calls.
  - Updates README and adds unit tests for schema exposure, idempotency scoping, and argument validation.

<sup>Written for commit abdb13268417b4ee9d4222d8fc9b631ccee62d97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

