### PR TITLE
Add MCP standalone guide UAT harness

### DIFF
--- a/Docs/MCP/Unified/Smoke_Client.md
+++ b/Docs/MCP/Unified/Smoke_Client.md
@@ -27,6 +27,12 @@ absolute paths, bearer tokens, API keys, or long payloads.
 
 ## Commands
 
+Install the package-local gateway extra first:
+
+```bash
+python -m pip install -e "mcp_unified[gateway]"
+```
+
 Run the deterministic in-process fixture:
 
 ```bash

--- a/Docs/superpowers/plans/2026-06-20-mcp-standalone-user-guide-uat-harness.md
+++ b/Docs/superpowers/plans/2026-06-20-mcp-standalone-user-guide-uat-harness.md
@@ -1,0 +1,108 @@
+# MCP Standalone User Guide UAT Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add and run a one-off UAT harness that validates the package-local MCP Unified standalone user guide from a new-user perspective.
+
+**Architecture:** Keep the harness outside the packaged `mcp_unified` module so it does not become a public package surface. The harness creates isolated temporary workspaces, installs the package boundary the way the guide documents, executes guide commands through subprocess argv, writes temporary fixture servers for stdio/HTTP/WebSocket smoke transport UAT, and emits a redacted JSON report. Confirmed guide/package mismatches are fixed minimally.
+
+**Tech Stack:** Python subprocess/tempfile/json/venv, pytest, Ruff, Bandit, `mcp_unified` package CLI.
+
+---
+
+### Task 1: Package Boundary Exposure Test
+
+**Files:**
+- Test: `tldw_Server_API/tests/Helper_Scripts/test_mcp_standalone_user_guide_uat.py`
+- Modify: `mcp_unified/pyproject.toml`
+
+- [x] **Step 1: Write the failing test**
+
+Add a test that parses `mcp_unified/pyproject.toml` and asserts the standalone package exposes both documented console scripts: `mcp-unified-gateway` and `mcp-unified-smoke`, and includes `mcp_unified.smoke` in packaged modules.
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Helper_Scripts/test_mcp_standalone_user_guide_uat.py -q`
+
+Expected: FAIL because `mcp-unified-smoke` and `mcp_unified.smoke` are missing from the package-local project metadata.
+
+- [x] **Step 3: Fix package metadata**
+
+Add the missing script and smoke package mapping to `mcp_unified/pyproject.toml`.
+
+- [x] **Step 4: Run test to verify it passes**
+
+Run the same pytest command and expect PASS.
+
+### Task 2: One-Off UAT Harness
+
+**Files:**
+- Create: `Helper_Scripts/Testing-related/mcp_standalone_user_guide_uat.py`
+- Test: `tldw_Server_API/tests/Helper_Scripts/test_mcp_standalone_user_guide_uat.py`
+
+- [x] **Step 1: Add failing harness contract tests**
+
+Test redacted report helpers and that the harness command plan includes install, gateway CLI, smoke CLI, config/profile, external server, credential grant, snapshot, and reporting phases.
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run the focused pytest command and expect failures for the missing harness module.
+
+- [x] **Step 3: Implement minimal harness**
+
+Implement an executable Python helper that:
+- creates a temp UAT workspace
+- optionally creates a temp venv
+- installs `mcp_unified[gateway]` from the package-local path
+- runs documented local CLI commands
+- writes temp `gateway.json`, `search-server.json`, grant, snapshot, and policy args files
+- runs smoke CLI in-process, stdio subprocess, live HTTP, and live WebSocket fixture paths when installed
+- emits redacted JSON report to a requested path or stdout
+
+- [x] **Step 4: Run tests to verify pass**
+
+Run focused pytest and expect PASS.
+
+### Task 3: Full UAT Run And Guide Fixes
+
+**Files:**
+- Modify: `mcp_unified/USER_GUIDE.md` if confirmed guide issues are found
+- Modify: `mcp_unified/README.md` if confirmed package/script issues are found
+- Modify: `backlog/tasks/task-2393 - Add-MCP-standalone-user-guide-UAT-harness.md`
+
+- [x] **Step 1: Run the harness from a clean temp workspace**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python Helper_Scripts/Testing-related/mcp_standalone_user_guide_uat.py --repo-root . --json-report /tmp/mcp_standalone_user_guide_uat.json`
+
+- [x] **Step 2: Investigate any failures**
+
+Use systematic debugging: read stderr/stdout, reproduce the smallest failed command, identify root cause, then fix only confirmed product/docs/package mismatches.
+
+- [x] **Step 3: Re-run harness**
+
+Expected: report has no failed required local guide or fixture transport steps. Remote/runtime steps may be marked skipped when no live gateway URL/admin key is supplied.
+
+### Task 4: Final Validation And Commit
+
+**Files:**
+- All touched files
+
+- [x] **Step 1: Run compile checks**
+
+Run py_compile on the helper script and touched package modules.
+
+- [x] **Step 2: Run Ruff**
+
+Run Ruff on touched Python files.
+
+- [x] **Step 3: Run Bandit**
+
+Run Bandit on the helper script and touched package runtime files.
+
+- [x] **Step 4: Run `git diff --check`**
+
+Expected: no whitespace errors.
+
+- [x] **Step 5: Update Backlog and commit**
+
+Record verification and UAT report summary in `TASK-2393`, then commit.

--- a/Helper_Scripts/Testing-related/mcp_standalone_user_guide_uat.py
+++ b/Helper_Scripts/Testing-related/mcp_standalone_user_guide_uat.py
@@ -145,12 +145,11 @@ def build_uat_plan(
     steps = [
         UatStep(
             "create_venv",
-            "Create an isolated virtual environment with shared site packages.",
+            "Create an isolated virtual environment.",
             command=[
                 python_executable,
                 "-m",
                 "venv",
-                "--system-site-packages",
                 str(venv_dir),
             ],
             cwd=workspace,
@@ -521,6 +520,7 @@ def build_uat_plan(
         UatStep(
             "stop_fixture_gateway",
             "Stop the local fixture gateway.",
+            required=False,
             stop_process_key="fixture_gateway",
         ),
     ]
@@ -562,7 +562,12 @@ def redact_text(
             redacted = redacted.replace(path, "<redacted-path>")
     for secret in sorted({secret for secret in secrets if secret}, key=len, reverse=True):
         redacted = redacted.replace(secret, "<redacted-secret>")
-    redacted = re.sub(r"Bearer\s+[^\s\"']+", "Bearer <redacted-secret>", redacted)
+    redacted = re.sub(
+        r"Bearer\s+[^\s\"']+",
+        "Bearer <redacted-secret>",
+        redacted,
+        flags=re.IGNORECASE,
+    )
     redacted = re.sub(
         r"(X-MCP-Gateway-Admin-Key\s*[:=]\s*)[^\s\"']+",
         r"\1<redacted-secret>",
@@ -852,10 +857,10 @@ def _stop_background_process(
         return UatStepResult(
             step_id=step.step_id,
             description=step.description,
-            status="failed",
+            status="skipped",
             required=step.required,
             duration_ms=_elapsed_ms(started),
-            reason="background process was not running",
+            reason="process not running",
         )
     stdout, stderr = _terminate_process(process)
     return UatStepResult(
@@ -884,6 +889,7 @@ def _wait_for_http_health(
     while perf_counter() < deadline:
         if process.poll() is not None:
             return f"process exited before health check passed: {process.returncode}"
+        connection: HTTPConnection | None = None
         try:
             connection = HTTPConnection(host, port, timeout=0.5)
             connection.request("GET", path)
@@ -895,10 +901,8 @@ def _wait_for_http_health(
         except OSError as exc:
             last_error = f"{exc.__class__.__name__}: {exc}"
         finally:
-            try:
+            if connection is not None:
                 connection.close()
-            except UnboundLocalError:
-                pass
         sleep(0.1)
     return last_error
 
@@ -915,7 +919,10 @@ def _terminate_process(process: subprocess.Popen[str]) -> tuple[str, str]:
 
 def _stop_remaining_processes(context: UatRunContext) -> None:
     for process in list(context.processes.values()):
-        _terminate_process(process)
+        try:
+            _terminate_process(process)
+        except (OSError, subprocess.SubprocessError, ValueError):
+            continue
     context.processes.clear()
 
 
@@ -1020,7 +1027,9 @@ def _elapsed_ms(started: float) -> float:
     return round((perf_counter() - started) * 1000, 3)
 
 
-def _truncate(value: str) -> str:
+def _truncate(value: str | None) -> str:
+    if value is None:
+        return ""
     if len(value) <= _MAX_CAPTURE_CHARS:
         return value
     return value[:_MAX_CAPTURE_CHARS] + "\n<truncated>"

--- a/Helper_Scripts/Testing-related/mcp_standalone_user_guide_uat.py
+++ b/Helper_Scripts/Testing-related/mcp_standalone_user_guide_uat.py
@@ -1,0 +1,1030 @@
+#!/usr/bin/env python3
+"""Run a one-off UAT pass against the MCP Unified standalone user guide.
+
+The harness intentionally lives outside the packaged ``mcp_unified`` module.
+It validates the package boundary from an isolated workspace by installing the
+package-local project and then executing the documented CLI flows through argv
+subprocess calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess  # nosec B404
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from http.client import HTTPConnection
+from pathlib import Path
+from time import perf_counter, sleep
+from typing import Any
+
+_MAX_CAPTURE_CHARS = 6000
+_DEFAULT_TIMEOUT_SECONDS = 120.0
+_FIXTURE_HOST = "127.0.0.1"
+_SERVER_STOP_TIMEOUT_SECONDS = 5.0
+
+_STDIO_FIXTURE_SOURCE = '''\
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from mcp_unified.gateway.stdio import GatewayStdioServer
+from mcp_unified.smoke.fixtures import SmokeFixtureGatewayRuntime
+
+
+async def main() -> None:
+    server = GatewayStdioServer(SmokeFixtureGatewayRuntime(include_denied_tool=True))
+    for line in sys.stdin:
+        response = await server.handle_line(line)
+        if response is not None:
+            sys.stdout.write(response)
+            sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+'''
+
+_ASGI_FIXTURE_SOURCE = '''\
+from __future__ import annotations
+
+from mcp_unified.gateway.fastapi import create_gateway_app
+from mcp_unified.smoke.fixtures import SmokeFixtureGatewayRuntime
+
+
+app = create_gateway_app(SmokeFixtureGatewayRuntime(include_denied_tool=True))
+'''
+
+
+@dataclass(frozen=True)
+class UatStep:
+    """One executable or synthetic user-guide UAT step."""
+
+    step_id: str
+    description: str
+    command: list[str] | None = None
+    cwd: Path | None = None
+    required: bool = True
+    expected_exit_codes: tuple[int, ...] = (0,)
+    write_json_path: Path | None = None
+    write_json_payload: dict[str, Any] | None = None
+    write_text_path: Path | None = None
+    write_text_payload: str | None = None
+    skip_reason: str | None = None
+    background_process_key: str | None = None
+    stop_process_key: str | None = None
+    health_check_host: str | None = None
+    health_check_port: int | None = None
+    health_check_path: str | None = None
+
+
+@dataclass
+class UatStepResult:
+    """Redacted result for one UAT step."""
+
+    step_id: str
+    description: str
+    status: str
+    required: bool
+    duration_ms: float
+    command: list[str] | None = None
+    exit_code: int | None = None
+    stdout: str = ""
+    stderr: str = ""
+    reason: str | None = None
+
+
+@dataclass
+class UatRunContext:
+    """Paths and settings shared across one UAT run."""
+
+    repo_root: Path
+    workspace: Path
+    bootstrap_python: str
+    gateway_url: str | None
+    admin_key: str | None
+    timeout_seconds: float
+    secrets: list[str] = field(default_factory=list)
+    processes: dict[str, subprocess.Popen[str]] = field(default_factory=dict)
+
+
+def build_uat_plan(
+    *,
+    repo_root: Path,
+    workspace: Path,
+    python_executable: str,
+    gateway_executable: str,
+    smoke_executable: str,
+    gateway_url: str | None,
+    fixture_port: int | None = None,
+) -> list[UatStep]:
+    """Build the ordered standalone user-guide UAT command plan."""
+
+    venv_dir = workspace / ".venv"
+    venv_python = _venv_python(venv_dir)
+    gateway_config = workspace / "gateway.json"
+    reporting_config = workspace / "gateway-reporting.json"
+    policy_args = workspace / "policy-args.json"
+    external_server = workspace / "search-server.json"
+    credential_grant = workspace / "researcher-search-grant.json"
+    snapshot = workspace / "gateway-snapshot.json"
+    smoke_report = workspace / "mcp-smoke-inprocess.json"
+    stdio_fixture = workspace / "smoke_stdio_fixture.py"
+    stdio_smoke_report = workspace / "mcp-smoke-stdio.json"
+    asgi_fixture = workspace / "smoke_asgi_fixture.py"
+    http_smoke_report = workspace / "mcp-smoke-http.json"
+    websocket_smoke_report = workspace / "mcp-smoke-websocket.json"
+    fixture_port = fixture_port or _fixture_port_for_workspace(workspace)
+
+    steps = [
+        UatStep(
+            "create_venv",
+            "Create an isolated virtual environment with shared site packages.",
+            command=[
+                python_executable,
+                "-m",
+                "venv",
+                "--system-site-packages",
+                str(venv_dir),
+            ],
+            cwd=workspace,
+        ),
+        UatStep(
+            "install_package_boundary",
+            "Install the package-local MCP Unified boundary as documented.",
+            command=[
+                str(venv_python),
+                "-m",
+                "pip",
+                "install",
+                "-e",
+                f"{repo_root / 'mcp_unified'}[gateway]",
+            ],
+            cwd=workspace,
+        ),
+        UatStep(
+            "gateway_package_info",
+            "Confirm the gateway CLI reports package status.",
+            command=[gateway_executable, "package-info"],
+            cwd=workspace,
+        ),
+        UatStep(
+            "smoke_cli_help",
+            "Confirm the documented smoke CLI is installed.",
+            command=[smoke_executable, "--help"],
+            cwd=workspace,
+        ),
+        UatStep(
+            "write_gateway_config",
+            "Write the guide's minimal SQLite gateway config.",
+            write_json_path=gateway_config,
+            write_json_payload={
+                "store": {
+                    "kind": "sqlite",
+                    "sqlite_path": "./mcp-gateway.db",
+                },
+                "default_preset_id": "project-researcher",
+            },
+        ),
+        UatStep(
+            "validate_gateway_config",
+            "Validate the minimal gateway config.",
+            command=[gateway_executable, "validate-config", str(gateway_config)],
+            cwd=workspace,
+        ),
+        UatStep(
+            "list_presets",
+            "List bundled profile presets.",
+            command=[gateway_executable, "list-presets"],
+            cwd=workspace,
+        ),
+        UatStep(
+            "show_project_researcher_preset",
+            "Inspect the project-researcher preset.",
+            command=[gateway_executable, "show-preset", "project-researcher"],
+            cwd=workspace,
+        ),
+        UatStep(
+            "duplicate_project_researcher_preset",
+            "Duplicate project-researcher into persistent storage.",
+            command=[
+                gateway_executable,
+                "duplicate-preset",
+                "project-researcher",
+                "--profile-id",
+                "researcher",
+                "--name",
+                "Project Researcher",
+                "--config",
+                str(gateway_config),
+            ],
+            cwd=workspace,
+        ),
+        UatStep(
+            "set_default_profile",
+            "Set the duplicated profile as the default.",
+            command=[
+                gateway_executable,
+                "set-default-profile",
+                "researcher",
+                "--config",
+                str(gateway_config),
+            ],
+            cwd=workspace,
+        ),
+        UatStep(
+            "get_default_profile",
+            "Read back the active default profile.",
+            command=[gateway_executable, "get-default-profile", "--config", str(gateway_config)],
+            cwd=workspace,
+        ),
+        UatStep(
+            "write_policy_args",
+            "Write safe policy-explain arguments.",
+            write_json_path=policy_args,
+            write_json_payload={"path": "docs/example.md"},
+        ),
+        UatStep(
+            "explain_policy",
+            "Explain one local profile/tool policy decision.",
+            command=[
+                gateway_executable,
+                "explain-policy",
+                "--profile",
+                "researcher",
+                "--tool",
+                "fs.read",
+                "--args-json-file",
+                str(policy_args),
+                "--config",
+                str(gateway_config),
+            ],
+            cwd=workspace,
+        ),
+        UatStep(
+            "preview_profile_tools",
+            "Preview the profile's filesystem tool surface.",
+            command=[
+                gateway_executable,
+                "preview-profile-tools",
+                "--profile",
+                "researcher",
+                "--category",
+                "filesystem",
+                "--config",
+                str(gateway_config),
+            ],
+            cwd=workspace,
+        ),
+        UatStep(
+            "write_external_server",
+            "Write the guide's external server registry example.",
+            write_json_path=external_server,
+            write_json_payload={
+                "id": "search",
+                "name": "Search MCP Server",
+                "transport": "stdio",
+                "command": ["python", "-m", "search_mcp_server"],
+                "env_allowlist": ["PATH", "SEARCH_API_ENDPOINT"],
+                "credential_slots": ["search_api_key"],
+                "enabled": True,
+                "auto_start": False,
+            },
+        ),
+        UatStep(
+            "create_external_server",
+            "Create an external server registry entry.",
+            command=[
+                gateway_executable,
+                "create-external-server",
+                "--server-file",
+                str(external_server),
+                "--config",
+                str(gateway_config),
+            ],
+            cwd=workspace,
+        ),
+        UatStep(
+            "list_external_servers",
+            "List registered external servers.",
+            command=[gateway_executable, "list-external-servers", "--config", str(gateway_config)],
+            cwd=workspace,
+        ),
+        UatStep(
+            "write_credential_grant",
+            "Write the guide's metadata-only credential grant.",
+            write_json_path=credential_grant,
+            write_json_payload={
+                "id": "researcher-search-api-key",
+                "profile_id": "researcher",
+                "external_server_id": "search",
+                "broker_id": "env",
+                "credential_slot": "search_api_key",
+                "scopes": ["search:read"],
+                "enabled": True,
+            },
+        ),
+        UatStep(
+            "create_credential_grant",
+            "Create the metadata-only credential grant.",
+            command=[
+                gateway_executable,
+                "create-credential-grant",
+                "--grant-file",
+                str(credential_grant),
+                "--config",
+                str(gateway_config),
+            ],
+            cwd=workspace,
+        ),
+        UatStep(
+            "list_credential_grants",
+            "List credential grants for the researcher profile.",
+            command=[
+                gateway_executable,
+                "list-credential-grants",
+                "--profile-id",
+                "researcher",
+                "--config",
+                str(gateway_config),
+            ],
+            cwd=workspace,
+        ),
+        UatStep(
+            "export_config_snapshot",
+            "Export a gateway configuration snapshot.",
+            command=[
+                gateway_executable,
+                "export-config",
+                "--output",
+                str(snapshot),
+                "--config",
+                str(gateway_config),
+            ],
+            cwd=workspace,
+        ),
+        UatStep(
+            "import_config_snapshot_dry_run",
+            "Validate snapshot import without writing.",
+            command=[
+                gateway_executable,
+                "import-config",
+                "--snapshot-file",
+                str(snapshot),
+                "--dry-run",
+                "--config",
+                str(gateway_config),
+            ],
+            cwd=workspace,
+        ),
+        UatStep(
+            "import_config_snapshot_apply",
+            "Apply the exported snapshot to the configured store.",
+            command=[
+                gateway_executable,
+                "import-config",
+                "--snapshot-file",
+                str(snapshot),
+                "--config",
+                str(gateway_config),
+            ],
+            cwd=workspace,
+        ),
+        UatStep(
+            "write_reporting_config",
+            "Write a config with metadata-only tool-use reporting enabled.",
+            write_json_path=reporting_config,
+            write_json_payload={
+                "store": {
+                    "kind": "sqlite",
+                    "sqlite_path": "./mcp-reporting-gateway.db",
+                },
+                "default_preset_id": "project-researcher",
+                "tool_use_reporting": {
+                    "enabled": True,
+                    "store": {
+                        "kind": "sqlite",
+                        "sqlite_path": "./mcp-tool-events.db",
+                    },
+                    "retention_max_age_days": 30,
+                    "retention_max_events": 100000,
+                },
+            },
+        ),
+        UatStep(
+            "tool_events_report",
+            "Build an empty aggregate tool-use report from the configured store.",
+            command=[
+                gateway_executable,
+                "tool-events",
+                "report",
+                "--group-by",
+                "profile",
+                "--config",
+                str(reporting_config),
+            ],
+            cwd=workspace,
+        ),
+        UatStep(
+            "smoke_inprocess",
+            "Run the documented in-process MCP smoke scenario.",
+            command=[
+                smoke_executable,
+                "inprocess",
+                "--json-report",
+                str(smoke_report),
+            ],
+            cwd=workspace,
+        ),
+        UatStep(
+            "write_stdio_fixture",
+            "Write a temporary stdio MCP fixture server.",
+            write_text_path=stdio_fixture,
+            write_text_payload=_STDIO_FIXTURE_SOURCE,
+        ),
+        UatStep(
+            "smoke_stdio_subprocess",
+            "Run the smoke client against a stdio subprocess fixture.",
+            command=[
+                smoke_executable,
+                "stdio",
+                "--command",
+                str(venv_python),
+                "--arg",
+                str(stdio_fixture),
+                "--cwd",
+                str(workspace),
+                "--json-report",
+                str(stdio_smoke_report),
+            ],
+            cwd=workspace,
+        ),
+        UatStep(
+            "write_asgi_fixture",
+            "Write a temporary FastAPI MCP fixture gateway.",
+            write_text_path=asgi_fixture,
+            write_text_payload=_ASGI_FIXTURE_SOURCE,
+        ),
+        UatStep(
+            "start_fixture_gateway",
+            "Start the local fixture gateway for live HTTP/WebSocket smoke tests.",
+            command=[
+                str(venv_python),
+                "-m",
+                "uvicorn",
+                "smoke_asgi_fixture:app",
+                "--host",
+                _FIXTURE_HOST,
+                "--port",
+                str(fixture_port),
+                "--log-level",
+                "warning",
+            ],
+            cwd=workspace,
+            background_process_key="fixture_gateway",
+            health_check_host=_FIXTURE_HOST,
+            health_check_port=fixture_port,
+            health_check_path="/mcp/status",
+        ),
+        UatStep(
+            "smoke_http",
+            "Run the smoke client against the live HTTP fixture gateway.",
+            command=[
+                smoke_executable,
+                "http",
+                "--url",
+                f"http://{_FIXTURE_HOST}:{fixture_port}/mcp/request",
+                "--json-report",
+                str(http_smoke_report),
+            ],
+            cwd=workspace,
+        ),
+        UatStep(
+            "smoke_websocket",
+            "Run the smoke client against the live WebSocket fixture gateway.",
+            command=[
+                smoke_executable,
+                "websocket",
+                "--url",
+                f"ws://{_FIXTURE_HOST}:{fixture_port}/mcp/ws",
+                "--json-report",
+                str(websocket_smoke_report),
+            ],
+            cwd=workspace,
+        ),
+        UatStep(
+            "stop_fixture_gateway",
+            "Stop the local fixture gateway.",
+            stop_process_key="fixture_gateway",
+        ),
+    ]
+
+    if gateway_url:
+        steps.append(
+            UatStep(
+                "remote_runtime_list",
+                "List remote runtime state from a configured gateway URL.",
+                command=[gateway_executable, "runtime-list", "--gateway-url", gateway_url],
+                cwd=workspace,
+                required=False,
+            )
+        )
+    else:
+        steps.append(
+            UatStep(
+                "remote_runtime_skipped",
+                "Remote runtime commands require a live gateway URL.",
+                required=False,
+                skip_reason="Set --gateway-url or MCP_UNIFIED_GATEWAY_URL to run remote runtime UAT.",
+            )
+        )
+
+    return steps
+
+
+def redact_text(
+    text: str,
+    *,
+    secrets: list[str],
+    sensitive_paths: list[Path],
+) -> str:
+    """Redact secrets, bearer values, and local paths from captured text."""
+
+    redacted = text
+    for path in sorted({str(path) for path in sensitive_paths if path}, key=len, reverse=True):
+        if path:
+            redacted = redacted.replace(path, "<redacted-path>")
+    for secret in sorted({secret for secret in secrets if secret}, key=len, reverse=True):
+        redacted = redacted.replace(secret, "<redacted-secret>")
+    redacted = re.sub(r"Bearer\s+[^\s\"']+", "Bearer <redacted-secret>", redacted)
+    redacted = re.sub(
+        r"(X-MCP-Gateway-Admin-Key\s*[:=]\s*)[^\s\"']+",
+        r"\1<redacted-secret>",
+        redacted,
+        flags=re.IGNORECASE,
+    )
+    return redacted
+
+
+def run_uat(context: UatRunContext) -> dict[str, Any]:
+    """Run the standalone user-guide UAT plan and return a JSON-safe report."""
+
+    started = perf_counter()
+    started_at = datetime.now(UTC).isoformat()
+    context.workspace.mkdir(parents=True, exist_ok=True)
+    venv_bin = _venv_bin_dir(context.workspace / ".venv")
+    gateway_executable = str(venv_bin / _script_name("mcp-unified-gateway"))
+    smoke_executable = str(venv_bin / _script_name("mcp-unified-smoke"))
+    plan = build_uat_plan(
+        repo_root=context.repo_root,
+        workspace=context.workspace,
+        python_executable=context.bootstrap_python,
+        gateway_executable=gateway_executable,
+        smoke_executable=smoke_executable,
+        gateway_url=context.gateway_url,
+    )
+    try:
+        results = [_run_step(step, context) for step in plan]
+    finally:
+        _stop_remaining_processes(context)
+    ok = all(result.status in {"passed", "skipped"} for result in results if result.required)
+    return {
+        "ok": ok,
+        "started_at": started_at,
+        "duration_ms": _elapsed_ms(started),
+        "workspace": "<redacted-path>",
+        "repo_root": "<redacted-path>",
+        "guide": "mcp_unified/USER_GUIDE.md",
+        "steps": [_step_result_payload(result, context) for result in results],
+        "summary": {
+            "passed": sum(1 for result in results if result.status == "passed"),
+            "failed": sum(1 for result in results if result.status == "failed"),
+            "skipped": sum(1 for result in results if result.status == "skipped"),
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the user-guide UAT harness from the command line."""
+
+    args = _parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    gateway_url = args.gateway_url or os.getenv("MCP_UNIFIED_GATEWAY_URL")
+    admin_key = os.getenv("MCP_UNIFIED_GATEWAY_ADMIN_KEY")
+    secrets = [admin_key] if admin_key else []
+
+    if args.workspace:
+        workspace = args.workspace.resolve()
+        report = run_uat(
+            UatRunContext(
+                repo_root=repo_root,
+                workspace=workspace,
+                bootstrap_python=sys.executable,
+                gateway_url=gateway_url,
+                admin_key=admin_key,
+                timeout_seconds=args.timeout_seconds,
+                secrets=secrets,
+            )
+        )
+    else:
+        with tempfile.TemporaryDirectory(prefix="mcp-standalone-uat-") as temp_dir:
+            report = run_uat(
+                UatRunContext(
+                    repo_root=repo_root,
+                    workspace=Path(temp_dir),
+                    bootstrap_python=sys.executable,
+                    gateway_url=gateway_url,
+                    admin_key=admin_key,
+                    timeout_seconds=args.timeout_seconds,
+                    secrets=secrets,
+                )
+            )
+
+    _write_report(report, args.json_report)
+    return 0 if report["ok"] else 1
+
+
+def _run_step(step: UatStep, context: UatRunContext) -> UatStepResult:
+    started = perf_counter()
+    if step.skip_reason:
+        return UatStepResult(
+            step_id=step.step_id,
+            description=step.description,
+            status="skipped",
+            required=step.required,
+            duration_ms=_elapsed_ms(started),
+            reason=step.skip_reason,
+        )
+    if step.stop_process_key is not None:
+        return _stop_background_process(step, context, started)
+    if step.background_process_key is not None:
+        return _start_background_process(step, context, started)
+    if step.write_json_path is not None:
+        if step.write_json_payload is None:
+            return UatStepResult(
+                step_id=step.step_id,
+                description=step.description,
+                status="failed",
+                required=step.required,
+                duration_ms=_elapsed_ms(started),
+                reason="write step is missing a JSON payload",
+            )
+        step.write_json_path.parent.mkdir(parents=True, exist_ok=True)
+        step.write_json_path.write_text(
+            json.dumps(step.write_json_payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return UatStepResult(
+            step_id=step.step_id,
+            description=step.description,
+            status="passed",
+            required=step.required,
+            duration_ms=_elapsed_ms(started),
+            reason=f"wrote {step.write_json_path.name}",
+        )
+    if step.write_text_path is not None:
+        if step.write_text_payload is None:
+            return UatStepResult(
+                step_id=step.step_id,
+                description=step.description,
+                status="failed",
+                required=step.required,
+                duration_ms=_elapsed_ms(started),
+                reason="write step is missing a text payload",
+            )
+        step.write_text_path.parent.mkdir(parents=True, exist_ok=True)
+        step.write_text_path.write_text(step.write_text_payload, encoding="utf-8")
+        return UatStepResult(
+            step_id=step.step_id,
+            description=step.description,
+            status="passed",
+            required=step.required,
+            duration_ms=_elapsed_ms(started),
+            reason=f"wrote {step.write_text_path.name}",
+        )
+    if step.command is None:
+        return UatStepResult(
+            step_id=step.step_id,
+            description=step.description,
+            status="failed",
+            required=step.required,
+            duration_ms=_elapsed_ms(started),
+            reason="step has no command, write payload, or skip reason",
+        )
+
+    env = os.environ.copy()
+    if context.admin_key:
+        env["MCP_UNIFIED_GATEWAY_ADMIN_KEY"] = context.admin_key
+    try:
+        # Commands are fixed argv lists, never shell strings.
+        completed = subprocess.run(  # nosec B603
+            step.command,
+            cwd=step.cwd,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=context.timeout_seconds,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return UatStepResult(
+            step_id=step.step_id,
+            description=step.description,
+            status="failed",
+            required=step.required,
+            duration_ms=_elapsed_ms(started),
+            command=step.command,
+            reason=f"{exc.__class__.__name__}: {exc}",
+        )
+
+    status = "passed" if completed.returncode in step.expected_exit_codes else "failed"
+    return UatStepResult(
+        step_id=step.step_id,
+        description=step.description,
+        status=status,
+        required=step.required,
+        duration_ms=_elapsed_ms(started),
+        command=step.command,
+        exit_code=completed.returncode,
+        stdout=_truncate(completed.stdout),
+        stderr=_truncate(completed.stderr),
+        reason=None if status == "passed" else "unexpected exit code",
+    )
+
+
+def _start_background_process(
+    step: UatStep,
+    context: UatRunContext,
+    started: float,
+) -> UatStepResult:
+    if step.command is None:
+        return UatStepResult(
+            step_id=step.step_id,
+            description=step.description,
+            status="failed",
+            required=step.required,
+            duration_ms=_elapsed_ms(started),
+            reason="background process step is missing a command",
+        )
+    if step.health_check_port is None or step.health_check_path is None:
+        return UatStepResult(
+            step_id=step.step_id,
+            description=step.description,
+            status="failed",
+            required=step.required,
+            duration_ms=_elapsed_ms(started),
+            command=step.command,
+            reason="background process step is missing a health check",
+        )
+
+    env = os.environ.copy()
+    if context.admin_key:
+        env["MCP_UNIFIED_GATEWAY_ADMIN_KEY"] = context.admin_key
+    try:
+        # Commands are fixed argv lists, never shell strings.
+        process = subprocess.Popen(  # nosec B603
+            step.command,
+            cwd=step.cwd,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except OSError as exc:
+        return UatStepResult(
+            step_id=step.step_id,
+            description=step.description,
+            status="failed",
+            required=step.required,
+            duration_ms=_elapsed_ms(started),
+            command=step.command,
+            reason=f"{exc.__class__.__name__}: {exc}",
+        )
+
+    context.processes[step.background_process_key or step.step_id] = process
+    health_reason = _wait_for_http_health(
+        process,
+        host=step.health_check_host or _FIXTURE_HOST,
+        port=step.health_check_port,
+        path=step.health_check_path,
+        timeout_seconds=context.timeout_seconds,
+    )
+    if health_reason is None:
+        return UatStepResult(
+            step_id=step.step_id,
+            description=step.description,
+            status="passed",
+            required=step.required,
+            duration_ms=_elapsed_ms(started),
+            command=step.command,
+            reason="health check passed",
+        )
+
+    context.processes.pop(step.background_process_key or step.step_id, None)
+    stdout, stderr = _terminate_process(process)
+    return UatStepResult(
+        step_id=step.step_id,
+        description=step.description,
+        status="failed",
+        required=step.required,
+        duration_ms=_elapsed_ms(started),
+        command=step.command,
+        exit_code=process.returncode,
+        stdout=_truncate(stdout),
+        stderr=_truncate(stderr),
+        reason=health_reason,
+    )
+
+
+def _stop_background_process(
+    step: UatStep,
+    context: UatRunContext,
+    started: float,
+) -> UatStepResult:
+    process = context.processes.pop(step.stop_process_key or "", None)
+    if process is None:
+        return UatStepResult(
+            step_id=step.step_id,
+            description=step.description,
+            status="failed",
+            required=step.required,
+            duration_ms=_elapsed_ms(started),
+            reason="background process was not running",
+        )
+    stdout, stderr = _terminate_process(process)
+    return UatStepResult(
+        step_id=step.step_id,
+        description=step.description,
+        status="passed",
+        required=step.required,
+        duration_ms=_elapsed_ms(started),
+        exit_code=process.returncode,
+        stdout=_truncate(stdout),
+        stderr=_truncate(stderr),
+        reason="process stopped",
+    )
+
+
+def _wait_for_http_health(
+    process: subprocess.Popen[str],
+    *,
+    host: str,
+    port: int,
+    path: str,
+    timeout_seconds: float,
+) -> str | None:
+    deadline = perf_counter() + timeout_seconds
+    last_error = "health check did not complete"
+    while perf_counter() < deadline:
+        if process.poll() is not None:
+            return f"process exited before health check passed: {process.returncode}"
+        try:
+            connection = HTTPConnection(host, port, timeout=0.5)
+            connection.request("GET", path)
+            response = connection.getresponse()
+            response.read()
+            if response.status == 200:
+                return None
+            last_error = f"health check returned HTTP {response.status}"
+        except OSError as exc:
+            last_error = f"{exc.__class__.__name__}: {exc}"
+        finally:
+            try:
+                connection.close()
+            except UnboundLocalError:
+                pass
+        sleep(0.1)
+    return last_error
+
+
+def _terminate_process(process: subprocess.Popen[str]) -> tuple[str, str]:
+    if process.poll() is None:
+        process.terminate()
+    try:
+        return process.communicate(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        return process.communicate(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+
+
+def _stop_remaining_processes(context: UatRunContext) -> None:
+    for process in list(context.processes.values()):
+        _terminate_process(process)
+    context.processes.clear()
+
+
+def _step_result_payload(result: UatStepResult, context: UatRunContext) -> dict[str, Any]:
+    return {
+        "id": result.step_id,
+        "description": result.description,
+        "status": result.status,
+        "required": result.required,
+        "duration_ms": result.duration_ms,
+        "command": _redact_command(result.command, context) if result.command else None,
+        "exit_code": result.exit_code,
+        "stdout": redact_text(
+            result.stdout,
+            secrets=context.secrets,
+            sensitive_paths=[context.workspace, context.repo_root],
+        ),
+        "stderr": redact_text(
+            result.stderr,
+            secrets=context.secrets,
+            sensitive_paths=[context.workspace, context.repo_root],
+        ),
+        "reason": result.reason,
+    }
+
+
+def _redact_command(command: list[str], context: UatRunContext) -> list[str]:
+    return [
+        redact_text(
+            token,
+            secrets=context.secrets,
+            sensitive_paths=[context.workspace, context.repo_root],
+        )
+        for token in command
+    ]
+
+
+def _write_report(report: dict[str, Any], json_report: Path | None) -> None:
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if json_report is None:
+        sys.stdout.write(rendered)
+        return
+    json_report.parent.mkdir(parents=True, exist_ok=True)
+    json_report.write_text(rendered, encoding="utf-8")
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run one-off UAT against the MCP Unified standalone user guide.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="Repository root containing the mcp_unified package directory.",
+    )
+    parser.add_argument(
+        "--workspace",
+        type=Path,
+        help="Optional workspace directory to keep after the run.",
+    )
+    parser.add_argument(
+        "--json-report",
+        type=Path,
+        help="Path to write the redacted JSON report. Defaults to stdout.",
+    )
+    parser.add_argument(
+        "--gateway-url",
+        help="Optional live mounted gateway URL for remote runtime UAT.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=_DEFAULT_TIMEOUT_SECONDS,
+        help="Timeout per subprocess command.",
+    )
+    return parser.parse_args(argv)
+
+
+def _script_name(name: str) -> str:
+    if os.name == "nt":
+        return f"{name}.exe"
+    return name
+
+
+def _venv_bin_dir(venv_dir: Path) -> Path:
+    if os.name == "nt":
+        return venv_dir / "Scripts"
+    return venv_dir / "bin"
+
+
+def _venv_python(venv_dir: Path) -> Path:
+    return _venv_bin_dir(venv_dir) / _script_name("python")
+
+
+def _fixture_port_for_workspace(workspace: Path) -> int:
+    # Keep the plan side-effect-free; the actual bind happens in the Uvicorn step.
+    return 18000 + (sum(str(workspace).encode("utf-8")) % 1000)
+
+
+def _elapsed_ms(started: float) -> float:
+    return round((perf_counter() - started) * 1000, 3)
+
+
+def _truncate(value: str) -> str:
+    if len(value) <= _MAX_CAPTURE_CHARS:
+        return value
+    return value[:_MAX_CAPTURE_CHARS] + "\n<truncated>"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Helper_Scripts/Testing-related/mcp_standalone_user_guide_uat.py
+++ b/Helper_Scripts/Testing-related/mcp_standalone_user_guide_uat.py
@@ -921,8 +921,11 @@ def _stop_remaining_processes(context: UatRunContext) -> None:
     for process in list(context.processes.values()):
         try:
             _terminate_process(process)
-        except (OSError, subprocess.SubprocessError, ValueError):
-            continue
+        except Exception as exc:  # noqa: BLE001 - cleanup must not abort on unexpected process errors.
+            sys.stderr.write(
+                "warning: failed to stop background process "
+                f"{process.pid}: {exc.__class__.__name__}: {exc}\n"
+            )
     context.processes.clear()
 
 

--- a/backlog/tasks/task-2393 - Add-MCP-standalone-user-guide-UAT-harness.md
+++ b/backlog/tasks/task-2393 - Add-MCP-standalone-user-guide-UAT-harness.md
@@ -1,0 +1,47 @@
+---
+id: TASK-2393
+title: Add MCP standalone user guide UAT harness
+status: Done
+labels:
+- mcp
+- uat
+- docs
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a one-off harness that validates the package-local MCP Unified standalone user guide from a new-user perspective, including package-boundary install behavior, local CLI/config/profile/snapshot commands, smoke-client availability, and clear reporting of guide issues found during UAT.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] One-off standalone MCP user-guide UAT harness exists outside the packaged `mcp_unified` module.
+- [x] Harness creates an isolated workspace, installs the package-local boundary, runs documented gateway/smoke/profile/admin snapshot flows, exercises in-process/stdio/HTTP/WebSocket smoke transports with local fixtures, and writes a redacted JSON report.
+- [x] Package metadata exposes the documented `mcp-unified-smoke` console script and includes smoke package files.
+- [x] User guide, README, and smoke-client docs reflect the install/smoke prerequisites discovered during UAT.
+- [x] Validation results and known non-required remote-runtime skip are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added `Helper_Scripts/Testing-related/mcp_standalone_user_guide_uat.py` as a one-off harness. Added focused metadata/harness tests in `tldw_Server_API/tests/Helper_Scripts/test_mcp_standalone_user_guide_uat.py`. Fixed `mcp_unified` package metadata so `mcp-unified-smoke` is installed and the gateway extra includes `httpx`/`websockets` for the smoke client. Added local stdio and ASGI smoke fixtures to the harness so it can exercise stdio subprocess, live HTTP, and live WebSocket transports without requiring a deployed gateway. Updated standalone README, USER_GUIDE, and smoke-client documentation based on UAT findings.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Standalone MCP user-guide UAT completed from an isolated temp workspace. Final harness report: 33 passed, 0 failed, 1 skipped. The passed steps include package install, gateway CLI flows, profile/default assignment, policy explain, external server/grant setup, snapshot import/export, tool-use reporting, in-process smoke, stdio subprocess smoke, live HTTP smoke, and live WebSocket smoke. The only skip is the optional remote-runtime live URL path, which requires --gateway-url or MCP_UNIFIED_GATEWAY_URL. Validation passed: focused pytest, Ruff, Bandit with 0 findings, git diff --check, and full UAT harness run.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2393 - Add-MCP-standalone-user-guide-UAT-harness.md
+++ b/backlog/tasks/task-2393 - Add-MCP-standalone-user-guide-UAT-harness.md
@@ -27,13 +27,13 @@ Create a one-off harness that validates the package-local MCP Unified standalone
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Added `Helper_Scripts/Testing-related/mcp_standalone_user_guide_uat.py` as a one-off harness. Added focused metadata/harness tests in `tldw_Server_API/tests/Helper_Scripts/test_mcp_standalone_user_guide_uat.py`. Fixed `mcp_unified` package metadata so `mcp-unified-smoke` is installed and the gateway extra includes `httpx`/`websockets` for the smoke client. Added local stdio and ASGI smoke fixtures to the harness so it can exercise stdio subprocess, live HTTP, and live WebSocket transports without requiring a deployed gateway. Updated standalone README, USER_GUIDE, and smoke-client documentation based on UAT findings.
+Added `Helper_Scripts/Testing-related/mcp_standalone_user_guide_uat.py` as a one-off harness. Added focused metadata/harness tests in `tldw_Server_API/tests/Helper_Scripts/test_mcp_standalone_user_guide_uat.py`. Fixed `mcp_unified` package metadata so `mcp-unified-smoke` is installed and base package installs include `httpx`/`websockets` because the smoke console script is unconditional. Added local stdio and ASGI smoke fixtures to the harness so it can exercise stdio subprocess, live HTTP, and live WebSocket transports without requiring a deployed gateway. Updated standalone README, USER_GUIDE, and smoke-client documentation based on UAT findings. Review follow-up made the UAT venv fully isolated by default, marked new tests as unit tests, hardened bearer-token redaction, and made fixture process cleanup idempotent.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Standalone MCP user-guide UAT completed from an isolated temp workspace. Final harness report: 33 passed, 0 failed, 1 skipped. The passed steps include package install, gateway CLI flows, profile/default assignment, policy explain, external server/grant setup, snapshot import/export, tool-use reporting, in-process smoke, stdio subprocess smoke, live HTTP smoke, and live WebSocket smoke. The only skip is the optional remote-runtime live URL path, which requires --gateway-url or MCP_UNIFIED_GATEWAY_URL. Validation passed: focused pytest, Ruff, Bandit with 0 findings, git diff --check, and full UAT harness run.
+Standalone MCP user-guide UAT completed from an isolated temp workspace. Final harness report: 33 passed, 0 failed, 1 skipped. The passed steps include package install from a fully isolated venv, gateway CLI flows, profile/default assignment, policy explain, external server/grant setup, snapshot import/export, tool-use reporting, in-process smoke, stdio subprocess smoke, live HTTP smoke, and live WebSocket smoke. The only skip is the optional remote-runtime live URL path, which requires --gateway-url or MCP_UNIFIED_GATEWAY_URL. Validation passed: focused pytest, Ruff, Bandit with 0 findings, git diff --check, and full UAT harness run.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/mcp_unified/README.md
+++ b/mcp_unified/README.md
@@ -29,8 +29,9 @@ surface for early standalone gateway work.
   read-before-mutate workflows. The memory backend is the default.
   An optional SQLite backend can coordinate cooperating processes that point at
   the same local database file.
-- A package CLI, `mcp-unified-gateway`, for local config management and remote
-  gateway runtime operations.
+- Package CLIs: `mcp-unified-gateway` for local config management and remote
+  gateway runtime operations, plus `mcp-unified-smoke` for JSON-RPC gateway
+  smoke validation.
 
 For hands-on setup and operations, see [USER_GUIDE.md](USER_GUIDE.md).
 
@@ -59,10 +60,11 @@ Use the package-local project file when testing the standalone boundary:
 python -m pip install -e "mcp_unified[gateway]"
 ```
 
-For test and packaging work:
+For test and packaging work, install both the gateway runtime and development
+tools:
 
 ```bash
-python -m pip install -e "mcp_unified[dev]"
+python -m pip install -e "mcp_unified[gateway,dev]"
 ```
 
 The package dependency groups intentionally stay small. Heavy `tldw-server`
@@ -81,6 +83,12 @@ List bundled profile presets:
 
 ```bash
 mcp-unified-gateway list-presets
+```
+
+Run the deterministic in-process smoke scenario:
+
+```bash
+mcp-unified-smoke inprocess --json-report -
 ```
 
 Validate a gateway config file:

--- a/mcp_unified/USER_GUIDE.md
+++ b/mcp_unified/USER_GUIDE.md
@@ -15,16 +15,25 @@ From the repository root:
 python -m pip install -e "mcp_unified[gateway]"
 ```
 
-For development and artifact checks:
+For development and artifact checks, install both the gateway runtime and
+development tools:
 
 ```bash
-python -m pip install -e "mcp_unified[dev]"
+python -m pip install -e "mcp_unified[gateway,dev]"
 ```
 
 Confirm the CLI is available:
 
 ```bash
 mcp-unified-gateway package-info
+```
+
+For a quick standalone JSON-RPC smoke check, confirm the smoke client is also
+available and run the deterministic in-process fixture:
+
+```bash
+mcp-unified-smoke --help
+mcp-unified-smoke inprocess --json-report -
 ```
 
 ## 2. Choose A Store

--- a/mcp_unified/pyproject.toml
+++ b/mcp_unified/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
   "pydantic>=2.0.0",
   "loguru>=0.7.0",
   "PyYAML>=6.0.0",
+  "httpx>=0.24.0",
+  "websockets>=12.0",
 ]
 
 [project.optional-dependencies]

--- a/mcp_unified/pyproject.toml
+++ b/mcp_unified/pyproject.toml
@@ -38,9 +38,11 @@ gateway = [
   "loguru>=0.7.0",
   "PyYAML>=6.0.0",
   "fastapi>=0.136.3",
+  "httpx>=0.24.0",
   "starlette>=1.0.1",
   "SQLAlchemy>=2.0.29",
   "uvicorn[standard]>=0.23.0",
+  "websockets>=12.0",
 ]
 dev = [
   "pytest>=9.0.3",
@@ -50,6 +52,7 @@ dev = [
 
 [project.scripts]
 mcp-unified-gateway = "mcp_unified.gateway.cli:main"
+mcp-unified-smoke = "mcp_unified.smoke.cli:main"
 
 [tool.setuptools]
 include-package-data = false
@@ -60,6 +63,7 @@ packages = [
   "mcp_unified.gateway",
   "mcp_unified.interfaces",
   "mcp_unified.profiles",
+  "mcp_unified.smoke",
   "mcp_unified.storage",
   "mcp_unified.tool_hooks",
   "mcp_unified.tool_use_reporting",
@@ -72,6 +76,7 @@ mcp_unified = "."
 "mcp_unified.gateway" = "gateway"
 "mcp_unified.interfaces" = "interfaces"
 "mcp_unified.profiles" = "profiles"
+"mcp_unified.smoke" = "smoke"
 "mcp_unified.storage" = "storage"
 "mcp_unified.tool_hooks" = "tool_hooks"
 "mcp_unified.tool_use_reporting" = "tool_use_reporting"

--- a/tldw_Server_API/tests/Helper_Scripts/test_mcp_standalone_user_guide_uat.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_mcp_standalone_user_guide_uat.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
+import pytest
 import tomllib
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -34,6 +35,7 @@ def _load_harness() -> ModuleType:
     return module
 
 
+@pytest.mark.unit
 def test_standalone_package_exposes_documented_gateway_and_smoke_clis() -> None:
     metadata = _mcp_package_metadata()
 
@@ -47,15 +49,17 @@ def test_standalone_package_exposes_documented_gateway_and_smoke_clis() -> None:
     assert package_dirs["mcp_unified.smoke"] == "smoke"
 
 
-def test_gateway_extra_installs_smoke_cli_runtime_dependencies() -> None:
+@pytest.mark.unit
+def test_base_install_includes_smoke_cli_runtime_dependencies() -> None:
     metadata = _mcp_package_metadata()
 
-    gateway_dependencies = metadata["project"]["optional-dependencies"]["gateway"]
+    dependencies = metadata["project"]["dependencies"]
 
-    assert any(dependency.startswith("httpx") for dependency in gateway_dependencies)
-    assert any(dependency.startswith("websockets") for dependency in gateway_dependencies)
+    assert any(dependency.startswith("httpx") for dependency in dependencies)
+    assert any(dependency.startswith("websockets") for dependency in dependencies)
 
 
+@pytest.mark.unit
 def test_user_guide_uat_plan_covers_documented_local_flows(tmp_path: Path) -> None:
     module = _load_harness()
 
@@ -105,8 +109,12 @@ def test_user_guide_uat_plan_covers_documented_local_flows(tmp_path: Path) -> No
         "stop_fixture_gateway",
         "remote_runtime_skipped",
     ]
+    create_venv = plan[0]
+    assert create_venv.command is not None
+    assert "--system-site-packages" not in create_venv.command
 
 
+@pytest.mark.unit
 def test_user_guide_uat_redaction_removes_secrets_and_workspace_paths(tmp_path: Path) -> None:
     module = _load_harness()
     workspace = tmp_path / "uat-workspace"
@@ -126,4 +134,18 @@ def test_user_guide_uat_redaction_removes_secrets_and_workspace_paths(tmp_path: 
     assert str(workspace) not in redacted
     assert "<redacted-secret>" in redacted
     assert "<redacted-path>" in redacted
+    assert "Bearer <redacted-secret>" in redacted
+
+
+@pytest.mark.unit
+def test_user_guide_uat_redaction_removes_lowercase_bearer_tokens() -> None:
+    module = _load_harness()
+
+    redacted = module.redact_text(
+        "authorization: bearer abc.def",
+        secrets=[],
+        sensitive_paths=[],
+    )
+
+    assert "abc.def" not in redacted
     assert "Bearer <redacted-secret>" in redacted

--- a/tldw_Server_API/tests/Helper_Scripts/test_mcp_standalone_user_guide_uat.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_mcp_standalone_user_guide_uat.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import tomllib
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MCP_PACKAGE_PYPROJECT = REPO_ROOT / "mcp_unified" / "pyproject.toml"
+HARNESS_PATH = (
+    REPO_ROOT
+    / "Helper_Scripts"
+    / "Testing-related"
+    / "mcp_standalone_user_guide_uat.py"
+)
+
+
+def _mcp_package_metadata() -> dict:
+    return tomllib.loads(MCP_PACKAGE_PYPROJECT.read_text(encoding="utf-8"))
+
+
+def _load_harness() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "mcp_standalone_user_guide_uat",
+        HARNESS_PATH,
+    )
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_standalone_package_exposes_documented_gateway_and_smoke_clis() -> None:
+    metadata = _mcp_package_metadata()
+
+    scripts = metadata["project"]["scripts"]
+    packages = metadata["tool"]["setuptools"]["packages"]
+    package_dirs = metadata["tool"]["setuptools"]["package-dir"]
+
+    assert scripts["mcp-unified-gateway"] == "mcp_unified.gateway.cli:main"
+    assert scripts["mcp-unified-smoke"] == "mcp_unified.smoke.cli:main"
+    assert "mcp_unified.smoke" in packages
+    assert package_dirs["mcp_unified.smoke"] == "smoke"
+
+
+def test_gateway_extra_installs_smoke_cli_runtime_dependencies() -> None:
+    metadata = _mcp_package_metadata()
+
+    gateway_dependencies = metadata["project"]["optional-dependencies"]["gateway"]
+
+    assert any(dependency.startswith("httpx") for dependency in gateway_dependencies)
+    assert any(dependency.startswith("websockets") for dependency in gateway_dependencies)
+
+
+def test_user_guide_uat_plan_covers_documented_local_flows(tmp_path: Path) -> None:
+    module = _load_harness()
+
+    plan = module.build_uat_plan(
+        repo_root=REPO_ROOT,
+        workspace=tmp_path,
+        python_executable="/tmp/uat-python",
+        gateway_executable="/tmp/mcp-unified-gateway",
+        smoke_executable="/tmp/mcp-unified-smoke",
+        gateway_url=None,
+    )
+
+    step_ids = [step.step_id for step in plan]
+    assert step_ids == [
+        "create_venv",
+        "install_package_boundary",
+        "gateway_package_info",
+        "smoke_cli_help",
+        "write_gateway_config",
+        "validate_gateway_config",
+        "list_presets",
+        "show_project_researcher_preset",
+        "duplicate_project_researcher_preset",
+        "set_default_profile",
+        "get_default_profile",
+        "write_policy_args",
+        "explain_policy",
+        "preview_profile_tools",
+        "write_external_server",
+        "create_external_server",
+        "list_external_servers",
+        "write_credential_grant",
+        "create_credential_grant",
+        "list_credential_grants",
+        "export_config_snapshot",
+        "import_config_snapshot_dry_run",
+        "import_config_snapshot_apply",
+        "write_reporting_config",
+        "tool_events_report",
+        "smoke_inprocess",
+        "write_stdio_fixture",
+        "smoke_stdio_subprocess",
+        "write_asgi_fixture",
+        "start_fixture_gateway",
+        "smoke_http",
+        "smoke_websocket",
+        "stop_fixture_gateway",
+        "remote_runtime_skipped",
+    ]
+
+
+def test_user_guide_uat_redaction_removes_secrets_and_workspace_paths(tmp_path: Path) -> None:
+    module = _load_harness()
+    workspace = tmp_path / "uat-workspace"
+    secret = "super-secret-admin-key"
+    text = (
+        f"workspace={workspace} key={secret} "
+        "header=X-MCP-Gateway-Admin-Key token=Bearer abc.def"
+    )
+
+    redacted = module.redact_text(
+        text,
+        secrets=[secret],
+        sensitive_paths=[workspace],
+    )
+
+    assert secret not in redacted
+    assert str(workspace) not in redacted
+    assert "<redacted-secret>" in redacted
+    assert "<redacted-path>" in redacted
+    assert "Bearer <redacted-secret>" in redacted


### PR DESCRIPTION
## Summary
- Add a one-off MCP standalone user-guide UAT harness that installs the package boundary in an isolated workspace and exercises the documented gateway CLI flows.
- Package the documented `mcp-unified-smoke` CLI and add gateway extra dependencies needed for smoke transport checks.
- Update the standalone README/user guide/smoke docs with install and smoke-client prerequisites discovered during UAT.

## Test Plan
- [x] `python -m pytest tldw_Server_API/tests/Helper_Scripts/test_mcp_standalone_user_guide_uat.py -q` — 4 passed, 6 warnings
- [x] `python -m ruff check Helper_Scripts/Testing-related/mcp_standalone_user_guide_uat.py tldw_Server_API/tests/Helper_Scripts/test_mcp_standalone_user_guide_uat.py`
- [x] `python -m bandit -r Helper_Scripts/Testing-related/mcp_standalone_user_guide_uat.py -f json -o /tmp/bandit_mcp_standalone_uat.json` — 0 findings
- [x] `git diff --check HEAD~1..HEAD`
- [x] `python Helper_Scripts/Testing-related/mcp_standalone_user_guide_uat.py --repo-root . --json-report /tmp/mcp_standalone_user_guide_uat.json` — 33 passed, 0 failed, 1 skipped

## Validation
- [x] Harness creates a fresh isolated temp workspace and installs `mcp_unified[gateway]` from the package-local path.
- [x] Harness exercises documented gateway config, preset/profile, default assignment, policy explain, tool preview, external server, credential grant, snapshot import/export, and reporting flows.
- [x] Harness runs `mcp-unified-smoke` against in-process, stdio subprocess, live HTTP, and live WebSocket local fixtures.
- [x] Report output redacts local paths and secrets.

## Risk & Rollback
- Risk: This adds a helper-script UAT harness and adjusts package metadata for the smoke CLI/runtime dependencies; no production runtime behavior is changed.
- Mitigation: Focused metadata/harness tests and full UAT run verify the intended package/docs behavior.
- Rollback: Revert this PR to remove the helper harness/docs updates and restore the previous package metadata.

## Merge Note
Human-authored `Change summary` is required before merge by repository policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-off UAT harness that installs `mcp_unified[gateway]` in an isolated workspace and runs the documented gateway and smoke CLI flows across in-process, stdio, HTTP, and WebSocket, producing a redacted JSON report. Hardens fixture process startup/cleanup and redaction, publishes the `mcp-unified-smoke` CLI, and updates docs so install and smoke checks work out of the box.

- **New Features**
  - Added `Helper_Scripts/Testing-related/mcp_standalone_user_guide_uat.py` with fully isolated venv, health-checked background fixtures, stronger bearer-token redaction, and idempotent cleanup.
  - Added tests in `tldw_Server_API/tests/Helper_Scripts/test_mcp_standalone_user_guide_uat.py` covering the plan, redaction, package metadata, and base deps.
  - Updated `mcp_unified/README.md`, `mcp_unified/USER_GUIDE.md`, and `Docs/MCP/Unified/Smoke_Client.md` with `mcp_unified[gateway]` install steps and smoke examples.

- **Dependencies**
  - Exposed `mcp-unified-smoke` console script and packaged `mcp_unified.smoke`.
  - Added `httpx` and `websockets` to base and gateway extras to support HTTP/WebSocket smoke transports.

<sup>Written for commit 73b2fd0e567019980355b37a57e5ae32dbcc5d94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

