### PR TITLE
Add server Workspace frontend context contracts

### DIFF
--- a/Docs/superpowers/plans/2026-06-18-workspace-frontend-server-context-contract.md
+++ b/Docs/superpowers/plans/2026-06-18-workspace-frontend-server-context-contract.md
@@ -1,0 +1,404 @@
+# Workspace Frontend Server Context Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add shared frontend Workspace context contracts that unify Research Workspace and ACP Playground on the server Workspace model for issue #1993.
+
+**Architecture:** Keep `workspace-api.ts` as the raw server DTO layer. Add a focused `services/workspace-context` contract layer with pure normalizers, recovery-copy helpers, action eligibility helpers, and thin React hooks. Pilot the contract in Research Workspace and ACP Playground without creating #1994 resource index/activity UI.
+
+**Tech Stack:** TypeScript, React 18, Vitest, Testing Library, existing Tldw API client, existing Research Workspace and ACP session stores.
+
+---
+
+## File Map
+
+- Create `apps/packages/ui/src/services/workspace-context/contracts.ts`
+  - Export normalized Workspace summary, active context, eligibility, recovery, membership label, and ACP session context types.
+- Create `apps/packages/ui/src/services/workspace-context/normalizers.ts`
+  - Pure helpers that derive frontend display/action contracts from `WorkspaceApiResponse`, `WorkspaceContextResponse`, `WorkspaceCapabilitiesResponse`, and `WorkspaceAllowedAction`.
+- Create `apps/packages/ui/src/services/workspace-context/hooks.tsx`
+  - Thin hooks for resolving active server Workspace context and capability-derived action state.
+- Create `apps/packages/ui/src/services/workspace-context/index.ts`
+  - Barrel exports for the shared contract.
+- Create `apps/packages/ui/src/services/workspace-context/__tests__/normalizers.test.ts`
+  - Pure contract tests.
+- Create `apps/packages/ui/src/services/workspace-context/__tests__/hooks.test.tsx`
+  - Hook behavior tests with a mocked Workspace API client.
+- Modify `apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx`
+  - Render a compact server-authoritative Workspace context indicator and shared recovery copy.
+- Modify `apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx`
+  - Pilot rendering tests.
+- Modify `apps/packages/ui/src/components/Option/ACPPlayground/ACPWorkspacePanel.tsx`
+  - Render ACP session/server Workspace alignment and mismatch copy.
+- Modify `apps/packages/ui/src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx`
+  - ACP pilot tests.
+- Modify or add one global browse/list guard test near the existing global Workspace/search tests:
+  - Prefer `apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/workspace-global-search.test.ts` if it already covers the behavior.
+  - Otherwise add `apps/packages/ui/src/services/workspace-context/__tests__/global-visibility.guard.test.ts`.
+- Modify `Docs/superpowers/specs/2026-06-18-workspace-frontend-server-context-contract-design.md` only if implementation uncovers an API gap.
+- Modify `backlog/tasks/task-2386 - Implement-Workspace-Phase-2-frontend-context-contracts-pilot.md`
+  - Track plan path, touched files, verification, known skips, and final summary.
+
+## Task 1: Pure Server Contract Normalizers
+
+**Files:**
+- Create: `apps/packages/ui/src/services/workspace-context/contracts.ts`
+- Create: `apps/packages/ui/src/services/workspace-context/normalizers.ts`
+- Create: `apps/packages/ui/src/services/workspace-context/index.ts`
+- Test: `apps/packages/ui/src/services/workspace-context/__tests__/normalizers.test.ts`
+
+- [ ] **Step 1: Write failing normalizer tests**
+
+Add tests for:
+
+```ts
+import {
+  compareACPWorkspaceContext,
+  normalizeActiveWorkspaceContext,
+  normalizeWorkspaceSummary,
+  resolveWorkspaceActionEligibility,
+  resolveWorkspaceRecovery
+} from "../normalizers"
+
+it("keeps server workspace identity authoritative", () => {
+  const summary = normalizeWorkspaceSummary({
+    id: "ws-server-1",
+    name: null,
+    archived: false,
+    study_materials_policy: "workspace",
+    workspace_profile: "project",
+    deleted: false,
+    banner_title: null,
+    banner_subtitle: null,
+    banner_color: null,
+    audio_provider: null,
+    audio_model: null,
+    audio_voice: null,
+    audio_speed: null,
+    created_at: "2026-06-18T00:00:00Z",
+    last_modified: "2026-06-18T00:10:00Z",
+    version: 7
+  })
+
+  expect(summary.id).toBe("ws-server-1")
+  expect(summary.label).toBe("Workspace ws-server-1")
+  expect(summary.profile).toBe("project")
+})
+
+it("maps partial workspace context to visible recovery copy", () => {
+  const context = normalizeActiveWorkspaceContext({
+    workspace_id: "ws-1",
+    workspace_profile: "project",
+    workspace_kind: "project",
+    schema_version: 1,
+    generated_at: "2026-06-18T00:00:00Z",
+    workspace: workspaceFixture({ id: "ws-1", name: "Server Workspace" }),
+    attention_state: "needs_attention",
+    resolution: {
+      status: "partial",
+      partial_errors: [{ scope: "sources", code: "source_status_unavailable", message: "Source status unavailable" }]
+    },
+    project_root: projectRootFixture({ state: "attached" }),
+    sources: { items: [], summary: sourceSummaryFixture({ total: 2 }) },
+    capabilities: capabilitiesFixture({ workspace_id: "ws-1" }),
+    services: {},
+    allowed_actions: {},
+    active_jobs: [],
+    active_operations: [],
+    partial_errors: [{ scope: "sources", code: "source_status_unavailable", message: "Source status unavailable" }]
+  })
+
+  expect(context.state).toBe("partial")
+  expect(context.recovery.reasonCode).toBe("partial_context")
+})
+
+it("uses server action reason codes for eligibility recovery", () => {
+  const decision = resolveWorkspaceActionEligibility("open_terminal", {
+    allowed: false,
+    reason_code: "workspace_project_root_missing"
+  })
+
+  expect(decision.allowed).toBe(false)
+  expect(decision.recovery.nextStepHref).toBe("#/workspaces")
+})
+
+it("detects ACP session and active workspace mismatch without mutating either side", () => {
+  const context = compareACPWorkspaceContext({
+    sessionWorkspaceId: "ws-session",
+    activeWorkspaceId: "ws-active"
+  })
+
+  expect(context.state).toBe("mismatch")
+  expect(context.recovery.reasonCode).toBe("workspace_mismatch")
+})
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/workspace-context-contract/apps/packages/ui
+npx vitest run src/services/workspace-context/__tests__/normalizers.test.ts --maxWorkers=1
+```
+
+Expected: fail because `services/workspace-context` does not exist.
+
+- [ ] **Step 3: Implement minimal contract types and normalizers**
+
+Implement:
+
+- `normalizeWorkspaceSummary(response)`
+- `normalizeActiveWorkspaceContext(response | null, options?)`
+- `resolveWorkspaceRecovery(reasonCode, options?)`
+- `resolveWorkspaceActionEligibility(action, allowedAction?)`
+- `compareACPWorkspaceContext({ sessionWorkspaceId, activeWorkspaceId, sessionWorkspaceLabel?, activeWorkspaceLabel? })`
+
+Keep server enum values visible in the returned contracts. Add display labels only as derived fields.
+
+- [ ] **Step 4: Run test to verify GREEN**
+
+Run the same focused Vitest command. Expected: pass.
+
+- [ ] **Step 5: Refactor**
+
+Remove duplicated copy branches inside `normalizers.ts`. Do not add hooks or UI in this task.
+
+## Task 2: Active Workspace Context Hooks
+
+**Files:**
+- Create: `apps/packages/ui/src/services/workspace-context/hooks.tsx`
+- Test: `apps/packages/ui/src/services/workspace-context/__tests__/hooks.test.tsx`
+- Modify: `apps/packages/ui/src/services/workspace-context/index.ts`
+
+- [ ] **Step 1: Write failing hook tests**
+
+Add tests that mount a small component using `useActiveWorkspaceContext` with a mocked client:
+
+```tsx
+it("does not fetch when no active server workspace id exists", async () => {
+  const getWorkspaceContext = vi.fn()
+  render(<Probe workspaceId={null} client={{ getWorkspaceContext }} />)
+
+  expect(screen.getByTestId("state")).toHaveTextContent("none")
+  expect(getWorkspaceContext).not.toHaveBeenCalled()
+})
+
+it("normalizes fetched server context", async () => {
+  const getWorkspaceContext = vi.fn(async () => workspaceContextFixture({ workspace_id: "ws-1" }))
+  render(<Probe workspaceId="ws-1" client={{ getWorkspaceContext }} />)
+
+  expect(await screen.findByTestId("state")).toHaveTextContent("ready")
+  expect(getWorkspaceContext).toHaveBeenCalledWith("ws-1")
+})
+
+it("surfaces failed server resolution as degraded context", async () => {
+  const getWorkspaceContext = vi.fn(async () => {
+    throw new Error("network down")
+  })
+  render(<Probe workspaceId="ws-1" client={{ getWorkspaceContext }} />)
+
+  expect(await screen.findByTestId("state")).toHaveTextContent("error")
+})
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/workspace-context-contract/apps/packages/ui
+npx vitest run src/services/workspace-context/__tests__/hooks.test.tsx --maxWorkers=1
+```
+
+Expected: fail because hook file does not exist.
+
+- [ ] **Step 3: Implement minimal hook**
+
+Implement `useActiveWorkspaceContext({ workspaceId, client })`.
+
+Rules:
+
+- `workspaceId` is the server Workspace ID.
+- `null` or blank ID returns `state: "none"` and does not fetch.
+- Fetch `client.getWorkspaceContext(workspaceId)` on ID change.
+- Use an ignore flag in `useEffect` cleanup to avoid stale updates.
+- Return `{ context, loading, error, refresh }`.
+- Default the client to the existing Tldw API client only after checking the local import pattern.
+
+- [ ] **Step 4: Run hook tests**
+
+Expected: pass.
+
+## Task 3: Research Workspace Pilot
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx`
+- Test: `apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx`
+
+- [ ] **Step 1: Write failing rendering tests**
+
+Add tests for:
+
+- Ready server Workspace context renders a compact server Workspace label.
+- Missing/error context renders shared recovery copy and a canonical Workspaces link.
+- Existing local workspace title editing still works.
+
+Example expected UI assertions:
+
+```tsx
+expect(await screen.findByText(/Server Workspace/i)).toBeInTheDocument()
+expect(screen.getByText(/Server context ready/i)).toBeInTheDocument()
+expect(screen.getByRole("link", { name: /open Workspaces/i })).toHaveAttribute("href", "#/workspaces")
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/workspace-context-contract/apps/packages/ui
+npx vitest run src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx --maxWorkers=1
+```
+
+Expected: fail because the header does not render the server-context contract.
+
+- [ ] **Step 3: Implement compact server context indicator**
+
+Use `useWorkspaceStore((s) => s.workspaceId)` as the server Workspace ID candidate, then call `useActiveWorkspaceContext`.
+
+Render a small unframed inline indicator near existing header status controls:
+
+- Ready: server Workspace label and state.
+- Partial: label plus recovery message.
+- Missing/error: recovery message and `#/workspaces` link.
+
+Keep copy concise. Do not add a new Workspace browser or index.
+
+- [ ] **Step 4: Run Research Workspace test**
+
+Expected: pass.
+
+## Task 4: ACP Playground Pilot
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/ACPPlayground/ACPWorkspacePanel.tsx`
+- Test: `apps/packages/ui/src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx`
+
+- [ ] **Step 1: Write failing ACP panel tests**
+
+Add tests for:
+
+- No-session state still links to canonical Workspaces.
+- Aligned ACP session Workspace displays aligned context.
+- Mismatch state displays both Workspace references and recovery copy.
+- Terminal unavailable copy remains visible when `sshWsUrl` is missing.
+
+Use the existing ACP session store test setup and add `workspaceId` to the active session fixture.
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/workspace-context-contract/apps/packages/ui
+npx vitest run src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx --maxWorkers=1
+```
+
+Expected: fail because the ACP panel does not render alignment/mismatch contract copy.
+
+- [ ] **Step 3: Implement ACP session comparison**
+
+Use `compareACPWorkspaceContext` with:
+
+- `sessionWorkspaceId` from `activeSession.workspaceId` if present.
+- `activeWorkspaceId` from the active server Workspace context hook or local Workspace store ID.
+
+Render a compact notice in the panel header or empty-state copy. Do not mutate either store and do not auto-switch Workspaces.
+
+- [ ] **Step 4: Run ACP panel test**
+
+Expected: pass.
+
+## Task 5: Global Visibility Guard, Docs, Backlog, And Verification
+
+**Files:**
+- Test: `apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/workspace-global-search.test.ts` or `apps/packages/ui/src/services/workspace-context/__tests__/global-visibility.guard.test.ts`
+- Modify: `backlog/tasks/task-2386 - Implement-Workspace-Phase-2-frontend-context-contracts-pilot.md`
+- Modify: `Docs/superpowers/specs/2026-06-18-workspace-frontend-server-context-contract-design.md` only if needed
+
+- [ ] **Step 1: Write global visibility guard test**
+
+Add a focused test proving active Workspace context does not filter global browse/search/list rows. The test can be pure if the existing global search utility is pure:
+
+```ts
+it("does not filter global rows by active workspace context unless an explicit workspace filter is passed", () => {
+  const rows = [
+    { id: "note-1", workspaceId: "ws-active", title: "Active" },
+    { id: "note-2", workspaceId: "ws-other", title: "Other" }
+  ]
+
+  const visible = applyGlobalWorkspaceVisibility(rows, { activeWorkspaceId: "ws-active" })
+
+  expect(visible.map((row) => row.id)).toEqual(["note-1", "note-2"])
+})
+```
+
+If no shared utility exists, assert the invariant through the closest existing global search/list rendering test and do not introduce a fake product API.
+
+- [ ] **Step 2: Run guard test to verify RED or baseline**
+
+If the behavior already exists, the test may pass on first run. In that case, note it as a characterization guard in the Backlog task.
+
+- [ ] **Step 3: Implement only if needed**
+
+If the guard exposes accidental filtering, fix only that filtering path. Do not build Workspace filter UI in this task.
+
+- [ ] **Step 4: Run focused verification**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/workspace-context-contract/apps/packages/ui
+npx vitest run \
+  src/services/workspace-context/__tests__/normalizers.test.ts \
+  src/services/workspace-context/__tests__/hooks.test.tsx \
+  src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx \
+  src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx \
+  --maxWorkers=1
+```
+
+Also run the global guard test if it is in a separate file.
+
+- [ ] **Step 5: Record Bandit skip**
+
+Because this slice is frontend/docs only, record in `TASK-2386` that Bandit is not applicable unless Python files were touched.
+
+- [ ] **Step 6: Finalize Backlog task**
+
+Update `TASK-2386` with:
+
+- plan path;
+- touched files;
+- verification commands and results;
+- known skips or blockers;
+- final summary.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git status --short
+git add Docs/superpowers/specs/2026-06-18-workspace-frontend-server-context-contract-design.md \
+  Docs/superpowers/plans/2026-06-18-workspace-frontend-server-context-contract.md \
+  "backlog/tasks/task-2386 - Implement-Workspace-Phase-2-frontend-context-contracts-pilot.md" \
+  apps/packages/ui/src/services/workspace-context \
+  apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx \
+  apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx \
+  apps/packages/ui/src/components/Option/ACPPlayground/ACPWorkspacePanel.tsx \
+  apps/packages/ui/src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx
+git commit -m "feat(ui): add server workspace context contracts"
+```
+
+Add any global guard test path if separate.

--- a/Docs/superpowers/plans/2026-06-18-workspace-frontend-server-context-contract.md
+++ b/Docs/superpowers/plans/2026-06-18-workspace-frontend-server-context-contract.md
@@ -47,7 +47,7 @@
 - Create: `apps/packages/ui/src/services/workspace-context/index.ts`
 - Test: `apps/packages/ui/src/services/workspace-context/__tests__/normalizers.test.ts`
 
-- [ ] **Step 1: Write failing normalizer tests**
+- [x] **Step 1: Write failing normalizer tests**
 
 Add tests for:
 
@@ -133,7 +133,7 @@ it("detects ACP session and active workspace mismatch without mutating either si
 })
 ```
 
-- [ ] **Step 2: Run test to verify RED**
+- [x] **Step 2: Run test to verify RED**
 
 Run:
 
@@ -144,7 +144,7 @@ npx vitest run src/services/workspace-context/__tests__/normalizers.test.ts --ma
 
 Expected: fail because `services/workspace-context` does not exist.
 
-- [ ] **Step 3: Implement minimal contract types and normalizers**
+- [x] **Step 3: Implement minimal contract types and normalizers**
 
 Implement:
 
@@ -156,11 +156,11 @@ Implement:
 
 Keep server enum values visible in the returned contracts. Add display labels only as derived fields.
 
-- [ ] **Step 4: Run test to verify GREEN**
+- [x] **Step 4: Run test to verify GREEN**
 
 Run the same focused Vitest command. Expected: pass.
 
-- [ ] **Step 5: Refactor**
+- [x] **Step 5: Refactor**
 
 Remove duplicated copy branches inside `normalizers.ts`. Do not add hooks or UI in this task.
 
@@ -171,7 +171,7 @@ Remove duplicated copy branches inside `normalizers.ts`. Do not add hooks or UI 
 - Test: `apps/packages/ui/src/services/workspace-context/__tests__/hooks.test.tsx`
 - Modify: `apps/packages/ui/src/services/workspace-context/index.ts`
 
-- [ ] **Step 1: Write failing hook tests**
+- [x] **Step 1: Write failing hook tests**
 
 Add tests that mount a small component using `useActiveWorkspaceContext` with a mocked client:
 
@@ -202,7 +202,7 @@ it("surfaces failed server resolution as degraded context", async () => {
 })
 ```
 
-- [ ] **Step 2: Run test to verify RED**
+- [x] **Step 2: Run test to verify RED**
 
 Run:
 
@@ -213,7 +213,7 @@ npx vitest run src/services/workspace-context/__tests__/hooks.test.tsx --maxWork
 
 Expected: fail because hook file does not exist.
 
-- [ ] **Step 3: Implement minimal hook**
+- [x] **Step 3: Implement minimal hook**
 
 Implement `useActiveWorkspaceContext({ workspaceId, client })`.
 
@@ -226,7 +226,7 @@ Rules:
 - Return `{ context, loading, error, refresh }`.
 - Default the client to the existing Tldw API client only after checking the local import pattern.
 
-- [ ] **Step 4: Run hook tests**
+- [x] **Step 4: Run hook tests**
 
 Expected: pass.
 
@@ -236,7 +236,7 @@ Expected: pass.
 - Modify: `apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx`
 - Test: `apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx`
 
-- [ ] **Step 1: Write failing rendering tests**
+- [x] **Step 1: Write failing rendering tests**
 
 Add tests for:
 
@@ -252,7 +252,7 @@ expect(screen.getByText(/Server context ready/i)).toBeInTheDocument()
 expect(screen.getByRole("link", { name: /open Workspaces/i })).toHaveAttribute("href", "#/workspaces")
 ```
 
-- [ ] **Step 2: Run test to verify RED**
+- [x] **Step 2: Run test to verify RED**
 
 Run:
 
@@ -263,7 +263,7 @@ npx vitest run src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader
 
 Expected: fail because the header does not render the server-context contract.
 
-- [ ] **Step 3: Implement compact server context indicator**
+- [x] **Step 3: Implement compact server context indicator**
 
 Use `useWorkspaceStore((s) => s.workspaceId)` as the server Workspace ID candidate, then call `useActiveWorkspaceContext`.
 
@@ -275,7 +275,7 @@ Render a small unframed inline indicator near existing header status controls:
 
 Keep copy concise. Do not add a new Workspace browser or index.
 
-- [ ] **Step 4: Run Research Workspace test**
+- [x] **Step 4: Run Research Workspace test**
 
 Expected: pass.
 
@@ -285,7 +285,7 @@ Expected: pass.
 - Modify: `apps/packages/ui/src/components/Option/ACPPlayground/ACPWorkspacePanel.tsx`
 - Test: `apps/packages/ui/src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx`
 
-- [ ] **Step 1: Write failing ACP panel tests**
+- [x] **Step 1: Write failing ACP panel tests**
 
 Add tests for:
 
@@ -296,7 +296,7 @@ Add tests for:
 
 Use the existing ACP session store test setup and add `workspaceId` to the active session fixture.
 
-- [ ] **Step 2: Run test to verify RED**
+- [x] **Step 2: Run test to verify RED**
 
 Run:
 
@@ -307,7 +307,7 @@ npx vitest run src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.t
 
 Expected: fail because the ACP panel does not render alignment/mismatch contract copy.
 
-- [ ] **Step 3: Implement ACP session comparison**
+- [x] **Step 3: Implement ACP session comparison**
 
 Use `compareACPWorkspaceContext` with:
 
@@ -316,7 +316,7 @@ Use `compareACPWorkspaceContext` with:
 
 Render a compact notice in the panel header or empty-state copy. Do not mutate either store and do not auto-switch Workspaces.
 
-- [ ] **Step 4: Run ACP panel test**
+- [x] **Step 4: Run ACP panel test**
 
 Expected: pass.
 
@@ -327,7 +327,7 @@ Expected: pass.
 - Modify: `backlog/tasks/task-2386 - Implement-Workspace-Phase-2-frontend-context-contracts-pilot.md`
 - Modify: `Docs/superpowers/specs/2026-06-18-workspace-frontend-server-context-contract-design.md` only if needed
 
-- [ ] **Step 1: Write global visibility guard test**
+- [x] **Step 1: Write global visibility guard test**
 
 Add a focused test proving active Workspace context does not filter global browse/search/list rows. The test can be pure if the existing global search utility is pure:
 
@@ -346,15 +346,15 @@ it("does not filter global rows by active workspace context unless an explicit w
 
 If no shared utility exists, assert the invariant through the closest existing global search/list rendering test and do not introduce a fake product API.
 
-- [ ] **Step 2: Run guard test to verify RED or baseline**
+- [x] **Step 2: Run guard test to verify RED or baseline**
 
 If the behavior already exists, the test may pass on first run. In that case, note it as a characterization guard in the Backlog task.
 
-- [ ] **Step 3: Implement only if needed**
+- [x] **Step 3: Implement only if needed**
 
 If the guard exposes accidental filtering, fix only that filtering path. Do not build Workspace filter UI in this task.
 
-- [ ] **Step 4: Run focused verification**
+- [x] **Step 4: Run focused verification**
 
 Run:
 
@@ -370,11 +370,11 @@ npx vitest run \
 
 Also run the global guard test if it is in a separate file.
 
-- [ ] **Step 5: Record Bandit skip**
+- [x] **Step 5: Record Bandit skip**
 
 Because this slice is frontend/docs only, record in `TASK-2386` that Bandit is not applicable unless Python files were touched.
 
-- [ ] **Step 6: Finalize Backlog task**
+- [x] **Step 6: Finalize Backlog task**
 
 Update `TASK-2386` with:
 
@@ -384,7 +384,7 @@ Update `TASK-2386` with:
 - known skips or blockers;
 - final summary.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 Run:
 

--- a/Docs/superpowers/specs/2026-06-18-workspace-frontend-server-context-contract-design.md
+++ b/Docs/superpowers/specs/2026-06-18-workspace-frontend-server-context-contract-design.md
@@ -1,0 +1,209 @@
+# Workspace Frontend Server Context Contract Design
+
+Date: 2026-06-18
+Status: Approved For Implementation Planning
+Owner: Codex brainstorming session
+Backlog: TASK-2386
+
+Related:
+
+- GitHub issue #1993: Workspace Phase 2 frontend context contracts
+- GitHub issue #1984: Workspace Phase 2 release tracker
+- GitHub issue #1994: Workspace activity and resource index follow-up
+- `Docs/superpowers/specs/2026-06-17-workspace-membership-adapters-design.md`
+
+## Goal
+
+Implement the #1993 frontend contract slice by making the server Workspace model the authoritative source for Workspace identity, membership, active-context state, eligibility decisions, and recovery copy.
+
+The frontend may cache, hydrate, decorate, and normalize server responses for rendering. It must not create another independent Workspace semantic model.
+
+## Product Decision
+
+Unify on the server Workspace model.
+
+`apps/packages/ui/src/services/tldw/domains/workspace-api.ts` already exposes the raw server Workspace DTOs, including workspaces, sources, context, capabilities, roots, allowed actions, and partial errors. The #1993 contract layer should sit above those DTOs and below feature UI. Its job is to normalize server-owned state into stable client display helpers and action guards.
+
+The existing Research Workspace store remains useful for local UI state, browser persistence, drafts, layout state, import/export, source-pane state, and display decoration. It is not authoritative for Workspace membership, server resource ownership, project roots, ACP runtime association, or whether a Workspace-sensitive action is available.
+
+## Scope
+
+In scope:
+
+- Shared frontend contract types for normalized server Workspace summaries, active Workspace context, membership labels, eligibility decisions, and recovery actions.
+- Pure helper functions that consume existing server DTOs and produce display/action contracts.
+- Thin hooks or services that fetch active Workspace context and capability data through the existing Tldw API client.
+- Research Workspace pilot integration that displays server-authoritative active Workspace context and uses shared recovery copy for Workspace-sensitive operations.
+- ACP Playground pilot integration that displays ACP session Workspace state, including active-session and active-Workspace mismatch copy.
+- Tests proving active Workspace selection does not silently filter global browse/search or list rendering.
+- Adoption guidance for later surfaces to reuse the same contracts.
+
+Out of scope:
+
+- #1994 contained-resource index, activity feed, or Workspace dashboard UI.
+- Broad migration of all Notes, Media, Sources, Prompts, Workflows, Watchlists, and Chats surfaces.
+- Backend API changes unless implementation discovers a blocking contract gap.
+- Changing ACP execution admission, sandbox trust, path authorization, MCP permissions, or agent runtime policy.
+- Treating local Research Workspace state as a replacement for server membership.
+
+## Architecture
+
+Use three explicit layers.
+
+| Layer | Responsibility |
+| --- | --- |
+| Server DTOs | Raw API response types and request methods in `workspace-api.ts`. These mirror the backend contract. |
+| Frontend contract | Pure normalization, labels, recovery copy, and action decisions derived from server DTOs. |
+| Feature UI | Research Workspace and ACP Playground consume the contract without reinterpreting Workspace semantics. |
+
+The contract layer should live in a shared frontend location such as `apps/packages/ui/src/services/workspace-context/` or another existing shared-services convention if code review shows a better local pattern.
+
+The contract layer should not duplicate `WorkspaceApiResponse` or `WorkspaceContextResponse` as a competing model. It should import the DTO types, keep server enum values visible where possible, and add only display-focused fields that are clearly derived.
+
+## Contract Shapes
+
+### Workspace Summary
+
+Normalize `WorkspaceApiResponse` into a compact display summary:
+
+- `id`
+- `name`
+- `profile`
+- `archived`
+- `deleted`
+- `studyMaterialsPolicy`
+- `label`
+- `statusLabel`
+- `version`
+- `lastModified`
+
+The summary keeps the server ID as the identity key. Generated labels are display-only fallbacks.
+
+### Active Workspace Context
+
+Represent active context as:
+
+- `state`: `none`, `loading`, `ready`, `partial`, `missing`, or `error`
+- `workspaceId`
+- `workspace`
+- `attentionState`
+- `resolution`
+- `projectRoot`
+- `sourceSummary`
+- `allowedActions`
+- `partialErrors`
+- `recovery`
+
+`ready` and `partial` are derived from `WorkspaceContextResponse.resolution.status`. `missing` is used only when a local active Workspace ID cannot be resolved from the server.
+
+### Membership Label
+
+Membership labels should answer "where does this resource belong?" without implying filtering or authorization:
+
+- `workspaceId`
+- `workspaceLabel`
+- `membershipLabel`
+- `tone`
+- `isAuthoritative`
+- `reasonCode`
+
+Membership labels are display metadata. They do not grant access.
+
+### Eligibility Decision
+
+Eligibility should wrap `WorkspaceAllowedAction` and capability data:
+
+- `action`
+- `allowed`
+- `reasonCode`
+- `severity`
+- `primaryMessage`
+- `nextStepLabel`
+- `nextStepHref`
+
+Live eligibility checks should be action-scoped. Lists should not issue eager eligibility checks for every row.
+
+### ACP Session Context
+
+ACP session context should compare the ACP session's server Workspace association against the currently active server Workspace context:
+
+- `sessionWorkspaceId`
+- `activeWorkspaceId`
+- `state`: `aligned`, `mismatch`, `session_only`, `active_only`, `missing`, or `unknown`
+- `message`
+- `recovery`
+
+Mismatch handling must be visible. It must not silently switch Research Workspace state or mutate the ACP session.
+
+## Data Flow
+
+1. Research Workspace reads its current local Workspace ID and asks the server contract hook to resolve the server Workspace context.
+2. The hook fetches server context or capabilities through the existing Tldw API client only when a server Workspace ID exists.
+3. Contract helpers normalize the server response into display and action contracts.
+4. Research Workspace renders active context and recovery notices from the shared contract.
+5. ACP Playground reads the active ACP session Workspace ID from its session store and compares it with the shared active Workspace context.
+6. Global browse/search/list surfaces keep using their existing data sources and must not filter rows just because an active Workspace context exists.
+
+## Error Handling
+
+Use conservative, visible fallbacks:
+
+- Missing server Workspace: show missing context and point to the Workspaces manager.
+- Archived Workspace: show archived context and disable Workspace-sensitive mutations.
+- Partial server resolution: show partial context and surface partial-error messages without blocking read-only rendering.
+- Unsupported action: render stable disabled-action copy from the server reason code.
+- ACP mismatch: show both IDs or labels when available and explain that the session is attached to a different server Workspace.
+- API failure: show degraded context and avoid allowing Workspace-sensitive actions until the server state can be resolved.
+
+Reason-code mapping should be centralized so later surfaces use the same copy.
+
+## Pilot Details
+
+### Research Workspace
+
+Add a compact server Workspace context indicator near the existing header status controls. It should answer:
+
+- Which server Workspace is active?
+- Is server context ready, partial, missing, archived, or degraded?
+- What next step is available when a Workspace-sensitive action cannot proceed?
+
+This is not a new Workspace browser. Existing local browser behavior can remain, but server authority should be clear in the pilot copy and action guards.
+
+### ACP Playground
+
+Add a compact terminal/session Workspace notice in `ACPWorkspacePanel`:
+
+- No session: continue linking to canonical Workspaces.
+- Session without Workspace terminal: continue showing sandbox-required copy.
+- Session Workspace aligned with active Workspace: show aligned server Workspace context.
+- Session Workspace differs from active Workspace: show mismatch copy and link to canonical Workspaces.
+
+Do not auto-switch the active Research Workspace from ACP session state.
+
+## Testing
+
+Add tests before implementation for:
+
+- Pure normalization from `WorkspaceApiResponse`, `WorkspaceContextResponse`, `WorkspaceCapabilitiesResponse`, and `WorkspaceAllowedAction`.
+- Recovery-copy mapping for common reason codes and unknown reason codes.
+- ACP session/active Workspace comparison states.
+- Research Workspace pilot rendering for ready, partial, missing, and failed server context.
+- ACP Playground pilot rendering for aligned and mismatch session Workspace states.
+- A global list/search rendering guard proving active Workspace context does not filter existing global browse/search data.
+
+Focused verification should run the new frontend tests plus nearby existing Research Workspace and ACP Playground tests. Bandit is not applicable to this frontend/docs-only slice unless backend Python files are touched.
+
+## Adoption Guidance
+
+Future Workspace-aware surfaces should:
+
+- Import shared contract helpers instead of reading raw DTOs directly for display/recovery copy.
+- Treat membership badges as labels, not authorization.
+- Use action-scoped eligibility checks for Workspace-sensitive mutations.
+- Keep global browse/search/list surfaces global unless the user explicitly chooses a Workspace filter.
+- Link back to #1994 for resource index and activity affordances instead of building them inline.
+
+## Open Questions
+
+- Whether the API should eventually expose a dedicated "active context" endpoint is out of scope for #1993. The first implementation should use existing context and capabilities endpoints.
+- If any pilot action needs a reason code that the server does not currently return, this slice should add a frontend `unknown` fallback and document the API gap instead of inventing client-only semantics.

--- a/Docs/superpowers/specs/2026-06-18-workspace-frontend-server-context-contract-design.md
+++ b/Docs/superpowers/specs/2026-06-18-workspace-frontend-server-context-contract-design.md
@@ -38,6 +38,17 @@ In scope:
 - Tests proving active Workspace selection does not silently filter global browse/search or list rendering.
 - Adoption guidance for later surfaces to reuse the same contracts.
 
+Workspace tag/status display rules for later surfaces:
+
+- Notes, Media, Sources, Artifacts, Chats, Prompts, Workflows, and Watchlists should render Workspace membership as a display badge derived from the shared membership contract, not from ad hoc local tag strings.
+- Rows with no server `workspace_id` render a neutral `Global` badge when a membership badge is needed. The badge is informational and must not imply the row is unavailable in global browse/search.
+- Rows with a known active server Workspace render `Workspace: {workspace label}`. The label comes from the server Workspace list/context response; the server Workspace ID remains the identity key.
+- Rows whose server Workspace is archived render `Archived Workspace: {workspace label}` with a warning tone. Rows whose server Workspace is deleted render `Deleted Workspace: {workspace label}` with an error tone.
+- Rows whose `workspace_id` cannot be resolved from the current server Workspace list render `Unknown Workspace` with a warning tone and preserve the unresolved ID for diagnostics.
+- Surface-specific lifecycle state remains separate from membership. For example, Sources keep source readiness/status, Artifacts keep artifact status/review state, Workflows/Watchlists keep run state, and Chats/Prompts keep their own availability state alongside the Workspace badge.
+- Active Workspace selection must never silently hide global rows or rows from other Workspaces. Any filtering must be user-selected and visibly represented as a filter, not inferred from active context.
+- These display rules are defined in this contract slice so later migrations can adopt the same labels and tones incrementally. Full UI adoption across every listed surface remains staged work.
+
 Out of scope:
 
 - #1994 contained-resource index, activity feed, or Workspace dashboard UI.

--- a/apps/packages/ui/src/components/Option/ACPPlayground/ACPWorkspacePanel.tsx
+++ b/apps/packages/ui/src/components/Option/ACPPlayground/ACPWorkspacePanel.tsx
@@ -5,7 +5,9 @@ import { useTranslation } from "react-i18next"
 
 import { useCanonicalConnectionConfig } from "@/hooks/useCanonicalConnectionConfig"
 import { buildACPAuthHeaders, resolveACPServerUrl } from "@/services/acp/connection"
+import { compareACPWorkspaceContext } from "@/services/workspace-context"
 import { useACPSessionsStore } from "@/store/acp-sessions"
+import { useWorkspaceStore } from "@/store/workspace"
 import { WORKSPACES_PATH } from "@/routes/route-paths"
 
 type WebSocketWithHeaders = new (
@@ -60,6 +62,16 @@ const resolveTokenColor = (tokenName: string, fallbackRgb: string): string => {
 
 const WORKSPACES_MANAGER_HREF = `#${WORKSPACES_PATH}`
 
+const getACPWorkspaceStateLabel = (
+  state: ReturnType<typeof compareACPWorkspaceContext>["state"]
+): string => {
+  if (state === "aligned") return "Aligned with active Workspace"
+  if (state === "mismatch") return "Workspace mismatch"
+  if (state === "session_only") return "Session Workspace"
+  if (state === "active_only") return "Active Workspace only"
+  return "Session Workspace"
+}
+
 export const ACPWorkspacePanel: React.FC = () => {
   const { t } = useTranslation("playground")
   const { config: connectionConfig } = useCanonicalConnectionConfig()
@@ -71,8 +83,28 @@ export const ACPWorkspacePanel: React.FC = () => {
   const activeSession = useACPSessionsStore((s) =>
     s.activeSessionId ? s.getSession(s.activeSessionId) : undefined
   )
+  const activeWorkspaceId = useWorkspaceStore((s) => s.workspaceId)
 
   const sshPath = activeSession?.sshWsUrl || ""
+  const sessionWorkspaceContext = React.useMemo(
+    () =>
+      compareACPWorkspaceContext({
+        sessionWorkspaceId: activeSession?.workspaceId ?? null,
+        activeWorkspaceId: activeWorkspaceId ?? null
+      }),
+    [activeSession?.workspaceId, activeWorkspaceId]
+  )
+  const sessionWorkspaceStateLabel = getACPWorkspaceStateLabel(
+    sessionWorkspaceContext.state
+  )
+  const sessionWorkspaceMessage =
+    sessionWorkspaceContext.state === "mismatch"
+      ? sessionWorkspaceContext.recovery.message
+      : sessionWorkspaceContext.message
+  const showWorkspaceRecovery =
+    sessionWorkspaceContext.recovery.reasonCode !== "aligned" &&
+    Boolean(sessionWorkspaceContext.recovery.nextStepHref) &&
+    Boolean(sessionWorkspaceContext.recovery.nextStepLabel)
 
   const [wsStatus, setWsStatus] = React.useState<"connecting" | "connected" | "disconnected">("disconnected")
   const [reconnectKey, setReconnectKey] = React.useState(0)
@@ -284,22 +316,63 @@ export const ACPWorkspacePanel: React.FC = () => {
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center justify-between border-b border-border bg-surface px-3 py-2 text-sm">
-        <div className="flex items-center gap-2 text-text-muted">
-          <TerminalIcon className="h-4 w-4" />
-          {t("playground:acp.workspace.title", "Workspace Terminal")}
-          <span
-            className={`h-2 w-2 rounded-full ${
-              wsStatus === "connected" ? "bg-success" :
-              wsStatus === "connecting" ? "bg-info animate-pulse" :
-              "bg-error"
-            }`}
-            aria-label={
-              wsStatus === "connected" ? "Connected" :
-              wsStatus === "connecting" ? "Connecting" :
-              "Disconnected"
-            }
-            role="status"
-          />
+        <div className="flex min-w-0 flex-wrap items-center gap-2 text-text-muted">
+          <div className="flex items-center gap-2">
+            <TerminalIcon className="h-4 w-4" />
+            {t("playground:acp.workspace.title", "Workspace Terminal")}
+            <span
+              className={`h-2 w-2 rounded-full ${
+                wsStatus === "connected" ? "bg-success" :
+                wsStatus === "connecting" ? "bg-info animate-pulse" :
+                "bg-error"
+              }`}
+              aria-label={
+                wsStatus === "connected" ? "Connected" :
+                wsStatus === "connecting" ? "Connecting" :
+                "Disconnected"
+              }
+              role="status"
+            />
+          </div>
+          <div
+            data-testid="acp-session-workspace-context"
+            className="flex min-w-0 flex-wrap items-center gap-1.5 rounded border border-border bg-surface2 px-2 py-0.5 text-xs"
+          >
+            <span className="font-medium text-text">
+              {t("playground:acp.workspace.sessionWorkspace", "Session Workspace")}
+            </span>
+            <span className="rounded bg-surface px-1.5 py-0.5 text-text">
+              {t(
+                `playground:acp.workspace.${sessionWorkspaceStateLabel.replace(/\s+/g, "")}`,
+                sessionWorkspaceStateLabel
+              )}
+            </span>
+            {(sessionWorkspaceContext.sessionWorkspaceId ||
+              sessionWorkspaceContext.activeWorkspaceId) && (
+              <span className="rounded bg-surface px-1.5 py-0.5 font-mono text-[11px] text-text">
+                {sessionWorkspaceContext.sessionWorkspaceId ||
+                  sessionWorkspaceContext.activeWorkspaceId}
+              </span>
+            )}
+            {sessionWorkspaceContext.activeWorkspaceId &&
+              sessionWorkspaceContext.activeWorkspaceId !==
+                sessionWorkspaceContext.sessionWorkspaceId && (
+                <span className="rounded bg-surface px-1.5 py-0.5 font-mono text-[11px] text-text">
+                  {sessionWorkspaceContext.activeWorkspaceId}
+                </span>
+              )}
+            <span className="min-w-0 max-w-[22rem] truncate">
+              {sessionWorkspaceMessage}
+            </span>
+            {showWorkspaceRecovery && (
+              <a
+                href={sessionWorkspaceContext.recovery.nextStepHref || WORKSPACES_MANAGER_HREF}
+                className="font-medium text-primary hover:text-primary/80"
+              >
+                {sessionWorkspaceContext.recovery.nextStepLabel}
+              </a>
+            )}
+          </div>
         </div>
         <div className="flex items-center gap-2">
           <a

--- a/apps/packages/ui/src/components/Option/ACPPlayground/ACPWorkspacePanel.tsx
+++ b/apps/packages/ui/src/components/Option/ACPPlayground/ACPWorkspacePanel.tsx
@@ -103,7 +103,6 @@ export const ACPWorkspacePanel: React.FC = () => {
       : sessionWorkspaceContext.message
   const showWorkspaceRecovery =
     sessionWorkspaceContext.recovery.reasonCode !== "aligned" &&
-    Boolean(sessionWorkspaceContext.recovery.nextStepHref) &&
     Boolean(sessionWorkspaceContext.recovery.nextStepLabel)
 
   const [wsStatus, setWsStatus] = React.useState<"connecting" | "connected" | "disconnected">("disconnected")

--- a/apps/packages/ui/src/components/Option/ACPPlayground/ACPWorkspacePanel.tsx
+++ b/apps/packages/ui/src/components/Option/ACPPlayground/ACPWorkspacePanel.tsx
@@ -355,6 +355,7 @@ export const ACPWorkspacePanel: React.FC = () => {
               </span>
             )}
             {sessionWorkspaceContext.activeWorkspaceId &&
+              sessionWorkspaceContext.sessionWorkspaceId &&
               sessionWorkspaceContext.activeWorkspaceId !==
                 sessionWorkspaceContext.sessionWorkspaceId && (
                 <span className="rounded bg-surface px-1.5 py-0.5 font-mono text-[11px] text-text">

--- a/apps/packages/ui/src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx
@@ -4,6 +4,10 @@ import { render, screen } from "@testing-library/react"
 import { useACPSessionsStore } from "@/store/acp-sessions"
 import { ACPWorkspacePanel } from "../ACPWorkspacePanel"
 
+const workspaceStoreMock = vi.hoisted(() => ({
+  workspaceId: "workspace-alpha"
+}))
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (_key: string, fallback?: string) => fallback ?? _key
@@ -16,9 +20,16 @@ vi.mock("@/hooks/useCanonicalConnectionConfig", () => ({
   })
 }))
 
+vi.mock("@/store/workspace", () => ({
+  useWorkspaceStore: (
+    selector: (state: { workspaceId: string | null }) => unknown
+  ) => selector({ workspaceId: workspaceStoreMock.workspaceId })
+}))
+
 describe("ACPWorkspacePanel canonical Workspace handoff", () => {
   beforeEach(() => {
     useACPSessionsStore.getState().reset()
+    workspaceStoreMock.workspaceId = "workspace-alpha"
   })
 
   it("links no-session users to the canonical Workspaces manager", () => {
@@ -32,6 +43,47 @@ describe("ACPWorkspacePanel canonical Workspace handoff", () => {
     ).toBeTruthy()
     expect(
       screen.getByRole("link", { name: /manage canonical Workspaces/i })
+    ).toHaveAttribute("href", "#/workspaces")
+  })
+
+  it("shows when the ACP session workspace matches the active server workspace", () => {
+    const store = useACPSessionsStore.getState()
+    const sessionId = store.createSession({
+      cwd: "/workspace/alpha",
+      name: "Alpha Session",
+      workspaceId: "workspace-alpha"
+    })
+    store.updateSessionMetadata(sessionId, {
+      sshWsUrl: "/api/v1/acp/sessions/alpha/ssh"
+    })
+
+    render(<ACPWorkspacePanel />)
+
+    expect(screen.getByText("Session Workspace")).toBeInTheDocument()
+    expect(
+      screen.getByText(/Aligned with active Workspace/i)
+    ).toBeInTheDocument()
+    expect(screen.getByText("workspace-alpha")).toBeInTheDocument()
+  })
+
+  it("shows mismatch recovery when the ACP session workspace differs from the active workspace", () => {
+    const store = useACPSessionsStore.getState()
+    const sessionId = store.createSession({
+      cwd: "/workspace/beta",
+      name: "Beta Session",
+      workspaceId: "workspace-beta"
+    })
+    store.updateSessionMetadata(sessionId, {
+      sshWsUrl: "/api/v1/acp/sessions/beta/ssh"
+    })
+
+    render(<ACPWorkspacePanel />)
+
+    expect(screen.getByText("Workspace mismatch")).toBeInTheDocument()
+    expect(screen.getByText(/workspace-beta/)).toBeInTheDocument()
+    expect(screen.getByText(/workspace-alpha/)).toBeInTheDocument()
+    expect(
+      screen.getByRole("link", { name: "Open Workspaces" })
     ).toHaveAttribute("href", "#/workspaces")
   })
 })

--- a/apps/packages/ui/src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx
@@ -86,4 +86,20 @@ describe("ACPWorkspacePanel canonical Workspace handoff", () => {
       screen.getByRole("link", { name: "Open Workspaces" })
     ).toHaveAttribute("href", "#/workspaces")
   })
+
+  it("does not duplicate the active workspace id when the ACP session has no workspace id", () => {
+    const store = useACPSessionsStore.getState()
+    const sessionId = store.createSession({
+      cwd: "/workspace/alpha",
+      name: "Unattached Session"
+    })
+    store.updateSessionMetadata(sessionId, {
+      sshWsUrl: "/api/v1/acp/sessions/unattached/ssh"
+    })
+
+    render(<ACPWorkspacePanel />)
+
+    expect(screen.getByText("Active Workspace only")).toBeInTheDocument()
+    expect(screen.getAllByText("workspace-alpha")).toHaveLength(1)
+  })
 })

--- a/apps/packages/ui/src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx
@@ -7,6 +7,23 @@ import { ACPWorkspacePanel } from "../ACPWorkspacePanel"
 const workspaceStoreMock = vi.hoisted(() => ({
   workspaceId: "workspace-alpha"
 }))
+const workspaceContextMock = vi.hoisted(() => ({
+  compareOverride: null as null | (() => {
+    state: "active_only"
+    sessionWorkspaceId: null
+    activeWorkspaceId: string
+    sessionWorkspaceLabel: null
+    activeWorkspaceLabel: string
+    message: string
+    recovery: {
+      reasonCode: string
+      severity: "warning"
+      message: string
+      nextStepLabel: string
+      nextStepHref: null
+    }
+  })
+}))
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -26,10 +43,26 @@ vi.mock("@/store/workspace", () => ({
   ) => selector({ workspaceId: workspaceStoreMock.workspaceId })
 }))
 
+vi.mock("@/services/workspace-context", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/services/workspace-context")>(
+      "@/services/workspace-context"
+    )
+  return {
+    ...actual,
+    compareACPWorkspaceContext: (
+      input: Parameters<typeof actual.compareACPWorkspaceContext>[0]
+    ) =>
+      workspaceContextMock.compareOverride?.() ??
+      actual.compareACPWorkspaceContext(input)
+  }
+})
+
 describe("ACPWorkspacePanel canonical Workspace handoff", () => {
   beforeEach(() => {
     useACPSessionsStore.getState().reset()
     workspaceStoreMock.workspaceId = "workspace-alpha"
+    workspaceContextMock.compareOverride = null
   })
 
   it("links no-session users to the canonical Workspaces manager", () => {
@@ -101,5 +134,37 @@ describe("ACPWorkspacePanel canonical Workspace handoff", () => {
 
     expect(screen.getByText("Active Workspace only")).toBeInTheDocument()
     expect(screen.getAllByText("workspace-alpha")).toHaveLength(1)
+  })
+
+  it("uses the Workspaces fallback href when recovery copy omits a href", () => {
+    workspaceContextMock.compareOverride = () => ({
+      state: "active_only",
+      sessionWorkspaceId: null,
+      activeWorkspaceId: "workspace-alpha",
+      sessionWorkspaceLabel: null,
+      activeWorkspaceLabel: "workspace-alpha",
+      message: "Active server Workspace is not attached.",
+      recovery: {
+        reasonCode: "active_workspace_only",
+        severity: "warning",
+        message: "Active server Workspace is not attached.",
+        nextStepLabel: "Open Workspaces",
+        nextStepHref: null
+      }
+    })
+    const store = useACPSessionsStore.getState()
+    const sessionId = store.createSession({
+      cwd: "/workspace/alpha",
+      name: "Unattached Session"
+    })
+    store.updateSessionMetadata(sessionId, {
+      sshWsUrl: "/api/v1/acp/sessions/unattached/ssh"
+    })
+
+    render(<ACPWorkspacePanel />)
+
+    expect(
+      screen.getByRole("link", { name: "Open Workspaces" })
+    ).toHaveAttribute("href", "#/workspaces")
   })
 })

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx
@@ -154,24 +154,55 @@ const WORKSPACE_ROLLOUT_CONTROL_ORDER: WorkspaceRolloutControlKey[] = [
 ]
 const WORKSPACE_ROLLOUT_PRESET_PERCENTAGES = [0, 10, 50, 100] as const
 
-const getServerWorkspaceContextStatusLabel = (
+const getServerWorkspaceContextStatusCopy = (
   context: ReturnType<typeof useActiveWorkspaceContext>["context"],
   loading: boolean
-): string => {
-  if (loading) return "Server context loading"
+): { key: string; fallback: string } => {
+  if (loading) {
+    return {
+      key: "playground:workspace.serverContextLoading",
+      fallback: "Server context loading"
+    }
+  }
   if (
     context.attentionState === "archived" ||
     context.workspace?.archived ||
     context.recovery.reasonCode === "workspace_archived"
   ) {
-    return "Server context archived"
+    return {
+      key: "playground:workspace.serverContextArchived",
+      fallback: "Server context archived"
+    }
   }
   const state = context.state
-  if (state === "partial") return "Server context partial"
-  if (state === "error") return "Server context unavailable"
-  if (state === "missing") return "Server context missing"
-  if (state === "none") return "No server context"
-  return "Server context ready"
+  if (state === "partial") {
+    return {
+      key: "playground:workspace.serverContextPartial",
+      fallback: "Server context partial"
+    }
+  }
+  if (state === "error") {
+    return {
+      key: "playground:workspace.serverContextUnavailable",
+      fallback: "Server context unavailable"
+    }
+  }
+  if (state === "missing") {
+    return {
+      key: "playground:workspace.serverContextMissing",
+      fallback: "Server context missing"
+    }
+  }
+  if (state === "none") {
+    return {
+      key: "playground:workspace.noServerContext",
+      fallback: "No server context"
+    }
+  }
+  return {
+    key: "playground:workspace.serverContextReady",
+    fallback: "Server context ready"
+  }
 }
 
 export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
@@ -1417,12 +1448,14 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
       })),
     [workspaceCollections]
   )
-  const serverWorkspaceContextStatusLabel = getServerWorkspaceContextStatusLabel(
+  const serverWorkspaceContextStatusCopy = getServerWorkspaceContextStatusCopy(
     serverWorkspaceContext,
     serverWorkspaceContextLoading
   )
   const serverWorkspaceContextLabel =
-    serverWorkspaceContext.workspace?.label || workspaceId || "No server Workspace"
+    serverWorkspaceContext.workspace?.label ||
+    workspaceId ||
+    t("playground:workspace.noServerWorkspace", "No server Workspace")
   const serverWorkspaceRecovery = serverWorkspaceContext.recovery
   const showServerWorkspaceRecovery =
     !serverWorkspaceContextLoading &&
@@ -1753,8 +1786,8 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
           </span>
           <span className="rounded bg-surface2 px-1.5 py-0.5">
             {t(
-              `playground:workspace.${serverWorkspaceContextStatusLabel.replace(/\s+/g, "")}`,
-              serverWorkspaceContextStatusLabel
+              serverWorkspaceContextStatusCopy.key,
+              serverWorkspaceContextStatusCopy.fallback
             )}
           </span>
           {showServerWorkspaceRecovery && (

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx
@@ -155,10 +155,18 @@ const WORKSPACE_ROLLOUT_CONTROL_ORDER: WorkspaceRolloutControlKey[] = [
 const WORKSPACE_ROLLOUT_PRESET_PERCENTAGES = [0, 10, 50, 100] as const
 
 const getServerWorkspaceContextStatusLabel = (
-  state: ReturnType<typeof useActiveWorkspaceContext>["context"]["state"],
+  context: ReturnType<typeof useActiveWorkspaceContext>["context"],
   loading: boolean
 ): string => {
   if (loading) return "Server context loading"
+  if (
+    context.attentionState === "archived" ||
+    context.workspace?.archived ||
+    context.recovery.reasonCode === "workspace_archived"
+  ) {
+    return "Server context archived"
+  }
+  const state = context.state
   if (state === "partial") return "Server context partial"
   if (state === "error") return "Server context unavailable"
   if (state === "missing") return "Server context missing"
@@ -1410,7 +1418,7 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
     [workspaceCollections]
   )
   const serverWorkspaceContextStatusLabel = getServerWorkspaceContextStatusLabel(
-    serverWorkspaceContext.state,
+    serverWorkspaceContext,
     serverWorkspaceContextLoading
   )
   const serverWorkspaceContextLabel =

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx
@@ -95,6 +95,7 @@ import { WorkspaceAgentTaskHandoffModal } from "./WorkspaceAgentTaskHandoffModal
 import { WorkspaceACPHistoryModal } from "./WorkspaceACPHistoryModal"
 import { WorkspaceSandboxDiagnosticsPanel } from "./WorkspaceSandboxDiagnosticsPanel"
 import { WORKSPACES_PATH } from "@/routes/route-paths"
+import { useActiveWorkspaceContext } from "@/services/workspace-context"
 
 interface WorkspaceHeaderProps {
   leftPaneOpen: boolean
@@ -152,6 +153,18 @@ const WORKSPACE_ROLLOUT_CONTROL_ORDER: WorkspaceRolloutControlKey[] = [
   "research_workspace_status_guardrails_v1"
 ]
 const WORKSPACE_ROLLOUT_PRESET_PERCENTAGES = [0, 10, 50, 100] as const
+
+const getServerWorkspaceContextStatusLabel = (
+  state: ReturnType<typeof useActiveWorkspaceContext>["context"]["state"],
+  loading: boolean
+): string => {
+  if (loading) return "Server context loading"
+  if (state === "partial") return "Server context partial"
+  if (state === "error") return "Server context unavailable"
+  if (state === "missing") return "Server context missing"
+  if (state === "none") return "No server context"
+  return "Server context ready"
+}
 
 export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
   leftPaneOpen,
@@ -436,6 +449,10 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
   const workspaceName = useWorkspaceStore((s) => s.workspaceName)
   const workspaceId = useWorkspaceStore((s) => s.workspaceId)
   const workspaceTag = useWorkspaceStore((s) => s.workspaceTag)
+  const {
+    context: serverWorkspaceContext,
+    loading: serverWorkspaceContextLoading
+  } = useActiveWorkspaceContext({ workspaceId })
   const workspaceBanner = useWorkspaceStore((s) => s.workspaceBanner) || {
     title: "",
     subtitle: "",
@@ -1392,6 +1409,17 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
       })),
     [workspaceCollections]
   )
+  const serverWorkspaceContextStatusLabel = getServerWorkspaceContextStatusLabel(
+    serverWorkspaceContext.state,
+    serverWorkspaceContextLoading
+  )
+  const serverWorkspaceContextLabel =
+    serverWorkspaceContext.workspace?.label || workspaceId || "No server Workspace"
+  const serverWorkspaceRecovery = serverWorkspaceContext.recovery
+  const showServerWorkspaceRecovery =
+    !serverWorkspaceContextLoading &&
+    serverWorkspaceRecovery.reasonCode !== "allowed" &&
+    Boolean(serverWorkspaceRecovery.message)
 
   // ── Workspace Switcher dropdown: recent/pinned workspaces + navigation ──
   const workspaceSwitcherItems: MenuProps["items"] = [
@@ -1704,6 +1732,38 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
               </Tooltip>
             </div>
           )}
+        </div>
+        <div
+          data-testid="workspace-server-context-indicator"
+          className="flex min-w-0 max-w-full flex-wrap items-center gap-1.5 rounded-md border border-border bg-surface/80 px-2 py-1 text-xs text-text-muted"
+        >
+          <span className="font-medium text-text">
+            {t("playground:workspace.serverWorkspace", "Server Workspace")}
+          </span>
+          <span className="max-w-[14rem] truncate">
+            {serverWorkspaceContextLabel}
+          </span>
+          <span className="rounded bg-surface2 px-1.5 py-0.5">
+            {t(
+              `playground:workspace.${serverWorkspaceContextStatusLabel.replace(/\s+/g, "")}`,
+              serverWorkspaceContextStatusLabel
+            )}
+          </span>
+          {showServerWorkspaceRecovery && (
+            <span className="min-w-0">
+              {serverWorkspaceRecovery.message}
+            </span>
+          )}
+          {showServerWorkspaceRecovery &&
+            serverWorkspaceRecovery.nextStepHref &&
+            serverWorkspaceRecovery.nextStepLabel && (
+              <a
+                href={serverWorkspaceRecovery.nextStepHref}
+                className="font-medium text-primary hover:text-primary/80"
+              >
+                {serverWorkspaceRecovery.nextStepLabel}
+              </a>
+            )}
         </div>
       </div>
 

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
@@ -653,6 +653,39 @@ describe("WorkspaceHeader workspace browser modal", () => {
     ).toHaveAttribute("href", "#/workspaces")
   })
 
+  it("labels archived server workspace context explicitly", async () => {
+    workspaceContextMocks.useActiveWorkspaceContext.mockReturnValue(
+      makeActiveWorkspaceHookResult({
+        state: "ready",
+        attentionState: "archived",
+        workspace: {
+          ...(makeActiveWorkspaceContext().workspace as Record<string, unknown>),
+          archived: true,
+          statusLabel: "Archived"
+        },
+        recovery: {
+          reasonCode: "workspace_archived",
+          severity: "warning",
+          message: "This server Workspace is archived. Restore it before making changes.",
+          nextStepLabel: "Open Workspaces",
+          nextStepHref: "#/workspaces"
+        }
+      })
+    )
+
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    expect(await screen.findByText("Server context archived")).toBeInTheDocument()
+    expect(screen.queryByText("Server context ready")).not.toBeInTheDocument()
+  })
+
   it("does not filter the workspace browser list by active server context", async () => {
     workspaceContextMocks.useActiveWorkspaceContext.mockReturnValue(
       makeActiveWorkspaceHookResult({

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
@@ -43,6 +43,9 @@ const mockResetResearchWorkspaceTelemetryState = vi.fn()
 const workspaceContextMocks = vi.hoisted(() => ({
   useActiveWorkspaceContext: vi.fn()
 }))
+const translationMock = vi.hoisted(() => ({
+  keys: [] as string[]
+}))
 
 const now = new Date("2026-02-18T12:00:00.000Z")
 
@@ -245,6 +248,7 @@ vi.mock("react-i18next", () => ({
             defaultValue?: string
           }
     ) => {
+      translationMock.keys.push(key)
       if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
       if (defaultValueOrOptions?.defaultValue) return defaultValueOrOptions.defaultValue
       return key
@@ -363,6 +367,7 @@ if (!(globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver) {
 describe("WorkspaceHeader workspace browser modal", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    translationMock.keys = []
     workspaceContextMocks.useActiveWorkspaceContext.mockReturnValue(
       makeActiveWorkspaceHookResult()
     )
@@ -615,6 +620,12 @@ describe("WorkspaceHeader workspace browser modal", () => {
     ).toBeInTheDocument()
     expect(screen.getByText("Canonical Alpha")).toBeInTheDocument()
     expect(screen.getByText("Server context ready")).toBeInTheDocument()
+    expect(translationMock.keys).toContain(
+      "playground:workspace.serverContextReady"
+    )
+    expect(translationMock.keys).not.toContain(
+      "playground:workspace.Servercontextready"
+    )
     expect(workspaceContextMocks.useActiveWorkspaceContext).toHaveBeenCalledWith(
       expect.objectContaining({ workspaceId: "workspace-alpha" })
     )

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx
@@ -40,6 +40,9 @@ const mockNormalizeWorkspaceBannerImage = vi.fn()
 const mockTrackResearchWorkspaceTelemetry = vi.fn()
 const mockGetResearchWorkspaceTelemetryState = vi.fn()
 const mockResetResearchWorkspaceTelemetryState = vi.fn()
+const workspaceContextMocks = vi.hoisted(() => ({
+  useActiveWorkspaceContext: vi.fn()
+}))
 
 const now = new Date("2026-02-18T12:00:00.000Z")
 
@@ -179,6 +182,59 @@ const ACP_PROJECTS_FOR_ALPHA_URL =
 const ACP_SESSIONS_FOR_ALPHA_URL =
   "http://127.0.0.1:8000/api/v1/acp/sessions?workspace_id=workspace-alpha&limit=6"
 
+const sourceSummaryFixture = {
+  total: 0,
+  selected: 0,
+  queryable: 0,
+  partially_queryable: 0,
+  processing: 0,
+  failed: 0,
+  missing: 0
+}
+
+const makeActiveWorkspaceContext = (
+  overrides: Record<string, unknown> = {}
+) => ({
+  state: "ready",
+  workspaceId: "workspace-alpha",
+  workspace: {
+    id: "workspace-alpha",
+    name: "Canonical Alpha",
+    label: "Canonical Alpha",
+    profile: "research",
+    archived: false,
+    deleted: false,
+    studyMaterialsPolicy: "workspace",
+    statusLabel: "Active",
+    version: 3,
+    lastModified: "2026-02-18T12:00:00.000Z"
+  },
+  attentionState: "ready",
+  resolution: { status: "complete", partial_errors: [] },
+  projectRoot: null,
+  sourceSummary: sourceSummaryFixture,
+  capabilities: null,
+  allowedActions: {},
+  partialErrors: [],
+  recovery: {
+    reasonCode: "allowed",
+    severity: "info",
+    message: "Workspace action is available.",
+    nextStepLabel: null,
+    nextStepHref: null
+  },
+  ...overrides
+})
+
+const makeActiveWorkspaceHookResult = (
+  contextOverrides: Record<string, unknown> = {}
+) => ({
+  context: makeActiveWorkspaceContext(contextOverrides),
+  loading: false,
+  error: null,
+  refresh: vi.fn()
+})
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (
@@ -270,6 +326,8 @@ vi.mock("../workspace-banner-image", () => ({
   }
 }))
 
+vi.mock("@/services/workspace-context", () => workspaceContextMocks)
+
 vi.mock("../WorkspaceSandboxDiagnosticsPanel", () => ({
   WorkspaceSandboxDiagnosticsPanel: ({ workspaceId }: { workspaceId: string }) => (
     <div data-testid="workspace-sandbox-diagnostics-panel">
@@ -305,6 +363,9 @@ if (!(globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver) {
 describe("WorkspaceHeader workspace browser modal", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    workspaceContextMocks.useActiveWorkspaceContext.mockReturnValue(
+      makeActiveWorkspaceHookResult()
+    )
     window.localStorage.clear()
     clearWorkspaceUndoActionsForTests()
     registryStateOverrides.missingDegraded = false
@@ -537,6 +598,91 @@ describe("WorkspaceHeader workspace browser modal", () => {
       "min-w-0",
       "max-w-full"
     )
+  })
+
+  it("renders server-authoritative workspace context", async () => {
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    expect(
+      await screen.findByText("Server Workspace")
+    ).toBeInTheDocument()
+    expect(screen.getByText("Canonical Alpha")).toBeInTheDocument()
+    expect(screen.getByText("Server context ready")).toBeInTheDocument()
+    expect(workspaceContextMocks.useActiveWorkspaceContext).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: "workspace-alpha" })
+    )
+  })
+
+  it("renders shared recovery copy when server workspace context fails", async () => {
+    workspaceContextMocks.useActiveWorkspaceContext.mockReturnValue(
+      makeActiveWorkspaceHookResult({
+        state: "error",
+        workspaceId: null,
+        workspace: null,
+        recovery: {
+          reasonCode: "workspace_context_error",
+          severity: "error",
+          message: "Server Workspace context is unavailable right now.",
+          nextStepLabel: "Open Workspaces",
+          nextStepHref: "#/workspaces"
+        }
+      })
+    )
+
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    expect(
+      await screen.findByText("Server Workspace context is unavailable right now.")
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("link", { name: "Open Workspaces" })
+    ).toHaveAttribute("href", "#/workspaces")
+  })
+
+  it("does not filter the workspace browser list by active server context", async () => {
+    workspaceContextMocks.useActiveWorkspaceContext.mockReturnValue(
+      makeActiveWorkspaceHookResult({
+        workspaceId: "workspace-alpha",
+        workspace: {
+          ...(makeActiveWorkspaceContext().workspace as Record<string, unknown>),
+          id: "workspace-alpha",
+          label: "Canonical Alpha"
+        }
+      })
+    )
+
+    render(
+      <WorkspaceHeader
+        leftPaneOpen={true}
+        rightPaneOpen={true}
+        onToggleLeftPane={vi.fn()}
+        onToggleRightPane={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Workspaces" }))
+    fireEvent.click(await screen.findByText("View all workspaces"))
+
+    const modal = await screen.findByRole("dialog", {
+      name: "All Workspaces"
+    })
+    expect(within(modal).getByText("Alpha Research")).toBeInTheDocument()
+    expect(within(modal).getByText("Beta Deep Dive")).toBeInTheDocument()
+    expect(within(modal).getByText("Gamma Notes")).toBeInTheDocument()
   })
 
   it("opens view-all modal and filters workspaces by search query", async () => {

--- a/apps/packages/ui/src/services/workspace-context/__tests__/hooks.test.tsx
+++ b/apps/packages/ui/src/services/workspace-context/__tests__/hooks.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react"
+import { act, renderHook, waitFor } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import type {
   WorkspaceApiResponse,
@@ -114,6 +114,17 @@ const contextFixture = (
   }
 }
 
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+
+  return { promise, resolve, reject }
+}
+
 describe("useActiveWorkspaceContext", () => {
   it("does not fetch when no active server workspace id exists", () => {
     const getWorkspaceContext = vi.fn()
@@ -204,5 +215,57 @@ describe("useActiveWorkspaceContext", () => {
     await waitFor(() => {
       expect(result.current.context.workspace?.label).toBe("Second")
     })
+  })
+
+  it("keeps the latest refresh result when workspace requests overlap", async () => {
+    const firstRequest = deferred<WorkspaceContextResponse>()
+    const secondRequest = deferred<WorkspaceContextResponse>()
+    const getWorkspaceContext = vi.fn()
+      .mockReturnValueOnce(firstRequest.promise)
+      .mockReturnValueOnce(secondRequest.promise)
+
+    const { result } = renderHook(() =>
+      useActiveWorkspaceContext({
+        workspaceId: "ws-1",
+        client: { getWorkspaceContext }
+      })
+    )
+
+    await waitFor(() => {
+      expect(getWorkspaceContext).toHaveBeenCalledTimes(1)
+    })
+
+    let refreshPromise!: Promise<void>
+    act(() => {
+      refreshPromise = result.current.refresh()
+    })
+
+    await waitFor(() => {
+      expect(getWorkspaceContext).toHaveBeenCalledTimes(2)
+    })
+
+    await act(async () => {
+      secondRequest.resolve(
+        contextFixture({
+          workspace: workspaceFixture({ id: "ws-1", name: "Second" })
+        })
+      )
+      await refreshPromise
+    })
+
+    await waitFor(() => {
+      expect(result.current.context.workspace?.label).toBe("Second")
+    })
+
+    await act(async () => {
+      firstRequest.resolve(
+        contextFixture({
+          workspace: workspaceFixture({ id: "ws-1", name: "First" })
+        })
+      )
+      await firstRequest.promise
+    })
+
+    expect(result.current.context.workspace?.label).toBe("Second")
   })
 })

--- a/apps/packages/ui/src/services/workspace-context/__tests__/hooks.test.tsx
+++ b/apps/packages/ui/src/services/workspace-context/__tests__/hooks.test.tsx
@@ -4,10 +4,14 @@ import type {
   WorkspaceApiResponse,
   WorkspaceCapabilitiesResponse,
   WorkspaceContextResponse,
+  WorkspaceListApiResponse,
   WorkspaceProjectRoot,
   WorkspaceSourceStatusSummary
 } from "@/services/tldw/domains/workspace-api"
-import { useActiveWorkspaceContext } from "../hooks"
+import {
+  useActiveWorkspaceContext,
+  useWorkspaceMembershipLookup
+} from "../hooks"
 
 const workspaceFixture = (
   overrides: Partial<WorkspaceApiResponse> = {}
@@ -267,5 +271,54 @@ describe("useActiveWorkspaceContext", () => {
     })
 
     expect(result.current.context.workspace?.label).toBe("Second")
+  })
+})
+
+describe("useWorkspaceMembershipLookup", () => {
+  it("fetches the server workspace list and resolves membership labels", async () => {
+    const listWorkspaces = vi.fn(async (): Promise<WorkspaceListApiResponse> => ({
+      items: [
+        workspaceFixture({ id: "ws-1", name: "Alpha Workspace" }),
+        workspaceFixture({
+          id: "ws-2",
+          name: "Archived Workspace",
+          archived: true
+        })
+      ],
+      total: 2
+    }))
+
+    const { result } = renderHook(() =>
+      useWorkspaceMembershipLookup({
+        client: { listWorkspaces }
+      })
+    )
+
+    expect(result.current.loading).toBe(true)
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(listWorkspaces).toHaveBeenCalledTimes(1)
+    expect(result.current.resolveMembership("ws-1")).toMatchObject({
+      workspaceId: "ws-1",
+      workspaceLabel: "Alpha Workspace",
+      membershipLabel: "Workspace: Alpha Workspace",
+      isAuthoritative: true,
+      reasonCode: null
+    })
+    expect(result.current.resolveMembership("ws-2")).toMatchObject({
+      workspaceId: "ws-2",
+      membershipLabel: "Archived Workspace: Archived Workspace",
+      tone: "warning",
+      reasonCode: "workspace_archived"
+    })
+    expect(result.current.resolveMembership("missing")).toMatchObject({
+      workspaceId: "missing",
+      membershipLabel: "Unknown Workspace",
+      isAuthoritative: false,
+      reasonCode: "workspace_missing"
+    })
   })
 })

--- a/apps/packages/ui/src/services/workspace-context/__tests__/hooks.test.tsx
+++ b/apps/packages/ui/src/services/workspace-context/__tests__/hooks.test.tsx
@@ -1,0 +1,208 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import type {
+  WorkspaceApiResponse,
+  WorkspaceCapabilitiesResponse,
+  WorkspaceContextResponse,
+  WorkspaceProjectRoot,
+  WorkspaceSourceStatusSummary
+} from "@/services/tldw/domains/workspace-api"
+import { useActiveWorkspaceContext } from "../hooks"
+
+const workspaceFixture = (
+  overrides: Partial<WorkspaceApiResponse> = {}
+): WorkspaceApiResponse => ({
+  id: "ws-1",
+  name: "Server Workspace",
+  archived: false,
+  study_materials_policy: "workspace",
+  workspace_profile: "research",
+  deleted: false,
+  banner_title: null,
+  banner_subtitle: null,
+  banner_color: null,
+  audio_provider: null,
+  audio_model: null,
+  audio_voice: null,
+  audio_speed: null,
+  created_at: "2026-06-18T00:00:00Z",
+  last_modified: "2026-06-18T00:10:00Z",
+  version: 7,
+  ...overrides
+})
+
+const sourceSummaryFixture = (
+  overrides: Partial<WorkspaceSourceStatusSummary> = {}
+): WorkspaceSourceStatusSummary => ({
+  total: 0,
+  selected: 0,
+  queryable: 0,
+  partially_queryable: 0,
+  processing: 0,
+  failed: 0,
+  missing: 0,
+  ...overrides
+})
+
+const projectRootFixture = (
+  overrides: Partial<WorkspaceProjectRoot> = {}
+): WorkspaceProjectRoot => ({
+  state: "not_configured",
+  root_id: null,
+  backend: null,
+  display_name: null,
+  path_hint: null,
+  git_state: null,
+  file_inventory_state: "not_started",
+  file_inventory: {
+    state: "not_started",
+    indexed_file_count: null,
+    total_file_count: null,
+    updated_at: null,
+    available: false
+  },
+  indexing_state: null,
+  sandbox_mount_state: null,
+  mcp_trust_state: null,
+  ...overrides
+})
+
+const capabilitiesFixture = (
+  overrides: Partial<WorkspaceCapabilitiesResponse> = {}
+): WorkspaceCapabilitiesResponse => ({
+  workspace_id: "ws-1",
+  workspace_profile: "research",
+  workspace_kind: "research_workspace",
+  access_level: "owner",
+  source_summary: sourceSummaryFixture(),
+  workspace_services: {},
+  allowed_actions: {},
+  ...overrides
+})
+
+const contextFixture = (
+  overrides: Partial<WorkspaceContextResponse> = {}
+): WorkspaceContextResponse => {
+  const workspace = overrides.workspace ?? workspaceFixture()
+  return {
+    workspace_id: workspace.id,
+    workspace_profile: workspace.workspace_profile,
+    workspace_kind:
+      workspace.workspace_profile === "project"
+        ? "project_workspace"
+        : "research_workspace",
+    schema_version: 2,
+    generated_at: "2026-06-18T00:11:00Z",
+    workspace,
+    attention_state: workspace.archived ? "archived" : "ready",
+    resolution: { status: "complete", partial_errors: [] },
+    project_root: projectRootFixture(),
+    sources: {
+      items: [],
+      summary: sourceSummaryFixture()
+    },
+    capabilities: capabilitiesFixture({
+      workspace_id: workspace.id,
+      workspace_profile: workspace.workspace_profile
+    }),
+    services: {},
+    allowed_actions: {},
+    active_jobs: [],
+    active_operations: [],
+    partial_errors: [],
+    ...overrides
+  }
+}
+
+describe("useActiveWorkspaceContext", () => {
+  it("does not fetch when no active server workspace id exists", () => {
+    const getWorkspaceContext = vi.fn()
+    const { result } = renderHook(() =>
+      useActiveWorkspaceContext({
+        workspaceId: null,
+        client: { getWorkspaceContext }
+      })
+    )
+
+    expect(result.current.context.state).toBe("none")
+    expect(result.current.loading).toBe(false)
+    expect(getWorkspaceContext).not.toHaveBeenCalled()
+  })
+
+  it("normalizes fetched server context", async () => {
+    const getWorkspaceContext = vi.fn(async () =>
+      contextFixture({
+        workspace: workspaceFixture({ id: "ws-1", name: "Fetched Workspace" })
+      })
+    )
+
+    const { result } = renderHook(() =>
+      useActiveWorkspaceContext({
+        workspaceId: "ws-1",
+        client: { getWorkspaceContext }
+      })
+    )
+
+    expect(result.current.loading).toBe(true)
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+      expect(result.current.context.state).toBe("ready")
+    })
+
+    expect(result.current.context.workspace?.label).toBe("Fetched Workspace")
+    expect(getWorkspaceContext).toHaveBeenCalledWith("ws-1")
+  })
+
+  it("surfaces failed server resolution as degraded context", async () => {
+    const getWorkspaceContext = vi.fn(async () => {
+      throw new Error("network down")
+    })
+
+    const { result } = renderHook(() =>
+      useActiveWorkspaceContext({
+        workspaceId: "ws-1",
+        client: { getWorkspaceContext }
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+      expect(result.current.context.state).toBe("error")
+    })
+
+    expect(result.current.error).toBeInstanceOf(Error)
+    expect(result.current.context.recovery.reasonCode).toBe("workspace_context_error")
+  })
+
+  it("refreshes context on demand", async () => {
+    const getWorkspaceContext = vi.fn()
+      .mockResolvedValueOnce(
+        contextFixture({
+          workspace: workspaceFixture({ id: "ws-1", name: "First" })
+        })
+      )
+      .mockResolvedValueOnce(
+        contextFixture({
+          workspace: workspaceFixture({ id: "ws-1", name: "Second" })
+        })
+      )
+
+    const { result } = renderHook(() =>
+      useActiveWorkspaceContext({
+        workspaceId: "ws-1",
+        client: { getWorkspaceContext }
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.context.workspace?.label).toBe("First")
+    })
+
+    await result.current.refresh()
+
+    await waitFor(() => {
+      expect(result.current.context.workspace?.label).toBe("Second")
+    })
+  })
+})

--- a/apps/packages/ui/src/services/workspace-context/__tests__/normalizers.test.ts
+++ b/apps/packages/ui/src/services/workspace-context/__tests__/normalizers.test.ts
@@ -8,7 +8,9 @@ import type {
 } from "@/services/tldw/domains/workspace-api"
 import {
   compareACPWorkspaceContext,
+  createWorkspaceMembershipLookup,
   normalizeActiveWorkspaceContext,
+  normalizeWorkspaceMembershipLabel,
   normalizeWorkspaceSummary,
   resolveWorkspaceActionEligibility,
   resolveWorkspaceRecovery
@@ -190,6 +192,63 @@ describe("workspace context normalizers", () => {
 
     expect(decision.allowed).toBe(true)
     expect(decision.recovery.reasonCode).toBe("allowed")
+  })
+
+  it("builds membership labels from the server workspace list", () => {
+    const lookupMembership = createWorkspaceMembershipLookup([
+      workspaceFixture({ id: "ws-active", name: "Alpha" }),
+      workspaceFixture({ id: "ws-archived", name: "Archive", archived: true })
+    ])
+
+    expect(lookupMembership("ws-active")).toMatchObject({
+      workspaceId: "ws-active",
+      workspaceLabel: "Alpha",
+      membershipLabel: "Workspace: Alpha",
+      tone: "neutral",
+      isAuthoritative: true,
+      reasonCode: null
+    })
+    expect(lookupMembership("ws-archived")).toMatchObject({
+      workspaceId: "ws-archived",
+      workspaceLabel: "Archive",
+      membershipLabel: "Archived Workspace: Archive",
+      tone: "warning",
+      isAuthoritative: true,
+      reasonCode: "workspace_archived"
+    })
+    expect(lookupMembership("ws-missing")).toMatchObject({
+      workspaceId: "ws-missing",
+      workspaceLabel: "Workspace ws-missing",
+      membershipLabel: "Unknown Workspace",
+      tone: "warning",
+      isAuthoritative: false,
+      reasonCode: "workspace_missing"
+    })
+    expect(lookupMembership(null)).toMatchObject({
+      workspaceId: null,
+      workspaceLabel: "Global",
+      membershipLabel: "Global",
+      tone: "neutral",
+      isAuthoritative: true,
+      reasonCode: null
+    })
+  })
+
+  it("normalizes direct membership lookups without silently granting authority", () => {
+    expect(
+      normalizeWorkspaceMembershipLabel("ws-deleted", {
+        workspace: workspaceFixture({
+          id: "ws-deleted",
+          name: "Deleted Workspace",
+          deleted: true
+        })
+      })
+    ).toMatchObject({
+      membershipLabel: "Deleted Workspace: Deleted Workspace",
+      tone: "error",
+      isAuthoritative: true,
+      reasonCode: "workspace_deleted"
+    })
   })
 
   it("returns missing context when no server workspace id exists", () => {

--- a/apps/packages/ui/src/services/workspace-context/__tests__/normalizers.test.ts
+++ b/apps/packages/ui/src/services/workspace-context/__tests__/normalizers.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest"
+import type {
+  WorkspaceApiResponse,
+  WorkspaceCapabilitiesResponse,
+  WorkspaceContextResponse,
+  WorkspaceProjectRoot,
+  WorkspaceSourceStatusSummary
+} from "@/services/tldw/domains/workspace-api"
+import {
+  compareACPWorkspaceContext,
+  normalizeActiveWorkspaceContext,
+  normalizeWorkspaceSummary,
+  resolveWorkspaceActionEligibility,
+  resolveWorkspaceRecovery
+} from "../normalizers"
+
+const workspaceFixture = (
+  overrides: Partial<WorkspaceApiResponse> = {}
+): WorkspaceApiResponse => ({
+  id: "ws-1",
+  name: "Server Workspace",
+  archived: false,
+  study_materials_policy: "workspace",
+  workspace_profile: "research",
+  deleted: false,
+  banner_title: null,
+  banner_subtitle: null,
+  banner_color: null,
+  audio_provider: null,
+  audio_model: null,
+  audio_voice: null,
+  audio_speed: null,
+  created_at: "2026-06-18T00:00:00Z",
+  last_modified: "2026-06-18T00:10:00Z",
+  version: 7,
+  ...overrides
+})
+
+const sourceSummaryFixture = (
+  overrides: Partial<WorkspaceSourceStatusSummary> = {}
+): WorkspaceSourceStatusSummary => ({
+  total: 0,
+  selected: 0,
+  queryable: 0,
+  partially_queryable: 0,
+  processing: 0,
+  failed: 0,
+  missing: 0,
+  ...overrides
+})
+
+const projectRootFixture = (
+  overrides: Partial<WorkspaceProjectRoot> = {}
+): WorkspaceProjectRoot => ({
+  state: "not_configured",
+  root_id: null,
+  backend: null,
+  display_name: null,
+  path_hint: null,
+  git_state: null,
+  file_inventory_state: "not_started",
+  file_inventory: {
+    state: "not_started",
+    indexed_file_count: null,
+    total_file_count: null,
+    updated_at: null,
+    available: false
+  },
+  indexing_state: null,
+  sandbox_mount_state: null,
+  mcp_trust_state: null,
+  ...overrides
+})
+
+const capabilitiesFixture = (
+  overrides: Partial<WorkspaceCapabilitiesResponse> = {}
+): WorkspaceCapabilitiesResponse => ({
+  workspace_id: "ws-1",
+  workspace_profile: "research",
+  workspace_kind: "research_workspace",
+  access_level: "owner",
+  source_summary: sourceSummaryFixture(),
+  workspace_services: {},
+  allowed_actions: {},
+  ...overrides
+})
+
+const contextFixture = (
+  overrides: Partial<WorkspaceContextResponse> = {}
+): WorkspaceContextResponse => {
+  const workspace = overrides.workspace ?? workspaceFixture()
+  return {
+    workspace_id: workspace.id,
+    workspace_profile: workspace.workspace_profile,
+    workspace_kind:
+      workspace.workspace_profile === "project"
+        ? "project_workspace"
+        : "research_workspace",
+    schema_version: 2,
+    generated_at: "2026-06-18T00:11:00Z",
+    workspace,
+    attention_state: workspace.archived ? "archived" : "ready",
+    resolution: { status: "complete", partial_errors: [] },
+    project_root: projectRootFixture(),
+    sources: {
+      items: [],
+      summary: sourceSummaryFixture()
+    },
+    capabilities: capabilitiesFixture({
+      workspace_id: workspace.id,
+      workspace_profile: workspace.workspace_profile
+    }),
+    services: {},
+    allowed_actions: {},
+    active_jobs: [],
+    active_operations: [],
+    partial_errors: [],
+    ...overrides
+  }
+}
+
+describe("workspace context normalizers", () => {
+  it("keeps server workspace identity authoritative", () => {
+    const summary = normalizeWorkspaceSummary(
+      workspaceFixture({
+        id: "ws-server-1",
+        name: null,
+        workspace_profile: "project"
+      })
+    )
+
+    expect(summary.id).toBe("ws-server-1")
+    expect(summary.label).toBe("Workspace ws-server-1")
+    expect(summary.profile).toBe("project")
+    expect(summary.version).toBe(7)
+  })
+
+  it("maps partial workspace context to visible recovery copy", () => {
+    const context = normalizeActiveWorkspaceContext(
+      contextFixture({
+        attention_state: "needs_attention",
+        resolution: {
+          status: "partial",
+          partial_errors: [
+            {
+              scope: "sources",
+              code: "source_status_unavailable",
+              message: "Source status unavailable"
+            }
+          ]
+        },
+        sources: {
+          items: [],
+          summary: sourceSummaryFixture({ total: 2 })
+        },
+        partial_errors: [
+          {
+            scope: "sources",
+            code: "source_status_unavailable",
+            message: "Source status unavailable"
+          }
+        ]
+      })
+    )
+
+    expect(context.state).toBe("partial")
+    expect(context.workspace?.label).toBe("Server Workspace")
+    expect(context.sourceSummary.total).toBe(2)
+    expect(context.recovery.reasonCode).toBe("partial_context")
+    expect(context.recovery.message).toMatch(/partially resolved/i)
+  })
+
+  it("uses server action reason codes for eligibility recovery", () => {
+    const decision = resolveWorkspaceActionEligibility("open_terminal", {
+      allowed: false,
+      reason_code: "workspace_project_root_missing"
+    })
+
+    expect(decision.allowed).toBe(false)
+    expect(decision.reasonCode).toBe("workspace_project_root_missing")
+    expect(decision.recovery.nextStepHref).toBe("#/workspaces")
+    expect(decision.recovery.nextStepLabel).toMatch(/Workspaces/i)
+  })
+
+  it("allows action when the server allowed action permits it", () => {
+    const decision = resolveWorkspaceActionEligibility("read_sources", {
+      allowed: true,
+      reason_code: null
+    })
+
+    expect(decision.allowed).toBe(true)
+    expect(decision.recovery.reasonCode).toBe("allowed")
+  })
+
+  it("returns missing context when no server workspace id exists", () => {
+    const context = normalizeActiveWorkspaceContext(null)
+
+    expect(context.state).toBe("none")
+    expect(context.workspaceId).toBeNull()
+    expect(context.recovery.reasonCode).toBe("no_active_workspace")
+  })
+
+  it("detects ACP session and active workspace mismatch without mutating either side", () => {
+    const context = compareACPWorkspaceContext({
+      sessionWorkspaceId: "ws-session",
+      activeWorkspaceId: "ws-active"
+    })
+
+    expect(context.state).toBe("mismatch")
+    expect(context.sessionWorkspaceId).toBe("ws-session")
+    expect(context.activeWorkspaceId).toBe("ws-active")
+    expect(context.recovery.reasonCode).toBe("workspace_mismatch")
+  })
+
+  it("reports ACP alignment when session and active workspace match", () => {
+    const context = compareACPWorkspaceContext({
+      sessionWorkspaceId: "ws-1",
+      activeWorkspaceId: "ws-1",
+      activeWorkspaceLabel: "Server Workspace"
+    })
+
+    expect(context.state).toBe("aligned")
+    expect(context.message).toMatch(/Server Workspace/)
+    expect(context.recovery.reasonCode).toBe("aligned")
+  })
+
+  it("provides stable copy for unknown reason codes", () => {
+    const recovery = resolveWorkspaceRecovery("future_reason_code")
+
+    expect(recovery.reasonCode).toBe("future_reason_code")
+    expect(recovery.message).toMatch(/cannot complete/i)
+    expect(recovery.nextStepHref).toBe("#/workspaces")
+  })
+})

--- a/apps/packages/ui/src/services/workspace-context/contracts.ts
+++ b/apps/packages/ui/src/services/workspace-context/contracts.ts
@@ -1,0 +1,112 @@
+import type {
+  WorkspaceAllowedAction,
+  WorkspaceAttentionState,
+  WorkspaceCapabilitiesResponse,
+  WorkspaceContextPartialError,
+  WorkspaceProjectRoot,
+  WorkspaceProfile,
+  WorkspaceResolution,
+  WorkspaceSourceStatusSummary
+} from "@/services/tldw/domains/workspace-api"
+
+export type ActiveWorkspaceContextState =
+  | "none"
+  | "loading"
+  | "ready"
+  | "partial"
+  | "missing"
+  | "error"
+
+export type WorkspaceRecoverySeverity = "info" | "warning" | "error"
+
+export interface WorkspaceSummaryContract {
+  id: string
+  name: string | null
+  label: string
+  profile: WorkspaceProfile
+  archived: boolean
+  deleted: boolean
+  studyMaterialsPolicy: "general" | "workspace"
+  statusLabel: string
+  version: number
+  lastModified: string
+}
+
+export interface WorkspaceRecoveryContract {
+  reasonCode: string
+  severity: WorkspaceRecoverySeverity
+  message: string
+  nextStepLabel: string | null
+  nextStepHref: string | null
+}
+
+export interface ActiveWorkspaceContextContract {
+  state: ActiveWorkspaceContextState
+  workspaceId: string | null
+  workspace: WorkspaceSummaryContract | null
+  attentionState: WorkspaceAttentionState | null
+  resolution: WorkspaceResolution | null
+  projectRoot: WorkspaceProjectRoot | null
+  sourceSummary: WorkspaceSourceStatusSummary
+  capabilities: WorkspaceCapabilitiesResponse | null
+  allowedActions: Record<string, WorkspaceAllowedAction>
+  partialErrors: WorkspaceContextPartialError[]
+  recovery: WorkspaceRecoveryContract
+}
+
+export interface WorkspaceEligibilityDecision {
+  action: string
+  allowed: boolean
+  reasonCode: string
+  severity: WorkspaceRecoverySeverity
+  primaryMessage: string
+  nextStepLabel: string | null
+  nextStepHref: string | null
+  recovery: WorkspaceRecoveryContract
+}
+
+export type WorkspaceMembershipTone = "neutral" | "success" | "warning" | "error"
+
+export interface WorkspaceMembershipLabel {
+  workspaceId: string | null
+  workspaceLabel: string
+  membershipLabel: string
+  tone: WorkspaceMembershipTone
+  isAuthoritative: boolean
+  reasonCode: string | null
+}
+
+export type ACPWorkspaceContextState =
+  | "aligned"
+  | "mismatch"
+  | "session_only"
+  | "active_only"
+  | "missing"
+  | "unknown"
+
+export interface ACPWorkspaceContextInput {
+  sessionWorkspaceId?: string | null
+  activeWorkspaceId?: string | null
+  sessionWorkspaceLabel?: string | null
+  activeWorkspaceLabel?: string | null
+}
+
+export interface ACPWorkspaceContextContract {
+  state: ACPWorkspaceContextState
+  sessionWorkspaceId: string | null
+  activeWorkspaceId: string | null
+  sessionWorkspaceLabel: string | null
+  activeWorkspaceLabel: string | null
+  message: string
+  recovery: WorkspaceRecoveryContract
+}
+
+export const EMPTY_WORKSPACE_SOURCE_SUMMARY: WorkspaceSourceStatusSummary = {
+  total: 0,
+  selected: 0,
+  queryable: 0,
+  partially_queryable: 0,
+  processing: 0,
+  failed: 0,
+  missing: 0
+}

--- a/apps/packages/ui/src/services/workspace-context/hooks.tsx
+++ b/apps/packages/ui/src/services/workspace-context/hooks.tsx
@@ -36,6 +36,8 @@ export const useActiveWorkspaceContext = ({
   const defaultClient = useTldwApiClient() as WorkspaceContextClient
   const resolvedClient = client ?? defaultClient
   const clientRef = React.useRef(resolvedClient)
+  const mountedRef = React.useRef(false)
+  const requestIdRef = React.useRef(0)
   const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId)
 
   clientRef.current = resolvedClient
@@ -47,75 +49,57 @@ export const useActiveWorkspaceContext = ({
   const [error, setError] = React.useState<Error | null>(null)
 
   const loadContext = React.useCallback(async () => {
-    if (!normalizedWorkspaceId) {
-      setLoading(false)
-      setError(null)
-      setContext(normalizeActiveWorkspaceContext(null))
+    const currentWorkspaceId = normalizedWorkspaceId
+    const requestId = requestIdRef.current + 1
+    requestIdRef.current = requestId
+    const isCurrentRequest = () =>
+      mountedRef.current && requestIdRef.current === requestId
+
+    if (!currentWorkspaceId) {
+      if (isCurrentRequest()) {
+        setLoading(false)
+        setError(null)
+        setContext(normalizeActiveWorkspaceContext(null))
+      }
       return
     }
 
-    setLoading(true)
-    setError(null)
+    if (isCurrentRequest()) {
+      setLoading(true)
+      setError(null)
+    }
     try {
-      const response = await clientRef.current.getWorkspaceContext(normalizedWorkspaceId)
-      setContext(normalizeActiveWorkspaceContext(response))
+      const response = await clientRef.current.getWorkspaceContext(currentWorkspaceId)
+      if (isCurrentRequest()) {
+        setContext(normalizeActiveWorkspaceContext(response))
+      }
     } catch (err) {
-      const normalizedError = toError(err)
-      setError(normalizedError)
-      setContext(
-        normalizeActiveWorkspaceContext(null, {
-          state: "error",
-          reasonCode: "workspace_context_error"
-        })
-      )
+      if (isCurrentRequest()) {
+        const normalizedError = toError(err)
+        setError(normalizedError)
+        setContext(
+          normalizeActiveWorkspaceContext(null, {
+            state: "error",
+            reasonCode: "workspace_context_error"
+          })
+        )
+      }
     } finally {
-      setLoading(false)
+      if (isCurrentRequest()) {
+        setLoading(false)
+      }
     }
   }, [normalizedWorkspaceId])
 
   React.useEffect(() => {
-    let disposed = false
-
-    const run = async () => {
-      if (!normalizedWorkspaceId) {
-        if (!disposed) {
-          setLoading(false)
-          setError(null)
-          setContext(normalizeActiveWorkspaceContext(null))
-        }
-        return
-      }
-
-      setLoading(true)
-      setError(null)
-      try {
-        const response = await clientRef.current.getWorkspaceContext(normalizedWorkspaceId)
-        if (!disposed) {
-          setContext(normalizeActiveWorkspaceContext(response))
-        }
-      } catch (err) {
-        if (!disposed) {
-          setError(toError(err))
-          setContext(
-            normalizeActiveWorkspaceContext(null, {
-              state: "error",
-              reasonCode: "workspace_context_error"
-            })
-          )
-        }
-      } finally {
-        if (!disposed) {
-          setLoading(false)
-        }
-      }
-    }
-
-    void run()
+    mountedRef.current = true
+    void loadContext()
 
     return () => {
-      disposed = true
+      mountedRef.current = false
+      requestIdRef.current += 1
     }
-  }, [normalizedWorkspaceId])
+  }, [loadContext])
 
   return {
     context,

--- a/apps/packages/ui/src/services/workspace-context/hooks.tsx
+++ b/apps/packages/ui/src/services/workspace-context/hooks.tsx
@@ -1,0 +1,126 @@
+import React from "react"
+import { useTldwApiClient } from "@/hooks/useTldwApiClient"
+import type { WorkspaceContextResponse } from "@/services/tldw/domains/workspace-api"
+import type { ActiveWorkspaceContextContract } from "./contracts"
+import { normalizeActiveWorkspaceContext } from "./normalizers"
+
+export interface WorkspaceContextClient {
+  getWorkspaceContext(workspaceId: string): Promise<WorkspaceContextResponse>
+}
+
+export interface UseActiveWorkspaceContextOptions {
+  workspaceId?: string | null
+  client?: WorkspaceContextClient
+}
+
+export interface UseActiveWorkspaceContextResult {
+  context: ActiveWorkspaceContextContract
+  loading: boolean
+  error: Error | null
+  refresh: () => Promise<void>
+}
+
+const normalizeWorkspaceId = (workspaceId?: string | null): string | null => {
+  if (typeof workspaceId !== "string") return null
+  const trimmed = workspaceId.trim()
+  return trimmed || null
+}
+
+const toError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error))
+
+export const useActiveWorkspaceContext = ({
+  workspaceId,
+  client
+}: UseActiveWorkspaceContextOptions): UseActiveWorkspaceContextResult => {
+  const defaultClient = useTldwApiClient() as WorkspaceContextClient
+  const resolvedClient = client ?? defaultClient
+  const clientRef = React.useRef(resolvedClient)
+  const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId)
+
+  clientRef.current = resolvedClient
+
+  const [context, setContext] = React.useState<ActiveWorkspaceContextContract>(
+    () => normalizeActiveWorkspaceContext(null)
+  )
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState<Error | null>(null)
+
+  const loadContext = React.useCallback(async () => {
+    if (!normalizedWorkspaceId) {
+      setLoading(false)
+      setError(null)
+      setContext(normalizeActiveWorkspaceContext(null))
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await clientRef.current.getWorkspaceContext(normalizedWorkspaceId)
+      setContext(normalizeActiveWorkspaceContext(response))
+    } catch (err) {
+      const normalizedError = toError(err)
+      setError(normalizedError)
+      setContext(
+        normalizeActiveWorkspaceContext(null, {
+          state: "error",
+          reasonCode: "workspace_context_error"
+        })
+      )
+    } finally {
+      setLoading(false)
+    }
+  }, [normalizedWorkspaceId])
+
+  React.useEffect(() => {
+    let disposed = false
+
+    const run = async () => {
+      if (!normalizedWorkspaceId) {
+        if (!disposed) {
+          setLoading(false)
+          setError(null)
+          setContext(normalizeActiveWorkspaceContext(null))
+        }
+        return
+      }
+
+      setLoading(true)
+      setError(null)
+      try {
+        const response = await clientRef.current.getWorkspaceContext(normalizedWorkspaceId)
+        if (!disposed) {
+          setContext(normalizeActiveWorkspaceContext(response))
+        }
+      } catch (err) {
+        if (!disposed) {
+          setError(toError(err))
+          setContext(
+            normalizeActiveWorkspaceContext(null, {
+              state: "error",
+              reasonCode: "workspace_context_error"
+            })
+          )
+        }
+      } finally {
+        if (!disposed) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void run()
+
+    return () => {
+      disposed = true
+    }
+  }, [normalizedWorkspaceId])
+
+  return {
+    context,
+    loading,
+    error,
+    refresh: loadContext
+  }
+}

--- a/apps/packages/ui/src/services/workspace-context/hooks.tsx
+++ b/apps/packages/ui/src/services/workspace-context/hooks.tsx
@@ -1,11 +1,27 @@
 import React from "react"
 import { useTldwApiClient } from "@/hooks/useTldwApiClient"
-import type { WorkspaceContextResponse } from "@/services/tldw/domains/workspace-api"
-import type { ActiveWorkspaceContextContract } from "./contracts"
-import { normalizeActiveWorkspaceContext } from "./normalizers"
+import type {
+  WorkspaceApiResponse,
+  WorkspaceContextResponse,
+  WorkspaceListApiResponse
+} from "@/services/tldw/domains/workspace-api"
+import type {
+  ActiveWorkspaceContextContract,
+  WorkspaceMembershipLabel,
+  WorkspaceSummaryContract
+} from "./contracts"
+import {
+  createWorkspaceMembershipLookup,
+  normalizeActiveWorkspaceContext,
+  normalizeWorkspaceSummary
+} from "./normalizers"
 
 export interface WorkspaceContextClient {
   getWorkspaceContext(workspaceId: string): Promise<WorkspaceContextResponse>
+}
+
+export interface WorkspaceMembershipClient {
+  listWorkspaces(): Promise<WorkspaceListApiResponse>
 }
 
 export interface UseActiveWorkspaceContextOptions {
@@ -18,6 +34,18 @@ export interface UseActiveWorkspaceContextResult {
   loading: boolean
   error: Error | null
   refresh: () => Promise<void>
+}
+
+export interface UseWorkspaceMembershipLookupOptions {
+  client?: WorkspaceMembershipClient
+}
+
+export interface UseWorkspaceMembershipLookupResult {
+  workspaces: WorkspaceSummaryContract[]
+  loading: boolean
+  error: Error | null
+  refresh: () => Promise<void>
+  resolveMembership: (workspaceId?: string | null) => WorkspaceMembershipLabel
 }
 
 const normalizeWorkspaceId = (workspaceId?: string | null): string | null => {
@@ -106,5 +134,75 @@ export const useActiveWorkspaceContext = ({
     loading,
     error,
     refresh: loadContext
+  }
+}
+
+export const useWorkspaceMembershipLookup = ({
+  client
+}: UseWorkspaceMembershipLookupOptions = {}): UseWorkspaceMembershipLookupResult => {
+  const defaultClient = useTldwApiClient() as WorkspaceMembershipClient
+  const resolvedClient = client ?? defaultClient
+  const clientRef = React.useRef(resolvedClient)
+  const mountedRef = React.useRef(false)
+  const requestIdRef = React.useRef(0)
+
+  clientRef.current = resolvedClient
+
+  const [workspaces, setWorkspaces] = React.useState<WorkspaceApiResponse[]>([])
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState<Error | null>(null)
+
+  const loadWorkspaces = React.useCallback(async () => {
+    const requestId = requestIdRef.current + 1
+    requestIdRef.current = requestId
+    const isCurrentRequest = () =>
+      mountedRef.current && requestIdRef.current === requestId
+
+    if (isCurrentRequest()) {
+      setLoading(true)
+      setError(null)
+    }
+
+    try {
+      const response = await clientRef.current.listWorkspaces()
+      if (isCurrentRequest()) {
+        setWorkspaces(response.items)
+      }
+    } catch (err) {
+      if (isCurrentRequest()) {
+        setError(toError(err))
+      }
+    } finally {
+      if (isCurrentRequest()) {
+        setLoading(false)
+      }
+    }
+  }, [])
+
+  React.useEffect(() => {
+    mountedRef.current = true
+    void loadWorkspaces()
+
+    return () => {
+      mountedRef.current = false
+      requestIdRef.current += 1
+    }
+  }, [loadWorkspaces])
+
+  const resolveMembership = React.useMemo(
+    () => createWorkspaceMembershipLookup(workspaces),
+    [workspaces]
+  )
+  const workspaceSummaries = React.useMemo(
+    () => workspaces.map(normalizeWorkspaceSummary),
+    [workspaces]
+  )
+
+  return {
+    workspaces: workspaceSummaries,
+    loading,
+    error,
+    refresh: loadWorkspaces,
+    resolveMembership
   }
 }

--- a/apps/packages/ui/src/services/workspace-context/index.ts
+++ b/apps/packages/ui/src/services/workspace-context/index.ts
@@ -1,0 +1,3 @@
+export * from "./contracts"
+export * from "./hooks"
+export * from "./normalizers"

--- a/apps/packages/ui/src/services/workspace-context/normalizers.ts
+++ b/apps/packages/ui/src/services/workspace-context/normalizers.ts
@@ -8,6 +8,7 @@ import type {
   ACPWorkspaceContextInput,
   ActiveWorkspaceContextContract,
   WorkspaceEligibilityDecision,
+  WorkspaceMembershipLabel,
   WorkspaceRecoveryContract,
   WorkspaceRecoverySeverity,
   WorkspaceSummaryContract
@@ -48,6 +49,90 @@ export const normalizeWorkspaceSummary = (
   version: workspace.version,
   lastModified: workspace.last_modified
 })
+
+export const normalizeWorkspaceMembershipLabel = (
+  workspaceId?: string | null,
+  options: {
+    workspace?: WorkspaceApiResponse | null
+  } = {}
+): WorkspaceMembershipLabel => {
+  const normalizedWorkspaceId = normalizeOptionalId(workspaceId)
+
+  if (!normalizedWorkspaceId) {
+    return {
+      workspaceId: null,
+      workspaceLabel: "Global",
+      membershipLabel: "Global",
+      tone: "neutral",
+      isAuthoritative: true,
+      reasonCode: null
+    }
+  }
+
+  const workspace =
+    options.workspace?.id === normalizedWorkspaceId ? options.workspace : null
+
+  if (!workspace) {
+    return {
+      workspaceId: normalizedWorkspaceId,
+      workspaceLabel: fallbackWorkspaceLabel(normalizedWorkspaceId),
+      membershipLabel: "Unknown Workspace",
+      tone: "warning",
+      isAuthoritative: false,
+      reasonCode: "workspace_missing"
+    }
+  }
+
+  const summary = normalizeWorkspaceSummary(workspace)
+
+  if (summary.deleted) {
+    return {
+      workspaceId: summary.id,
+      workspaceLabel: summary.label,
+      membershipLabel: `Deleted Workspace: ${summary.label}`,
+      tone: "error",
+      isAuthoritative: true,
+      reasonCode: "workspace_deleted"
+    }
+  }
+
+  if (summary.archived) {
+    return {
+      workspaceId: summary.id,
+      workspaceLabel: summary.label,
+      membershipLabel: `Archived Workspace: ${summary.label}`,
+      tone: "warning",
+      isAuthoritative: true,
+      reasonCode: "workspace_archived"
+    }
+  }
+
+  return {
+    workspaceId: summary.id,
+    workspaceLabel: summary.label,
+    membershipLabel: `Workspace: ${summary.label}`,
+    tone: "neutral",
+    isAuthoritative: true,
+    reasonCode: null
+  }
+}
+
+export const createWorkspaceMembershipLookup = (
+  workspaces: WorkspaceApiResponse[] = []
+): ((workspaceId?: string | null) => WorkspaceMembershipLabel) => {
+  const workspaceById = new Map(
+    workspaces.map((workspace) => [workspace.id, workspace])
+  )
+
+  return (workspaceId?: string | null) => {
+    const normalizedWorkspaceId = normalizeOptionalId(workspaceId)
+    return normalizeWorkspaceMembershipLabel(normalizedWorkspaceId, {
+      workspace: normalizedWorkspaceId
+        ? workspaceById.get(normalizedWorkspaceId) ?? null
+        : null
+    })
+  }
+}
 
 const recoveryMap: Record<string, WorkspaceRecoveryContract> = {
   allowed: {

--- a/apps/packages/ui/src/services/workspace-context/normalizers.ts
+++ b/apps/packages/ui/src/services/workspace-context/normalizers.ts
@@ -1,0 +1,327 @@
+import type {
+  WorkspaceAllowedAction,
+  WorkspaceApiResponse,
+  WorkspaceContextResponse
+} from "@/services/tldw/domains/workspace-api"
+import type {
+  ACPWorkspaceContextContract,
+  ACPWorkspaceContextInput,
+  ActiveWorkspaceContextContract,
+  WorkspaceEligibilityDecision,
+  WorkspaceRecoveryContract,
+  WorkspaceRecoverySeverity,
+  WorkspaceSummaryContract
+} from "./contracts"
+import { EMPTY_WORKSPACE_SOURCE_SUMMARY } from "./contracts"
+
+const WORKSPACES_MANAGER_HREF = "#/workspaces"
+
+const normalizeOptionalId = (value?: string | null): string | null => {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed || null
+}
+
+const fallbackWorkspaceLabel = (workspaceId: string): string =>
+  `Workspace ${workspaceId}`
+
+const workspaceLabel = (workspace: WorkspaceApiResponse): string => {
+  const name = workspace.name?.trim()
+  return name || fallbackWorkspaceLabel(workspace.id)
+}
+
+export const normalizeWorkspaceSummary = (
+  workspace: WorkspaceApiResponse
+): WorkspaceSummaryContract => ({
+  id: workspace.id,
+  name: workspace.name,
+  label: workspaceLabel(workspace),
+  profile: workspace.workspace_profile,
+  archived: workspace.archived,
+  deleted: workspace.deleted,
+  studyMaterialsPolicy: workspace.study_materials_policy,
+  statusLabel: workspace.deleted
+    ? "Deleted"
+    : workspace.archived
+      ? "Archived"
+      : "Active",
+  version: workspace.version,
+  lastModified: workspace.last_modified
+})
+
+const recoveryMap: Record<string, WorkspaceRecoveryContract> = {
+  allowed: {
+    reasonCode: "allowed",
+    severity: "info",
+    message: "Workspace action is available.",
+    nextStepLabel: null,
+    nextStepHref: null
+  },
+  no_active_workspace: {
+    reasonCode: "no_active_workspace",
+    severity: "warning",
+    message: "Select a server Workspace before using Workspace-specific actions.",
+    nextStepLabel: "Open Workspaces",
+    nextStepHref: WORKSPACES_MANAGER_HREF
+  },
+  partial_context: {
+    reasonCode: "partial_context",
+    severity: "warning",
+    message: "Server Workspace context partially resolved. Some Workspace actions may be unavailable.",
+    nextStepLabel: "Open Workspaces",
+    nextStepHref: WORKSPACES_MANAGER_HREF
+  },
+  workspace_archived: {
+    reasonCode: "workspace_archived",
+    severity: "warning",
+    message: "This server Workspace is archived. Restore it before making changes.",
+    nextStepLabel: "Open Workspaces",
+    nextStepHref: WORKSPACES_MANAGER_HREF
+  },
+  workspace_missing: {
+    reasonCode: "workspace_missing",
+    severity: "error",
+    message: "The selected server Workspace could not be found.",
+    nextStepLabel: "Open Workspaces",
+    nextStepHref: WORKSPACES_MANAGER_HREF
+  },
+  workspace_context_error: {
+    reasonCode: "workspace_context_error",
+    severity: "error",
+    message: "Server Workspace context is unavailable right now.",
+    nextStepLabel: "Open Workspaces",
+    nextStepHref: WORKSPACES_MANAGER_HREF
+  },
+  workspace_project_root_missing: {
+    reasonCode: "workspace_project_root_missing",
+    severity: "warning",
+    message: "Attach or provision a project root before using this Workspace action.",
+    nextStepLabel: "Open Workspaces",
+    nextStepHref: WORKSPACES_MANAGER_HREF
+  },
+  workspace_mismatch: {
+    reasonCode: "workspace_mismatch",
+    severity: "warning",
+    message: "This ACP session is attached to a different server Workspace than the active Workspace.",
+    nextStepLabel: "Open Workspaces",
+    nextStepHref: WORKSPACES_MANAGER_HREF
+  },
+  aligned: {
+    reasonCode: "aligned",
+    severity: "info",
+    message: "ACP session Workspace matches the active server Workspace.",
+    nextStepLabel: null,
+    nextStepHref: null
+  },
+  session_workspace_only: {
+    reasonCode: "session_workspace_only",
+    severity: "info",
+    message: "This ACP session has a server Workspace, but no active server Workspace is selected.",
+    nextStepLabel: "Open Workspaces",
+    nextStepHref: WORKSPACES_MANAGER_HREF
+  },
+  active_workspace_only: {
+    reasonCode: "active_workspace_only",
+    severity: "warning",
+    message: "The active server Workspace is not attached to this ACP session.",
+    nextStepLabel: "Open Workspaces",
+    nextStepHref: WORKSPACES_MANAGER_HREF
+  },
+  acp_workspace_missing: {
+    reasonCode: "acp_workspace_missing",
+    severity: "warning",
+    message: "No server Workspace is associated with this ACP session.",
+    nextStepLabel: "Open Workspaces",
+    nextStepHref: WORKSPACES_MANAGER_HREF
+  }
+}
+
+export const resolveWorkspaceRecovery = (
+  reasonCode: string | null | undefined,
+  options: Partial<WorkspaceRecoveryContract> = {}
+): WorkspaceRecoveryContract => {
+  const normalizedReason = reasonCode || "workspace_context_error"
+  const base =
+    recoveryMap[normalizedReason] ?? {
+      reasonCode: normalizedReason,
+      severity: "warning" satisfies WorkspaceRecoverySeverity,
+      message: "This Workspace action cannot complete until server Workspace context is resolved.",
+      nextStepLabel: "Open Workspaces",
+      nextStepHref: WORKSPACES_MANAGER_HREF
+    }
+
+  return {
+    ...base,
+    ...options,
+    reasonCode: options.reasonCode ?? base.reasonCode
+  }
+}
+
+export const normalizeActiveWorkspaceContext = (
+  response: WorkspaceContextResponse | null,
+  options: {
+    state?: ActiveWorkspaceContextContract["state"]
+    reasonCode?: string | null
+  } = {}
+): ActiveWorkspaceContextContract => {
+  if (!response) {
+    const state = options.state ?? "none"
+    const reasonCode =
+      options.reasonCode ??
+      (state === "error"
+        ? "workspace_context_error"
+        : state === "missing"
+          ? "workspace_missing"
+          : "no_active_workspace")
+
+    return {
+      state,
+      workspaceId: null,
+      workspace: null,
+      attentionState: null,
+      resolution: null,
+      projectRoot: null,
+      sourceSummary: EMPTY_WORKSPACE_SOURCE_SUMMARY,
+      capabilities: null,
+      allowedActions: {},
+      partialErrors: [],
+      recovery: resolveWorkspaceRecovery(reasonCode)
+    }
+  }
+
+  const resolutionStatus = response.resolution?.status
+  const isArchived = response.workspace.archived || response.attention_state === "archived"
+  const state: ActiveWorkspaceContextContract["state"] = isArchived
+    ? "ready"
+    : resolutionStatus === "partial"
+      ? "partial"
+      : resolutionStatus === "failed"
+        ? "error"
+        : "ready"
+
+  const reasonCode =
+    options.reasonCode ??
+    (isArchived
+      ? "workspace_archived"
+      : state === "partial"
+        ? "partial_context"
+        : state === "error"
+          ? "workspace_context_error"
+          : "allowed")
+
+  return {
+    state: options.state ?? state,
+    workspaceId: response.workspace_id,
+    workspace: normalizeWorkspaceSummary(response.workspace),
+    attentionState: response.attention_state,
+    resolution: response.resolution,
+    projectRoot: response.project_root,
+    sourceSummary: response.sources.summary,
+    capabilities: response.capabilities,
+    allowedActions: response.allowed_actions,
+    partialErrors: response.partial_errors,
+    recovery: resolveWorkspaceRecovery(reasonCode)
+  }
+}
+
+export const resolveWorkspaceActionEligibility = (
+  action: string,
+  allowedAction?: WorkspaceAllowedAction | null
+): WorkspaceEligibilityDecision => {
+  if (allowedAction?.allowed) {
+    const recovery = resolveWorkspaceRecovery("allowed")
+    return {
+      action,
+      allowed: true,
+      reasonCode: "allowed",
+      severity: recovery.severity,
+      primaryMessage: recovery.message,
+      nextStepLabel: recovery.nextStepLabel,
+      nextStepHref: recovery.nextStepHref,
+      recovery
+    }
+  }
+
+  const reasonCode = allowedAction?.reason_code || "workspace_context_error"
+  const recovery = resolveWorkspaceRecovery(reasonCode)
+  return {
+    action,
+    allowed: false,
+    reasonCode,
+    severity: recovery.severity,
+    primaryMessage: recovery.message,
+    nextStepLabel: recovery.nextStepLabel,
+    nextStepHref: recovery.nextStepHref,
+    recovery
+  }
+}
+
+export const compareACPWorkspaceContext = ({
+  sessionWorkspaceId,
+  activeWorkspaceId,
+  sessionWorkspaceLabel,
+  activeWorkspaceLabel
+}: ACPWorkspaceContextInput): ACPWorkspaceContextContract => {
+  const sessionId = normalizeOptionalId(sessionWorkspaceId)
+  const activeId = normalizeOptionalId(activeWorkspaceId)
+  const sessionLabel = sessionWorkspaceLabel?.trim() || sessionId
+  const activeLabel = activeWorkspaceLabel?.trim() || activeId
+
+  if (sessionId && activeId && sessionId === activeId) {
+    return {
+      state: "aligned",
+      sessionWorkspaceId: sessionId,
+      activeWorkspaceId: activeId,
+      sessionWorkspaceLabel: sessionLabel,
+      activeWorkspaceLabel: activeLabel,
+      message: `ACP session is aligned with ${activeLabel ?? "the active server Workspace"}.`,
+      recovery: resolveWorkspaceRecovery("aligned")
+    }
+  }
+
+  if (sessionId && activeId) {
+    return {
+      state: "mismatch",
+      sessionWorkspaceId: sessionId,
+      activeWorkspaceId: activeId,
+      sessionWorkspaceLabel: sessionLabel,
+      activeWorkspaceLabel: activeLabel,
+      message: `ACP session uses ${sessionLabel ?? sessionId}; active server Workspace is ${activeLabel ?? activeId}.`,
+      recovery: resolveWorkspaceRecovery("workspace_mismatch")
+    }
+  }
+
+  if (sessionId) {
+    return {
+      state: "session_only",
+      sessionWorkspaceId: sessionId,
+      activeWorkspaceId: null,
+      sessionWorkspaceLabel: sessionLabel,
+      activeWorkspaceLabel: null,
+      message: `ACP session is attached to ${sessionLabel ?? sessionId}.`,
+      recovery: resolveWorkspaceRecovery("session_workspace_only")
+    }
+  }
+
+  if (activeId) {
+    return {
+      state: "active_only",
+      sessionWorkspaceId: null,
+      activeWorkspaceId: activeId,
+      sessionWorkspaceLabel: null,
+      activeWorkspaceLabel: activeLabel,
+      message: `Active server Workspace is ${activeLabel ?? activeId}, but this ACP session is not attached to it.`,
+      recovery: resolveWorkspaceRecovery("active_workspace_only")
+    }
+  }
+
+  return {
+    state: "missing",
+    sessionWorkspaceId: null,
+    activeWorkspaceId: null,
+    sessionWorkspaceLabel: null,
+    activeWorkspaceLabel: null,
+    message: "No server Workspace is associated with this ACP session.",
+    recovery: resolveWorkspaceRecovery("acp_workspace_missing")
+  }
+}

--- a/backlog/tasks/task-2386 - Implement-Workspace-Phase-2-frontend-context-contracts-pilot.md
+++ b/backlog/tasks/task-2386 - Implement-Workspace-Phase-2-frontend-context-contracts-pilot.md
@@ -48,10 +48,10 @@ Track #1993 implementation for server-authoritative frontend Workspace context c
   - `apps/packages/ui/src/components/Option/ACPPlayground/ACPWorkspacePanel.tsx`
   - `apps/packages/ui/src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx`
 - Verification:
-  - `./node_modules/.bin/vitest run src/services/workspace-context/__tests__/normalizers.test.ts src/services/workspace-context/__tests__/hooks.test.tsx src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx --maxWorkers=1` passed: 4 files, 67 tests.
+  - `./node_modules/.bin/vitest run src/services/workspace-context/__tests__/normalizers.test.ts src/services/workspace-context/__tests__/hooks.test.tsx src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx --maxWorkers=1` passed: 4 files, 68 tests.
   - `git diff --check` passed.
 - Visible UI evidence:
-  - Testing Library render assertions cover the Research Workspace server-context indicator for ready, failed, archived, and global-browser-list states, and cover ACP Workspace panel aligned, mismatch, no-session, and active-only ID-chip states.
+  - Testing Library render assertions cover the Research Workspace server-context indicator for ready, failed, archived, stable i18n status-key, and global-browser-list states, and cover ACP Workspace panel aligned, mismatch, no-session, active-only ID-chip, and recovery fallback-link states.
   - Browser attempt: `../node_modules/.bin/playwright test e2e/workflows/research-workspace.parity.spec.ts --project=chromium --reporter=line --workers=1` from `apps/tldw-frontend` failed before browser launch because the worktree frontend app has no local `next` binary (`next: command not found`). The main checkout has `next`, but its workspace `@tldw/ui` symlink resolves to the main checkout package, so it was not used as evidence for this PR worktree.
 - Bandit: not applicable; this slice touched frontend TypeScript/tests/docs/Backlog only and no Python production paths.
 - Typecheck: skipped because no `tsc` binary is exposed in this worktree or the linked frontend dependency roots; focused Vitest transpilation and behavior checks passed.

--- a/backlog/tasks/task-2386 - Implement-Workspace-Phase-2-frontend-context-contracts-pilot.md
+++ b/backlog/tasks/task-2386 - Implement-Workspace-Phase-2-frontend-context-contracts-pilot.md
@@ -1,0 +1,55 @@
+---
+id: TASK-2386
+title: Implement Workspace Phase 2 frontend context contracts pilot
+status: In Progress
+labels:
+- workspace
+- phase2
+- frontend
+- acp
+priority: High
+references:
+- https://github.com/rmusser01/tldw_server/issues/1993
+- https://github.com/rmusser01/tldw_server/issues/1984
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track #1993 implementation for server-authoritative frontend Workspace context contracts, using Research Workspace and ACP Playground as the pilot surfaces.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Spec documents the server Workspace model as the authoritative frontend contract source.
+- [ ] #2 Shared frontend contract types/helpers normalize server workspace, membership, active context, eligibility, and recovery responses without inventing parallel semantics.
+- [ ] #3 Research Workspace pilot consumes the shared contract for active workspace context/recovery copy.
+- [ ] #4 ACP Playground pilot consumes the shared contract for session workspace state and mismatch/recovery copy.
+- [ ] #5 Tests prove global browse/list rendering is not filtered by active workspace context.
+- [ ] #6 Focused frontend tests pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- User clarification: goal is to unify on the server Workspace model. Client-local Research Workspace state can cache/hydrate and decorate, but server workspace identity, memberships, eligibility decisions, and recovery reason codes are authoritative.
+- Keep #1993 scoped to frontend/client contracts plus Research Workspace and ACP Playground pilots. Do not build #1994 activity/index UI in this slice.
+- Design spec: `Docs/superpowers/specs/2026-06-18-workspace-frontend-server-context-contract-design.md`.
+- Implementation plan: `Docs/superpowers/plans/2026-06-18-workspace-frontend-server-context-contract.md`.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2386 - Implement-Workspace-Phase-2-frontend-context-contracts-pilot.md
+++ b/backlog/tasks/task-2386 - Implement-Workspace-Phase-2-frontend-context-contracts-pilot.md
@@ -48,8 +48,11 @@ Track #1993 implementation for server-authoritative frontend Workspace context c
   - `apps/packages/ui/src/components/Option/ACPPlayground/ACPWorkspacePanel.tsx`
   - `apps/packages/ui/src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx`
 - Verification:
-  - `./node_modules/.bin/vitest run src/services/workspace-context/__tests__/normalizers.test.ts src/services/workspace-context/__tests__/hooks.test.tsx src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx --maxWorkers=1` passed: 4 files, 61 tests.
+  - `./node_modules/.bin/vitest run src/services/workspace-context/__tests__/normalizers.test.ts src/services/workspace-context/__tests__/hooks.test.tsx src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx --maxWorkers=1` passed: 4 files, 67 tests.
   - `git diff --check` passed.
+- Visible UI evidence:
+  - Testing Library render assertions cover the Research Workspace server-context indicator for ready, failed, archived, and global-browser-list states, and cover ACP Workspace panel aligned, mismatch, no-session, and active-only ID-chip states.
+  - Browser attempt: `../node_modules/.bin/playwright test e2e/workflows/research-workspace.parity.spec.ts --project=chromium --reporter=line --workers=1` from `apps/tldw-frontend` failed before browser launch because the worktree frontend app has no local `next` binary (`next: command not found`). The main checkout has `next`, but its workspace `@tldw/ui` symlink resolves to the main checkout package, so it was not used as evidence for this PR worktree.
 - Bandit: not applicable; this slice touched frontend TypeScript/tests/docs/Backlog only and no Python production paths.
 - Typecheck: skipped because no `tsc` binary is exposed in this worktree or the linked frontend dependency roots; focused Vitest transpilation and behavior checks passed.
 - Local test environment note: added ignored symlink `apps/node_modules -> /Users/macbook-dev/Documents/GitHub/tldw_server2/apps/node_modules` so existing package symlinks resolve in this worktree. This is not tracked by git.

--- a/backlog/tasks/task-2386 - Implement-Workspace-Phase-2-frontend-context-contracts-pilot.md
+++ b/backlog/tasks/task-2386 - Implement-Workspace-Phase-2-frontend-context-contracts-pilot.md
@@ -21,12 +21,12 @@ Track #1993 implementation for server-authoritative frontend Workspace context c
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Spec documents the server Workspace model as the authoritative frontend contract source.
-- [ ] #2 Shared frontend contract types/helpers normalize server workspace, membership, active context, eligibility, and recovery responses without inventing parallel semantics.
-- [ ] #3 Research Workspace pilot consumes the shared contract for active workspace context/recovery copy.
-- [ ] #4 ACP Playground pilot consumes the shared contract for session workspace state and mismatch/recovery copy.
-- [ ] #5 Tests prove global browse/list rendering is not filtered by active workspace context.
-- [ ] #6 Focused frontend tests pass.
+- [x] #1 Spec documents the server Workspace model as the authoritative frontend contract source.
+- [x] #2 Shared frontend contract types/helpers normalize server workspace, membership, active context, eligibility, and recovery responses without inventing parallel semantics.
+- [x] #3 Research Workspace pilot consumes the shared contract for active workspace context/recovery copy.
+- [x] #4 ACP Playground pilot consumes the shared contract for session workspace state and mismatch/recovery copy.
+- [x] #5 Tests prove global browse/list rendering is not filtered by active workspace context.
+- [x] #6 Focused frontend tests pass.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -36,20 +36,37 @@ Track #1993 implementation for server-authoritative frontend Workspace context c
 - Keep #1993 scoped to frontend/client contracts plus Research Workspace and ACP Playground pilots. Do not build #1994 activity/index UI in this slice.
 - Design spec: `Docs/superpowers/specs/2026-06-18-workspace-frontend-server-context-contract-design.md`.
 - Implementation plan: `Docs/superpowers/plans/2026-06-18-workspace-frontend-server-context-contract.md`.
+- Touched files:
+  - `apps/packages/ui/src/services/workspace-context/contracts.ts`
+  - `apps/packages/ui/src/services/workspace-context/normalizers.ts`
+  - `apps/packages/ui/src/services/workspace-context/hooks.tsx`
+  - `apps/packages/ui/src/services/workspace-context/index.ts`
+  - `apps/packages/ui/src/services/workspace-context/__tests__/normalizers.test.ts`
+  - `apps/packages/ui/src/services/workspace-context/__tests__/hooks.test.tsx`
+  - `apps/packages/ui/src/components/Option/ResearchWorkspace/WorkspaceHeader.tsx`
+  - `apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx`
+  - `apps/packages/ui/src/components/Option/ACPPlayground/ACPWorkspacePanel.tsx`
+  - `apps/packages/ui/src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx`
+- Verification:
+  - `./node_modules/.bin/vitest run src/services/workspace-context/__tests__/normalizers.test.ts src/services/workspace-context/__tests__/hooks.test.tsx src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx --maxWorkers=1` passed: 4 files, 61 tests.
+  - `git diff --check` passed.
+- Bandit: not applicable; this slice touched frontend TypeScript/tests/docs/Backlog only and no Python production paths.
+- Typecheck: skipped because no `tsc` binary is exposed in this worktree or the linked frontend dependency roots; focused Vitest transpilation and behavior checks passed.
+- Local test environment note: added ignored symlink `apps/node_modules -> /Users/macbook-dev/Documents/GitHub/tldw_server2/apps/node_modules` so existing package symlinks resolve in this worktree. This is not tracked by git.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Implemented a server-authoritative frontend Workspace context contract for #1993. Added shared normalizers, recovery copy, action eligibility helpers, and an active-context hook over existing server Workspace DTOs. Piloted the contract in Research Workspace and ACP Playground, including ACP session/active Workspace mismatch copy. Added tests for contract normalization, hook behavior, pilot rendering, and the guard that active server context does not filter the Workspace browser list.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Add shared frontend Workspace context contracts that normalize server Workspace DTOs into summaries, active context, eligibility decisions, recovery copy, and ACP session comparison state.
- Pilot the shared contract in Research Workspace and ACP Playground without adding the #1994 activity/resource-index UI.
- Add guard coverage proving active server Workspace context does not filter the Workspace browser list.

## Test Plan
- [x] `./node_modules/.bin/vitest run src/services/workspace-context/__tests__/normalizers.test.ts src/services/workspace-context/__tests__/hooks.test.tsx src/components/Option/ResearchWorkspace/__tests__/WorkspaceHeader.test.tsx src/components/Option/ACPPlayground/__tests__/ACPWorkspacePanel.test.tsx --maxWorkers=1`
- [x] `git diff --check`

## Change summary
Maintainer-written change summary required before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

## Notes
- Bandit is not applicable because this slice touches frontend TypeScript/tests/docs/Backlog only.
- Typecheck was not run because no `tsc` binary is exposed in this worktree or linked frontend dependency roots.
- Local worktree test setup used an ignored `apps/node_modules` symlink to the main checkout dependency root so existing package symlinks resolve.

Fixes #1993.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds shared frontend Workspace context contracts over server DTOs and pilots them in Research Workspace and ACP Playground. Improves ACP session vs active Workspace messaging and adds recovery-link fallbacks. Fixes #1993.

- **New Features**
  - Added `services/workspace-context` with contracts, pure normalizers, and hooks (`useActiveWorkspaceContext`, `useWorkspaceMembershipLookup`, `compareACPWorkspaceContext`).
  - Research Workspace header shows server context state (ready/partial/archived/error) with shared recovery and `#/workspaces` link.
  - ACP Playground displays session vs active Workspace (aligned/mismatch/session-only/active-only) with ID chips, concise copy, and recovery links (fallback to `#/workspaces`).
  - Membership helpers return authoritative labels and tones (archived/deleted/unknown/global); added docs/specs and focused tests; guard ensures active context does not filter global browse/list.

- **Bug Fixes**
  - Prevent stale updates by guarding overlapping `useActiveWorkspaceContext` fetches and ignoring obsolete requests.
  - Default recovery links to `#/workspaces` when a next-step href is not provided.

<sup>Written for commit cfa3eaa226e430907ff4427b5271a9608c999cce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

