### PR TITLE
test: preserve ACP conservative support guardrails

### DIFF
--- a/IMPLEMENTATION_PLAN_acp_support_guardrails_2399.md
+++ b/IMPLEMENTATION_PLAN_acp_support_guardrails_2399.md
@@ -1,0 +1,22 @@
+# Implementation Plan: ACP Support Guardrails (#2399)
+
+## Stage 1: Registry And Setup-Guide Guardrails
+
+**Goal**: Reconcile stale Aider registry expectations and add focused setup-guide coverage for Aider, Continue, and the seeded custom profile.
+**Success Criteria**: Tests assert Aider remains `documented_unverified` / `documented_only` as an unverified `aider-acp` external adapter candidate; Continue remains documented-only with no ACP command; custom remains template-only and non-runnable.
+**Tests**: Focused pytest for `test_acp_agent_registry.py`, `test_registry_entrypoint_strategy.py`, `test_acp_health.py`, and `test_acp_certification_smoke.py`.
+**Status**: Complete
+
+## Stage 2: Cross-Surface Conservative Audit
+
+**Goal**: Audit compatibility docs, `agents.yaml`, bundled runner config, helper manifests, and Agent Registry UI for overclaims.
+**Success Criteria**: No surface claims live ACP support for Aider, Continue, or generic custom profiles without evidence; any drift found is corrected with minimal changes.
+**Tests**: Targeted grep/audit commands, focused UI Vitest only if UI changes are needed.
+**Status**: Complete
+
+## Stage 3: Verification And Tracker Closeout
+
+**Goal**: Record evidence in Backlog and GitHub, then open the PR for #2399.
+**Success Criteria**: Focused tests pass, `git diff --check` passes, Bandit is run for touched Python scope, Backlog task is finalized, and #2399/#2398 are updated with PR evidence.
+**Tests**: Focused pytest, Bandit on touched Python tests/helpers when applicable, `git diff --check`.
+**Status**: Complete

--- a/backlog/tasks/task-2394 - Preserve-ACP-conservative-support-guardrails-for-Aider-Continue-and-custom-profiles.md
+++ b/backlog/tasks/task-2394 - Preserve-ACP-conservative-support-guardrails-for-Aider-Continue-and-custom-profiles.md
@@ -1,0 +1,66 @@
+---
+id: TASK-2394
+title: Preserve ACP conservative support guardrails for Aider Continue and custom
+  profiles
+status: Done
+labels:
+- ACP
+- guardrail
+- github-2399
+references:
+- https://github.com/rmusser01/tldw_server/issues/2399
+- https://github.com/rmusser01/tldw_server/issues/2398
+- https://github.com/rmusser01/tldw_server/pull/2417
+modified_files:
+- IMPLEMENTATION_PLAN_acp_support_guardrails_2399.md
+- tldw_Server_API/tests/Agent_Client_Protocol/test_acp_agent_registry.py
+- tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track GitHub issue #2399. Reconcile and harden the conservative ACP support state for Aider, Continue, and the seeded custom profile across registry tests, setup-guide responses, smoke manifests, docs, runner config, and Agent Registry UI. This is a guardrail audit only; do not certify or upgrade support for these profiles without new live evidence.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Aider remains documented_unverified/documented_only and is modeled only as an unverified external aider-acp adapter candidate until adapter evidence exists.
+- [x] #2 Continue remains documented_unverified/documented_only with no ACP stdio command or maintained adapter identified.
+- [x] #3 The seeded custom profile remains a template-only/non-runnable profile requiring a distinct named profile and evidence bundle before support claims.
+- [x] #4 Setup guide, registry/smoke manifest tests, compatibility docs, runner config, and Agent Registry UI surfaces are audited for overclaims.
+- [x] #5 Verification results, skipped surfaces, and final issue updates are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+- Reproduced the stale Aider guardrail test failure on current dev: `test_default_agents_yaml_keeps_aider_blocked_without_acp_entrypoint` failed because Aider is now correctly modeled as `external_acp_adapter` with `acp_command=aider-acp`.
+- Updated the Aider registry test to assert the current conservative adapter-candidate model while keeping `support_state=documented_unverified` and `verification_level=documented_only`.
+- Added setup-guide guardrail coverage for Aider, Continue, and the seeded custom profile so runtime/setup metadata cannot silently become a release support claim.
+- Audited `agents.yaml`, `ACP_Compatibility_Matrix.md`, `ACP_OSS_Custom_Certification_2026_05_11.md`, bundled runner config, helper smoke manifests, Go runner passive status copy, and Agent Registry UI copy. No support overclaims were found; no docs/UI/runner edits were needed.
+- UI Vitest was attempted but blocked by this worktree's incomplete Bun dependency symlink layout (`vitest/config` / `@testing-library/jest-dom/vitest` resolution). Since no UI files changed and the UI audit found conservative copy, this is recorded as an environment skip.
+- Verification so far: focused pytest for ACP registry/entrypoint/setup-guide/smoke manifests passed with 139 tests; `git diff --check` passed; Bandit on touched Python tests reported only B101 assert baseline, and rerun with `-s B101` reported `results=[]`, `errors=[]`.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented as test guardrails only. Updated the Aider default registry assertion to match the current conservative external adapter candidate model while preserving `documented_unverified` / `documented_only`. Added setup-guide regression coverage for Aider, Continue, and the seeded custom profile so entrypoint metadata cannot be mistaken for certified support. No production code, docs, runner config, or UI code required changes after audit.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Preserved ACP conservative support guardrails for GitHub #2399 in PR #2417. Verification: focused ACP pytest batch passed (139 passed, 6 warnings); git diff --check passed; Bandit on touched Python tests passed with B101 test-assert baseline excluded and reported results=[], errors=[]. UI Vitest was attempted but skipped because this fresh worktree lacks the Bun dependency symlink layout needed to resolve vitest/config and @testing-library/jest-dom/vitest; no UI files changed and UI copy was audited as conservative.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_agent_registry.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_agent_registry.py
@@ -417,8 +417,8 @@ def test_default_agents_yaml_includes_codex_backend_live_e2e_metadata() -> None:
     assert "codex/acp-codex-orchestration-progress" in entry.compatibility_notes
 
 
-def test_default_agents_yaml_keeps_aider_blocked_without_acp_entrypoint() -> None:
-    """Aider can be locally configured while remaining blocked for ACP certification."""
+def test_default_agents_yaml_keeps_aider_as_unverified_adapter_candidate() -> None:
+    """Aider can expose an adapter candidate while remaining uncertified for ACP support."""
     from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistry
 
     real_yaml = os.path.join(
@@ -431,15 +431,20 @@ def test_default_agents_yaml_keeps_aider_blocked_without_acp_entrypoint() -> Non
     entry = registry.get_entry("aider")
 
     assert entry is not None
-    assert entry.entrypoint_strategy == "documented_candidate"
+    assert entry.entrypoint_strategy == "external_acp_adapter"
     assert entry.command == "aider"
-    assert entry.acp_command == ""
+    assert entry.acp_command == "aider-acp"
     assert entry.acp_args == []
+    assert entry.adapter_source == "jorgejhms/aider-acp"
+    assert entry.adapter_docs_url == "https://github.com/jorgejhms/aider-acp"
+    assert entry.adapter_package == "aider-acp"
+    assert entry.adapter_version_policy == "operator_managed"
+    assert entry.adapter_install_source == "operator_managed"
+    assert entry.credential_policy == "delegated_to_adapter"
     assert entry.support_state == "documented_unverified"
     assert entry.verification_level == "documented_only"
-    assert entry.certification_blocker == "entrypoint_strategy_missing"
-    assert "local llama.cpp" in entry.compatibility_notes
-    assert "no ACP-compatible" in entry.compatibility_notes
+    assert "external adapter candidate" in entry.compatibility_notes
+    assert "not installed or live-E2E certified" in entry.compatibility_notes
 
 
 def test_default_runner_home_config_exposes_goose_backend_profile() -> None:

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py
@@ -4,6 +4,7 @@ import os
 import sys
 import types
 
+from fastapi.testclient import TestClient
 import pytest
 
 pytestmark = pytest.mark.unit
@@ -292,6 +293,75 @@ def test_acp_setup_guide_codex_includes_entrypoint_blocker_steps(client_user_onl
         "live_certification_required",
     }
     assert any("adapter" in step.lower() for step in guide["steps"])
+
+
+def test_acp_setup_guide_preserves_aider_unverified_adapter_candidate(
+    client_user_only: TestClient,
+    stub_runner_client: StubRunnerClient,
+) -> None:
+    """Aider setup guidance must not convert adapter metadata into a support claim."""
+    resp = client_user_only.get("/api/v1/acp/setup-guide?agent_type=aider")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["guides"]) == 1
+    guide = data["guides"][0]
+
+    assert guide["agent_type"] == "aider"
+    compatibility = guide["compatibility"]
+    assert compatibility["support_state"] == "documented_unverified"
+    assert compatibility["verification_level"] == "documented_only"
+    assert compatibility["docs_url"] == "/docs-static/Development/ACP_Compatibility_Matrix.md"
+    entrypoint = guide["entrypoint"]
+    assert entrypoint["entrypoint_strategy"] == "external_acp_adapter"
+    assert entrypoint["acp_command"] == "aider-acp"
+    assert entrypoint["adapter_source"] == "jorgejhms/aider-acp"
+    assert any("certification checklist" in step.lower() for step in guide["steps"])
+
+
+def test_acp_setup_guide_preserves_continue_documented_only_status(
+    client_user_only: TestClient,
+    stub_runner_client: StubRunnerClient,
+) -> None:
+    """Continue setup guidance must require a concrete ACP entrypoint before support claims."""
+    resp = client_user_only.get("/api/v1/acp/setup-guide?agent_type=continue_dev")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["guides"]) == 1
+    guide = data["guides"][0]
+
+    assert guide["agent_type"] == "continue_dev"
+    compatibility = guide["compatibility"]
+    assert compatibility["support_state"] == "documented_unverified"
+    assert compatibility["verification_level"] == "documented_only"
+    entrypoint = guide["entrypoint"]
+    assert entrypoint["entrypoint_strategy"] == "documented_candidate"
+    assert entrypoint["acp_command"] == ""
+    assert entrypoint["primary_blocker"] == "entrypoint_strategy_missing"
+    assert any("concrete acp stdio entrypoint" in step.lower() for step in guide["steps"])
+    assert any("certification checklist" in step.lower() for step in guide["steps"])
+
+
+def test_acp_setup_guide_preserves_custom_template_only_status(
+    client_user_only: TestClient,
+    stub_runner_client: StubRunnerClient,
+) -> None:
+    """The seeded custom profile is a template, not a certifiable generic profile."""
+    resp = client_user_only.get("/api/v1/acp/setup-guide?agent_type=custom")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["guides"]) == 1
+    guide = data["guides"][0]
+
+    assert guide["agent_type"] == "custom"
+    compatibility = guide["compatibility"]
+    assert compatibility["support_state"] == "documented_unverified"
+    assert compatibility["verification_level"] == "documented_only"
+    entrypoint = guide["entrypoint"]
+    assert entrypoint["entrypoint_strategy"] == "custom_template"
+    assert entrypoint["probe_state"] == "custom_template"
+    assert entrypoint["primary_blocker"] == "custom_template"
+    assert any("distinct named custom acp profile" in step.lower() for step in guide["steps"])
+    assert any("certification checklist" in step.lower() for step in guide["steps"])
 
 
 def test_entrypoint_setup_steps_include_external_adapter_specific_actions() -> None:


### PR DESCRIPTION
## Change summary
- Updates the stale Aider registry guardrail test to assert the current external `aider-acp` adapter-candidate metadata while preserving `documented_unverified` / `documented_only`.
- Adds setup-guide regression coverage for Aider, Continue, and the seeded custom profile so entrypoint metadata cannot become a support claim without evidence.
- Records the Backlog task and implementation plan for GitHub #2399.

## Why
This keeps ACP-adjacent profiles conservative until each has a concrete maintained entrypoint, credential model, and certification evidence. The change is test-only for product behavior; no production code, docs, runner config, or UI behavior changed after audit.

## Validation
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_acp_agent_registry.py tldw_Server_API/tests/Agent_Client_Protocol/test_registry_entrypoint_strategy.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py tldw_Server_API/tests/Helper_Scripts/test_acp_certification_smoke.py -q` -> 139 passed, 6 warnings
- `git diff --check`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/tests/Agent_Client_Protocol/test_acp_agent_registry.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py -s B101 -f json -o /tmp/bandit_acp_guardrails_2399_no_b101_final.json` -> results=[], errors=[]
- UI Vitest was attempted, but this fresh worktree lacks the Bun dependency symlink layout needed to resolve `vitest/config` and `@testing-library/jest-dom/vitest`; no UI files changed and UI copy was audited as conservative.

Refs #2399
Refs #2398

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Test-only update preserving conservative ACP support guardrails for Aider, Continue, and the seeded custom profile (refs #2399).
Tests now assert: Aider stays an unverified external adapter candidate (`external_acp_adapter`, `documented_unverified`/`documented_only`) with `acp_command`=`aider-acp` and extended adapter metadata (source/docs/package, operator‑managed install/version, delegated credentials); Continue stays documented‑only with no ACP command and `primary_blocker`=`entrypoint_strategy_missing`; the `custom` profile stays template‑only with `custom_template` probe/primary_blocker.

<sup>Written for commit e0ab9a95a72a91dc54fa76bfd6aaf4058d5a9553. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

