### PR TITLE
Document ACP sandbox host runtime evidence

### DIFF
--- a/Docs/Development/ACP_Certification_Checklist.md
+++ b/Docs/Development/ACP_Certification_Checklist.md
@@ -218,6 +218,9 @@ retention/redaction boundaries are summarized in
 Run this only when a support claim includes sandbox behavior:
 
 - Record sandbox runtime (`docker`, `lima`, `vz`, or other configured backend).
+- Link release-host runtime evidence when the claim depends on generic runtime
+  support. The current Docker evidence is recorded in
+  [ACP Sandbox Host Runtime Verification - 2026-06-19](ACP_Sandbox_Host_Runtime_Verification_2026_06_19.md).
 - Confirm missing runtime/configuration fails closed with actionable setup
   guidance.
 - Confirm workspace bind/mount behavior, cwd, env, and network policy.
@@ -225,7 +228,10 @@ Run this only when a support claim includes sandbox behavior:
   from downstream-agent protocol errors.
 
 Sandbox evidence can be separate from host live E2E evidence. A host-supported
-agent is not sandbox-supported until these checks pass.
+agent is not sandbox-supported until these checks pass. A generic Docker
+lifecycle pass does not promote any named agent to `sandbox_tested`; use
+`workspace-live-e2e` with `ACP_E2E_EXPECT_SANDBOX=1` for agent-specific sandbox
+claims.
 
 ## Evidence Record
 

--- a/Docs/Development/ACP_Production_Readiness.md
+++ b/Docs/Development/ACP_Production_Readiness.md
@@ -33,6 +33,7 @@ verified production deployment on a specific host.
 | [#1532](https://github.com/rmusser01/tldw_server/issues/1532) | ACP-adjacent release work tracker | Tracks artifact storage/API, promotion, UI, export, verification, compatibility, and product-state follow-ups after the first ACP productionization pass. |
 | [#1704](https://github.com/rmusser01/tldw_server/issues/1704) | ACP artifact release verification | Records release-grade verification for the first accepted ACP-to-workspace-artifact golden path. |
 | [#2401](https://github.com/rmusser01/tldw_server/issues/2401) | Artifact retention and transcript redaction release policy | Makes the release retention/redaction boundaries explicit for ACP session evidence, audit records, diagnostics, artifacts, run previews, and promoted workspace artifacts. |
+| [#2400](https://github.com/rmusser01/tldw_server/issues/2400) | Sandbox host-runtime release verification | Records release-host evidence for selected ACP sandbox runtimes before sandbox-backed support claims are made. |
 
 Recommended order: seed #1472, then complete #1479, #1478, #1476, #1475,
 #1477, #1474, #1473, #1480, and finally close #1472. ACP maturity
@@ -42,6 +43,20 @@ claims, with [#2401](https://github.com/rmusser01/tldw_server/issues/2401)
 capturing the release retention/redaction policy and
 [#1529](https://github.com/rmusser01/tldw_server/issues/1529) capturing
 admin/deployment posture.
+
+## Sandbox Host-Runtime Evidence
+
+[#2400](https://github.com/rmusser01/tldw_server/issues/2400) selected Docker
+as the only runtime with current release-host pass evidence. See
+[ACP Sandbox Host Runtime Verification - 2026-06-19](ACP_Sandbox_Host_Runtime_Verification_2026_06_19.md)
+for the recorded host OS, Docker version, commands, commit, results, and
+cleanup probes.
+
+Release surfaces may say the Docker-backed ACP sandbox runtime lifecycle was
+verified on that macOS/Docker Desktop host. They must not claim Lima, VZ, or
+all-runtimes sandbox support from this evidence. Named downstream-agent rows
+also remain `sandbox=skip` until the agent has its own sandbox run, preferably
+`workspace-live-e2e` with `ACP_E2E_EXPECT_SANDBOX=1`.
 
 ## Readiness Matrix
 
@@ -182,11 +197,13 @@ python -m bandit -r <touched_python_paths> -f json -o /tmp/bandit_acp_<task>.jso
 ## Optional Runtime Caveats
 
 - Docker sandbox verification requires the ACP sandbox dependencies and a local
-  Docker runtime. If Docker is unavailable, mark the Docker row blocked or
+  Docker runtime. The current release-host Docker pass evidence is recorded in
+  [ACP Sandbox Host Runtime Verification - 2026-06-19](ACP_Sandbox_Host_Runtime_Verification_2026_06_19.md).
+  If Docker is unavailable on another host, mark the Docker row blocked or
   skipped with host evidence instead of marking it passed.
 - Lima and Apple Virtualization Framework coverage is host-specific. These can
   be optional rows unless one of them is selected as the default production
-  runtime.
+  runtime. They remain unverified in the current #2400 release-host evidence.
 - Workspace creation and dispatch require `ACP-WORKSPACE.allowed_base_paths` or
   `ACP_WORKSPACE_ALLOWED_BASE_PATHS`. A missing allowlist is a configuration
   failure, not an implicit permission to run anywhere on the host.

--- a/Docs/Development/ACP_Sandbox_Host_Runtime_Verification_2026_06_19.md
+++ b/Docs/Development/ACP_Sandbox_Host_Runtime_Verification_2026_06_19.md
@@ -1,0 +1,142 @@
+# ACP Sandbox Host Runtime Verification - 2026-06-19
+
+This records release-host evidence for
+[#2400](https://github.com/rmusser01/tldw_server/issues/2400) under parent
+[#2398](https://github.com/rmusser01/tldw_server/issues/2398).
+
+## Release Decision
+
+Docker is the only sandbox runtime selected for this release-host evidence. The
+Docker-backed sandbox service lifecycle has explicit pass evidence on the host
+below. Lima and Apple Virtualization Framework runtimes remain untested for this
+release and must stay caveated in setup, compatibility, and release surfaces.
+
+This evidence is a core sandbox runtime check, not a named downstream-agent ACP
+certification. Do not mark a named agent as sandbox-supported unless that agent
+also has an agent-specific `workspace-live-e2e` run with sandbox expectations
+enabled, such as `ACP_E2E_EXPECT_SANDBOX=1`.
+
+Allowed release wording:
+
+- Docker-backed ACP sandbox runtime lifecycle was verified on the recorded
+  macOS/Docker Desktop host.
+- Named downstream-agent rows can keep `sandbox=skip` until their own sandbox
+  run passes.
+
+Disallowed release wording:
+
+- ACP sandbox support is verified for Lima, VZ, or all runtimes.
+- A named downstream agent is sandbox-supported because the generic Docker
+  lifecycle test passed.
+
+## Host And Commit
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-06-19 |
+| Host OS | macOS 15.6, build 24G84 |
+| Host architecture | arm64 |
+| Repo commit | `7d7fc4f3908c92fcd7b7ffde10b0a8bff3221c3a` |
+| Worktree | `.worktrees/acp-sandbox-host-runtime-verification` |
+
+## Runtime Inventory
+
+| Runtime | Result | Evidence |
+| --- | --- | --- |
+| Docker | Pass for core sandbox lifecycle | Docker Desktop 4.59.1, Docker Engine 29.2.0, API 1.53, server OS/arch `linux/arm64`, client OS/arch `darwin/arm64`, context `desktop-linux`. |
+| Lima | Not selected; untested | `limactl --version` exited 127 with `zsh:1: command not found: limactl`. |
+| Apple Virtualization Framework / VZ Linux or macOS | Not selected; untested | No VZ helper/template lifecycle was run for this release evidence. Existing unit/fail-closed coverage remains useful, but it is not release-host pass evidence. |
+
+The Docker image `python:3.11-slim` was already available locally
+(`sha256:a3ab0b966bc4e91546a033e22093cb840908979487a9fc0e6e38295747e49ac0`),
+so the live Docker run did not require an image pull.
+
+## Commands And Results
+
+Host/runtime probes:
+
+```bash
+sw_vers
+# ProductName: macOS
+# ProductVersion: 15.6
+# BuildVersion: 24G84
+
+uname -m
+# arm64
+
+docker version
+# Client: Docker 29.2.0, darwin/arm64, context desktop-linux
+# Server: Docker Desktop 4.59.1, Engine 29.2.0, linux/arm64
+
+limactl --version
+# zsh:1: command not found: limactl
+```
+
+Live Docker sandbox lifecycle:
+
+```bash
+source .venv/bin/activate
+SANDBOX_ENABLE_EXECUTION=1 python -m pytest \
+  tldw_Server_API/tests/sandbox/test_docker_runner_integration.py \
+  -q -m sandbox_real_docker
+```
+
+Result: `1 passed, 3 warnings in 13.82s`.
+
+The passing test created a Docker sandbox session, uploaded an inline Python
+script into the workspace, started a run in `python:3.11-slim`, observed exit
+code 0, checked artifact listing, and asserted no run-owned container or
+network remained after completion.
+
+Workspace allowlist, ACP sandbox policy, and runner coverage:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Agent_Orchestration/test_workspace_api_helpers.py \
+  -q
+
+python -m pytest \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_acp_runtime_policy_service.py \
+  tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py \
+  -q
+```
+
+Workspace allowlist result: `17 passed, 6 warnings in 2.23s`.
+
+Result: `33 passed, 8 warnings in 2.75s`.
+
+The workspace helper coverage explicitly checked allowed base path enforcement,
+empty allowlist rejection, relative cwd containment inside a workspace root, and
+absolute cwd override rejection. The ACP sandbox coverage checked
+workspace/runtime policy fail-closed behavior, default sandbox network policy,
+runtime availability rejection for unselected runtimes, configured plus
+per-session env merging through `ACP_AGENT_ENV_JSON`, session control metadata,
+and stream-backed sandbox session paths.
+
+Post-run cleanup probes:
+
+```bash
+docker ps -a --filter label=tldw_run_id -q
+# no output
+
+docker network ls --filter name=tldw_sbx -q
+# no output
+```
+
+Docker socket access required running Docker commands outside the managed Codex
+command sandbox. The runtime evidence therefore depends on host Docker Desktop
+access, not only on the repository test harness.
+
+## Remaining Caveats
+
+- Lima remains `host_runtime_missing` / `sandbox_unverified` until `limactl` is
+  installed and a Lima sandbox lifecycle run passes.
+- VZ Linux/macOS remains `sandbox_unverified` until the helper, image/template,
+  session lifecycle, and cleanup path pass on the target macOS host.
+- Named agents remain `sandbox=skip` unless their compatibility row links
+  agent-specific sandbox evidence. Use `workspace-live-e2e` with
+  `ACP_E2E_EXPECT_SANDBOX=1` when promoting a named agent to `sandbox_tested`.
+- The Docker lifecycle run verifies runtime/session/artifact/cleanup behavior.
+  It does not prove provider auth, downstream ACP protocol behavior, MCP
+  injection, reviewer-loop behavior, or artifact-producing agent workflows.

--- a/Docs/Development/Agent_Client_Protocol.md
+++ b/Docs/Development/Agent_Client_Protocol.md
@@ -671,6 +671,11 @@ SANDBOX_DOCKER_BIND_WORKSPACE=1
 - Docker, Lima, and VZ runtimes depend on host prerequisites. If the selected
   runtime is unavailable or not opted in, session creation should fail before
   launching the downstream agent with an operator-facing runtime reason code.
+- The current release-host runtime evidence verifies Docker sandbox lifecycle
+  behavior only. See
+  [ACP Sandbox Host Runtime Verification - 2026-06-19](ACP_Sandbox_Host_Runtime_Verification_2026_06_19.md).
+  Lima, VZ, and named downstream-agent sandbox support remain caveated until
+  runtime-specific or agent-specific sandbox evidence is recorded.
 - Sandbox mode ignores host `cwd` and uses `/workspace` inside the runtime.
   Workspace setup guidance should make the bind/mount requirement explicit for
   the selected backend.

--- a/Docs/User_Guides/Integrations_Experiments/Getting_Started_with_ACP.md
+++ b/Docs/User_Guides/Integrations_Experiments/Getting_Started_with_ACP.md
@@ -87,6 +87,13 @@ pip install -e ".[acp]"
 
 ### Optional: Sandbox Mode (Run ACP in Containers)
 
+Current release evidence verifies the Docker sandbox runtime lifecycle on one
+macOS/Docker Desktop host. Lima and Apple Virtualization Framework are not
+certified by that evidence, and named downstream agents still need their own
+sandbox run before their compatibility row can claim sandbox support. See
+[ACP Sandbox Host Runtime Verification - 2026-06-19](../../Development/ACP_Sandbox_Host_Runtime_Verification_2026_06_19.md)
+for the exact host, runtime, commands, and caveats.
+
 To run the ACP agent inside a sandbox container and access it via web SSH:
 
 1. Build the ACP image:

--- a/IMPLEMENTATION_PLAN_acp_sandbox_host_runtime_verification_2400.md
+++ b/IMPLEMENTATION_PLAN_acp_sandbox_host_runtime_verification_2400.md
@@ -1,0 +1,23 @@
+## Stage 1: Host Runtime Evidence
+**Goal**: Record the release host, available sandbox runtime tools, and why a runtime can or cannot be selected for ACP sandbox support.
+**Success Criteria**: Docker, Lima, and macOS virtualization availability are checked with exact commands and results.
+**Tests**: Host/runtime probe commands and targeted read review of existing sandbox runtime docs/tests.
+**Status**: Complete
+
+## Stage 2: Release Posture
+**Goal**: Decide whether this release has a passing sandbox-backed ACP runtime claim or explicitly declines that claim.
+**Success Criteria**: Documentation states the selected posture and keeps untested runtimes caveated.
+**Tests**: Read review of ACP readiness, compatibility, certification, and user setup docs.
+**Status**: Complete
+
+## Stage 3: Documentation Updates
+**Goal**: Add a durable #2400 evidence artifact and connect it from the ACP readiness and setup surfaces.
+**Success Criteria**: Evidence includes host OS, runtime versions or absence, command, commit, result, and remaining next steps.
+**Tests**: `git diff --check` and targeted doc grep/read review.
+**Status**: Complete
+
+## Stage 4: Verification and Handoff
+**Goal**: Verify touched docs and relevant fail-closed tests, then open the PR against `dev`.
+**Success Criteria**: Verification output is recorded in Backlog and PR notes; #2400 and parent #2398 are linked.
+**Tests**: Targeted pytest for ACP runtime policy/sandbox runner behavior when feasible, plus docs checks.
+**Status**: Complete

--- a/backlog/tasks/task-2391 - ACP-release-caveat-sandbox-host-runtime-verification.md
+++ b/backlog/tasks/task-2391 - ACP-release-caveat-sandbox-host-runtime-verification.md
@@ -1,0 +1,64 @@
+---
+id: TASK-2391
+title: ACP release caveat sandbox host-runtime verification
+status: In Progress
+labels:
+- ACP
+- release-caveat
+- sandbox
+- verification
+references:
+- https://github.com/rmusser01/tldw_server/issues/2400
+- https://github.com/rmusser01/tldw_server/issues/2398
+modified_files:
+- Docs/Development/ACP_Sandbox_Host_Runtime_Verification_2026_06_19.md
+- Docs/Development/ACP_Production_Readiness.md
+- Docs/Development/Agent_Client_Protocol.md
+- Docs/Development/ACP_Certification_Checklist.md
+- Docs/User_Guides/Integrations_Experiments/Getting_Started_with_ACP.md
+- IMPLEMENTATION_PLAN_acp_sandbox_host_runtime_verification_2400.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track GitHub issue #2400: resolve or explicitly accept the ACP sandbox host-runtime release caveat by verifying a selected host runtime or documenting that sandbox support is not claimed for this release.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+IMPLEMENTATION_PLAN_acp_sandbox_host_runtime_verification_2400.md
+
+Stages:
+1. Host runtime evidence: record macOS host details and Docker/Lima/macOS virtualization availability.
+2. Release posture: select verified runtime support or explicitly decline sandbox-backed ACP support for this release host.
+3. Documentation updates: add durable #2400 evidence and link it from ACP readiness/setup surfaces.
+4. Verification and handoff: run doc checks and targeted ACP sandbox fail-closed tests where feasible.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added durable ACP sandbox host-runtime verification evidence for #2400. Docker-backed sandbox lifecycle passed on the recorded macOS/Docker Desktop host; Lima and VZ remain unverified; named downstream-agent sandbox support remains gated on agent-specific workspace-live-e2e evidence with ACP_E2E_EXPECT_SANDBOX=1. Verification: Docker lifecycle pytest 1 passed; workspace allowlist helper pytest 17 passed; ACP runtime policy/sandbox runner pytest 33 passed; docker cleanup probes returned no tldw containers/networks; git diff --check passed. PR: https://github.com/rmusser01/tldw_server/pull/2410. Parent #2398 comment: https://github.com/rmusser01/tldw_server/issues/2398#issuecomment-4753238301.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary

This closes the ACP sandbox host-runtime release caveat by recording Docker as the only runtime with current release-host pass evidence. The new evidence doc captures the host OS, Docker version, Lima absence, commit, commands, results, cleanup probes, and the remaining caveats for Lima, VZ, and named downstream agents.

The docs now make the support boundary explicit: Docker-backed sandbox runtime lifecycle evidence is available for the recorded macOS/Docker Desktop host, but this does not promote any named downstream ACP agent to sandbox-supported. Agent-specific sandbox claims still require a `workspace-live-e2e` run with `ACP_E2E_EXPECT_SANDBOX=1`.

## Updated surfaces

- Added `Docs/Development/ACP_Sandbox_Host_Runtime_Verification_2026_06_19.md`.
- Linked #2400 evidence from the ACP production readiness matrix.
- Updated the ACP operator guide, certification checklist, and user setup guide to preserve Lima/VZ and per-agent caveats.
- Added Backlog task `TASK-2391` and a scoped implementation plan.

## Verification

- `docker version`
  - Docker Desktop 4.59.1, Docker Engine 29.2.0, API 1.53, server `linux/arm64`, client `darwin/arm64`.
- `limactl --version`
  - exited 127: `zsh:1: command not found: limactl`.
- `source .venv/bin/activate && SANDBOX_ENABLE_EXECUTION=1 python -m pytest tldw_Server_API/tests/sandbox/test_docker_runner_integration.py -q -m sandbox_real_docker`
  - `1 passed, 3 warnings in 13.82s`.
- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Agent_Orchestration/test_workspace_api_helpers.py -q`
  - `17 passed, 6 warnings in 2.23s`.
- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_acp_runtime_policy_service.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py -q`
  - `33 passed, 8 warnings in 2.75s`.
- Docker cleanup probes:
  - `docker ps -a --filter label=tldw_run_id -q`: no output.
  - `docker network ls --filter name=tldw_sbx -q`: no output.
- `git diff --check`
  - passed.

Bandit was not run because this branch changes docs/tracking only.

Closes #2400.
Refs #2398.
