### PR TITLE
Address MCP prompt catalog review findings

### DIFF
--- a/backlog/tasks/task-2397 - Address-PR-2428-prompt-catalog-review-findings.md
+++ b/backlog/tasks/task-2397 - Address-PR-2428-prompt-catalog-review-findings.md
@@ -8,7 +8,7 @@ priority: High
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Follow-up remediation for Qodo review findings on merged PR #2428: centralize PromptCatalogError, add missing annotations/docstrings, restore prompts.available compatibility, and update test markers/type hints.
+Follow-up remediation for Qodo/Gemini review findings on merged PR #2428 and PR #2429: keep PromptCatalogError available through core compatibility imports while moving the MCP dependency to a framework-neutral exception type, add missing structured docstrings, preserve prompt capability compatibility, and advertise prompts only when a prompt-capable module is registered.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -30,14 +30,15 @@ Follow-up remediation for Qodo review findings on merged PR #2428: centralize Pr
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Addressed the actionable Qodo findings from PR #2428 by moving `PromptCatalogError` into the core exception module, restoring the legacy `capabilities.prompts.available` field alongside MCP `listChanged`, adding missing docstrings/type hints, and marking/typing the new tests.
+Initial PR #2428 review findings were addressed, and PR #2429 review follow-ups now add the framework-neutral `PromptCatalogError` module, keep the legacy `app.core.exceptions` re-export, update MCP imports away from FastAPI-coupled exceptions, expand `PromptsModule.on_initialize()` with structured side-effect/return documentation, and make initialize advertise prompt availability only when a registered module declares prompt listing hooks.
 
-Verification:
-- Red checks first failed for missing centralized exception and missing prompt `available` capability, then passed after implementation.
-- `python -m pytest ...test_prompts_catalog.py ...test_protocol_prompts_catalog.py ...test_dynamic_module_catalog.py::test_default_mcp_modules_config_declares_prompts_module_with_empty_config_allowlist ...test_mcp_prompts_http.py ...test_rbac_seed_helper.py -v` passed: 62 passed.
-- `python -m pytest ...test_gateway_fastapi_package.py::test_gateway_fastapi_app_handles_basic_jsonrpc_flow ...test_smoke_client.py::test_inprocess_gateway_transport_exposes_fixture_tools_resources_and_prompts ...test_basic_functionality.py ...test_registry_iteration_race.py ...test_protocol_catalog_filter.py ...test_dynamic_module_catalog.py ...test_extraction_contracts.py -v` passed: 78 passed.
+Final verification after rebasing onto latest `origin/dev`:
+- Red checks first failed for missing `exception_types` and imprecise prompt capability advertisement, then passed after implementation.
+- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py tldw_Server_API/tests/MCP_unified/test_mcp_prompts_http.py -q` passed: 58 passed.
+- `python -m pytest -c mcp_unified/pytest-artifact-gate.ini .github/tests/test_mcp_unified_artifact_gate.py::test_mcp_unified_standalone_distribution_metadata_matches_extras -q` passed: 1 passed.
 - `python -m py_compile` on touched production files passed.
-- Bandit touched production scope exited 0 with `results: []`.
+- Bandit touched production scope exited 0 with `results: 0`, `errors: 0` in `/tmp/bandit_pr2429_rebased.json`.
+- Latest PR #2429 package/UX check failures were triaged as stale-base CI failures; the package metadata gate is verified green locally after rebase, and the frontend UX failure was outside this backend-only diff and should rerun on the rebased branch.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2397 - Address-PR-2428-prompt-catalog-review-findings.md
+++ b/backlog/tasks/task-2397 - Address-PR-2428-prompt-catalog-review-findings.md
@@ -1,0 +1,51 @@
+---
+id: TASK-2397
+title: Address PR 2428 prompt catalog review findings
+status: Done
+priority: High
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up remediation for Qodo review findings on merged PR #2428: centralize PromptCatalogError, add missing annotations/docstrings, restore prompts.available compatibility, and update test markers/type hints.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] Centralize `PromptCatalogError` in `tldw_Server_API.app.core.exceptions`.
+- [x] Preserve MCP prompt capability compatibility by returning both `available` and `listChanged`.
+- [x] Add missing return annotation/docstrings for modified prompt API/module helpers.
+- [x] Add unit markers and explicit fixture/helper type annotations to new prompt catalog tests.
+- [x] Verify targeted prompt, RBAC, and MCP regression tests pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- PR #2428 was already merged, so these review remediations were implemented as follow-up branch `codex/pr2428-review-followups` from latest `origin/dev`.
+- Qodo's stale Gemini/Docker findings were not included because they refer to files outside the merged prompt-catalog PR diff.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the actionable Qodo findings from PR #2428 by moving `PromptCatalogError` into the core exception module, restoring the legacy `capabilities.prompts.available` field alongside MCP `listChanged`, adding missing docstrings/type hints, and marking/typing the new tests.
+
+Verification:
+- Red checks first failed for missing centralized exception and missing prompt `available` capability, then passed after implementation.
+- `python -m pytest ...test_prompts_catalog.py ...test_protocol_prompts_catalog.py ...test_dynamic_module_catalog.py::test_default_mcp_modules_config_declares_prompts_module_with_empty_config_allowlist ...test_mcp_prompts_http.py ...test_rbac_seed_helper.py -v` passed: 62 passed.
+- `python -m pytest ...test_gateway_fastapi_package.py::test_gateway_fastapi_app_handles_basic_jsonrpc_flow ...test_smoke_client.py::test_inprocess_gateway_transport_exposes_fixture_tools_resources_and_prompts ...test_basic_functionality.py ...test_registry_iteration_race.py ...test_protocol_catalog_filter.py ...test_dynamic_module_catalog.py ...test_extraction_contracts.py -v` passed: 78 passed.
+- `python -m py_compile` on touched production files passed.
+- Bandit touched production scope exited 0 with `results: []`.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
@@ -1507,7 +1507,7 @@ async def list_prompts(
     cursor: str | None = Query(None, description="Opaque MCP prompt list cursor"),
     auth: McpAuthContext = Depends(get_mcp_auth_context),
     _guard: None = Depends(enforce_http_security),
-):
+) -> dict[str, Any]:
     """
     List available MCP prompts.
 

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_catalog.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_catalog.py
@@ -13,6 +13,7 @@ from typing import Any
 from loguru import logger
 
 from ....DB_Management.Prompts_DB import DatabaseError, PromptsDatabase
+from ....exceptions import PromptCatalogError
 from ....Prompt_Management.structured_prompts import (
     PromptBlock,
     PromptDefinition,
@@ -38,16 +39,6 @@ _ALLOWED_CONFIG_ROLES = {"system", "developer", "user", "assistant"}
 _CATALOG_DB_EXCEPTIONS = (DatabaseError, OSError, RuntimeError, TypeError, ValueError)
 
 
-class PromptCatalogError(Exception):
-    """Sanitized prompt catalog error suitable for MCP protocol mapping."""
-
-    def __init__(self, code: str, message: str, internal: bool = False) -> None:
-        super().__init__(message)
-        self.code = code
-        self.message = message
-        self.internal = internal
-
-
 @dataclass(frozen=True)
 class PromptCatalogCursor:
     """Opaque pagination cursor state for prompt catalog sources."""
@@ -68,7 +59,16 @@ class PromptCatalogListResult:
 
 
 def encode_prompt_cursor(cursor: PromptCatalogCursor | None) -> str | None:
-    """Encode cursor state as unpadded URL-safe base64 JSON."""
+    """Encode prompt catalog pagination state for MCP clients.
+
+    Args:
+        cursor: Cursor state returned by a catalog source, or ``None`` when
+            there is no next page.
+
+    Returns:
+        An unpadded URL-safe base64 JSON cursor string, or ``None`` when no
+        cursor was provided.
+    """
 
     if cursor is None:
         return None
@@ -87,7 +87,19 @@ def encode_prompt_cursor(cursor: PromptCatalogCursor | None) -> str | None:
 
 
 def decode_prompt_cursor(raw_cursor: str | None) -> PromptCatalogCursor:
-    """Decode and validate an opaque prompt catalog cursor."""
+    """Decode and validate an MCP prompt catalog cursor.
+
+    Args:
+        raw_cursor: Opaque cursor string supplied by the MCP client. ``None``
+            and the empty string both represent the first page.
+
+    Returns:
+        Parsed prompt catalog cursor state.
+
+    Raises:
+        PromptCatalogError: If the cursor is malformed, unsupported, or
+            contains inconsistent pagination state.
+    """
 
     if raw_cursor is None or raw_cursor == "":
         return PromptCatalogCursor()

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_catalog.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_catalog.py
@@ -13,7 +13,7 @@ from typing import Any
 from loguru import logger
 
 from ....DB_Management.Prompts_DB import DatabaseError, PromptsDatabase
-from ....exceptions import PromptCatalogError
+from ....exception_types import PromptCatalogError
 from ....Prompt_Management.structured_prompts import (
     PromptBlock,
     PromptDefinition,

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_module.py
@@ -11,6 +11,7 @@ from typing import Any
 from loguru import logger
 
 from ....DB_Management.Prompts_DB import PromptsDatabase
+from ....exceptions import PromptCatalogError
 from ...persona_scope import assert_identifier_in_scope
 from ..base import BaseModule, create_tool_definition
 from ..disk_space import get_free_disk_space_gb
@@ -20,7 +21,6 @@ from .prompts_catalog import (
     ConfigPromptCatalogSource,
     MCPPromptFormatter,
     PromptCatalogCursor,
-    PromptCatalogError,
     UserPromptCatalogSource,
     clamp_prompt_page_size,
     decode_prompt_cursor,
@@ -39,6 +39,7 @@ _PROMPTS_CLOSE_EXCEPTIONS = (OSError, RuntimeError, SQLiteError, TypeError, Valu
 
 class PromptsModule(BaseModule):
     async def on_initialize(self) -> None:
+        """Initialize prompt catalog sources from module settings."""
         logger.info(f"Initializing Prompts module: {self.name}")
         settings = self.config.settings or {}
         self._prompt_list_page_size = clamp_prompt_page_size(settings.get("prompt_list_page_size", 50))

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_module.py
@@ -11,7 +11,7 @@ from typing import Any
 from loguru import logger
 
 from ....DB_Management.Prompts_DB import PromptsDatabase
-from ....exceptions import PromptCatalogError
+from ....exception_types import PromptCatalogError
 from ...persona_scope import assert_identifier_in_scope
 from ..base import BaseModule, create_tool_definition
 from ..disk_space import get_free_disk_space_gb
@@ -39,7 +39,15 @@ _PROMPTS_CLOSE_EXCEPTIONS = (OSError, RuntimeError, SQLiteError, TypeError, Valu
 
 class PromptsModule(BaseModule):
     async def on_initialize(self) -> None:
-        """Initialize prompt catalog sources from module settings."""
+        """Initialize prompt catalog sources from module settings.
+
+        Side Effects:
+            Sets prompt list pagination, rendering limits, library prompt
+            source, and allowlisted config prompt source from module settings.
+
+        Returns:
+            None.
+        """
         logger.info(f"Initializing Prompts module: {self.name}")
         settings = self.config.settings or {}
         self._prompt_list_page_size = clamp_prompt_page_size(settings.get("prompt_list_page_size", 50))

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -55,7 +55,7 @@ from mcp_unified.tool_use_reporting.recorder import record_tool_use_safely
 from .auth.authnz_rbac import Action, Resource
 from .auth.rate_limiter import RateLimitExceeded
 from .config import get_config
-from ..exceptions import PromptCatalogError
+from ..exception_types import PromptCatalogError
 from .interfaces.runtime import (
     MCPRuntimeDependencies,
     NoopToolCallHookManager,
@@ -776,6 +776,24 @@ class MCPProtocol:
         }
 
         logger.info("MCP Protocol handler initialized")
+
+    @staticmethod
+    def _module_declares_prompts(module: BaseModule) -> bool:
+        """Return whether a module can expose MCP prompts without querying catalogs.
+
+        Args:
+            module: Registered MCP module instance to inspect.
+
+        Returns:
+            True when the module overrides prompt listing hooks and can back
+            MCP ``prompts/list`` calls, otherwise False.
+        """
+
+        module_type = type(module)
+        return any(
+            getattr(module_type, method_name, None) is not getattr(BaseModule, method_name, None)
+            for method_name in ("get_prompts", "get_prompts_for_context")
+        )
 
     @property
     def telemetry(self) -> TelemetryProvider:
@@ -2715,11 +2733,12 @@ class MCPProtocol:
 
         # Get server capabilities
         modules = await self.module_registry.get_all_modules()
+        has_prompt_module = any(self._module_declares_prompts(module) for module in modules.values())
 
         capabilities = {
             "tools": {"available": bool(modules)},
             "resources": {"available": bool(modules)},
-            "prompts": {"available": bool(modules), "listChanged": False}
+            "prompts": {"available": has_prompt_module, "listChanged": False}
         }
 
         return {

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -55,6 +55,7 @@ from mcp_unified.tool_use_reporting.recorder import record_tool_use_safely
 from .auth.authnz_rbac import Action, Resource
 from .auth.rate_limiter import RateLimitExceeded
 from .config import get_config
+from ..exceptions import PromptCatalogError
 from .interfaces.runtime import (
     MCPRuntimeDependencies,
     NoopToolCallHookManager,
@@ -67,7 +68,6 @@ from .interfaces.runtime import (
 from .modules.implementations.prompts_catalog import (
     CONFIG_PROMPT_PREFIX,
     LIBRARY_PROMPT_PREFIX,
-    PromptCatalogError,
     decode_prompt_cursor,
 )
 from .modules.base import BaseModule
@@ -2719,7 +2719,7 @@ class MCPProtocol:
         capabilities = {
             "tools": {"available": bool(modules)},
             "resources": {"available": bool(modules)},
-            "prompts": {"listChanged": False}
+            "prompts": {"available": bool(modules), "listChanged": False}
         }
 
         return {

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py
@@ -6,6 +6,7 @@ import importlib
 import json
 import sys
 import uuid
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -29,6 +30,14 @@ from tldw_Server_API.app.core.MCP_unified.modules.implementations.prompts_catalo
     decode_prompt_cursor,
     encode_prompt_cursor,
 )
+
+pytestmark = pytest.mark.unit
+
+
+def test_prompt_catalog_error_uses_core_exception_type() -> None:
+    from tldw_Server_API.app.core.exceptions import PromptCatalogError as CorePromptCatalogError
+
+    assert PromptCatalogError is CorePromptCatalogError
 
 
 def test_prompt_cursor_encodes_none_as_none() -> None:
@@ -359,7 +368,7 @@ def _add_legacy_prompt(db_path: str, *, name: str, deleted: bool = False) -> dic
         db.close_connection()
 
 
-def test_user_source_lists_non_deleted_library_prompts_with_uuid_names(tmp_path) -> None:
+def test_user_source_lists_non_deleted_library_prompts_with_uuid_names(tmp_path: Path) -> None:
     db_path = str(tmp_path / "prompts.db")
     alpha = _add_legacy_prompt(db_path, name="Alpha")
     _add_legacy_prompt(db_path, name="Deleted", deleted=True)
@@ -376,7 +385,7 @@ def test_user_source_lists_non_deleted_library_prompts_with_uuid_names(tmp_path)
     assert result.warnings == []
 
 
-def test_user_source_filters_by_prompt_id_scope(tmp_path) -> None:
+def test_user_source_filters_by_prompt_id_scope(tmp_path: Path) -> None:
     db_path = str(tmp_path / "prompts.db")
     allowed = _add_legacy_prompt(db_path, name="Allowed")
     _add_legacy_prompt(db_path, name="Blocked")
@@ -405,7 +414,7 @@ def test_user_source_list_missing_prompts_db_warns_without_leaking() -> None:
     assert result.warnings == [{"source": "library", "code": "prompt_db_unavailable"}]
 
 
-def test_user_source_list_internal_formatting_failure_warns(tmp_path) -> None:
+def test_user_source_list_internal_formatting_failure_warns(tmp_path: Path) -> None:
     db_path = str(tmp_path / "prompts.db")
     bad = _add_legacy_prompt(db_path, name="Bad Structured Prompt")
 
@@ -428,7 +437,7 @@ def test_user_source_list_internal_formatting_failure_warns(tmp_path) -> None:
     ]
 
 
-def test_user_source_list_skips_bad_row_and_keeps_cursor_moving(tmp_path) -> None:
+def test_user_source_list_skips_bad_row_and_keeps_cursor_moving(tmp_path: Path) -> None:
     db_path = str(tmp_path / "prompts.db")
     bad = _add_legacy_prompt(db_path, name="Alpha Bad")
     good = _add_legacy_prompt(db_path, name="Beta Good")
@@ -463,7 +472,7 @@ def test_user_source_list_skips_bad_row_and_keeps_cursor_moving(tmp_path) -> Non
     assert second_page.warnings == []
 
 
-def test_user_source_get_validates_uuid_and_scope(tmp_path) -> None:
+def test_user_source_get_validates_uuid_and_scope(tmp_path: Path) -> None:
     db_path = str(tmp_path / "prompts.db")
     allowed = _add_legacy_prompt(db_path, name="Allowed")
     source = UserPromptCatalogSource(MCPPromptFormatter(max_rendered_chars=10_000))
@@ -477,7 +486,7 @@ def test_user_source_get_validates_uuid_and_scope(tmp_path) -> None:
     assert result["messages"][0]["content"]["text"].endswith("Summarize scoped prompts")
 
 
-def test_user_source_get_rejects_malformed_library_prompt_name(tmp_path) -> None:
+def test_user_source_get_rejects_malformed_library_prompt_name(tmp_path: Path) -> None:
     db_path = str(tmp_path / "prompts.db")
     source = UserPromptCatalogSource(MCPPromptFormatter(max_rendered_chars=10_000))
 
@@ -491,7 +500,7 @@ def test_user_source_get_rejects_malformed_library_prompt_name(tmp_path) -> None
     assert excinfo.value.code == "invalid_prompt_name"
 
 
-def test_user_source_get_rejects_prompt_outside_scope(tmp_path) -> None:
+def test_user_source_get_rejects_prompt_outside_scope(tmp_path: Path) -> None:
     db_path = str(tmp_path / "prompts.db")
     allowed = _add_legacy_prompt(db_path, name="Allowed")
     blocked = _add_legacy_prompt(db_path, name="Blocked")
@@ -533,7 +542,7 @@ def test_user_source_get_sanitizes_db_failure() -> None:
     assert "raw db failure" not in excinfo.value.message
 
 
-def test_user_source_get_sanitizes_internal_formatting_failure(tmp_path) -> None:
+def test_user_source_get_sanitizes_internal_formatting_failure(tmp_path: Path) -> None:
     db_path = str(tmp_path / "prompts.db")
     prompt = _add_legacy_prompt(db_path, name="Bad Render")
 
@@ -555,7 +564,7 @@ def test_user_source_get_sanitizes_internal_formatting_failure(tmp_path) -> None
     assert "Invalid row" not in excinfo.value.message
 
 
-def test_config_source_lists_only_explicit_entries(monkeypatch, tmp_path) -> None:
+def test_config_source_lists_only_explicit_entries(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     override_path = tmp_path / "rag_retrieval.txt"
     override_path.write_text("Retrieve context for {query}", encoding="utf-8")
     monkeypatch.setenv("TLDW_PROMPT_FILE_RAG__RETRIEVAL_GUIDANCE", str(override_path))
@@ -582,7 +591,7 @@ def test_config_source_lists_only_explicit_entries(monkeypatch, tmp_path) -> Non
     assert result.prompts[0]["arguments"][0]["name"] == "query"
 
 
-def test_config_source_grouped_render_folds_system_user_and_preserves_assistant(monkeypatch, tmp_path) -> None:
+def test_config_source_grouped_render_folds_system_user_and_preserves_assistant(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     system_path = tmp_path / "system.txt"
     user_path = tmp_path / "user.txt"
     assistant_path = tmp_path / "assistant.txt"
@@ -657,7 +666,7 @@ def test_config_source_omits_missing_allowlist_entry() -> None:
     ]
 
 
-def test_missing_config_entry_error_does_not_include_override_path(monkeypatch, tmp_path) -> None:
+def test_missing_config_entry_error_does_not_include_override_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     missing_path = tmp_path / "missing-prompt.txt"
     monkeypatch.setenv("TLDW_PROMPT_FILE_MISSING__ENTRY", str(missing_path))
     source = ConfigPromptCatalogSource(
@@ -683,7 +692,7 @@ def test_missing_config_entry_error_does_not_include_override_path(monkeypatch, 
     assert str(missing_path) not in str(excinfo.value)  # nosec B101
 
 
-def test_config_source_get_respects_disabled_flag(monkeypatch, tmp_path) -> None:
+def test_config_source_get_respects_disabled_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     override_path = tmp_path / "prompt.txt"
     override_path.write_text("Search {query}", encoding="utf-8")
     monkeypatch.setenv("TLDW_PROMPT_FILE_MCP__SEARCH_KNOWLEDGE", str(override_path))
@@ -708,7 +717,7 @@ def test_config_source_get_respects_disabled_flag(monkeypatch, tmp_path) -> None
     assert excinfo.value.code == "prompt_not_found"
 
 
-def test_config_source_reports_entries_after_index(monkeypatch, tmp_path) -> None:
+def test_config_source_reports_entries_after_index(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     override_path = tmp_path / "prompt.txt"
     override_path.write_text("Search {query}", encoding="utf-8")
     monkeypatch.setenv("TLDW_PROMPT_FILE_MCP__SEARCH_KNOWLEDGE", str(override_path))
@@ -731,7 +740,7 @@ def test_config_source_reports_entries_after_index(monkeypatch, tmp_path) -> Non
     assert source.has_entries_after(1) is False
 
 
-def test_user_source_skips_library_when_cursor_is_inside_config_page(tmp_path) -> None:
+def test_user_source_skips_library_when_cursor_is_inside_config_page(tmp_path: Path) -> None:
     db_path = str(tmp_path / "prompts.db")
     _add_legacy_prompt(db_path, name="Alpha")
     source = UserPromptCatalogSource(MCPPromptFormatter(max_rendered_chars=10_000))
@@ -747,7 +756,7 @@ def test_user_source_skips_library_when_cursor_is_inside_config_page(tmp_path) -
     assert result.warnings == []
 
 
-def test_user_source_uses_collate_nocase_keyset_with_raw_name_cursor(tmp_path) -> None:
+def test_user_source_uses_collate_nocase_keyset_with_raw_name_cursor(tmp_path: Path) -> None:
     db_path = str(tmp_path / "prompts.db")
     alpha = _add_legacy_prompt(db_path, name="Alpha")
     beta = _add_legacy_prompt(db_path, name="beta")
@@ -769,7 +778,7 @@ def test_user_source_uses_collate_nocase_keyset_with_raw_name_cursor(tmp_path) -
     assert second_page.prompts[0]["name"] == f"{LIBRARY_PROMPT_PREFIX}{beta['uuid']}"
 
 
-def test_user_source_keyset_page_is_stable_when_prompt_inserted_before_cursor(tmp_path) -> None:
+def test_user_source_keyset_page_is_stable_when_prompt_inserted_before_cursor(tmp_path: Path) -> None:
     db_path = str(tmp_path / "prompts.db")
     alpha = _add_legacy_prompt(db_path, name="Alpha")
     charlie = _add_legacy_prompt(db_path, name="Charlie")
@@ -817,7 +826,7 @@ def _prompts_module_config(page_size: int) -> ModuleConfig:
 
 
 @pytest.mark.asyncio
-async def test_prompts_module_context_list_combines_library_and_config(monkeypatch, tmp_path) -> None:
+async def test_prompts_module_context_list_combines_library_and_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     db_path = str(tmp_path / "prompts.db")
     library_prompt = _add_legacy_prompt(db_path, name="Library Prompt")
     override_path = tmp_path / "search_knowledge.txt"
@@ -837,8 +846,8 @@ async def test_prompts_module_context_list_combines_library_and_config(monkeypat
 
 @pytest.mark.asyncio
 async def test_prompts_module_returns_config_cursor_when_library_exactly_fills_page(
-    monkeypatch,
-    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     db_path = str(tmp_path / "prompts.db")
     library_prompt = _add_legacy_prompt(db_path, name="Library Prompt")
@@ -865,7 +874,7 @@ async def test_prompts_module_returns_config_cursor_when_library_exactly_fills_p
 
 
 @pytest.mark.asyncio
-async def test_prompts_module_context_get_routes_by_namespace(tmp_path) -> None:
+async def test_prompts_module_context_get_routes_by_namespace(tmp_path: Path) -> None:
     db_path = str(tmp_path / "prompts.db")
     library_prompt = _add_legacy_prompt(db_path, name="Library Prompt")
     module = PromptsModule(_prompts_module_config(page_size=50))
@@ -881,7 +890,7 @@ async def test_prompts_module_context_get_routes_by_namespace(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_prompts_module_bad_cursor_raises_catalog_error(tmp_path) -> None:
+async def test_prompts_module_bad_cursor_raises_catalog_error(tmp_path: Path) -> None:
     module = PromptsModule(_prompts_module_config(page_size=50))
     await module.on_initialize()
 
@@ -894,7 +903,7 @@ async def test_prompts_module_bad_cursor_raises_catalog_error(tmp_path) -> None:
     assert excinfo.value.code == "invalid_cursor"
 
 
-def test_catalog_adapter_does_not_import_prompt_studio(monkeypatch) -> None:
+def test_catalog_adapter_does_not_import_prompt_studio(monkeypatch: pytest.MonkeyPatch) -> None:
     module_name = "tldw_Server_API.app.core.MCP_unified.modules.implementations.prompts_catalog"
     blocked_segments = (
         "Prompt_Management.PromptStudio",
@@ -904,7 +913,13 @@ def test_catalog_adapter_does_not_import_prompt_studio(monkeypatch) -> None:
     )
     real_import = builtins.__import__
 
-    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+    def guarded_import(
+        name: str,
+        globals: dict[str, Any] | None = None,
+        locals: dict[str, Any] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> Any:
         if any(segment in name for segment in blocked_segments):
             raise AssertionError(f"prompts_catalog imported Prompt Studio module: {name}")
         return real_import(name, globals, locals, fromlist, level)

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py
@@ -35,9 +35,11 @@ pytestmark = pytest.mark.unit
 
 
 def test_prompt_catalog_error_uses_core_exception_type() -> None:
-    from tldw_Server_API.app.core.exceptions import PromptCatalogError as CorePromptCatalogError
+    from tldw_Server_API.app.core.exception_types import PromptCatalogError as CorePromptCatalogError
+    from tldw_Server_API.app.core.exceptions import PromptCatalogError as ReexportedPromptCatalogError
 
     assert PromptCatalogError is CorePromptCatalogError
+    assert ReexportedPromptCatalogError is CorePromptCatalogError
 
 
 def test_prompt_cursor_encodes_none_as_none() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py
@@ -132,6 +132,28 @@ class ContextPromptModule(BaseModule):
         }
 
 
+class ToolOnlyModule(BaseModule):
+    async def on_initialize(self) -> None:
+        return None
+
+    async def on_shutdown(self) -> None:
+        return None
+
+    async def check_health(self) -> dict[str, bool]:
+        return {"ok": True}
+
+    async def get_tools(self) -> list[dict[str, Any]]:
+        return [{"name": "tool.echo", "description": "Echo tool"}]
+
+    async def execute_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: Any | None = None,
+    ) -> Any:
+        return {"tool": tool_name, "arguments": arguments, "context": context}
+
+
 class FailingPromptModule(ContextPromptModule):
     async def get_prompts_for_context(
         self,
@@ -282,6 +304,16 @@ def _prompt_module() -> ContextPromptModule:
     )
 
 
+def _tool_only_module() -> ToolOnlyModule:
+    return ToolOnlyModule(
+        ModuleConfig(
+            name="tools",
+            version="1.0.0",
+            description="Tool-only test module",
+        )
+    )
+
+
 def _context() -> RequestContext:
     return RequestContext(request_id="prompt-catalog", user_id="u1", client_id="unit")
 
@@ -304,6 +336,19 @@ async def test_initialize_declares_mcp_prompt_capability() -> None:
 
     assert result["capabilities"]["prompts"] == {  # nosec B101
         "available": True,
+        "listChanged": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_initialize_does_not_advertise_prompts_for_tool_only_modules() -> None:
+    handler = _handler_with_registry(PromptOnlyRegistry({"tools": _tool_only_module()}))
+
+    result = await handler._handle_initialize({"clientInfo": {"name": "unit"}}, _context())
+
+    assert result["capabilities"]["tools"] == {"available": True}  # nosec B101
+    assert result["capabilities"]["prompts"] == {  # nosec B101
+        "available": False,
         "listChanged": False,
     }
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py
@@ -24,6 +24,8 @@ from tldw_Server_API.app.core.MCP_unified.protocol import (
     RequestContext,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class PromptOnlyRegistry:
     def __init__(self, modules: dict[str, BaseModule] | None = None) -> None:
@@ -300,11 +302,14 @@ async def test_initialize_declares_mcp_prompt_capability() -> None:
 
     result = await handler._handle_initialize({"clientInfo": {"name": "unit"}}, _context())
 
-    assert result["capabilities"]["prompts"] == {"listChanged": False}  # nosec B101
+    assert result["capabilities"]["prompts"] == {  # nosec B101
+        "available": True,
+        "listChanged": False,
+    }
 
 
 @pytest.mark.asyncio
-async def test_prompts_list_uses_context_hook_and_preserves_cursor_and_warnings(monkeypatch) -> None:
+async def test_prompts_list_uses_context_hook_and_preserves_cursor_and_warnings(monkeypatch: pytest.MonkeyPatch) -> None:
     handler = _handler_with_registry(PromptOnlyRegistry({"prompts": _prompt_module()}))
 
     async def _allow_namespaced(context: RequestContext, prompt_name: str) -> bool:
@@ -441,7 +446,7 @@ async def test_prompts_list_maps_internal_catalog_error_to_runtime_error() -> No
 
 
 @pytest.mark.asyncio
-async def test_prompts_get_dispatches_namespaced_prompt_before_global_registry(monkeypatch) -> None:
+async def test_prompts_get_dispatches_namespaced_prompt_before_global_registry(monkeypatch: pytest.MonkeyPatch) -> None:
     registry = PromptOnlyRegistry({"prompts": _prompt_module()})
     handler = _handler_with_registry(registry)
 
@@ -464,7 +469,7 @@ async def test_prompts_get_dispatches_namespaced_prompt_before_global_registry(m
 
 
 @pytest.mark.asyncio
-async def test_prompts_get_rejects_non_object_arguments(monkeypatch) -> None:
+async def test_prompts_get_rejects_non_object_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
     handler = _handler_with_registry(PromptOnlyRegistry({"prompts": _prompt_module()}))
 
     async def _allow_namespaced(context: RequestContext, prompt_name: str) -> bool:
@@ -483,7 +488,7 @@ async def test_prompts_get_rejects_non_object_arguments(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_protocol_maps_catalog_invalid_params_without_body_leak(monkeypatch) -> None:
+async def test_protocol_maps_catalog_invalid_params_without_body_leak(monkeypatch: pytest.MonkeyPatch) -> None:
     handler = _handler_with_registry(
         PromptOnlyRegistry(
             {
@@ -516,7 +521,7 @@ async def test_protocol_maps_catalog_invalid_params_without_body_leak(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_protocol_maps_internal_catalog_error_to_internal_message(monkeypatch) -> None:
+async def test_protocol_maps_internal_catalog_error_to_internal_message(monkeypatch: pytest.MonkeyPatch) -> None:
     handler = _handler_with_registry(
         PromptOnlyRegistry(
             {
@@ -554,7 +559,7 @@ async def test_protocol_maps_internal_catalog_error_to_internal_message(monkeypa
 
 @pytest.mark.asyncio
 async def test_process_request_internal_catalog_error_does_not_leak_to_response_or_logs(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     handler = _handler_with_registry(
         PromptOnlyRegistry(

--- a/tldw_Server_API/app/core/exception_types.py
+++ b/tldw_Server_API/app/core/exception_types.py
@@ -1,0 +1,21 @@
+"""Framework-neutral exception types shared by core services."""
+
+from __future__ import annotations
+
+
+class PromptCatalogError(Exception):
+    """Sanitized prompt catalog error suitable for MCP protocol mapping."""
+
+    def __init__(self, code: str, message: str, internal: bool = False) -> None:
+        """Create a sanitized prompt catalog error.
+
+        Args:
+            code: Stable machine-readable prompt catalog error code.
+            message: Safe public message for MCP protocol responses.
+            internal: Whether the underlying failure should be mapped to a
+                generic internal error for clients.
+        """
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.internal = internal

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -7,6 +7,8 @@ from fastapi import FastAPI, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from loguru import logger
 
+from .exception_types import PromptCatalogError
+
 if hasattr(status, "HTTP_422_UNPROCESSABLE_CONTENT"):
     DEFAULT_VALIDATION_STATUS = status.HTTP_422_UNPROCESSABLE_CONTENT
 else:
@@ -39,24 +41,6 @@ class TokenizerUnavailable(Exception):
 
 class BadRequestError(ValueError):
     """Raised when a caller provides invalid arguments for an operation."""
-
-
-class PromptCatalogError(Exception):
-    """Sanitized prompt catalog error suitable for MCP protocol mapping."""
-
-    def __init__(self, code: str, message: str, internal: bool = False) -> None:
-        """Create a sanitized prompt catalog error.
-
-        Args:
-            code: Stable machine-readable prompt catalog error code.
-            message: Safe public message for MCP protocol responses.
-            internal: Whether the underlying failure should be mapped to a
-                generic internal error for clients.
-        """
-        super().__init__(message)
-        self.code = code
-        self.message = message
-        self.internal = internal
 
 
 class RecipeEnqueueError(RuntimeError):

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -41,6 +41,24 @@ class BadRequestError(ValueError):
     """Raised when a caller provides invalid arguments for an operation."""
 
 
+class PromptCatalogError(Exception):
+    """Sanitized prompt catalog error suitable for MCP protocol mapping."""
+
+    def __init__(self, code: str, message: str, internal: bool = False) -> None:
+        """Create a sanitized prompt catalog error.
+
+        Args:
+            code: Stable machine-readable prompt catalog error code.
+            message: Safe public message for MCP protocol responses.
+            internal: Whether the underlying failure should be mapped to a
+                generic internal error for clients.
+        """
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.internal = internal
+
+
 class RecipeEnqueueError(RuntimeError):
     """Raised when a recipe run cannot be enqueued into Jobs."""
 

--- a/tldw_Server_API/tests/AuthNZ/unit/test_rbac_seed_helper.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_rbac_seed_helper.py
@@ -5,7 +5,7 @@ pytestmark = pytest.mark.unit
 
 
 @pytest.mark.asyncio
-async def test_ensure_baseline_rbac_seed_sqlite_idempotent():
+async def test_ensure_baseline_rbac_seed_sqlite_idempotent() -> None:
     import aiosqlite
 
     from tldw_Server_API.app.core.AuthNZ.rbac_seed import ensure_baseline_rbac_seed
@@ -110,7 +110,7 @@ async def test_ensure_baseline_rbac_seed_sqlite_idempotent():
             assert perm_id[name] in admin_perm_ids
 
 
-def test_migration_089_seeds_prompts_read_for_existing_admin_and_user_roles():
+def test_migration_089_seeds_prompts_read_for_existing_admin_and_user_roles() -> None:
     import sqlite3
 
     from tldw_Server_API.app.core.AuthNZ.migrations import (
@@ -174,7 +174,7 @@ def test_migration_089_seeds_prompts_read_for_existing_admin_and_user_roles():
 
 
 @pytest.mark.asyncio
-async def test_ensure_sqlite_rbac_tables_creates_minimal_schema():
+async def test_ensure_sqlite_rbac_tables_creates_minimal_schema() -> None:
     import aiosqlite
 
     from tldw_Server_API.app.core.AuthNZ.rbac_seed import ensure_sqlite_rbac_tables
@@ -194,7 +194,7 @@ async def test_ensure_sqlite_rbac_tables_creates_minimal_schema():
 @pytest.mark.asyncio
 async def test_ensure_baseline_rbac_seed_explicit_backend_hint_skips_detection(
     monkeypatch: pytest.MonkeyPatch,
-):
+) -> None:
     import aiosqlite
 
     from tldw_Server_API.app.core.AuthNZ import rbac_seed

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_prompts_http.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_prompts_http.py
@@ -1,23 +1,35 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.api.v1.endpoints import mcp_unified_endpoint
+
+pytestmark = pytest.mark.unit
 
 
 class _CaptureServer:
     initialized = True
 
     def __init__(self) -> None:
-        self.request = None
+        self.request: mcp_unified_endpoint.MCPRequest | None = None
 
-    async def handle_http_request(self, request, user_id=None, metadata=None):  # noqa: ANN001, ARG002
+    async def handle_http_request(
+        self,
+        request: mcp_unified_endpoint.MCPRequest,
+        user_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> SimpleNamespace:
+        _ = (user_id, metadata)
         self.request = request
-        return type("Response", (), {"error": None, "result": {"prompts": [], "nextCursor": "next"}})()
+        return SimpleNamespace(error=None, result={"prompts": [], "nextCursor": "next"})
 
 
-def test_get_mcp_prompts_maps_cursor_to_protocol_request(monkeypatch) -> None:
+def test_get_mcp_prompts_maps_cursor_to_protocol_request(monkeypatch: pytest.MonkeyPatch) -> None:
     server = _CaptureServer()
     monkeypatch.setattr(mcp_unified_endpoint, "get_mcp_server", lambda: server)
     app = FastAPI()
@@ -41,7 +53,7 @@ def test_get_mcp_prompts_maps_cursor_to_protocol_request(monkeypatch) -> None:
     assert server.request.params == {"cursor": "abc"}  # nosec B101
 
 
-def test_get_mcp_prompts_preserves_empty_cursor_query(monkeypatch) -> None:
+def test_get_mcp_prompts_preserves_empty_cursor_query(monkeypatch: pytest.MonkeyPatch) -> None:
     server = _CaptureServer()
     monkeypatch.setattr(mcp_unified_endpoint, "get_mcp_server", lambda: server)
     app = FastAPI()


### PR DESCRIPTION
## Change summary

Follow-up to merged PR #2428. This addresses the current Qodo review findings by centralizing `PromptCatalogError`, restoring the legacy `capabilities.prompts.available` compatibility field while retaining MCP `listChanged: false`, adding missing prompt API/module docstrings and return annotations, and marking/typing the new prompt/RBAC tests.

The stale Gemini Docker comments on PR #2428 refer to files outside the merged MCP prompt-catalog diff, so they are not folded into this follow-up.

## Verification

- Red checks first failed for missing centralized exception and missing prompt `available` capability, then passed after implementation.
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_prompts_catalog.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_prompts_catalog.py tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py::test_default_mcp_modules_config_declares_prompts_module_with_empty_config_allowlist tldw_Server_API/tests/MCP_unified/test_mcp_prompts_http.py tldw_Server_API/tests/AuthNZ/unit/test_rbac_seed_helper.py -v` passed: 62 passed.
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_fastapi_package.py::test_gateway_fastapi_app_handles_basic_jsonrpc_flow tldw_Server_API/app/core/MCP_unified/tests/test_smoke_client.py::test_inprocess_gateway_transport_exposes_fixture_tools_resources_and_prompts tldw_Server_API/app/core/MCP_unified/tests/test_basic_functionality.py tldw_Server_API/app/core/MCP_unified/tests/test_registry_iteration_race.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_catalog_filter.py tldw_Server_API/app/core/MCP_unified/tests/test_dynamic_module_catalog.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py -v` passed: 78 passed.
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile ...` on touched production files passed.
- Bandit touched production scope exited 0 with `results: []` in `/tmp/bandit_pr2428_review_followups.json`.

## Backlog

- TASK-2397

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores MCP prompt capability compatibility, advertises prompts only when a prompt-capable module is registered, and centralizes prompt catalog errors in a framework‑neutral type. Adds missing docs and type annotations. Addresses TASK-2397.

- **Bug Fixes**
  - Initialize now sets `capabilities.prompts` to `{ available: <has_prompt_module>, listChanged: false }`, preserving legacy compatibility.

- **Refactors**
  - Moved `PromptCatalogError` to `tldw_Server_API.app.core.exception_types` and re-exported from `tldw_Server_API.app.core.exceptions`; updated imports across modules.
  - Added docstrings to cursor helpers and `PromptsModule.on_initialize`; annotated the `list_prompts` endpoint to return `dict[str, Any]`; marked tests as unit and tightened type hints.

<sup>Written for commit 8e0ecaa39cf8daa433ee7d3a7fe5e271ae0e618f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

