### PR TITLE
Fix MCP Unified TestPyPI package contents

### DIFF
--- a/apps/mcp-unified/pyproject.toml
+++ b/apps/mcp-unified/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-unified"
-version = "0.1.0"
+version = "0.1.1"
 description = "Standalone MCP Unified runtime and gateway package boundary."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -95,6 +95,7 @@ packages = [
   "mcp_unified.filesystem_locks",
   "mcp_unified.gateway",
   "mcp_unified.interfaces",
+  "mcp_unified.policy_grants",
   "mcp_unified.profiles",
   "mcp_unified.smoke",
   "mcp_unified.storage",

--- a/apps/mcp-unified/src/mcp_unified/__init__.py
+++ b/apps/mcp-unified/src/mcp_unified/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/backlog/tasks/task-2401 - Run-MCP-Unified-standalone-release-rehearsal-after-publish-readiness-merge.md
+++ b/backlog/tasks/task-2401 - Run-MCP-Unified-standalone-release-rehearsal-after-publish-readiness-merge.md
@@ -51,6 +51,12 @@ Safe publishing prerequisite check:
 Blocker before live upload:
 - A maintainer needs to create protected GitHub Actions environments named `testpypi` and `pypi`, then add environment secrets `MCP_UNIFIED_TESTPYPI_API_TOKEN` and `MCP_UNIFIED_PYPI_API_TOKEN`. This keeps the existing token-based publish workflow intact; no secret values were accessed or logged.
 
+Update 2026-06-24:
+- Created the GitHub Actions environment `testpypi` and stored the environment secret name `MCP_UNIFIED_TESTPYPI_API_TOKEN` from the local token file without logging the token value.
+- Verified non-secret repo state with `gh secret list --env testpypi --repo rmusser01/tldw_server --json name,updatedAt`, which returned `MCP_UNIFIED_TESTPYPI_API_TOKEN`.
+- Verified `gh api repos/rmusser01/tldw_server/environments --jq '{total_count, environments: [.environments[].name]}'` now returns `testpypi` and `tldw with API Keys`.
+- The production `pypi` environment and `MCP_UNIFIED_PYPI_API_TOKEN` remain unconfigured until a production PyPI token is available.
+
 Bandit: skipped because no code or workflow files were changed in this rehearsal branch; only the Backlog evidence record changed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 

--- a/backlog/tasks/task-2401 - Run-MCP-Unified-standalone-release-rehearsal-after-publish-readiness-merge.md
+++ b/backlog/tasks/task-2401 - Run-MCP-Unified-standalone-release-rehearsal-after-publish-readiness-merge.md
@@ -1,0 +1,65 @@
+---
+id: TASK-2401
+title: Run MCP Unified standalone release rehearsal after publish-readiness merge
+status: Done
+labels:
+- mcp
+- packaging
+- release
+- uat
+priority: medium
+modified_files:
+- backlog/tasks/task-2401 - Run-MCP-Unified-standalone-release-rehearsal-after-publish-readiness-merge.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Run the standalone MCP Unified release rehearsal from latest dev after the publish-readiness PR merge. Verify RC build/UAT, dry-run publish plan, and maintainer-owned TestPyPI readiness without exposing secrets.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 MCP Unified internal RC runs from latest dev and records evidence.
+- [x] #2 Dry-run publish plan runs from freshly built artifacts and records TestPyPI command evidence without upload.
+- [x] #3 Maintainer-owned TestPyPI/PyPI workflow path is checked for safe non-secret prerequisites where available.
+- [x] #4 Any discovered blockers are documented with concrete next steps.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Release rehearsal completed from latest dev worktree `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/mcp-unified-release-rehearsal`.
+
+Verification:
+- `make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python mcp-unified-rc` exited 0 and wrote `.artifacts/mcp-unified-rc/mcp-unified-rc-evidence.json` plus `.artifacts/mcp-unified-rc/mcp-unified-rc-summary.md`; RC status was `ok`.
+- `make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python mcp-unified-publish-dry-run` exited 0. It rebuilt artifacts and ran `publish-plan --target testpypi --dry-run` without upload.
+- Evidence summary reports `mcp-unified 0.1.0`, source path `apps/mcp-unified`, layout `src`, wheel `mcp_unified-0.1.0-py3-none-any.whl` sha256 `575828add28ac815fbc2419c640ba112774c7333ac9cf9851171a89efc7f4a9e`, and sdist `mcp_unified-0.1.0.tar.gz` sha256 `569eac5b08851b5223e6a776ab550af81131c43904a1514f57514e06829b7ee6`.
+
+Safe publishing prerequisite check:
+- `.github/workflows/mcp-unified-publish.yml` defines `environment: testpypi` and `environment: pypi`, with secret names `MCP_UNIFIED_TESTPYPI_API_TOKEN` and `MCP_UNIFIED_PYPI_API_TOKEN` only.
+- `gh api repos/rmusser01/tldw_server/environments --jq '{environments: [.environments[].name]}'` returned only `tldw with API Keys`.
+- `gh secret list --env testpypi --repo rmusser01/tldw_server --json name,updatedAt` returned HTTP 404 because the `testpypi` environment is absent or inaccessible.
+- `gh secret list --env pypi --repo rmusser01/tldw_server --json name,updatedAt` returned HTTP 404 because the `pypi` environment is absent or inaccessible.
+
+Blocker before live upload:
+- A maintainer needs to create protected GitHub Actions environments named `testpypi` and `pypi`, then add environment secrets `MCP_UNIFIED_TESTPYPI_API_TOKEN` and `MCP_UNIFIED_PYPI_API_TOKEN`. This keeps the existing token-based publish workflow intact; no secret values were accessed or logged.
+
+Bandit: skipped because no code or workflow files were changed in this rehearsal branch; only the Backlog evidence record changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2402 - Fix-MCP-Unified-TestPyPI-wheel-missing-policy-grants-package.md
+++ b/backlog/tasks/task-2402 - Fix-MCP-Unified-TestPyPI-wheel-missing-policy-grants-package.md
@@ -1,0 +1,68 @@
+---
+id: TASK-2402
+title: Fix MCP Unified TestPyPI wheel missing policy grants package
+status: Done
+labels:
+- mcp
+- packaging
+- testpypi
+- bug
+priority: high
+modified_files:
+- apps/mcp-unified/pyproject.toml
+- apps/mcp-unified/src/mcp_unified/__init__.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+- backlog/tasks/task-2402 - Fix-MCP-Unified-TestPyPI-wheel-missing-policy-grants-package.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TestPyPI smoke for mcp-unified 0.1.0 uploaded successfully, but installed console scripts fail with ModuleNotFoundError for mcp_unified.policy_grants because the standalone package manifest omits that package. Add package-boundary coverage and update the package manifest so built wheels include policy_grants.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Package boundary tests fail before the manifest fix when policy_grants is missing from built artifacts.
+- [x] #2 apps/mcp-unified packaging manifest includes mcp_unified.policy_grants.
+- [x] #3 Built wheel and sdist include policy_grants package files.
+- [x] #4 Fresh local wheel install runs mcp-unified-gateway package-info and mcp-unified-smoke --help successfully.
+- [x] #5 TestPyPI smoke outcome is recorded without exposing token values.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+TestPyPI smoke found a real packaging issue after uploading `mcp-unified 0.1.0`: installed console scripts failed with `ModuleNotFoundError: No module named 'mcp_unified.policy_grants'`. The root cause was the manual setuptools package list in `apps/mcp-unified/pyproject.toml`, which omitted `mcp_unified.policy_grants` even though gateway bootstrap imports it.
+
+Fix:
+- Added package-boundary expectations for `mcp_unified.policy_grants` in the standalone pyproject package list and built wheel/sdist members.
+- Added `mcp_unified.policy_grants` to the standalone package manifest.
+- Bumped the standalone package version to `0.1.1` because TestPyPI does not allow replacing the already-uploaded broken `0.1.0` artifacts.
+
+Verification:
+- Red test before fix: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q -k "pyproject_matches_release_metadata or artifacts_include_package_docs"` failed on the missing package list entry and missing wheel member.
+- Green test after fix: same command passed, 2 passed / 44 deselected.
+- Full RC: `make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python mcp-unified-rc` exited 0 with RC status `ok`; evidence reported `mcp-unified 0.1.1`, wheel sha256 `0a8187e94d4931ff38ac01138cca737dbb53d7764eca23f1254a89a19ef76601`, sdist sha256 `ff821cf00926f2bc547875046caca2b49711926cad7e27d762b968ceb97ed9b4`.
+- TestPyPI upload: guarded live upload using local token file exited 0 and wrote evidence for `https://test.pypi.org/project/mcp-unified/0.1.1/` without logging token values.
+- TestPyPI install smoke: fresh venv installed dependencies from PyPI, then installed `mcp-unified==0.1.1` from TestPyPI with `--no-deps`; import printed `0.1.1`; `mcp-unified-gateway package-info`, `mcp-unified-gateway list-presets`, `mcp-unified-smoke --help`, and `mcp-unified-smoke inprocess --json-report -` exited 0.
+- First naive TestPyPI install attempt with TestPyPI as primary index failed because pip selected a broken TestPyPI `FASTAPI-1.0` dependency. The successful smoke used the safer pattern: install dependencies from PyPI, then install the TestPyPI wheel with `--no-deps`.
+- Bandit: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r apps/mcp-unified/src/mcp_unified/__init__.py -f json -o /tmp/bandit_mcp_unified_testpypi_packaging.json` exited 0 with zero findings.
+
+Known follow-up:
+- Installed CLI commands emit a non-fatal Pydantic warning from `mcp_unified.gateway.snapshots.GatewayConfigSnapshot` because the `schema` field shadows a BaseModel attribute. It does not block the smoke, but should be cleaned up separately if warning-clean CLI output is required.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Tests or verification recorded.
+- [x] #2 No TestPyPI token values are logged or committed.
+- [x] #3 Bandit run for touched code when applicable or documented skip for package metadata/test-only changes.
+- [x] #4 Backlog task updated with final summary.
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -746,6 +746,7 @@ def test_mcp_unified_standalone_pyproject_matches_release_metadata() -> None:
         "mcp_unified.filesystem_locks",
         "mcp_unified.gateway",
         "mcp_unified.interfaces",
+        "mcp_unified.policy_grants",
         "mcp_unified.profiles",
         "mcp_unified.smoke",
         "mcp_unified.storage",
@@ -964,9 +965,11 @@ def test_mcp_unified_standalone_artifacts_include_package_docs(
     assert "mcp_unified/README.md" in wheel_members  # nosec B101
     assert "mcp_unified/USER_GUIDE.md" in wheel_members  # nosec B101
     assert "mcp_unified/filesystem_locks/__init__.py" in wheel_members  # nosec B101
+    assert "mcp_unified/policy_grants/__init__.py" in wheel_members  # nosec B101
     assert "src/mcp_unified/README.md" in sdist_members  # nosec B101
     assert "src/mcp_unified/USER_GUIDE.md" in sdist_members  # nosec B101
     assert "src/mcp_unified/filesystem_locks/__init__.py" in sdist_members  # nosec B101
+    assert "src/mcp_unified/policy_grants/__init__.py" in sdist_members  # nosec B101
 
 
 def _load_workflow(path: Path) -> dict[str, object]:


### PR DESCRIPTION
## Summary
- Records the MCP Unified release rehearsal and TestPyPI smoke results.
- Fixes the standalone package manifest so `mcp_unified.policy_grants` is included in built wheels/sdists.
- Bumps the standalone package to `0.1.1` because the broken `0.1.0` artifacts were already uploaded to TestPyPI and cannot be overwritten.
- Configures the repo-side `testpypi` GitHub Actions environment and stores the environment secret name `MCP_UNIFIED_TESTPYPI_API_TOKEN`; the secret value was not logged or committed.

## Validation
- RED: `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q -k "pyproject_matches_release_metadata or artifacts_include_package_docs"` failed before the manifest fix on the missing package list entry and missing wheel member.
- GREEN: same focused pytest command passed after the fix.
- `make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python mcp-unified-rc` passed with RC status `ok` for `mcp-unified 0.1.1`.
- Live TestPyPI upload passed for `https://test.pypi.org/project/mcp-unified/0.1.1/`; token was loaded from the local token file and not logged or committed.
- Fresh TestPyPI install smoke passed using PyPI-only dependencies plus `pip install --no-deps --index-url https://test.pypi.org/simple mcp-unified==0.1.1`.
- Installed-wheel checks passed: import prints `0.1.1`, `mcp-unified-gateway package-info`, `mcp-unified-gateway list-presets`, `mcp-unified-smoke --help`, and `mcp-unified-smoke inprocess --json-report -`.
- Verified `gh secret list --env testpypi --repo rmusser01/tldw_server --json name,updatedAt` returns `MCP_UNIFIED_TESTPYPI_API_TOKEN`.
- Verified repo environments now include `testpypi` and `tldw with API Keys`; production `pypi` remains unconfigured until a production token is available.
- Bandit on touched runtime code passed with zero findings.

## Notes
- A naive install with TestPyPI as the primary index failed because pip selected a broken TestPyPI `FASTAPI-1.0` dependency. The successful smoke used the safer dependency pattern above.
- Installed CLI commands emit a non-fatal Pydantic warning about `GatewayConfigSnapshot.schema` shadowing BaseModel; this does not block the smoke and should be handled separately if warning-clean CLI output is required.

## Change summary
The standalone packaging metadata omitted `mcp_unified.policy_grants`, but gateway bootstrap imports that package. The fix adds the missing package to the manifest and strengthens artifact-boundary tests so built wheels and sdists must include it. The version moves to `0.1.1` because TestPyPI already accepted the broken `0.1.0` artifacts and will not allow replacement.