### PR TITLE
docs(acp): record live backend browser e2e closeout

### DIFF
--- a/IMPLEMENTATION_PLAN_acp_live_backend_browser_e2e_closeout_2404.md
+++ b/IMPLEMENTATION_PLAN_acp_live_backend_browser_e2e_closeout_2404.md
@@ -1,0 +1,25 @@
+# ACP Live Backend Browser E2E Closeout Plan
+
+## Stage 1: Establish Live Backend Baseline
+**Goal**: Start the API with a reproducible single-user test configuration and confirm ACP health endpoints respond with the seeded API key.
+**Success Criteria**: `/api/v1/health` and `/api/v1/acp/sessions` return successful responses against the live server.
+**Tests**: Local backend startup plus API smoke checks.
+**Status**: Complete
+
+## Stage 2: Reproduce Browser E2E Results
+**Goal**: Run the Tier 3 ACP browser specs against the live backend and record exact pass, fail, and skip behavior.
+**Success Criteria**: ACP Playground, Agent Registry, and Agent Tasks results are attributable to concrete server or runtime behavior.
+**Tests**: Playwright ACP Tier 3 specs with `TLDW_E2E_SERVER_URL` and `TLDW_E2E_API_KEY`.
+**Status**: Complete
+
+## Stage 3: Resolve E2E Setup Gap
+**Goal**: Use the product's bundled ACP runner home so the server and runner share the expected downstream agent registry.
+**Success Criteria**: The Research Workspace ACP history test creates a diagnostics-linked live ACP run instead of skipping on `unknown agent type`.
+**Tests**: Focused Playwright rerun for `binds a Research Workspace to a real ACP run history and diagnostics path`.
+**Status**: Complete
+
+## Stage 4: Verify and Publish Evidence
+**Goal**: Clean local artifacts, run relevant verification, and update the Backlog and GitHub tracker with command/output evidence.
+**Success Criteria**: `TASK-2388`, `#2404`, and parent `#2398` show the final state and exact verification command.
+**Tests**: Final Playwright result, non-code Bandit rationale, and git status review.
+**Status**: Complete

--- a/backlog/tasks/task-2388 - ACP-release-caveat-live-backend-browser-E2E-closeout.md
+++ b/backlog/tasks/task-2388 - ACP-release-caveat-live-backend-browser-E2E-closeout.md
@@ -1,0 +1,61 @@
+---
+id: TASK-2388
+title: ACP release caveat live-backend browser E2E closeout
+status: Done
+labels:
+- ACP
+- release-caveat
+- E2E
+references:
+- https://github.com/rmusser01/tldw_server/issues/2404
+- https://github.com/rmusser01/tldw_server/issues/2398
+- https://github.com/rmusser01/tldw_server/pull/2405
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track GitHub issue #2404: run and document the final live-backend ACP browser E2E gate against a seeded backend/API key so release claims are backed by real server behavior, not only mocked UI coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Live backend E2E command is reproducible from recorded evidence.
+- [x] #2 Results distinguish pass, skip, and external-runtime blocker.
+- [x] #3 ACP Playground, Agent Registry, and Agent Tasks are covered or explicitly scoped out with rationale.
+- [x] #4 Parent issue #2398 and child issue #2404 are updated with evidence and final status.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Live backend command setup:
+
+- Started the API in single-user mode with `SINGLE_USER_API_KEY=test-api-key-12345`, test DB/output paths under `/private/tmp`, `TLDW_ACP_HOST_HOME=/Users/macbook-dev`, and `GOCACHE=/tmp/tldw-acp-go-cache`.
+- Important runner setup detail: do not override `ACP_RUNNER_ENV` for this gate. The product default `runner_env = HOME=./acp_runner_home,PYTHONUNBUFFERED=1` resolves to the bundled runner home at `tldw_Server_API/Config_Files/acp_runner_home`, which contains the downstream `opencode`, `goose`, and `hermes` runner profiles.
+
+Evidence:
+
+- API smoke checks passed: `/api/v1/health` returned `status: ok`; `/api/v1/acp/sessions` returned `200` with an empty list before the browser run.
+- Initial misconfigured run with `ACP_RUNNER_ENV=HOME=/Users/macbook-dev,...` produced `19 passed, 1 skipped`. The focused JSON rerun showed the skip reason: `Dispatch did not create a diagnostics-linked ACP run; dispatch status was HTTP 502`. Backend logs showed `ACPResponseError: unknown agent type: opencode`, proving the server registry and runner registry had diverged due to the env override.
+- Corrected run without `ACP_RUNNER_ENV` showed `/api/v1/acp/agents` reporting `opencode`, `goose`, and `hermes` as configured.
+- Focused rerun passed: `binds a Research Workspace to a real ACP run history and diagnostics path` -> `1 passed (18.0s)`.
+- Final full run passed: `20 passed (29.6s)`.
+- GitHub evidence posted to #2404 at https://github.com/rmusser01/tldw_server/issues/2404#issuecomment-4748491132; #2404 was closed as completed. Parent #2398 was updated at https://github.com/rmusser01/tldw_server/issues/2398#issuecomment-4748493270. Evidence-only PR: https://github.com/rmusser01/tldw_server/pull/2405.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed the ACP live-backend browser E2E closeout for GitHub #2404. The reproducible command uses the product's bundled ACP runner home rather than a host HOME override. Final verification: `env TLDW_E2E_SERVER_URL=http://127.0.0.1:8000 TLDW_E2E_API_KEY=test-api-key-12345 TLDW_WEB_URL=http://localhost:18080 TLDW_WEB_CMD='bun run dev -- -p 18080' TLDW_E2E_ACP_WORKSPACE_ROOT_BASE=/private/tmp npx playwright test e2e/workflows/tier-3-automation/acp-playground.spec.ts e2e/workflows/tier-3-automation/agent-registry.spec.ts e2e/workflows/tier-3-automation/agent-tasks.spec.ts --project=tier-3 --reporter=line --workers=1` -> `20 passed (29.6s)`. No Python/application code changed; Bandit is not applicable for this evidence-only closeout.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Records the ACP live-backend browser E2E closeout plan and Backlog task for #2404 under parent #2398.
- Captures the corrected runner setup: use the bundled `Config_Files/acp_runner_home` via the default `runner_env = HOME=./acp_runner_home,PYTHONUNBUFFERED=1`; do not override `ACP_RUNNER_ENV` for this gate.
- Documents the initial misconfigured skip, the root cause (`unknown agent type: opencode` from runner-home divergence), and the final clean run.

## Verification
- `env TLDW_E2E_SERVER_URL=http://127.0.0.1:8000 TLDW_E2E_API_KEY=test-api-key-12345 TLDW_WEB_URL=http://localhost:18080 TLDW_WEB_CMD='bun run dev -- -p 18080' TLDW_E2E_ACP_WORKSPACE_ROOT_BASE=/private/tmp npx playwright test e2e/workflows/tier-3-automation/acp-playground.spec.ts e2e/workflows/tier-3-automation/agent-registry.spec.ts e2e/workflows/tier-3-automation/agent-tasks.spec.ts --project=tier-3 --reporter=line --workers=1` -> `20 passed (29.6s)`
- Focused Research Workspace ACP diagnostics path rerun -> `1 passed (18.0s)`
- `git diff --cached --check`

## Change Summary
Human-authored change summary required before merge per repo policy. This PR is evidence-only and does not change application behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the ACP live-backend browser E2E closeout for #2404 (parent #2398) with an implementation plan and backlog task (`TASK-2388`).
Records the fixed runner setup (use bundled `Config_Files/acp_runner_home` via default `runner_env`; do not set `ACP_RUNNER_ENV`), the initial skip cause (`unknown agent type: opencode`), and the final passing run (20 passed).

<sup>Written for commit 1651ad54bb7a988536fb8a2a439a619bc89e9a6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

