### PR TITLE
TASK-2283 add PowerShell run guardrails

### DIFF
--- a/backlog/tasks/task-2283 - Add-Claude-style-governed-Bash-and-PowerShell-runtime-tools.md
+++ b/backlog/tasks/task-2283 - Add-Claude-style-governed-Bash-and-PowerShell-runtime-tools.md
@@ -4,7 +4,7 @@ title: Add Claude-style governed Bash and PowerShell runtime tools
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-06-18 14:12'
+updated_date: '2026-06-18 14:20'
 labels:
   - mcp
   - command-runtime
@@ -61,6 +61,8 @@ PR #2386 review pass: rebased branch onto latest origin/dev (already up to date)
 PR #2386 follow-up refinement: changed RunEnvFileValidationError to inherit the project ValidationError base while preserving ValueError-compatible behavior through the existing exception hierarchy. Verification rerun after refinement: run-command plus protocol hook pytest 81 passed; Ruff passed for touched Python files; py_compile passed for touched Python files; Bandit report /tmp/bandit_mcp_run_env_file_review.json had results=0 errors=0 skipped=0; git diff --check passed.
 
 Seventh slice implemented: added explicit shellName / shell_name selection for the governed virtual CLI. The selector accepts bash, shell, powershell, and pwsh labels, validates alias consistency, pins bash/powershell/pwsh tool aliases to their matching selector, carries the selected label in AdapterContext for future adapter behavior, and salts nested idempotency keys by shell selection without enabling raw host shell execution. Verification: focused run-command pytest 80 passed; Ruff passed for touched Python files; py_compile passed for touched Python files; Bandit report /tmp/bandit_mcp_run_shell_selection.json had results=0 errors=0 skipped=0; git diff --check passed.
+
+Eighth slice implemented: added PowerShell-specific fail-closed guardrails for the governed virtual CLI. When shellName is powershell/pwsh or the powershell alias is used, raw PowerShell invocation operator syntax (&) and unquoted script blocks ({ ... }) are rejected before parsing or backend MCP preparation, with PowerShell-specific diagnostics. Verification: focused run-command pytest 83 passed; Ruff passed for touched Python files; py_compile passed for touched Python files; Bandit report /tmp/bandit_mcp_run_powershell_guardrails.json had results=0 errors=0 skipped=0; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2283 - Add-Claude-style-governed-Bash-and-PowerShell-runtime-tools.md
+++ b/backlog/tasks/task-2283 - Add-Claude-style-governed-Bash-and-PowerShell-runtime-tools.md
@@ -4,7 +4,7 @@ title: Add Claude-style governed Bash and PowerShell runtime tools
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-06-18 14:20'
+updated_date: '2026-06-18 14:31'
 labels:
   - mcp
   - command-runtime
@@ -63,6 +63,10 @@ PR #2386 follow-up refinement: changed RunEnvFileValidationError to inherit the 
 Seventh slice implemented: added explicit shellName / shell_name selection for the governed virtual CLI. The selector accepts bash, shell, powershell, and pwsh labels, validates alias consistency, pins bash/powershell/pwsh tool aliases to their matching selector, carries the selected label in AdapterContext for future adapter behavior, and salts nested idempotency keys by shell selection without enabling raw host shell execution. Verification: focused run-command pytest 80 passed; Ruff passed for touched Python files; py_compile passed for touched Python files; Bandit report /tmp/bandit_mcp_run_shell_selection.json had results=0 errors=0 skipped=0; git diff --check passed.
 
 Eighth slice implemented: added PowerShell-specific fail-closed guardrails for the governed virtual CLI. When shellName is powershell/pwsh or the powershell alias is used, raw PowerShell invocation operator syntax (&) and unquoted script blocks ({ ... }) are rejected before parsing or backend MCP preparation, with PowerShell-specific diagnostics. Verification: focused run-command pytest 83 passed; Ruff passed for touched Python files; py_compile passed for touched Python files; Bandit report /tmp/bandit_mcp_run_powershell_guardrails.json had results=0 errors=0 skipped=0; git diff --check passed.
+
+PR #2391 review pass: rebased against latest origin/dev (already up to date) and addressed still-valid PowerShell scanner review items. Changes: narrowed script-block rejection to unquoted opening braces that are token-shaped like PowerShell script blocks so rg patterns such as foo{2} remain allowed; made PowerShell backtick handling quote-aware so single-quoted backticks are literals while outside/double-quoted backticks escape the next character for preflight scanning; and stopped classifying 2>&1 redirection ampersands as invocation operators so the generic redirection guard reports the denial. Verification recorded below.
+
+PR #2391 review verification: targeted review regressions passed (3 passed); full run-command pytest passed (86 passed, 4 warnings); Ruff passed for touched Python files; py_compile passed for touched Python files; Bandit report /tmp/bandit_mcp_run_powershell_guardrails_review.json had results=0 errors=0 skipped=0; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/app/core/MCP_unified/README.md
+++ b/tldw_Server_API/app/core/MCP_unified/README.md
@@ -425,6 +425,8 @@ Phase-1 adds a governed virtual CLI foundation to MCP Unified.
 
 `shellName` / `shell_name` may be set to `bash`, `shell`, `powershell`, or `pwsh` to label the intended virtual shell dialect for a `run` invocation. The selector is validated, included in nested idempotency scope, and never enables raw host shell execution. The `bash`, `powershell`, and `pwsh` aliases are pinned to their matching `shellName` values; conflicting selectors fail before backend MCP calls are prepared.
 
+PowerShell-facing invocations also fail closed on raw PowerShell syntax that the virtual CLI does not emulate, including the invocation operator (`&`) and unquoted script blocks (`{ ... }`). Use curated virtual CLI commands such as `ls`, `cat`, `rg`, and `sandbox` instead of shell scripts.
+
 `run` and its shell-facing aliases also accept optional `timeoutSeconds` / `timeout_seconds` values. The timeout covers the governed command chain, including policy preflight and nested MCP tool execution, and returns exit code `124` when exceeded.
 
 `cwd` / `workingDirectory` may be set to a workspace-relative directory for a single governed command chain. Relative file paths and search base paths are evaluated beneath that cwd, while absolute paths and final read/write decisions still flow through the backing MCP tools and profile policy. The cwd value rejects absolute paths, Windows drive roots, home-relative paths, and `..` traversal.

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
@@ -128,7 +128,7 @@ class RunCommandModule(BaseModule):
             )
 
         start = time.perf_counter()
-        unsupported_feature = self._unsupported_shell_feature_message(command_text)
+        unsupported_feature = self._unsupported_shell_feature_message(command_text, shell_name=shell_name)
         if unsupported_feature is not None:
             return present_command_execution_result(
                 CommandExecutionResult(
@@ -1141,8 +1141,13 @@ class RunCommandModule(BaseModule):
         return value
 
     @staticmethod
-    def _unsupported_shell_feature_message(command_text: str) -> str | None:
+    def _unsupported_shell_feature_message(command_text: str, *, shell_name: str | None = None) -> str | None:
         """Detect raw-shell syntax that the governed facade intentionally rejects."""
+
+        if shell_name in {"powershell", "pwsh"}:
+            powershell_message = RunCommandModule._unsupported_powershell_feature_message(command_text)
+            if powershell_message is not None:
+                return powershell_message
 
         first_token = RunCommandModule._first_unquoted_token(command_text)
         if first_token and RunCommandModule._looks_like_env_assignment(first_token):
@@ -1202,6 +1207,54 @@ class RunCommandModule(BaseModule):
 
             if char == "`":
                 return "Unsupported shell feature: command substitution is not supported by the governed shell facade"
+
+            position += 1
+
+        return None
+
+    @staticmethod
+    def _unsupported_powershell_feature_message(command_text: str) -> str | None:
+        """Detect PowerShell-only raw syntax that the virtual CLI does not emulate."""
+
+        quote: str | None = None
+        escaped = False
+        position = 0
+        length = len(command_text)
+        while position < length:
+            char = command_text[position]
+
+            if escaped:
+                escaped = False
+                position += 1
+                continue
+
+            if char == "`":
+                escaped = True
+                position += 1
+                continue
+
+            if quote is not None:
+                if char == quote:
+                    quote = None
+                position += 1
+                continue
+
+            if char in {'"', "'"}:
+                quote = char
+                position += 1
+                continue
+
+            if char in {"{", "}"}:
+                return "Unsupported PowerShell feature: script blocks are not supported by the governed shell facade"
+
+            if char == "&":
+                next_char = command_text[position + 1] if position + 1 < length else ""
+                previous_char = command_text[position - 1] if position > 0 else ""
+                if next_char != "&" and previous_char != "&":
+                    return (
+                        "Unsupported PowerShell feature: invocation operator is not supported by "
+                        "the governed shell facade"
+                    )
 
             position += 1
 

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
@@ -1228,13 +1228,19 @@ class RunCommandModule(BaseModule):
                 position += 1
                 continue
 
+            if quote == "'":
+                if char == "'":
+                    quote = None
+                position += 1
+                continue
+
             if char == "`":
                 escaped = True
                 position += 1
                 continue
 
-            if quote is not None:
-                if char == quote:
+            if quote == '"':
+                if char == '"':
                     quote = None
                 position += 1
                 continue
@@ -1244,13 +1250,13 @@ class RunCommandModule(BaseModule):
                 position += 1
                 continue
 
-            if char in {"{", "}"}:
+            if char == "{" and RunCommandModule._looks_like_powershell_script_block_start(command_text, position):
                 return "Unsupported PowerShell feature: script blocks are not supported by the governed shell facade"
 
             if char == "&":
                 next_char = command_text[position + 1] if position + 1 < length else ""
                 previous_char = command_text[position - 1] if position > 0 else ""
-                if next_char != "&" and previous_char != "&":
+                if next_char != "&" and previous_char not in {"&", ">"}:
                     return (
                         "Unsupported PowerShell feature: invocation operator is not supported by "
                         "the governed shell facade"
@@ -1259,6 +1265,25 @@ class RunCommandModule(BaseModule):
             position += 1
 
         return None
+
+    @staticmethod
+    def _looks_like_powershell_script_block_start(command_text: str, position: int) -> bool:
+        """Return whether an unquoted ``{`` is token-shaped like a PowerShell script block."""
+
+        if position <= 0:
+            return True
+
+        previous_char = command_text[position - 1]
+        if previous_char.isspace():
+            return True
+
+        previous_nonspace_position = position - 1
+        while previous_nonspace_position >= 0 and command_text[previous_nonspace_position].isspace():
+            previous_nonspace_position -= 1
+        if previous_nonspace_position < 0:
+            return True
+
+        return command_text[previous_nonspace_position] in {"|", ";", "&", "=", "(", "[", ","}
 
     @staticmethod
     def _shell_expansion_message(command_text: str, position: int) -> str:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
@@ -943,6 +943,56 @@ async def test_powershell_shell_selection_rejects_unsupported_platform_syntax_be
     assert protocol.execute_calls == []
 
 
+@pytest.mark.unit
+async def test_powershell_shell_selection_allows_brace_quantifier_search_pattern() -> None:
+    """Brace quantifiers in virtual CLI arguments are not PowerShell script blocks."""
+
+    protocol = _ProtocolStub()
+    module = _build_module(protocol)
+    context = RequestContext(request_id="run-powershell-brace-pattern", user_id="1", client_id="unit")
+
+    rendered = await module.execute_tool(
+        "run",
+        {"command": "rg foo{2} src", "shellName": "powershell"},
+        context=context,
+    )
+
+    assert "[exit:0 |" in rendered
+    assert [call.params["name"] for call in protocol.prepare_calls] == ["fs.grep"]
+    assert protocol.prepare_calls[0].params["arguments"] == {"pattern": "foo{2}", "base_path": "src"}
+
+
+@pytest.mark.unit
+async def test_powershell_redirection_is_not_reported_as_invocation_operator() -> None:
+    """PowerShell redirection containing & should keep the generic redirection diagnostic."""
+
+    protocol = _ProtocolStub()
+    module = _build_module(protocol)
+    context = RequestContext(request_id="run-powershell-redirection", user_id="1", client_id="unit")
+
+    rendered = await module.execute_tool(
+        "run",
+        {"command": "cat notes.txt 2>&1", "shellName": "powershell"},
+        context=context,
+    )
+
+    assert "Unsupported shell feature: redirection" in rendered
+    assert "Unsupported PowerShell feature: invocation operator" not in rendered
+    assert "[exit:2 |" in rendered
+    assert protocol.prepare_calls == []
+    assert protocol.execute_calls == []
+
+
+@pytest.mark.unit
+def test_powershell_single_quoted_backtick_does_not_escape_closing_quote() -> None:
+    """PowerShell treats backticks as literals inside single-quoted strings."""
+
+    message = RunCommandModule._unsupported_powershell_feature_message("rg '`' & src")
+
+    assert message is not None
+    assert "Unsupported PowerShell feature: invocation operator" in message
+
+
 @pytest.mark.asyncio
 async def test_run_filesystem_aliases_route_to_backing_tools() -> None:
     protocol = _ProtocolStub()

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
@@ -903,6 +903,46 @@ async def test_shell_alias_rejects_unsupported_raw_shell_syntax_before_backend_c
     assert protocol.execute_calls == []
 
 
+@pytest.mark.parametrize(
+    ("tool_name", "arguments", "expected_message"),
+    [
+        (
+            "powershell",
+            {"command": "& ./script.ps1"},
+            "Unsupported PowerShell feature: invocation operator",
+        ),
+        (
+            "pwsh",
+            {"command": "& ./script.ps1"},
+            "Unsupported PowerShell feature: invocation operator",
+        ),
+        (
+            "run",
+            {"command": "ForEach-Object { Get-ChildItem }", "shellName": "powershell"},
+            "Unsupported PowerShell feature: script blocks",
+        ),
+    ],
+)
+@pytest.mark.unit
+async def test_powershell_shell_selection_rejects_unsupported_platform_syntax_before_backend_calls(
+    tool_name: str,
+    arguments: dict[str, Any],
+    expected_message: str,
+) -> None:
+    """PowerShell-only raw shell syntax must fail before any governed backend call."""
+
+    protocol = _ProtocolStub()
+    module = _build_module(protocol)
+    context = RequestContext(request_id="run-powershell-unsupported", user_id="1", client_id="unit")
+
+    rendered = await module.execute_tool(tool_name, arguments, context=context)
+
+    assert expected_message in rendered
+    assert "[exit:2 |" in rendered
+    assert protocol.prepare_calls == []
+    assert protocol.execute_calls == []
+
+
 @pytest.mark.asyncio
 async def test_run_filesystem_aliases_route_to_backing_tools() -> None:
     protocol = _ProtocolStub()


### PR DESCRIPTION
## Summary
- Add PowerShell-specific fail-closed checks to the governed virtual CLI runtime.
- Reject raw PowerShell invocation operator usage (`&`) and unquoted script blocks before command parsing or backend MCP preparation.
- Cover `powershell`, `pwsh`, and `run` with `shellName: powershell`; document the behavior in the MCP README and TASK-2283.

## Change summary
Human-authored summary required before merge: explain what changed and why these PowerShell-specific guardrails are acceptable for the virtual CLI.

## Risk & Rollback
Human-authored rollback assessment required before merge.

## Verification
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py -q` -> 83 passed, 4 warnings
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m ruff check tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py` -> passed
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m py_compile tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py` -> passed
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py -f json -o /tmp/bandit_mcp_run_powershell_guardrails.json` -> results=0 errors=0 skipped=0
- `git diff --check` -> passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PowerShell guardrails to the governed virtual CLI to block unsafe raw syntax and fail early with clear errors. Refines the scanner to avoid false positives and aligns with TASK-2283.

- **New Features**
  - Reject `&` and unquoted PowerShell script blocks when using `powershell`/`pwsh` or `run` with `shellName: "powershell"`.
  - Fail closed before parsing or preparing backend MCP calls; docs and tests updated.

- **Bug Fixes**
  - Do not flag `2>&1` as an invocation operator; keep the redirection denial.
  - Allow brace-quantifier patterns like `foo{2}`; only block token-shaped unquoted `{` script blocks.
  - Make backtick handling quote-aware (single-quoted backticks are literals).

<sup>Written for commit 3abfea8602058c0ed2fea0c3f33b53f7e1c96da8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

