### PR TITLE
Add MCP prompt catalog support

### DIFF
--- a/Docs/MCP/README.md
+++ b/Docs/MCP/README.md
@@ -13,11 +13,13 @@ This directory contains the Model Context Protocol (MCP) documentation for the T
   - `Documentation_Ingestion_Playbook.md` - How to ingest project docs and query them via MCP tools
 - `mcp_hub_management.md` - MCP Hub UI and API management surface (ACP profiles + external servers)
 - `mcp_tool_catalogs.md` - Tool catalog governance and scope-aware APIs
+- `mcp_prompts.md` - Protocol-level prompt discovery and rendering
 
 ## Picking the Right Guide
 
 - Building or extending MCP? Start with `Unified/README.md`, then the developer and modules guides.
 - Operating the service in production? Use the system admin guide.
 - Integrating a client or testing workflows? The user guide covers HTTP and WebSocket flows.
+- Building a prompt-capability client? Use `mcp_prompts.md` for `prompts/list` and `prompts/get`.
 
 > Tip: The backend README at `tldw_Server_API/app/core/MCP_unified/README.md` links back to these guides for fast navigation.

--- a/Docs/MCP/mcp_prompts.md
+++ b/Docs/MCP/mcp_prompts.md
@@ -1,0 +1,174 @@
+# MCP Prompts
+
+This guide covers protocol-level MCP prompt discovery and rendering through
+`prompts/list` and `prompts/get`.
+
+This is separate from MCP tools named `prompts.search` and `prompts.get`. Those
+tools search and fetch records through the tool-execution API. Protocol prompts
+are discovered with MCP prompt methods and rendered as MCP prompt messages.
+
+## Capability
+
+During MCP initialization the server advertises prompt support as:
+
+```json
+{
+  "prompts": {
+    "listChanged": false
+  }
+}
+```
+
+`listChanged: false` means v1 does not send
+`notifications/prompts/list_changed`. Clients should call a fresh
+`prompts/list` when they need current prompt discovery results.
+
+## Sources
+
+`prompts/list` includes:
+
+- readable, non-deleted prompts from the authenticated user's regular Prompt
+  Library
+- config prompts explicitly allowlisted in
+  `tldw_Server_API/Config_Files/mcp_modules.yaml`
+
+Prompt Studio prompts are excluded in this version.
+
+Config prompt publishing defaults to an empty allowlist:
+
+```yaml
+settings:
+  config_prompts:
+    enabled: true
+    entries: []
+```
+
+Single config prompt example:
+
+```yaml
+settings:
+  config_prompts:
+    enabled: true
+    entries:
+      - id: rag.retrieval_guidance
+        module: rag
+        key: retrieval_guidance
+        title: Retrieval Guidance
+```
+
+Grouped config prompt example:
+
+```yaml
+settings:
+  config_prompts:
+    enabled: true
+    entries:
+      - id: chat.summary
+        title: Conversation Summary
+        messages:
+          - role: system
+            module: chat
+            key: summary_system
+          - role: user
+            module: chat
+            key: summary_user
+```
+
+Config roles may be `system`, `developer`, `user`, or `assistant`. MCP prompt
+messages only permit `user` and `assistant`, so `system` and `developer`
+content is folded into labeled `user` text when rendered.
+
+## Stable Names
+
+Prompt protocol names are stable identifiers:
+
+- `library:<uuid>` for regular Prompt Library prompts
+- `config:<id>` for allowlisted config prompts
+
+The `title` field carries the human-readable name. Renaming a library prompt
+changes the title but does not change its `library:<uuid>` name.
+
+For config prompts, `id` is the allowlist entry id. `module` and `key` locate
+the source prompt content loaded from config prompt files. Recommended id
+values use module/key-style names such as `rag.retrieval_guidance`,
+`chat.summary`, or `mcp.search_knowledge`.
+
+## Arguments
+
+Structured Prompt Library prompts expose their declared variables as MCP prompt
+arguments.
+
+Legacy library prompts and config prompts infer variables from placeholders such
+as:
+
+- `{{topic}}`
+- `{context}`
+- `$query`
+- `<input>`
+
+Argument values must be strings. Missing required arguments or non-string values
+return MCP invalid params errors. Unknown extra arguments may be ignored unless
+the structured prompt renderer rejects them.
+
+## Pagination And Routes
+
+`prompts/list` accepts the MCP `cursor` parameter and may return `nextCursor`.
+The cursor is opaque to clients.
+
+JSON-RPC list:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "prompts/list",
+  "params": {
+    "cursor": "<nextCursor>"
+  },
+  "id": 1
+}
+```
+
+HTTP list convenience route:
+
+```text
+GET /api/v1/mcp/prompts
+GET /api/v1/mcp/prompts?cursor=<nextCursor>
+```
+
+Use `/api/v1/mcp/request` for `prompts/get`; there is no single-prompt HTTP
+convenience route in v1.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "prompts/get",
+  "params": {
+    "name": "library:2f5cf2fd-0000-4000-8000-000000000000",
+    "arguments": {
+      "topic": "MCP prompts"
+    }
+  },
+  "id": 2
+}
+```
+
+## Permissions And Scope
+
+Authenticated MCP callers need `prompts.read` for protocol-level
+`prompts/list` and `prompts/get`.
+
+Protocol-level prompt access does not require `modules.read`.
+
+Library prompts are read from the authenticated user's per-user Prompt Library
+database. Persona prompt scopes filter library list and get results.
+
+Allowlisted config prompts are visible to authenticated callers with
+`prompts.read`.
+
+## Safety
+
+`prompts/list` responses include names, titles, descriptions, arguments, and
+metadata, but not prompt bodies.
+
+Rendered argument values and config override file paths are not included in
+errors or logs.

--- a/Docs/MCP/mcp_tool_catalogs.md
+++ b/Docs/MCP/mcp_tool_catalogs.md
@@ -1,5 +1,7 @@
 ## MCP Tool Catalogs - Minimal Design (v0.1)
 
+For protocol-level prompt discovery and rendering, see [MCP Prompts](mcp_prompts.md).
+
 Goal
 - Introduce first-class, named tool catalogs to group MCP tools for discovery without breaking existing flows.
 - Allow admin/org/team owners to create catalogs and entries; clients can request tools filtered by catalog.
@@ -7,7 +9,7 @@ Goal
 Scope (Minimal Spike)
 - Data model: two SQLite tables (AuthNZ DB) - `tool_catalogs` and `tool_catalog_entries`.
 - Admin API: CRUD-lite endpoints to list/create/delete catalogs and manage entries.
-- MCP: Extend `tools/list` to accept a `catalog` (name) or `catalog_id` filter.
+- MCP: Extend `tools/list` to accept a `catalog` (name), `catalog_id`, and optional `catalog_strict` filter.
 - Backward compatible: if no catalog specified, behavior unchanged.
 
 Data Model
@@ -32,15 +34,19 @@ Data Model
 
 Notes
 - Scope precedence (for name lookup): team > org > global (NULL scope).
-- Default deployment uses SQLite; Postgres DDL to be added to the project’s PG schema later.
+- SQLite migration 022 creates the tables. Postgres deployments use the AuthNZ `pg_migrations_extra.py` runtime ensure path.
 
 API Changes
 1) MCP tools list filter
    - HTTP: `GET /api/v1/mcp/tools?catalog=<name>` or `?catalog_id=<id>` (requires auth; RBAC still applies)
-   - JSON-RPC: `tools/list` accepts params `{ catalog?: string, catalog_id?: number }`
+   - HTTP strict mode: add `catalog_strict=true` to fail closed for unresolved catalogs
+   - JSON-RPC: `tools/list` accepts params `{ catalog?: string, catalog_id?: number, catalog_strict?: boolean }`
    - Catalog filters shape discovery only; RBAC still gates visibility/`canExecute` and execution.
 
-2) Admin endpoints (all require admin)
+2) User-visible catalog discovery
+   - `GET /api/v1/mcp/tool_catalogs?scope=all|global|org|team` - list catalog names visible to the caller before filtering tools
+
+3) Admin endpoints (all require admin)
    - `GET  /api/v1/admin/mcp/tool_catalogs` - list catalogs (optional `org_id`, `team_id` filters)
    - `POST /api/v1/admin/mcp/tool_catalogs` - create catalog
    - `DELETE /api/v1/admin/mcp/tool_catalogs/{catalog_id}` - delete catalog (cascades entries)
@@ -48,7 +54,7 @@ API Changes
    - `POST /api/v1/admin/mcp/tool_catalogs/{catalog_id}/entries` - add entry `{ tool_name, module_id? }`
 - `DELETE /api/v1/admin/mcp/tool_catalogs/{catalog_id}/entries/{tool_name}` - remove entry
 
-3) Org/Team management endpoints (manager roles)
+4) Org/Team management endpoints (manager roles)
 - Organization-scoped (requires org manager: owner/admin/lead, or global admin):
   - `GET  /api/v1/orgs/{org_id}/mcp/tool_catalogs` - list org catalogs
   - `POST /api/v1/orgs/{org_id}/mcp/tool_catalogs` - create org catalog
@@ -72,17 +78,24 @@ HTTP Usage Notes
 - `GET /api/v1/mcp/tools` accepts catalog filters:
   - `catalog`: catalog name; resolved by precedence `team > org > global` using authenticated context
   - `catalog_id`: numeric id; takes precedence over `catalog` when both provided
-- If the catalog name/id can’t be resolved, the server fails open (no catalog filter). RBAC is still enforced, and `canExecute` reflects effective permissions.
+  - `catalog_strict`: when `true`, unresolved catalogs return an empty tool list
+- By default, if the catalog name/id can't be resolved, the server fails open (no catalog filter). RBAC is still enforced, and `canExecute` reflects effective permissions.
+- With `catalog_strict=true`, unresolved catalogs fail closed with an empty tool list.
+- `GET /api/v1/mcp/tool_catalogs?scope=all|global|org|team` lists visible catalogs for clients that need to discover names before filtering.
 
 JSON-RPC Usage
 ```json
 {
   "jsonrpc": "2.0",
   "method": "tools/list",
-  "params": { "catalog": "research-kit" },
+  "params": { "catalog": "research-kit", "catalog_strict": true },
   "id": 1
 }
 ```
+
+When `catalog_strict` is omitted or false, unresolved catalogs use the default
+fail-open behavior. When `catalog_strict: true`, unresolved catalogs return an
+empty tool list.
 
 Recommended Catalog: `kanban-safe-orchestrator`
 - Use this catalog to expose only workflow-control primitives to autonomous agents.
@@ -104,8 +117,8 @@ Recommended Catalog: `kanban-safe-orchestrator`
   - `kanban.workflow.recovery.force_reassign`
 
 Migration
-- Add migration 022 to AuthNZ migrations (SQLite) to create the two tables (with indexes/constraints above).
-- Future: add Postgres DDL to `Databases/Postgres/Schema` and include in PG init path.
+- SQLite migration 022 creates the two tables with the indexes and constraints above.
+- Postgres deployments are covered by the AuthNZ `pg_migrations_extra.py` runtime ensure path.
 
 Backward Compatibility
 - No change to default `tools/list` when `catalog` is omitted.

--- a/Docs/superpowers/plans/2026-06-22-mcp-prompt-catalog-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-22-mcp-prompt-catalog-implementation-plan.md
@@ -1,0 +1,2537 @@
+# MCP Prompt Catalog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Expose user Prompt Library prompts and explicitly allowlisted config prompts through MCP protocol-level `prompts/list` and `prompts/get`.
+
+**Architecture:** Keep `PromptsModule` as the MCP module boundary and add a focused catalog adapter file that owns listing, cursor parsing, config allowlist parsing, argument validation, and MCP-safe message formatting. Update protocol handlers to use context-aware prompt hooks for dynamic prompts, route `library:` and `config:` names directly to `PromptsModule`, and preserve the existing static prompt registry for context-free modules.
+
+**Tech Stack:** FastAPI, Python async/await, SQLite via `PromptsDatabase`, Pydantic structured prompt models, MCP Unified protocol handlers, pytest, Bandit.
+
+---
+
+## Source References
+
+- Spec: `Docs/superpowers/specs/2026-06-22-mcp-prompt-catalog-support-design.md`
+- Backlog task: `TASK-2343`
+- Follow-up backlog task: `TASK-2341`
+- MCP prompt spec: `https://modelcontextprotocol.io/specification/2025-06-18/server/prompts`
+
+## File Structure
+
+- Create `tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_catalog.py`
+  - Owns `PromptCatalogError`, cursor encoding/decoding, MCP prompt definition formatting, user Prompt Library source, and config prompt allowlist source.
+  - Keeps prompt body rendering and prompt body validation out of `protocol.py`.
+- Modify `tldw_Server_API/app/core/MCP_unified/modules/base.py`
+  - Adds backward-compatible context-aware prompt hooks.
+- Modify `tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_module.py`
+  - Initializes the catalog adapter and exposes context-aware prompt hooks.
+  - Leaves `prompts.search` and `prompts.get` tool behavior unchanged.
+- Modify `tldw_Server_API/app/core/MCP_unified/protocol.py`
+  - Advertises MCP-compliant prompt capability.
+  - Uses context-aware prompt hooks for listing.
+  - Routes `library:` and `config:` prompt names directly to `PromptsModule`.
+  - Preserves static module prompt behavior for future context-free modules.
+- Modify `tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py`
+  - Adds `cursor` query support to list-only `GET /api/v1/mcp/prompts`.
+- Modify `tldw_Server_API/Config_Files/mcp_modules.yaml`
+  - Registers the `prompts` module with an empty explicit config prompt allowlist.
+- Create `tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py`
+  - Unit coverage for formatter, cursor, user source, config source, and module hooks.
+- Create `tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py`
+  - Protocol coverage for capabilities, routing, permissions, invalid params, and warnings.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py`
+  - Asserts the shipped YAML registers the prompts module with an empty config allowlist.
+- Create `tldw_Server_API/tests/MCP_unified/test_mcp_prompts_http.py`
+  - Covers the HTTP convenience `cursor` mapping if an existing MCP endpoint test file is not a better local fit.
+- Create `Docs/MCP/mcp_prompts.md`
+  - Documents protocol prompt support, stable names, permissions, config allowlisting, and HTTP list-only behavior.
+- Modify `Docs/MCP/mcp_tool_catalogs.md`
+  - Links to the new prompt catalog doc from the MCP docs area.
+
+## Data Contracts
+
+Add these public contracts in `prompts_catalog.py`:
+
+```python
+LIBRARY_PROMPT_PREFIX = "library:"
+CONFIG_PROMPT_PREFIX = "config:"
+DEFAULT_PROMPT_LIST_PAGE_SIZE = 50
+MAX_PROMPT_LIST_PAGE_SIZE = 100
+DEFAULT_MAX_RENDERED_PROMPT_CHARS = 100_000
+
+
+class PromptCatalogError(ValueError):
+    """Sanitized prompt catalog failure suitable for JSON-RPC invalid params."""
+
+    def __init__(self, code: str, message: str, *, internal: bool = False) -> None:
+        super().__init__(message)
+        self.code = code
+        self.internal = internal
+
+
+@dataclass(frozen=True)
+class PromptCatalogCursor:
+    library_after_name: str | None = None
+    library_after_uuid: str | None = None
+    library_done: bool = False
+    config_index: int = 0
+```
+
+Context-aware module hooks use this shape:
+
+```python
+async def get_prompts_for_context(
+    self,
+    context: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    ...
+
+
+async def get_prompt_for_context(
+    self,
+    name: str,
+    arguments: dict[str, Any],
+    context: Any,
+) -> dict[str, Any]:
+    ...
+```
+
+MCP prompt definitions use this shape:
+
+```python
+{
+    "name": "library:2f5cf2fd-...",
+    "title": "Summarizer",
+    "description": "Short summary without prompt body",
+    "arguments": [
+        {
+            "name": "topic",
+            "title": "Topic",
+            "description": "Topic to summarize",
+            "required": True,
+        }
+    ],
+    "_meta": {
+        "tldw": {
+            "source": "library",
+            "prompt_uuid": "2f5cf2fd-...",
+            "prompt_id": 123,
+            "version": 4,
+            "tags": ["summary"],
+        }
+    },
+}
+```
+
+## Task 1: Add Catalog Adapter Tests First
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py`
+- Read: `tldw_Server_API/app/core/DB_Management/Prompts_DB.py`
+- Read: `tldw_Server_API/app/core/Prompt_Management/structured_prompts/models.py`
+- Read: `tldw_Server_API/app/core/Prompt_Management/structured_prompts/conversion.py`
+
+- [x] **Step 1: Create focused failing tests for cursor handling and formatter behavior**
+
+Create `tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py` with these imports and first tests:
+
+```python
+from __future__ import annotations
+
+import base64
+import json
+import uuid
+
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.prompts_catalog import (
+    CONFIG_PROMPT_PREFIX,
+    LIBRARY_PROMPT_PREFIX,
+    MCPPromptFormatter,
+    PromptCatalogCursor,
+    PromptCatalogError,
+    decode_prompt_cursor,
+    encode_prompt_cursor,
+)
+
+
+def test_prompt_cursor_round_trips_without_padding() -> None:
+    cursor = PromptCatalogCursor(
+        library_after_name="alpha",
+        library_after_uuid="11111111-1111-4111-8111-111111111111",
+    )
+
+    encoded = encode_prompt_cursor(cursor)
+
+    assert "=" not in encoded
+    assert decode_prompt_cursor(encoded) == cursor
+
+
+def test_prompt_cursor_round_trips_config_segment() -> None:
+    cursor = PromptCatalogCursor(library_done=True, config_index=3)
+
+    assert decode_prompt_cursor(encode_prompt_cursor(cursor)) == cursor
+
+
+def test_prompt_cursor_rejects_bad_payload() -> None:
+    with pytest.raises(PromptCatalogError) as excinfo:
+        decode_prompt_cursor("not-valid-base64")
+
+    assert excinfo.value.code == "invalid_cursor"
+
+
+def test_prompt_cursor_rejects_partial_library_keyset() -> None:
+    raw = _encode_raw_cursor({"v": 1, "library_after_name": "alpha", "config_index": 0})
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        decode_prompt_cursor(raw)
+
+    assert excinfo.value.code == "invalid_cursor"
+
+
+def test_prompt_cursor_rejects_config_index_before_library_done() -> None:
+    raw = _encode_raw_cursor({"v": 1, "library_done": False, "config_index": 1})
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        decode_prompt_cursor(raw)
+
+    assert excinfo.value.code == "invalid_cursor"
+
+
+def _encode_raw_cursor(payload: dict) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def test_formatter_creates_stable_library_definition() -> None:
+    prompt_uuid = str(uuid.uuid4())
+    row = {
+        "id": 42,
+        "uuid": prompt_uuid,
+        "name": "Summarizer",
+        "details": "Summarize a document without leaking the body.",
+        "author": "tester",
+        "version": 7,
+        "keywords": ["summary", "docs"],
+        "system_prompt": "Be concise.",
+        "user_prompt": "Summarize {topic}",
+        "prompt_definition": None,
+    }
+    formatter = MCPPromptFormatter(max_rendered_chars=10_000)
+
+    prompt = formatter.library_prompt_definition(row)
+
+    assert prompt["name"] == f"{LIBRARY_PROMPT_PREFIX}{prompt_uuid}"
+    assert prompt["title"] == "Summarizer"
+    assert prompt["description"] == "Summarize a document without leaking the body."
+    assert prompt["arguments"] == [
+        {
+            "name": "topic",
+            "title": "Topic",
+            "description": None,
+            "required": True,
+        }
+    ]
+    assert prompt["_meta"]["tldw"]["source"] == "library"
+    assert prompt["_meta"]["tldw"]["prompt_uuid"] == prompt_uuid
+    assert prompt["_meta"]["tldw"]["prompt_id"] == 42
+    assert prompt["_meta"]["tldw"]["version"] == 7
+    assert prompt["_meta"]["tldw"]["tags"] == ["summary", "docs"]
+
+
+def test_formatter_folds_system_and_user_into_mcp_user_message() -> None:
+    row = {
+        "id": 42,
+        "uuid": "11111111-1111-4111-8111-111111111111",
+        "name": "Summarizer",
+        "details": "",
+        "version": 1,
+        "keywords": [],
+        "system_prompt": "Be concise.",
+        "user_prompt": "Summarize {topic}",
+        "prompt_definition": None,
+    }
+    formatter = MCPPromptFormatter(max_rendered_chars=10_000)
+
+    result = formatter.render_library_prompt(row, {"topic": "MCP prompts"})
+
+    assert result["description"] == "Summarizer"
+    assert result["messages"] == [
+        {
+            "role": "user",
+            "content": {
+                "type": "text",
+                "text": "System instructions:\nBe concise.\n\nUser prompt:\nSummarize MCP prompts",
+            },
+        }
+    ]
+    assert result["_meta"]["tldw"]["source"] == "library"
+
+
+def test_formatter_preserves_assistant_messages_from_structured_prompt() -> None:
+    row = {
+        "id": 1,
+        "uuid": "22222222-2222-4222-8222-222222222222",
+        "name": "Few shot",
+        "details": "",
+        "version": 2,
+        "keywords": [],
+        "system_prompt": "",
+        "user_prompt": "",
+        "prompt_definition": {
+            "schema_version": 1,
+            "format": "structured",
+            "variables": [
+                {"name": "topic", "label": "Topic", "required": True, "input_type": "text"}
+            ],
+            "blocks": [
+                {
+                    "id": "instructions",
+                    "name": "Instructions",
+                    "role": "system",
+                    "content": "Teach clearly.",
+                    "enabled": True,
+                    "order": 10,
+                    "is_template": False,
+                },
+                {
+                    "id": "question",
+                    "name": "Question",
+                    "role": "user",
+                    "content": "Explain {{topic}}",
+                    "enabled": True,
+                    "order": 20,
+                    "is_template": True,
+                },
+                {
+                    "id": "sample",
+                    "name": "Sample",
+                    "role": "assistant",
+                    "content": "Here is a concise answer.",
+                    "enabled": True,
+                    "order": 30,
+                    "is_template": False,
+                },
+            ],
+        },
+    }
+    formatter = MCPPromptFormatter(max_rendered_chars=10_000)
+
+    result = formatter.render_library_prompt(row, {"topic": "vectors"})
+
+    assert result["messages"] == [
+        {
+            "role": "user",
+            "content": {
+                "type": "text",
+                "text": "System instructions:\nTeach clearly.\n\nUser prompt:\nExplain vectors",
+            },
+        },
+        {
+            "role": "assistant",
+            "content": {
+                "type": "text",
+                "text": "Here is a concise answer.",
+            },
+        },
+    ]
+
+
+def test_formatter_rejects_non_string_arguments() -> None:
+    formatter = MCPPromptFormatter(max_rendered_chars=10_000)
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        formatter.validate_arguments({"topic": 123})
+
+    assert excinfo.value.code == "invalid_argument_type"
+```
+
+- [x] **Step 2: Run the new tests to verify imports fail**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py -v
+```
+
+Expected: FAIL with `ModuleNotFoundError` or import errors for `prompts_catalog` symbols.
+
+- [x] **Step 3: Add failing user-source and config-source tests**
+
+Append these tests to `test_prompts_catalog.py`:
+
+```python
+from types import SimpleNamespace
+
+from tldw_Server_API.app.core.DB_Management.Prompts_DB import PromptsDatabase
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.prompts_catalog import (
+    ConfigPromptCatalogSource,
+    UserPromptCatalogSource,
+)
+
+
+def _context_for_prompts_db(db_path: str, *, scoped_ids: list[str] | None = None) -> SimpleNamespace:
+    metadata = {}
+    if scoped_ids is not None:
+        metadata["persona_scope"] = {"explicit_ids": {"prompt_id": scoped_ids}}
+    return SimpleNamespace(
+        db_paths={"prompts": db_path},
+        metadata=metadata,
+        logger=SimpleNamespace(debug=lambda *args, **kwargs: None),
+    )
+
+
+def _add_legacy_prompt(db_path: str, *, name: str, deleted: bool = False) -> dict:
+    db = PromptsDatabase(db_path=db_path, client_id="test_prompts_catalog")
+    try:
+        prompt_id, _prompt_uuid, _message = db.add_prompt(
+            name=name,
+            author="tester",
+            details=f"{name} details",
+            system_prompt="Be concise.",
+            user_prompt="Summarize {topic}",
+            keywords=["summary"],
+        )
+        if deleted:
+            db.soft_delete_prompt(prompt_id)
+        return db.get_prompt_by_id(prompt_id, include_deleted=True)
+    finally:
+        db.close_connection()
+
+
+def test_user_source_lists_non_deleted_library_prompts_with_uuid_names(tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    alpha = _add_legacy_prompt(db_path, name="Alpha")
+    _add_legacy_prompt(db_path, name="Deleted", deleted=True)
+    source = UserPromptCatalogSource(MCPPromptFormatter(max_rendered_chars=10_000))
+
+    result = source.list_prompts(
+        context=_context_for_prompts_db(db_path),
+        cursor=PromptCatalogCursor(),
+        limit=50,
+    )
+
+    assert [prompt["name"] for prompt in result.prompts] == [f"{LIBRARY_PROMPT_PREFIX}{alpha['uuid']}"]
+    assert result.next_cursor is None
+    assert result.warnings == []
+
+
+def test_user_source_filters_by_prompt_id_scope(tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    allowed = _add_legacy_prompt(db_path, name="Allowed")
+    _add_legacy_prompt(db_path, name="Blocked")
+    source = UserPromptCatalogSource(MCPPromptFormatter(max_rendered_chars=10_000))
+
+    result = source.list_prompts(
+        context=_context_for_prompts_db(db_path, scoped_ids=[str(allowed["id"])]),
+        cursor=PromptCatalogCursor(),
+        limit=50,
+    )
+
+    assert [prompt["name"] for prompt in result.prompts] == [f"{LIBRARY_PROMPT_PREFIX}{allowed['uuid']}"]
+
+
+def test_user_source_get_validates_uuid_and_scope(tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    allowed = _add_legacy_prompt(db_path, name="Allowed")
+    source = UserPromptCatalogSource(MCPPromptFormatter(max_rendered_chars=10_000))
+
+    result = source.get_prompt(
+        context=_context_for_prompts_db(db_path, scoped_ids=[str(allowed["id"])]),
+        name=f"{LIBRARY_PROMPT_PREFIX}{allowed['uuid']}",
+        arguments={"topic": "scoped prompts"},
+    )
+
+    assert result["messages"][0]["content"]["text"].endswith("Summarize scoped prompts")
+
+
+def test_config_source_lists_only_explicit_entries(monkeypatch, tmp_path) -> None:
+    override_path = tmp_path / "rag_retrieval.txt"
+    override_path.write_text("Retrieve context for {query}", encoding="utf-8")
+    monkeypatch.setenv("TLDW_PROMPT_FILE_RAG__RETRIEVAL_GUIDANCE", str(override_path))
+    source = ConfigPromptCatalogSource(
+        MCPPromptFormatter(max_rendered_chars=10_000),
+        {
+            "enabled": True,
+            "entries": [
+                {
+                    "id": "rag.retrieval_guidance",
+                    "module": "rag",
+                    "key": "retrieval_guidance",
+                    "title": "Retrieval Guidance",
+                }
+            ],
+        },
+    )
+
+    result = source.list_prompts(cursor=PromptCatalogCursor(), limit=50)
+
+    assert [prompt["name"] for prompt in result.prompts] == [
+        f"{CONFIG_PROMPT_PREFIX}rag.retrieval_guidance"
+    ]
+    assert result.prompts[0]["arguments"][0]["name"] == "query"
+
+
+def test_config_source_grouped_render_folds_system_user_and_preserves_assistant(monkeypatch, tmp_path) -> None:
+    system_path = tmp_path / "system.txt"
+    user_path = tmp_path / "user.txt"
+    assistant_path = tmp_path / "assistant.txt"
+    system_path.write_text("Use brief answers.", encoding="utf-8")
+    user_path.write_text("Summarize {topic}", encoding="utf-8")
+    assistant_path.write_text("Example summary.", encoding="utf-8")
+    monkeypatch.setenv("TLDW_PROMPT_FILE_CHAT__SUMMARY_SYSTEM", str(system_path))
+    monkeypatch.setenv("TLDW_PROMPT_FILE_CHAT__SUMMARY_USER", str(user_path))
+    monkeypatch.setenv("TLDW_PROMPT_FILE_CHAT__SUMMARY_EXAMPLE", str(assistant_path))
+    source = ConfigPromptCatalogSource(
+        MCPPromptFormatter(max_rendered_chars=10_000),
+        {
+            "enabled": True,
+            "entries": [
+                {
+                    "id": "chat.summary",
+                    "title": "Conversation Summary",
+                    "messages": [
+                        {"role": "system", "module": "chat", "key": "summary_system"},
+                        {"role": "user", "module": "chat", "key": "summary_user"},
+                        {"role": "assistant", "module": "chat", "key": "summary_example"},
+                    ],
+                }
+            ],
+        },
+    )
+
+    result = source.get_prompt(
+        name=f"{CONFIG_PROMPT_PREFIX}chat.summary",
+        arguments={"topic": "release notes"},
+    )
+
+    assert result["messages"] == [
+        {
+            "role": "user",
+            "content": {
+                "type": "text",
+                "text": "System instructions:\nUse brief answers.\n\nUser prompt:\nSummarize release notes",
+            },
+        },
+        {
+            "role": "assistant",
+            "content": {
+                "type": "text",
+                "text": "Example summary.",
+            },
+        },
+    ]
+
+
+def test_config_source_omits_missing_allowlist_entry() -> None:
+    source = ConfigPromptCatalogSource(
+        MCPPromptFormatter(max_rendered_chars=10_000),
+        {
+            "enabled": True,
+            "entries": [
+                {
+                    "id": "missing.entry",
+                    "module": "missing",
+                    "key": "entry",
+                    "title": "Missing Entry",
+                }
+            ],
+        },
+    )
+
+    result = source.list_prompts(cursor=PromptCatalogCursor(), limit=50)
+
+    assert result.prompts == []
+    assert result.warnings == [
+        {"source": "config", "code": "config_prompt_unavailable", "id": "missing.entry"}
+    ]
+
+
+def test_config_source_get_respects_disabled_flag(monkeypatch, tmp_path) -> None:
+    override_path = tmp_path / "prompt.txt"
+    override_path.write_text("Search {query}", encoding="utf-8")
+    monkeypatch.setenv("TLDW_PROMPT_FILE_MCP__SEARCH_KNOWLEDGE", str(override_path))
+    source = ConfigPromptCatalogSource(
+        MCPPromptFormatter(max_rendered_chars=10_000),
+        {
+            "enabled": False,
+            "entries": [
+                {
+                    "id": "mcp.search_knowledge",
+                    "module": "mcp",
+                    "key": "search_knowledge",
+                    "title": "Search Knowledge",
+                }
+            ],
+        },
+    )
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        source.get_prompt(name=f"{CONFIG_PROMPT_PREFIX}mcp.search_knowledge", arguments={"query": "x"})
+
+    assert excinfo.value.code == "prompt_not_found"
+
+
+def test_config_source_reports_entries_after_index(monkeypatch, tmp_path) -> None:
+    override_path = tmp_path / "prompt.txt"
+    override_path.write_text("Search {query}", encoding="utf-8")
+    monkeypatch.setenv("TLDW_PROMPT_FILE_MCP__SEARCH_KNOWLEDGE", str(override_path))
+    source = ConfigPromptCatalogSource(
+        MCPPromptFormatter(max_rendered_chars=10_000),
+        {
+            "enabled": True,
+            "entries": [
+                {
+                    "id": "mcp.search_knowledge",
+                    "module": "mcp",
+                    "key": "search_knowledge",
+                    "title": "Search Knowledge",
+                }
+            ],
+        },
+    )
+
+    assert source.has_entries_after(0) is True
+    assert source.has_entries_after(1) is False
+
+
+def test_user_source_skips_library_when_cursor_is_inside_config_page(tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    _add_legacy_prompt(db_path, name="Alpha")
+    source = UserPromptCatalogSource(MCPPromptFormatter(max_rendered_chars=10_000))
+
+    result = source.list_prompts(
+        context=_context_for_prompts_db(db_path),
+        cursor=PromptCatalogCursor(library_done=True, config_index=1),
+        limit=50,
+    )
+
+    assert result.prompts == []
+    assert result.next_cursor is None
+    assert result.warnings == []
+
+
+def test_user_source_uses_collate_nocase_keyset_with_raw_name_cursor(tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    alpha = _add_legacy_prompt(db_path, name="Alpha")
+    beta = _add_legacy_prompt(db_path, name="beta")
+    source = UserPromptCatalogSource(MCPPromptFormatter(max_rendered_chars=10_000))
+
+    first_page = source.list_prompts(
+        context=_context_for_prompts_db(db_path),
+        cursor=PromptCatalogCursor(),
+        limit=1,
+    )
+    second_page = source.list_prompts(
+        context=_context_for_prompts_db(db_path),
+        cursor=first_page.next_cursor,
+        limit=1,
+    )
+
+    assert first_page.prompts[0]["name"] == f"{LIBRARY_PROMPT_PREFIX}{alpha['uuid']}"
+    assert first_page.next_cursor.library_after_name == "Alpha"
+    assert second_page.prompts[0]["name"] == f"{LIBRARY_PROMPT_PREFIX}{beta['uuid']}"
+
+
+def test_catalog_adapter_does_not_import_prompt_studio() -> None:
+    import inspect
+    import tldw_Server_API.app.core.MCP_unified.modules.implementations.prompts_catalog as prompts_catalog
+
+    assert "PromptStudio" not in inspect.getsource(prompts_catalog)
+```
+
+- [x] **Step 4: Run catalog tests to verify adapter symbols fail**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py -v
+```
+
+Expected: FAIL on missing `prompts_catalog` symbols.
+
+## Task 2: Implement Prompt Catalog Adapter
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_catalog.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py`
+
+- [x] **Step 1: Add cursor, result, and error primitives**
+
+Create `prompts_catalog.py` with this foundation:
+
+```python
+"""MCP prompt catalog adapters for user-library and allowlisted config prompts."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import re
+import uuid
+from dataclasses import dataclass
+from sqlite3 import Error as SQLiteError
+from typing import Any, Mapping
+
+from loguru import logger
+
+from tldw_Server_API.app.core.DB_Management.Prompts_DB import DatabaseError, PromptsDatabase
+from tldw_Server_API.app.core.MCP_unified.persona_scope import (
+    assert_identifier_in_scope,
+    get_explicit_scope_ids,
+)
+from tldw_Server_API.app.core.Prompt_Management.structured_prompts import (
+    PromptBlock,
+    PromptDefinition,
+    PromptVariableDefinition,
+    StructuredPromptAssemblyError,
+    assemble_prompt_definition,
+    convert_legacy_prompt_to_definition,
+    extract_legacy_prompt_variables,
+    normalize_legacy_prompt_template,
+)
+from tldw_Server_API.app.core.Utils.prompt_loader import load_prompt
+
+LIBRARY_PROMPT_PREFIX = "library:"
+CONFIG_PROMPT_PREFIX = "config:"
+DEFAULT_PROMPT_LIST_PAGE_SIZE = 50
+MAX_PROMPT_LIST_PAGE_SIZE = 100
+DEFAULT_MAX_RENDERED_PROMPT_CHARS = 100_000
+_CONFIG_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,100}$")
+
+_CATALOG_DB_EXCEPTIONS = (OSError, RuntimeError, SQLiteError, DatabaseError, TypeError, ValueError)
+
+
+class PromptCatalogError(ValueError):
+    """Sanitized prompt catalog failure suitable for JSON-RPC errors."""
+
+    def __init__(self, code: str, message: str, *, internal: bool = False) -> None:
+        super().__init__(message)
+        self.code = code
+        self.internal = internal
+
+
+@dataclass(frozen=True)
+class PromptCatalogCursor:
+    library_after_name: str | None = None
+    library_after_uuid: str | None = None
+    library_done: bool = False
+    config_index: int = 0
+
+
+@dataclass(frozen=True)
+class PromptCatalogListResult:
+    prompts: list[dict[str, Any]]
+    next_cursor: PromptCatalogCursor | None
+    warnings: list[dict[str, Any]]
+
+
+def encode_prompt_cursor(cursor: PromptCatalogCursor | None) -> str | None:
+    if cursor is None:
+        return None
+    payload = {
+        "v": 1,
+        "library_after_name": cursor.library_after_name,
+        "library_after_uuid": cursor.library_after_uuid,
+        "library_done": cursor.library_done,
+        "config_index": cursor.config_index,
+    }
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def decode_prompt_cursor(raw_cursor: str | None) -> PromptCatalogCursor:
+    if not raw_cursor:
+        return PromptCatalogCursor()
+    try:
+        padding = "=" * (-len(raw_cursor) % 4)
+        raw = base64.urlsafe_b64decode((raw_cursor + padding).encode("ascii"))
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeEncodeError, UnicodeDecodeError, binascii.Error, json.JSONDecodeError) as exc:
+        raise PromptCatalogError("invalid_cursor", "Invalid prompt list cursor") from exc
+    if not isinstance(payload, dict) or payload.get("v") != 1:
+        raise PromptCatalogError("invalid_cursor", "Unsupported prompt list cursor")
+    library_after_name = payload.get("library_after_name")
+    library_after_uuid = payload.get("library_after_uuid")
+    library_done = payload.get("library_done", False)
+    config_index = payload.get("config_index", 0)
+    if library_after_name is not None and not isinstance(library_after_name, str):
+        raise PromptCatalogError("invalid_cursor", "Invalid prompt list cursor")
+    if (library_after_name is None) != (library_after_uuid is None):
+        raise PromptCatalogError("invalid_cursor", "Invalid prompt list cursor")
+    if library_after_uuid is not None:
+        if not isinstance(library_after_uuid, str):
+            raise PromptCatalogError("invalid_cursor", "Invalid prompt list cursor")
+        try:
+            uuid.UUID(library_after_uuid)
+        except ValueError as exc:
+            raise PromptCatalogError("invalid_cursor", "Invalid prompt list cursor") from exc
+    if not isinstance(library_done, bool):
+        raise PromptCatalogError("invalid_cursor", "Invalid prompt list cursor")
+    if library_done and (library_after_name is not None or library_after_uuid is not None):
+        raise PromptCatalogError("invalid_cursor", "Invalid prompt list cursor")
+    if not isinstance(config_index, int) or config_index < 0:
+        raise PromptCatalogError("invalid_cursor", "Invalid prompt list cursor")
+    if not library_done and config_index != 0:
+        raise PromptCatalogError("invalid_cursor", "Invalid prompt list cursor")
+    return PromptCatalogCursor(
+        library_after_name=library_after_name,
+        library_after_uuid=library_after_uuid,
+        library_done=library_done,
+        config_index=config_index,
+    )
+
+
+def clamp_prompt_page_size(raw_value: Any) -> int:
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        value = DEFAULT_PROMPT_LIST_PAGE_SIZE
+    return min(MAX_PROMPT_LIST_PAGE_SIZE, max(1, value))
+```
+
+- [x] **Step 2: Run cursor tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py::test_prompt_cursor_round_trips_without_padding tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py::test_prompt_cursor_rejects_bad_payload -v
+```
+
+Expected: PASS.
+
+- [x] **Step 3: Add formatter implementation**
+
+Append this `MCPPromptFormatter` class to `prompts_catalog.py`:
+
+```python
+class MCPPromptFormatter:
+    """Format tldw prompt records and config entries as MCP prompt payloads."""
+
+    def __init__(self, *, max_rendered_chars: int = DEFAULT_MAX_RENDERED_PROMPT_CHARS) -> None:
+        self.max_rendered_chars = max(1, int(max_rendered_chars or DEFAULT_MAX_RENDERED_PROMPT_CHARS))
+
+    def validate_arguments(self, arguments: Mapping[str, Any] | None) -> dict[str, str]:
+        if arguments is None:
+            return {}
+        if not isinstance(arguments, Mapping):
+            raise PromptCatalogError("invalid_arguments", "Prompt arguments must be an object")
+        validated: dict[str, str] = {}
+        for key, value in arguments.items():
+            if not isinstance(key, str) or not key:
+                raise PromptCatalogError("invalid_argument_name", "Prompt argument names must be non-empty strings")
+            if not isinstance(value, str):
+                raise PromptCatalogError("invalid_argument_type", f"Prompt argument '{key}' must be a string")
+            validated[key] = value
+        return validated
+
+    def library_prompt_definition(self, row: Mapping[str, Any]) -> dict[str, Any]:
+        prompt_uuid = self._required_uuid(row)
+        definition = self._coerce_definition(row)
+        if definition is not None:
+            arguments = self._arguments_from_definition(definition)
+        else:
+            arguments = self._legacy_arguments(row.get("system_prompt"), row.get("user_prompt"))
+        return {
+            "name": f"{LIBRARY_PROMPT_PREFIX}{prompt_uuid}",
+            "title": str(row.get("name") or prompt_uuid),
+            "description": self._list_description(row),
+            "arguments": arguments,
+            "_meta": {
+                "tldw": {
+                    "source": "library",
+                    "prompt_uuid": prompt_uuid,
+                    "prompt_id": row.get("id"),
+                    "version": row.get("version"),
+                    "tags": row.get("keywords") or [],
+                }
+            },
+        }
+
+    def render_library_prompt(self, row: Mapping[str, Any], arguments: Mapping[str, Any] | None) -> dict[str, Any]:
+        validated_arguments = self.validate_arguments(arguments)
+        prompt_uuid = self._required_uuid(row)
+        definition = self._coerce_definition(row)
+        if definition is None:
+            definition = convert_legacy_prompt_to_definition(
+                system_prompt=str(row.get("system_prompt") or ""),
+                user_prompt=str(row.get("user_prompt") or ""),
+            )
+        messages = self._assemble_messages(definition, validated_arguments)
+        mcp_messages = self._to_mcp_messages(messages)
+        self._enforce_rendered_size(mcp_messages)
+        return {
+            "description": str(row.get("details") or row.get("name") or prompt_uuid),
+            "messages": mcp_messages,
+            "_meta": {
+                "tldw": {
+                    "source": "library",
+                    "prompt_uuid": prompt_uuid,
+                    "prompt_id": row.get("id"),
+                    "version": row.get("version"),
+                }
+            },
+        }
+
+    def config_prompt_definition(self, entry: Mapping[str, Any], parts: list[dict[str, str]]) -> dict[str, Any]:
+        entry_id = str(entry["id"])
+        variables = extract_legacy_prompt_variables(*(part["content"] for part in parts))
+        return {
+            "name": f"{CONFIG_PROMPT_PREFIX}{entry_id}",
+            "title": str(entry.get("title") or entry_id),
+            "description": str(entry.get("description") or ""),
+            "arguments": [
+                {"name": name, "title": name.replace("_", " ").title(), "description": None, "required": True}
+                for name in variables
+            ],
+            "_meta": {
+                "tldw": {
+                    "source": "config",
+                    "config_id": entry_id,
+                }
+            },
+        }
+
+    def render_config_prompt(
+        self,
+        entry: Mapping[str, Any],
+        parts: list[dict[str, str]],
+        arguments: Mapping[str, Any] | None,
+    ) -> dict[str, Any]:
+        validated_arguments = self.validate_arguments(arguments)
+        variables = [
+            PromptVariableDefinition(
+                name=name,
+                label=name.replace("_", " ").title(),
+                required=True,
+                input_type="textarea",
+            )
+            for name in extract_legacy_prompt_variables(*(part["content"] for part in parts))
+        ]
+        blocks = [
+            PromptBlock(
+                id=f"config_{idx}",
+                name=f"Config Part {idx + 1}",
+                role=part["role"],  # type: ignore[arg-type]
+                content=normalize_legacy_prompt_template(part["content"]),
+                enabled=True,
+                order=(idx + 1) * 10,
+                is_template=bool(extract_legacy_prompt_variables(part["content"])),
+            )
+            for idx, part in enumerate(parts)
+        ]
+        definition = PromptDefinition(variables=variables, blocks=blocks)
+        messages = self._assemble_messages(definition, validated_arguments)
+        mcp_messages = self._to_mcp_messages(messages)
+        self._enforce_rendered_size(mcp_messages)
+        return {
+            "description": str(entry.get("description") or entry.get("title") or entry["id"]),
+            "messages": mcp_messages,
+            "_meta": {
+                "tldw": {
+                    "source": "config",
+                    "config_id": str(entry["id"]),
+                }
+            },
+        }
+
+    def _coerce_definition(self, row: Mapping[str, Any]) -> PromptDefinition | None:
+        payload = row.get("prompt_definition")
+        if not payload:
+            return None
+        try:
+            return PromptDefinition.model_validate(payload)
+        except (TypeError, ValueError) as exc:
+            raise PromptCatalogError("invalid_prompt_definition", "Stored prompt definition is invalid", internal=True) from exc
+
+    def _arguments_from_definition(self, definition: PromptDefinition) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": variable.name,
+                "title": variable.label or variable.name.replace("_", " ").title(),
+                "description": variable.description,
+                "required": bool(variable.required),
+            }
+            for variable in definition.variables
+        ]
+
+    def _legacy_arguments(self, *templates: Any) -> list[dict[str, Any]]:
+        return [
+            {"name": name, "title": name.replace("_", " ").title(), "description": None, "required": True}
+            for name in extract_legacy_prompt_variables(*(str(template or "") for template in templates))
+        ]
+
+    def _assemble_messages(self, definition: PromptDefinition, arguments: Mapping[str, str]) -> list[dict[str, str]]:
+        try:
+            return assemble_prompt_definition(definition, arguments).messages
+        except StructuredPromptAssemblyError as exc:
+            raise PromptCatalogError(exc.code, str(exc)) from exc
+
+    def _to_mcp_messages(self, messages: list[dict[str, str]]) -> list[dict[str, Any]]:
+        output: list[dict[str, Any]] = []
+        pending_system: list[str] = []
+        for message in messages:
+            role = message.get("role")
+            content = str(message.get("content") or "")
+            if role in {"system", "developer"}:
+                pending_system.append(content)
+                continue
+            if role == "assistant":
+                output.append({"role": "assistant", "content": {"type": "text", "text": content}})
+                continue
+            if role == "user":
+                text = content
+                if pending_system:
+                    text = "System instructions:\n" + "\n\n".join(pending_system) + "\n\nUser prompt:\n" + content
+                    pending_system = []
+                output.append({"role": "user", "content": {"type": "text", "text": text}})
+                continue
+            pending_system.append(content)
+
+        if pending_system:
+            output.append(
+                {
+                    "role": "user",
+                    "content": {"type": "text", "text": "System instructions:\n" + "\n\n".join(pending_system)},
+                }
+            )
+        return output
+
+    def _enforce_rendered_size(self, messages: list[dict[str, Any]]) -> None:
+        total = 0
+        for message in messages:
+            content = message.get("content") if isinstance(message, dict) else None
+            if isinstance(content, dict):
+                total += len(str(content.get("text") or ""))
+        if total > self.max_rendered_chars:
+            raise PromptCatalogError("rendered_prompt_too_large", "Rendered prompt exceeds configured size limit")
+
+    def _required_uuid(self, row: Mapping[str, Any]) -> str:
+        raw_uuid = str(row.get("uuid") or "").strip()
+        try:
+            parsed = uuid.UUID(raw_uuid)
+        except ValueError as exc:
+            raise PromptCatalogError("invalid_prompt_record", "Stored prompt UUID is invalid", internal=True) from exc
+        return str(parsed)
+
+    def _list_description(self, row: Mapping[str, Any]) -> str:
+        details = str(row.get("details") or "").strip()
+        if details:
+            return " ".join(details.split())[:500]
+        author = str(row.get("author") or "").strip()
+        if author:
+            return f"Prompt by {author}"
+        return ""
+```
+
+- [x] **Step 4: Run formatter tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py -k "formatter or cursor" -v
+```
+
+Expected: PASS.
+
+- [x] **Step 5: Add user and config source implementation**
+
+Append these source classes to `prompts_catalog.py`:
+
+```python
+class UserPromptCatalogSource:
+    """Read MCP prompts from the authenticated user's regular Prompt Library DB."""
+
+    def __init__(self, formatter: MCPPromptFormatter) -> None:
+        self.formatter = formatter
+
+    def list_prompts(
+        self,
+        *,
+        context: Any,
+        cursor: PromptCatalogCursor,
+        limit: int,
+    ) -> PromptCatalogListResult:
+        if limit <= 0:
+            return PromptCatalogListResult([], cursor, [])
+        if cursor.library_done:
+            return PromptCatalogListResult([], None, [])
+        try:
+            db = self._open_db(context)
+        except PromptCatalogError:
+            return PromptCatalogListResult(
+                prompts=[],
+                next_cursor=None,
+                warnings=[{"source": "library", "code": "prompt_db_unavailable"}],
+            )
+        except _CATALOG_DB_EXCEPTIONS:
+            return PromptCatalogListResult(
+                prompts=[],
+                next_cursor=None,
+                warnings=[{"source": "library", "code": "prompt_db_unavailable"}],
+            )
+        try:
+            rows = self._query_rows(db, context, cursor, limit + 1)
+            visible_rows = rows[:limit]
+            prompts = [self.formatter.library_prompt_definition(row) for row in visible_rows]
+            next_cursor = None
+            if len(rows) > limit and visible_rows:
+                last = visible_rows[-1]
+                next_cursor = PromptCatalogCursor(
+                    library_after_name=str(last.get("name") or ""),
+                    library_after_uuid=str(last.get("uuid")),
+                    library_done=False,
+                    config_index=cursor.config_index,
+                )
+            return PromptCatalogListResult(prompts=prompts, next_cursor=next_cursor, warnings=[])
+        except PromptCatalogError as exc:
+            if not exc.internal:
+                raise
+            logger.debug("MCP prompt library list failed with sanitized warning: {}", exc.code)
+            return PromptCatalogListResult(
+                prompts=[],
+                next_cursor=None,
+                warnings=[{"source": "library", "code": "prompt_db_unavailable"}],
+            )
+        except _CATALOG_DB_EXCEPTIONS as exc:
+            logger.debug("MCP prompt library list failed with sanitized warning: {}", exc.__class__.__name__)
+            return PromptCatalogListResult(
+                prompts=[],
+                next_cursor=None,
+                warnings=[{"source": "library", "code": "prompt_db_unavailable"}],
+            )
+        finally:
+            self._close_db(db)
+
+    def get_prompt(self, *, context: Any, name: str, arguments: Mapping[str, Any] | None) -> dict[str, Any]:
+        prompt_uuid = self._uuid_from_name(name)
+        try:
+            db = self._open_db(context)
+            row = db.get_prompt_by_uuid(prompt_uuid, include_deleted=False)
+            if not row:
+                raise PromptCatalogError("prompt_not_found", "Prompt not found")
+            assert_identifier_in_scope(context, "prompt_id", row.get("id"), label="Prompt")
+            return self.formatter.render_library_prompt(row, arguments)
+        except PromptCatalogError:
+            raise
+        except PermissionError as exc:
+            raise PromptCatalogError("permission_denied", "Permission denied for prompt") from exc
+        except _CATALOG_DB_EXCEPTIONS as exc:
+            raise PromptCatalogError("prompt_db_unavailable", "Prompt library is unavailable", internal=True) from exc
+        finally:
+            if "db" in locals():
+                self._close_db(db)
+
+    def _query_rows(
+        self,
+        db: PromptsDatabase,
+        context: Any,
+        cursor: PromptCatalogCursor,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        where_clauses = ["deleted = 0"]
+        params: list[Any] = []
+        scoped_ids = get_explicit_scope_ids(context, "prompt_id")
+        if scoped_ids is not None:
+            if not scoped_ids:
+                return []
+            sorted_ids = sorted(int(value) for value in scoped_ids if str(value).isdigit())
+            if not sorted_ids:
+                return []
+            placeholders = ", ".join("?" for _ in sorted_ids)
+            where_clauses.append(f"id IN ({placeholders})")  # nosec B608
+            params.extend(sorted_ids)
+        if cursor.library_after_name is not None and cursor.library_after_uuid is not None:
+            where_clauses.append("(name COLLATE NOCASE > ? OR (name COLLATE NOCASE = ? AND uuid > ?))")
+            params.extend([cursor.library_after_name, cursor.library_after_name, cursor.library_after_uuid])
+        query = f"""
+            SELECT *
+            FROM Prompts
+            WHERE {' AND '.join(where_clauses)}
+            ORDER BY name COLLATE NOCASE ASC, uuid ASC
+            LIMIT ?
+        """  # nosec B608
+        params.append(limit)
+        db_cursor = db.execute_query(query, tuple(params))
+        return [db._deserialize_prompt_record(dict(row)) for row in db_cursor.fetchall()]
+
+    def _uuid_from_name(self, name: str) -> str:
+        if not name.startswith(LIBRARY_PROMPT_PREFIX):
+            raise PromptCatalogError("invalid_prompt_name", "Invalid library prompt name")
+        raw_uuid = name[len(LIBRARY_PROMPT_PREFIX):]
+        try:
+            return str(uuid.UUID(raw_uuid))
+        except ValueError as exc:
+            raise PromptCatalogError("invalid_prompt_name", "Invalid library prompt name") from exc
+
+    def _open_db(self, context: Any) -> PromptsDatabase:
+        db_paths = getattr(context, "db_paths", None)
+        if not isinstance(db_paths, dict) or not db_paths.get("prompts"):
+            raise PromptCatalogError("prompt_db_unavailable", "Prompt library is unavailable", internal=True)
+        return PromptsDatabase(db_path=str(db_paths["prompts"]), client_id="mcp_prompt_catalog")
+
+    def _close_db(self, db: PromptsDatabase) -> None:
+        try:
+            db.close_connection()
+        except _CATALOG_DB_EXCEPTIONS as exc:
+            logger.debug("Failed to close Prompt Library DB after MCP prompt catalog access: {}", exc.__class__.__name__)
+
+
+class ConfigPromptCatalogSource:
+    """Read MCP prompts from explicit server-config allowlist entries."""
+
+    def __init__(self, formatter: MCPPromptFormatter, config: Mapping[str, Any] | None) -> None:
+        self.formatter = formatter
+        config = config or {}
+        self.enabled = bool(config.get("enabled", True))
+        raw_entries = config.get("entries") if isinstance(config.get("entries"), list) else []
+        self.entries = [entry for entry in raw_entries if isinstance(entry, Mapping)]
+
+    def list_prompts(self, *, cursor: PromptCatalogCursor, limit: int) -> PromptCatalogListResult:
+        if not self.enabled or limit <= 0:
+            return PromptCatalogListResult([], None, [])
+        prompts: list[dict[str, Any]] = []
+        warnings: list[dict[str, Any]] = []
+        next_cursor: PromptCatalogCursor | None = None
+        for index in range(cursor.config_index, len(self.entries)):
+            if len(prompts) >= limit:
+                next_cursor = PromptCatalogCursor(library_done=True, config_index=index)
+                break
+            entry = self.entries[index]
+            try:
+                parts = self._load_entry_parts(entry)
+                prompts.append(self.formatter.config_prompt_definition(entry, parts))
+            except PromptCatalogError:
+                warnings.append({"source": "config", "code": "config_prompt_unavailable", "id": str(entry.get("id") or "")})
+        return PromptCatalogListResult(prompts=prompts, next_cursor=next_cursor, warnings=warnings)
+
+    def has_entries_after(self, config_index: int) -> bool:
+        return self.enabled and max(0, config_index) < len(self.entries)
+
+    def get_prompt(self, *, name: str, arguments: Mapping[str, Any] | None) -> dict[str, Any]:
+        if not self.enabled:
+            raise PromptCatalogError("prompt_not_found", "Prompt not found")
+        entry_id = self._entry_id_from_name(name)
+        for entry in self.entries:
+            if str(entry.get("id") or "") == entry_id:
+                parts = self._load_entry_parts(entry)
+                return self.formatter.render_config_prompt(entry, parts, arguments)
+        raise PromptCatalogError("prompt_not_found", "Prompt not found")
+
+    def _entry_id_from_name(self, name: str) -> str:
+        if not name.startswith(CONFIG_PROMPT_PREFIX):
+            raise PromptCatalogError("invalid_prompt_name", "Invalid config prompt name")
+        entry_id = name[len(CONFIG_PROMPT_PREFIX):]
+        if not _CONFIG_ID_RE.fullmatch(entry_id):
+            raise PromptCatalogError("invalid_prompt_name", "Invalid config prompt name")
+        return entry_id
+
+    def _load_entry_parts(self, entry: Mapping[str, Any]) -> list[dict[str, str]]:
+        entry_id = str(entry.get("id") or "")
+        if not _CONFIG_ID_RE.fullmatch(entry_id):
+            raise PromptCatalogError("invalid_config_entry", "Invalid config prompt entry")
+        messages = entry.get("messages")
+        if isinstance(messages, list):
+            return [self._load_part(part) for part in messages if isinstance(part, Mapping)]
+        module = str(entry.get("module") or "")
+        key = str(entry.get("key") or "")
+        if not module or not key:
+            raise PromptCatalogError("invalid_config_entry", "Invalid config prompt entry")
+        return [self._load_part({"role": "user", "module": module, "key": key})]
+
+    def _load_part(self, part: Mapping[str, Any]) -> dict[str, str]:
+        role = str(part.get("role") or "user")
+        if role not in {"system", "developer", "user", "assistant"}:
+            raise PromptCatalogError("invalid_config_entry", "Invalid config prompt role")
+        module = str(part.get("module") or "")
+        key = str(part.get("key") or "")
+        if not module or not key:
+            raise PromptCatalogError("invalid_config_entry", "Invalid config prompt source")
+        content = load_prompt(module, key)
+        if content is None:
+            raise PromptCatalogError("config_prompt_unavailable", "Config prompt is unavailable")
+        return {"role": role, "content": content}
+```
+
+- [x] **Step 6: Run full catalog tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py -v
+```
+
+Expected: PASS.
+
+- [x] **Step 7: Commit adapter and tests**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_catalog.py tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py
+git commit -m "feat: add MCP prompt catalog adapter"
+```
+
+## Task 3: Add Context-Aware Prompt Hooks To BaseModule And PromptsModule
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/base.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_module.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py`
+
+- [x] **Step 1: Add failing module hook tests**
+
+Append these tests to `test_prompts_catalog.py`:
+
+```python
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.prompts_module import PromptsModule
+
+
+@pytest.mark.asyncio
+async def test_prompts_module_context_list_combines_library_and_config(monkeypatch, tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    row = _add_legacy_prompt(db_path, name="Alpha")
+    override_path = tmp_path / "config.txt"
+    override_path.write_text("Search for {query}", encoding="utf-8")
+    monkeypatch.setenv("TLDW_PROMPT_FILE_MCP__SEARCH_KNOWLEDGE", str(override_path))
+    module = PromptsModule(
+        ModuleConfig(
+            name="prompts",
+            settings={
+                "prompt_list_page_size": 50,
+                "max_rendered_prompt_chars": 10_000,
+                "config_prompts": {
+                    "enabled": True,
+                    "entries": [
+                        {
+                            "id": "mcp.search_knowledge",
+                            "module": "mcp",
+                            "key": "search_knowledge",
+                            "title": "Search Knowledge",
+                        }
+                    ],
+                },
+            },
+        )
+    )
+    await module.on_initialize()
+
+    result = await module.get_prompts_for_context(_context_for_prompts_db(db_path), {})
+
+    assert [prompt["name"] for prompt in result["prompts"]] == [
+        f"{LIBRARY_PROMPT_PREFIX}{row['uuid']}",
+        f"{CONFIG_PROMPT_PREFIX}mcp.search_knowledge",
+    ]
+    assert "nextCursor" not in result
+
+
+@pytest.mark.asyncio
+async def test_prompts_module_returns_config_cursor_when_library_exactly_fills_page(monkeypatch, tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    row = _add_legacy_prompt(db_path, name="Alpha")
+    override_path = tmp_path / "config.txt"
+    override_path.write_text("Search for {query}", encoding="utf-8")
+    monkeypatch.setenv("TLDW_PROMPT_FILE_MCP__SEARCH_KNOWLEDGE", str(override_path))
+    module = PromptsModule(
+        ModuleConfig(
+            name="prompts",
+            settings={
+                "prompt_list_page_size": 1,
+                "max_rendered_prompt_chars": 10_000,
+                "config_prompts": {
+                    "enabled": True,
+                    "entries": [
+                        {
+                            "id": "mcp.search_knowledge",
+                            "module": "mcp",
+                            "key": "search_knowledge",
+                            "title": "Search Knowledge",
+                        }
+                    ],
+                },
+            },
+        )
+    )
+    await module.on_initialize()
+
+    first_page = await module.get_prompts_for_context(_context_for_prompts_db(db_path), {})
+    second_page = await module.get_prompts_for_context(
+        _context_for_prompts_db(db_path),
+        {"cursor": first_page["nextCursor"]},
+    )
+
+    assert [prompt["name"] for prompt in first_page["prompts"]] == [f"{LIBRARY_PROMPT_PREFIX}{row['uuid']}"]
+    assert [prompt["name"] for prompt in second_page["prompts"]] == [
+        f"{CONFIG_PROMPT_PREFIX}mcp.search_knowledge"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_prompts_module_context_get_routes_by_namespace(tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    row = _add_legacy_prompt(db_path, name="Alpha")
+    module = PromptsModule(ModuleConfig(name="prompts", settings={"max_rendered_prompt_chars": 10_000}))
+    await module.on_initialize()
+
+    result = await module.get_prompt_for_context(
+        f"{LIBRARY_PROMPT_PREFIX}{row['uuid']}",
+        {"topic": "module hooks"},
+        _context_for_prompts_db(db_path),
+    )
+
+    assert result["messages"][0]["content"]["text"].endswith("Summarize module hooks")
+
+
+@pytest.mark.asyncio
+async def test_prompts_module_bad_cursor_raises_catalog_error(tmp_path) -> None:
+    module = PromptsModule(ModuleConfig(name="prompts"))
+    await module.on_initialize()
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        await module.get_prompts_for_context(_context_for_prompts_db(str(tmp_path / "prompts.db")), {"cursor": "bad"})
+
+    assert excinfo.value.code == "invalid_cursor"
+```
+
+- [x] **Step 2: Run module hook tests to verify failures**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py -k "prompts_module" -v
+```
+
+Expected: FAIL because context-aware hooks are not implemented on `PromptsModule`.
+
+- [x] **Step 3: Add backward-compatible hooks to BaseModule**
+
+Modify `tldw_Server_API/app/core/MCP_unified/modules/base.py` after `get_prompt()`:
+
+```python
+    async def get_prompts_for_context(self, context: Optional[Any], params: dict[str, Any]) -> dict[str, Any]:
+        """Get prompts for a request context.
+
+        Dynamic modules can override this to honor per-user databases,
+        permissions, scopes, and pagination. Static modules inherit the
+        existing context-free prompt list behavior.
+        """
+        return {"prompts": await self.get_prompts()}
+
+    async def get_prompt_for_context(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: Optional[Any],
+    ) -> dict[str, Any]:
+        """Get one prompt for a request context."""
+        return await self.get_prompt(name, arguments)
+```
+
+- [x] **Step 4: Add catalog setup and hooks to PromptsModule**
+
+Modify `tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_module.py` imports:
+
+```python
+from .prompts_catalog import (
+    CONFIG_PROMPT_PREFIX,
+    LIBRARY_PROMPT_PREFIX,
+    ConfigPromptCatalogSource,
+    MCPPromptFormatter,
+    PromptCatalogError,
+    UserPromptCatalogSource,
+    clamp_prompt_page_size,
+    decode_prompt_cursor,
+    encode_prompt_cursor,
+)
+```
+
+Add initialization in `on_initialize()`:
+
+```python
+    async def on_initialize(self) -> None:
+        logger.info(f"Initializing Prompts module: {self.name}")
+        settings = self.config.settings or {}
+        self._prompt_list_page_size = clamp_prompt_page_size(settings.get("prompt_list_page_size", 50))
+        self._prompt_formatter = MCPPromptFormatter(
+            max_rendered_chars=int(settings.get("max_rendered_prompt_chars", 100000) or 100000)
+        )
+        self._user_prompt_source = UserPromptCatalogSource(self._prompt_formatter)
+        self._config_prompt_source = ConfigPromptCatalogSource(
+            self._prompt_formatter,
+            settings.get("config_prompts") if isinstance(settings.get("config_prompts"), dict) else {},
+        )
+```
+
+Add context-aware prompt methods before `validate_tool_arguments()`:
+
+```python
+    async def get_prompts_for_context(self, context: Any, params: dict[str, Any]) -> dict[str, Any]:
+        params = params or {}
+        cursor = decode_prompt_cursor(params.get("cursor"))
+        page_size = self._prompt_list_page_size
+        library_result = await asyncio.to_thread(
+            self._user_prompt_source.list_prompts,
+            context=context,
+            cursor=cursor,
+            limit=page_size,
+        )
+        prompts = list(library_result.prompts)
+        warnings = list(library_result.warnings)
+        next_cursor = library_result.next_cursor
+
+        if len(prompts) < page_size and library_result.next_cursor is None:
+            remaining = page_size - len(prompts)
+            config_result = await asyncio.to_thread(
+                self._config_prompt_source.list_prompts,
+                cursor=cursor,
+                limit=remaining,
+            )
+            prompts.extend(config_result.prompts)
+            warnings.extend(config_result.warnings)
+            next_cursor = config_result.next_cursor
+        elif (
+            len(prompts) == page_size
+            and library_result.next_cursor is None
+            and self._config_prompt_source.has_entries_after(cursor.config_index)
+        ):
+            next_cursor = PromptCatalogCursor(library_done=True, config_index=cursor.config_index)
+
+        result: dict[str, Any] = {"prompts": prompts}
+        encoded_cursor = encode_prompt_cursor(next_cursor)
+        if encoded_cursor:
+            result["nextCursor"] = encoded_cursor
+        if warnings:
+            result["_meta"] = {"tldw": {"warnings": warnings}}
+        return result
+
+    async def get_prompt_for_context(self, name: str, arguments: dict[str, Any], context: Any) -> dict[str, Any]:
+        if name.startswith(LIBRARY_PROMPT_PREFIX):
+            return await asyncio.to_thread(
+                self._user_prompt_source.get_prompt,
+                context=context,
+                name=name,
+                arguments=arguments,
+            )
+        if name.startswith(CONFIG_PROMPT_PREFIX):
+            return await asyncio.to_thread(
+                self._config_prompt_source.get_prompt,
+                name=name,
+                arguments=arguments,
+            )
+        raise PromptCatalogError("prompt_not_found", "Prompt not found")
+```
+
+- [x] **Step 5: Run module hook tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py -k "prompts_module" -v
+```
+
+Expected: PASS.
+
+- [x] **Step 6: Run full catalog test file**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py -v
+```
+
+Expected: PASS.
+
+- [x] **Step 7: Commit module hooks**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/base.py tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_module.py tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py
+git commit -m "feat: wire MCP prompt catalog hooks"
+```
+
+## Task 4: Update Protocol Prompt Capability, Listing, Routing, And Errors
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/protocol.py`
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py`
+
+- [x] **Step 1: Create protocol-focused failing tests**
+
+Create `tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.modules.base import BaseModule, ModuleConfig
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.prompts_catalog import (
+    LIBRARY_PROMPT_PREFIX,
+    PromptCatalogError,
+)
+from tldw_Server_API.app.core.MCP_unified.auth.rbac import Action, Resource
+from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol, RequestContext
+
+
+class PromptOnlyRegistry:
+    def __init__(self, modules):
+        self.modules = modules
+        self.find_calls: list[str] = []
+
+    async def get_all_modules(self):
+        return self.modules
+
+    async def get_module(self, module_id: str):
+        return self.modules.get(module_id)
+
+    async def find_module_for_prompt(self, name: str):
+        self.find_calls.append(name)
+        return None
+
+    def get_module_id_for_prompt(self, name: str):
+        return None
+
+
+class PromptPermissionPolicy:
+    def __init__(self, *, prompt_read: bool, module_read: bool) -> None:
+        self.prompt_read = prompt_read
+        self.module_read = module_read
+
+    def check_permission(self, user_id, resource, action, resource_id=None):
+        if resource == Resource.PROMPT and action == Action.READ:
+            return self.prompt_read
+        if resource == Resource.MODULE and action == Action.READ:
+            return self.module_read
+        return False
+
+
+def _handler_with_registry(registry) -> MCPProtocol:
+    handler = MCPProtocol()
+    handler.module_registry = registry
+    return handler
+
+
+class ContextPromptModule(BaseModule):
+    async def on_initialize(self) -> None:
+        return None
+
+    async def on_shutdown(self) -> None:
+        return None
+
+    async def check_health(self) -> dict[str, bool]:
+        return {"ok": True}
+
+    async def get_tools(self) -> list[dict]:
+        return []
+
+    async def execute_tool(self, tool_name: str, arguments: dict, context=None):
+        raise NotImplementedError
+
+    async def get_prompts_for_context(self, context, params):
+        return {
+            "prompts": [{"name": "library:11111111-1111-4111-8111-111111111111", "title": "A"}],
+            "nextCursor": "abc",
+            "_meta": {"tldw": {"warnings": [{"source": "library", "code": "prompt_db_unavailable"}]}},
+        }
+
+    async def get_prompt_for_context(self, name, arguments, context):
+        return {"description": name, "messages": [{"role": "user", "content": {"type": "text", "text": "ok"}}]}
+
+
+@pytest.mark.asyncio
+async def test_initialize_declares_mcp_prompt_capability() -> None:
+    handler = _handler_with_registry(PromptOnlyRegistry({}))
+    context = RequestContext("req-1", user_id="1")
+
+    result = await handler._handle_initialize({"clientInfo": {"name": "test"}}, context)
+
+    assert result["capabilities"]["prompts"] == {"listChanged": False}
+
+
+@pytest.mark.asyncio
+async def test_prompts_list_uses_context_hook_and_preserves_cursor_and_warnings(monkeypatch) -> None:
+    module = ContextPromptModule(ModuleConfig(name="prompts"))
+    handler = _handler_with_registry(PromptOnlyRegistry({"prompts": module}))
+    monkeypatch.setattr(handler, "_has_namespaced_prompt_permission", lambda *args, **kwargs: _async_true())
+
+    result = await handler._handle_prompts_list({"cursor": "incoming"}, RequestContext("req-1", user_id="1"))
+
+    assert result["prompts"][0]["module"] == "prompts"
+    assert result["nextCursor"] == "abc"
+    assert result["_meta"]["tldw"]["warnings"][0]["code"] == "prompt_db_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_prompts_get_dispatches_namespaced_prompt_before_global_registry(monkeypatch) -> None:
+    module = ContextPromptModule(ModuleConfig(name="prompts"))
+    registry = PromptOnlyRegistry({"prompts": module})
+    handler = _handler_with_registry(registry)
+    monkeypatch.setattr(handler, "_has_namespaced_prompt_permission", lambda *args, **kwargs: _async_true())
+
+    result = await handler._handle_prompts_get(
+        {"name": f"{LIBRARY_PROMPT_PREFIX}11111111-1111-4111-8111-111111111111", "arguments": {}},
+        RequestContext("req-1", user_id="1"),
+    )
+
+    assert result["description"].startswith(LIBRARY_PROMPT_PREFIX)
+    assert registry.find_calls == []
+
+
+@pytest.mark.asyncio
+async def test_prompts_get_rejects_non_object_arguments(monkeypatch) -> None:
+    module = ContextPromptModule(ModuleConfig(name="prompts"))
+    handler = _handler_with_registry(PromptOnlyRegistry({"prompts": module}))
+
+    with pytest.raises(Exception) as excinfo:
+        await handler._handle_prompts_get(
+            {"name": f"{LIBRARY_PROMPT_PREFIX}11111111-1111-4111-8111-111111111111", "arguments": []},
+            RequestContext("req-1", user_id="1"),
+        )
+
+    assert "Prompt arguments must be an object" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_namespaced_prompts_read_does_not_require_module_read() -> None:
+    module = ContextPromptModule(ModuleConfig(name="prompts"))
+    handler = _handler_with_registry(PromptOnlyRegistry({"prompts": module}))
+    handler.rbac_policy = PromptPermissionPolicy(prompt_read=True, module_read=False)
+
+    result = await handler._handle_prompts_list({}, RequestContext("req-1", user_id="1"))
+
+    assert result["prompts"][0]["name"].startswith(LIBRARY_PROMPT_PREFIX)
+
+
+@pytest.mark.asyncio
+async def test_namespaced_prompt_denies_when_only_module_read_is_granted() -> None:
+    module = ContextPromptModule(ModuleConfig(name="prompts"))
+    handler = _handler_with_registry(PromptOnlyRegistry({"prompts": module}))
+    handler.rbac_policy = PromptPermissionPolicy(prompt_read=False, module_read=True)
+
+    result = await handler._handle_prompts_list({}, RequestContext("req-1", user_id="1"))
+
+    assert result["prompts"] == []
+
+
+async def _async_true(*args, **kwargs):
+    return True
+```
+
+- [x] **Step 2: Run protocol tests to verify failures**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py -v
+```
+
+Expected: FAIL on capability shape, module permission behavior, and namespace dispatch.
+
+- [x] **Step 3: Import catalog error and prefixes in protocol.py**
+
+Modify imports in `tldw_Server_API/app/core/MCP_unified/protocol.py`:
+
+```python
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.prompts_catalog import (
+    CONFIG_PROMPT_PREFIX,
+    LIBRARY_PROMPT_PREFIX,
+    PromptCatalogError,
+)
+```
+
+Place this import near other MCP Unified imports. If importing this module introduces a circular import, move only constants and `PromptCatalogError` into a tiny new `tldw_Server_API/app/core/MCP_unified/prompt_catalog_contract.py` and import that contract from both `protocol.py` and `prompts_catalog.py`.
+
+- [x] **Step 4: Fix initialize capability shape**
+
+Replace the current `capabilities` block in `_handle_initialize()`:
+
+```python
+        capabilities = {
+            "tools": {"available": bool(modules)},
+            "resources": {"available": bool(modules)},
+            "prompts": {"listChanged": False},
+        }
+```
+
+- [x] **Step 5: Add namespaced prompt permission helper**
+
+Add this helper near `_has_prompt_permission()` in `tldw_Server_API/app/core/MCP_unified/protocol.py`:
+
+```python
+    async def _has_namespaced_prompt_permission(self, context: RequestContext, prompt_name: str) -> bool:
+        """Check prompt catalog namespace access without falling back to module permission."""
+        if not await self._rbac_check(context.user_id, Resource.PROMPT, Action.READ, prompt_name):
+            return False
+        if not self._scope_allows(context, Resource.PROMPT.value, prompt_name):
+            return False
+        return self._api_key_allows(context, is_write=None)
+```
+
+- [x] **Step 6: Replace prompts/list handler with context-aware behavior**
+
+Replace `_handle_prompts_list()` with:
+
+```python
+    async def _handle_prompts_list(
+        self,
+        params: dict[str, Any],
+        context: RequestContext
+    ) -> dict[str, Any]:
+        """List available prompts."""
+        prompts: list[Any] = []
+        warnings: list[dict[str, Any]] = []
+        next_cursor: str | None = None
+        modules = await self.module_registry.get_all_modules()
+
+        for module_id, module in modules.items():
+            try:
+                if module_id != "prompts" and not await self._has_module_permission(context, module_id):
+                    continue
+
+                module_result = await module.get_prompts_for_context(context, params or {})
+                module_prompts = module_result.get("prompts", []) if isinstance(module_result, dict) else []
+
+                for prompt in module_prompts:
+                    name = prompt.get("name") if isinstance(prompt, dict) else None
+                    if name and name.startswith((LIBRARY_PROMPT_PREFIX, CONFIG_PROMPT_PREFIX)):
+                        if not await self._has_namespaced_prompt_permission(context, name):
+                            continue
+                    elif name and not await self._has_prompt_permission(context, name, module_id):
+                        continue
+                    prompt_copy = prompt.copy() if isinstance(prompt, dict) else prompt
+                    if isinstance(prompt_copy, dict):
+                        prompt_copy["module"] = module_id
+                    prompts.append(prompt_copy)
+
+                if isinstance(module_result, dict):
+                    if module_result.get("nextCursor"):
+                        next_cursor = str(module_result["nextCursor"])
+                    module_meta = module_result.get("_meta")
+                    if isinstance(module_meta, dict):
+                        tldw_meta = module_meta.get("tldw")
+                        if isinstance(tldw_meta, dict) and isinstance(tldw_meta.get("warnings"), list):
+                            warnings.extend(
+                                warning
+                                for warning in tldw_meta["warnings"]
+                                if isinstance(warning, dict)
+                            )
+
+            except PromptCatalogError as exc:
+                if exc.internal:
+                    context.logger.exception("Error getting prompts from module {}", module_id)
+                else:
+                    context.logger.debug("Prompt catalog list rejected request for module {}: {}", module_id, exc.code)
+                raise InvalidParamsException(str(exc)) from exc
+            except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as e:
+                context.logger.exception(f"Error getting prompts from module {module_id}: {e}")
+
+        result: dict[str, Any] = {"prompts": prompts}
+        if next_cursor:
+            result["nextCursor"] = next_cursor
+        if warnings:
+            result["_meta"] = {"tldw": {"warnings": warnings}}
+        return result
+```
+
+- [x] **Step 7: Replace prompts/get handler with namespace dispatch and argument validation**
+
+Replace `_handle_prompts_get()` with:
+
+```python
+    async def _handle_prompts_get(
+        self,
+        params: dict[str, Any],
+        context: RequestContext
+    ) -> dict[str, Any]:
+        """Get a specific prompt."""
+        name = params.get("name")
+        if not isinstance(name, str) or not name:
+            raise InvalidParamsException("Prompt name is required")
+
+        arguments = params.get("arguments", {})
+        if arguments is None:
+            arguments = {}
+        if not isinstance(arguments, dict):
+            raise InvalidParamsException("Prompt arguments must be an object")
+
+        if name.startswith((LIBRARY_PROMPT_PREFIX, CONFIG_PROMPT_PREFIX)):
+            module = await self.module_registry.get_module("prompts")
+            if not module:
+                raise InvalidParamsException(f"Prompt not found: {name}")
+            if not await self._has_namespaced_prompt_permission(context, name):
+                raise PermissionError(f"Permission denied for prompt: {name}")
+            try:
+                return await module.get_prompt_for_context(name, arguments, context)
+            except PromptCatalogError as exc:
+                if exc.code == "permission_denied":
+                    raise PermissionError(f"Permission denied for prompt: {name}") from exc
+                if exc.internal:
+                    context.logger.exception("MCP prompt catalog get failed for {}", name.split(":", 1)[0])
+                    raise RuntimeError("Failed to get prompt") from exc
+                raise InvalidParamsException(str(exc)) from exc
+
+        module = await self.module_registry.find_module_for_prompt(name)
+        if not module:
+            raise InvalidParamsException(f"Prompt not found: {name}")
+        module_id = self.module_registry.get_module_id_for_prompt(name) or getattr(module, "name", None)
+
+        if not await self._has_prompt_permission(context, name, module_id):
+            raise PermissionError(f"Permission denied for prompt: {name}")
+
+        return await module.get_prompt_for_context(name, arguments, context)
+```
+
+- [x] **Step 8: Run protocol tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py -v
+```
+
+Expected: PASS.
+
+- [x] **Step 9: Run existing MCP regression tests around basic protocol behavior**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_registry_iteration_race.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py \
+  -v
+```
+
+Expected: PASS.
+
+- [x] **Step 10: Commit protocol changes**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py
+git commit -m "feat: route MCP prompt catalog protocol calls"
+```
+
+## Task 5: Add HTTP Cursor Mapping And Default Module Configuration
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py`
+- Modify: `tldw_Server_API/Config_Files/mcp_modules.yaml`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py`
+- Create: `tldw_Server_API/tests/MCP_unified/test_mcp_prompts_http.py`
+
+- [x] **Step 1: Add failing config YAML test**
+
+Append this test to `tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py`:
+
+```python
+from pathlib import Path
+
+import yaml
+
+
+def test_default_mcp_modules_config_declares_prompts_module_with_empty_config_allowlist() -> None:
+    config_path = Path("tldw_Server_API/Config_Files/mcp_modules.yaml")
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    modules = {module["id"]: module for module in data["modules"]}
+
+    prompts_module = modules["prompts"]
+
+    assert prompts_module["enabled"] is True
+    assert prompts_module["settings"]["prompt_list_page_size"] == 50
+    assert prompts_module["settings"]["max_rendered_prompt_chars"] == 100000
+    assert prompts_module["settings"]["config_prompts"] == {"enabled": True, "entries": []}
+```
+
+- [x] **Step 2: Run config test to verify failure**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py::test_default_mcp_modules_config_declares_prompts_module_with_empty_config_allowlist -v
+```
+
+Expected: FAIL because the shipped YAML does not have a `prompts` module entry.
+
+- [x] **Step 3: Add prompts module entry to mcp_modules.yaml**
+
+Insert this module entry after the `notes` module entry in `tldw_Server_API/Config_Files/mcp_modules.yaml`:
+
+```yaml
+  - id: prompts
+    class: tldw_Server_API.app.core.MCP_unified.modules.implementations.prompts_module:PromptsModule
+    enabled: true
+    name: Prompts
+    version: "1.0.0"
+    department: knowledge
+    max_concurrent: 10
+    settings:
+      prompt_list_page_size: 50
+      max_rendered_prompt_chars: 100000
+      config_prompts:
+        enabled: true
+        entries: []
+        # Example entries; replace entries: [] with explicit entries like these
+        # to publish config prompts through MCP.
+        # entries:
+        #   - id: rag.retrieval_guidance
+        #     module: rag
+        #     key: retrieval_guidance
+        #     title: Retrieval Guidance
+        #   - id: chat.summary
+        #     title: Conversation Summary
+        #     messages:
+        #       - role: system
+        #         module: chat
+        #         key: summary_system
+        #       - role: user
+        #         module: chat
+        #         key: summary_user
+        #   - id: mcp.search_knowledge
+        #     module: mcp
+        #     key: search_knowledge
+        #     title: Search Knowledge
+```
+
+- [x] **Step 4: Run config test**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py::test_default_mcp_modules_config_declares_prompts_module_with_empty_config_allowlist -v
+```
+
+Expected: PASS.
+
+- [x] **Step 5: Add HTTP cursor query test**
+
+Create `tldw_Server_API/tests/MCP_unified/test_mcp_prompts_http.py` with this focused route test.
+
+```python
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.endpoints import mcp_unified_endpoint
+
+
+class _CaptureServer:
+    initialized = True
+
+    def __init__(self) -> None:
+        self.request = None
+
+    async def handle_http_request(self, request, user_id=None, metadata=None):
+        self.request = request
+        return type("Response", (), {"error": None, "result": {"prompts": [], "nextCursor": "next"}})()
+
+
+def test_get_mcp_prompts_maps_cursor_to_protocol_request(monkeypatch) -> None:
+    server = _CaptureServer()
+    monkeypatch.setattr(mcp_unified_endpoint, "get_mcp_server", lambda: server)
+    app = FastAPI()
+    app.include_router(mcp_unified_endpoint.router, prefix="/api/v1")
+    app.dependency_overrides[mcp_unified_endpoint.enforce_http_security] = lambda: None
+    app.dependency_overrides[mcp_unified_endpoint.get_mcp_auth_context] = lambda: mcp_unified_endpoint.McpAuthContext(
+        user=None,
+        principal=None,
+        api_key_info=None,
+        raw_api_key=None,
+    )
+    client = TestClient(app)
+
+    response = client.get("/api/v1/mcp/prompts?cursor=abc")
+
+    assert response.status_code == 200
+    assert response.json() == {"prompts": [], "nextCursor": "next"}
+    assert server.request.method == "prompts/list"
+    assert server.request.params == {"cursor": "abc"}
+```
+
+- [x] **Step 6: Run HTTP cursor test to verify failure**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_prompts_http.py::test_get_mcp_prompts_maps_cursor_to_protocol_request -v
+```
+
+Expected: FAIL because the endpoint does not accept or pass `cursor`.
+
+- [x] **Step 7: Add cursor query parameter to endpoint**
+
+Modify `list_prompts()` in `tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py`:
+
+```python
+async def list_prompts(
+    http_request: Request,
+    cursor: str | None = Query(None, description="Opaque MCP prompt list cursor"),
+    auth: McpAuthContext = Depends(get_mcp_auth_context),
+    _guard: None = Depends(enforce_http_security),
+):
+```
+
+Replace the current request creation with:
+
+```python
+    params = {"cursor": cursor} if cursor else None
+    request = MCPRequest(method="prompts/list", params=params, id="http-prompts-list")
+```
+
+- [x] **Step 8: Run HTTP cursor test**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_prompts_http.py::test_get_mcp_prompts_maps_cursor_to_protocol_request -v
+```
+
+Expected: PASS.
+
+- [x] **Step 9: Commit config and HTTP changes**
+
+Run:
+
+```bash
+git add tldw_Server_API/Config_Files/mcp_modules.yaml tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py tldw_Server_API/tests/MCP_unified/test_mcp_prompts_http.py
+git commit -m "feat: enable MCP prompts module configuration"
+```
+
+## Task 6: Add Integration And Security Regression Coverage
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py`
+
+- [x] **Step 1: Add keyset pagination regression test**
+
+Append to `test_prompts_catalog.py`:
+
+```python
+def test_user_source_keyset_cursor_survives_prompt_insert_between_pages(tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    alpha = _add_legacy_prompt(db_path, name="Alpha")
+    charlie = _add_legacy_prompt(db_path, name="Charlie")
+    source = UserPromptCatalogSource(MCPPromptFormatter(max_rendered_chars=10_000))
+
+    first_page = source.list_prompts(
+        context=_context_for_prompts_db(db_path),
+        cursor=PromptCatalogCursor(),
+        limit=1,
+    )
+    _add_legacy_prompt(db_path, name="Aardvark")
+    second_page = source.list_prompts(
+        context=_context_for_prompts_db(db_path),
+        cursor=first_page.next_cursor,
+        limit=10,
+    )
+
+    assert first_page.prompts[0]["name"] == f"{LIBRARY_PROMPT_PREFIX}{alpha['uuid']}"
+    assert [prompt["name"] for prompt in second_page.prompts] == [
+        f"{LIBRARY_PROMPT_PREFIX}{charlie['uuid']}"
+    ]
+```
+
+- [x] **Step 2: Add sanitized error regression tests**
+
+Append to `test_prompts_catalog.py`:
+
+```python
+def test_formatter_size_error_does_not_include_argument_value() -> None:
+    row = {
+        "id": 42,
+        "uuid": "11111111-1111-4111-8111-111111111111",
+        "name": "Large",
+        "details": "",
+        "version": 1,
+        "keywords": [],
+        "system_prompt": "",
+        "user_prompt": "Echo {secret}",
+        "prompt_definition": None,
+    }
+    formatter = MCPPromptFormatter(max_rendered_chars=5)
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        formatter.render_library_prompt(row, {"secret": "SENSITIVE_VALUE"})
+
+    assert excinfo.value.code == "rendered_prompt_too_large"
+    assert "SENSITIVE_VALUE" not in str(excinfo.value)
+
+
+def test_missing_config_entry_error_does_not_include_override_path(monkeypatch, tmp_path) -> None:
+    override_path = tmp_path / "missing.txt"
+    monkeypatch.setenv("TLDW_PROMPT_FILE_MISSING__ENTRY", str(override_path))
+    source = ConfigPromptCatalogSource(
+        MCPPromptFormatter(max_rendered_chars=10_000),
+        {
+            "enabled": True,
+            "entries": [
+                {
+                    "id": "missing.entry",
+                    "module": "missing",
+                    "key": "entry",
+                    "title": "Missing Entry",
+                }
+            ],
+        },
+    )
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        source.get_prompt(name=f"{CONFIG_PROMPT_PREFIX}missing.entry", arguments={})
+
+    assert str(override_path) not in str(excinfo.value)
+```
+
+- [x] **Step 3: Add protocol error mapping regression tests**
+
+Append to `test_protocol_prompts_catalog.py`:
+
+```python
+class ErrorPromptModule(ContextPromptModule):
+    def __init__(self, config: ModuleConfig, error: PromptCatalogError) -> None:
+        super().__init__(config)
+        self.error = error
+
+    async def get_prompt_for_context(self, name, arguments, context):
+        raise self.error
+
+
+@pytest.mark.asyncio
+async def test_protocol_maps_catalog_invalid_params_without_body_leak(monkeypatch) -> None:
+    module = ErrorPromptModule(ModuleConfig(name="prompts"), PromptCatalogError("missing_required_variable", "Missing required variable: topic"))
+    handler = _handler_with_registry(PromptOnlyRegistry({"prompts": module}))
+    monkeypatch.setattr(handler, "_has_namespaced_prompt_permission", lambda *args, **kwargs: _async_true())
+
+    with pytest.raises(Exception) as excinfo:
+        await handler._handle_prompts_get(
+            {"name": f"{LIBRARY_PROMPT_PREFIX}11111111-1111-4111-8111-111111111111", "arguments": {}},
+            RequestContext("req-1", user_id="1"),
+        )
+
+    assert "Missing required variable: topic" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_protocol_maps_internal_catalog_error_to_internal_message(monkeypatch) -> None:
+    module = ErrorPromptModule(ModuleConfig(name="prompts"), PromptCatalogError("prompt_db_unavailable", "Prompt body SENSITIVE", internal=True))
+    handler = _handler_with_registry(PromptOnlyRegistry({"prompts": module}))
+    monkeypatch.setattr(handler, "_has_namespaced_prompt_permission", lambda *args, **kwargs: _async_true())
+
+    with pytest.raises(Exception) as excinfo:
+        await handler._handle_prompts_get(
+            {"name": f"{LIBRARY_PROMPT_PREFIX}11111111-1111-4111-8111-111111111111", "arguments": {}},
+            RequestContext("req-1", user_id="1"),
+        )
+
+    assert "Failed to get prompt" in str(excinfo.value)
+    assert "SENSITIVE" not in str(excinfo.value)
+```
+
+- [x] **Step 4: Run focused security and regression tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py \
+  -v
+```
+
+Expected: PASS.
+
+- [x] **Step 5: Commit regression coverage**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py
+git commit -m "test: cover MCP prompt catalog edge cases"
+```
+
+## Task 7: Add MCP Prompt Documentation
+
+**Files:**
+- Create: `Docs/MCP/mcp_prompts.md`
+- Modify: `Docs/MCP/mcp_tool_catalogs.md`
+- Modify: `backlog/tasks/task-2343 - Plan-MCP-prompt-catalog-implementation.md`
+
+- [x] **Step 1: Create prompt catalog documentation**
+
+Create `Docs/MCP/mcp_prompts.md`:
+
+```markdown
+# MCP Prompts
+
+tldw_server exposes selected prompts through MCP protocol-level prompts:
+
+- `prompts/list`
+- `prompts/get`
+
+This is separate from the MCP tools `prompts.search` and `prompts.get`. Tools return Prompt Library records for retrieval workflows. Protocol prompts return MCP prompt definitions and rendered MCP prompt messages for MCP clients that understand the prompt capability.
+
+## Capability
+
+The MCP server advertises:
+
+```json
+{
+  "prompts": {
+    "listChanged": false
+  }
+}
+```
+
+`listChanged: false` means clients should call `prompts/list` again when they need a fresh view. The server does not emit `notifications/prompts/list_changed` in this version.
+
+## Prompt Sources
+
+The server lists:
+
+- non-deleted records from the authenticated user's regular Prompt Library
+- config prompts explicitly allowlisted in `tldw_Server_API/Config_Files/mcp_modules.yaml`
+
+Prompt Studio prompts are not exposed through MCP prompts in this version.
+
+## Stable Names
+
+Prompt names are stable protocol identifiers:
+
+- `library:<uuid>` for Prompt Library prompts
+- `config:<module>.<key-or-group>` for allowlisted config prompts
+
+The human-readable prompt name is returned as `title`. Renaming a Prompt Library prompt does not change its `library:<uuid>` name.
+
+## Config Prompt Allowlist
+
+Config prompt exposure is opt-in. The shipped default allowlist is empty:
+
+```yaml
+settings:
+  config_prompts:
+    enabled: true
+    entries: []
+```
+
+Publish one config prompt:
+
+```yaml
+settings:
+  config_prompts:
+    enabled: true
+    entries:
+      - id: rag.retrieval_guidance
+        module: rag
+        key: retrieval_guidance
+        title: Retrieval Guidance
+```
+
+Publish a grouped prompt:
+
+```yaml
+settings:
+  config_prompts:
+    enabled: true
+    entries:
+      - id: chat.summary
+        title: Conversation Summary
+        messages:
+          - role: system
+            module: chat
+            key: summary_system
+          - role: user
+            module: chat
+            key: summary_user
+```
+
+Config roles may be `system`, `developer`, `user`, or `assistant`. MCP only allows `user` and `assistant` prompt message roles, so `system` and `developer` content is folded into labeled `user` text when a prompt is rendered.
+
+## Arguments
+
+Structured Prompt Library prompts use their declared variables. Legacy and config prompts infer variables from placeholders such as:
+
+- `{{topic}}`
+- `{context}`
+- `$query`
+- `<input>`
+
+Argument values must be strings. Missing required arguments and non-string values return JSON-RPC invalid params errors.
+
+## Pagination
+
+`prompts/list` accepts MCP's `cursor` parameter and may return `nextCursor`.
+
+The HTTP convenience route remains list-only:
+
+```http
+GET /api/v1/mcp/prompts
+GET /api/v1/mcp/prompts?cursor=<nextCursor>
+```
+
+Use `/api/v1/mcp/request` for `prompts/get`.
+
+## Permissions
+
+Authenticated MCP callers need `prompts.read`. Protocol-level prompt access does not require `modules.read`.
+
+Prompt Library results are read from the authenticated user's per-user Prompt Library database. Persona prompt scopes still filter Prompt Library list and get operations. Allowlisted config prompts are visible to authenticated callers with `prompts.read`.
+
+## Safety Notes
+
+The server does not include prompt bodies in `prompts/list` descriptions. Prompt bodies, rendered argument values, and prompt override file paths are not included in errors.
+```
+
+- [x] **Step 2: Link docs from MCP tool catalog docs**
+
+Open `Docs/MCP/mcp_tool_catalogs.md` and add this line near the top-level related-links or overview section:
+
+```markdown
+For protocol-level prompt discovery and rendering, see [MCP Prompts](mcp_prompts.md).
+```
+
+- [x] **Step 3: Update Backlog task with plan link**
+
+Use Backlog MCP:
+
+```text
+task_edit(project="/Users/macbook-dev/Documents/GitHub/tldw_server2", task_id="TASK-2343", notes_append="Implementation plan created: Docs/superpowers/plans/2026-06-22-mcp-prompt-catalog-implementation-plan.md")
+```
+
+- [x] **Step 4: Commit docs**
+
+Run:
+
+```bash
+git add Docs/MCP/mcp_prompts.md Docs/MCP/mcp_tool_catalogs.md "backlog/tasks/task-2343 - Plan-MCP-prompt-catalog-implementation.md"
+git commit -m "docs: document MCP prompt catalog support"
+```
+
+## Task 8: Final Verification
+
+**Files:**
+- Verify all touched files from Tasks 1-7.
+
+- [x] **Step 1: Run focused MCP prompt catalog tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py::test_default_mcp_modules_config_declares_prompts_module_with_empty_config_allowlist \
+  -v
+```
+
+Expected: PASS.
+
+- [x] **Step 2: Run existing MCP Unified smoke and regression tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_registry_iteration_race.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py \
+  -v
+```
+
+Expected: PASS.
+
+- [x] **Step 3: Run HTTP MCP prompt endpoint test**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_prompts_http.py -v
+```
+
+Expected: PASS.
+
+- [x] **Step 4: Run Bandit on touched backend scope**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m bandit -r \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_catalog.py \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_module.py \
+  tldw_Server_API/app/core/MCP_unified/modules/base.py \
+  tldw_Server_API/app/core/MCP_unified/protocol.py \
+  tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py \
+  -f json -o /tmp/bandit_mcp_prompt_catalog.json
+```
+
+Expected: PASS with no new high or medium findings in touched code.
+
+- [x] **Step 5: Inspect final diff**
+
+Run:
+
+```bash
+BASE_SHA=$(git merge-base HEAD origin/dev)
+git diff --stat "${BASE_SHA}..HEAD"
+git diff "${BASE_SHA}..HEAD" -- tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_catalog.py
+git diff "${BASE_SHA}..HEAD" -- tldw_Server_API/app/core/MCP_unified/protocol.py
+```
+
+Expected:
+
+- Catalog logic is isolated in `prompts_catalog.py`.
+- `protocol.py` only contains protocol routing and MCP error mapping.
+- Existing `prompts.search` and `prompts.get` tools remain unchanged.
+- No prompt bodies or argument values appear in log messages or exception messages.
+
+- [x] **Step 6: Update Backlog verification notes**
+
+Use Backlog MCP:
+
+```text
+task_edit(project="/Users/macbook-dev/Documents/GitHub/tldw_server2", task_id="TASK-2343", status="Done", notes_append="Verified MCP prompt catalog implementation with focused pytest, MCP regression tests, HTTP cursor test, and touched-scope Bandit. See commit history for task-level commits.")
+```
+
+- [x] **Step 7: Final commit if verification notes changed**
+
+Run:
+
+```bash
+git add "backlog/tasks/task-2343 - Plan-MCP-prompt-catalog-implementation.md"
+git commit -m "chore: finalize MCP prompt catalog task notes"
+```
+
+## Review Checklist
+
+- [x] `initialize` returns `{"prompts": {"listChanged": false}}`.
+- [x] `prompts/list` supports `cursor` and returns `nextCursor` only when another page exists.
+- [x] `prompts/get` resolves `library:` and `config:` before the global prompt registry.
+- [x] `prompts.read` is enough for prompt catalog access; `modules.read` is not required for `PromptsModule` protocol prompts.
+- [x] Prompt Library prompts are per-user through `RequestContext.db_paths["prompts"]`.
+- [x] Prompt Library list excludes deleted rows.
+- [x] Persona prompt scopes filter Prompt Library list and get.
+- [x] Config prompts require explicit allowlist entries.
+- [x] The shipped config allowlist is empty.
+- [x] Prompt Studio prompts are absent from the catalog.
+- [x] MCP prompt messages use only `user` and `assistant` roles.
+- [x] Non-string prompt arguments return invalid params.
+- [x] Errors do not include prompt bodies, rendered values, override paths, or DB paths.
+- [x] Existing `prompts.search` and `prompts.get` tools still pass existing tests.
+
+## Out Of Scope For This Plan
+
+- Prompt Studio prompt exposure.
+- Live `notifications/prompts/list_changed`.
+- Shared prompt registry service beyond MCP.
+- Frontend prompt catalog UI.
+- New HTTP convenience route for `prompts/get`.

--- a/Docs/superpowers/specs/2026-06-22-mcp-prompt-catalog-support-design.md
+++ b/Docs/superpowers/specs/2026-06-22-mcp-prompt-catalog-support-design.md
@@ -129,6 +129,8 @@ Protocol prompt names are routed by stable namespace prefix:
 
 `PromptsModule` owns these namespaces. Other future static prompt modules can still use the existing static registry path.
 
+For `prompts/get`, the protocol handler must dispatch `library:` and `config:` names directly to `PromptsModule` before consulting the global prompt registry. The global prompt registry is only appropriate for static, context-free prompt providers.
+
 ### Listing Prompts
 
 `prompts/list` supports cursor pagination.
@@ -145,12 +147,15 @@ The cursor is opaque to clients. Use base64url JSON with this internal shape:
 ```json
 {
   "v": 1,
-  "library_offset": 50,
-  "config_offset": 0
+  "library_after_name": "casefolded last prompt name",
+  "library_after_uuid": "last-library-prompt-uuid",
+  "config_index": 0
 }
 ```
 
 Malformed, unsupported, or tampered cursors return JSON-RPC invalid params.
+
+Library pagination uses keyset semantics over `(normalized_name, uuid)` rather than raw offsets, so prompt inserts/deletes/renames between pages are best-effort but do not depend on unstable row offsets. Config pagination uses the allowlist index because config ordering is fixed by server config.
 
 Each prompt definition includes:
 
@@ -234,11 +239,13 @@ Legacy library prompts and config prompts use the existing legacy variable extra
 
 Arguments in `prompts/list` are marked required when the source declares them required. Legacy/config extracted placeholders are treated as required in v1 because no default-value contract exists for them.
 
-Unknown extra arguments are ignored unless the structured prompt assembler already rejects them. Missing required arguments return invalid params.
+MCP prompt argument values must be strings in v1. Non-string argument values return invalid params instead of being implicitly coerced. Unknown extra arguments are ignored unless the structured prompt assembler already rejects them. Missing required arguments return invalid params.
 
 ## Permissions And Scope
 
 Any authenticated MCP caller with `prompts.read` may call `prompts/list` and `prompts/get`.
+
+Protocol-level prompt access must not also require `modules.read`. The `library:` and `config:` namespaces exposed by `PromptsModule` are gated by `Resource.PROMPT` read permission, API-key read allowance, and prompt/resource scopes. Existing module-level permission checks can remain for module management APIs and for unrelated static prompt providers, but they must not block `PromptsModule` prompt catalog access when `prompts.read` is granted.
 
 User-library prompts are restricted to the authenticated user's Prompts DB through `RequestContext.db_paths["prompts"]`. The caller must not be able to provide or override DB paths through MCP prompt arguments.
 
@@ -263,23 +270,28 @@ Add the `prompts` module to `tldw_Server_API/Config_Files/mcp_modules.yaml`:
     max_rendered_prompt_chars: 100000
     config_prompts:
       enabled: true
-      entries:
-        - id: rag.retrieval_guidance
-          module: rag
-          key: retrieval_guidance
-          title: Retrieval Guidance
-        - id: chat.summary
-          title: Conversation Summary
-          messages:
-            - role: system
-              module: chat
-              key: summary_system
-            - role: user
-              module: chat
-              key: summary_user
+      entries: []
+      # Example entries; replace entries: [] with entries like these to publish
+      # config prompts through MCP.
+      # entries:
+      #   - id: rag.retrieval_guidance
+      #     module: rag
+      #     key: retrieval_guidance
+      #     title: Retrieval Guidance
+      #   - id: chat.summary
+      #     title: Conversation Summary
+      #     messages:
+      #       - role: system
+      #         module: chat
+      #         key: summary_system
+      #       - role: user
+      #         module: chat
+      #         key: summary_user
 ```
 
 Config entries are explicit. The server must not publish every prompt-loader file or every key in a file by default.
+
+The shipped default configuration should keep `config_prompts.entries` empty. Config prompt publication is opt-in by replacing the empty list with explicit entries.
 
 Single config entries use:
 
@@ -307,7 +319,7 @@ Allowed config roles are `system`, `developer`, `user`, and `assistant`; they ar
 - Permission denied: MCP permission error.
 - Config allowlist entry points to a missing file/key: omit from list; direct get returns invalid params.
 - User Prompts DB unavailable: direct library get returns internal error with sanitized message.
-- User Prompts DB unavailable during list: list may still return allowlisted config prompts and log sanitized metadata.
+- User Prompts DB unavailable during list: return allowlisted config prompts when available, and include a sanitized `_meta.tldw.warnings` entry such as `{"source": "library", "code": "prompt_db_unavailable"}`.
 - Rendered output exceeds `max_rendered_prompt_chars`: invalid params if caused by supplied arguments; otherwise internal error with sanitized message.
 
 Error messages must not include prompt bodies, rendered prompt text, argument values, or override file paths.
@@ -360,17 +372,22 @@ Protocol tests:
 - `initialize` returns `{"prompts": {"listChanged": false}}`
 - `prompts/list`
 - `prompts/get`
+- direct namespace dispatch for `library:` and `config:` before global prompt registry lookup
 - malformed cursor handling
 - cursor resume across library and config sources
+- keyset cursor behavior when prompts are inserted or deleted between pages
 - permission denied
+- `prompts.read` grants prompt access without requiring `modules.read`
 - unknown prompt
 - missing argument mapping
+- non-string argument value mapping
 - output-size error mapping
+- partial list warning metadata when the library source fails but config prompts are returned
 
 Integration tests:
 
 - use `/api/v1/mcp/request` for both protocol-level `prompts/list` and `prompts/get`
-- keep `GET /api/v1/mcp/prompts` list-only in v1
+- keep `GET /api/v1/mcp/prompts` list-only in v1 and add a `cursor` query parameter that maps to protocol-level `prompts/list`
 - cover context DB-path isolation at unit/protocol level
 - check the existing multi-user fixtures during implementation planning; if they support isolated user Prompt DB setup, add an integration test proving user A cannot list or get user B's library prompt
 - if the existing fixtures do not support that setup, record the limitation in the test module and in the Backlog task verification notes
@@ -383,6 +400,7 @@ Security tests:
 ## Rollout And Compatibility
 
 - Add the `prompts` module to `mcp_modules.yaml`.
+- Ship `config_prompts.entries` empty by default so config prompt exposure remains opt-in.
 - Keep tool-level `prompts.search` and `prompts.get` unchanged.
 - Document the distinction between protocol-level `prompts/get` and tool-level `prompts.get`.
 - Add MCP prompt support behind normal module enablement config, not a new global flag.
@@ -406,10 +424,15 @@ User prompt protocol names use UUIDs, so prompt renames do not break MCP clients
 - `initialize` advertises `prompts.listChanged: false`.
 - `prompts/list` returns paginated, permission-filtered prompt definitions from the user prompt library and allowlisted config prompt entries.
 - `prompts/get` renders `library:<uuid>` prompts and `config:<module>.<key-or-group>` prompts with strict argument validation.
+- `library:` and `config:` prompt names route directly to `PromptsModule` before global prompt registry lookup.
+- `prompts.read` is sufficient for protocol-level prompt catalog access and does not require `modules.read`.
 - User prompt-library entries include all readable, non-deleted prompts and exclude deleted prompts.
 - Prompt Studio prompts are not listed or retrievable.
-- Config prompts are excluded unless explicitly allowlisted in the `prompts` module settings.
+- Config prompts are excluded unless explicitly allowlisted in the `prompts` module settings, and the shipped default allowlist is empty.
 - Prompt names are stable and namespace-prefixed.
 - MCP messages use only spec-compliant `user` and `assistant` roles.
+- MCP prompt arguments reject non-string values with invalid params.
+- `GET /api/v1/mcp/prompts` remains list-only but supports cursor pagination.
+- Partial list results include sanitized warning metadata when a source fails.
 - Existing tool-level `prompts.search` and `prompts.get` behavior remains compatible.
 - Prompt bodies, rendered arguments, and override file paths are not exposed in logs or errors.

--- a/Docs/superpowers/specs/2026-06-22-mcp-prompt-catalog-support-design.md
+++ b/Docs/superpowers/specs/2026-06-22-mcp-prompt-catalog-support-design.md
@@ -1,0 +1,415 @@
+# MCP Prompt Catalog Support Design
+
+Date: 2026-06-22
+Status: Draft for spec review
+Backlog: TASK-2342
+Related follow-up: TASK-2341
+MCP reference: https://modelcontextprotocol.io/specification/2025-06-18/server/prompts
+
+## Summary
+
+Expose tldw prompt libraries through MCP protocol-level prompts so MCP clients can discover and invoke prompts with `prompts/list` and `prompts/get`.
+
+The v1 scope is deliberately narrow but useful:
+
+- all readable, non-deleted records from the authenticated user's regular Prompts library
+- explicitly allowlisted config-file prompts from `tldw_Server_API/Config_Files/Prompts`
+- no Prompt Studio prompts
+- no live `notifications/prompts/list_changed` support
+
+The implementation should use a Prompt Catalog Adapter Layer behind the existing `PromptsModule`. It should not build the broader shared prompt registry service in this slice; that larger Approach C follow-up is tracked by TASK-2341.
+
+## Goals
+
+- Make regular user prompt-library records available as MCP prompts.
+- Make selected config-file prompts available as MCP prompts only when explicitly allowlisted by server config.
+- Keep prompt protocol names stable across prompt renames by using prompt UUIDs.
+- Preserve tldw prompt semantics while returning MCP-compliant prompt messages.
+- Keep existing MCP prompt tools, especially tool-level `prompts.search` and `prompts.get`, compatible.
+- Add enough protocol support to handle dynamic per-user prompts safely.
+- Add cursor pagination from the first implementation.
+
+## Non-Goals
+
+- No Prompt Studio prompt exposure in v1.
+- No frontend changes in v1.
+- No per-config-entry RBAC in v1.
+- No live prompt list-change notifications in v1.
+- No broad shared prompt registry service in v1.
+- No arbitrary execution of template logic. Rendering remains strict placeholder substitution through existing prompt-schema and legacy extraction behavior.
+- No new HTTP convenience route for fetching one prompt in v1.
+
+## Current State
+
+MCP Unified already has protocol handlers for:
+
+- `prompts/list`
+- `prompts/get`
+- `GET /api/v1/mcp/prompts` as a list-only HTTP convenience route
+
+The existing `PromptsModule` exposes prompt access as MCP tools:
+
+- tool `prompts.search`
+- tool `prompts.get`
+
+It does not yet expose actual MCP prompt definitions through the module prompt hooks.
+
+The current module registry caches prompt names globally at module initialization through context-free `get_prompts()`. That is not safe for user-library prompts because they are dynamic and per-user. The protocol currently advertises prompts as `{"available": bool(modules)}`, while the MCP prompt spec expects a `prompts` capability with `listChanged`.
+
+The regular Prompts DB already supports:
+
+- legacy prompts with `system_prompt` and `user_prompt`
+- structured prompts with `prompt_definition_json`
+- UUIDs
+- soft deletes
+- search/list/get operations
+
+The structured prompt foundation already assembles structured prompts into role-based messages and legacy snapshots. This should be reused for MCP rendering.
+
+## Approved Approach
+
+Use Approach B: a Prompt Catalog Adapter Layer behind `PromptsModule`.
+
+`PromptsModule` remains the MCP boundary and delegates to focused helpers:
+
+- `UserPromptCatalogSource`: lists and renders prompt records from the authenticated user's regular Prompts DB.
+- `ConfigPromptCatalogSource`: lists and renders config prompts that are explicitly published in the MCP module settings.
+- `MCPPromptFormatter`: converts tldw prompt records, structured prompt definitions, legacy prompt fields, and config prompt entries into MCP prompt definitions and messages.
+
+This keeps the protocol integration focused while avoiding a large mixed-responsibility `PromptsModule`.
+
+## Protocol Changes
+
+### Capability Declaration
+
+During `initialize`, the server should advertise:
+
+```json
+{
+  "prompts": {
+    "listChanged": false
+  }
+}
+```
+
+`listChanged: false` means the server supports fresh `prompts/list` calls but will not emit `notifications/prompts/list_changed` in v1.
+
+### Context-Aware Prompt Hooks
+
+Add backward-compatible context-aware prompt hooks to `BaseModule`:
+
+```python
+async def get_prompts_for_context(
+    self,
+    context: RequestContext,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    return {"prompts": await self.get_prompts()}
+
+async def get_prompt_for_context(
+    self,
+    name: str,
+    arguments: dict[str, Any],
+    context: RequestContext,
+) -> dict[str, Any]:
+    return await self.get_prompt(name, arguments)
+```
+
+Existing static modules can keep overriding `get_prompts()` and `get_prompt()`. `PromptsModule` should override the context-aware hooks.
+
+The protocol handler should use the context-aware hooks when available. Dynamic user-library prompt names must not be inserted into the registry's global `_prompt_registry`, because doing so risks stale names and cross-user leakage.
+
+### Prompt Routing
+
+Protocol prompt names are routed by stable namespace prefix:
+
+- `library:<uuid>`: prompt from the authenticated user's regular Prompts DB
+- `config:<module>.<key>`: single allowlisted config prompt
+- `config:<module>.<group>`: grouped allowlisted config prompt
+
+`PromptsModule` owns these namespaces. Other future static prompt modules can still use the existing static registry path.
+
+### Listing Prompts
+
+`prompts/list` supports cursor pagination.
+
+Ordering is deterministic:
+
+1. user-library prompts sorted by `name COLLATE NOCASE ASC`, then UUID ascending
+2. config prompts in allowlist order
+
+The server uses a module setting `prompt_list_page_size`, default `50`, clamped to `1..100`. MCP clients provide only `cursor`; they do not control page size in v1.
+
+The cursor is opaque to clients. Use base64url JSON with this internal shape:
+
+```json
+{
+  "v": 1,
+  "library_offset": 50,
+  "config_offset": 0
+}
+```
+
+Malformed, unsupported, or tampered cursors return JSON-RPC invalid params.
+
+Each prompt definition includes:
+
+- `name`: stable MCP name, for example `library:2f...` or `config:rag.retrieval_guidance`
+- `title`: user-facing name
+- `description`: short human-readable summary without the full prompt body
+- `arguments`: customization arguments
+- `_meta`: tldw metadata for tldw-aware clients
+
+`_meta.tldw` may include:
+
+- source type: `library` or `config`
+- prompt UUID
+- prompt version
+- tags
+- config module/key/group
+- original role summary
+
+### Getting A Prompt
+
+`prompts/get` resolves by stable prompt name and renders with supplied arguments.
+
+Library prompt rendering:
+
+- Structured prompts use `assemble_prompt_definition`.
+- Legacy prompts use existing legacy placeholder extraction and rendering behavior, either by temporary conversion into a structured definition or by an equivalent shared renderer.
+- Missing required variables return JSON-RPC invalid params with sanitized variable metadata.
+
+Config prompt rendering:
+
+- Single entries load one template through prompt-loader-compatible resolution.
+- Grouped entries load multiple templates as role-labeled parts.
+- Environment file overrides supported by `load_prompt()` are respected.
+- Override file paths are never returned or logged.
+
+Rendered output uses MCP text content only in v1.
+
+### Role Mapping
+
+MCP prompt messages are spec-compliant:
+
+- tldw `system` and `developer` content folds into labeled `user` text
+- tldw `user` content remains `user` text
+- tldw `assistant` blocks remain `assistant` messages
+- legacy `system_prompt + user_prompt` becomes one labeled `user` message
+- grouped config entries with system/user parts follow the same folding rule
+
+Example:
+
+```json
+{
+  "description": "Summary prompt from user library",
+  "messages": [
+    {
+      "role": "user",
+      "content": {
+        "type": "text",
+        "text": "System instructions:\nYou are concise.\n\nUser prompt:\nSummarize: ..."
+      }
+    }
+  ],
+  "_meta": {
+    "tldw": {
+      "source": "library",
+      "prompt_uuid": "..."
+    }
+  }
+}
+```
+
+## Prompt Arguments
+
+Structured library prompts use declared `variables`.
+
+Legacy library prompts and config prompts use the existing legacy variable extraction style, including placeholders such as:
+
+- `{{topic}}`
+- `{context}`
+- `$query`
+- `<input>`
+
+Arguments in `prompts/list` are marked required when the source declares them required. Legacy/config extracted placeholders are treated as required in v1 because no default-value contract exists for them.
+
+Unknown extra arguments are ignored unless the structured prompt assembler already rejects them. Missing required arguments return invalid params.
+
+## Permissions And Scope
+
+Any authenticated MCP caller with `prompts.read` may call `prompts/list` and `prompts/get`.
+
+User-library prompts are restricted to the authenticated user's Prompts DB through `RequestContext.db_paths["prompts"]`. The caller must not be able to provide or override DB paths through MCP prompt arguments.
+
+Existing persona/path-scope checks still apply to user-library prompts. When context scopes contain prompt IDs, list and get behavior filters by those IDs after UUID lookup. Config prompts are visible to any authenticated MCP caller with `prompts.read` once allowlisted by server config.
+
+Prompt Studio prompts are not a source in v1.
+
+## Configuration
+
+Add the `prompts` module to `tldw_Server_API/Config_Files/mcp_modules.yaml`:
+
+```yaml
+- id: prompts
+  class: tldw_Server_API.app.core.MCP_unified.modules.implementations.prompts_module:PromptsModule
+  enabled: true
+  name: Prompts
+  version: "1.0.0"
+  department: knowledge
+  max_concurrent: 10
+  settings:
+    prompt_list_page_size: 50
+    max_rendered_prompt_chars: 100000
+    config_prompts:
+      enabled: true
+      entries:
+        - id: rag.retrieval_guidance
+          module: rag
+          key: retrieval_guidance
+          title: Retrieval Guidance
+        - id: chat.summary
+          title: Conversation Summary
+          messages:
+            - role: system
+              module: chat
+              key: summary_system
+            - role: user
+              module: chat
+              key: summary_user
+```
+
+Config entries are explicit. The server must not publish every prompt-loader file or every key in a file by default.
+
+Single config entries use:
+
+- `id`
+- `module`
+- `key`
+- optional `title`
+- optional `description`
+
+Grouped config entries use:
+
+- `id`
+- `title`
+- optional `description`
+- `messages`, each with `role`, `module`, and `key`
+
+Allowed config roles are `system`, `developer`, `user`, and `assistant`; they are mapped to MCP-safe roles during rendering.
+
+## Error Handling
+
+- Missing or invalid `name`: invalid params.
+- Unknown prompt: invalid params.
+- Malformed cursor: invalid params.
+- Missing required argument: invalid params.
+- Permission denied: MCP permission error.
+- Config allowlist entry points to a missing file/key: omit from list; direct get returns invalid params.
+- User Prompts DB unavailable: direct library get returns internal error with sanitized message.
+- User Prompts DB unavailable during list: list may still return allowlisted config prompts and log sanitized metadata.
+- Rendered output exceeds `max_rendered_prompt_chars`: invalid params if caused by supplied arguments; otherwise internal error with sanitized message.
+
+Error messages must not include prompt bodies, rendered prompt text, argument values, or override file paths.
+
+## Security Guardrails
+
+- Validate prompt name prefixes and UUID format before DB access.
+- Never log prompt bodies or rendered arguments.
+- Never expose prompt override file paths.
+- Strip/ignore user-provided fields that could override ownership or DB paths.
+- Cap list page size and rendered output size.
+- Treat config prompt publication as an admin/server configuration decision.
+- Do not fail open if prompt DB access, scope filtering, or config prompt resolution errors occur.
+
+## Testing
+
+Unit tests for `MCPPromptFormatter`:
+
+- stable names
+- variable extraction
+- role folding
+- assistant message preservation
+- metadata
+- missing-variable errors
+- rendered output size limits
+
+Unit tests for `UserPromptCatalogSource`:
+
+- non-deleted filtering
+- UUID-based names
+- mixed pagination state
+- structured assembly
+- legacy rendering
+- prompt ID scope filtering
+- DB unavailable behavior
+
+Unit tests for `ConfigPromptCatalogSource`:
+
+- explicit allowlist only
+- single entries
+- grouped entries
+- missing key omission
+- environment override behavior
+- argument extraction across grouped templates
+- allowlist ordering
+- mixed pagination with user-library results
+
+Protocol tests:
+
+- `initialize` returns `{"prompts": {"listChanged": false}}`
+- `prompts/list`
+- `prompts/get`
+- malformed cursor handling
+- cursor resume across library and config sources
+- permission denied
+- unknown prompt
+- missing argument mapping
+- output-size error mapping
+
+Integration tests:
+
+- use `/api/v1/mcp/request` for both protocol-level `prompts/list` and `prompts/get`
+- keep `GET /api/v1/mcp/prompts` list-only in v1
+- cover context DB-path isolation at unit/protocol level
+- check the existing multi-user fixtures during implementation planning; if they support isolated user Prompt DB setup, add an integration test proving user A cannot list or get user B's library prompt
+- if the existing fixtures do not support that setup, record the limitation in the test module and in the Backlog task verification notes
+
+Security tests:
+
+- targeted tests for catalog-source and formatter error paths to ensure prompt bodies, rendered arguments, and override file paths are not logged
+- avoid brittle global assertions over all logs
+
+## Rollout And Compatibility
+
+- Add the `prompts` module to `mcp_modules.yaml`.
+- Keep tool-level `prompts.search` and `prompts.get` unchanged.
+- Document the distinction between protocol-level `prompts/get` and tool-level `prompts.get`.
+- Add MCP prompt support behind normal module enablement config, not a new global flag.
+- No prompt list-change notifications in v1.
+- No frontend work in v1.
+- Add focused docs at `Docs/MCP/mcp_prompts.md`.
+- Link the new docs from `Docs/MCP/mcp_tool_catalogs.md`.
+
+Existing `tools/list` and `tools/call` clients should see no behavior change.
+
+Existing `GET /api/v1/mcp/prompts` starts returning real prompt definitions once the module is enabled and permissions allow it.
+
+Protocol-level `prompts/get` uses `/api/v1/mcp/request` in v1.
+
+Static context-free prompt modules, if added later, can keep using existing `get_prompts()` and `get_prompt()` methods.
+
+User prompt protocol names use UUIDs, so prompt renames do not break MCP clients.
+
+## Acceptance Criteria
+
+- `initialize` advertises `prompts.listChanged: false`.
+- `prompts/list` returns paginated, permission-filtered prompt definitions from the user prompt library and allowlisted config prompt entries.
+- `prompts/get` renders `library:<uuid>` prompts and `config:<module>.<key-or-group>` prompts with strict argument validation.
+- User prompt-library entries include all readable, non-deleted prompts and exclude deleted prompts.
+- Prompt Studio prompts are not listed or retrievable.
+- Config prompts are excluded unless explicitly allowlisted in the `prompts` module settings.
+- Prompt names are stable and namespace-prefixed.
+- MCP messages use only spec-compliant `user` and `assistant` roles.
+- Existing tool-level `prompts.search` and `prompts.get` behavior remains compatible.
+- Prompt bodies, rendered arguments, and override file paths are not exposed in logs or errors.

--- a/Docs/superpowers/specs/2026-06-22-mcp-prompt-catalog-support-design.md
+++ b/Docs/superpowers/specs/2026-06-22-mcp-prompt-catalog-support-design.md
@@ -1,7 +1,7 @@
 # MCP Prompt Catalog Support Design
 
 Date: 2026-06-22
-Status: Draft for spec review
+Status: Implemented in TASK-2344
 Backlog: TASK-2342
 Related follow-up: TASK-2341
 MCP reference: https://modelcontextprotocol.io/specification/2025-06-18/server/prompts
@@ -147,15 +147,18 @@ The cursor is opaque to clients. Use base64url JSON with this internal shape:
 ```json
 {
   "v": 1,
-  "library_after_name": "casefolded last prompt name",
+  "library_after_name": "last prompt name",
   "library_after_uuid": "last-library-prompt-uuid",
+  "library_done": false,
   "config_index": 0
 }
 ```
 
-Malformed, unsupported, or tampered cursors return JSON-RPC invalid params.
+Malformed, unsupported, or tampered cursors return JSON-RPC invalid params. `library_after_name` and `library_after_uuid` must be both present or both absent; partial keyset cursors are invalid. `library_done: true` means the cursor has moved into the config-prompt segment and the next list call must skip user-library rows. Cursors with `library_done: true` must not also contain library keyset fields. A nonzero `config_index` is valid only when `library_done: true`.
 
-Library pagination uses keyset semantics over `(normalized_name, uuid)` rather than raw offsets, so prompt inserts/deletes/renames between pages are best-effort but do not depend on unstable row offsets. Config pagination uses the allowlist index because config ordering is fixed by server config.
+Library pagination uses keyset semantics over `(name COLLATE NOCASE, uuid)` rather than raw offsets, so prompt inserts/deletes/renames between pages are best-effort but do not depend on unstable row offsets. Config pagination uses the allowlist index because config ordering is fixed by server config.
+
+When the user-library page exactly fills `prompt_list_page_size` but the library source has no additional rows, the server must still emit a cursor into the config segment when allowlisted config entries remain. Otherwise config prompts can be hidden forever behind an exactly full library page.
 
 Each prompt definition includes:
 
@@ -246,6 +249,8 @@ MCP prompt argument values must be strings in v1. Non-string argument values ret
 Any authenticated MCP caller with `prompts.read` may call `prompts/list` and `prompts/get`.
 
 Protocol-level prompt access must not also require `modules.read`. The `library:` and `config:` namespaces exposed by `PromptsModule` are gated by `Resource.PROMPT` read permission, API-key read allowance, and prompt/resource scopes. Existing module-level permission checks can remain for module management APIs and for unrelated static prompt providers, but they must not block `PromptsModule` prompt catalog access when `prompts.read` is granted.
+
+The protocol layer should use a dedicated namespaced prompt permission path for `library:` and `config:` names. That path must require `Resource.PROMPT` read and must not fall back to module permission. The legacy `_has_prompt_permission()` module fallback can remain only for static context-free prompt providers.
 
 User-library prompts are restricted to the authenticated user's Prompts DB through `RequestContext.db_paths["prompts"]`. The caller must not be able to provide or override DB paths through MCP prompt arguments.
 

--- a/backlog/tasks/task-2341 - Design-shared-prompt-registry-service-beyond-MCP-prompts.md
+++ b/backlog/tasks/task-2341 - Design-shared-prompt-registry-service-beyond-MCP-prompts.md
@@ -1,0 +1,46 @@
+---
+id: TASK-2341
+title: Design shared prompt registry service beyond MCP prompts
+status: To Do
+labels:
+- mcp
+- prompts
+- design
+- future-work
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Future follow-up for the broader Approach C considered during MCP prompt support brainstorming. Define a shared prompt registry service that can eventually unify MCP prompt exposure, WebUI prompt selection, prompt-loader config templates, user prompt libraries, and other prompt-like sources while excluding Prompt Studio unless explicitly re-scoped. This is intentionally out of scope for the initial MCP prompt support slice, which will use a narrower Prompt Catalog Adapter Layer behind PromptsModule.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Inventory prompt-like sources across user prompt libraries, config prompt files, prompt-loader consumers, character/chat prompt surfaces, and internal templates.
+- [ ] #2 Define source ownership, publishing policy, RBAC boundaries, metadata schema, stable identifiers, and compatibility rules for legacy and structured prompts.
+- [ ] #3 Specify migration path from MCP-local prompt catalog adapters to a shared registry without breaking existing MCP prompts/list and prompts/get behavior.
+- [ ] #4 Explicitly decide whether Prompt Studio remains excluded or becomes an optional registry source in a later phase.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2342 - Design-MCP-prompt-catalog-support-for-user-and-allowlisted-config-prompts.md
+++ b/backlog/tasks/task-2342 - Design-MCP-prompt-catalog-support-for-user-and-allowlisted-config-prompts.md
@@ -1,0 +1,57 @@
+---
+id: TASK-2342
+title: Design MCP prompt catalog support for user and allowlisted config prompts
+status: In Progress
+labels:
+- mcp
+- prompts
+- design
+references:
+- TASK-2341
+documentation:
+- Docs/superpowers/specs/2026-06-22-mcp-prompt-catalog-support-design.md
+modified_files:
+- Docs/superpowers/specs/2026-06-22-mcp-prompt-catalog-support-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design the v1 MCP prompt support slice that exposes all readable non-deleted user prompt-library records and explicitly allowlisted config-file prompts through MCP protocol-level prompts/list and prompts/get, excluding Prompt Studio. The approved approach uses a Prompt Catalog Adapter Layer behind PromptsModule rather than a broad shared prompt registry service.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Capture the approved architecture, protocol/data shape, permissions/config/error handling, and testing/rollout design in a spec document.
+- [ ] #2 Specify that user prompt-library entries use stable library:<uuid> MCP names and config entries use config:<module>.<key-or-group> names.
+- [ ] #3 Specify listChanged:false, cursor pagination, context-aware prompt hooks, and no live list_changed notifications in v1.
+- [ ] #4 Document that Prompt Studio prompts are excluded and the broader shared prompt registry service is tracked separately by TASK-2341.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Design spec written and self-reviewed. Scope covers Approach B: Prompt Catalog Adapter Layer behind PromptsModule. Approach C broad registry follow-up is tracked separately by TASK-2341.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Spec drafted for user review at Docs/superpowers/specs/2026-06-22-mcp-prompt-catalog-support-design.md. Verification performed: placeholder/ambiguity scan found no remaining TBD/TODO/FIXME/loose review terms after cleanup. Bandit not applicable because this change is documentation/task tracking only.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2342 - Design-MCP-prompt-catalog-support-for-user-and-allowlisted-config-prompts.md
+++ b/backlog/tasks/task-2342 - Design-MCP-prompt-catalog-support-for-user-and-allowlisted-config-prompts.md
@@ -31,7 +31,7 @@ Design the v1 MCP prompt support slice that exposes all readable non-deleted use
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-Design spec written and self-reviewed. Scope covers Approach B: Prompt Catalog Adapter Layer behind PromptsModule. Approach C broad registry follow-up is tracked separately by TASK-2341.
+Design spec written, reviewed, and revised after spec review findings. Scope covers Approach B: Prompt Catalog Adapter Layer behind PromptsModule. Approach C broad registry follow-up is tracked separately by TASK-2341.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -43,7 +43,7 @@ Design spec written and self-reviewed. Scope covers Approach B: Prompt Catalog A
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Spec drafted for user review at Docs/superpowers/specs/2026-06-22-mcp-prompt-catalog-support-design.md. Verification performed: placeholder/ambiguity scan found no remaining TBD/TODO/FIXME/loose review terms after cleanup. Bandit not applicable because this change is documentation/task tracking only.
+Spec drafted and revised for user review at Docs/superpowers/specs/2026-06-22-mcp-prompt-catalog-support-design.md. Review fixes addressed: prompts.read without modules.read, direct namespace dispatch before global registry lookup, empty default config prompt allowlist, keyset cursor semantics, string-only MCP arguments, cursor support on the list-only HTTP convenience route, and sanitized partial-list warnings. Verification performed: placeholder/ambiguity scan found no remaining TBD/TODO/FIXME/loose review terms after cleanup; git diff --check passed. Bandit not applicable because this change is documentation/task tracking only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2343 - Plan-MCP-prompt-catalog-implementation.md
+++ b/backlog/tasks/task-2343 - Plan-MCP-prompt-catalog-implementation.md
@@ -1,0 +1,60 @@
+---
+id: TASK-2343
+title: Plan MCP prompt catalog implementation
+status: Done
+labels:
+- mcp
+- prompts
+- plan
+references:
+- TASK-2342
+- TASK-2341
+documentation:
+- Docs/superpowers/specs/2026-06-22-mcp-prompt-catalog-support-design.md
+modified_files:
+- Docs/superpowers/specs/2026-06-22-mcp-prompt-catalog-support-design.md
+- Docs/superpowers/plans/2026-06-22-mcp-prompt-catalog-implementation-plan.md
+- backlog/tasks/task-2343 - Plan-MCP-prompt-catalog-implementation.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write the detailed implementation plan for MCP protocol-level prompt catalog support. The plan must implement the approved TASK-2342 design: user-library prompts plus explicitly allowlisted config prompts through prompts/list and prompts/get, excluding Prompt Studio, with listChanged:false, context-aware prompt hooks, keyset pagination, stable namespace names, and compatibility for existing prompt tools.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Create a detailed task-by-task implementation plan under Docs/superpowers/plans/.
+- [x] #2 Plan covers tests first, protocol changes, catalog source helpers, formatter behavior, config/module activation, docs, and verification commands.
+- [x] #3 Plan calls out Bandit, targeted pytest commands, and compatibility expectations.
+- [x] #4 Plan preserves the approved exclusion of Prompt Studio and links the broader registry service to TASK-2341.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-22-mcp-prompt-catalog-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Created and completed `Docs/superpowers/plans/2026-06-22-mcp-prompt-catalog-implementation-plan.md`. The plan was kept with the implementation package because TASK-2344 references it and it records the TDD, verification, docs, and review checklist used for the MCP prompt catalog implementation.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed all plan/design review findings before implementation. Updated the spec and implementation plan for the actual MCPProtocol test scaffold, real PromptsDatabase.add_prompt tuple API, a coherent cursor state machine with library_done, exact-boundary pagination into config prompts, partial cursor rejection, namespaced prompt permission checks without modules.read fallback, COLLATE NOCASE keyset ordering, default test-tree HTTP coverage, branch-base diff verification, explicit Prompt Studio exclusion coverage, list-time DB fallback behavior, and disabled config direct-get behavior. Verification was documentation/plan review plus targeted rg scans; no executable code changed, so pytest and Bandit are deferred to the implementation plan.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2344 - Implement-MCP-prompt-catalog-support.md
+++ b/backlog/tasks/task-2344 - Implement-MCP-prompt-catalog-support.md
@@ -1,0 +1,105 @@
+---
+id: TASK-2344
+title: Implement MCP prompt catalog support
+status: Done
+labels:
+- mcp
+- prompts
+- implementation
+references:
+- TASK-2342
+- TASK-2343
+- TASK-2341
+documentation:
+- Docs/superpowers/specs/2026-06-22-mcp-prompt-catalog-support-design.md
+- Docs/superpowers/plans/2026-06-22-mcp-prompt-catalog-implementation-plan.md
+modified_files:
+- tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_catalog.py
+- tldw_Server_API/app/core/MCP_unified/modules/base.py
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_module.py
+- tldw_Server_API/app/core/MCP_unified/protocol.py
+- tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
+- tldw_Server_API/Config_Files/mcp_modules.yaml
+- tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py
+- tldw_Server_API/tests/MCP_unified/test_mcp_prompts_http.py
+- Docs/MCP/mcp_prompts.md
+- Docs/MCP/mcp_tool_catalogs.md
+- Docs/MCP/README.md
+- Docs/superpowers/plans/2026-06-22-mcp-prompt-catalog-implementation-plan.md
+- tldw_Server_API/app/core/AuthNZ/rbac_seed.py
+- tldw_Server_API/app/core/AuthNZ/migrations.py
+- tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
+- tldw_Server_API/app/core/AuthNZ/initialize.py
+- tldw_Server_API/app/core/MCP_unified/server.py
+- tldw_Server_API/tests/AuthNZ/unit/test_rbac_seed_helper.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement MCP protocol-level prompt catalog support for regular user Prompt Library prompts and explicitly allowlisted config prompts. Follow the reviewed implementation plan: tests first, context-aware prompt hooks, namespaced prompt routing, cursor pagination, prompts.read permission behavior, HTTP cursor support, docs, focused pytest, and Bandit. Prompt Studio remains out of scope; broader shared prompt registry remains tracked by TASK-2341.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 MCP initialize advertises prompts capability with `listChanged: false`.
+- [x] #2 `prompts/list` returns fresh readable, non-deleted Prompt Library prompts and explicitly allowlisted config prompts, excluding Prompt Studio prompts.
+- [x] #3 `prompts/get` renders namespaced `library:` and `config:` prompts with sanitized errors and argument validation.
+- [x] #4 Namespaced prompt access uses `prompts.read` and does not require `modules.read`.
+- [x] #5 Config prompt allowlist defaults empty in `tldw_Server_API/Config_Files/mcp_modules.yaml`.
+- [x] #6 Docs and focused verification cover protocol, HTTP cursor forwarding, AuthNZ seeding, and warning sanitization.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-22-mcp-prompt-catalog-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented MCP prompt discovery/rendering through the existing Prompts MCP module rather than a new shared registry. Regular Prompt Library prompts are exposed as `library:<uuid>` after user/readability and soft-delete filtering; Prompt Studio prompts remain excluded. Explicit config prompt entries are exposed as `config:<id>` only when allowlisted under the prompts MCP module config.
+
+Final review fixes:
+- Provisioned `prompts.read` as a baseline MCP read permission in RBAC seed helpers, SQLite migration/backfill paths, Postgres ensure/bootstrap paths, and MCP startup backstop.
+- Added regression coverage that `prompts/list` works with `prompts.read` but without `modules.read`.
+- Filtered and sanitized prompt-list warning metadata so scoped callers cannot see denied prompt identifiers.
+
+Final privacy review fixes:
+- Suppressed identifier-bearing Prompt Library cursors from `prompts/list` responses when restrictive MCP scopes are active, preventing scoped callers from decoding denied prompt names or UUIDs.
+- Stripped known prompt identifier warning keys (`_prompt_name`, `prompt_name`, `prompt_uuid`, `prompt_id`, and `id`) unconditionally after warning visibility resolution, including explicit-name and mismatched-source warnings.
+
+Verification recorded:
+- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py::test_default_mcp_modules_config_declares_prompts_module_with_empty_config_allowlist -v` -> 55 passed.
+- `python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_prompts_http.py tldw_Server_API/tests/AuthNZ/unit/test_rbac_seed_helper.py -v` -> 6 passed.
+- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py tldw_Server_API/app/core/MCP_unified/tests/test_registry_iteration_race.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py -v` -> 34 passed.
+- `python -m py_compile` on touched production Python files -> exit 0.
+- `python -m bandit -r <touched production Python files> -f json -o /tmp/bandit_mcp_prompt_catalog_final.json` -> exit 0, `results: []`, `errors: []`.
+- Docs grep, ASCII check, and focused `git diff --check` passed.
+- Red test run: `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py::test_prompts_list_does_not_return_denied_identifier_cursor_for_scoped_callers tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py::test_visible_prompt_warning_strips_identifier_fields_after_explicit_name_resolution -v` -> 2 failed as expected.
+- Green regression run: same focused command -> 2 passed.
+- Green focused suite: `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py -v` -> 54 passed.
+- Final broader MCP prompt/config suite rerun after privacy fixes -> 55 passed.
+- `python -m py_compile tldw_Server_API/app/core/MCP_unified/protocol.py` -> exit 0.
+- `python -m bandit -r tldw_Server_API/app/core/MCP_unified/protocol.py -f json -o /tmp/bandit_mcp_prompt_catalog_privacy.json` -> exit 0, `results: 0`, `errors: []`.
+- `git diff --check -- tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py` -> exit 0.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented MCP prompt catalog support for readable, non-deleted user Prompt Library prompts and explicitly allowlisted config prompts. The MCP initialize response advertises prompts with listChanged false, prompts/list is fresh on each call, and prompts/get renders namespaced library:/config: prompts through the Prompts MCP module. Config prompts default to an empty allowlist in tldw_Server_API/Config_Files/mcp_modules.yaml. AuthNZ now provisions prompts.read across SQLite, Postgres, baseline seeding, initialization, and MCP startup; namespaced prompt access does not require modules.read. Final review fixes filtered/sanitized prompt-list warning metadata and suppress identifier-bearing Prompt Library cursors for restrictive scoped callers so denied prompt names/UUIDs are not returned. Verification: prompt catalog/protocol/config pytest 55 passed; MCP HTTP/AuthNZ pytest 6 passed; broader MCP regression pytest 34 passed; py_compile exited 0; Bandit JSON at /tmp/bandit_mcp_prompt_catalog_continue.json has results: [] and errors: []; docs grep, ASCII check, and git diff --check passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/Config_Files/mcp_modules.yaml
+++ b/tldw_Server_API/Config_Files/mcp_modules.yaml
@@ -64,6 +64,40 @@ modules:
     max_concurrent: 10
     settings: {}
 
+  - id: prompts
+    class: tldw_Server_API.app.core.MCP_unified.modules.implementations.prompts_module:PromptsModule
+    enabled: true
+    name: Prompts
+    version: "1.0.0"
+    department: knowledge
+    max_concurrent: 10
+    settings:
+      prompt_list_page_size: 50
+      max_rendered_prompt_chars: 100000
+      config_prompts:
+        enabled: true
+        entries: []
+        # Example entries; replace entries: [] with explicit entries like these
+        # to publish config prompts through MCP.
+        # entries:
+        #   - id: rag.retrieval_guidance
+        #     module: rag
+        #     key: retrieval_guidance
+        #     title: Retrieval Guidance
+        #   - id: chat.summary
+        #     title: Conversation Summary
+        #     messages:
+        #       - role: system
+        #         module: chat
+        #         key: summary_system
+        #       - role: user
+        #         module: chat
+        #         key: summary_user
+        #   - id: mcp.search_knowledge
+        #     module: mcp
+        #     key: search_knowledge
+        #     title: Search Knowledge
+
   - id: persona_visuals
     class: tldw_Server_API.app.core.MCP_unified.modules.implementations.persona_visuals_module:PersonaVisualsModule
     enabled: false

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
@@ -1476,6 +1476,7 @@ async def list_resources(
 @router.get("/prompts")
 async def list_prompts(
     http_request: Request,
+    cursor: str | None = Query(None, description="Opaque MCP prompt list cursor"),
     auth: McpAuthContext = Depends(get_mcp_auth_context),
     _guard: None = Depends(enforce_http_security),
 ):
@@ -1484,7 +1485,8 @@ async def list_prompts(
 
     Prompts are filtered based on user permissions if authenticated.
     """
-    request = MCPRequest(method="prompts/list", id="http-prompts-list")
+    params = {"cursor": cursor} if cursor is not None else None
+    request = MCPRequest(method="prompts/list", params=params, id="http-prompts-list")
 
     server = get_mcp_server()
     if not server.initialized:

--- a/tldw_Server_API/app/core/AuthNZ/initialize.py
+++ b/tldw_Server_API/app/core/AuthNZ/initialize.py
@@ -493,7 +493,7 @@ async def setup_database():
             async with pool.transaction() as conn:
                 await ensure_baseline_rbac_seed(
                     conn,
-                    include_mcp_permissions=False,
+                    include_mcp_permissions=True,
                     is_postgres=True,
                 )
 

--- a/tldw_Server_API/app/core/AuthNZ/migrations.py
+++ b/tldw_Server_API/app/core/AuthNZ/migrations.py
@@ -1012,6 +1012,39 @@ def migration_087_expand_share_tokens_resource_type_for_prototypes(conn: sqlite3
     )
 
 
+def migration_089_seed_mcp_prompts_read_permission(conn: sqlite3.Connection) -> None:
+    """Seed prompts.read and default role grants for existing SQLite AuthNZ DBs."""
+    logger.info("Migration 089: START seed MCP prompts.read permission")
+
+    if not (
+        _sqlite_table_exists(conn, "roles")
+        and _sqlite_table_exists(conn, "permissions")
+        and _sqlite_table_exists(conn, "role_permissions")
+    ):
+        logger.info("Migration 089: RBAC tables missing; skipping prompts.read seed")
+        return
+
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO permissions (name, description, category)
+        VALUES (?, ?, ?)
+        """,
+        ("prompts.read", "Read MCP prompts", "prompts"),
+    )
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO role_permissions (role_id, permission_id)
+        SELECT r.id, p.id
+        FROM roles r
+        JOIN permissions p ON p.name = ?
+        WHERE r.name IN (?, ?, ?)
+        """,
+        ("prompts.read", "admin", "user", "moderator"),
+    )
+    conn.commit()
+    logger.info("Migration 089: Seeded MCP prompts.read permission")
+
+
 def rollback_086_drop_prototype_workspace_tables(conn: sqlite3.Connection) -> None:
     """Rollback migration 086 by dropping prototype workspace metadata tables."""
     conn.execute("DROP TABLE IF EXISTS prototype_promotion_requests")
@@ -1267,7 +1300,9 @@ def migration_014_seed_roles_permissions(conn: sqlite3.Connection) -> None:
         ('moderation.review.read','Read moderation review items','moderation'),
         ('moderation.review.decide','Decide moderation review items','moderation'),
         ('moderation.review.bulk_decide','Bulk decide moderation review items','moderation'),
-        ('moderation.audit.read','Read moderation review audit events','moderation')
+        ('moderation.audit.read','Read moderation review audit events','moderation'),
+        # MCP prompt catalog
+        ('prompts.read','Read MCP prompts','prompts'),
     ]
     for name, description, category in perms:
         conn.execute(
@@ -1300,7 +1335,7 @@ def migration_014_seed_roles_permissions(conn: sqlite3.Connection) -> None:
     # Baseline user permissions
     baseline = [
         'media.create','media.read','media.update','media.transcribe',
-        'users.read'
+        'users.read','prompts.read'
     ]
     for code in baseline:
         pid = _id('permissions', code)
@@ -5270,6 +5305,11 @@ def get_authnz_migrations() -> list[Migration]:
             88,
             "Add llm_usage_log cache accounting columns",
             migration_088_add_llm_usage_cache_accounting_columns,
+        ),
+        Migration(
+            89,
+            "Seed MCP prompts.read permission",
+            migration_089_seed_mcp_prompts_read_permission,
         ),
     ]
 

--- a/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
+++ b/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
@@ -2572,6 +2572,58 @@ async def ensure_privilege_snapshots_table_pg(pool: DatabasePool | None = None) 
         return False
 
 
+async def ensure_mcp_prompt_read_permission_pg(pool: DatabasePool | None = None) -> bool:
+    """Ensure prompts.read and default admin/user grants exist on PostgreSQL."""
+    try:
+        db_pool = pool or await get_db_pool()
+        if getattr(db_pool, "pool", None) is None:
+            return False
+
+        async with db_pool.transaction() as conn:
+            existing_tables = await conn.fetch(
+                """
+                SELECT table_name
+                FROM information_schema.tables
+                WHERE table_schema = current_schema()
+                  AND table_name = ANY($1::text[])
+                """,
+                ["roles", "permissions", "role_permissions"],
+            )
+            table_names = {str(row["table_name"]) for row in existing_tables}
+            if {"roles", "permissions", "role_permissions"} - table_names:
+                logger.debug("PG MCP prompts.read seed skipped; RBAC core tables are incomplete")
+                return False
+
+            await conn.execute(
+                """
+                INSERT INTO permissions (name, description, category)
+                VALUES ($1, $2, $3)
+                ON CONFLICT (name) DO NOTHING
+                """,
+                "prompts.read",
+                "Read MCP prompts",
+                "prompts",
+            )
+            await conn.execute(
+                """
+                INSERT INTO role_permissions (role_id, permission_id)
+                SELECT r.id, p.id
+                FROM roles r
+                JOIN permissions p ON p.name = $1
+                WHERE r.name = ANY($2::text[])
+                ON CONFLICT (role_id, permission_id) DO NOTHING
+                """,
+                "prompts.read",
+                ["admin", "user"],
+            )
+
+        logger.info("Ensured PostgreSQL MCP prompts.read permission and default grants")
+        return True
+    except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
+        logger.warning(f"Failed to ensure PostgreSQL MCP prompts.read permission: {exc}")
+        return False
+
+
 async def ensure_authnz_core_tables_pg(pool: DatabasePool | None = None) -> bool:
     """Ensure core AuthNZ tables exist for PostgreSQL backends.
 
@@ -2589,6 +2641,7 @@ async def ensure_authnz_core_tables_pg(pool: DatabasePool | None = None) -> bool
                 await db_pool.execute(sql, *params)
             except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
                 logger.debug(f"PG ensure authnz core tables DDL failed: {exc}")
+        await ensure_mcp_prompt_read_permission_pg(db_pool)
         logger.info(
             "Ensured PostgreSQL AuthNZ core tables "
             "(audit_logs, sessions, registration_codes, RBAC, orgs/teams)"

--- a/tldw_Server_API/app/core/AuthNZ/rbac_seed.py
+++ b/tldw_Server_API/app/core/AuthNZ/rbac_seed.py
@@ -44,6 +44,7 @@ _BASELINE_PERMISSIONS: Sequence[PermissionDef] = (
 
 _MCP_PERMISSIONS: Sequence[PermissionDef] = (
     ("modules.read", "Read MCP modules", "modules"),
+    ("prompts.read", "Read MCP prompts", "prompts"),
     ("tools.execute:*", "Execute any MCP tool", "tools"),
 )
 
@@ -74,9 +75,10 @@ def _build_role_grants(permission_names: Iterable[str], *, include_mcp_permissio
     }
 
     if include_mcp_permissions:
-        if "modules.read" in base and "modules.read" not in grants["user"]:
-            grants["user"].append("modules.read")
-        for p in ("modules.read", "tools.execute:*"):
+        for p in ("modules.read", "prompts.read"):
+            if p in base and p not in grants["user"]:
+                grants["user"].append(p)
+        for p in ("modules.read", "prompts.read", "tools.execute:*"):
             if p in base and p not in grants["admin"]:
                 grants["admin"].append(p)
     return grants

--- a/tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/adapters/tldw_runtime.py
@@ -342,19 +342,18 @@ class TldwPermissionSeeder:
     """Seed MCP compatibility permissions through the current AuthNZ database."""
 
     async def seed_default_tool_permissions(self) -> None:
-        """Ensure the legacy wildcard tool execution permission exists."""
+        """Ensure MCP startup permissions and default role grants exist."""
         from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
-        from tldw_Server_API.app.services.admin_roles_permissions_service import (
-            ensure_permission,
+        from tldw_Server_API.app.core.AuthNZ.rbac_seed import (
+            ensure_baseline_rbac_seed,
         )
 
         pool = await get_db_pool()
         async with pool.acquire() as conn:
-            await ensure_permission(
+            await ensure_baseline_rbac_seed(
                 conn,
-                "tools.execute:*",
-                "Wildcard tool execution",
-                category="tools",
+                include_mcp_permissions=True,
+                is_postgres=callable(getattr(conn, "fetch", None)),
             )
 
 

--- a/tldw_Server_API/app/core/MCP_unified/modules/base.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/base.py
@@ -590,6 +590,24 @@ class BaseModule(ABC):
         """Get a prompt with arguments"""
         raise NotImplementedError(f"Prompt not implemented for {self.name}")
 
+    async def get_prompts_for_context(self, context: Optional[Any], params: dict[str, Any]) -> dict[str, Any]:
+        """Get prompts for a request context.
+
+        Dynamic modules can override this to honor per-user databases,
+        permissions, scopes, and pagination. Static modules inherit the
+        existing context-free prompt list behavior.
+        """
+        return {"prompts": await self.get_prompts()}
+
+    async def get_prompt_for_context(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: Optional[Any],
+    ) -> dict[str, Any]:
+        """Get one prompt for a request context."""
+        return await self.get_prompt(name, arguments)
+
     # Validation helpers
 
     def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]):  # noqa: B027

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_catalog.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_catalog.py
@@ -1,0 +1,629 @@
+"""MCP prompt catalog adapter for library and allowlisted config prompts."""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from loguru import logger
+
+from ....DB_Management.Prompts_DB import DatabaseError, PromptsDatabase
+from ....Prompt_Management.structured_prompts import (
+    PromptBlock,
+    PromptDefinition,
+    PromptVariableDefinition,
+    StructuredPromptAssemblyError,
+    assemble_prompt_definition,
+    convert_legacy_prompt_to_definition,
+    extract_legacy_prompt_variables,
+    normalize_legacy_prompt_template,
+)
+from ....Utils.prompt_loader import load_prompt
+from ...persona_scope import assert_identifier_in_scope, get_explicit_scope_ids
+
+LIBRARY_PROMPT_PREFIX = "library:"
+CONFIG_PROMPT_PREFIX = "config:"
+DEFAULT_PROMPT_PAGE_SIZE = 50
+MAX_PROMPT_PAGE_SIZE = 100
+MAX_RENDERED_PROMPT_CHARS = 100_000
+
+_CURSOR_VERSION = 1
+_CONFIG_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,100}$")
+_ALLOWED_CONFIG_ROLES = {"system", "developer", "user", "assistant"}
+_CATALOG_DB_EXCEPTIONS = (DatabaseError, OSError, RuntimeError, TypeError, ValueError)
+
+
+class PromptCatalogError(Exception):
+    """Sanitized prompt catalog error suitable for MCP protocol mapping."""
+
+    def __init__(self, code: str, message: str, internal: bool = False) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.internal = internal
+
+
+@dataclass(frozen=True)
+class PromptCatalogCursor:
+    """Opaque pagination cursor state for prompt catalog sources."""
+
+    library_after_name: str | None = None
+    library_after_uuid: str | None = None
+    library_done: bool = False
+    config_index: int = 0
+
+
+@dataclass(frozen=True)
+class PromptCatalogListResult:
+    """Prompt catalog list page with optional cursor and sanitized warnings."""
+
+    prompts: list[dict[str, Any]]
+    next_cursor: PromptCatalogCursor | None = None
+    warnings: list[dict[str, Any]] = field(default_factory=list)
+
+
+def encode_prompt_cursor(cursor: PromptCatalogCursor | None) -> str | None:
+    """Encode cursor state as unpadded URL-safe base64 JSON."""
+
+    if cursor is None:
+        return None
+
+    payload: dict[str, Any] = {
+        "v": _CURSOR_VERSION,
+        "library_done": cursor.library_done,
+        "config_index": cursor.config_index,
+    }
+    if cursor.library_after_name is not None:
+        payload["library_after_name"] = cursor.library_after_name
+    if cursor.library_after_uuid is not None:
+        payload["library_after_uuid"] = cursor.library_after_uuid
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def decode_prompt_cursor(raw_cursor: str | None) -> PromptCatalogCursor:
+    """Decode and validate an opaque prompt catalog cursor."""
+
+    if raw_cursor is None or raw_cursor == "":
+        return PromptCatalogCursor()
+    if not isinstance(raw_cursor, str):
+        raise PromptCatalogError("invalid_cursor", "Invalid prompt cursor.")
+
+    try:
+        padding = "=" * (-len(raw_cursor) % 4)
+        raw = base64.urlsafe_b64decode((raw_cursor + padding).encode("ascii"))
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeEncodeError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+        raise PromptCatalogError("invalid_cursor", "Invalid prompt cursor.") from exc
+
+    version = payload.get("v") if isinstance(payload, dict) else None
+    if not isinstance(payload, dict) or type(version) is not int or version != _CURSOR_VERSION:
+        raise PromptCatalogError("invalid_cursor", "Invalid prompt cursor.")
+
+    library_after_name = payload.get("library_after_name")
+    library_after_uuid = payload.get("library_after_uuid")
+    has_library_name = "library_after_name" in payload
+    has_library_uuid = "library_after_uuid" in payload
+    if has_library_name != has_library_uuid:
+        raise PromptCatalogError("invalid_cursor", "Invalid prompt cursor.")
+    if has_library_name:
+        if (
+            not isinstance(library_after_name, str)
+            or not library_after_name
+            or not isinstance(library_after_uuid, str)
+            or not library_after_uuid
+        ):
+            raise PromptCatalogError("invalid_cursor", "Invalid prompt cursor.")
+        try:
+            uuid.UUID(library_after_uuid)
+        except ValueError as exc:
+            raise PromptCatalogError("invalid_cursor", "Invalid prompt cursor.") from exc
+
+    library_done = payload.get("library_done", False)
+    if not isinstance(library_done, bool):
+        raise PromptCatalogError("invalid_cursor", "Invalid prompt cursor.")
+    if library_done and has_library_name:
+        raise PromptCatalogError("invalid_cursor", "Invalid prompt cursor.")
+
+    config_index = payload.get("config_index", 0)
+    if isinstance(config_index, bool) or not isinstance(config_index, int) or config_index < 0:
+        raise PromptCatalogError("invalid_cursor", "Invalid prompt cursor.")
+    if not library_done and config_index != 0:
+        raise PromptCatalogError("invalid_cursor", "Invalid prompt cursor.")
+
+    return PromptCatalogCursor(
+        library_after_name=library_after_name,
+        library_after_uuid=library_after_uuid,
+        library_done=library_done,
+        config_index=config_index,
+    )
+
+
+def clamp_prompt_page_size(raw_value: Any) -> int:
+    """Clamp a requested prompt page size to catalog defaults and limits."""
+
+    if type(raw_value) is not int:
+        return DEFAULT_PROMPT_PAGE_SIZE
+    if raw_value < 1:
+        return 1
+    return min(raw_value, MAX_PROMPT_PAGE_SIZE)
+
+
+class MCPPromptFormatter:
+    """Convert tldw prompt records and config entries into MCP prompt shapes."""
+
+    def __init__(self, max_rendered_chars: int = MAX_RENDERED_PROMPT_CHARS) -> None:
+        self.max_rendered_chars = max(1, int(max_rendered_chars))
+
+    def validate_arguments(self, arguments: Any | None) -> dict[str, str]:
+        """Validate MCP prompt arguments as a mapping of string names to strings."""
+
+        if arguments is None:
+            return {}
+        if not isinstance(arguments, Mapping):
+            raise PromptCatalogError("invalid_arguments", "Prompt arguments must be an object.")
+        validated: dict[str, str] = {}
+        for key, value in arguments.items():
+            if not isinstance(key, str) or not key:
+                raise PromptCatalogError("invalid_argument_name", "Prompt argument names must be valid strings.")
+            if not isinstance(value, str):
+                raise PromptCatalogError("invalid_argument_type", "Prompt argument values must be strings.")
+            validated[key] = value
+        return validated
+
+    def library_prompt_definition(self, row: Mapping[str, Any]) -> dict[str, Any]:
+        """Build an MCP list definition for a Prompt Library row."""
+
+        definition = self._definition_from_library_row(row)
+        prompt_uuid = str(row.get("uuid") or "")
+        return {
+            "name": f"{LIBRARY_PROMPT_PREFIX}{prompt_uuid}",
+            "title": str(row.get("name") or prompt_uuid),
+            "description": row.get("details") or None,
+            "arguments": self._mcp_arguments(definition.variables),
+            "_meta": {
+                "tldw": {
+                    "source": "library",
+                    "prompt_id": row.get("id"),
+                    "prompt_uuid": prompt_uuid,
+                    "version": row.get("version"),
+                    "tags": row.get("keywords") or [],
+                }
+            },
+        }
+
+    def render_library_prompt(self, row: Mapping[str, Any], arguments: Any | None) -> dict[str, Any]:
+        """Render a Prompt Library row as MCP prompt messages."""
+
+        validated_arguments = self.validate_arguments(arguments)
+        definition = self._definition_from_library_row(row)
+        messages = self._assemble_to_mcp_messages(definition, validated_arguments)
+        return {
+            "description": str(row.get("name") or row.get("uuid") or ""),
+            "messages": messages,
+            "_meta": self.library_prompt_definition(row)["_meta"],
+        }
+
+    def config_prompt_definition(
+        self,
+        entry: Mapping[str, Any],
+        parts: list[Mapping[str, str]],
+    ) -> dict[str, Any]:
+        """Build an MCP list definition for an allowlisted config prompt."""
+
+        definition = self._definition_from_config_parts(entry, parts)
+        prompt_id = str(entry.get("id") or "")
+        return {
+            "name": f"{CONFIG_PROMPT_PREFIX}{prompt_id}",
+            "title": str(entry.get("title") or prompt_id),
+            "description": entry.get("description") or None,
+            "arguments": self._mcp_arguments(definition.variables),
+            "_meta": {
+                "tldw": {
+                    "source": "config",
+                    "prompt_id": prompt_id,
+                    "part_count": len(parts),
+                }
+            },
+        }
+
+    def render_config_prompt(
+        self,
+        entry: Mapping[str, Any],
+        parts: list[Mapping[str, str]],
+        arguments: Any | None,
+    ) -> dict[str, Any]:
+        """Render an allowlisted config prompt as MCP prompt messages."""
+
+        validated_arguments = self.validate_arguments(arguments)
+        definition = self._definition_from_config_parts(entry, parts)
+        messages = self._assemble_to_mcp_messages(definition, validated_arguments)
+        return {
+            "description": str(entry.get("title") or entry.get("id") or ""),
+            "messages": messages,
+            "_meta": self.config_prompt_definition(entry, parts)["_meta"],
+        }
+
+    def _definition_from_library_row(self, row: Mapping[str, Any]) -> PromptDefinition:
+        raw_definition = row.get("prompt_definition")
+        if raw_definition:
+            try:
+                return PromptDefinition.model_validate(raw_definition)
+            except ValueError as exc:
+                raise PromptCatalogError(
+                    "invalid_prompt_definition",
+                    "Prompt definition is invalid.",
+                    internal=True,
+                ) from exc
+        return convert_legacy_prompt_to_definition(
+            system_prompt=str(row.get("system_prompt") or ""),
+            user_prompt=str(row.get("user_prompt") or ""),
+        )
+
+    def _definition_from_config_parts(
+        self,
+        entry: Mapping[str, Any],
+        parts: list[Mapping[str, str]],
+    ) -> PromptDefinition:
+        variables = extract_legacy_prompt_variables(*(part.get("content") for part in parts))
+        blocks = [
+            PromptBlock(
+                id=f"config_part_{index}",
+                name=str(part.get("name") or f"Part {index + 1}"),
+                role=part["role"],
+                content=normalize_legacy_prompt_template(part.get("content")),
+                enabled=True,
+                order=(index + 1) * 10,
+                is_template=bool(extract_legacy_prompt_variables(part.get("content"))),
+            )
+            for index, part in enumerate(parts)
+        ]
+        variable_definitions = [
+            PromptVariableDefinition(
+                name=variable_name,
+                label=variable_name.replace("_", " ").title(),
+                required=True,
+                input_type="textarea",
+            )
+            for variable_name in variables
+        ]
+        return PromptDefinition(variables=variable_definitions, blocks=blocks)
+
+    def _assemble_to_mcp_messages(
+        self,
+        definition: PromptDefinition,
+        arguments: Mapping[str, str],
+    ) -> list[dict[str, Any]]:
+        try:
+            assembled = assemble_prompt_definition(definition, arguments)
+        except StructuredPromptAssemblyError as exc:
+            raise PromptCatalogError("invalid_arguments", "Prompt arguments are invalid.") from exc
+        mcp_messages = self._to_mcp_messages(assembled.messages)
+        rendered_size = sum(len(message["content"]["text"]) for message in mcp_messages)
+        if rendered_size > self.max_rendered_chars:
+            raise PromptCatalogError("rendered_prompt_too_large", "Rendered prompt is too large.")
+        return mcp_messages
+
+    def _to_mcp_messages(self, messages: list[dict[str, str]]) -> list[dict[str, Any]]:
+        mcp_messages: list[dict[str, Any]] = []
+        pending_instructions: list[str] = []
+
+        for message in messages:
+            role = str(message.get("role") or "")
+            content = str(message.get("content") or "")
+            if role in {"system", "developer"}:
+                if content:
+                    pending_instructions.append(content)
+                continue
+            if role == "user":
+                if pending_instructions:
+                    content = (
+                        "System instructions:\n"
+                        + "\n\n".join(pending_instructions)
+                        + "\n\nUser prompt:\n"
+                        + content
+                    )
+                    pending_instructions = []
+                mcp_messages.append(self._mcp_text_message("user", content))
+                continue
+            if role == "assistant":
+                mcp_messages.append(self._mcp_text_message("assistant", content))
+
+        if pending_instructions:
+            mcp_messages.append(
+                self._mcp_text_message(
+                    "user",
+                    "System instructions:\n" + "\n\n".join(pending_instructions),
+                )
+            )
+        return mcp_messages
+
+    @staticmethod
+    def _mcp_text_message(role: str, text: str) -> dict[str, Any]:
+        return {"role": role, "content": {"type": "text", "text": text}}
+
+    @staticmethod
+    def _mcp_arguments(variables: list[PromptVariableDefinition]) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": variable.name,
+                "title": variable.label or variable.name.replace("_", " ").title(),
+                "description": variable.description,
+                "required": bool(variable.required),
+            }
+            for variable in variables
+        ]
+
+
+class UserPromptCatalogSource:
+    """Catalog source backed by the per-user Prompt Library database."""
+
+    def __init__(self, formatter: MCPPromptFormatter) -> None:
+        self.formatter = formatter
+
+    def list_prompts(
+        self,
+        context: Any,
+        cursor: PromptCatalogCursor,
+        limit: int,
+    ) -> PromptCatalogListResult:
+        """List visible non-deleted Prompt Library prompts."""
+
+        if cursor.library_done:
+            return PromptCatalogListResult(prompts=[])
+
+        db: PromptsDatabase | None = None
+        try:
+            db = self._open_db(context)
+            query, params = self._list_query(context, cursor, limit + 1)
+            rows = [db._deserialize_prompt_record(dict(row)) for row in db.execute_query(query, params).fetchall()]
+        except PromptCatalogError as exc:
+            if not exc.internal:
+                raise
+            return self._library_unavailable_result(exc)
+        except _CATALOG_DB_EXCEPTIONS as exc:
+            return self._library_unavailable_result(exc)
+        finally:
+            if db is not None:
+                self._close_db(db)
+
+        page_rows = rows[:limit]
+        prompts: list[dict[str, Any]] = []
+        warnings: list[dict[str, Any]] = []
+        for row in page_rows:
+            try:
+                prompts.append(self.formatter.library_prompt_definition(row))
+            except PromptCatalogError as exc:
+                if not exc.internal:
+                    raise
+                warnings.append(self._prompt_unavailable_warning(row))
+            except (TypeError, ValueError) as exc:
+                logger.debug("Prompt Library row unavailable during list: {}", exc.__class__.__name__)
+                warnings.append(self._prompt_unavailable_warning(row))
+
+        next_cursor = None
+        if len(rows) > limit and page_rows:
+            last_row = page_rows[-1]
+            next_cursor = PromptCatalogCursor(
+                library_after_name=str(last_row.get("name") or ""),
+                library_after_uuid=str(last_row.get("uuid") or ""),
+            )
+        return PromptCatalogListResult(prompts=prompts, next_cursor=next_cursor, warnings=warnings)
+
+    @staticmethod
+    def _library_unavailable_result(exc: Exception) -> PromptCatalogListResult:
+        logger.debug("Prompt Library catalog unavailable during list: {}", exc.__class__.__name__)
+        return PromptCatalogListResult(
+            prompts=[],
+            warnings=[{"source": "library", "code": "prompt_db_unavailable"}],
+        )
+
+    @staticmethod
+    def _prompt_unavailable_warning(row: Mapping[str, Any]) -> dict[str, Any]:
+        warning: dict[str, Any] = {"source": "library", "code": "prompt_unavailable"}
+        prompt_uuid = row.get("uuid")
+        if isinstance(prompt_uuid, str) and prompt_uuid:
+            warning["prompt_uuid"] = prompt_uuid
+        return warning
+
+    def get_prompt(self, context: Any, name: str, arguments: Any | None) -> dict[str, Any]:
+        """Fetch and render a single Prompt Library prompt by MCP name."""
+
+        prompt_uuid = self._parse_library_name(name)
+        db: PromptsDatabase | None = None
+        try:
+            db = self._open_db(context)
+            row = db.get_prompt_by_uuid(prompt_uuid, include_deleted=False)
+            if not row:
+                raise PromptCatalogError("prompt_not_found", "Prompt not found.")
+            try:
+                assert_identifier_in_scope(context, "prompt_id", row.get("id"), label="Prompt")
+            except PermissionError as exc:
+                raise PromptCatalogError("permission_denied", "Prompt access denied.") from exc
+            return self.formatter.render_library_prompt(row, arguments)
+        except PromptCatalogError as exc:
+            if exc.internal:
+                raise self._prompt_db_unavailable_error() from exc
+            raise
+        except _CATALOG_DB_EXCEPTIONS as exc:
+            raise self._prompt_db_unavailable_error() from exc
+        finally:
+            if db is not None:
+                self._close_db(db)
+
+    @staticmethod
+    def _prompt_db_unavailable_error() -> PromptCatalogError:
+        return PromptCatalogError(
+            "prompt_db_unavailable",
+            "Prompt library is unavailable.",
+            internal=True,
+        )
+
+    def _open_db(self, context: Any) -> PromptsDatabase:
+        db_paths = getattr(context, "db_paths", None)
+        if not isinstance(db_paths, Mapping) or not db_paths.get("prompts"):
+            raise PromptCatalogError("prompt_db_unavailable", "Prompt database is unavailable.", internal=True)
+        return PromptsDatabase(db_path=str(db_paths["prompts"]), client_id="mcp_prompt_catalog")
+
+    def _list_query(
+        self,
+        context: Any,
+        cursor: PromptCatalogCursor,
+        limit: int,
+    ) -> tuple[str, tuple[Any, ...]]:
+        where_clauses = ["deleted = 0"]
+        params: list[Any] = []
+
+        scoped_ids = get_explicit_scope_ids(context, "prompt_id")
+        if scoped_ids is not None:
+            numeric_ids = sorted({int(value) for value in scoped_ids if str(value).isdigit()})
+            if not numeric_ids:
+                return "SELECT * FROM Prompts WHERE 1 = 0 LIMIT ?", (limit,)
+            placeholders = ",".join("?" for _ in numeric_ids)
+            where_clauses.append(f"id IN ({placeholders})")
+            params.extend(numeric_ids)
+
+        if cursor.library_after_name is not None and cursor.library_after_uuid is not None:
+            where_clauses.append("(name COLLATE NOCASE > ? OR (name COLLATE NOCASE = ? AND uuid > ?))")
+            params.extend(
+                [
+                    cursor.library_after_name,
+                    cursor.library_after_name,
+                    cursor.library_after_uuid,
+                ]
+            )
+
+        params.append(limit)
+        # The only dynamic SQL fragment above is an id IN placeholder list built
+        # from "?" tokens; all user-derived values remain bound parameters.
+        query = (
+            "SELECT * FROM Prompts WHERE "  # nosec B608
+            + " AND ".join(where_clauses)
+            + " ORDER BY name COLLATE NOCASE ASC, uuid ASC LIMIT ?"
+        )
+        return query, tuple(params)
+
+    @staticmethod
+    def _parse_library_name(name: str) -> str:
+        if not isinstance(name, str) or not name.startswith(LIBRARY_PROMPT_PREFIX):
+            raise PromptCatalogError("invalid_prompt_name", "Invalid library prompt name.")
+        prompt_uuid = name[len(LIBRARY_PROMPT_PREFIX) :]
+        try:
+            return str(uuid.UUID(prompt_uuid))
+        except ValueError as exc:
+            raise PromptCatalogError("invalid_prompt_name", "Invalid library prompt name.") from exc
+
+    @staticmethod
+    def _close_db(db: PromptsDatabase) -> None:
+        try:
+            db.close_connection()
+        except _CATALOG_DB_EXCEPTIONS as exc:
+            logger.debug("Failed to close Prompt Library catalog DB: {}", exc.__class__.__name__)
+
+
+class ConfigPromptCatalogSource:
+    """Catalog source backed by explicit allowlisted config prompt entries."""
+
+    def __init__(self, formatter: MCPPromptFormatter, config: Mapping[str, Any] | None = None) -> None:
+        self.formatter = formatter
+        self.config = dict(config or {})
+        self.enabled = self.config.get("enabled", True) is not False
+        raw_entries = self.config.get("entries") or []
+        self.entries = [entry for entry in raw_entries if isinstance(entry, Mapping)]
+
+    def list_prompts(self, cursor: PromptCatalogCursor, limit: int) -> PromptCatalogListResult:
+        """List available allowlisted config prompts, omitting missing entries."""
+
+        if not self.enabled:
+            return PromptCatalogListResult(prompts=[])
+
+        prompts: list[dict[str, Any]] = []
+        warnings: list[dict[str, Any]] = []
+        index = max(0, cursor.config_index)
+        while index < len(self.entries) and len(prompts) < limit:
+            entry = self.entries[index]
+            entry_id = self._entry_id(entry)
+            try:
+                parts = self._load_entry_parts(entry)
+                prompts.append(self.formatter.config_prompt_definition(entry, parts))
+            except PromptCatalogError:
+                if entry_id:
+                    warnings.append(
+                        {"source": "config", "code": "config_prompt_unavailable", "id": entry_id}
+                    )
+            index += 1
+
+        next_cursor = None
+        if index < len(self.entries):
+            next_cursor = PromptCatalogCursor(library_done=True, config_index=index)
+        return PromptCatalogListResult(prompts=prompts, next_cursor=next_cursor, warnings=warnings)
+
+    def has_entries_after(self, config_index: int) -> bool:
+        """Return whether the config source has entries at or after an index."""
+
+        return self.enabled and 0 <= config_index < len(self.entries)
+
+    def get_prompt(self, name: str, arguments: Any | None) -> dict[str, Any]:
+        """Fetch and render an allowlisted config prompt by MCP name."""
+
+        if not self.enabled:
+            raise PromptCatalogError("prompt_not_found", "Prompt not found.")
+        prompt_id = self._parse_config_name(name)
+        for entry in self.entries:
+            if self._entry_id(entry) != prompt_id:
+                continue
+            parts = self._load_entry_parts(entry)
+            return self.formatter.render_config_prompt(entry, parts, arguments)
+        raise PromptCatalogError("prompt_not_found", "Prompt not found.")
+
+    def _load_entry_parts(self, entry: Mapping[str, Any]) -> list[Mapping[str, str]]:
+        entry_id = self._entry_id(entry)
+        if not entry_id:
+            raise PromptCatalogError("invalid_config_prompt", "Config prompt entry is invalid.", internal=True)
+
+        raw_messages = entry.get("messages")
+        if isinstance(raw_messages, list):
+            parts = [self._load_part(part) for part in raw_messages if isinstance(part, Mapping)]
+        else:
+            parts = [self._load_part({**entry, "role": "user"})]
+        if not parts:
+            raise PromptCatalogError("config_prompt_unavailable", "Config prompt is unavailable.", internal=True)
+        return parts
+
+    def _load_part(self, part: Mapping[str, Any]) -> Mapping[str, str]:
+        role = str(part.get("role") or "user")
+        module = part.get("module")
+        key = part.get("key")
+        if role not in _ALLOWED_CONFIG_ROLES or not isinstance(module, str) or not isinstance(key, str):
+            raise PromptCatalogError("invalid_config_prompt", "Config prompt entry is invalid.", internal=True)
+        content = load_prompt(module, key)
+        if not isinstance(content, str) or not content:
+            raise PromptCatalogError("config_prompt_unavailable", "Config prompt is unavailable.", internal=True)
+        return {
+            "role": role,
+            "module": module,
+            "key": key,
+            "name": str(part.get("title") or key),
+            "content": content,
+        }
+
+    @staticmethod
+    def _parse_config_name(name: str) -> str:
+        if not isinstance(name, str) or not name.startswith(CONFIG_PROMPT_PREFIX):
+            raise PromptCatalogError("invalid_prompt_name", "Invalid config prompt name.")
+        prompt_id = name[len(CONFIG_PROMPT_PREFIX) :]
+        if not _CONFIG_ID_RE.fullmatch(prompt_id):
+            raise PromptCatalogError("invalid_prompt_name", "Invalid config prompt name.")
+        return prompt_id
+
+    @staticmethod
+    def _entry_id(entry: Mapping[str, Any]) -> str | None:
+        entry_id = entry.get("id")
+        if not isinstance(entry_id, str) or not _CONFIG_ID_RE.fullmatch(entry_id):
+            return None
+        return entry_id

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_module.py
@@ -14,6 +14,18 @@ from ....DB_Management.Prompts_DB import PromptsDatabase
 from ...persona_scope import assert_identifier_in_scope
 from ..base import BaseModule, create_tool_definition
 from ..disk_space import get_free_disk_space_gb
+from .prompts_catalog import (
+    CONFIG_PROMPT_PREFIX,
+    LIBRARY_PROMPT_PREFIX,
+    ConfigPromptCatalogSource,
+    MCPPromptFormatter,
+    PromptCatalogCursor,
+    PromptCatalogError,
+    UserPromptCatalogSource,
+    clamp_prompt_page_size,
+    decode_prompt_cursor,
+    encode_prompt_cursor,
+)
 
 _PROMPTS_HEALTHCHECK_EXCEPTIONS = (
     OSError,
@@ -28,6 +40,19 @@ _PROMPTS_CLOSE_EXCEPTIONS = (OSError, RuntimeError, SQLiteError, TypeError, Valu
 class PromptsModule(BaseModule):
     async def on_initialize(self) -> None:
         logger.info(f"Initializing Prompts module: {self.name}")
+        settings = self.config.settings or {}
+        self._prompt_list_page_size = clamp_prompt_page_size(settings.get("prompt_list_page_size", 50))
+        try:
+            max_rendered_prompt_chars = int(settings.get("max_rendered_prompt_chars", 100000) or 100000)
+        except (TypeError, ValueError):
+            max_rendered_prompt_chars = 100000
+        self._prompt_formatter = MCPPromptFormatter(max_rendered_chars=max_rendered_prompt_chars)
+        self._user_prompt_source = UserPromptCatalogSource(self._prompt_formatter)
+        config_prompts = settings.get("config_prompts")
+        self._config_prompt_source = ConfigPromptCatalogSource(
+            self._prompt_formatter,
+            config_prompts if isinstance(config_prompts, dict) else {},
+        )
 
     async def on_shutdown(self) -> None:
         logger.info(f"Shutting down Prompts module: {self.name}")
@@ -102,6 +127,73 @@ class PromptsModule(BaseModule):
         if tool_name == "prompts.get":
             return await self._get(args, context)
         raise ValueError(f"Unknown tool: {tool_name}")
+
+    async def get_prompts_for_context(self, context: Any, params: dict[str, Any]) -> dict[str, Any]:
+        """List MCP prompts visible to the request context."""
+
+        cursor = decode_prompt_cursor((params or {}).get("cursor"))
+        page_size = getattr(self, "_prompt_list_page_size", 50)
+        library_result = await asyncio.to_thread(
+            self._user_prompt_source.list_prompts,
+            context=context,
+            cursor=cursor,
+            limit=page_size,
+        )
+
+        prompts = list(library_result.prompts)
+        warnings = list(library_result.warnings)
+        next_cursor = library_result.next_cursor
+        remaining = page_size - len(prompts)
+
+        if remaining > 0 and library_result.next_cursor is None:
+            config_result = await asyncio.to_thread(
+                self._config_prompt_source.list_prompts,
+                cursor=cursor,
+                limit=remaining,
+            )
+            prompts.extend(config_result.prompts)
+            warnings.extend(config_result.warnings)
+            next_cursor = config_result.next_cursor
+        elif (
+            remaining == 0
+            and library_result.next_cursor is None
+            and self._config_prompt_source.has_entries_after(cursor.config_index)
+        ):
+            next_cursor = PromptCatalogCursor(
+                library_done=True,
+                config_index=cursor.config_index,
+            )
+
+        result: dict[str, Any] = {"prompts": prompts}
+        encoded_cursor = encode_prompt_cursor(next_cursor)
+        if encoded_cursor:
+            result["nextCursor"] = encoded_cursor
+        if warnings:
+            result["_meta"] = {"tldw": {"warnings": warnings}}
+        return result
+
+    async def get_prompt_for_context(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: Any,
+    ) -> dict[str, Any]:
+        """Get one MCP prompt by catalog namespace for the request context."""
+
+        if isinstance(name, str) and name.startswith(LIBRARY_PROMPT_PREFIX):
+            return await asyncio.to_thread(
+                self._user_prompt_source.get_prompt,
+                context=context,
+                name=name,
+                arguments=arguments,
+            )
+        if isinstance(name, str) and name.startswith(CONFIG_PROMPT_PREFIX):
+            return await asyncio.to_thread(
+                self._config_prompt_source.get_prompt,
+                name=name,
+                arguments=arguments,
+            )
+        raise PromptCatalogError("prompt_not_found", "Prompt not found")
 
     def _open_db(self, context: Any) -> PromptsDatabase:
         if context is None or not getattr(context, "db_paths", None):

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -64,6 +64,12 @@ from .interfaces.runtime import (
     ToolHookCallContext,
     ToolHookDecision,
 )
+from .modules.implementations.prompts_catalog import (
+    CONFIG_PROMPT_PREFIX,
+    LIBRARY_PROMPT_PREFIX,
+    PromptCatalogError,
+    decode_prompt_cursor,
+)
 from .modules.base import BaseModule
 from .tool_observability import (
     attach_execution_eval_metadata,
@@ -1258,6 +1264,96 @@ class MCPProtocol:
         if await self._has_module_permission(context, module_id):
             return self._scope_allows(context, Resource.PROMPT.value, prompt_name)
         return False
+
+    async def _has_namespaced_prompt_permission(self, context: RequestContext, prompt_name: str) -> bool:
+        """Check prompt catalog namespace access without falling back to module permission."""
+        if not await self._rbac_check(context.user_id, Resource.PROMPT, Action.READ, prompt_name):
+            return False
+        if not self._scope_allows(context, Resource.PROMPT.value, prompt_name):
+            return False
+        return self._api_key_allows(context, is_write=None)
+
+    @staticmethod
+    def _prompt_warning_name(warning: dict[str, Any]) -> Optional[str]:
+        """Resolve an optional prompt name from catalog warning metadata."""
+
+        explicit_name = warning.get("_prompt_name") or warning.get("prompt_name")
+        if isinstance(explicit_name, str) and explicit_name:
+            return explicit_name
+
+        source = warning.get("source")
+        if source == "library":
+            prompt_uuid = warning.get("prompt_uuid")
+            if isinstance(prompt_uuid, str) and prompt_uuid:
+                return f"{LIBRARY_PROMPT_PREFIX}{prompt_uuid}"
+        if source == "config":
+            entry_id = warning.get("id")
+            if isinstance(entry_id, str) and entry_id:
+                return f"{CONFIG_PROMPT_PREFIX}{entry_id}"
+        return None
+
+    async def _visible_prompt_warning(
+        self,
+        context: RequestContext,
+        warning: dict[str, Any],
+        module_id: Optional[str],
+    ) -> Optional[dict[str, Any]]:
+        """Return sanitized prompt warning metadata when visible to the caller."""
+
+        prompt_name = self._prompt_warning_name(warning)
+        if prompt_name:
+            if self._is_namespaced_prompt_name(prompt_name):
+                if not await self._has_namespaced_prompt_permission(context, prompt_name):
+                    return None
+            elif not await self._has_prompt_permission(context, prompt_name, module_id):
+                return None
+
+        sanitized = warning.copy()
+        for key in ("_prompt_name", "prompt_name", "prompt_uuid", "prompt_id", "id"):
+            sanitized.pop(key, None)
+        return sanitized
+
+    @staticmethod
+    def _is_namespaced_prompt_name(prompt_name: Any) -> bool:
+        return (
+            isinstance(prompt_name, str)
+            and (
+                prompt_name.startswith(LIBRARY_PROMPT_PREFIX)
+                or prompt_name.startswith(CONFIG_PROMPT_PREFIX)
+            )
+        )
+
+    def _has_restrictive_prompt_scope(self, context: RequestContext) -> bool:
+        """Return whether MCP scopes restrict prompt visibility for this request."""
+
+        scopes = self._mcp_scopes(context)
+        if not scopes:
+            return False
+        for scope in scopes:
+            try:
+                parts = scope.strip().lower().split(":")
+            except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
+                continue
+            if len(parts) == 2 and parts[0] == "mcp" and parts[1] == "*":
+                return False
+            if len(parts) >= 3 and parts[0] == "mcp":
+                kind = parts[1]
+                value = ":".join(parts[2:])
+                if kind in {"*", "prompt"} and value in {"", "*"}:
+                    return False
+        return True
+
+    @staticmethod
+    def _prompt_cursor_has_identifier_fields(cursor: Any) -> bool:
+        """Return whether a prompt catalog cursor carries prompt identifiers."""
+
+        if not isinstance(cursor, str) or not cursor:
+            return False
+        try:
+            decoded = decode_prompt_cursor(cursor)
+        except PromptCatalogError:
+            return False
+        return decoded.library_after_name is not None or decoded.library_after_uuid is not None
 
     @staticmethod
     def _hash_arguments(arguments: dict[str, Any]) -> Optional[str]:
@@ -2623,7 +2719,7 @@ class MCPProtocol:
         capabilities = {
             "tools": {"available": bool(modules)},
             "resources": {"available": bool(modules)},
-            "prompts": {"available": bool(modules)}
+            "prompts": {"listChanged": False}
         }
 
         return {
@@ -3996,27 +4092,73 @@ class MCPProtocol:
     ) -> dict[str, Any]:
         """List available prompts"""
         prompts = []
+        warnings: list[dict[str, Any]] = []
+        next_cursor: Any = None
         modules = await self.module_registry.get_all_modules()
 
         for module_id, module in modules.items():
             try:
-                if not await self._has_module_permission(context, module_id):
+                if module_id != "prompts" and not await self._has_module_permission(context, module_id):
                     continue
-                module_prompts = await module.get_prompts()
+                module_warnings: list[dict[str, Any]] = []
+                module_result = await module.get_prompts_for_context(context, params or {})
+                if not isinstance(module_result, dict):
+                    module_prompts = []
+                else:
+                    module_prompts = module_result.get("prompts", [])
+                    if "nextCursor" in module_result:
+                        next_cursor = module_result.get("nextCursor")
+                    meta = module_result.get("_meta")
+                    if isinstance(meta, dict):
+                        tldw_meta = meta.get("tldw")
+                        if isinstance(tldw_meta, dict):
+                            module_warnings = tldw_meta.get("warnings")
+                            if isinstance(module_warnings, list):
+                                module_warnings = [
+                                    warning for warning in module_warnings if isinstance(warning, dict)
+                                ]
 
                 for prompt in module_prompts:
                     name = prompt.get("name") if isinstance(prompt, dict) else None
-                    if name and not await self._has_prompt_permission(context, name, module_id):
+                    if self._is_namespaced_prompt_name(name):
+                        if not await self._has_namespaced_prompt_permission(context, name):
+                            continue
+                    elif name and not await self._has_prompt_permission(context, name, module_id):
                         continue
                     prompt_copy = prompt.copy() if isinstance(prompt, dict) else prompt
                     if isinstance(prompt_copy, dict):
                         prompt_copy["module"] = module_id
                     prompts.append(prompt_copy)
 
+                for warning in module_warnings:
+                    visible_warning = await self._visible_prompt_warning(context, warning, module_id)
+                    if visible_warning:
+                        warnings.append(visible_warning)
+
+            except PromptCatalogError as e:
+                if e.internal:
+                    context.logger.error(
+                        "Internal prompt catalog list error from module {}: {}",
+                        module_id,
+                        e.code,
+                    )
+                    raise RuntimeError("Failed to list prompts") from None
+                raise InvalidParamsException(str(e)) from e
             except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as e:
                 context.logger.exception(f"Error getting prompts from module {module_id}: {e}")
 
-        return {"prompts": prompts}
+        if (
+            self._has_restrictive_prompt_scope(context)
+            and self._prompt_cursor_has_identifier_fields(next_cursor)
+        ):
+            next_cursor = None
+
+        result: dict[str, Any] = {"prompts": prompts}
+        if next_cursor is not None:
+            result["nextCursor"] = next_cursor
+        if warnings:
+            result["_meta"] = {"tldw": {"warnings": warnings}}
+        return result
 
     async def _handle_prompts_get(
         self,
@@ -4025,10 +4167,40 @@ class MCPProtocol:
     ) -> dict[str, Any]:
         """Get a specific prompt"""
         name = params.get("name")
-        if not name:
+        if not isinstance(name, str) or not name:
             raise InvalidParamsException("Prompt name is required")
 
         arguments = params.get("arguments", {})
+        if arguments is None:
+            arguments = {}
+        if not isinstance(arguments, dict):
+            raise InvalidParamsException("Prompt arguments must be an object")
+
+        if self._is_namespaced_prompt_name(name):
+            module = await self.module_registry.get_module("prompts")
+            if not module:
+                raise InvalidParamsException(f"Prompt not found: {name}")
+            if not await self._has_namespaced_prompt_permission(context, name):
+                raise PermissionError(f"Permission denied for prompt: {name}")
+            try:
+                return await module.get_prompt_for_context(name, arguments, context)
+            except PromptCatalogError as e:
+                if e.code == "permission_denied":
+                    raise PermissionError(f"Permission denied for prompt: {name}") from e
+                if e.internal:
+                    if name.startswith(LIBRARY_PROMPT_PREFIX):
+                        prompt_namespace = "library"
+                    elif name.startswith(CONFIG_PROMPT_PREFIX):
+                        prompt_namespace = "config"
+                    else:
+                        prompt_namespace = "unknown"
+                    context.logger.error(
+                        "Internal prompt catalog get error for namespace {}: {}",
+                        prompt_namespace,
+                        e.code,
+                    )
+                    raise RuntimeError("Failed to get prompt") from None
+                raise InvalidParamsException(str(e)) from e
 
         # Find module for prompt
         module = await self.module_registry.find_module_for_prompt(name)
@@ -4040,7 +4212,7 @@ class MCPProtocol:
             raise PermissionError(f"Permission denied for prompt: {name}")
 
         # Get prompt
-        prompt = await module.get_prompt(name, arguments)
+        prompt = await module.get_prompt_for_context(name, arguments, context)
 
         return prompt
 

--- a/tldw_Server_API/app/core/MCP_unified/server.py
+++ b/tldw_Server_API/app/core/MCP_unified/server.py
@@ -543,7 +543,7 @@ class MCPServer:
                 # Register default modules (will be implemented when migrating modules)
                 await self._register_default_modules()
 
-                # Ensure default tool permissions exist (wildcard)
+                # Ensure default MCP permissions exist.
                 await self._ensure_default_tool_permissions()
 
                 # Start background tasks
@@ -557,11 +557,11 @@ class MCPServer:
                 raise
 
     async def _ensure_default_tool_permissions(self):
-        """Seed wildcard tool permission tools.execute:* if missing."""
+        """Seed MCP startup permissions if missing."""
         try:
             await self.permission_seeder.seed_default_tool_permissions()
         except _MCP_SERVER_NONCRITICAL_EXCEPTIONS as e:
-            logger.debug(f"Seed wildcard tool permission failed: {self._mask_secrets(str(e))}")
+            logger.debug(f"Seed default MCP permissions failed: {self._mask_secrets(str(e))}")
 
     async def shutdown(self):
         """Gracefully shutdown the server"""

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py
@@ -135,6 +135,28 @@ def test_default_mcp_modules_config_declares_codegraph_disabled():
     )
 
 
+def test_default_mcp_modules_config_declares_prompts_module_with_empty_config_allowlist() -> None:
+    config_path = Path("tldw_Server_API/Config_Files/mcp_modules.yaml")
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    module_ids = [module["id"] for module in data["modules"]]
+    modules = {module["id"]: module for module in data["modules"]}
+
+    prompts_module = modules["prompts"]
+
+    assert module_ids[module_ids.index("notes") + 1] == "prompts"  # nosec B101
+    assert prompts_module["class"] == (  # nosec B101
+        "tldw_Server_API.app.core.MCP_unified.modules.implementations.prompts_module:PromptsModule"
+    )
+    assert prompts_module["enabled"] is True  # nosec B101
+    assert prompts_module["name"] == "Prompts"  # nosec B101
+    assert prompts_module["version"] == "1.0.0"  # nosec B101
+    assert prompts_module["department"] == "knowledge"  # nosec B101
+    assert prompts_module["max_concurrent"] == 10  # nosec B101
+    assert prompts_module["settings"]["prompt_list_page_size"] == 50  # nosec B101
+    assert prompts_module["settings"]["max_rendered_prompt_chars"] == 100000  # nosec B101
+    assert prompts_module["settings"]["config_prompts"] == {"enabled": True, "entries": []}  # nosec B101
+
+
 @pytest.mark.asyncio
 async def test_server_skips_disabled_codegraph_module_from_config(monkeypatch, tmp_path: Path) -> None:
     from tldw_Server_API.app.core.MCP_unified.server import MCPServer

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
@@ -899,7 +899,7 @@ def test_mcp_server_logs_host_adapter_fallbacks(
 
 
 @pytest.mark.asyncio
-async def test_tldw_permission_seeder_uses_acquired_connection(
+async def test_tldw_permission_seeder_uses_shared_rbac_seed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from tldw_Server_API.app.core.MCP_unified.adapters import tldw_runtime
@@ -922,34 +922,32 @@ async def test_tldw_permission_seeder_uses_acquired_connection(
             return _AcquireContext(self.conn)
 
     pool = _Pool()
-    ensure_calls: list[tuple[object, str, str, str]] = []
+    ensure_calls: list[tuple[object, bool, bool]] = []
 
     async def _get_db_pool() -> _Pool:
         return pool
 
-    async def _ensure_permission(
+    async def _ensure_baseline_rbac_seed(
         db: object,
-        name: str,
-        description: str,
         *,
-        category: str,
-    ) -> dict[str, Any]:
-        ensure_calls.append((db, name, description, category))
-        return {"id": 1, "name": name, "description": description, "category": category}
+        include_mcp_permissions: bool,
+        is_postgres: bool | None = None,
+    ) -> None:
+        ensure_calls.append((db, include_mcp_permissions, bool(is_postgres)))
 
     monkeypatch.setattr(
         "tldw_Server_API.app.core.AuthNZ.database.get_db_pool",
         _get_db_pool,
     )
     monkeypatch.setattr(
-        "tldw_Server_API.app.services.admin_roles_permissions_service.ensure_permission",
-        _ensure_permission,
+        "tldw_Server_API.app.core.AuthNZ.rbac_seed.ensure_baseline_rbac_seed",
+        _ensure_baseline_rbac_seed,
     )
 
     await tldw_runtime.TldwPermissionSeeder().seed_default_tool_permissions()
 
     assert ensure_calls == [
-        (pool.conn, "tools.execute:*", "Wildcard tool execution", "tools")
+        (pool.conn, True, False)
     ]
 
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py
@@ -1,0 +1,917 @@
+from __future__ import annotations
+
+import base64
+import builtins
+import importlib
+import json
+import sys
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.Prompts_DB import DatabaseError, PromptsDatabase
+from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.prompts_module import (
+    PromptsModule,
+)
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.prompts_catalog import (
+    CONFIG_PROMPT_PREFIX,
+    DEFAULT_PROMPT_PAGE_SIZE,
+    LIBRARY_PROMPT_PREFIX,
+    MAX_PROMPT_PAGE_SIZE,
+    ConfigPromptCatalogSource,
+    MCPPromptFormatter,
+    PromptCatalogCursor,
+    PromptCatalogError,
+    UserPromptCatalogSource,
+    clamp_prompt_page_size,
+    decode_prompt_cursor,
+    encode_prompt_cursor,
+)
+
+
+def test_prompt_cursor_encodes_none_as_none() -> None:
+    assert encode_prompt_cursor(None) is None
+
+
+def test_prompt_cursor_round_trips_without_padding() -> None:
+    cursor = PromptCatalogCursor(
+        library_after_name="alpha",
+        library_after_uuid="11111111-1111-4111-8111-111111111111",
+    )
+
+    encoded = encode_prompt_cursor(cursor)
+
+    assert "=" not in encoded
+    assert "+" not in encoded
+    assert "/" not in encoded
+    assert decode_prompt_cursor(encoded) == cursor
+
+
+def test_prompt_cursor_round_trips_config_segment() -> None:
+    cursor = PromptCatalogCursor(library_done=True, config_index=3)
+
+    assert decode_prompt_cursor(encode_prompt_cursor(cursor)) == cursor
+
+
+def test_prompt_cursor_rejects_bad_payload() -> None:
+    with pytest.raises(PromptCatalogError) as excinfo:
+        decode_prompt_cursor("not-valid-base64")
+
+    assert excinfo.value.code == "invalid_cursor"
+
+
+def test_prompt_cursor_rejects_boolean_version() -> None:
+    raw = _encode_raw_cursor({"v": True, "library_done": False, "config_index": 0})
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        decode_prompt_cursor(raw)
+
+    assert excinfo.value.code == "invalid_cursor"
+
+
+def test_prompt_cursor_rejects_partial_library_keyset() -> None:
+    raw = _encode_raw_cursor({"v": 1, "library_after_name": "alpha", "config_index": 0})
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        decode_prompt_cursor(raw)
+
+    assert excinfo.value.code == "invalid_cursor"
+
+
+def test_prompt_cursor_rejects_partial_library_uuid_keyset() -> None:
+    raw = _encode_raw_cursor(
+        {
+            "v": 1,
+            "library_after_uuid": "11111111-1111-4111-8111-111111111111",
+            "config_index": 0,
+        }
+    )
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        decode_prompt_cursor(raw)
+
+    assert excinfo.value.code == "invalid_cursor"
+
+
+def test_prompt_cursor_rejects_config_index_before_library_done() -> None:
+    raw = _encode_raw_cursor({"v": 1, "library_done": False, "config_index": 1})
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        decode_prompt_cursor(raw)
+
+    assert excinfo.value.code == "invalid_cursor"
+
+
+def test_prompt_cursor_rejects_library_keyset_when_library_done() -> None:
+    raw = _encode_raw_cursor(
+        {
+            "v": 1,
+            "library_done": True,
+            "library_after_name": "alpha",
+            "library_after_uuid": "11111111-1111-4111-8111-111111111111",
+            "config_index": 0,
+        }
+    )
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        decode_prompt_cursor(raw)
+
+    assert excinfo.value.code == "invalid_cursor"
+
+
+def test_prompt_cursor_rejects_null_library_keyset_fields() -> None:
+    raw = _encode_raw_cursor(
+        {
+            "v": 1,
+            "library_after_name": None,
+            "library_after_uuid": None,
+            "config_index": 0,
+        }
+    )
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        decode_prompt_cursor(raw)
+
+    assert excinfo.value.code == "invalid_cursor"
+
+
+def test_clamp_prompt_page_size_uses_default_for_invalid_and_clamps_bounds() -> None:
+    assert clamp_prompt_page_size("25") == DEFAULT_PROMPT_PAGE_SIZE
+    assert clamp_prompt_page_size(True) == DEFAULT_PROMPT_PAGE_SIZE
+    assert clamp_prompt_page_size("not-an-int") == DEFAULT_PROMPT_PAGE_SIZE
+    assert clamp_prompt_page_size(0) == 1
+    assert clamp_prompt_page_size(-5) == 1
+    assert clamp_prompt_page_size(MAX_PROMPT_PAGE_SIZE + 1000) == MAX_PROMPT_PAGE_SIZE
+
+
+def _encode_raw_cursor(payload: dict) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def test_formatter_creates_stable_library_definition() -> None:
+    prompt_uuid = str(uuid.uuid4())
+    row = {
+        "id": 42,
+        "uuid": prompt_uuid,
+        "name": "Summarizer",
+        "details": "Summarize a document without leaking the body.",
+        "author": "tester",
+        "version": 7,
+        "keywords": ["summary", "docs"],
+        "system_prompt": "Be concise.",
+        "user_prompt": "Summarize {topic}",
+        "prompt_definition": None,
+    }
+    formatter = MCPPromptFormatter(max_rendered_chars=10_000)
+
+    prompt = formatter.library_prompt_definition(row)
+
+    assert prompt["name"] == f"{LIBRARY_PROMPT_PREFIX}{prompt_uuid}"
+    assert prompt["title"] == "Summarizer"
+    assert prompt["description"] == "Summarize a document without leaking the body."
+    assert prompt["arguments"] == [
+        {
+            "name": "topic",
+            "title": "Topic",
+            "description": None,
+            "required": True,
+        }
+    ]
+    assert prompt["_meta"]["tldw"]["source"] == "library"
+    assert prompt["_meta"]["tldw"]["prompt_uuid"] == prompt_uuid
+    assert prompt["_meta"]["tldw"]["prompt_id"] == 42
+    assert prompt["_meta"]["tldw"]["version"] == 7
+    assert prompt["_meta"]["tldw"]["tags"] == ["summary", "docs"]
+
+
+def test_formatter_folds_system_and_user_into_mcp_user_message() -> None:
+    row = {
+        "id": 42,
+        "uuid": "11111111-1111-4111-8111-111111111111",
+        "name": "Summarizer",
+        "details": "",
+        "version": 1,
+        "keywords": [],
+        "system_prompt": "Be concise.",
+        "user_prompt": "Summarize {topic}",
+        "prompt_definition": None,
+    }
+    formatter = MCPPromptFormatter(max_rendered_chars=10_000)
+
+    result = formatter.render_library_prompt(row, {"topic": "MCP prompts"})
+
+    assert result["description"] == "Summarizer"
+    assert result["messages"] == [
+        {
+            "role": "user",
+            "content": {
+                "type": "text",
+                "text": "System instructions:\nBe concise.\n\nUser prompt:\nSummarize MCP prompts",
+            },
+        }
+    ]
+    assert result["_meta"]["tldw"]["source"] == "library"
+
+
+def test_formatter_preserves_assistant_messages_from_structured_prompt() -> None:
+    row = {
+        "id": 1,
+        "uuid": "22222222-2222-4222-8222-222222222222",
+        "name": "Few shot",
+        "details": "",
+        "version": 2,
+        "keywords": [],
+        "system_prompt": "",
+        "user_prompt": "",
+        "prompt_definition": {
+            "schema_version": 1,
+            "format": "structured",
+            "variables": [
+                {"name": "topic", "label": "Topic", "required": True, "input_type": "text"}
+            ],
+            "blocks": [
+                {
+                    "id": "instructions",
+                    "name": "Instructions",
+                    "role": "system",
+                    "content": "Teach clearly.",
+                    "enabled": True,
+                    "order": 10,
+                    "is_template": False,
+                },
+                {
+                    "id": "question",
+                    "name": "Question",
+                    "role": "user",
+                    "content": "Explain {{topic}}",
+                    "enabled": True,
+                    "order": 20,
+                    "is_template": True,
+                },
+                {
+                    "id": "sample",
+                    "name": "Sample",
+                    "role": "assistant",
+                    "content": "Here is a concise answer.",
+                    "enabled": True,
+                    "order": 30,
+                    "is_template": False,
+                },
+            ],
+        },
+    }
+    formatter = MCPPromptFormatter(max_rendered_chars=10_000)
+
+    result = formatter.render_library_prompt(row, {"topic": "vectors"})
+
+    assert result["messages"] == [
+        {
+            "role": "user",
+            "content": {
+                "type": "text",
+                "text": "System instructions:\nTeach clearly.\n\nUser prompt:\nExplain vectors",
+            },
+        },
+        {
+            "role": "assistant",
+            "content": {
+                "type": "text",
+                "text": "Here is a concise answer.",
+            },
+        },
+    ]
+
+
+def test_formatter_rejects_non_string_arguments() -> None:
+    formatter = MCPPromptFormatter(max_rendered_chars=10_000)
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        formatter.validate_arguments({"topic": 123})
+
+    assert excinfo.value.code == "invalid_argument_type"
+
+
+def test_formatter_accepts_non_empty_non_identifier_argument_names() -> None:
+    formatter = MCPPromptFormatter(max_rendered_chars=10_000)
+
+    assert formatter.validate_arguments({"topic-name": "MCP"}) == {"topic-name": "MCP"}
+
+
+def test_formatter_size_error_does_not_include_argument_value() -> None:
+    row = {
+        "id": 1,
+        "uuid": "33333333-3333-4333-8333-333333333333",
+        "name": "Echo",
+        "details": "",
+        "version": 1,
+        "keywords": [],
+        "system_prompt": "",
+        "user_prompt": "Echo {secret}",
+        "prompt_definition": None,
+    }
+    formatter = MCPPromptFormatter(max_rendered_chars=5)
+    sensitive_value = "SENSITIVE" + "_VALUE"
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        formatter.render_library_prompt(row, {"secret": sensitive_value})
+
+    assert excinfo.value.code == "rendered_prompt_too_large"  # nosec B101
+    assert sensitive_value not in str(excinfo.value)  # nosec B101
+
+
+def _context_for_prompts_db(db_path: str, *, scoped_ids: list[str] | None = None) -> SimpleNamespace:
+    metadata = {}
+    if scoped_ids is not None:
+        metadata["persona_scope"] = {"explicit_ids": {"prompt_id": scoped_ids}}
+    return SimpleNamespace(
+        db_paths={"prompts": db_path},
+        metadata=metadata,
+        logger=SimpleNamespace(debug=lambda *args, **kwargs: None),
+    )
+
+
+def _context_without_prompts_db() -> SimpleNamespace:
+    return SimpleNamespace(
+        db_paths={},
+        metadata={},
+        logger=SimpleNamespace(debug=lambda *args, **kwargs: None),
+    )
+
+
+def _add_legacy_prompt(db_path: str, *, name: str, deleted: bool = False) -> dict:
+    db = PromptsDatabase(db_path=db_path, client_id="test_prompts_catalog")
+    try:
+        prompt_id, _prompt_uuid, _message = db.add_prompt(
+            name=name,
+            author="tester",
+            details=f"{name} details",
+            system_prompt="Be concise.",
+            user_prompt="Summarize {topic}",
+            keywords=["summary"],
+        )
+        if deleted:
+            db.soft_delete_prompt(prompt_id)
+        return db.get_prompt_by_id(prompt_id, include_deleted=True)
+    finally:
+        db.close_connection()
+
+
+def test_user_source_lists_non_deleted_library_prompts_with_uuid_names(tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    alpha = _add_legacy_prompt(db_path, name="Alpha")
+    _add_legacy_prompt(db_path, name="Deleted", deleted=True)
+    source = UserPromptCatalogSource(MCPPromptFormatter(max_rendered_chars=10_000))
+
+    result = source.list_prompts(
+        context=_context_for_prompts_db(db_path),
+        cursor=PromptCatalogCursor(),
+        limit=50,
+    )
+
+    assert [prompt["name"] for prompt in result.prompts] == [f"{LIBRARY_PROMPT_PREFIX}{alpha['uuid']}"]
+    assert result.next_cursor is None
+    assert result.warnings == []
+
+
+def test_user_source_filters_by_prompt_id_scope(tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    allowed = _add_legacy_prompt(db_path, name="Allowed")
+    _add_legacy_prompt(db_path, name="Blocked")
+    source = UserPromptCatalogSource(MCPPromptFormatter(max_rendered_chars=10_000))
+
+    result = source.list_prompts(
+        context=_context_for_prompts_db(db_path, scoped_ids=[str(allowed["id"])]),
+        cursor=PromptCatalogCursor(),
+        limit=50,
+    )
+
+    assert [prompt["name"] for prompt in result.prompts] == [f"{LIBRARY_PROMPT_PREFIX}{allowed['uuid']}"]
+
+
+def test_user_source_list_missing_prompts_db_warns_without_leaking() -> None:
+    source = UserPromptCatalogSource(MCPPromptFormatter(max_rendered_chars=10_000))
+
+    result = source.list_prompts(
+        context=_context_without_prompts_db(),
+        cursor=PromptCatalogCursor(),
+        limit=50,
+    )
+
+    assert result.prompts == []
+    assert result.next_cursor is None
+    assert result.warnings == [{"source": "library", "code": "prompt_db_unavailable"}]
+
+
+def test_user_source_list_internal_formatting_failure_warns(tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    bad = _add_legacy_prompt(db_path, name="Bad Structured Prompt")
+
+    class InternalFailureFormatter(MCPPromptFormatter):
+        def library_prompt_definition(self, row):
+            raise PromptCatalogError("invalid_prompt_definition", "Invalid row.", internal=True)
+
+    source = UserPromptCatalogSource(InternalFailureFormatter(max_rendered_chars=10_000))
+
+    result = source.list_prompts(
+        context=_context_for_prompts_db(db_path),
+        cursor=PromptCatalogCursor(),
+        limit=50,
+    )
+
+    assert result.prompts == []
+    assert result.next_cursor is None
+    assert result.warnings == [
+        {"source": "library", "code": "prompt_unavailable", "prompt_uuid": bad["uuid"]}
+    ]
+
+
+def test_user_source_list_skips_bad_row_and_keeps_cursor_moving(tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    bad = _add_legacy_prompt(db_path, name="Alpha Bad")
+    good = _add_legacy_prompt(db_path, name="Beta Good")
+
+    class OneBadFormatter(MCPPromptFormatter):
+        def library_prompt_definition(self, row):
+            if row.get("uuid") == bad["uuid"]:
+                raise PromptCatalogError("invalid_prompt_definition", "Invalid row.", internal=True)
+            return super().library_prompt_definition(row)
+
+    source = UserPromptCatalogSource(OneBadFormatter(max_rendered_chars=10_000))
+
+    first_page = source.list_prompts(
+        context=_context_for_prompts_db(db_path),
+        cursor=PromptCatalogCursor(),
+        limit=1,
+    )
+    second_page = source.list_prompts(
+        context=_context_for_prompts_db(db_path),
+        cursor=first_page.next_cursor,
+        limit=1,
+    )
+
+    assert first_page.prompts == []
+    assert first_page.next_cursor.library_after_uuid == bad["uuid"]
+    assert first_page.warnings == [
+        {"source": "library", "code": "prompt_unavailable", "prompt_uuid": bad["uuid"]}
+    ]
+    assert [prompt["name"] for prompt in second_page.prompts] == [
+        f"{LIBRARY_PROMPT_PREFIX}{good['uuid']}"
+    ]
+    assert second_page.warnings == []
+
+
+def test_user_source_get_validates_uuid_and_scope(tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    allowed = _add_legacy_prompt(db_path, name="Allowed")
+    source = UserPromptCatalogSource(MCPPromptFormatter(max_rendered_chars=10_000))
+
+    result = source.get_prompt(
+        context=_context_for_prompts_db(db_path, scoped_ids=[str(allowed["id"])]),
+        name=f"{LIBRARY_PROMPT_PREFIX}{allowed['uuid']}",
+        arguments={"topic": "scoped prompts"},
+    )
+
+    assert result["messages"][0]["content"]["text"].endswith("Summarize scoped prompts")
+
+
+def test_user_source_get_rejects_malformed_library_prompt_name(tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    source = UserPromptCatalogSource(MCPPromptFormatter(max_rendered_chars=10_000))
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        source.get_prompt(
+            context=_context_for_prompts_db(db_path),
+            name=f"{LIBRARY_PROMPT_PREFIX}not-a-uuid",
+            arguments={"topic": "x"},
+        )
+
+    assert excinfo.value.code == "invalid_prompt_name"
+
+
+def test_user_source_get_rejects_prompt_outside_scope(tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    allowed = _add_legacy_prompt(db_path, name="Allowed")
+    blocked = _add_legacy_prompt(db_path, name="Blocked")
+    source = UserPromptCatalogSource(MCPPromptFormatter(max_rendered_chars=10_000))
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        source.get_prompt(
+            context=_context_for_prompts_db(db_path, scoped_ids=[str(allowed["id"])]),
+            name=f"{LIBRARY_PROMPT_PREFIX}{blocked['uuid']}",
+            arguments={"topic": "x"},
+        )
+
+    assert excinfo.value.code == "permission_denied"
+
+
+def test_user_source_get_sanitizes_db_failure() -> None:
+    class FailingDb:
+        def get_prompt_by_uuid(self, prompt_uuid, include_deleted=False):
+            raise DatabaseError("raw db failure")
+
+        def close_connection(self):
+            pass
+
+    class FailingSource(UserPromptCatalogSource):
+        def _open_db(self, context):
+            return FailingDb()
+
+    source = FailingSource(MCPPromptFormatter(max_rendered_chars=10_000))
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        source.get_prompt(
+            context=_context_without_prompts_db(),
+            name=f"{LIBRARY_PROMPT_PREFIX}11111111-1111-4111-8111-111111111111",
+            arguments={"topic": "x"},
+        )
+
+    assert excinfo.value.code == "prompt_db_unavailable"
+    assert excinfo.value.internal is True
+    assert "raw db failure" not in excinfo.value.message
+
+
+def test_user_source_get_sanitizes_internal_formatting_failure(tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    prompt = _add_legacy_prompt(db_path, name="Bad Render")
+
+    class InternalFailureFormatter(MCPPromptFormatter):
+        def render_library_prompt(self, row, arguments):
+            raise PromptCatalogError("invalid_prompt_definition", "Invalid row.", internal=True)
+
+    source = UserPromptCatalogSource(InternalFailureFormatter(max_rendered_chars=10_000))
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        source.get_prompt(
+            context=_context_for_prompts_db(db_path),
+            name=f"{LIBRARY_PROMPT_PREFIX}{prompt['uuid']}",
+            arguments={"topic": "x"},
+        )
+
+    assert excinfo.value.code == "prompt_db_unavailable"
+    assert excinfo.value.internal is True
+    assert "Invalid row" not in excinfo.value.message
+
+
+def test_config_source_lists_only_explicit_entries(monkeypatch, tmp_path) -> None:
+    override_path = tmp_path / "rag_retrieval.txt"
+    override_path.write_text("Retrieve context for {query}", encoding="utf-8")
+    monkeypatch.setenv("TLDW_PROMPT_FILE_RAG__RETRIEVAL_GUIDANCE", str(override_path))
+    source = ConfigPromptCatalogSource(
+        MCPPromptFormatter(max_rendered_chars=10_000),
+        {
+            "enabled": True,
+            "entries": [
+                {
+                    "id": "rag.retrieval_guidance",
+                    "module": "rag",
+                    "key": "retrieval_guidance",
+                    "title": "Retrieval Guidance",
+                }
+            ],
+        },
+    )
+
+    result = source.list_prompts(cursor=PromptCatalogCursor(), limit=50)
+
+    assert [prompt["name"] for prompt in result.prompts] == [
+        f"{CONFIG_PROMPT_PREFIX}rag.retrieval_guidance"
+    ]
+    assert result.prompts[0]["arguments"][0]["name"] == "query"
+
+
+def test_config_source_grouped_render_folds_system_user_and_preserves_assistant(monkeypatch, tmp_path) -> None:
+    system_path = tmp_path / "system.txt"
+    user_path = tmp_path / "user.txt"
+    assistant_path = tmp_path / "assistant.txt"
+    system_path.write_text("Use brief answers.", encoding="utf-8")
+    user_path.write_text("Summarize {topic}", encoding="utf-8")
+    assistant_path.write_text("Example summary.", encoding="utf-8")
+    monkeypatch.setenv("TLDW_PROMPT_FILE_CHAT__SUMMARY_SYSTEM", str(system_path))
+    monkeypatch.setenv("TLDW_PROMPT_FILE_CHAT__SUMMARY_USER", str(user_path))
+    monkeypatch.setenv("TLDW_PROMPT_FILE_CHAT__SUMMARY_EXAMPLE", str(assistant_path))
+    source = ConfigPromptCatalogSource(
+        MCPPromptFormatter(max_rendered_chars=10_000),
+        {
+            "enabled": True,
+            "entries": [
+                {
+                    "id": "chat.summary",
+                    "title": "Conversation Summary",
+                    "messages": [
+                        {"role": "system", "module": "chat", "key": "summary_system"},
+                        {"role": "user", "module": "chat", "key": "summary_user"},
+                        {"role": "assistant", "module": "chat", "key": "summary_example"},
+                    ],
+                }
+            ],
+        },
+    )
+
+    result = source.get_prompt(
+        name=f"{CONFIG_PROMPT_PREFIX}chat.summary",
+        arguments={"topic": "release notes"},
+    )
+
+    assert result["messages"] == [
+        {
+            "role": "user",
+            "content": {
+                "type": "text",
+                "text": "System instructions:\nUse brief answers.\n\nUser prompt:\nSummarize release notes",
+            },
+        },
+        {
+            "role": "assistant",
+            "content": {
+                "type": "text",
+                "text": "Example summary.",
+            },
+        },
+    ]
+
+
+def test_config_source_omits_missing_allowlist_entry() -> None:
+    source = ConfigPromptCatalogSource(
+        MCPPromptFormatter(max_rendered_chars=10_000),
+        {
+            "enabled": True,
+            "entries": [
+                {
+                    "id": "missing.entry",
+                    "module": "missing",
+                    "key": "entry",
+                    "title": "Missing Entry",
+                }
+            ],
+        },
+    )
+
+    result = source.list_prompts(cursor=PromptCatalogCursor(), limit=50)
+
+    assert result.prompts == []
+    assert result.warnings == [
+        {"source": "config", "code": "config_prompt_unavailable", "id": "missing.entry"}
+    ]
+
+
+def test_missing_config_entry_error_does_not_include_override_path(monkeypatch, tmp_path) -> None:
+    missing_path = tmp_path / "missing-prompt.txt"
+    monkeypatch.setenv("TLDW_PROMPT_FILE_MISSING__ENTRY", str(missing_path))
+    source = ConfigPromptCatalogSource(
+        MCPPromptFormatter(max_rendered_chars=10_000),
+        {
+            "enabled": True,
+            "entries": [
+                {
+                    "id": "missing.entry",
+                    "module": "missing",
+                    "key": "entry",
+                    "title": "Missing Entry",
+                }
+            ],
+        },
+    )
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        source.get_prompt(name=f"{CONFIG_PROMPT_PREFIX}missing.entry", arguments={})
+
+    assert excinfo.value.code == "config_prompt_unavailable"  # nosec B101
+    assert "Config prompt is unavailable." in str(excinfo.value)  # nosec B101
+    assert str(missing_path) not in str(excinfo.value)  # nosec B101
+
+
+def test_config_source_get_respects_disabled_flag(monkeypatch, tmp_path) -> None:
+    override_path = tmp_path / "prompt.txt"
+    override_path.write_text("Search {query}", encoding="utf-8")
+    monkeypatch.setenv("TLDW_PROMPT_FILE_MCP__SEARCH_KNOWLEDGE", str(override_path))
+    source = ConfigPromptCatalogSource(
+        MCPPromptFormatter(max_rendered_chars=10_000),
+        {
+            "enabled": False,
+            "entries": [
+                {
+                    "id": "mcp.search_knowledge",
+                    "module": "mcp",
+                    "key": "search_knowledge",
+                    "title": "Search Knowledge",
+                }
+            ],
+        },
+    )
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        source.get_prompt(name=f"{CONFIG_PROMPT_PREFIX}mcp.search_knowledge", arguments={"query": "x"})
+
+    assert excinfo.value.code == "prompt_not_found"
+
+
+def test_config_source_reports_entries_after_index(monkeypatch, tmp_path) -> None:
+    override_path = tmp_path / "prompt.txt"
+    override_path.write_text("Search {query}", encoding="utf-8")
+    monkeypatch.setenv("TLDW_PROMPT_FILE_MCP__SEARCH_KNOWLEDGE", str(override_path))
+    source = ConfigPromptCatalogSource(
+        MCPPromptFormatter(max_rendered_chars=10_000),
+        {
+            "enabled": True,
+            "entries": [
+                {
+                    "id": "mcp.search_knowledge",
+                    "module": "mcp",
+                    "key": "search_knowledge",
+                    "title": "Search Knowledge",
+                }
+            ],
+        },
+    )
+
+    assert source.has_entries_after(0) is True
+    assert source.has_entries_after(1) is False
+
+
+def test_user_source_skips_library_when_cursor_is_inside_config_page(tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    _add_legacy_prompt(db_path, name="Alpha")
+    source = UserPromptCatalogSource(MCPPromptFormatter(max_rendered_chars=10_000))
+
+    result = source.list_prompts(
+        context=_context_for_prompts_db(db_path),
+        cursor=PromptCatalogCursor(library_done=True, config_index=1),
+        limit=50,
+    )
+
+    assert result.prompts == []
+    assert result.next_cursor is None
+    assert result.warnings == []
+
+
+def test_user_source_uses_collate_nocase_keyset_with_raw_name_cursor(tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    alpha = _add_legacy_prompt(db_path, name="Alpha")
+    beta = _add_legacy_prompt(db_path, name="beta")
+    source = UserPromptCatalogSource(MCPPromptFormatter(max_rendered_chars=10_000))
+
+    first_page = source.list_prompts(
+        context=_context_for_prompts_db(db_path),
+        cursor=PromptCatalogCursor(),
+        limit=1,
+    )
+    second_page = source.list_prompts(
+        context=_context_for_prompts_db(db_path),
+        cursor=first_page.next_cursor,
+        limit=1,
+    )
+
+    assert first_page.prompts[0]["name"] == f"{LIBRARY_PROMPT_PREFIX}{alpha['uuid']}"
+    assert first_page.next_cursor.library_after_name == "Alpha"
+    assert second_page.prompts[0]["name"] == f"{LIBRARY_PROMPT_PREFIX}{beta['uuid']}"
+
+
+def test_user_source_keyset_page_is_stable_when_prompt_inserted_before_cursor(tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    alpha = _add_legacy_prompt(db_path, name="Alpha")
+    charlie = _add_legacy_prompt(db_path, name="Charlie")
+    source = UserPromptCatalogSource(MCPPromptFormatter(max_rendered_chars=10_000))
+
+    first_page = source.list_prompts(
+        context=_context_for_prompts_db(db_path),
+        cursor=PromptCatalogCursor(),
+        limit=1,
+    )
+    _add_legacy_prompt(db_path, name="Aardvark")
+    second_page = source.list_prompts(
+        context=_context_for_prompts_db(db_path),
+        cursor=first_page.next_cursor,
+        limit=10,
+    )
+
+    assert [prompt["name"] for prompt in first_page.prompts] == [  # nosec B101
+        f"{LIBRARY_PROMPT_PREFIX}{alpha['uuid']}"
+    ]
+    assert [prompt["name"] for prompt in second_page.prompts] == [  # nosec B101
+        f"{LIBRARY_PROMPT_PREFIX}{charlie['uuid']}"
+    ]
+
+
+def _prompts_module_config(page_size: int) -> ModuleConfig:
+    return ModuleConfig(
+        name="prompts",
+        settings={
+            "prompt_list_page_size": page_size,
+            "max_rendered_prompt_chars": 10_000,
+            "config_prompts": {
+                "enabled": True,
+                "entries": [
+                    {
+                        "id": "mcp.search_knowledge",
+                        "module": "mcp",
+                        "key": "search_knowledge",
+                        "title": "Search Knowledge",
+                    }
+                ],
+            },
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_prompts_module_context_list_combines_library_and_config(monkeypatch, tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    library_prompt = _add_legacy_prompt(db_path, name="Library Prompt")
+    override_path = tmp_path / "search_knowledge.txt"
+    override_path.write_text("Search for {query}", encoding="utf-8")
+    monkeypatch.setenv("TLDW_PROMPT_FILE_MCP__SEARCH_KNOWLEDGE", str(override_path))
+    module = PromptsModule(_prompts_module_config(page_size=50))
+    await module.on_initialize()
+
+    result = await module.get_prompts_for_context(_context_for_prompts_db(db_path), {})
+
+    assert [prompt["name"] for prompt in result["prompts"]] == [
+        f"{LIBRARY_PROMPT_PREFIX}{library_prompt['uuid']}",
+        f"{CONFIG_PROMPT_PREFIX}mcp.search_knowledge",
+    ]
+    assert "nextCursor" not in result
+
+
+@pytest.mark.asyncio
+async def test_prompts_module_returns_config_cursor_when_library_exactly_fills_page(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    library_prompt = _add_legacy_prompt(db_path, name="Library Prompt")
+    override_path = tmp_path / "search_knowledge.txt"
+    override_path.write_text("Search for {query}", encoding="utf-8")
+    monkeypatch.setenv("TLDW_PROMPT_FILE_MCP__SEARCH_KNOWLEDGE", str(override_path))
+    module = PromptsModule(_prompts_module_config(page_size=1))
+    await module.on_initialize()
+
+    first_page = await module.get_prompts_for_context(_context_for_prompts_db(db_path), {})
+    second_page = await module.get_prompts_for_context(
+        _context_for_prompts_db(db_path),
+        {"cursor": first_page["nextCursor"]},
+    )
+
+    assert [prompt["name"] for prompt in first_page["prompts"]] == [
+        f"{LIBRARY_PROMPT_PREFIX}{library_prompt['uuid']}"
+    ]
+    assert first_page["nextCursor"]
+    assert [prompt["name"] for prompt in second_page["prompts"]] == [
+        f"{CONFIG_PROMPT_PREFIX}mcp.search_knowledge"
+    ]
+    assert "nextCursor" not in second_page
+
+
+@pytest.mark.asyncio
+async def test_prompts_module_context_get_routes_by_namespace(tmp_path) -> None:
+    db_path = str(tmp_path / "prompts.db")
+    library_prompt = _add_legacy_prompt(db_path, name="Library Prompt")
+    module = PromptsModule(_prompts_module_config(page_size=50))
+    await module.on_initialize()
+
+    result = await module.get_prompt_for_context(
+        f"{LIBRARY_PROMPT_PREFIX}{library_prompt['uuid']}",
+        {"topic": "MCP catalog"},
+        _context_for_prompts_db(db_path),
+    )
+
+    assert result["messages"][0]["content"]["text"].endswith("Summarize MCP catalog")
+
+
+@pytest.mark.asyncio
+async def test_prompts_module_bad_cursor_raises_catalog_error(tmp_path) -> None:
+    module = PromptsModule(_prompts_module_config(page_size=50))
+    await module.on_initialize()
+
+    with pytest.raises(PromptCatalogError) as excinfo:
+        await module.get_prompts_for_context(
+            _context_for_prompts_db(str(tmp_path / "prompts.db")),
+            {"cursor": "not-valid-base64"},
+        )
+
+    assert excinfo.value.code == "invalid_cursor"
+
+
+def test_catalog_adapter_does_not_import_prompt_studio(monkeypatch) -> None:
+    module_name = "tldw_Server_API.app.core.MCP_unified.modules.implementations.prompts_catalog"
+    blocked_segments = (
+        "Prompt_Management.PromptStudio",
+        "PromptStudio",
+        "prompt_studio",
+        "promptstudio",
+    )
+    real_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if any(segment in name for segment in blocked_segments):
+            raise AssertionError(f"prompts_catalog imported Prompt Studio module: {name}")
+        return real_import(name, globals, locals, fromlist, level)
+
+    sys.modules.pop(module_name, None)
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    prompts_catalog = importlib.import_module(module_name)
+
+    assert hasattr(prompts_catalog, "MCPPromptFormatter")

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py
@@ -1,0 +1,630 @@
+"""Protocol coverage for MCP prompt catalog routing."""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+import pytest
+from loguru import logger
+
+from tldw_Server_API.app.core.MCP_unified.auth.authnz_rbac import Action, Resource
+from tldw_Server_API.app.core.MCP_unified.modules.base import BaseModule, ModuleConfig
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.prompts_catalog import (
+    LIBRARY_PROMPT_PREFIX,
+    PromptCatalogCursor,
+    PromptCatalogError,
+    encode_prompt_cursor,
+)
+from tldw_Server_API.app.core.MCP_unified.protocol import (
+    InvalidParamsException,
+    MCPRequest,
+    MCPProtocol,
+    RequestContext,
+)
+
+
+class PromptOnlyRegistry:
+    def __init__(self, modules: dict[str, BaseModule] | None = None) -> None:
+        self.modules = modules or {}
+        self.find_calls: list[str] = []
+
+    async def get_all_modules(self) -> dict[str, BaseModule]:
+        return self.modules
+
+    async def get_module(self, module_id: str) -> BaseModule | None:
+        return self.modules.get(module_id)
+
+    async def find_module_for_prompt(self, name: str) -> None:
+        self.find_calls.append(name)
+        return None
+
+    def get_module_id_for_prompt(self, name: str) -> None:
+        return None
+
+
+class PromptPermissionPolicy:
+    def __init__(self, *, prompt_read: bool, module_read: bool) -> None:
+        self.prompt_read = prompt_read
+        self.module_read = module_read
+
+    def check_permission(
+        self,
+        user_id: str | None,
+        resource: Resource,
+        action: Action,
+        resource_id: str | None = None,
+    ) -> bool:
+        if action is not Action.READ:
+            return False
+        if resource is Resource.PROMPT:
+            return self.prompt_read
+        if resource is Resource.MODULE:
+            return self.module_read
+        return False
+
+
+class ContextPromptModule(BaseModule):
+    async def on_initialize(self) -> None:
+        return None
+
+    async def on_shutdown(self) -> None:
+        return None
+
+    async def check_health(self) -> dict[str, bool]:
+        return {"ok": True}
+
+    async def get_tools(self) -> list[dict[str, Any]]:
+        return []
+
+    async def execute_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: Any | None = None,
+    ) -> Any:
+        raise NotImplementedError
+
+    async def get_prompts_for_context(
+        self,
+        context: RequestContext,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "prompts": [
+                {
+                    "name": "library:550e8400-e29b-41d4-a716-446655440000",
+                    "description": "Prompt library entry",
+                    "arguments": [],
+                }
+            ],
+            "nextCursor": "next-page-token",
+            "_meta": {
+                "tldw": {
+                    "warnings": [
+                        {"code": "config_skipped", "message": "Config prompt skipped"},
+                        "ignored",
+                    ]
+                }
+            },
+        }
+
+    async def get_prompt_for_context(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: RequestContext,
+    ) -> dict[str, Any]:
+        return {
+            "description": f"Resolved {name}",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": {
+                        "type": "text",
+                        "text": f"argument-count={len(arguments)}",
+                    },
+                }
+            ],
+        }
+
+
+class FailingPromptModule(ContextPromptModule):
+    async def get_prompts_for_context(
+        self,
+        context: RequestContext,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        raise PromptCatalogError(
+            "prompt_db_unavailable",
+            "Prompt library is unavailable.",
+            internal=True,
+        )
+
+
+class ScopedWarningPromptModule(ContextPromptModule):
+    async def get_prompts_for_context(
+        self,
+        context: RequestContext,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        allowed_uuid = "550e8400-e29b-41d4-a716-446655440000"
+        denied_uuid = "550e8400-e29b-41d4-a716-446655440001"
+        return {
+            "prompts": [
+                {
+                    "name": f"{LIBRARY_PROMPT_PREFIX}{allowed_uuid}",
+                    "description": "Allowed prompt library entry",
+                    "arguments": [],
+                },
+                {
+                    "name": f"{LIBRARY_PROMPT_PREFIX}{denied_uuid}",
+                    "description": "Denied prompt library entry",
+                    "arguments": [],
+                },
+            ],
+            "_meta": {
+                "tldw": {
+                    "warnings": [
+                        {
+                            "source": "library",
+                            "code": "prompt_unavailable",
+                            "prompt_uuid": allowed_uuid,
+                        },
+                        {
+                            "source": "library",
+                            "code": "prompt_unavailable",
+                            "prompt_uuid": denied_uuid,
+                        },
+                    ]
+                }
+            },
+        }
+
+
+class ScopedCursorPromptModule(ContextPromptModule):
+    async def get_prompts_for_context(
+        self,
+        context: RequestContext,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        allowed_uuid = "550e8400-e29b-41d4-a716-446655440000"
+        denied_uuid = "550e8400-e29b-41d4-a716-446655440001"
+        denied_name = "Denied Private Prompt"
+        return {
+            "prompts": [
+                {
+                    "name": f"{LIBRARY_PROMPT_PREFIX}{allowed_uuid}",
+                    "description": "Allowed prompt library entry",
+                    "arguments": [],
+                }
+            ],
+            "nextCursor": encode_prompt_cursor(
+                PromptCatalogCursor(
+                    library_after_name=denied_name,
+                    library_after_uuid=denied_uuid,
+                )
+            ),
+        }
+
+
+class IdentifierWarningPromptModule(ContextPromptModule):
+    async def get_prompts_for_context(
+        self,
+        context: RequestContext,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        allowed_uuid = "550e8400-e29b-41d4-a716-446655440000"
+        return {
+            "prompts": [
+                {
+                    "name": f"{LIBRARY_PROMPT_PREFIX}{allowed_uuid}",
+                    "description": "Allowed prompt library entry",
+                    "arguments": [],
+                }
+            ],
+            "_meta": {
+                "tldw": {
+                    "warnings": [
+                        {
+                            "source": "library",
+                            "code": "prompt_unavailable",
+                            "_prompt_name": f"{LIBRARY_PROMPT_PREFIX}{allowed_uuid}",
+                            "prompt_name": f"{LIBRARY_PROMPT_PREFIX}{allowed_uuid}",
+                            "prompt_uuid": allowed_uuid,
+                            "prompt_id": 42,
+                            "id": "library-row-42",
+                        },
+                        {
+                            "source": "config",
+                            "code": "config_prompt_unavailable",
+                            "_prompt_name": f"{LIBRARY_PROMPT_PREFIX}{allowed_uuid}",
+                            "prompt_uuid": allowed_uuid,
+                            "prompt_id": 43,
+                            "id": "mismatched.config.id",
+                        },
+                    ]
+                }
+            },
+        }
+
+
+class ErrorPromptModule(ContextPromptModule):
+    def __init__(self, config: ModuleConfig, error: PromptCatalogError) -> None:
+        super().__init__(config)
+        self.error = error
+
+    async def get_prompt_for_context(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: RequestContext,
+    ) -> dict[str, Any]:
+        raise self.error
+
+
+def _handler_with_registry(registry: PromptOnlyRegistry) -> MCPProtocol:
+    handler = MCPProtocol()
+    handler.module_registry = registry
+    return handler
+
+
+def _prompt_module() -> ContextPromptModule:
+    return ContextPromptModule(
+        ModuleConfig(
+            name="prompts",
+            version="1.0.0",
+            description="Prompt catalog test module",
+        )
+    )
+
+
+def _context() -> RequestContext:
+    return RequestContext(request_id="prompt-catalog", user_id="u1", client_id="unit")
+
+
+async def _async_true(*args: Any, **kwargs: Any) -> bool:
+    return True
+
+
+def _decoded_cursor_text(cursor: str) -> str:
+    padding = "=" * (-len(cursor) % 4)
+    payload = base64.urlsafe_b64decode((cursor + padding).encode("ascii"))
+    return json.dumps(json.loads(payload.decode("utf-8")), sort_keys=True)
+
+
+@pytest.mark.asyncio
+async def test_initialize_declares_mcp_prompt_capability() -> None:
+    handler = _handler_with_registry(PromptOnlyRegistry({"prompts": _prompt_module()}))
+
+    result = await handler._handle_initialize({"clientInfo": {"name": "unit"}}, _context())
+
+    assert result["capabilities"]["prompts"] == {"listChanged": False}  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_prompts_list_uses_context_hook_and_preserves_cursor_and_warnings(monkeypatch) -> None:
+    handler = _handler_with_registry(PromptOnlyRegistry({"prompts": _prompt_module()}))
+
+    async def _allow_namespaced(context: RequestContext, prompt_name: str) -> bool:
+        return True
+
+    monkeypatch.setattr(handler, "_has_namespaced_prompt_permission", _allow_namespaced)
+
+    result = await handler._handle_prompts_list({}, _context())
+
+    assert result["prompts"] == [  # nosec B101
+        {
+            "name": "library:550e8400-e29b-41d4-a716-446655440000",
+            "description": "Prompt library entry",
+            "arguments": [],
+            "module": "prompts",
+        }
+    ]
+    assert result["nextCursor"] == "next-page-token"  # nosec B101
+    assert result["_meta"]["tldw"]["warnings"] == [  # nosec B101
+        {"code": "config_skipped", "message": "Config prompt skipped"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_prompts_list_filters_and_sanitizes_scoped_warning_metadata() -> None:
+    module = ScopedWarningPromptModule(
+        ModuleConfig(
+            name="prompts",
+            version="1.0.0",
+            description="Scoped warning prompt catalog test module",
+        )
+    )
+    handler = _handler_with_registry(PromptOnlyRegistry({"prompts": module}))
+    handler.rbac_policy = PromptPermissionPolicy(prompt_read=True, module_read=False)
+    allowed_prompt_name = f"{LIBRARY_PROMPT_PREFIX}550e8400-e29b-41d4-a716-446655440000"
+    denied_prompt_name = f"{LIBRARY_PROMPT_PREFIX}550e8400-e29b-41d4-a716-446655440001"
+    context = RequestContext(
+        request_id="prompt-catalog-scoped-warnings",
+        user_id="u1",
+        client_id="unit",
+        metadata={"permissions": [f"mcp:prompt:{allowed_prompt_name}"]},
+    )
+
+    result = await handler._handle_prompts_list({}, context)
+
+    assert [prompt["name"] for prompt in result["prompts"]] == [allowed_prompt_name]  # nosec B101
+    assert denied_prompt_name not in str(result)  # nosec B101
+    assert "550e8400-e29b-41d4-a716-446655440001" not in str(result)  # nosec B101
+    assert result["_meta"]["tldw"]["warnings"] == [  # nosec B101
+        {"source": "library", "code": "prompt_unavailable"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_prompts_list_does_not_return_denied_identifier_cursor_for_scoped_callers() -> None:
+    module = ScopedCursorPromptModule(
+        ModuleConfig(
+            name="prompts",
+            version="1.0.0",
+            description="Scoped cursor prompt catalog test module",
+        )
+    )
+    handler = _handler_with_registry(PromptOnlyRegistry({"prompts": module}))
+    handler.rbac_policy = PromptPermissionPolicy(prompt_read=True, module_read=False)
+    allowed_prompt_name = f"{LIBRARY_PROMPT_PREFIX}550e8400-e29b-41d4-a716-446655440000"
+    denied_uuid = "550e8400-e29b-41d4-a716-446655440001"
+    denied_name = "Denied Private Prompt"
+    context = RequestContext(
+        request_id="prompt-catalog-scoped-cursor",
+        user_id="u1",
+        client_id="unit",
+        metadata={"permissions": [f"mcp:prompt:{allowed_prompt_name}"]},
+    )
+
+    result = await handler._handle_prompts_list({}, context)
+
+    assert [prompt["name"] for prompt in result["prompts"]] == [allowed_prompt_name]  # nosec B101
+    assert denied_name not in str(result["prompts"])  # nosec B101
+    assert denied_uuid not in str(result["prompts"])  # nosec B101
+    if "nextCursor" in result:
+        decoded_cursor = _decoded_cursor_text(result["nextCursor"])
+        assert denied_name not in decoded_cursor  # nosec B101
+        assert denied_uuid not in decoded_cursor  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_visible_prompt_warning_strips_identifier_fields_after_explicit_name_resolution() -> None:
+    module = IdentifierWarningPromptModule(
+        ModuleConfig(
+            name="prompts",
+            version="1.0.0",
+            description="Identifier warning prompt catalog test module",
+        )
+    )
+    handler = _handler_with_registry(PromptOnlyRegistry({"prompts": module}))
+    handler.rbac_policy = PromptPermissionPolicy(prompt_read=True, module_read=False)
+    allowed_prompt_name = f"{LIBRARY_PROMPT_PREFIX}550e8400-e29b-41d4-a716-446655440000"
+    context = RequestContext(
+        request_id="prompt-catalog-warning-identifiers",
+        user_id="u1",
+        client_id="unit",
+        metadata={"permissions": [f"mcp:prompt:{allowed_prompt_name}"]},
+    )
+
+    result = await handler._handle_prompts_list({}, context)
+
+    assert result["_meta"]["tldw"]["warnings"] == [  # nosec B101
+        {"source": "library", "code": "prompt_unavailable"},
+        {"source": "config", "code": "config_prompt_unavailable"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_prompts_list_maps_internal_catalog_error_to_runtime_error() -> None:
+    handler = _handler_with_registry(
+        PromptOnlyRegistry(
+            {
+                "prompts": FailingPromptModule(
+                    ModuleConfig(
+                        name="prompts",
+                        version="1.0.0",
+                        description="Failing prompt catalog test module",
+                    )
+                )
+            }
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="Failed to list prompts") as excinfo:
+        await handler._handle_prompts_list({}, _context())
+
+    assert excinfo.value.__cause__ is None  # nosec B101
+    assert excinfo.value.__suppress_context__ is True  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_prompts_get_dispatches_namespaced_prompt_before_global_registry(monkeypatch) -> None:
+    registry = PromptOnlyRegistry({"prompts": _prompt_module()})
+    handler = _handler_with_registry(registry)
+
+    async def _allow_namespaced(context: RequestContext, prompt_name: str) -> bool:
+        return True
+
+    monkeypatch.setattr(handler, "_has_namespaced_prompt_permission", _allow_namespaced)
+
+    result = await handler._handle_prompts_get(
+        {
+            "name": "library:550e8400-e29b-41d4-a716-446655440000",
+            "arguments": {"topic": "catalog"},
+        },
+        _context(),
+    )
+
+    assert result["description"] == "Resolved library:550e8400-e29b-41d4-a716-446655440000"  # nosec B101
+    assert result["messages"][0]["content"]["text"] == "argument-count=1"  # nosec B101
+    assert registry.find_calls == []  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_prompts_get_rejects_non_object_arguments(monkeypatch) -> None:
+    handler = _handler_with_registry(PromptOnlyRegistry({"prompts": _prompt_module()}))
+
+    async def _allow_namespaced(context: RequestContext, prompt_name: str) -> bool:
+        return True
+
+    monkeypatch.setattr(handler, "_has_namespaced_prompt_permission", _allow_namespaced)
+
+    with pytest.raises(InvalidParamsException, match="Prompt arguments must be an object"):
+        await handler._handle_prompts_get(
+            {
+                "name": "library:550e8400-e29b-41d4-a716-446655440000",
+                "arguments": [],
+            },
+            _context(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_protocol_maps_catalog_invalid_params_without_body_leak(monkeypatch) -> None:
+    handler = _handler_with_registry(
+        PromptOnlyRegistry(
+            {
+                "prompts": ErrorPromptModule(
+                    ModuleConfig(
+                        name="prompts",
+                        version="1.0.0",
+                        description="Error prompt catalog test module",
+                    ),
+                    PromptCatalogError(
+                        "missing_required_variable",
+                        "Missing required variable: topic",
+                    ),
+                )
+            }
+        )
+    )
+    monkeypatch.setattr(handler, "_has_namespaced_prompt_permission", _async_true)
+
+    with pytest.raises(InvalidParamsException) as excinfo:
+        await handler._handle_prompts_get(
+            {
+                "name": f"{LIBRARY_PROMPT_PREFIX}550e8400-e29b-41d4-a716-446655440000",
+                "arguments": {},
+            },
+            _context(),
+        )
+
+    assert "Missing required variable: topic" in str(excinfo.value)  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_protocol_maps_internal_catalog_error_to_internal_message(monkeypatch) -> None:
+    handler = _handler_with_registry(
+        PromptOnlyRegistry(
+            {
+                "prompts": ErrorPromptModule(
+                    ModuleConfig(
+                        name="prompts",
+                        version="1.0.0",
+                        description="Internal error prompt catalog test module",
+                    ),
+                    PromptCatalogError(
+                        "prompt_db_unavailable",
+                        "Prompt body SENSITIVE",
+                        internal=True,
+                    ),
+                )
+            }
+        )
+    )
+    monkeypatch.setattr(handler, "_has_namespaced_prompt_permission", _async_true)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await handler._handle_prompts_get(
+            {
+                "name": f"{LIBRARY_PROMPT_PREFIX}550e8400-e29b-41d4-a716-446655440000",
+                "arguments": {},
+            },
+            _context(),
+        )
+
+    assert "Failed to get prompt" in str(excinfo.value)  # nosec B101
+    assert "SENSITIVE" not in str(excinfo.value)  # nosec B101
+    assert excinfo.value.__cause__ is None  # nosec B101
+    assert excinfo.value.__suppress_context__ is True  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_process_request_internal_catalog_error_does_not_leak_to_response_or_logs(
+    monkeypatch,
+) -> None:
+    handler = _handler_with_registry(
+        PromptOnlyRegistry(
+            {
+                "prompts": ErrorPromptModule(
+                    ModuleConfig(
+                        name="prompts",
+                        version="1.0.0",
+                        description="Internal error prompt catalog test module",
+                    ),
+                    PromptCatalogError(
+                        "prompt_db_unavailable",
+                        "Prompt body SENSITIVE",
+                        internal=True,
+                    ),
+                )
+            }
+        )
+    )
+    handler.rbac_policy = PromptPermissionPolicy(prompt_read=True, module_read=False)
+    monkeypatch.setattr(handler, "_has_namespaced_prompt_permission", _async_true)
+    captured_logs: list[str] = []
+    sink_id = logger.add(lambda message: captured_logs.append(str(message)), level="DEBUG")
+
+    try:
+        response = await handler.process_request(
+            MCPRequest(
+                method="prompts/get",
+                params={
+                    "name": f"{LIBRARY_PROMPT_PREFIX}550e8400-e29b-41d4-a716-446655440000",
+                    "arguments": {},
+                },
+                id="prompt-internal-error",
+            ),
+            _context(),
+        )
+    finally:
+        logger.remove(sink_id)
+
+    assert response is not None  # nosec B101
+    assert response.error is not None  # nosec B101
+    assert response.error.code == -32603  # nosec B101
+    assert response.error.message == "Internal error"  # nosec B101
+    assert "SENSITIVE" not in str(response)  # nosec B101
+    assert "SENSITIVE" not in "".join(captured_logs)  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_prompts_list_allows_prompts_read_without_module_read_for_namespaced_prompts() -> None:
+    handler = _handler_with_registry(PromptOnlyRegistry({"prompts": _prompt_module()}))
+    handler.rbac_policy = PromptPermissionPolicy(prompt_read=True, module_read=False)
+
+    response = await handler.process_request(
+        MCPRequest(method="prompts/list", params={}, id="prompt-list-no-module-read"),
+        _context(),
+    )
+
+    assert response is not None  # nosec B101
+    assert response.error is None  # nosec B101
+    assert response.result is not None  # nosec B101
+    assert [prompt["name"] for prompt in response.result["prompts"]] == [  # nosec B101
+        "library:550e8400-e29b-41d4-a716-446655440000"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_namespaced_prompt_denies_when_only_module_read_is_granted() -> None:
+    handler = _handler_with_registry(PromptOnlyRegistry({"prompts": _prompt_module()}))
+    handler.rbac_policy = PromptPermissionPolicy(prompt_read=False, module_read=True)
+
+    result = await handler._handle_prompts_list({}, _context())
+
+    assert result["prompts"] == []  # nosec B101

--- a/tldw_Server_API/tests/AuthNZ/unit/test_rbac_seed_helper.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_rbac_seed_helper.py
@@ -59,6 +59,7 @@ async def test_ensure_baseline_rbac_seed_sqlite_idempotent():
             "system.configure",
             "users.manage_roles",
             "modules.read",
+            "prompts.read",
             "tools.execute:*",
         }
         cur = await conn.execute("SELECT name FROM permissions")
@@ -74,7 +75,8 @@ async def test_ensure_baseline_rbac_seed_sqlite_idempotent():
             FROM permissions
             WHERE name IN (
                 'media.read','media.create','media.delete','system.configure',
-                'users.manage_roles','sql.read','sql.target:media_db','modules.read','tools.execute:*'
+                'users.manage_roles','sql.read','sql.target:media_db','modules.read',
+                'prompts.read','tools.execute:*'
             )
             """
         )
@@ -90,6 +92,7 @@ async def test_ensure_baseline_rbac_seed_sqlite_idempotent():
         assert perm_id["sql.read"] in user_perm_ids
         assert perm_id["sql.target:media_db"] in user_perm_ids
         assert perm_id["modules.read"] in user_perm_ids
+        assert perm_id["prompts.read"] in user_perm_ids
 
         cur = await conn.execute(
             "SELECT permission_id FROM role_permissions WHERE role_id = ?",
@@ -105,6 +108,69 @@ async def test_ensure_baseline_rbac_seed_sqlite_idempotent():
         admin_perm_ids = {row[0] for row in await cur.fetchall()}
         for name in expected_permissions:
             assert perm_id[name] in admin_perm_ids
+
+
+def test_migration_089_seeds_prompts_read_for_existing_admin_and_user_roles():
+    import sqlite3
+
+    from tldw_Server_API.app.core.AuthNZ.migrations import (
+        get_authnz_migrations,
+        migration_089_seed_mcp_prompts_read_permission,
+    )
+
+    assert get_authnz_migrations()[-1].version == 89
+
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE roles (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL,
+                description TEXT,
+                is_system INTEGER DEFAULT 0
+            );
+            CREATE TABLE permissions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL,
+                description TEXT,
+                category TEXT
+            );
+            CREATE TABLE role_permissions (
+                role_id INTEGER NOT NULL,
+                permission_id INTEGER NOT NULL,
+                PRIMARY KEY (role_id, permission_id)
+            );
+            INSERT INTO roles (name, description, is_system)
+            VALUES
+                ('admin', 'Administrator', 1),
+                ('user', 'Standard User', 1);
+            """
+        )
+
+        migration_089_seed_mcp_prompts_read_permission(conn)
+        migration_089_seed_mcp_prompts_read_permission(conn)
+
+        permission_rows = conn.execute(
+            "SELECT name, description, category FROM permissions WHERE name = ?",
+            ("prompts.read",),
+        ).fetchall()
+        assert permission_rows == [("prompts.read", "Read MCP prompts", "prompts")]
+
+        grant_rows = conn.execute(
+            """
+            SELECT r.name, p.name
+            FROM role_permissions rp
+            JOIN roles r ON r.id = rp.role_id
+            JOIN permissions p ON p.id = rp.permission_id
+            WHERE p.name = ?
+            ORDER BY r.name
+            """,
+            ("prompts.read",),
+        ).fetchall()
+        assert grant_rows == [("admin", "prompts.read"), ("user", "prompts.read")]
+    finally:
+        conn.close()
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_prompts_http.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_prompts_http.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.endpoints import mcp_unified_endpoint
+
+
+class _CaptureServer:
+    initialized = True
+
+    def __init__(self) -> None:
+        self.request = None
+
+    async def handle_http_request(self, request, user_id=None, metadata=None):  # noqa: ANN001, ARG002
+        self.request = request
+        return type("Response", (), {"error": None, "result": {"prompts": [], "nextCursor": "next"}})()
+
+
+def test_get_mcp_prompts_maps_cursor_to_protocol_request(monkeypatch) -> None:
+    server = _CaptureServer()
+    monkeypatch.setattr(mcp_unified_endpoint, "get_mcp_server", lambda: server)
+    app = FastAPI()
+    app.include_router(mcp_unified_endpoint.router, prefix="/api/v1")
+    app.dependency_overrides[mcp_unified_endpoint.enforce_http_security] = lambda: None
+    app.dependency_overrides[mcp_unified_endpoint.get_mcp_auth_context] = (
+        lambda: mcp_unified_endpoint.McpAuthContext(
+            user=None,
+            principal=None,
+            api_key_info=None,
+            raw_api_key=None,
+        )
+    )
+    client = TestClient(app)
+
+    response = client.get("/api/v1/mcp/prompts?cursor=abc")
+
+    assert response.status_code == 200  # nosec B101
+    assert response.json() == {"prompts": [], "nextCursor": "next"}  # nosec B101
+    assert server.request.method == "prompts/list"  # nosec B101
+    assert server.request.params == {"cursor": "abc"}  # nosec B101
+
+
+def test_get_mcp_prompts_preserves_empty_cursor_query(monkeypatch) -> None:
+    server = _CaptureServer()
+    monkeypatch.setattr(mcp_unified_endpoint, "get_mcp_server", lambda: server)
+    app = FastAPI()
+    app.include_router(mcp_unified_endpoint.router, prefix="/api/v1")
+    app.dependency_overrides[mcp_unified_endpoint.enforce_http_security] = lambda: None
+    app.dependency_overrides[mcp_unified_endpoint.get_mcp_auth_context] = (
+        lambda: mcp_unified_endpoint.McpAuthContext(
+            user=None,
+            principal=None,
+            api_key_info=None,
+            raw_api_key=None,
+        )
+    )
+    client = TestClient(app)
+
+    response = client.get("/api/v1/mcp/prompts?cursor=")
+
+    assert response.status_code == 200  # nosec B101
+    assert response.json() == {"prompts": [], "nextCursor": "next"}  # nosec B101
+    assert server.request.method == "prompts/list"  # nosec B101
+    assert server.request.params == {"cursor": ""}  # nosec B101


### PR DESCRIPTION
## Summary
- Adds MCP protocol-level prompt support for readable non-deleted Prompt Library prompts and explicitly allowlisted config prompts.
- Wires context-aware prompt hooks, namespaced library:/config: routing, listChanged:false capability, HTTP cursor forwarding, and prompts.read provisioning.
- Adds docs, plan/task tracking, and regression coverage for permission checks, sanitization, cursor privacy, and Prompt Studio exclusion.

## Test Plan
- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py::test_default_mcp_modules_config_declares_prompts_module_with_empty_config_allowlist -v` -> 55 passed
- `python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_prompts_http.py tldw_Server_API/tests/AuthNZ/unit/test_rbac_seed_helper.py -v` -> 6 passed
- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py tldw_Server_API/app/core/MCP_unified/tests/test_registry_iteration_race.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py -v` -> 34 passed
- `python -m py_compile` on touched production Python files -> exit 0
- `python -m bandit -r <touched production Python files> -f json -o /tmp/bandit_mcp_prompt_catalog_continue.json` -> exit 0, results: []
- `git diff --cached --check` -> exit 0

## Merge Gate
- Draft PR because this was materially AI-authored. A human-authored Change summary explaining what changed and why is required before merge per project policy.

## Notes
- Restrictive scoped callers may lose pagination when a Prompt Library cursor would otherwise carry prompt identifiers; this avoids returning denied prompt names or UUIDs.