### PR TITLE
TASK-530.7 add Skills dry render mode

### DIFF
--- a/Docs/Plans/IMPLEMENTATION_PLAN_skills_dry_render_TASK_530_7.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_skills_dry_render_TASK_530_7.md
@@ -1,0 +1,23 @@
+## Stage 1: Contract And Red Tests
+**Goal**: Lock down the dry-render contract before implementation.
+**Success Criteria**: Backend tests fail because `dry_run` is not yet accepted/returned and fork execution is still invoked; frontend tests fail because the client/modal do not send dry-render requests.
+**Tests**: Targeted Skills executor/API tests and SkillPreview/workspace-api Vitest coverage.
+**Status**: Complete
+
+## Stage 2: Backend Dry Render
+**Goal**: Add `dry_run` to the Skills execute request/result and short-circuit model/tool/fork execution when requested.
+**Success Criteria**: Inline and fork skills return rendered prompt metadata with `dry_run: true`; fork output remains null; normal test execution behavior remains unchanged.
+**Tests**: `test_skill_executor.py` and `test_skills_api.py` targeted cases.
+**Status**: Complete
+
+## Stage 3: Frontend Dry Render Action
+**Goal**: Expose a safe "Render prompt only" action next to "Run test" in the Skills preview modal.
+**Success Criteria**: The client sends `dry_run: true` only for the render-only action, the existing test-run action sends `dry_run: false`, pending state prevents duplicates, and results identify whether they were dry-rendered or executed.
+**Tests**: SkillPreview modal tests and workspace-api client payload tests.
+**Status**: Complete
+
+## Stage 4: Verification And Closeout
+**Goal**: Verify the scoped change and prepare it for review.
+**Success Criteria**: Targeted backend tests, targeted frontend tests, `git diff --check`, and Bandit on touched backend scope are recorded; Backlog task has final notes; branch is committed and PR is opened against `dev`.
+**Tests**: Targeted pytest, targeted Vitest, Bandit, diff check.
+**Status**: Complete

--- a/apps/packages/ui/src/components/Option/Skills/SkillPreview.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/SkillPreview.tsx
@@ -10,6 +10,8 @@ interface SkillPreviewProps {
   onClose: () => void
 }
 
+type SkillRunMode = "dry-run" | "test-run"
+
 export const SkillPreview: React.FC<SkillPreviewProps> = ({
   skillName,
   onClose
@@ -17,32 +19,40 @@ export const SkillPreview: React.FC<SkillPreviewProps> = ({
   const { t } = useTranslation(["option", "common"])
   const [args, setArgs] = React.useState("")
   const [result, setResult] = React.useState<SkillExecutionResult | null>(null)
-  const testRunPendingRef = React.useRef(false)
+  const [activeRunMode, setActiveRunMode] = React.useState<SkillRunMode | null>(null)
+  const skillRunPendingRef = React.useRef(false)
 
   React.useEffect(() => {
     if (!skillName) {
       setArgs("")
       setResult(null)
-      testRunPendingRef.current = false
+      setActiveRunMode(null)
+      skillRunPendingRef.current = false
     }
   }, [skillName])
 
   const executeMutation = useMutation({
-    mutationFn: () => tldwClient.executeSkill(skillName!, args),
+    mutationFn: ({ dryRun }: { dryRun: boolean }) =>
+      tldwClient.executeSkill(skillName!, args, { dryRun }),
     onSuccess: (data: SkillExecutionResult) => {
       setResult(data)
     },
     onSettled: () => {
-      testRunPendingRef.current = false
+      skillRunPendingRef.current = false
+      setActiveRunMode(null)
     }
   })
 
-  const handleRunTest = () => {
-    if (!skillName || testRunPendingRef.current || executeMutation.isPending) return
+  const handleRun = (dryRun: boolean) => {
+    if (!skillName || skillRunPendingRef.current || executeMutation.isPending) return
 
-    testRunPendingRef.current = true
-    executeMutation.mutate()
+    skillRunPendingRef.current = true
+    setActiveRunMode(dryRun ? "dry-run" : "test-run")
+    executeMutation.mutate({ dryRun })
   }
+
+  const handleRunTest = () => handleRun(false)
+  const handleRenderOnly = () => handleRun(true)
 
   const errorMessage =
     executeMutation.error instanceof Error
@@ -86,14 +96,23 @@ export const SkillPreview: React.FC<SkillPreviewProps> = ({
           })}
         </p>
 
-        <Button
-          type="primary"
-          onClick={handleRunTest}
-          loading={executeMutation.isPending}
-          disabled={executeMutation.isPending}
-        >
-          {t("option:skills.testRunAction", { defaultValue: "Run test" })}
-        </Button>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Button
+            onClick={handleRenderOnly}
+            loading={executeMutation.isPending && activeRunMode === "dry-run"}
+            disabled={executeMutation.isPending}
+          >
+            {t("option:skills.renderOnlyAction", { defaultValue: "Render prompt only" })}
+          </Button>
+          <Button
+            type="primary"
+            onClick={handleRunTest}
+            loading={executeMutation.isPending && activeRunMode === "test-run"}
+            disabled={executeMutation.isPending}
+          >
+            {t("option:skills.testRunAction", { defaultValue: "Run test" })}
+          </Button>
+        </div>
 
         {executeMutation.isError && (
           <Alert role="alert" type="error" showIcon title={errorMessage} />
@@ -102,6 +121,11 @@ export const SkillPreview: React.FC<SkillPreviewProps> = ({
         {result && (
           <div className="flex flex-col gap-3">
             <div className="flex items-center gap-2">
+              <Tag color={result.dry_run ? "default" : "green"}>
+                {result.dry_run
+                  ? t("option:skills.dryRenderResult", { defaultValue: "Dry render" })
+                  : t("option:skills.executedResult", { defaultValue: "Executed test" })}
+              </Tag>
               <Tag color={result.execution_mode === "fork" ? "blue" : "green"}>
                 {result.execution_mode}
               </Tag>

--- a/apps/packages/ui/src/components/Option/Skills/__tests__/SkillPreview.test.tsx
+++ b/apps/packages/ui/src/components/Option/Skills/__tests__/SkillPreview.test.tsx
@@ -81,7 +81,8 @@ describe("SkillPreview test-run semantics", () => {
       allowed_tools: ["search"],
       model_override: null,
       execution_mode: "fork",
-      fork_output: "Summary output"
+      fork_output: "Summary output",
+      dry_run: false
     })
   })
 
@@ -99,6 +100,7 @@ describe("SkillPreview test-run semantics", () => {
         "This renders the skill with your arguments. Fork-mode skills may call the configured model and allowed tools."
       )
     ).toBeInTheDocument()
+    expect(within(dialog).getByRole("button", { name: "Render prompt only" })).toBeInTheDocument()
     expect(within(dialog).getByRole("button", { name: "Run test" })).toBeInTheDocument()
     expect(within(dialog).queryByRole("button", { name: "Preview" })).not.toBeInTheDocument()
   })
@@ -113,8 +115,43 @@ describe("SkillPreview test-run semantics", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: "Run test" }))
 
     await waitFor(() => {
-      expect(tldwClientMock.executeSkill).toHaveBeenCalledWith("summarize", "chapter 1")
+      expect(tldwClientMock.executeSkill).toHaveBeenCalledWith(
+        "summarize",
+        "chapter 1",
+        { dryRun: false }
+      )
     })
+  })
+
+  it("renders the prompt only without executing fork output", async () => {
+    tldwClientMock.executeSkill.mockResolvedValueOnce({
+      skill_name: "summarize",
+      rendered_prompt: "Summarize chapter 1",
+      allowed_tools: ["search"],
+      model_override: null,
+      execution_mode: "fork",
+      fork_output: null,
+      dry_run: true
+    })
+
+    renderPreview()
+
+    const dialog = screen.getByRole("dialog", { name: "Test run" })
+    fireEvent.change(within(dialog).getByPlaceholderText("Enter test arguments..."), {
+      target: { value: "chapter 1" }
+    })
+    fireEvent.click(within(dialog).getByRole("button", { name: "Render prompt only" }))
+
+    await waitFor(() => {
+      expect(tldwClientMock.executeSkill).toHaveBeenCalledWith(
+        "summarize",
+        "chapter 1",
+        { dryRun: true }
+      )
+    })
+
+    expect(await within(dialog).findByText("Dry render")).toBeInTheDocument()
+    expect(within(dialog).queryByText("Fork Output")).not.toBeInTheDocument()
   })
 
   it("prevents duplicate skill executions while a test run is pending", async () => {
@@ -125,6 +162,7 @@ describe("SkillPreview test-run semantics", () => {
       model_override: null
       execution_mode: "fork"
       fork_output: string
+      dry_run: false
     }) => void = () => {}
     tldwClientMock.executeSkill.mockImplementationOnce(
       () =>
@@ -153,7 +191,8 @@ describe("SkillPreview test-run semantics", () => {
       allowed_tools: ["search"],
       model_override: null,
       execution_mode: "fork",
-      fork_output: "Summary output"
+      fork_output: "Summary output",
+      dry_run: false
     })
   })
 

--- a/apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts
+++ b/apps/packages/ui/src/services/tldw/domains/__tests__/workspace-api.skills.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { bgRequest } from "@/services/background-proxy"
+import { workspaceApiMethods } from "../workspace-api"
+
+vi.mock("@/services/background-proxy", () => ({
+  bgRequest: vi.fn()
+}))
+
+describe("workspace API skill methods", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("sends dry-run intent when rendering a skill without execution", async () => {
+    vi.mocked(bgRequest).mockResolvedValueOnce({
+      skill_name: "summarize",
+      rendered_prompt: "Summarize chapter 1",
+      allowed_tools: [],
+      model_override: null,
+      execution_mode: "fork",
+      fork_output: null,
+      dry_run: true
+    })
+
+    const clientCore = {
+      resolveApiPath: vi.fn().mockResolvedValue("/api/v1/skills/{name}/execute"),
+      fillPathParams: vi.fn().mockReturnValue("/api/v1/skills/summarize/execute")
+    }
+
+    await workspaceApiMethods.executeSkill.call(
+      clientCore as any,
+      "summarize",
+      "chapter 1",
+      { dryRun: true }
+    )
+
+    expect(bgRequest).toHaveBeenCalledWith({
+      path: "/api/v1/skills/summarize/execute",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: { args: "chapter 1", dry_run: true }
+    })
+  })
+})

--- a/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
+++ b/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
@@ -3,7 +3,7 @@ import { buildQuery } from "../client-utils"
 import { appendPathQuery } from "../path-utils"
 import type { AllowedPath } from "@/services/tldw/openapi-guard"
 import type { OffsetPaginationMeta } from "@/services/response-envelope"
-import type { SkillsListParams, SkillsListResponse } from "@/types/skill"
+import type { SkillExecutionResult, SkillsListParams, SkillsListResponse } from "@/types/skill"
 
 /**
  * Minimal interface for the TldwApiClient methods referenced via `this`.
@@ -18,6 +18,10 @@ export interface TldwApiClientCore {
 
 type SkillsListPayload = SkillsListResponse & {
   pagination?: OffsetPaginationMeta
+}
+
+export interface ExecuteSkillOptions {
+  dryRun?: boolean
 }
 
 export type WorkspaceArtifactJsonRecord = Record<string, unknown>
@@ -880,18 +884,22 @@ export const workspaceApiMethods = {
   async executeSkill(
     this: TldwApiClientCore,
     name: string,
-    args?: string
-  ): Promise<any> {
+    args?: string,
+    options?: ExecuteSkillOptions
+  ): Promise<SkillExecutionResult> {
     const base = await this.resolveApiPath("skills.execute", [
       "/api/v1/skills/{name}/execute",
       "/api/v1/skills/{name}/execute/"
     ])
     const path = this.fillPathParams(base, name)
-    return await bgRequest<any>({
+    return await bgRequest<SkillExecutionResult>({
       path,
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: { args: args || "" }
+      body: {
+        args: args || "",
+        dry_run: Boolean(options?.dryRun)
+      }
     })
   },
 

--- a/apps/packages/ui/src/types/skill.ts
+++ b/apps/packages/ui/src/types/skill.ts
@@ -70,6 +70,7 @@ export interface SkillUpdate {
 
 export interface SkillExecuteRequest {
   args?: string | null
+  dry_run?: boolean
 }
 
 export interface SkillExecutionResult {
@@ -79,6 +80,7 @@ export interface SkillExecutionResult {
   model_override: string | null
   execution_mode: SkillContext
   fork_output: string | null
+  dry_run: boolean
 }
 
 export interface SkillImportRequest {

--- a/backlog/tasks/task-530.7 - Implement-Skills-dry-render-execution-mode.md
+++ b/backlog/tasks/task-530.7 - Implement-Skills-dry-render-execution-mode.md
@@ -1,0 +1,81 @@
+---
+id: TASK-530.7
+title: Implement Skills dry render execution mode
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-21 17:24'
+labels:
+  - skills
+  - webui
+  - safe-operations
+  - backend
+dependencies: []
+parent_task_id: TASK-530
+priority: high
+ordinal: 530.7
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Continue TASK-530 Safe Operations after TASK-530.6 by adding a true dry-render path for Skills. Add SkillExecuteRequest.dry_run, return SkillExecutionResult.dry_run, prevent model/tool/fork execution when dry_run is true, and expose a frontend Render prompt only action beside Run test. Keep import review, delete/versioning, permission metadata panels, and bulk actions out of scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Skill execute request accepts dry_run without changing existing args behavior.
+- [x] #2 Skill execute result includes dry_run for dry-rendered and executed results.
+- [x] #3 When dry_run is true, fork-mode skills return rendered prompt metadata without invoking model calls, tool listing, or tool execution, and fork_output is null.
+- [x] #4 When dry_run is false or omitted, existing inline/fork execution behavior remains unchanged.
+- [x] #5 Frontend API client sends dry_run: true for render-only requests and dry_run: false for test runs.
+- [x] #6 Skills preview modal exposes distinct Render prompt only and Run test actions, blocks duplicate pending actions, and labels returned results as dry-rendered or executed.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/Plans/IMPLEMENTATION_PLAN_skills_dry_render_TASK_530_7.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Plan: Docs/Plans/IMPLEMENTATION_PLAN_skills_dry_render_TASK_530_7.md
+
+Implementation notes:
+- Added backend dry_run contract and executor short-circuit for render-only Skills execution.
+- Added frontend Render prompt only action beside Run test in the Skills preview modal.
+- Kept import review, delete/versioning, permission metadata panels, and bulk actions out of scope.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented true Skills dry-render support.
+
+Changed:
+- Added dry_run to the backend execute request/result contract and executor result metadata.
+- Short-circuited dry-run execution before fork/model/tool paths while preserving normal execute behavior when dry_run is false or omitted.
+- Added a Render prompt only action beside Run test in the Skills preview modal, plus visible Dry render / Executed test result labeling.
+- Added focused backend and frontend regression coverage.
+
+Verification:
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Skills/unit/test_skill_executor.py tldw_Server_API/tests/Skills/integration/test_skills_api.py -q (78 passed)
+- bunx vitest run src/components/Option/Skills/__tests__/SkillPreview.test.tsx src/services/tldw/domains/__tests__/workspace-api.skills.test.ts --reporter=dot (6 passed)
+- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/core/Skills -f json -o /tmp/bandit_skills_dry_render_TASK_530_7.json (0 findings)
+- git diff --check (passed)
+
+Known skips/blockers:
+- No blockers. The broad workspace-api.status-capabilities.test.ts file was not used as a final verification target because it currently has unrelated baseline path-segment failures; this PR adds focused Skills client coverage in workspace-api.skills.test.ts.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-530.7 - Implement-Skills-dry-render-execution-mode.md
+++ b/backlog/tasks/task-530.7 - Implement-Skills-dry-render-execution-mode.md
@@ -61,9 +61,9 @@ Changed:
 - Added focused backend and frontend regression coverage.
 
 Verification:
-- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Skills/unit/test_skill_executor.py tldw_Server_API/tests/Skills/integration/test_skills_api.py -q (78 passed)
+- source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Skills/unit/test_skill_executor.py tldw_Server_API/tests/Skills/integration/test_skills_api.py -q (78 passed)
 - bunx vitest run src/components/Option/Skills/__tests__/SkillPreview.test.tsx src/services/tldw/domains/__tests__/workspace-api.skills.test.ts --reporter=dot (6 passed)
-- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/core/Skills -f json -o /tmp/bandit_skills_dry_render_TASK_530_7.json (0 findings)
+- source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/core/Skills -f json -o /tmp/bandit_skills_dry_render_TASK_530_7.json (0 findings)
 - git diff --check (passed)
 
 Known skips/blockers:

--- a/tldw_Server_API/app/api/v1/endpoints/skills.py
+++ b/tldw_Server_API/app/api/v1/endpoints/skills.py
@@ -535,6 +535,7 @@ async def execute_skill(
             skill_data=skill_data,
             arguments=request.args or "",
             context=ctx,
+            dry_run=request.dry_run,
         )
 
         return SkillExecutionResult(
@@ -544,6 +545,7 @@ async def execute_skill(
             model_override=result.model_override,
             execution_mode=result.execution_mode,
             fork_output=result.fork_output,
+            dry_run=result.dry_run,
         )
     except SkillNotFoundError:
         raise HTTPException(

--- a/tldw_Server_API/app/api/v1/schemas/skills_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/skills_schemas.py
@@ -219,6 +219,10 @@ class SkillsListResponse(BaseModel):
 class SkillExecuteRequest(BaseModel):
     """Request to execute/preview a skill."""
     args: str | None = Field(None, max_length=10000, description="Arguments to pass to the skill")
+    dry_run: bool = Field(
+        False,
+        description="Render the skill prompt without invoking model, fork, or tool execution",
+    )
 
 
 class SkillExecutionResult(BaseModel):
@@ -229,6 +233,7 @@ class SkillExecutionResult(BaseModel):
     model_override: str | None = Field(None, description="Model override if specified")
     execution_mode: SkillContext = Field(..., description="How the skill was executed")
     fork_output: str | None = Field(None, description="Output from fork execution (if applicable)")
+    dry_run: bool = Field(False, description="Whether the result came from a dry render")
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tldw_Server_API/app/core/Skills/skill_executor.py
+++ b/tldw_Server_API/app/core/Skills/skill_executor.py
@@ -30,6 +30,7 @@ class SkillExecutionResult:
     model_override: Optional[str] = None
     execution_mode: str = "inline"  # "inline" or "fork"
     fork_output: Optional[str] = None
+    dry_run: bool = False
 
 
 @dataclass
@@ -287,6 +288,7 @@ class SkillExecutor:
         skill_data: dict[str, Any],
         arguments: str,
         context: Optional[RequestContext] = None,
+        dry_run: bool = False,
     ) -> SkillExecutionResult:
         """
         Execute a skill.
@@ -295,6 +297,7 @@ class SkillExecutor:
             skill_data: The skill data dict (from SkillsService.get_skill)
             arguments: Arguments to pass to the skill
             context: Request context for execution
+            dry_run: If true, render prompt metadata without model/tool execution
 
         Returns:
             SkillExecutionResult with rendered prompt and metadata
@@ -311,6 +314,17 @@ class SkillExecutor:
         # Resolve allowed tools
         available = context.available_tools if context else None
         resolved_tools = self.resolve_allowed_tools(allowed_tools, available)
+
+        if dry_run:
+            return SkillExecutionResult(
+                skill_name=skill_name,
+                rendered_prompt=rendered,
+                allowed_tools=resolved_tools,
+                model_override=model,
+                execution_mode="fork" if execution_context == "fork" else "inline",
+                fork_output=None,
+                dry_run=True,
+            )
 
         if execution_context == "fork":
             return await self._execute_forked(
@@ -346,6 +360,7 @@ class SkillExecutor:
             allowed_tools=allowed_tools,
             model_override=model,
             execution_mode="inline",
+            dry_run=False,
         )
 
     async def _execute_forked(
@@ -478,6 +493,7 @@ class SkillExecutor:
             model_override=None,
             execution_mode="fork",
             fork_output=final_output,
+            dry_run=False,
         )
 
 

--- a/tldw_Server_API/tests/Skills/integration/test_skills_api.py
+++ b/tldw_Server_API/tests/Skills/integration/test_skills_api.py
@@ -864,6 +864,46 @@ class TestExecuteSkill:
         assert result["skill_name"] == "exec-skill"
         assert "my test args" in result["rendered_prompt"]
         assert result["execution_mode"] == "inline"
+        assert result["dry_run"] is False
+
+    def test_execute_skill_forwards_and_returns_dry_run(self, client, monkeypatch):
+        client.post(
+            f"{SKILLS_PREFIX}/",
+            json={
+                "name": "dry-run-exec-skill",
+                "content": "---\ncontext: fork\n---\nDo: $ARGUMENTS",
+            },
+        )
+        observed = {}
+
+        async def fake_execute(self, *, skill_data, arguments, context, dry_run):
+            observed["dry_run"] = dry_run
+            observed["arguments"] = arguments
+            return SimpleNamespace(
+                skill_name=skill_data["name"],
+                rendered_prompt=f"rendered {arguments}",
+                allowed_tools=[],
+                model_override=None,
+                execution_mode="fork",
+                fork_output=None,
+                dry_run=dry_run,
+            )
+
+        monkeypatch.setattr(
+            "tldw_Server_API.app.api.v1.endpoints.skills.SkillExecutor.execute",
+            fake_execute,
+        )
+
+        r = client.post(
+            f"{SKILLS_PREFIX}/dry-run-exec-skill/execute",
+            json={"args": "safe args", "dry_run": True},
+        )
+
+        assert r.status_code == 200, r.text
+        result = r.json()
+        assert observed == {"dry_run": True, "arguments": "safe args"}
+        assert result["dry_run"] is True
+        assert result["fork_output"] is None
 
     def test_execute_skill_sanitizes_skills_error(self, client, monkeypatch):
         async def _boom(self, name):  # noqa: ANN001, ANN202
@@ -896,8 +936,9 @@ class TestExecuteSkill:
         assert create_resp.status_code == 201, create_resp.text
         observed = {}
 
-        async def fake_execute(self, *, skill_data, arguments, context):
+        async def fake_execute(self, *, skill_data, arguments, context, dry_run):
             observed["user_id"] = context.user_id if context else None
+            observed["dry_run"] = dry_run
             return SimpleNamespace(
                 skill_name=skill_data["name"],
                 rendered_prompt=f"rendered {arguments}",
@@ -905,6 +946,7 @@ class TestExecuteSkill:
                 model_override=None,
                 execution_mode="inline",
                 fork_output=None,
+                dry_run=False,
             )
 
         monkeypatch.setattr(
@@ -919,6 +961,7 @@ class TestExecuteSkill:
 
         assert r.status_code == 200, r.text
         assert observed["user_id"] == TEST_USER_ID
+        assert observed["dry_run"] is False
 
 
 class TestContextPayload:

--- a/tldw_Server_API/tests/Skills/integration/test_skills_api.py
+++ b/tldw_Server_API/tests/Skills/integration/test_skills_api.py
@@ -8,6 +8,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from fastapi import Request
@@ -867,6 +868,7 @@ class TestExecuteSkill:
         assert result["dry_run"] is False
 
     def test_execute_skill_forwards_and_returns_dry_run(self, client, monkeypatch):
+        """Verify the API forwards dry_run to the executor and returns it to clients."""
         client.post(
             f"{SKILLS_PREFIX}/",
             json={
@@ -876,7 +878,15 @@ class TestExecuteSkill:
         )
         observed = {}
 
-        async def fake_execute(self, *, skill_data, arguments, context, dry_run):
+        async def fake_execute(
+            self: object,
+            *,
+            skill_data: dict[str, Any],
+            arguments: str,
+            context: object | None,
+            dry_run: bool,
+        ) -> SimpleNamespace:
+            """Capture endpoint-to-executor dry-run arguments without executing a skill."""
             observed["dry_run"] = dry_run
             observed["arguments"] = arguments
             return SimpleNamespace(
@@ -936,7 +946,15 @@ class TestExecuteSkill:
         assert create_resp.status_code == 201, create_resp.text
         observed = {}
 
-        async def fake_execute(self, *, skill_data, arguments, context, dry_run):
+        async def fake_execute(
+            self: object,
+            *,
+            skill_data: dict[str, Any],
+            arguments: str,
+            context: Any | None,
+            dry_run: bool,
+        ) -> SimpleNamespace:
+            """Capture principal context propagation while bypassing real execution."""
             observed["user_id"] = context.user_id if context else None
             observed["dry_run"] = dry_run
             return SimpleNamespace(

--- a/tldw_Server_API/tests/Skills/unit/test_skill_executor.py
+++ b/tldw_Server_API/tests/Skills/unit/test_skill_executor.py
@@ -289,6 +289,52 @@ class TestSkillExecution:
         assert result.fork_output == "fork output"
 
     @pytest.mark.asyncio
+    async def test_execute_dry_run_renders_fork_without_model_or_tools(self, executor, monkeypatch):
+        """Dry-rendering a fork skill must not invoke model calls or tool execution."""
+        skill_data = {
+            "name": "fork-dry-run-skill",
+            "content": "Forked task: $ARGUMENTS",
+            "context": "fork",
+            "allowed_tools": ["Read", "Grep"],
+            "model": "gpt-4",
+        }
+
+        async def _unexpected_chat_call(**_kwargs):
+            raise AssertionError("dry_run must not call the model adapter")
+
+        from tldw_Server_API.app.core.Chat import chat_service as chat_service_mod
+        monkeypatch.setattr(chat_service_mod, "perform_chat_api_call_async", _unexpected_chat_call)
+
+        class _UnexpectedToolExecutor:
+            async def list_tools(self, **_kwargs):
+                raise AssertionError("dry_run must not list tools")
+
+            async def execute(self, **_kwargs):
+                raise AssertionError("dry_run must not execute tools")
+
+        ctx = RequestContext(
+            user_id=1,
+            default_provider="openai",
+            available_tools=["Read", "Grep"],
+            tool_executor=_UnexpectedToolExecutor(),
+        )
+
+        result = await executor.execute(
+            skill_data,
+            "task-args",
+            context=ctx,
+            dry_run=True,
+        )
+
+        assert result.skill_name == "fork-dry-run-skill"
+        assert result.rendered_prompt == "Forked task: task-args"
+        assert result.allowed_tools == ["Read", "Grep"]
+        assert result.model_override == "gpt-4"
+        assert result.execution_mode == "fork"
+        assert result.fork_output is None
+        assert result.dry_run is True
+
+    @pytest.mark.asyncio
     async def test_execute_with_model_override(self, executor):
         """Test that model override is preserved."""
         skill_data = {


### PR DESCRIPTION
## Change summary
- Added a backend `dry_run` contract for Skills execution so clients can render prompt metadata without invoking fork/model/tool paths.
- Added a `Render prompt only` action beside `Run test` in the Skills preview modal and labeled results as dry-rendered or executed.
- Added focused backend and frontend regression tests plus Backlog task tracking for TASK-530.7.

## Why
This keeps the existing test-run workflow intact while giving users a safe way to inspect rendered skill prompts before allowing potentially expensive or tool-capable fork execution. The executor short-circuit lives before fork setup so dry renders cannot list tools, call models, or execute tools.

## Verification
- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Skills/unit/test_skill_executor.py tldw_Server_API/tests/Skills/integration/test_skills_api.py -q` (78 passed)
- `bunx vitest run src/components/Option/Skills/__tests__/SkillPreview.test.tsx src/services/tldw/domains/__tests__/workspace-api.skills.test.ts --reporter=dot` (6 passed)
- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/app/core/Skills -f json -o /tmp/bandit_skills_dry_render_TASK_530_7_rebase.json` (0 findings)
- `git diff --check`

## Notes
- Broad `workspace-api.status-capabilities.test.ts` was not used as final verification because it currently has unrelated baseline path-segment failures; this PR adds focused Skills client coverage in `workspace-api.skills.test.ts`.
- Out of scope: import review, delete/versioning, permission metadata panels, and bulk actions.