### PR TITLE
Local CI runner + make targets + pre-push hook + docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,10 +35,10 @@ repos:
       # pytest on changed tests). The runner auto-uses .venv, so it never runs
       # against system Python. Enable with:
       #   pre-commit install --hook-type pre-push
-      # (Windows: invoke the script directly, or swap python3 -> python.)
+      # The python launcher name is used for Windows/macOS/Linux compatibility.
       - id: local-ci-fast
         name: Local CI fast tier (pre-push)
-        entry: python3 Helper_Scripts/ci/run_local_ci.py --fast
+        entry: python Helper_Scripts/ci/run_local_ci.py --fast
         language: system
         pass_filenames: false
         always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,18 @@ repos:
         entry: python3 Helper_Scripts/checks/check_python_syntax.py
         language: system
         types: [python]
+      # Pre-push only: reproduce the gating CI lanes (compileall + guards +
+      # pytest on changed tests). The runner auto-uses .venv, so it never runs
+      # against system Python. Enable with:
+      #   pre-commit install --hook-type pre-push
+      # (Windows: invoke the script directly, or swap python3 -> python.)
+      - id: local-ci-fast
+        name: Local CI fast tier (pre-push)
+        entry: python3 Helper_Scripts/ci/run_local_ci.py --fast
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [push]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.9
     hooks:

--- a/Docs/Development/Local-CI.md
+++ b/Docs/Development/Local-CI.md
@@ -2,8 +2,8 @@
 
 `Helper_Scripts/ci/run_local_ci.py` reproduces the **blocking** lanes of
 `.github/workflows/ci.yml` on your machine so you can get the same signal locally
-and avoid waiting on (or burning minutes in) the remote GitHub runners. It is
-pure standard library and works the same on Linux, macOS, and Windows Server.
+and avoid waiting on (or burning minutes in) the remote GitHub runners. It avoids
+shell-specific behavior and works the same on Linux, macOS, and Windows Server.
 
 ## One-time setup (uv venv — never the system Python)
 
@@ -41,7 +41,8 @@ Or call the script directly (Windows, or when you want flags):
 
 Useful flags: `--base <ref>` (diff base for change detection; defaults to the
 merge-base with `origin/dev`/`origin/main`), `--jobs auto|N|0` (xdist workers),
-`--mypy` (run mypy too, non-blocking), `--no-pytest`, `--list-changed`.
+`--pytest-args "<args>"` (parsed with platform shell quoting rules), `--mypy`
+(run mypy too, non-blocking), `--no-pytest`, `--list-changed`.
 
 ## How phases map to CI jobs
 

--- a/Docs/Development/Local-CI.md
+++ b/Docs/Development/Local-CI.md
@@ -1,0 +1,85 @@
+# Local CI — run the gating checks before you push
+
+`Helper_Scripts/ci/run_local_ci.py` reproduces the **blocking** lanes of
+`.github/workflows/ci.yml` on your machine so you can get the same signal locally
+and avoid waiting on (or burning minutes in) the remote GitHub runners. It is
+pure standard library and works the same on Linux, macOS, and Windows Server.
+
+## One-time setup (uv venv — never the system Python)
+
+The project targets Python 3.11–3.13. Create a uv-managed venv and install dev deps:
+
+```bash
+uv venv --python 3.12 .venv
+uv pip install --python .venv/bin/python -e ".[dev]"
+# align lint tools with the versions CI pins:
+uv pip install --python .venv/bin/python "ruff==0.15.10" "mypy==1.20.1"
+```
+
+> The runner **auto-detects `.venv` and re-executes itself under it**, so even if
+> you launch it with a system `python3`, the actual checks run against the venv
+> interpreter. Set `TLDW_CI_NO_REEXEC=1` to opt out.
+
+## Usage
+
+| Command | What it runs |
+|---|---|
+| `make ci-local` | **Fast tier**: compileall + ruff(changed) + guards + pytest on changed test files |
+| `make ci-local-full` | **Full tier**: compileall + ruff(all) + guards + whole suite under `-n auto` |
+| `make ci-local-lane LANE=tldw_Server_API/tests/Security` | compileall + guards + pytest on one area |
+
+Or call the script directly (Windows, or when you want flags):
+
+```bash
+.venv/bin/python Helper_Scripts/ci/run_local_ci.py --fast
+.venv/bin/python Helper_Scripts/ci/run_local_ci.py --full --jobs 8
+.venv/bin/python Helper_Scripts/ci/run_local_ci.py --lane tldw_Server_API/tests/RAG
+.venv/bin/python Helper_Scripts/ci/run_local_ci.py --full --pytest-args "-k embeddings"
+# Windows:
+.venv\Scripts\python.exe Helper_Scripts\ci\run_local_ci.py --fast
+```
+
+Useful flags: `--base <ref>` (diff base for change detection; defaults to the
+merge-base with `origin/dev`/`origin/main`), `--jobs auto|N|0` (xdist workers),
+`--mypy` (run mypy too, non-blocking), `--no-pytest`, `--list-changed`.
+
+## How phases map to CI jobs
+
+| Local phase | CI job | Blocking? |
+|---|---|---|
+| `compileall (syntax-check)` | `syntax-check` (compileall over `app/`) | **Yes** |
+| `repo guards` | pre-commit local hooks (http-client patch / legacy body / syntax) | **Yes** |
+| `pytest` | `full-suite-*` shard jobs | **Yes** |
+| `ruff (non-blocking)` | `lint` job (ruff) | No (baseline backlog) |
+| `mypy (non-blocking)` | `lint` job (mypy) | No (baseline backlog) |
+
+ruff/mypy are reported for visibility but never fail the local run, matching the
+remote `lint` job's `continue-on-error`. The phases that actually gate a PR
+(compileall, guards, pytest) do fail the local run.
+
+## Postgres / Redis dependent tests
+
+The runner honors the same environment the suite already uses:
+
+- `TEST_DATABASE_URL=postgresql://…` — point at a running Postgres.
+- `TLDW_TEST_NO_DOCKER=1` — skip the autostart (for pure-SQLite lanes).
+- Spin up a throwaway Postgres: `bash Helper_Scripts/Testing-related/start_postgres_for_tests.sh`.
+
+## Pre-push hook (optional)
+
+Run the fast tier automatically on `git push`:
+
+```bash
+uv pip install --python .venv/bin/python pre-commit   # if not already present
+pre-commit install --hook-type pre-push
+```
+
+The `local-ci-fast` hook in `.pre-commit-config.yaml` runs `--fast` and (via the
+auto re-exec) uses `.venv`. Bypass a single push with `git push --no-verify`.
+
+## Cross-OS strategy (your linux / macOS / windows boxes)
+
+Run `make ci-local-full` (or the script) **natively on each box** to validate the
+same suite per-OS without GitHub. This is the recommended way to cover
+macOS/Windows-specific behavior locally. For unattended, scheduled cross-OS runs
+on your hardware, see [Self-Hosted-Runners.md](./Self-Hosted-Runners.md).

--- a/Docs/Development/Self-Hosted-Runners.md
+++ b/Docs/Development/Self-Hosted-Runners.md
@@ -1,0 +1,91 @@
+# Self-hosted runners (linux / macOS / Windows)
+
+Run the **OS full-suite coverage on your own boxes** — free cross-OS signal with no
+GitHub macOS/Windows minutes. This pairs with PR #2258, which already moves the
+OS full runs to `release` / push-to-`main` / `workflow_dispatch` (off PRs).
+
+> ⚠️ **Security — read first. `rmusser01/tldw_server` is a public repo.**
+> A self-hosted runner executes whatever code the job checks out. If a job that
+> runs on a self-hosted runner is ever triggered by an untrusted **fork pull
+> request**, that PR gets arbitrary code execution on your machine and network.
+> **Therefore: only ever target self-hosted runners at trusted events** —
+> `push` to `main`, `release: published`, and `workflow_dispatch`. Keep all
+> `pull_request` validation on GitHub-hosted runners.
+> PR #2258's OS full shards are already guarded with
+> `if: github.event_name != 'pull_request'`, so they are the *only* jobs that
+> should opt into self-hosted execution.
+
+## 1. Register a runner on each box
+
+Repo → **Settings → Actions → Runners → New self-hosted runner**. Pick the OS, then
+run the shown `config`/`run` commands on the box. Use clear labels:
+
+| Box | Suggested labels |
+|---|---|
+| Linux | `self-hosted, linux, x64` |
+| macOS (Apple Silicon) | `self-hosted, macOS, arm64` |
+| Windows Server | `self-hosted, windows, x64` |
+
+Prefer a **runner group** restricted to this repo, and consider
+`--ephemeral` runners (one job per registration) so state never leaks between runs.
+In **Settings → Actions → General**, set "Require approval for all outside
+collaborators" so first-time contributors' workflows never auto-run.
+
+## 2. Toggle `runs-on` without exposing PRs
+
+Add a repo **variable** `OS_RUNNER_MODE` (Settings → Actions → Variables). Leave it
+unset/`hosted` normally; set it to `self-hosted` when you want the OS shards to land
+on your boxes. The OS full-suite jobs (already non-PR) select the runner by mode:
+
+```yaml
+  full-suite-macos-312:
+    if: github.event_name != 'pull_request'   # never untrusted PRs
+    runs-on: >-
+      ${{ vars.OS_RUNNER_MODE == 'self-hosted'
+          && fromJSON('["self-hosted","macOS","arm64"]')
+          || 'macos-14' }}
+```
+
+```yaml
+  full-suite-windows-312:
+    if: github.event_name != 'pull_request'
+    runs-on: >-
+      ${{ vars.OS_RUNNER_MODE == 'self-hosted'
+          && fromJSON('["self-hosted","windows","x64"]')
+          || 'windows-latest' }}
+```
+
+`runs-on` accepts either a string (hosted label) or an array (self-hosted label
+set); the ternary yields one or the other. Flipping the variable needs no code change.
+
+## 3. Provision each box
+
+The jobs assume these are present (GitHub-hosted images bundle them; your boxes need
+them installed once):
+
+- **ffmpeg** on PATH (audio/video tests).
+- **Docker** — for the `services:` Postgres/Redis containers. On macOS/Windows
+  self-hosted runners, service containers are **not** supported the same way as on
+  Linux; instead run Postgres/Redis on the host and export
+  `TEST_DATABASE_URL=postgresql://…` (and `REDIS_URL`) in the runner environment, or
+  set `TLDW_TEST_NO_DOCKER=1` for SQLite-only lanes. See
+  `Helper_Scripts/Testing-related/start_postgres_for_tests.sh`.
+- **uv** + Python 3.12 and 3.13 (`uv python install 3.12 3.13`).
+- **Node 20 + Bun 1.3.2** if the box also runs frontend lanes.
+- Git, and enough disk for model/HF caches (set `HF_HOME` to a persistent path to
+  avoid re-downloads between runs).
+
+## 4. Validate
+
+1. Set `OS_RUNNER_MODE=self-hosted`.
+2. Trigger the workflow via **Run workflow** (`workflow_dispatch`) on `main`.
+3. Confirm the macOS/Windows full-suite jobs pick up on your boxes (runner name shows
+   in the job log) and that a normal fork PR still uses GitHub-hosted runners.
+
+## Alternative: skip GitHub entirely
+
+If you only want local validation (not GitHub orchestration), just run the suite
+natively on each box with [Local-CI.md](./Local-CI.md):
+`make ci-local-full`. Self-hosted runners are the right tool when you want the
+*scheduled / release* OS coverage to run unattended on your hardware with the normal
+required-check integration.

--- a/Docs/superpowers/plans/2026-06-21-pr-2426-local-ci-review-rebase-plan.md
+++ b/Docs/superpowers/plans/2026-06-21-pr-2426-local-ci-review-rebase-plan.md
@@ -60,3 +60,15 @@
 - [x] Run Bandit on the touched Python runner.
 - [x] Update `TASK-2396` with verification and final summary.
 - [x] Commit and push the rebased PR branch.
+
+## Stage 5: Follow-Up CodeRabbit Review
+
+**Goal:** Address the new CodeRabbit comments posted after the first review-fix push.
+**Success Criteria:** The pre-push hook uses a cross-platform Python launcher and full local CI runs send `app/` to the syntax guard even when changed files exist.
+**Tests:** `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/CI/test_run_local_ci.py -q`
+**Status:** Complete
+
+- [x] Add failing tests for `local-ci-fast` launcher portability and full-tier guard syntax scope.
+- [x] Change `local-ci-fast` from `python3` to `python`.
+- [x] Thread `full` context into `phase_guards`.
+- [x] Rerun targeted pytest, Ruff, compileall, Bandit, and local CI smoke verification.

--- a/Docs/superpowers/plans/2026-06-21-pr-2426-local-ci-review-rebase-plan.md
+++ b/Docs/superpowers/plans/2026-06-21-pr-2426-local-ci-review-rebase-plan.md
@@ -1,0 +1,62 @@
+# PR 2426 Local CI Review Rebase Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebase PR 2426 on latest `dev` and address all open review comments on the local CI runner.
+
+**Architecture:** Keep the runner as a stdlib-first command-line tool while adding narrow tests around argument parsing, changed-file detection, pytest command/env parity, and venv re-exec behavior. Use Loguru only for runner-owned status/error reporting and continue to let subprocesses stream their own output.
+
+**Tech Stack:** Python stdlib, pytest, Loguru, Git, Backlog.md.
+
+---
+
+## Stage 1: Rebase And Review Inventory
+
+**Goal:** Confirm the branch is based on latest `origin/dev` and all current PR review threads are understood.
+**Success Criteria:** Rebase reports clean/up-to-date; review inventory covers Gemini and Qodo threads.
+**Tests:** `git rebase --autostash origin/dev`, PR review thread query.
+**Status:** In Progress
+
+- [x] Create Backlog task `TASK-2396` for this PR work.
+- [x] Fetch latest `dev` and PR refs.
+- [x] Rebase `local-ci-tooling` onto `origin/dev`.
+- [x] Collect open review threads and map each to a code/test change.
+
+## Stage 2: Failing Runner Tests
+
+**Goal:** Add focused tests that fail against the reviewed runner behavior.
+**Success Criteria:** Tests demonstrate current failures for quoted pytest args, recursive changed-file detection, CI-like pytest env/xdist loading, and Windows re-exec exit propagation.
+**Tests:** `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/CI/test_run_local_ci.py -q`
+**Status:** Complete
+
+- [x] Add `tldw_Server_API/tests/CI/test_run_local_ci.py` with direct function-level coverage.
+- [x] Run the new tests and confirm the behavior tests fail before implementation.
+
+## Stage 3: Runner Fixes
+
+**Goal:** Implement the minimal runner changes required by the review feedback.
+**Success Criteria:** The runner preserves quoted pytest args, detects nested changed `.py` files, uses CI-like pytest env defaults, loads xdist explicitly when jobs are enabled, propagates Windows re-exec exit status, uses Loguru for runner-owned messages, and has docstrings for new classes/functions.
+**Tests:** New CI runner unit tests plus syntax/import checks.
+**Status:** Complete
+
+- [x] Add docstrings to runner dataclasses and functions.
+- [x] Replace direct `print()` status/error output with Loguru-backed helper output.
+- [x] Extend `_run()` with optional environment overrides.
+- [x] Filter git diff output in Python instead of relying on non-recursive `*.py` pathspecs.
+- [x] Parse `--pytest-args` with `shlex.split(...)`.
+- [x] Add CI-like pytest environment defaults and explicit `xdist.plugin` loading.
+- [x] Use `subprocess.call(...)` on Windows venv re-exec and exit with its return code.
+
+## Stage 4: Documentation, Backlog, And Verification
+
+**Goal:** Update tracking/docs as needed and verify the changed scope.
+**Success Criteria:** Tests and Bandit pass on touched scope; Backlog task records verification and final summary; PR branch is pushed.
+**Tests:** Targeted pytest, `compileall`, Bandit on `Helper_Scripts/ci/run_local_ci.py`.
+**Status:** In Progress
+
+- [x] Update Local CI docs only if behavior or quoting guidance changes.
+- [x] Run targeted pytest for the new runner tests.
+- [x] Run syntax/compile verification for the runner.
+- [x] Run Bandit on the touched Python runner.
+- [x] Update `TASK-2396` with verification and final summary.
+- [ ] Commit and push the rebased PR branch.

--- a/Docs/superpowers/plans/2026-06-21-pr-2426-local-ci-review-rebase-plan.md
+++ b/Docs/superpowers/plans/2026-06-21-pr-2426-local-ci-review-rebase-plan.md
@@ -15,7 +15,7 @@
 **Goal:** Confirm the branch is based on latest `origin/dev` and all current PR review threads are understood.
 **Success Criteria:** Rebase reports clean/up-to-date; review inventory covers Gemini and Qodo threads.
 **Tests:** `git rebase --autostash origin/dev`, PR review thread query.
-**Status:** In Progress
+**Status:** Complete
 
 - [x] Create Backlog task `TASK-2396` for this PR work.
 - [x] Fetch latest `dev` and PR refs.
@@ -59,4 +59,4 @@
 - [x] Run syntax/compile verification for the runner.
 - [x] Run Bandit on the touched Python runner.
 - [x] Update `TASK-2396` with verification and final summary.
-- [ ] Commit and push the rebased PR branch.
+- [x] Commit and push the rebased PR branch.

--- a/Helper_Scripts/ci/run_local_ci.py
+++ b/Helper_Scripts/ci/run_local_ci.py
@@ -2,9 +2,9 @@
 """Run the gating CI checks locally, on any of linux/macOS/Windows.
 
 This mirrors the *blocking* lanes of ``.github/workflows/ci.yml`` so you can get
-the same signal locally and skip waiting on the remote GitHub runners. It is pure
-standard library and invokes tools through ``sys.executable -m ...`` so it works
-identically on a Windows Server box (no bash required).
+the same signal locally and skip waiting on the remote GitHub runners. It avoids
+shell-specific behavior and invokes tools through ``sys.executable -m ...`` so it
+works identically on a Windows Server box (no bash required).
 
 Tiers
 -----
@@ -44,13 +44,16 @@ from __future__ import annotations
 
 import argparse
 import os
+import shlex
 import shutil
-import subprocess
+import subprocess  # nosec: B404
 import sys
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
+
+from loguru import logger
 
 # Tool versions the remote CI pins (see the `lint` job). Local installs may
 # differ; we only warn so the script stays usable without an exact match.
@@ -66,10 +69,19 @@ GUARD_SCRIPTS = (
     "Helper_Scripts/checks/guard_no_nonempty_legacy_complete.py",
 )
 SYNTAX_GUARD = "Helper_Scripts/checks/check_python_syntax.py"
+CI_PYTEST_ENV_DEFAULTS = {
+    "PYTHONPATH": ".",
+    "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+    "TEST_MODE": "true",
+    "DISABLE_HEAVY_STARTUP": "1",
+    "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": "python",
+}
 
 
 @dataclass
 class PhaseResult:
+    """Result metadata for one local CI phase."""
+
     name: str
     ok: bool
     seconds: float
@@ -79,6 +91,8 @@ class PhaseResult:
 
 @dataclass
 class Context:
+    """Shared execution context for local CI phases."""
+
     repo_root: Path
     base: str | None
     changed_py: list[str] = field(default_factory=list)
@@ -89,24 +103,47 @@ class Context:
 # Helpers
 # --------------------------------------------------------------------------- #
 def _c(text: str, color: str) -> str:
+    """Colorize ``text`` when stdout is a TTY and colors are enabled."""
     if not sys.stdout.isatty() or os.environ.get("NO_COLOR"):
         return text
     codes = {"green": "32", "red": "31", "yellow": "33", "cyan": "36", "bold": "1"}
     return f"\033[{codes.get(color, '0')}m{text}\033[0m"
 
 
-def _run(cmd: Sequence[str], cwd: Path) -> int:
-    print(_c("$ " + " ".join(cmd), "cyan"))
+def _emit(text: str, color: str = "") -> None:
+    """Emit a runner-owned status line through Loguru without extra formatting."""
+    logger.opt(raw=True).info(_c(text, color) + "\n")
+
+
+def _emit_error(text: str, color: str = "red") -> None:
+    """Emit a runner-owned error line through Loguru without extra formatting."""
+    logger.opt(raw=True).error(_c(text, color) + "\n")
+
+
+def _run(cmd: Sequence[str], cwd: Path, env: Mapping[str, str] | None = None) -> int:
+    """Run ``cmd`` in ``cwd`` with optional env overrides and return its status."""
+    _emit("$ " + " ".join(cmd), "cyan")
+    run_env = None
+    if env is not None:
+        run_env = os.environ.copy()
+        run_env.update(env)
     try:
-        return subprocess.run(list(cmd), cwd=str(cwd)).returncode
+        # Local CI intentionally runs explicit project command argv without a shell.
+        return subprocess.run(  # nosec: B603
+            list(cmd),
+            cwd=str(cwd),
+            env=run_env,
+        ).returncode
     except FileNotFoundError as exc:  # missing executable
-        print(_c(f"  command not found: {exc}", "red"), file=sys.stderr)
+        _emit_error(f"  command not found: {exc}")
         return 127
 
 
 def _capture(cmd: Sequence[str], cwd: Path) -> tuple[int, str]:
+    """Run ``cmd`` and return ``(exit_status, stdout)`` without streaming output."""
     try:
-        proc = subprocess.run(
+        # Local CI intentionally captures explicit project command argv without a shell.
+        proc = subprocess.run(  # nosec: B603
             list(cmd), cwd=str(cwd), capture_output=True, text=True
         )
         return proc.returncode, proc.stdout
@@ -144,15 +181,29 @@ def _maybe_reexec_into_venv(repo_root: Path) -> None:
         same = Path(sys.executable).resolve() == venv_py.resolve()
     if same:
         return
-    print(_c(f"Re-executing under project venv: {venv_py}", "cyan"))
+    _emit(f"Re-executing under project venv: {venv_py}", "cyan")
     env = dict(os.environ, TLDW_CI_REEXEC="1")
-    os.execve(str(venv_py), [str(venv_py), str(Path(__file__).resolve()), *sys.argv[1:]], env)
+    if sys.platform == "win32":
+        # Windows must wait for the trusted venv Python process and return its status.
+        raise SystemExit(
+            subprocess.call(  # nosec
+                [str(venv_py), str(Path(__file__).resolve()), *sys.argv[1:]],
+                env=env,
+            )
+        )
+    # POSIX re-exec replaces the current process with the trusted venv Python.
+    os.execve(  # nosec: B606
+        str(venv_py),
+        [str(venv_py), str(Path(__file__).resolve()), *sys.argv[1:]],
+        env,
+    )
 
 
 def _git_repo_root() -> Path:
+    """Return the absolute git repository root for the current working tree."""
     rc, out = _capture(["git", "rev-parse", "--show-toplevel"], Path.cwd())
     if rc != 0 or not out.strip():
-        print(_c("Not inside a git repository.", "red"), file=sys.stderr)
+        _emit_error("Not inside a git repository.")
         raise SystemExit(2)
     return Path(out.strip())
 
@@ -173,25 +224,38 @@ def _resolve_base(repo_root: Path, explicit: str | None) -> str | None:
 
 
 def _changed_python(repo_root: Path, base: str | None) -> list[str]:
+    """Return changed Python files relative to ``repo_root``."""
     files: set[str] = set()
     if base:
         rc, out = _capture(
-            ["git", "diff", "--name-only", "--diff-filter=ACMRTUXB", f"{base}...HEAD", "--", "*.py"],
+            ["git", "diff", "--name-only", "--diff-filter=ACMRTUXB", f"{base}...HEAD"],
             repo_root,
         )
         if rc == 0:
-            files.update(line for line in out.splitlines() if line.strip())
+            files.update(
+                path
+                for path in (line.strip() for line in out.splitlines())
+                if path.endswith(".py")
+            )
     # Always include working-tree + untracked changes so local edits count.
     rc, out = _capture(
-        ["git", "diff", "--name-only", "--diff-filter=ACMRTUXB", "--", "*.py"], repo_root
+        ["git", "diff", "--name-only", "--diff-filter=ACMRTUXB"], repo_root
     )
     if rc == 0:
-        files.update(line for line in out.splitlines() if line.strip())
+        files.update(
+            path
+            for path in (line.strip() for line in out.splitlines())
+            if path.endswith(".py")
+        )
     rc, out = _capture(
-        ["git", "ls-files", "--others", "--exclude-standard", "--", "*.py"], repo_root
+        ["git", "ls-files", "--others", "--exclude-standard"], repo_root
     )
     if rc == 0:
-        files.update(line for line in out.splitlines() if line.strip())
+        files.update(
+            path
+            for path in (line.strip() for line in out.splitlines())
+            if path.endswith(".py")
+        )
     # Keep only files that still exist (skip deletions).
     return sorted(f for f in files if (repo_root / f).exists())
 
@@ -205,17 +269,20 @@ def _is_test_file(path: str) -> bool:
 
 
 def _py(*args: str) -> list[str]:
+    """Build a command that invokes the current Python interpreter."""
     return [sys.executable, *args]
 
 
 def _check_tool_version(repo_root: Path, module: str, expected: str) -> None:
+    """Warn when local tool versions differ from CI-pinned versions."""
     rc, out = _capture(_py("-m", module, "--version"), repo_root)
     if rc != 0:
         return
     if expected not in out:
         got = out.strip().splitlines()[0] if out.strip() else "unknown"
-        print(
-            _c(f"  note: local {module} ({got}) != CI pin {expected}; results may differ.", "yellow")
+        _emit(
+            f"  note: local {module} ({got}) != CI pin {expected}; results may differ.",
+            "yellow",
         )
 
 
@@ -223,12 +290,14 @@ def _check_tool_version(repo_root: Path, module: str, expected: str) -> None:
 # Phases
 # --------------------------------------------------------------------------- #
 def phase_compileall(ctx: Context) -> PhaseResult:
+    """Run the compileall syntax-check phase."""
     start = time.time()
     rc = _run(_py("-m", "compileall", "-q", APP_DIR), ctx.repo_root)
     return PhaseResult("compileall (syntax-check)", rc == 0, time.time() - start)
 
 
 def phase_ruff(ctx: Context, full: bool) -> PhaseResult:
+    """Run the non-blocking Ruff visibility phase."""
     # Non-blocking, mirroring the CI `lint` job (continue-on-error against a large
     # baseline). Reported for visibility but never fails the local run.
     start = time.time()
@@ -251,6 +320,7 @@ def phase_ruff(ctx: Context, full: bool) -> PhaseResult:
 
 
 def phase_guards(ctx: Context) -> PhaseResult:
+    """Run repository guard scripts that mirror pre-commit CI hooks."""
     start = time.time()
     ok = True
     for guard in GUARD_SCRIPTS:
@@ -266,23 +336,34 @@ def phase_guards(ctx: Context) -> PhaseResult:
 
 
 def _pytest_base_cmd(jobs: str) -> list[str]:
+    """Build the base pytest command for local CI."""
     cmd = _py("-m", "pytest", "-q", "--disable-warnings", "-p", "no:cacheprovider")
     if jobs and jobs != "0":
-        cmd += ["-n", jobs]
+        cmd += ["-p", "xdist.plugin", "-n", jobs]
     return cmd
 
 
+def _ci_pytest_env() -> dict[str, str]:
+    """Return pytest environment defaults aligned with GitHub CI."""
+    env = os.environ.copy()
+    for key, value in CI_PYTEST_ENV_DEFAULTS.items():
+        env.setdefault(key, value)
+    return env
+
+
 def phase_pytest(ctx: Context, paths: list[str], jobs: str, extra: list[str]) -> PhaseResult:
+    """Run pytest over selected paths."""
     start = time.time()
     if not paths:
         return PhaseResult("pytest", True, time.time() - start, skipped=True,
                            note="no test paths selected (touch a test file or use --lane/--full)")
     cmd = _pytest_base_cmd(jobs) + extra + paths
-    rc = _run(cmd, ctx.repo_root)
+    rc = _run(cmd, ctx.repo_root, env=_ci_pytest_env())
     return PhaseResult("pytest", rc == 0, time.time() - start)
 
 
 def phase_mypy(ctx: Context) -> PhaseResult:
+    """Run the non-blocking mypy visibility phase."""
     start = time.time()
     _check_tool_version(ctx.repo_root, "mypy", CI_MYPY_VERSION)
     rc = _run(_py("-m", "mypy", RUFF_TARGET), ctx.repo_root)
@@ -295,6 +376,7 @@ def phase_mypy(ctx: Context) -> PhaseResult:
 # Main
 # --------------------------------------------------------------------------- #
 def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse local CI command-line arguments."""
     p = argparse.ArgumentParser(
         description="Run the gating CI checks locally (compileall, ruff, guards, pytest).",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -319,6 +401,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 
 def main(argv: list[str]) -> int:
+    """Run local CI and return a process exit status."""
     args = parse_args(argv)
     repo_root = _git_repo_root()
     _maybe_reexec_into_venv(repo_root)  # never silently use system Python
@@ -328,20 +411,20 @@ def main(argv: list[str]) -> int:
     ctx = Context(repo_root=repo_root, base=base, changed_py=changed, changed_tests=changed_tests)
 
     if args.list_changed:
-        print(f"base: {base or '(working tree only)'}")
+        _emit(f"base: {base or '(working tree only)'}")
         for f in changed:
-            print(f"  {f}")
+            _emit(f"  {f}")
         return 0
 
     full = bool(args.full)
     lane = args.lane
-    extra = args.pytest_args.split() if args.pytest_args else []
+    extra = shlex.split(args.pytest_args, posix=(os.name != "nt")) if args.pytest_args else []
 
-    print(_c("=" * 70, "bold"))
+    _emit("=" * 70, "bold")
     tier_name = "lane" if lane else ("full" if full else "fast")
-    print(_c(f"Local CI — tier: {tier_name}   base: {base or '(working tree only)'}", "bold"))
-    print(_c(f"changed .py: {len(changed)}   changed tests: {len(changed_tests)}", "bold"))
-    print(_c("=" * 70, "bold"))
+    _emit(f"Local CI — tier: {tier_name}   base: {base or '(working tree only)'}", "bold")
+    _emit(f"changed .py: {len(changed)}   changed tests: {len(changed_tests)}", "bold")
+    _emit("=" * 70, "bold")
 
     results: list[PhaseResult] = []
     results.append(phase_compileall(ctx))
@@ -361,9 +444,9 @@ def main(argv: list[str]) -> int:
         results.append(phase_pytest(ctx, pytest_paths, args.jobs, extra))
 
     # Summary
-    print()
-    print(_c("-" * 70, "bold"))
-    print(_c("Summary", "bold"))
+    _emit("")
+    _emit("-" * 70, "bold")
+    _emit("Summary", "bold")
     failed = False
     for r in results:
         if r.skipped:
@@ -374,13 +457,13 @@ def main(argv: list[str]) -> int:
             status = _c("FAIL", "red")
             failed = True
         note = f"  ({r.note})" if r.note else ""
-        print(f"  {status}  {r.name:<28} {r.seconds:6.1f}s{note}")
-    print(_c("-" * 70, "bold"))
+        _emit(f"  {status}  {r.name:<28} {r.seconds:6.1f}s{note}")
+    _emit("-" * 70, "bold")
 
     if failed:
-        print(_c("Local CI FAILED — fix the above before pushing.", "red"))
+        _emit("Local CI FAILED — fix the above before pushing.", "red")
         return 1
-    print(_c("Local CI passed.", "green"))
+    _emit("Local CI passed.", "green")
     return 0
 
 

--- a/Helper_Scripts/ci/run_local_ci.py
+++ b/Helper_Scripts/ci/run_local_ci.py
@@ -319,7 +319,7 @@ def phase_ruff(ctx: Context, full: bool) -> PhaseResult:
     return PhaseResult("ruff (non-blocking)", True, time.time() - start, note=note)
 
 
-def phase_guards(ctx: Context) -> PhaseResult:
+def phase_guards(ctx: Context, full: bool = False) -> PhaseResult:
     """Run repository guard scripts that mirror pre-commit CI hooks."""
     start = time.time()
     ok = True
@@ -328,7 +328,7 @@ def phase_guards(ctx: Context) -> PhaseResult:
             rc = _run(_py(guard), ctx.repo_root)
             ok = ok and rc == 0
     # Syntax guard takes file paths; run on changed files (or app/ in full runs).
-    syntax_targets = ctx.changed_py or [APP_DIR]
+    syntax_targets = [APP_DIR] if full else (ctx.changed_py or [APP_DIR])
     if (ctx.repo_root / SYNTAX_GUARD).exists():
         rc = _run(_py(SYNTAX_GUARD, *syntax_targets), ctx.repo_root)
         ok = ok and rc == 0
@@ -430,7 +430,7 @@ def main(argv: list[str]) -> int:
     results.append(phase_compileall(ctx))
     if not lane:  # ruff covered by lint job; lane runs skip it for speed
         results.append(phase_ruff(ctx, full=full))
-    results.append(phase_guards(ctx))
+    results.append(phase_guards(ctx, full=full))
     if args.mypy:
         results.append(phase_mypy(ctx))
 

--- a/Helper_Scripts/ci/run_local_ci.py
+++ b/Helper_Scripts/ci/run_local_ci.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Run the gating CI checks locally, on any of linux/macOS/Windows.
+
+This mirrors the *blocking* lanes of ``.github/workflows/ci.yml`` so you can get
+the same signal locally and skip waiting on the remote GitHub runners. It is pure
+standard library and invokes tools through ``sys.executable -m ...`` so it works
+identically on a Windows Server box (no bash required).
+
+Tiers
+-----
+``--fast`` (default)
+    compileall + ruff (changed files) + repo guards + pytest on the changed test
+    files only. Sub-couple-of-minutes feedback loop for the "did I break what I
+    touched" question.
+``--full``
+    compileall + ruff (whole backend) + guards + the whole pytest suite under
+    ``-n auto`` (pytest-xdist, already a project dependency). The local stand-in
+    for the remote full suite.
+``--lane PATH [PATH ...]``
+    compileall + guards + pytest on the given path(s) under ``-n auto``. Use this
+    to run one area (e.g. a directory matching a CI shard).
+
+Mapping to CI jobs
+------------------
+- compileall            -> ``syntax-check`` job (compileall over app/)
+- ruff                  -> ``lint`` job (ruff check tldw_Server_API/)
+- guards                -> pre-commit local hooks (http-client patch / legacy body / syntax)
+- pytest                -> ``full-suite-*`` shard jobs
+
+Postgres / Redis dependent tests honor the same env the test suite already uses:
+set ``TEST_DATABASE_URL`` to point at a running Postgres, or
+``TLDW_TEST_NO_DOCKER=1`` to skip the autostart. See
+``Helper_Scripts/Testing-related/start_postgres_for_tests.sh`` to spin one up.
+
+Examples
+--------
+    python Helper_Scripts/ci/run_local_ci.py            # fast tier
+    python Helper_Scripts/ci/run_local_ci.py --full
+    python Helper_Scripts/ci/run_local_ci.py --lane tldw_Server_API/tests/Security
+    python Helper_Scripts/ci/run_local_ci.py --base origin/dev
+    python Helper_Scripts/ci/run_local_ci.py --full --pytest-args "-k embeddings"
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Tool versions the remote CI pins (see the `lint` job). Local installs may
+# differ; we only warn so the script stays usable without an exact match.
+CI_RUFF_VERSION = "0.15.10"
+CI_MYPY_VERSION = "1.20.1"
+
+APP_DIR = "tldw_Server_API/app"
+TESTS_DIR = "tldw_Server_API/tests"
+RUFF_TARGET = "tldw_Server_API/"
+
+GUARD_SCRIPTS = (
+    "Helper_Scripts/checks/guard_http_client_patching.py",
+    "Helper_Scripts/checks/guard_no_nonempty_legacy_complete.py",
+)
+SYNTAX_GUARD = "Helper_Scripts/checks/check_python_syntax.py"
+
+
+@dataclass
+class PhaseResult:
+    name: str
+    ok: bool
+    seconds: float
+    skipped: bool = False
+    note: str = ""
+
+
+@dataclass
+class Context:
+    repo_root: Path
+    base: str | None
+    changed_py: list[str] = field(default_factory=list)
+    changed_tests: list[str] = field(default_factory=list)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _c(text: str, color: str) -> str:
+    if not sys.stdout.isatty() or os.environ.get("NO_COLOR"):
+        return text
+    codes = {"green": "32", "red": "31", "yellow": "33", "cyan": "36", "bold": "1"}
+    return f"\033[{codes.get(color, '0')}m{text}\033[0m"
+
+
+def _run(cmd: Sequence[str], cwd: Path) -> int:
+    print(_c("$ " + " ".join(cmd), "cyan"))
+    try:
+        return subprocess.run(list(cmd), cwd=str(cwd)).returncode
+    except FileNotFoundError as exc:  # missing executable
+        print(_c(f"  command not found: {exc}", "red"), file=sys.stderr)
+        return 127
+
+
+def _capture(cmd: Sequence[str], cwd: Path) -> tuple[int, str]:
+    try:
+        proc = subprocess.run(
+            list(cmd), cwd=str(cwd), capture_output=True, text=True
+        )
+        return proc.returncode, proc.stdout
+    except FileNotFoundError:
+        return 127, ""
+
+
+def _venv_python(repo_root: Path) -> Path | None:
+    """Return the repo's .venv interpreter path if it exists, else None."""
+    candidates = [
+        repo_root / ".venv" / "bin" / "python",          # POSIX
+        repo_root / ".venv" / "Scripts" / "python.exe",  # Windows
+    ]
+    for c in candidates:
+        if c.exists():
+            return c
+    return None
+
+
+def _maybe_reexec_into_venv(repo_root: Path) -> None:
+    """Re-exec under the project venv so we never silently use system Python.
+
+    Honors the project rule of not running against the system interpreter. A
+    guard env var prevents infinite re-exec loops, and ``TLDW_CI_NO_REEXEC=1``
+    opts out entirely (e.g. when the caller already manages the environment).
+    """
+    if os.environ.get("TLDW_CI_REEXEC") == "1" or os.environ.get("TLDW_CI_NO_REEXEC") == "1":
+        return
+    venv_py = _venv_python(repo_root)
+    if venv_py is None:
+        return
+    try:
+        same = os.path.samefile(str(venv_py), sys.executable)
+    except OSError:
+        same = Path(sys.executable).resolve() == venv_py.resolve()
+    if same:
+        return
+    print(_c(f"Re-executing under project venv: {venv_py}", "cyan"))
+    env = dict(os.environ, TLDW_CI_REEXEC="1")
+    os.execve(str(venv_py), [str(venv_py), str(Path(__file__).resolve()), *sys.argv[1:]], env)
+
+
+def _git_repo_root() -> Path:
+    rc, out = _capture(["git", "rev-parse", "--show-toplevel"], Path.cwd())
+    if rc != 0 or not out.strip():
+        print(_c("Not inside a git repository.", "red"), file=sys.stderr)
+        raise SystemExit(2)
+    return Path(out.strip())
+
+
+def _resolve_base(repo_root: Path, explicit: str | None) -> str | None:
+    """Pick a base ref to diff against for 'changed files' detection."""
+    candidates = []
+    if explicit:
+        candidates.append(explicit)
+    if os.environ.get("TLDW_CI_BASE"):
+        candidates.append(os.environ["TLDW_CI_BASE"])
+    candidates += ["origin/dev", "origin/main", "HEAD~1"]
+    for ref in candidates:
+        rc, out = _capture(["git", "merge-base", "HEAD", ref], repo_root)
+        if rc == 0 and out.strip():
+            return out.strip()
+    return None
+
+
+def _changed_python(repo_root: Path, base: str | None) -> list[str]:
+    files: set[str] = set()
+    if base:
+        rc, out = _capture(
+            ["git", "diff", "--name-only", "--diff-filter=ACMRTUXB", f"{base}...HEAD", "--", "*.py"],
+            repo_root,
+        )
+        if rc == 0:
+            files.update(line for line in out.splitlines() if line.strip())
+    # Always include working-tree + untracked changes so local edits count.
+    rc, out = _capture(
+        ["git", "diff", "--name-only", "--diff-filter=ACMRTUXB", "--", "*.py"], repo_root
+    )
+    if rc == 0:
+        files.update(line for line in out.splitlines() if line.strip())
+    rc, out = _capture(
+        ["git", "ls-files", "--others", "--exclude-standard", "--", "*.py"], repo_root
+    )
+    if rc == 0:
+        files.update(line for line in out.splitlines() if line.strip())
+    # Keep only files that still exist (skip deletions).
+    return sorted(f for f in files if (repo_root / f).exists())
+
+
+def _is_test_file(path: str) -> bool:
+    """True if ``path`` is a pytest-collectable test module under the tests dir."""
+    if not path.startswith(TESTS_DIR):
+        return False
+    name = Path(path).name
+    return name.startswith("test_") or name.endswith("_test.py")
+
+
+def _py(*args: str) -> list[str]:
+    return [sys.executable, *args]
+
+
+def _check_tool_version(repo_root: Path, module: str, expected: str) -> None:
+    rc, out = _capture(_py("-m", module, "--version"), repo_root)
+    if rc != 0:
+        return
+    if expected not in out:
+        got = out.strip().splitlines()[0] if out.strip() else "unknown"
+        print(
+            _c(f"  note: local {module} ({got}) != CI pin {expected}; results may differ.", "yellow")
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Phases
+# --------------------------------------------------------------------------- #
+def phase_compileall(ctx: Context) -> PhaseResult:
+    start = time.time()
+    rc = _run(_py("-m", "compileall", "-q", APP_DIR), ctx.repo_root)
+    return PhaseResult("compileall (syntax-check)", rc == 0, time.time() - start)
+
+
+def phase_ruff(ctx: Context, full: bool) -> PhaseResult:
+    # Non-blocking, mirroring the CI `lint` job (continue-on-error against a large
+    # baseline). Reported for visibility but never fails the local run.
+    start = time.time()
+    if shutil.which("ruff") is None:
+        rc, _ = _capture(_py("-m", "ruff", "--version"), ctx.repo_root)
+        if rc != 0:
+            return PhaseResult("ruff (non-blocking)", True, time.time() - start, skipped=True,
+                               note="ruff not installed (pip install ruff)")
+    _check_tool_version(ctx.repo_root, "ruff", CI_RUFF_VERSION)
+    if full:
+        targets = [RUFF_TARGET]
+    else:
+        if not ctx.changed_py:
+            return PhaseResult("ruff (non-blocking)", True, time.time() - start, skipped=True,
+                               note="no changed .py files")
+        targets = ctx.changed_py
+    rc = _run(_py("-m", "ruff", "check", *targets), ctx.repo_root)
+    note = "" if rc == 0 else "lint findings reported (informational, like CI)"
+    return PhaseResult("ruff (non-blocking)", True, time.time() - start, note=note)
+
+
+def phase_guards(ctx: Context) -> PhaseResult:
+    start = time.time()
+    ok = True
+    for guard in GUARD_SCRIPTS:
+        if (ctx.repo_root / guard).exists():
+            rc = _run(_py(guard), ctx.repo_root)
+            ok = ok and rc == 0
+    # Syntax guard takes file paths; run on changed files (or app/ in full runs).
+    syntax_targets = ctx.changed_py or [APP_DIR]
+    if (ctx.repo_root / SYNTAX_GUARD).exists():
+        rc = _run(_py(SYNTAX_GUARD, *syntax_targets), ctx.repo_root)
+        ok = ok and rc == 0
+    return PhaseResult("repo guards", ok, time.time() - start)
+
+
+def _pytest_base_cmd(jobs: str) -> list[str]:
+    cmd = _py("-m", "pytest", "-q", "--disable-warnings", "-p", "no:cacheprovider")
+    if jobs and jobs != "0":
+        cmd += ["-n", jobs]
+    return cmd
+
+
+def phase_pytest(ctx: Context, paths: list[str], jobs: str, extra: list[str]) -> PhaseResult:
+    start = time.time()
+    if not paths:
+        return PhaseResult("pytest", True, time.time() - start, skipped=True,
+                           note="no test paths selected (touch a test file or use --lane/--full)")
+    cmd = _pytest_base_cmd(jobs) + extra + paths
+    rc = _run(cmd, ctx.repo_root)
+    return PhaseResult("pytest", rc == 0, time.time() - start)
+
+
+def phase_mypy(ctx: Context) -> PhaseResult:
+    start = time.time()
+    _check_tool_version(ctx.repo_root, "mypy", CI_MYPY_VERSION)
+    rc = _run(_py("-m", "mypy", RUFF_TARGET), ctx.repo_root)
+    # mypy is non-blocking in CI (baseline backlog); report but never fail the run.
+    return PhaseResult("mypy (non-blocking)", True, time.time() - start,
+                       note="" if rc == 0 else "type errors reported (informational)")
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Run the gating CI checks locally (compileall, ruff, guards, pytest).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    tier = p.add_mutually_exclusive_group()
+    tier.add_argument("--fast", action="store_true",
+                      help="Default. compileall + ruff(changed) + guards + pytest(changed tests).")
+    tier.add_argument("--full", action="store_true",
+                      help="compileall + ruff(all) + guards + whole pytest suite under -n auto.")
+    tier.add_argument("--lane", nargs="+", metavar="PATH",
+                      help="compileall + guards + pytest on the given path(s) under -n auto.")
+    p.add_argument("--base", help="Git ref to diff against for changed-file detection.")
+    p.add_argument("--jobs", default="auto",
+                   help="pytest-xdist worker count ('auto', a number, or '0' to disable). Default: auto.")
+    p.add_argument("--mypy", action="store_true", help="Also run mypy (non-blocking, like CI).")
+    p.add_argument("--no-pytest", action="store_true", help="Skip the pytest phase.")
+    p.add_argument("--pytest-args", default="",
+                   help="Extra args appended to pytest, e.g. --pytest-args \"-k embeddings\".")
+    p.add_argument("--list-changed", action="store_true",
+                   help="Print detected changed Python files and exit.")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    repo_root = _git_repo_root()
+    _maybe_reexec_into_venv(repo_root)  # never silently use system Python
+    base = _resolve_base(repo_root, args.base)
+    changed = _changed_python(repo_root, base)
+    changed_tests = [f for f in changed if _is_test_file(f)]
+    ctx = Context(repo_root=repo_root, base=base, changed_py=changed, changed_tests=changed_tests)
+
+    if args.list_changed:
+        print(f"base: {base or '(working tree only)'}")
+        for f in changed:
+            print(f"  {f}")
+        return 0
+
+    full = bool(args.full)
+    lane = args.lane
+    extra = args.pytest_args.split() if args.pytest_args else []
+
+    print(_c("=" * 70, "bold"))
+    tier_name = "lane" if lane else ("full" if full else "fast")
+    print(_c(f"Local CI — tier: {tier_name}   base: {base or '(working tree only)'}", "bold"))
+    print(_c(f"changed .py: {len(changed)}   changed tests: {len(changed_tests)}", "bold"))
+    print(_c("=" * 70, "bold"))
+
+    results: list[PhaseResult] = []
+    results.append(phase_compileall(ctx))
+    if not lane:  # ruff covered by lint job; lane runs skip it for speed
+        results.append(phase_ruff(ctx, full=full))
+    results.append(phase_guards(ctx))
+    if args.mypy:
+        results.append(phase_mypy(ctx))
+
+    if not args.no_pytest:
+        if lane:
+            pytest_paths = list(lane)
+        elif full:
+            pytest_paths = [TESTS_DIR]
+        else:
+            pytest_paths = changed_tests
+        results.append(phase_pytest(ctx, pytest_paths, args.jobs, extra))
+
+    # Summary
+    print()
+    print(_c("-" * 70, "bold"))
+    print(_c("Summary", "bold"))
+    failed = False
+    for r in results:
+        if r.skipped:
+            status = _c("SKIP", "yellow")
+        elif r.ok:
+            status = _c("PASS", "green")
+        else:
+            status = _c("FAIL", "red")
+            failed = True
+        note = f"  ({r.note})" if r.note else ""
+        print(f"  {status}  {r.name:<28} {r.seconds:6.1f}s{note}")
+    print(_c("-" * 70, "bold"))
+
+    if failed:
+        print(_c("Local CI FAILED — fix the above before pushing.", "red"))
+        return 1
+    print(_c("Local CI passed.", "green"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ help:
 	@echo "  make tooling-install         Install test/smoke extras"
 	@echo "  make tooling-smoke           Run unified smoke checks"
 	@echo "  make lint-changed            Lint only changed files"
+	@echo "  make ci-local                Run gating CI checks locally (fast tier)"
+	@echo "  make ci-local-full           Run the full suite locally (-n auto)"
+	@echo "  make ci-local-lane LANE=...  Run one test area locally"
 	@echo "  make release                 Cut a patch release from main"
 	@echo "  make release-patch           Cut a patch release from main"
 	@echo "  make release-minor           Cut a minor release from main"
@@ -454,6 +457,27 @@ BASE ?=
 
 lint-changed:
 	@bash Helper_Scripts/Testing-related/lint-changed.sh $(BASE)
+
+# -----------------------------------------------------------------------------
+# Local CI — reproduce the gating GitHub checks before pushing
+# -----------------------------------------------------------------------------
+.PHONY: ci-local ci-local-full ci-local-lane
+
+# Prefer the project venv python ($(VENV_PYTHON)); fall back to $(PYTHON).
+CI_LOCAL_PYTHON ?= $(shell [ -x "$(VENV_PYTHON)" ] && echo "$(VENV_PYTHON)" || echo "$(PYTHON)")
+RUN_LOCAL_CI ?= $(CI_LOCAL_PYTHON) Helper_Scripts/ci/run_local_ci.py
+CI_ARGS ?=
+LANE ?=
+
+ci-local:            ## Fast tier: compileall + ruff(changed) + guards + pytest(changed)
+	$(RUN_LOCAL_CI) --fast $(CI_ARGS)
+
+ci-local-full:       ## Full tier: compileall + ruff(all) + guards + whole suite (-n auto)
+	$(RUN_LOCAL_CI) --full $(CI_ARGS)
+
+ci-local-lane:       ## One area: make ci-local-lane LANE=tldw_Server_API/tests/Security
+	@test -n "$(LANE)" || (echo "Usage: make ci-local-lane LANE=<path> [CI_ARGS=...]" && exit 2)
+	$(RUN_LOCAL_CI) --lane $(LANE) $(CI_ARGS)
 
 # -----------------------------------------------------------------------------
 # Chat Streaming Load Harness (Scenario A starter)

--- a/backlog/tasks/task-2396 - Address-PR-2426-review-comments-and-rebase-local-CI-tooling.md
+++ b/backlog/tasks/task-2396 - Address-PR-2426-review-comments-and-rebase-local-CI-tooling.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2396
 title: Address PR 2426 review comments and rebase local CI tooling
-status: In Progress
+status: Done
 references:
 - https://github.com/rmusser01/tldw_server/pull/2426
 modified_files:
@@ -37,15 +37,15 @@ Docs/superpowers/plans/2026-06-21-pr-2426-local-ci-review-rebase-plan.md
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Rebased local-ci-tooling onto origin/dev (already up to date) and addressed PR 2426 review comments. Added focused tests for quoted pytest args, Python-side changed-file filtering, nested changed file detection, CI-like pytest env/xdist loading, Windows venv re-exec status propagation, Loguru output usage, and runner docstrings. Updated the runner to use Loguru for runner-owned messages, shlex for pytest args, CI pytest env defaults, explicit xdist loading, Python-side .py filtering, Windows subprocess.call re-exec, and docstrings throughout. Updated Local CI docs to remove the pure-stdlib claim and document pytest arg quoting. Verification: targeted pytest 8 passed; ruff changed Python files passed; compileall changed Python files passed; Bandit on Helper_Scripts/ci/run_local_ci.py reported 0 findings/errors; run_local_ci.py --fast --no-pytest passed.
+Rebased local-ci-tooling onto origin/dev (already up to date) and addressed PR 2426 review comments. Added focused tests for quoted pytest args, Python-side changed-file filtering, nested changed file detection, CI-like pytest env/xdist loading, Windows venv re-exec status propagation, Loguru output usage, and runner docstrings. Updated the runner to use Loguru for runner-owned messages, shlex for pytest args, CI pytest env defaults, explicit xdist loading, Python-side .py filtering, Windows subprocess.call re-exec, and docstrings throughout. Updated Local CI docs to remove the pure-stdlib claim and document pytest arg quoting. Verification: targeted pytest 8 passed; ruff changed Python files passed; compileall changed Python files passed; Bandit on Helper_Scripts/ci/run_local_ci.py reported 0 findings/errors; run_local_ci.py --fast --no-pytest passed. Pushed to origin/local-ci-tooling for PR 2426.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2396 - Address-PR-2426-review-comments-and-rebase-local-CI-tooling.md
+++ b/backlog/tasks/task-2396 - Address-PR-2426-review-comments-and-rebase-local-CI-tooling.md
@@ -5,6 +5,7 @@ status: Done
 references:
 - https://github.com/rmusser01/tldw_server/pull/2426
 modified_files:
+- .pre-commit-config.yaml
 - Helper_Scripts/ci/run_local_ci.py
 - tldw_Server_API/tests/CI/test_run_local_ci.py
 - Docs/Development/Local-CI.md
@@ -37,7 +38,7 @@ Docs/superpowers/plans/2026-06-21-pr-2426-local-ci-review-rebase-plan.md
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Rebased local-ci-tooling onto origin/dev (already up to date) and addressed PR 2426 review comments. Added focused tests for quoted pytest args, Python-side changed-file filtering, nested changed file detection, CI-like pytest env/xdist loading, Windows venv re-exec status propagation, Loguru output usage, and runner docstrings. Updated the runner to use Loguru for runner-owned messages, shlex for pytest args, CI pytest env defaults, explicit xdist loading, Python-side .py filtering, Windows subprocess.call re-exec, and docstrings throughout. Updated Local CI docs to remove the pure-stdlib claim and document pytest arg quoting. Verification: targeted pytest 8 passed; ruff changed Python files passed; compileall changed Python files passed; Bandit on Helper_Scripts/ci/run_local_ci.py reported 0 findings/errors; run_local_ci.py --fast --no-pytest passed. Pushed to origin/local-ci-tooling for PR 2426.
+Rebased local-ci-tooling onto origin/dev (already up to date) and addressed PR 2426 review comments. Added focused tests for quoted pytest args, Python-side changed-file filtering, nested changed file detection, CI-like pytest env/xdist loading, Windows venv re-exec status propagation, Loguru output usage, runner docstrings, full-tier guard syntax scope, and the local CI pre-push hook launcher. Updated the runner to use Loguru for runner-owned messages, shlex for pytest args, CI pytest env defaults, explicit xdist loading, Python-side .py filtering, Windows subprocess.call re-exec, full-run syntax guard targeting, and docstrings throughout. Updated the local-ci-fast pre-push hook to use python for cross-platform launcher compatibility. Updated Local CI docs to remove the pure-stdlib claim and document pytest arg quoting. Verification: targeted pytest 10 passed; ruff changed Python files passed; compileall changed Python files passed; Bandit on Helper_Scripts/ci/run_local_ci.py reported 0 findings/errors; run_local_ci.py --fast --no-pytest passed. Pushed to origin/local-ci-tooling for PR 2426.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2396 - Address-PR-2426-review-comments-and-rebase-local-CI-tooling.md
+++ b/backlog/tasks/task-2396 - Address-PR-2426-review-comments-and-rebase-local-CI-tooling.md
@@ -1,0 +1,51 @@
+---
+id: TASK-2396
+title: Address PR 2426 review comments and rebase local CI tooling
+status: In Progress
+references:
+- https://github.com/rmusser01/tldw_server/pull/2426
+modified_files:
+- Helper_Scripts/ci/run_local_ci.py
+- tldw_Server_API/tests/CI/test_run_local_ci.py
+- Docs/Development/Local-CI.md
+- Docs/superpowers/plans/2026-06-21-pr-2426-local-ci-review-rebase-plan.md
+- backlog/tasks/task-2396 - Address-PR-2426-review-comments-and-rebase-local-CI-tooling.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-21-pr-2426-local-ci-review-rebase-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased local-ci-tooling onto origin/dev (already up to date) and addressed PR 2426 review comments. Added focused tests for quoted pytest args, Python-side changed-file filtering, nested changed file detection, CI-like pytest env/xdist loading, Windows venv re-exec status propagation, Loguru output usage, and runner docstrings. Updated the runner to use Loguru for runner-owned messages, shlex for pytest args, CI pytest env defaults, explicit xdist loading, Python-side .py filtering, Windows subprocess.call re-exec, and docstrings throughout. Updated Local CI docs to remove the pure-stdlib claim and document pytest arg quoting. Verification: targeted pytest 8 passed; ruff changed Python files passed; compileall changed Python files passed; Bandit on Helper_Scripts/ci/run_local_ci.py reported 0 findings/errors; run_local_ci.py --fast --no-pytest passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/tests/CI/test_run_local_ci.py
+++ b/tldw_Server_API/tests/CI/test_run_local_ci.py
@@ -7,6 +7,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 from Helper_Scripts.ci import run_local_ci
 
 
@@ -179,6 +180,39 @@ def test_phase_pytest_does_not_load_xdist_when_jobs_disabled(
     assert "-n" not in cmd
 
 
+def test_phase_guards_full_run_checks_app_dir_even_with_changed_files(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Full runs send app/ to the syntax guard instead of changed files."""
+    syntax_guard = tmp_path / run_local_ci.SYNTAX_GUARD
+    syntax_guard.parent.mkdir(parents=True)
+    syntax_guard.write_text("")
+    captured: list[list[str]] = []
+
+    def fake_run(cmd: list[str], _cwd: Path) -> int:
+        captured.append(cmd)
+        return 0
+
+    monkeypatch.setattr(run_local_ci, "_run", fake_run)
+    ctx = run_local_ci.Context(
+        repo_root=tmp_path,
+        base=None,
+        changed_py=["Helper_Scripts/ci/run_local_ci.py"],
+    )
+
+    result = run_local_ci.phase_guards(ctx, full=True)
+
+    assert result.ok is True
+    assert captured == [
+        [
+            run_local_ci.sys.executable,
+            run_local_ci.SYNTAX_GUARD,
+            run_local_ci.APP_DIR,
+        ]
+    ]
+
+
 def test_windows_reexec_waits_and_exits_with_child_status(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -218,6 +252,15 @@ def test_windows_reexec_waits_and_exits_with_child_status(
     env = captured["env"]
     assert isinstance(env, dict)
     assert env["TLDW_CI_REEXEC"] == "1"
+
+
+def test_local_ci_pre_push_hook_uses_cross_platform_python_launcher() -> None:
+    """The local CI pre-push hook uses ``python`` instead of ``python3``."""
+    config = yaml.safe_load(Path(".pre-commit-config.yaml").read_text())
+    local_repo = next(repo for repo in config["repos"] if repo["repo"] == "local")
+    local_ci_hook = next(hook for hook in local_repo["hooks"] if hook["id"] == "local-ci-fast")
+
+    assert local_ci_hook["entry"].split()[0] == "python"
 
 
 def test_runner_owned_messages_use_loguru_instead_of_prints() -> None:

--- a/tldw_Server_API/tests/CI/test_run_local_ci.py
+++ b/tldw_Server_API/tests/CI/test_run_local_ci.py
@@ -1,0 +1,268 @@
+"""Regression tests for the local CI runner."""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+from pathlib import Path
+
+import pytest
+from Helper_Scripts.ci import run_local_ci
+
+
+def _git(repo: Path, *args: str) -> str:
+    """Run a git command in ``repo`` and return stdout."""
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout.strip()
+
+
+def _phase(name: str):
+    """Return a passing phase stub for ``run_local_ci.main`` tests."""
+
+    def stub(*_args, **_kwargs) -> run_local_ci.PhaseResult:
+        return run_local_ci.PhaseResult(name, True, 0.0)
+
+    return stub
+
+
+def _has_arg_pair(cmd: list[str], left: str, right: str) -> bool:
+    """Return True when adjacent arguments are present in order."""
+    return any(cmd[index : index + 2] == [left, right] for index in range(len(cmd) - 1))
+
+
+def test_pytest_args_preserve_quoted_expressions(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Quoted ``--pytest-args`` expressions are passed to pytest as one argument."""
+    captured: dict[str, list[str]] = {}
+
+    def fake_phase_pytest(
+        _ctx: run_local_ci.Context,
+        _paths: list[str],
+        _jobs: str,
+        extra: list[str],
+    ) -> run_local_ci.PhaseResult:
+        captured["extra"] = extra
+        return run_local_ci.PhaseResult("pytest", True, 0.0)
+
+    monkeypatch.setattr(run_local_ci, "_git_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(run_local_ci, "_maybe_reexec_into_venv", lambda _repo_root: None)
+    monkeypatch.setattr(run_local_ci, "_resolve_base", lambda _repo_root, _explicit: None)
+    monkeypatch.setattr(
+        run_local_ci,
+        "_changed_python",
+        lambda _repo_root, _base: ["tldw_Server_API/tests/CI/test_example.py"],
+    )
+    monkeypatch.setattr(run_local_ci, "phase_compileall", _phase("compileall"))
+    monkeypatch.setattr(run_local_ci, "phase_ruff", _phase("ruff"))
+    monkeypatch.setattr(run_local_ci, "phase_guards", _phase("guards"))
+    monkeypatch.setattr(run_local_ci, "phase_pytest", fake_phase_pytest)
+
+    rc = run_local_ci.main(["--pytest-args", "-k 'alpha and beta'"])
+
+    assert rc == 0
+    assert captured["extra"] == ["-k", "alpha and beta"]
+
+
+def test_changed_python_filters_git_output_in_python(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Changed-file detection filters Python files after collecting git output."""
+    seen_commands: list[list[str]] = []
+
+    def fake_capture(cmd: list[str], _cwd: Path) -> tuple[int, str]:
+        seen_commands.append(cmd)
+        if cmd[1] == "diff":
+            return 0, "nested/changed.py\nREADME.md\nscripts/tool.py\n"
+        if cmd[1] == "ls-files":
+            return 0, "notes.txt\nuntracked/new_test.py\n"
+        return 1, ""
+
+    for rel_path in ("nested/changed.py", "scripts/tool.py", "untracked/new_test.py"):
+        path = tmp_path / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("print('ok')\n")
+
+    monkeypatch.setattr(run_local_ci, "_capture", fake_capture)
+
+    changed = run_local_ci._changed_python(tmp_path, "base-ref")
+
+    assert changed == ["nested/changed.py", "scripts/tool.py", "untracked/new_test.py"]
+    assert all("--" not in cmd for cmd in seen_commands)
+
+
+def test_changed_python_detects_nested_committed_files(tmp_path: Path) -> None:
+    """Nested Python files committed after the base ref are detected."""
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "tests@example.invalid")
+    _git(tmp_path, "config", "user.name", "Tests")
+    (tmp_path / "README.md").write_text("base\n")
+    _git(tmp_path, "add", "README.md")
+    _git(tmp_path, "commit", "-q", "-m", "base")
+    base = _git(tmp_path, "rev-parse", "HEAD")
+
+    nested = tmp_path / "tldw_Server_API" / "app" / "nested" / "changed.py"
+    nested.parent.mkdir(parents=True)
+    nested.write_text("VALUE = 1\n")
+    _git(tmp_path, "add", str(nested.relative_to(tmp_path)))
+    _git(tmp_path, "commit", "-q", "-m", "changed")
+
+    assert run_local_ci._changed_python(tmp_path, base) == [
+        "tldw_Server_API/app/nested/changed.py"
+    ]
+
+
+def test_phase_pytest_uses_ci_like_env_and_explicit_xdist(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Pytest runs with CI-like environment defaults and explicit xdist loading."""
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd: list[str], cwd: Path, env: dict[str, str] | None = None) -> int:
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        captured["env"] = env
+        return 0
+
+    for key in run_local_ci.CI_PYTEST_ENV_DEFAULTS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(run_local_ci, "_run", fake_run)
+
+    result = run_local_ci.phase_pytest(
+        run_local_ci.Context(repo_root=tmp_path, base=None),
+        [run_local_ci.TESTS_DIR],
+        "auto",
+        [],
+    )
+
+    assert result.ok is True
+    cmd = captured["cmd"]
+    assert isinstance(cmd, list)
+    assert _has_arg_pair(cmd, "-p", "xdist.plugin")
+    assert "-n" in cmd
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["PYTHONPATH"] == "."
+    assert env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] == "1"
+    assert env["TEST_MODE"] == "true"
+    assert env["DISABLE_HEAVY_STARTUP"] == "1"
+    assert env["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] == "python"
+
+
+def test_phase_pytest_does_not_load_xdist_when_jobs_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Passing ``--jobs 0`` disables xdist arguments while keeping CI env defaults."""
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd: list[str], cwd: Path, env: dict[str, str] | None = None) -> int:
+        captured["cmd"] = cmd
+        captured["env"] = env
+        return 0
+
+    monkeypatch.setattr(run_local_ci, "_run", fake_run)
+
+    run_local_ci.phase_pytest(
+        run_local_ci.Context(repo_root=tmp_path, base=None),
+        [run_local_ci.TESTS_DIR],
+        "0",
+        [],
+    )
+
+    cmd = captured["cmd"]
+    assert isinstance(cmd, list)
+    assert "xdist.plugin" not in cmd
+    assert "-n" not in cmd
+
+
+def test_windows_reexec_waits_and_exits_with_child_status(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Windows venv re-exec waits for the child process and returns its status."""
+    venv_python = tmp_path / ".venv" / "Scripts" / "python.exe"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("")
+    captured: dict[str, object] = {}
+
+    def fake_call(cmd: list[str], env: dict[str, str]) -> int:
+        captured["cmd"] = cmd
+        captured["env"] = env
+        return 23
+
+    monkeypatch.delenv("TLDW_CI_REEXEC", raising=False)
+    monkeypatch.delenv("TLDW_CI_NO_REEXEC", raising=False)
+    monkeypatch.setattr(run_local_ci, "_venv_python", lambda _repo_root: venv_python)
+    monkeypatch.setattr(run_local_ci.os.path, "samefile", lambda _left, _right: False)
+    monkeypatch.setattr(run_local_ci.sys, "platform", "win32")
+    monkeypatch.setattr(run_local_ci.sys, "argv", ["run_local_ci.py"])
+    monkeypatch.setattr(run_local_ci.subprocess, "call", fake_call)
+    monkeypatch.setattr(
+        run_local_ci.os,
+        "execve",
+        lambda *_args, **_kwargs: pytest.fail("Windows re-exec must not use os.execve"),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        run_local_ci._maybe_reexec_into_venv(tmp_path)
+
+    assert exc.value.code == 23
+    assert captured["cmd"] == [
+        str(venv_python),
+        str(Path(run_local_ci.__file__).resolve()),
+    ]
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["TLDW_CI_REEXEC"] == "1"
+
+
+def test_runner_owned_messages_use_loguru_instead_of_prints() -> None:
+    """The runner does not use direct print calls for its own messages."""
+    tree = ast.parse(Path(run_local_ci.__file__).read_text())
+    print_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "print"
+    ]
+
+    assert print_calls == []
+
+
+def test_runner_classes_and_functions_have_docstrings() -> None:
+    """New runner classes and functions provide docstrings for maintainability."""
+    names = [
+        "PhaseResult",
+        "Context",
+        "_c",
+        "_emit",
+        "_emit_error",
+        "_run",
+        "_capture",
+        "_venv_python",
+        "_maybe_reexec_into_venv",
+        "_git_repo_root",
+        "_resolve_base",
+        "_changed_python",
+        "_is_test_file",
+        "_py",
+        "_check_tool_version",
+        "phase_compileall",
+        "phase_ruff",
+        "phase_guards",
+        "_pytest_base_cmd",
+        "_ci_pytest_env",
+        "phase_pytest",
+        "phase_mypy",
+        "parse_args",
+        "main",
+    ]
+
+    missing = [name for name in names if not getattr(run_local_ci, name).__doc__]
+
+    assert missing == []


### PR DESCRIPTION
## What

Adds a portable **local CI runner** so changes can be validated on linux/macOS/Windows before pushing — reproducing the *gating* GitHub CI lanes without waiting on (or burning minutes in) remote Actions.

- **`Helper_Scripts/ci/run_local_ci.py`** — pure-stdlib runner. Mirrors the blocking lanes: `compileall` (syntax-check job), the repo pre-commit guards, and `pytest` under `-n auto` (xdist). ruff/mypy are reported but non-blocking, matching the remote `lint` job. **Auto re-execs into the project `.venv`**, so it never runs against the system interpreter.
  - Tiers: `--fast` (compileall + ruff-changed + guards + pytest on changed tests), `--full` (whole suite, `-n auto`), `--lane PATH`.
  - Honors `TEST_DATABASE_URL` / `TLDW_TEST_NO_DOCKER` for Postgres-dependent lanes.
- **Make targets**: `make ci-local`, `ci-local-full`, `ci-local-lane LANE=…` (venv-aware).
- **pre-commit pre-push hook** (`local-ci-fast`) running the fast tier — enable with `pre-commit install --hook-type pre-push`.
- **Docs**: `Docs/Development/Local-CI.md` (usage + how phases map to CI jobs) and `Docs/Development/Self-Hosted-Runners.md` (cross-OS strategy on self-hosted runners, with the public-repo security rules).

## Usage

```bash
uv venv --python 3.12 .venv && uv pip install --python .venv/bin/python -e ".[dev]"
make ci-local            # fast tier
make ci-local-full       # whole suite under -n auto
make ci-local-lane LANE=tldw_Server_API/tests/Security
```

## Notes

- Self-contained: no new runtime deps (uses the existing `pytest-xdist`).
- The companion remote-CI work (shard-coverage guard, path-filter gating, pytest-split) lives in #2258; this PR is just the local tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local CI runner and Make targets that mirror the blocking GitHub CI lanes across Linux/macOS/Windows. Provides a fast feedback loop, a pre-push hook, docs, and fixes around quoting, env parity, Windows re-exec, and full-run syntax guard scope.

- New Features
  - `Helper_Scripts/ci/run_local_ci.py`: runner using `loguru` for status; mirrors compileall, repo guards, and `pytest` with `xdist`; `ruff`/`mypy` reported but non-blocking; auto re-execs into `.venv`.
  - Tiers and flags: `--fast`, `--full`, `--lane PATH`; `--pytest-args`, `--jobs`, `--base`, `--list-changed`; honors `TEST_DATABASE_URL` and `TLDW_TEST_NO_DOCKER`.
  - Make targets: `make ci-local`, `make ci-local-full`, `make ci-local-lane LANE=…` (venv-aware). Pre-push: `local-ci-fast` in `.pre-commit-config.yaml` (`pre-commit`) using the cross-platform `python` launcher.
  - Docs: `Docs/Development/Local-CI.md` and `Docs/Development/Self-Hosted-Runners.md`.

- Bug Fixes
  - Preserve quoted expressions in `--pytest-args`; detect nested changed `.py` files and filter git output in Python.
  - Align pytest with CI: set env defaults, load `xdist` explicitly when jobs > 0, and disable with `--jobs 0`.
  - Windows re-exec now waits for the venv child and returns its status.
  - Full-tier syntax guard now checks `app/` even when changed files exist.

<sup>Written for commit 732288b931c21d4123a6ccf3f32ffa4dc982c38e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

