### PR TITLE
Add VZ smoke evidence env handoff

### DIFF
--- a/Docs/superpowers/plans/2026-06-19-vz-smoke-evidence-bundle-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-19-vz-smoke-evidence-bundle-implementation-plan.md
@@ -1,0 +1,144 @@
+# VZ Smoke Evidence Bundle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the host-side VZ Linux smoke wrapper emit the canonical evidence bundle consumed by sandbox operator status.
+
+**Architecture:** Keep evidence generation inside `run-host-e2e-smoke.sh` so the same command that proves host execution also produces operator-consumable diagnostics. The wrapper records bounded phase metadata, expected sidecar files, runtime paths, bundle hashes, cleanup state, and a final server env export without requiring the API server to scrape logs or accept request-supplied paths.
+
+**Tech Stack:** Bash smoke wrapper, Python/pytest shell-level tests, existing sandbox operator evidence JSON contract.
+
+**Baseline discovery:** Current `dev` already includes default evidence directory handling, expected sidecars, JSON evidence generation, private directory checks, and failure-preserving cleanup evidence. This slice is therefore narrowed to the missing operator handoff contract: make the wrapper print a sourceable `TLDW_SANDBOX_VZ_EVIDENCE_DIR` export and document how to use it.
+
+---
+
+### Task 1: Add Evidence Bundle Tests
+
+**Files:**
+- Modify: `tools/vz-linux-image/tests/test_host_e2e_smoke_script.py`
+
+- [x] **Step 1: Write dry-run option coverage**
+
+Add a test that runs `run-host-e2e-smoke.sh --dry-run --evidence-dir <path>` and asserts:
+- help mentions `--evidence-dir PATH`
+- dry-run output includes `TLDW_SANDBOX_VZ_EVIDENCE_DIR=<path>`
+- dry-run does not create the evidence directory
+
+- [x] **Step 2: Write fake-run success evidence coverage**
+
+Add a test with fake helper and fake pytest runner that completes successfully and asserts:
+- `<evidence_dir>/host-smoke-evidence.json` exists
+- JSON includes `schema_version=1`, `final_exit_code=0`, `evidence_dir`, runtime paths, skip flags, and phase statuses
+- expected sidecars exist: `source-bundle-hashes-before.txt`, `source-bundle-hashes-after.txt`, `run-bundle-hashes.txt`, `runtime-paths.txt`, `cleanup-status.txt`
+
+- [x] **Step 3: Write fake-run failure evidence coverage**
+
+Add a test where fake pytest fails one phase and asserts:
+- wrapper exits non-zero
+- `host-smoke-evidence.json` still exists
+- `final_exit_code` is non-zero
+- failed phase is recorded with non-zero `exit_code`
+- cleanup sidecar is still written
+
+- [x] **Step 4: Run tests and verify RED**
+
+Run:
+
+```bash
+source ../../.venv/bin/activate && python -m pytest tools/vz-linux-image/tests/test_host_e2e_smoke_script.py -q --tb=short
+```
+
+Result: focused tests failed on the missing `export TLDW_SANDBOX_VZ_EVIDENCE_DIR=...` line in dry-run and real-run output; existing bundle emission coverage was already present.
+
+### Task 2: Implement Wrapper Evidence Emission
+
+**Files:**
+- Modify: `tools/vz-linux-image/scripts/run-host-e2e-smoke.sh`
+
+- [x] **Step 1: Add option and defaults**
+
+Add:
+- `EVIDENCE_DIR="${DEFAULT_RUNTIME_DIR}/evidence"`
+- `--evidence-dir PATH`
+- usage text documenting that the path should be private if reused across runs
+
+- [x] **Step 2: Add phase runner helper**
+
+Replace direct phase calls with a helper that:
+- prints/runs the command
+- captures exit code without aborting immediately
+- records `status`, `exit_code`, and UTC timestamp in shell variables
+- preserves existing command output behavior
+
+- [x] **Step 3: Add evidence directory preparation**
+
+For real runs:
+- reject symlink evidence dirs
+- reject non-directory existing paths
+- create missing dir as `0700`
+- require owner-private permissions
+
+For dry-run:
+- print intended `TLDW_SANDBOX_VZ_EVIDENCE_DIR` without creating directories
+
+- [x] **Step 4: Write sidecars and JSON**
+
+At cleanup/finalization:
+- write bundle hashes before/after using portable `shasum -a 256` or `sha256sum`
+- write run-bundle hashes against the same bundle path for this slice
+- write runtime path and cleanup status sidecars
+- write `host-smoke-evidence.json` with bounded JSON fields using Python from `PYTHON_BIN`
+- print `export TLDW_SANDBOX_VZ_EVIDENCE_DIR=<path>` after writing evidence
+
+- [x] **Step 5: Preserve failure semantics**
+
+Ensure the wrapper:
+- still exits non-zero when a phase fails
+- still attempts helper cleanup
+- still writes evidence on failed phases
+- does not delete or mutate non-socket socket paths
+
+### Task 3: Document Operator Wiring
+
+**Files:**
+- Modify: `tools/vz-linux-image/README.md`
+
+- [x] **Step 1: Update Helper Smoke section**
+
+Document:
+- default evidence path under the runtime dir
+- optional `--evidence-dir PATH`
+- the printed `export TLDW_SANDBOX_VZ_EVIDENCE_DIR=...`
+- starting/restarting the API server with that env var to show evidence in operator status
+
+- [x] **Step 2: Keep docs copy/paste-safe**
+
+Preserve the existing `trap 'rm -rf "${runtime_dir}"' EXIT` cleanup pattern.
+
+### Task 4: Validate And Commit
+
+**Files:**
+- Modify: Backlog task `TASK-2393`
+
+- [ ] **Step 1: Run focused tests**
+
+```bash
+source ../../.venv/bin/activate && python -m pytest tools/vz-linux-image/tests/test_host_e2e_smoke_script.py -q --tb=short
+```
+
+- [ ] **Step 2: Run shell/static checks**
+
+```bash
+bash -n tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+git diff --check
+```
+
+- [ ] **Step 3: Run Bandit for touched Python tests if required**
+
+```bash
+source ../../.venv/bin/activate && python -m bandit -r tools/vz-linux-image/tests/test_host_e2e_smoke_script.py -f json -o /tmp/bandit_vz_smoke_evidence_bundle.json
+```
+
+- [ ] **Step 4: Update Backlog and commit**
+
+Record verification in `TASK-2393`, then commit the wrapper, tests, docs, plan, and task.

--- a/backlog/tasks/task-2393 - Emit-host-smoke-evidence-bundle-from-VZ-smoke-wrapper.md
+++ b/backlog/tasks/task-2393 - Emit-host-smoke-evidence-bundle-from-VZ-smoke-wrapper.md
@@ -1,0 +1,63 @@
+---
+id: TASK-2393
+title: Emit host smoke evidence bundle from VZ smoke wrapper
+status: Done
+labels:
+- sandbox
+- vz_linux
+- operator-ux
+- implementation
+modified_files:
+- Docs/superpowers/plans/2026-06-19-vz-smoke-evidence-bundle-implementation-plan.md
+- tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+- tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
+- tools/vz-linux-image/README.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the approved operator workflow closeout slice: make run-host-e2e-smoke.sh produce the canonical host smoke evidence bundle consumed by sandbox operator-status, expose an evidence-dir option/default, print server wiring guidance, update docs, and add portable tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] `run-host-e2e-smoke.sh --dry-run` prints the default evidence directory without creating it.
+- [x] `run-host-e2e-smoke.sh --dry-run --evidence-dir PATH` prints the override without creating it.
+- [x] The wrapper prints a sourceable `export TLDW_SANDBOX_VZ_EVIDENCE_DIR=...` handoff in dry-run plans.
+- [x] The wrapper prints the same handoff after successful real-run evidence finalization.
+- [x] Operator-facing docs explain how to use the printed env var with `operator-status`.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-19-vz-smoke-evidence-bundle-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Current `dev` already contained default evidence directory handling, expected sidecars, JSON evidence, private evidence directory checks, and failure-preserving cleanup evidence.
+- This slice was narrowed to the missing operator handoff contract: printing a sourceable `TLDW_SANDBOX_VZ_EVIDENCE_DIR` export in dry-run plans and after successful real-run evidence finalization.
+- Tests were added to assert help advertises `--evidence-dir PATH`, dry-run output includes the export for default and override paths, and real fake-helper runs print the export after writing evidence.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+- Added `print_evidence_env_hint()` to `run-host-e2e-smoke.sh` and call it from dry-run evidence planning and successful evidence finalization.
+- Updated host smoke wrapper tests for the env handoff contract.
+- Documented using the printed `TLDW_SANDBOX_VZ_EVIDENCE_DIR` value to surface local smoke evidence in `GET /api/v1/sandbox/admin/operator-status`.
+- Verification: focused wrapper tests passed (`25 passed, 3 skipped`), `bash -n` passed, `git diff --check` passed, and Bandit produced the same 122 findings as the `dev` baseline for the touched test file.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2393 - Emit-host-smoke-evidence-bundle-from-VZ-smoke-wrapper.md
+++ b/backlog/tasks/task-2393 - Emit-host-smoke-evidence-bundle-from-VZ-smoke-wrapper.md
@@ -41,6 +41,7 @@ Docs/superpowers/plans/2026-06-19-vz-smoke-evidence-bundle-implementation-plan.m
 - Current `dev` already contained default evidence directory handling, expected sidecars, JSON evidence, private evidence directory checks, and failure-preserving cleanup evidence.
 - This slice was narrowed to the missing operator handoff contract: printing a sourceable `TLDW_SANDBOX_VZ_EVIDENCE_DIR` export in dry-run plans and after successful real-run evidence finalization.
 - Tests were added to assert help advertises `--evidence-dir PATH`, dry-run output includes the export for default and override paths, and real fake-helper runs print the export after writing evidence.
+- PR review follow-up rebased the branch onto latest `origin/dev`, added a module-level `unit` pytest marker, hardened the shell export helper for `set -u`, and changed tests/docs to validate bash-escaped `%q` output instead of raw path substrings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -49,7 +50,7 @@ Docs/superpowers/plans/2026-06-19-vz-smoke-evidence-bundle-implementation-plan.m
 - Added `print_evidence_env_hint()` to `run-host-e2e-smoke.sh` and call it from dry-run evidence planning and successful evidence finalization.
 - Updated host smoke wrapper tests for the env handoff contract.
 - Documented using the printed `TLDW_SANDBOX_VZ_EVIDENCE_DIR` value to surface local smoke evidence in `GET /api/v1/sandbox/admin/operator-status`.
-- Verification: focused wrapper tests passed (`25 passed, 3 skipped`), `bash -n` passed, `git diff --check` passed, and Bandit produced the same 122 findings as the `dev` baseline for the touched test file.
+- Verification after PR review fixes: focused wrapper tests passed (`25 passed, 3 skipped`), `bash -n` passed, `git diff --check` passed, and Bandit produced the same 122 findings as the `origin/dev` baseline for the touched test file.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tools/vz-linux-image/README.md
+++ b/tools/vz-linux-image/README.md
@@ -213,6 +213,17 @@ bundle hashes separately from disposable run bundle hashes. A post-smoke change
 to the disposable run bundle is expected; a source bundle hash or mtime change
 is not.
 
+The wrapper prints a sourceable evidence handoff when planning or finishing a
+run:
+
+```bash
+export TLDW_SANDBOX_VZ_EVIDENCE_DIR=/path/to/runtime/evidence
+```
+
+Use that value when starting the API server if you want
+`GET /api/v1/sandbox/admin/operator-status` to include the latest local host
+smoke evidence.
+
 The helper refuses sockets whose parent directory is not owner-only. Do not put
 the helper socket directly under `/tmp`; use the script defaults or create a
 private `0700` runtime directory as shown above.

--- a/tools/vz-linux-image/README.md
+++ b/tools/vz-linux-image/README.md
@@ -213,14 +213,16 @@ bundle hashes separately from disposable run bundle hashes. A post-smoke change
 to the disposable run bundle is expected; a source bundle hash or mtime change
 is not.
 
-The wrapper prints a sourceable evidence handoff when planning or finishing a
-run:
+The wrapper prints a bash-sourceable evidence handoff when planning or finishing
+a run:
 
 ```bash
 export TLDW_SANDBOX_VZ_EVIDENCE_DIR=/path/to/runtime/evidence
 ```
 
-Use that value when starting the API server if you want
+Copy the printed line verbatim when paths contain spaces or shell-special
+characters; the value may be escaped for the current shell. Use that value when
+starting the API server if you want
 `GET /api/v1/sandbox/admin/operator-status` to include the latest local host
 smoke evidence.
 

--- a/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+++ b/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
@@ -413,6 +413,11 @@ print_evidence_plan() {
   for evidence_file in "${EVIDENCE_FILE_NAMES[@]}"; do
     echo "evidence file: ${EVIDENCE_DIR}/${evidence_file}"
   done
+  print_evidence_env_hint
+}
+
+print_evidence_env_hint() {
+  printf 'export TLDW_SANDBOX_VZ_EVIDENCE_DIR=%q\n' "${EVIDENCE_DIR}"
 }
 
 prepare_runtime_paths() {
@@ -908,6 +913,7 @@ finalize_evidence() {
     write_json_evidence "${final_exit}" "$(phase_records_text; printf '%s\n' "${evidence_success_record}")" || status="$?"
     if [[ "${status}" -eq 0 ]]; then
       PHASE_RECORDS+=("${evidence_success_record}")
+      print_evidence_env_hint
     fi
   fi
   if [[ "${status}" -ne 0 ]]; then

--- a/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+++ b/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
@@ -417,7 +417,9 @@ print_evidence_plan() {
 }
 
 print_evidence_env_hint() {
-  printf 'export TLDW_SANDBOX_VZ_EVIDENCE_DIR=%q\n' "${EVIDENCE_DIR}"
+  if [[ -n "${EVIDENCE_DIR:-}" ]]; then
+    printf 'export TLDW_SANDBOX_VZ_EVIDENCE_DIR=%q\n' "${EVIDENCE_DIR}"
+  fi
 }
 
 prepare_runtime_paths() {

--- a/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
+++ b/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import os
 import re
+import shlex
 import signal
 import socket
 import subprocess
@@ -14,9 +15,12 @@ from pathlib import Path
 import pytest
 
 
+pytestmark = pytest.mark.unit
+
 IMAGE_DIR = Path(__file__).resolve().parents[1]
 REPO_ROOT = IMAGE_DIR.parents[1]
 SMOKE_SCRIPT = IMAGE_DIR / "scripts" / "run-host-e2e-smoke.sh"
+EVIDENCE_EXPORT_PREFIX = "export TLDW_SANDBOX_VZ_EVIDENCE_DIR="
 EVIDENCE_FILES = {
     "host-smoke-evidence.json",
     "source-bundle-hashes-before.txt",
@@ -44,6 +48,24 @@ def _planned_evidence_files(stdout: str) -> set[str]:
         for line in stdout.splitlines()
         if line.startswith("evidence file: ")
     }
+
+
+def _assert_evidence_export_value(stdout: str, expected: Path | str) -> None:
+    """Assert that stdout includes a sourceable evidence-dir export with the expected value."""
+    lines = [line for line in stdout.splitlines() if line.startswith(EVIDENCE_EXPORT_PREFIX)]
+    if len(lines) != 1:
+        pytest.fail(f"expected exactly one evidence export line, found {len(lines)}")
+    try:
+        tokens = shlex.split(lines[0])
+    except ValueError as exc:
+        pytest.fail(f"evidence export line is not shell-parseable: {exc}")
+    if len(tokens) != 2 or tokens[0] != "export" or "=" not in tokens[1]:
+        pytest.fail(f"unexpected evidence export format: {lines[0]}")
+    name, value = tokens[1].split("=", 1)
+    if name != "TLDW_SANDBOX_VZ_EVIDENCE_DIR":
+        pytest.fail(f"unexpected evidence export variable: {name}")
+    if value != str(expected):
+        pytest.fail(f"expected evidence export {expected!s}, got {value}")
 
 
 def _assert_owner_only(path: Path) -> None:
@@ -78,7 +100,8 @@ def test_host_e2e_smoke_script_help_mentions_required_bundle() -> None:
     assert "Usage:" in result.stdout
     assert "--bundle PATH" in result.stdout
     assert "Canonical source vz_linux bundle" in result.stdout
-    assert "--evidence-dir PATH" in result.stdout  # nosec B101
+    if "--evidence-dir PATH" not in result.stdout:
+        pytest.fail("help output is missing --evidence-dir PATH")
     assert "--include-failure-drills" in result.stdout
 
 
@@ -196,7 +219,7 @@ def test_host_e2e_smoke_script_dry_run_prints_default_evidence_bundle(tmp_path: 
     evidence_dir = Path(evidence_dir_text)
     assert evidence_dir.name == "evidence"
     assert not evidence_dir.exists()
-    assert f"export TLDW_SANDBOX_VZ_EVIDENCE_DIR={evidence_dir_text}" in result.stdout  # nosec B101
+    _assert_evidence_export_value(result.stdout, evidence_dir_text)
     expected_paths = {f"{evidence_dir_text}/{evidence_file}" for evidence_file in EVIDENCE_FILES}
     assert expected_paths <= _planned_evidence_files(result.stdout)
 
@@ -208,7 +231,7 @@ def test_host_e2e_smoke_script_dry_run_accepts_evidence_dir_override(tmp_path: P
     (bundle / "kernel").write_bytes(b"kernel")
     (bundle / "rootfs.img").write_bytes(b"rootfs")
     helper = tmp_path / "macos-vz-helper"
-    evidence_dir = tmp_path / "custom-evidence"
+    evidence_dir = tmp_path / "custom evidence"
 
     result = _run_smoke_script(
         "--dry-run",
@@ -224,7 +247,7 @@ def test_host_e2e_smoke_script_dry_run_accepts_evidence_dir_override(tmp_path: P
 
     assert result.returncode == 0, result.stderr
     assert f"evidence directory: {evidence_dir}" in result.stdout
-    assert f"export TLDW_SANDBOX_VZ_EVIDENCE_DIR={evidence_dir}" in result.stdout  # nosec B101
+    _assert_evidence_export_value(result.stdout, evidence_dir)
     assert not evidence_dir.exists()
     expected_paths = {str(evidence_dir / evidence_file) for evidence_file in EVIDENCE_FILES}
     assert expected_paths <= _planned_evidence_files(result.stdout)
@@ -366,7 +389,7 @@ def test_host_e2e_smoke_script_real_run_writes_evidence_bundle(tmp_path: Path) -
     )
     tmp_dir = tmp_path / "tmp"
     tmp_dir.mkdir()
-    evidence_dir = tmp_path / "evidence"
+    evidence_dir = tmp_path / "evidence with spaces"
     fake_python = tmp_path / "fake-python"
     fake_helper = tmp_path / "fake-helper"
     fake_python.write_text(
@@ -432,7 +455,7 @@ def test_host_e2e_smoke_script_real_run_writes_evidence_bundle(tmp_path: Path) -
         assert f"{_sha256_file(kernel)}  kernel" in source_before_hashes
         assert f"{_sha256_file(rootfs)}  rootfs.img" in source_after_hashes
         assert f"{_sha256_file(rootfs)}  rootfs.img" in run_hashes
-        assert f"export TLDW_SANDBOX_VZ_EVIDENCE_DIR={evidence_dir}" in result.stdout  # nosec B101
+        _assert_evidence_export_value(result.stdout, evidence_dir)
         evidence = json.loads((evidence_dir / "host-smoke-evidence.json").read_text(encoding="utf-8"))
     finally:
         for unreadable_log in tmp_dir.glob("**/unreadable.log"):

--- a/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
+++ b/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
@@ -78,6 +78,7 @@ def test_host_e2e_smoke_script_help_mentions_required_bundle() -> None:
     assert "Usage:" in result.stdout
     assert "--bundle PATH" in result.stdout
     assert "Canonical source vz_linux bundle" in result.stdout
+    assert "--evidence-dir PATH" in result.stdout  # nosec B101
     assert "--include-failure-drills" in result.stdout
 
 
@@ -195,6 +196,7 @@ def test_host_e2e_smoke_script_dry_run_prints_default_evidence_bundle(tmp_path: 
     evidence_dir = Path(evidence_dir_text)
     assert evidence_dir.name == "evidence"
     assert not evidence_dir.exists()
+    assert f"export TLDW_SANDBOX_VZ_EVIDENCE_DIR={evidence_dir_text}" in result.stdout  # nosec B101
     expected_paths = {f"{evidence_dir_text}/{evidence_file}" for evidence_file in EVIDENCE_FILES}
     assert expected_paths <= _planned_evidence_files(result.stdout)
 
@@ -222,6 +224,7 @@ def test_host_e2e_smoke_script_dry_run_accepts_evidence_dir_override(tmp_path: P
 
     assert result.returncode == 0, result.stderr
     assert f"evidence directory: {evidence_dir}" in result.stdout
+    assert f"export TLDW_SANDBOX_VZ_EVIDENCE_DIR={evidence_dir}" in result.stdout  # nosec B101
     assert not evidence_dir.exists()
     expected_paths = {str(evidence_dir / evidence_file) for evidence_file in EVIDENCE_FILES}
     assert expected_paths <= _planned_evidence_files(result.stdout)
@@ -429,6 +432,7 @@ def test_host_e2e_smoke_script_real_run_writes_evidence_bundle(tmp_path: Path) -
         assert f"{_sha256_file(kernel)}  kernel" in source_before_hashes
         assert f"{_sha256_file(rootfs)}  rootfs.img" in source_after_hashes
         assert f"{_sha256_file(rootfs)}  rootfs.img" in run_hashes
+        assert f"export TLDW_SANDBOX_VZ_EVIDENCE_DIR={evidence_dir}" in result.stdout  # nosec B101
         evidence = json.loads((evidence_dir / "host-smoke-evidence.json").read_text(encoding="utf-8"))
     finally:
         for unreadable_log in tmp_dir.glob("**/unreadable.log"):


### PR DESCRIPTION
## Summary
- Print a sourceable `TLDW_SANDBOX_VZ_EVIDENCE_DIR` export from host smoke dry-run planning.
- Print the same export after successful real-run evidence finalization.
- Document using the env var to surface smoke evidence in sandbox operator-status.

## Test Plan
- [x] `source ../../.venv/bin/activate && python -m pytest tools/vz-linux-image/tests/test_host_e2e_smoke_script.py -q --tb=short`
- [x] `bash -n tools/vz-linux-image/scripts/run-host-e2e-smoke.sh`
- [x] `git diff --check`
- [x] Bandit touched test-file comparison against `dev` baseline: current 122 findings, baseline 122 findings

## Change summary
TODO: human-written change summary required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose a sourceable, bash-escaped env handoff for the VZ smoke evidence directory so operator-status can read local evidence when the server starts with that env (completes TASK-2393).

- **New Features**
  - Print `export TLDW_SANDBOX_VZ_EVIDENCE_DIR=...` in dry-run plans and after successful evidence finalization; value is `printf %q`-escaped for safe copy/paste.
  - Add `--evidence-dir PATH`; skip creation on dry-run, create a private `0700` dir on real runs, reject symlinks, and support paths with spaces.
  - Update README with how to start the API server using the printed env and why to copy the line verbatim.

- **Bug Fixes**
  - Harden env export helper for `set -u` and update tests to verify a single, shell-parseable export using `shlex`; ensure help advertises `--evidence-dir` and cover spaces-in-paths and real-run evidence.

<sup>Written for commit 75adde861ca797e85569291d0e659daf7a1c9186. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

