### PR TITLE
docs(acp): record go runner verification refresh

### DIFF
--- a/IMPLEMENTATION_PLAN_acp_go_runner_verification_refresh_2403.md
+++ b/IMPLEMENTATION_PLAN_acp_go_runner_verification_refresh_2403.md
@@ -1,0 +1,19 @@
+# ACP Go Runner Verification Refresh Plan
+
+## Stage 1: Inspect Runner Verification Surface
+**Goal**: Confirm the expected `tools/tldw-agent` verification commands, host prerequisites, and current dev commit.
+**Success Criteria**: Verification commands are identified before execution and toolchain/OS context is captured.
+**Tests**: Read `tools/tldw-agent/scripts/verify-local-build.sh`, `go version`, and current commit metadata.
+**Status**: Complete
+
+## Stage 2: Run Go Runner Build And Test Gates
+**Goal**: Execute the runner build/test verification on current dev with local cache paths that are safe in this environment.
+**Success Criteria**: Host and ACP binaries build, and Go tests either pass or produce classified failures.
+**Tests**: `tools/tldw-agent/scripts/verify-local-build.sh` and focused/full `go test` as needed.
+**Status**: Complete
+
+## Stage 3: Classify Results And Update Trackers
+**Goal**: Record command evidence, failure classification if any, and final status on `TASK-2389`, #2403, and parent #2398.
+**Success Criteria**: The GitHub child issue and parent tracker contain reproducible evidence and final status.
+**Tests**: Backlog/issue evidence review and final git status.
+**Status**: Complete

--- a/backlog/tasks/task-2389 - ACP-release-caveat-Go-runner-verification-refresh.md
+++ b/backlog/tasks/task-2389 - ACP-release-caveat-Go-runner-verification-refresh.md
@@ -1,0 +1,67 @@
+---
+id: TASK-2389
+title: ACP release caveat Go runner verification refresh
+status: Done
+labels:
+- ACP
+- release-caveat
+- go-runner
+- verification
+references:
+- https://github.com/rmusser01/tldw_server/issues/2403
+- https://github.com/rmusser01/tldw_server/issues/2398
+- https://github.com/rmusser01/tldw_server/pull/2407
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track GitHub issue #2403: refresh `tools/tldw-agent` Go runner build/test evidence on current dev before release notes claim ACP runner readiness.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 `tools/tldw-agent` build and test evidence is attached.
+- [x] #2 Any failures are classified as code regression, host prerequisite, or accepted release skip.
+- [x] #3 Parent #2398 is updated with the evidence link and final status.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Verification context:
+
+- Worktree branch: `codex/acp-go-runner-verification-refresh`.
+- Base commit: `1aa093ee7a752f1cad8c9e9d62a318b96a4dbec8` (`origin/dev`, merge commit for #2405).
+- Host: macOS 15.6 (`24G84`), darwin/arm64.
+- Toolchain: `go version go1.26.2 darwin/arm64`.
+
+Commands and results:
+
+- `./scripts/verify-local-build.sh` from `tools/tldw-agent` -> pass. The script built `./cmd/tldw-agent-host`, built `./cmd/tldw-agent-acp`, and ran `go test ./...`.
+- Explicit host binary build: `env GOCACHE=/tmp/tldw-acp-go-runner-refresh-cache go build -o /tmp/tldw-agent-host-2403 ./cmd/tldw-agent-host` -> pass.
+- Explicit ACP binary build: `env GOCACHE=/tmp/tldw-acp-go-runner-refresh-cache go build -o /tmp/tldw-agent-acp-2403 ./cmd/tldw-agent-acp` -> pass.
+- Explicit full test rerun: `env GOCACHE=/tmp/tldw-acp-go-runner-refresh-cache go test ./...` -> pass.
+
+Failure classification:
+
+- No failures observed. No code regression, host prerequisite blocker, or accepted release skip is required for this verification refresh.
+- No application/Python code changed; Bandit is not applicable for this evidence-only closeout.
+- GitHub evidence posted to #2403 at https://github.com/rmusser01/tldw_server/issues/2403#issuecomment-4752491179; #2403 was closed as completed. Parent #2398 was updated at https://github.com/rmusser01/tldw_server/issues/2398#issuecomment-4752517484. Evidence-only PR: https://github.com/rmusser01/tldw_server/pull/2407.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Go runner verification refreshed successfully for #2403 on current dev. `tools/tldw-agent/scripts/verify-local-build.sh` passed, explicit host and ACP binary builds passed, and `go test ./...` passed. No runner caveat or verification command changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Records the ACP Go runner verification refresh plan and Backlog task for #2403 under parent #2398.
- Captures host/toolchain context: macOS 15.6 (`24G84`), `go version go1.26.2 darwin/arm64`, commit `1aa093ee7a752f1cad8c9e9d62a318b96a4dbec8`.
- Documents passing build/test evidence and closes the release-caveat classification with no failures observed.

## Verification
- `cd tools/tldw-agent && ./scripts/verify-local-build.sh` -> pass
- `env GOCACHE=/tmp/tldw-acp-go-runner-refresh-cache go build -o /tmp/tldw-agent-host-2403 ./cmd/tldw-agent-host` -> pass
- `env GOCACHE=/tmp/tldw-acp-go-runner-refresh-cache go build -o /tmp/tldw-agent-acp-2403 ./cmd/tldw-agent-acp` -> pass
- `env GOCACHE=/tmp/tldw-acp-go-runner-refresh-cache go test ./...` -> pass
- `git diff --cached --check`

## Change Summary
Human-authored change summary required before merge per repo policy. This PR is evidence-only and does not change application behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records the ACP Go runner verification refresh on current dev with passing build/test evidence. Adds implementation plan and backlog task; no code or behavior changes.

- **Verification**
  - Added `IMPLEMENTATION_PLAN_acp_go_runner_verification_refresh_2403.md` and `backlog/tasks/task-2389 - ACP-release-caveat-Go-runner-verification-refresh.md`.
  - Passed all `tools/tldw-agent` build/test commands (`scripts/verify-local-build.sh`, host and ACP `go build`, `go test ./...`).
  - Posted evidence to #2403 and parent #2398; no failures observed.

<sup>Written for commit fb17dae9021be3d7c8fc4ee6fdc7c05b9cde6310. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

