### PR TITLE
TASK-530.6 clarify Skills test-run semantics

### DIFF
--- a/Docs/Plans/IMPLEMENTATION_PLAN_skills_test_run_semantics_TASK_530_6.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_skills_test_run_semantics_TASK_530_6.md
@@ -1,0 +1,25 @@
+# Skills Test Run Semantics Implementation Plan
+
+## Stage 1: Red Tests For Test-Run Copy
+**Goal**: Capture the safe-operations behavior expected from the Skills test-run modal and row action.
+**Success Criteria**: Focused tests fail on the current passive Preview copy and non-alert error rendering.
+**Tests**: `bunx vitest run src/components/Option/Skills/__tests__/SkillPreview.test.tsx src/components/Option/Skills/__tests__/Manager.test.tsx -t "test run|execution risk|alert"`
+**Status**: Complete
+
+## Stage 2: Rename Preview Semantics
+**Goal**: Replace passive Preview language with explicit Test run / Run test language in row actions and the modal.
+**Success Criteria**: Users can tell that the action executes the skill path rather than merely opening a read-only preview.
+**Tests**: Focused SkillPreview and Manager tests.
+**Status**: Complete
+
+## Stage 3: Execution-Risk Disclosure And Error Alert
+**Goal**: Add pre-run copy naming argument rendering and fork-mode model/tool risk, and expose execution failures through alert semantics.
+**Success Criteria**: The risk copy is visible before execution and errors render with `role="alert"`.
+**Tests**: Focused SkillPreview tests.
+**Status**: Complete
+
+## Stage 4: Verification And Closeout
+**Goal**: Verify the focused frontend slice, update Backlog notes, and keep later Safe Operations work out of this PR.
+**Success Criteria**: Focused Vitest passes, `git diff --check` passes, Bandit is documented as not applicable for frontend-only TypeScript, and `TASK-530.6` records verification.
+**Tests**: `bunx vitest run src/components/Option/Skills/__tests__/SkillPreview.test.tsx src/components/Option/Skills/__tests__/Manager.test.tsx`; `git diff --check`.
+**Status**: Complete

--- a/apps/packages/ui/src/components/Option/Skills/Manager.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/Manager.tsx
@@ -746,10 +746,10 @@ export const SkillsManager: React.FC = () => {
       width: 180,
       render: (_: unknown, record: SkillSummary) => (
         <div className="flex items-center gap-1">
-          <Tooltip title={t("option:skills.preview", { defaultValue: "Preview" })}>
+          <Tooltip title={t("option:skills.testRun", { defaultValue: "Test run" })}>
             <Button
-              aria-label={t("option:skills.previewSkill", {
-                defaultValue: `Preview ${record.name}`,
+              aria-label={t("option:skills.testRunSkill", {
+                defaultValue: `Test run ${record.name}`,
                 name: record.name
               })}
               type="text"

--- a/apps/packages/ui/src/components/Option/Skills/SkillPreview.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/SkillPreview.tsx
@@ -17,11 +17,13 @@ export const SkillPreview: React.FC<SkillPreviewProps> = ({
   const { t } = useTranslation(["option", "common"])
   const [args, setArgs] = React.useState("")
   const [result, setResult] = React.useState<SkillExecutionResult | null>(null)
+  const testRunPendingRef = React.useRef(false)
 
   React.useEffect(() => {
     if (!skillName) {
       setArgs("")
       setResult(null)
+      testRunPendingRef.current = false
     }
   }, [skillName])
 
@@ -29,13 +31,17 @@ export const SkillPreview: React.FC<SkillPreviewProps> = ({
     mutationFn: () => tldwClient.executeSkill(skillName!, args),
     onSuccess: (data: SkillExecutionResult) => {
       setResult(data)
+    },
+    onSettled: () => {
+      testRunPendingRef.current = false
     }
   })
 
   const handleRunTest = () => {
-    if (skillName) {
-      executeMutation.mutate()
-    }
+    if (!skillName || testRunPendingRef.current || executeMutation.isPending) return
+
+    testRunPendingRef.current = true
+    executeMutation.mutate()
   }
 
   const errorMessage =
@@ -69,6 +75,7 @@ export const SkillPreview: React.FC<SkillPreviewProps> = ({
               defaultValue: "Enter test arguments..."
             })}
             onPressEnter={handleRunTest}
+            disabled={executeMutation.isPending}
           />
         </div>
 
@@ -83,6 +90,7 @@ export const SkillPreview: React.FC<SkillPreviewProps> = ({
           type="primary"
           onClick={handleRunTest}
           loading={executeMutation.isPending}
+          disabled={executeMutation.isPending}
         >
           {t("option:skills.testRunAction", { defaultValue: "Run test" })}
         </Button>

--- a/apps/packages/ui/src/components/Option/Skills/SkillPreview.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/SkillPreview.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { useMutation } from "@tanstack/react-query"
-import { Button, Input, Modal, Tag } from "antd"
+import { Alert, Button, Input, Modal, Tag } from "antd"
 import { useTranslation } from "react-i18next"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 import type { SkillExecutionResult } from "@/types/skill"
@@ -32,23 +32,28 @@ export const SkillPreview: React.FC<SkillPreviewProps> = ({
     }
   })
 
-  const handlePreview = () => {
+  const handleRunTest = () => {
     if (skillName) {
       executeMutation.mutate()
     }
   }
 
+  const errorMessage =
+    executeMutation.error instanceof Error
+      ? executeMutation.error.message
+      : t("option:skills.testRunError", { defaultValue: "Execution failed" })
+
   return (
     <Modal
-      title={t("option:skills.previewTitle", {
-        defaultValue: "Preview Skill",
+      title={t("option:skills.testRunTitle", {
+        defaultValue: "Test run",
         name: skillName
       })}
       open={Boolean(skillName)}
       onCancel={onClose}
       footer={null}
       width={640}
-      destroyOnClose
+      destroyOnHidden
     >
       <div className="flex flex-col gap-4">
         <div>
@@ -63,22 +68,27 @@ export const SkillPreview: React.FC<SkillPreviewProps> = ({
             placeholder={t("option:skills.previewArgsPlaceholder", {
               defaultValue: "Enter test arguments..."
             })}
-            onPressEnter={handlePreview}
+            onPressEnter={handleRunTest}
           />
         </div>
 
+        <p className="m-0 text-sm text-text-muted">
+          {t("option:skills.testRunDisclosure", {
+            defaultValue:
+              "This renders the skill with your arguments. Fork-mode skills may call the configured model and allowed tools."
+          })}
+        </p>
+
         <Button
           type="primary"
-          onClick={handlePreview}
+          onClick={handleRunTest}
           loading={executeMutation.isPending}
         >
-          {t("option:skills.previewRun", { defaultValue: "Preview" })}
+          {t("option:skills.testRunAction", { defaultValue: "Run test" })}
         </Button>
 
         {executeMutation.isError && (
-          <div className="rounded border border-danger/30 bg-danger/10 p-3 text-sm text-danger">
-            {(executeMutation.error as any)?.message || "Execution failed"}
-          </div>
+          <Alert role="alert" type="error" showIcon title={errorMessage} />
         )}
 
         {result && (

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx
@@ -587,6 +587,25 @@ describe("SkillsManager imports", () => {
     })
   })
 
+  it("labels the row execution action as a test run", async () => {
+    tldwClientMock.listSkills.mockResolvedValue({
+      skills: [makeSkill(1)],
+      count: 1,
+      total: 1,
+      limit: 10,
+      offset: 0
+    })
+
+    renderManager()
+
+    expect(await screen.findByText("1 skill")).toBeInTheDocument()
+    const testRunButton = screen.getByRole("button", { name: "Test run skill-1" })
+    expect(screen.queryByRole("button", { name: "Preview skill-1" })).not.toBeInTheDocument()
+
+    fireEvent.click(testRunButton)
+    expect(screen.getByTestId("skill-preview-open")).toHaveTextContent("skill-1")
+  })
+
   it("clears server-backed mode sorting when the mode column is hidden", async () => {
     tldwClientMock.listSkills.mockResolvedValue({
       skills: [

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/SkillPreview.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/SkillPreview.test.tsx
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { Modal } from "antd"
+import { SkillPreview } from "../SkillPreview"
+import type React from "react"
+
+const tldwClientMock = vi.hoisted(() => ({
+  executeSkill: vi.fn()
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: tldwClientMock
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      fallbackOrOptions?: string | { defaultValue?: string; [k: string]: unknown }
+    ) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+      if (fallbackOrOptions && typeof fallbackOrOptions === "object") {
+        return fallbackOrOptions.defaultValue || key
+      }
+      return key
+    }
+  })
+}))
+
+const renderPreview = (props: Partial<React.ComponentProps<typeof SkillPreview>> = {}) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false }
+    }
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SkillPreview
+        skillName={props.skillName ?? "summarize"}
+        onClose={props.onClose ?? vi.fn()}
+      />
+    </QueryClientProvider>
+  )
+}
+
+describe("SkillPreview test-run semantics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    if (!window.matchMedia) {
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn()
+        }))
+      })
+    }
+
+    if (typeof globalThis.ResizeObserver === "undefined") {
+      globalThis.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      } as unknown as typeof ResizeObserver
+    }
+
+    tldwClientMock.executeSkill.mockResolvedValue({
+      skill_name: "summarize",
+      rendered_prompt: "Summarize chapter 1",
+      allowed_tools: ["search"],
+      model_override: null,
+      execution_mode: "fork",
+      fork_output: "Summary output"
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    Modal.destroyAll()
+  })
+
+  it("discloses execution risk before running a skill", () => {
+    renderPreview()
+
+    const dialog = screen.getByRole("dialog", { name: "Test run" })
+    expect(
+      within(dialog).getByText(
+        "This renders the skill with your arguments. Fork-mode skills may call the configured model and allowed tools."
+      )
+    ).toBeInTheDocument()
+    expect(within(dialog).getByRole("button", { name: "Run test" })).toBeInTheDocument()
+    expect(within(dialog).queryByRole("button", { name: "Preview" })).not.toBeInTheDocument()
+  })
+
+  it("runs the skill with supplied arguments from the explicit test action", async () => {
+    renderPreview()
+
+    const dialog = screen.getByRole("dialog", { name: "Test run" })
+    fireEvent.change(within(dialog).getByPlaceholderText("Enter test arguments..."), {
+      target: { value: "chapter 1" }
+    })
+    fireEvent.click(within(dialog).getByRole("button", { name: "Run test" }))
+
+    await waitFor(() => {
+      expect(tldwClientMock.executeSkill).toHaveBeenCalledWith("summarize", "chapter 1")
+    })
+  })
+
+  it("renders execution failures as alerts", async () => {
+    tldwClientMock.executeSkill.mockRejectedValueOnce(new Error("Model unavailable"))
+    renderPreview()
+
+    fireEvent.click(screen.getByRole("button", { name: "Run test" }))
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Model unavailable")
+  })
+})

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/SkillPreview.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/SkillPreview.test.tsx
@@ -117,6 +117,46 @@ describe("SkillPreview test-run semantics", () => {
     })
   })
 
+  it("prevents duplicate skill executions while a test run is pending", async () => {
+    let resolveExecution: (value: {
+      skill_name: string
+      rendered_prompt: string
+      allowed_tools: string[]
+      model_override: null
+      execution_mode: "fork"
+      fork_output: string
+    }) => void = () => {}
+    tldwClientMock.executeSkill.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveExecution = resolve
+        })
+    )
+
+    renderPreview()
+
+    const dialog = screen.getByRole("dialog", { name: "Test run" })
+    const argsInput = within(dialog).getByPlaceholderText("Enter test arguments...")
+    fireEvent.click(within(dialog).getByRole("button", { name: "Run test" }))
+
+    await waitFor(() => {
+      expect(tldwClientMock.executeSkill).toHaveBeenCalledTimes(1)
+    })
+
+    expect(argsInput).toBeDisabled()
+    fireEvent.keyDown(argsInput, { key: "Enter", code: "Enter", charCode: 13 })
+    expect(tldwClientMock.executeSkill).toHaveBeenCalledTimes(1)
+
+    resolveExecution({
+      skill_name: "summarize",
+      rendered_prompt: "Summarize chapter 1",
+      allowed_tools: ["search"],
+      model_override: null,
+      execution_mode: "fork",
+      fork_output: "Summary output"
+    })
+  })
+
   it("renders execution failures as alerts", async () => {
     tldwClientMock.executeSkill.mockRejectedValueOnce(new Error("Model unavailable"))
     renderPreview()

--- a/backlog/tasks/task-530.6 - Implement-Skills-test-run-semantics-and-execution-risk-disclosure.md
+++ b/backlog/tasks/task-530.6 - Implement-Skills-test-run-semantics-and-execution-risk-disclosure.md
@@ -4,13 +4,15 @@ title: Implement Skills test-run semantics and execution-risk disclosure
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-21 16:22'
+updated_date: '2026-06-21 16:38'
 labels:
   - skills
   - webui
   - ux
   - safe-operations
 dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/2423'
 parent_task_id: TASK-530
 priority: high
 ordinal: 530.6

--- a/backlog/tasks/task-530.6 - Implement-Skills-test-run-semantics-and-execution-risk-disclosure.md
+++ b/backlog/tasks/task-530.6 - Implement-Skills-test-run-semantics-and-execution-risk-disclosure.md
@@ -4,7 +4,7 @@ title: Implement Skills test-run semantics and execution-risk disclosure
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-21 16:38'
+updated_date: '2026-06-21 16:47'
 labels:
   - skills
   - webui
@@ -47,7 +47,9 @@ Docs/Plans/IMPLEMENTATION_PLAN_skills_test_run_semantics_TASK_530_6.md
 - Updated SkillPreview to use Test run / Run test language, disclose fork-mode model/tool execution risk before execution, render execution failures with AntD Alert semantics, and replace deprecated Modal destroyOnClose with destroyOnHidden.
 - Updated the SkillsManager row action tooltip and accessible name to Test run semantics.
 - Kept backend dry-run support, import review, delete/versioning, permission metadata panels, and bulk actions out of scope.
-- Verification: focused Skills Vitest files pass: 26 tests; git diff --check passes.
+- PR review follow-up: verified CodeRabbit duplicate-execution finding, added a synchronous pending guard, disabled the argument input and Run test button while execution is pending, and added a regression test.
+- PR review follow-up: verified Gemini Alert/message and Modal/destroyOnClose suggestions against installed AntD 6.2.1; title and destroyOnHidden are the current non-deprecated APIs, so no code change was made for those threads.
+- Verification: focused Skills Vitest files pass: 27 tests; git diff --check passes.
 - Optional UI typecheck was run with NODE_OPTIONS=--max-old-space-size=8192 and fails on existing unrelated Notes, ScheduledTasks, background, and voice-cloning TypeScript errors; no Skills diagnostics were reported.
 - Bandit is not applicable for this frontend-only TypeScript/TSX and markdown slice.
 - Known skip/blocker: no backend dry-run semantics are claimed or changed in this task.
@@ -56,7 +58,7 @@ Docs/Plans/IMPLEMENTATION_PLAN_skills_test_run_semantics_TASK_530_6.md
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the first Safe Operations slice for Skills test runs: row and modal actions now use explicit Test run / Run test language, the modal discloses fork-mode model/tool execution risk before execution, and execution failures render as accessible alerts. Focused Skills manager and SkillPreview tests cover the updated workflow. Bandit is not applicable because this task only changes frontend TypeScript/TSX and task/plan markdown. Optional UI typecheck currently fails on unrelated repo baseline errors outside Skills.
+Implemented the first Safe Operations slice for Skills test runs and PR review follow-up: row and modal actions now use explicit Test run / Run test language, the modal discloses fork-mode model/tool execution risk before execution, execution failures render as accessible alerts, and pending test runs cannot be duplicated through repeated actions. Focused Skills manager and SkillPreview tests cover the updated workflow. Bandit is not applicable because this task only changes frontend TypeScript/TSX and task/plan markdown. Optional UI typecheck currently fails on unrelated repo baseline errors outside Skills.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-530.6 - Implement-Skills-test-run-semantics-and-execution-risk-disclosure.md
+++ b/backlog/tasks/task-530.6 - Implement-Skills-test-run-semantics-and-execution-risk-disclosure.md
@@ -1,0 +1,68 @@
+---
+id: TASK-530.6
+title: Implement Skills test-run semantics and execution-risk disclosure
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-21 16:22'
+labels:
+  - skills
+  - webui
+  - ux
+  - safe-operations
+dependencies: []
+parent_task_id: TASK-530
+priority: high
+ordinal: 530.6
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the first Safe Operations slice for /skills. Rename misleading passive preview language to explicit test-run language, disclose model/tool execution risk before running a skill, and render execution errors with alert semantics. Keep dry-run backend support, import review, delete/versioning, and permission metadata panels out of scope for this PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The Skills manager row action and modal title use Test run language instead of passive Preview language.
+- [x] #2 The modal primary action is named Run test.
+- [x] #3 The modal explains before execution that skill rendering uses the supplied arguments and fork-mode skills may call configured models and allowed tools.
+- [x] #4 Execution errors render with alert semantics so they are discoverable to assistive technology.
+- [x] #5 Focused SkillPreview and Skills manager tests cover the copy, action naming, risk disclosure, and error alert behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/Plans/IMPLEMENTATION_PLAN_skills_test_run_semantics_TASK_530_6.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added focused SkillPreview coverage for test-run title/action copy, execution-risk disclosure, executeSkill argument forwarding, and alert-based error rendering.
+- Added SkillsManager coverage that the row play action is labeled as a test run instead of Preview.
+- Updated SkillPreview to use Test run / Run test language, disclose fork-mode model/tool execution risk before execution, render execution failures with AntD Alert semantics, and replace deprecated Modal destroyOnClose with destroyOnHidden.
+- Updated the SkillsManager row action tooltip and accessible name to Test run semantics.
+- Kept backend dry-run support, import review, delete/versioning, permission metadata panels, and bulk actions out of scope.
+- Verification: focused Skills Vitest files pass: 26 tests; git diff --check passes.
+- Optional UI typecheck was run with NODE_OPTIONS=--max-old-space-size=8192 and fails on existing unrelated Notes, ScheduledTasks, background, and voice-cloning TypeScript errors; no Skills diagnostics were reported.
+- Bandit is not applicable for this frontend-only TypeScript/TSX and markdown slice.
+- Known skip/blocker: no backend dry-run semantics are claimed or changed in this task.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the first Safe Operations slice for Skills test runs: row and modal actions now use explicit Test run / Run test language, the modal discloses fork-mode model/tool execution risk before execution, and execution failures render as accessible alerts. Focused Skills manager and SkillPreview tests cover the updated workflow. Bandit is not applicable because this task only changes frontend TypeScript/TSX and task/plan markdown. Optional UI typecheck currently fails on unrelated repo baseline errors outside Skills.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Change summary
- Rename the Skills row action and execution modal from passive Preview language to explicit Test run / Run test language because the current action calls the skill execution endpoint.
- Add pre-run disclosure that supplied arguments are rendered and fork-mode skills may call the configured model and allowed tools, so users understand the execution risk before running.
- Render execution failures with alert semantics and add focused regression coverage for the row action, modal copy, execution call, and error state.

## Scope
- Frontend-only Skills safe-operations slice.
- Does not add backend dry-run support, import review, delete/versioning, permission metadata panels, or bulk actions.

## Verification
- bunx vitest run src/components/Option/Skills/__tests__/SkillPreview.test.tsx src/components/Option/Skills/__tests__/Manager.test.tsx --reporter=verbose (26 passed)
- git diff --check
- NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit -p tsconfig.json --pretty false (fails on existing unrelated Notes, ScheduledTasks, background, and voice-cloning TypeScript errors; no Skills diagnostics reported)
- Bandit not applicable: frontend TypeScript/TSX and markdown only

## Backlog
- TASK-530.6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies Skills “Preview” to explicit Test run semantics, adds a pre-run risk notice, shows failures as accessible alerts, and prevents duplicate runs. Meets TASK-530.6 to improve clarity and safety in the Skills manager.

- **New Features**
  - Row action tooltip/aria-label and modal title/primary action use Test run / Run test.
  - Pre-run notice explains argument rendering and that fork-mode may call configured models and allowed tools.
  - Execution updates: errors render as alerts via `antd` `Alert`, and duplicate test runs are blocked by disabling the input and action while pending.

<sup>Written for commit f3a154dae901306e1e41bd41f7d5eba20be69a90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

