### PR TITLE
Fix onboarding quickstart docs for first-time users

### DIFF
--- a/Docs/Getting_Started/Profile_Local_Single_User.md
+++ b/Docs/Getting_Started/Profile_Local_Single_User.md
@@ -64,8 +64,21 @@ Start the WebUI in a second terminal when you are ready for the cohesive first-t
 
 ```bash
 cd apps/tldw-frontend
+cp .env.local.example .env.local
+bun install
 bun run dev -- -p 8080
 ```
+
+Confirm `.env.local` contains:
+
+```bash
+NEXT_PUBLIC_API_URL=http://127.0.0.1:8000
+NEXT_PUBLIC_API_VERSION=v1
+# Optional local single-user bootstrap auth:
+# NEXT_PUBLIC_X_API_KEY=your_single_user_api_key
+```
+
+If Bun is not installed, use the Bun install steps or npm fallback in [Local Profile: Add the WebUI](../../README.md#local-profile-add-the-webui).
 
 Then open http://127.0.0.1:8080 to open the WebUI.
 

--- a/Docs/Getting_Started/QUICKSTART.md
+++ b/Docs/Getting_Started/QUICKSTART.md
@@ -178,6 +178,9 @@ source .venv/bin/activate        # Windows: .venv\Scripts\Activate.ps1
 pip install --upgrade pip
 pip install -e .
 cp tldw_Server_API/Config_Files/.env.example tldw_Server_API/Config_Files/.env
+python -m tldw_Server_API.cli.wizard.cli init --profile local-single --env-file tldw_Server_API/Config_Files/.env --default --yes
+# Lower-level equivalent if you already edited .env manually:
+# python -m tldw_Server_API.app.core.AuthNZ.initialize --non-interactive
 python -m uvicorn tldw_Server_API.app.main:app --reload
 ```
 
@@ -259,9 +262,11 @@ curl -sS -X POST http://localhost:8000/api/v1/media/search \
 
 ---
 
-## Guided Setup Wizard (Optional)
+## Backend Setup Recovery Surface (Optional)
 
-For a visual configuration experience, edit `tldw_Server_API/Config_Files/config.txt`:
+The normal solo first-run path is the WebUI at http://localhost:8080 after your selected profile verifies. Use the WebUI first-time setup flow for provider/chat setup, then complete the first successful chat gate and add your first source.
+
+The backend `/setup` page is a backend/operator recovery surface for cases where the WebUI setup flow cannot save provider settings or you need direct server-side recovery. To enable it, edit `tldw_Server_API/Config_Files/config.txt`:
 
 ```ini
 [Setup]
@@ -269,7 +274,7 @@ enable_first_time_setup = true
 setup_completed = false
 ```
 
-Restart the server, then visit http://localhost:8000/setup. The wizard walks you through provider configuration, audio setup, and more.
+Restart the server, then visit http://localhost:8000/setup.
 
 ---
 
@@ -317,7 +322,7 @@ docker compose --env-file tldw_Server_API/Config_Files/.env \
 - **Chat**: Open the WebUI and send a message, or use the `/api/v1/chat/completions` endpoint
 - **Ingest media**: Upload a PDF, paste a YouTube URL, or use the `/api/v1/media/process` endpoint
 - **Speech**: Set up audio with the [CPU](./First_Time_Audio_Setup_CPU.md) or [GPU/Accelerated](./First_Time_Audio_Setup_GPU_Accelerated.md) audio guide
-- **Setup wizard**: Try the guided wizard at http://localhost:8000/setup
+- **Setup recovery**: Use the backend/operator recovery surface at http://localhost:8000/setup only when the WebUI setup flow is unavailable or cannot save settings
 - **API reference**: Browse the full API at http://localhost:8000/docs
 
 ---

--- a/Docs/Getting_Started/TROUBLESHOOTING.md
+++ b/Docs/Getting_Started/TROUBLESHOOTING.md
@@ -256,7 +256,7 @@ pip install "numpy<2"
 
 ```powershell
 if (!(Test-Path "tldw_Server_API/Config_Files/.env")) { Copy-Item "tldw_Server_API/Config_Files/.env.example" "tldw_Server_API/Config_Files/.env" }
-py -3.12 -m venv .setup-venv
+py -m venv .setup-venv
 .\.setup-venv\Scripts\python -m pip install --upgrade pip setuptools wheel
 .\.setup-venv\Scripts\python -m pip install "typer>=0.12.0" "loguru>=0.7.0" "httpx>=0.24.0" "python-dotenv>=1.0.0" "cryptography>=41.0.0"
 .\.setup-venv\Scripts\python -m tldw_Server_API.cli.wizard.cli init --profile docker-single-webui --env-file tldw_Server_API/Config_Files/.env --default --yes

--- a/Docs/Getting_Started/TROUBLESHOOTING.md
+++ b/Docs/Getting_Started/TROUBLESHOOTING.md
@@ -252,11 +252,15 @@ pip install "numpy<2"
 
 **Symptoms:** `make quickstart` fails on Windows.
 
-**Fix:** Use WSL2 or Git Bash. Alternatively, run the Docker commands directly:
-```bash
-docker compose --env-file tldw_Server_API/Config_Files/.env \
-  -f Dockerfiles/docker-compose.yml \
-  -f Dockerfiles/docker-compose.webui.yml up -d --build
+**Fix:** Use WSL2 for the documented Makefile path, or run the PowerShell/no-`make` setup from the profile guide. For Docker single-user + WebUI, the current direct compose command is:
+
+```powershell
+if (!(Test-Path "tldw_Server_API/Config_Files/.env")) { Copy-Item "tldw_Server_API/Config_Files/.env.example" "tldw_Server_API/Config_Files/.env" }
+py -3.12 -m venv .setup-venv
+.\.setup-venv\Scripts\python -m pip install --upgrade pip setuptools wheel
+.\.setup-venv\Scripts\python -m pip install "typer>=0.12.0" "loguru>=0.7.0" "httpx>=0.24.0" "python-dotenv>=1.0.0" "cryptography>=41.0.0"
+.\.setup-venv\Scripts\python -m tldw_Server_API.cli.wizard.cli init --profile docker-single-webui --env-file tldw_Server_API/Config_Files/.env --default --yes
+docker compose --env-file tldw_Server_API/Config_Files/.env -f Dockerfiles/docker-compose.single-user.yml -f Dockerfiles/docker-compose.webui.yml up -d --wait
 ```
 
 ---
@@ -448,7 +452,7 @@ Docker single-user WebUI quickstart uses runtime auth bootstrap. Check these whe
 - `SINGLE_USER_API_KEY` is not `change-me`.
 - The backend `app` service has the same `SINGLE_USER_API_KEY`.
 
-Only advanced/static deployments should set `NEXT_PUBLIC_X_API_KEY` before building the WebUI.
+`NEXT_PUBLIC_X_API_KEY` is a browser-visible copy of the single-user API key. Only advanced/static local single-user deployments should set it before building the WebUI. In a separate local WebUI dev server, set it only if you want automatic single-user auth. Do not set it for multi-user/JWT deployments, shared production deployments, or any browser bundle where exposing the single-user API key is unacceptable. If you intentionally change it for a built WebUI image, rebuild the WebUI so the public build-time value changes.
 
 ---
 

--- a/Docs/Published/Getting_Started/Profile_Local_Single_User.md
+++ b/Docs/Published/Getting_Started/Profile_Local_Single_User.md
@@ -64,8 +64,21 @@ Start the WebUI in a second terminal when you are ready for the cohesive first-t
 
 ```bash
 cd apps/tldw-frontend
+cp .env.local.example .env.local
+bun install
 bun run dev -- -p 8080
 ```
+
+Confirm `.env.local` contains:
+
+```bash
+NEXT_PUBLIC_API_URL=http://127.0.0.1:8000
+NEXT_PUBLIC_API_VERSION=v1
+# Optional local single-user bootstrap auth:
+# NEXT_PUBLIC_X_API_KEY=your_single_user_api_key
+```
+
+If Bun is not installed, use the Bun install steps or npm fallback in [Local Profile: Add the WebUI](../../../README.md#local-profile-add-the-webui).
 
 Then open http://127.0.0.1:8080 to open the WebUI.
 
@@ -122,6 +135,6 @@ Local audio setup can use host-side config and model files directly. After this 
 
 ## Optional Add-ons
 
-- Add the WebUI after the API is healthy: see [Local Profile: Add the WebUI](../../README.md#local-profile-add-the-webui).
+- Add the WebUI after the API is healthy: see [Local Profile: Add the WebUI](../../../README.md#local-profile-add-the-webui).
 - Keep provider setup in the WebUI first-run wizard for the normal path; use file-based configuration only for recovery, automation, or advanced deployments.
 - Install development extras with `source .venv/bin/activate && pip install -e ".[dev]"`.

--- a/Docs/superpowers/plans/2026-06-29-pr2427-review-rebase.md
+++ b/Docs/superpowers/plans/2026-06-29-pr2427-review-rebase.md
@@ -32,4 +32,4 @@
 **Goal**: Commit, push the rebased branch, resolve addressed review threads, and report remaining CI status.
 **Success Criteria**: PR branch is updated on GitHub, review threads are resolved or documented as non-actionable, and final status is reported.
 **Tests**: `gh pr view`, `gh pr checks`, and review-thread query.
-**Status**: In Progress
+**Status**: Complete

--- a/Docs/superpowers/plans/2026-06-29-pr2427-review-rebase.md
+++ b/Docs/superpowers/plans/2026-06-29-pr2427-review-rebase.md
@@ -1,0 +1,35 @@
+# PR 2427 Review Rebase Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebase PR #2427 onto latest `dev`, address active onboarding-docs review comments, and push the verified branch.
+
+**Architecture:** Keep changes scoped to onboarding/getting-started documentation and its docs-contract tests. Verify every review comment against the rebased diff before editing, and avoid broad docs rewrites outside the reviewed onboarding surface.
+
+**Tech Stack:** Markdown documentation, pytest docs-contract tests, Backlog.md, GitHub CLI.
+
+---
+
+## Stage 1: Rebase And Inventory
+**Goal**: Rebase PR #2427 onto latest `origin/dev` and identify all active review threads/comments.
+**Success Criteria**: Branch rebases cleanly or conflicts are resolved, review comments are mapped to touched files, and Backlog task `TASK-2395` tracks the work.
+**Tests**: Git rebase status and GitHub review-thread query.
+**Status**: In Progress
+
+## Stage 2: Review Fixes
+**Goal**: Verify each review comment against current docs/tests and implement only technically valid fixes.
+**Success Criteria**: Each active comment has a docs/test change or a documented technical rationale.
+**Tests**: Focused docs-contract tests for changed onboarding guidance.
+**Status**: Not Started
+
+## Stage 3: Verification
+**Goal**: Run focused docs tests and required quality gates for touched scope.
+**Success Criteria**: Docs-contract tests, Markdown link/path checks where applicable, and Bandit for touched Python tests pass or are reported with evidence.
+**Tests**: Commands recorded in `TASK-2395`.
+**Status**: Not Started
+
+## Stage 4: Push And Resolve
+**Goal**: Commit, push the rebased branch, resolve addressed review threads, and report remaining CI status.
+**Success Criteria**: PR branch is updated on GitHub, review threads are resolved or documented as non-actionable, and final status is reported.
+**Tests**: `gh pr view`, `gh pr checks`, and review-thread query.
+**Status**: Not Started

--- a/Docs/superpowers/plans/2026-06-29-pr2427-review-rebase.md
+++ b/Docs/superpowers/plans/2026-06-29-pr2427-review-rebase.md
@@ -14,22 +14,22 @@
 **Goal**: Rebase PR #2427 onto latest `origin/dev` and identify all active review threads/comments.
 **Success Criteria**: Branch rebases cleanly or conflicts are resolved, review comments are mapped to touched files, and Backlog task `TASK-2395` tracks the work.
 **Tests**: Git rebase status and GitHub review-thread query.
-**Status**: In Progress
+**Status**: Complete
 
 ## Stage 2: Review Fixes
 **Goal**: Verify each review comment against current docs/tests and implement only technically valid fixes.
 **Success Criteria**: Each active comment has a docs/test change or a documented technical rationale.
 **Tests**: Focused docs-contract tests for changed onboarding guidance.
-**Status**: Not Started
+**Status**: Complete
 
 ## Stage 3: Verification
 **Goal**: Run focused docs tests and required quality gates for touched scope.
 **Success Criteria**: Docs-contract tests, Markdown link/path checks where applicable, and Bandit for touched Python tests pass or are reported with evidence.
 **Tests**: Commands recorded in `TASK-2395`.
-**Status**: Not Started
+**Status**: Complete
 
 ## Stage 4: Push And Resolve
 **Goal**: Commit, push the rebased branch, resolve addressed review threads, and report remaining CI status.
 **Success Criteria**: PR branch is updated on GitHub, review threads are resolved or documented as non-actionable, and final status is reported.
 **Tests**: `gh pr view`, `gh pr checks`, and review-thread query.
-**Status**: Not Started
+**Status**: In Progress

--- a/README.md
+++ b/README.md
@@ -82,8 +82,7 @@ Good fit for:
 
 ## Start Here
 
-1. **Check prerequisites:** `make quickstart-prereqs` (or verify Python 3.10+, ffmpeg, and Docker manually for your chosen profile)
-2. **Pick one peer setup profile:**
+1. **Clone this repository and pick one peer setup profile.**
 
 | Profile | Best for | Prepare | Start | Verify |
 |---------|----------|---------|-------|--------|
@@ -95,7 +94,9 @@ Good fit for:
 
 For a user-facing map of key workflows across the server API, WebUI, and browser extension, start with the [User Guides documentation map](Docs/User_Guides/index.md).
 
-1. **Follow your profile guide** end-to-end. It covers prepare, start, verify, first value, audio path, troubleshoot, and optional add-ons.
+After cloning, you can run the optional Makefile helper checks with `make quickstart-prereqs`, or verify Python 3.10+, ffmpeg, and Docker manually for your chosen profile. On a fresh checkout, the setup targets are still the source of truth because they create the lightweight setup environment they need.
+
+2. **Follow your profile guide** end-to-end. It covers prepare, start, verify, first value, audio path, troubleshoot, and optional add-ons.
 
 Developers working on the WebUI, extension, or shared app packages should also start with [apps/DEVELOPMENT.md](apps/DEVELOPMENT.md).
 
@@ -214,12 +215,14 @@ For now, use this repository checkout and the setup paths below (`make` and no-`
 
 ### Preflight Check (Recommended)
 
-If you plan to use Makefile quickstart targets:
+After cloning the repository, you can run the optional Makefile helper checks:
 ```bash
 make quickstart-prereqs
 ```
 
-If `make` is unavailable (common on Windows), run the equivalent checks manually:
+This helper checks your host Python and optional media tooling. If it reports missing project Python packages on a fresh checkout, continue with the selected setup profile; `make setup-docker-single`, `make setup-docker-multi`, and `make install-local` create the setup environments they need.
+
+If `make` is unavailable (common on Windows), run equivalent host checks manually:
 ```powershell
 py -3.12 --version  # or py -3.13 / -3.11 / -3.10
 ffmpeg -version

--- a/apps/tldw-frontend/.env.local.example
+++ b/apps/tldw-frontend/.env.local.example
@@ -1,7 +1,7 @@
 ## Frontend configuration for tldw-frontend
 
 # Backend server URL and API version (frontend-safe values only)
-NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_API_URL=http://127.0.0.1:8000
 NEXT_PUBLIC_API_VERSION=v1
 
 # Optional: Explicit base URL for static assets (origin without /api/vN)
@@ -12,12 +12,13 @@ NEXT_PUBLIC_API_VERSION=v1
 
 # Authentication options (choose one of the below for local/dev):
 
-# 1) Admin UI API key (sent in X-API-KEY header)
-# NOTE: This is for the frontend admin API, NOT the same as SINGLE_USER_API_KEY
-# used for backend API access. Must match NEXT_PUBLIC_X_API_KEY in the backend .env.
-# Only needed in advanced (non-proxy) deployment mode — the default Docker quickstart
-# uses a same-origin proxy and does not require this.
-#NEXT_PUBLIC_X_API_KEY=CHANGE_ME_TO_UNIQUE_FRONTEND_KEY
+# 1) Optional local single-user bootstrap API key (sent in X-API-KEY header)
+# For local single-user setups, this can match the backend SINGLE_USER_API_KEY
+# when you want the browser dev server to authenticate automatically.
+# Only set this in local/dev or advanced static deployments where exposing the
+# single-user API key in the browser bundle is acceptable. Do not set it for
+# multi-user/JWT deployments or shared production browser builds.
+#NEXT_PUBLIC_X_API_KEY=your_single_user_api_key
 
 # 2) Chat module API_BEARER (when required by /api/v1/chat/completions)
 # If your server sets API_BEARER, put it here to send as Authorization: Bearer <token>

--- a/backlog/tasks/task-2395 - Fix-README-and-getting-started-P1-P2-onboarding-docs.md
+++ b/backlog/tasks/task-2395 - Fix-README-and-getting-started-P1-P2-onboarding-docs.md
@@ -1,19 +1,19 @@
 ---
 id: TASK-2395
 title: Fix README and getting-started P1/P2 onboarding docs
-status: Done
+status: In Progress
 assignee: []
-created_date: '2026-06-21 23:46'
-updated_date: '2026-06-22 00:01'
+created_date: 2026-06-21 23:46
+updated_date: 2026-06-22 00:01
 labels:
-  - docs
-  - onboarding
+- docs
+- onboarding
 dependencies: []
 references:
-  - README.md
-  - Docs/Getting_Started/QUICKSTART.md
-  - Docs/Getting_Started/Profile_Local_Single_User.md
-  - Docs/Getting_Started/TROUBLESHOOTING.md
+- README.md
+- Docs/Getting_Started/QUICKSTART.md
+- Docs/Getting_Started/Profile_Local_Single_User.md
+- Docs/Getting_Started/TROUBLESHOOTING.md
 priority: high
 ---
 
@@ -43,6 +43,10 @@ Verification: source .venv/bin/activate && python -m pytest -q tldw_Server_API/t
 Known skips/blockers: no app/server runtime smoke was started because this change only edits documentation and a docs contract test. No subagent code-reviewer was spawned because the available subagent tool requires the user to explicitly request delegation; local verification was run instead.
 
 PR: https://github.com/rmusser01/tldw_server/pull/2427
+
+Review-rebase follow-up started 2026-06-29:
+- Reopened this task to track rebasing PR #2427 onto latest `origin/dev` and addressing any still-open PR review comments.
+- Plan: `Docs/superpowers/plans/2026-06-29-pr2427-review-rebase.md`
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2395 - Fix-README-and-getting-started-P1-P2-onboarding-docs.md
+++ b/backlog/tasks/task-2395 - Fix-README-and-getting-started-P1-P2-onboarding-docs.md
@@ -4,7 +4,7 @@ title: Fix README and getting-started P1/P2 onboarding docs
 status: Done
 assignee: []
 created_date: '2026-06-21 23:46'
-updated_date: '2026-06-21 23:50'
+updated_date: '2026-06-22 00:01'
 labels:
   - docs
   - onboarding
@@ -41,6 +41,8 @@ Implemented docs repairs for P1/P2 onboarding review: README preflight wording, 
 Verification: source .venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Docs/test_onboarding_guides_structure.py tldw_Server_API/tests/Docs/test_onboarding_entrypoints.py tldw_Server_API/tests/Docs/test_onboarding_default_contract.py tldw_Server_API/tests/Docs/test_quickstart_same_origin_docs.py tldw_Server_API/tests/Docs/test_public_onboarding_profile_parity.py tldw_Server_API/tests/Docs/test_published_onboarding_parity.py => 30 passed. Local Markdown path check for edited files => MISSING_LINKS=0. Bandit: source .venv/bin/activate && python -m bandit -r tldw_Server_API/tests/Docs/test_onboarding_guides_structure.py -f json -o /tmp/bandit_task_2395.json => 0 issues. Bandit not applicable to Markdown-only touched docs.
 
 Known skips/blockers: no app/server runtime smoke was started because this change only edits documentation and a docs contract test. No subagent code-reviewer was spawned because the available subagent tool requires the user to explicitly request delegation; local verification was run instead.
+
+PR: https://github.com/rmusser01/tldw_server/pull/2427
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2395 - Fix-README-and-getting-started-P1-P2-onboarding-docs.md
+++ b/backlog/tasks/task-2395 - Fix-README-and-getting-started-P1-P2-onboarding-docs.md
@@ -1,0 +1,60 @@
+---
+id: TASK-2395
+title: Fix README and getting-started P1/P2 onboarding docs
+status: Done
+assignee: []
+created_date: '2026-06-21 23:46'
+updated_date: '2026-06-21 23:50'
+labels:
+  - docs
+  - onboarding
+dependencies: []
+references:
+  - README.md
+  - Docs/Getting_Started/QUICKSTART.md
+  - Docs/Getting_Started/Profile_Local_Single_User.md
+  - Docs/Getting_Started/TROUBLESHOOTING.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address reviewed P1/P2 new-user documentation issues in README and Docs/Getting_Started. Scope: command guidance, manual local auth setup, local WebUI setup completeness, setup surface consistency, current Windows/no-make troubleshooting, and NEXT_PUBLIC_X_API_KEY wording.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 README no longer recommends make quickstart-prereqs as a first fresh-checkout Docker step that can fail before setup tooling exists.
+- [x] #2 QUICKSTART manual local path includes single-user auth setup before starting uvicorn.
+- [x] #3 NEXT_PUBLIC_X_API_KEY guidance consistently describes local single-user quickstart bootstrap behavior and production caution.
+- [x] #4 Local profile includes or links complete WebUI dependency/setup commands before bun run dev.
+- [x] #5 QUICKSTART setup wizard wording matches the canonical WebUI-first setup and /setup recovery/operator positioning.
+- [x] #6 Windows/no-make troubleshooting uses current single-user compose files and PowerShell syntax.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented docs repairs for P1/P2 onboarding review: README preflight wording, QUICKSTART manual local auth init and /setup recovery wording, Local profile WebUI setup commands plus published mirror, TROUBLESHOOTING Windows/no-make compose update and NEXT_PUBLIC_X_API_KEY clarification, and focused docs regression coverage.
+
+Verification: source .venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Docs/test_onboarding_guides_structure.py tldw_Server_API/tests/Docs/test_onboarding_entrypoints.py tldw_Server_API/tests/Docs/test_onboarding_default_contract.py tldw_Server_API/tests/Docs/test_quickstart_same_origin_docs.py tldw_Server_API/tests/Docs/test_public_onboarding_profile_parity.py tldw_Server_API/tests/Docs/test_published_onboarding_parity.py => 30 passed. Local Markdown path check for edited files => MISSING_LINKS=0. Bandit: source .venv/bin/activate && python -m bandit -r tldw_Server_API/tests/Docs/test_onboarding_guides_structure.py -f json -o /tmp/bandit_task_2395.json => 0 issues. Bandit not applicable to Markdown-only touched docs.
+
+Known skips/blockers: no app/server runtime smoke was started because this change only edits documentation and a docs contract test. No subagent code-reviewer was spawned because the available subagent tool requires the user to explicitly request delegation; local verification was run instead.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the P1/P2 onboarding documentation issues from the README/Getting Started review. Updated README preflight positioning, QUICKSTART manual local auth setup and /setup recovery language, local WebUI setup steps plus published mirror, troubleshooting for Windows/no-make compose commands, and NEXT_PUBLIC_X_API_KEY guidance. Added a focused docs regression test for these contracts.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2395 - Fix-README-and-getting-started-P1-P2-onboarding-docs.md
+++ b/backlog/tasks/task-2395 - Fix-README-and-getting-started-P1-P2-onboarding-docs.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2395
 title: Fix README and getting-started P1/P2 onboarding docs
-status: In Progress
+status: Done
 assignee: []
 created_date: 2026-06-21 23:46
 updated_date: 2026-06-29 00:00
@@ -53,12 +53,15 @@ Review-rebase follow-up started 2026-06-29:
 - Verification follow-up: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest -q tldw_Server_API/tests/Docs/test_onboarding_guides_structure.py tldw_Server_API/tests/Docs/test_onboarding_entrypoints.py tldw_Server_API/tests/Docs/test_onboarding_default_contract.py tldw_Server_API/tests/Docs/test_quickstart_same_origin_docs.py tldw_Server_API/tests/Docs/test_public_onboarding_profile_parity.py tldw_Server_API/tests/Docs/test_published_onboarding_parity.py tldw_Server_API/tests/Docs/test_onboarding_dev_docs.py` => 52 passed, 3 warnings.
 - Quality follow-up: `black --check` and `ruff check` passed for `tldw_Server_API/tests/Docs/test_onboarding_guides_structure.py`; `compileall` passed; `git diff --check` passed; README/top-guide docs path hygiene, onboarding command boundary, and onboarding endpoint drift checks passed.
 - Security follow-up: raw Bandit on the touched pytest file only reported B101 pytest `assert` false positives, which were intentionally introduced to satisfy review feedback for standard pytest assertions. Rerun with `-s B101` on the touched test file wrote `/tmp/bandit_pr2427_skip_b101.json` with 0 findings.
+- Push/review follow-up: pushed rebased branch `codex/fix-onboarding-docs-p1-p2` at `6452b23097`, resolved all previously open review threads, and posted PR summary comment https://github.com/rmusser01/tldw_server/pull/2427#issuecomment-4828456659.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Fixed the P1/P2 onboarding documentation issues from the README/Getting Started review. Updated README preflight positioning, QUICKSTART manual local auth setup and /setup recovery language, local WebUI setup steps plus published mirror, troubleshooting for Windows/no-make compose commands, and NEXT_PUBLIC_X_API_KEY guidance. Added a focused docs regression test for these contracts.
+
+Follow-up rebased PR #2427 onto latest `origin/dev`, resolved README/TROUBLESHOOTING conflicts, addressed all active Gemini/Qodo/CodeRabbit review threads, aligned `apps/tldw-frontend/.env.local.example` with the local single-user docs, split/marked/docstringed the onboarding docs contract tests, verified the focused docs scope, pushed the updated branch, and posted a PR summary comment.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2395 - Fix-README-and-getting-started-P1-P2-onboarding-docs.md
+++ b/backlog/tasks/task-2395 - Fix-README-and-getting-started-P1-P2-onboarding-docs.md
@@ -4,13 +4,14 @@ title: Fix README and getting-started P1/P2 onboarding docs
 status: In Progress
 assignee: []
 created_date: 2026-06-21 23:46
-updated_date: 2026-06-22 00:01
+updated_date: 2026-06-29 00:00
 labels:
 - docs
 - onboarding
 dependencies: []
 references:
 - README.md
+- apps/tldw-frontend/.env.local.example
 - Docs/Getting_Started/QUICKSTART.md
 - Docs/Getting_Started/Profile_Local_Single_User.md
 - Docs/Getting_Started/TROUBLESHOOTING.md
@@ -47,6 +48,11 @@ PR: https://github.com/rmusser01/tldw_server/pull/2427
 Review-rebase follow-up started 2026-06-29:
 - Reopened this task to track rebasing PR #2427 onto latest `origin/dev` and addressing any still-open PR review comments.
 - Plan: `Docs/superpowers/plans/2026-06-29-pr2427-review-rebase.md`
+- Rebased onto `origin/dev` and resolved README/TROUBLESHOOTING conflicts while preserving current dev docs map/runtime-auth guidance plus the PR onboarding fixes.
+- Addressed open Gemini/Qodo/CodeRabbit feedback by splitting the new contract test into marked, docstringed pytest tests with direct assertions, adding ordering checks for wizard auth init before uvicorn and WebUI setup before `bun run dev`, and aligning `apps/tldw-frontend/.env.local.example` with the local single-user WebUI docs.
+- Verification follow-up: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest -q tldw_Server_API/tests/Docs/test_onboarding_guides_structure.py tldw_Server_API/tests/Docs/test_onboarding_entrypoints.py tldw_Server_API/tests/Docs/test_onboarding_default_contract.py tldw_Server_API/tests/Docs/test_quickstart_same_origin_docs.py tldw_Server_API/tests/Docs/test_public_onboarding_profile_parity.py tldw_Server_API/tests/Docs/test_published_onboarding_parity.py tldw_Server_API/tests/Docs/test_onboarding_dev_docs.py` => 52 passed, 3 warnings.
+- Quality follow-up: `black --check` and `ruff check` passed for `tldw_Server_API/tests/Docs/test_onboarding_guides_structure.py`; `compileall` passed; `git diff --check` passed; README/top-guide docs path hygiene, onboarding command boundary, and onboarding endpoint drift checks passed.
+- Security follow-up: raw Bandit on the touched pytest file only reported B101 pytest `assert` false positives, which were intentionally introduced to satisfy review feedback for standard pytest assertions. Rerun with `-s B101` on the touched test file wrote `/tmp/bandit_pr2427_skip_b101.json` with 0 findings.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/tests/Docs/test_onboarding_guides_structure.py
+++ b/tldw_Server_API/tests/Docs/test_onboarding_guides_structure.py
@@ -1,3 +1,5 @@
+"""Contract tests for the Getting Started onboarding documentation."""
+
 from pathlib import Path
 
 import pytest
@@ -14,11 +16,14 @@ REQUIRED = [
 
 
 def _require(condition: bool, message: str) -> None:
+    """Fail a docs contract with a readable message."""
     if not condition:
         pytest.fail(message)
 
 
+@pytest.mark.unit
 def test_each_profile_has_required_sections() -> None:
+    """Ensure each canonical onboarding profile keeps required sections."""
     guides = [
         "Docs/Getting_Started/Profile_Local_Single_User.md",
         "Docs/Getting_Started/Profile_Docker_Single_User.md",
@@ -44,7 +49,9 @@ def test_each_profile_has_required_sections() -> None:
         )
 
 
+@pytest.mark.unit
 def test_getting_started_presents_peer_solo_paths_and_first_chat_journey() -> None:
+    """Ensure the Getting Started index presents peer solo setup paths."""
     text = Path("Docs/Getting_Started/README.md").read_text(encoding="utf-8")
 
     for phrase in (
@@ -66,7 +73,9 @@ def test_getting_started_presents_peer_solo_paths_and_first_chat_journey() -> No
     )
 
 
+@pytest.mark.unit
 def test_single_user_profiles_handoff_to_webui_first_chat_and_first_source() -> None:
+    """Ensure single-user profiles guide users into first WebUI value."""
     for guide in (
         "Docs/Getting_Started/Profile_Docker_Single_User.md",
         "Docs/Getting_Started/Profile_Local_Single_User.md",
@@ -92,10 +101,10 @@ def test_single_user_profiles_handoff_to_webui_first_chat_and_first_source() -> 
             )
 
 
+@pytest.mark.unit
 def test_multi_user_profile_routes_operators_out_of_solo_wizard() -> None:
-    text = Path("Docs/Getting_Started/Profile_Docker_Multi_User_Postgres.md").read_text(
-        encoding="utf-8"
-    )
+    """Ensure the multi-user profile directs operators away from solo setup."""
+    text = Path("Docs/Getting_Started/Profile_Docker_Multi_User_Postgres.md").read_text(encoding="utf-8")
 
     for phrase in (
         "shared server/operator path",
@@ -106,7 +115,9 @@ def test_multi_user_profile_routes_operators_out_of_solo_wizard() -> None:
         _require(phrase in text, f"Multi-user profile should mention: {phrase}")
 
 
+@pytest.mark.unit
 def test_gpu_addon_is_legacy_pointer_to_hardware_guides() -> None:
+    """Ensure the GPU add-on points users to current hardware guides."""
     text = Path("Docs/Getting_Started/GPU_STT_Addon.md").read_text(encoding="utf-8")
     _require("legacy pointer" in text, "GPU_STT_Addon should be marked as a legacy pointer")
     _require(
@@ -119,7 +130,9 @@ def test_gpu_addon_is_legacy_pointer_to_hardware_guides() -> None:
     )
 
 
+@pytest.mark.unit
 def test_first_time_audio_guides_have_core_sections() -> None:
+    """Ensure first-time audio setup guides keep their core sections."""
     guide_requirements = {
         "Docs/Getting_Started/First_Time_Audio_Setup_CPU.md": [
             "## Before You Start",
@@ -149,43 +162,168 @@ def test_first_time_audio_guides_have_core_sections() -> None:
             _require(item in text, f"{guide} missing expected content: {item}")
 
 
-def test_p1_p2_onboarding_repair_contract() -> None:
+@pytest.mark.unit
+def test_readme_positions_quickstart_prereqs_after_clone() -> None:
+    """Ensure Makefile prerequisite checks are optional post-clone helpers."""
     readme = Path("README.md").read_text(encoding="utf-8")
-    quickstart = Path("Docs/Getting_Started/QUICKSTART.md").read_text(encoding="utf-8")
-    local_profile = Path("Docs/Getting_Started/Profile_Local_Single_User.md").read_text(
-        encoding="utf-8"
-    )
-    troubleshooting = Path("Docs/Getting_Started/TROUBLESHOOTING.md").read_text(
-        encoding="utf-8"
-    )
 
-    _require(
-        "After cloning, you can run the optional Makefile helper checks" in readme,
-        "README should not present quickstart-prereqs as the first fresh-checkout step",
-    )
-    _require(
-        "python -m tldw_Server_API.app.core.AuthNZ.initialize --non-interactive"
-        in quickstart,
-        "QUICKSTART manual local setup should initialize single-user auth before uvicorn",
-    )
-    _require(
-        "cp .env.local.example .env.local" in local_profile
-        and "bun install" in local_profile
-        and "bun run dev -- -p 8080" in local_profile,
-        "Local profile should include complete WebUI setup commands before starting Bun",
-    )
-    _require(
-        "backend/operator recovery surface" in quickstart,
-        "QUICKSTART should frame /setup as a recovery/operator surface, not the normal first-run path",
-    )
-    _require(
-        "browser-visible copy of the single-user API key" in troubleshooting,
-        "Troubleshooting should explain NEXT_PUBLIC_X_API_KEY as local single-user bootstrap auth",
-    )
-    _require(
-        "Dockerfiles/docker-compose.single-user.yml" in troubleshooting
-        and "Dockerfiles/docker-compose.webui.yml" in troubleshooting
-        and "Dockerfiles/docker-compose.yml ^" not in troubleshooting
-        and "docker-compose.webui.yml up -d --build" not in troubleshooting,
-        "Windows/no-make troubleshooting should use current compose files and avoid stale cmd.exe continuations",
-    )
+    assert "After cloning, you can run the optional Makefile helper checks" in readme
+
+
+@pytest.mark.unit
+def test_quickstart_runs_wizard_init_before_uvicorn() -> None:
+    """Ensure manual local setup initializes auth before server startup."""
+    quickstart = Path("Docs/Getting_Started/QUICKSTART.md").read_text(encoding="utf-8")
+
+    init_at = quickstart.find("python -m tldw_Server_API.cli.wizard.cli init --profile local-single")
+    uvicorn_at = quickstart.find("python -m uvicorn tldw_Server_API.app.main:app --reload")
+
+    assert 0 <= init_at < uvicorn_at
+
+
+@pytest.mark.unit
+def test_quickstart_mentions_lower_level_auth_init_equivalent() -> None:
+    """Ensure the lower-level AuthNZ initializer remains documented."""
+    quickstart = Path("Docs/Getting_Started/QUICKSTART.md").read_text(encoding="utf-8")
+
+    assert "python -m tldw_Server_API.app.core.AuthNZ.initialize --non-interactive" in quickstart
+
+
+@pytest.mark.unit
+def test_local_profile_runs_webui_setup_before_bun_dev() -> None:
+    """Ensure WebUI setup commands precede starting the dev server."""
+    local_profile = Path("Docs/Getting_Started/Profile_Local_Single_User.md").read_text(encoding="utf-8")
+
+    copy_at = local_profile.find("cp .env.local.example .env.local")
+    install_at = local_profile.find("bun install")
+    dev_at = local_profile.find("bun run dev -- -p 8080")
+
+    assert 0 <= copy_at < install_at < dev_at
+
+
+@pytest.mark.unit
+def test_local_profile_documents_loopback_api_url() -> None:
+    """Ensure the local profile shows the expected WebUI API URL."""
+    local_profile = Path("Docs/Getting_Started/Profile_Local_Single_User.md").read_text(encoding="utf-8")
+
+    assert "NEXT_PUBLIC_API_URL=http://127.0.0.1:8000" in local_profile
+
+
+@pytest.mark.unit
+def test_local_profile_documents_api_version() -> None:
+    """Ensure the local profile shows the expected WebUI API version."""
+    local_profile = Path("Docs/Getting_Started/Profile_Local_Single_User.md").read_text(encoding="utf-8")
+
+    assert "NEXT_PUBLIC_API_VERSION=v1" in local_profile
+
+
+@pytest.mark.unit
+def test_local_profile_documents_single_user_key_hint() -> None:
+    """Ensure the local profile shows the optional single-user key hint."""
+    local_profile = Path("Docs/Getting_Started/Profile_Local_Single_User.md").read_text(encoding="utf-8")
+
+    assert "# NEXT_PUBLIC_X_API_KEY=your_single_user_api_key" in local_profile
+
+
+@pytest.mark.unit
+def test_published_local_profile_documents_loopback_api_url() -> None:
+    """Ensure the published local profile mirrors the WebUI API URL."""
+    published_profile = Path("Docs/Published/Getting_Started/Profile_Local_Single_User.md").read_text(encoding="utf-8")
+
+    assert "NEXT_PUBLIC_API_URL=http://127.0.0.1:8000" in published_profile
+
+
+@pytest.mark.unit
+def test_published_local_profile_documents_api_version() -> None:
+    """Ensure the published local profile mirrors the WebUI API version."""
+    published_profile = Path("Docs/Published/Getting_Started/Profile_Local_Single_User.md").read_text(encoding="utf-8")
+
+    assert "NEXT_PUBLIC_API_VERSION=v1" in published_profile
+
+
+@pytest.mark.unit
+def test_published_local_profile_documents_single_user_key_hint() -> None:
+    """Ensure the published local profile mirrors the single-user key hint."""
+    published_profile = Path("Docs/Published/Getting_Started/Profile_Local_Single_User.md").read_text(encoding="utf-8")
+
+    assert "# NEXT_PUBLIC_X_API_KEY=your_single_user_api_key" in published_profile
+
+
+@pytest.mark.unit
+def test_frontend_env_example_uses_loopback_api_url() -> None:
+    """Ensure the copied WebUI env example matches the local profile docs."""
+    env_example = Path("apps/tldw-frontend/.env.local.example").read_text(encoding="utf-8")
+
+    assert "NEXT_PUBLIC_API_URL=http://127.0.0.1:8000" in env_example
+
+
+@pytest.mark.unit
+def test_frontend_env_example_describes_single_user_api_key() -> None:
+    """Ensure the WebUI env example describes local single-user bootstrap auth."""
+    env_example = Path("apps/tldw-frontend/.env.local.example").read_text(encoding="utf-8")
+
+    assert "single-user API key" in env_example
+
+
+@pytest.mark.unit
+def test_frontend_env_example_references_backend_single_user_key() -> None:
+    """Ensure the WebUI env example names the backend single-user key."""
+    env_example = Path("apps/tldw-frontend/.env.local.example").read_text(encoding="utf-8")
+
+    assert "SINGLE_USER_API_KEY" in env_example
+
+
+@pytest.mark.unit
+def test_frontend_env_example_allows_backend_key_match() -> None:
+    """Ensure the WebUI env example does not contradict single-user setup."""
+    env_example = Path("apps/tldw-frontend/.env.local.example").read_text(encoding="utf-8")
+
+    assert "NOT the same as SINGLE_USER_API_KEY" not in env_example
+
+
+@pytest.mark.unit
+def test_quickstart_frames_setup_as_operator_recovery() -> None:
+    """Ensure /setup is documented as a recovery surface, not the default path."""
+    quickstart = Path("Docs/Getting_Started/QUICKSTART.md").read_text(encoding="utf-8")
+
+    assert "backend/operator recovery surface" in quickstart
+
+
+@pytest.mark.unit
+def test_troubleshooting_explains_next_public_x_api_key_bootstrap() -> None:
+    """Ensure troubleshooting explains browser-visible single-user bootstrap auth."""
+    troubleshooting = Path("Docs/Getting_Started/TROUBLESHOOTING.md").read_text(encoding="utf-8")
+
+    assert "browser-visible copy of the single-user API key" in troubleshooting
+
+
+@pytest.mark.unit
+def test_troubleshooting_uses_current_single_user_compose_file() -> None:
+    """Ensure Windows/no-make troubleshooting uses single-user compose."""
+    troubleshooting = Path("Docs/Getting_Started/TROUBLESHOOTING.md").read_text(encoding="utf-8")
+
+    assert "Dockerfiles/docker-compose.single-user.yml" in troubleshooting
+
+
+@pytest.mark.unit
+def test_troubleshooting_uses_current_webui_compose_file() -> None:
+    """Ensure Windows/no-make troubleshooting uses WebUI compose."""
+    troubleshooting = Path("Docs/Getting_Started/TROUBLESHOOTING.md").read_text(encoding="utf-8")
+
+    assert "Dockerfiles/docker-compose.webui.yml" in troubleshooting
+
+
+@pytest.mark.unit
+def test_troubleshooting_omits_stale_cmd_continuation_compose() -> None:
+    """Ensure Windows/no-make troubleshooting avoids stale cmd syntax."""
+    troubleshooting = Path("Docs/Getting_Started/TROUBLESHOOTING.md").read_text(encoding="utf-8")
+
+    assert "Dockerfiles/docker-compose.yml ^" not in troubleshooting
+
+
+@pytest.mark.unit
+def test_troubleshooting_omits_stale_webui_build_command() -> None:
+    """Ensure Windows/no-make troubleshooting avoids stale build syntax."""
+    troubleshooting = Path("Docs/Getting_Started/TROUBLESHOOTING.md").read_text(encoding="utf-8")
+
+    assert "docker-compose.webui.yml up -d --build" not in troubleshooting

--- a/tldw_Server_API/tests/Docs/test_onboarding_guides_structure.py
+++ b/tldw_Server_API/tests/Docs/test_onboarding_guides_structure.py
@@ -147,3 +147,45 @@ def test_first_time_audio_guides_have_core_sections() -> None:
         text = Path(guide).read_text(encoding="utf-8")
         for item in required_content:
             _require(item in text, f"{guide} missing expected content: {item}")
+
+
+def test_p1_p2_onboarding_repair_contract() -> None:
+    readme = Path("README.md").read_text(encoding="utf-8")
+    quickstart = Path("Docs/Getting_Started/QUICKSTART.md").read_text(encoding="utf-8")
+    local_profile = Path("Docs/Getting_Started/Profile_Local_Single_User.md").read_text(
+        encoding="utf-8"
+    )
+    troubleshooting = Path("Docs/Getting_Started/TROUBLESHOOTING.md").read_text(
+        encoding="utf-8"
+    )
+
+    _require(
+        "After cloning, you can run the optional Makefile helper checks" in readme,
+        "README should not present quickstart-prereqs as the first fresh-checkout step",
+    )
+    _require(
+        "python -m tldw_Server_API.app.core.AuthNZ.initialize --non-interactive"
+        in quickstart,
+        "QUICKSTART manual local setup should initialize single-user auth before uvicorn",
+    )
+    _require(
+        "cp .env.local.example .env.local" in local_profile
+        and "bun install" in local_profile
+        and "bun run dev -- -p 8080" in local_profile,
+        "Local profile should include complete WebUI setup commands before starting Bun",
+    )
+    _require(
+        "backend/operator recovery surface" in quickstart,
+        "QUICKSTART should frame /setup as a recovery/operator surface, not the normal first-run path",
+    )
+    _require(
+        "browser-visible copy of the single-user API key" in troubleshooting,
+        "Troubleshooting should explain NEXT_PUBLIC_X_API_KEY as local single-user bootstrap auth",
+    )
+    _require(
+        "Dockerfiles/docker-compose.single-user.yml" in troubleshooting
+        and "Dockerfiles/docker-compose.webui.yml" in troubleshooting
+        and "Dockerfiles/docker-compose.yml ^" not in troubleshooting
+        and "docker-compose.webui.yml up -d --build" not in troubleshooting,
+        "Windows/no-make troubleshooting should use current compose files and avoid stale cmd.exe continuations",
+    )


### PR DESCRIPTION
## Summary
- Repositions `make quickstart-prereqs` as an optional post-clone check instead of a first fresh-checkout step.
- Adds missing manual local auth initialization, fuller local WebUI startup steps, and consistent `/setup` recovery wording.
- Updates Windows/no-make troubleshooting and clarifies `NEXT_PUBLIC_X_API_KEY` as local single-user bootstrap auth with production cautions.
- Adds a focused docs regression test covering the repaired P1/P2 onboarding contracts.

## Verification
- `source .venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Docs/test_onboarding_guides_structure.py tldw_Server_API/tests/Docs/test_onboarding_entrypoints.py tldw_Server_API/tests/Docs/test_onboarding_default_contract.py tldw_Server_API/tests/Docs/test_quickstart_same_origin_docs.py tldw_Server_API/tests/Docs/test_public_onboarding_profile_parity.py tldw_Server_API/tests/Docs/test_published_onboarding_parity.py` => 30 passed
- Edited Markdown local link check => `MISSING_LINKS=0`
- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/tests/Docs/test_onboarding_guides_structure.py -f json -o /tmp/bandit_task_2395_pr.json` => `BANDIT_ISSUES 0`

## Human Change summary required before merge
This PR was materially authored by AI. Per project policy, a human requester must add a Change summary explaining what changed and why these implementation choices were made before this PR is merge-ready.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes P1/P2 onboarding so first-time users can start the API and WebUI without dead ends, clarifies `/setup` as a recovery surface, and expands tests to prevent future drift. Addresses Linear TASK-2395.

- **Bug Fixes**
  - Repositioned `make quickstart-prereqs` as an optional post-clone check in README; setup targets remain the source of truth.
  - Added manual auth init before `uvicorn` in QUICKSTART (`python -m tldw_Server_API.cli.wizard.cli init ...`), with lower-level `AuthNZ.initialize` noted.
  - Completed local WebUI steps: copy `.env.local`, `bun install`, `bun run dev`; documented `.env.local` values and npm fallback; set API URL to `http://127.0.0.1:8000`; mirrored in Published docs and synced `apps/tldw-frontend/.env.local.example`.
  - Set the WebUI as the normal first-run path; documented `/setup` as a backend/operator recovery surface.
  - Updated Windows/no-`make` troubleshooting with a PowerShell flow using `--profile docker-single-webui`, current compose files (`docker-compose.single-user.yml` + `docker-compose.webui.yml`), and `--wait`.
  - Clarified `NEXT_PUBLIC_X_API_KEY` as a browser-visible local single-user bootstrap only and when to rebuild the WebUI.
  - Expanded docs-contract tests to cover ordering (auth init before server; WebUI setup before dev), README preflight wording, env example parity, and troubleshooting compose paths.

<sup>Written for commit 92e8a35cd3e8df3df1bec2df8ddb8e5c4fd9cb89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

