### PR TITLE
Prepare MCP Unified publish readiness

### DIFF
--- a/.github/workflows/mcp-unified-publish.yml
+++ b/.github/workflows/mcp-unified-publish.yml
@@ -1,0 +1,131 @@
+name: MCP Unified Publish Readiness
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Standalone MCP Unified publish target.
+        required: true
+        type: choice
+        options:
+          - dry-run
+          - testpypi
+          - pypi
+        default: dry-run
+      confirm_publish:
+        description: Type MCP_UNIFIED_PUBLISH to enable a live upload job.
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mcp-unified-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish-plan:
+    name: Build RC and publish dry-run plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+
+      - name: Install packaging tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine setuptools wheel pytest pytest-asyncio bandit
+          python -m pip install "pydantic>=2.0.0" "loguru>=0.7.0" "PyYAML>=6.0.0" "httpx>=0.24.0" "websockets>=12.0"
+
+      - name: Run internal RC and publish dry run
+        run: |
+          make mcp-unified-rc
+          make mcp-unified-publish-dry-run
+
+      - name: Upload MCP Unified publish plan artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: mcp-unified-publish-plan
+          path: .artifacts/mcp-unified-rc/**
+          if-no-files-found: error
+
+  publish-testpypi:
+    name: Upload MCP Unified to TestPyPI
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi' && inputs.confirm_publish == 'MCP_UNIFIED_PUBLISH' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    environment:
+      name: testpypi
+    env:
+      TWINE_USERNAME: __token__
+      TWINE_PASSWORD: ${{ secrets.MCP_UNIFIED_TESTPYPI_API_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+
+      - name: Install packaging tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine setuptools wheel pytest pytest-asyncio bandit
+          python -m pip install "pydantic>=2.0.0" "loguru>=0.7.0" "PyYAML>=6.0.0" "httpx>=0.24.0" "websockets>=12.0"
+
+      - name: Build and upload to TestPyPI
+        run: |
+          python Helper_Scripts/mcp_unified_rc.py build
+          MCP_UNIFIED_ALLOW_PUBLISH=1 python Helper_Scripts/mcp_unified_rc.py publish-plan --target testpypi --execute
+
+  publish-pypi:
+    name: Upload MCP Unified to PyPI
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.target == 'pypi' && inputs.confirm_publish == 'MCP_UNIFIED_PUBLISH' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    environment:
+      name: pypi
+    env:
+      TWINE_USERNAME: __token__
+      TWINE_PASSWORD: ${{ secrets.MCP_UNIFIED_PYPI_API_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+
+      - name: Install packaging tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine setuptools wheel pytest pytest-asyncio bandit
+          python -m pip install "pydantic>=2.0.0" "loguru>=0.7.0" "PyYAML>=6.0.0" "httpx>=0.24.0" "websockets>=12.0"
+
+      - name: Build and upload to PyPI
+        run: |
+          python Helper_Scripts/mcp_unified_rc.py build
+          MCP_UNIFIED_ALLOW_PUBLISH=1 python Helper_Scripts/mcp_unified_rc.py publish-plan --target pypi --execute

--- a/.github/workflows/mcp-unified-publish.yml
+++ b/.github/workflows/mcp-unified-publish.yml
@@ -64,6 +64,7 @@ jobs:
 
   publish-testpypi:
     name: Upload MCP Unified to TestPyPI
+    needs: publish-plan
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi' && inputs.confirm_publish == 'MCP_UNIFIED_PUBLISH' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -98,6 +99,7 @@ jobs:
 
   publish-pypi:
     name: Upload MCP Unified to PyPI
+    needs: publish-plan
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.target == 'pypi' && inputs.confirm_publish == 'MCP_UNIFIED_PUBLISH' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.gitignore
+++ b/.gitignore
@@ -273,6 +273,9 @@ mediawiki_import.log
 audit.log
 errors.log
 
+# Local generated artifacts
+.artifacts/
+
 # Data files
 *.csv
 *.json

--- a/Docs/superpowers/plans/2026-06-23-mcp-unified-publish-readiness-plan.md
+++ b/Docs/superpowers/plans/2026-06-23-mcp-unified-publish-readiness-plan.md
@@ -209,6 +209,6 @@ make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python mc
 make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python mcp-unified-publish-dry-run
 ```
 
-- [ ] **Step 4: Finalize task and commit**
+- [x] **Step 4: Finalize task and commit**
 
 Update `TASK-2400` with validation evidence, then commit the branch.

--- a/Docs/superpowers/plans/2026-06-23-mcp-unified-publish-readiness-plan.md
+++ b/Docs/superpowers/plans/2026-06-23-mcp-unified-publish-readiness-plan.md
@@ -1,0 +1,214 @@
+# MCP Unified Publish Readiness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden the standalone `mcp-unified` package for an opt-in TestPyPI/publish dry run without allowing normal PR CI to publish artifacts.
+
+**Architecture:** Extend the existing internal RC harness instead of adding a separate release script. Keep publishing disabled by default through explicit CLI flags, workflow dispatch inputs, and package metadata that still reports `internal-experimental` / `not-published`.
+
+**Tech Stack:** Python 3.10+, setuptools/build/twine, pytest, GitHub Actions, Make, existing `Helper_Scripts/mcp_unified_rc.py` evidence model.
+
+---
+
+## File Structure
+
+- Modify: `apps/mcp-unified/pyproject.toml`
+  - Add publish-ready metadata: authors, maintainers, keywords, classifiers, URLs, and license-file declaration.
+- Create: `apps/mcp-unified/LICENSE`
+  - Package-local license copy so built standalone artifacts include the license from the nested project root.
+- Modify: `apps/mcp-unified/src/mcp_unified/package_metadata.py`
+  - Add metadata constants that mirror the new pyproject publish-readiness fields.
+- Modify: `Helper_Scripts/mcp_unified_rc.py`
+  - Add guarded publish-plan/TestPyPI dry-run command construction and evidence recording without live upload by default.
+- Modify: `Makefile`
+  - Add a dry-run publishing target that delegates to the RC harness.
+- Create: `.github/workflows/mcp-unified-publish.yml`
+  - Manual-dispatch-only workflow for dry-run/TestPyPI/PyPI targets with environment gates and no PR trigger.
+- Modify: `apps/mcp-unified/README.md`
+- Modify: `apps/mcp-unified/USER_GUIDE.md`
+- Modify: `apps/mcp-unified/src/mcp_unified/README.md`
+- Modify: `apps/mcp-unified/src/mcp_unified/USER_GUIDE.md`
+  - Document internal RC, publish dry run, TestPyPI prerequisites, and real publish guardrails.
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+  - Add metadata, license, workflow, and Make target assertions.
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py`
+  - Add RC harness publish-plan command/redaction tests.
+
+## Task 1: Publish-Ready Package Metadata
+
+**Files:**
+- Modify: `apps/mcp-unified/pyproject.toml`
+- Create: `apps/mcp-unified/LICENSE`
+- Modify: `apps/mcp-unified/src/mcp_unified/package_metadata.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+
+- [x] **Step 1: Write failing metadata tests**
+
+Add tests asserting:
+- pyproject has `authors`, `maintainers`, `keywords`, `classifiers`, `[project.urls]`, and `license-files = ["LICENSE"]`;
+- classifiers include Python 3.10-3.13, FastAPI, OS Independent, and internal/alpha development status;
+- project URLs point at the repository, issues, docs/user guide path, and source package path;
+- package metadata summary mirrors those publish-readiness fields;
+- `apps/mcp-unified/LICENSE` exists and matches the root license text.
+
+Run:
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py::test_mcp_unified_publish_metadata_is_ready_but_internal \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py::test_mcp_unified_package_license_file_is_local_to_project \
+  -v
+```
+
+Expected: fail because metadata/license fields are missing.
+
+- [x] **Step 2: Add minimal metadata and license file**
+
+Update `apps/mcp-unified/pyproject.toml` with:
+- `authors = [{ name = "Robert Musser", email = "contact@tldwproject.com" }]`
+- matching `maintainers`
+- concise package keywords
+- PyPI classifiers
+- `license-files = ["LICENSE"]`
+- `[project.urls]` entries for repository, issues, docs, user guide, and source path.
+
+Copy the root `LICENSE` content into `apps/mcp-unified/LICENSE`.
+
+- [x] **Step 3: Mirror metadata constants**
+
+Add package metadata constants for authors, maintainers, keywords, classifiers, URLs, and license files, then include them in `package_metadata_summary()`.
+
+- [x] **Step 4: Verify metadata tests pass**
+
+Run the focused pytest command from Step 1.
+
+## Task 2: Guarded Publish/TestPyPI Dry-Run Tooling
+
+**Files:**
+- Modify: `Helper_Scripts/mcp_unified_rc.py`
+- Modify: `Makefile`
+- Create: `.github/workflows/mcp-unified-publish.yml`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+
+- [x] **Step 1: Write failing guardrail tests**
+
+Add tests asserting:
+- RC parser exposes `publish-plan`;
+- default publish plan is dry-run only and never uploads;
+- `--target testpypi` builds a redacted `twine upload --repository-url https://test.pypi.org/legacy/ ...` plan;
+- `--execute` is rejected unless `MCP_UNIFIED_ALLOW_PUBLISH=1`;
+- Make target calls `publish-plan --target testpypi --dry-run`;
+- workflow is `workflow_dispatch` only, has no `pull_request` or `push` trigger, uses pinned actions, has `contents: read`, and keeps upload jobs behind explicit confirmation plus environment-scoped token secrets.
+
+Run:
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py::test_rc_publish_plan_is_dry_run_by_default \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py::test_mcp_unified_publish_workflow_is_manual_and_gated \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py::test_mcp_unified_make_targets_do_not_call_root_pypi_check \
+  -v
+```
+
+Expected: fail because the command, workflow, and target do not exist.
+
+- [x] **Step 2: Implement publish-plan command**
+
+Add `publish-plan` to `Helper_Scripts/mcp_unified_rc.py`. It should:
+- record existing artifacts and require a built wheel/sdist;
+- accept `--target testpypi|pypi`, `--dry-run`, and `--execute`;
+- default to dry-run;
+- reject `--execute` unless `MCP_UNIFIED_ALLOW_PUBLISH=1`;
+- construct but not log secrets;
+- record the target, repository URL, artifact filenames, command shape, and execution mode in RC evidence.
+
+- [x] **Step 3: Add Make and workflow guardrails**
+
+Add:
+
+```make
+mcp-unified-publish-dry-run:
+	$(MCP_UNIFIED_RC) build
+	$(MCP_UNIFIED_RC) publish-plan --target testpypi --dry-run
+```
+
+Create `.github/workflows/mcp-unified-publish.yml` as manual-dispatch-only with targets `dry-run`, `testpypi`, and `pypi`. The dry-run job should run RC + `publish-plan --dry-run`. The upload jobs should be environment-gated and require explicit dispatch input, but this implementation may keep actual upload steps as guarded command-plan placeholders until credentials/trusted publishing are explicitly configured.
+
+- [x] **Step 4: Verify guardrail tests pass**
+
+Run the focused pytest command from Step 1.
+
+## Task 3: Publish-Readiness Documentation
+
+**Files:**
+- Modify: `apps/mcp-unified/README.md`
+- Modify: `apps/mcp-unified/USER_GUIDE.md`
+- Modify: `apps/mcp-unified/src/mcp_unified/README.md`
+- Modify: `apps/mcp-unified/src/mcp_unified/USER_GUIDE.md`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
+
+- [x] **Step 1: Write failing docs parity/readiness test**
+
+Extend package docs tests to assert project docs and package-resource docs mention:
+- internal RC;
+- `make mcp-unified-rc`;
+- `make mcp-unified-publish-dry-run`;
+- TestPyPI is opt-in and requires maintainer-owned credentials/trusted publishing;
+- public PyPI remains disabled while `PUBLISHING_STATUS` is `not-published`.
+
+Expected: fail until docs are updated and package-resource copies match.
+
+- [x] **Step 2: Update docs and package resource copies**
+
+Add a short “Publishing Readiness” section to README and USER_GUIDE. Keep the language explicit that `pip install mcp-unified` is not yet public availability guidance.
+
+- [x] **Step 3: Verify docs tests pass**
+
+Run the focused docs test.
+
+## Task 4: Final Validation And Task Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-2400 - Prepare-MCP-Unified-standalone-publish-readiness-and-TestPyPI-gate.md`
+
+- [x] **Step 1: Run focused tests**
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest \
+  tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py \
+  -v
+```
+
+- [x] **Step 2: Run static checks**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check \
+  Helper_Scripts/mcp_unified_rc.py \
+  apps/mcp-unified/src/mcp_unified/package_metadata.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m compileall \
+  Helper_Scripts/mcp_unified_rc.py \
+  apps/mcp-unified/src/mcp_unified/package_metadata.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r \
+  Helper_Scripts/mcp_unified_rc.py \
+  apps/mcp-unified/src/mcp_unified/package_metadata.py \
+  -f json -o /tmp/bandit_mcp_unified_publish_readiness.json
+```
+
+- [x] **Step 3: Run RC and dry-run publish plan**
+
+```bash
+make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python mcp-unified-rc
+make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python mcp-unified-publish-dry-run
+```
+
+- [ ] **Step 4: Finalize task and commit**
+
+Update `TASK-2400` with validation evidence, then commit the branch.

--- a/Helper_Scripts/mcp_unified_rc.py
+++ b/Helper_Scripts/mcp_unified_rc.py
@@ -43,6 +43,11 @@ EVIDENCE_JSON = "mcp-unified-rc-evidence.json"
 EVIDENCE_MARKDOWN = "mcp-unified-rc-summary.md"
 PACKAGE_IMPORT_NAME = "mcp_unified"
 OPTIONAL_EXTRAS = ("core", "fastapi", "sqlite", "federation", "gateway", "dev")
+PUBLISH_ALLOW_ENV = "MCP_UNIFIED_ALLOW_PUBLISH"
+PUBLISH_TARGET_REPOSITORIES = {
+    "testpypi": "https://test.pypi.org/legacy/",
+    "pypi": "https://upload.pypi.org/legacy/",
+}
 USER_GUIDE_UAT_SCRIPT = Path("Helper_Scripts") / "Testing-related" / "mcp_standalone_user_guide_uat.py"
 PIP_DEPENDENCY_FAILURE_MARKERS = (
     "could not find a version that satisfies the requirement",
@@ -124,6 +129,30 @@ class RcCommandResult:
             "stdout": self.stdout,
             "stderr": self.stderr,
             "duration_ms": self.duration_ms,
+        }
+
+
+@dataclass(frozen=True)
+class PublishPlan:
+    """Dry-run or executable publish command plan for built MCP Unified artifacts."""
+
+    target: str
+    repository_url: str
+    dry_run: bool
+    execute: bool
+    artifact_filenames: list[str]
+    command: list[str]
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe representation for RC evidence output."""
+
+        return {
+            "target": self.target,
+            "repository_url": self.repository_url,
+            "dry_run": self.dry_run,
+            "execute": self.execute,
+            "artifact_filenames": self.artifact_filenames,
+            "command": self.command,
         }
 
 
@@ -435,6 +464,102 @@ def run_evidence(paths: RcPaths) -> int:
     return _write_and_report(recorder)
 
 
+def build_publish_plan(
+    paths: RcPaths,
+    *,
+    target: str,
+    execute: bool = False,
+    dry_run: bool = True,
+) -> PublishPlan:
+    """Build a guarded twine upload plan for existing MCP Unified artifacts."""
+
+    repository_url = PUBLISH_TARGET_REPOSITORIES.get(target)
+    if repository_url is None:
+        valid_targets = ", ".join(sorted(PUBLISH_TARGET_REPOSITORIES))
+        raise ValueError(f"invalid publish target {target!r}; expected one of: {valid_targets}")
+
+    if execute and os.environ.get(PUBLISH_ALLOW_ENV) != "1":
+        raise RuntimeError(
+            f"live MCP Unified publishing requires {PUBLISH_ALLOW_ENV}=1"
+        )
+
+    wheels, sdists = _dist_artifacts(paths)
+    if not wheels or not sdists:
+        raise FileNotFoundError(
+            "expected built wheel and sdist in .artifacts/mcp-unified-rc/dist; run build first"
+        )
+
+    artifact_paths = [*wheels, *sdists]
+    return PublishPlan(
+        target=target,
+        repository_url=repository_url,
+        dry_run=False if execute else dry_run,
+        execute=execute,
+        artifact_filenames=[artifact.name for artifact in artifact_paths],
+        command=[
+            sys.executable,
+            "-m",
+            "twine",
+            "upload",
+            "--repository-url",
+            repository_url,
+            "--non-interactive",
+            *[str(artifact) for artifact in artifact_paths],
+        ],
+    )
+
+
+def run_publish_plan(
+    paths: RcPaths,
+    *,
+    target: str,
+    execute: bool,
+    dry_run: bool,
+) -> int:
+    """Record or execute a guarded publish plan for built artifacts."""
+
+    started = time.perf_counter()
+    recorder = _new_recorder(paths)
+    _record_existing_artifacts(paths, recorder)
+    try:
+        plan = build_publish_plan(
+            paths,
+            target=target,
+            execute=execute,
+            dry_run=dry_run,
+        )
+    except (FileNotFoundError, RuntimeError, ValueError) as exc:
+        recorder.record(
+            phase="publish_plan",
+            name="twine_upload_plan",
+            status="failed",
+            duration_ms=int((time.perf_counter() - started) * 1000),
+            reason=str(exc),
+            details={"target": target, "execute": execute, "dry_run": dry_run},
+        )
+        return _write_and_report(recorder)
+
+    if not plan.execute:
+        recorder.record(
+            phase="publish_plan",
+            name="twine_upload_plan",
+            status="passed",
+            duration_ms=int((time.perf_counter() - started) * 1000),
+            details={"plan": plan.as_dict()},
+        )
+        return _write_and_report(recorder)
+
+    result = run_command(plan.command, cwd=paths.repo_root, timeout=300)
+    _record_command_result(
+        recorder,
+        phase="publish_plan",
+        name="twine_upload",
+        result=result,
+        details={"plan": plan.as_dict()},
+    )
+    return _write_and_report(recorder)
+
+
 def run_all(paths: RcPaths) -> int:
     """Run the internal RC sequence and write combined evidence."""
 
@@ -473,6 +598,27 @@ def build_parser() -> argparse.ArgumentParser:
         "all",
     ):
         subparsers.add_parser(name, help=f"Run the {name} RC phase.")
+    publish_parser = subparsers.add_parser(
+        "publish-plan",
+        help="Build or execute a guarded MCP Unified publish plan.",
+    )
+    publish_parser.add_argument(
+        "--target",
+        choices=tuple(PUBLISH_TARGET_REPOSITORIES),
+        default="testpypi",
+        help="Publish target repository. Defaults to TestPyPI.",
+    )
+    publish_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="Record the publish command without uploading artifacts.",
+    )
+    publish_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help=f"Run twine upload. Requires {PUBLISH_ALLOW_ENV}=1.",
+    )
     return parser
 
 
@@ -496,6 +642,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         return run_smoke_uat(paths)
     if args.command == "evidence":
         return run_evidence(paths)
+    if args.command == "publish-plan":
+        return run_publish_plan(
+            paths,
+            target=args.target,
+            execute=args.execute,
+            dry_run=args.dry_run,
+        )
     return run_all(paths)
 
 
@@ -1080,7 +1233,7 @@ def _new_recorder(paths: RcPaths) -> RcEvidenceRecorder:
             "pyproject": pyproject_metadata,
         },
         known_limitations=[
-            "Internal RC only: this harness does not upload or publish to TestPyPI or PyPI.",
+            "Publishing is guarded: publish-plan is dry-run by default and live upload requires MCP_UNIFIED_ALLOW_PUBLISH=1.",
             "Remote runtime UAT requires MCP_UNIFIED_GATEWAY_URL or --gateway-url and is optional in local RC runs.",
         ],
         repo_root=paths.repo_root,
@@ -1282,6 +1435,12 @@ def _read_package_constants(metadata_path: Path) -> dict[str, Any]:
         "LICENSE_EXPRESSION",
         "SOURCE_DISTRIBUTION",
         "DEPENDENCY_VERSION_POLICY",
+        "PACKAGE_AUTHORS",
+        "PACKAGE_MAINTAINERS",
+        "PACKAGE_KEYWORDS",
+        "PACKAGE_CLASSIFIERS",
+        "PACKAGE_URLS",
+        "LICENSE_FILES",
     }
     for node in tree.body:
         target_name: str | None = None
@@ -1292,8 +1451,12 @@ def _read_package_constants(metadata_path: Path) -> dict[str, Any]:
         elif isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
             target_name = node.targets[0].id
             value_node = node.value
-        if target_name in wanted and isinstance(value_node, ast.Constant):
-            constants[target_name] = value_node.value
+        if target_name in wanted and value_node is not None:
+            try:
+                constants[target_name] = ast.literal_eval(value_node)
+            except (SyntaxError, ValueError):
+                if isinstance(value_node, ast.Constant):
+                    constants[target_name] = value_node.value
     return constants
 
 

--- a/Helper_Scripts/mcp_unified_rc.py
+++ b/Helper_Scripts/mcp_unified_rc.py
@@ -488,6 +488,12 @@ def build_publish_plan(
         raise FileNotFoundError(
             "expected built wheel and sdist in .artifacts/mcp-unified-rc/dist; run build first"
         )
+    if len(wheels) != 1 or len(sdists) != 1:
+        raise ValueError(
+            "expected exactly one wheel and one sdist in .artifacts/mcp-unified-rc/dist; "
+            f"found wheels={[path.name for path in wheels]}, "
+            f"sdists={[path.name for path in sdists]}"
+        )
 
     artifact_paths = [*wheels, *sdists]
     return PublishPlan(
@@ -549,14 +555,26 @@ def run_publish_plan(
         )
         return _write_and_report(recorder)
 
-    result = run_command(plan.command, cwd=paths.repo_root, timeout=300)
-    _record_command_result(
-        recorder,
-        phase="publish_plan",
-        name="twine_upload",
-        result=result,
-        details={"plan": plan.as_dict()},
-    )
+    try:
+        result = run_command(plan.command, cwd=paths.repo_root, timeout=300)
+    except (RuntimeError, subprocess.SubprocessError, OSError) as exc:
+        logger.exception("MCP Unified publish upload command failed unexpectedly")
+        recorder.record(
+            phase="publish_plan",
+            name="twine_upload",
+            status="failed",
+            duration_ms=int((time.perf_counter() - started) * 1000),
+            reason=f"unexpected upload execution error: {exc}",
+            details={"plan": plan.as_dict()},
+        )
+    else:
+        _record_command_result(
+            recorder,
+            phase="publish_plan",
+            name="twine_upload",
+            result=result,
+            details={"plan": plan.as_dict()},
+        )
     return _write_and_report(recorder)
 
 
@@ -610,9 +628,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     publish_parser.add_argument(
         "--dry-run",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         default=True,
-        help="Record the publish command without uploading artifacts.",
+        help="Record the publish command without uploading artifacts. Use --no-dry-run to request guarded upload.",
     )
     publish_parser.add_argument(
         "--execute",
@@ -646,7 +664,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return run_publish_plan(
             paths,
             target=args.target,
-            execute=args.execute,
+            execute=args.execute or not args.dry_run,
             dry_run=args.dry_run,
         )
     return run_all(paths)
@@ -1454,7 +1472,7 @@ def _read_package_constants(metadata_path: Path) -> dict[str, Any]:
         if target_name in wanted and value_node is not None:
             try:
                 constants[target_name] = ast.literal_eval(value_node)
-            except (SyntaxError, ValueError):
+            except (SyntaxError, ValueError, TypeError):
                 if isinstance(value_node, ast.Constant):
                     constants[target_name] = value_node.value
     return constants

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ help:
 	@echo "  make mcp-unified-check       Run MCP Unified RC artifact gates"
 	@echo "  make mcp-unified-uat         Run MCP Unified RC UAT checks"
 	@echo "  make mcp-unified-rc          Run the full MCP Unified internal RC"
+	@echo "  make mcp-unified-publish-dry-run"
 	@echo "  make lint-changed            Lint only changed files"
 	@echo "  make ci-local                Run gating CI checks locally (fast tier)"
 	@echo "  make ci-local-full           Run the full suite locally (-n auto)"
@@ -58,7 +59,7 @@ help:
 # -----------------------------------------------------------------------------
 # Quickstart targets (first-time setup)
 # -----------------------------------------------------------------------------
-.PHONY: setup-wizard-tools setup-docker-single start-docker-single verify-docker-single setup-docker-multi start-docker-multi verify-docker-multi install-local setup-local-single start-local-single verify-local-single quickstart quickstart-install quickstart-prereqs quickstart-local quickstart-docker quickstart-docker-bootstrap quickstart-docker-webui model-cycle verify pypi-build pypi-check tooling-install tooling-smoke show-api-key release release-patch release-minor mcp-unified-build mcp-unified-check mcp-unified-uat mcp-unified-rc
+.PHONY: setup-wizard-tools setup-docker-single start-docker-single verify-docker-single setup-docker-multi start-docker-multi verify-docker-multi install-local setup-local-single start-local-single verify-local-single quickstart quickstart-install quickstart-prereqs quickstart-local quickstart-docker quickstart-docker-bootstrap quickstart-docker-webui model-cycle verify pypi-build pypi-check tooling-install tooling-smoke show-api-key release release-patch release-minor mcp-unified-build mcp-unified-check mcp-unified-uat mcp-unified-rc mcp-unified-publish-dry-run
 
 PYTHON ?= python3
 VENV_DIR ?= .venv
@@ -284,6 +285,10 @@ mcp-unified-uat:
 
 mcp-unified-rc:
 	$(MCP_UNIFIED_RC) all
+
+mcp-unified-publish-dry-run:
+	$(MCP_UNIFIED_RC) build
+	$(MCP_UNIFIED_RC) publish-plan --target testpypi --dry-run
 
 # -----------------------------------------------------------------------------
 # PostgreSQL backup/restore

--- a/apps/mcp-unified/LICENSE
+++ b/apps/mcp-unified/LICENSE
@@ -1,0 +1,226 @@
+
+GNU GENERAL PUBLIC LICENSE
+
+Version 3, 29 June 2007
+
+Copyright © 2007 Free Software Foundation, Inc. <https://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+Preamble
+
+The GNU General Public License is a free, copyleft license for software and other kinds of works.
+
+The licenses for most software and other practical works are designed to take away your freedom to share and change the works. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users. We, the Free Software Foundation, use the GNU General Public License for most of our software; it applies also to any other work released this way by its authors. You can apply it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things.
+
+To protect your rights, we need to prevent others from denying you these rights or asking you to surrender the rights. Therefore, you have certain responsibilities if you distribute copies of the software, or if you modify it: responsibilities to respect the freedom of others.
+
+For example, if you distribute copies of such a program, whether gratis or for a fee, you must pass on to the recipients the same freedoms that you received. You must make sure that they, too, receive or can get the source code. And you must show them these terms so they know their rights.
+
+Developers that use the GNU GPL protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License giving you legal permission to copy, distribute and/or modify it.
+
+For the developers' and authors' protection, the GPL clearly explains that there is no warranty for this free software. For both users' and authors' sake, the GPL requires that modified versions be marked as changed, so that their problems will not be attributed erroneously to authors of previous versions.
+
+Some devices are designed to deny users access to install or run modified versions of the software inside them, although the manufacturer can do so. This is fundamentally incompatible with the aim of protecting users' freedom to change the software. The systematic pattern of such abuse occurs in the area of products for individuals to use, which is precisely where it is most unacceptable. Therefore, we have designed this version of the GPL to prohibit the practice for those products. If such problems arise substantially in other domains, we stand ready to extend this provision to those domains in future versions of the GPL, as needed to protect the freedom of users.
+
+Finally, every program is threatened constantly by software patents. States should not allow patents to restrict development and use of software on general-purpose computers, but in those that do, we wish to avoid the special danger that patents applied to a free program could make it effectively proprietary. To prevent this, the GPL assures that patents cannot be used to render the program non-free.
+
+The precise terms and conditions for copying, distribution and modification follow.
+TERMS AND CONDITIONS
+0. Definitions.
+
+“This License” refers to version 3 of the GNU General Public License.
+
+“Copyright” also means copyright-like laws that apply to other kinds of works, such as semiconductor masks.
+
+“The Program” refers to any copyrightable work licensed under this License. Each licensee is addressed as “you”. “Licensees” and “recipients” may be individuals or organizations.
+
+To “modify” a work means to copy from or adapt all or part of the work in a fashion requiring copyright permission, other than the making of an exact copy. The resulting work is called a “modified version” of the earlier work or a work “based on” the earlier work.
+
+A “covered work” means either the unmodified Program or a work based on the Program.
+
+To “propagate” a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy. Propagation includes copying, distribution (with or without modification), making available to the public, and in some countries other activities as well.
+
+To “convey” a work means any kind of propagation that enables other parties to make or receive copies. Mere interaction with a user through a computer network, with no transfer of a copy, is not conveying.
+
+An interactive user interface displays “Appropriate Legal Notices” to the extent that it includes a convenient and prominently visible feature that (1) displays an appropriate copyright notice, and (2) tells the user that there is no warranty for the work (except to the extent that warranties are provided), that licensees may convey the work under this License, and how to view a copy of this License. If the interface presents a list of user commands or options, such as a menu, a prominent item in the list meets this criterion.
+1. Source Code.
+
+The “source code” for a work means the preferred form of the work for making modifications to it. “Object code” means any non-source form of a work.
+
+A “Standard Interface” means an interface that either is an official standard defined by a recognized standards body, or, in the case of interfaces specified for a particular programming language, one that is widely used among developers working in that language.
+
+The “System Libraries” of an executable work include anything, other than the work as a whole, that (a) is included in the normal form of packaging a Major Component, but which is not part of that Major Component, and (b) serves only to enable use of the work with that Major Component, or to implement a Standard Interface for which an implementation is available to the public in source code form. A “Major Component”, in this context, means a major essential component (kernel, window system, and so on) of the specific operating system (if any) on which the executable work runs, or a compiler used to produce the work, or an object code interpreter used to run it.
+
+The “Corresponding Source” for a work in object code form means all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities. However, it does not include the work's System Libraries, or general-purpose tools or generally available free programs which are used unmodified in performing those activities but which are not part of the work. For example, Corresponding Source includes interface definition files associated with source files for the work, and the source code for shared libraries and dynamically linked subprograms that the work is specifically designed to require, such as by intimate data communication or control flow between those subprograms and other parts of the work.
+
+The Corresponding Source need not include anything that users can regenerate automatically from other parts of the Corresponding Source.
+
+The Corresponding Source for a work in source code form is that same work.
+2. Basic Permissions.
+
+All rights granted under this License are granted for the term of copyright on the Program, and are irrevocable provided the stated conditions are met. This License explicitly affirms your unlimited permission to run the unmodified Program. The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work. This License acknowledges your rights of fair use or other equivalent, as provided by copyright law.
+
+You may make, run and propagate covered works that you do not convey, without conditions so long as your license otherwise remains in force. You may convey covered works to others for the sole purpose of having them make modifications exclusively for you, or provide you with facilities for running those works, provided that you comply with the terms of this License in conveying all material for which you do not control copyright. Those thus making or running the covered works for you must do so exclusively on your behalf, under your direction and control, on terms that prohibit them from making any copies of your copyrighted material outside their relationship with you.
+
+Conveying under any other circumstances is permitted solely under the conditions stated below. Sublicensing is not allowed; section 10 makes it unnecessary.
+3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+No covered work shall be deemed part of an effective technological measure under any applicable law fulfilling obligations under article 11 of the WIPO copyright treaty adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention of such measures.
+
+When you convey a covered work, you waive any legal power to forbid circumvention of technological measures to the extent such circumvention is effected by exercising rights under this License with respect to the covered work, and you disclaim any intention to limit operation or modification of the work as a means of enforcing, against the work's users, your or third parties' legal rights to forbid circumvention of technological measures.
+4. Conveying Verbatim Copies.
+
+You may convey verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice; keep intact all notices stating that this License and any non-permissive terms added in accord with section 7 apply to the code; keep intact all notices of the absence of any warranty; and give all recipients a copy of this License along with the Program.
+
+You may charge any price or no price for each copy that you convey, and you may offer support or warranty protection for a fee.
+5. Conveying Modified Source Versions.
+
+You may convey a work based on the Program, or the modifications to produce it from the Program, in the form of source code under the terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified it, and giving a relevant date.
+    b) The work must carry prominent notices stating that it is released under this License and any conditions added under section 7. This requirement modifies the requirement in section 4 to “keep intact all notices”.
+    c) You must license the entire work, as a whole, under this License to anyone who comes into possession of a copy. This License will therefore apply, along with any applicable section 7 additional terms, to the whole of the work, and all its parts, regardless of how they are packaged. This License gives no permission to license the work in any other way, but it does not invalidate such permission if you have separately received it.
+    d) If the work has interactive user interfaces, each must display Appropriate Legal Notices; however, if the Program has interactive interfaces that do not display Appropriate Legal Notices, your work need not make them do so.
+
+A compilation of a covered work with other separate and independent works, which are not by their nature extensions of the covered work, and which are not combined with it such as to form a larger program, in or on a volume of a storage or distribution medium, is called an “aggregate” if the compilation and its resulting copyright are not used to limit the access or legal rights of the compilation's users beyond what the individual works permit. Inclusion of a covered work in an aggregate does not cause this License to apply to the other parts of the aggregate.
+6. Conveying Non-Source Forms.
+
+You may convey a covered work in object code form under the terms of sections 4 and 5, provided that you also convey the machine-readable Corresponding Source under the terms of this License, in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by the Corresponding Source fixed on a durable physical medium customarily used for software interchange.
+    b) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by a written offer, valid for at least three years and valid for as long as you offer spare parts or customer support for that product model, to give anyone who possesses the object code either (1) a copy of the Corresponding Source for all the software in the product that is covered by this License, on a durable physical medium customarily used for software interchange, for a price no more than your reasonable cost of physically performing this conveying of source, or (2) access to copy the Corresponding Source from a network server at no charge.
+    c) Convey individual copies of the object code with a copy of the written offer to provide the Corresponding Source. This alternative is allowed only occasionally and noncommercially, and only if you received the object code with such an offer, in accord with subsection 6b.
+    d) Convey the object code by offering access from a designated place (gratis or for a charge), and offer equivalent access to the Corresponding Source in the same way through the same place at no further charge. You need not require recipients to copy the Corresponding Source along with the object code. If the place to copy the object code is a network server, the Corresponding Source may be on a different server (operated by you or a third party) that supports equivalent copying facilities, provided you maintain clear directions next to the object code saying where to find the Corresponding Source. Regardless of what server hosts the Corresponding Source, you remain obligated to ensure that it is available for as long as needed to satisfy these requirements.
+    e) Convey the object code using peer-to-peer transmission, provided you inform other peers where the object code and Corresponding Source of the work are being offered to the general public at no charge under subsection 6d.
+
+A separable portion of the object code, whose source code is excluded from the Corresponding Source as a System Library, need not be included in conveying the object code work.
+
+A “User Product” is either (1) a “consumer product”, which means any tangible personal property which is normally used for personal, family, or household purposes, or (2) anything designed or sold for incorporation into a dwelling. In determining whether a product is a consumer product, doubtful cases shall be resolved in favor of coverage. For a particular product received by a particular user, “normally used” refers to a typical or common use of that class of product, regardless of the status of the particular user or of the way in which the particular user actually uses, or expects or is expected to use, the product. A product is a consumer product regardless of whether the product has substantial commercial, industrial or non-consumer uses, unless such uses represent the only significant mode of use of the product.
+
+“Installation Information” for a User Product means any methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source. The information must suffice to ensure that the continued functioning of the modified object code is in no case prevented or interfered with solely because modification has been made.
+
+If you convey an object code work under this section in, or with, or specifically for use in, a User Product, and the conveying occurs as part of a transaction in which the right of possession and use of the User Product is transferred to the recipient in perpetuity or for a fixed term (regardless of how the transaction is characterized), the Corresponding Source conveyed under this section must be accompanied by the Installation Information. But this requirement does not apply if neither you nor any third party retains the ability to install modified object code on the User Product (for example, the work has been installed in ROM).
+
+The requirement to provide Installation Information does not include a requirement to continue to provide support service, warranty, or updates for a work that has been modified or installed by the recipient, or for the User Product in which it has been modified or installed. Access to a network may be denied when the modification itself materially and adversely affects the operation of the network or violates the rules and protocols for communication across the network.
+
+Corresponding Source conveyed, and Installation Information provided, in accord with this section must be in a format that is publicly documented (and with an implementation available to the public in source code form), and must require no special password or key for unpacking, reading or copying.
+7. Additional Terms.
+
+“Additional permissions” are terms that supplement the terms of this License by making exceptions from one or more of its conditions. Additional permissions that are applicable to the entire Program shall be treated as though they were included in this License, to the extent that they are valid under applicable law. If additional permissions apply only to part of the Program, that part may be used separately under those permissions, but the entire Program remains governed by this License without regard to the additional permissions.
+
+When you convey a copy of a covered work, you may at your option remove any additional permissions from that copy, or from any part of it. (Additional permissions may be written to require their own removal in certain cases when you modify the work.) You may place additional permissions on material, added by you to a covered work, for which you have or can give appropriate copyright permission.
+
+Notwithstanding any other provision of this License, for material you add to a covered work, you may (if authorized by the copyright holders of that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16 of this License; or
+    b) Requiring preservation of specified reasonable legal notices or author attributions in that material or in the Appropriate Legal Notices displayed by works containing it; or
+    c) Prohibiting misrepresentation of the origin of that material, or requiring that modified versions of such material be marked in reasonable ways as different from the original version; or
+    d) Limiting the use for publicity purposes of names of licensors or authors of the material; or
+    e) Declining to grant rights under trademark law for use of some trade names, trademarks, or service marks; or
+    f) Requiring indemnification of licensors and authors of that material by anyone who conveys the material (or modified versions of it) with contractual assumptions of liability to the recipient, for any liability that these contractual assumptions directly impose on those licensors and authors.
+
+All other non-permissive additional terms are considered “further restrictions” within the meaning of section 10. If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term. If a license document contains a further restriction but permits relicensing or conveying under this License, you may add to a covered work material governed by the terms of that license document, provided that the further restriction does not survive such relicensing or conveying.
+
+If you add terms to a covered work in accord with this section, you must place, in the relevant source files, a statement of the additional terms that apply to those files, or a notice indicating where to find the applicable terms.
+
+Additional terms, permissive or non-permissive, may be stated in the form of a separately written license, or stated as exceptions; the above requirements apply either way.
+8. Termination.
+
+You may not propagate or modify a covered work except as expressly provided under this License. Any attempt otherwise to propagate or modify it is void, and will automatically terminate your rights under this License (including any patent licenses granted under the third paragraph of section 11).
+
+However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice.
+
+Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License. If your rights have been terminated and not permanently reinstated, you do not qualify to receive new licenses for the same material under section 10.
+9. Acceptance Not Required for Having Copies.
+
+You are not required to accept this License in order to receive or run a copy of the Program. Ancillary propagation of a covered work occurring solely as a consequence of using peer-to-peer transmission to receive a copy likewise does not require acceptance. However, nothing other than this License grants you permission to propagate or modify any covered work. These actions infringe copyright if you do not accept this License. Therefore, by modifying or propagating a covered work, you indicate your acceptance of this License to do so.
+10. Automatic Licensing of Downstream Recipients.
+
+Each time you convey a covered work, the recipient automatically receives a license from the original licensors, to run, modify and propagate that work, subject to this License. You are not responsible for enforcing compliance by third parties with this License.
+
+An “entity transaction” is a transaction transferring control of an organization, or substantially all assets of one, or subdividing an organization, or merging organizations. If propagation of a covered work results from an entity transaction, each party to that transaction who receives a copy of the work also receives whatever licenses to the work the party's predecessor in interest had or could give under the previous paragraph, plus a right to possession of the Corresponding Source of the work from the predecessor in interest, if the predecessor has it or can get it with reasonable efforts.
+
+You may not impose any further restrictions on the exercise of the rights granted or affirmed under this License. For example, you may not impose a license fee, royalty, or other charge for exercise of rights granted under this License, and you may not initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is infringed by making, using, selling, offering for sale, or importing the Program or any portion of it.
+11. Patents.
+
+A “contributor” is a copyright holder who authorizes use under this License of the Program or a work on which the Program is based. The work thus licensed is called the contributor's “contributor version”.
+
+A contributor's “essential patent claims” are all patent claims owned or controlled by the contributor, whether already acquired or hereafter acquired, that would be infringed by some manner, permitted by this License, of making, using, or selling its contributor version, but do not include claims that would be infringed only as a consequence of further modification of the contributor version. For purposes of this definition, “control” includes the right to grant patent sublicenses in a manner consistent with the requirements of this License.
+
+Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the contributor's essential patent claims, to make, use, sell, offer for sale, import and otherwise run, modify and propagate the contents of its contributor version.
+
+In the following three paragraphs, a “patent license” is any express agreement or commitment, however denominated, not to enforce a patent (such as an express permission to practice a patent or covenant not to sue for patent infringement). To “grant” such a patent license to a party means to make such an agreement or commitment not to enforce a patent against the party.
+
+If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source of the work is not available for anyone to copy, free of charge and under the terms of this License, through a publicly available network server or other readily accessible means, then you must either (1) cause the Corresponding Source to be so available, or (2) arrange to deprive yourself of the benefit of the patent license for this particular work, or (3) arrange, in a manner consistent with the requirements of this License, to extend the patent license to downstream recipients. “Knowingly relying” means you have actual knowledge that, but for the patent license, your conveying the covered work in a country, or your recipient's use of the covered work in a country, would infringe one or more identifiable patents in that country that you have reason to believe are valid.
+
+If, pursuant to or in connection with a single transaction or arrangement, you convey, or propagate by procuring conveyance of, a covered work, and grant a patent license to some of the parties receiving the covered work authorizing them to use, propagate, modify or convey a specific copy of the covered work, then the patent license you grant is automatically extended to all recipients of the covered work and works based on it.
+
+A patent license is “discriminatory” if it does not include within the scope of its coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of the rights that are specifically granted under this License. You may not convey a covered work if you are a party to an arrangement with a third party that is in the business of distributing software, under which you make payment to the third party based on the extent of your activity of conveying the work, and under which the third party grants, to any of the parties who would receive the covered work from you, a discriminatory patent license (a) in connection with copies of the covered work conveyed by you (or copies made from those copies), or (b) primarily for and in connection with specific products or compilations that contain the covered work, unless you entered into that arrangement, or that patent license was granted, prior to 28 March 2007.
+
+Nothing in this License shall be construed as excluding or limiting any implied license or other defenses to infringement that may otherwise be available to you under applicable patent law.
+12. No Surrender of Others' Freedom.
+
+If conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot convey a covered work so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not convey it at all. For example, if you agree to terms that obligate you to collect a royalty for further conveying from those to whom you convey the Program, the only way you could satisfy both those terms and this License would be to refrain entirely from conveying the Program.
+13. Use with the GNU Affero General Public License.
+
+Notwithstanding any other provision of this License, you have permission to link or combine any covered work with a work licensed under version 3 of the GNU Affero General Public License into a single combined work, and to convey the resulting work. The terms of this License will continue to apply to the part which is the covered work, but the special requirements of the GNU Affero General Public License, section 13, concerning interaction through a network will apply to the combination as such.
+14. Revised Versions of this License.
+
+The Free Software Foundation may publish revised and/or new versions of the GNU General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Program specifies that a certain numbered version of the GNU General Public License “or any later version” applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of the GNU General Public License, you may choose any version ever published by the Free Software Foundation.
+
+If the Program specifies that a proxy can decide which future versions of the GNU General Public License can be used, that proxy's public statement of acceptance of a version permanently authorizes you to choose that version for the Program.
+
+Later license versions may give you additional or different permissions. However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version.
+15. Disclaimer of Warranty.
+
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM “AS IS” WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+16. Limitation of Liability.
+
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+17. Interpretation of Sections 15 and 16.
+
+If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program, unless a warranty or assumption of liability accompanies a copy of the Program in return for a fee.
+
+END OF TERMS AND CONDITIONS
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the “copyright” line and a pointer to where the full notice is found.
+
+    tldw_server - A Researcher's Multi-Tool
+    Copyright (C) 2025  Robert Musser
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program does terminal interaction, make it output a short notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) 2025  Robert Musser
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate parts of the General Public License. Of course, your program's commands might be different; for a GUI interface, you would use an “about box”.
+
+You should also get your employer (if you work as a programmer) or school, if any, to sign a “copyright disclaimer” for the program, if necessary. For more information on this, and how to apply and follow the GNU GPL, see <https://www.gnu.org/licenses/>.
+
+The GNU General Public License does not permit incorporating your program into proprietary programs. If your program is a subroutine library, you may consider it more useful to permit linking proprietary applications with the library. If this is what you want to do, use the GNU Lesser General Public License instead of this License. But first, please read <https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/apps/mcp-unified/README.md
+++ b/apps/mcp-unified/README.md
@@ -52,6 +52,29 @@ Expected current status:
 The package ships `py.typed` as a PEP 561 marker so downstream type checkers can
 recognize the inline type annotations when consuming built artifacts.
 
+## Publishing Readiness
+
+Standalone package publishing is prepared but still guarded. The package
+metadata is PyPI-shaped, while the runtime metadata remains
+`internal-experimental` and `not-published` until maintainers intentionally
+promote it.
+
+Run the full internal release candidate gate:
+
+```bash
+make mcp-unified-rc
+```
+
+Build artifacts and generate the TestPyPI upload plan without uploading:
+
+```bash
+make mcp-unified-publish-dry-run
+```
+
+Live TestPyPI or PyPI upload is not part of normal PR CI. It requires the manual
+workflow, maintainer-owned credentials, an explicit confirmation input, and the
+RC helper's publish opt-in guard.
+
 ## Install From This Repository
 
 Use the package-local project file when testing the standalone boundary:

--- a/apps/mcp-unified/USER_GUIDE.md
+++ b/apps/mcp-unified/USER_GUIDE.md
@@ -7,6 +7,30 @@ credential grants, configuration snapshots, and remote runtime commands.
 The package is currently internal/experimental and distributed with the
 `tldw-server` source tree. It is not a separately published standalone package.
 
+## Publishing Readiness
+
+The standalone package has publish-ready metadata and package-local artifacts,
+but it remains `not-published`. New users should install it from the repository
+until maintainers complete a deliberate TestPyPI and PyPI promotion.
+
+Run the full internal release candidate gate from the repository root:
+
+```bash
+make mcp-unified-rc
+```
+
+Generate a TestPyPI publish plan without uploading artifacts:
+
+```bash
+make mcp-unified-publish-dry-run
+```
+
+Live upload is intentionally gated. A maintainer-owned TestPyPI or PyPI token
+must be configured in the manual publish workflow, the workflow confirmation
+must be set to `MCP_UNIFIED_PUBLISH`, and the RC helper refuses execution unless
+`MCP_UNIFIED_ALLOW_PUBLISH=1` is present in the environment. Do not use public
+PyPI install guidance while package metadata reports `not-published`.
+
 ## 1. Install The Package Boundary
 
 From the repository root:

--- a/apps/mcp-unified/pyproject.toml
+++ b/apps/mcp-unified/pyproject.toml
@@ -9,6 +9,26 @@ description = "Standalone MCP Unified runtime and gateway package boundary."
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "GPL-3.0-only"}
+authors = [
+  { name = "Robert Musser", email = "contact@tldwproject.com" },
+]
+maintainers = [
+  { name = "Robert Musser", email = "contact@tldwproject.com" },
+]
+keywords = ["mcp", "model-context-protocol", "gateway", "agent-tools", "tool-governance"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Framework :: FastAPI",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+]
 dependencies = [
   "pydantic>=2.0.0",
   "loguru>=0.7.0",
@@ -16,6 +36,13 @@ dependencies = [
   "httpx>=0.24.0",
   "websockets>=12.0",
 ]
+
+[project.urls]
+Homepage = "https://tldwproject.com"
+Repository = "https://github.com/rmusser01/tldw_server"
+Issues = "https://github.com/rmusser01/tldw_server/issues"
+"Source Package" = "https://github.com/rmusser01/tldw_server/tree/dev/apps/mcp-unified"
+"User Guide" = "https://github.com/rmusser01/tldw_server/blob/dev/apps/mcp-unified/USER_GUIDE.md"
 
 [project.optional-dependencies]
 core = [
@@ -61,6 +88,7 @@ mcp-unified-smoke = "mcp_unified.smoke.cli:main"
 
 [tool.setuptools]
 include-package-data = false
+license-files = ["LICENSE"]
 packages = [
   "mcp_unified",
   "mcp_unified.federation",

--- a/apps/mcp-unified/src/mcp_unified/README.md
+++ b/apps/mcp-unified/src/mcp_unified/README.md
@@ -52,6 +52,29 @@ Expected current status:
 The package ships `py.typed` as a PEP 561 marker so downstream type checkers can
 recognize the inline type annotations when consuming built artifacts.
 
+## Publishing Readiness
+
+Standalone package publishing is prepared but still guarded. The package
+metadata is PyPI-shaped, while the runtime metadata remains
+`internal-experimental` and `not-published` until maintainers intentionally
+promote it.
+
+Run the full internal release candidate gate:
+
+```bash
+make mcp-unified-rc
+```
+
+Build artifacts and generate the TestPyPI upload plan without uploading:
+
+```bash
+make mcp-unified-publish-dry-run
+```
+
+Live TestPyPI or PyPI upload is not part of normal PR CI. It requires the manual
+workflow, maintainer-owned credentials, an explicit confirmation input, and the
+RC helper's publish opt-in guard.
+
 ## Install From This Repository
 
 Use the package-local project file when testing the standalone boundary:

--- a/apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
+++ b/apps/mcp-unified/src/mcp_unified/USER_GUIDE.md
@@ -7,6 +7,30 @@ credential grants, configuration snapshots, and remote runtime commands.
 The package is currently internal/experimental and distributed with the
 `tldw-server` source tree. It is not a separately published standalone package.
 
+## Publishing Readiness
+
+The standalone package has publish-ready metadata and package-local artifacts,
+but it remains `not-published`. New users should install it from the repository
+until maintainers complete a deliberate TestPyPI and PyPI promotion.
+
+Run the full internal release candidate gate from the repository root:
+
+```bash
+make mcp-unified-rc
+```
+
+Generate a TestPyPI publish plan without uploading artifacts:
+
+```bash
+make mcp-unified-publish-dry-run
+```
+
+Live upload is intentionally gated. A maintainer-owned TestPyPI or PyPI token
+must be configured in the manual publish workflow, the workflow confirmation
+must be set to `MCP_UNIFIED_PUBLISH`, and the RC helper refuses execution unless
+`MCP_UNIFIED_ALLOW_PUBLISH=1` is present in the environment. Do not use public
+PyPI install guidance while package metadata reports `not-published`.
+
 ## 1. Install The Package Boundary
 
 From the repository root:

--- a/apps/mcp-unified/src/mcp_unified/package_metadata.py
+++ b/apps/mcp-unified/src/mcp_unified/package_metadata.py
@@ -12,6 +12,40 @@ PUBLISHING_STATUS: Final = "not-published"
 LICENSE_EXPRESSION: Final = "GPL-3.0-only"
 SOURCE_DISTRIBUTION: Final = "tldw-server"
 DEPENDENCY_VERSION_POLICY: Final = "names-only"
+PACKAGE_AUTHORS: Final = (
+    {"name": "Robert Musser", "email": "contact@tldwproject.com"},
+)
+PACKAGE_MAINTAINERS: Final = (
+    {"name": "Robert Musser", "email": "contact@tldwproject.com"},
+)
+PACKAGE_KEYWORDS: Final = (
+    "mcp",
+    "model-context-protocol",
+    "gateway",
+    "agent-tools",
+    "tool-governance",
+)
+PACKAGE_CLASSIFIERS: Final = (
+    "Development Status :: 3 - Alpha",
+    "Framework :: FastAPI",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+)
+PACKAGE_URLS: Final = {
+    "Homepage": "https://tldwproject.com",
+    "Repository": "https://github.com/rmusser01/tldw_server",
+    "Issues": "https://github.com/rmusser01/tldw_server/issues",
+    "Source Package": "https://github.com/rmusser01/tldw_server/tree/dev/apps/mcp-unified",
+    "User Guide": "https://github.com/rmusser01/tldw_server/blob/dev/apps/mcp-unified/USER_GUIDE.md",
+}
+LICENSE_FILES: Final = ("LICENSE",)
 
 CORE_DEPENDENCIES: Final = (
     "pydantic",
@@ -72,6 +106,12 @@ def package_metadata_summary() -> dict[str, object]:
         "license_expression": LICENSE_EXPRESSION,
         "source_distribution": SOURCE_DISTRIBUTION,
         "dependency_version_policy": DEPENDENCY_VERSION_POLICY,
+        "authors": list(PACKAGE_AUTHORS),
+        "maintainers": list(PACKAGE_MAINTAINERS),
+        "keywords": list(PACKAGE_KEYWORDS),
+        "classifiers": list(PACKAGE_CLASSIFIERS),
+        "urls": dict(PACKAGE_URLS),
+        "license_files": list(LICENSE_FILES),
         "base_dependencies": list(PROJECT_DEPENDENCIES),
         "optional_extras": {
             extra: list(dependencies)

--- a/backlog/tasks/task-2400 - Prepare-MCP-Unified-standalone-publish-readiness-and-TestPyPI-gate.md
+++ b/backlog/tasks/task-2400 - Prepare-MCP-Unified-standalone-publish-readiness-and-TestPyPI-gate.md
@@ -4,7 +4,7 @@ title: Prepare MCP Unified standalone publish readiness and TestPyPI gate
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-23 07:05'
+updated_date: '2026-06-23 14:17'
 labels:
   - mcp
   - packaging
@@ -33,12 +33,16 @@ Harden the standalone MCP Unified package for publish-readiness after the intern
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented publish-ready metadata, package-local LICENSE handling, guarded publish-plan support in Helper_Scripts/mcp_unified_rc.py, Makefile dry-run target, manual-only publish workflow, package docs, and focused regression coverage. Validation: focused pytest suite reported 73 passed; Ruff reported all checks passed; compileall completed; Bandit wrote /tmp/bandit_mcp_unified_publish_readiness.json with exit 0; make mcp-unified-rc reported RC status ok; make mcp-unified-publish-dry-run reported RC status ok for build and publish-plan.
+
+Reopened after PR review on 2026-06-23. Actionable items to verify/fix: direct run_publish_plan unit coverage, publish upload jobs depend on publish-plan, functional dry-run CLI semantics, single wheel+sdist invariant for publish plans, TypeError handling in package metadata AST extraction, and defensive evidence recording if publish upload execution raises unexpectedly.
+
+PR review fixes completed after rebase onto origin/dev (ee7a73c9c1): added direct run_publish_plan dry-run/error coverage, made --dry-run a BooleanOptionalAction with --no-dry-run support, enforced exactly one wheel and one sdist for publish plans, added publish job needs: publish-plan, caught TypeError during metadata literal extraction, and recorded unexpected upload runner failures as evidence. Validation after fixes: targeted review tests 6 passed; focused MCP RC/package-boundary suite 78 passed; Ruff all checks passed; compileall passed; Bandit exit 0 with /tmp/bandit_mcp_unified_publish_readiness_review_fixes.json; make mcp-unified-rc RC status ok; make mcp-unified-publish-dry-run RC status ok.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-MCP Unified standalone package is now publish-ready for dry-run/TestPyPI planning while still internal/not-published. Live upload remains opt-in through manual workflow confirmation, environment-scoped tokens, and MCP_UNIFIED_ALLOW_PUBLISH=1.
+MCP Unified standalone publish-readiness PR is rebased onto latest dev and review comments are addressed. Live upload remains guarded by manual workflow confirmation, publish-plan dependency, token environment gates, and MCP_UNIFIED_ALLOW_PUBLISH=1; publish plans now reject stale extra dist artifacts.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2400 - Prepare-MCP-Unified-standalone-publish-readiness-and-TestPyPI-gate.md
+++ b/backlog/tasks/task-2400 - Prepare-MCP-Unified-standalone-publish-readiness-and-TestPyPI-gate.md
@@ -1,0 +1,52 @@
+---
+id: TASK-2400
+title: Prepare MCP Unified standalone publish readiness and TestPyPI gate
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-23 07:05'
+labels:
+  - mcp
+  - packaging
+  - release
+  - uat
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Harden the standalone MCP Unified package for publish-readiness after the internal RC pipeline merge. Add metadata and release-gate checks needed before TestPyPI/public publishing, while keeping publication guarded and opt-in only.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Standalone package metadata includes publish-ready project URLs, authors/maintainers, keywords, classifiers, license-file handling, and README rendering coverage without changing the internal experimental status.
+- [x] #2 Release tooling provides explicit, guarded TestPyPI/publish dry-run support and cannot publish from normal PR CI by accident.
+- [x] #3 Tests cover the package metadata contract, workflow/manual-dispatch guardrails, and publish command construction/redaction without requiring live credentials.
+- [x] #4 Docs explain internal RC, TestPyPI dry run, and real publish prerequisites/credentials clearly.
+- [x] #5 Focused package-boundary/RC validation, Ruff, Bandit, compileall, and diff checks are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented publish-ready metadata, package-local LICENSE handling, guarded publish-plan support in Helper_Scripts/mcp_unified_rc.py, Makefile dry-run target, manual-only publish workflow, package docs, and focused regression coverage. Validation: focused pytest suite reported 73 passed; Ruff reported all checks passed; compileall completed; Bandit wrote /tmp/bandit_mcp_unified_publish_readiness.json with exit 0; make mcp-unified-rc reported RC status ok; make mcp-unified-publish-dry-run reported RC status ok for build and publish-plan.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+MCP Unified standalone package is now publish-ready for dry-run/TestPyPI planning while still internal/not-published. Live upload remains opt-in through manual workflow confirmation, environment-scoped tokens, and MCP_UNIFIED_ALLOW_PUBLISH=1.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched Python scope or documented skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py
@@ -108,6 +108,31 @@ def test_rc_publish_plan_is_dry_run_by_default(
     assert not any("token" in part.lower() for part in plan.command)  # nosec B101
 
 
+def test_rc_publish_plan_parser_supports_no_dry_run() -> None:
+    """The publish-plan dry-run flag should be a real boolean option."""
+
+    parser = mcp_unified_rc.build_parser()
+
+    parsed = parser.parse_args(["publish-plan", "--target", "testpypi", "--no-dry-run"])
+
+    assert parsed.command == "publish-plan"  # nosec B101
+    assert parsed.dry_run is False  # nosec B101
+    assert parsed.execute is False  # nosec B101
+
+
+def test_rc_publish_plan_rejects_stale_extra_artifacts(tmp_path: Path) -> None:
+    """Publish plans should not include stale dist artifacts."""
+
+    paths = _create_publish_plan_artifacts(tmp_path)
+    (paths.dist_dir / "mcp_unified-0.1.0+stale-py3-none-any.whl").write_text(
+        "stale wheel",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="expected exactly one wheel and one sdist"):
+        mcp_unified_rc.build_publish_plan(paths, target="testpypi")
+
+
 def test_rc_publish_plan_execute_requires_opt_in_env(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -135,6 +160,119 @@ def test_rc_publish_plan_execute_requires_opt_in_env(
     assert plan.repository_url == "https://upload.pypi.org/legacy/"  # nosec B101
     assert plan.execute is True  # nosec B101
     assert plan.dry_run is False  # nosec B101
+
+
+def test_run_publish_plan_records_dry_run_evidence(tmp_path: Path) -> None:
+    """run_publish_plan should directly record dry-run evidence."""
+
+    paths = _create_publish_plan_artifacts(tmp_path)
+
+    exit_code = mcp_unified_rc.run_publish_plan(
+        paths,
+        target="testpypi",
+        execute=False,
+        dry_run=True,
+    )
+
+    evidence = json.loads(
+        (paths.evidence_dir / mcp_unified_rc.EVIDENCE_JSON).read_text(
+            encoding="utf-8",
+        )
+    )
+    result = next(
+        item
+        for item in evidence["results"]
+        if item["phase"] == "publish_plan" and item["name"] == "twine_upload_plan"
+    )
+    assert exit_code == 0  # nosec B101
+    assert result["status"] == "passed"  # nosec B101
+    assert result["details"]["plan"]["dry_run"] is True  # nosec B101
+    assert result["details"]["plan"]["execute"] is False  # nosec B101
+
+
+def test_run_publish_plan_records_upload_execution_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unexpected upload execution errors should be recorded as evidence."""
+
+    paths = _create_publish_plan_artifacts(tmp_path)
+    monkeypatch.setenv("MCP_UNIFIED_ALLOW_PUBLISH", "1")
+
+    def fail_run_command(
+        command: list[str],
+        *,
+        cwd: Path,
+        timeout: int = 180,
+        env: dict[str, str] | None = None,
+    ) -> mcp_unified_rc.RcCommandResult:
+        del env, timeout
+        if command[:3] == [sys.executable, "-m", "twine"]:
+            raise RuntimeError("upload transport failed")
+        return mcp_unified_rc.RcCommandResult(
+            command=command,
+            cwd=str(cwd),
+            returncode=0,
+            stdout="abc123\n",
+            stderr="",
+            duration_ms=0,
+        )
+
+    monkeypatch.setattr(mcp_unified_rc, "run_command", fail_run_command)
+
+    exit_code = mcp_unified_rc.run_publish_plan(
+        paths,
+        target="testpypi",
+        execute=True,
+        dry_run=False,
+    )
+
+    evidence = json.loads(
+        (paths.evidence_dir / mcp_unified_rc.EVIDENCE_JSON).read_text(
+            encoding="utf-8",
+        )
+    )
+    result = next(
+        item
+        for item in evidence["results"]
+        if item["phase"] == "publish_plan" and item["name"] == "twine_upload"
+    )
+    assert exit_code == 1  # nosec B101
+    assert result["status"] == "failed"  # nosec B101
+    assert "upload transport failed" in result["reason"]  # nosec B101
+    assert result["details"]["plan"]["execute"] is True  # nosec B101
+
+
+def test_read_package_constants_ignores_literal_eval_type_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Metadata extraction should not crash when literal_eval raises TypeError."""
+
+    metadata_path = tmp_path / "package_metadata.py"
+    metadata_path.write_text(
+        "\n".join(
+            [
+                "from typing import Final",
+                "PACKAGE_NAME: Final = 'mcp-unified'",
+                "PACKAGE_URLS: Final = {'Homepage': 'https://tldwproject.com'}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    original_literal_eval = mcp_unified_rc.ast.literal_eval
+
+    def literal_eval_with_type_error(node: object) -> object:
+        if isinstance(node, mcp_unified_rc.ast.Dict):
+            raise TypeError("unsupported literal")
+        return original_literal_eval(node)
+
+    monkeypatch.setattr(mcp_unified_rc.ast, "literal_eval", literal_eval_with_type_error)
+
+    constants = mcp_unified_rc._read_package_constants(metadata_path)
+
+    assert constants["PACKAGE_NAME"] == "mcp-unified"  # nosec B101
+    assert "PACKAGE_URLS" not in constants  # nosec B101
 
 
 def test_user_guide_uat_install_spec_uses_apps_project_by_default() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py
@@ -54,6 +54,89 @@ def test_default_paths_point_to_apps_package() -> None:
     assert paths.evidence_dir == Path("/repo/.artifacts/mcp-unified-rc")  # nosec B101
 
 
+def _create_publish_plan_artifacts(tmp_path: Path) -> mcp_unified_rc.RcPaths:
+    """Create placeholder dist files for publish-plan unit tests."""
+
+    paths = mcp_unified_rc.RcPaths.from_repo_root(tmp_path)
+    paths.dist_dir.mkdir(parents=True)
+    (paths.dist_dir / "mcp_unified-0.1.0-py3-none-any.whl").write_text(
+        "wheel",
+        encoding="utf-8",
+    )
+    (paths.dist_dir / "mcp_unified-0.1.0.tar.gz").write_text(
+        "sdist",
+        encoding="utf-8",
+    )
+    return paths
+
+
+def test_rc_publish_plan_is_dry_run_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Publish plans should default to a non-uploading TestPyPI dry run."""
+
+    monkeypatch.delenv("MCP_UNIFIED_ALLOW_PUBLISH", raising=False)
+    paths = _create_publish_plan_artifacts(tmp_path)
+    parser = mcp_unified_rc.build_parser()
+
+    parsed = parser.parse_args(["publish-plan", "--target", "testpypi"])
+    plan = mcp_unified_rc.build_publish_plan(
+        paths,
+        target=parsed.target,
+        execute=parsed.execute,
+    )
+
+    assert parsed.command == "publish-plan"  # nosec B101
+    assert plan.target == "testpypi"  # nosec B101
+    assert plan.repository_url == "https://test.pypi.org/legacy/"  # nosec B101
+    assert plan.execute is False  # nosec B101
+    assert plan.dry_run is True  # nosec B101
+    assert plan.artifact_filenames == [  # nosec B101
+        "mcp_unified-0.1.0-py3-none-any.whl",
+        "mcp_unified-0.1.0.tar.gz",
+    ]
+    assert plan.command[:5] == [  # nosec B101
+        sys.executable,
+        "-m",
+        "twine",
+        "upload",
+        "--repository-url",
+    ]
+    assert "https://test.pypi.org/legacy/" in plan.command  # nosec B101
+    assert "--non-interactive" in plan.command  # nosec B101
+    assert not any("token" in part.lower() for part in plan.command)  # nosec B101
+
+
+def test_rc_publish_plan_execute_requires_opt_in_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Live publish plans should require an explicit environment opt-in."""
+
+    paths = _create_publish_plan_artifacts(tmp_path)
+    monkeypatch.delenv("MCP_UNIFIED_ALLOW_PUBLISH", raising=False)
+
+    with pytest.raises(RuntimeError, match="MCP_UNIFIED_ALLOW_PUBLISH"):
+        mcp_unified_rc.build_publish_plan(
+            paths,
+            target="pypi",
+            execute=True,
+        )
+
+    monkeypatch.setenv("MCP_UNIFIED_ALLOW_PUBLISH", "1")
+    plan = mcp_unified_rc.build_publish_plan(
+        paths,
+        target="pypi",
+        execute=True,
+    )
+
+    assert plan.target == "pypi"  # nosec B101
+    assert plan.repository_url == "https://upload.pypi.org/legacy/"  # nosec B101
+    assert plan.execute is True  # nosec B101
+    assert plan.dry_run is False  # nosec B101
+
+
 def test_user_guide_uat_install_spec_uses_apps_project_by_default() -> None:
     """User-guide UAT install specs should default to the app package project."""
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -1097,6 +1097,7 @@ def test_mcp_unified_publish_workflow_is_manual_and_gated() -> None:
         ("publish-pypi", "pypi", "MCP_UNIFIED_PYPI_API_TOKEN"),
     ):
         job = jobs[job_name]
+        assert job["needs"] == "publish-plan"  # nosec B101
         assert "inputs.confirm_publish == 'MCP_UNIFIED_PUBLISH'" in job["if"]  # nosec B101
         assert job["permissions"] == {"contents": "read"}  # nosec B101
         assert job["environment"]["name"] == environment_name  # nosec B101

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -40,6 +40,7 @@ STANDALONE_PYPROJECT = STANDALONE_PROJECT_ROOT / "pyproject.toml"
 PY_TYPED_MARKER = PACKAGE_ROOT / "py.typed"
 PACKAGE_README = STANDALONE_PROJECT_ROOT / "README.md"
 PACKAGE_USER_GUIDE = STANDALONE_PROJECT_ROOT / "USER_GUIDE.md"
+PACKAGE_LICENSE = STANDALONE_PROJECT_ROOT / "LICENSE"
 PACKAGE_RESOURCE_README = PACKAGE_ROOT / "README.md"
 PACKAGE_RESOURCE_USER_GUIDE = PACKAGE_ROOT / "USER_GUIDE.md"
 
@@ -543,6 +544,65 @@ def test_mcp_unified_package_metadata_declares_release_gate() -> None:
     }
 
 
+def test_mcp_unified_publish_metadata_is_ready_but_internal() -> None:
+    """Standalone package metadata should be publish-ready but still internal."""
+
+    metadata = importlib.import_module("mcp_unified.package_metadata")
+    pyproject = _load_standalone_pyproject()
+    project = pyproject["project"]
+    setuptools_config = pyproject["tool"]["setuptools"]
+
+    expected_urls = {
+        "Homepage": "https://tldwproject.com",
+        "Repository": "https://github.com/rmusser01/tldw_server",
+        "Issues": "https://github.com/rmusser01/tldw_server/issues",
+        "Source Package": "https://github.com/rmusser01/tldw_server/tree/dev/apps/mcp-unified",
+        "User Guide": "https://github.com/rmusser01/tldw_server/blob/dev/apps/mcp-unified/USER_GUIDE.md",
+    }
+    expected_classifiers = {
+        "Development Status :: 3 - Alpha",
+        "Framework :: FastAPI",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    }
+
+    assert project["authors"] == list(metadata.PACKAGE_AUTHORS)  # nosec B101
+    assert project["maintainers"] == list(metadata.PACKAGE_MAINTAINERS)  # nosec B101
+    assert project["keywords"] == list(metadata.PACKAGE_KEYWORDS)  # nosec B101
+    assert set(project["classifiers"]) >= expected_classifiers  # nosec B101
+    assert project["urls"] == expected_urls  # nosec B101
+    assert setuptools_config["license-files"] == ["LICENSE"]  # nosec B101
+    assert expected_urls == metadata.PACKAGE_URLS  # nosec B101
+    assert metadata.LICENSE_FILES == ("LICENSE",)  # nosec B101
+
+    summary = metadata.package_metadata_summary()
+    assert summary["publishing_status"] == "not-published"  # nosec B101
+    assert summary["package_status"] == "internal-experimental"  # nosec B101
+    assert summary["authors"] == list(metadata.PACKAGE_AUTHORS)  # nosec B101
+    assert summary["maintainers"] == list(metadata.PACKAGE_MAINTAINERS)  # nosec B101
+    assert summary["keywords"] == list(metadata.PACKAGE_KEYWORDS)  # nosec B101
+    assert summary["classifiers"] == list(metadata.PACKAGE_CLASSIFIERS)  # nosec B101
+    assert summary["urls"] == expected_urls  # nosec B101
+    assert summary["license_files"] == ["LICENSE"]  # nosec B101
+
+
+def test_mcp_unified_package_license_file_is_local_to_project() -> None:
+    """Standalone artifacts should include a package-local license file."""
+
+    root_license = REPO_ROOT / "LICENSE"
+
+    assert root_license.is_file()  # nosec B101
+    assert PACKAGE_LICENSE.is_file()  # nosec B101
+    assert PACKAGE_LICENSE.read_text(encoding="utf-8") == root_license.read_text(encoding="utf-8")  # nosec B101
+
+
 def test_mcp_unified_package_declares_pep561_typed_marker() -> None:
     """The standalone package source must advertise typed-package support."""
 
@@ -569,12 +629,22 @@ def test_mcp_unified_package_docs_are_local_to_package_boundary() -> None:
     assert "# MCP Unified" in readme  # nosec B101
     assert "USER_GUIDE.md" in readme  # nosec B101
     assert "internal/experimental" in readme  # nosec B101
+    assert "Publishing Readiness" in readme  # nosec B101
+    assert "make mcp-unified-rc" in readme  # nosec B101
+    assert "make mcp-unified-publish-dry-run" in readme  # nosec B101
+    assert "TestPyPI" in readme  # nosec B101
+    assert "not-published" in readme  # nosec B101
     assert "mcp-unified-gateway package-info" in readme  # nosec B101
     assert "filesystem advisory lock backends" in readme  # nosec B101
     assert "memory backend" in readme  # nosec B101
     assert "optional SQLite backend" in readme  # nosec B101
     assert "same local database file" in readme  # nosec B101
     assert "# MCP Unified User Guide" in user_guide  # nosec B101
+    assert "Publishing Readiness" in user_guide  # nosec B101
+    assert "make mcp-unified-rc" in user_guide  # nosec B101
+    assert "make mcp-unified-publish-dry-run" in user_guide  # nosec B101
+    assert "MCP_UNIFIED_ALLOW_PUBLISH=1" in user_guide  # nosec B101
+    assert "maintainer-owned TestPyPI" in user_guide  # nosec B101
     assert "profiles" in user_guide  # nosec B101
     assert "external servers" in user_guide  # nosec B101
     assert "credential grants" in user_guide  # nosec B101
@@ -831,6 +901,7 @@ def test_mcp_unified_standalone_sdist_contains_only_package_boundary(
     members = _sdist_project_members(_read_sdist_members(sdist))
 
     allowed_project_root_members = {
+        "LICENSE",
         "PKG-INFO",
         "README.md",
         "USER_GUIDE.md",
@@ -907,6 +978,14 @@ def _load_workflow(path: Path) -> dict[str, object]:
     return workflow
 
 
+def _workflow_triggers(workflow: dict[str, object]) -> dict[str, object]:
+    """Return GitHub workflow triggers with YAML boolean-key fallback."""
+
+    triggers = workflow.get("on") or workflow.get(True)
+    assert isinstance(triggers, dict)  # nosec B101
+    return triggers
+
+
 def _workflow_run_blocks(workflow: dict[str, object]) -> list[str]:
     """Return shell run blocks from every workflow job step."""
 
@@ -920,8 +999,7 @@ def _workflow_run_blocks(workflow: dict[str, object]) -> list[str]:
 def _workflow_trigger_paths(workflow: dict[str, object]) -> dict[str, list[str]]:
     """Return GitHub workflow trigger paths with YAML boolean-key fallback."""
 
-    triggers = workflow.get("on") or workflow.get(True)
-    assert isinstance(triggers, dict)  # nosec B101
+    triggers = _workflow_triggers(workflow)
     return {
         trigger_name: trigger_config.get("paths", [])
         for trigger_name, trigger_config in triggers.items()
@@ -990,6 +1068,43 @@ def test_mcp_unified_rc_workflow_uses_private_permissions() -> None:
     assert "pip install --editable" not in install_runs  # nosec B101
 
 
+def test_mcp_unified_publish_workflow_is_manual_and_gated() -> None:
+    """Standalone publish workflow must be manual and explicitly gated."""
+
+    workflow_path = REPO_ROOT / ".github" / "workflows" / "mcp-unified-publish.yml"
+    workflow = _load_workflow(workflow_path)
+    triggers = _workflow_triggers(workflow)
+    serialized_workflow = yaml.safe_dump(workflow, sort_keys=True)
+    run_blocks = "\n".join(_workflow_run_blocks(workflow))
+    jobs = workflow["jobs"]
+
+    assert set(triggers) == {"workflow_dispatch"}  # nosec B101
+    inputs = triggers["workflow_dispatch"]["inputs"]
+    assert inputs["target"]["options"] == ["dry-run", "testpypi", "pypi"]  # nosec B101
+    assert inputs["target"]["default"] == "dry-run"  # nosec B101
+    assert inputs["confirm_publish"]["required"] is False  # nosec B101
+    assert workflow["permissions"] == {"contents": "read"}  # nosec B101
+    assert "pull_request" not in serialized_workflow  # nosec B101
+    assert "push:" not in serialized_workflow  # nosec B101
+    assert "make mcp-unified-rc" in run_blocks  # nosec B101
+    assert "mcp-unified-publish-dry-run" in run_blocks  # nosec B101
+    assert "MCP_UNIFIED_ALLOW_PUBLISH=1" in run_blocks  # nosec B101
+
+    plan_job = jobs["publish-plan"]
+    assert plan_job["permissions"] == {"contents": "read"}  # nosec B101
+    for job_name, environment_name, token_secret in (
+        ("publish-testpypi", "testpypi", "MCP_UNIFIED_TESTPYPI_API_TOKEN"),
+        ("publish-pypi", "pypi", "MCP_UNIFIED_PYPI_API_TOKEN"),
+    ):
+        job = jobs[job_name]
+        assert "inputs.confirm_publish == 'MCP_UNIFIED_PUBLISH'" in job["if"]  # nosec B101
+        assert job["permissions"] == {"contents": "read"}  # nosec B101
+        assert job["environment"]["name"] == environment_name  # nosec B101
+        job_text = yaml.safe_dump(job, sort_keys=True)
+        assert token_secret in job_text  # nosec B101
+        assert "TWINE_USERNAME: __token__" in job_text  # nosec B101
+
+
 def test_mcp_unified_make_targets_do_not_call_root_pypi_check() -> None:
     """Standalone RC targets must not delegate to the root PyPI package check."""
 
@@ -999,6 +1114,7 @@ def test_mcp_unified_make_targets_do_not_call_root_pypi_check() -> None:
         "mcp-unified-check",
         "mcp-unified-uat",
         "mcp-unified-rc",
+        "mcp-unified-publish-dry-run",
     ):
         assert re.search(rf"^{target_name}:", makefile, flags=re.MULTILINE)  # nosec B101
 
@@ -1017,6 +1133,10 @@ def test_mcp_unified_make_targets_do_not_call_root_pypi_check() -> None:
     ]
     assert _make_target_commands(makefile, "mcp-unified-rc") == [  # nosec B101
         "$(MCP_UNIFIED_RC) all",
+    ]
+    assert _make_target_commands(makefile, "mcp-unified-publish-dry-run") == [  # nosec B101
+        "$(MCP_UNIFIED_RC) build",
+        "$(MCP_UNIFIED_RC) publish-plan --target testpypi --dry-run",
     ]
 
 


### PR DESCRIPTION
## Change summary

Human requester: replace this section before merge with your own summary of what changed and why this implementation path was chosen. This PR was materially authored by AI, so this section is intentionally not treated as merge-ready until you own it.

## Summary

- What changed:
  - Added publish-ready metadata and a package-local `LICENSE` for `apps/mcp-unified`.
  - Added guarded `publish-plan` support to the MCP Unified RC harness, plus a Make dry-run target.
  - Added a manual-only MCP Unified publish workflow with explicit confirmation, environment gates, and token-secret upload jobs.
  - Updated package docs/resource docs and package-boundary tests for metadata, workflow, Make target, license, docs parity, and publish-plan guardrails.
- Why:
  - This keeps the standalone package prepared for TestPyPI/PyPI validation without allowing PR CI or default local commands to publish artifacts.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed)
- [x] `PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -v` - 73 passed
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check Helper_Scripts/mcp_unified_rc.py apps/mcp-unified/src/mcp_unified/package_metadata.py tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m compileall Helper_Scripts/mcp_unified_rc.py apps/mcp-unified/src/mcp_unified/package_metadata.py tldw_Server_API/app/core/MCP_unified/tests/test_mcp_unified_rc_harness.py tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r Helper_Scripts/mcp_unified_rc.py apps/mcp-unified/src/mcp_unified/package_metadata.py -f json -o /tmp/bandit_mcp_unified_publish_readiness.json`
- [x] `make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python mcp-unified-rc`
- [x] `make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python mcp-unified-publish-dry-run`

## UX Audit Checklist (v2 Stage 5)

- [x] Not applicable: no WebUI/extension UX changes.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] Not applicable: no Watchlists UI behavior changed.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] Not applicable: no Watchlists scale/polling behavior changed.

## Risk & Rollback

- Risk level: Low
- Rollback plan: revert the PR commit; standalone MCP publishing remains unavailable because the package status stays `not-published` and the new upload path is manual/guarded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the `apps/mcp-unified` standalone package for publish readiness with full metadata and a package-local `LICENSE`, and adds a guarded publish flow that defaults to dry-run and is manual-only. Uploads remain opt-in and out of PR CI.

- **New Features**
  - Added publish-ready metadata in `pyproject.toml` (authors, maintainers, keywords, classifiers, URLs) and a local `LICENSE`; mirrored fields in `mcp_unified.package_metadata`.
  - Added `publish-plan` to the RC harness guarded by `MCP_UNIFIED_ALLOW_PUBLISH`; supports `testpypi|pypi`, defaults to dry-run, supports `--no-dry-run`, enforces exactly one wheel+sdist, and records evidence (including upload failures).
  - Added `make mcp-unified-publish-dry-run` to build artifacts and generate the TestPyPI upload plan.
  - Added a manual-only GitHub Actions workflow (`workflow_dispatch`) with `dry-run|testpypi|pypi` targets, explicit confirmation (`MCP_UNIFIED_PUBLISH`), environment-scoped tokens, pinned actions, concurrency control, and upload jobs that depend on the publish plan.
  - Updated package docs with “Publishing Readiness” in both project and in-package copies; ignored `.artifacts/`; expanded tests for metadata, workflow gates, guardrails (`--no-dry-run`, env checks, single-dist invariant), Make target, and docs parity.

<sup>Written for commit 28956b208ab458614b27f2bead3d8d91ce6e2420. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

