### PR TITLE
Migrate Onboarding retrying label to design-system registry

### DIFF
--- a/apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.design-system.test.ts
+++ b/apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.design-system.test.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises"
 import path from "node:path"
+import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vitest"
 
 const guard = await import(
@@ -8,7 +9,9 @@ const guard = await import(
 
 const firstChatStepRelativePath =
   "src/components/Option/Onboarding/steps/FirstChatStep.tsx"
-const firstChatStepPath = path.resolve(process.cwd(), firstChatStepRelativePath)
+const here = path.dirname(fileURLToPath(import.meta.url))
+const packageRoot = path.resolve(here, "../../../../..")
+const firstChatStepPath = path.resolve(packageRoot, firstChatStepRelativePath)
 
 describe("FirstChatStep design-system state labels", () => {
   it("routes the retrying label through the design-system state registry", async () => {

--- a/apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.design-system.test.ts
+++ b/apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.design-system.test.ts
@@ -1,0 +1,28 @@
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const guard = await import(
+  "../../../../../scripts/design-system-product-state-rules.mjs"
+)
+
+const firstChatStepRelativePath =
+  "src/components/Option/Onboarding/steps/FirstChatStep.tsx"
+const firstChatStepPath = path.resolve(process.cwd(), firstChatStepRelativePath)
+
+describe("FirstChatStep design-system state labels", () => {
+  it("routes the retrying label through the design-system state registry", async () => {
+    const source = await readFile(firstChatStepPath, "utf8")
+    const findings = guard.analyzeSource({
+      relativePath: firstChatStepRelativePath,
+      source
+    })
+
+    expect(findings).not.toContainEqual(
+      expect.objectContaining({
+        rule: "canonical-state-label",
+        subject: "Retrying"
+      })
+    )
+  })
+})

--- a/apps/packages/ui/src/components/Option/Onboarding/steps/FirstChatStep.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/steps/FirstChatStep.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { MessageCircle } from "lucide-react";
 
+import { getDesignSystemState } from "@/design-system";
 import type {
   FirstChatVerifyRequest,
   FirstChatVerifyResponse,
@@ -27,6 +28,7 @@ type FirstChatStepProps = {
 };
 
 const DEFAULT_FIRST_PROMPT = "Say hello in one short sentence.";
+const FIRST_CHAT_RETRYING_STATE = getDesignSystemState("retrying");
 
 type FirstChatRecoveryCategory =
   | "auth_failed"
@@ -292,7 +294,7 @@ export function FirstChatStep({
             </div>
             {running ? (
               <span className="rounded-full border border-border bg-surface px-2 py-0.5 text-xs font-medium text-text-muted">
-                Retrying
+                {FIRST_CHAT_RETRYING_STATE.label}
               </span>
             ) : null}
           </div>

--- a/backlog/tasks/task-45.54 - Migrate-Onboarding-retrying-label-to-design-system-registry.md
+++ b/backlog/tasks/task-45.54 - Migrate-Onboarding-retrying-label-to-design-system-registry.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.54
 title: Migrate Onboarding retrying label to design-system registry
-status: To Do
+status: Done
 labels:
 - design-system
 - webui
@@ -15,6 +15,10 @@ references:
 documentation:
 - Docs/Design/tldw_web_design_system_contract.md
 - Docs/Design/tldw_web_design_system_inventory.md
+modified_files:
+- apps/packages/ui/src/components/Option/Onboarding/steps/FirstChatStep.tsx
+- apps/packages/ui/src/components/Option/Onboarding/__tests__/FirstChatStep.design-system.test.ts
+- backlog/tasks/task-45.54 - Migrate-Onboarding-retrying-label-to-design-system-registry.md
 ---
 
 ## Description
@@ -25,30 +29,39 @@ Continue the tldw_server WebUI design-system migration by routing the remaining 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 FirstChatStep Retrying label comes from the design-system state registry.
-- [ ] #2 Existing first-chat retry behavior and copy are preserved.
-- [ ] #3 Focused Onboarding coverage preserves the retrying state label.
-- [ ] #4 Direct product-state guard scan over FirstChatStep reports zero findings.
+- [x] #1 FirstChatStep Retrying label comes from the design-system state registry.
+- [x] #2 Existing first-chat retry behavior and copy are preserved.
+- [x] #3 Focused Onboarding coverage preserves the retrying state label.
+- [x] #4 Direct product-state guard scan over FirstChatStep reports zero findings.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+- 2026-06-23: Added a focused FirstChatStep design-system guard test that runs the product-state analyzer against the real component source. Red check failed on the hardcoded Retrying label, then passed after migration.
+- 2026-06-23: Migrated the FirstChatStep retrying pill label to `getDesignSystemState("retrying").label` without changing retry behavior.
+- 2026-06-23 verification: `bunx vitest run src/components/Option/Onboarding/__tests__/FirstChatStep.design-system.test.ts` passed.
+- 2026-06-23 verification: `bunx vitest run src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx` passed.
+- 2026-06-23 verification: direct analyzer scan of `src/components/Option/Onboarding/steps/FirstChatStep.tsx` returned `[]`.
+- 2026-06-23 verification after rebasing onto `origin/dev`: `bunx vitest run src/components/Option/Onboarding/__tests__/FirstChatStep.design-system.test.ts` passed.
+- 2026-06-23 verification after rebasing onto `origin/dev`: `bunx vitest run src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx` passed.
+- 2026-06-23 verification after rebasing onto `origin/dev`: direct analyzer scan of `src/components/Option/Onboarding/steps/FirstChatStep.tsx` returned `[]`.
+- 2026-06-23 note: package-wide `node scripts/verify-design-system-product-state.mjs` still reports unrelated current-base blocked findings in `src/components/Option/Skills/SkillPreview.tsx`, `src/components/Option/ScheduledTasks/ScheduledTaskDetailDrawer.tsx`, `src/components/Option/Skills/Manager.tsx`, and `src/services/acp/readiness.ts`.
+- 2026-06-23 note: Bandit is not applicable for this task because the touched implementation/test files are TypeScript and the remaining touched file is a Backlog task record.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Migrated the Onboarding `FirstChatStep` retrying pill from a local `Retrying` literal to the shared design-system `retrying` state label. Added focused regression coverage that runs the product-state analyzer over the real component source so future hardcoded canonical state labels in this component are caught.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-45.54 - Migrate-Onboarding-retrying-label-to-design-system-registry.md
+++ b/backlog/tasks/task-45.54 - Migrate-Onboarding-retrying-label-to-design-system-registry.md
@@ -48,6 +48,8 @@ Continue the tldw_server WebUI design-system migration by routing the remaining 
 - 2026-06-23 verification after rebasing onto `origin/dev`: direct analyzer scan of `src/components/Option/Onboarding/steps/FirstChatStep.tsx` returned `[]`.
 - 2026-06-23 note: package-wide `node scripts/verify-design-system-product-state.mjs` still reports unrelated current-base blocked findings in `src/components/Option/Skills/SkillPreview.tsx`, `src/components/Option/ScheduledTasks/ScheduledTaskDetailDrawer.tsx`, `src/components/Option/Skills/Manager.tsx`, and `src/services/acp/readiness.ts`.
 - 2026-06-23 note: Bandit is not applicable for this task because the touched implementation/test files are TypeScript and the remaining touched file is a Backlog task record.
+- 2026-06-23 review fix: Updated the focused design-system test to resolve `FirstChatStep.tsx` from `import.meta.url` instead of `process.cwd()` so the test is stable across Vitest launch directories.
+- 2026-06-23 verification: `apps/packages/ui/node_modules/.bin/vitest run --root apps/packages/ui --config vitest.config.ts src/components/Option/Onboarding/__tests__/FirstChatStep.design-system.test.ts` passed from the repository root.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary


### PR DESCRIPTION
## Summary

- Migrates the Onboarding `FirstChatStep` retrying pill label from a local `Retrying` literal to `getDesignSystemState("retrying").label`.
- Adds focused guard coverage that runs the product-state analyzer over the real `FirstChatStep.tsx` source.
- Closes `TASK-45.54` with verification notes and the known current-base full-guard blockers.

## Verification

- `git diff --check`
- `bunx vitest run src/components/Option/Onboarding/__tests__/FirstChatStep.design-system.test.ts`
- `bunx vitest run src/components/Option/Onboarding/__tests__/FirstChatStep.test.tsx`
- Direct analyzer scan of `src/components/Option/Onboarding/steps/FirstChatStep.tsx` returned `[]`.
- `node scripts/verify-design-system-product-state.mjs` currently fails on unrelated current-base findings in `Skills`, `ScheduledTasks`, and `services/acp/readiness.ts`; this PR does not add a `FirstChatStep` finding.

## Change Summary

AI-generated implementation summary: the retrying label now comes from the existing design-system state registry so canonical state copy stays centralized, and the focused analyzer test guards against reintroducing a hardcoded canonical state label in this component.

Human-authored change summary required before merge: TODO.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the Onboarding `FirstChatStep` retrying pill to the design-system `retrying` state label via `getDesignSystemState("retrying").label`, and stabilized the focused design-system guard test by resolving the component path via `import.meta.url` to avoid launch-dir flakiness. Completes TASK-45.54; no UI or behavior changes.

<sup>Written for commit 8cd1c9a663d972b27d12f59f92d2bf7a9d8163f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

