### PR TITLE
Continue CI stability follow-up

### DIFF
--- a/.github/actions/setup-ffmpeg/action.yml
+++ b/.github/actions/setup-ffmpeg/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Install FFmpeg (Linux)
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && (inputs.install-ffmpeg == 'true' || inputs.install-portaudio == 'true')
       shell: bash
       run: |
         if [ -d /etc/apt/sources.list.d ]; then
@@ -23,9 +23,7 @@ runs:
         if [ -f /etc/apt/sources.list ]; then
           sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
         fi
-        if [ "${{ inputs.install-ffmpeg }}" = "true" ] || [ "${{ inputs.install-portaudio }}" = "true" ]; then
-          sudo apt-get update -o Acquire::Retries=2 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20
-        fi
+        sudo apt-get update -o Acquire::Retries=2 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20
         if [ "${{ inputs.install-ffmpeg }}" = "true" ] && [ "${{ inputs.install-portaudio }}" = "true" ]; then
           sudo apt-get install -y --no-install-recommends ffmpeg portaudio19-dev python3-all-dev
         elif [ "${{ inputs.install-ffmpeg }}" = "true" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         # Fails if a NEW test file is in no full-suite shard (would be silently
         # skipped). Known-unshared backlog is tracked in
         # Helper_Scripts/ci/shard_coverage_baseline.txt; shrink it over time.
-        run: python Helper_Scripts/ci/check_shard_coverage.py
+        run: python Helper_Scripts/ci/check_shard_coverage.py --ci-file .github/workflows/ci.yml
   quickstart-dry-run:
     name: Quickstart Dry-Run Smoke
     runs-on: ubuntu-latest
@@ -168,7 +168,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
       redis:
-        image: mirror.gcr.io/library/redis:8-alpine
+        image: mirror.gcr.io/library/redis:8-alpine@sha256:9eb6a7ba3d344e1958c7e1589fa3dee90373a934e8159c634562a91d622759a0
         ports:
           - 6379/tcp
         options: >-
@@ -226,6 +226,8 @@ jobs:
           DB_PASSWORD="${POSTGRES_TEST_PASSWORD:?POSTGRES_TEST_PASSWORD is required}"
           DB_NAME="${POSTGRES_TEST_DB:-tldw_content}"
           DB_URL="postgresql://${DB_USER}:${DB_PASSWORD}@127.0.0.1:${PORT}/${DB_NAME}"
+          echo "::add-mask::${DB_PASSWORD}"
+          echo "::add-mask::${DB_URL}"
           {
             echo "POSTGRES_TEST_PORT=${PORT}"
             echo "TEST_DB_PORT=${PORT}"
@@ -392,6 +394,8 @@ jobs:
           DB_PASSWORD="${POSTGRES_TEST_PASSWORD:?POSTGRES_TEST_PASSWORD is required}"
           DB_NAME="${POSTGRES_TEST_DB:-tldw_content}"
           DB_URL="postgresql://${DB_USER}:${DB_PASSWORD}@127.0.0.1:${PORT}/${DB_NAME}"
+          echo "::add-mask::${DB_PASSWORD}"
+          echo "::add-mask::${DB_URL}"
           {
             echo "POSTGRES_TEST_PORT=${PORT}"
             echo "TEST_DB_PORT=${PORT}"
@@ -1655,6 +1659,8 @@ jobs:
           DB_PASSWORD="${POSTGRES_TEST_PASSWORD:?POSTGRES_TEST_PASSWORD is required}"
           DB_NAME="${POSTGRES_TEST_DB:-tldw_content}"
           DB_URL="postgresql://${DB_USER}:${DB_PASSWORD}@127.0.0.1:${PORT}/${DB_NAME}"
+          echo "::add-mask::${DB_PASSWORD}"
+          echo "::add-mask::${DB_URL}"
           {
             echo "POSTGRES_TEST_PORT=${PORT}"
             echo "TEST_DB_PORT=${PORT}"
@@ -3022,6 +3028,8 @@ jobs:
           DB_PASSWORD="${POSTGRES_TEST_PASSWORD:?POSTGRES_TEST_PASSWORD is required}"
           DB_NAME="${POSTGRES_TEST_DB:-tldw_content}"
           DB_URL="postgresql://${DB_USER}:${DB_PASSWORD}@127.0.0.1:${PORT}/${DB_NAME}"
+          echo "::add-mask::${DB_PASSWORD}"
+          echo "::add-mask::${DB_URL}"
           {
             echo "POSTGRES_TEST_PORT=${PORT}"
             echo "TEST_DB_PORT=${PORT}"

--- a/.github/workflows/e2e-required.yml
+++ b/.github/workflows/e2e-required.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 40
     services:
       redis:
-        image: mirror.gcr.io/library/redis:8-alpine
+        image: mirror.gcr.io/library/redis:8-alpine@sha256:9eb6a7ba3d344e1958c7e1589fa3dee90373a934e8159c634562a91d622759a0
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/frontend-e2e-tiers.yml
+++ b/.github/workflows/frontend-e2e-tiers.yml
@@ -43,7 +43,7 @@ jobs:
        contains(fromJSON('["critical","all-tiers"]'), github.event.inputs.tier))
     services:
       redis:
-        image: mirror.gcr.io/library/redis:8-alpine
+        image: mirror.gcr.io/library/redis:8-alpine@sha256:9eb6a7ba3d344e1958c7e1589fa3dee90373a934e8159c634562a91d622759a0
         ports: ['6379:6379']
         options: >-
           --health-cmd "redis-cli ping"
@@ -136,7 +136,7 @@ jobs:
       contains(fromJSON('["features","all-tiers"]'), github.event.inputs.tier)
     services:
       redis:
-        image: mirror.gcr.io/library/redis:8-alpine
+        image: mirror.gcr.io/library/redis:8-alpine@sha256:9eb6a7ba3d344e1958c7e1589fa3dee90373a934e8159c634562a91d622759a0
         ports: ['6379:6379']
         options: >-
           --health-cmd "redis-cli ping"
@@ -221,7 +221,7 @@ jobs:
       contains(fromJSON('["admin","all-tiers"]'), github.event.inputs.tier)
     services:
       redis:
-        image: mirror.gcr.io/library/redis:8-alpine
+        image: mirror.gcr.io/library/redis:8-alpine@sha256:9eb6a7ba3d344e1958c7e1589fa3dee90373a934e8159c634562a91d622759a0
         ports: ['6379:6379']
         options: >-
           --health-cmd "redis-cli ping"

--- a/Dockerfiles/docker-compose.webui.yml
+++ b/Dockerfiles/docker-compose.webui.yml
@@ -18,7 +18,7 @@ services:
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-}
         NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-}
         NEXT_PUBLIC_API_VERSION: ${NEXT_PUBLIC_API_VERSION:-v1}
-        NEXT_PUBLIC_X_API_KEY: ${NEXT_PUBLIC_X_API_KEY:-${SINGLE_USER_API_KEY:-}}
+        NEXT_PUBLIC_X_API_KEY: ${NEXT_PUBLIC_X_API_KEY:-}
         NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE: ${NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE:-quickstart}
         TLDW_INTERNAL_API_ORIGIN: ${TLDW_INTERNAL_API_ORIGIN:-http://app:8000}
     image: tldw-webui:prod
@@ -33,8 +33,8 @@ services:
       - HOSTNAME=0.0.0.0
       - PORT=3000
       - NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL:-}
-      # Local quickstart falls back to SINGLE_USER_API_KEY from the env file so
-      # the first WebUI load can authenticate without manual browser config.
-      - NEXT_PUBLIC_X_API_KEY=${NEXT_PUBLIC_X_API_KEY:-${SINGLE_USER_API_KEY:-}}
+      # Browser-visible credentials must be explicitly supplied with a public
+      # scoped value; never fall back to the server-side SINGLE_USER_API_KEY.
+      - NEXT_PUBLIC_X_API_KEY=${NEXT_PUBLIC_X_API_KEY:-}
       - NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE=${NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE:-quickstart}
       - TLDW_INTERNAL_API_ORIGIN=${TLDW_INTERNAL_API_ORIGIN:-http://app:8000}

--- a/Docs/Plans/2026-06-23-pr2258-review-followups.md
+++ b/Docs/Plans/2026-06-23-pr2258-review-followups.md
@@ -1,0 +1,47 @@
+# PR 2258 Review Follow-ups Implementation Plan
+
+Backlog: TASK-2397
+
+## Stage 1: Audit Review Feedback
+**Goal**: Verify which unresolved PR #2258 comments remain valid on the current `dev`-based follow-up branch.
+**Success Criteria**: Inline and outside-diff comments are categorized as fixed, still-valid, or intentionally skipped with rationale.
+**Tests**: GitHub review-thread/comment extraction and local code inspection.
+**Status**: Complete
+
+Notes:
+- All unresolved inline Gemini/CodeRabbit comments and outside-diff CodeRabbit comments were reviewed against the current branch.
+- Qodo's DB URL exposure concern remained valid and is addressed in Stage 2 with GitHub log masks before env export.
+- Qodo's PR full-suite and OS Postgres auto-start concerns are obsolete in the current branch: macOS/Windows full-suite shards run on PRs when backend files changed and set `TLDW_TEST_NO_DOCKER=1`.
+
+## Stage 2: CI, Config, And Documentation Fixes
+**Goal**: Address workflow/config/documentation findings that do not require application runtime changes.
+**Success Criteria**: Redis service images are pinned, public frontend envs do not fall back to server secrets, shard coverage invocation is explicit, setup-ffmpeg no-ops when disabled, duplicate task headings are resolved, and PostgreSQL URL exports are masked before writing to `GITHUB_ENV`.
+**Tests**: YAML parsing, targeted workflow contract tests where available, and `git diff --check`.
+**Status**: Complete
+
+## Stage 3: Runtime Correctness And Lifecycle Fixes
+**Goal**: Address still-valid application code findings around FTS updates, sync state isolation, message ordering, SQLite rollback, Chroma retry behavior, evaluation service cleanup, analytics bootstrap validation, persona WebSocket ordering, and APKG connection cleanup.
+**Success Criteria**: Runtime paths are corrected without broad refactors and with focused regression coverage where practical.
+**Tests**: Targeted pytest modules for touched runtime areas plus compile checks.
+**Status**: Complete
+
+## Stage 4: Test Isolation And Assertion Hardening
+**Goal**: Address test-only findings that can mask regressions or leak state across modules.
+**Success Criteria**: Fixtures restore env/state, tests assert the intended boundaries, and skip conditions only cover explicit environment failures.
+**Tests**: Targeted pytest modules for touched tests.
+**Status**: Complete
+
+## Stage 5: Final Verification And PR Update
+**Goal**: Verify the complete follow-up change set and update PR #2431.
+**Success Criteria**: Relevant tests pass without `--maxfail`, Bandit is run on touched Python code, task notes summarize results, and the branch is pushed to PR #2431.
+**Tests**: Targeted pytest, compileall on touched Python files, Bandit on touched Python scope, YAML parse/contract checks, `git diff --check`, and fresh PR check polling after push.
+**Status**: In Progress
+
+Verification:
+- `python -m py_compile` on touched Python files passed.
+- `python -m pytest -q tldw_Server_API/tests/CI/test_required_workflow_contracts.py tldw_Server_API/tests/CI/test_e2e_required_redis_contract.py`: 36 passed.
+- Focused backend regression suite covering API deps, collections, DB/cache/media, evaluations webhook, sync, media import resilience, personalization, and RAG: 81 passed, 1 skipped.
+- APKG/media guard/embeddings verification: 64 passed, 14 skipped. The real HuggingFace embedding tests are now explicit opt-in via `RUN_REAL_HF_EMBEDDING_TESTS=true`.
+- `bunx vitest run __tests__/frontend-quickstart-networking.test.ts`: 11 passed.
+- `git diff --check` passed.
+- Bandit on touched production Python and touched tests exited 0.

--- a/apps/tldw-frontend/__tests__/frontend-quickstart-networking.test.ts
+++ b/apps/tldw-frontend/__tests__/frontend-quickstart-networking.test.ts
@@ -245,7 +245,7 @@ describe("frontend quickstart networking", () => {
     expect(makefile).toContain("TLDW_INTERNAL_API_ORIGIN ?= http://app:8000")
   })
 
-  it("passes the generated single-user key through WebUI quickstart compose interpolation", () => {
+  it("keeps server single-user keys out of WebUI public compose interpolation", () => {
     const makefile = readFileSync(makefilePath, "utf8")
     const compose = readFileSync(composeWebuiPath, "utf8")
     const startTarget = makefile.match(
@@ -254,12 +254,9 @@ describe("frontend quickstart networking", () => {
 
     expect(startTarget?.groups?.recipe).toBeTruthy()
     expect(startTarget?.groups?.recipe).not.toMatch(/grep '\^SINGLE_USER_API_KEY='/)
-    expect(compose).toContain(
-      "NEXT_PUBLIC_X_API_KEY: ${NEXT_PUBLIC_X_API_KEY:-${SINGLE_USER_API_KEY:-}}"
-    )
-    expect(compose).toContain(
-      "NEXT_PUBLIC_X_API_KEY=${NEXT_PUBLIC_X_API_KEY:-${SINGLE_USER_API_KEY:-}}"
-    )
+    expect(compose).toContain("NEXT_PUBLIC_X_API_KEY: ${NEXT_PUBLIC_X_API_KEY:-}")
+    expect(compose).toContain("NEXT_PUBLIC_X_API_KEY=${NEXT_PUBLIC_X_API_KEY:-}")
+    expect(compose).not.toContain("NEXT_PUBLIC_X_API_KEY:-${SINGLE_USER_API_KEY")
     expect(makefile).toContain(
       "docker compose --env-file \"$(TLDW_ENV_FILE)\" -f \"$(DOCKER_SINGLE_COMPOSE)\" -f \"$(DOCKER_WEBUI_COMPOSE)\""
     )

--- a/backlog/tasks/task-2396 - Stabilize-workflow-media-ingest-chunking-CI-test.md
+++ b/backlog/tasks/task-2396 - Stabilize-workflow-media-ingest-chunking-CI-test.md
@@ -51,7 +51,7 @@ Fix PR #2258 CI failures in workflow test shards: media ingest polling should fa
 - [x] #4 Approval permission tests set up waiting approval runs deterministically without depending on background scheduler timing.
 <!-- AC:END -->
 
-## Implementation Notes
+## Additional CI Failure Notes
 
 <!-- SECTION:NOTES:BEGIN -->
 CI run 27886920141 direct failures addressed:

--- a/backlog/tasks/task-2397 - Continue-CI-stability-work-after-full-suite-shard-merge.md
+++ b/backlog/tasks/task-2397 - Continue-CI-stability-work-after-full-suite-shard-merge.md
@@ -12,7 +12,7 @@ priority: medium
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Track follow-up work after PR #2258 merged the full-suite shard split into dev. Initial scope: monitor the merged workflow behavior on dev/main/release triggers, inspect any remaining queued or stale workflow-run behavior, and address residual CI runtime/stability issues without reintroducing early pytest maxfail behavior.
+Track follow-up work after PR #2258 merged the full-suite shard split into `dev`. Initial scope: monitor the merged workflow behavior on `dev`/`main`/release triggers, inspect any remaining queued or stale workflow-run behavior, and address residual CI runtime/stability issues without reintroducing early pytest `--maxfail` behavior.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -36,6 +36,7 @@ Track follow-up work after PR #2258 merged the full-suite shard split into dev. 
 - Qodo's prior PR full-suite and OS Postgres auto-start concerns are obsolete in this branch: macOS/Windows full-suite shards run for PRs with backend changes and set `TLDW_TEST_NO_DOCKER=1`.
 - Local verification for the review follow-up: py_compile on touched Python passed; CI contract tests 36 passed; focused backend regression suite 81 passed, 1 skipped; APKG/media guard/embeddings suite 64 passed, 14 skipped; frontend quickstart networking Vitest 11 passed; `git diff --check` passed; Bandit exited 0 for touched production Python and touched tests.
 - Known skip: real HuggingFace embedding tests now require explicit `RUN_REAL_HF_EMBEDDING_TESTS=true` to avoid accidental local/network-dependent runs.
+- PR #2431 review comments addressed: Qodo shutdown scheduling now logs non-critical failures, persona final-answer turns persist before assistant deltas are emitted, and the task description now formats `dev`, `main`, and `--maxfail` consistently. The Backlog task filename remains in the existing Backlog.md task-file convention used throughout `backlog/tasks/`.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2397 - Continue-CI-stability-work-after-full-suite-shard-merge.md
+++ b/backlog/tasks/task-2397 - Continue-CI-stability-work-after-full-suite-shard-merge.md
@@ -1,0 +1,48 @@
+---
+id: TASK-2397
+title: Continue CI stability work after full-suite shard merge
+status: In Progress
+labels:
+- ci
+- github-actions
+- stability
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track follow-up work after PR #2258 merged the full-suite shard split into dev. Initial scope: monitor the merged workflow behavior on dev/main/release triggers, inspect any remaining queued or stale workflow-run behavior, and address residual CI runtime/stability issues without reintroducing early pytest maxfail behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] Monitor the merged CI shard workflow behavior on `dev`, `main`, and release/manual triggers.
+- [ ] Inspect any remaining queued, cancelled, or failing GitHub Actions jobs before pushing follow-up fixes.
+- [ ] Address residual CI runtime or stability issues without reintroducing early pytest `--maxfail` behavior.
+- [ ] Record local and GitHub verification evidence before merging follow-up work.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- PR #2258 merged into `dev` at 2026-06-23T05:55:28Z with merge commit `c16aada8dd7e3061eb89c3c312ffcc1986fafa35`.
+- Fresh PR #2258 checks before merge: 755 passed, 4 skipped, 0 pending, 0 failed, 0 cancelled.
+- One unrelated stale queued CodeQL run for PR #1985 returned HTTP 500 when cancellation was attempted; it did not block #2258 completion.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2397 - Continue-CI-stability-work-after-full-suite-shard-merge.md
+++ b/backlog/tasks/task-2397 - Continue-CI-stability-work-after-full-suite-shard-merge.md
@@ -20,6 +20,7 @@ Track follow-up work after PR #2258 merged the full-suite shard split into dev. 
 - [ ] Monitor the merged CI shard workflow behavior on `dev`, `main`, and release/manual triggers.
 - [ ] Inspect any remaining queued, cancelled, or failing GitHub Actions jobs before pushing follow-up fixes.
 - [ ] Address residual CI runtime or stability issues without reintroducing early pytest `--maxfail` behavior.
+- [ ] Verify and address still-valid unresolved PR #2258 review comments, including inline and outside-diff CodeRabbit/Gemini/Qodo findings.
 - [ ] Record local and GitHub verification evidence before merging follow-up work.
 <!-- AC:END -->
 
@@ -29,20 +30,26 @@ Track follow-up work after PR #2258 merged the full-suite shard split into dev. 
 - PR #2258 merged into `dev` at 2026-06-23T05:55:28Z with merge commit `c16aada8dd7e3061eb89c3c312ffcc1986fafa35`.
 - Fresh PR #2258 checks before merge: 755 passed, 4 skipped, 0 pending, 0 failed, 0 cancelled.
 - One unrelated stale queued CodeQL run for PR #1985 returned HTTP 500 when cancellation was attempted; it did not block #2258 completion.
+- Follow-up scope expanded to cover unresolved PR #2258 review feedback after merge: 1 Gemini inline thread, 26 CodeRabbit inline comments, 3 CodeRabbit outside-diff comments, and Qodo's top-level CI coverage/security concerns.
+- Implementation plan: `Docs/Plans/2026-06-23-pr2258-review-followups.md`.
+- PR #2258 review follow-up fixes added to PR #2431 include CI/config/doc fixes, runtime lifecycle/correctness fixes, and test isolation/assertion hardening. Qodo's DB URL exposure concern is handled by masking PostgreSQL passwords and assembled URLs before writing CI env vars.
+- Qodo's prior PR full-suite and OS Postgres auto-start concerns are obsolete in this branch: macOS/Windows full-suite shards run for PRs with backend changes and set `TLDW_TEST_NO_DOCKER=1`.
+- Local verification for the review follow-up: py_compile on touched Python passed; CI contract tests 36 passed; focused backend regression suite 81 passed, 1 skipped; APKG/media guard/embeddings suite 64 passed, 14 skipped; frontend quickstart networking Vitest 11 passed; `git diff --check` passed; Bandit exited 0 for touched production Python and touched tests.
+- Known skip: real HuggingFace embedding tests now require explicit `RUN_REAL_HF_EMBEDDING_TESTS=true` to avoid accidental local/network-dependent runs.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Added PR #2258 review follow-up fixes to PR #2431: CI/config hardening, runtime correctness/lifecycle fixes, test isolation improvements, and local verification evidence. The broader task remains open until the pushed PR #2431 run is observed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -10579,30 +10579,23 @@ async def persona_stream(
                             summary_text=assistant_text,
                             surface=activity_surface,
                         )
+                        await _record_turn(
+                            session_id=session_id,
+                            role="assistant",
+                            content=assistant_text,
+                            turn_type="assistant_delta",
+                            metadata={"source": "plan", "step_idx": step.idx, "step_type": step_type},
+                            persist_as_memory=True,
+                            persona_id_override=runtime_persona_id,
+                            runtime_mode_override=runtime_mode,
+                            scope_snapshot_id_override=runtime_scope_snapshot_id,
+                            memory_kind="summary",
+                        )
                         await _emit_assistant_delta(
                             session_id=session_id,
                             step_idx=step.idx,
                             text_delta=assistant_text,
                         )
-                        try:
-                            await _record_turn(
-                                session_id=session_id,
-                                role="assistant",
-                                content=assistant_text,
-                                turn_type="assistant_delta",
-                                metadata={"source": "plan", "step_idx": step.idx, "step_type": step_type},
-                                persist_as_memory=True,
-                                persona_id_override=runtime_persona_id,
-                                runtime_mode_override=runtime_mode,
-                                scope_snapshot_id_override=runtime_scope_snapshot_id,
-                                memory_kind="summary",
-                            )
-                        except Exception as exc:
-                            logger.debug(
-                                "persona assistant turn persistence skipped for session_hash {}: {}",
-                                _redacted_id_for_logs(session_id),
-                                exc,
-                            )
                         await _emit_persona_live_tts_for_assistant_text(
                             session_id=session_id,
                             assistant_text=assistant_text,

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -10579,23 +10579,30 @@ async def persona_stream(
                             summary_text=assistant_text,
                             surface=activity_surface,
                         )
-                        await _record_turn(
-                            session_id=session_id,
-                            role="assistant",
-                            content=assistant_text,
-                            turn_type="assistant_delta",
-                            metadata={"source": "plan", "step_idx": step.idx, "step_type": step_type},
-                            persist_as_memory=True,
-                            persona_id_override=runtime_persona_id,
-                            runtime_mode_override=runtime_mode,
-                            scope_snapshot_id_override=runtime_scope_snapshot_id,
-                            memory_kind="summary",
-                        )
                         await _emit_assistant_delta(
                             session_id=session_id,
                             step_idx=step.idx,
                             text_delta=assistant_text,
                         )
+                        try:
+                            await _record_turn(
+                                session_id=session_id,
+                                role="assistant",
+                                content=assistant_text,
+                                turn_type="assistant_delta",
+                                metadata={"source": "plan", "step_idx": step.idx, "step_type": step_type},
+                                persist_as_memory=True,
+                                persona_id_override=runtime_persona_id,
+                                runtime_mode_override=runtime_mode,
+                                scope_snapshot_id_override=runtime_scope_snapshot_id,
+                                memory_kind="summary",
+                            )
+                        except Exception as exc:
+                            logger.debug(
+                                "persona assistant turn persistence skipped for session_hash {}: {}",
+                                _redacted_id_for_logs(session_id),
+                                exc,
+                            )
                         await _emit_persona_live_tts_for_assistant_text(
                             session_id=session_id,
                             assistant_text=assistant_text,

--- a/tldw_Server_API/app/api/v1/endpoints/sync.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sync.py
@@ -1865,12 +1865,11 @@ class ServerSyncProcessor:
     callers that still exercise the old batch-application semantics.
     """
 
-    _server_column_cache: dict[str, list[str]] = {}
-
     def __init__(self, db: Any, user_id: str, requesting_client_id: str) -> None:
         self.db = db
         self.user_id = user_id
         self.requesting_client_id = requesting_client_id
+        self._server_column_cache: dict[str, list[str]] = {}
 
     @staticmethod
     def _validate_entity_operation(entity: str, operation: str) -> Optional[str]:

--- a/tldw_Server_API/app/core/DB_Management/Workflows_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Workflows_DB.py
@@ -2106,6 +2106,8 @@ class WorkflowsDatabase:
             conn.execute("UPDATE workflow_runs SET cancel_requested = ? WHERE run_id = ?", params)
             conn.commit()
         except sqlite3.OperationalError as e:
+            with contextlib.suppress(sqlite3.Error):
+                conn.rollback()
             if "locked" not in str(e).lower():
                 raise
             import time as _time
@@ -2118,9 +2120,13 @@ class WorkflowsDatabase:
                     break
                 except sqlite3.OperationalError as retry_error:
                     if "locked" in str(retry_error).lower() and tries < 4:
+                        with contextlib.suppress(sqlite3.Error):
+                            conn.rollback()
                         _time.sleep(0.05 * (2 ** tries))
                         tries += 1
                         continue
+                    with contextlib.suppress(sqlite3.Error):
+                        conn.rollback()
                     raise
         finally:
             self._release_sqlite(conn)

--- a/tldw_Server_API/app/core/DB_Management/chacha/message_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/message_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import threading
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -25,19 +26,21 @@ class MessageStore:
     def __init__(self, db: CharactersRAGDB) -> None:
         self._db = db
         self._last_message_order_timestamp: str | None = None
+        self._message_order_lock = threading.Lock()
 
     def _next_message_order_timestamp(self) -> str:
         """Return a millisecond ISO timestamp that is monotonic for message inserts."""
-        now = self._db._get_current_utc_timestamp_iso()
-        last = self._last_message_order_timestamp
-        if last is not None and now <= last:
-            try:
-                bumped = datetime.fromisoformat(last.replace("Z", "+00:00")) + timedelta(milliseconds=1)
-                now = bumped.isoformat(timespec="milliseconds").replace("+00:00", "Z")
-            except ValueError:
-                logger.warning("Could not parse last message timestamp {}; using current timestamp.", last)
-        self._last_message_order_timestamp = now
-        return now
+        with self._message_order_lock:
+            now = self._db._get_current_utc_timestamp_iso()
+            last = self._last_message_order_timestamp
+            if last is not None and now <= last:
+                try:
+                    bumped = datetime.fromisoformat(last.replace("Z", "+00:00")) + timedelta(milliseconds=1)
+                    now = bumped.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+                except ValueError:
+                    logger.warning("Could not parse last message timestamp {}; using current timestamp.", last)
+            self._last_message_order_timestamp = now
+            return now
 
     # ------------------------------------------------------------------
     # Message creation

--- a/tldw_Server_API/app/core/DB_Management/media_db/runtime/fts_ops.py
+++ b/tldw_Server_API/app/core/DB_Management/media_db/runtime/fts_ops.py
@@ -57,10 +57,15 @@ def _update_fts_media(
         expansion_suffix = (" " + " ".join(expanded_terms)) if expanded_terms else ""
         try:
             if old_title is not None or old_content is not None:
-                conn.execute(
-                    "INSERT INTO media_fts (media_fts, rowid, title, content) VALUES ('delete', ?, ?, ?)",
-                    (media_id, old_title or "", old_content or ""),
-                )
+                existing_fts = conn.execute(
+                    "SELECT title, content FROM media_fts WHERE rowid = ?",
+                    (media_id,),
+                ).fetchone()
+                if existing_fts:
+                    conn.execute(
+                        "INSERT INTO media_fts (media_fts, rowid, title, content) VALUES ('delete', ?, ?, ?)",
+                        (media_id, existing_fts[0] or "", existing_fts[1] or ""),
+                    )
             conn.execute(
                 "INSERT OR REPLACE INTO media_fts (rowid, title, content) VALUES (?, ?, ?)",
                 (media_id, title, f"{content}{expansion_suffix}"),

--- a/tldw_Server_API/app/core/DB_Management/migration_tools.py
+++ b/tldw_Server_API/app/core/DB_Management/migration_tools.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import argparse
 import contextlib
-import logging
 import sqlite3
+import sys
 from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -499,7 +499,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument('--log-level', default='INFO')
 
     args = parser.parse_args(argv)
-    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+    log_level = args.log_level.upper()
+    try:
+        logger.level(log_level)
+    except ValueError:
+        log_level = "INFO"
+    logger.remove()
+    logger.add(sys.stderr, level=log_level)
 
     targets = list(_iter_migration_targets(args))
     if args.workflows_sqlite:

--- a/tldw_Server_API/app/core/Embeddings/ChromaDB_Library.py
+++ b/tldw_Server_API/app/core/Embeddings/ChromaDB_Library.py
@@ -1746,16 +1746,17 @@ class ChromaDBManager:
                 )
             # Use the more specific ChromaError imports if they work for your version
             except ChromaError as ce:
-                if collection_name and _is_transient_chroma_segment_error(ce):
+                retry_collection_name = target_collection.name
+                if _is_transient_chroma_segment_error(ce):
                     for retry_attempt, retry_delay in enumerate(_CHROMA_SEGMENT_RETRY_DELAYS_SECONDS, start=1):
                         logger.warning(
                             f"User '{self.user_id}': Retrying ChromaDB query for collection "
-                            f"'{target_collection.name}' after transient segment-reader error "
+                            f"'{retry_collection_name}' after transient segment-reader error "
                             f"(attempt {retry_attempt}/{len(_CHROMA_SEGMENT_RETRY_DELAYS_SECONDS)}): {ce}"
                         )
                         time.sleep(retry_delay)
                         try:
-                            target_collection = self.client.get_or_create_collection(name=collection_name)
+                            target_collection = self.client.get_or_create_collection(name=retry_collection_name)
                             return target_collection.query(
                                 query_embeddings=query_embeddings,
                                 n_results=n_results,

--- a/tldw_Server_API/app/core/Evaluations/unified_evaluation_service.py
+++ b/tldw_Server_API/app/core/Evaluations/unified_evaluation_service.py
@@ -1573,6 +1573,20 @@ _MAX_SERVICE_INSTANCES = 128
 _service_instances_by_user: "OrderedDict[str, UnifiedEvaluationService]" = OrderedDict()  # type: ignore[name-defined]
 
 
+def _schedule_service_shutdown(svc: "UnifiedEvaluationService") -> None:
+    """Schedule best-effort async shutdown for a cached service instance."""
+    shutdown = getattr(svc, "shutdown", None)
+    if not callable(shutdown):
+        return
+    try:
+        loop = asyncio.get_running_loop()
+        result = shutdown()
+        if asyncio.iscoroutine(result):
+            loop.create_task(result)
+    except _UNIFIED_EVAL_NONCRITICAL_EXCEPTIONS:
+        pass
+
+
 def get_unified_evaluation_service(db_path: Optional[str] = None) -> UnifiedEvaluationService:
     """
     Get or create the unified evaluation service singleton.
@@ -1617,7 +1631,9 @@ def get_unified_evaluation_service_for_user(user_id: str | int) -> UnifiedEvalua
                 import os as _os
                 override_path = _os.getenv("EVALUATIONS_TEST_DB_PATH")
                 if override_path and getattr(getattr(svc, "db", None), "db_path", None) != override_path:
-                    return UnifiedEvaluationService(db_path=override_path)
+                    replacement = UnifiedEvaluationService(db_path=override_path)
+                    _schedule_service_shutdown(svc)
+                    return replacement
             except _UNIFIED_EVAL_NONCRITICAL_EXCEPTIONS:
                 pass
             return svc
@@ -1647,13 +1663,7 @@ def get_unified_evaluation_service_for_user(user_id: str | int) -> UnifiedEvalua
         if hasattr(_service_instances_by_user, "popitem") and len(_service_instances_by_user) > _MAX_SERVICE_INSTANCES:  # type: ignore[attr-defined]
             try:
                 old_user_id, old_svc = _service_instances_by_user.popitem(last=False)  # type: ignore[arg-type]
-                # Best effort shutdown without blocking
-                try:
-                    import asyncio as _aio
-                    if hasattr(old_svc, "shutdown"):
-                        _aio.create_task(old_svc.shutdown())
-                except _UNIFIED_EVAL_NONCRITICAL_EXCEPTIONS:
-                    pass
+                _schedule_service_shutdown(old_svc)
             except _UNIFIED_EVAL_NONCRITICAL_EXCEPTIONS:
                 pass
         return svc

--- a/tldw_Server_API/app/core/Evaluations/unified_evaluation_service.py
+++ b/tldw_Server_API/app/core/Evaluations/unified_evaluation_service.py
@@ -1583,8 +1583,12 @@ def _schedule_service_shutdown(svc: "UnifiedEvaluationService") -> None:
         result = shutdown()
         if asyncio.iscoroutine(result):
             loop.create_task(result)
-    except _UNIFIED_EVAL_NONCRITICAL_EXCEPTIONS:
-        pass
+    except _UNIFIED_EVAL_NONCRITICAL_EXCEPTIONS as exc:
+        logger.debug(
+            "Unified evaluation service shutdown scheduling skipped for {}: {}",
+            type(svc).__name__,
+            exc,
+        )
 
 
 def get_unified_evaluation_service(db_path: Optional[str] = None) -> UnifiedEvaluationService:

--- a/tldw_Server_API/app/core/Flashcards/apkg_exporter.py
+++ b/tldw_Server_API/app/core/Flashcards/apkg_exporter.py
@@ -358,254 +358,251 @@ def export_apkg_from_rows(
     # Open temp sqlite
     with tempfile.TemporaryDirectory() as tmp:
         col_path = os.path.join(tmp, "collection.anki2")
-        conn = sqlite3.connect(col_path)
-        c = conn.cursor()
-        # Create schema
-        c.executescript(
-            """
-            PRAGMA foreign_keys=ON;
-            CREATE TABLE IF NOT EXISTS col(
-              id integer primary key,
-              crt integer not null,
-              mod integer not null,
-              scm integer not null,
-              ver integer not null,
-              dty integer not null,
-              usn integer not null,
-              ls integer not null,
-              conf text not null,
-              models text not null,
-              decks text not null,
-              dconf text not null,
-              tags text not null
-            );
-            CREATE TABLE IF NOT EXISTS notes(
-              id integer primary key,
-              guid text not null,
-              mid integer not null,
-              mod integer not null,
-              usn integer not null,
-              tags text not null,
-              flds text not null,
-              sfld integer not null,
-              csum integer not null,
-              flags integer not null,
-              data text not null
-            );
-            CREATE TABLE IF NOT EXISTS cards(
-              id integer primary key,
-              nid integer not null,
-              did integer not null,
-              ord integer not null,
-              mod integer not null,
-              usn integer not null,
-              type integer not null,
-              queue integer not null,
-              due integer not null,
-              ivl integer not null,
-              factor integer not null,
-              reps integer not null,
-              lapses integer not null,
-              left integer not null,
-              odue integer not null,
-              odid integer not null,
-              flags integer not null,
-              data text not null
-            );
-            CREATE TABLE IF NOT EXISTS revlog(
-              id integer primary key,
-              cid integer not null,
-              usn integer not null,
-              ease integer not null,
-              ivl integer not null,
-              lastIvl integer not null,
-              factor integer not null,
-              time integer not null,
-              type integer not null
-            );
-            CREATE TABLE IF NOT EXISTS graves(
-              usn integer not null,
-              oid integer not null,
-              type integer not null
-            );
-            """
-        )
-
-        col_id = 1
-        crt = _day_start_secs()
-        now_ms = _now_millis()
-        models_json = _build_models_json(basic_mid, cloze_mid)
-        decks_json = _build_decks_json({deck_ids[name]: name for name in unique_decks})
-        dconf_json = _build_dconf_json()
-        conf_json = _build_conf_json(next(iter(deck_ids.values())))
-        tags_json = {}
-        c.execute(
-            "INSERT INTO col(id,crt,mod,scm,ver,dty,usn,ls,conf,models,decks,dconf,tags) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)",
-            (
-                col_id, crt, now_ms, now_ms, 11, 0, 0, now_ms,
-                json.dumps(conf_json), json.dumps(models_json), json.dumps(decks_json), json.dumps(dconf_json), json.dumps(tags_json)
+        with contextlib.closing(sqlite3.connect(col_path)) as conn:
+            c = conn.cursor()
+            # Create schema
+            c.executescript(
+                """
+                PRAGMA foreign_keys=ON;
+                CREATE TABLE IF NOT EXISTS col(
+                  id integer primary key,
+                  crt integer not null,
+                  mod integer not null,
+                  scm integer not null,
+                  ver integer not null,
+                  dty integer not null,
+                  usn integer not null,
+                  ls integer not null,
+                  conf text not null,
+                  models text not null,
+                  decks text not null,
+                  dconf text not null,
+                  tags text not null
+                );
+                CREATE TABLE IF NOT EXISTS notes(
+                  id integer primary key,
+                  guid text not null,
+                  mid integer not null,
+                  mod integer not null,
+                  usn integer not null,
+                  tags text not null,
+                  flds text not null,
+                  sfld integer not null,
+                  csum integer not null,
+                  flags integer not null,
+                  data text not null
+                );
+                CREATE TABLE IF NOT EXISTS cards(
+                  id integer primary key,
+                  nid integer not null,
+                  did integer not null,
+                  ord integer not null,
+                  mod integer not null,
+                  usn integer not null,
+                  type integer not null,
+                  queue integer not null,
+                  due integer not null,
+                  ivl integer not null,
+                  factor integer not null,
+                  reps integer not null,
+                  lapses integer not null,
+                  left integer not null,
+                  odue integer not null,
+                  odid integer not null,
+                  flags integer not null,
+                  data text not null
+                );
+                CREATE TABLE IF NOT EXISTS revlog(
+                  id integer primary key,
+                  cid integer not null,
+                  usn integer not null,
+                  ease integer not null,
+                  ivl integer not null,
+                  lastIvl integer not null,
+                  factor integer not null,
+                  time integer not null,
+                  type integer not null
+                );
+                CREATE TABLE IF NOT EXISTS graves(
+                  usn integer not null,
+                  oid integer not null,
+                  type integer not null
+                );
+                """
             )
-        )
 
-        # Insert notes + cards
-        next_new_pos = 1
-        nid_base = now_ms + 200000
-        cid_base = now_ms + 300000
-        card_seq = 0
-        media_accum: list[tuple[str, bytes]] = []
-        media_idx_map: dict[str, int] = {}
-        media_total_bytes = [0]
-        managed_asset_filenames: dict[str, str] = {}
-
-        def _register_managed_asset(asset_uuid: str) -> str:
-            if asset_uuid in managed_asset_filenames:
-                return managed_asset_filenames[asset_uuid]
-            if asset_loader is None:
-                raise ValueError(f"Managed flashcard asset export is unavailable for {asset_uuid}")
-
-            loaded = asset_loader(asset_uuid)
-            if isinstance(loaded, dict):
-                content = loaded.get("content") or loaded.get("bytes")
-                mime_type = loaded.get("mime_type")
-                original_filename = loaded.get("original_filename")
-            elif isinstance(loaded, (tuple, list)) and len(loaded) >= 2:
-                content = loaded[0]
-                mime_type = loaded[1]
-                original_filename = loaded[2] if len(loaded) > 2 else None
-            else:
-                raise ValueError(f"Unsupported asset loader payload for {asset_uuid}")
-
-            if not isinstance(content, (bytes, bytearray, memoryview)):
-                raise ValueError(f"Managed flashcard asset {asset_uuid} is missing bytes")
-            content_bytes = bytes(content)
-            media_total_bytes[0] += len(content_bytes)
-            if max_total_media_bytes is not None and media_total_bytes[0] > max_total_media_bytes:
-                with contextlib.suppress(Exception):
-                    conn.close()
-                raise ValueError(f"APKG media exceeds max total size of {max_total_media_bytes} bytes")
-
-            filename = f"managed_{asset_uuid.replace('-', '')[:12]}.{_guess_extension(mime_type, original_filename)}"
-            media_idx_map[filename] = len(media_accum)
-            media_accum.append((filename, content_bytes))
-            managed_asset_filenames[asset_uuid] = filename
-            return filename
-
-        for i, r in enumerate(rows):
-            deck_name = r.get("deck_name") or default_deck_name
-            did = deck_ids[deck_name]
-            model_type = r.get("model_type") or ("cloze" if r.get("is_cloze") else "basic")
-            is_cloze = (model_type == 'cloze')
-            reverse_flag = bool(r.get("reverse"))
-            ef = float(r.get("ef") or 2.5)
-            interval_days = int(r.get("interval_days") or 0)
-            repetitions = int(r.get("repetitions") or 0)
-            lapses = int(r.get("lapses") or 0)
-            due_at = r.get("due_at")
-
-            front = r.get("front") or ""
-            back = r.get("back") or ""
-            notes = r.get("notes") or ""
-            extra = r.get("extra") or ""
-            if asset_loader is not None:
-                front = replace_markdown_asset_refs_for_export(front, _register_managed_asset)
-                back = replace_markdown_asset_refs_for_export(back, _register_managed_asset)
-                extra = replace_markdown_asset_refs_for_export(extra, _register_managed_asset)
-                notes = replace_markdown_asset_refs_for_export(notes, _register_managed_asset)
-            # Extract media from HTML fields and replace with filenames
-            front = _extract_media_from_html(
-                front,
-                media_accum,
-                media_idx_map,
-                media_total_bytes=media_total_bytes,
-                max_total_media_bytes=max_total_media_bytes,
-            )
-            back = _extract_media_from_html(
-                back,
-                media_accum,
-                media_idx_map,
-                media_total_bytes=media_total_bytes,
-                max_total_media_bytes=max_total_media_bytes,
-            )
-            extra = _extract_media_from_html(
-                extra,
-                media_accum,
-                media_idx_map,
-                media_total_bytes=media_total_bytes,
-                max_total_media_bytes=max_total_media_bytes,
-            )
-            notes = _extract_media_from_html(
-                notes,
-                media_accum,
-                media_idx_map,
-                media_total_bytes=media_total_bytes,
-                max_total_media_bytes=max_total_media_bytes,
-            )
-            tags_json_str = r.get("tags_json")
-            tags_list = []
-            if tags_json_str:
-                try:
-                    tags_list = json.loads(tags_json_str)
-                except Exception:
-                    tags_list = []
-            tags_str = " " + " ".join(t for t in tags_list) + " " if tags_list else ""
-
-            if is_cloze:
-                mid = cloze_mid
-                flds = f"{front}\x1f{extra}\x1f{notes}"
-                sfld = 0
-            else:
-                mid = basic_mid
-                flds = f"{front}\x1f{back}\x1f{extra}\x1f{notes}"
-                sfld = 0
-
-            nid = nid_base + i
-            guid = uuid.uuid4().hex[:10]
-            csum = _sha1_8_int(front)
+            col_id = 1
+            crt = _day_start_secs()
+            now_ms = _now_millis()
+            models_json = _build_models_json(basic_mid, cloze_mid)
+            decks_json = _build_decks_json({deck_ids[name]: name for name in unique_decks})
+            dconf_json = _build_dconf_json()
+            conf_json = _build_conf_json(next(iter(deck_ids.values())))
+            tags_json = {}
             c.execute(
-                "INSERT INTO notes(id,guid,mid,mod,usn,tags,flds,sfld,csum,flags,data) VALUES(?,?,?,?,?,?,?,?,?,?,?)",
-                (nid, guid, mid, _now_secs(), -1, tags_str, flds, sfld, csum, 0, "")
+                "INSERT INTO col(id,crt,mod,scm,ver,dty,usn,ls,conf,models,decks,dconf,tags) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    col_id, crt, now_ms, now_ms, 11, 0, 0, now_ms,
+                    json.dumps(conf_json), json.dumps(models_json), json.dumps(decks_json), json.dumps(dconf_json), json.dumps(tags_json)
+                )
             )
 
-            if is_cloze:
-                # Generate one card per unique cloze index N in Text
-                cloze_ids = {int(m.group(1)) for m in re.finditer(r"\{\{c(\d+)::", front)}
-                if not cloze_ids:
-                    cloze_ids = {1}
-                for n in sorted(cloze_ids):
+            # Insert notes + cards
+            next_new_pos = 1
+            nid_base = now_ms + 200000
+            cid_base = now_ms + 300000
+            card_seq = 0
+            media_accum: list[tuple[str, bytes]] = []
+            media_idx_map: dict[str, int] = {}
+            media_total_bytes = [0]
+            managed_asset_filenames: dict[str, str] = {}
+
+            def _register_managed_asset(asset_uuid: str) -> str:
+                if asset_uuid in managed_asset_filenames:
+                    return managed_asset_filenames[asset_uuid]
+                if asset_loader is None:
+                    raise ValueError(f"Managed flashcard asset export is unavailable for {asset_uuid}")
+
+                loaded = asset_loader(asset_uuid)
+                if isinstance(loaded, dict):
+                    content = loaded.get("content") or loaded.get("bytes")
+                    mime_type = loaded.get("mime_type")
+                    original_filename = loaded.get("original_filename")
+                elif isinstance(loaded, (tuple, list)) and len(loaded) >= 2:
+                    content = loaded[0]
+                    mime_type = loaded[1]
+                    original_filename = loaded[2] if len(loaded) > 2 else None
+                else:
+                    raise ValueError(f"Unsupported asset loader payload for {asset_uuid}")
+
+                if not isinstance(content, (bytes, bytearray, memoryview)):
+                    raise ValueError(f"Managed flashcard asset {asset_uuid} is missing bytes")
+                content_bytes = bytes(content)
+                media_total_bytes[0] += len(content_bytes)
+                if max_total_media_bytes is not None and media_total_bytes[0] > max_total_media_bytes:
+                    raise ValueError(f"APKG media exceeds max total size of {max_total_media_bytes} bytes")
+
+                filename = f"managed_{asset_uuid.replace('-', '')[:12]}.{_guess_extension(mime_type, original_filename)}"
+                media_idx_map[filename] = len(media_accum)
+                media_accum.append((filename, content_bytes))
+                managed_asset_filenames[asset_uuid] = filename
+                return filename
+
+            for i, r in enumerate(rows):
+                deck_name = r.get("deck_name") or default_deck_name
+                did = deck_ids[deck_name]
+                model_type = r.get("model_type") or ("cloze" if r.get("is_cloze") else "basic")
+                is_cloze = (model_type == 'cloze')
+                reverse_flag = bool(r.get("reverse"))
+                ef = float(r.get("ef") or 2.5)
+                interval_days = int(r.get("interval_days") or 0)
+                repetitions = int(r.get("repetitions") or 0)
+                lapses = int(r.get("lapses") or 0)
+                due_at = r.get("due_at")
+
+                front = r.get("front") or ""
+                back = r.get("back") or ""
+                notes = r.get("notes") or ""
+                extra = r.get("extra") or ""
+                if asset_loader is not None:
+                    front = replace_markdown_asset_refs_for_export(front, _register_managed_asset)
+                    back = replace_markdown_asset_refs_for_export(back, _register_managed_asset)
+                    extra = replace_markdown_asset_refs_for_export(extra, _register_managed_asset)
+                    notes = replace_markdown_asset_refs_for_export(notes, _register_managed_asset)
+                # Extract media from HTML fields and replace with filenames
+                front = _extract_media_from_html(
+                    front,
+                    media_accum,
+                    media_idx_map,
+                    media_total_bytes=media_total_bytes,
+                    max_total_media_bytes=max_total_media_bytes,
+                )
+                back = _extract_media_from_html(
+                    back,
+                    media_accum,
+                    media_idx_map,
+                    media_total_bytes=media_total_bytes,
+                    max_total_media_bytes=max_total_media_bytes,
+                )
+                extra = _extract_media_from_html(
+                    extra,
+                    media_accum,
+                    media_idx_map,
+                    media_total_bytes=media_total_bytes,
+                    max_total_media_bytes=max_total_media_bytes,
+                )
+                notes = _extract_media_from_html(
+                    notes,
+                    media_accum,
+                    media_idx_map,
+                    media_total_bytes=media_total_bytes,
+                    max_total_media_bytes=max_total_media_bytes,
+                )
+                tags_json_str = r.get("tags_json")
+                tags_list = []
+                if tags_json_str:
+                    try:
+                        tags_list = json.loads(tags_json_str)
+                    except Exception:
+                        tags_list = []
+                tags_str = " " + " ".join(t for t in tags_list) + " " if tags_list else ""
+
+                if is_cloze:
+                    mid = cloze_mid
+                    flds = f"{front}\x1f{extra}\x1f{notes}"
+                    sfld = 0
+                else:
+                    mid = basic_mid
+                    flds = f"{front}\x1f{back}\x1f{extra}\x1f{notes}"
+                    sfld = 0
+
+                nid = nid_base + i
+                guid = uuid.uuid4().hex[:10]
+                csum = _sha1_8_int(front)
+                c.execute(
+                    "INSERT INTO notes(id,guid,mid,mod,usn,tags,flds,sfld,csum,flags,data) VALUES(?,?,?,?,?,?,?,?,?,?,?)",
+                    (nid, guid, mid, _now_secs(), -1, tags_str, flds, sfld, csum, 0, "")
+                )
+
+                if is_cloze:
+                    # Generate one card per unique cloze index N in Text
+                    cloze_ids = {int(m.group(1)) for m in re.finditer(r"\{\{c(\d+)::", front)}
+                    if not cloze_ids:
+                        cloze_ids = {1}
+                    for n in sorted(cloze_ids):
+                        type_v, queue_v, due_v, ivl_v, factor_v, reps_v, lapses_v = _compute_card_sched(model_type, ef, interval_days, repetitions, lapses, due_at, crt)
+                        if type_v == 0:
+                            due_v = next_new_pos
+                            next_new_pos += 1
+                        cid = cid_base + card_seq
+                        card_seq += 1
+                        ord_n = max(0, n - 1)
+                        c.execute(
+                            "INSERT INTO cards(id,nid,did,ord,mod,usn,type,queue,due,ivl,factor,reps,lapses,left,odue,odid,flags,data) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                            (cid, nid, did, ord_n, _now_secs(), -1, type_v, queue_v, due_v, ivl_v, factor_v, reps_v, lapses_v, 0, 0, 0, 0, "")
+                        )
+                else:
+                    # Card 1
                     type_v, queue_v, due_v, ivl_v, factor_v, reps_v, lapses_v = _compute_card_sched(model_type, ef, interval_days, repetitions, lapses, due_at, crt)
                     if type_v == 0:
                         due_v = next_new_pos
                         next_new_pos += 1
                     cid = cid_base + card_seq
                     card_seq += 1
-                    ord_n = max(0, n - 1)
                     c.execute(
                         "INSERT INTO cards(id,nid,did,ord,mod,usn,type,queue,due,ivl,factor,reps,lapses,left,odue,odid,flags,data) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
-                        (cid, nid, did, ord_n, _now_secs(), -1, type_v, queue_v, due_v, ivl_v, factor_v, reps_v, lapses_v, 0, 0, 0, 0, "")
+                        (cid, nid, did, 0, _now_secs(), -1, type_v, queue_v, due_v, ivl_v, factor_v, reps_v, lapses_v, 0, 0, 0, 0, "")
                     )
-            else:
-                # Card 1
-                type_v, queue_v, due_v, ivl_v, factor_v, reps_v, lapses_v = _compute_card_sched(model_type, ef, interval_days, repetitions, lapses, due_at, crt)
-                if type_v == 0:
-                    due_v = next_new_pos
-                    next_new_pos += 1
-                cid = cid_base + card_seq
-                card_seq += 1
-                c.execute(
-                    "INSERT INTO cards(id,nid,did,ord,mod,usn,type,queue,due,ivl,factor,reps,lapses,left,odue,odid,flags,data) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
-                    (cid, nid, did, 0, _now_secs(), -1, type_v, queue_v, due_v, ivl_v, factor_v, reps_v, lapses_v, 0, 0, 0, 0, "")
-                )
-                # Reverse card if requested/model says so
-                if reverse_flag or model_type == 'basic_reverse' or include_reverse:
-                    cid2 = cid_base + card_seq
-                    card_seq += 1
-                    c.execute(
-                        "INSERT INTO cards(id,nid,did,ord,mod,usn,type,queue,due,ivl,factor,reps,lapses,left,odue,odid,flags,data) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
-                        (cid2, nid, did, 1, _now_secs(), -1, type_v, queue_v, due_v, ivl_v, factor_v, reps_v, lapses_v, 0, 0, 0, 0, "")
-                    )
+                    # Reverse card if requested/model says so
+                    if reverse_flag or model_type == 'basic_reverse' or include_reverse:
+                        cid2 = cid_base + card_seq
+                        card_seq += 1
+                        c.execute(
+                            "INSERT INTO cards(id,nid,did,ord,mod,usn,type,queue,due,ivl,factor,reps,lapses,left,odue,odid,flags,data) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                            (cid2, nid, did, 1, _now_secs(), -1, type_v, queue_v, due_v, ivl_v, factor_v, reps_v, lapses_v, 0, 0, 0, 0, "")
+                        )
 
-        conn.commit()
-        conn.close()
+            conn.commit()
 
         # Package zip
         apkg_bytes = io.BytesIO()

--- a/tldw_Server_API/app/core/RAG/rag_service/analytics_db.py
+++ b/tldw_Server_API/app/core/RAG/rag_service/analytics_db.py
@@ -88,6 +88,12 @@ class AnalyticsDatabase:
     """
 
     _bootstrapped_backend_targets: set[str] = set()
+    _REQUIRED_BOOTSTRAP_TABLES: tuple[str, ...] = (
+        "search_analytics",
+        "document_performance",
+        "feedback_analytics",
+        "analytics_events",
+    )
 
     _SCHEMA_SQLITE = """
     CREATE TABLE IF NOT EXISTS search_analytics (
@@ -465,7 +471,12 @@ class AnalyticsDatabase:
         target = self._describe_backend(backend)
         with self._lock:
             if target in type(self)._bootstrapped_backend_targets:
-                return
+                with backend.transaction() as conn:
+                    if all(
+                        backend.table_exists(table, connection=conn)
+                        for table in self._REQUIRED_BOOTSTRAP_TABLES
+                    ):
+                        return
             self._bootstrap_backend_schema(backend, target)
             type(self)._bootstrapped_backend_targets.add(target)
 

--- a/tldw_Server_API/tests/API_Deps/test_chacha_notes_db_deps_error_mapping.py
+++ b/tldw_Server_API/tests/API_Deps/test_chacha_notes_db_deps_error_mapping.py
@@ -64,7 +64,7 @@ async def test_chacha_init_uses_hard_timeout_headroom_beyond_watchdog(monkeypatc
     db = await chacha_deps._get_or_init_db_instance(42, "client-42")
 
     assert isinstance(db, _FakeDB)
-    assert recorded_timeouts == [30.0]
+    assert recorded_timeouts == [chacha_deps._CHACHA_INIT_TIMEOUT_SECS]
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/CI/test_e2e_required_redis_contract.py
+++ b/tldw_Server_API/tests/CI/test_e2e_required_redis_contract.py
@@ -4,6 +4,10 @@ import yaml
 
 
 EXPECTED_REDIS_URL = "redis://127.0.0.1:6379/0"
+EXPECTED_REDIS_IMAGE = (
+    "mirror.gcr.io/library/redis:8-alpine@"
+    "sha256:9eb6a7ba3d344e1958c7e1589fa3dee90373a934e8159c634562a91d622759a0"
+)
 
 
 def _load_workflow() -> dict:
@@ -23,8 +27,8 @@ def test_e2e_required_declares_redis_service_and_environment_contract() -> None:
     redis_service = services.get("redis")
     _expect(isinstance(redis_service, dict), "e2e-required.redis service missing")
     _expect(
-        redis_service.get("image") == "mirror.gcr.io/library/redis:8-alpine",
-        "e2e-required redis image must be mirror.gcr.io/library/redis:8-alpine (mirror avoids Docker Hub rate limits; matches ci.yml)",
+        redis_service.get("image") == EXPECTED_REDIS_IMAGE,
+        "e2e-required redis image must use the pinned mirror.gcr.io Redis 8-alpine digest",
     )
     _expect(
         "6379:6379" in (redis_service.get("ports") or []),

--- a/tldw_Server_API/tests/CI/test_required_workflow_contracts.py
+++ b/tldw_Server_API/tests/CI/test_required_workflow_contracts.py
@@ -87,6 +87,24 @@ def _assert_setup_skips_ffmpeg_but_keeps_portaudio(
     assert install_step["with"]["install-portaudio"] == "true"
 
 
+def test_ci_postgres_url_exports_are_masked_before_env_write() -> None:
+    workflow = _load(".github/workflows/ci.yml")
+    export_steps = [
+        step
+        for job in workflow["jobs"].values()
+        for step in job.get("steps", [])
+        if step.get("name") == "Export PG env vars"
+    ]
+    assert export_steps, "Export PG env vars steps missing"
+    for step in export_steps:
+        run_script = step["run"]
+        password_mask_index = run_script.index('echo "::add-mask::${DB_PASSWORD}"')
+        url_mask_index = run_script.index('echo "::add-mask::${DB_URL}"')
+        env_write_index = run_script.index('echo "TEST_DATABASE_URL=${DB_URL}"')
+        assert password_mask_index < env_write_index
+        assert url_mask_index < env_write_index
+
+
 def test_backend_required_has_noop_and_execute_paths() -> None:
     workflow = _load(".github/workflows/backend-required.yml")
     jobs = workflow["jobs"]
@@ -390,6 +408,10 @@ def test_setup_ffmpeg_action_can_skip_ffmpeg_but_keep_portaudio() -> None:
     assert action["inputs"]["install-ffmpeg"]["default"] == "true"
 
     linux_step = _get_step(action["runs"]["steps"], "Install FFmpeg (Linux)")
+    assert (
+        "runner.os == 'Linux' && (inputs.install-ffmpeg == 'true' || inputs.install-portaudio == 'true')"
+        in linux_step["if"]
+    )
     linux_script = linux_step["run"]
     assert 'inputs.install-ffmpeg' in linux_script
     assert "azure.archive.ubuntu.com" in linux_script
@@ -407,10 +429,6 @@ def test_setup_ffmpeg_action_can_skip_ffmpeg_but_keep_portaudio() -> None:
         in linux_script
     )
     assert "Acquire::http::Timeout=20" in linux_script
-    assert (
-        '"${{ inputs.install-ffmpeg }}" = "true" ] || [ "${{ inputs.install-portaudio }}" = "true"'
-        in linux_script
-    )
     assert (
         "sudo apt-get install -y --no-install-recommends ffmpeg portaudio19-dev python3-all-dev"
         in linux_script

--- a/tldw_Server_API/tests/Collections/test_reminders_notifications_db.py
+++ b/tldw_Server_API/tests/Collections/test_reminders_notifications_db.py
@@ -24,11 +24,13 @@ def collections_db(monkeypatch: pytest.MonkeyPatch) -> CollectionsDatabase:
     settings.USER_DB_BASE_DIR = str(base_dir)
     monkeypatch.setenv("USER_DB_BASE_DIR", str(base_dir))
 
-    db = CollectionsDatabase.for_user(user_id=778)
+    db: CollectionsDatabase | None = None
     try:
+        db = CollectionsDatabase.for_user(user_id=778)
         yield db
     finally:
-        db.close()
+        if db is not None:
+            db.close()
         close_all_backends()
         if prev_base_dir is not None:
             settings.USER_DB_BASE_DIR = prev_base_dir

--- a/tldw_Server_API/tests/DB_Management/test_content_backend_cache.py
+++ b/tldw_Server_API/tests/DB_Management/test_content_backend_cache.py
@@ -68,6 +68,7 @@ class _FakeBackend:
         self.execute_calls: list[tuple[str, tuple | None, _FakeConnection | None]] = []
         self.execute_many_calls: list[tuple[str, list | None, _FakeConnection | None]] = []
         self.create_tables_calls: list[tuple[str, _FakeConnection | None]] = []
+        self.existing_tables: set[str] = set()
         self.config = type(
             "_FakeConfig",
             (),
@@ -96,6 +97,17 @@ class _FakeBackend:
 
     def create_tables(self, ddl: str, connection=None) -> None:
         self.create_tables_calls.append((ddl, connection))
+        for table_name in (
+            "search_analytics",
+            "document_performance",
+            "feedback_analytics",
+            "analytics_events",
+        ):
+            if table_name in ddl:
+                self.existing_tables.add(table_name)
+
+    def table_exists(self, table_name: str, connection=None) -> bool:
+        return table_name in self.existing_tables
 
     def get_table_info(self, _table: str):
         return []
@@ -688,6 +700,7 @@ def test_analytics_database_initialization_uses_pinned_backend_during_refresh(
         "_resolve_backend",
         lambda self, *, db_path, backend, config: holder["backend"],
     )
+    monkeypatch.setattr(analytics_db.AnalyticsDatabase, "_bootstrapped_backend_targets", set())
     _ = analytics_db.AnalyticsDatabase(db_path="analytics.db")
 
     assert len(old_backend.create_tables_calls) == 1
@@ -787,6 +800,10 @@ def test_analytics_database_bootstrap_runs_once_per_shared_target_across_instanc
     shared_backend = _FakeBackend(label="shared")
     bootstrap_calls: list[str] = []
 
+    def fake_bootstrap(self, backend, target_identifier=None):
+        bootstrap_calls.append(target_identifier or self._describe_backend(backend))
+        backend.existing_tables.update(analytics_db.AnalyticsDatabase._REQUIRED_BOOTSTRAP_TABLES)
+
     monkeypatch.setattr(analytics_db.AnalyticsDatabase, "_bootstrapped_backend_targets", set())
     monkeypatch.setattr(
         analytics_db.AnalyticsDatabase,
@@ -796,9 +813,7 @@ def test_analytics_database_bootstrap_runs_once_per_shared_target_across_instanc
     monkeypatch.setattr(
         analytics_db.AnalyticsDatabase,
         "_bootstrap_backend_schema",
-        lambda self, backend, target_identifier=None: bootstrap_calls.append(
-            target_identifier or self._describe_backend(backend)
-        ),
+        fake_bootstrap,
     )
 
     _ = analytics_db.AnalyticsDatabase(db_path="analytics.db")

--- a/tldw_Server_API/tests/DB_Management/test_media_postgres_support.py
+++ b/tldw_Server_API/tests/DB_Management/test_media_postgres_support.py
@@ -490,6 +490,61 @@ def test_runtime_fts_ops_update_fts_media_sqlite_preserves_synonym_expansion_and
     assert conn_fallback.calls[0][1] == (10, "Title", "Body")
 
 
+def test_runtime_fts_ops_update_fts_media_sqlite_deletes_exact_existing_fts_values(
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.DB_Management.media_db.runtime import fts_ops
+
+    class _Cursor:
+        def __init__(self, row):
+            self._row = row
+
+        def fetchone(self):
+            return self._row
+
+    class _Conn:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, tuple[object, ...]]] = []
+
+        def execute(self, sql: str, params: tuple[object, ...]):
+            self.calls.append((sql, params))
+            if sql.startswith("SELECT title, content FROM media_fts"):
+                return _Cursor(("Old title", "Old content alias"))
+            return _Cursor(None)
+
+    class _Db:
+        backend_type = BackendType.SQLITE
+
+    module_name = "tldw_Server_API.app.core.RAG.rag_service.synonyms_registry"
+    synonym_module = types.ModuleType(module_name)
+    synonym_module.get_corpus_synonyms = lambda _corpus: {}  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, module_name, synonym_module)
+
+    conn = _Conn()
+    fts_ops._update_fts_media(
+        _Db(),
+        conn,
+        11,
+        "New title",
+        "New content",
+        old_title="Old title",
+        old_content="Old content",
+    )
+
+    assert conn.calls[0] == (
+        "SELECT title, content FROM media_fts WHERE rowid = ?",
+        (11,),
+    )
+    assert conn.calls[1] == (
+        "INSERT INTO media_fts (media_fts, rowid, title, content) VALUES ('delete', ?, ?, ?)",
+        (11, "Old title", "Old content alias"),
+    )
+    assert conn.calls[2] == (
+        "INSERT OR REPLACE INTO media_fts (rowid, title, content) VALUES (?, ?, ?)",
+        (11, "New title", "New content"),
+    )
+
+
 def test_runtime_fts_ops_sync_refresh_noops_when_update_payload_has_no_relevant_fields() -> None:
     from tldw_Server_API.app.core.DB_Management.media_db.runtime import fts_ops
 

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_v5_integration.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_v5_integration.py
@@ -12,10 +12,8 @@ import pytest
 pytestmark = pytest.mark.integration
 import numpy as np
 
-IN_CI = os.getenv("CI", "").lower() == "true"
 RUN_REAL_HF_EMBEDDING_TESTS = (
     os.getenv("RUN_REAL_HF_EMBEDDING_TESTS", "").lower() in {"1", "true", "yes", "on"}
-    or not IN_CI
 )
 
 try:
@@ -104,13 +102,16 @@ def _skip_if_hf_service_unavailable(resp) -> None:
 @pytest.fixture(autouse=True)
 def disable_rate_limiting():
     """Disable rate limiting for all tests in this module"""
+    previous_testing = os.environ.get("TESTING")
     previous_auto_download = os.environ.get("AUTO_DOWNLOAD_MODELS")
     os.environ["TESTING"] = "true"
     os.environ["AUTO_DOWNLOAD_MODELS"] = "false"
     yield
     # Clean up after tests
-    if "TESTING" in os.environ:
-        del os.environ["TESTING"]
+    if previous_testing is None:
+        os.environ.pop("TESTING", None)
+    else:
+        os.environ["TESTING"] = previous_testing
     if previous_auto_download is None:
         os.environ.pop("AUTO_DOWNLOAD_MODELS", None)
     else:

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_v5_production.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_v5_production.py
@@ -20,16 +20,15 @@ from httpx import AsyncClient, ASGITransport
 from tldw_Server_API.app.main import app
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 
-IN_CI = os.getenv("CI", "").lower() == "true"
 RUN_REAL_HF_EMBEDDING_TESTS = (
     os.getenv("RUN_REAL_HF_EMBEDDING_TESTS", "").lower() in {"1", "true", "yes", "on"}
-    or not IN_CI
 )
 
 # Disable rate limiting for all tests
 @pytest.fixture(autouse=True)
 def disable_rate_limiting():
     """Disable rate limiting for all tests in this module"""
+    previous_testing = os.environ.get("TESTING")
     previous_auto_download = os.environ.get("AUTO_DOWNLOAD_MODELS")
     os.environ["TESTING"] = "true"
     os.environ["AUTO_DOWNLOAD_MODELS"] = "false"
@@ -37,8 +36,10 @@ def disable_rate_limiting():
         yield
     finally:
         # Clean up after tests
-        if "TESTING" in os.environ:
-            del os.environ["TESTING"]
+        if previous_testing is None:
+            os.environ.pop("TESTING", None)
+        else:
+            os.environ["TESTING"] = previous_testing
         if previous_auto_download is None:
             os.environ.pop("AUTO_DOWNLOAD_MODELS", None)
         else:
@@ -775,8 +776,8 @@ class TestEndToEnd:
 
 @pytest.mark.integration
 @pytest.mark.skipif(
-    IN_CI and not RUN_REAL_HF_EMBEDDING_TESTS,
-    reason="Real HuggingFace embedding tests require RUN_REAL_HF_EMBEDDING_TESTS=true in CI",
+    not RUN_REAL_HF_EMBEDDING_TESTS,
+    reason="Real HuggingFace embedding tests require RUN_REAL_HF_EMBEDDING_TESTS=true",
 )
 class TestIntegration:
     """True integration tests without mocking - requires actual services"""

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_v5_unit.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_v5_unit.py
@@ -4,6 +4,9 @@
 
 import os
 import uuid
+_ORIG_TESTING = os.environ.get("TESTING")
+_ORIG_AUTO_DOWNLOAD_MODELS = os.environ.get("AUTO_DOWNLOAD_MODELS")
+
 # Set TESTING environment variable BEFORE importing anything else
 os.environ["TESTING"] = "true"
 os.environ["AUTO_DOWNLOAD_MODELS"] = "false"
@@ -26,19 +29,17 @@ from starlette.requests import Request
 @pytest.fixture(autouse=True, scope="module")
 def cleanup_testing_env():
     """Cleanup TESTING environment variable after module tests"""
-    previous_testing = os.environ.get("TESTING")
-    previous_auto_download = os.environ.get("AUTO_DOWNLOAD_MODELS")
     os.environ["TESTING"] = "true"
     os.environ["AUTO_DOWNLOAD_MODELS"] = "false"
     yield
-    if previous_testing is None:
+    if _ORIG_TESTING is None:
         os.environ.pop("TESTING", None)
     else:
-        os.environ["TESTING"] = previous_testing
-    if previous_auto_download is None:
+        os.environ["TESTING"] = _ORIG_TESTING
+    if _ORIG_AUTO_DOWNLOAD_MODELS is None:
         os.environ.pop("AUTO_DOWNLOAD_MODELS", None)
     else:
-        os.environ["AUTO_DOWNLOAD_MODELS"] = previous_auto_download
+        os.environ["AUTO_DOWNLOAD_MODELS"] = _ORIG_AUTO_DOWNLOAD_MODELS
 
 # Mock metrics for tests to avoid registry conflicts
 @pytest.fixture(autouse=True)

--- a/tldw_Server_API/tests/Evaluations/integration/test_webhook_multi_user_api.py
+++ b/tldw_Server_API/tests/Evaluations/integration/test_webhook_multi_user_api.py
@@ -74,8 +74,6 @@ def multi_user_webhook_client(tmp_path, monkeypatch):
     app.dependency_overrides[eval_auth.get_eval_request_user] = _get_eval_request_user
     app.dependency_overrides[webhooks.verify_api_key] = _verify_api_key
     app.dependency_overrides[webhooks.get_eval_request_user] = _get_eval_request_user
-    app.dependency_overrides[webhooks.verify_api_key] = _verify_api_key
-    app.dependency_overrides[webhooks.get_eval_request_user] = _get_eval_request_user
 
     with TestClient(app) as client:
         yield client

--- a/tldw_Server_API/tests/Evaluations/unit/test_unified_evaluation_service_mapping.py
+++ b/tldw_Server_API/tests/Evaluations/unit/test_unified_evaluation_service_mapping.py
@@ -7,6 +7,29 @@ import pytest
 from tldw_Server_API.app.core.Evaluations.unified_evaluation_service import UnifiedEvaluationService
 
 
+def test_schedule_service_shutdown_logs_noncritical_failure(monkeypatch):
+    from tldw_Server_API.app.core.Evaluations import unified_evaluation_service as svc_mod
+
+    class _BrokenService:
+        def shutdown(self):
+            raise RuntimeError("shutdown unavailable")
+
+    debug_calls: list[tuple[str, tuple[object, ...]]] = []
+    monkeypatch.setattr(
+        svc_mod.logger,
+        "debug",
+        lambda message, *args, **_kwargs: debug_calls.append((message, args)),
+    )
+
+    svc_mod._schedule_service_shutdown(_BrokenService())  # type: ignore[arg-type]
+
+    assert debug_calls
+    message, args = debug_calls[0]
+    assert "shutdown scheduling skipped" in message
+    assert args[0] == "_BrokenService"
+    assert isinstance(args[1], RuntimeError)
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("eval_type", "expected_sub_type"),

--- a/tldw_Server_API/tests/MediaDB2/test_sync_endpoint_errors.py
+++ b/tldw_Server_API/tests/MediaDB2/test_sync_endpoint_errors.py
@@ -10,7 +10,6 @@ from tldw_Server_API.app.api.v1.schemas.sync_server_models import (
 )
 from tldw_Server_API.app.api.v1.schemas.sync_server_models import (
     ClientChangesPayload,
-    SyncSendLogEntry,
 )
 from tldw_Server_API.app.core.Sync.Sync_Client import (
     ALLOWED_SYNC_SEND_ENTITIES as CLIENT_ALLOWED_SYNC_SEND_ENTITIES,
@@ -55,16 +54,16 @@ def test_client_changes_payload_schema_rejects_non_send_entity() -> None:
             client_id="client_sender_1",
             last_processed_server_id=0,
             changes=[
-                SyncSendLogEntry(
-                    change_id=1,
-                    entity="Transcripts",
-                    entity_uuid="entity-uuid-1",
-                    operation="create",
-                    timestamp="2023-10-27T11:00:00Z",
-                    client_id="client_sender_1",
-                    version=1,
-                    payload='{"uuid":"entity-uuid-1","keyword":"k1"}',
-                )
+                {
+                    "change_id": 1,
+                    "entity": "Transcripts",
+                    "entity_uuid": "entity-uuid-1",
+                    "operation": "create",
+                    "timestamp": "2023-10-27T11:00:00Z",
+                    "client_id": "client_sender_1",
+                    "version": 1,
+                    "payload": '{"uuid":"entity-uuid-1","keyword":"k1"}',
+                }
             ],
         )
 

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_audio_transcription_import_resilience.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_audio_transcription_import_resilience.py
@@ -15,7 +15,7 @@ def _parent_module_binding(name: str) -> tuple[ModuleType | None, str]:
 def _pop_module(name: str) -> ModuleType | None:
     module = sys.modules.pop(name, None)
     parent, attr = _parent_module_binding(name)
-    if parent is not None and hasattr(parent, attr):
+    if isinstance(module, ModuleType) and parent is not None and getattr(parent, attr, None) is module:
         delattr(parent, attr)
     return module if isinstance(module, ModuleType) else None
 

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_media_processing.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_media_processing.py
@@ -445,12 +445,15 @@ def test_skip_if_external_fixture_url_unreachable_preserves_unrelated_download_e
         }
     )
 
-    skip_if_external_fixture_url_unreachable(
-        response,
-        VALID_EPUB_URL,
-        "EPUB fixture",
-        allow_single_error_fallback=False,
-    )
+    try:
+        skip_if_external_fixture_url_unreachable(
+            response,
+            VALID_EPUB_URL,
+            "EPUB fixture",
+            allow_single_error_fallback=False,
+        )
+    except pytest.skip.Exception as exc:
+        pytest.fail(f"Unexpected skip for unrelated fixture error: {exc}")
 
 
 # --- Test Classes ---
@@ -711,7 +714,7 @@ class TestProcessAudios:
                 or "Audio processing failed" in error_str
                 or "Processing execution failed" in response_str
                 or "Transcription failed" in response_str
-            ) or errors:
+            ):
                 pytest.skip(
                     "Audio URL download/transcription failed in the processing "
                     "pipeline - likely due to restricted test environment egress "
@@ -786,8 +789,7 @@ class TestProcessAudios:
             response_str = str(data_debug)
             errors = data_debug.get("errors", [])
             if data_debug.get("processed_count") == 0 and (
-                errors
-                or "Download failed" in response_str
+                "Download failed" in response_str
                 or "Host could not be resolved" in response_str
                 or "URL blocked by security policy" in response_str
                 or "Host not in allowlist" in response_str
@@ -846,8 +848,7 @@ class TestProcessAudios:
                 data_debug = {}
             response_str = str(data_debug)
             if data_debug.get("processed_count") == 0 and (
-                data_debug.get("errors")
-                or "Audio processing failed" in response_str
+                "Audio processing failed" in response_str
                 or "Processing execution failed" in response_str
                 or "Transcription failed" in response_str
                 or "No module named" in response_str

--- a/tldw_Server_API/tests/Personalization/test_companion_activity_db.py
+++ b/tldw_Server_API/tests/Personalization/test_companion_activity_db.py
@@ -58,7 +58,9 @@ def test_personalization_dependency_uses_safe_for_user_factory(monkeypatch):
 
 
 def test_personalization_db_constructor_does_not_resolve_input_path(monkeypatch, tmp_path) -> None:
-    db_path = tmp_path / "personalization.db"
+    nested_dir = tmp_path / "nested"
+    nested_dir.mkdir()
+    db_path = nested_dir / ".." / "personalization.db"
 
     def fake_require_trusted_database_parent_exists(path, **kwargs):
         assert path == db_path

--- a/tldw_Server_API/tests/RAG_NEW/integration/test_bm25_weights.py
+++ b/tldw_Server_API/tests/RAG_NEW/integration/test_bm25_weights.py
@@ -1,4 +1,3 @@
-import os
 import sqlite3
 from datetime import datetime
 from pathlib import Path
@@ -64,7 +63,7 @@ def _setup_sqlite_media_db(db_path: str):
 @pytest.mark.integration
 def test_bm25_title_vs_content_weights_flip_order(monkeypatch, tmp_path: Path):
     # Ensure raw SQL fallback is allowed (not production)
-    os.environ["tldw_production"] = "false"
+    monkeypatch.setenv("tldw_production", "false")
 
     db_path = str(tmp_path / "media.db")
     _setup_sqlite_media_db(db_path)

--- a/tldw_Server_API/tests/RAG_NEW/unit/test_agentic_chunker_sanitizers.py
+++ b/tldw_Server_API/tests/RAG_NEW/unit/test_agentic_chunker_sanitizers.py
@@ -103,7 +103,7 @@ async def test_coarse_retrieval_fallback_warning_omits_raw_exception(
 
     assert result.documents
     assert result.metadata["coarse_docs"] == []
-    assert "Agentic coarse retrieval failed" in logger_stub.warnings
+    assert any("Agentic coarse retrieval failed" in msg for msg in logger_stub.warnings)
     _assert_no_sensitive_log_fragments(logger_stub.warnings)
 
 
@@ -129,7 +129,7 @@ async def test_media_db_fallback_retrieval_warning_omits_raw_exception(
 
     assert result.documents
     assert result.metadata["coarse_docs"] == []
-    assert "Agentic Media DB fallback retrieval failed" in logger_stub.warnings
+    assert any("Agentic Media DB fallback retrieval failed" in msg for msg in logger_stub.warnings)
     _assert_no_sensitive_log_fragments(logger_stub.warnings)
 
 


### PR DESCRIPTION
## Change summary

This draft PR starts the follow-up branch after PR #2258 merged the full-suite CI shard split into `dev`.

## What changed

- Added Backlog task `TASK-2397` to track continued CI stability work after the shard merge.
- Captured the clean PR #2258 check state and merge commit as the starting context for the next round.

## Why

The previous PR is merged. This branch gives the next CI stabilization work a clean base from current `dev` and a traceable task before making further workflow or test changes.

## Verification

- `git diff --cached --check`
- PR #2258 final checks before merge: 755 passed, 4 skipped, 0 pending, 0 failed, 0 cancelled.
- Bandit not applicable: documentation/task tracking only.

Refs TASK-2397

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Continues CI stability follow-up from PR #2258 under TASK-2397 and addresses PR #2431 feedback, hardening CI (pin Redis digests, pass `--ci-file` to shard coverage, mask Postgres password+URL before env export, gate `setup-ffmpeg`, remove WebUI `NEXT_PUBLIC_X_API_KEY` fallback) to cut flakiness. Also fixes FTS updates, monotonic message ordering with per-instance sync cache, safer SQLite rollback/connection scoping, async eval-service shutdown with debug logging, steadier Chroma retries, and analytics bootstrap verification; tests and docs updated.

<sup>Written for commit 3db726d9bf2a697b18586ef4eda37639aae36f06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

