### PR TITLE
feat(workspaces): add activity index contract

### DIFF
--- a/Docs/Design/Workspace_Container_Contract_2026_06.md
+++ b/Docs/Design/Workspace_Container_Contract_2026_06.md
@@ -359,27 +359,57 @@ Secret handling:
 
 ## Activity And Index Contract
 
-The Workspace activity/index view should be an inspection surface, not a clone
-of every owner domain UI.
+`GET /api/v1/workspaces/{workspace_id}/index` is the concrete #1994
+inspection/navigation contract. It is a server-owned read model over existing
+Workspace registry data and owner-domain membership summaries. It is not a new
+Workspace dashboard and must not implement edit/detail behavior that belongs to
+Media, Notes, Chat, Prompts, Workflows, Watchlists, ACP, Sandbox, MCP, or Jobs.
 
-It should expose:
+The response shape is versioned with `schema_version: 1` and includes:
 
-- workspace identity, profile, authority/status, archive/delete state.
-- membership counts and membership pages by resource type/role/state.
-- runtime binding descriptors and readiness.
-- recent membership changes, imports, root changes, runtime binding changes,
-  active-context denials, and recovery actions.
-- links back to owning domain routes for full edit/detail behavior.
+- `workspace`: workspace identity, profile, archive/delete state, and version.
+- `membership_summary`: active membership totals by resource type and role.
+- `resource_groups`: bounded resolved membership previews grouped by resource
+  type. Each group includes an `owner_surface` `{label, href}` supplied by the
+  server so clients can navigate back to the owning UI.
+- `runtime_summary`: descriptor-only runtime binding totals, status counts, and
+  redacted binding payloads.
+- `warnings`: recovery/navigation hints for archived/deleted workspaces,
+  unresolved resource previews, and missing/degraded runtime bindings.
+- `recent_activity`: bounded newest-first activity rows.
+- `partial_errors`: reserved list for future dependency-specific partial read
+  failures.
 
-It should not:
+Current activity categories and event types:
 
-- duplicate Media, Notes, Chat, Prompts, Workflows, Watchlists, ACP, Sandbox, or
-  Jobs management UIs.
-- expose secret metadata, raw filesystem paths, file contents, prompt bodies, or
-  model outputs.
-- treat activity/index membership as an authorization grant.
+| Category | Event types | Source |
+| --- | --- | --- |
+| `membership` | `membership.linked`, `membership.restored`, `membership.unlinked` | Workspace membership service write paths. |
+| `runtime_binding` | `runtime_binding.upserted`, `runtime_binding.archived` | Runtime binding endpoint helper write paths. |
 
-Child issue #1994 owns the concrete activity/index API and UI contract.
+Current warning reason codes:
+
+| Reason code | Meaning |
+| --- | --- |
+| `workspace_archived` | Workspace is inspectable but write/active-context actions are blocked. |
+| `workspace_deleted` | Deleted workspace state is exposed only for recovery-safe inspection. |
+| `resource_unresolved` | A linked owner-domain resource could not be resolved for preview. |
+| `resource_<state>` | A resolved resource preview reported a non-available state. |
+| `runtime_binding_missing` | A runtime binding points at a missing runtime/path/session. |
+| `runtime_binding_<status>` | A runtime binding reported another degraded status such as blocked, detached, conflict, unavailable, or unsupported. |
+
+Security constraints:
+
+- Activity metadata is bounded JSON and must omit secret-shaped keys, API keys,
+  tokens, passwords, private keys, raw env values, prompt bodies, model outputs,
+  file contents, and unredacted absolute paths.
+- Runtime binding rows in the index use the same redacted descriptor contract as
+  `/runtime-bindings`; the index must not become a secret store or runtime
+  admission authority.
+- Resource previews are summaries only. Clients must open the owner `href` for
+  full content, editing, execution, or recovery actions.
+- Unknown warning reason codes are forward-compatible and should be displayed as
+  generic warnings by clients rather than rejected.
 
 ## Open Questions And Assigned Follow-Ups
 

--- a/Docs/superpowers/plans/2026-06-18-workspace-activity-index-contract-plan.md
+++ b/Docs/superpowers/plans/2026-06-18-workspace-activity-index-contract-plan.md
@@ -1,0 +1,177 @@
+# Workspace Activity Index Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement GitHub issue #1994 by adding a server-owned Workspace contained-resource index and recent activity contract without duplicating each owner tool UI.
+
+**Architecture:** Add an append-only Workspace activity event table in ChaChaNotes and a read-only Workspace index service that composes existing Workspace registry, membership summaries, resolved membership previews, runtime bindings, and recovery warnings. Expose the contract through `GET /api/v1/workspaces/{workspace_id}/index`, then add a minimal frontend TypeScript contract/normalizer so UI surfaces can render it later without inventing wire semantics.
+
+**Tech Stack:** FastAPI, Pydantic, ChaChaNotes SQLite/PostgreSQL schema helpers, existing Workspace membership/runtime services, Vitest for TypeScript normalizers, pytest for backend API/DB coverage.
+
+---
+
+## Stage 1: Backend Red Tests
+**Goal:** Prove the missing DB and API behavior before production changes.
+**Success Criteria:** Tests fail because activity primitives, schemas, and index endpoint do not exist.
+**Tests:** `python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py -q`
+**Status:** Complete
+
+### Task 1: DB Activity Contract Tests
+**Files:**
+- Create: `tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py`
+- Modify: none
+
+- [ ] Add tests that create a workspace, record membership/runtime-style activity events, and assert `list_workspace_activity_events()` returns stable timestamped rows in newest-first order.
+- [ ] Add a redaction regression asserting event metadata does not expose obvious secret-shaped keys or absolute path values.
+- [ ] Run the focused test file and confirm failure on missing `record_workspace_activity_event`.
+
+### Task 2: API Index Contract Red Test
+**Files:**
+- Create: `tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py`
+- Reuse fixtures/patterns from: `tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py`
+
+- [ ] Build a small FastAPI test app with `workspaces_endpoint.router`.
+- [ ] Seed memberships for at least `chat` and `prompt`, plus one unresolved/missing summary case.
+- [ ] Assert `GET /api/v1/workspaces/workspace-1/index` returns:
+  - `schema_version: 1`
+  - Workspace identity/profile/archive state.
+  - Workspace-level membership totals grouped by resource type and role.
+  - Resource groups with bounded resolved item previews and owner `href` values.
+  - Runtime binding summary and warnings.
+  - Recent activity rows with `event_type`, `category`, timestamp, and safe metadata.
+- [ ] Run the focused API test and confirm failure on missing route/schema.
+
+---
+
+## Stage 2: Activity Persistence
+**Goal:** Add durable, bounded, secret-safe activity records for Workspace events.
+**Success Criteria:** DB tests pass for event insert/list ordering and metadata safety.
+**Tests:** `python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py -q`
+**Status:** Complete
+
+### Task 3: Add ChaChaNotes Activity Table
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+
+- [ ] Add `workspace_activity_events` to SQLite and PostgreSQL schema creation near other Workspace tables.
+- [ ] Columns: `workspace_id`, `event_id`, `event_type`, `category`, `actor_user_id`, `resource_type`, `resource_id`, `summary`, `metadata_json`, `created_at`, `client_id`, `version`.
+- [ ] Add indexes for `(workspace_id, created_at)` and `(workspace_id, category, created_at)`.
+- [ ] Keep all DDL as fixed strings; do not interpolate identifiers.
+
+### Task 4: Add Activity DB APIs
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+
+- [ ] Add `record_workspace_activity_event(workspace_id, data, user_id=None)` with bounded JSON metadata normalization and secret/path redaction.
+- [ ] Add `list_workspace_activity_events(workspace_id, limit=50, category=None)` with deterministic newest-first ordering.
+- [ ] Normalize rows into response-safe dictionaries.
+- [ ] Re-run the focused DB tests and fix only the minimal code needed.
+
+---
+
+## Stage 3: Read-Only Index Service And Schemas
+**Goal:** Compose the index contract from existing Workspace services without owner-domain duplication.
+**Success Criteria:** Service unit/API tests pass for grouped resources, totals, warnings, and recent activity.
+**Tests:** `python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py -q`
+**Status:** Complete
+
+### Task 5: Add Pydantic Response Models
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/workspace_schemas.py`
+
+- [ ] Add `WorkspaceIndexResponse`, `WorkspaceIndexResourceGroup`, `WorkspaceIndexRuntimeSummary`, `WorkspaceIndexWarning`, and `WorkspaceActivityEventResponse`.
+- [ ] Reuse existing membership summary/response models where possible.
+- [ ] Use explicit literals for warning severity/category where the set is known; keep reason codes as strings for forward compatibility.
+
+### Task 6: Add Workspace Index Service
+**Files:**
+- Create: `tldw_Server_API/app/core/Workspaces/activity_index.py`
+
+- [ ] Implement `WorkspaceActivityIndexService.build_index(...)`.
+- [ ] Use `WorkspaceMembershipService.workspace_membership_summary()` for global totals.
+- [ ] For each active resource type with a nonzero count, call `list_workspace_memberships(resource_type=..., resolve=True, limit=group_limit)`.
+- [ ] Use `db.list_workspace_runtime_bindings(..., limit=50)` for runtime grouping and warning inputs.
+- [ ] Use `db.list_workspace_activity_events(..., limit=activity_limit)` for recent activity.
+- [ ] Add warnings for archived/deleted workspace state, unresolved membership summaries, missing/degraded runtime bindings, and partial dependency failures.
+- [ ] Return owner-domain `href` from membership summaries; never synthesize edit UI behavior inside the index.
+
+---
+
+## Stage 4: Endpoint And Event Hooks
+**Goal:** Expose the index and start recording events from existing write paths.
+**Success Criteria:** API tests pass and existing membership/runtime tests remain green.
+**Tests:**
+- `python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py -q`
+- `python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py -q`
+**Status:** Complete
+
+### Task 7: Add Read Endpoint
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/workspaces.py`
+
+- [ ] Add `GET /{workspace_id}/index` with `group_limit` and `activity_limit` query params.
+- [ ] Inject the same optional Media/Prompts/Workflows/Watchlists DB dependencies used by memberships.
+- [ ] Map DB/service errors through existing workspace HTTP error helpers.
+- [ ] Keep the endpoint read-only and behind `WORKSPACES_READ_RATE_LIMIT`.
+
+### Task 8: Record Activity Events
+**Files:**
+- Modify: `tldw_Server_API/app/core/Workspaces/membership_service.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/workspaces.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+
+- [ ] Record `membership.linked`, `membership.restored`, and `membership.unlinked` events from membership service paths.
+- [ ] Record `runtime_binding.upserted` and `runtime_binding.archived` events from runtime binding endpoint helper paths.
+- [ ] Keep event recording best-effort only where the primary write already succeeded; log warning on event write failure without rolling back the primary write unless both occur inside the same DB transaction.
+- [ ] Ensure metadata contains IDs, roles, transfer policy, and binding status/kind only; no secrets, raw paths, prompt bodies, model outputs, or file contents.
+
+---
+
+## Stage 5: Frontend Contract And Documentation
+**Goal:** Provide the minimal client-side contract and document that this is an inspection/navigation surface.
+**Success Criteria:** TypeScript normalizer tests pass and docs link the endpoint to #1994 acceptance criteria.
+**Tests:** `./node_modules/.bin/vitest run src/services/workspace-index/__tests__/normalizers.test.ts --maxWorkers=1`
+**Status:** Complete
+
+### Task 9: Add Frontend Contract Normalizers
+**Files:**
+- Create: `apps/packages/ui/src/services/workspace-index/contracts.ts`
+- Create: `apps/packages/ui/src/services/workspace-index/normalizers.ts`
+- Create: `apps/packages/ui/src/services/workspace-index/index.ts`
+- Create: `apps/packages/ui/src/services/workspace-index/__tests__/normalizers.test.ts`
+
+- [ ] Define TypeScript contracts matching `WorkspaceIndexResponse`.
+- [ ] Normalize warnings, resource groups, runtime summary, and activity rows into display-safe values.
+- [ ] Preserve `href` links from the server without inventing owner UI routes.
+- [ ] Add tests for unknown warning reason codes and empty index payloads.
+
+### Task 10: Update Docs And Backlog
+**Files:**
+- Modify: `Docs/Design/Workspace_Container_Contract_2026_06.md`
+- Modify: `backlog/tasks/task-2387 - Implement-Workspace-activity-and-contained-resource-index-contract-for-issue-1994.md`
+
+- [ ] Document the new endpoint as an inspection/navigation contract, not a Workspace dashboard.
+- [ ] List event categories and warnings with security constraints.
+- [ ] Update Backlog with touched files and verification results.
+
+---
+
+## Stage 6: Final Verification
+**Goal:** Prove the slice is merge-ready.
+**Success Criteria:** Focused backend/frontend tests pass, whitespace check passes, Bandit reports no new findings for touched backend files.
+**Tests:**
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py -q`
+- `cd apps/packages/ui && ./node_modules/.bin/vitest run src/services/workspace-index/__tests__/normalizers.test.ts --maxWorkers=1`
+- `git diff --check`
+- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/core/Workspaces/activity_index.py tldw_Server_API/app/api/v1/endpoints/workspaces.py -f json -o /tmp/bandit_workspace_activity_index.json`
+**Status:** Complete
+
+### Task 11: Finalize
+**Files:**
+- Modify: Backlog task final summary.
+- Create commit and PR after verification.
+
+- [x] Rebase onto actual `origin/dev` once Git DNS is healthy.
+- [x] Run final verification commands and record results.
+- [x] Commit with a message referencing `TASK-2387` and GitHub #1994.
+- [x] Push `codex/workspace-activity-index-contract` and open a PR against `dev`.

--- a/apps/packages/ui/src/services/workspace-index/__tests__/normalizers.test.ts
+++ b/apps/packages/ui/src/services/workspace-index/__tests__/normalizers.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildWorkspaceIndexPath,
+  normalizeWorkspaceIndexResponse
+} from "../normalizers"
+
+describe("workspace index normalizers", () => {
+  it("normalizes empty index payloads into stable display defaults", () => {
+    const snapshot = normalizeWorkspaceIndexResponse({})
+
+    expect(snapshot.schemaVersion).toBe(1)
+    expect(snapshot.workspaceId).toBe("")
+    expect(snapshot.workspace.id).toBe("")
+    expect(snapshot.membershipSummary).toEqual({
+      total: 0,
+      byResourceType: {},
+      byRole: {}
+    })
+    expect(snapshot.resourceGroups).toEqual([])
+    expect(snapshot.runtimeSummary).toEqual({
+      total: 0,
+      byKind: {},
+      byStatus: {},
+      bindings: []
+    })
+    expect(snapshot.warnings).toEqual([])
+    expect(snapshot.recentActivity).toEqual([])
+  })
+
+  it("preserves unknown warning reason codes and server owner hrefs", () => {
+    const snapshot = normalizeWorkspaceIndexResponse({
+      workspace_id: "workspace-1",
+      schema_version: 1,
+      generated_at: "2026-06-18T12:00:00Z",
+      workspace: {
+        id: "workspace-1",
+        name: "Research Workspace",
+        workspace_profile: "project",
+        archived: false,
+        deleted: false
+      },
+      membership_summary: {
+        total: 1,
+        by_resource_type: { chat: 1 },
+        by_role: { conversation: 1 }
+      },
+      resource_groups: [
+        {
+          resource_type: "chat",
+          count: 1,
+          owner_surface: { label: "Chat", href: "#/chat" },
+          items: [
+            {
+              workspace_id: "workspace-1",
+              resource_type: "chat",
+              resource_id: "chat-1",
+              role: "conversation",
+              transfer_policy: "link",
+              provenance: {},
+              metadata: {},
+              summary: {
+                title: "Planning chat",
+                href: "#/chat/chat-1",
+                state: "available"
+              },
+              created_at: "2026-06-18T12:00:00Z",
+              updated_at: "2026-06-18T12:00:00Z",
+              version: 1,
+              deleted: false
+            }
+          ]
+        }
+      ],
+      warnings: [
+        {
+          severity: "future-severity",
+          reason_code: "future_agent_runtime_notice",
+          message: "The server exposed a future warning.",
+          resource_type: "acp_session",
+          resource_id: "session-1",
+          action_href: "#/agent-playground"
+        }
+      ],
+      recent_activity: [
+        {
+          workspace_id: "workspace-1",
+          event_id: "event-1",
+          event_type: "membership.linked",
+          category: "membership",
+          resource_type: "chat",
+          resource_id: "chat-1",
+          metadata: { role: "conversation" },
+          created_at: "2026-06-18T12:00:00Z",
+          version: 1
+        }
+      ]
+    })
+
+    expect(snapshot.workspace.profile).toBe("project")
+    expect(snapshot.resourceGroups[0].ownerSurface.href).toBe("#/chat")
+    expect(snapshot.resourceGroups[0].items[0].summary?.href).toBe("#/chat/chat-1")
+    expect(snapshot.warnings[0]).toMatchObject({
+      severity: "warning",
+      reasonCode: "future_agent_runtime_notice",
+      actionHref: "#/agent-playground"
+    })
+    expect(snapshot.recentActivity[0]).toMatchObject({
+      eventType: "membership.linked",
+      metadata: { role: "conversation" }
+    })
+  })
+
+  it("builds the server index endpoint path with bounded query parameters", () => {
+    expect(buildWorkspaceIndexPath("workspace 1", { groupLimit: 3, activityLimit: 7 })).toBe(
+      "/api/v1/workspaces/workspace%201/index?group_limit=3&activity_limit=7"
+    )
+    expect(buildWorkspaceIndexPath("workspace/1", { groupLimit: 0, activityLimit: 999 })).toBe(
+      "/api/v1/workspaces/workspace%2F1/index?group_limit=1&activity_limit=100"
+    )
+  })
+})

--- a/apps/packages/ui/src/services/workspace-index/contracts.ts
+++ b/apps/packages/ui/src/services/workspace-index/contracts.ts
@@ -1,0 +1,102 @@
+export type WorkspaceIndexWarningSeverity = "info" | "warning" | "error"
+
+export interface WorkspaceIndexCounts {
+  total: number
+  byResourceType: Record<string, number>
+  byRole: Record<string, number>
+}
+
+export interface WorkspaceIndexOwnerSurface {
+  label: string
+  href: string
+}
+
+export interface WorkspaceIndexResourceSummary {
+  title?: string
+  subtitle?: string
+  href?: string
+  updatedAt?: string
+  state: string
+  metadata: Record<string, unknown>
+}
+
+export interface WorkspaceIndexResourceItem {
+  workspaceId: string
+  resourceType: string
+  resourceId: string
+  role: string
+  label?: string
+  transferPolicy: string
+  provenance: Record<string, unknown>
+  metadata: Record<string, unknown>
+  summary?: WorkspaceIndexResourceSummary
+  createdAt: string
+  updatedAt: string
+  version: number
+  deleted: boolean
+}
+
+export interface WorkspaceIndexResourceGroup {
+  resourceType: string
+  count: number
+  ownerSurface: WorkspaceIndexOwnerSurface
+  items: WorkspaceIndexResourceItem[]
+  nextCursor?: string
+}
+
+export interface WorkspaceIndexRuntimeSummary {
+  total: number
+  byKind: Record<string, number>
+  byStatus: Record<string, number>
+  bindings: Array<Record<string, unknown>>
+}
+
+export interface WorkspaceIndexWarning {
+  severity: WorkspaceIndexWarningSeverity
+  reasonCode: string
+  message: string
+  resourceType?: string
+  resourceId?: string
+  actionHref?: string
+}
+
+export interface WorkspaceActivityEvent {
+  workspaceId: string
+  eventId: string
+  eventType: string
+  category: string
+  actorUserId?: string
+  resourceType?: string
+  resourceId?: string
+  summary?: string
+  metadata: Record<string, unknown>
+  createdAt: string
+  version: number
+}
+
+export interface WorkspaceIndexWorkspaceSummary {
+  id: string
+  name?: string
+  profile?: string
+  archived: boolean
+  deleted: boolean
+  version: number
+}
+
+export interface WorkspaceIndexSnapshot {
+  workspaceId: string
+  schemaVersion: number
+  generatedAt: string
+  workspace: WorkspaceIndexWorkspaceSummary
+  membershipSummary: WorkspaceIndexCounts
+  resourceGroups: WorkspaceIndexResourceGroup[]
+  runtimeSummary: WorkspaceIndexRuntimeSummary
+  warnings: WorkspaceIndexWarning[]
+  recentActivity: WorkspaceActivityEvent[]
+  partialErrors: Array<Record<string, unknown>>
+}
+
+export interface WorkspaceIndexPathOptions {
+  groupLimit?: number
+  activityLimit?: number
+}

--- a/apps/packages/ui/src/services/workspace-index/index.ts
+++ b/apps/packages/ui/src/services/workspace-index/index.ts
@@ -1,0 +1,19 @@
+export type {
+  WorkspaceActivityEvent,
+  WorkspaceIndexCounts,
+  WorkspaceIndexOwnerSurface,
+  WorkspaceIndexPathOptions,
+  WorkspaceIndexResourceGroup,
+  WorkspaceIndexResourceItem,
+  WorkspaceIndexResourceSummary,
+  WorkspaceIndexRuntimeSummary,
+  WorkspaceIndexSnapshot,
+  WorkspaceIndexWarning,
+  WorkspaceIndexWarningSeverity,
+  WorkspaceIndexWorkspaceSummary
+} from "./contracts"
+
+export {
+  buildWorkspaceIndexPath,
+  normalizeWorkspaceIndexResponse
+} from "./normalizers"

--- a/apps/packages/ui/src/services/workspace-index/normalizers.ts
+++ b/apps/packages/ui/src/services/workspace-index/normalizers.ts
@@ -1,0 +1,205 @@
+import type {
+  WorkspaceActivityEvent,
+  WorkspaceIndexCounts,
+  WorkspaceIndexPathOptions,
+  WorkspaceIndexResourceGroup,
+  WorkspaceIndexResourceItem,
+  WorkspaceIndexResourceSummary,
+  WorkspaceIndexRuntimeSummary,
+  WorkspaceIndexSnapshot,
+  WorkspaceIndexWarning,
+  WorkspaceIndexWarningSeverity,
+  WorkspaceIndexWorkspaceSummary
+} from "./contracts"
+
+const warningSeverities = new Set<WorkspaceIndexWarningSeverity>([
+  "info",
+  "warning",
+  "error"
+])
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value)
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  isRecord(value) ? value : {}
+
+const asString = (value: unknown, fallback = ""): string =>
+  typeof value === "string" ? value : fallback
+
+const asOptionalString = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined
+  return value.length > 0 ? value : undefined
+}
+
+const asNumber = (value: unknown, fallback = 0): number =>
+  typeof value === "number" && Number.isFinite(value) ? value : fallback
+
+const asBoolean = (value: unknown): boolean =>
+  value === true || value === 1 || value === "1" || value === "true" || value === "True"
+
+const asArray = (value: unknown): unknown[] =>
+  Array.isArray(value) ? value : []
+
+const asCountRecord = (value: unknown): Record<string, number> => {
+  const record = asRecord(value)
+  const counts: Record<string, number> = {}
+  for (const [key, rawCount] of Object.entries(record)) {
+    const count = asNumber(rawCount, Number.NaN)
+    if (key && Number.isFinite(count) && count >= 0) {
+      counts[key] = count
+    }
+  }
+  return counts
+}
+
+const normalizeCounts = (value: unknown): WorkspaceIndexCounts => {
+  const record = asRecord(value)
+  return {
+    total: Math.max(0, asNumber(record.total, 0)),
+    byResourceType: asCountRecord(record.by_resource_type ?? record.byResourceType),
+    byRole: asCountRecord(record.by_role ?? record.byRole)
+  }
+}
+
+const normalizeWorkspace = (
+  value: unknown,
+  fallbackWorkspaceId: string
+): WorkspaceIndexWorkspaceSummary => {
+  const record = asRecord(value)
+  const id = asString(record.id, fallbackWorkspaceId)
+  return {
+    id,
+    name: asOptionalString(record.name),
+    profile: asOptionalString(record.workspace_profile ?? record.profile),
+    archived: asBoolean(record.archived),
+    deleted: asBoolean(record.deleted),
+    version: Math.max(1, asNumber(record.version, 1))
+  }
+}
+
+const normalizeSummary = (value: unknown): WorkspaceIndexResourceSummary | undefined => {
+  if (!isRecord(value)) return undefined
+  return {
+    title: asOptionalString(value.title),
+    subtitle: asOptionalString(value.subtitle),
+    href: asOptionalString(value.href),
+    updatedAt: asOptionalString(value.updated_at ?? value.updatedAt),
+    state: asString(value.state, "unknown"),
+    metadata: asRecord(value.metadata)
+  }
+}
+
+const normalizeResourceItem = (value: unknown): WorkspaceIndexResourceItem => {
+  const record = asRecord(value)
+  return {
+    workspaceId: asString(record.workspace_id ?? record.workspaceId),
+    resourceType: asString(record.resource_type ?? record.resourceType),
+    resourceId: asString(record.resource_id ?? record.resourceId),
+    role: asString(record.role, "member"),
+    label: asOptionalString(record.label),
+    transferPolicy: asString(record.transfer_policy ?? record.transferPolicy, "link"),
+    provenance: asRecord(record.provenance),
+    metadata: asRecord(record.metadata),
+    summary: normalizeSummary(record.summary),
+    createdAt: asString(record.created_at ?? record.createdAt),
+    updatedAt: asString(record.updated_at ?? record.updatedAt),
+    version: Math.max(1, asNumber(record.version, 1)),
+    deleted: asBoolean(record.deleted)
+  }
+}
+
+const normalizeResourceGroup = (value: unknown): WorkspaceIndexResourceGroup => {
+  const record = asRecord(value)
+  const ownerSurface = asRecord(record.owner_surface ?? record.ownerSurface)
+  return {
+    resourceType: asString(record.resource_type ?? record.resourceType),
+    count: Math.max(0, asNumber(record.count, 0)),
+    ownerSurface: {
+      label: asString(ownerSurface.label),
+      href: asString(ownerSurface.href)
+    },
+    items: asArray(record.items).map(normalizeResourceItem),
+    nextCursor: asOptionalString(record.next_cursor ?? record.nextCursor)
+  }
+}
+
+const normalizeRuntimeSummary = (value: unknown): WorkspaceIndexRuntimeSummary => {
+  const record = asRecord(value)
+  return {
+    total: Math.max(0, asNumber(record.total, 0)),
+    byKind: asCountRecord(record.by_kind ?? record.byKind),
+    byStatus: asCountRecord(record.by_status ?? record.byStatus),
+    bindings: asArray(record.bindings)
+      .map(asRecord)
+      .filter((binding) => Object.keys(binding).length > 0)
+  }
+}
+
+const normalizeWarningSeverity = (value: unknown): WorkspaceIndexWarningSeverity => {
+  const severity = asString(value) as WorkspaceIndexWarningSeverity
+  return warningSeverities.has(severity) ? severity : "warning"
+}
+
+const normalizeWarning = (value: unknown): WorkspaceIndexWarning => {
+  const record = asRecord(value)
+  const reasonCode = asString(record.reason_code ?? record.reasonCode, "unknown")
+  return {
+    severity: normalizeWarningSeverity(record.severity),
+    reasonCode,
+    message: asString(record.message, reasonCode),
+    resourceType: asOptionalString(record.resource_type ?? record.resourceType),
+    resourceId: asOptionalString(record.resource_id ?? record.resourceId),
+    actionHref: asOptionalString(record.action_href ?? record.actionHref)
+  }
+}
+
+const normalizeActivityEvent = (value: unknown): WorkspaceActivityEvent => {
+  const record = asRecord(value)
+  return {
+    workspaceId: asString(record.workspace_id ?? record.workspaceId),
+    eventId: asString(record.event_id ?? record.eventId),
+    eventType: asString(record.event_type ?? record.eventType),
+    category: asString(record.category),
+    actorUserId: asOptionalString(record.actor_user_id ?? record.actorUserId),
+    resourceType: asOptionalString(record.resource_type ?? record.resourceType),
+    resourceId: asOptionalString(record.resource_id ?? record.resourceId),
+    summary: asOptionalString(record.summary),
+    metadata: asRecord(record.metadata),
+    createdAt: asString(record.created_at ?? record.createdAt),
+    version: Math.max(1, asNumber(record.version, 1))
+  }
+}
+
+export const normalizeWorkspaceIndexResponse = (value: unknown): WorkspaceIndexSnapshot => {
+  const record = asRecord(value)
+  const workspaceId = asString(record.workspace_id ?? record.workspaceId)
+  return {
+    workspaceId,
+    schemaVersion: Math.max(1, asNumber(record.schema_version ?? record.schemaVersion, 1)),
+    generatedAt: asString(record.generated_at ?? record.generatedAt),
+    workspace: normalizeWorkspace(record.workspace, workspaceId),
+    membershipSummary: normalizeCounts(record.membership_summary ?? record.membershipSummary),
+    resourceGroups: asArray(record.resource_groups ?? record.resourceGroups).map(normalizeResourceGroup),
+    runtimeSummary: normalizeRuntimeSummary(record.runtime_summary ?? record.runtimeSummary),
+    warnings: asArray(record.warnings).map(normalizeWarning),
+    recentActivity: asArray(record.recent_activity ?? record.recentActivity).map(normalizeActivityEvent),
+    partialErrors: asArray(record.partial_errors ?? record.partialErrors).map(asRecord)
+  }
+}
+
+const boundedLimit = (value: number | undefined, fallback: number, max: number): number => {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback
+  return Math.max(1, Math.min(Math.trunc(value), max))
+}
+
+export const buildWorkspaceIndexPath = (
+  workspaceId: string,
+  options: WorkspaceIndexPathOptions = {}
+): string => {
+  const query = new URLSearchParams({
+    group_limit: String(boundedLimit(options.groupLimit, 5, 25)),
+    activity_limit: String(boundedLimit(options.activityLimit, 25, 100))
+  })
+  return `/api/v1/workspaces/${encodeURIComponent(workspaceId)}/index?${query.toString()}`
+}

--- a/backlog/tasks/task-2387 - Implement-Workspace-activity-and-contained-resource-index-contract-for-issue-1994.md
+++ b/backlog/tasks/task-2387 - Implement-Workspace-activity-and-contained-resource-index-contract-for-issue-1994.md
@@ -45,15 +45,15 @@ Docs/superpowers/plans/2026-06-18-workspace-activity-index-contract-plan.md
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Created implementation plan in isolated worktree `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/workspace-activity-index-contract`.
+Created implementation plan in isolated worktree `.worktrees/workspace-activity-index-contract`.
 
 Implemented ChaChaNotes schema v50 activity storage; activity DB APIs; WorkspaceActivityIndexService; `GET /api/v1/workspaces/{workspace_id}/index`; best-effort membership/runtime binding activity hooks; frontend `src/services/workspace-index` contract normalizers; and docs updates.
 
 Verification:
-- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py -q` passed 138 tests after rebase onto `origin/dev` (`a798b78f60`).
+- `python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py -q` passed 138 tests after rebase onto `origin/dev` (`a798b78f60`).
 - `./node_modules/.bin/vitest run src/services/workspace-index/__tests__/normalizers.test.ts --maxWorkers=1` passed 3 tests.
 - `git diff --check` passed.
-- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/core/Workspaces/activity_index.py tldw_Server_API/app/core/Workspaces/membership_service.py tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/api/v1/schemas/workspace_schemas.py -f json -o /tmp/bandit_workspace_activity_index.json` completed with zero results.
+- `python -m bandit -r tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/core/Workspaces/activity_index.py tldw_Server_API/app/core/Workspaces/membership_service.py tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/api/v1/schemas/workspace_schemas.py -f json -o /tmp/bandit_workspace_activity_index.json` completed with zero results.
 
 PR opened: https://github.com/rmusser01/tldw_server/pull/2396. Earlier Git DNS fetch blocker is resolved; branch was rebased onto `origin/dev` before final verification.
 <!-- SECTION:NOTES:END -->
@@ -80,9 +80,17 @@ Implemented the Workspace #1994 activity/index contract in PR https://github.com
 Review follow-up for PR #2396: rebased branch against latest origin/dev (already up to date), addressed Gemini/Qodo comments by moving runtime-binding activity event construction into core, isolating the workspace index builder in run_in_threadpool, narrowing runtime-binding upsert activity to normalized user-field changes, replacing activity listing dynamic SQL with static parameterized query variants, returning deleted-workspace index payloads with workspace_deleted warnings, and replacing list+scan activity insert readback with direct primary-key lookup plus return_row=False support for best-effort write hooks.
 
 Review verification:
-- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed 107 tests.
-- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py -q` passed 139 tests.
+- `python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed 107 tests after activating the project venv.
+- `python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py -q` passed 139 tests after activating the project venv.
 - `./node_modules/.bin/vitest run src/services/workspace-index/__tests__/normalizers.test.ts --maxWorkers=1` passed 3 tests.
 - `git diff --check` passed.
-- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/core/Workspaces/activity_index.py tldw_Server_API/app/core/Workspaces/membership_service.py tldw_Server_API/app/core/Workspaces/runtime_bindings.py tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/api/v1/schemas/workspace_schemas.py -f json -o /tmp/bandit_workspace_activity_index_review.json` completed with zero results/errors.
+- `python -m bandit -r tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/core/Workspaces/activity_index.py tldw_Server_API/app/core/Workspaces/membership_service.py tldw_Server_API/app/core/Workspaces/runtime_bindings.py tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/api/v1/schemas/workspace_schemas.py -f json -o /tmp/bandit_workspace_activity_index_review.json` completed with zero results/errors after activating the project venv.
+Second review follow-up for PR #2396: addressed fresh CodeRabbit comments by making Backlog verification notes environment-agnostic, closing the DB-backed activity test connection, adding unpaginated runtime binding aggregate counts for index summaries, and scanning membership pages independently of the preview `group_limit` so resource warnings are not silently missed. The direct activity insert readback comment was already fixed in commit 20958f6159 with a primary-key lookup.
+
+Second review verification:
+- `python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py -q` passed 5 tests after activating the project venv.
+- `python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py -q` passed 141 tests after activating the project venv.
+- `./node_modules/.bin/vitest run src/services/workspace-index/__tests__/normalizers.test.ts --maxWorkers=1` passed 3 tests.
+- `git diff --check` passed.
+- `python -m bandit -r tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/core/Workspaces/activity_index.py tldw_Server_API/app/core/Workspaces/membership_service.py tldw_Server_API/app/core/Workspaces/runtime_bindings.py tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/api/v1/schemas/workspace_schemas.py -f json -o /tmp/bandit_workspace_activity_index_review2.json` completed with zero results/errors after activating the project venv.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-2387 - Implement-Workspace-activity-and-contained-resource-index-contract-for-issue-1994.md
+++ b/backlog/tasks/task-2387 - Implement-Workspace-activity-and-contained-resource-index-contract-for-issue-1994.md
@@ -1,24 +1,41 @@
 ---
 id: TASK-2387
-title: >-
-  Implement Workspace activity and contained-resource index contract for issue
+title: Implement Workspace activity and contained-resource index contract for issue
   1994
 status: In Progress
 assignee: []
 created_date: ''
-updated_date: '2026-06-18 20:12'
+updated_date: 2026-06-18 20:12
 labels:
-  - workspaces
-  - acp
-  - implementation
+- workspaces
+- acp
+- implementation
 dependencies: []
 references:
-  - 'https://github.com/rmusser01/tldw_server/issues/1994'
-  - 'https://github.com/rmusser01/tldw_server/issues/1984'
+- https://github.com/rmusser01/tldw_server/issues/1994
+- https://github.com/rmusser01/tldw_server/issues/1984
 documentation:
-  - Docs/Design/Workspace_Container_Contract_2026_06.md
-  - Docs/superpowers/plans/2026-06-18-workspace-activity-index-contract-plan.md
+- Docs/Design/Workspace_Container_Contract_2026_06.md
+- Docs/superpowers/plans/2026-06-18-workspace-activity-index-contract-plan.md
+- 'PR #2396 Qodo follow-up: replace activity-event listing nosec query with fixed
+  SQL variants.'
 priority: high
+modified_files:
+- tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+- tldw_Server_API/app/core/Workspaces/activity_index.py
+- tldw_Server_API/app/core/Workspaces/membership_service.py
+- tldw_Server_API/app/core/Workspaces/runtime_bindings.py
+- tldw_Server_API/app/api/v1/endpoints/workspaces.py
+- tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+- tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py
+- tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
+- tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py
+- tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py
+- tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py
+- apps/packages/ui/src/services/workspace-index/contracts.ts
+- apps/packages/ui/src/services/workspace-index/normalizers.ts
+- apps/packages/ui/src/services/workspace-index/index.ts
+- apps/packages/ui/src/services/workspace-index/__tests__/normalizers.test.ts
 ---
 
 ## Description

--- a/backlog/tasks/task-2387 - Implement-Workspace-activity-and-contained-resource-index-contract-for-issue-1994.md
+++ b/backlog/tasks/task-2387 - Implement-Workspace-activity-and-contained-resource-index-contract-for-issue-1994.md
@@ -73,3 +73,16 @@ Implemented the Workspace #1994 activity/index contract in PR https://github.com
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Review follow-up for PR #2396: rebased branch against latest origin/dev (already up to date), addressed Gemini/Qodo comments by moving runtime-binding activity event construction into core, isolating the workspace index builder in run_in_threadpool, narrowing runtime-binding upsert activity to normalized user-field changes, replacing activity listing dynamic SQL with static parameterized query variants, returning deleted-workspace index payloads with workspace_deleted warnings, and replacing list+scan activity insert readback with direct primary-key lookup plus return_row=False support for best-effort write hooks.
+
+Review verification:
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py -q` passed 107 tests.
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py -q` passed 139 tests.
+- `./node_modules/.bin/vitest run src/services/workspace-index/__tests__/normalizers.test.ts --maxWorkers=1` passed 3 tests.
+- `git diff --check` passed.
+- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/core/Workspaces/activity_index.py tldw_Server_API/app/core/Workspaces/membership_service.py tldw_Server_API/app/core/Workspaces/runtime_bindings.py tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/api/v1/schemas/workspace_schemas.py -f json -o /tmp/bandit_workspace_activity_index_review.json` completed with zero results/errors.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-2387 - Implement-Workspace-activity-and-contained-resource-index-contract-for-issue-1994.md
+++ b/backlog/tasks/task-2387 - Implement-Workspace-activity-and-contained-resource-index-contract-for-issue-1994.md
@@ -1,0 +1,75 @@
+---
+id: TASK-2387
+title: >-
+  Implement Workspace activity and contained-resource index contract for issue
+  1994
+status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-06-18 20:12'
+labels:
+  - workspaces
+  - acp
+  - implementation
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1994'
+  - 'https://github.com/rmusser01/tldw_server/issues/1984'
+documentation:
+  - Docs/Design/Workspace_Container_Contract_2026_06.md
+  - Docs/superpowers/plans/2026-06-18-workspace-activity-index-contract-plan.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement GitHub issue #1994 as the Workspace Phase 2 activity/index slice: durable workspace activity events, a contained-resource index endpoint, minimal frontend TypeScript contract normalizers, docs, and verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Workspace activity events are stored durably, listed newest-first, and redact secrets/path-like metadata.
+- [x] #2 Workspace index endpoint returns identity, grouped resource previews, membership totals, runtime summary, warnings, recent activity, and partial-error field.
+- [x] #3 Membership and runtime binding write paths append best-effort activity events without breaking primary writes.
+- [x] #4 Frontend TypeScript contract normalizers provide stable display-safe defaults and preserve server owner hrefs.
+- [x] #5 Design docs, Backlog task, backend/frontend tests, diff check, Bandit, commit, push, and PR are completed.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-18-workspace-activity-index-contract-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created implementation plan in isolated worktree `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/workspace-activity-index-contract`.
+
+Implemented ChaChaNotes schema v50 activity storage; activity DB APIs; WorkspaceActivityIndexService; `GET /api/v1/workspaces/{workspace_id}/index`; best-effort membership/runtime binding activity hooks; frontend `src/services/workspace-index` contract normalizers; and docs updates.
+
+Verification:
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py -q` passed 138 tests after rebase onto `origin/dev` (`a798b78f60`).
+- `./node_modules/.bin/vitest run src/services/workspace-index/__tests__/normalizers.test.ts --maxWorkers=1` passed 3 tests.
+- `git diff --check` passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/core/Workspaces/activity_index.py tldw_Server_API/app/core/Workspaces/membership_service.py tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/api/v1/schemas/workspace_schemas.py -f json -o /tmp/bandit_workspace_activity_index.json` completed with zero results.
+
+PR opened: https://github.com/rmusser01/tldw_server/pull/2396. Earlier Git DNS fetch blocker is resolved; branch was rebased onto `origin/dev` before final verification.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the Workspace #1994 activity/index contract in PR https://github.com/rmusser01/tldw_server/pull/2396. The backend now stores secret-safe workspace activity events, exposes a contained-resource index endpoint with grouped previews/runtime warnings/recent activity, and records best-effort membership/runtime binding events. The frontend has minimal TypeScript contract normalizers for future UI consumption, and the design doc records the endpoint as an inspection/navigation contract rather than a duplicate workspace dashboard. Verification passed: 138 focused backend tests, 3 frontend normalizer tests, `git diff --check`, and Bandit with zero results.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspaces.py
@@ -36,6 +36,7 @@ from tldw_Server_API.app.api.v1.schemas.workspace_schemas import (
     WorkspaceFileInventoryItemsResponse,
     WorkspaceFileInventoryScanRequest,
     WorkspaceFileInventoryStatusResponse,
+    WorkspaceIndexResponse,
     WorkspaceListResponse,
     WorkspaceMembershipCreateRequest,
     WorkspaceMembershipListResponse,
@@ -81,6 +82,7 @@ from tldw_Server_API.app.core.Workspaces.file_inventory_jobs import (
     WorkspaceFileInventoryEnqueueError,
     enqueue_workspace_file_inventory_scan_job,
 )
+from tldw_Server_API.app.core.Workspaces.activity_index import WorkspaceActivityIndexService
 from tldw_Server_API.app.core.Workspaces.context import build_workspace_core_context
 from tldw_Server_API.app.core.Workspaces.membership_request_metadata import (
     build_workspace_membership_request_metadata,
@@ -589,6 +591,41 @@ def _list_workspace_runtime_bindings_sync(
     )
 
 
+def _record_runtime_binding_activity_event(
+    db: CharactersRAGDB,
+    workspace_id: str,
+    event_type: str,
+    binding: dict[str, Any],
+    *,
+    user_id: str,
+) -> None:
+    """Record runtime binding activity without making descriptor writes depend on it."""
+    try:
+        db.record_workspace_activity_event(
+            workspace_id,
+            {
+                "event_type": event_type,
+                "category": "runtime_binding",
+                "resource_type": "workspace_runtime_binding",
+                "resource_id": str(binding.get("binding_id") or ""),
+                "summary": "Updated workspace runtime binding",
+                "metadata": {
+                    "binding_kind": str(binding.get("binding_kind") or ""),
+                    "owner_domain": str(binding.get("owner_domain") or ""),
+                    "status": str(binding.get("status") or ""),
+                },
+            },
+            user_id=user_id,
+        )
+    except Exception:  # noqa: BLE001 - activity is an inspection aid, not write-path authority.
+        logger.opt(exception=True).warning(
+            "Failed to record Workspace runtime binding activity workspace={} event_type={} binding_id={}",
+            workspace_id,
+            event_type,
+            binding.get("binding_id"),
+        )
+
+
 def _upsert_workspace_runtime_binding_sync(
     db: CharactersRAGDB,
     workspace_id: str,
@@ -599,11 +636,26 @@ def _upsert_workspace_runtime_binding_sync(
     workspace = _require_workspace(db, workspace_id)
     if bool(workspace.get("archived", False)):
         raise _workspace_runtime_binding_archived_conflict(workspace_id)
-    return db.upsert_workspace_runtime_binding(
+    payload = body.persistence_payload()
+    before = db.get_workspace_runtime_binding(
         workspace_id,
-        body.persistence_payload(),
+        str(payload.get("binding_id") or ""),
+        include_deleted=True,
+    )
+    binding = db.upsert_workspace_runtime_binding(
+        workspace_id,
+        payload,
         user_id=user_id,
     )
+    if before != binding:
+        _record_runtime_binding_activity_event(
+            db,
+            workspace_id,
+            "runtime_binding.upserted",
+            binding,
+            user_id=user_id,
+        )
+    return binding
 
 
 def _get_workspace_runtime_binding_sync(
@@ -631,6 +683,14 @@ def _archive_workspace_runtime_binding_sync(
         binding_id,
         user_id=user_id,
     )
+    if archived is not None:
+        _record_runtime_binding_activity_event(
+            db,
+            workspace_id,
+            "runtime_binding.archived",
+            archived,
+            user_id=user_id,
+        )
     if archived is None:
         existing = db.get_workspace_runtime_binding(
             workspace_id,
@@ -1163,6 +1223,43 @@ async def delete_workspace(
 
 
 # ── Memberships ─────────────────────────────────────────────────
+
+@router.get(
+    "/{workspace_id}/index",
+    response_model=WorkspaceIndexResponse,
+    dependencies=[Depends(WORKSPACES_READ_RATE_LIMIT)],
+    summary="Get workspace contained-resource index",
+)
+async def get_workspace_index(
+    workspace_id: str,
+    group_limit: int = Query(default=5, ge=1, le=25),
+    activity_limit: int = Query(default=25, ge=1, le=100),
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+    media_db: Any | None = Depends(try_get_media_db_for_user),
+    prompts_db: Any | None = Depends(try_get_prompts_db_for_user),
+    workflows_db: WorkflowsDatabase | None = Depends(try_get_workflows_db_for_user),
+    watchlists_db: Any | None = Depends(try_get_watchlists_db_for_user),
+    current_user: User = Depends(get_request_user),
+) -> WorkspaceIndexResponse:
+    """Return a lightweight inspection/navigation index for one workspace."""
+    try:
+        payload = WorkspaceActivityIndexService(db).build_index(
+            workspace_id,
+            group_limit=group_limit,
+            activity_limit=activity_limit,
+            media_db=media_db,
+            prompts_db=prompts_db,
+            workflows_db=workflows_db,
+            watchlists_db=watchlists_db,
+            user_id=_request_user_id(current_user),
+            request_metadata=build_workspace_membership_request_metadata(current_user),
+        )
+    except WorkspaceMembershipServiceError as exc:
+        raise _membership_service_error_to_http(exc) from exc
+    except (ConflictError, InputError, CharactersRAGDBError) as exc:
+        raise map_db_error_to_http(exc, default_detail="Failed to fetch workspace index") from exc
+    return WorkspaceIndexResponse(**payload)
+
 
 @router.get(
     "/{workspace_id}/memberships",

--- a/tldw_Server_API/app/api/v1/endpoints/workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspaces.py
@@ -109,6 +109,8 @@ from tldw_Server_API.app.core.Workspaces.operations import workspace_operation_r
 from tldw_Server_API.app.core.Workspaces.runtime_bindings import (
     WORKSPACE_RUNTIME_BINDING_KINDS,
     WORKSPACE_RUNTIME_BINDING_OWNER_DOMAINS,
+    record_runtime_binding_activity_event,
+    runtime_binding_payload_changed,
     runtime_binding_response_payload,
 )
 from tldw_Server_API.app.core.Workspaces.sandbox_root_provisioning import (
@@ -591,41 +593,6 @@ def _list_workspace_runtime_bindings_sync(
     )
 
 
-def _record_runtime_binding_activity_event(
-    db: CharactersRAGDB,
-    workspace_id: str,
-    event_type: str,
-    binding: dict[str, Any],
-    *,
-    user_id: str,
-) -> None:
-    """Record runtime binding activity without making descriptor writes depend on it."""
-    try:
-        db.record_workspace_activity_event(
-            workspace_id,
-            {
-                "event_type": event_type,
-                "category": "runtime_binding",
-                "resource_type": "workspace_runtime_binding",
-                "resource_id": str(binding.get("binding_id") or ""),
-                "summary": "Updated workspace runtime binding",
-                "metadata": {
-                    "binding_kind": str(binding.get("binding_kind") or ""),
-                    "owner_domain": str(binding.get("owner_domain") or ""),
-                    "status": str(binding.get("status") or ""),
-                },
-            },
-            user_id=user_id,
-        )
-    except Exception:  # noqa: BLE001 - activity is an inspection aid, not write-path authority.
-        logger.opt(exception=True).warning(
-            "Failed to record Workspace runtime binding activity workspace={} event_type={} binding_id={}",
-            workspace_id,
-            event_type,
-            binding.get("binding_id"),
-        )
-
-
 def _upsert_workspace_runtime_binding_sync(
     db: CharactersRAGDB,
     workspace_id: str,
@@ -642,13 +609,14 @@ def _upsert_workspace_runtime_binding_sync(
         str(payload.get("binding_id") or ""),
         include_deleted=True,
     )
+    should_record_activity = runtime_binding_payload_changed(before, payload)
     binding = db.upsert_workspace_runtime_binding(
         workspace_id,
         payload,
         user_id=user_id,
     )
-    if before != binding:
-        _record_runtime_binding_activity_event(
+    if should_record_activity:
+        record_runtime_binding_activity_event(
             db,
             workspace_id,
             "runtime_binding.upserted",
@@ -684,7 +652,7 @@ def _archive_workspace_runtime_binding_sync(
         user_id=user_id,
     )
     if archived is not None:
-        _record_runtime_binding_activity_event(
+        record_runtime_binding_activity_event(
             db,
             workspace_id,
             "runtime_binding.archived",
@@ -1243,16 +1211,18 @@ async def get_workspace_index(
 ) -> WorkspaceIndexResponse:
     """Return a lightweight inspection/navigation index for one workspace."""
     try:
-        payload = WorkspaceActivityIndexService(db).build_index(
-            workspace_id,
-            group_limit=group_limit,
-            activity_limit=activity_limit,
-            media_db=media_db,
-            prompts_db=prompts_db,
-            workflows_db=workflows_db,
-            watchlists_db=watchlists_db,
-            user_id=_request_user_id(current_user),
-            request_metadata=build_workspace_membership_request_metadata(current_user),
+        payload = await run_in_threadpool(
+            lambda: WorkspaceActivityIndexService(db).build_index(
+                workspace_id,
+                group_limit=group_limit,
+                activity_limit=activity_limit,
+                media_db=media_db,
+                prompts_db=prompts_db,
+                workflows_db=workflows_db,
+                watchlists_db=watchlists_db,
+                user_id=_request_user_id(current_user),
+                request_metadata=build_workspace_membership_request_metadata(current_user),
+            )
         )
     except WorkspaceMembershipServiceError as exc:
         raise _membership_service_error_to_http(exc) from exc

--- a/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/workspace_schemas.py
@@ -329,6 +329,67 @@ class WorkspaceContextMembershipSummary(BaseModel):
     by_role: dict[str, int] = Field(default_factory=dict)
 
 
+# --- Activity/index schemas ---
+
+WorkspaceIndexWarningSeverity = Literal["info", "warning", "error"]
+
+
+class WorkspaceIndexOwnerSurface(BaseModel):
+    label: str
+    href: str
+
+
+class WorkspaceIndexResourceGroup(BaseModel):
+    resource_type: WorkspaceMembershipResourceType
+    count: int = 0
+    owner_surface: WorkspaceIndexOwnerSurface
+    items: list[WorkspaceMembershipResponse] = Field(default_factory=list)
+    next_cursor: str | None = None
+
+
+class WorkspaceActivityEventResponse(BaseModel):
+    workspace_id: str
+    event_id: str
+    event_type: str
+    category: str
+    actor_user_id: str | None = None
+    resource_type: str | None = None
+    resource_id: str | None = None
+    summary: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    created_at: str
+    version: int = 1
+
+
+class WorkspaceIndexRuntimeSummary(BaseModel):
+    total: int = 0
+    by_kind: dict[str, int] = Field(default_factory=dict)
+    by_status: dict[str, int] = Field(default_factory=dict)
+    bindings: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class WorkspaceIndexWarning(BaseModel):
+    severity: WorkspaceIndexWarningSeverity = "warning"
+    reason_code: str
+    message: str
+    resource_type: str | None = None
+    resource_id: str | None = None
+    action_href: str | None = None
+
+
+class WorkspaceIndexResponse(BaseModel):
+    workspace_id: str
+    schema_version: int = 1
+    generated_at: str
+    workspace: WorkspaceResponse
+    membership_summary: WorkspaceMembershipListSummary = Field(default_factory=WorkspaceMembershipListSummary)
+    resource_groups: list[WorkspaceIndexResourceGroup] = Field(default_factory=list)
+    runtime_summary: WorkspaceIndexRuntimeSummary = Field(default_factory=WorkspaceIndexRuntimeSummary)
+    warnings: list[WorkspaceIndexWarning] = Field(default_factory=list)
+    recent_activity: list[WorkspaceActivityEventResponse] = Field(default_factory=list)
+    partial_errors: list[dict[str, Any]] = Field(default_factory=list)
+
+
 # --- Eligibility schemas ---
 
 class WorkspaceEligibilityCheckRequest(BaseModel):

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -42,6 +42,7 @@ import re  # noqa: E402
 import sqlite3  # noqa: E402
 import tempfile  # noqa: E402
 import threading  # noqa: E402
+import time  # noqa: E402
 import uuid  # noqa: E402
 from collections.abc import Mapping
 from configparser import ConfigParser  # noqa: E402
@@ -601,7 +602,7 @@ class CharactersRAGDB:
         is_memory_db (bool): True if the database is in-memory.
         db_path_str (str): String representation of the database path for SQLite connection.
     """
-    _CURRENT_SCHEMA_VERSION = 49  # Schema v49 adds Workspace Assistant Defaults storage
+    _CURRENT_SCHEMA_VERSION = 50  # Schema v50 adds Workspace activity/index event storage
     _SCHEMA_NAME = "rag_char_chat_schema"  # Used for the db_schema_version table
     _ALLOWED_CONVERSATION_STATES: tuple[str, ...] = ("in-progress", "resolved", "backlog", "non-viable")
     _ALLOWED_CONVERSATION_CHARACTER_SCOPES: tuple[str, ...] = ("all", "character", "non_character")
@@ -620,6 +621,28 @@ class CharactersRAGDB:
     _ALLOWED_PERSONA_SESSION_STATUSES: tuple[str, ...] = ("active", "paused", "closed", "archived")
     _ALLOWED_CONVERSATION_ASSISTANT_KINDS: tuple[str, ...] = ("character", "persona")
     _ALLOWED_PERSONA_MEMORY_MODES: tuple[str, ...] = ("read_only", "read_write")
+    _WORKSPACE_ACTIVITY_MAX_METADATA_BYTES = 16 * 1024
+    _WORKSPACE_ACTIVITY_SECRET_KEY_RE = re.compile(
+        r"(^|[_\-.])("
+        r"api[_\-.]?key|access[_\-.]?key|secret|token|password|passwd|pwd|"
+        r"credential|credentials|private[_\-.]?key|client[_\-.]?secret|"
+        r"bearer|authorization|auth[_\-.]?header"
+        r")($|[_\-.])",
+        re.IGNORECASE,
+    )
+    _WORKSPACE_ACTIVITY_SECRET_VALUE_RE = re.compile(
+        r"(-----BEGIN [A-Z ]*PRIVATE KEY-----|"
+        r"\bsk-[A-Za-z0-9_\-]{8,}|"
+        r"\b(?:ghp|github_pat|xox[baprs])_[A-Za-z0-9_\-]{8,})",
+        re.IGNORECASE,
+    )
+    _WORKSPACE_ACTIVITY_PATH_KEY_RE = re.compile(
+        r"(^|[_\-.])("
+        r"absolute[_\-.]?root|root|paths?|mount[_\-.]?path|workspace[_\-.]?path|"
+        r"repo[_\-.]?path|local[_\-.]?path|project[_\-.]?root|dir|directory"
+        r")($|[_\-.])",
+        re.IGNORECASE,
+    )
     _ALLOWED_PERSONA_EXEMPLAR_KINDS: tuple[str, ...] = (
         "style",
         "catchphrase",
@@ -5600,6 +5623,37 @@ UPDATE db_schema_version
    AND version < 49;
 """
 
+    _MIGRATION_SQL_V49_TO_V50 = """
+/*───────────────────────────────────────────────────────────────
+  Migration to Version 50 — Workspace activity event storage (2026-06-18)
+───────────────────────────────────────────────────────────────*/
+CREATE TABLE IF NOT EXISTS workspace_activity_events (
+  workspace_id   TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  event_id       TEXT NOT NULL,
+  event_type     TEXT NOT NULL,
+  category       TEXT NOT NULL,
+  actor_user_id  TEXT,
+  resource_type  TEXT,
+  resource_id    TEXT,
+  summary        TEXT,
+  metadata_json  TEXT NOT NULL DEFAULT '{}',
+  created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  client_id      TEXT NOT NULL DEFAULT 'unknown',
+  version        INTEGER NOT NULL DEFAULT 1,
+  PRIMARY KEY (workspace_id, event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ws_activity_events_created
+  ON workspace_activity_events(workspace_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_ws_activity_events_category
+  ON workspace_activity_events(workspace_id, category, created_at);
+
+UPDATE db_schema_version
+   SET version = 50
+ WHERE schema_name = 'rag_char_chat_schema'
+   AND version < 50;
+"""
+
     _MIGRATION_SQL_V47_TO_V48_POSTGRES = """
 /*───────────────────────────────────────────────────────────────
   Migration to Version 48 — Notes task-backed checklist storage (2026-06-05) [Postgres]
@@ -5717,6 +5771,37 @@ UPDATE db_schema_version
    SET version = 49
  WHERE schema_name = 'rag_char_chat_schema'
    AND version < 49;
+"""
+
+    _MIGRATION_SQL_V49_TO_V50_POSTGRES = """
+/*───────────────────────────────────────────────────────────────
+  Migration to Version 50 — Workspace activity event storage (2026-06-18) [Postgres]
+───────────────────────────────────────────────────────────────*/
+CREATE TABLE IF NOT EXISTS workspace_activity_events (
+  workspace_id   TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  event_id       TEXT NOT NULL,
+  event_type     TEXT NOT NULL,
+  category       TEXT NOT NULL,
+  actor_user_id  TEXT,
+  resource_type  TEXT,
+  resource_id    TEXT,
+  summary        TEXT,
+  metadata_json  TEXT NOT NULL DEFAULT '{}',
+  created_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  client_id      TEXT NOT NULL DEFAULT 'unknown',
+  version        INTEGER NOT NULL DEFAULT 1,
+  PRIMARY KEY (workspace_id, event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ws_activity_events_created
+  ON workspace_activity_events(workspace_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_ws_activity_events_category
+  ON workspace_activity_events(workspace_id, category, created_at);
+
+UPDATE db_schema_version
+   SET version = 50
+ WHERE schema_name = 'rag_char_chat_schema'
+   AND version < 50;
 """
 
     _MIGRATION_SQL_V10_TO_V11_POSTGRES = """
@@ -7938,6 +8023,27 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             logger.error(f"[{self._SCHEMA_NAME}] Unexpected error during migration V48->V49: {e}", exc_info=True)
             raise SchemaError(f"Unexpected error migrating to V49 for '{self._SCHEMA_NAME}': {e}") from e  # noqa: TRY003
 
+    def _migrate_from_v49_to_v50(self, conn: sqlite3.Connection) -> None:
+        """Migrate schema from V49 to V50 (Workspace activity event storage)."""
+        logger.info(f"Migrating '{self._SCHEMA_NAME}' schema from V49 to V50 for DB: {self.db_path_str}...")
+        try:
+            self._ensure_workspace_activity_events_schema_sqlite(conn)
+            conn.executescript(self._MIGRATION_SQL_V49_TO_V50)
+            final_version = self._get_db_version(conn)
+            if final_version != 50:
+                raise SchemaError(  # noqa: TRY003, TRY301
+                    f"[{self._SCHEMA_NAME}] Migration V49->V50 failed version check. Expected 50, got: {final_version}"
+                )
+            logger.info(f"[{self._SCHEMA_NAME}] Migration to V50 completed.")
+        except sqlite3.Error as e:
+            logger.error(f"[{self._SCHEMA_NAME}] Migration V49->V50 failed: {e}", exc_info=True)
+            raise SchemaError(f"Migration V49->V50 failed for '{self._SCHEMA_NAME}': {e}") from e  # noqa: TRY003
+        except SchemaError:
+            raise
+        except _CHACHA_NONCRITICAL_EXCEPTIONS as e:
+            logger.error(f"[{self._SCHEMA_NAME}] Unexpected error during migration V49->V50: {e}", exc_info=True)
+            raise SchemaError(f"Unexpected error migrating to V50 for '{self._SCHEMA_NAME}': {e}") from e  # noqa: TRY003
+
     def _ensure_persona_persistence_schema_sqlite(self, conn: sqlite3.Connection) -> None:
         """Ensure persona persistence tables and columns exist for drifted SQLite schemas."""
         try:
@@ -9181,8 +9287,37 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 "CREATE INDEX IF NOT EXISTS idx_ws_runtime_bindings_updated "
                 "ON workspace_runtime_bindings(workspace_id, updated_at)"
             )
+            self._ensure_workspace_activity_events_schema_sqlite(conn)
         except sqlite3.Error as exc:
             raise SchemaError(f"Failed ensuring SQLite workspace sub-resource schema: {exc}") from exc  # noqa: TRY003
+
+    def _ensure_workspace_activity_events_schema_sqlite(self, conn: sqlite3.Connection) -> None:
+        """Ensure Workspace activity event storage exists for SQLite."""
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS workspace_activity_events (
+                workspace_id   TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+                event_id       TEXT NOT NULL,
+                event_type     TEXT NOT NULL,
+                category       TEXT NOT NULL,
+                actor_user_id  TEXT,
+                resource_type  TEXT,
+                resource_id    TEXT,
+                summary        TEXT,
+                metadata_json  TEXT NOT NULL DEFAULT '{}',
+                created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                client_id      TEXT NOT NULL DEFAULT 'unknown',
+                version        INTEGER NOT NULL DEFAULT 1,
+                PRIMARY KEY (workspace_id, event_id)
+            )
+        """)
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_ws_activity_events_created "
+            "ON workspace_activity_events(workspace_id, created_at)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_ws_activity_events_category "
+            "ON workspace_activity_events(workspace_id, category, created_at)"
+        )
 
     def _ensure_workspace_assistant_defaults_schema_sqlite(self, conn: sqlite3.Connection) -> None:
         """Ensure Workspace Assistant Defaults storage exists for SQLite."""
@@ -9417,6 +9552,27 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             "ON workspace_runtime_bindings(owner_domain, locator_ref, deleted)",
             "CREATE INDEX IF NOT EXISTS idx_ws_runtime_bindings_updated "
             "ON workspace_runtime_bindings(workspace_id, updated_at)",
+            """
+            CREATE TABLE IF NOT EXISTS workspace_activity_events (
+                workspace_id   TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+                event_id       TEXT NOT NULL,
+                event_type     TEXT NOT NULL,
+                category       TEXT NOT NULL,
+                actor_user_id  TEXT,
+                resource_type  TEXT,
+                resource_id    TEXT,
+                summary        TEXT,
+                metadata_json  TEXT NOT NULL DEFAULT '{}',
+                created_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                client_id      TEXT NOT NULL DEFAULT 'unknown',
+                version        INTEGER NOT NULL DEFAULT 1,
+                PRIMARY KEY (workspace_id, event_id)
+            )
+            """,
+            "CREATE INDEX IF NOT EXISTS idx_ws_activity_events_created "
+            "ON workspace_activity_events(workspace_id, created_at)",
+            "CREATE INDEX IF NOT EXISTS idx_ws_activity_events_category "
+            "ON workspace_activity_events(workspace_id, category, created_at)",
         ]
         for statement in statements:
             self.backend.execute(statement, connection=conn)
@@ -10013,6 +10169,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     if target_version >= 49 and current_db_version == 48:
                         self._migrate_from_v48_to_v49(conn)
                         current_db_version = self._get_db_version(conn)
+                    if target_version >= 50 and current_db_version == 49:
+                        self._migrate_from_v49_to_v50(conn)
+                        current_db_version = self._get_db_version(conn)
                 # Ensure helpful indexes that may have been introduced post-creation
                 try:
                     conn.execute("CREATE INDEX IF NOT EXISTS idx_flashcards_created_at ON flashcards(created_at)")
@@ -10489,6 +10648,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 if target_version >= 49 and current_db_version == 48:
                     self._migrate_from_v48_to_v49(conn)
                     current_db_version = self._get_db_version(conn)
+                if target_version >= 50 and current_db_version == 49:
+                    self._migrate_from_v49_to_v50(conn)
+                    current_db_version = self._get_db_version(conn)
 
                 self._ensure_recent_persona_schema_sqlite(conn)
                 self._ensure_recent_voice_command_schema_sqlite(conn)
@@ -10496,6 +10658,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 self._ensure_note_studio_schema_sqlite(conn)
                 self._ensure_web_clipper_schema_sqlite(conn)
                 self._ensure_workspace_assistant_defaults_schema_sqlite(conn)
+                self._ensure_workspace_activity_events_schema_sqlite(conn)
 
                 final_version_check = self._get_db_version(conn)
                 if final_version_check != target_version:
@@ -14328,6 +14491,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             if current_version < 49:
                 self._apply_postgres_migration_script(self._MIGRATION_SQL_V48_TO_V49_POSTGRES, conn, expected_version=49)
                 current_version = 49
+            if current_version < 50:
+                self._apply_postgres_migration_script(self._MIGRATION_SQL_V49_TO_V50_POSTGRES, conn, expected_version=50)
+                current_version = 50
 
             if current_version > target_version:
                 raise SchemaError(  # noqa: TRY003
@@ -18330,6 +18496,206 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             (workspace_id,),
         )
         return [dict(row) for row in cursor.fetchall()]
+
+    @classmethod
+    def _redact_workspace_activity_metadata(cls, value: Any, *, key: str | None = None) -> Any:
+        if isinstance(value, Mapping):
+            redacted: dict[str, Any] = {}
+            for raw_key, raw_value in value.items():
+                item_key = str(raw_key)
+                if cls._WORKSPACE_ACTIVITY_SECRET_KEY_RE.search(item_key):
+                    continue
+                redacted[item_key] = cls._redact_workspace_activity_metadata(raw_value, key=item_key)
+            return redacted
+        if isinstance(value, list):
+            return [cls._redact_workspace_activity_metadata(item, key=key) for item in value]
+        if isinstance(value, tuple):
+            return [cls._redact_workspace_activity_metadata(item, key=key) for item in value]
+        if isinstance(value, str):
+            if cls._WORKSPACE_ACTIVITY_SECRET_VALUE_RE.search(value):
+                return "[redacted]"
+            if key and cls._WORKSPACE_ACTIVITY_PATH_KEY_RE.search(key):
+                from tldw_Server_API.app.core.Workspaces.runtime_bindings import redacted_path_hint
+
+                return redacted_path_hint(value)
+        return value
+
+    @classmethod
+    def _workspace_activity_metadata_json(cls, value: Any) -> tuple[dict[str, Any], str]:
+        if value is None:
+            normalized: dict[str, Any] = {}
+        elif isinstance(value, str):
+            if not value.strip():
+                normalized = {}
+            else:
+                try:
+                    parsed = json.loads(value)
+                except json.JSONDecodeError as exc:
+                    raise InputError("metadata must be valid JSON.") from exc  # noqa: TRY003
+                if not isinstance(parsed, Mapping):
+                    raise InputError("metadata must be a JSON object.")  # noqa: TRY003
+                normalized = dict(parsed)
+        elif isinstance(value, Mapping):
+            normalized = dict(value)
+        else:
+            raise InputError("metadata must be a JSON object.")  # noqa: TRY003
+
+        redacted = cls._redact_workspace_activity_metadata(normalized)
+        try:
+            dumped = json.dumps(
+                redacted,
+                ensure_ascii=True,
+                allow_nan=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        except (TypeError, ValueError) as exc:
+            raise InputError("metadata must be JSON serializable.") from exc  # noqa: TRY003
+        if len(dumped.encode("utf-8")) > cls._WORKSPACE_ACTIVITY_MAX_METADATA_BYTES:
+            raise InputError(
+                f"metadata exceeds {cls._WORKSPACE_ACTIVITY_MAX_METADATA_BYTES} bytes."
+            ) from None  # noqa: TRY003
+        return redacted, dumped
+
+    @staticmethod
+    def _normalize_workspace_activity_required_string(value: Any, field_name: str) -> str:
+        normalized = str(value or "").strip()
+        if not normalized:
+            raise InputError(f"{field_name} is required.")  # noqa: TRY003
+        return normalized
+
+    @staticmethod
+    def _normalize_workspace_activity_optional_string(value: Any, *, max_length: int) -> str | None:
+        if value is None:
+            return None
+        normalized = str(value).strip()
+        if not normalized:
+            return None
+        return normalized[:max_length]
+
+    @staticmethod
+    def _normalize_workspace_activity_limit(limit: int) -> int:
+        if isinstance(limit, bool) or not isinstance(limit, int):
+            raise InputError("limit must be an integer.")  # noqa: TRY003
+        if limit < 1 or limit > 100:
+            raise InputError("limit must be between 1 and 100.")  # noqa: TRY003
+        return limit
+
+    def _normalize_workspace_activity_row(self, row: Mapping[str, Any] | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        item = dict(row)
+        raw_metadata = item.pop("metadata_json", None)
+        if isinstance(raw_metadata, Mapping):
+            metadata = dict(raw_metadata)
+        elif isinstance(raw_metadata, str) and raw_metadata.strip():
+            try:
+                parsed = json.loads(raw_metadata)
+                metadata = dict(parsed) if isinstance(parsed, Mapping) else {}
+            except json.JSONDecodeError:
+                logger.warning(
+                    "Failed to decode workspace activity metadata_json for workspace={} event={} ({} chars); raw value omitted.",
+                    item.get("workspace_id"),
+                    item.get("event_id"),
+                    len(raw_metadata),
+                )
+                metadata = {}
+        else:
+            metadata = {}
+        item["metadata"] = metadata
+        item["version"] = int(item.get("version") or 1)
+        return item
+
+    def record_workspace_activity_event(
+        self,
+        workspace_id: str,
+        data: Mapping[str, Any],
+        *,
+        user_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Append a bounded, secret-safe activity event for a workspace."""
+        normalized_workspace_id = self._normalize_workspace_activity_required_string(workspace_id, "workspace_id")
+        event_type = self._normalize_workspace_activity_required_string(data.get("event_type"), "event_type")
+        category = self._normalize_workspace_activity_required_string(data.get("category"), "category")
+        event_id = self._normalize_workspace_activity_optional_string(data.get("event_id"), max_length=128)
+        if event_id is None:
+            event_id = f"wae_{time.time_ns():020d}_{uuid.uuid4().hex}"
+        actor = self._normalize_workspace_membership_actor(user_id)
+        resource_type = self._normalize_workspace_activity_optional_string(data.get("resource_type"), max_length=80)
+        resource_id = self._normalize_workspace_activity_optional_string(data.get("resource_id"), max_length=512)
+        summary = self._normalize_workspace_activity_optional_string(data.get("summary"), max_length=512)
+        metadata, metadata_json = self._workspace_activity_metadata_json(data.get("metadata"))
+        _ = metadata
+        now = self._get_current_utc_timestamp_iso()
+
+        try:
+            with self.transaction() as conn:
+                conn.execute(
+                    """
+                    INSERT INTO workspace_activity_events (
+                        workspace_id,
+                        event_id,
+                        event_type,
+                        category,
+                        actor_user_id,
+                        resource_type,
+                        resource_id,
+                        summary,
+                        metadata_json,
+                        created_at,
+                        client_id,
+                        version
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+                    """,
+                    (
+                        normalized_workspace_id,
+                        event_id,
+                        event_type,
+                        category,
+                        actor,
+                        resource_type,
+                        resource_id,
+                        summary,
+                        metadata_json,
+                        now,
+                        self.client_id or "unknown",
+                    ),
+                )
+        except (sqlite3.IntegrityError, BackendDatabaseError) as exc:
+            raise CharactersRAGDBError(f"Workspace activity event write failed: {exc}") from exc  # noqa: TRY003
+
+        rows = self.list_workspace_activity_events(normalized_workspace_id, limit=100)
+        for row in rows:
+            if row.get("event_id") == event_id:
+                return row
+        raise CharactersRAGDBError("Created workspace activity event could not be reloaded.")  # noqa: TRY003
+
+    def list_workspace_activity_events(
+        self,
+        workspace_id: str,
+        *,
+        limit: int = 50,
+        category: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """List recent workspace activity events in deterministic newest-first order."""
+        normalized_workspace_id = self._normalize_workspace_activity_required_string(workspace_id, "workspace_id")
+        normalized_limit = self._normalize_workspace_activity_limit(limit)
+        clauses = ["workspace_id = ?"]
+        params: list[Any] = [normalized_workspace_id]
+        if category is not None:
+            clauses.append("category = ?")
+            params.append(self._normalize_workspace_activity_required_string(category, "category"))
+        params.append(normalized_limit)
+        cursor = self.execute_query(
+            f"SELECT * FROM workspace_activity_events WHERE {' AND '.join(clauses)} "  # nosec B608
+            "ORDER BY created_at DESC, event_id DESC LIMIT ?",
+            tuple(params),
+        )
+        return [
+            item
+            for row in cursor.fetchall()
+            if (item := self._normalize_workspace_activity_row(row)) is not None
+        ]
 
     def update_workspace_source(
         self,

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -16337,10 +16337,20 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             raise  # pragma: no cover
         return self.get_workspace(workspace_id)  # type: ignore[return-value]
 
-    def get_workspace(self, workspace_id: str) -> dict[str, Any] | None:
-        """Retrieve a non-deleted workspace by id."""
-        query = "SELECT * FROM workspaces WHERE id = ? AND deleted = 0"
-        cursor = self.execute_query(query, (workspace_id,))
+    def get_workspace(
+        self,
+        workspace_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, Any] | None:
+        """Retrieve a workspace by id, optionally including soft-deleted rows."""
+        if include_deleted:
+            cursor = self.execute_query("SELECT * FROM workspaces WHERE id = ?", (workspace_id,))
+        else:
+            cursor = self.execute_query(
+                "SELECT * FROM workspaces WHERE id = ? AND deleted = 0",
+                (workspace_id,),
+            )
         row = cursor.fetchone()
         return self._workspace_row_to_dict(row) if row else None
 
@@ -18612,7 +18622,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         data: Mapping[str, Any],
         *,
         user_id: str | None = None,
-    ) -> dict[str, Any]:
+        return_row: bool = True,
+    ) -> dict[str, Any] | None:
         """Append a bounded, secret-safe activity event for a workspace."""
         normalized_workspace_id = self._normalize_workspace_activity_required_string(workspace_id, "workspace_id")
         event_type = self._normalize_workspace_activity_required_string(data.get("event_type"), "event_type")
@@ -18664,10 +18675,16 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         except (sqlite3.IntegrityError, BackendDatabaseError) as exc:
             raise CharactersRAGDBError(f"Workspace activity event write failed: {exc}") from exc  # noqa: TRY003
 
-        rows = self.list_workspace_activity_events(normalized_workspace_id, limit=100)
-        for row in rows:
-            if row.get("event_id") == event_id:
-                return row
+        if not return_row:
+            return None
+
+        cursor = self.execute_query(
+            "SELECT * FROM workspace_activity_events WHERE workspace_id = ? AND event_id = ?",
+            (normalized_workspace_id, event_id),
+        )
+        row = self._normalize_workspace_activity_row(cursor.fetchone())
+        if row is not None:
+            return row
         raise CharactersRAGDBError("Created workspace activity event could not be reloaded.")  # noqa: TRY003
 
     def list_workspace_activity_events(
@@ -18680,17 +18697,30 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         """List recent workspace activity events in deterministic newest-first order."""
         normalized_workspace_id = self._normalize_workspace_activity_required_string(workspace_id, "workspace_id")
         normalized_limit = self._normalize_workspace_activity_limit(limit)
-        clauses = ["workspace_id = ?"]
-        params: list[Any] = [normalized_workspace_id]
-        if category is not None:
-            clauses.append("category = ?")
-            params.append(self._normalize_workspace_activity_required_string(category, "category"))
-        params.append(normalized_limit)
-        cursor = self.execute_query(
-            f"SELECT * FROM workspace_activity_events WHERE {' AND '.join(clauses)} "  # nosec B608
-            "ORDER BY created_at DESC, event_id DESC LIMIT ?",
-            tuple(params),
-        )
+        if category is None:
+            cursor = self.execute_query(
+                """
+                SELECT *
+                  FROM workspace_activity_events
+                 WHERE workspace_id = ?
+                 ORDER BY created_at DESC, event_id DESC
+                 LIMIT ?
+                """,
+                (normalized_workspace_id, normalized_limit),
+            )
+        else:
+            normalized_category = self._normalize_workspace_activity_required_string(category, "category")
+            cursor = self.execute_query(
+                """
+                SELECT *
+                  FROM workspace_activity_events
+                 WHERE workspace_id = ?
+                   AND category = ?
+                 ORDER BY created_at DESC, event_id DESC
+                 LIMIT ?
+                """,
+                (normalized_workspace_id, normalized_category, normalized_limit),
+            )
         return [
             item
             for row in cursor.fetchall()

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -44,6 +44,7 @@ import tempfile  # noqa: E402
 import threading  # noqa: E402
 import time  # noqa: E402
 import uuid  # noqa: E402
+from collections import Counter
 from collections.abc import Mapping
 from configparser import ConfigParser  # noqa: E402
 from datetime import datetime, timedelta, timezone  # noqa: E402
@@ -19162,6 +19163,50 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             for row in cursor.fetchall()
             if (normalized := self._normalize_workspace_runtime_binding_row(row)) is not None
         ]
+
+    def workspace_runtime_binding_summary(
+        self,
+        workspace_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, Any]:
+        """Return unpaginated runtime binding counts for one Workspace."""
+        normalized_workspace_id = self._normalize_workspace_runtime_binding_required_string(
+            workspace_id,
+            "workspace_id",
+        )
+        include_deleted_flag = 1 if include_deleted else 0
+        cursor = self.execute_query(
+            """
+            SELECT binding_kind, status, COUNT(*) AS count
+              FROM workspace_runtime_bindings
+             WHERE workspace_id = ?
+               AND (? = 1 OR deleted = ?)
+             GROUP BY binding_kind, status
+            """,
+            (
+                normalized_workspace_id,
+                include_deleted_flag,
+                self._workspace_active_deleted_value(),
+            ),
+        )
+        by_kind: Counter[str] = Counter()
+        by_status: Counter[str] = Counter()
+        total = 0
+        for row in cursor.fetchall():
+            count = int(row["count"] if isinstance(row, Mapping) else row[2])
+            binding_kind = str((row["binding_kind"] if isinstance(row, Mapping) else row[0]) or "")
+            status = str((row["status"] if isinstance(row, Mapping) else row[1]) or "")
+            total += count
+            if binding_kind:
+                by_kind[binding_kind] += count
+            if status:
+                by_status[status] += count
+        return {
+            "total": total,
+            "by_kind": dict(sorted(by_kind.items())),
+            "by_status": dict(sorted(by_status.items())),
+        }
 
     def archive_workspace_runtime_binding(
         self,

--- a/tldw_Server_API/app/core/Workspaces/activity_index.py
+++ b/tldw_Server_API/app/core/Workspaces/activity_index.py
@@ -94,11 +94,25 @@ class WorkspaceActivityIndexService:
                 request_metadata=request_metadata,
             )
             runtime_summary = self._runtime_summary(workspace_id)
+        resource_warnings = (
+            []
+            if _workspace_truthy(workspace.get("deleted"))
+            else self._resource_warnings(
+                workspace_id,
+                resource_groups=resource_groups,
+                user_id=user_id,
+                media_db=media_db,
+                prompts_db=prompts_db,
+                workflows_db=workflows_db,
+                watchlists_db=watchlists_db,
+                request_metadata=request_metadata,
+            )
+        )
         recent_activity = self._recent_activity(workspace_id, normalized_activity_limit)
         warnings = self._warnings(
             workspace=workspace,
-            resource_groups=resource_groups,
-            runtime_bindings=runtime_summary["bindings"],
+            resource_warnings=resource_warnings,
+            runtime_summary=runtime_summary,
         )
 
         return {
@@ -161,6 +175,22 @@ class WorkspaceActivityIndexService:
         except AttributeError:
             rows = []
         bindings = [runtime_binding_response_payload(row) for row in rows]
+        summary = self._runtime_binding_summary(workspace_id, bindings)
+        return {
+            "total": int(summary.get("total") or 0),
+            "by_kind": dict(summary.get("by_kind") or {}),
+            "by_status": dict(summary.get("by_status") or {}),
+            "bindings": bindings,
+        }
+
+    def _runtime_binding_summary(
+        self,
+        workspace_id: str,
+        bindings: list[Mapping[str, Any]],
+    ) -> dict[str, Any]:
+        summary = getattr(self.chacha_db, "workspace_runtime_binding_summary", None)
+        if callable(summary):
+            return summary(workspace_id)
         by_kind = Counter(str(item.get("binding_kind") or "") for item in bindings)
         by_status = Counter(str(item.get("status") or "") for item in bindings)
         by_kind.pop("", None)
@@ -169,7 +199,6 @@ class WorkspaceActivityIndexService:
             "total": len(bindings),
             "by_kind": dict(sorted(by_kind.items())),
             "by_status": dict(sorted(by_status.items())),
-            "bindings": bindings,
         }
 
     def _recent_activity(self, workspace_id: str, activity_limit: int) -> list[dict[str, Any]]:
@@ -182,8 +211,8 @@ class WorkspaceActivityIndexService:
         self,
         *,
         workspace: Mapping[str, Any],
-        resource_groups: list[Mapping[str, Any]],
-        runtime_bindings: list[Mapping[str, Any]],
+        resource_warnings: list[dict[str, Any]],
+        runtime_summary: Mapping[str, Any],
     ) -> list[dict[str, Any]]:
         warnings: list[dict[str, Any]] = []
         if _workspace_truthy(workspace.get("deleted")):
@@ -205,28 +234,15 @@ class WorkspaceActivityIndexService:
                 }
             )
 
-        for group in resource_groups:
-            for item in group.get("items") or []:
-                summary = item.get("summary") or {}
-                state = str(summary.get("state") or "available")
-                if state == "available":
-                    continue
-                reason = "resource_unresolved" if state == "unresolved" else f"resource_{state}"
-                warnings.append(
-                    {
-                        "severity": "warning",
-                        "reason_code": reason,
-                        "message": "A workspace resource needs attention in its owning surface.",
-                        "resource_type": item.get("resource_type"),
-                        "resource_id": item.get("resource_id"),
-                        "action_href": (summary.get("href") or _owner_surface(str(item.get("resource_type") or ""))["href"]),
-                    }
-                )
+        warnings.extend(resource_warnings)
 
+        runtime_bindings = list(runtime_summary.get("bindings") or [])
+        warned_runtime_statuses: set[str] = set()
         for binding in runtime_bindings:
             status = str(binding.get("status") or "").strip().lower()
             if status not in _RUNTIME_WARNING_STATUSES:
                 continue
+            warned_runtime_statuses.add(status)
             reason = "runtime_binding_missing" if status in {"missing", "runtime-missing"} else (
                 f"runtime_binding_{status.replace('-', '_')}"
             )
@@ -240,6 +256,64 @@ class WorkspaceActivityIndexService:
                     "action_href": "#/workspaces",
                 }
             )
+        for status, count in dict(runtime_summary.get("by_status") or {}).items():
+            normalized_status = str(status or "").strip().lower()
+            if normalized_status not in _RUNTIME_WARNING_STATUSES or normalized_status in warned_runtime_statuses:
+                continue
+            reason = "runtime_binding_missing" if normalized_status in {"missing", "runtime-missing"} else (
+                f"runtime_binding_{normalized_status.replace('-', '_')}"
+            )
+            warnings.append(
+                {
+                    "severity": "warning",
+                    "reason_code": reason,
+                    "message": (
+                        f"{int(count or 0)} workspace runtime binding(s) need attention "
+                        "before runtime-backed actions are reliable."
+                    ),
+                    "resource_type": "workspace_runtime_binding",
+                    "resource_id": None,
+                    "action_href": "#/workspaces",
+                }
+            )
+        return warnings
+
+    def _resource_warnings(
+        self,
+        workspace_id: str,
+        *,
+        resource_groups: list[Mapping[str, Any]],
+        user_id: str | None,
+        media_db: Any | None,
+        prompts_db: Any | None,
+        workflows_db: Any | None,
+        watchlists_db: Any | None,
+        request_metadata: Mapping[str, Any] | None,
+    ) -> list[dict[str, Any]]:
+        warnings: list[dict[str, Any]] = []
+        for group in resource_groups:
+            resource_type = str(group.get("resource_type") or "")
+            if not resource_type:
+                continue
+            cursor: str | None = None
+            while True:
+                page = self.memberships.list_workspace_memberships(
+                    workspace_id,
+                    resource_type=resource_type,
+                    resolve=True,
+                    limit=1000,
+                    cursor=cursor,
+                    user_id=user_id,
+                    media_db=media_db,
+                    prompts_db=prompts_db,
+                    workflows_db=workflows_db,
+                    watchlists_db=watchlists_db,
+                    request_metadata=request_metadata,
+                )
+                warnings.extend(_warnings_from_resource_items(page.get("items") or []))
+                cursor = page.get("next_cursor")
+                if not cursor:
+                    break
         return warnings
 
 
@@ -260,6 +334,28 @@ def _bounded_limit(value: int, *, default: int, max_value: int) -> int:
     except (TypeError, ValueError):
         return default
     return max(1, min(normalized, max_value))
+
+
+def _warnings_from_resource_items(items: list[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    warnings: list[dict[str, Any]] = []
+    for item in items:
+        summary = item.get("summary") or {}
+        state = str(summary.get("state") or "available")
+        if state == "available":
+            continue
+        resource_type = str(item.get("resource_type") or "")
+        reason = "resource_unresolved" if state == "unresolved" else f"resource_{state}"
+        warnings.append(
+            {
+                "severity": "warning",
+                "reason_code": reason,
+                "message": "A workspace resource needs attention in its owning surface.",
+                "resource_type": item.get("resource_type"),
+                "resource_id": item.get("resource_id"),
+                "action_href": (summary.get("href") or _owner_surface(resource_type)["href"]),
+            }
+        )
+    return warnings
 
 
 def _workspace_truthy(value: Any) -> bool:

--- a/tldw_Server_API/app/core/Workspaces/activity_index.py
+++ b/tldw_Server_API/app/core/Workspaces/activity_index.py
@@ -1,0 +1,257 @@
+"""Workspace contained-resource index and recent activity read model."""
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any
+
+from tldw_Server_API.app.core.Workspaces.membership_models import WORKSPACE_MEMBERSHIP_RESOURCE_TYPES
+from tldw_Server_API.app.core.Workspaces.membership_service import (
+    WorkspaceMembershipService,
+    WorkspaceMembershipServiceError,
+)
+from tldw_Server_API.app.core.Workspaces.runtime_bindings import runtime_binding_response_payload
+
+
+_GROUP_LIMIT_MAX = 25
+_ACTIVITY_LIMIT_MAX = 100
+_RUNTIME_WARNING_STATUSES = frozenset(
+    {
+        "missing",
+        "blocked",
+        "unavailable",
+        "detached",
+        "conflict",
+        "runtime-missing",
+        "unsupported",
+    }
+)
+_OWNER_SURFACES = {
+    "workspace_note": {"label": "Workspace notes", "href": "#/research-workspace"},
+    "media": {"label": "Media library", "href": "#/media"},
+    "workspace_source": {"label": "Research Workspace sources", "href": "#/research-workspace"},
+    "workspace_artifact": {"label": "Research Workspace studio", "href": "#/research-workspace"},
+    "chat": {"label": "Chat", "href": "#/chat"},
+    "prompt": {"label": "Prompts", "href": "#/prompts"},
+    "workflow": {"label": "Workflows", "href": "#/workflows"},
+    "watchlist": {"label": "Watchlists", "href": "#/watchlists"},
+    "acp_session": {"label": "ACP Playground", "href": "#/agent-playground"},
+    "sandbox_session": {"label": "Sandbox", "href": "#/sandbox"},
+}
+
+
+class WorkspaceActivityIndexService:
+    """Compose a read-only Workspace resource index without duplicating owner UIs."""
+
+    def __init__(self, chacha_db: Any) -> None:
+        self.chacha_db = chacha_db
+        self.memberships = WorkspaceMembershipService(chacha_db)
+
+    def build_index(
+        self,
+        workspace_id: str,
+        *,
+        user_id: str | None = None,
+        media_db: Any | None = None,
+        prompts_db: Any | None = None,
+        workflows_db: Any | None = None,
+        watchlists_db: Any | None = None,
+        request_metadata: Mapping[str, Any] | None = None,
+        group_limit: int = 5,
+        activity_limit: int = 25,
+    ) -> dict[str, Any]:
+        """Return the Workspace index/activity contract for API responses."""
+        workspace = self.chacha_db.get_workspace(workspace_id)
+        if workspace is None:
+            raise WorkspaceMembershipServiceError(
+                "workspace_not_found",
+                f"Workspace '{workspace_id}' was not found.",
+                status_code=404,
+            )
+
+        normalized_group_limit = _bounded_limit(group_limit, default=5, max_value=_GROUP_LIMIT_MAX)
+        normalized_activity_limit = _bounded_limit(
+            activity_limit,
+            default=25,
+            max_value=_ACTIVITY_LIMIT_MAX,
+        )
+        membership_summary = self.memberships.workspace_membership_summary(workspace_id)
+        resource_groups = self._resource_groups(
+            workspace_id,
+            membership_summary=membership_summary,
+            group_limit=normalized_group_limit,
+            user_id=user_id,
+            media_db=media_db,
+            prompts_db=prompts_db,
+            workflows_db=workflows_db,
+            watchlists_db=watchlists_db,
+            request_metadata=request_metadata,
+        )
+        runtime_summary = self._runtime_summary(workspace_id)
+        recent_activity = self._recent_activity(workspace_id, normalized_activity_limit)
+        warnings = self._warnings(
+            workspace=workspace,
+            resource_groups=resource_groups,
+            runtime_bindings=runtime_summary["bindings"],
+        )
+
+        return {
+            "workspace_id": workspace_id,
+            "schema_version": 1,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "workspace": dict(workspace),
+            "membership_summary": membership_summary,
+            "resource_groups": resource_groups,
+            "runtime_summary": runtime_summary,
+            "warnings": warnings,
+            "recent_activity": recent_activity,
+            "partial_errors": [],
+        }
+
+    def _resource_groups(
+        self,
+        workspace_id: str,
+        *,
+        membership_summary: Mapping[str, Any],
+        group_limit: int,
+        user_id: str | None,
+        media_db: Any | None,
+        prompts_db: Any | None,
+        workflows_db: Any | None,
+        watchlists_db: Any | None,
+        request_metadata: Mapping[str, Any] | None,
+    ) -> list[dict[str, Any]]:
+        counts = dict(membership_summary.get("by_resource_type") or {})
+        groups: list[dict[str, Any]] = []
+        for resource_type in sorted(counts):
+            if resource_type not in WORKSPACE_MEMBERSHIP_RESOURCE_TYPES:
+                continue
+            page = self.memberships.list_workspace_memberships(
+                workspace_id,
+                resource_type=resource_type,
+                resolve=True,
+                limit=group_limit,
+                user_id=user_id,
+                media_db=media_db,
+                prompts_db=prompts_db,
+                workflows_db=workflows_db,
+                watchlists_db=watchlists_db,
+                request_metadata=request_metadata,
+            )
+            groups.append(
+                {
+                    "resource_type": resource_type,
+                    "count": int(counts.get(resource_type) or 0),
+                    "owner_surface": _owner_surface(resource_type),
+                    "items": page.get("items") or [],
+                    "next_cursor": page.get("next_cursor"),
+                }
+            )
+        return groups
+
+    def _runtime_summary(self, workspace_id: str) -> dict[str, Any]:
+        try:
+            rows = self.chacha_db.list_workspace_runtime_bindings(workspace_id, limit=50)
+        except AttributeError:
+            rows = []
+        bindings = [runtime_binding_response_payload(row) for row in rows]
+        by_kind = Counter(str(item.get("binding_kind") or "") for item in bindings)
+        by_status = Counter(str(item.get("status") or "") for item in bindings)
+        by_kind.pop("", None)
+        by_status.pop("", None)
+        return {
+            "total": len(bindings),
+            "by_kind": dict(sorted(by_kind.items())),
+            "by_status": dict(sorted(by_status.items())),
+            "bindings": bindings,
+        }
+
+    def _recent_activity(self, workspace_id: str, activity_limit: int) -> list[dict[str, Any]]:
+        try:
+            return self.chacha_db.list_workspace_activity_events(workspace_id, limit=activity_limit)
+        except AttributeError:
+            return []
+
+    def _warnings(
+        self,
+        *,
+        workspace: Mapping[str, Any],
+        resource_groups: list[Mapping[str, Any]],
+        runtime_bindings: list[Mapping[str, Any]],
+    ) -> list[dict[str, Any]]:
+        warnings: list[dict[str, Any]] = []
+        if workspace.get("deleted") in (True, 1, "1", "true", "True"):
+            warnings.append(
+                {
+                    "severity": "error",
+                    "reason_code": "workspace_deleted",
+                    "message": "Workspace is deleted and only recovery-safe inspection is available.",
+                    "action_href": "#/workspaces",
+                }
+            )
+        elif workspace.get("archived") in (True, 1, "1", "true", "True"):
+            warnings.append(
+                {
+                    "severity": "warning",
+                    "reason_code": "workspace_archived",
+                    "message": "Workspace is archived; write actions are disabled until it is restored.",
+                    "action_href": "#/workspaces",
+                }
+            )
+
+        for group in resource_groups:
+            for item in group.get("items") or []:
+                summary = item.get("summary") or {}
+                state = str(summary.get("state") or "available")
+                if state == "available":
+                    continue
+                reason = "resource_unresolved" if state == "unresolved" else f"resource_{state}"
+                warnings.append(
+                    {
+                        "severity": "warning",
+                        "reason_code": reason,
+                        "message": "A workspace resource needs attention in its owning surface.",
+                        "resource_type": item.get("resource_type"),
+                        "resource_id": item.get("resource_id"),
+                        "action_href": (summary.get("href") or _owner_surface(str(item.get("resource_type") or ""))["href"]),
+                    }
+                )
+
+        for binding in runtime_bindings:
+            status = str(binding.get("status") or "").strip().lower()
+            if status not in _RUNTIME_WARNING_STATUSES:
+                continue
+            reason = "runtime_binding_missing" if status in {"missing", "runtime-missing"} else (
+                f"runtime_binding_{status.replace('-', '_')}"
+            )
+            warnings.append(
+                {
+                    "severity": "warning",
+                    "reason_code": reason,
+                    "message": "A workspace runtime binding needs attention before runtime-backed actions are reliable.",
+                    "resource_type": "workspace_runtime_binding",
+                    "resource_id": binding.get("binding_id"),
+                    "action_href": "#/workspaces",
+                }
+            )
+        return warnings
+
+
+def _owner_surface(resource_type: str) -> dict[str, str]:
+    return dict(
+        _OWNER_SURFACES.get(
+            resource_type,
+            {"label": "Workspace resources", "href": "#/workspaces"},
+        )
+    )
+
+
+def _bounded_limit(value: int, *, default: int, max_value: int) -> int:
+    if isinstance(value, bool):
+        return default
+    try:
+        normalized = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(1, min(normalized, max_value))

--- a/tldw_Server_API/app/core/Workspaces/activity_index.py
+++ b/tldw_Server_API/app/core/Workspaces/activity_index.py
@@ -62,7 +62,7 @@ class WorkspaceActivityIndexService:
         activity_limit: int = 25,
     ) -> dict[str, Any]:
         """Return the Workspace index/activity contract for API responses."""
-        workspace = self.chacha_db.get_workspace(workspace_id)
+        workspace = self.chacha_db.get_workspace(workspace_id, include_deleted=True)
         if workspace is None:
             raise WorkspaceMembershipServiceError(
                 "workspace_not_found",
@@ -76,19 +76,24 @@ class WorkspaceActivityIndexService:
             default=25,
             max_value=_ACTIVITY_LIMIT_MAX,
         )
-        membership_summary = self.memberships.workspace_membership_summary(workspace_id)
-        resource_groups = self._resource_groups(
-            workspace_id,
-            membership_summary=membership_summary,
-            group_limit=normalized_group_limit,
-            user_id=user_id,
-            media_db=media_db,
-            prompts_db=prompts_db,
-            workflows_db=workflows_db,
-            watchlists_db=watchlists_db,
-            request_metadata=request_metadata,
-        )
-        runtime_summary = self._runtime_summary(workspace_id)
+        if _workspace_truthy(workspace.get("deleted")):
+            membership_summary: dict[str, Any] = {"total": 0, "by_resource_type": {}, "by_role": {}}
+            resource_groups: list[dict[str, Any]] = []
+            runtime_summary = {"total": 0, "by_kind": {}, "by_status": {}, "bindings": []}
+        else:
+            membership_summary = self.memberships.workspace_membership_summary(workspace_id)
+            resource_groups = self._resource_groups(
+                workspace_id,
+                membership_summary=membership_summary,
+                group_limit=normalized_group_limit,
+                user_id=user_id,
+                media_db=media_db,
+                prompts_db=prompts_db,
+                workflows_db=workflows_db,
+                watchlists_db=watchlists_db,
+                request_metadata=request_metadata,
+            )
+            runtime_summary = self._runtime_summary(workspace_id)
         recent_activity = self._recent_activity(workspace_id, normalized_activity_limit)
         warnings = self._warnings(
             workspace=workspace,
@@ -181,7 +186,7 @@ class WorkspaceActivityIndexService:
         runtime_bindings: list[Mapping[str, Any]],
     ) -> list[dict[str, Any]]:
         warnings: list[dict[str, Any]] = []
-        if workspace.get("deleted") in (True, 1, "1", "true", "True"):
+        if _workspace_truthy(workspace.get("deleted")):
             warnings.append(
                 {
                     "severity": "error",
@@ -190,7 +195,7 @@ class WorkspaceActivityIndexService:
                     "action_href": "#/workspaces",
                 }
             )
-        elif workspace.get("archived") in (True, 1, "1", "true", "True"):
+        elif _workspace_truthy(workspace.get("archived")):
             warnings.append(
                 {
                     "severity": "warning",
@@ -255,3 +260,7 @@ def _bounded_limit(value: int, *, default: int, max_value: int) -> int:
     except (TypeError, ValueError):
         return default
     return max(1, min(normalized, max_value))
+
+
+def _workspace_truthy(value: Any) -> bool:
+    return value in (True, 1, "1", "true", "True")

--- a/tldw_Server_API/app/core/Workspaces/membership_service.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_service.py
@@ -99,6 +99,13 @@ class WorkspaceMembershipService:
             },
             user_id=user_id,
         )
+        if existing is None or restore_deleted:
+            self._record_membership_activity_event(
+                workspace_id,
+                "membership.restored" if restore_deleted else "membership.linked",
+                row,
+                user_id=user_id,
+            )
         return self._serialize_membership(row, context=context, summary_ref=ref if resolve else None, resolve=resolve)
 
     def get_membership(
@@ -342,6 +349,12 @@ class WorkspaceMembershipService:
                 adapter.resource_type,
                 canonical_resource_id,
             )
+        self._record_membership_activity_event(
+            workspace_id,
+            "membership.unlinked",
+            row,
+            user_id=user_id,
+        )
         return self._serialize_membership(row, context=context, resolve=False)
 
     def workspace_membership_summary(self, workspace_id: str) -> dict[str, Any]:
@@ -998,3 +1011,43 @@ class WorkspaceMembershipService:
             "by_resource_type": dict(sorted(by_resource_type.items())),
             "by_role": dict(sorted(by_role.items())),
         }
+
+    def _record_membership_activity_event(
+        self,
+        workspace_id: str,
+        event_type: str,
+        row: Mapping[str, Any],
+        *,
+        user_id: str | None,
+    ) -> None:
+        recorder = getattr(self.chacha_db, "record_workspace_activity_event", None)
+        if not callable(recorder):
+            return
+        resource_type = str(row.get("resource_type") or "")
+        resource_id = str(row.get("resource_id") or "")
+        role = str(row.get("role") or "member")
+        transfer_policy = str(row.get("transfer_policy") or "link")
+        try:
+            recorder(
+                workspace_id,
+                {
+                    "event_type": event_type,
+                    "category": "membership",
+                    "resource_type": resource_type,
+                    "resource_id": resource_id,
+                    "summary": f"{event_type.removeprefix('membership.').title()} {resource_type} resource",
+                    "metadata": {
+                        "role": role,
+                        "transfer_policy": transfer_policy,
+                    },
+                },
+                user_id=user_id,
+            )
+        except Exception:  # noqa: BLE001 - activity recording must not fail membership writes.
+            logger.opt(exception=True).warning(
+                "Failed to record Workspace membership activity event workspace={} event_type={} resource_type={} resource_id={}",
+                workspace_id,
+                event_type,
+                resource_type,
+                resource_id,
+            )

--- a/tldw_Server_API/app/core/Workspaces/membership_service.py
+++ b/tldw_Server_API/app/core/Workspaces/membership_service.py
@@ -1042,6 +1042,7 @@ class WorkspaceMembershipService:
                     },
                 },
                 user_id=user_id,
+                return_row=False,
             )
         except Exception:  # noqa: BLE001 - activity recording must not fail membership writes.
             logger.opt(exception=True).warning(

--- a/tldw_Server_API/app/core/Workspaces/runtime_bindings.py
+++ b/tldw_Server_API/app/core/Workspaces/runtime_bindings.py
@@ -50,6 +50,17 @@ _PATH_METADATA_KEY_RE = re.compile(
     re.IGNORECASE,
 )
 _WRITE_STATUSES = WORKSPACE_RUNTIME_BINDING_STATUSES - {"archived"}
+_RUNTIME_BINDING_USER_FIELDS = (
+    "binding_kind",
+    "owner_domain",
+    "locator_ref",
+    "label",
+    "status",
+    "path_hint",
+    "portability",
+    "metadata",
+    "redaction_report",
+)
 
 
 def _input_error(message: str) -> ValueError:
@@ -150,6 +161,58 @@ def runtime_binding_response_payload(row: Mapping[str, Any]) -> dict[str, Any]:
     item["deleted"] = bool(item.get("deleted", False))
     item["version"] = int(item.get("version") or 1)
     return item
+
+
+def runtime_binding_payload_changed(
+    existing: Mapping[str, Any] | None,
+    requested: Mapping[str, Any],
+) -> bool:
+    """Return true when a runtime binding write changes user-controlled fields."""
+    if existing is None:
+        return True
+    if existing.get("deleted") in (True, 1, "1", "true", "True"):
+        return True
+    normalized = normalize_runtime_binding_payload(requested)
+    return any(existing.get(field_name) != normalized.get(field_name) for field_name in _RUNTIME_BINDING_USER_FIELDS)
+
+
+def record_runtime_binding_activity_event(
+    db: Any,
+    workspace_id: str,
+    event_type: str,
+    binding: Mapping[str, Any],
+    *,
+    user_id: str,
+) -> None:
+    """Record best-effort runtime binding activity without coupling endpoints to payload details."""
+    recorder = getattr(db, "record_workspace_activity_event", None)
+    if not callable(recorder):
+        return
+    try:
+        recorder(
+            workspace_id,
+            {
+                "event_type": event_type,
+                "category": "runtime_binding",
+                "resource_type": "workspace_runtime_binding",
+                "resource_id": str(binding.get("binding_id") or ""),
+                "summary": "Updated workspace runtime binding",
+                "metadata": {
+                    "binding_kind": str(binding.get("binding_kind") or ""),
+                    "owner_domain": str(binding.get("owner_domain") or ""),
+                    "status": str(binding.get("status") or ""),
+                },
+            },
+            user_id=user_id,
+            return_row=False,
+        )
+    except Exception:  # noqa: BLE001 - activity is an inspection aid, not write-path authority.
+        logger.opt(exception=True).warning(
+            "Failed to record Workspace runtime binding activity workspace={} event_type={} binding_id={}",
+            workspace_id,
+            event_type,
+            binding.get("binding_id"),
+        )
 
 
 def redacted_path_hint(value: Any) -> str:

--- a/tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import try_get_media_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.Prompts_DB_Deps import try_get_prompts_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.Watchlists_DB_Deps import try_get_watchlists_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user
+from tldw_Server_API.app.api.v1.endpoints import workspaces as workspaces_endpoint
+from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import WORKSPACES_READ_RATE_LIMIT
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+
+def test_workspace_activity_events_are_timestamped_newest_first_and_safe(tmp_path) -> None:
+    db = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="test-client")
+    db.upsert_workspace("workspace-1", "Activity Workspace")
+
+    db.record_workspace_activity_event(
+        "workspace-1",
+        {
+            "event_type": "membership.linked",
+            "category": "membership",
+            "resource_type": "chat",
+            "resource_id": "chat-1",
+            "summary": "Linked chat",
+            "metadata": {
+                "role": "conversation",
+                "absolute_root": "/Users/alice/private/project",
+                "api_key": "sk-secret-value",
+            },
+        },
+        user_id="user-1",
+    )
+    db.record_workspace_activity_event(
+        "workspace-1",
+        {
+            "event_type": "runtime_binding.upserted",
+            "category": "runtime_binding",
+            "resource_type": "workspace_runtime_binding",
+            "resource_id": "repo-main",
+            "summary": "Updated runtime binding",
+            "metadata": {"binding_kind": "repo", "status": "missing"},
+        },
+        user_id="user-1",
+    )
+
+    rows = db.list_workspace_activity_events("workspace-1", limit=10)
+
+    assert [row["event_type"] for row in rows] == [
+        "runtime_binding.upserted",
+        "membership.linked",
+    ]
+    assert rows[0]["category"] == "runtime_binding"
+    assert rows[0]["actor_user_id"] == "user-1"
+    assert rows[0]["created_at"]
+    assert rows[1]["metadata"]["absolute_root"] == "project"
+    assert "api_key" not in rows[1]["metadata"]
+    assert "/Users/alice" not in repr(rows)
+    assert "sk-secret" not in repr(rows)
+
+
+class FakeWorkspaceIndexDB:
+    def __init__(self) -> None:
+        self.workspaces: dict[str, dict[str, object]] = {
+            "workspace-1": {
+                "id": "workspace-1",
+                "name": "Activity Workspace",
+                "archived": False,
+                "deleted": False,
+                "workspace_profile": "project",
+                "study_materials_policy": "workspace",
+                "created_at": "2026-06-18T12:00:00Z",
+                "last_modified": "2026-06-18T12:00:00Z",
+                "version": 3,
+            }
+        }
+        self.conversations: dict[str, dict[str, object]] = {
+            "chat-1": {
+                "id": "chat-1",
+                "title": "Research chat",
+                "scope_type": "global",
+                "workspace_id": None,
+                "last_modified": "2026-06-18T12:05:00Z",
+                "version": 1,
+            }
+        }
+        self.memberships: list[dict[str, object]] = [
+            {
+                "workspace_id": "workspace-1",
+                "resource_type": "chat",
+                "resource_id": "chat-1",
+                "role": "conversation",
+                "label": "Research chat",
+                "transfer_policy": "link",
+                "provenance": {},
+                "metadata": {},
+                "created_at": "2026-06-18T12:10:00Z",
+                "updated_at": "2026-06-18T12:10:00Z",
+                "version": 1,
+                "deleted": False,
+            },
+            {
+                "workspace_id": "workspace-1",
+                "resource_type": "prompt",
+                "resource_id": "7",
+                "role": "reference",
+                "label": "Research Prompt",
+                "transfer_policy": "link",
+                "provenance": {},
+                "metadata": {},
+                "created_at": "2026-06-18T12:09:00Z",
+                "updated_at": "2026-06-18T12:09:00Z",
+                "version": 1,
+                "deleted": False,
+            },
+        ]
+
+    def get_workspace(self, workspace_id: str) -> dict[str, object] | None:
+        return self.workspaces.get(workspace_id)
+
+    def get_conversation_for_workspace_membership(self, conversation_id: str) -> dict[str, object] | None:
+        return self.conversations.get(conversation_id)
+
+    def list_workspace_resource_memberships(
+        self,
+        workspace_id: str,
+        *,
+        resource_type: str | None = None,
+        role: str | None = None,
+        include_deleted: bool = False,
+        limit: int = 100,
+        cursor: tuple[str, str, str] | None = None,
+    ) -> list[dict[str, object]]:
+        _ = cursor
+        rows = [
+            row
+            for row in self.memberships
+            if row["workspace_id"] == workspace_id
+            and (resource_type is None or row["resource_type"] == resource_type)
+            and (role is None or row["role"] == role)
+            and (include_deleted or not row.get("deleted"))
+        ]
+        rows.sort(
+            key=lambda row: (
+                str(row["updated_at"]),
+                str(row["resource_type"]),
+                str(row["resource_id"]),
+            ),
+            reverse=True,
+        )
+        return [dict(row) for row in rows[:limit]]
+
+    def workspace_resource_membership_summary(self, workspace_id: str) -> dict[str, object]:
+        rows = [
+            row
+            for row in self.memberships
+            if row["workspace_id"] == workspace_id and not row.get("deleted")
+        ]
+        by_resource_type: dict[str, int] = {}
+        by_role: dict[str, int] = {}
+        for row in rows:
+            by_resource_type[str(row["resource_type"])] = by_resource_type.get(str(row["resource_type"]), 0) + 1
+            by_role[str(row["role"])] = by_role.get(str(row["role"]), 0) + 1
+        return {"total": len(rows), "by_resource_type": by_resource_type, "by_role": by_role}
+
+    def list_workspace_runtime_bindings(
+        self,
+        workspace_id: str,
+        *,
+        binding_kind: str | None = None,
+        owner_domain: str | None = None,
+        include_deleted: bool = False,
+        limit: int = 100,
+    ) -> list[dict[str, object]]:
+        _ = workspace_id, binding_kind, owner_domain, include_deleted, limit
+        return [
+            {
+                "workspace_id": "workspace-1",
+                "binding_id": "repo-main",
+                "binding_kind": "repo",
+                "owner_domain": "workspaces",
+                "locator_ref": "repo-1",
+                "label": "Main Repo",
+                "status": "missing",
+                "path_hint": "/Users/alice/private/project",
+                "portability": "reference",
+                "metadata": {"branch": "dev"},
+                "redaction_report": {"redacted": True, "redacted_fields": ["path_hint"], "rejected_fields": []},
+                "created_at": "2026-06-18T12:00:00Z",
+                "updated_at": "2026-06-18T12:00:00Z",
+                "deleted": False,
+                "version": 1,
+            }
+        ]
+
+    def list_workspace_activity_events(
+        self,
+        workspace_id: str,
+        *,
+        limit: int = 50,
+        category: str | None = None,
+    ) -> list[dict[str, object]]:
+        _ = workspace_id, category
+        return [
+            {
+                "workspace_id": "workspace-1",
+                "event_id": "evt-1",
+                "event_type": "membership.linked",
+                "category": "membership",
+                "actor_user_id": "user-1",
+                "resource_type": "chat",
+                "resource_id": "chat-1",
+                "summary": "Linked chat",
+                "metadata": {"role": "conversation"},
+                "created_at": "2026-06-18T12:10:00Z",
+                "version": 1,
+            }
+        ][:limit]
+
+
+class FakePromptsDB:
+    def fetch_prompt_details(self, prompt_id_or_name_or_uuid: object, include_deleted: bool = False) -> dict[str, object] | None:
+        _ = include_deleted
+        if str(prompt_id_or_name_or_uuid) != "7":
+            return None
+        return {
+            "id": 7,
+            "uuid": "11111111-1111-4111-8111-111111111111",
+            "name": "Research Prompt",
+            "author": "analyst",
+            "details": "do not expose",
+            "last_modified": "2026-06-18T12:04:00Z",
+            "deleted": 0,
+        }
+
+
+def test_workspace_index_api_groups_resources_activity_and_warnings() -> None:
+    db = FakeWorkspaceIndexDB()
+    app = FastAPI()
+    app.include_router(workspaces_endpoint.router, prefix="/api/v1/workspaces")
+
+    async def _allow_rate_limit() -> None:
+        return None
+
+    app.dependency_overrides[get_request_user] = lambda: SimpleNamespace(id="user-1", tenant_id="tenant-a")
+    app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    app.dependency_overrides[try_get_media_db_for_user] = lambda: None
+    app.dependency_overrides[try_get_prompts_db_for_user] = lambda: FakePromptsDB()
+    app.dependency_overrides[workspaces_endpoint.try_get_workflows_db_for_user] = lambda: None
+    app.dependency_overrides[try_get_watchlists_db_for_user] = lambda: None
+    app.dependency_overrides[WORKSPACES_READ_RATE_LIMIT] = _allow_rate_limit
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/api/v1/workspaces/workspace-1/index", params={"group_limit": "2", "activity_limit": "5"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["schema_version"] == 1
+    assert body["workspace"]["id"] == "workspace-1"
+    assert body["workspace"]["workspace_profile"] == "project"
+    assert body["membership_summary"] == {
+        "total": 2,
+        "by_resource_type": {"chat": 1, "prompt": 1},
+        "by_role": {"conversation": 1, "reference": 1},
+    }
+    groups = {group["resource_type"]: group for group in body["resource_groups"]}
+    assert groups["chat"]["count"] == 1
+    assert groups["chat"]["owner_surface"]["href"]
+    assert groups["chat"]["items"][0]["summary"]["title"] == "Research chat"
+    assert groups["prompt"]["items"][0]["summary"]["title"] == "Research Prompt"
+    assert body["runtime_summary"]["total"] == 1
+    assert body["runtime_summary"]["by_status"] == {"missing": 1}
+    assert body["recent_activity"][0]["event_type"] == "membership.linked"
+    assert body["recent_activity"][0]["created_at"] == "2026-06-18T12:10:00Z"
+    assert any(warning["reason_code"] == "runtime_binding_missing" for warning in body["warnings"])
+    assert "/Users/alice" not in response.text
+    assert "do not expose" not in response.text

--- a/tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py
@@ -18,54 +18,57 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGD
 
 def test_workspace_activity_events_are_timestamped_newest_first_and_safe(tmp_path) -> None:
     db = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="test-client")
-    db.upsert_workspace("workspace-1", "Activity Workspace")
+    try:
+        db.upsert_workspace("workspace-1", "Activity Workspace")
 
-    db.record_workspace_activity_event(
-        "workspace-1",
-        {
-            "event_type": "membership.linked",
-            "category": "membership",
-            "resource_type": "chat",
-            "resource_id": "chat-1",
-            "summary": "Linked chat",
-            "metadata": {
-                "role": "conversation",
-                "absolute_root": "/Users/alice/private/project",
-                "api_key": "sk-secret-value",
+        db.record_workspace_activity_event(
+            "workspace-1",
+            {
+                "event_type": "membership.linked",
+                "category": "membership",
+                "resource_type": "chat",
+                "resource_id": "chat-1",
+                "summary": "Linked chat",
+                "metadata": {
+                    "role": "conversation",
+                    "absolute_root": "/Users/alice/private/project",
+                    "api_key": "sk-secret-value",
+                },
             },
-        },
-        user_id="user-1",
-    )
-    db.record_workspace_activity_event(
-        "workspace-1",
-        {
-            "event_type": "runtime_binding.upserted",
-            "category": "runtime_binding",
-            "resource_type": "workspace_runtime_binding",
-            "resource_id": "repo-main",
-            "summary": "Updated runtime binding",
-            "metadata": {"binding_kind": "repo", "status": "missing"},
-        },
-        user_id="user-1",
-    )
+            user_id="user-1",
+        )
+        db.record_workspace_activity_event(
+            "workspace-1",
+            {
+                "event_type": "runtime_binding.upserted",
+                "category": "runtime_binding",
+                "resource_type": "workspace_runtime_binding",
+                "resource_id": "repo-main",
+                "summary": "Updated runtime binding",
+                "metadata": {"binding_kind": "repo", "status": "missing"},
+            },
+            user_id="user-1",
+        )
 
-    rows = db.list_workspace_activity_events("workspace-1", limit=10)
+        rows = db.list_workspace_activity_events("workspace-1", limit=10)
 
-    assert [row["event_type"] for row in rows] == [
-        "runtime_binding.upserted",
-        "membership.linked",
-    ]
-    assert rows[0]["category"] == "runtime_binding"
-    assert rows[0]["actor_user_id"] == "user-1"
-    assert rows[0]["created_at"]
-    assert rows[1]["metadata"]["absolute_root"] == "project"
-    assert "api_key" not in rows[1]["metadata"]
-    assert "/Users/alice" not in repr(rows)
-    assert "sk-secret" not in repr(rows)
-    assert [
-        row["event_type"]
-        for row in db.list_workspace_activity_events("workspace-1", limit=10, category="runtime_binding")
-    ] == ["runtime_binding.upserted"]
+        assert [row["event_type"] for row in rows] == [
+            "runtime_binding.upserted",
+            "membership.linked",
+        ]
+        assert rows[0]["category"] == "runtime_binding"
+        assert rows[0]["actor_user_id"] == "user-1"
+        assert rows[0]["created_at"]
+        assert rows[1]["metadata"]["absolute_root"] == "project"
+        assert "api_key" not in rows[1]["metadata"]
+        assert "/Users/alice" not in repr(rows)
+        assert "sk-secret" not in repr(rows)
+        assert [
+            row["event_type"]
+            for row in db.list_workspace_activity_events("workspace-1", limit=10, category="runtime_binding")
+        ] == ["runtime_binding.upserted"]
+    finally:
+        db.close_connection()
 
 
 class FakeWorkspaceIndexDB:
@@ -122,6 +125,25 @@ class FakeWorkspaceIndexDB:
                 "version": 1,
                 "deleted": False,
             },
+        ]
+        self.runtime_bindings: list[dict[str, object]] = [
+            {
+                "workspace_id": "workspace-1",
+                "binding_id": "repo-main",
+                "binding_kind": "repo",
+                "owner_domain": "workspaces",
+                "locator_ref": "repo-1",
+                "label": "Main Repo",
+                "status": "missing",
+                "path_hint": "/Users/alice/private/project",
+                "portability": "reference",
+                "metadata": {"branch": "dev"},
+                "redaction_report": {"redacted": True, "redacted_fields": ["path_hint"], "rejected_fields": []},
+                "created_at": "2026-06-18T12:00:00Z",
+                "updated_at": "2026-06-18T12:00:00Z",
+                "deleted": False,
+                "version": 1,
+            }
         ]
 
     def get_workspace(self, workspace_id: str, *, include_deleted: bool = False) -> dict[str, object] | None:
@@ -183,25 +205,27 @@ class FakeWorkspaceIndexDB:
         limit: int = 100,
     ) -> list[dict[str, object]]:
         _ = workspace_id, binding_kind, owner_domain, include_deleted, limit
-        return [
-            {
-                "workspace_id": "workspace-1",
-                "binding_id": "repo-main",
-                "binding_kind": "repo",
-                "owner_domain": "workspaces",
-                "locator_ref": "repo-1",
-                "label": "Main Repo",
-                "status": "missing",
-                "path_hint": "/Users/alice/private/project",
-                "portability": "reference",
-                "metadata": {"branch": "dev"},
-                "redaction_report": {"redacted": True, "redacted_fields": ["path_hint"], "rejected_fields": []},
-                "created_at": "2026-06-18T12:00:00Z",
-                "updated_at": "2026-06-18T12:00:00Z",
-                "deleted": False,
-                "version": 1,
-            }
-        ]
+        return [dict(row) for row in self.runtime_bindings[:limit]]
+
+    def workspace_runtime_binding_summary(
+        self,
+        workspace_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> dict[str, object]:
+        _ = workspace_id, include_deleted
+        by_kind: dict[str, int] = {}
+        by_status: dict[str, int] = {}
+        for row in self.runtime_bindings:
+            kind = str(row.get("binding_kind") or "")
+            status = str(row.get("status") or "")
+            by_kind[kind] = by_kind.get(kind, 0) + 1
+            by_status[status] = by_status.get(status, 0) + 1
+        return {
+            "total": len(self.runtime_bindings),
+            "by_kind": by_kind,
+            "by_status": by_status,
+        }
 
     def list_workspace_activity_events(
         self,
@@ -285,6 +309,101 @@ def test_workspace_index_api_groups_resources_activity_and_warnings() -> None:
     assert any(warning["reason_code"] == "runtime_binding_missing" for warning in body["warnings"])
     assert "/Users/alice" not in response.text
     assert "do not expose" not in response.text
+
+
+def test_workspace_index_scans_resource_warnings_beyond_preview_limit() -> None:
+    db = FakeWorkspaceIndexDB()
+    db.memberships.append(
+        {
+            "workspace_id": "workspace-1",
+            "resource_type": "chat",
+            "resource_id": "chat-missing",
+            "role": "conversation",
+            "label": "Missing chat",
+            "transfer_policy": "link",
+            "provenance": {},
+            "metadata": {},
+            "created_at": "2026-06-18T11:00:00Z",
+            "updated_at": "2026-06-18T11:00:00Z",
+            "version": 1,
+            "deleted": False,
+        }
+    )
+    app = FastAPI()
+    app.include_router(workspaces_endpoint.router, prefix="/api/v1/workspaces")
+
+    async def _allow_rate_limit() -> None:
+        return None
+
+    app.dependency_overrides[get_request_user] = lambda: SimpleNamespace(id="user-1", tenant_id="tenant-a")
+    app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    app.dependency_overrides[try_get_media_db_for_user] = lambda: None
+    app.dependency_overrides[try_get_prompts_db_for_user] = lambda: FakePromptsDB()
+    app.dependency_overrides[workspaces_endpoint.try_get_workflows_db_for_user] = lambda: None
+    app.dependency_overrides[try_get_watchlists_db_for_user] = lambda: None
+    app.dependency_overrides[WORKSPACES_READ_RATE_LIMIT] = _allow_rate_limit
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/api/v1/workspaces/workspace-1/index", params={"group_limit": "1"})
+
+    assert response.status_code == 200
+    body = response.json()
+    groups = {group["resource_type"]: group for group in body["resource_groups"]}
+    assert groups["chat"]["count"] == 2
+    assert [item["resource_id"] for item in groups["chat"]["items"]] == ["chat-1"]
+    assert any(
+        warning["reason_code"] == "resource_unresolved"
+        and warning["resource_id"] == "chat-missing"
+        for warning in body["warnings"]
+    )
+
+
+def test_workspace_index_runtime_summary_counts_beyond_binding_preview() -> None:
+    db = FakeWorkspaceIndexDB()
+    base = db.runtime_bindings[0]
+    db.runtime_bindings = [
+        {
+            **base,
+            "binding_id": f"repo-ready-{idx}",
+            "status": "ready",
+        }
+        for idx in range(50)
+    ] + [
+        {
+            **base,
+            "binding_id": f"repo-missing-{idx}",
+            "status": "missing",
+        }
+        for idx in range(10)
+    ]
+    app = FastAPI()
+    app.include_router(workspaces_endpoint.router, prefix="/api/v1/workspaces")
+
+    async def _allow_rate_limit() -> None:
+        return None
+
+    app.dependency_overrides[get_request_user] = lambda: SimpleNamespace(id="user-1", tenant_id="tenant-a")
+    app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    app.dependency_overrides[try_get_media_db_for_user] = lambda: None
+    app.dependency_overrides[try_get_prompts_db_for_user] = lambda: FakePromptsDB()
+    app.dependency_overrides[workspaces_endpoint.try_get_workflows_db_for_user] = lambda: None
+    app.dependency_overrides[try_get_watchlists_db_for_user] = lambda: None
+    app.dependency_overrides[WORKSPACES_READ_RATE_LIMIT] = _allow_rate_limit
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/api/v1/workspaces/workspace-1/index")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["runtime_summary"]["total"] == 60
+    assert body["runtime_summary"]["by_status"] == {"missing": 10, "ready": 50}
+    assert len(body["runtime_summary"]["bindings"]) == 50
+    assert all(binding["status"] == "ready" for binding in body["runtime_summary"]["bindings"])
+    assert any(
+        warning["reason_code"] == "runtime_binding_missing"
+        and warning["resource_id"] is None
+        for warning in body["warnings"]
+    )
 
 
 def test_workspace_index_api_returns_deleted_warning_for_soft_deleted_workspace(tmp_path) -> None:

--- a/tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py
@@ -62,6 +62,10 @@ def test_workspace_activity_events_are_timestamped_newest_first_and_safe(tmp_pat
     assert "api_key" not in rows[1]["metadata"]
     assert "/Users/alice" not in repr(rows)
     assert "sk-secret" not in repr(rows)
+    assert [
+        row["event_type"]
+        for row in db.list_workspace_activity_events("workspace-1", limit=10, category="runtime_binding")
+    ] == ["runtime_binding.upserted"]
 
 
 class FakeWorkspaceIndexDB:
@@ -120,7 +124,8 @@ class FakeWorkspaceIndexDB:
             },
         ]
 
-    def get_workspace(self, workspace_id: str) -> dict[str, object] | None:
+    def get_workspace(self, workspace_id: str, *, include_deleted: bool = False) -> dict[str, object] | None:
+        _ = include_deleted
         return self.workspaces.get(workspace_id)
 
     def get_conversation_for_workspace_membership(self, conversation_id: str) -> dict[str, object] | None:
@@ -280,3 +285,46 @@ def test_workspace_index_api_groups_resources_activity_and_warnings() -> None:
     assert any(warning["reason_code"] == "runtime_binding_missing" for warning in body["warnings"])
     assert "/Users/alice" not in response.text
     assert "do not expose" not in response.text
+
+
+def test_workspace_index_api_returns_deleted_warning_for_soft_deleted_workspace(tmp_path) -> None:
+    db = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="test-client")
+    try:
+        workspace = db.upsert_workspace("workspace-deleted", "Deleted Workspace")
+        db.record_workspace_activity_event(
+            "workspace-deleted",
+            {
+                "event_type": "workspace.deleted",
+                "category": "workspace",
+                "summary": "Deleted workspace",
+            },
+            user_id="user-1",
+        )
+        db.delete_workspace("workspace-deleted", expected_version=workspace["version"])
+        app = FastAPI()
+        app.include_router(workspaces_endpoint.router, prefix="/api/v1/workspaces")
+
+        async def _allow_rate_limit() -> None:
+            return None
+
+        app.dependency_overrides[get_request_user] = lambda: SimpleNamespace(id="user-1")
+        app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+        app.dependency_overrides[try_get_media_db_for_user] = lambda: None
+        app.dependency_overrides[try_get_prompts_db_for_user] = lambda: None
+        app.dependency_overrides[workspaces_endpoint.try_get_workflows_db_for_user] = lambda: None
+        app.dependency_overrides[try_get_watchlists_db_for_user] = lambda: None
+        app.dependency_overrides[WORKSPACES_READ_RATE_LIMIT] = _allow_rate_limit
+
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = client.get("/api/v1/workspaces/workspace-deleted/index")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["workspace"]["deleted"] in (True, 1)
+        assert body["membership_summary"] == {"total": 0, "by_resource_type": {}, "by_role": {}}
+        assert body["resource_groups"] == []
+        assert body["runtime_summary"] == {"total": 0, "by_kind": {}, "by_status": {}, "bindings": []}
+        assert body["recent_activity"][0]["event_type"] == "workspace.deleted"
+        assert any(warning["reason_code"] == "workspace_deleted" for warning in body["warnings"])
+    finally:
+        db.close_connection()

--- a/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
@@ -575,7 +575,8 @@ class FakeChaChaDB:
         data: dict[str, object],
         *,
         user_id: str | None = None,
-    ) -> dict[str, object]:
+        return_row: bool = True,
+    ) -> dict[str, object] | None:
         event = {
             "workspace_id": workspace_id,
             "actor_user_id": user_id,
@@ -585,6 +586,8 @@ class FakeChaChaDB:
             **dict(data),
         }
         self.activity_events.append(event)
+        if not return_row:
+            return None
         return dict(event)
 
 

--- a/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py
@@ -370,6 +370,7 @@ class FakeChaChaDB:
         self.memberships: dict[tuple[str, str, str], dict[str, object]] = {}
         self.last_add_data: dict[str, object] | None = None
         self.last_list_resource_key: tuple[str, str] | None = None
+        self.activity_events: list[dict[str, object]] = []
         self.list_workspace_calls = 0
         self.summary_calls = 0
         self._clock = 0
@@ -567,6 +568,24 @@ class FakeChaChaDB:
         row["updated_at"] = self._timestamp()
         row["version"] = int(row.get("version", 1)) + 1
         return dict(row)
+
+    def record_workspace_activity_event(
+        self,
+        workspace_id: str,
+        data: dict[str, object],
+        *,
+        user_id: str | None = None,
+    ) -> dict[str, object]:
+        event = {
+            "workspace_id": workspace_id,
+            "actor_user_id": user_id,
+            "created_at": self._timestamp(),
+            "event_id": f"event-{len(self.activity_events) + 1}",
+            "version": 1,
+            **dict(data),
+        }
+        self.activity_events.append(event)
+        return dict(event)
 
 
 def _membership_row(
@@ -1285,6 +1304,39 @@ def test_link_membership_idempotent_retry_does_not_invoke_reserved_on_link_hook(
     assert first_payload["resource_id"] == "42"
     assert retry_payload["resource_id"] == "42"
     assert adapter.linked == []
+    assert [event["event_type"] for event in db.activity_events] == ["membership.linked"]
+
+
+def test_link_membership_records_created_and_restored_activity_events() -> None:
+    db = FakeChaChaDB()
+    db.memberships[("workspace-1", "media", "41")] = _membership_row(resource_id="41", deleted=True)
+    adapter = RecordingAdapter()
+    service = WorkspaceMembershipService(db, adapters={"media": adapter})
+
+    service.link_membership(
+        "workspace-1",
+        {"resource_type": "media", "resource_id": "0042", "role": "source", "transfer_policy": "copy"},
+        user_id="user-1",
+        media_db=object(),
+    )
+    service.link_membership(
+        "workspace-1",
+        {"resource_type": "media", "resource_id": "0041", "role": "source"},
+        user_id="user-2",
+        media_db=object(),
+    )
+
+    assert [event["event_type"] for event in db.activity_events] == [
+        "membership.linked",
+        "membership.restored",
+    ]
+    linked, restored = db.activity_events
+    assert linked["resource_type"] == "media"
+    assert linked["resource_id"] == "42"
+    assert linked["metadata"] == {"role": "source", "transfer_policy": "copy"}
+    assert linked["actor_user_id"] == "user-1"
+    assert restored["resource_id"] == "41"
+    assert restored["actor_user_id"] == "user-2"
 
 
 def test_get_membership_returns_unresolved_summary_when_media_db_is_unavailable() -> None:
@@ -1335,6 +1387,10 @@ def test_unlink_membership_soft_deletes_active_membership_and_calls_adapter_hook
     assert payload["deleted"] is True
     assert db.memberships[("workspace-1", "media", "42")]["deleted"] is True
     assert adapter.unlinked == [db.memberships[("workspace-1", "media", "42")]]
+    assert [event["event_type"] for event in db.activity_events] == ["membership.unlinked"]
+    assert db.activity_events[0]["resource_type"] == "media"
+    assert db.activity_events[0]["resource_id"] == "42"
+    assert db.activity_events[0]["metadata"] == {"role": "source", "transfer_policy": "link"}
 
 
 def test_unlink_membership_noops_without_adapter_hook_for_missing_or_deleted_membership() -> None:

--- a/tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py
@@ -100,6 +100,14 @@ def test_workspace_runtime_binding_api_upserts_lists_gets_and_archives(
     assert [event["event_type"] for event in db.list_workspace_activity_events("ws-runtime", limit=5)] == [
         "runtime_binding.upserted"
     ]
+    repeated = workspace_client.post(
+        "/api/v1/workspaces/ws-runtime/runtime-bindings",
+        json=_descriptor_payload(),
+    )
+    assert repeated.status_code == 201
+    assert [event["event_type"] for event in db.list_workspace_activity_events("ws-runtime", limit=5)] == [
+        "runtime_binding.upserted"
+    ]
 
     listed = workspace_client.get(
         "/api/v1/workspaces/ws-runtime/runtime-bindings?binding_kind=acp_session"

--- a/tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py
@@ -97,6 +97,9 @@ def test_workspace_runtime_binding_api_upserts_lists_gets_and_archives(
         "path_hint",
     ]
     assert "absolute_root" not in created
+    assert [event["event_type"] for event in db.list_workspace_activity_events("ws-runtime", limit=5)] == [
+        "runtime_binding.upserted"
+    ]
 
     listed = workspace_client.get(
         "/api/v1/workspaces/ws-runtime/runtime-bindings?binding_kind=acp_session"
@@ -115,6 +118,18 @@ def test_workspace_runtime_binding_api_upserts_lists_gets_and_archives(
         "/api/v1/workspaces/ws-runtime/runtime-bindings/acp-session-1"
     )
     assert deleted.status_code == 204
+    events = db.list_workspace_activity_events("ws-runtime", limit=5)
+    assert [event["event_type"] for event in events] == [
+        "runtime_binding.archived",
+        "runtime_binding.upserted",
+    ]
+    assert events[0]["resource_type"] == "workspace_runtime_binding"
+    assert events[0]["resource_id"] == "acp-session-1"
+    assert events[0]["metadata"] == {
+        "binding_kind": "acp_session",
+        "owner_domain": "acp",
+        "status": "archived",
+    }
     assert (
         workspace_client.get(
             "/api/v1/workspaces/ws-runtime/runtime-bindings/acp-session-1"


### PR DESCRIPTION
## Summary
- Adds ChaChaNotes schema v50 `workspace_activity_events` storage plus record/list APIs with bounded metadata and secret/path redaction.
- Adds `GET /api/v1/workspaces/{workspace_id}/index` backed by a read-only WorkspaceActivityIndexService for grouped resource previews, membership totals, runtime summaries, warnings, and recent activity.
- Adds best-effort activity hooks for membership link/restore/unlink and runtime binding upsert/archive, plus frontend workspace-index TypeScript contract normalizers.
- Documents the #1994 index/activity contract as an inspection/navigation surface, not a duplicate owner-domain dashboard.

## Verification
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Workspaces/test_workspace_activity_index.py tldw_Server_API/tests/Workspaces/test_workspace_membership_adapters.py tldw_Server_API/tests/Workspaces/test_workspace_memberships_api.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings.py tldw_Server_API/tests/Workspaces/test_workspace_runtime_bindings_api.py -q` passed 138 tests.
- `./node_modules/.bin/vitest run src/services/workspace-index/__tests__/normalizers.test.ts --maxWorkers=1` passed 3 tests.
- `git diff --check` passed.
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/core/Workspaces/activity_index.py tldw_Server_API/app/core/Workspaces/membership_service.py tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/api/v1/schemas/workspace_schemas.py -f json -o /tmp/bandit_workspace_activity_index.json` completed with zero results.

## Merge Gate
- AI-authored PR: requester must add a human-owned `Change summary` before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

Closes #1994
Refs #1984
Refs TASK-2387

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only workspace activity index with durable, redacted activity event storage so clients can inspect resources, membership totals, runtime bindings, warnings, and recent activity without duplicating owner-domain UIs. Implements #1994 and satisfies TASK-2387; documentation updated to note review follow-ups.

- New Features
  - GET /api/v1/workspaces/{workspace_id}/index (schema_version: 1) returns workspace summary, membership totals, grouped resource previews with owner_surface.href, runtime summary (descriptor-only, redacted), warnings, recent activity, and partial_errors; supports group_limit (1–25), activity_limit (1–100), and per-group next_cursor.
  - Schema v50 adds workspace_activity_events with record_workspace_activity_event and list_workspace_activity_events; metadata is size-bounded and redacts secrets and absolute paths; DB auto-migrates to v50 on startup.
  - Best-effort activity hooks for membership.linked/restored/unlinked and runtime_binding.upserted/archived on write paths.
  - Frontend contract in apps/packages/ui/src/services/workspace-index: TypeScript types, normalizers, and a path builder that clamps query params; preserves server hrefs and unknown warning codes.

- Bug Fixes
  - Idempotent runtime-binding events: skip runtime_binding.upserted when the payload is unchanged; archive events recorded once.
  - Activity events ordered newest-first and sanitized per redaction rules.
  - Tighter index defaults and validation: stable handling for empty/partial payloads, consistent counts and ordering, and stricter clamping of query params.

<sup>Written for commit 7c839ad1837747216d55b0e53d732c4b0a543aa1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

