### PR TITLE
Close TASK-2342 after MCP prompt support merge

### DIFF
--- a/backlog/tasks/task-2342 - Design-MCP-prompt-catalog-support-for-user-and-allowlisted-config-prompts.md
+++ b/backlog/tasks/task-2342 - Design-MCP-prompt-catalog-support-for-user-and-allowlisted-config-prompts.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2342
 title: Design MCP prompt catalog support for user and allowlisted config prompts
-status: In Progress
+status: Done
 labels:
 - mcp
 - prompts
@@ -22,10 +22,10 @@ Design the v1 MCP prompt support slice that exposes all readable non-deleted use
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Capture the approved architecture, protocol/data shape, permissions/config/error handling, and testing/rollout design in a spec document.
-- [ ] #2 Specify that user prompt-library entries use stable library:<uuid> MCP names and config entries use config:<module>.<key-or-group> names.
-- [ ] #3 Specify listChanged:false, cursor pagination, context-aware prompt hooks, and no live list_changed notifications in v1.
-- [ ] #4 Document that Prompt Studio prompts are excluded and the broader shared prompt registry service is tracked separately by TASK-2341.
+- [x] #1 Capture the approved architecture, protocol/data shape, permissions/config/error handling, and testing/rollout design in a spec document.
+- [x] #2 Specify that user prompt-library entries use stable library:<uuid> MCP names and config entries use config:<module>.<key-or-group> names.
+- [x] #3 Specify listChanged:false, cursor pagination, context-aware prompt hooks, and no live list_changed notifications in v1.
+- [x] #4 Document that Prompt Studio prompts are excluded and the broader shared prompt registry service is tracked separately by TASK-2341.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -43,15 +43,17 @@ Design spec written, reviewed, and revised after spec review findings. Scope cov
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Spec drafted and revised for user review at Docs/superpowers/specs/2026-06-22-mcp-prompt-catalog-support-design.md. Review fixes addressed: prompts.read without modules.read, direct namespace dispatch before global registry lookup, empty default config prompt allowlist, keyset cursor semantics, string-only MCP arguments, cursor support on the list-only HTTP convenience route, and sanitized partial-list warnings. Verification performed: placeholder/ambiguity scan found no remaining TBD/TODO/FIXME/loose review terms after cleanup; git diff --check passed. Bandit not applicable because this change is documentation/task tracking only.
+Spec drafted, reviewed, revised, and followed by the merged v1 MCP prompt support implementation PR. The approved v1 scope uses the Prompt Catalog Adapter Layer behind PromptsModule, exposes readable non-deleted user-library prompts and explicitly allowlisted config prompts, excludes Prompt Studio, declares prompt capability with listChanged:false, and leaves the broader shared registry service to TASK-2341.
+
+Verification already recorded for the design: placeholder/ambiguity scan found no remaining TBD/TODO/FIXME/loose review terms after cleanup; git diff --check passed. Follow-up implementation and review remediation landed in the merged PR, so this design task is complete.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
Agent notes:
- Marks TASK-2342 as Done now that the v1 MCP prompt support work has merged.
- Checks the task acceptance criteria and Definition of Done items.
- Updates the final summary to point at the merged implementation and TASK-2341 follow-up registry design.

Verification:
- git diff --check

Merge note:
- Per repository policy, add or confirm a human-authored Change summary before merge if required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks TASK-2342 (MCP prompt catalog design) as Done after the v1 MCP prompt support merged. Updates the task doc with completed acceptance criteria and DoD, and a final summary pointing to the merged implementation and the TASK-2341 follow-up.

<sup>Written for commit 8f2562c01f24f675c373fca1d07bf49bb7ffdd66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

