### PR TITLE
Harden Chat core review findings

### DIFF
--- a/backlog/tasks/task-9925 - Harden-Chat-core-review-findings-2026-06-23.md
+++ b/backlog/tasks/task-9925 - Harden-Chat-core-review-findings-2026-06-23.md
@@ -1,0 +1,59 @@
+---
+id: TASK-9925
+title: Harden Chat core review findings 2026-06-23
+status: Done
+assignee: []
+created_date: '2026-06-23 18:46'
+updated_date: '2026-06-23 18:53'
+labels:
+  - chat
+  - security
+  - review
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Validate and address current-code Chat module review findings for streaming moderation fail-open behavior, slash command permissions, dictionary regex safety, non-stream moderation review capture, and document generator compatibility methods.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Validated findings have targeted regression tests before production fixes
+- [x] #2 Streaming output moderation fails closed on transform errors
+- [x] #3 Slash commands enforce required permissions by default for RBAC-marked commands in multi-user mode
+- [x] #4 Unsafe chat dictionary regexes are rejected at runtime
+- [x] #5 Non-stream moderation review capture paths are reachable and covered
+- [x] #6 Document generator legacy prompt and bulk-generation methods use current storage/config paths
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Final verification after the last code change:
+- pytest --confcutdir=tldw_Server_API/tests/Chat/unit tldw_Server_API/tests/Chat/unit/test_streaming_utils.py -q -> 34 passed, 1 skipped
+- pytest --confcutdir=tldw_Server_API/tests/Chat_NEW/unit tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py -q -> 22 passed
+- pytest --confcutdir=tldw_Server_API/tests/Chat/unit tldw_Server_API/tests/Chat/unit/test_chat_processing_unit.py tldw_Server_API/tests/Chat/unit/test_chat_service_content.py -q -> 25 passed
+- pytest --confcutdir=tldw_Server_API/tests/Chat/unit tldw_Server_API/tests/Chat/unit/test_document_generator.py -k "save_custom_prompt_config or get_prompt_config or bulk_generation" -q -> 3 passed
+- python compile check for touched production/test files -> exit 0, no warnings
+- bandit touched production files -> 0 findings
+Known skip/blocker: running selected Chat tests without confcutdir can import full app via Chat parent fixtures and currently hit an unrelated Collections.utils truncate_text_hard import issue.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed validated Chat core review findings: stream transforms fail closed, multi-user RBAC-marked commands enforce permissions by default, ChatDictionary rejects unsafe regex keys at runtime, non-stream output moderation review capture is reachable for block/redact/warn, document generator legacy prompt/bulk methods use current user_prompts and LLM config paths, the touched-scope Bandit B311 warning was removed with secrets.randbelow, and the stream finalizer no longer emits Python return-in-finally warnings. Broad chat_service decomposition remains a residual architecture risk outside this targeted defect patch.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-9925 - Harden-Chat-core-review-findings-2026-06-23.md
+++ b/backlog/tasks/task-9925 - Harden-Chat-core-review-findings-2026-06-23.md
@@ -4,7 +4,7 @@ title: Harden Chat core review findings 2026-06-23
 status: Done
 assignee: []
 created_date: '2026-06-23 18:46'
-updated_date: '2026-06-23 18:53'
+updated_date: '2026-06-24 01:03'
 labels:
   - chat
   - security
@@ -32,20 +32,23 @@ Validate and address current-code Chat module review findings for streaming mode
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Final verification after the last code change:
-- pytest --confcutdir=tldw_Server_API/tests/Chat/unit tldw_Server_API/tests/Chat/unit/test_streaming_utils.py -q -> 34 passed, 1 skipped
-- pytest --confcutdir=tldw_Server_API/tests/Chat_NEW/unit tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py -q -> 22 passed
-- pytest --confcutdir=tldw_Server_API/tests/Chat/unit tldw_Server_API/tests/Chat/unit/test_chat_processing_unit.py tldw_Server_API/tests/Chat/unit/test_chat_service_content.py -q -> 25 passed
-- pytest --confcutdir=tldw_Server_API/tests/Chat/unit tldw_Server_API/tests/Chat/unit/test_document_generator.py -k "save_custom_prompt_config or get_prompt_config or bulk_generation" -q -> 3 passed
+PR #2437 follow-up:
+- Rebased codex/chat-core-review-fixes-9925 onto latest fetched origin/dev.
+- Addressed validated review comments: command-router ambiguous AuthNZ mode now fails closed; get_prompt_config handles tuple rows; legacy prompt saves validate before writing and replace affected prompt rows atomically; bulk_generate offloads synchronous generation via asyncio.to_thread; explicit bulk_generate overrides are covered; newly added test helpers/cases have type hints.
+Verification after review fixes:
+- pytest --confcutdir=tldw_Server_API/tests/Chat_NEW/unit tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py -q -> 23 passed
+- pytest --confcutdir=tldw_Server_API/tests/Chat/unit tldw_Server_API/tests/Chat/unit/test_document_generator.py -k "save_custom_prompt_config or get_prompt_config or bulk_generation" -q -> 6 passed
+- pytest --confcutdir=tldw_Server_API/tests/Chat/unit tldw_Server_API/tests/Chat/unit/test_streaming_utils.py tldw_Server_API/tests/Chat/unit/test_chat_processing_unit.py tldw_Server_API/tests/Chat/unit/test_chat_service_content.py -q -> 59 passed, 1 skipped
+- git diff --check -> clean
 - python compile check for touched production/test files -> exit 0, no warnings
 - bandit touched production files -> 0 findings
-Known skip/blocker: running selected Chat tests without confcutdir can import full app via Chat parent fixtures and currently hit an unrelated Collections.utils truncate_text_hard import issue.
+Known skip/blocker: broader Chat collection without confcutdir can import full app via Chat parent fixtures and has previously hit an unrelated Collections.utils truncate_text_hard import issue.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixed validated Chat core review findings: stream transforms fail closed, multi-user RBAC-marked commands enforce permissions by default, ChatDictionary rejects unsafe regex keys at runtime, non-stream output moderation review capture is reachable for block/redact/warn, document generator legacy prompt/bulk methods use current user_prompts and LLM config paths, the touched-scope Bandit B311 warning was removed with secrets.randbelow, and the stream finalizer no longer emits Python return-in-finally warnings. Broad chat_service decomposition remains a residual architecture risk outside this targeted defect patch.
+Fixed validated Chat core review findings and PR #2437 review comments: stream transforms fail closed, RBAC-marked commands enforce permissions by default and fail closed when AuthNZ mode is ambiguous, ChatDictionary rejects unsafe regex keys, non-stream output moderation review capture is reachable, legacy document prompt APIs use current user_prompts storage with atomic repeated saves and tuple-row-safe reads, and async bulk_generate no longer blocks the event loop while preserving override support. Broad chat_service decomposition remains a residual architecture risk outside this targeted defect patch.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/core/Chat/chat_dictionary.py
+++ b/tldw_Server_API/app/core/Chat/chat_dictionary.py
@@ -8,8 +8,8 @@ transforming user input with probability, grouping, and token-budget controls.
 from __future__ import annotations
 
 import os
-import random
 import re
+import secrets
 import warnings
 from datetime import datetime, timedelta
 from typing import Any
@@ -17,6 +17,7 @@ from typing import Any
 from loguru import logger
 
 from tldw_Server_API.app.core.config import load_comprehensive_config
+from tldw_Server_API.app.core.Chunking.regex_safety import check_pattern as check_regex_pattern
 from tldw_Server_API.app.core.Metrics.metrics_logger import log_counter
 from tldw_Server_API.app.core.testing import is_truthy
 from tldw_Server_API.app.core.Templating.template_renderer import (
@@ -222,7 +223,11 @@ class ChatDictionary:
     def compile_key(key: str) -> str | re.Pattern:
         """Compile a key string into a regex pattern if wrapped in '/'."""
         if key.startswith("/") and key.endswith("/"):
-            return re.compile(key[1:-1], re.IGNORECASE)
+            pattern = key[1:-1]
+            safety_error = check_regex_pattern(pattern, max_len=256)
+            if safety_error:
+                raise ValueError(f"Unsafe chat dictionary regex: {safety_error}")
+            return re.compile(pattern, re.IGNORECASE)
         return key
 
     def matches(self, text: str) -> bool:
@@ -254,7 +259,7 @@ def apply_strategy(entries: list[ChatDictionary], strategy: str = "sorted_evenly
 
 def filter_by_probability(entries: list[ChatDictionary]) -> list[ChatDictionary]:
     """Filter entries by applying their probability thresholds."""
-    return [entry for entry in entries if random.randint(1, 100) <= entry.probability]
+    return [entry for entry in entries if secrets.randbelow(100) + 1 <= entry.probability]
 
 
 def group_scoring(entries: list[ChatDictionary]) -> list[ChatDictionary]:

--- a/tldw_Server_API/app/core/Chat/chat_service.py
+++ b/tldw_Server_API/app/core/Chat/chat_service.py
@@ -5427,10 +5427,10 @@ async def execute_non_stream_call(
                                 "pattern": sample,
                             },
                         )
-                        await _capture_moderation_review_item_safely_async(
-                            phase="output",
-                            action="block",
-                            excerpt=sample,
+                    await _capture_moderation_review_item_safely_async(
+                        phase="output",
+                        action="block",
+                        excerpt=sample,
                         category=out_category2,
                         matched_pattern=matched_pattern,
                         effective_policy=eff_policy,
@@ -5466,10 +5466,10 @@ async def execute_non_stream_call(
                             )
                     except MandatoryAuditWriteError:
                         raise
-                        await _capture_moderation_review_item_safely_async(
-                            phase="output",
-                            action="redact",
-                            excerpt=sample,
+                    await _capture_moderation_review_item_safely_async(
+                        phase="output",
+                        action="redact",
+                        excerpt=sample,
                         category=out_category2,
                         matched_pattern=matched_pattern,
                         effective_policy=eff_policy,
@@ -5493,11 +5493,11 @@ async def execute_non_stream_call(
                                     msg["content"] = content_to_save
                     except _CHAT_NONCRITICAL_EXCEPTIONS:
                         pass
-                    if resolved_action == "warn":
-                        await _capture_moderation_review_item_safely_async(
-                            phase="output",
-                            action="warn",
-                            excerpt=sample,
+                if resolved_action == "warn":
+                    await _capture_moderation_review_item_safely_async(
+                        phase="output",
+                        action="warn",
+                        excerpt=sample,
                         category=out_category2,
                         matched_pattern=matched_pattern,
                         effective_policy=eff_policy,

--- a/tldw_Server_API/app/core/Chat/command_router.py
+++ b/tldw_Server_API/app/core/Chat/command_router.py
@@ -191,11 +191,11 @@ def is_single_user_mode() -> bool:
             return env_mode == "single_user"
         cp = _cfg()
         if cp and cp.has_section("AuthNZ"):
-            raw_mode = cp.get("AuthNZ", "auth_mode", fallback="single_user")
+            raw_mode = cp.get("AuthNZ", "auth_mode", fallback="multi_user")
             return str(raw_mode).strip().lower() == "single_user"
     except _COMMAND_ROUTER_NONCRITICAL_EXCEPTIONS:
-        return True
-    return True
+        return False
+    return False
 
 
 def _should_enforce_command_rbac(spec: "CommandSpec") -> bool:

--- a/tldw_Server_API/app/core/Chat/command_router.py
+++ b/tldw_Server_API/app/core/Chat/command_router.py
@@ -18,6 +18,7 @@ Env flags:
 - CHAT_COMMANDS_MAX_CHARS: max chars in command output (default: 300)
 - CHAT_COMMAND_INJECTION_MODE: 'system', 'preface', or 'replace' (default: 'system')
 - DEFAULT_LOCATION: fallback location for /weather (default: '')
+- CHAT_COMMANDS_REQUIRE_PERMISSIONS: force command RBAC in every auth mode
 """
 
 from __future__ import annotations
@@ -62,7 +63,8 @@ try:
     from tldw_Server_API.app.core.AuthNZ.rbac import user_has_permission as _user_has_permission
 except ImportError:  # pragma: no cover - fallback if AuthNZ is trimmed in tests
     def _user_has_permission(user_id: int, permission: str) -> bool:  # type: ignore
-        return True
+        logger.warning("AuthNZ RBAC unavailable; denying chat command permission check for {}", permission)
+        return False
 
 
 SLASH_RE = re.compile(r"^/(\w+)(?:\s+(.*))?$")
@@ -184,9 +186,25 @@ def is_single_user_mode() -> bool:
     code should prefer env/config-driven enforcement.
     """
     try:
-        return str(os.getenv("AUTH_MODE", "")).strip().lower() == "single_user"
+        env_mode = str(os.getenv("AUTH_MODE", "")).strip().lower()
+        if env_mode:
+            return env_mode == "single_user"
+        cp = _cfg()
+        if cp and cp.has_section("AuthNZ"):
+            raw_mode = cp.get("AuthNZ", "auth_mode", fallback="single_user")
+            return str(raw_mode).strip().lower() == "single_user"
     except _COMMAND_ROUTER_NONCRITICAL_EXCEPTIONS:
+        return True
+    return True
+
+
+def _should_enforce_command_rbac(spec: "CommandSpec") -> bool:
+    """Return whether a command's permission metadata must be enforced."""
+    if not spec.required_permission:
         return False
+    if _cfg_bool("CHAT_COMMANDS_REQUIRE_PERMISSIONS", "require_permissions", False):
+        return True
+    return bool(spec.rbac_required and not is_single_user_mode())
 
 
 def get_injection_mode() -> str:
@@ -429,8 +447,9 @@ async def async_dispatch_command(ctx: CommandContext, command: str, args: str | 
             )
         )
 
-    # RBAC: optional enforcement via env flag
-    rbac_enforced = _cfg_bool("CHAT_COMMANDS_REQUIRE_PERMISSIONS", "require_permissions", False)
+    # RBAC: enforced for RBAC-marked commands in multi-user mode, with an
+    # explicit flag available to force the same checks in single-user mode.
+    rbac_enforced = _should_enforce_command_rbac(spec)
     if rbac_enforced and spec.required_permission:
         permitted = False
         details = {"checked": True, "required_permission": spec.required_permission}

--- a/tldw_Server_API/app/core/Chat/document_generator.py
+++ b/tldw_Server_API/app/core/Chat/document_generator.py
@@ -153,6 +153,7 @@ class DocumentGeneratorService:
 
         # Request-scoped cache for prompts
         self._prompt_cache: dict[DocumentType, dict[str, Any]] = {}
+        self.llm_config: dict[str, Any] = {}
 
         # No longer need provider mapping - using adapter registry
     @staticmethod
@@ -1217,7 +1218,7 @@ class DocumentGeneratorService:
 
     def save_prompt_config(self, config: dict[DocumentType, str]) -> bool:
         """
-        Save custom prompt configuration.
+        Save legacy custom prompt configuration.
 
         Args:
             config: Dictionary mapping document types to custom prompts
@@ -1226,18 +1227,22 @@ class DocumentGeneratorService:
             True if saved successfully
         """
         try:
-            with self.db.get_connection() as conn:
-                for doc_type, prompt in config.items():
-                    conn.execute(
-                        """
-                        INSERT OR REPLACE INTO user_prompt_configs
-                        (user_id, document_type, custom_prompt, updated_at)
-                        VALUES (?, ?, ?, CURRENT_TIMESTAMP)
-                        """,
-                        (self.user_id, doc_type.value, prompt)
-                    )
-                conn.commit()
-                return True
+            for doc_type, prompt in config.items():
+                normalized_doc_type = doc_type if isinstance(doc_type, DocumentType) else DocumentType(str(doc_type))
+                default_prompt = self.DEFAULT_PROMPTS.get(
+                    normalized_doc_type,
+                    self.DEFAULT_PROMPTS[DocumentType.SUMMARY],
+                )
+                saved = self.save_user_prompt_config(
+                    document_type=normalized_doc_type,
+                    system_prompt=str(default_prompt["system"]),
+                    user_prompt=str(prompt),
+                    temperature=float(default_prompt.get("temperature", 0.7)),
+                    max_tokens=int(default_prompt.get("max_tokens", 2000)),
+                )
+                if not saved:
+                    return False
+            return True
 
         except _DOCGEN_NONCRITICAL_EXCEPTIONS as e:
             logger.error(f"Error saving prompt config: {e}")
@@ -1257,14 +1262,14 @@ class DocumentGeneratorService:
             with self.db.get_connection() as conn:
                 cursor = conn.execute(
                     """
-                    SELECT custom_prompt FROM user_prompt_configs
-                    WHERE user_id = ? AND document_type = ?
+                    SELECT user_prompt FROM user_prompts
+                    WHERE document_type = ? AND is_active = 1
                     """,
-                    (self.user_id, document_type.value)
+                    (document_type.value,)
                 )
                 row = cursor.fetchone()
                 if row:
-                    return row['custom_prompt']
+                    return row["user_prompt"] if "user_prompt" in row.keys() else row[0]
                 return None
 
         except _DOCGEN_NONCRITICAL_EXCEPTIONS as e:
@@ -1274,8 +1279,12 @@ class DocumentGeneratorService:
     async def bulk_generate(
         self,
         conversation_id: str,
-        document_types: list[DocumentType]
-    ) -> list[dict[str, Any]]:
+        document_types: list[DocumentType],
+        provider: Optional[str] = None,
+        model: Optional[str] = None,
+        api_key: Optional[str] = None,
+        app_config: Optional[dict[str, Any]] = None,
+    ) -> list[Any]:
         """
         Generate multiple document types at once.
 
@@ -1286,13 +1295,25 @@ class DocumentGeneratorService:
         Returns:
             List of generation results
         """
+        config = getattr(self, "llm_config", {}) or {}
+        effective_provider = provider or config.get("provider") or config.get("api_provider")
+        effective_model = model or config.get("model")
+        effective_api_key = api_key if api_key is not None else config.get("api_key", "")
+        effective_app_config = app_config if app_config is not None else config.get("app_config")
+
+        if not effective_provider or not effective_model:
+            raise ValueError("provider and model are required for bulk document generation")
+
         results = []
         for doc_type in document_types:
+            normalized_doc_type = doc_type if isinstance(doc_type, DocumentType) else DocumentType(str(doc_type))
             result = self.generate_document(
                 conversation_id,
-                doc_type,
-                self.llm_config['provider'],
-                self.llm_config['model']
+                normalized_doc_type,
+                str(effective_provider),
+                str(effective_model),
+                str(effective_api_key or ""),
+                app_config=effective_app_config,
             )
             results.append(result)
         return results

--- a/tldw_Server_API/app/core/Chat/document_generator.py
+++ b/tldw_Server_API/app/core/Chat/document_generator.py
@@ -22,8 +22,10 @@ Key Adaptations from Single-User:
 - Background job support for long generations
 """
 
+import asyncio
 import base64
 import json
+import sqlite3
 import time
 from datetime import datetime
 from enum import Enum
@@ -48,6 +50,7 @@ _DOCGEN_NONCRITICAL_EXCEPTIONS = (
     ConnectionError,
     TimeoutError,
     json.JSONDecodeError,
+    sqlite3.Error,
     ChatAPIError,
     CharactersRAGDBError,
 )
@@ -439,6 +442,54 @@ class DocumentGeneratorService:
         self._prompt_cache[document_type] = default_config
         return default_config
 
+    def _save_prompt_rows(self, prompt_rows: list[tuple[DocumentType, str, str, float, int]]) -> bool:
+        """Replace prompt rows for document types in one transaction."""
+        if not prompt_rows:
+            return True
+
+        try:
+            with self.db.get_connection() as conn:
+                try:
+                    for document_type, *_ in prompt_rows:
+                        conn.execute(
+                            "DELETE FROM user_prompts WHERE document_type = ?",
+                            (document_type.value,),
+                        )
+
+                    conn.executemany(
+                        """
+                        INSERT INTO user_prompts
+                        (document_type, system_prompt, user_prompt, temperature, max_tokens, is_active)
+                        VALUES (?, ?, ?, ?, ?, 1)
+                        """,
+                        [
+                            (
+                                document_type.value,
+                                system_prompt,
+                                user_prompt,
+                                temperature,
+                                max_tokens,
+                            )
+                            for document_type, system_prompt, user_prompt, temperature, max_tokens
+                            in prompt_rows
+                        ],
+                    )
+                    conn.commit()
+                except _DOCGEN_NONCRITICAL_EXCEPTIONS:
+                    try:
+                        conn.rollback()
+                    except _DOCGEN_NONCRITICAL_EXCEPTIONS as rollback_err:
+                        logger.debug(f"Prompt config rollback failed: {rollback_err}")
+                    raise
+
+            for document_type, *_ in prompt_rows:
+                self._prompt_cache.pop(document_type, None)
+            return True
+
+        except _DOCGEN_NONCRITICAL_EXCEPTIONS as e:
+            logger.error(f"Failed to save prompt config rows: {e}")
+            return False
+
     def save_user_prompt_config(
         self,
         document_type: DocumentType,
@@ -461,30 +512,23 @@ class DocumentGeneratorService:
             True if saved successfully
         """
         try:
-            with self.db.get_connection() as conn:
-                # Deactivate existing active prompt
-                conn.execute(
-                    "UPDATE user_prompts SET is_active = 0 WHERE document_type = ? AND is_active = 1",
-                    (document_type.value,)
+            normalized_doc_type = (
+                document_type
+                if isinstance(document_type, DocumentType)
+                else DocumentType(str(document_type))
+            )
+            saved = self._save_prompt_rows([
+                (
+                    normalized_doc_type,
+                    str(system_prompt),
+                    str(user_prompt),
+                    float(temperature),
+                    int(max_tokens),
                 )
-
-                # Insert new prompt
-                conn.execute(
-                    """
-                    INSERT INTO user_prompts
-                    (document_type, system_prompt, user_prompt, temperature, max_tokens, is_active)
-                    VALUES (?, ?, ?, ?, ?, 1)
-                    """,
-                    (document_type.value, system_prompt, user_prompt, temperature, max_tokens)
-                )
-                conn.commit()
-
-                # Clear cache
-                if document_type in self._prompt_cache:
-                    del self._prompt_cache[document_type]
-
-                logger.info(f"Saved user prompt config for {document_type.value}")
-                return True
+            ])
+            if saved:
+                logger.info(f"Saved user prompt config for {normalized_doc_type.value}")
+            return saved
 
         except _DOCGEN_NONCRITICAL_EXCEPTIONS as e:
             logger.error(f"Failed to save user prompt config: {e}")
@@ -1227,22 +1271,21 @@ class DocumentGeneratorService:
             True if saved successfully
         """
         try:
+            prompt_rows_by_type: dict[DocumentType, tuple[DocumentType, str, str, float, int]] = {}
             for doc_type, prompt in config.items():
                 normalized_doc_type = doc_type if isinstance(doc_type, DocumentType) else DocumentType(str(doc_type))
                 default_prompt = self.DEFAULT_PROMPTS.get(
                     normalized_doc_type,
                     self.DEFAULT_PROMPTS[DocumentType.SUMMARY],
                 )
-                saved = self.save_user_prompt_config(
-                    document_type=normalized_doc_type,
-                    system_prompt=str(default_prompt["system"]),
-                    user_prompt=str(prompt),
-                    temperature=float(default_prompt.get("temperature", 0.7)),
-                    max_tokens=int(default_prompt.get("max_tokens", 2000)),
+                prompt_rows_by_type[normalized_doc_type] = (
+                    normalized_doc_type,
+                    str(default_prompt["system"]),
+                    str(prompt),
+                    float(default_prompt.get("temperature", 0.7)),
+                    int(default_prompt.get("max_tokens", 2000)),
                 )
-                if not saved:
-                    return False
-            return True
+            return self._save_prompt_rows(list(prompt_rows_by_type.values()))
 
         except _DOCGEN_NONCRITICAL_EXCEPTIONS as e:
             logger.error(f"Error saving prompt config: {e}")
@@ -1269,7 +1312,10 @@ class DocumentGeneratorService:
                 )
                 row = cursor.fetchone()
                 if row:
-                    return row["user_prompt"] if "user_prompt" in row.keys() else row[0]
+                    try:
+                        return row["user_prompt"]
+                    except (AttributeError, TypeError, KeyError, IndexError):
+                        return row[0]
                 return None
 
         except _DOCGEN_NONCRITICAL_EXCEPTIONS as e:
@@ -1307,7 +1353,8 @@ class DocumentGeneratorService:
         results = []
         for doc_type in document_types:
             normalized_doc_type = doc_type if isinstance(doc_type, DocumentType) else DocumentType(str(doc_type))
-            result = self.generate_document(
+            result = await asyncio.to_thread(
+                self.generate_document,
                 conversation_id,
                 normalized_doc_type,
                 str(effective_provider),

--- a/tldw_Server_API/app/core/Chat/streaming_utils.py
+++ b/tldw_Server_API/app/core/Chat/streaming_utils.py
@@ -688,7 +688,17 @@ class StreamingResponseHandler:
                                     except StopIteration:
                                         return outputs, True
                                     except _STREAMING_NONCRITICAL_EXCEPTIONS as transform_err:
-                                        logger.debug(f"text_transform error ignored: {transform_err}")
+                                        logger.error(f"text_transform failed for {self.conversation_id}: {transform_err}")
+                                        err_payload = {
+                                            "error": {
+                                                "message": "Stream transform failed",
+                                                "type": "stream_transform_error",
+                                            }
+                                        }
+                                        self._attach_stream_metadata(err_payload)
+                                        outputs.append(f"data: {json.dumps(err_payload)}\n\n")
+                                        self.error_occurred = True
+                                        return outputs, True
                                     if text_piece and not append_content(text_piece):
                                         err_payload = {"error": {"message": "Response size limit exceeded"}}
                                         self._attach_stream_metadata(err_payload)
@@ -726,7 +736,17 @@ class StreamingResponseHandler:
                 except StopIteration:
                     return outputs, True
                 except _STREAMING_NONCRITICAL_EXCEPTIONS as transform_err:
-                    logger.debug(f"text_transform error ignored: {transform_err}")
+                    logger.error(f"text_transform failed for {self.conversation_id}: {transform_err}")
+                    err_payload = {
+                        "error": {
+                            "message": "Stream transform failed",
+                            "type": "stream_transform_error",
+                        }
+                    }
+                    self._attach_stream_metadata(err_payload)
+                    outputs.append(f"data: {json.dumps(err_payload)}\n\n")
+                    self.error_occurred = True
+                    return outputs, True
                 if text_piece and not append_content(text_piece):
                     err_payload = {"error": {"message": "Response size limit exceeded"}}
                     self._attach_stream_metadata(err_payload)
@@ -895,10 +915,9 @@ class StreamingResponseHandler:
                                 await maybe_result
                         except _STREAMING_NONCRITICAL_EXCEPTIONS as finalize_err:
                             logger.debug(f"Finalize callback error after cancel: {finalize_err}")
-                    return  # noqa: B012
 
                 # Flush any pending tail from text_transform (e.g., moderation holdback)
-                if not self.error_occurred and self.text_transform:
+                if not self.is_cancelled and not self.error_occurred and self.text_transform:
                     flush_fn = getattr(self.text_transform, "flush", None)
                     if callable(flush_fn):
                         try:
@@ -1021,7 +1040,7 @@ class StreamingResponseHandler:
                             )
 
                 # Send completion marker(s) after save so metadata includes IDs.
-                if not self.error_occurred:
+                if not self.is_cancelled and not self.error_occurred:
                     done_payload = {
                         "id": f"chatcmpl-{datetime.now(timezone.utc).timestamp()}",
                         "object": "chat.completion.chunk",
@@ -1032,7 +1051,7 @@ class StreamingResponseHandler:
                     self._attach_stream_metadata(done_payload)
                     yield f"data: {json.dumps(done_payload)}\n\n"
 
-                if finalize_callback and self.error_occurred:
+                if not self.is_cancelled and finalize_callback and self.error_occurred:
                     try:
                         maybe_result = finalize_callback(
                             success=False,
@@ -1055,10 +1074,11 @@ class StreamingResponseHandler:
                     yield f"event: stream_end\ndata: {json.dumps(end_payload)}\n\n"
                 # Ensure final [DONE] sentinel for client compatibility (unless already sent).
                 # If upstream already sent [DONE], defer emission until after stream_end.
-                if self.upstream_done_received and not self.done_sent or not self.done_sent:
-                    yield "data: [DONE]\n\n"
-                    self.done_sent = True
-                self.upstream_done_received = False
+                if not self.is_cancelled:
+                    if (self.upstream_done_received and not self.done_sent) or not self.done_sent:
+                        yield "data: [DONE]\n\n"
+                        self.done_sent = True
+                    self.upstream_done_received = False
 
             except _STREAMING_NONCRITICAL_EXCEPTIONS as e:
                 logger.error(f"Error in stream cleanup for {self.conversation_id}: {e}")

--- a/tldw_Server_API/tests/Chat/unit/test_chat_processing_unit.py
+++ b/tldw_Server_API/tests/Chat/unit/test_chat_processing_unit.py
@@ -88,6 +88,11 @@ class TestChatDictionaryUtilities:
         ordered = apply_strategy([character_entry, default_entry, global_entry], strategy="global_lore_first")
 
         assert [entry.key_raw for entry in ordered] == ["alpha", "beta", "gamma"]
+
+    @pytest.mark.unit
+    def test_chat_dictionary_rejects_unsafe_regex_key_at_runtime(self):
+        with pytest.raises(ValueError, match="Unsafe chat dictionary regex"):
+            ChatDictionary(key="/^(a+)+$/", content="unsafe")
 # ========================================================================
 # update_chat_content tests
 # ========================================================================

--- a/tldw_Server_API/tests/Chat/unit/test_chat_processing_unit.py
+++ b/tldw_Server_API/tests/Chat/unit/test_chat_processing_unit.py
@@ -90,7 +90,7 @@ class TestChatDictionaryUtilities:
         assert [entry.key_raw for entry in ordered] == ["alpha", "beta", "gamma"]
 
     @pytest.mark.unit
-    def test_chat_dictionary_rejects_unsafe_regex_key_at_runtime(self):
+    def test_chat_dictionary_rejects_unsafe_regex_key_at_runtime(self) -> None:
         with pytest.raises(ValueError, match="Unsafe chat dictionary regex"):
             ChatDictionary(key="/^(a+)+$/", content="unsafe")
 # ========================================================================

--- a/tldw_Server_API/tests/Chat/unit/test_chat_service_content.py
+++ b/tldw_Server_API/tests/Chat/unit/test_chat_service_content.py
@@ -49,6 +49,109 @@ class _RedactingModeration:
         return f"REDACTED:{text}"
 
 
+class _ActionModeration:
+    class _Policy:
+        enabled = True
+        output_enabled = True
+        output_action = "block"
+
+        def to_dict(self):
+            return {"enabled": True, "output_enabled": True, "output_action": self.output_action}
+
+    def __init__(self, action: str):
+        self.action = action
+        self._policy = self._Policy()
+        self._policy.output_action = action
+
+    def get_effective_policy(self, *_args, **_kwargs):
+        return self._policy
+
+    def evaluate_action_with_match(self, *_args, **_kwargs):
+        redacted = "redacted assistant output" if self.action == "redact" else None
+        return (self.action, redacted, "secret", "pii", (0, 6))
+
+    def build_sanitized_snippet(self, *_args, **_kwargs):
+        return "sanitized secret"
+
+    def check_text(self, *_args, **_kwargs):
+        return (True, "sanitized secret")
+
+    def redact_text(self, *_args, **_kwargs):
+        return "redacted assistant output"
+
+
+async def _run_non_stream_moderation_capture_case(monkeypatch, action: str, captured=None):
+    if captured is None:
+        captured = []
+
+    async def fake_log_llm_usage(**_kwargs):
+        return None
+
+    async def fake_capture(**kwargs):
+        captured.append(kwargs)
+
+    monkeypatch.setattr(chat_service, "log_llm_usage", fake_log_llm_usage)
+    monkeypatch.setattr(chat_service, "get_topic_monitoring_service", lambda: None)
+    monkeypatch.setattr(chat_service, "is_moderation_review_capture_enabled", lambda: True)
+    monkeypatch.setattr(chat_service, "_capture_moderation_review_item_safely_async", fake_capture)
+
+    def llm_call_func():
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "secret assistant output",
+                    },
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+
+    async def save_message_fn(*_args, **_kwargs):
+        return None
+
+    request = SimpleNamespace(
+        method="POST",
+        url=SimpleNamespace(path="/api/v1/chat/completions"),
+        headers={},
+        state=SimpleNamespace(user_id="user-1", api_key_id=None),
+    )
+
+    response = await execute_non_stream_call(
+        current_loop=asyncio.get_running_loop(),
+        cleaned_args={
+            "api_endpoint": "openai",
+            "api_key": "test-key",
+            "messages_payload": [{"role": "user", "content": "hi"}],
+            "model": "gpt-4o-mini",
+            "streaming": False,
+        },
+        selected_provider="openai",
+        provider="openai",
+        model="gpt-4o-mini",
+        request_json="{}",
+        request=request,
+        metrics=_DummyMetrics(),
+        provider_manager=None,
+        templated_llm_payload=[{"role": "user", "content": "hi"}],
+        should_persist=False,
+        final_conversation_id="conv-123",
+        character_card_for_context={"name": "Test"},
+        chat_db=None,
+        save_message_fn=save_message_fn,
+        audit_service=None,
+        audit_context=None,
+        client_id="client",
+        queue_execution_enabled=False,
+        enable_provider_fallback=False,
+        llm_call_func=llm_call_func,
+        refresh_provider_params=lambda *_args, **_kwargs: None,
+        moderation_getter=lambda: _ActionModeration(action),
+    )
+    return response, captured
+
+
 @pytest.mark.asyncio
 async def test_execute_non_stream_call_redacts_list_content(monkeypatch):
     async def fake_log_llm_usage(**_kwargs):
@@ -122,6 +225,39 @@ async def test_execute_non_stream_call_redacts_list_content(monkeypatch):
     assert isinstance(content, list)
     assert content[0]["text"].startswith("REDACTED:")
     assert content[1]["type"] == "image_url"
+
+
+@pytest.mark.asyncio
+async def test_execute_non_stream_call_captures_redact_review_item(monkeypatch):
+    response, captured = await _run_non_stream_moderation_capture_case(monkeypatch, "redact")
+
+    assert response["choices"][0]["message"]["content"] == "redacted assistant output"
+    assert captured
+    assert captured[0]["action"] == "redact"
+    assert captured[0]["excerpt"] == "sanitized secret"
+    assert captured[0]["category"] == "pii"
+
+
+@pytest.mark.asyncio
+async def test_execute_non_stream_call_captures_warn_review_item(monkeypatch):
+    response, captured = await _run_non_stream_moderation_capture_case(monkeypatch, "warn")
+
+    assert response["choices"][0]["message"]["content"] == "secret assistant output"
+    assert captured
+    assert captured[0]["action"] == "warn"
+    assert captured[0]["matched_pattern"] == "secret"
+
+
+@pytest.mark.asyncio
+async def test_execute_non_stream_call_captures_block_review_item_without_audit_service(monkeypatch):
+    captured = []
+
+    with pytest.raises(HTTPException):
+        await _run_non_stream_moderation_capture_case(monkeypatch, "block", captured=captured)
+
+    assert captured
+    assert captured[0]["action"] == "block"
+    assert captured[0]["source_id"] == "conv-123"
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Chat/unit/test_chat_service_content.py
+++ b/tldw_Server_API/tests/Chat/unit/test_chat_service_content.py
@@ -1,5 +1,6 @@
 import asyncio
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from fastapi import HTTPException
@@ -55,39 +56,47 @@ class _ActionModeration:
         output_enabled = True
         output_action = "block"
 
-        def to_dict(self):
+        def to_dict(self) -> dict[str, object]:
             return {"enabled": True, "output_enabled": True, "output_action": self.output_action}
 
-    def __init__(self, action: str):
+    def __init__(self, action: str) -> None:
         self.action = action
         self._policy = self._Policy()
         self._policy.output_action = action
 
-    def get_effective_policy(self, *_args, **_kwargs):
+    def get_effective_policy(self, *_args: Any, **_kwargs: Any) -> "_ActionModeration._Policy":
         return self._policy
 
-    def evaluate_action_with_match(self, *_args, **_kwargs):
+    def evaluate_action_with_match(
+        self,
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> tuple[str, str | None, str, str, tuple[int, int]]:
         redacted = "redacted assistant output" if self.action == "redact" else None
         return (self.action, redacted, "secret", "pii", (0, 6))
 
-    def build_sanitized_snippet(self, *_args, **_kwargs):
+    def build_sanitized_snippet(self, *_args: Any, **_kwargs: Any) -> str:
         return "sanitized secret"
 
-    def check_text(self, *_args, **_kwargs):
+    def check_text(self, *_args: Any, **_kwargs: Any) -> tuple[bool, str]:
         return (True, "sanitized secret")
 
-    def redact_text(self, *_args, **_kwargs):
+    def redact_text(self, *_args: Any, **_kwargs: Any) -> str:
         return "redacted assistant output"
 
 
-async def _run_non_stream_moderation_capture_case(monkeypatch, action: str, captured=None):
+async def _run_non_stream_moderation_capture_case(
+    monkeypatch: pytest.MonkeyPatch,
+    action: str,
+    captured: list[dict[str, Any]] | None = None,
+) -> tuple[Any, list[dict[str, Any]]]:
     if captured is None:
         captured = []
 
-    async def fake_log_llm_usage(**_kwargs):
+    async def fake_log_llm_usage(**_kwargs: Any) -> None:
         return None
 
-    async def fake_capture(**kwargs):
+    async def fake_capture(**kwargs: Any) -> None:
         captured.append(kwargs)
 
     monkeypatch.setattr(chat_service, "log_llm_usage", fake_log_llm_usage)
@@ -95,7 +104,7 @@ async def _run_non_stream_moderation_capture_case(monkeypatch, action: str, capt
     monkeypatch.setattr(chat_service, "is_moderation_review_capture_enabled", lambda: True)
     monkeypatch.setattr(chat_service, "_capture_moderation_review_item_safely_async", fake_capture)
 
-    def llm_call_func():
+    def llm_call_func() -> dict[str, Any]:
         return {
             "choices": [
                 {
@@ -108,7 +117,7 @@ async def _run_non_stream_moderation_capture_case(monkeypatch, action: str, capt
             ]
         }
 
-    async def save_message_fn(*_args, **_kwargs):
+    async def save_message_fn(*_args: Any, **_kwargs: Any) -> None:
         return None
 
     request = SimpleNamespace(

--- a/tldw_Server_API/tests/Chat/unit/test_document_generator.py
+++ b/tldw_Server_API/tests/Chat/unit/test_document_generator.py
@@ -17,6 +17,7 @@ import os
 import shutil
 from unittest.mock import patch
 from datetime import datetime
+from typing import Any
 from uuid import uuid4
 
 from tldw_Server_API.app.core.Chat.document_generator import DocumentGeneratorService, DocumentType
@@ -354,7 +355,11 @@ class TestDocumentGeneratorService:
         if not hasattr(service, 'delete_document'):
             pytest.skip("delete_document not implemented")
 
-    def test_save_custom_prompt_config(self, service, real_db):
+    def test_save_custom_prompt_config(
+        self,
+        service: DocumentGeneratorService,
+        real_db: CharactersRAGDB,
+    ) -> None:
 
         """Test saving custom prompt configuration."""
         assert service.save_prompt_config({DocumentType.SUMMARY: "Custom summary prompt"}) is True
@@ -372,27 +377,93 @@ class TestDocumentGeneratorService:
         assert row is not None
         assert row["user_prompt"] == "Custom summary prompt"
 
-    def test_get_prompt_config(self, service, real_db):
+    def test_save_custom_prompt_config_repeated_updates(
+        self,
+        service: DocumentGeneratorService,
+        real_db: CharactersRAGDB,
+    ) -> None:
+        """Repeated prompt edits should replace old rows without unique collisions."""
+        assert service.save_prompt_config({DocumentType.SUMMARY: "First prompt"}) is True
+        assert service.save_prompt_config({DocumentType.SUMMARY: "Second prompt"}) is True
+        assert service.save_prompt_config({DocumentType.SUMMARY: "Third prompt"}) is True
+
+        with real_db.get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT user_prompt, is_active
+                FROM user_prompts
+                WHERE document_type = ?
+                ORDER BY id
+                """,
+                (DocumentType.SUMMARY.value,),
+            ).fetchall()
+
+        assert [(row["user_prompt"], row["is_active"]) for row in rows] == [("Third prompt", 1)]
+
+    def test_save_custom_prompt_config_validates_batch_before_writing(
+        self,
+        service: DocumentGeneratorService,
+    ) -> None:
+        """Invalid batch entries should not partially overwrite existing prompts."""
+        assert service.save_prompt_config({DocumentType.SUMMARY: "Stable prompt"}) is True
+
+        assert service.save_prompt_config({
+            DocumentType.SUMMARY: "Partial prompt",
+            "not-a-document-type": "Invalid prompt",
+        }) is False
+
+        assert service.get_prompt_config(DocumentType.SUMMARY) == "Stable prompt"
+
+    def test_get_prompt_config(self, service: DocumentGeneratorService, real_db: CharactersRAGDB) -> None:
 
         """Test retrieving custom prompt configuration."""
         assert service.save_prompt_config({DocumentType.SUMMARY: "Saved prompt"}) is True
 
         assert service.get_prompt_config(DocumentType.SUMMARY) == "Saved prompt"
 
+    def test_get_prompt_config_handles_tuple_rows(self, service: DocumentGeneratorService) -> None:
+        """Prompt lookups should tolerate tuple rows from connections without row_factory."""
+        class _Cursor:
+            def fetchone(self) -> tuple[str]:
+                return ("Tuple prompt",)
+
+        class _Connection:
+            def __enter__(self) -> "_Connection":
+                return self
+
+            def __exit__(self, *_args: Any) -> None:
+                return None
+
+            def execute(self, *_args: Any, **_kwargs: Any) -> _Cursor:
+                return _Cursor()
+
+        class _DB:
+            def get_connection(self) -> _Connection:
+                return _Connection()
+
+        service.db = _DB()
+
+        assert service.get_prompt_config(DocumentType.SUMMARY) == "Tuple prompt"
+
     @pytest.mark.asyncio
-    async def test_bulk_generation(self, service, real_db, monkeypatch):
+    async def test_bulk_generation(
+        self,
+        service: DocumentGeneratorService,
+        real_db: CharactersRAGDB,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """Test generating multiple document types at once."""
-        calls = []
+        calls: list[tuple[str, DocumentType, str, str, str, dict[str, Any] | None]] = []
 
         def fake_generate_document(
-            conversation_id,
-            document_type,
-            provider,
-            model,
-            api_key,
-            app_config=None,
-            **_kwargs,
-        ):
+            conversation_id: str,
+            document_type: DocumentType,
+            provider: str,
+            model: str,
+            api_key: str,
+            app_config: dict[str, Any] | None = None,
+            **_kwargs: Any,
+        ) -> str:
             calls.append((conversation_id, document_type, provider, model, api_key, app_config))
             return f"{document_type.value} result"
 
@@ -426,6 +497,35 @@ class TestDocumentGeneratorService:
                 "gpt-4o-mini",
                 "test-key",
                 {"timeout": 30},
+            ),
+        ]
+
+        calls.clear()
+        service.llm_config = {
+            "provider": "configured-provider",
+            "model": "configured-model",
+            "api_key": "configured-key",
+            "app_config": {"timeout": 30},
+        }
+
+        override_results = await service.bulk_generate(
+            str(real_db.test_conversation_id),
+            [DocumentType.BRIEFING],
+            provider="override-provider",
+            model="override-model",
+            api_key="override-key",
+            app_config={"timeout": 5},
+        )
+
+        assert override_results == ["briefing result"]
+        assert calls == [
+            (
+                str(real_db.test_conversation_id),
+                DocumentType.BRIEFING,
+                "override-provider",
+                "override-model",
+                "override-key",
+                {"timeout": 5},
             ),
         ]
 

--- a/tldw_Server_API/tests/Chat/unit/test_document_generator.py
+++ b/tldw_Server_API/tests/Chat/unit/test_document_generator.py
@@ -357,23 +357,77 @@ class TestDocumentGeneratorService:
     def test_save_custom_prompt_config(self, service, real_db):
 
         """Test saving custom prompt configuration."""
-        # Skip if method doesn't exist
-        if not hasattr(service, 'save_prompt_config'):
-            pytest.skip("save_prompt_config not implemented")
+        assert service.save_prompt_config({DocumentType.SUMMARY: "Custom summary prompt"}) is True
+
+        with real_db.get_connection() as conn:
+            row = conn.execute(
+                """
+                SELECT user_prompt
+                FROM user_prompts
+                WHERE document_type = ? AND is_active = 1
+                """,
+                (DocumentType.SUMMARY.value,),
+            ).fetchone()
+
+        assert row is not None
+        assert row["user_prompt"] == "Custom summary prompt"
 
     def test_get_prompt_config(self, service, real_db):
 
         """Test retrieving custom prompt configuration."""
-        # Skip if method doesn't exist
-        if not hasattr(service, 'get_prompt_config'):
-            pytest.skip("get_prompt_config not implemented")
+        assert service.save_prompt_config({DocumentType.SUMMARY: "Saved prompt"}) is True
+
+        assert service.get_prompt_config(DocumentType.SUMMARY) == "Saved prompt"
 
     @pytest.mark.asyncio
-    async def test_bulk_generation(self, service, real_db):
+    async def test_bulk_generation(self, service, real_db, monkeypatch):
         """Test generating multiple document types at once."""
-        # Skip if method doesn't exist
-        if not hasattr(service, 'bulk_generate'):
-            pytest.skip("bulk_generate not implemented")
+        calls = []
+
+        def fake_generate_document(
+            conversation_id,
+            document_type,
+            provider,
+            model,
+            api_key,
+            app_config=None,
+            **_kwargs,
+        ):
+            calls.append((conversation_id, document_type, provider, model, api_key, app_config))
+            return f"{document_type.value} result"
+
+        monkeypatch.setattr(service, "generate_document", fake_generate_document)
+        service.llm_config = {
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "api_key": "test-key",
+            "app_config": {"timeout": 30},
+        }
+
+        results = await service.bulk_generate(
+            str(real_db.test_conversation_id),
+            [DocumentType.SUMMARY, DocumentType.QA],
+        )
+
+        assert results == ["summary result", "q_and_a result"]
+        assert calls == [
+            (
+                str(real_db.test_conversation_id),
+                DocumentType.SUMMARY,
+                "openai",
+                "gpt-4o-mini",
+                "test-key",
+                {"timeout": 30},
+            ),
+            (
+                str(real_db.test_conversation_id),
+                DocumentType.QA,
+                "openai",
+                "gpt-4o-mini",
+                "test-key",
+                {"timeout": 30},
+            ),
+        ]
 
     def test_get_statistics(self, service, real_db):
 

--- a/tldw_Server_API/tests/Chat/unit/test_streaming_utils.py
+++ b/tldw_Server_API/tests/Chat/unit/test_streaming_utils.py
@@ -255,6 +255,30 @@ class TestSafeStreamGenerator:
         assert len(error_messages) > 0
         assert handler.error_occurred is True
 
+    async def test_text_transform_error_stops_without_emitting_original_content(self):
+        """Text-transform failures should fail closed instead of leaking raw chunks."""
+        def failing_transform(_text):
+            raise RuntimeError("moderation unavailable")
+
+        handler = StreamingResponseHandler(
+            "conv_transform_fail",
+            "gpt-4",
+            text_transform=failing_transform,
+        )
+
+        async def mock_stream():
+            yield "secret output"
+
+        messages = []
+        async for message in handler.safe_stream_generator(mock_stream()):
+            messages.append(message)
+
+        combined_messages = "".join(messages)
+        assert "secret output" not in combined_messages
+        assert handler.full_response == []
+        assert any('"error"' in message for message in messages)
+        assert handler.error_occurred is True
+
     async def test_save_callback_execution(self):
         """Test save callback is executed."""
         handler = StreamingResponseHandler("conv_123", "gpt-4")

--- a/tldw_Server_API/tests/Chat/unit/test_streaming_utils.py
+++ b/tldw_Server_API/tests/Chat/unit/test_streaming_utils.py
@@ -4,6 +4,7 @@
 import asyncio
 import json
 import time
+from collections.abc import AsyncIterator
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch, call
 import pytest
@@ -255,9 +256,9 @@ class TestSafeStreamGenerator:
         assert len(error_messages) > 0
         assert handler.error_occurred is True
 
-    async def test_text_transform_error_stops_without_emitting_original_content(self):
+    async def test_text_transform_error_stops_without_emitting_original_content(self) -> None:
         """Text-transform failures should fail closed instead of leaking raw chunks."""
-        def failing_transform(_text):
+        def failing_transform(_text: str) -> str:
             raise RuntimeError("moderation unavailable")
 
         handler = StreamingResponseHandler(
@@ -266,7 +267,7 @@ class TestSafeStreamGenerator:
             text_transform=failing_transform,
         )
 
-        async def mock_stream():
+        async def mock_stream() -> AsyncIterator[str]:
             yield "secret output"
 
         messages = []

--- a/tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py
+++ b/tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py
@@ -268,10 +268,29 @@ async def test_rbac_enforcement(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_rbac_marked_commands_enforce_permissions_by_default_in_multi_user(monkeypatch):
+async def test_rbac_marked_commands_enforce_permissions_by_default_in_multi_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("AUTH_MODE", "multi_user")
     monkeypatch.delenv("CHAT_COMMANDS_REQUIRE_PERMISSIONS", raising=False)
     monkeypatch.setenv("CHAT_COMMANDS_RATE_LIMIT_GLOBAL", "100")
+
+    ctx = command_router.CommandContext(user_id="anon", auth_user_id=None)
+    denied = await command_router.async_dispatch_command(ctx, "time", None)
+
+    assert not denied.ok
+    assert denied.metadata.get("error") == "permission_denied"
+    assert denied.metadata.get("required_permission") == "chat.commands.time"
+
+
+@pytest.mark.asyncio
+async def test_rbac_marked_commands_enforce_permissions_when_auth_mode_ambiguous(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AUTH_MODE", raising=False)
+    monkeypatch.delenv("CHAT_COMMANDS_REQUIRE_PERMISSIONS", raising=False)
+    monkeypatch.setenv("CHAT_COMMANDS_RATE_LIMIT_GLOBAL", "100")
+    monkeypatch.setattr(command_router, "_cfg", lambda: None)
 
     ctx = command_router.CommandContext(user_id="anon", auth_user_id=None)
     denied = await command_router.async_dispatch_command(ctx, "time", None)

--- a/tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py
+++ b/tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py
@@ -267,6 +267,20 @@ async def test_rbac_enforcement(monkeypatch):
     assert allowed.ok
 
 
+@pytest.mark.asyncio
+async def test_rbac_marked_commands_enforce_permissions_by_default_in_multi_user(monkeypatch):
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.delenv("CHAT_COMMANDS_REQUIRE_PERMISSIONS", raising=False)
+    monkeypatch.setenv("CHAT_COMMANDS_RATE_LIMIT_GLOBAL", "100")
+
+    ctx = command_router.CommandContext(user_id="anon", auth_user_id=None)
+    denied = await command_router.async_dispatch_command(ctx, "time", None)
+
+    assert not denied.ok
+    assert denied.metadata.get("error") == "permission_denied"
+    assert denied.metadata.get("required_permission") == "chat.commands.time"
+
+
 def test_dispatch_command_removed_raises():
 
     ctx = command_router.CommandContext(user_id="legacy")


### PR DESCRIPTION
## Summary

- What changed:
Bug fixes

- Why:

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Chat core: closes moderation gaps, enforces RBAC for slash commands, rejects unsafe regex keys, and fails closed on stream transform errors. Adds atomic prompt writes and async bulk document generation. Addresses Linear TASK-9925 acceptance criteria.

- **Bug Fixes**
  - Streaming: `text_transform` errors emit an error event and stop; no raw chunks; flush/completion/[DONE] only when not cancelled; finalize callback gated by cancel state.
  - Moderation (non-stream): capture review items for block/redact/warn and persist sanitized snippets.
  - Slash commands: RBAC-marked commands enforce permissions by default in multi-user and when AuthNZ mode is ambiguous; `CHAT_COMMANDS_REQUIRE_PERMISSIONS` can force checks; RBAC fallback denies when AuthNZ is unavailable.
  - `ChatDictionary`: rejects unsafe regex keys via `check_regex_pattern` (max_len=256); probability filtering uses `secrets.randbelow`.
  - Document generator: transactional prompt saves replace rows atomically; legacy `save_prompt_config` writes to `user_prompts`; `get_prompt_config` reads active `user_prompt` and tolerates tuple rows; `bulk_generate` validates `provider`/`model`, offloads via `asyncio.to_thread`, and uses `llm_config` or overrides (`provider`, `model`, `api_key`, `app_config`).
  - Cleanup: targeted unit tests added for all changes.

<sup>Written for commit 09368c0c499500dbe2cf0f00857895c127819423. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

