### PR TITLE
Harden Agent Orchestration review findings

### DIFF
--- a/Docs/superpowers/plans/2026-06-23-agent-orchestration-review-hardening-plan.md
+++ b/Docs/superpowers/plans/2026-06-23-agent-orchestration-review-hardening-plan.md
@@ -1,0 +1,40 @@
+# Agent Orchestration Review Hardening Implementation Plan
+
+> Backlog task: TASK-2403
+
+## Stage 1: Retry Dispatch State Gate
+**Goal**: Allow reviewer-rejected tasks to run again without permitting duplicate active runs.
+**Success Criteria**: A task returned to `inprogress` by a rejected review can dispatch a new run after prior runs are terminal; a task with an active running run rejects duplicate dispatch.
+**Tests**: Focused API dispatch tests in `tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py` and DB unit coverage for active-run rejection.
+**Status**: Complete
+
+## Stage 2: Per-User DB Scoping
+**Goal**: Make `OrchestrationDB` project, task, run, review, and MCP-server methods enforce the instance user boundary.
+**Success Criteria**: Shared-database tests prove user 2 cannot read, list, transition, review, or mutate user 1 records.
+**Tests**: Cross-user tests in `tldw_Server_API/tests/Agent_Orchestration/test_orchestration_db.py` and `test_workspace_db.py`.
+**Status**: Complete
+
+## Stage 3: Run State Machine
+**Goal**: Reject missing run updates and terminal run rewrites.
+**Success Criteria**: Completing or failing an already terminal run raises a deterministic transition error; missing run updates raise `OrchestrationNotFoundError`.
+**Tests**: Run lifecycle tests in `test_orchestration_db.py` plus model transition helper tests.
+**Status**: Complete
+
+## Stage 4: Artifact Bounds
+**Goal**: Add explicit limits for ACP completion artifact count and promoted artifact payload size.
+**Success Criteria**: Oversized artifact lists fail completion validation; oversized promotable payloads are skipped with structured error reasons before DB writes.
+**Tests**: Parser and promotion tests in `test_orchestration_api.py` and `test_artifact_promotion.py`.
+**Status**: Complete
+
+## Stage 5: Legacy Service Isolation
+**Goal**: Keep production imports pointed at a SQLite DB factory and remove stale architecture guidance around the legacy in-memory service.
+**Success Criteria**: Production routes and resolver import the factory from a dedicated module; README and tests reflect the SQLite-backed path as the production contract.
+**Tests**: Existing route/resolver tests continue to patch the route-level factory and a focused factory test covers `OrchestrationDB.for_user`.
+**Status**: Complete
+
+## Verification
+
+- `TEST_MODE=1 ULTRA_MINIMAL_APP=1 python -m pytest --confcutdir=tldw_Server_API/tests/Agent_Orchestration tldw_Server_API/tests/Agent_Orchestration -q`
+  - Result: 204 passed, 2 warnings.
+- `python -m bandit -r tldw_Server_API/app/core/Agent_Orchestration tldw_Server_API/app/core/DB_Management/Orchestration_DB.py tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py tldw_Server_API/app/services/mcp_hub_workspace_root_resolver.py -f json -o /tmp/bandit_agent_orchestration_2403.json`
+  - Result: 0 findings, 0 errors.

--- a/backlog/tasks/task-2403 - Harden-Agent-Orchestration-review-findings.md
+++ b/backlog/tasks/task-2403 - Harden-Agent-Orchestration-review-findings.md
@@ -1,0 +1,57 @@
+---
+id: TASK-2403
+title: Harden Agent Orchestration review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 18:10'
+updated_date: '2026-06-23 18:47'
+labels:
+  - backend
+  - acp
+  - hardening
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address current-code Agent_Orchestration review findings: rejected-review retry dispatch, per-user DB scoping, run terminal-state validation, ACP artifact size/count bounds, and legacy in-memory service cleanup or deprecation.
+
+Review source: current Agent_Orchestration module review requested in Codex thread on 2026-06-23.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Rejected review retry tasks can be dispatched through a valid state-machine path without allowing duplicate active runs
+- [x] #2 OrchestrationDB project/task/run/review and MCP server reads/writes are scoped to the owning user
+- [x] #3 Run completion/failure updates reject missing runs and terminal-state rewrites
+- [x] #4 ACP completion artifact parsing/promotion enforces explicit count and size limits
+- [x] #5 Legacy in-memory service is removed or clearly isolated without stale architecture guidance
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation plan: Docs/superpowers/plans/2026-06-23-agent-orchestration-review-hardening-plan.md
+
+Implemented all five review hardening stages from Docs/superpowers/plans/2026-06-23-agent-orchestration-review-hardening-plan.md. Verification: focused regression set passed cleanly with TEST_MODE=1 ULTRA_MINIMAL_APP=1 and --confcutdir; full Agent_Orchestration suite passed 204 tests, 2 warnings. Bandit touched backend scope reported 0 findings and 0 errors in /tmp/bandit_agent_orchestration_2403.json.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened Agent Orchestration retry dispatch, per-user DB scoping, run terminal-state handling, ACP artifact bounds, and legacy service factory isolation. Full Agent_Orchestration tests passed and Bandit reported no findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+- [x] #7 Focused pytest coverage demonstrates each fixed review finding
+- [x] #8 Bandit runs on touched backend scope with no new findings
+<!-- DOD:END -->

--- a/backlog/tasks/task-2403 - Harden-Agent-Orchestration-review-findings.md
+++ b/backlog/tasks/task-2403 - Harden-Agent-Orchestration-review-findings.md
@@ -3,12 +3,12 @@ id: TASK-2403
 title: Harden Agent Orchestration review findings
 status: Done
 assignee: []
-created_date: '2026-06-23 18:10'
-updated_date: '2026-06-23 18:47'
+created_date: 2026-06-23 18:10
+updated_date: 2026-06-24 01:11
 labels:
-  - backend
-  - acp
-  - hardening
+- backend
+- acp
+- hardening
 dependencies: []
 priority: high
 ---
@@ -42,6 +42,7 @@ Implemented all five review hardening stages from Docs/superpowers/plans/2026-06
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Hardened Agent Orchestration retry dispatch, per-user DB scoping, run terminal-state handling, ACP artifact bounds, and legacy service factory isolation. Full Agent_Orchestration tests passed and Bandit reported no findings.
+Rebased PR #2438 onto latest `origin/dev` and addressed follow-up review comments by enforcing one running run per task in SQLite, making run terminal updates conditional, making workspace updates use static SQL inside transactions, moving active-run checks into `OrchestrationDB`, creating ACP sessions before running run rows, cleaning up failed sessions, bounding direct dict completion/review payloads, and adding focused regression coverage.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -55,3 +56,10 @@ Hardened Agent Orchestration retry dispatch, per-user DB scoping, run terminal-s
 - [x] #7 Focused pytest coverage demonstrates each fixed review finding
 - [x] #8 Bandit runs on touched backend scope with no new findings
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Rebased PR #2438 onto latest origin/dev and addressing follow-up review comments: static workspace update SQL with transaction rollback, DB-enforced one-running-run invariant, session-before-run dispatch ordering with cleanup, bounded structured signal payloads, and focused regression tests.
+PR #2438 follow-up verification after rebase: `TEST_MODE=1 ULTRA_MINIMAL_APP=1 python -m pytest --confcutdir=tldw_Server_API/tests/Agent_Orchestration tldw_Server_API/tests/Agent_Orchestration -q` passed 211 tests with 2 warnings. `python -m bandit -r tldw_Server_API/app/core/DB_Management/Orchestration_DB.py tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py tldw_Server_API/app/core/Agent_Orchestration/completion_signals.py tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py -f json -o /tmp/bandit_agent_orchestration_pr2438_followup.json` reported results=0 and errors=0. `git diff --check` passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-2403 - Harden-Agent-Orchestration-review-findings.md
+++ b/backlog/tasks/task-2403 - Harden-Agent-Orchestration-review-findings.md
@@ -4,7 +4,7 @@ title: Harden Agent Orchestration review findings
 status: Done
 assignee: []
 created_date: 2026-06-23 18:10
-updated_date: 2026-06-24 01:11
+updated_date: 2026-06-24 01:30
 labels:
 - backend
 - acp
@@ -43,6 +43,7 @@ Implemented all five review hardening stages from Docs/superpowers/plans/2026-06
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Hardened Agent Orchestration retry dispatch, per-user DB scoping, run terminal-state handling, ACP artifact bounds, and legacy service factory isolation. Full Agent_Orchestration tests passed and Bandit reported no findings.
 Rebased PR #2438 onto latest `origin/dev` and addressed follow-up review comments by enforcing one running run per task in SQLite, making run terminal updates conditional, making workspace updates use static SQL inside transactions, moving active-run checks into `OrchestrationDB`, creating ACP sessions before running run rows, cleaning up failed sessions, bounding direct dict completion/review payloads, and adding focused regression coverage.
+Final PR comment pass included the remote GitHub-applied Gemini artifact validation change, a fresh rebase onto latest `origin/dev`, duplicate guard cleanup, and targeted docstrings for PR-added definitions so CodeRabbit's docstring coverage warning is addressed without broad unrelated doc churn.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -62,4 +63,6 @@ Rebased PR #2438 onto latest `origin/dev` and addressed follow-up review comment
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Rebased PR #2438 onto latest origin/dev and addressing follow-up review comments: static workspace update SQL with transaction rollback, DB-enforced one-running-run invariant, session-before-run dispatch ordering with cleanup, bounded structured signal payloads, and focused regression tests.
 PR #2438 follow-up verification after rebase: `TEST_MODE=1 ULTRA_MINIMAL_APP=1 python -m pytest --confcutdir=tldw_Server_API/tests/Agent_Orchestration tldw_Server_API/tests/Agent_Orchestration -q` passed 211 tests with 2 warnings. `python -m bandit -r tldw_Server_API/app/core/DB_Management/Orchestration_DB.py tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py tldw_Server_API/app/core/Agent_Orchestration/completion_signals.py tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py -f json -o /tmp/bandit_agent_orchestration_pr2438_followup.json` reported results=0 and errors=0. `git diff --check` passed.
+Follow-up after user requested all PR issues/comments addressed again: included remote GitHub-applied Gemini commit, rebased onto latest origin/dev, and reopening to clean duplicated artifact mapping guard plus CodeRabbit docstring coverage warning.
+Second PR #2438 follow-up: fast-forwarded Robert/Gemini's GitHub-applied artifact validation commit, rebased branch onto latest origin/dev (`4fb8eafd5`), removed the duplicate mapping guard left by combining fixes, added docstrings to PR-added definitions for CodeRabbit docstring coverage, and verified PR-added definition docstring coverage at 100%. Verification: Agent_Orchestration pytest suite passed 211 tests with 2 warnings; Bandit touched backend scope `/tmp/bandit_agent_orchestration_pr2438_all_comments.json` reported results=0/errors=0; `git diff --check` passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
@@ -3,9 +3,11 @@
 Provides project/task management, run dispatch, reviewer gate,
 and workspace CRUD with discovery and health monitoring.
 """
+
 from __future__ import annotations
 
 import asyncio
+import inspect
 import os
 from collections.abc import Mapping
 from pathlib import Path
@@ -28,7 +30,7 @@ from tldw_Server_API.app.core.Agent_Orchestration.completion_signals import (
     validate_task_completion_signal,
 )
 from tldw_Server_API.app.core.Agent_Orchestration.db_factory import get_orchestration_db
-from tldw_Server_API.app.core.Agent_Orchestration.models import ACPWorkspace, RunStatus, TaskStatus
+from tldw_Server_API.app.core.Agent_Orchestration.models import ACPWorkspace, TaskStatus
 from tldw_Server_API.app.core.Agent_Orchestration.orchestration_service import (
     CycleDependencyError,
 )
@@ -75,6 +77,21 @@ async def _run_sync(fn: Any) -> Any:
     """Run a synchronous callable in a threadpool to avoid blocking the event loop."""
     loop = asyncio.get_running_loop()
     return await loop.run_in_executor(None, fn)
+
+
+async def _close_acp_session_safely(client: Any, session_id: str | None) -> None:
+    """Best-effort cleanup for sessions created before orchestration failure."""
+    if not session_id:
+        return
+    close_session = getattr(client, "close_session", None)
+    if close_session is None:
+        return
+    try:
+        result = close_session(session_id)
+        if inspect.isawaitable(result):
+            await result
+    except Exception:
+        logger.warning("Failed to close orchestration ACP session after dispatch failure")
 
 
 _TASK_COMPLETION_SIGNAL_INSTRUCTIONS = """\
@@ -222,21 +239,12 @@ def _preview_message(message: dict[str, Any] | None) -> dict[str, Any] | None:
 
 
 def _message_raw_data(message: dict[str, Any]) -> dict[str, Any]:
-    raw = (
-        message.get("raw_result")
-        or message.get("raw_prompt")
-        or message.get("raw_data")
-        or {}
-    )
+    raw = message.get("raw_result") or message.get("raw_prompt") or message.get("raw_data") or {}
     return raw if isinstance(raw, dict) else {}
 
 
 def _assistant_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    return [
-        msg
-        for msg in messages
-        if isinstance(msg, dict) and str(msg.get("role") or "").lower() == "assistant"
-    ]
+    return [msg for msg in messages if isinstance(msg, dict) and str(msg.get("role") or "").lower() == "assistant"]
 
 
 def _first_user_message(messages: list[dict[str, Any]]) -> dict[str, Any] | None:
@@ -393,11 +401,7 @@ def _review_decision_for_run(run: Any, reviews: list[dict[str, Any]]) -> dict[st
     agent_type = getattr(run, "agent_type", None)
     if not agent_type:
         return None
-    matching = [
-        review
-        for review in reviews
-        if str(review.get("reviewer") or "") == str(agent_type)
-    ]
+    matching = [review for review in reviews if str(review.get("reviewer") or "") == str(agent_type)]
     if not matching:
         return None
     review = matching[-1]
@@ -482,16 +486,8 @@ def _redact_diagnostic_payload(value: Any) -> dict[str, Any]:
         "timestamp": value.get("timestamp"),
         "role": value.get("role"),
         "reason_code": value.get("reason_code"),
-        "message": (
-            _RUN_SUMMARY_REDACTED_VALUE
-            if value.get("message") is not None
-            else value.get("message")
-        ),
-        "diagnostic_uri": (
-            _RUN_SUMMARY_REDACTED_VALUE
-            if value.get("diagnostic_uri")
-            else value.get("diagnostic_uri")
-        ),
+        "message": (_RUN_SUMMARY_REDACTED_VALUE if value.get("message") is not None else value.get("message")),
+        "diagnostic_uri": (_RUN_SUMMARY_REDACTED_VALUE if value.get("diagnostic_uri") else value.get("diagnostic_uri")),
     }
     return redacted
 
@@ -502,10 +498,7 @@ def _redact_run_history_summary(history: dict[str, Any]) -> dict[str, Any]:
     redacted["redacted_fields"] = list(_RUN_HISTORY_REDACTED_FIELDS)
     redacted["prompt"] = _redact_preview_payload(history.get("prompt"))
     redacted["result"] = _redact_preview_payload(history.get("result"))
-    redacted["diagnostics"] = [
-        _redact_diagnostic_payload(item)
-        for item in (history.get("diagnostics") or [])
-    ]
+    redacted["diagnostics"] = [_redact_diagnostic_payload(item) for item in (history.get("diagnostics") or [])]
     return redacted
 
 
@@ -584,11 +577,7 @@ def _coerce_task_review_payload(review: Any) -> dict[str, Any]:
         instance_attrs = vars(review)
     except TypeError:
         instance_attrs = {}
-    filtered_attrs = {
-        key: value
-        for key, value in instance_attrs.items()
-        if not key.startswith("_")
-    }
+    filtered_attrs = {key: value for key, value in instance_attrs.items() if not key.startswith("_")}
     if filtered_attrs:
         return filtered_attrs
 
@@ -694,18 +683,22 @@ def _allowed_workspace_roots() -> tuple[Path, ...]:
     raw_values: list[str] = []
     raw_values.extend(
         entry.strip()
-        for entry in str(get_config_value("ACP-WORKSPACE", "allowed_base_paths", "") or "").replace(
+        for entry in str(get_config_value("ACP-WORKSPACE", "allowed_base_paths", "") or "")
+        .replace(
             os.pathsep,
             ",",
-        ).split(",")
+        )
+        .split(",")
         if entry.strip()
     )
     raw_values.extend(
         entry.strip()
-        for entry in str(os.getenv("ACP_WORKSPACE_ALLOWED_BASE_PATHS", "") or "").replace(
+        for entry in str(os.getenv("ACP_WORKSPACE_ALLOWED_BASE_PATHS", "") or "")
+        .replace(
             os.pathsep,
             ",",
-        ).split(",")
+        )
+        .split(",")
         if entry.strip()
     )
 
@@ -766,8 +759,7 @@ def _validate_workspace_root(root_path: str) -> str:
             detail={
                 "code": "workspace_root_not_allowed",
                 "message": (
-                    "root_path must be under ACP-WORKSPACE.allowed_base_paths "
-                    "or ACP_WORKSPACE_ALLOWED_BASE_PATHS."
+                    "root_path must be under ACP-WORKSPACE.allowed_base_paths " "or ACP_WORKSPACE_ALLOWED_BASE_PATHS."
                 ),
             },
         )
@@ -823,7 +815,9 @@ class ACPWorkspaceCreateRequest(BaseModel):
     description: str = Field(default="", description="Workspace description")
     workspace_type: str = Field(default="manual", description="manual | discovered | monorepo_child")
     parent_workspace_id: int | None = Field(default=None, description="Parent workspace ID for monorepo children")
-    env_vars: dict[str, str] = Field(default_factory=dict, description="Environment variables for sessions (stored as plaintext)")
+    env_vars: dict[str, str] = Field(
+        default_factory=dict, description="Environment variables for sessions (stored as plaintext)"
+    )
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("workspace_type")
@@ -853,9 +847,7 @@ class CanonicalWorkspaceBridgeRequest(BaseModel):
         default="",
         description="Optional ACP execution workspace description",
     )
-    canonical_workspace_source: str = Field(
-        default=CANONICAL_WORKSPACE_SOURCE_RESEARCH_WORKSPACE
-    )
+    canonical_workspace_source: str = Field(default=CANONICAL_WORKSPACE_SOURCE_RESEARCH_WORKSPACE)
     env_vars: dict[str, str] = Field(default_factory=dict)
     metadata: dict[str, Any] = Field(default_factory=dict)
 
@@ -871,9 +863,7 @@ class CanonicalWorkspaceBridgeRequest(BaseModel):
     @classmethod
     def check_canonical_workspace_source(cls, value: str) -> str:
         if value not in _VALID_CANONICAL_WORKSPACE_SOURCES:
-            raise ValueError(
-                f"canonical_workspace_source must be one of {_VALID_CANONICAL_WORKSPACE_SOURCES}"
-            )
+            raise ValueError(f"canonical_workspace_source must be one of {_VALID_CANONICAL_WORKSPACE_SOURCES}")
         return value
 
 
@@ -1022,8 +1012,7 @@ def _canonical_workspace_link_from_workspace(workspace: Any | None) -> dict[str,
             metadata.get(CANONICAL_WORKSPACE_SOURCE_METADATA_KEY)
         ),
         "link_status": str(
-            metadata.get(CANONICAL_WORKSPACE_LINK_STATUS_METADATA_KEY)
-            or CANONICAL_WORKSPACE_LINKED_STATUS
+            metadata.get(CANONICAL_WORKSPACE_LINK_STATUS_METADATA_KEY) or CANONICAL_WORKSPACE_LINKED_STATUS
         ),
     }
 
@@ -1136,10 +1125,7 @@ def _ensure_canonical_workspace_bridge_sync(
         canonical_workspace,
         payload.canonical_workspace_id,
     )
-    workspace_name = (
-        payload.name
-        or f"ACP: {canonical_name} ({payload.canonical_workspace_id})"
-    )
+    workspace_name = payload.name or f"ACP: {canonical_name} ({payload.canonical_workspace_id})"
     return db.find_or_create_canonical_workspace_bridge(
         canonical_workspace_id=payload.canonical_workspace_id,
         canonical_workspace_source=payload.canonical_workspace_source,
@@ -1160,7 +1146,9 @@ def _ensure_canonical_workspace_bridge_sync(
     "/workspaces",
     response_model=ACPWorkspaceResponse,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))
+    ],
 )
 async def create_workspace(
     payload: ACPWorkspaceCreateRequest,
@@ -1170,15 +1158,17 @@ async def create_workspace(
     validated_path = _validate_workspace_root(payload.root_path)
     db = get_orchestration_db(_user_id_int(user))
     try:
-        ws = await _run_sync(lambda: db.create_workspace(
-            name=payload.name,
-            root_path=validated_path,
-            description=payload.description,
-            workspace_type=payload.workspace_type,
-            parent_workspace_id=payload.parent_workspace_id,
-            env_vars=payload.env_vars,
-            metadata=payload.metadata,
-        ))
+        ws = await _run_sync(
+            lambda: db.create_workspace(
+                name=payload.name,
+                root_path=validated_path,
+                description=payload.description,
+                workspace_type=payload.workspace_type,
+                parent_workspace_id=payload.parent_workspace_id,
+                env_vars=payload.env_vars,
+                metadata=payload.metadata,
+            )
+        )
     except OrchestrationNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ValueError as exc:
@@ -1189,7 +1179,9 @@ async def create_workspace(
 @router.get(
     "/workspaces",
     response_model=list[ACPWorkspaceResponse],
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.read"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.read"))
+    ],
 )
 async def list_workspaces(
     workspace_type: str | None = Query(default=None, description="Filter by type"),
@@ -1198,10 +1190,12 @@ async def list_workspaces(
 ) -> list[ACPWorkspaceResponse]:
     """List all workspaces for the current user."""
     db = get_orchestration_db(_user_id_int(user))
-    workspaces = await _run_sync(lambda: db.list_workspaces(
-        workspace_type=workspace_type,
-        health_status=health_status,
-    ))
+    workspaces = await _run_sync(
+        lambda: db.list_workspaces(
+            workspace_type=workspace_type,
+            health_status=health_status,
+        )
+    )
     return [ACPWorkspaceResponse(**_workspace_response_payload(ws)) for ws in workspaces]
 
 
@@ -1209,7 +1203,9 @@ async def list_workspaces(
     "/workspaces/canonical-bridge",
     response_model=ACPWorkspaceResponse,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))
+    ],
 )
 async def ensure_canonical_workspace_bridge(
     payload: CanonicalWorkspaceBridgeRequest,
@@ -1217,9 +1213,7 @@ async def ensure_canonical_workspace_bridge(
     canonical_db: CharactersRAGDB = Depends(get_chacha_db_for_user),
 ) -> ACPWorkspaceResponse:
     """Find or create an ACP execution workspace linked to a canonical workspace."""
-    canonical_workspace = await _run_sync(
-        lambda: canonical_db.get_workspace(payload.canonical_workspace_id)
-    )
+    canonical_workspace = await _run_sync(lambda: canonical_db.get_workspace(payload.canonical_workspace_id))
     if not canonical_workspace:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
@@ -1246,7 +1240,9 @@ async def ensure_canonical_workspace_bridge(
 @router.get(
     "/workspaces/{workspace_id}",
     response_model=ACPWorkspaceResponse,
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.read"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.read"))
+    ],
 )
 async def get_workspace(
     workspace_id: int,
@@ -1263,10 +1259,7 @@ async def get_workspace(
 
     d = ws.to_dict()
     d["canonical_workspace"] = _canonical_workspace_link_from_workspace(ws)
-    d["children"] = [
-        ACPWorkspaceResponse(**_workspace_response_payload(c)).model_dump()
-        for c in children
-    ]
+    d["children"] = [ACPWorkspaceResponse(**_workspace_response_payload(c)).model_dump() for c in children]
     d["mcp_servers"] = mcp_servers
     return ACPWorkspaceResponse(**d)
 
@@ -1274,7 +1267,9 @@ async def get_workspace(
 @router.put(
     "/workspaces/{workspace_id}",
     response_model=ACPWorkspaceResponse,
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))
+    ],
 )
 async def update_workspace(
     workspace_id: int,
@@ -1300,7 +1295,9 @@ async def update_workspace(
 
 @router.delete(
     "/workspaces/{workspace_id}",
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))
+    ],
 )
 async def delete_workspace(
     workspace_id: int,
@@ -1321,7 +1318,9 @@ async def delete_workspace(
 
 @router.get(
     "/workspaces/{workspace_id}/health",
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.read"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.read"))
+    ],
 )
 async def check_workspace_health(
     workspace_id: int,
@@ -1334,26 +1333,31 @@ async def check_workspace_health(
         raise HTTPException(status_code=404, detail="Workspace not found")
 
     from tldw_Server_API.app.services.workspace_health_service import WorkspaceHealthService
+
     svc = WorkspaceHealthService()
     result = await svc.check_health(ws)
 
     # Persist health update
-    await _run_sync(lambda: db.update_workspace_health(
-        workspace_id=ws.id,
-        health_status=result.health_status,
-        git_remote_url=result.git_remote_url,
-        git_default_branch=result.git_default_branch,
-        git_current_branch=result.git_current_branch,
-        git_is_dirty=result.git_is_dirty,
-        last_health_check=result.checked_at,
-    ))
+    await _run_sync(
+        lambda: db.update_workspace_health(
+            workspace_id=ws.id,
+            health_status=result.health_status,
+            git_remote_url=result.git_remote_url,
+            git_default_branch=result.git_default_branch,
+            git_current_branch=result.git_current_branch,
+            git_is_dirty=result.git_is_dirty,
+            last_health_check=result.checked_at,
+        )
+    )
 
     return result.to_dict()
 
 
 @router.post(
     "/workspaces/health/refresh-all",
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))
+    ],
 )
 async def refresh_all_workspace_health(
     user: User = Depends(get_request_user),
@@ -1362,6 +1366,7 @@ async def refresh_all_workspace_health(
     db = get_orchestration_db(_user_id_int(user))
 
     from tldw_Server_API.app.services.workspace_health_service import WorkspaceHealthService
+
     svc = WorkspaceHealthService()
     results = await svc.refresh_all(db)
     return [r.to_dict() for r in results]
@@ -1374,7 +1379,9 @@ async def refresh_all_workspace_health(
 
 @router.get(
     "/workspaces/{workspace_id}/mcp-servers",
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.read"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.read"))
+    ],
 )
 async def list_workspace_mcp_servers(
     workspace_id: int,
@@ -1392,7 +1399,9 @@ async def list_workspace_mcp_servers(
 @router.post(
     "/workspaces/{workspace_id}/mcp-servers",
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))
+    ],
 )
 async def create_workspace_mcp_server(
     workspace_id: int,
@@ -1402,16 +1411,18 @@ async def create_workspace_mcp_server(
     """Add an MCP server configuration to a workspace."""
     db = get_orchestration_db(_user_id_int(user))
     try:
-        server = await _run_sync(lambda: db.create_workspace_mcp_server(
-            workspace_id=workspace_id,
-            server_name=payload.server_name,
-            server_type=payload.server_type,
-            command=payload.command,
-            args=payload.args,
-            env=payload.env,
-            url=payload.url,
-            enabled=payload.enabled,
-        ))
+        server = await _run_sync(
+            lambda: db.create_workspace_mcp_server(
+                workspace_id=workspace_id,
+                server_name=payload.server_name,
+                server_type=payload.server_type,
+                command=payload.command,
+                args=payload.args,
+                env=payload.env,
+                url=payload.url,
+                enabled=payload.enabled,
+            )
+        )
     except OrchestrationNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ValueError as exc:
@@ -1421,7 +1432,9 @@ async def create_workspace_mcp_server(
 
 @router.delete(
     "/workspaces/{workspace_id}/mcp-servers/{server_id}",
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))
+    ],
 )
 async def delete_workspace_mcp_server(
     workspace_id: int,
@@ -1431,9 +1444,7 @@ async def delete_workspace_mcp_server(
     """Remove an MCP server from a workspace."""
     db = get_orchestration_db(_user_id_int(user))
     # Single atomic delete that verifies workspace ownership
-    deleted = await _run_sync(
-        lambda: db.delete_workspace_mcp_server(workspace_id, server_id)
-    )
+    deleted = await _run_sync(lambda: db.delete_workspace_mcp_server(workspace_id, server_id))
     if not deleted:
         raise HTTPException(
             status_code=404,
@@ -1449,7 +1460,9 @@ async def delete_workspace_mcp_server(
 
 @router.post(
     "/workspaces/discover",
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))
+    ],
 )
 async def discover_workspaces(
     payload: WorkspaceDiscoverRequest,
@@ -1466,6 +1479,7 @@ async def discover_workspaces(
 
     # Read config defaults for discovery
     from tldw_Server_API.app.core.config import get_config_value as _gcv
+
     max_depth = payload.max_depth
     patterns = payload.patterns
     if patterns is None:
@@ -1474,6 +1488,7 @@ async def discover_workspaces(
             patterns = [p.strip() for p in config_patterns.split(",") if p.strip()]
 
     from tldw_Server_API.app.services.workspace_discovery_service import WorkspaceDiscoveryService
+
     svc = WorkspaceDiscoveryService()
     candidates = await svc.discover(
         base_path=validated_path,
@@ -1493,7 +1508,9 @@ async def discover_workspaces(
     "/projects",
     response_model=ProjectResponse,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.projects.manage"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.projects.manage"))
+    ],
 )
 async def create_project(
     payload: ProjectCreateRequest,
@@ -1502,12 +1519,14 @@ async def create_project(
     """Create a new agent project."""
     db = get_orchestration_db(_user_id_int(user))
     try:
-        project = await _run_sync(lambda: db.create_project(
-            name=payload.name,
-            description=payload.description,
-            workspace_id=payload.workspace_id,
-            metadata=payload.metadata,
-        ))
+        project = await _run_sync(
+            lambda: db.create_project(
+                name=payload.name,
+                description=payload.description,
+                workspace_id=payload.workspace_id,
+                metadata=payload.metadata,
+            )
+        )
     except OrchestrationNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     d = project.to_dict()
@@ -1523,7 +1542,9 @@ async def create_project(
 @router.get(
     "/projects",
     response_model=list[ProjectResponse],
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.projects.read"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.projects.read"))
+    ],
 )
 async def list_projects(
     workspace_id: int | None = Query(default=None, description="Filter by workspace ID (omit for all)"),
@@ -1541,9 +1562,7 @@ async def list_projects(
     """List projects for the current user, optionally filtered by workspace."""
     db = get_orchestration_db(_user_id_int(user))
     canonical_filter_id = str(canonical_workspace_id or "").strip()
-    canonical_filter_source = _normalize_canonical_workspace_filter_source(
-        canonical_workspace_source
-    )
+    canonical_filter_source = _normalize_canonical_workspace_filter_source(canonical_workspace_source)
 
     def _list() -> list[dict[str, Any]]:
         if workspace_id is not None:
@@ -1552,9 +1571,7 @@ async def list_projects(
             projects = db.list_projects(workspace_id=None)
         else:
             projects = db.list_projects()
-        workspaces_by_id = db.get_workspaces_by_ids([
-            p.workspace_id for p in projects if p.workspace_id
-        ])
+        workspaces_by_id = db.get_workspaces_by_ids([p.workspace_id for p in projects if p.workspace_id])
         results = []
         for p in projects:
             d = p.to_dict()
@@ -1584,7 +1601,9 @@ async def list_projects(
 @router.get(
     "/projects/{project_id}",
     response_model=ProjectResponse,
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.projects.read"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.projects.read"))
+    ],
 )
 async def get_project(
     project_id: int,
@@ -1609,7 +1628,9 @@ async def get_project(
 
 @router.delete(
     "/projects/{project_id}",
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.projects.manage"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.projects.manage"))
+    ],
 )
 async def delete_project(
     project_id: int,
@@ -1633,7 +1654,9 @@ async def delete_project(
     "/projects/{project_id}/tasks",
     response_model=TaskResponse,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.manage"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.manage"))
+    ],
 )
 async def create_task(
     project_id: int,
@@ -1646,17 +1669,19 @@ async def create_task(
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")
     try:
-        task = await _run_sync(lambda: db.create_task(
-            project_id=project_id,
-            title=payload.title,
-            description=payload.description,
-            agent_type=payload.agent_type,
-            dependency_id=payload.dependency_id,
-            reviewer_agent_type=payload.reviewer_agent_type,
-            max_review_attempts=payload.max_review_attempts,
-            success_criteria=payload.success_criteria,
-            metadata=payload.metadata,
-        ))
+        task = await _run_sync(
+            lambda: db.create_task(
+                project_id=project_id,
+                title=payload.title,
+                description=payload.description,
+                agent_type=payload.agent_type,
+                dependency_id=payload.dependency_id,
+                reviewer_agent_type=payload.reviewer_agent_type,
+                max_review_attempts=payload.max_review_attempts,
+                success_criteria=payload.success_criteria,
+                metadata=payload.metadata,
+            )
+        )
     except CycleDependencyError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -1672,7 +1697,9 @@ async def create_task(
 @router.get(
     "/projects/{project_id}/tasks",
     response_model=list[TaskResponse],
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.read"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.read"))
+    ],
 )
 async def list_tasks(
     project_id: int,
@@ -1700,7 +1727,9 @@ async def list_tasks(
 @router.get(
     "/tasks/{task_id}",
     response_model=TaskResponse,
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.read"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.read"))
+    ],
 )
 async def get_task(
     task_id: int,
@@ -1727,11 +1756,7 @@ async def get_task(
     if project and project.workspace_id:
         workspace = await _run_sync(lambda: db.get_workspace(project.workspace_id))
         d["canonical_workspace"] = _canonical_workspace_link_from_workspace(workspace)
-    d["reviews"] = (
-        _redact_task_review_payloads(reviews)
-        if run_summary_mode == _RUN_SUMMARY_MODE_REDACTED
-        else reviews
-    )
+    d["reviews"] = _redact_task_review_payloads(reviews) if run_summary_mode == _RUN_SUMMARY_MODE_REDACTED else reviews
     d["runs"] = await _enrich_task_runs(
         runs,
         reviews,
@@ -1748,7 +1773,9 @@ async def get_task(
 
 @router.post(
     "/tasks/{task_id}/run",
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.manage"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.manage"))
+    ],
 )
 async def dispatch_run(
     task_id: int,
@@ -1774,8 +1801,7 @@ async def dispatch_run(
             detail=f"Task dependency {task.dependency_id} is not complete",
         )
 
-    active_runs = await _run_sync(lambda: db.list_runs(task_id))
-    if any(run.status == RunStatus.RUNNING for run in active_runs):
+    if await _run_sync(lambda: db.has_running_run(task_id)):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="Task already has a running run",
@@ -1795,9 +1821,7 @@ async def dispatch_run(
     # Gather workspace MCP servers for injection
     workspace_mcp_servers: list[dict[str, Any]] = []
     if workspace:
-        workspace_mcp_servers = await _run_sync(
-            lambda: db.list_workspace_mcp_servers(workspace.id)
-        )
+        workspace_mcp_servers = await _run_sync(lambda: db.list_workspace_mcp_servers(workspace.id))
 
     # Convert workspace MCP servers to create_session format
     mcp_servers_param: list[dict[str, Any]] | None = None
@@ -1820,6 +1844,7 @@ async def dispatch_run(
     session_id: str | None = None
     agent_type = payload.agent_type or task.agent_type
     run = None
+    client = None
     try:
         from tldw_Server_API.app.core.Agent_Client_Protocol.runner_client import get_runner_client
         from tldw_Server_API.app.services.admin_acp_sessions_service import get_acp_session_store
@@ -1834,14 +1859,8 @@ async def dispatch_run(
             )
 
         if task.status != TaskStatus.IN_PROGRESS:
-            task = await _run_sync(
-                lambda: db.transition_task(task_id, TaskStatus.IN_PROGRESS)
-            )
+            task = await _run_sync(lambda: db.transition_task(task_id, TaskStatus.IN_PROGRESS))
 
-        run = await _run_sync(lambda: db.create_run(
-            task_id,
-            agent_type=agent_type,
-        ))
         client = await get_runner_client()
         session_id = await client.create_session(
             effective_cwd,
@@ -1850,7 +1869,17 @@ async def dispatch_run(
             user_id=user.id,
             session_env=session_env_param,
         )
-        run = await _run_sync(lambda: db.update_run_session_id(run.id, session_id))
+        try:
+            run = await _run_sync(
+                lambda: db.create_run(
+                    task_id,
+                    agent_type=agent_type,
+                    session_id=session_id,
+                )
+            )
+        except (InvalidTransitionError, OrchestrationNotFoundError):
+            await _close_acp_session_safely(client, session_id)
+            raise
 
         # Register in session store
         try:
@@ -1869,19 +1898,12 @@ async def dispatch_run(
     except OrchestrationNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except InvalidTransitionError as exc:
-        status_code = (
-            status.HTTP_409_CONFLICT
-            if "running run" in str(exc)
-            else status.HTTP_400_BAD_REQUEST
-        )
-        detail = (
-            "Task already has a running run"
-            if status_code == status.HTTP_409_CONFLICT
-            else str(exc)
-        )
+        status_code = status.HTTP_409_CONFLICT if "running run" in str(exc) else status.HTTP_400_BAD_REQUEST
+        detail = "Task already has a running run" if status_code == status.HTTP_409_CONFLICT else str(exc)
         raise HTTPException(status_code=status_code, detail=detail) from exc
     except Exception as exc:
         logger.exception("Failed to create ACP session")
+        await _close_acp_session_safely(client, session_id)
         if run is not None:
             await _run_sync(lambda: db.fail_run(run.id, error=SESSION_CREATE_FAILED))
             triaged_task = await _run_sync(lambda: db.transition_task(task_id, TaskStatus.TRIAGE))
@@ -1891,6 +1913,15 @@ async def dispatch_run(
                 task=triaged_task,
                 session_id=session_id,
                 run_id=run.id,
+                metadata={"reason_code": SESSION_CREATE_FAILED},
+            )
+        elif task.status == TaskStatus.IN_PROGRESS:
+            triaged_task = await _run_sync(lambda: db.transition_task(task_id, TaskStatus.TRIAGE))
+            _record_orchestration_audit_event(
+                action="orchestration_task_triaged",
+                user=user,
+                task=triaged_task,
+                session_id=session_id,
                 metadata={"reason_code": SESSION_CREATE_FAILED},
             )
         raise HTTPException(
@@ -1925,6 +1956,7 @@ async def dispatch_run(
             run_id=run.id,
             metadata={"reason_code": PROMPT_FAILED},
         )
+        await _close_acp_session_safely(client, session_id)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="ACP prompt failed",
@@ -1944,16 +1976,19 @@ async def dispatch_run(
             run_id=run.id,
             metadata={"reason_code": COMPLETION_SIGNAL_INVALID, "completion_signal_reason": exc.reason},
         )
+        await _close_acp_session_safely(client, session_id)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="ACP completion signal invalid",
         ) from exc
 
-    await _run_sync(lambda: db.complete_run(
-        run.id,
-        result_summary=completion_signal.summary,
-        token_usage=result.get("usage", {}),
-    ))
+    await _run_sync(
+        lambda: db.complete_run(
+            run.id,
+            result_summary=completion_signal.summary,
+            token_usage=result.get("usage", {}),
+        )
+    )
     task = await _run_sync(lambda: db.transition_task(task_id, TaskStatus.REVIEW))
     _record_orchestration_audit_event(
         action="orchestration_task_completed",
@@ -1991,11 +2026,13 @@ async def dispatch_run(
             except Exception:
                 logger.warning("Failed to register orchestration ACP review session")
 
-            review_run = await _run_sync(lambda: db.create_run(
-                task_id,
-                agent_type=task.reviewer_agent_type,
-                session_id=review_session_id,
-            ))
+            review_run = await _run_sync(
+                lambda: db.create_run(
+                    task_id,
+                    agent_type=task.reviewer_agent_type,
+                    session_id=review_session_id,
+                )
+            )
             _record_orchestration_audit_event(
                 action="orchestration_review_started",
                 user=user,
@@ -2013,18 +2050,22 @@ async def dispatch_run(
             review_error = REVIEW_DECISION_INVALID
             logger.warning("ACP review decision invalid for task {}: {}", task_id, exc)
             if review_run is None:
-                review_run = await _run_sync(lambda: db.create_run(
-                    task_id,
-                    agent_type=task.reviewer_agent_type,
-                    session_id=review_session_id,
-                ))
+                review_run = await _run_sync(
+                    lambda: db.create_run(
+                        task_id,
+                        agent_type=task.reviewer_agent_type,
+                        session_id=review_session_id,
+                    )
+                )
             await _run_sync(lambda: db.fail_run(review_run.id, error=review_error))
-            task = await _run_sync(lambda: db.submit_review(
-                task_id,
-                False,
-                review_error,
-                reviewer=task.reviewer_agent_type,
-            ))
+            task = await _run_sync(
+                lambda: db.submit_review(
+                    task_id,
+                    False,
+                    review_error,
+                    reviewer=task.reviewer_agent_type,
+                )
+            )
             _record_orchestration_audit_event(
                 action="orchestration_review_decision",
                 user=user,
@@ -2043,18 +2084,22 @@ async def dispatch_run(
             review_error = REVIEWER_FAILED
             logger.exception("ACP reviewer failed")
             if review_run is None:
-                review_run = await _run_sync(lambda: db.create_run(
-                    task_id,
-                    agent_type=task.reviewer_agent_type,
-                    session_id=review_session_id,
-                ))
+                review_run = await _run_sync(
+                    lambda: db.create_run(
+                        task_id,
+                        agent_type=task.reviewer_agent_type,
+                        session_id=review_session_id,
+                    )
+                )
             await _run_sync(lambda: db.fail_run(review_run.id, error=review_error))
-            task = await _run_sync(lambda: db.submit_review(
-                task_id,
-                False,
-                review_error,
-                reviewer=task.reviewer_agent_type,
-            ))
+            task = await _run_sync(
+                lambda: db.submit_review(
+                    task_id,
+                    False,
+                    review_error,
+                    reviewer=task.reviewer_agent_type,
+                )
+            )
             _record_orchestration_audit_event(
                 action="orchestration_review_decision",
                 user=user,
@@ -2069,19 +2114,23 @@ async def dispatch_run(
                 },
             )
         else:
-            await _run_sync(lambda: db.complete_run(
-                review_run.id,
-                result_summary=review_decision.feedback,
-                token_usage=review_result.get("usage", {}),
-            ))
+            await _run_sync(
+                lambda: db.complete_run(
+                    review_run.id,
+                    result_summary=review_decision.feedback,
+                    token_usage=review_result.get("usage", {}),
+                )
+            )
             review_decision_for_promotion = review_decision
             review_run_for_promotion = review_run
-            task = await _run_sync(lambda: db.submit_review(
-                task_id,
-                review_decision.approved,
-                review_decision.feedback,
-                reviewer=task.reviewer_agent_type,
-            ))
+            task = await _run_sync(
+                lambda: db.submit_review(
+                    task_id,
+                    review_decision.approved,
+                    review_decision.feedback,
+                    reviewer=task.reviewer_agent_type,
+                )
+            )
             _record_orchestration_audit_event(
                 action="orchestration_review_decision",
                 user=user,
@@ -2192,7 +2241,9 @@ async def dispatch_run(
 @router.post(
     "/tasks/{task_id}/review",
     response_model=TaskResponse,
-    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.manage"))],
+    dependencies=[
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.manage"))
+    ],
 )
 async def submit_review(
     task_id: int,
@@ -2208,12 +2259,14 @@ async def submit_review(
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
     try:
-        updated = await _run_sync(lambda: db.submit_review(
-            task_id,
-            payload.approved,
-            payload.feedback,
-            reviewer="manual",
-        ))
+        updated = await _run_sync(
+            lambda: db.submit_review(
+                task_id,
+                payload.approved,
+                payload.feedback,
+                reviewer="manual",
+            )
+        )
         _record_orchestration_audit_event(
             action="orchestration_review_decision",
             user=user,

--- a/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
@@ -27,10 +27,10 @@ from tldw_Server_API.app.core.Agent_Orchestration.completion_signals import (
     validate_review_decision_signal,
     validate_task_completion_signal,
 )
-from tldw_Server_API.app.core.Agent_Orchestration.models import ACPWorkspace, TaskStatus
+from tldw_Server_API.app.core.Agent_Orchestration.db_factory import get_orchestration_db
+from tldw_Server_API.app.core.Agent_Orchestration.models import ACPWorkspace, RunStatus, TaskStatus
 from tldw_Server_API.app.core.Agent_Orchestration.orchestration_service import (
     CycleDependencyError,
-    get_orchestration_db,
 )
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.Orchestration_DB import (
@@ -1774,11 +1774,12 @@ async def dispatch_run(
             detail=f"Task dependency {task.dependency_id} is not complete",
         )
 
-    # Transition to in_progress
-    try:
-        await _run_sync(lambda: db.transition_task(task_id, TaskStatus.IN_PROGRESS))
-    except (InvalidTransitionError, ValueError) as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    active_runs = await _run_sync(lambda: db.list_runs(task_id))
+    if any(run.status == RunStatus.RUNNING for run in active_runs):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Task already has a running run",
+        )
 
     # --- CWD resolution: explicit > workspace root > "." ---
     project = await _run_sync(lambda: db.get_project(task.project_id))
@@ -1818,6 +1819,7 @@ async def dispatch_run(
     # Create ACP session
     session_id: str | None = None
     agent_type = payload.agent_type or task.agent_type
+    run = None
     try:
         from tldw_Server_API.app.core.Agent_Client_Protocol.runner_client import get_runner_client
         from tldw_Server_API.app.services.admin_acp_sessions_service import get_acp_session_store
@@ -1831,6 +1833,15 @@ async def dispatch_run(
                 detail=quota_error,
             )
 
+        if task.status != TaskStatus.IN_PROGRESS:
+            task = await _run_sync(
+                lambda: db.transition_task(task_id, TaskStatus.IN_PROGRESS)
+            )
+
+        run = await _run_sync(lambda: db.create_run(
+            task_id,
+            agent_type=agent_type,
+        ))
         client = await get_runner_client()
         session_id = await client.create_session(
             effective_cwd,
@@ -1839,6 +1850,7 @@ async def dispatch_run(
             user_id=user.id,
             session_env=session_env_param,
         )
+        run = await _run_sync(lambda: db.update_run_session_id(run.id, session_id))
 
         # Register in session store
         try:
@@ -1854,30 +1866,37 @@ async def dispatch_run(
 
     except HTTPException:
         raise
+    except OrchestrationNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except InvalidTransitionError as exc:
+        status_code = (
+            status.HTTP_409_CONFLICT
+            if "running run" in str(exc)
+            else status.HTTP_400_BAD_REQUEST
+        )
+        detail = (
+            "Task already has a running run"
+            if status_code == status.HTTP_409_CONFLICT
+            else str(exc)
+        )
+        raise HTTPException(status_code=status_code, detail=detail) from exc
     except Exception as exc:
         logger.exception("Failed to create ACP session")
-        # Create a failed run record
-        run = await _run_sync(lambda: db.create_run(task_id, agent_type=agent_type))
-        await _run_sync(lambda: db.fail_run(run.id, error=SESSION_CREATE_FAILED))
-        triaged_task = await _run_sync(lambda: db.transition_task(task_id, TaskStatus.TRIAGE))
-        _record_orchestration_audit_event(
-            action="orchestration_task_triaged",
-            user=user,
-            task=triaged_task,
-            run_id=run.id,
-            metadata={"reason_code": SESSION_CREATE_FAILED},
-        )
+        if run is not None:
+            await _run_sync(lambda: db.fail_run(run.id, error=SESSION_CREATE_FAILED))
+            triaged_task = await _run_sync(lambda: db.transition_task(task_id, TaskStatus.TRIAGE))
+            _record_orchestration_audit_event(
+                action="orchestration_task_triaged",
+                user=user,
+                task=triaged_task,
+                session_id=session_id,
+                run_id=run.id,
+                metadata={"reason_code": SESSION_CREATE_FAILED},
+            )
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="Failed to create ACP session",
         ) from exc
-
-    # Create run record
-    run = await _run_sync(lambda: db.create_run(
-        task_id,
-        agent_type=payload.agent_type or task.agent_type,
-        session_id=session_id,
-    ))
     _record_orchestration_audit_event(
         action="orchestration_dispatch_started",
         user=user,

--- a/tldw_Server_API/app/core/Agent_Orchestration/README.md
+++ b/tldw_Server_API/app/core/Agent_Orchestration/README.md
@@ -5,7 +5,8 @@ Agent_Orchestration coordinates ACP-backed workspaces, projects, tasks, runs, re
 ## Start Here
 
 - `models.py` defines workspaces, projects, tasks, runs, task statuses, run statuses, and valid state transitions.
-- `orchestration_service.py` contains the service-level task and run orchestration rules.
+- `db_factory.py` exposes the production per-user SQLite factory.
+- `orchestration_service.py` is a legacy in-memory service retained for older service-level tests.
 - `completion_signals.py` parses structured ACP completion and review markers.
 - `artifact_promotion.py` promotes accepted ACP work products into workspace artifacts.
 - Related API surface: `tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py`, declared under `/agent-orchestration`.
@@ -25,7 +26,8 @@ Agent_Orchestration coordinates ACP-backed workspaces, projects, tasks, runs, re
 ## Module Map
 
 - `models.py`: dataclasses, enums, and state-transition helpers.
-- `orchestration_service.py`: orchestration operations, dependency checks, review handling, and run coordination.
+- `db_factory.py`: cached per-user `OrchestrationDB` construction for production callers.
+- `orchestration_service.py`: legacy in-memory orchestration operations used by older tests.
 - `completion_signals.py`: parsing and validation for structured ACP completion and review markers.
 - `artifact_promotion.py`: conversion of accepted ACP work products into durable workspace artifacts.
 - `__init__.py`: package marker.
@@ -62,22 +64,22 @@ Agent_Orchestration coordinates ACP-backed workspaces, projects, tasks, runs, re
 
 ### Extension Checklist
 
-- New task or run state: update `models.py`, `orchestration_service.py`, `DB_Management/Orchestration_DB.py`, API schemas, and service/API tests.
+- New task or run state: update `models.py`, `DB_Management/Orchestration_DB.py`, API schemas, and DB/API tests.
 - New completion or review marker: update `completion_signals.py`, endpoint review handling, parser tests, and orchestration API tests.
 - New promotable artifact type: update `artifact_promotion.py`, workspace artifact expectations, and `tests/Agent_Orchestration/test_artifact_promotion_contract.py`.
 
 ## Extension Points
 
-- Add a task transition by starting in `models.py`, then update `orchestration_service.py`, API schemas, and tests.
+- Add a task transition by starting in `models.py`, then update `DB_Management/Orchestration_DB.py`, API schemas, and tests.
 - Add new completion or review payload fields in `completion_signals.py` before changing endpoint behavior.
 - Add a promotable artifact type in `artifact_promotion.py` and verify the corresponding workspace artifact storage contract.
 - Extend workspace discovery or health behavior in `agent_orchestration.py` together with `Orchestration_DB.py`.
-- Change run creation or reviewer behavior by inspecting `orchestration_service.py` and ACP runner interactions first.
+- Change run creation or reviewer behavior by inspecting `DB_Management/Orchestration_DB.py`, `agent_orchestration.py`, and ACP runner interactions first.
 
 ## Testing
 
 - Direct tests live under `tldw_Server_API/tests/Agent_Orchestration/`.
-- Use `test_orchestration_service.py` for service-level task and run rules.
+- Use `test_orchestration_service.py` for legacy in-memory service behavior.
 - Use `test_orchestration_api.py` for route behavior.
 - Use `test_orchestration_db.py`, `test_workspace_db.py`, and workspace discovery or health tests for persistence changes.
 - Use `test_artifact_promotion.py` and `test_artifact_promotion_contract.py` for promoted work-product behavior.

--- a/tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py
+++ b/tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py
@@ -1,4 +1,5 @@
 """Promotion helpers for ACP deliverables that become workspace artifacts."""
+
 from __future__ import annotations
 
 import sqlite3
@@ -85,18 +86,14 @@ def promote_acp_completion_artifacts(
     if not completion_signal.artifacts:
         return result
     if len(completion_signal.artifacts) > MAX_COMPLETION_ARTIFACTS:
-        return ACPArtifactPromotionResult(
-            errors=[{"artifact_id": "all", "reason": "too_many_artifacts"}]
-        )
+        return ACPArtifactPromotionResult(errors=[{"artifact_id": "all", "reason": "too_many_artifacts"}])
 
     decision = _promotion_decision(final_status, review_decision)
     target_workspace_id = _target_workspace_id(workspace)
     existing_by_id: dict[str, dict[str, Any]] = {}
     if target_workspace_id and note_db.get_workspace(target_workspace_id):
         existing_by_id = {
-            str(item["id"]): item
-            for item in note_db.list_workspace_artifacts(target_workspace_id)
-            if item.get("id")
+            str(item["id"]): item for item in note_db.list_workspace_artifacts(target_workspace_id) if item.get("id")
         }
 
     for index, raw_artifact in enumerate(completion_signal.artifacts):
@@ -199,24 +196,24 @@ def _target_workspace_id(workspace: ACPWorkspace | None) -> str | None:
 
 def _artifact_identifier(raw_artifact: Any, *, task: AgentTask, run: AgentRun, index: int) -> str:
     if isinstance(raw_artifact, Mapping):
-        artifact_id = (
-            raw_artifact.get("id")
-            or raw_artifact.get("artifact_id")
-            or raw_artifact.get("root_artifact_id")
-        )
+        artifact_id = raw_artifact.get("id") or raw_artifact.get("artifact_id") or raw_artifact.get("root_artifact_id")
         if artifact_id:
             return str(artifact_id)
     return f"acp-task-{task.id}-run-{run.id}-{index + 1}"
 
 
 def _artifact_type(artifact: Mapping[str, Any]) -> str:
-    return str(
-        artifact.get("artifact_type")
-        or artifact.get("type")
-        or artifact.get("kind")
-        or artifact.get("promote_as")
-        or ""
-    ).strip().lower()
+    return (
+        str(
+            artifact.get("artifact_type")
+            or artifact.get("type")
+            or artifact.get("kind")
+            or artifact.get("promote_as")
+            or ""
+        )
+        .strip()
+        .lower()
+    )
 
 
 def _is_promotable_artifact(artifact: Mapping[str, Any]) -> bool:
@@ -224,10 +221,12 @@ def _is_promotable_artifact(artifact: Mapping[str, Any]) -> bool:
 
 
 def _validate_artifact_payload(
-    artifact: Mapping[str, Any],
+    artifact: Any,
     target_workspace_id: str | None,
     note_db: CharactersRAGDB,
 ) -> str | None:
+    if not isinstance(artifact, Mapping):
+        return "invalid_artifact_format"
     if not target_workspace_id:
         return "missing_workspace"
     if note_db.get_workspace(target_workspace_id) is None:
@@ -255,10 +254,7 @@ def _validate_artifact_payload(
     export_refs = artifact.get("export_refs")
     if export_refs is not None and not isinstance(export_refs, (list, tuple)):
         return "invalid_export_refs"
-    if (
-        export_refs is not None
-        and len(export_refs) > MAX_PROMOTED_ARTIFACT_EXPORT_REFS
-    ):
+    if export_refs is not None and len(export_refs) > MAX_PROMOTED_ARTIFACT_EXPORT_REFS:
         return "too_many_export_refs"
     if "schema_version" in artifact:
         try:

--- a/tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py
+++ b/tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py
@@ -229,6 +229,8 @@ def _validate_artifact_payload(
         return "invalid_artifact_format"
     if not target_workspace_id:
         return "missing_workspace"
+    if not isinstance(artifact, Mapping):
+        return "invalid_artifact_format"
     if note_db.get_workspace(target_workspace_id) is None:
         return "workspace_not_found"
     title = str(artifact.get("title") or "").strip()

--- a/tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py
+++ b/tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py
@@ -225,12 +225,11 @@ def _validate_artifact_payload(
     target_workspace_id: str | None,
     note_db: CharactersRAGDB,
 ) -> str | None:
+    """Validate a candidate artifact payload before promotion."""
     if not isinstance(artifact, Mapping):
         return "invalid_artifact_format"
     if not target_workspace_id:
         return "missing_workspace"
-    if not isinstance(artifact, Mapping):
-        return "invalid_artifact_format"
     if note_db.get_workspace(target_workspace_id) is None:
         return "workspace_not_found"
     title = str(artifact.get("title") or "").strip()

--- a/tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py
+++ b/tldw_Server_API/app/core/Agent_Orchestration/artifact_promotion.py
@@ -10,6 +10,7 @@ from typing import Any
 from loguru import logger
 
 from tldw_Server_API.app.core.Agent_Orchestration.completion_signals import (
+    MAX_COMPLETION_ARTIFACTS,
     TaskCompletionSignal,
     TaskReviewDecision,
 )
@@ -38,6 +39,10 @@ _PROMOTABLE_ARTIFACT_TYPES = frozenset(
 )
 _DEFAULT_REDACTION = {"support_safe": True, "redacted": False}
 _PREVIEW_TEXT_MAX_CHARS = 500
+MAX_PROMOTED_ARTIFACT_CONTENT_CHARS = 500_000
+MAX_PROMOTED_ARTIFACT_TITLE_CHARS = 1_000
+MAX_PROMOTED_ARTIFACT_SUMMARY_CHARS = 10_000
+MAX_PROMOTED_ARTIFACT_EXPORT_REFS = 50
 _OPTIONAL_MAPPING_FIELDS = {
     "producer_metadata": "invalid_producer_metadata",
     "review_metadata": "invalid_review_metadata",
@@ -79,6 +84,10 @@ def promote_acp_completion_artifacts(
     result = ACPArtifactPromotionResult()
     if not completion_signal.artifacts:
         return result
+    if len(completion_signal.artifacts) > MAX_COMPLETION_ARTIFACTS:
+        return ACPArtifactPromotionResult(
+            errors=[{"artifact_id": "all", "reason": "too_many_artifacts"}]
+        )
 
     decision = _promotion_decision(final_status, review_decision)
     target_workspace_id = _target_workspace_id(workspace)
@@ -223,10 +232,19 @@ def _validate_artifact_payload(
         return "missing_workspace"
     if note_db.get_workspace(target_workspace_id) is None:
         return "workspace_not_found"
-    if not str(artifact.get("title") or "").strip():
+    title = str(artifact.get("title") or "").strip()
+    if not title:
         return "missing_title"
-    if not str(artifact.get("content") or "").strip():
+    if len(title) > MAX_PROMOTED_ARTIFACT_TITLE_CHARS:
+        return "title_too_large"
+    content = str(artifact.get("content") or "").strip()
+    if not content:
         return "missing_content"
+    if len(content) > MAX_PROMOTED_ARTIFACT_CONTENT_CHARS:
+        return "content_too_large"
+    summary = str(artifact.get("summary") or "").strip()
+    if len(summary) > MAX_PROMOTED_ARTIFACT_SUMMARY_CHARS:
+        return "summary_too_large"
     source_lineage = artifact.get("source_lineage")
     if not isinstance(source_lineage, Mapping) or not source_lineage:
         return "missing_source_lineage"
@@ -237,6 +255,11 @@ def _validate_artifact_payload(
     export_refs = artifact.get("export_refs")
     if export_refs is not None and not isinstance(export_refs, (list, tuple)):
         return "invalid_export_refs"
+    if (
+        export_refs is not None
+        and len(export_refs) > MAX_PROMOTED_ARTIFACT_EXPORT_REFS
+    ):
+        return "too_many_export_refs"
     if "schema_version" in artifact:
         try:
             _schema_version(artifact.get("schema_version"))

--- a/tldw_Server_API/app/core/Agent_Orchestration/completion_signals.py
+++ b/tldw_Server_API/app/core/Agent_Orchestration/completion_signals.py
@@ -1,11 +1,11 @@
 """Structured completion signal parsing for ACP orchestration runs."""
+
 from __future__ import annotations
 
 import json
 import re
 from dataclasses import dataclass, field
 from typing import Any
-
 
 _COMPLETION_MARKER_RE = re.compile(
     r"<acp-task-completion>\s*(?P<payload>.*?)\s*</acp-task-completion>",
@@ -32,6 +32,8 @@ _ACCEPTED_STATUSES = {"completed", "complete", "succeeded", "success", "accepted
 _REJECTED_STATUSES = {"rejected", "failed", "failure", "incomplete"}
 MAX_COMPLETION_ARTIFACTS = 20
 MAX_COMPLETION_SIGNAL_JSON_CHARS = 1_000_000
+MAX_COMPLETION_SUMMARY_CHARS = 20_000
+MAX_REVIEW_FEEDBACK_CHARS = 20_000
 
 
 class CompletionSignalValidationError(ValueError):
@@ -71,6 +73,11 @@ class TaskReviewDecision:
 
 def _coerce_payload(candidate: Any) -> dict[str, Any]:
     if isinstance(candidate, dict):
+        if _json_payload_size(candidate) > MAX_COMPLETION_SIGNAL_JSON_CHARS:
+            raise CompletionSignalValidationError(
+                "too_large",
+                "ACP completion signal JSON exceeds maximum size",
+            )
         return dict(candidate)
     if isinstance(candidate, str):
         if len(candidate) > MAX_COMPLETION_SIGNAL_JSON_CHARS:
@@ -91,6 +98,13 @@ def _coerce_payload(candidate: Any) -> dict[str, Any]:
         "malformed",
         "malformed ACP completion signal: payload must be a JSON object",
     )
+
+
+def _json_payload_size(candidate: Any) -> int:
+    try:
+        return len(json.dumps(candidate, separators=(",", ":"), ensure_ascii=False))
+    except (TypeError, ValueError):
+        return MAX_COMPLETION_SIGNAL_JSON_CHARS + 1
 
 
 def _raise_review_error(reason: str, message: str) -> None:
@@ -211,6 +225,11 @@ def validate_task_completion_signal(acp_result: dict[str, Any]) -> TaskCompletio
             "malformed",
             "malformed ACP completion signal: status must be completed",
         )
+    if len(summary) > MAX_COMPLETION_SUMMARY_CHARS:
+        raise CompletionSignalValidationError(
+            "summary_too_large",
+            f"ACP completion summary exceeds limit of {MAX_COMPLETION_SUMMARY_CHARS} characters",
+        )
     if not isinstance(artifacts, list):
         raise CompletionSignalValidationError(
             "malformed",
@@ -255,6 +274,11 @@ def validate_review_decision_signal(acp_result: dict[str, Any]) -> TaskReviewDec
         )
 
     feedback = str(payload.get("feedback") or payload.get("summary") or "").strip()
+    if len(feedback) > MAX_REVIEW_FEEDBACK_CHARS:
+        _raise_review_error(
+            "feedback_too_large",
+            f"ACP review feedback exceeds limit of {MAX_REVIEW_FEEDBACK_CHARS} characters",
+        )
     if not feedback:
         feedback = "Reviewer approved task" if approved else "Reviewer rejected task"
 

--- a/tldw_Server_API/app/core/Agent_Orchestration/completion_signals.py
+++ b/tldw_Server_API/app/core/Agent_Orchestration/completion_signals.py
@@ -30,6 +30,8 @@ _DIRECT_REVIEW_KEYS = (
 
 _ACCEPTED_STATUSES = {"completed", "complete", "succeeded", "success", "accepted"}
 _REJECTED_STATUSES = {"rejected", "failed", "failure", "incomplete"}
+MAX_COMPLETION_ARTIFACTS = 20
+MAX_COMPLETION_SIGNAL_JSON_CHARS = 1_000_000
 
 
 class CompletionSignalValidationError(ValueError):
@@ -71,6 +73,11 @@ def _coerce_payload(candidate: Any) -> dict[str, Any]:
     if isinstance(candidate, dict):
         return dict(candidate)
     if isinstance(candidate, str):
+        if len(candidate) > MAX_COMPLETION_SIGNAL_JSON_CHARS:
+            raise CompletionSignalValidationError(
+                "too_large",
+                "ACP completion signal JSON exceeds maximum size",
+            )
         try:
             loaded = json.loads(candidate)
         except json.JSONDecodeError as exc:
@@ -208,6 +215,11 @@ def validate_task_completion_signal(acp_result: dict[str, Any]) -> TaskCompletio
         raise CompletionSignalValidationError(
             "malformed",
             "malformed ACP completion signal: artifacts must be a list",
+        )
+    if len(artifacts) > MAX_COMPLETION_ARTIFACTS:
+        raise CompletionSignalValidationError(
+            "too_many_artifacts",
+            f"ACP completion signal artifacts exceed limit of {MAX_COMPLETION_ARTIFACTS}",
         )
 
     return TaskCompletionSignal(

--- a/tldw_Server_API/app/core/Agent_Orchestration/completion_signals.py
+++ b/tldw_Server_API/app/core/Agent_Orchestration/completion_signals.py
@@ -101,6 +101,7 @@ def _coerce_payload(candidate: Any) -> dict[str, Any]:
 
 
 def _json_payload_size(candidate: Any) -> int:
+    """Return the serialized payload size, or over-limit for unserializable values."""
     try:
         return len(json.dumps(candidate, separators=(",", ":"), ensure_ascii=False))
     except (TypeError, ValueError):

--- a/tldw_Server_API/app/core/Agent_Orchestration/db_factory.py
+++ b/tldw_Server_API/app/core/Agent_Orchestration/db_factory.py
@@ -1,0 +1,12 @@
+"""Per-user SQLite-backed orchestration DB factory."""
+from __future__ import annotations
+
+import functools
+
+from tldw_Server_API.app.core.DB_Management.Orchestration_DB import OrchestrationDB
+
+
+@functools.lru_cache(maxsize=64)
+def get_orchestration_db(user_id: int) -> OrchestrationDB:
+    """Get or create the current user's durable orchestration DB."""
+    return OrchestrationDB.for_user(int(user_id))

--- a/tldw_Server_API/app/core/Agent_Orchestration/models.py
+++ b/tldw_Server_API/app/core/Agent_Orchestration/models.py
@@ -47,6 +47,20 @@ class RunStatus(str, Enum):
     CANCELLED = "cancelled"
 
 
+_VALID_RUN_TRANSITIONS: dict[RunStatus, set[RunStatus]] = {
+    RunStatus.PENDING: {RunStatus.RUNNING, RunStatus.FAILED, RunStatus.CANCELLED},
+    RunStatus.RUNNING: {RunStatus.COMPLETED, RunStatus.FAILED, RunStatus.CANCELLED},
+    RunStatus.COMPLETED: set(),
+    RunStatus.FAILED: set(),
+    RunStatus.CANCELLED: set(),
+}
+
+
+def is_valid_run_transition(from_status: RunStatus, to_status: RunStatus) -> bool:
+    """Check if a run status transition is allowed."""
+    return to_status in _VALID_RUN_TRANSITIONS.get(from_status, set())
+
+
 @dataclass
 class ACPWorkspace:
     """A persistent workspace binding a project to a filesystem directory.

--- a/tldw_Server_API/app/core/Agent_Orchestration/orchestration_service.py
+++ b/tldw_Server_API/app/core/Agent_Orchestration/orchestration_service.py
@@ -1,7 +1,8 @@
-"""In-memory orchestration service for agent projects, tasks, and runs.
+"""Legacy in-memory orchestration service for agent projects, tasks, and runs.
 
 Provides CRUD operations, dependency gating, cycle detection,
-and reviewer gate logic. A future iteration can persist to SQLite.
+and reviewer gate logic for older service-level tests. Production code uses
+``db_factory.get_orchestration_db`` for durable per-user SQLite state.
 """
 from __future__ import annotations
 
@@ -295,16 +296,6 @@ async def get_orchestration_service() -> OrchestrationService:
     return _service
 
 
-# ---------------------------------------------------------------------------
-# Per-user SQLite-backed factory
-# ---------------------------------------------------------------------------
-
-import functools
-
-from tldw_Server_API.app.core.DB_Management.Orchestration_DB import OrchestrationDB
-
-
-@functools.lru_cache(maxsize=64)
-def get_orchestration_db(user_id: int) -> OrchestrationDB:
-    """Get or create per-user OrchestrationDB instance."""
-    return OrchestrationDB.for_user(user_id)
+# Backward-compatible import for older callers. New production code should
+# import this from Agent_Orchestration.db_factory directly.
+from .db_factory import get_orchestration_db  # noqa: E402

--- a/tldw_Server_API/app/core/DB_Management/Orchestration_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Orchestration_DB.py
@@ -1229,6 +1229,7 @@ class OrchestrationDB:
         conn: sqlite3.Connection,
         run_id: int,
     ) -> sqlite3.Row | None:
+        """Return a run row only when its parent task belongs to this DB user."""
         return conn.execute(
             "SELECT r.* FROM runs r " "JOIN tasks t ON t.id = r.task_id " "WHERE r.id = ? AND t.user_id = ?",
             (run_id, self._user_id),
@@ -1236,6 +1237,7 @@ class OrchestrationDB:
 
     @staticmethod
     def _validate_run_transition(current: RunStatus, target: RunStatus) -> None:
+        """Raise when a run transition would rewrite a terminal or invalid state."""
         if not is_valid_run_transition(current, target):
             raise InvalidTransitionError(f"Invalid run transition from {current.value} to {target.value}")
 
@@ -1298,6 +1300,7 @@ class OrchestrationDB:
         )
 
     def update_run_session_id(self, run_id: int, session_id: str | None) -> AgentRun:
+        """Attach an ACP session id to an owned run with an atomic ownership check."""
         self._ensure_schema()
         conn = self._get_conn()
         with conn:

--- a/tldw_Server_API/app/core/DB_Management/Orchestration_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Orchestration_DB.py
@@ -8,7 +8,10 @@ Schema versions:
     v1 — original projects/tasks/runs/reviews tables
     v2 — adds acp_workspaces, acp_workspace_mcp_servers tables;
           adds workspace_id FK to projects
+    v3 — adds canonical workspace link column and uniqueness index
+    v4 — enforces at most one running run per task
 """
+
 from __future__ import annotations
 
 import json
@@ -50,7 +53,7 @@ class CanonicalWorkspaceBridgeConflictError(ValueError):
     """Raised when a canonical workspace bridge would create an ambiguous link."""
 
 
-_SCHEMA_VERSION = 3
+_SCHEMA_VERSION = 4
 CANONICAL_WORKSPACE_ID_METADATA_KEY = "canonical_workspace_id"
 CANONICAL_WORKSPACE_SOURCE_METADATA_KEY = "canonical_workspace_source"
 CANONICAL_WORKSPACE_LINK_STATUS_METADATA_KEY = "link_status"
@@ -164,6 +167,12 @@ _SCHEMA_V3_SQL = """\
 CREATE UNIQUE INDEX IF NOT EXISTS idx_acp_workspaces_user_canonical
 ON acp_workspaces(user_id, canonical_workspace_id)
 WHERE canonical_workspace_id IS NOT NULL;
+"""
+
+_SCHEMA_V4_SQL = """\
+CREATE UNIQUE INDEX IF NOT EXISTS idx_runs_one_running_per_task
+ON runs(task_id)
+WHERE status = 'running';
 """
 
 
@@ -287,6 +296,11 @@ class OrchestrationDB:
                 self._migrate_v2_to_v3(conn)
                 current_version = 3
 
+            if current_version < 4:
+                # Migrate v3 → v4
+                self._migrate_v3_to_v4(conn)
+                current_version = 4
+
             conn.execute(f"PRAGMA user_version={_SCHEMA_VERSION}")
             conn.commit()
             self._initialized = True
@@ -310,9 +324,7 @@ class OrchestrationDB:
         if not _col_exists(conn, "acp_workspaces", "canonical_workspace_id"):
             conn.execute("ALTER TABLE acp_workspaces ADD COLUMN canonical_workspace_id TEXT")
 
-        rows = conn.execute(
-            "SELECT id, user_id, metadata, canonical_workspace_id FROM acp_workspaces"
-        ).fetchall()
+        rows = conn.execute("SELECT id, user_id, metadata, canonical_workspace_id FROM acp_workspaces").fetchall()
         seen: dict[tuple[int, str], int] = {}
         duplicates: list[tuple[int, str, int, int]] = []
         updates: list[tuple[str, int]] = []
@@ -331,8 +343,7 @@ class OrchestrationDB:
 
         if duplicates:
             details = "; ".join(
-                f"user_id={user_id} canonical_workspace_id={canonical_id} "
-                f"workspace_ids={first_id},{duplicate_id}"
+                f"user_id={user_id} canonical_workspace_id={canonical_id} " f"workspace_ids={first_id},{duplicate_id}"
                 for user_id, canonical_id, first_id, duplicate_id in duplicates
             )
             raise ValueError(
@@ -345,6 +356,32 @@ class OrchestrationDB:
             updates,
         )
         conn.executescript(_SCHEMA_V3_SQL)
+        conn.commit()
+
+    def _migrate_v3_to_v4(self, conn: sqlite3.Connection) -> None:
+        """Apply v4 run uniqueness invariant for active dispatches."""
+        logger.info("Orchestration DB: migrating schema v3 → v4")
+        # Some legacy test/dev databases were stamped with a version after
+        # creating only a subset of the base tables. The base schema is
+        # idempotent and guarantees the runs table exists before indexing it.
+        conn.executescript(_SCHEMA_V1_SQL)
+        duplicates = conn.execute(
+            "SELECT task_id, COUNT(*) AS count "
+            "FROM runs "
+            "WHERE status = ? "
+            "GROUP BY task_id "
+            "HAVING COUNT(*) > 1",
+            (RunStatus.RUNNING.value,),
+        ).fetchall()
+        if duplicates:
+            details = "; ".join(
+                f"task_id={int(row['task_id'])} running_count={int(row['count'])}" for row in duplicates
+            )
+            raise ValueError(
+                "Duplicate running orchestration runs detected during schema migration; "
+                f"resolve duplicate active runs before retrying: {details}"
+            )
+        conn.executescript(_SCHEMA_V4_SQL)
         conn.commit()
 
     # ------------------------------------------------------------------
@@ -457,13 +494,14 @@ class OrchestrationDB:
 
         # Validate parent exists if provided
         if parent_workspace_id is not None:
-            if conn.execute(
-                "SELECT 1 FROM acp_workspaces WHERE id = ? AND user_id = ?",
-                (parent_workspace_id, self._user_id),
-            ).fetchone() is None:
-                raise OrchestrationNotFoundError(
-                    f"Parent workspace {parent_workspace_id} not found"
-                )
+            if (
+                conn.execute(
+                    "SELECT 1 FROM acp_workspaces WHERE id = ? AND user_id = ?",
+                    (parent_workspace_id, self._user_id),
+                ).fetchone()
+                is None
+            ):
+                raise OrchestrationNotFoundError(f"Parent workspace {parent_workspace_id} not found")
 
         now = _now_iso()
         try:
@@ -474,12 +512,21 @@ class OrchestrationDB:
                 " git_is_dirty, health_status, user_id, metadata, canonical_workspace_id, created_at) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
-                    name, root_path, description, workspace_type,
-                    parent_workspace_id, json.dumps(env_vars or {}),
-                    git_remote_url, git_default_branch, git_current_branch,
+                    name,
+                    root_path,
+                    description,
+                    workspace_type,
+                    parent_workspace_id,
+                    json.dumps(env_vars or {}),
+                    git_remote_url,
+                    git_default_branch,
+                    git_current_branch,
                     int(git_is_dirty) if git_is_dirty is not None else None,
-                    health_status, self._user_id,
-                    json.dumps(metadata_payload), canonical_workspace_id, now,
+                    health_status,
+                    self._user_id,
+                    json.dumps(metadata_payload),
+                    canonical_workspace_id,
+                    now,
                 ),
             )
             conn.commit()
@@ -558,8 +605,7 @@ class OrchestrationDB:
         self._ensure_schema()
         conn = self._get_conn()
         row = conn.execute(
-            "SELECT * FROM acp_workspaces "
-            "WHERE canonical_workspace_id = ? AND user_id = ?",
+            "SELECT * FROM acp_workspaces " "WHERE canonical_workspace_id = ? AND user_id = ?",
             (canonical_id, self._user_id),
         ).fetchone()
         if row is None:
@@ -590,9 +636,7 @@ class OrchestrationDB:
         merged_metadata = dict(workspace.metadata or {})
         merged_metadata.update(metadata or {})
         merged_metadata[CANONICAL_WORKSPACE_ID_METADATA_KEY] = canonical_id
-        merged_metadata[CANONICAL_WORKSPACE_SOURCE_METADATA_KEY] = str(
-            canonical_workspace_source
-        )
+        merged_metadata[CANONICAL_WORKSPACE_SOURCE_METADATA_KEY] = str(canonical_workspace_source)
         merged_metadata[CANONICAL_WORKSPACE_LINK_STATUS_METADATA_KEY] = str(link_status)
         conn = self._get_conn()
         try:
@@ -649,9 +693,7 @@ class OrchestrationDB:
 
             existing_root = self.get_workspace_by_root_path(root_path)
             if existing_root:
-                existing_canonical_id = _canonical_workspace_id_from_metadata(
-                    existing_root.metadata
-                )
+                existing_canonical_id = _canonical_workspace_id_from_metadata(existing_root.metadata)
                 if existing_canonical_id and existing_canonical_id != canonical_id:
                     raise CanonicalWorkspaceBridgeConflictError(
                         "ACP workspace root is already linked to a different canonical workspace."
@@ -665,12 +707,8 @@ class OrchestrationDB:
 
             bridge_metadata = dict(metadata or {})
             bridge_metadata[CANONICAL_WORKSPACE_ID_METADATA_KEY] = canonical_id
-            bridge_metadata[CANONICAL_WORKSPACE_SOURCE_METADATA_KEY] = (
-                canonical_workspace_source
-            )
-            bridge_metadata[CANONICAL_WORKSPACE_LINK_STATUS_METADATA_KEY] = (
-                CANONICAL_WORKSPACE_LINKED_STATUS
-            )
+            bridge_metadata[CANONICAL_WORKSPACE_SOURCE_METADATA_KEY] = canonical_workspace_source
+            bridge_metadata[CANONICAL_WORKSPACE_LINK_STATUS_METADATA_KEY] = CANONICAL_WORKSPACE_LINKED_STATUS
             try:
                 return self.create_workspace(
                     name=name,
@@ -720,36 +758,39 @@ class OrchestrationDB:
 
         # workspace_type and parent_workspace_id are immutable after creation
         allowed = {"name", "root_path", "description", "env_vars", "metadata"}
-        sets: list[str] = []
-        params: list[Any] = []
-        for key, value in fields.items():
-            if key not in allowed:
-                continue
-            if key in ("env_vars", "metadata"):
-                sets.append(f"{key} = ?")
-                params.append(json.dumps(value or {}))
-                if key == "metadata":
-                    sets.append("canonical_workspace_id = ?")
-                    params.append(_canonical_workspace_id_from_metadata(value or {}))
-            else:
-                sets.append(f"{key} = ?")
-                params.append(value)
-
-        if not sets:
+        if not any(key in allowed for key in fields):
             return self._row_to_workspace(existing)
 
-        sets.append("updated_at = ?")
-        params.append(_now_iso())
-        params.append(workspace_id)
-        params.append(self._user_id)
+        name = fields["name"] if "name" in fields else existing["name"]
+        root_path = fields["root_path"] if "root_path" in fields else existing["root_path"]
+        description = fields["description"] if "description" in fields else existing["description"]
+        env_vars_payload = json.dumps(fields.get("env_vars") or {}) if "env_vars" in fields else existing["env_vars"]
+        metadata_payload = json.dumps(fields.get("metadata") or {}) if "metadata" in fields else existing["metadata"]
+        canonical_workspace_id = (
+            _canonical_workspace_id_from_metadata(fields.get("metadata") or {})
+            if "metadata" in fields
+            else existing["canonical_workspace_id"]
+        )
 
         try:
-            # Column names are constrained by the local allowlist above.
-            conn.execute(
-                f"UPDATE acp_workspaces SET {', '.join(sets)} WHERE id = ? AND user_id = ?",  # nosec B608
-                params,
-            )
-            conn.commit()
+            with conn:
+                conn.execute(
+                    "UPDATE acp_workspaces "
+                    "SET name = ?, root_path = ?, description = ?, env_vars = ?, "
+                    "metadata = ?, canonical_workspace_id = ?, updated_at = ? "
+                    "WHERE id = ? AND user_id = ?",
+                    (
+                        name,
+                        root_path,
+                        description,
+                        env_vars_payload,
+                        metadata_payload,
+                        canonical_workspace_id,
+                        _now_iso(),
+                        workspace_id,
+                        self._user_id,
+                    ),
+                )
         except sqlite3.IntegrityError as exc:
             err = str(exc).lower()
             if "unique" in err:
@@ -799,10 +840,15 @@ class OrchestrationDB:
             "git_default_branch = ?, git_current_branch = ?, git_is_dirty = ?, "
             "last_health_check = ?, updated_at = ? WHERE id = ? AND user_id = ?",
             (
-                health_status, git_remote_url, git_default_branch,
+                health_status,
+                git_remote_url,
+                git_default_branch,
                 git_current_branch,
                 int(git_is_dirty) if git_is_dirty is not None else None,
-                now, _now_iso(), workspace_id, self._user_id,
+                now,
+                _now_iso(),
+                workspace_id,
+                self._user_id,
             ),
         )
         conn.commit()
@@ -816,8 +862,7 @@ class OrchestrationDB:
         self._ensure_schema()
         conn = self._get_conn()
         rows = conn.execute(
-            "SELECT * FROM acp_workspaces WHERE parent_workspace_id = ? AND user_id = ? "
-            "ORDER BY name",
+            "SELECT * FROM acp_workspaces WHERE parent_workspace_id = ? AND user_id = ? " "ORDER BY name",
             (workspace_id, self._user_id),
         ).fetchall()
         return [self._row_to_workspace(r) for r in rows]
@@ -841,10 +886,13 @@ class OrchestrationDB:
         conn = self._get_conn()
 
         # Verify workspace exists and belongs to user
-        if conn.execute(
-            "SELECT 1 FROM acp_workspaces WHERE id = ? AND user_id = ?",
-            (workspace_id, self._user_id),
-        ).fetchone() is None:
+        if (
+            conn.execute(
+                "SELECT 1 FROM acp_workspaces WHERE id = ? AND user_id = ?",
+                (workspace_id, self._user_id),
+            ).fetchone()
+            is None
+        ):
             raise OrchestrationNotFoundError(f"Workspace {workspace_id} not found")
 
         try:
@@ -853,16 +901,19 @@ class OrchestrationDB:
                 "(workspace_id, server_name, server_type, command, args, env, url, enabled) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 (
-                    workspace_id, server_name, server_type, command,
-                    json.dumps(args or []), json.dumps(env or {}),
-                    url, int(enabled),
+                    workspace_id,
+                    server_name,
+                    server_type,
+                    command,
+                    json.dumps(args or []),
+                    json.dumps(env or {}),
+                    url,
+                    int(enabled),
                 ),
             )
             conn.commit()
         except sqlite3.IntegrityError as exc:
-            raise ValueError(
-                f"MCP server '{server_name}' already exists for workspace {workspace_id}"
-            ) from exc
+            raise ValueError(f"MCP server '{server_name}' already exists for workspace {workspace_id}") from exc
 
         return {
             "id": cur.lastrowid,
@@ -918,10 +969,13 @@ class OrchestrationDB:
 
         # Validate workspace exists if provided
         if workspace_id is not None:
-            if conn.execute(
-                "SELECT 1 FROM acp_workspaces WHERE id = ? AND user_id = ?",
-                (workspace_id, self._user_id),
-            ).fetchone() is None:
+            if (
+                conn.execute(
+                    "SELECT 1 FROM acp_workspaces WHERE id = ? AND user_id = ?",
+                    (workspace_id, self._user_id),
+                ).fetchone()
+                is None
+            ):
                 raise OrchestrationNotFoundError(f"Workspace {workspace_id} not found")
 
         now = _now_iso()
@@ -969,14 +1023,12 @@ class OrchestrationDB:
             ).fetchall()
         elif workspace_id is None:
             rows = conn.execute(
-                "SELECT * FROM projects WHERE user_id = ? AND workspace_id IS NULL "
-                "ORDER BY created_at DESC",
+                "SELECT * FROM projects WHERE user_id = ? AND workspace_id IS NULL " "ORDER BY created_at DESC",
                 (self._user_id,),
             ).fetchall()
         else:
             rows = conn.execute(
-                "SELECT * FROM projects WHERE user_id = ? AND workspace_id = ? "
-                "ORDER BY created_at DESC",
+                "SELECT * FROM projects WHERE user_id = ? AND workspace_id = ? " "ORDER BY created_at DESC",
                 (self._user_id, workspace_id),
             ).fetchall()
         return [self._row_to_project(r) for r in rows]
@@ -1011,18 +1063,24 @@ class OrchestrationDB:
         conn = self._get_conn()
 
         # Validate project exists
-        if conn.execute(
-            "SELECT 1 FROM projects WHERE id = ? AND user_id = ?",
-            (project_id, self._user_id),
-        ).fetchone() is None:
+        if (
+            conn.execute(
+                "SELECT 1 FROM projects WHERE id = ? AND user_id = ?",
+                (project_id, self._user_id),
+            ).fetchone()
+            is None
+        ):
             raise OrchestrationNotFoundError(f"Project {project_id} not found")
 
         # Validate dependency exists
         if dependency_id is not None:
-            if conn.execute(
-                "SELECT 1 FROM tasks WHERE id = ? AND user_id = ?",
-                (dependency_id, self._user_id),
-            ).fetchone() is None:
+            if (
+                conn.execute(
+                    "SELECT 1 FROM tasks WHERE id = ? AND user_id = ?",
+                    (dependency_id, self._user_id),
+                ).fetchone()
+                is None
+            ):
                 raise OrchestrationNotFoundError(f"Dependency task {dependency_id} not found")
 
         now = _now_iso()
@@ -1033,10 +1091,18 @@ class OrchestrationDB:
             " user_id, metadata, created_at) "
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?)",
             (
-                project_id, title, description, TaskStatus.TODO.value,
-                agent_type, dependency_id, reviewer_agent_type,
-                max_review_attempts, success_criteria,
-                self._user_id, json.dumps(metadata or {}), now,
+                project_id,
+                title,
+                description,
+                TaskStatus.TODO.value,
+                agent_type,
+                dependency_id,
+                reviewer_agent_type,
+                max_review_attempts,
+                success_criteria,
+                self._user_id,
+                json.dumps(metadata or {}),
+                now,
             ),
         )
         conn.commit()
@@ -1077,15 +1143,12 @@ class OrchestrationDB:
         conn = self._get_conn()
         if status is not None:
             rows = conn.execute(
-                "SELECT * FROM tasks "
-                "WHERE project_id = ? AND user_id = ? AND status = ? "
-                "ORDER BY created_at",
+                "SELECT * FROM tasks " "WHERE project_id = ? AND user_id = ? AND status = ? " "ORDER BY created_at",
                 (project_id, self._user_id, status.value),
             ).fetchall()
         else:
             rows = conn.execute(
-                "SELECT * FROM tasks WHERE project_id = ? AND user_id = ? "
-                "ORDER BY created_at",
+                "SELECT * FROM tasks WHERE project_id = ? AND user_id = ? " "ORDER BY created_at",
                 (project_id, self._user_id),
             ).fetchall()
         return [self._row_to_task(r) for r in rows]
@@ -1102,9 +1165,7 @@ class OrchestrationDB:
 
         current = TaskStatus(row["status"])
         if not is_valid_transition(current, new_status):
-            raise InvalidTransitionError(
-                f"Invalid transition from {current.value} to {new_status.value}"
-            )
+            raise InvalidTransitionError(f"Invalid transition from {current.value} to {new_status.value}")
 
         now = _now_iso()
         conn.execute(
@@ -1169,18 +1230,30 @@ class OrchestrationDB:
         run_id: int,
     ) -> sqlite3.Row | None:
         return conn.execute(
-            "SELECT r.* FROM runs r "
-            "JOIN tasks t ON t.id = r.task_id "
-            "WHERE r.id = ? AND t.user_id = ?",
+            "SELECT r.* FROM runs r " "JOIN tasks t ON t.id = r.task_id " "WHERE r.id = ? AND t.user_id = ?",
             (run_id, self._user_id),
         ).fetchone()
 
     @staticmethod
     def _validate_run_transition(current: RunStatus, target: RunStatus) -> None:
         if not is_valid_run_transition(current, target):
-            raise InvalidTransitionError(
-                f"Invalid run transition from {current.value} to {target.value}"
-            )
+            raise InvalidTransitionError(f"Invalid run transition from {current.value} to {target.value}")
+
+    def has_running_run(self, task_id: int) -> bool:
+        """Return whether the current user's task already has an active run."""
+        self._ensure_schema()
+        conn = self._get_conn()
+        task_row = conn.execute(
+            "SELECT 1 FROM tasks WHERE id = ? AND user_id = ?",
+            (task_id, self._user_id),
+        ).fetchone()
+        if task_row is None:
+            raise OrchestrationNotFoundError(f"Task {task_id} not found")
+        active = conn.execute(
+            "SELECT 1 FROM runs WHERE task_id = ? AND status = ?",
+            (task_id, RunStatus.RUNNING.value),
+        ).fetchone()
+        return active is not None
 
     def create_run(
         self,
@@ -1205,12 +1278,16 @@ class OrchestrationDB:
 
         now = _now_iso()
         resolved_agent_type = agent_type or task_row["agent_type"]
-        cur = conn.execute(
-            "INSERT INTO runs (task_id, session_id, status, agent_type, started_at) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (task_id, session_id, RunStatus.RUNNING.value, resolved_agent_type, now),
-        )
-        conn.commit()
+        try:
+            with conn:
+                cur = conn.execute(
+                    "INSERT INTO runs (task_id, session_id, status, agent_type, started_at) " "VALUES (?, ?, ?, ?, ?)",
+                    (task_id, session_id, RunStatus.RUNNING.value, resolved_agent_type, now),
+                )
+        except sqlite3.IntegrityError as exc:
+            if "unique" in str(exc).lower():
+                raise InvalidTransitionError(f"Task {task_id} already has a running run") from exc
+            raise
         return AgentRun(
             id=cur.lastrowid,
             task_id=task_id,
@@ -1223,15 +1300,22 @@ class OrchestrationDB:
     def update_run_session_id(self, run_id: int, session_id: str | None) -> AgentRun:
         self._ensure_schema()
         conn = self._get_conn()
-        row = self._get_owned_run_row(conn, run_id)
-        if row is None:
-            raise OrchestrationNotFoundError(f"Run {run_id} not found")
-        conn.execute(
-            "UPDATE runs SET session_id = ? WHERE id = ?",
-            (session_id, run_id),
-        )
-        conn.commit()
+        with conn:
+            cur = conn.execute(
+                "UPDATE runs "
+                "SET session_id = ? "
+                "WHERE id = ? "
+                "AND EXISTS ("
+                "    SELECT 1 FROM tasks t "
+                "    WHERE t.id = runs.task_id AND t.user_id = ?"
+                ")",
+                (session_id, run_id, self._user_id),
+            )
+            if cur.rowcount == 0:
+                raise OrchestrationNotFoundError(f"Run {run_id} not found")
         updated = self._get_owned_run_row(conn, run_id)
+        if updated is None:
+            raise OrchestrationNotFoundError(f"Run {run_id} not found")
         return self._row_to_run(updated)
 
     def complete_run(
@@ -1247,16 +1331,30 @@ class OrchestrationDB:
             raise OrchestrationNotFoundError(f"Run {run_id} not found")
         self._validate_run_transition(RunStatus(row["status"]), RunStatus.COMPLETED)
         now = _now_iso()
-        conn.execute(
-            "UPDATE runs SET status = ?, completed_at = ?, result_summary = ?, token_usage = ? "
-            "WHERE id = ?",
-            (
-                RunStatus.COMPLETED.value, now, result_summary,
-                json.dumps(token_usage or {}), run_id,
-            ),
-        )
-        conn.commit()
+        with conn:
+            cur = conn.execute(
+                "UPDATE runs "
+                "SET status = ?, completed_at = ?, result_summary = ?, token_usage = ? "
+                "WHERE id = ? AND status = ? "
+                "AND EXISTS ("
+                "    SELECT 1 FROM tasks t "
+                "    WHERE t.id = runs.task_id AND t.user_id = ?"
+                ")",
+                (
+                    RunStatus.COMPLETED.value,
+                    now,
+                    result_summary,
+                    json.dumps(token_usage or {}),
+                    run_id,
+                    row["status"],
+                    self._user_id,
+                ),
+            )
+            if cur.rowcount == 0:
+                raise InvalidTransitionError(f"Run {run_id} changed status before completion could be recorded")
         updated = self._get_owned_run_row(conn, run_id)
+        if updated is None:
+            raise OrchestrationNotFoundError(f"Run {run_id} not found")
         return self._row_to_run(updated)
 
     def fail_run(self, run_id: int, error: str = "") -> AgentRun:
@@ -1267,12 +1365,29 @@ class OrchestrationDB:
             raise OrchestrationNotFoundError(f"Run {run_id} not found")
         self._validate_run_transition(RunStatus(row["status"]), RunStatus.FAILED)
         now = _now_iso()
-        conn.execute(
-            "UPDATE runs SET status = ?, completed_at = ?, error = ? WHERE id = ?",
-            (RunStatus.FAILED.value, now, error, run_id),
-        )
-        conn.commit()
+        with conn:
+            cur = conn.execute(
+                "UPDATE runs "
+                "SET status = ?, completed_at = ?, error = ? "
+                "WHERE id = ? AND status = ? "
+                "AND EXISTS ("
+                "    SELECT 1 FROM tasks t "
+                "    WHERE t.id = runs.task_id AND t.user_id = ?"
+                ")",
+                (
+                    RunStatus.FAILED.value,
+                    now,
+                    error,
+                    run_id,
+                    row["status"],
+                    self._user_id,
+                ),
+            )
+            if cur.rowcount == 0:
+                raise InvalidTransitionError(f"Run {run_id} changed status before failure could be recorded")
         updated = self._get_owned_run_row(conn, run_id)
+        if updated is None:
+            raise OrchestrationNotFoundError(f"Run {run_id} not found")
         return self._row_to_run(updated)
 
     def list_runs(self, task_id: int) -> list[AgentRun]:
@@ -1321,13 +1436,11 @@ class OrchestrationDB:
             new_status = TaskStatus.IN_PROGRESS
 
         conn.execute(
-            "UPDATE tasks SET status = ?, review_count = ?, updated_at = ? "
-            "WHERE id = ? AND user_id = ?",
+            "UPDATE tasks SET status = ?, review_count = ?, updated_at = ? " "WHERE id = ? AND user_id = ?",
             (new_status.value, new_review_count, now, task_id, self._user_id),
         )
         conn.execute(
-            "INSERT INTO reviews (task_id, approved, feedback, reviewer, created_at) "
-            "VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO reviews (task_id, approved, feedback, reviewer, created_at) " "VALUES (?, ?, ?, ?, ?)",
             (task_id, int(approved), feedback, reviewer, now),
         )
         conn.commit()

--- a/tldw_Server_API/app/core/DB_Management/Orchestration_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Orchestration_DB.py
@@ -27,6 +27,7 @@ from tldw_Server_API.app.core.Agent_Orchestration.models import (
     AgentTask,
     RunStatus,
     TaskStatus,
+    is_valid_run_transition,
     is_valid_transition,
 )
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
@@ -457,7 +458,8 @@ class OrchestrationDB:
         # Validate parent exists if provided
         if parent_workspace_id is not None:
             if conn.execute(
-                "SELECT 1 FROM acp_workspaces WHERE id = ?", (parent_workspace_id,)
+                "SELECT 1 FROM acp_workspaces WHERE id = ? AND user_id = ?",
+                (parent_workspace_id, self._user_id),
             ).fetchone() is None:
                 raise OrchestrationNotFoundError(
                     f"Parent workspace {parent_workspace_id} not found"
@@ -739,11 +741,12 @@ class OrchestrationDB:
         sets.append("updated_at = ?")
         params.append(_now_iso())
         params.append(workspace_id)
+        params.append(self._user_id)
 
         try:
             # Column names are constrained by the local allowlist above.
             conn.execute(
-                f"UPDATE acp_workspaces SET {', '.join(sets)} WHERE id = ?",  # nosec B608
+                f"UPDATE acp_workspaces SET {', '.join(sets)} WHERE id = ? AND user_id = ?",  # nosec B608
                 params,
             )
             conn.commit()
@@ -756,7 +759,8 @@ class OrchestrationDB:
             raise
 
         row = conn.execute(
-            "SELECT * FROM acp_workspaces WHERE id = ?", (workspace_id,)
+            "SELECT * FROM acp_workspaces WHERE id = ? AND user_id = ?",
+            (workspace_id, self._user_id),
         ).fetchone()
         return self._row_to_workspace(row)
 
@@ -793,17 +797,18 @@ class OrchestrationDB:
         conn.execute(
             "UPDATE acp_workspaces SET health_status = ?, git_remote_url = ?, "
             "git_default_branch = ?, git_current_branch = ?, git_is_dirty = ?, "
-            "last_health_check = ?, updated_at = ? WHERE id = ?",
+            "last_health_check = ?, updated_at = ? WHERE id = ? AND user_id = ?",
             (
                 health_status, git_remote_url, git_default_branch,
                 git_current_branch,
                 int(git_is_dirty) if git_is_dirty is not None else None,
-                now, _now_iso(), workspace_id,
+                now, _now_iso(), workspace_id, self._user_id,
             ),
         )
         conn.commit()
         row = conn.execute(
-            "SELECT * FROM acp_workspaces WHERE id = ?", (workspace_id,)
+            "SELECT * FROM acp_workspaces WHERE id = ? AND user_id = ?",
+            (workspace_id, self._user_id),
         ).fetchone()
         return self._row_to_workspace(row)
 
@@ -875,8 +880,11 @@ class OrchestrationDB:
         self._ensure_schema()
         conn = self._get_conn()
         rows = conn.execute(
-            "SELECT * FROM acp_workspace_mcp_servers WHERE workspace_id = ? ORDER BY server_name",
-            (workspace_id,),
+            "SELECT s.* FROM acp_workspace_mcp_servers s "
+            "JOIN acp_workspaces w ON w.id = s.workspace_id "
+            "WHERE s.workspace_id = ? AND w.user_id = ? "
+            "ORDER BY s.server_name",
+            (workspace_id, self._user_id),
         ).fetchall()
         return [self._row_to_mcp_server(r) for r in rows]
 
@@ -936,7 +944,10 @@ class OrchestrationDB:
     def get_project(self, project_id: int) -> AgentProject | None:
         self._ensure_schema()
         conn = self._get_conn()
-        row = conn.execute("SELECT * FROM projects WHERE id = ?", (project_id,)).fetchone()
+        row = conn.execute(
+            "SELECT * FROM projects WHERE id = ? AND user_id = ?",
+            (project_id, self._user_id),
+        ).fetchone()
         if row is None:
             return None
         return self._row_to_project(row)
@@ -973,7 +984,10 @@ class OrchestrationDB:
     def delete_project(self, project_id: int) -> bool:
         self._ensure_schema()
         conn = self._get_conn()
-        cur = conn.execute("DELETE FROM projects WHERE id = ?", (project_id,))
+        cur = conn.execute(
+            "DELETE FROM projects WHERE id = ? AND user_id = ?",
+            (project_id, self._user_id),
+        )
         conn.commit()
         return cur.rowcount > 0
 
@@ -997,12 +1011,18 @@ class OrchestrationDB:
         conn = self._get_conn()
 
         # Validate project exists
-        if conn.execute("SELECT 1 FROM projects WHERE id = ?", (project_id,)).fetchone() is None:
+        if conn.execute(
+            "SELECT 1 FROM projects WHERE id = ? AND user_id = ?",
+            (project_id, self._user_id),
+        ).fetchone() is None:
             raise OrchestrationNotFoundError(f"Project {project_id} not found")
 
         # Validate dependency exists
         if dependency_id is not None:
-            if conn.execute("SELECT 1 FROM tasks WHERE id = ?", (dependency_id,)).fetchone() is None:
+            if conn.execute(
+                "SELECT 1 FROM tasks WHERE id = ? AND user_id = ?",
+                (dependency_id, self._user_id),
+            ).fetchone() is None:
                 raise OrchestrationNotFoundError(f"Dependency task {dependency_id} not found")
 
         now = _now_iso()
@@ -1040,7 +1060,10 @@ class OrchestrationDB:
     def get_task(self, task_id: int) -> AgentTask | None:
         self._ensure_schema()
         conn = self._get_conn()
-        row = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        row = conn.execute(
+            "SELECT * FROM tasks WHERE id = ? AND user_id = ?",
+            (task_id, self._user_id),
+        ).fetchone()
         if row is None:
             return None
         return self._row_to_task(row)
@@ -1054,20 +1077,26 @@ class OrchestrationDB:
         conn = self._get_conn()
         if status is not None:
             rows = conn.execute(
-                "SELECT * FROM tasks WHERE project_id = ? AND status = ? ORDER BY created_at",
-                (project_id, status.value),
+                "SELECT * FROM tasks "
+                "WHERE project_id = ? AND user_id = ? AND status = ? "
+                "ORDER BY created_at",
+                (project_id, self._user_id, status.value),
             ).fetchall()
         else:
             rows = conn.execute(
-                "SELECT * FROM tasks WHERE project_id = ? ORDER BY created_at",
-                (project_id,),
+                "SELECT * FROM tasks WHERE project_id = ? AND user_id = ? "
+                "ORDER BY created_at",
+                (project_id, self._user_id),
             ).fetchall()
         return [self._row_to_task(r) for r in rows]
 
     def transition_task(self, task_id: int, new_status: TaskStatus) -> AgentTask:
         self._ensure_schema()
         conn = self._get_conn()
-        row = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        row = conn.execute(
+            "SELECT * FROM tasks WHERE id = ? AND user_id = ?",
+            (task_id, self._user_id),
+        ).fetchone()
         if row is None:
             raise OrchestrationNotFoundError(f"Task {task_id} not found")
 
@@ -1079,18 +1108,22 @@ class OrchestrationDB:
 
         now = _now_iso()
         conn.execute(
-            "UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?",
-            (new_status.value, now, task_id),
+            "UPDATE tasks SET status = ?, updated_at = ? WHERE id = ? AND user_id = ?",
+            (new_status.value, now, task_id, self._user_id),
         )
         conn.commit()
-        updated = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        updated = conn.execute(
+            "SELECT * FROM tasks WHERE id = ? AND user_id = ?",
+            (task_id, self._user_id),
+        ).fetchone()
         return self._row_to_task(updated)
 
     def check_dependency_ready(self, task_id: int) -> bool:
         self._ensure_schema()
         conn = self._get_conn()
         row = conn.execute(
-            "SELECT dependency_id FROM tasks WHERE id = ?", (task_id,),
+            "SELECT dependency_id FROM tasks WHERE id = ? AND user_id = ?",
+            (task_id, self._user_id),
         ).fetchone()
         if row is None:
             raise OrchestrationNotFoundError(f"Task {task_id} not found")
@@ -1098,7 +1131,8 @@ class OrchestrationDB:
         if dep_id is None:
             return True
         dep_row = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (dep_id,),
+            "SELECT status FROM tasks WHERE id = ? AND user_id = ?",
+            (dep_id, self._user_id),
         ).fetchone()
         if dep_row is None:
             return True  # dependency deleted
@@ -1117,7 +1151,8 @@ class OrchestrationDB:
                 return True  # already a cycle in the chain
             visited.add(current)
             row = conn.execute(
-                "SELECT dependency_id FROM tasks WHERE id = ?", (current,),
+                "SELECT dependency_id FROM tasks WHERE id = ? AND user_id = ?",
+                (current, self._user_id),
             ).fetchone()
             if row is None:
                 break
@@ -1128,6 +1163,25 @@ class OrchestrationDB:
     # Runs
     # ------------------------------------------------------------------
 
+    def _get_owned_run_row(
+        self,
+        conn: sqlite3.Connection,
+        run_id: int,
+    ) -> sqlite3.Row | None:
+        return conn.execute(
+            "SELECT r.* FROM runs r "
+            "JOIN tasks t ON t.id = r.task_id "
+            "WHERE r.id = ? AND t.user_id = ?",
+            (run_id, self._user_id),
+        ).fetchone()
+
+    @staticmethod
+    def _validate_run_transition(current: RunStatus, target: RunStatus) -> None:
+        if not is_valid_run_transition(current, target):
+            raise InvalidTransitionError(
+                f"Invalid run transition from {current.value} to {target.value}"
+            )
+
     def create_run(
         self,
         task_id: int,
@@ -1136,11 +1190,25 @@ class OrchestrationDB:
     ) -> AgentRun:
         self._ensure_schema()
         conn = self._get_conn()
+        task_row = conn.execute(
+            "SELECT * FROM tasks WHERE id = ? AND user_id = ?",
+            (task_id, self._user_id),
+        ).fetchone()
+        if task_row is None:
+            raise OrchestrationNotFoundError(f"Task {task_id} not found")
+        active = conn.execute(
+            "SELECT 1 FROM runs WHERE task_id = ? AND status = ?",
+            (task_id, RunStatus.RUNNING.value),
+        ).fetchone()
+        if active is not None:
+            raise InvalidTransitionError(f"Task {task_id} already has a running run")
+
         now = _now_iso()
+        resolved_agent_type = agent_type or task_row["agent_type"]
         cur = conn.execute(
             "INSERT INTO runs (task_id, session_id, status, agent_type, started_at) "
             "VALUES (?, ?, ?, ?, ?)",
-            (task_id, session_id, RunStatus.RUNNING.value, agent_type, now),
+            (task_id, session_id, RunStatus.RUNNING.value, resolved_agent_type, now),
         )
         conn.commit()
         return AgentRun(
@@ -1148,9 +1216,23 @@ class OrchestrationDB:
             task_id=task_id,
             session_id=session_id,
             status=RunStatus.RUNNING,
-            agent_type=agent_type,
+            agent_type=resolved_agent_type,
             started_at=now,
         )
+
+    def update_run_session_id(self, run_id: int, session_id: str | None) -> AgentRun:
+        self._ensure_schema()
+        conn = self._get_conn()
+        row = self._get_owned_run_row(conn, run_id)
+        if row is None:
+            raise OrchestrationNotFoundError(f"Run {run_id} not found")
+        conn.execute(
+            "UPDATE runs SET session_id = ? WHERE id = ?",
+            (session_id, run_id),
+        )
+        conn.commit()
+        updated = self._get_owned_run_row(conn, run_id)
+        return self._row_to_run(updated)
 
     def complete_run(
         self,
@@ -1160,6 +1242,10 @@ class OrchestrationDB:
     ) -> AgentRun:
         self._ensure_schema()
         conn = self._get_conn()
+        row = self._get_owned_run_row(conn, run_id)
+        if row is None:
+            raise OrchestrationNotFoundError(f"Run {run_id} not found")
+        self._validate_run_transition(RunStatus(row["status"]), RunStatus.COMPLETED)
         now = _now_iso()
         conn.execute(
             "UPDATE runs SET status = ?, completed_at = ?, result_summary = ?, token_usage = ? "
@@ -1170,27 +1256,34 @@ class OrchestrationDB:
             ),
         )
         conn.commit()
-        row = conn.execute("SELECT * FROM runs WHERE id = ?", (run_id,)).fetchone()
-        return self._row_to_run(row)
+        updated = self._get_owned_run_row(conn, run_id)
+        return self._row_to_run(updated)
 
     def fail_run(self, run_id: int, error: str = "") -> AgentRun:
         self._ensure_schema()
         conn = self._get_conn()
+        row = self._get_owned_run_row(conn, run_id)
+        if row is None:
+            raise OrchestrationNotFoundError(f"Run {run_id} not found")
+        self._validate_run_transition(RunStatus(row["status"]), RunStatus.FAILED)
         now = _now_iso()
         conn.execute(
             "UPDATE runs SET status = ?, completed_at = ?, error = ? WHERE id = ?",
             (RunStatus.FAILED.value, now, error, run_id),
         )
         conn.commit()
-        row = conn.execute("SELECT * FROM runs WHERE id = ?", (run_id,)).fetchone()
-        return self._row_to_run(row)
+        updated = self._get_owned_run_row(conn, run_id)
+        return self._row_to_run(updated)
 
     def list_runs(self, task_id: int) -> list[AgentRun]:
         self._ensure_schema()
         conn = self._get_conn()
         rows = conn.execute(
-            "SELECT * FROM runs WHERE task_id = ? ORDER BY started_at DESC",
-            (task_id,),
+            "SELECT r.* FROM runs r "
+            "JOIN tasks t ON t.id = r.task_id "
+            "WHERE r.task_id = ? AND t.user_id = ? "
+            "ORDER BY r.started_at DESC",
+            (task_id, self._user_id),
         ).fetchall()
         return [self._row_to_run(r) for r in rows]
 
@@ -1207,7 +1300,10 @@ class OrchestrationDB:
     ) -> AgentTask:
         self._ensure_schema()
         conn = self._get_conn()
-        row = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        row = conn.execute(
+            "SELECT * FROM tasks WHERE id = ? AND user_id = ?",
+            (task_id, self._user_id),
+        ).fetchone()
         if row is None:
             raise OrchestrationNotFoundError(f"Task {task_id} not found")
         if TaskStatus(row["status"]) != TaskStatus.REVIEW:
@@ -1225,8 +1321,9 @@ class OrchestrationDB:
             new_status = TaskStatus.IN_PROGRESS
 
         conn.execute(
-            "UPDATE tasks SET status = ?, review_count = ?, updated_at = ? WHERE id = ?",
-            (new_status.value, new_review_count, now, task_id),
+            "UPDATE tasks SET status = ?, review_count = ?, updated_at = ? "
+            "WHERE id = ? AND user_id = ?",
+            (new_status.value, new_review_count, now, task_id, self._user_id),
         )
         conn.execute(
             "INSERT INTO reviews (task_id, approved, feedback, reviewer, created_at) "
@@ -1234,15 +1331,21 @@ class OrchestrationDB:
             (task_id, int(approved), feedback, reviewer, now),
         )
         conn.commit()
-        updated = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        updated = conn.execute(
+            "SELECT * FROM tasks WHERE id = ? AND user_id = ?",
+            (task_id, self._user_id),
+        ).fetchone()
         return self._row_to_task(updated)
 
     def list_reviews(self, task_id: int) -> list[dict[str, Any]]:
         self._ensure_schema()
         conn = self._get_conn()
         rows = conn.execute(
-            "SELECT * FROM reviews WHERE task_id = ? ORDER BY created_at",
-            (task_id,),
+            "SELECT r.* FROM reviews r "
+            "JOIN tasks t ON t.id = r.task_id "
+            "WHERE r.task_id = ? AND t.user_id = ? "
+            "ORDER BY r.created_at",
+            (task_id, self._user_id),
         ).fetchall()
         return [
             {
@@ -1264,8 +1367,11 @@ class OrchestrationDB:
         self._ensure_schema()
         conn = self._get_conn()
         rows = conn.execute(
-            "SELECT status, COUNT(*) as cnt FROM tasks WHERE project_id = ? GROUP BY status",
-            (project_id,),
+            "SELECT t.status, COUNT(*) as cnt FROM tasks t "
+            "JOIN projects p ON p.id = t.project_id "
+            "WHERE t.project_id = ? AND p.user_id = ? "
+            "GROUP BY t.status",
+            (project_id, self._user_id),
         ).fetchall()
         status_counts: dict[str, int] = {}
         total = 0

--- a/tldw_Server_API/app/services/mcp_hub_workspace_root_resolver.py
+++ b/tldw_Server_API/app/services/mcp_hub_workspace_root_resolver.py
@@ -160,7 +160,7 @@ class McpHubWorkspaceRootResolver:
         except (ValueError, TypeError):
             return None
         try:
-            from tldw_Server_API.app.core.Agent_Orchestration.orchestration_service import (
+            from tldw_Server_API.app.core.Agent_Orchestration.db_factory import (
                 get_orchestration_db,
             )
             db = get_orchestration_db(uid)

--- a/tldw_Server_API/tests/Agent_Orchestration/test_artifact_promotion.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_artifact_promotion.py
@@ -66,6 +66,7 @@ def _brief_payload(**overrides):
 
 
 def test_validate_artifact_payload_rejects_non_mapping(tmp_path):
+    """Malformed artifact objects should fail validation without attribute errors."""
     note_db = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="user-1")
     note_db.upsert_workspace("workspace-alpha", "Alpha Workspace")
 
@@ -380,6 +381,7 @@ def test_malformed_promotion_payload_is_not_promoted(tmp_path):
 
 
 def test_oversized_promoted_artifact_is_not_written(tmp_path):
+    """Oversized promoted artifact content should not be persisted."""
     orch_db, note_db, project, workspace, task, run, review_run = _build_context(tmp_path)
     signal = TaskCompletionSignal(
         status="completed",

--- a/tldw_Server_API/tests/Agent_Orchestration/test_artifact_promotion.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_artifact_promotion.py
@@ -45,6 +45,7 @@ def _build_context(tmp_path):
         reviewer_agent_type="reviewer",
     )
     run = orch_db.create_run(task.id, agent_type="codex", session_id="session-run-1")
+    orch_db.complete_run(run.id, result_summary="Brief ready")
     review_run = orch_db.create_run(task.id, agent_type="reviewer", session_id="session-review-1")
     return orch_db, note_db, project, workspace, task, run, review_run
 
@@ -364,6 +365,42 @@ def test_malformed_promotion_payload_is_not_promoted(tmp_path):
         assert result.updated_artifact_ids == []
         assert result.skipped == []
         assert result.errors == [{"artifact_id": "brief-1", "reason": "missing_source_lineage"}]
+        assert note_db.list_workspace_artifacts("workspace-alpha") == []
+    finally:
+        note_db.close_all_connections()
+        orch_db.close()
+
+
+def test_oversized_promoted_artifact_is_not_written(tmp_path):
+    orch_db, note_db, project, workspace, task, run, review_run = _build_context(tmp_path)
+    signal = TaskCompletionSignal(
+        status="completed",
+        summary="Oversized artifact",
+        artifacts=[
+            _brief_payload(
+                content="x" * 500_001,
+            )
+        ],
+        raw_payload={},
+    )
+
+    try:
+        result = promote_acp_completion_artifacts(
+            note_db,
+            task=task,
+            project=project,
+            workspace=workspace,
+            run=run,
+            completion_signal=signal,
+            final_status=TaskStatus.COMPLETE,
+            review_decision=TaskReviewDecision(approved=True, feedback="Accepted"),
+            review_run=review_run,
+        )
+
+        assert result.created_artifact_ids == []
+        assert result.updated_artifact_ids == []
+        assert result.skipped == []
+        assert result.errors == [{"artifact_id": "brief-1", "reason": "content_too_large"}]
         assert note_db.list_workspace_artifacts("workspace-alpha") == []
     finally:
         note_db.close_all_connections()

--- a/tldw_Server_API/tests/Agent_Orchestration/test_artifact_promotion.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_artifact_promotion.py
@@ -1,9 +1,11 @@
 """Tests for promoting accepted ACP deliverables into workspace artifacts."""
+
 from __future__ import annotations
 
 import pytest
 
 from tldw_Server_API.app.core.Agent_Orchestration.artifact_promotion import (
+    _validate_artifact_payload,
     promote_acp_completion_artifacts,
 )
 from tldw_Server_API.app.core.Agent_Orchestration.completion_signals import (
@@ -57,14 +59,22 @@ def _brief_payload(**overrides):
         "title": "ACP Research Brief",
         "content": "# Brief\nGrounded finding.",
         "summary": "Grounded finding.",
-        "source_lineage": {
-            "sources": [
-                {"source_id": "src-1", "source_type": "media", "label": "Transcript"}
-            ]
-        },
+        "source_lineage": {"sources": [{"source_id": "src-1", "source_type": "media", "label": "Transcript"}]},
     }
     payload.update(overrides)
     return payload
+
+
+def test_validate_artifact_payload_rejects_non_mapping(tmp_path):
+    note_db = CharactersRAGDB(db_path=str(tmp_path / "chacha.db"), client_id="user-1")
+    note_db.upsert_workspace("workspace-alpha", "Alpha Workspace")
+
+    try:
+        assert (
+            _validate_artifact_payload(["not", "a", "mapping"], "workspace-alpha", note_db) == "invalid_artifact_format"
+        )
+    finally:
+        note_db.close_all_connections()
 
 
 def test_promotes_accepted_acp_brief_with_traceable_metadata(tmp_path):
@@ -243,9 +253,7 @@ def test_promote_flag_without_allowed_artifact_type_is_not_promoted(tmp_path):
         assert result.created_artifact_ids == []
         assert result.updated_artifact_ids == []
         assert result.skipped == []
-        assert result.errors == [
-            {"artifact_id": "brief-missing-type", "reason": "missing_artifact_type"}
-        ]
+        assert result.errors == [{"artifact_id": "brief-missing-type", "reason": "missing_artifact_type"}]
         assert note_db.list_workspace_artifacts("workspace-alpha") == []
     finally:
         note_db.close_all_connections()

--- a/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py
@@ -1074,6 +1074,27 @@ async def test_task_completion_signal_rejects_multiple_markers():
     assert exc_info.value.reason == "multiple"
 
 
+async def test_task_completion_signal_rejects_too_many_artifacts():
+    """Completion validation should bound agent-provided artifact fanout."""
+    from tldw_Server_API.app.core.Agent_Orchestration.completion_signals import (
+        CompletionSignalValidationError,
+        validate_task_completion_signal,
+    )
+
+    with pytest.raises(CompletionSignalValidationError) as exc_info:
+        validate_task_completion_signal(
+            {
+                "taskCompletion": {
+                    "status": "completed",
+                    "summary": "too many artifacts",
+                    "artifacts": [{} for _ in range(21)],
+                }
+            }
+        )
+
+    assert exc_info.value.reason == "too_many_artifacts"
+
+
 async def test_review_decision_signal_rejects_multiple_markers():
     """Reviewer validation should require exactly one structured marker."""
     from tldw_Server_API.app.core.Agent_Orchestration.completion_signals import (
@@ -1305,6 +1326,89 @@ async def test_dispatch_run_reviewer_agent_rejection_retries_with_history(monkey
         assert "Missing required tests" not in serialized
     finally:
         _clear_acp_audit_events()
+        db.close()
+
+
+async def test_dispatch_run_allows_retry_after_rejected_review(monkeypatch, tmp_path):
+    from tldw_Server_API.app.api.v1.endpoints import agent_orchestration as orch_mod
+
+    db = OrchestrationDB(user_id=1, db_dir=tmp_path)
+    project = db.create_project(name="P1")
+    task = db.create_task(
+        project.id,
+        title="T1",
+        description="Dispatch me",
+        agent_type="codex",
+        reviewer_agent_type="reviewer",
+        max_review_attempts=3,
+    )
+    client_holder = {
+        "client": _ReviewerDecisionClient(
+            {"approved": False, "feedback": "Needs another pass"}
+        )
+    }
+
+    async def fake_store():
+        return _NoopSessionStore()
+
+    async def fake_client():
+        return client_holder["client"]
+
+    monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.services.admin_acp_sessions_service.get_acp_session_store",
+        fake_store,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Agent_Client_Protocol.runner_client.get_runner_client",
+        fake_client,
+    )
+
+    try:
+        first = await orch_mod.dispatch_run(
+            task.id,
+            orch_mod.RunDispatchRequest(),
+            user=_TestUser(),
+        )
+        assert first["status"] == TaskStatus.IN_PROGRESS
+
+        client_holder["client"] = _ReviewerDecisionClient(
+            {"approved": True, "feedback": "Ready now"}
+        )
+        second = await orch_mod.dispatch_run(
+            task.id,
+            orch_mod.RunDispatchRequest(),
+            user=_TestUser(),
+        )
+
+        assert second["status"] == TaskStatus.COMPLETE
+        runs = db.list_runs(task.id)
+        assert len(runs) == 4
+        assert all(run.status.value == "completed" for run in runs)
+        assert [review["approved"] for review in db.list_reviews(task.id)] == [False, True]
+    finally:
+        db.close()
+
+
+async def test_dispatch_run_rejects_duplicate_active_run(monkeypatch, tmp_path):
+    from tldw_Server_API.app.api.v1.endpoints import agent_orchestration as orch_mod
+
+    db, task = await _build_dispatch_task(tmp_path)
+    db.transition_task(task.id, TaskStatus.IN_PROGRESS)
+    db.create_run(task.id, agent_type="codex", session_id="active-session")
+    monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
+
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await orch_mod.dispatch_run(
+                task.id,
+                orch_mod.RunDispatchRequest(),
+                user=_TestUser(),
+            )
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail == "Task already has a running run"
+    finally:
         db.close()
 
 

--- a/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py
@@ -1,4 +1,5 @@
 """Tests for Agent Orchestration API endpoints (Phase 4.2)."""
+
 from __future__ import annotations
 
 import json
@@ -87,9 +88,7 @@ async def test_list_tasks_all_statuses(svc):
 async def test_run_inherits_agent_type(svc):
     """Run should inherit agent_type from its parent task."""
     project = await svc.create_project(name="P1", user_id=1)
-    task = await svc.create_task(
-        project.id, title="T1", agent_type="codex", user_id=1
-    )
+    task = await svc.create_task(project.id, title="T1", agent_type="codex", user_id=1)
     run = await svc.create_run(task.id, session_id="sess-1")
     assert run.agent_type == "codex"
 
@@ -161,11 +160,7 @@ async def test_get_task_run_history_includes_acp_session_drillthrough(monkeypatc
 
     def fake_audit_events(*, session_id: str):
         with acp_mod._ACP_AUDIT_LOCK:
-            return [
-                dict(event)
-                for event in acp_mod._ACP_AUDIT_EVENTS
-                if event.get("session_id") == session_id
-            ]
+            return [dict(event) for event in acp_mod._ACP_AUDIT_EVENTS if event.get("session_id") == session_id]
 
     monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
     monkeypatch.setattr(acp_mod, "_acp_list_audit_events", fake_audit_events)
@@ -190,9 +185,7 @@ async def test_get_task_run_history_includes_acp_session_drillthrough(monkeypatc
         assert enriched_run["history"]["stop_reason"] == "end"
         assert enriched_run["history"]["prompt"]["preview"] == "Task prompt text"
         assert enriched_run["history"]["result"]["preview"] == "Done"
-        assert enriched_run["history"]["artifacts"] == [
-            {"artifact_count": 1, "session_id": "session-success"}
-        ]
+        assert enriched_run["history"]["artifacts"] == [{"artifact_count": 1, "session_id": "session-success"}]
         assert enriched_run["failure_context"] is None
     finally:
         _clear_acp_audit_events()
@@ -270,11 +263,7 @@ async def test_get_task_run_history_redacted_mode_omits_support_unsafe_text(monk
 
     def fake_audit_events(*, session_id: str):
         with acp_mod._ACP_AUDIT_LOCK:
-            return [
-                dict(event)
-                for event in acp_mod._ACP_AUDIT_EVENTS
-                if event.get("session_id") == session_id
-            ]
+            return [dict(event) for event in acp_mod._ACP_AUDIT_EVENTS if event.get("session_id") == session_id]
 
     monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
     monkeypatch.setattr(acp_mod, "_acp_list_audit_events", fake_audit_events)
@@ -351,9 +340,7 @@ async def test_redact_task_review_payloads_preserves_model_like_reviews():
         reviewer="goose",
     )
 
-    payloads = orch_mod._redact_task_review_payloads(
-        [ModelLikeReview(), namespace_review]
-    )
+    payloads = orch_mod._redact_task_review_payloads([ModelLikeReview(), namespace_review])
 
     assert payloads[0]["id"] == 1
     assert payloads[0]["feedback"] == "[redacted]"
@@ -563,11 +550,17 @@ class _RejectedCompletionClient:
 
 
 class _PromptFailingClient:
+    def __init__(self) -> None:
+        self.closed_sessions: list[str] = []
+
     async def create_session(self, *_args, **_kwargs):
         return "session-1"
 
     async def prompt(self, *_args, **_kwargs):
         raise RuntimeError("acp prompt backend exploded")
+
+    async def close_session(self, session_id: str):
+        self.closed_sessions.append(session_id)
 
 
 class _ReviewerDecisionClient:
@@ -623,9 +616,7 @@ async def test_canonical_workspace_bridge_creates_linked_execution_workspace(mon
     db = OrchestrationDB(user_id=1, db_dir=tmp_path)
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()
-    canonical_db = _CanonicalWorkspaceDB(
-        {"workspace-alpha": {"id": "workspace-alpha", "name": "Alpha Workspace"}}
-    )
+    canonical_db = _CanonicalWorkspaceDB({"workspace-alpha": {"id": "workspace-alpha", "name": "Alpha Workspace"}})
 
     monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
     monkeypatch.setattr(orch_mod, "_allowed_workspace_roots", lambda: (tmp_path.resolve(),))
@@ -668,9 +659,7 @@ async def test_canonical_workspace_bridge_reuses_existing_link(monkeypatch, tmp_
             "link_status": "linked",
         },
     )
-    canonical_db = _CanonicalWorkspaceDB(
-        {"workspace-alpha": {"id": "workspace-alpha", "name": "Alpha Workspace"}}
-    )
+    canonical_db = _CanonicalWorkspaceDB({"workspace-alpha": {"id": "workspace-alpha", "name": "Alpha Workspace"}})
 
     monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
     monkeypatch.setattr(orch_mod, "_allowed_workspace_roots", lambda: (tmp_path.resolve(),))
@@ -702,9 +691,7 @@ async def test_canonical_workspace_bridge_links_existing_unlinked_root(monkeypat
         root_path=str(workspace_root),
         metadata={"owner": "research"},
     )
-    canonical_db = _CanonicalWorkspaceDB(
-        {"workspace-alpha": {"id": "workspace-alpha", "name": "Alpha Workspace"}}
-    )
+    canonical_db = _CanonicalWorkspaceDB({"workspace-alpha": {"id": "workspace-alpha", "name": "Alpha Workspace"}})
 
     monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
     monkeypatch.setattr(orch_mod, "_allowed_workspace_roots", lambda: (tmp_path.resolve(),))
@@ -760,9 +747,7 @@ async def test_canonical_workspace_bridge_requires_allowed_root(monkeypatch, tmp
     db = OrchestrationDB(user_id=1, db_dir=tmp_path)
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()
-    canonical_db = _CanonicalWorkspaceDB(
-        {"workspace-alpha": {"id": "workspace-alpha", "name": "Alpha Workspace"}}
-    )
+    canonical_db = _CanonicalWorkspaceDB({"workspace-alpha": {"id": "workspace-alpha", "name": "Alpha Workspace"}})
 
     monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
     monkeypatch.setattr(orch_mod, "_allowed_workspace_roots", lambda: ())
@@ -802,9 +787,7 @@ async def test_canonical_workspace_bridge_rejects_root_linked_to_other_workspace
             "link_status": "linked",
         },
     )
-    canonical_db = _CanonicalWorkspaceDB(
-        {"workspace-alpha": {"id": "workspace-alpha", "name": "Alpha Workspace"}}
-    )
+    canonical_db = _CanonicalWorkspaceDB({"workspace-alpha": {"id": "workspace-alpha", "name": "Alpha Workspace"}})
 
     monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
     monkeypatch.setattr(orch_mod, "_allowed_workspace_roots", lambda: (tmp_path.resolve(),))
@@ -958,10 +941,7 @@ async def test_list_projects_canonical_filter_normalizes_legacy_source(
         )
 
         assert [item.id for item in results] == [project.id]
-        assert (
-            results[0].canonical_workspace.canonical_workspace_source
-            == "research_workspace"
-        )
+        assert results[0].canonical_workspace.canonical_workspace_source == "research_workspace"
     finally:
         db.close()
 
@@ -1041,9 +1021,7 @@ def _acp_audit_events_for_task(task_id: int) -> list[dict]:
 
     with acp_mod._ACP_AUDIT_LOCK:
         return [
-            dict(event)
-            for event in acp_mod._ACP_AUDIT_EVENTS
-            if event.get("metadata", {}).get("task_id") == task_id
+            dict(event) for event in acp_mod._ACP_AUDIT_EVENTS if event.get("metadata", {}).get("task_id") == task_id
         ]
 
 
@@ -1095,6 +1073,48 @@ async def test_task_completion_signal_rejects_too_many_artifacts():
     assert exc_info.value.reason == "too_many_artifacts"
 
 
+async def test_task_completion_signal_rejects_oversized_direct_dict_payload():
+    """Direct dict signals should be size bounded like marker JSON strings."""
+    from tldw_Server_API.app.core.Agent_Orchestration.completion_signals import (
+        CompletionSignalValidationError,
+        MAX_COMPLETION_SIGNAL_JSON_CHARS,
+        validate_task_completion_signal,
+    )
+
+    with pytest.raises(CompletionSignalValidationError) as exc_info:
+        validate_task_completion_signal(
+            {
+                "taskCompletion": {
+                    "status": "completed",
+                    "summary": "x" * (MAX_COMPLETION_SIGNAL_JSON_CHARS + 1),
+                }
+            }
+        )
+
+    assert exc_info.value.reason == "too_large"
+
+
+async def test_task_completion_signal_rejects_oversized_summary():
+    """Completion summaries should have an explicit bound below full JSON size."""
+    from tldw_Server_API.app.core.Agent_Orchestration.completion_signals import (
+        CompletionSignalValidationError,
+        MAX_COMPLETION_SUMMARY_CHARS,
+        validate_task_completion_signal,
+    )
+
+    with pytest.raises(CompletionSignalValidationError) as exc_info:
+        validate_task_completion_signal(
+            {
+                "taskCompletion": {
+                    "status": "completed",
+                    "summary": "x" * (MAX_COMPLETION_SUMMARY_CHARS + 1),
+                }
+            }
+        )
+
+    assert exc_info.value.reason == "summary_too_large"
+
+
 async def test_review_decision_signal_rejects_multiple_markers():
     """Reviewer validation should require exactly one structured marker."""
     from tldw_Server_API.app.core.Agent_Orchestration.completion_signals import (
@@ -1113,6 +1133,27 @@ async def test_review_decision_signal_rejects_multiple_markers():
         )
 
     assert exc_info.value.reason == "multiple"
+
+
+async def test_review_decision_signal_rejects_oversized_feedback():
+    """Reviewer feedback should have an explicit bound."""
+    from tldw_Server_API.app.core.Agent_Orchestration.completion_signals import (
+        MAX_REVIEW_FEEDBACK_CHARS,
+        ReviewDecisionValidationError,
+        validate_review_decision_signal,
+    )
+
+    with pytest.raises(ReviewDecisionValidationError) as exc_info:
+        validate_review_decision_signal(
+            {
+                "reviewDecision": {
+                    "approved": False,
+                    "feedback": "x" * (MAX_REVIEW_FEEDBACK_CHARS + 1),
+                }
+            }
+        )
+
+    assert exc_info.value.reason == "feedback_too_large"
 
 
 async def test_dispatch_run_sanitizes_create_session_failure(monkeypatch, tmp_path):
@@ -1148,6 +1189,8 @@ async def test_dispatch_run_sanitizes_create_session_failure(monkeypatch, tmp_pa
 
         assert exc_info.value.status_code == 502
         assert exc_info.value.detail == "Failed to create ACP session"
+        assert db.list_runs(task.id) == []
+        assert db.get_task(task.id).status == TaskStatus.TRIAGE
         fake_logger.exception.assert_called_once_with("Failed to create ACP session")
     finally:
         db.close()
@@ -1212,9 +1255,7 @@ async def test_dispatch_run_reviewer_agent_approval_completes_and_records_review
         agent_type="codex",
         reviewer_agent_type="reviewer",
     )
-    client = _ReviewerDecisionClient(
-        {"approved": True, "feedback": "Meets the success criteria"}
-    )
+    client = _ReviewerDecisionClient({"approved": True, "feedback": "Meets the success criteria"})
     _clear_acp_audit_events()
 
     async def fake_store():
@@ -1284,9 +1325,7 @@ async def test_dispatch_run_reviewer_agent_rejection_retries_with_history(monkey
         reviewer_agent_type="reviewer",
         max_review_attempts=2,
     )
-    client = _ReviewerDecisionClient(
-        {"approved": False, "feedback": "Missing required tests"}
-    )
+    client = _ReviewerDecisionClient({"approved": False, "feedback": "Missing required tests"})
     _clear_acp_audit_events()
 
     async def fake_store():
@@ -1342,11 +1381,7 @@ async def test_dispatch_run_allows_retry_after_rejected_review(monkeypatch, tmp_
         reviewer_agent_type="reviewer",
         max_review_attempts=3,
     )
-    client_holder = {
-        "client": _ReviewerDecisionClient(
-            {"approved": False, "feedback": "Needs another pass"}
-        )
-    }
+    client_holder = {"client": _ReviewerDecisionClient({"approved": False, "feedback": "Needs another pass"})}
 
     async def fake_store():
         return _NoopSessionStore()
@@ -1372,9 +1407,7 @@ async def test_dispatch_run_allows_retry_after_rejected_review(monkeypatch, tmp_
         )
         assert first["status"] == TaskStatus.IN_PROGRESS
 
-        client_holder["client"] = _ReviewerDecisionClient(
-            {"approved": True, "feedback": "Ready now"}
-        )
+        client_holder["client"] = _ReviewerDecisionClient({"approved": True, "feedback": "Ready now"})
         second = await orch_mod.dispatch_run(
             task.id,
             orch_mod.RunDispatchRequest(),
@@ -1425,9 +1458,7 @@ async def test_dispatch_run_reviewer_agent_rejection_max_attempts_triages(monkey
         reviewer_agent_type="reviewer",
         max_review_attempts=1,
     )
-    client = _ReviewerDecisionClient(
-        {"approved": False, "feedback": "Still fails review"}
-    )
+    client = _ReviewerDecisionClient({"approved": False, "feedback": "Still fails review"})
     _clear_acp_audit_events()
 
     async def fake_store():
@@ -1830,12 +1861,13 @@ async def test_dispatch_run_sanitizes_prompt_failure(monkeypatch, tmp_path):
 
     db, task = await _build_dispatch_task(tmp_path)
     fake_logger = MagicMock()
+    client = _PromptFailingClient()
 
     async def fake_store():
         return _NoopSessionStore()
 
     async def fake_client():
-        return _PromptFailingClient()
+        return client
 
     monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
     monkeypatch.setattr(orch_mod, "logger", fake_logger)
@@ -1858,6 +1890,7 @@ async def test_dispatch_run_sanitizes_prompt_failure(monkeypatch, tmp_path):
 
         assert exc_info.value.status_code == 502
         assert exc_info.value.detail == "ACP prompt failed"
+        assert client.closed_sessions == ["session-1"]
         fake_logger.exception.assert_called_once_with("ACP prompt failed")
     finally:
         db.close()
@@ -1869,9 +1902,7 @@ async def test_dispatch_run_sanitizes_prompt_failure(monkeypatch, tmp_path):
 async def test_review_approval_after_rejection(svc):
     """Approve should work after a previous rejection."""
     project = await svc.create_project(name="P1", user_id=1)
-    task = await svc.create_task(
-        project.id, title="T1", max_review_attempts=5, user_id=1
-    )
+    task = await svc.create_task(project.id, title="T1", max_review_attempts=5, user_id=1)
 
     # First cycle: reject
     await svc.transition_task(task.id, TaskStatus.IN_PROGRESS)
@@ -1893,12 +1924,8 @@ async def test_three_level_dependency_chain(svc):
     """Three-level dependency chain: T3 → T2 → T1."""
     project = await svc.create_project(name="P1", user_id=1)
     t1 = await svc.create_task(project.id, title="T1", user_id=1)
-    t2 = await svc.create_task(
-        project.id, title="T2", dependency_id=t1.id, user_id=1
-    )
-    t3 = await svc.create_task(
-        project.id, title="T3", dependency_id=t2.id, user_id=1
-    )
+    t2 = await svc.create_task(project.id, title="T2", dependency_id=t1.id, user_id=1)
+    t3 = await svc.create_task(project.id, title="T3", dependency_id=t2.id, user_id=1)
 
     # T3 not ready because T2 not complete
     assert await svc.check_dependency_ready(t3.id) is False

--- a/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py
@@ -551,6 +551,7 @@ class _RejectedCompletionClient:
 
 class _PromptFailingClient:
     def __init__(self) -> None:
+        """Record best-effort cleanup calls for prompt failure tests."""
         self.closed_sessions: list[str] = []
 
     async def create_session(self, *_args, **_kwargs):
@@ -560,6 +561,7 @@ class _PromptFailingClient:
         raise RuntimeError("acp prompt backend exploded")
 
     async def close_session(self, session_id: str):
+        """Capture session cleanup calls without contacting a runner."""
         self.closed_sessions.append(session_id)
 
 
@@ -1369,6 +1371,7 @@ async def test_dispatch_run_reviewer_agent_rejection_retries_with_history(monkey
 
 
 async def test_dispatch_run_allows_retry_after_rejected_review(monkeypatch, tmp_path):
+    """Rejected reviewer feedback should allow a later dispatch after runs are terminal."""
     from tldw_Server_API.app.api.v1.endpoints import agent_orchestration as orch_mod
 
     db = OrchestrationDB(user_id=1, db_dir=tmp_path)
@@ -1384,9 +1387,11 @@ async def test_dispatch_run_allows_retry_after_rejected_review(monkeypatch, tmp_
     client_holder = {"client": _ReviewerDecisionClient({"approved": False, "feedback": "Needs another pass"})}
 
     async def fake_store():
+        """Return a store that accepts quota and session registration."""
         return _NoopSessionStore()
 
     async def fake_client():
+        """Return the mutable fake client for each dispatch attempt."""
         return client_holder["client"]
 
     monkeypatch.setattr(orch_mod, "get_orchestration_db", lambda _user_id: db)
@@ -1424,6 +1429,7 @@ async def test_dispatch_run_allows_retry_after_rejected_review(monkeypatch, tmp_
 
 
 async def test_dispatch_run_rejects_duplicate_active_run(monkeypatch, tmp_path):
+    """A task with an existing running run should reject duplicate dispatch."""
     from tldw_Server_API.app.api.v1.endpoints import agent_orchestration as orch_mod
 
     db, task = await _build_dispatch_task(tmp_path)

--- a/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_db.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_db.py
@@ -1,4 +1,6 @@
 """Tests for Orchestration SQLite persistence."""
+
+import sqlite3
 import tempfile
 
 import pytest
@@ -124,9 +126,7 @@ class TestRunCRUD:
         t = db.create_task(p.id, title="T1")
         run = db.create_run(t.id, agent_type="claude_code", session_id="sess-1")
         assert run.status == RunStatus.RUNNING
-        completed = db.complete_run(
-            run.id, result_summary="done", token_usage={"input_tokens": 100}
-        )
+        completed = db.complete_run(run.id, result_summary="done", token_usage={"input_tokens": 100})
         assert completed.status == RunStatus.COMPLETED
         assert completed.result_summary == "done"
         assert completed.token_usage == {"input_tokens": 100}
@@ -156,6 +156,33 @@ class TestRunCRUD:
         with pytest.raises(InvalidTransitionError, match="running run"):
             db.create_run(t.id)
 
+    def test_running_run_uniqueness_is_enforced_by_database(self, db):
+        p = db.create_project(name="P1")
+        t = db.create_task(p.id, title="T1")
+        db.create_run(t.id, agent_type="codex", session_id="session-1")
+
+        with pytest.raises(sqlite3.IntegrityError):
+            db._get_conn().execute(
+                "INSERT INTO runs (task_id, session_id, status, agent_type, started_at) " "VALUES (?, ?, ?, ?, ?)",
+                (
+                    t.id,
+                    "session-2",
+                    RunStatus.RUNNING.value,
+                    "codex",
+                    "2026-06-24T00:00:00+00:00",
+                ),
+            )
+
+    def test_has_running_run_tracks_active_status(self, db):
+        p = db.create_project(name="P1")
+        t = db.create_task(p.id, title="T1")
+
+        assert db.has_running_run(t.id) is False
+        run = db.create_run(t.id)
+        assert db.has_running_run(t.id) is True
+        db.complete_run(run.id)
+        assert db.has_running_run(t.id) is False
+
     def test_terminal_run_cannot_be_rewritten(self, db):
         p = db.create_project(name="P1")
         t = db.create_task(p.id, title="T1")
@@ -168,6 +195,10 @@ class TestRunCRUD:
     def test_missing_run_update_raises_not_found(self, db):
         with pytest.raises(OrchestrationNotFoundError, match="Run 999 not found"):
             db.complete_run(999)
+
+    def test_missing_run_session_update_raises_not_found(self, db):
+        with pytest.raises(OrchestrationNotFoundError, match="Run 999 not found"):
+            db.update_run_session_id(999, "session-999")
 
 
 class TestReviewerGate:

--- a/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_db.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_db.py
@@ -149,6 +149,7 @@ class TestRunCRUD:
         assert len(runs) == 2
 
     def test_create_run_rejects_duplicate_running_run(self, db):
+        """The DB facade should reject duplicate running runs for one task."""
         p = db.create_project(name="P1")
         t = db.create_task(p.id, title="T1")
         db.create_run(t.id)
@@ -157,6 +158,7 @@ class TestRunCRUD:
             db.create_run(t.id)
 
     def test_running_run_uniqueness_is_enforced_by_database(self, db):
+        """The SQLite partial index should enforce the active-run invariant."""
         p = db.create_project(name="P1")
         t = db.create_task(p.id, title="T1")
         db.create_run(t.id, agent_type="codex", session_id="session-1")
@@ -174,6 +176,7 @@ class TestRunCRUD:
             )
 
     def test_has_running_run_tracks_active_status(self, db):
+        """has_running_run should only be true while the run is active."""
         p = db.create_project(name="P1")
         t = db.create_task(p.id, title="T1")
 
@@ -184,6 +187,7 @@ class TestRunCRUD:
         assert db.has_running_run(t.id) is False
 
     def test_terminal_run_cannot_be_rewritten(self, db):
+        """Terminal completed runs should not be rewritten as failed."""
         p = db.create_project(name="P1")
         t = db.create_task(p.id, title="T1")
         run = db.create_run(t.id)
@@ -193,10 +197,12 @@ class TestRunCRUD:
             db.fail_run(run.id, error="late failure")
 
     def test_missing_run_update_raises_not_found(self, db):
+        """Completing a missing run should raise a deterministic not-found error."""
         with pytest.raises(OrchestrationNotFoundError, match="Run 999 not found"):
             db.complete_run(999)
 
     def test_missing_run_session_update_raises_not_found(self, db):
+        """Attaching a session to a missing run should raise not-found."""
         with pytest.raises(OrchestrationNotFoundError, match="Run 999 not found"):
             db.update_run_session_id(999, "session-999")
 
@@ -250,7 +256,10 @@ class TestProjectSummary:
 
 
 class TestUserScoping:
+    """Regression tests for shared-database user ownership scoping."""
+
     def test_shared_db_project_task_run_and_review_methods_are_user_scoped(self):
+        """Project, task, run, and review operations should not cross user ids."""
         with tempfile.TemporaryDirectory() as tmp:
             db1 = OrchestrationDB(user_id=1, db_dir=tmp)
             db2 = OrchestrationDB(user_id=2, db_dir=tmp)

--- a/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_db.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_db.py
@@ -4,7 +4,11 @@ import tempfile
 import pytest
 
 from tldw_Server_API.app.core.Agent_Orchestration.models import RunStatus, TaskStatus
-from tldw_Server_API.app.core.DB_Management.Orchestration_DB import OrchestrationDB
+from tldw_Server_API.app.core.DB_Management.Orchestration_DB import (
+    InvalidTransitionError,
+    OrchestrationDB,
+    OrchestrationNotFoundError,
+)
 
 
 @pytest.fixture
@@ -138,10 +142,32 @@ class TestRunCRUD:
     def test_list_runs(self, db):
         p = db.create_project(name="P1")
         t = db.create_task(p.id, title="T1")
-        db.create_run(t.id)
+        first = db.create_run(t.id)
+        db.complete_run(first.id)
         db.create_run(t.id)
         runs = db.list_runs(t.id)
         assert len(runs) == 2
+
+    def test_create_run_rejects_duplicate_running_run(self, db):
+        p = db.create_project(name="P1")
+        t = db.create_task(p.id, title="T1")
+        db.create_run(t.id)
+
+        with pytest.raises(InvalidTransitionError, match="running run"):
+            db.create_run(t.id)
+
+    def test_terminal_run_cannot_be_rewritten(self, db):
+        p = db.create_project(name="P1")
+        t = db.create_task(p.id, title="T1")
+        run = db.create_run(t.id)
+        db.complete_run(run.id)
+
+        with pytest.raises(InvalidTransitionError, match="completed to failed"):
+            db.fail_run(run.id, error="late failure")
+
+    def test_missing_run_update_raises_not_found(self, db):
+        with pytest.raises(OrchestrationNotFoundError, match="Run 999 not found"):
+            db.complete_run(999)
 
 
 class TestReviewerGate:
@@ -190,3 +216,42 @@ class TestProjectSummary:
         assert summary["total_tasks"] == 2
         assert summary["status_counts"]["todo"] == 1
         assert summary["status_counts"]["inprogress"] == 1
+
+
+class TestUserScoping:
+    def test_shared_db_project_task_run_and_review_methods_are_user_scoped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db1 = OrchestrationDB(user_id=1, db_dir=tmp)
+            db2 = OrchestrationDB(user_id=2, db_dir=tmp)
+            try:
+                project = db1.create_project(name="P1")
+                task = db1.create_task(project.id, title="T1")
+                db1.transition_task(task.id, TaskStatus.IN_PROGRESS)
+                run = db1.create_run(task.id)
+
+                assert db2.get_project(project.id) is None
+                assert db2.get_task(task.id) is None
+                assert db2.list_tasks(project.id) == []
+                assert db2.list_runs(task.id) == []
+                assert db2.list_reviews(task.id) == []
+                assert db2.get_project_summary(project.id) == {
+                    "project_id": project.id,
+                    "total_tasks": 0,
+                    "status_counts": {},
+                }
+
+                with pytest.raises(OrchestrationNotFoundError, match="Project"):
+                    db2.create_task(project.id, title="T2")
+                with pytest.raises(OrchestrationNotFoundError, match="Task"):
+                    db2.transition_task(task.id, TaskStatus.REVIEW)
+                with pytest.raises(OrchestrationNotFoundError, match="Task"):
+                    db2.create_run(task.id)
+                with pytest.raises(OrchestrationNotFoundError, match="Run"):
+                    db2.complete_run(run.id)
+                with pytest.raises(OrchestrationNotFoundError, match="Run"):
+                    db2.fail_run(run.id)
+                with pytest.raises(OrchestrationNotFoundError, match="Task"):
+                    db2.submit_review(task.id, approved=True)
+            finally:
+                db1.close()
+                db2.close()

--- a/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_service.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_service.py
@@ -1,16 +1,14 @@
 """Tests for Agent Orchestration service (Phase 4)."""
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
+from tldw_Server_API.app.core.Agent_Orchestration import db_factory
 from tldw_Server_API.app.core.Agent_Orchestration.models import (
     TaskStatus,
     RunStatus,
     is_valid_transition,
 )
-import tldw_Server_API.app.core.Agent_Orchestration.orchestration_service as orchestration_service_module
 from tldw_Server_API.app.core.Agent_Orchestration.orchestration_service import (
     CycleDependencyError,
     OrchestrationService,
@@ -200,22 +198,26 @@ async def test_fail_run(svc):
     assert failed.error == "Timeout"
 
 
-def test_get_orchestration_db_uses_safe_for_user_factory(monkeypatch, tmp_path):
+def test_legacy_sqlite_factory_reexports_dedicated_factory():
+    assert get_orchestration_db is db_factory.get_orchestration_db
+
+
+def test_sqlite_factory_is_available_from_dedicated_module(monkeypatch, tmp_path):
     sentinel = object()
 
     monkeypatch.setenv("USER_DB_BASE_DIR", str(tmp_path / "user_dbs"))
-    get_orchestration_db.cache_clear()
+    db_factory.get_orchestration_db.cache_clear()
     monkeypatch.setattr(
-        orchestration_service_module.OrchestrationDB,
+        db_factory.OrchestrationDB,
         "for_user",
         classmethod(lambda cls, user_id: sentinel),
         raising=False,
     )
 
     try:
-        assert get_orchestration_db(7) is sentinel
+        assert db_factory.get_orchestration_db(7) is sentinel
     finally:
-        get_orchestration_db.cache_clear()
+        db_factory.get_orchestration_db.cache_clear()
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_service.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_service.py
@@ -1,4 +1,5 @@
 """Tests for Agent Orchestration service (Phase 4)."""
+
 from __future__ import annotations
 
 import pytest
@@ -25,6 +26,7 @@ def svc():
 
 # ---- State machine tests ----
 
+
 def test_valid_transitions():
     assert is_valid_transition(TaskStatus.TODO, TaskStatus.IN_PROGRESS)
     assert is_valid_transition(TaskStatus.IN_PROGRESS, TaskStatus.REVIEW)
@@ -45,6 +47,7 @@ def test_invalid_transitions():
 
 
 # ---- Project CRUD tests ----
+
 
 @pytest.mark.asyncio
 async def test_create_project(svc):
@@ -77,12 +80,15 @@ async def test_delete_project_cascades(svc):
 
 # ---- Task CRUD tests ----
 
+
 @pytest.mark.asyncio
 async def test_create_task(svc):
     project = await svc.create_project(name="P1", user_id=1)
     task = await svc.create_task(
-        project.id, title="Task 1",
-        description="Do something", agent_type="claude_code",
+        project.id,
+        title="Task 1",
+        description="Do something",
+        agent_type="claude_code",
         user_id=1,
     )
     assert task.id == 1
@@ -112,6 +118,7 @@ async def test_list_tasks_with_status_filter(svc):
 
 
 # ---- Dependency tests ----
+
 
 @pytest.mark.asyncio
 async def test_dependency_gating(svc):
@@ -152,6 +159,7 @@ async def test_no_dependency_always_ready(svc):
 
 # ---- State transition tests ----
 
+
 @pytest.mark.asyncio
 async def test_transition_todo_to_inprogress(svc):
     project = await svc.create_project(name="P1", user_id=1)
@@ -171,6 +179,7 @@ async def test_invalid_transition_raises(svc):
 
 
 # ---- Run tests ----
+
 
 @pytest.mark.asyncio
 async def test_create_and_complete_run(svc):
@@ -199,10 +208,12 @@ async def test_fail_run(svc):
 
 
 def test_legacy_sqlite_factory_reexports_dedicated_factory():
+    """Legacy service imports should continue to expose the durable DB factory."""
     assert get_orchestration_db is db_factory.get_orchestration_db
 
 
 def test_sqlite_factory_is_available_from_dedicated_module(monkeypatch, tmp_path):
+    """The dedicated factory should construct per-user OrchestrationDB instances."""
     sentinel = object()
 
     monkeypatch.setenv("USER_DB_BASE_DIR", str(tmp_path / "user_dbs"))
@@ -233,6 +244,7 @@ async def test_list_runs(svc):
 
 
 # ---- Reviewer gate tests ----
+
 
 @pytest.mark.asyncio
 async def test_review_approved(svc):
@@ -285,6 +297,7 @@ async def test_review_on_non_review_task_raises(svc):
 
 
 # ---- Summary test ----
+
 
 @pytest.mark.asyncio
 async def test_project_summary(svc):

--- a/tldw_Server_API/tests/Agent_Orchestration/test_workspace_api_helpers.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_workspace_api_helpers.py
@@ -248,7 +248,7 @@ class TestMcpResolverAcpFallback:
 
             # Patch get_orchestration_db where it's imported inside _resolve_acp_workspace
             with patch(
-                "tldw_Server_API.app.core.Agent_Orchestration.orchestration_service.get_orchestration_db",
+                "tldw_Server_API.app.core.Agent_Orchestration.db_factory.get_orchestration_db",
                 return_value=db,
             ):
                 result = McpHubWorkspaceRootResolver._resolve_acp_workspace("1", str(ws.id))
@@ -261,7 +261,7 @@ class TestMcpResolverAcpFallback:
             db = OrchestrationDB(user_id=1, db_dir=tmp)
             db._ensure_schema()
             with patch(
-                "tldw_Server_API.app.core.Agent_Orchestration.orchestration_service.get_orchestration_db",
+                "tldw_Server_API.app.core.Agent_Orchestration.db_factory.get_orchestration_db",
                 return_value=db,
             ):
                 result = McpHubWorkspaceRootResolver._resolve_acp_workspace("1", "99999")

--- a/tldw_Server_API/tests/Agent_Orchestration/test_workspace_db.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_workspace_db.py
@@ -544,6 +544,7 @@ class TestWorkspaceMCPServers:
         assert len(servers) == 2
 
     def test_list_mcp_servers_wrong_user_returns_empty(self):
+        """Workspace MCP server reads should be scoped to the workspace owner."""
         with tempfile.TemporaryDirectory() as tmp:
             db1 = OrchestrationDB(user_id=1, db_dir=tmp)
             db2 = OrchestrationDB(user_id=2, db_dir=tmp)

--- a/tldw_Server_API/tests/Agent_Orchestration/test_workspace_db.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_workspace_db.py
@@ -556,6 +556,19 @@ class TestWorkspaceMCPServers:
         servers = db.list_workspace_mcp_servers(ws.id)
         assert len(servers) == 2
 
+    def test_list_mcp_servers_wrong_user_returns_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db1 = OrchestrationDB(user_id=1, db_dir=tmp)
+            db2 = OrchestrationDB(user_id=2, db_dir=tmp)
+            try:
+                ws = db1.create_workspace(name="WS1", root_path="/tmp/ws1")
+                db1.create_workspace_mcp_server(ws.id, "server-a", command="cmd-a")
+
+                assert db2.list_workspace_mcp_servers(ws.id) == []
+            finally:
+                db1.close()
+                db2.close()
+
     def test_delete_mcp_server(self, db):
         ws = db.create_workspace(name="WS1", root_path="/tmp/ws1")
         server = db.create_workspace_mcp_server(ws.id, "server-a", command="cmd")

--- a/tldw_Server_API/tests/Agent_Orchestration/test_workspace_db.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_workspace_db.py
@@ -1,4 +1,5 @@
 """Tests for ACPWorkspace DB CRUD and schema migration."""
+
 import tempfile
 
 import pytest
@@ -28,22 +29,17 @@ class TestSchemaMigration:
         """A fresh DB should have all current workspace tables and columns."""
         db._ensure_schema()
         conn = db._get_conn()
-        tables = {
-            r[0]
-            for r in conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table'"
-            ).fetchall()
-        }
+        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
         assert "acp_workspaces" in tables
         assert "acp_workspace_mcp_servers" in tables
         assert "projects" in tables
-        workspace_cols = {
-            r[1] for r in conn.execute("PRAGMA table_info(acp_workspaces)").fetchall()
-        }
+        workspace_cols = {r[1] for r in conn.execute("PRAGMA table_info(acp_workspaces)").fetchall()}
         assert "canonical_workspace_id" in workspace_cols
         # Check user_version
         version = conn.execute("PRAGMA user_version").fetchone()[0]
-        assert version == 3
+        assert version == 4
+        indexes = {r[1] for r in conn.execute("PRAGMA index_list(runs)").fetchall()}
+        assert "idx_runs_one_running_per_task" in indexes
 
     def test_projects_has_workspace_id_column(self, db):
         """The projects table should have a workspace_id column after migration."""
@@ -86,12 +82,7 @@ class TestSchemaMigration:
             c = db._get_conn()
 
             # Check v2 tables exist
-            tables = {
-                r[0]
-                for r in c.execute(
-                    "SELECT name FROM sqlite_master WHERE type='table'"
-                ).fetchall()
-            }
+            tables = {r[0] for r in c.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
             assert "acp_workspaces" in tables
             assert "acp_workspace_mcp_servers" in tables
 
@@ -104,13 +95,11 @@ class TestSchemaMigration:
             assert row is not None
             assert row[1] == "test"  # name
 
-            workspace_cols = {
-                r[1] for r in c.execute("PRAGMA table_info(acp_workspaces)").fetchall()
-            }
+            workspace_cols = {r[1] for r in c.execute("PRAGMA table_info(acp_workspaces)").fetchall()}
             assert "canonical_workspace_id" in workspace_cols
 
             version = c.execute("PRAGMA user_version").fetchone()[0]
-            assert version == 3
+            assert version == 4
             db.close()
 
     def test_v2_to_v3_migration_backfills_canonical_workspace_id(self):
@@ -444,9 +433,7 @@ class TestWorkspaceCRUD:
                 canonical_workspace_source="research_workspace",
             )
 
-        assert (
-            db.get_workspace_by_canonical_workspace_id("workspace-alpha").id == ws.id
-        )
+        assert db.get_workspace_by_canonical_workspace_id("workspace-alpha").id == ws.id
         assert db.get_workspace_by_canonical_workspace_id("workspace-beta") is None
 
     def test_workspace_with_git_info(self, db):


### PR DESCRIPTION
## Summary

- What changed:
AoM bugfixes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Agent Orchestration with per-user DB scoping, strict run-state rules, and tighter bounds on ACP completion/review payloads and artifact promotion. Moves the production DB factory to `db_factory`, enforces a single active run per task, and allows safe post-review redispatch without duplicates. Addresses TASK-2403.

- **Bug Fixes**
  - Dispatch: block duplicate active runs; allow retry after a rejected review once prior runs are terminal; create run before ACP session and triage on session failure.
  - DB: schema v4 enforces at most one running run per task; all reads/writes scoped by `user_id`; invalid run transitions blocked via `is_valid_run_transition`; missing run updates raise not-found.
  - ACP bounds: cap completion JSON size, artifacts (20), and summary/feedback length; promotion pre-validates payloads and enforces content/title/summary/export_refs limits; oversize artifacts are rejected before write with clear reasons.

- **Migration**
  - Import the production DB from `tldw_Server_API.app.core.Agent_Orchestration.db_factory.get_orchestration_db` (`orchestration_service` is now legacy for tests and no longer re-exports the factory).

<sup>Written for commit 299acdf1a4c21ddda04918e1f8eb9eedd040be2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

