### PR TITLE
Migrate ACP readiness setup-required labels to design-system registry

### DIFF
--- a/apps/packages/ui/src/design-system/__tests__/states.test.ts
+++ b/apps/packages/ui/src/design-system/__tests__/states.test.ts
@@ -5,6 +5,7 @@ import {
   EMPTY_STATE_LABEL,
   LOADING_STATE_LABEL,
   READY_STATE_LABEL,
+  SETUP_REQUIRED_STATE_LABEL,
   UNAVAILABLE_STATE_LABEL,
   getDesignSystemState,
   isDesignSystemStateKey
@@ -184,6 +185,9 @@ describe("design-system state registry", () => {
 
   it("exports canonical state labels through defensive fallbacks", () => {
     expect(READY_STATE_LABEL).toBe(DESIGN_SYSTEM_STATES.ready.label)
+    expect(SETUP_REQUIRED_STATE_LABEL).toBe(
+      DESIGN_SYSTEM_STATES.setup_required.label
+    )
     expect(UNAVAILABLE_STATE_LABEL).toBe(
       DESIGN_SYSTEM_STATES.unavailable.label
     )

--- a/apps/packages/ui/src/design-system/states.ts
+++ b/apps/packages/ui/src/design-system/states.ts
@@ -212,6 +212,10 @@ export function getDesignSystemStateLabel(
 }
 
 export const READY_STATE_LABEL = getDesignSystemStateLabel("ready", "Ready")
+export const SETUP_REQUIRED_STATE_LABEL = getDesignSystemStateLabel(
+  "setup_required",
+  "Setup required"
+)
 export const UNAVAILABLE_STATE_LABEL = getDesignSystemStateLabel(
   "unavailable",
   "Unavailable"

--- a/apps/packages/ui/src/services/acp/__tests__/readiness.test.ts
+++ b/apps/packages/ui/src/services/acp/__tests__/readiness.test.ts
@@ -1,4 +1,17 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
+
+const designSystemLabels = vi.hoisted(() => ({
+  setupRequired: "Registry setup required"
+}))
+
+vi.mock("@/design-system", async (importActual) => {
+  const actual = await importActual<typeof import("@/design-system")>()
+
+  return {
+    ...actual,
+    SETUP_REQUIRED_STATE_LABEL: designSystemLabels.setupRequired
+  }
+})
 
 import {
   buildACPAgentSetupSummary,
@@ -9,6 +22,12 @@ import {
 import type { ACPAgentInfo } from "@/services/acp/types"
 
 describe("ACP readiness normalization", () => {
+  it("preserves non-overridden design-system exports in the test mock", async () => {
+    const designSystem = await import("@/design-system")
+
+    expect(typeof designSystem.getDesignSystemState).toBe("function")
+  })
+
   it("treats an empty agent inventory as unavailable even when overall is degraded", () => {
     const health = normalizeACPHealthStatus({
       runner: { status: "ok" },
@@ -190,5 +209,37 @@ describe("ACP readiness normalization", () => {
     expect(summary.disabled).toBe(true)
     expect(summary.title).toBe("Install agent binary")
     expect(summary.description).toContain("Install Goose")
+  })
+
+  it("uses the design-system setup-required label for generic setup blockers", () => {
+    const missingEntrypointAgent: ACPAgentInfo = {
+      type: "custom",
+      name: "Custom Agent",
+      description: "Custom ACP agent.",
+      is_configured: false
+    }
+    const blockedEntrypointAgent: ACPAgentInfo = {
+      type: "custom",
+      name: "Custom Agent",
+      description: "Custom ACP agent.",
+      is_configured: false,
+      entrypoint: {
+        profile_key: "custom",
+        entrypoint_strategy: "native_acp",
+        probe_state: "blocked",
+        acp_command: "custom-acp",
+        acp_args: [],
+        primary_blocker: null,
+        blockers: [],
+        credential_state: "delegated"
+      }
+    }
+
+    expect(buildACPAgentSetupSummary(missingEntrypointAgent).title).toBe(
+      designSystemLabels.setupRequired
+    )
+    expect(buildACPAgentSetupSummary(blockedEntrypointAgent).title).toBe(
+      designSystemLabels.setupRequired
+    )
   })
 })

--- a/apps/packages/ui/src/services/acp/readiness.ts
+++ b/apps/packages/ui/src/services/acp/readiness.ts
@@ -1,3 +1,4 @@
+import { SETUP_REQUIRED_STATE_LABEL } from "@/design-system"
 import type {
   ACPAgentInfo,
   ACPExecutionHealthAgentSummary,
@@ -156,7 +157,7 @@ export const buildACPAgentSetupSummary = (agent: ACPAgentInfo): ACPAgentSetupSum
 
     return {
       disabled: true,
-      title: "Setup required",
+      title: SETUP_REQUIRED_STATE_LABEL,
       description: `Configure ${agent.name} before starting an ACP session.`
     }
   }
@@ -260,7 +261,7 @@ export const buildACPAgentSetupSummary = (agent: ACPAgentInfo): ACPAgentSetupSum
 
   return {
     disabled: true,
-    title: "Setup required",
+    title: SETUP_REQUIRED_STATE_LABEL,
     description: statusMessageOr(agent, `${agent.name} is not ready to start.`)
   }
 }

--- a/backlog/tasks/task-45.55 - Migrate-ACP-readiness-setup-required-labels-to-design-system-registry.md
+++ b/backlog/tasks/task-45.55 - Migrate-ACP-readiness-setup-required-labels-to-design-system-registry.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-45.55
 title: Migrate ACP readiness setup-required labels to design-system registry
-status: To Do
+status: Done
 labels:
 - design-system
 - webui
@@ -15,6 +15,12 @@ references:
 documentation:
 - Docs/Design/tldw_web_design_system_contract.md
 - Docs/Design/tldw_web_design_system_inventory.md
+modified_files:
+- apps/packages/ui/src/design-system/states.ts
+- apps/packages/ui/src/design-system/__tests__/states.test.ts
+- apps/packages/ui/src/services/acp/readiness.ts
+- apps/packages/ui/src/services/acp/__tests__/readiness.test.ts
+- backlog/tasks/task-45.55 - Migrate-ACP-readiness-setup-required-labels-to-design-system-registry.md
 ---
 
 ## Description
@@ -25,30 +31,39 @@ Continue the tldw_server WebUI design-system migration by routing the remaining 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 ACP readiness setup-required label values come from the design-system state registry.
-- [ ] #2 Existing ACP readiness normalization behavior is preserved.
-- [ ] #3 Focused ACP readiness coverage preserves setup-required labels.
-- [ ] #4 Direct product-state guard scan over ACP readiness reports zero findings.
+- [x] #1 ACP readiness setup-required label values come from the design-system state registry.
+- [x] #2 Existing ACP readiness normalization behavior is preserved.
+- [x] #3 Focused ACP readiness coverage preserves setup-required labels.
+- [x] #4 Direct product-state guard scan over ACP readiness reports zero findings.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+- 2026-06-23: Added `SETUP_REQUIRED_STATE_LABEL` as a defensive label alias in the design-system state registry.
+- 2026-06-23: Migrated ACP readiness generic setup-blocker titles to `SETUP_REQUIRED_STATE_LABEL`.
+- 2026-06-23: Added ACP readiness coverage that mocks the design-system setup-required label to prove generic setup blockers use the registry value.
+- 2026-06-23 verification: `bunx vitest run src/services/acp/__tests__/readiness.test.ts` passed.
+- 2026-06-23 verification: `bunx vitest run src/design-system/__tests__/states.test.ts` passed.
+- 2026-06-23 verification: direct analyzer scan of `src/services/acp/readiness.ts` returned `[]`.
+- 2026-06-23 note: package-wide `node scripts/verify-design-system-product-state.mjs` no longer reports ACP readiness findings, but still reports unrelated current-base findings in `src/components/Option/Skills/SkillPreview.tsx`, `src/components/Option/ScheduledTasks/ScheduledTaskDetailDrawer.tsx`, and `src/components/Option/Skills/Manager.tsx`.
+- 2026-06-23 note: Bandit is not applicable for this task because the touched implementation/test files are TypeScript and the remaining touched file is a Backlog task record.
+- 2026-06-28 review fix: changed the ACP readiness design-system test mock to a partial `vi.importActual` mock so non-overridden `@/design-system` exports remain available.
+- 2026-06-28 review verification: RED focused readiness test failed because the full `@/design-system` mock hid `getDesignSystemState`; GREEN `bunx vitest run src/services/acp/__tests__/readiness.test.ts` passed with 8 tests after switching to a partial mock. `bunx vitest run src/design-system/__tests__/states.test.ts`, `git diff --check`, and the direct ACP readiness analyzer also passed. Package-wide product-state guard still reports unrelated current-dev AudioStudio/TTS/ScheduledTasks/Skills findings and zero ACP readiness findings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Migrated ACP readiness setup-required titles from local literals to the shared design-system setup-required label alias. Added registry alias coverage and ACP readiness regression coverage so future generic setup-blocker labels continue to come from the design-system registry.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Add a shared `SETUP_REQUIRED_STATE_LABEL` alias backed by the design-system state registry.
- Route ACP readiness generic setup-blocker titles through that registry label.
- Add focused registry and ACP readiness tests, and close out `TASK-45.55`.

## Verification
- `bunx vitest run src/services/acp/__tests__/readiness.test.ts`
- `bunx vitest run src/design-system/__tests__/states.test.ts`
- `git diff --check HEAD~1..HEAD`
- Direct product-state analyzer scan of `src/services/acp/readiness.ts` returned `[]`.
- Broader product-state guard still exits 1 only on unrelated current-base findings in ScheduledTasks/Skills, with no ACP readiness findings.

## Merge gate
Human-authored Change summary required before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated ACP readiness "Setup required" titles to the design-system state registry via `SETUP_REQUIRED_STATE_LABEL` for consistent labeling across generic setup blockers. Updated normalization and strengthened tests; completes TASK-45.55.

- **Refactors**
  - Added `SETUP_REQUIRED_STATE_LABEL` with a defensive fallback in the state registry.
  - Switched ACP readiness summaries to that label for missing/blocked entrypoints.
  - Added tests that mock the registry label and verify readiness uses it, plus registry export coverage.

<sup>Written for commit 62156621f30cca05339640d37f111ef1d6d8791e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

