### PR TITLE
Harden ACP runner security controls

### DIFF
--- a/Docs/superpowers/plans/2026-06-23-acp-agent-client-protocol-hardening.md
+++ b/Docs/superpowers/plans/2026-06-23-acp-agent-client-protocol-hardening.md
@@ -27,3 +27,9 @@
 **Success Criteria**: Targeted pytest suite passes and Bandit reports no new actionable findings in the touched scope.
 **Tests**: Focused pytest plus Bandit JSON output.
 **Status**: Complete
+
+## Stage 6: PR Review Follow-Up
+**Goal**: Rebase on current `dev` and address PR review comments from Qodo and Gemini.
+**Success Criteria**: DNS-resolving SSRF checks, fail-closed cwd roots, stricter destructive permission tokens, redact-before-regex behavior, SSE URL cleanup, direct config field access, docstrings, and type hints are covered by focused tests.
+**Tests**: Focused ACP pytest slice including config cwd tests plus Bandit on touched ACP code.
+**Status**: Complete

--- a/Docs/superpowers/plans/2026-06-23-acp-agent-client-protocol-hardening.md
+++ b/Docs/superpowers/plans/2026-06-23-acp-agent-client-protocol-hardening.md
@@ -1,0 +1,29 @@
+## Stage 1: Regression Tests
+**Goal**: Capture the ACP review findings as focused tests for launch validation, permission tiers, timeouts, queue bounds, URL safety, redaction, SSH key persistence, and unsupported egress allowlists.
+**Success Criteria**: New tests fail against the current implementation for the risky behaviors.
+**Tests**: Targeted pytest runs under `tldw_Server_API/tests/Agent_Client_Protocol/`.
+**Status**: Complete
+
+## Stage 2: Host Runner And Permission Hardening
+**Goal**: Prevent unsafe non-sandbox launch inputs and make permission tier matching prefer destructive operations over broad substring auto-approval.
+**Success Criteria**: Host session creation rejects unsafe cwd/env/stdio MCP inputs by default; permission tiers classify ambiguous/destructive tools conservatively.
+**Tests**: ACP host-launch and permission tier tests.
+**Status**: Complete
+
+## Stage 3: Transport And Runtime Safety
+**Goal**: Add bounded RPC waits, bounded update queues, MCP HTTP/SSE URL controls, and stderr/output redaction.
+**Success Criteria**: Pending calls time out and clean up; update queues are capped; MCP transports reject local/cross-origin URLs; logs redact obvious secrets.
+**Tests**: ACP client, stream transport, MCP transport, and queue tests.
+**Status**: Complete
+
+## Stage 4: Sandbox Controls
+**Goal**: Stop persisting SSH private keys by default and fail fast when unsupported per-session egress allowlists are configured.
+**Success Criteria**: Durable control metadata omits private keys unless explicitly enabled; unsupported egress allowlist config is rejected instead of silently ignored.
+**Tests**: Sandbox runner configuration and metadata tests.
+**Status**: Complete
+
+## Stage 5: Verification
+**Goal**: Run the focused ACP tests and security scan for touched paths.
+**Success Criteria**: Targeted pytest suite passes and Bandit reports no new actionable findings in the touched scope.
+**Tests**: Focused pytest plus Bandit JSON output.
+**Status**: Complete

--- a/backlog/tasks/task-2402 - Harden-Agent-Client-Protocol-review-findings.md
+++ b/backlog/tasks/task-2402 - Harden-Agent-Client-Protocol-review-findings.md
@@ -1,0 +1,55 @@
+---
+id: TASK-2402
+title: Harden Agent Client Protocol review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 18:09'
+updated_date: '2026-06-23 18:28'
+labels:
+  - acp
+  - security
+  - reliability
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address current-code review findings in tldw_Server_API/app/core/Agent_Client_Protocol: session launch input hardening, permission tier classification, RPC timeouts, bounded update queues, MCP HTTP/SSE SSRF controls, stderr redaction, sandbox SSH key handling, and ACP sandbox egress config alignment.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Non-sandbox ACP session creation rejects unsafe cwd/env/MCP server launch surfaces unless explicitly allowed by policy.
+- [x] #2 Permission tier resolution cannot auto-approve destructive or execution-like tool names through read/get/list substrings.
+- [x] #3 ACP stdio and stream RPC calls time out and clean pending futures.
+- [x] #4 Runner update queues and stream buffers are bounded.
+- [x] #5 MCP HTTP/SSE transports reject unsafe endpoints and same-origin SSE post URL violations.
+- [x] #6 Downstream stderr logging is redacted and truncated.
+- [x] #7 Sandbox SSH private-key handling is encrypted or bounded by config and documented in code.
+- [x] #8 ACP sandbox allowed egress configuration is either enforced through sandbox policy or removed from the active contract.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented ACP hardening plan docs/superpowers/plans/2026-06-23-acp-agent-client-protocol-hardening.md. Added shared hardening helpers for URL validation, redaction, bounded queues, and launch validation; wired host runner, stream/stdio clients, MCP transports, and sandbox metadata handling.
+Verification: focused ACP pytest slice with local confcutdir passed: 86 passed, 4 warnings in 10.78s. Bandit on touched ACP code wrote /tmp/bandit_acp_hardening.json with 0 results and 0 errors.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened Agent_Client_Protocol current-code review findings: host runner launch surfaces now require explicit policy opt-ins, permission tiers classify destructive tokens conservatively, RPC calls time out and clean pending futures, update queues and stream buffers are bounded, MCP HTTP/SSE transports reject unsafe endpoints by default, stderr logging is redacted, sandbox SSH private keys are not persisted by default, and unsupported ACP sandbox egress allowlists now fail fast.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2402 - Harden-Agent-Client-Protocol-review-findings.md
+++ b/backlog/tasks/task-2402 - Harden-Agent-Client-Protocol-review-findings.md
@@ -3,12 +3,12 @@ id: TASK-2402
 title: Harden Agent Client Protocol review findings
 status: Done
 assignee: []
-created_date: '2026-06-23 18:09'
-updated_date: '2026-06-23 18:28'
+created_date: 2026-06-23 18:09
+updated_date: 2026-06-24 01:24
 labels:
-  - acp
-  - security
-  - reliability
+- acp
+- security
+- reliability
 dependencies: []
 priority: high
 ---
@@ -41,7 +41,7 @@ Verification: focused ACP pytest slice with local confcutdir passed: 86 passed, 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Hardened Agent_Client_Protocol current-code review findings: host runner launch surfaces now require explicit policy opt-ins, permission tiers classify destructive tokens conservatively, RPC calls time out and clean pending futures, update queues and stream buffers are bounded, MCP HTTP/SSE transports reject unsafe endpoints by default, stderr logging is redacted, sandbox SSH private keys are not persisted by default, and unsupported ACP sandbox egress allowlists now fail fast.
+Hardened Agent_Client_Protocol current-code review findings and PR review follow-ups: host runner launch surfaces now require explicit policy opt-ins and fail closed when cwd roots are unset, permission tiers classify destructive/write/update tokens conservatively, RPC calls time out and clean pending futures, update queues and stream buffers are bounded, MCP HTTP/SSE transports reject unsafe endpoints by default with DNS-resolving host checks, stderr logging truncates before redaction, sandbox SSH private keys are not persisted by default, unsupported ACP sandbox egress allowlists fail fast, and review-requested docstrings/type hints/SSE cleanup are in place.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -53,3 +53,12 @@ Hardened Agent_Client_Protocol current-code review findings: host runner launch 
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+PR review follow-up on 2026-06-24: rebased branch onto origin/dev and addressing review comments from Qodo/Gemini covering DNS-resolving SSRF validation, fail-closed cwd roots, stricter permission tokens, redact-before-regex, SSE URL cleanup, direct config field access, docstrings, and type hints.
+PR review follow-up completed on 2026-06-24: rebased onto origin/dev at 2ecb83fa4 and addressed Qodo/Gemini comments. Added DNS-resolving MCP HTTP host blocking with a bounded cache, fail-closed behavior when host runner cwd roots are unset, stricter destructive permission tokens, redact-before-regex output truncation, SSE post URL resolution cleanup, direct ACPRunnerConfig field access, module/function docstrings, and missing test type hints.
+Verification: focused ACP pytest slice including test_acp_config_cwd.py passed: 109 passed, 4 warnings in 0.57s. Bandit on the touched ACP code files wrote /tmp/bandit_acp_pr_review_touched.json with 0 results and 0 errors. Full ACP-directory Bandit scan still reports one pre-existing low finding in tldw_Server_API/app/core/Agent_Client_Protocol/events.py (B105 token_usage), which is outside the touched PR scope.
+Final rebase correction on 2026-06-24: origin/dev advanced again during review-fix work, so the branch was rebased onto 4fb8eafd5 before push. Re-ran the focused ACP pytest slice after that rebase: 109 passed, 4 warnings in 0.74s. Re-ran Bandit on touched ACP code files after that rebase: /tmp/bandit_acp_pr_review_rebased_touched.json completed with exit 0.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transport.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transport.py
@@ -93,12 +93,15 @@ def create_transport(protocol_config: dict[str, Any]) -> MCPTransport:
             post_url=protocol_config.get("post_url"),
             headers=protocol_config.get("headers"),
             timeout_sec=protocol_config.get("timeout_sec", 30),
+            allow_private_network=protocol_config.get("allow_private_network"),
+            allow_cross_origin_post_url=protocol_config.get("allow_cross_origin_post_url"),
         )
     elif protocol == "streamable_http":
         return MCPStreamableHTTPTransport(
             endpoint=_require_key("endpoint"),
             headers=protocol_config.get("headers"),
             timeout_sec=protocol_config.get("timeout_sec", 30),
+            allow_private_network=protocol_config.get("allow_private_network"),
         )
     else:
         raise ValidationError(

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/sse.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/sse.py
@@ -158,8 +158,7 @@ class MCPSSETransport(MCPTransport):
                     event_type, data = event
                     if event_type == "endpoint":
                         # Resolve relative URL against sse_url base
-                        base = self._sse_url.rsplit("/", 1)[0] + "/"
-                        post_url = urljoin(base, data)
+                        post_url = urljoin(self._sse_url, data)
                         return validate_sse_post_url(
                             self._sse_url,
                             post_url,
@@ -281,12 +280,6 @@ class MCPSSETransport(MCPTransport):
             raise RuntimeError("HTTP client not initialized")
         if self._post_url is None:
             raise RuntimeError("post_url must be set before making calls")
-        validate_sse_post_url(
-            self._sse_url,
-            self._post_url,
-            allow_private_network=self._allow_private_network,
-            allow_cross_origin=self._allow_cross_origin_post_url,
-        )
 
         try:
             response = await self._http_client.post(
@@ -314,12 +307,6 @@ class MCPSSETransport(MCPTransport):
             raise RuntimeError("HTTP client not initialized")
         if self._post_url is None:
             raise RuntimeError("post_url must be set before making calls")
-        validate_sse_post_url(
-            self._sse_url,
-            self._post_url,
-            allow_private_network=self._allow_private_network,
-            allow_cross_origin=self._allow_cross_origin_post_url,
-        )
 
         response = await self._http_client.post(
             self._post_url,

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/sse.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/sse.py
@@ -13,6 +13,10 @@ from loguru import logger
 from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transport import (
     MCPTransport,
 )
+from tldw_Server_API.app.core.Agent_Client_Protocol.hardening import (
+    validate_mcp_http_url,
+    validate_sse_post_url,
+)
 
 
 class MCPSSETransport(MCPTransport):
@@ -35,11 +39,15 @@ class MCPSSETransport(MCPTransport):
         post_url: str | None = None,
         headers: dict[str, str] | None = None,
         timeout_sec: int = 30,
+        allow_private_network: bool | None = None,
+        allow_cross_origin_post_url: bool | None = None,
     ) -> None:
         self._sse_url = sse_url
         self._post_url = post_url
         self._headers = headers
         self._timeout_sec = timeout_sec
+        self._allow_private_network = allow_private_network
+        self._allow_cross_origin_post_url = allow_cross_origin_post_url
         self._http_client: httpx.AsyncClient | None = None
         self._pending: dict[str, asyncio.Future] = {}
         self._next_id = 1
@@ -59,6 +67,18 @@ class MCPSSETransport(MCPTransport):
 
     async def connect(self) -> None:
         """Open the SSE stream, discover post_url if needed, and perform MCP handshake."""
+        validate_mcp_http_url(
+            self._sse_url,
+            allow_private_network=self._allow_private_network,
+            label="MCP SSE URL",
+        )
+        if self._post_url:
+            validate_sse_post_url(
+                self._sse_url,
+                self._post_url,
+                allow_private_network=self._allow_private_network,
+                allow_cross_origin=self._allow_cross_origin_post_url,
+            )
         self._http_client = self._create_http_client()
         try:
             if not self._post_url:
@@ -139,7 +159,13 @@ class MCPSSETransport(MCPTransport):
                     if event_type == "endpoint":
                         # Resolve relative URL against sse_url base
                         base = self._sse_url.rsplit("/", 1)[0] + "/"
-                        return urljoin(base, data)
+                        post_url = urljoin(base, data)
+                        return validate_sse_post_url(
+                            self._sse_url,
+                            post_url,
+                            allow_private_network=self._allow_private_network,
+                            allow_cross_origin=self._allow_cross_origin_post_url,
+                        )
 
         raise RuntimeError(
             f"SSE stream at {self._sse_url} closed without sending an endpoint event"
@@ -255,6 +281,12 @@ class MCPSSETransport(MCPTransport):
             raise RuntimeError("HTTP client not initialized")
         if self._post_url is None:
             raise RuntimeError("post_url must be set before making calls")
+        validate_sse_post_url(
+            self._sse_url,
+            self._post_url,
+            allow_private_network=self._allow_private_network,
+            allow_cross_origin=self._allow_cross_origin_post_url,
+        )
 
         try:
             response = await self._http_client.post(
@@ -282,6 +314,12 @@ class MCPSSETransport(MCPTransport):
             raise RuntimeError("HTTP client not initialized")
         if self._post_url is None:
             raise RuntimeError("post_url must be set before making calls")
+        validate_sse_post_url(
+            self._sse_url,
+            self._post_url,
+            allow_private_network=self._allow_private_network,
+            allow_cross_origin=self._allow_cross_origin_post_url,
+        )
 
         response = await self._http_client.post(
             self._post_url,

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/streamable_http.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/streamable_http.py
@@ -14,6 +14,7 @@ import httpx
 from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transport import (
     MCPTransport,
 )
+from tldw_Server_API.app.core.Agent_Client_Protocol.hardening import validate_mcp_http_url
 
 
 class MCPStreamableHTTPTransport(MCPTransport):
@@ -31,10 +32,12 @@ class MCPStreamableHTTPTransport(MCPTransport):
         endpoint: str,
         headers: dict[str, str] | None = None,
         timeout_sec: int = 30,
+        allow_private_network: bool | None = None,
     ) -> None:
         self._endpoint = endpoint
         self._headers = headers or {}
         self._timeout_sec = timeout_sec
+        self._allow_private_network = allow_private_network
         self._http_client: httpx.AsyncClient | None = None
         self._next_id = 1
         self._connected = False
@@ -47,6 +50,11 @@ class MCPStreamableHTTPTransport(MCPTransport):
 
     async def connect(self) -> None:
         """Establish a connection: create HTTP client, run MCP handshake."""
+        validate_mcp_http_url(
+            self._endpoint,
+            allow_private_network=self._allow_private_network,
+            label="MCP streamable HTTP endpoint",
+        )
         self._http_client = self._create_http_client()
         try:
             await self._json_rpc_call(
@@ -113,6 +121,11 @@ class MCPStreamableHTTPTransport(MCPTransport):
         }
         if self._http_client is None:
             raise RuntimeError("Not connected")
+        validate_mcp_http_url(
+            self._endpoint,
+            allow_private_network=self._allow_private_network,
+            label="MCP streamable HTTP endpoint",
+        )
         resp = await self._http_client.post(self._endpoint, json=payload)
         resp.raise_for_status()
 
@@ -134,6 +147,11 @@ class MCPStreamableHTTPTransport(MCPTransport):
         }
         if self._http_client is None:
             raise RuntimeError("Not connected")
+        validate_mcp_http_url(
+            self._endpoint,
+            allow_private_network=self._allow_private_network,
+            label="MCP streamable HTTP endpoint",
+        )
         resp = await self._http_client.post(self._endpoint, json=payload)
         resp.raise_for_status()
 

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/config.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/config.py
@@ -24,6 +24,10 @@ class ACPRunnerConfig:
     cwd: str | None = None
     startup_timeout_sec: float = 10.0
     binary_path: str | None = None
+    allowed_session_cwd_roots: list[str] = field(default_factory=list)
+    allow_session_env: bool = False
+    allow_inline_stdio_mcp_servers: bool = False
+    allow_private_mcp_http: bool = False
 
 
 @dataclass
@@ -46,6 +50,7 @@ class ACPSandboxConfig:
     agent_command: str = ""
     agent_args: list[str] = field(default_factory=list)
     agent_env: dict[str, str] = field(default_factory=dict)
+    persist_ssh_private_keys: bool = False
 
     # Session TTL and quotas
     session_ttl_seconds: int = 86400  # 24h default
@@ -234,6 +239,13 @@ def load_acp_runner_config() -> ACPRunnerConfig:
         _parse_env(env_raw),
         resolve_relative_home=not has_env_override,
     )
+    allowed_roots_raw = (
+        os.getenv("ACP_ALLOWED_SESSION_CWD_ROOTS")
+        or section.get("allowed_session_cwd_roots")
+        or section.get("session_cwd_roots")
+        or ""
+    )
+    allowed_roots = _resolve_cwd_roots(_parse_string_list(allowed_roots_raw))
 
     return ACPRunnerConfig(
         command=str(command or ""),
@@ -242,6 +254,19 @@ def load_acp_runner_config() -> ACPRunnerConfig:
         cwd=resolved_cwd,
         startup_timeout_sec=timeout_sec,
         binary_path=str(binary_path) if binary_path else None,
+        allowed_session_cwd_roots=allowed_roots,
+        allow_session_env=_parse_bool(
+            os.getenv("ACP_ALLOW_SESSION_ENV") or section.get("allow_session_env"),
+            False,
+        ),
+        allow_inline_stdio_mcp_servers=_parse_bool(
+            os.getenv("ACP_ALLOW_INLINE_STDIO_MCP") or section.get("allow_inline_stdio_mcp_servers"),
+            False,
+        ),
+        allow_private_mcp_http=_parse_bool(
+            os.getenv("ACP_ALLOW_PRIVATE_MCP_HTTP") or section.get("allow_private_mcp_http"),
+            False,
+        ),
     )
 
 
@@ -278,6 +303,15 @@ def _parse_string_list(raw: str | None) -> list[str]:
             return [str(item) for item in data]
         return []
     return [s.strip() for s in text.split(",") if s.strip()]
+
+
+def _resolve_cwd_roots(raw_roots: list[str]) -> list[str]:
+    roots: list[str] = []
+    for root in raw_roots:
+        resolved = _resolve_cwd(root)
+        if resolved:
+            roots.append(resolved)
+    return roots
 
 
 ##############################################################################
@@ -358,6 +392,10 @@ def load_acp_sandbox_config() -> ACPSandboxConfig:
     agent_command = os.getenv("ACP_SANDBOX_AGENT_COMMAND") or section.get("agent_command", "")
     agent_args_raw = os.getenv("ACP_SANDBOX_AGENT_ARGS") or section.get("agent_args", "")
     agent_env_raw = os.getenv("ACP_SANDBOX_AGENT_ENV") or section.get("agent_env", "")
+    persist_ssh_private_keys = _parse_bool(
+        os.getenv("ACP_SSH_PERSIST_PRIVATE_KEYS") or section.get("persist_ssh_private_keys"),
+        False,
+    )
 
     # Session management config
     session_ttl = _parse_int(
@@ -396,6 +434,7 @@ def load_acp_sandbox_config() -> ACPSandboxConfig:
         agent_command=str(agent_command or ""),
         agent_args=_parse_args(agent_args_raw),
         agent_env=_parse_env(agent_env_raw),
+        persist_ssh_private_keys=bool(persist_ssh_private_keys),
         session_ttl_seconds=session_ttl,
         max_concurrent_sessions_per_user=max_concurrent,
         max_tokens_per_session=max_tokens,

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/hardening.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/hardening.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import re
+from collections import deque
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+def _truthy(raw: str | None) -> bool:
+    if raw is None:
+        return False
+    return raw.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+ACP_DEFAULT_RPC_TIMEOUT_SECONDS = _float_env("ACP_RPC_TIMEOUT_SECONDS", 60.0)
+ACP_SESSION_UPDATE_QUEUE_MAXLEN = max(1, _int_env("ACP_SESSION_UPDATE_QUEUE_MAXLEN", 1000))
+ACP_SESSION_UPDATE_MAX_BYTES = max(1024, _int_env("ACP_SESSION_UPDATE_MAX_BYTES", 262_144))
+ACP_STREAM_BUFFER_MAX_BYTES = max(1024, _int_env("ACP_STREAM_BUFFER_MAX_BYTES", 1_048_576))
+
+_PRIVATE_KEY_RE = re.compile(
+    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+    re.DOTALL,
+)
+_AUTH_HEADER_RE = re.compile(r"(?i)(authorization\s*:\s*bearer\s+)[^\s]+")
+_KEY_VALUE_SECRET_RE = re.compile(
+    r"(?i)\b(api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password)\s*[:=]\s*['\"]?[^'\"\s,;]+"
+)
+_OPENAI_STYLE_TOKEN_RE = re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b")
+
+
+def make_session_update_queue() -> deque[dict[str, Any]]:
+    return deque(maxlen=ACP_SESSION_UPDATE_QUEUE_MAXLEN)
+
+
+def bounded_session_update_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    try:
+        rendered = json.dumps(payload, default=str, separators=(",", ":"))
+    except (TypeError, ValueError):
+        rendered = str(payload)
+    if len(rendered.encode("utf-8", errors="ignore")) <= ACP_SESSION_UPDATE_MAX_BYTES:
+        return payload
+    return {
+        "sessionId": payload.get("sessionId"),
+        "type": payload.get("type", "truncated"),
+        "truncated": True,
+        "message": "ACP session update exceeded queue payload limit",
+    }
+
+
+def redact_agent_output(value: str | bytes, *, max_chars: int = 1000) -> str:
+    if isinstance(value, bytes):
+        text = value.decode("utf-8", errors="ignore")
+    else:
+        text = str(value)
+
+    text = _PRIVATE_KEY_RE.sub("[REDACTED_PRIVATE_KEY]", text)
+    text = _AUTH_HEADER_RE.sub(r"\1[REDACTED]", text)
+    text = _KEY_VALUE_SECRET_RE.sub(lambda match: f"{match.group(1)}=[REDACTED]", text)
+    text = _OPENAI_STYLE_TOKEN_RE.sub("[REDACTED]", text)
+
+    if max_chars <= 0 or len(text) <= max_chars:
+        return text
+    marker = "...[truncated]"
+    keep = max(0, max_chars - len(marker))
+    return f"{text[:keep]}{marker}"
+
+
+def _normalized_origin(parsed) -> tuple[str, str, int | None]:
+    port = parsed.port
+    if port is None:
+        if parsed.scheme == "http":
+            port = 80
+        elif parsed.scheme == "https":
+            port = 443
+    return parsed.scheme, str(parsed.hostname or "").lower(), port
+
+
+def _is_blocked_host(hostname: str) -> bool:
+    host = hostname.strip("[]").strip().lower().rstrip(".")
+    if not host:
+        return True
+    if host in {"localhost", "ip6-localhost", "metadata.google.internal"}:
+        return True
+    if host.endswith(".localhost") or host.endswith(".local"):
+        return True
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return any(
+        (
+            ip.is_loopback,
+            ip.is_private,
+            ip.is_link_local,
+            ip.is_reserved,
+            ip.is_multicast,
+            ip.is_unspecified,
+        )
+    )
+
+
+def validate_mcp_http_url(
+    url: str,
+    *,
+    allow_private_network: bool | None = None,
+    label: str = "MCP endpoint",
+) -> str:
+    parsed = urlparse(str(url or ""))
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(f"{label} must use http or https")
+    if not parsed.hostname:
+        raise ValueError(f"{label} must include a hostname")
+    allow_private = _truthy(os.getenv("ACP_ALLOW_PRIVATE_MCP_HTTP")) if allow_private_network is None else allow_private_network
+    if not allow_private and _is_blocked_host(parsed.hostname):
+        raise ValueError(f"{label} targets a local, private, or otherwise unsafe host")
+    return str(url)
+
+
+def validate_sse_post_url(
+    sse_url: str,
+    post_url: str,
+    *,
+    allow_private_network: bool | None = None,
+    allow_cross_origin: bool | None = None,
+) -> str:
+    validate_mcp_http_url(sse_url, allow_private_network=allow_private_network, label="MCP SSE URL")
+    validate_mcp_http_url(post_url, allow_private_network=allow_private_network, label="MCP SSE post URL")
+
+    allow_cross = (
+        _truthy(os.getenv("ACP_ALLOW_CROSS_ORIGIN_SSE_POST"))
+        if allow_cross_origin is None
+        else allow_cross_origin
+    )
+    if not allow_cross and _normalized_origin(urlparse(sse_url)) != _normalized_origin(urlparse(post_url)):
+        raise ValueError("MCP SSE post URL must have the same origin as the SSE URL")
+    return str(post_url)
+
+
+def _resolve_path(raw_path: str) -> Path:
+    return Path(raw_path).expanduser().resolve(strict=False)
+
+
+def _is_within_root(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _mcp_server_url_fields(server: dict[str, Any]) -> list[str]:
+    urls: list[str] = []
+    for key in ("url", "endpoint", "sse_url", "post_url"):
+        value = server.get(key)
+        if isinstance(value, str) and value.strip():
+            urls.append(value.strip())
+    return urls
+
+
+def _is_stdio_mcp_server(server: dict[str, Any]) -> bool:
+    transport = str(
+        server.get("type")
+        or server.get("transport")
+        or server.get("mcp_transport")
+        or ""
+    ).strip().lower()
+    if transport == "stdio":
+        return True
+    return bool(server.get("command")) and not _mcp_server_url_fields(server)
+
+
+def validate_acp_session_launch_inputs(
+    *,
+    cwd: str,
+    allowed_cwd_roots: list[str],
+    runner_cwd: str | None = None,
+    mcp_servers: list[dict[str, Any]] | None = None,
+    session_env: dict[str, str] | None = None,
+    allow_session_env: bool = False,
+    allow_inline_stdio_mcp_servers: bool = False,
+    allow_private_mcp_http: bool = False,
+) -> None:
+    if not isinstance(cwd, str) or not cwd.strip():
+        raise ValueError("ACP session cwd is required")
+    cwd_path = Path(cwd).expanduser()
+    if not cwd_path.is_absolute():
+        raise ValueError("ACP session cwd must be absolute")
+
+    roots = list(allowed_cwd_roots or [])
+    if not roots and runner_cwd:
+        roots = [runner_cwd]
+    if not roots:
+        roots = [os.getcwd()]
+
+    resolved_cwd = _resolve_path(str(cwd_path))
+    resolved_roots = [_resolve_path(str(root)) for root in roots if str(root or "").strip()]
+    if not resolved_roots or not any(_is_within_root(resolved_cwd, root) for root in resolved_roots):
+        raise ValueError("ACP session cwd is outside the allowed runner roots")
+
+    if session_env and not allow_session_env:
+        raise ValueError("ACP session env forwarding is disabled by default")
+
+    for server in mcp_servers or []:
+        if not isinstance(server, dict):
+            raise ValueError("ACP mcpServers entries must be objects")
+        if _is_stdio_mcp_server(server) and not allow_inline_stdio_mcp_servers:
+            raise ValueError("ACP inline stdio MCP servers are disabled by default")
+        for url in _mcp_server_url_fields(server):
+            validate_mcp_http_url(
+                url,
+                allow_private_network=allow_private_mcp_http,
+                label="ACP mcpServers URL",
+            )

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/hardening.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/hardening.py
@@ -1,22 +1,34 @@
+"""Shared hardening helpers for Agent Client Protocol runner integrations.
+
+The helpers in this module keep security-sensitive defaults centralized for
+host-runner session creation, MCP HTTP/SSE endpoint validation, RPC buffering,
+and log redaction. They are intentionally conservative unless a caller passes
+an explicit opt-in for the relevant risk surface.
+"""
+
 from __future__ import annotations
 
 import ipaddress
 import json
 import os
 import re
+import socket
+import time
 from collections import deque
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, urlparse
 
 
 def _truthy(raw: str | None) -> bool:
+    """Return True when a config/env string uses a recognized truthy value."""
     if raw is None:
         return False
     return raw.strip().lower() in {"1", "true", "yes", "y", "on"}
 
 
 def _int_env(name: str, default: int) -> int:
+    """Read an integer environment variable, falling back on invalid values."""
     try:
         return int(os.getenv(name, str(default)))
     except (TypeError, ValueError):
@@ -24,6 +36,7 @@ def _int_env(name: str, default: int) -> int:
 
 
 def _float_env(name: str, default: float) -> float:
+    """Read a float environment variable, falling back on invalid values."""
     try:
         return float(os.getenv(name, str(default)))
     except (TypeError, ValueError):
@@ -34,9 +47,14 @@ ACP_DEFAULT_RPC_TIMEOUT_SECONDS = _float_env("ACP_RPC_TIMEOUT_SECONDS", 60.0)
 ACP_SESSION_UPDATE_QUEUE_MAXLEN = max(1, _int_env("ACP_SESSION_UPDATE_QUEUE_MAXLEN", 1000))
 ACP_SESSION_UPDATE_MAX_BYTES = max(1024, _int_env("ACP_SESSION_UPDATE_MAX_BYTES", 262_144))
 ACP_STREAM_BUFFER_MAX_BYTES = max(1024, _int_env("ACP_STREAM_BUFFER_MAX_BYTES", 1_048_576))
+ACP_MCP_DNS_CACHE_TTL_SECONDS = max(0.0, _float_env("ACP_MCP_DNS_CACHE_TTL_SECONDS", 60.0))
 
 _PRIVATE_KEY_RE = re.compile(
     r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+    re.DOTALL,
+)
+_PRIVATE_KEY_PREFIX_RE = re.compile(
+    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*",
     re.DOTALL,
 )
 _AUTH_HEADER_RE = re.compile(r"(?i)(authorization\s*:\s*bearer\s+)[^\s]+")
@@ -44,13 +62,20 @@ _KEY_VALUE_SECRET_RE = re.compile(
     r"(?i)\b(api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password)\s*[:=]\s*['\"]?[^'\"\s,;]+"
 )
 _OPENAI_STYLE_TOKEN_RE = re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b")
+_DNS_RESOLUTION_CACHE: dict[str, tuple[float, tuple[str, ...]]] = {}
 
 
 def make_session_update_queue() -> deque[dict[str, Any]]:
+    """Create a bounded FIFO queue for ACP ``session/update`` payloads."""
     return deque(maxlen=ACP_SESSION_UPDATE_QUEUE_MAXLEN)
 
 
 def bounded_session_update_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return ``payload`` unless its JSON representation exceeds the size cap.
+
+    Oversized updates are replaced with a small metadata payload that preserves
+    the session id and update type when available.
+    """
     try:
         rendered = json.dumps(payload, default=str, separators=(",", ":"))
     except (TypeError, ValueError):
@@ -66,24 +91,36 @@ def bounded_session_update_payload(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def redact_agent_output(value: str | bytes, *, max_chars: int = 1000) -> str:
+    """Redact common secret shapes from untrusted agent output.
+
+    The text is truncated before regex passes to keep stderr/log handling
+    bounded even when a runner emits a very large stream.
+    """
     if isinstance(value, bytes):
         text = value.decode("utf-8", errors="ignore")
     else:
         text = str(value)
 
+    truncated = False
+    marker = "...[truncated]"
+    if max_chars > 0 and len(text) > max_chars:
+        keep = max(0, max_chars - len(marker))
+        text = text[:keep]
+        truncated = True
+
     text = _PRIVATE_KEY_RE.sub("[REDACTED_PRIVATE_KEY]", text)
+    text = _PRIVATE_KEY_PREFIX_RE.sub("[REDACTED_PRIVATE_KEY]", text)
     text = _AUTH_HEADER_RE.sub(r"\1[REDACTED]", text)
     text = _KEY_VALUE_SECRET_RE.sub(lambda match: f"{match.group(1)}=[REDACTED]", text)
     text = _OPENAI_STYLE_TOKEN_RE.sub("[REDACTED]", text)
 
-    if max_chars <= 0 or len(text) <= max_chars:
-        return text
-    marker = "...[truncated]"
-    keep = max(0, max_chars - len(marker))
-    return f"{text[:keep]}{marker}"
+    if truncated:
+        return f"{text}{marker}"
+    return text
 
 
-def _normalized_origin(parsed) -> tuple[str, str, int | None]:
+def _normalized_origin(parsed: ParseResult) -> tuple[str, str, int | None]:
+    """Normalize URL origin components for same-origin comparison."""
     port = parsed.port
     if port is None:
         if parsed.scheme == "http":
@@ -93,18 +130,8 @@ def _normalized_origin(parsed) -> tuple[str, str, int | None]:
     return parsed.scheme, str(parsed.hostname or "").lower(), port
 
 
-def _is_blocked_host(hostname: str) -> bool:
-    host = hostname.strip("[]").strip().lower().rstrip(".")
-    if not host:
-        return True
-    if host in {"localhost", "ip6-localhost", "metadata.google.internal"}:
-        return True
-    if host.endswith(".localhost") or host.endswith(".local"):
-        return True
-    try:
-        ip = ipaddress.ip_address(host)
-    except ValueError:
-        return False
+def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True when an IP is unsafe for default MCP HTTP access."""
     return any(
         (
             ip.is_loopback,
@@ -117,18 +144,75 @@ def _is_blocked_host(hostname: str) -> bool:
     )
 
 
+def _resolved_hostname_addresses(host: str) -> tuple[str, ...]:
+    """Resolve a hostname to IP address strings using a short process cache."""
+    now = time.monotonic()
+    cached = _DNS_RESOLUTION_CACHE.get(host)
+    if cached is not None and now - cached[0] <= ACP_MCP_DNS_CACHE_TTL_SECONDS:
+        return cached[1]
+
+    try:
+        addr_infos = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    except OSError:
+        return ()
+
+    addresses = tuple(sorted({str(info[4][0]) for info in addr_infos if info and info[4]}))
+    if ACP_MCP_DNS_CACHE_TTL_SECONDS > 0.0 and addresses:
+        _DNS_RESOLUTION_CACHE[host] = (now, addresses)
+    return addresses
+
+
+def _is_blocked_host(hostname: str) -> bool:
+    """Return True when a host string resolves to a local/private target."""
+    host = hostname.strip("[]").strip().lower().rstrip(".")
+    if not host:
+        return True
+    if host in {"localhost", "ip6-localhost", "metadata.google.internal"}:
+        return True
+    if host.endswith(".localhost") or host.endswith(".local"):
+        return True
+    addresses = (host,)
+    try:
+        ip = ipaddress.ip_address(host)
+        return _is_blocked_ip(ip)
+    except ValueError:
+        addresses = _resolved_hostname_addresses(host)
+
+    if not addresses:
+        return True
+
+    for address in addresses:
+        try:
+            ip = ipaddress.ip_address(str(address).split("%", 1)[0])
+        except ValueError:
+            return True
+        if _is_blocked_ip(ip):
+            return True
+    return False
+
+
 def validate_mcp_http_url(
     url: str,
     *,
     allow_private_network: bool | None = None,
     label: str = "MCP endpoint",
 ) -> str:
+    """Validate that an MCP HTTP endpoint is safe to contact.
+
+    By default this rejects non-HTTP schemes and hosts that are local, private,
+    reserved, link-local, multicast, unspecified, or resolve to those ranges.
+    Set ``allow_private_network`` only for trusted local deployments/tests.
+    """
     parsed = urlparse(str(url or ""))
     if parsed.scheme not in {"http", "https"}:
         raise ValueError(f"{label} must use http or https")
     if not parsed.hostname:
         raise ValueError(f"{label} must include a hostname")
-    allow_private = _truthy(os.getenv("ACP_ALLOW_PRIVATE_MCP_HTTP")) if allow_private_network is None else allow_private_network
+    allow_private = (
+        _truthy(os.getenv("ACP_ALLOW_PRIVATE_MCP_HTTP"))
+        if allow_private_network is None
+        else allow_private_network
+    )
     if not allow_private and _is_blocked_host(parsed.hostname):
         raise ValueError(f"{label} targets a local, private, or otherwise unsafe host")
     return str(url)
@@ -141,24 +225,42 @@ def validate_sse_post_url(
     allow_private_network: bool | None = None,
     allow_cross_origin: bool | None = None,
 ) -> str:
-    validate_mcp_http_url(sse_url, allow_private_network=allow_private_network, label="MCP SSE URL")
-    validate_mcp_http_url(post_url, allow_private_network=allow_private_network, label="MCP SSE post URL")
+    """Validate an SSE-discovered JSON-RPC POST URL.
+
+    The POST URL must pass the same MCP HTTP endpoint policy as the SSE URL and
+    must share the SSE URL origin unless cross-origin posts are explicitly
+    allowed.
+    """
+    validate_mcp_http_url(
+        sse_url,
+        allow_private_network=allow_private_network,
+        label="MCP SSE URL",
+    )
+    validate_mcp_http_url(
+        post_url,
+        allow_private_network=allow_private_network,
+        label="MCP SSE post URL",
+    )
 
     allow_cross = (
         _truthy(os.getenv("ACP_ALLOW_CROSS_ORIGIN_SSE_POST"))
         if allow_cross_origin is None
         else allow_cross_origin
     )
-    if not allow_cross and _normalized_origin(urlparse(sse_url)) != _normalized_origin(urlparse(post_url)):
+    if not allow_cross and _normalized_origin(urlparse(sse_url)) != _normalized_origin(
+        urlparse(post_url)
+    ):
         raise ValueError("MCP SSE post URL must have the same origin as the SSE URL")
     return str(post_url)
 
 
 def _resolve_path(raw_path: str) -> Path:
+    """Resolve a path without requiring it to exist on disk."""
     return Path(raw_path).expanduser().resolve(strict=False)
 
 
 def _is_within_root(path: Path, root: Path) -> bool:
+    """Return True when ``path`` is inside ``root`` or equals it."""
     try:
         path.relative_to(root)
         return True
@@ -167,6 +269,7 @@ def _is_within_root(path: Path, root: Path) -> bool:
 
 
 def _mcp_server_url_fields(server: dict[str, Any]) -> list[str]:
+    """Extract URL-like fields from an ACP ``mcpServers`` entry."""
     urls: list[str] = []
     for key in ("url", "endpoint", "sse_url", "post_url"):
         value = server.get(key)
@@ -176,6 +279,7 @@ def _mcp_server_url_fields(server: dict[str, Any]) -> list[str]:
 
 
 def _is_stdio_mcp_server(server: dict[str, Any]) -> bool:
+    """Return True when an ``mcpServers`` entry launches a local stdio command."""
     transport = str(
         server.get("type")
         or server.get("transport")
@@ -198,6 +302,13 @@ def validate_acp_session_launch_inputs(
     allow_inline_stdio_mcp_servers: bool = False,
     allow_private_mcp_http: bool = False,
 ) -> None:
+    """Validate user-controlled ACP session launch inputs before runner calls.
+
+    Raises ``ValueError`` when the requested cwd is not absolute, no trusted cwd
+    roots are configured, cwd escapes the allowlist, env forwarding is disabled,
+    inline stdio MCP servers are present without opt-in, or MCP HTTP URLs fail
+    the default SSRF checks.
+    """
     if not isinstance(cwd, str) or not cwd.strip():
         raise ValueError("ACP session cwd is required")
     cwd_path = Path(cwd).expanduser()
@@ -208,7 +319,7 @@ def validate_acp_session_launch_inputs(
     if not roots and runner_cwd:
         roots = [runner_cwd]
     if not roots:
-        roots = [os.getcwd()]
+        raise ValueError("ACP session cwd roots are not configured")
 
     resolved_cwd = _resolve_path(str(cwd_path))
     resolved_roots = [_resolve_path(str(root)) for root in roots if str(root or "").strip()]

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/permission_tiers.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/permission_tiers.py
@@ -34,13 +34,20 @@ def determine_permission_tier(tool_name: str) -> str:
     tokens = set(re.findall(r"[a-z0-9]+", tool_lower))
 
     individual_tokens = {
+        "alter",
         "bash",
+        "create",
         "delete",
+        "destroy",
         "drop",
         "exec",
         "execute",
         "force",
         "kill",
+        "modify",
+        "patch",
+        "post",
+        "put",
         "push",
         "remove",
         "reset",
@@ -48,6 +55,8 @@ def determine_permission_tier(tool_name: str) -> str:
         "run",
         "shell",
         "terminal",
+        "update",
+        "write",
     }
     if tokens & individual_tokens:
         return "individual"

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/permission_tiers.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/permission_tiers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from loguru import logger
 
 
@@ -29,13 +31,29 @@ def determine_permission_tier(tool_name: str) -> str:
         return policy_tier
 
     tool_lower = tool_name.lower()
+    tokens = set(re.findall(r"[a-z0-9]+", tool_lower))
 
-    auto_patterns = ["read", "get", "list", "search", "find", "view", "show", "glob", "grep", "status"]
-    if any(pattern in tool_lower for pattern in auto_patterns):
-        return "auto"
-
-    individual_patterns = ["delete", "remove", "exec", "run", "shell", "bash", "terminal", "push", "force"]
-    if any(pattern in tool_lower for pattern in individual_patterns):
+    individual_tokens = {
+        "bash",
+        "delete",
+        "drop",
+        "exec",
+        "execute",
+        "force",
+        "kill",
+        "push",
+        "remove",
+        "reset",
+        "rm",
+        "run",
+        "shell",
+        "terminal",
+    }
+    if tokens & individual_tokens:
         return "individual"
+
+    auto_tokens = {"read", "get", "list", "search", "find", "view", "show", "glob", "grep", "status"}
+    if tokens & auto_tokens:
+        return "auto"
 
     return "batch"

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py
@@ -600,21 +600,16 @@ class ACPRunnerClient(ACPRuntimePolicySupportMixin):
         user_id: int | None = None,
         session_env: dict[str, str] | None = None,
     ) -> str:
-        allowed_roots_raw = getattr(self.config, "allowed_session_cwd_roots", [])
-        allowed_roots = allowed_roots_raw if isinstance(allowed_roots_raw, list) else []
-        allow_session_env = getattr(self.config, "allow_session_env", False)
-        allow_stdio_mcp = getattr(self.config, "allow_inline_stdio_mcp_servers", False)
-        allow_private_mcp_http = getattr(self.config, "allow_private_mcp_http", False)
         try:
             validate_acp_session_launch_inputs(
                 cwd=cwd,
-                allowed_cwd_roots=list(allowed_roots),
-                runner_cwd=getattr(self.config, "cwd", None),
+                allowed_cwd_roots=list(self.config.allowed_session_cwd_roots),
+                runner_cwd=self.config.cwd,
                 mcp_servers=mcp_servers,
                 session_env=session_env,
-                allow_session_env=allow_session_env if isinstance(allow_session_env, bool) else False,
-                allow_inline_stdio_mcp_servers=allow_stdio_mcp if isinstance(allow_stdio_mcp, bool) else False,
-                allow_private_mcp_http=allow_private_mcp_http if isinstance(allow_private_mcp_http, bool) else False,
+                allow_session_env=self.config.allow_session_env,
+                allow_inline_stdio_mcp_servers=self.config.allow_inline_stdio_mcp_servers,
+                allow_private_mcp_http=self.config.allow_private_mcp_http,
             )
         except ValueError as exc:
             raise ACPResponseError(str(exc)) from exc

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py
@@ -17,6 +17,11 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.config import (
     ACPRunnerConfig,
     load_acp_runner_config,
 )
+from tldw_Server_API.app.core.Agent_Client_Protocol.hardening import (
+    bounded_session_update_payload,
+    make_session_update_queue,
+    validate_acp_session_launch_inputs,
+)
 from tldw_Server_API.app.core.Agent_Client_Protocol.permission_tiers import determine_permission_tier
 from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import (
     ACPMessage,
@@ -534,7 +539,7 @@ class ACPRunnerClient(ACPRuntimePolicySupportMixin):
         )
         self._client.set_notification_handler(self._handle_notification)
         self._client.set_request_handler(self._handle_request)
-        self._updates: dict[str, deque[dict[str, Any]]] = defaultdict(deque)
+        self._updates: dict[str, deque[dict[str, Any]]] = defaultdict(make_session_update_queue)
         self._session_owners: dict[str, int] = {}
         self._agent_capabilities: dict[str, Any] = {}
         # WebSocket registry per session
@@ -595,6 +600,25 @@ class ACPRunnerClient(ACPRuntimePolicySupportMixin):
         user_id: int | None = None,
         session_env: dict[str, str] | None = None,
     ) -> str:
+        allowed_roots_raw = getattr(self.config, "allowed_session_cwd_roots", [])
+        allowed_roots = allowed_roots_raw if isinstance(allowed_roots_raw, list) else []
+        allow_session_env = getattr(self.config, "allow_session_env", False)
+        allow_stdio_mcp = getattr(self.config, "allow_inline_stdio_mcp_servers", False)
+        allow_private_mcp_http = getattr(self.config, "allow_private_mcp_http", False)
+        try:
+            validate_acp_session_launch_inputs(
+                cwd=cwd,
+                allowed_cwd_roots=list(allowed_roots),
+                runner_cwd=getattr(self.config, "cwd", None),
+                mcp_servers=mcp_servers,
+                session_env=session_env,
+                allow_session_env=allow_session_env if isinstance(allow_session_env, bool) else False,
+                allow_inline_stdio_mcp_servers=allow_stdio_mcp if isinstance(allow_stdio_mcp, bool) else False,
+                allow_private_mcp_http=allow_private_mcp_http if isinstance(allow_private_mcp_http, bool) else False,
+            )
+        except ValueError as exc:
+            raise ACPResponseError(str(exc)) from exc
+
         params: dict[str, Any] = {
             "cwd": cwd,
             "mcpServers": mcp_servers if mcp_servers is not None else [],
@@ -961,7 +985,7 @@ class ACPRunnerClient(ACPRuntimePolicySupportMixin):
             return
 
         # Queue update for polling clients
-        self._updates[session_id].append(params)
+        self._updates[str(session_id)].append(bounded_session_update_payload(params))
 
         # Broadcast to WebSocket clients
         update_message = {

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py
@@ -17,6 +17,11 @@ from loguru import logger
 
 from tldw_Server_API.app.api.v1.endpoints import sandbox as sandbox_ep
 from tldw_Server_API.app.core.Agent_Client_Protocol.config import ACPSandboxConfig, load_acp_sandbox_config
+from tldw_Server_API.app.core.Agent_Client_Protocol.hardening import (
+    bounded_session_update_payload,
+    make_session_update_queue,
+    redact_agent_output,
+)
 from tldw_Server_API.app.core.Agent_Client_Protocol.runner_client import (
     ACPGovernanceCoordinator,
     ACPGovernanceDeniedError,
@@ -96,7 +101,7 @@ class ACPSandboxRunnerManager(ACPRuntimePolicySupportMixin):
         self.config = config or load_acp_sandbox_config()
         self._sessions: dict[str, SandboxSessionHandle] = {}
         self._sessions_lock = asyncio.Lock()
-        self._updates: dict[str, deque[dict[str, Any]]] = defaultdict(deque)
+        self._updates: dict[str, deque[dict[str, Any]]] = defaultdict(make_session_update_queue)
         self._agent_capabilities: dict[str, Any] = {}
         self._ws_registry: dict[str, SessionWebSocketRegistry] = {}
         self._ws_registry_lock = asyncio.Lock()
@@ -109,7 +114,12 @@ class ACPSandboxRunnerManager(ACPRuntimePolicySupportMixin):
         self._runtime_policy_refresh_tasks: dict[str, asyncio.Task[ACPRuntimePolicySnapshot | None]] = {}
         self._runtime_policy_refresh_lock = asyncio.Lock()
 
-    def _control_record_from_handle(self, sess: SandboxSessionHandle) -> dict[str, Any]:
+    def _control_record_from_handle(
+        self,
+        sess: SandboxSessionHandle,
+        *,
+        include_private_key: bool = True,
+    ) -> dict[str, Any]:
         return {
             "id": sess.session_id,
             "user_id": int(sess.user_id),
@@ -118,7 +128,7 @@ class ACPSandboxRunnerManager(ACPRuntimePolicySupportMixin):
             "ssh_host": sess.ssh_host,
             "ssh_port": sess.ssh_port,
             "ssh_user": sess.ssh_user,
-            "ssh_private_key": sess.ssh_private_key,
+            "ssh_private_key": sess.ssh_private_key if include_private_key else None,
             "persona_id": sess.persona_id,
             "workspace_id": sess.workspace_id,
             "workspace_group_id": sess.workspace_group_id,
@@ -144,7 +154,10 @@ class ACPSandboxRunnerManager(ACPRuntimePolicySupportMixin):
             if required:
                 raise ACPResponseError("ACP sandbox control metadata store does not support ACP session control")
             return False
-        control = self._control_record_from_handle(sess)
+        control = self._control_record_from_handle(
+            sess,
+            include_private_key=bool(getattr(self.config, "persist_ssh_private_keys", False)),
+        )
         try:
             putter(
                 session_id=str(control.get("id") or ""),
@@ -413,6 +426,11 @@ class ACPSandboxRunnerManager(ACPRuntimePolicySupportMixin):
 
     def _validate_runtime_requirements(self, runtime: RuntimeType) -> None:
         network_policy = str(self.config.network_policy or "deny_all").strip().lower() or "deny_all"
+        if self.config.allowed_egress_hosts:
+            raise ACPResponseError(
+                "ACP sandbox allowed egress hosts are not enforced by the ACP runner. "
+                "Use the core sandbox egress policy or clear ACP_SANDBOX_ALLOWED_EGRESS_HOSTS."
+            )
         runtime_preflights = collect_runtime_preflights(network_policy=network_policy)
         preflight = runtime_preflights.get(runtime)
         if runtime == RuntimeType.lima:
@@ -904,7 +922,7 @@ class ACPSandboxRunnerManager(ACPRuntimePolicySupportMixin):
         if not session_id:
             return
 
-        self._updates[session_id].append(params)
+        self._updates[str(session_id)].append(bounded_session_update_payload(params))
 
         update_message = {
             "type": "update",
@@ -1072,7 +1090,7 @@ class ACPSandboxRunnerManager(ACPRuntimePolicySupportMixin):
                     if ftype == "stdout":
                         await client.feed_bytes(raw)
                     else:
-                        logger.debug(f"ACP sandbox stderr: {data_field}")
+                        logger.debug("ACP sandbox stderr: {}", redact_agent_output(raw).rstrip())
                 elif ftype == "event" and frame.get("event") == "end":
                     await client.close()
                     return

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/stdio_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/stdio_client.py
@@ -9,6 +9,11 @@ from typing import Any, Callable
 
 from loguru import logger
 
+from tldw_Server_API.app.core.Agent_Client_Protocol.hardening import (
+    ACP_DEFAULT_RPC_TIMEOUT_SECONDS,
+    redact_agent_output,
+)
+
 
 class ACPResponseError(RuntimeError):
     def __init__(
@@ -44,11 +49,13 @@ class ACPStdioClient:
         args: list[str],
         env: dict[str, str] | None = None,
         cwd: str | None = None,
+        rpc_timeout_sec: float | None = None,
     ) -> None:
         self.command = command
         self.args = args
         self.env = env or {}
         self.cwd = cwd
+        self.rpc_timeout_sec = ACP_DEFAULT_RPC_TIMEOUT_SECONDS if rpc_timeout_sec is None else float(rpc_timeout_sec)
         self._proc: asyncio.subprocess.Process | None = None
         self._reader_task: asyncio.Task | None = None
         self._stderr_task: asyncio.Task | None = None
@@ -118,8 +125,16 @@ class ACPStdioClient:
             "method": method,
             "params": params,
         }
-        await self._send(payload)
-        resp = await future
+        try:
+            await self._send(payload)
+            if self.rpc_timeout_sec > 0:
+                resp = await asyncio.wait_for(future, timeout=self.rpc_timeout_sec)
+            else:
+                resp = await future
+        except asyncio.TimeoutError as exc:
+            raise ACPResponseError(f"ACP call timed out waiting for {method}", code=-32000) from exc
+        finally:
+            self._pending.pop(str(request_id), None)
         if resp.error:
             raise ACPResponseError(
                 resp.error.get("message", "ACP error"),
@@ -232,7 +247,7 @@ class ACPStdioClient:
             line = await proc.stderr.readline()
             if not line:
                 break
-            logger.debug("ACP runner stderr: {}", line.decode("utf-8", errors="ignore").rstrip())
+            logger.debug("ACP runner stderr: {}", redact_agent_output(line).rstrip())
 
     def _drain_pending(self, reason: str) -> None:
         for future in self._pending.values():

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/stream_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/stream_client.py
@@ -14,6 +14,10 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import (
     NotificationHandler,
     RequestHandler,
 )
+from tldw_Server_API.app.core.Agent_Client_Protocol.hardening import (
+    ACP_DEFAULT_RPC_TIMEOUT_SECONDS,
+    ACP_STREAM_BUFFER_MAX_BYTES,
+)
 
 
 @dataclass
@@ -21,10 +25,14 @@ class ACPStreamClient:
     """ACP client that reads/writes newline-delimited JSON over an abstract byte stream."""
 
     send_bytes: Callable[[bytes], Awaitable[None]]
+    rpc_timeout_sec: float | None = None
+    max_buffer_bytes: int = ACP_STREAM_BUFFER_MAX_BYTES
     _request_handler: RequestHandler | None = None
     _notification_handler: NotificationHandler | None = None
 
     def __post_init__(self) -> None:
+        if self.rpc_timeout_sec is None:
+            self.rpc_timeout_sec = ACP_DEFAULT_RPC_TIMEOUT_SECONDS
         self._pending: dict[str, asyncio.Future] = {}
         self._next_id = 1
         self._write_lock = asyncio.Lock()
@@ -64,8 +72,16 @@ class ACPStreamClient:
             "method": method,
             "params": params,
         }
-        await self._send(payload)
-        resp = await future
+        try:
+            await self._send(payload)
+            if self.rpc_timeout_sec > 0:
+                resp = await asyncio.wait_for(future, timeout=self.rpc_timeout_sec)
+            else:
+                resp = await future
+        except asyncio.TimeoutError as exc:
+            raise ACPResponseError(f"ACP call timed out waiting for {method}", code=-32000) from exc
+        finally:
+            self._pending.pop(str(request_id), None)
         if resp.error:
             raise ACPResponseError(
                 resp.error.get("message", "ACP error"),
@@ -94,6 +110,10 @@ class ACPStreamClient:
     async def feed_bytes(self, data: bytes) -> None:
         if not data:
             return
+        if len(self._buffer) + len(data) > self.max_buffer_bytes:
+            self._buffer.clear()
+            self._drain_pending("ACP stream buffer exceeded limit")
+            raise ACPResponseError("ACP stream buffer exceeded limit")
         self._buffer.extend(data)
         while True:
             try:

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_hardening_helpers.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_hardening_helpers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import socket
+
 import pytest
 
 pytestmark = pytest.mark.unit
@@ -50,4 +52,33 @@ def test_sse_post_url_validation_requires_same_origin() -> None:
         validate_sse_post_url(
             "https://mcp.example.com/sse",
             "https://evil.example.com/messages",
+            allow_private_network=True,
+        )
+
+
+def test_mcp_http_url_validation_rejects_hostname_resolving_to_loopback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.Agent_Client_Protocol import hardening
+
+    def fake_getaddrinfo(*args: object, **kwargs: object) -> list[tuple[object, ...]]:
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 443))]
+
+    hardening._DNS_RESOLUTION_CACHE.clear()
+    monkeypatch.setattr(hardening.socket, "getaddrinfo", fake_getaddrinfo)
+
+    with pytest.raises(ValueError, match="unsafe host"):
+        hardening.validate_mcp_http_url("https://safe-looking.example/mcp")
+
+
+def test_session_launch_validation_rejects_missing_cwd_roots() -> None:
+    from tldw_Server_API.app.core.Agent_Client_Protocol.hardening import (
+        validate_acp_session_launch_inputs,
+    )
+
+    with pytest.raises(ValueError, match="cwd roots"):
+        validate_acp_session_launch_inputs(
+            cwd="/repo",
+            allowed_cwd_roots=[],
+            runner_cwd=None,
         )

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_hardening_helpers.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_hardening_helpers.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_redact_agent_output_masks_secret_shapes_and_truncates() -> None:
+    from tldw_Server_API.app.core.Agent_Client_Protocol.hardening import redact_agent_output
+
+    raw = (
+        "Authorization: Bearer sk-live-secret-token\n"
+        "api_key=sk-another-secret-token\n"
+        "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+        "private material\n"
+        "-----END OPENSSH PRIVATE KEY-----\n"
+        + ("x" * 500)
+    )
+
+    redacted = redact_agent_output(raw, max_chars=120)
+
+    assert "sk-live-secret-token" not in redacted
+    assert "sk-another-secret-token" not in redacted
+    assert "private material" not in redacted
+    assert "[REDACTED]" in redacted
+    assert "[truncated]" in redacted
+    assert len(redacted) <= 140
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:8080/mcp",
+        "http://localhost:8080/mcp",
+        "http://169.254.169.254/latest/meta-data",
+        "file:///tmp/mcp.sock",
+    ],
+)
+def test_mcp_http_url_validation_rejects_local_and_non_http_urls(url: str) -> None:
+    from tldw_Server_API.app.core.Agent_Client_Protocol.hardening import validate_mcp_http_url
+
+    with pytest.raises(ValueError):
+        validate_mcp_http_url(url)
+
+
+def test_sse_post_url_validation_requires_same_origin() -> None:
+    from tldw_Server_API.app.core.Agent_Client_Protocol.hardening import validate_sse_post_url
+
+    with pytest.raises(ValueError, match="same origin"):
+        validate_sse_post_url(
+            "https://mcp.example.com/sse",
+            "https://evil.example.com/messages",
+        )

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+from typing import Any
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -26,8 +27,8 @@ from tldw_Server_API.app.services.acp_runtime_policy_service import (
 )
 
 
-def _standard_runner_config(**overrides) -> ACPRunnerConfig:
-    config = {
+def _standard_runner_config(**overrides: Any) -> ACPRunnerConfig:
+    config: dict[str, Any] = {
         "command": "echo",
         "allowed_session_cwd_roots": ["/repo"],
     }

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py
@@ -26,6 +26,15 @@ from tldw_Server_API.app.services.acp_runtime_policy_service import (
 )
 
 
+def _standard_runner_config(**overrides) -> ACPRunnerConfig:
+    config = {
+        "command": "echo",
+        "allowed_session_cwd_roots": ["/repo"],
+    }
+    config.update(overrides)
+    return ACPRunnerConfig(**config)
+
+
 @pytest.mark.unit
 def test_acp_sandbox_config_default_network_policy_is_deny_all() -> None:
     cfg = ACPSandboxConfig()
@@ -152,7 +161,7 @@ async def test_create_session_requires_authenticated_user_id() -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_standard_runner_create_session_sends_session_env() -> None:
+async def test_standard_runner_create_session_rejects_session_env_by_default() -> None:
     class _CallResult:
         def __init__(self, result: dict[str, object]) -> None:
             self.result = result
@@ -167,7 +176,38 @@ async def test_standard_runner_create_session_sends_session_env() -> None:
             self.calls.append((method, payload))
             return _CallResult({"sessionId": "session-env"})
 
-    runner = ACPRunnerClient(ACPRunnerConfig(command="echo"))
+    runner = ACPRunnerClient(_standard_runner_config())
+    fake_client = _FakeClient()
+    runner._client = fake_client
+    workspace_auth_value = f"workspace-{uuid4().hex}"
+
+    with pytest.raises(ACPResponseError, match="session env"):
+        await runner.create_session(
+            "/repo",
+            session_env={"WORKSPACE_TOKEN": workspace_auth_value},
+        )
+
+    assert fake_client.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_standard_runner_create_session_sends_session_env_when_enabled() -> None:
+    class _CallResult:
+        def __init__(self, result: dict[str, object]) -> None:
+            self.result = result
+
+    class _FakeClient:
+        is_running = True
+
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict[str, object]]] = []
+
+        async def call(self, method: str, payload: dict[str, object]):
+            self.calls.append((method, payload))
+            return _CallResult({"sessionId": "session-env"})
+
+    runner = ACPRunnerClient(_standard_runner_config(allow_session_env=True))
     fake_client = _FakeClient()
     runner._client = fake_client
     workspace_auth_value = f"workspace-{uuid4().hex}"
@@ -203,7 +243,7 @@ async def test_standard_runner_create_session_sends_explicit_empty_mcp_servers()
             self.calls.append((method, payload))
             return _CallResult({"sessionId": "session-empty-mcp"})
 
-    runner = ACPRunnerClient(ACPRunnerConfig(command="echo"))
+    runner = ACPRunnerClient(_standard_runner_config())
     fake_client = _FakeClient()
     runner._client = fake_client
 
@@ -238,7 +278,7 @@ async def test_standard_runner_create_session_retries_without_agent_type_for_nat
                 raise ACPResponseError("Invalid params")
             return _CallResult({"sessionId": "session-native-hermes"})
 
-    runner = ACPRunnerClient(ACPRunnerConfig(command="echo"))
+    runner = ACPRunnerClient(_standard_runner_config())
     fake_client = _FakeClient()
     runner._client = fake_client
 
@@ -270,7 +310,7 @@ async def test_standard_runner_create_session_retries_without_mcp_servers_for_le
                 raise ACPResponseError("Invalid params")
             return _CallResult({"sessionId": "session-legacy-no-mcp"})
 
-    runner = ACPRunnerClient(ACPRunnerConfig(command="echo"))
+    runner = ACPRunnerClient(_standard_runner_config())
     fake_client = _FakeClient()
     runner._client = fake_client
 
@@ -302,7 +342,7 @@ async def test_standard_runner_create_session_retries_without_agent_type_then_mc
                 raise ACPResponseError("Invalid params")
             return _CallResult({"sessionId": "session-legacy-no-agent-mcp"})
 
-    runner = ACPRunnerClient(ACPRunnerConfig(command="echo"))
+    runner = ACPRunnerClient(_standard_runner_config())
     fake_client = _FakeClient()
     runner._client = fake_client
 
@@ -314,6 +354,77 @@ async def test_standard_runner_create_session_retries_without_agent_type_then_mc
         ("session/new", {"cwd": "/repo", "mcpServers": []}),
         ("session/new", {"cwd": "/repo"}),
     ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_standard_runner_create_session_rejects_cwd_outside_allowed_roots() -> None:
+    class _FakeClient:
+        is_running = True
+
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict[str, object]]] = []
+
+        async def call(self, method: str, payload: dict[str, object]):
+            self.calls.append((method, payload))
+            raise AssertionError("unsafe cwd should be rejected before runner call")
+
+    runner = ACPRunnerClient(_standard_runner_config())
+    fake_client = _FakeClient()
+    runner._client = fake_client
+
+    with pytest.raises(ACPResponseError, match="cwd"):
+        await runner.create_session("/etc")
+
+    assert fake_client.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_standard_runner_create_session_rejects_stdio_mcp_by_default() -> None:
+    class _FakeClient:
+        is_running = True
+
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict[str, object]]] = []
+
+        async def call(self, method: str, payload: dict[str, object]):
+            self.calls.append((method, payload))
+            raise AssertionError("stdio MCP should be rejected before runner call")
+
+    runner = ACPRunnerClient(_standard_runner_config())
+    fake_client = _FakeClient()
+    runner._client = fake_client
+
+    with pytest.raises(ACPResponseError, match="stdio MCP"):
+        await runner.create_session(
+            "/repo",
+            mcp_servers=[{"type": "stdio", "command": "python", "args": ["server.py"]}],
+        )
+
+    assert fake_client.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_standard_runner_update_queue_is_bounded() -> None:
+    from tldw_Server_API.app.core.Agent_Client_Protocol.hardening import ACP_SESSION_UPDATE_QUEUE_MAXLEN
+
+    runner = ACPRunnerClient(_standard_runner_config())
+    session_id = "bounded-session"
+
+    for index in range(ACP_SESSION_UPDATE_QUEUE_MAXLEN + 3):
+        await runner._handle_notification(
+            ACPMessage(
+                jsonrpc="2.0",
+                method="session/update",
+                params={"sessionId": session_id, "type": "progress", "index": index},
+            )
+        )
+
+    updates = runner.pop_updates(session_id, limit=ACP_SESSION_UPDATE_QUEUE_MAXLEN + 10)
+    assert len(updates) == ACP_SESSION_UPDATE_QUEUE_MAXLEN
+    assert updates[0]["index"] == 3
 
 
 @pytest.mark.unit
@@ -1249,6 +1360,70 @@ async def test_control_record_fallback_supports_access_and_metadata(monkeypatch)
     assert ssh_info[0] == "127.0.0.1"
     assert ssh_info[1] == 4022
     assert ssh_info[2] == "acp"
+
+
+@pytest.mark.unit
+def test_store_control_record_omits_ssh_private_key_by_default(monkeypatch) -> None:
+    manager = ACPSandboxRunnerManager(
+        ACPSandboxConfig(
+            enabled=True,
+            agent_command="/usr/local/bin/codex",
+            ssh_enabled=True,
+        )
+    )
+    persisted: dict[str, object] = {}
+
+    class _Store:
+        def put_acp_session_control(self, **kwargs) -> None:
+            persisted.update(kwargs)
+
+    handle = SandboxSessionHandle(
+        session_id="acp-session-key",
+        user_id=42,
+        sandbox_session_id="sandbox-key",
+        run_id="run-key",
+        client=MagicMock(),
+        reader_task=MagicMock(),
+        ssh_user="acp",
+        ssh_host="127.0.0.1",
+        ssh_port=4022,
+        ssh_private_key="PRIVATE-KEY-MATERIAL",
+    )
+    monkeypatch.setattr(manager, "_get_sandbox_store", lambda: _Store())
+
+    assert manager._store_control_record(handle, required=True) is True
+    assert persisted["ssh_private_key"] is None
+    assert manager._control_record_from_handle(handle)["ssh_private_key"] == "PRIVATE-KEY-MATERIAL"
+
+
+@pytest.mark.unit
+def test_sandbox_allowed_egress_hosts_fail_fast_until_enforced(monkeypatch) -> None:
+    import tldw_Server_API.app.core.Agent_Client_Protocol.sandbox_runner_client as src
+
+    manager = ACPSandboxRunnerManager(
+        ACPSandboxConfig(
+            enabled=True,
+            runtime="docker",
+            network_policy="allowlist",
+            allowed_egress_hosts=["api.openai.com"],
+            agent_command="/usr/local/bin/codex",
+        )
+    )
+    monkeypatch.setattr(
+        src,
+        "collect_runtime_preflights",
+        lambda *, network_policy=None: {
+            RuntimeType.docker: RuntimePreflightResult(
+                runtime=RuntimeType.docker,
+                available=True,
+                supported_trust_levels=["standard"],
+                enforcement_ready={"deny_all": True, "allowlist": True},
+            )
+        },
+    )
+
+    with pytest.raises(ACPResponseError, match="allowed egress"):
+        manager._validate_runtime_requirements(RuntimeType.docker)
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_stream_client.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_stream_client.py
@@ -4,7 +4,11 @@ import json
 import pytest
 
 from tldw_Server_API.app.core.Agent_Client_Protocol.stream_client import ACPStreamClient
-from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPMessage
+from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import (
+    ACPMessage,
+    ACPResponseError,
+    ACPStdioClient,
+)
 
 
 @pytest.mark.asyncio
@@ -79,3 +83,35 @@ async def test_stream_client_request_handler():
     payload = json.loads(sent[0].decode("utf-8").strip())
     assert payload["id"] == 7
     assert payload["result"]["outcome"]["outcome"] == "approved"
+
+
+@pytest.mark.asyncio
+async def test_stream_client_call_times_out_and_cleans_pending():
+    async def send_bytes(_: bytes):
+        return None
+
+    client = ACPStreamClient(send_bytes=send_bytes, rpc_timeout_sec=0.01)
+    await client.start()
+
+    with pytest.raises(ACPResponseError, match="timed out"):
+        await client.call("ping", {})
+
+    assert client._pending == {}
+
+
+@pytest.mark.asyncio
+async def test_stdio_client_call_times_out_and_cleans_pending(monkeypatch):
+    sent = []
+    client = ACPStdioClient("agent", [], rpc_timeout_sec=0.01)
+    client._proc = object()
+
+    async def send(payload: dict):
+        sent.append(payload)
+
+    monkeypatch.setattr(client, "_send", send)
+
+    with pytest.raises(ACPResponseError, match="timed out"):
+        await client.call("ping", {})
+
+    assert sent and sent[0]["method"] == "ping"
+    assert client._pending == {}

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_stream_client.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_stream_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from typing import Any
 
 import pytest
 
@@ -12,10 +13,10 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import (
 
 
 @pytest.mark.asyncio
-async def test_stream_client_call_roundtrip():
-    sent = []
+async def test_stream_client_call_roundtrip() -> None:
+    sent: list[bytes] = []
 
-    async def send_bytes(data: bytes):
+    async def send_bytes(data: bytes) -> None:
         sent.append(data)
 
     client = ACPStreamClient(send_bytes=send_bytes)
@@ -38,13 +39,13 @@ async def test_stream_client_call_roundtrip():
 
 
 @pytest.mark.asyncio
-async def test_stream_client_notification_handler():
-    seen = []
+async def test_stream_client_notification_handler() -> None:
+    seen: list[ACPMessage] = []
 
-    async def send_bytes(_: bytes):
+    async def send_bytes(_: bytes) -> None:
         return
 
-    async def on_note(msg: ACPMessage):
+    async def on_note(msg: ACPMessage) -> None:
         seen.append(msg)
 
     client = ACPStreamClient(send_bytes=send_bytes)
@@ -61,13 +62,13 @@ async def test_stream_client_notification_handler():
 
 
 @pytest.mark.asyncio
-async def test_stream_client_request_handler():
-    sent = []
+async def test_stream_client_request_handler() -> None:
+    sent: list[bytes] = []
 
-    async def send_bytes(data: bytes):
+    async def send_bytes(data: bytes) -> None:
         sent.append(data)
 
-    async def on_request(msg: ACPMessage):
+    async def on_request(msg: ACPMessage) -> ACPMessage:
         return ACPMessage(jsonrpc="2.0", id=msg.id, result={"outcome": {"outcome": "approved"}})
 
     client = ACPStreamClient(send_bytes=send_bytes)
@@ -86,8 +87,8 @@ async def test_stream_client_request_handler():
 
 
 @pytest.mark.asyncio
-async def test_stream_client_call_times_out_and_cleans_pending():
-    async def send_bytes(_: bytes):
+async def test_stream_client_call_times_out_and_cleans_pending() -> None:
+    async def send_bytes(_: bytes) -> None:
         return None
 
     client = ACPStreamClient(send_bytes=send_bytes, rpc_timeout_sec=0.01)
@@ -100,12 +101,12 @@ async def test_stream_client_call_times_out_and_cleans_pending():
 
 
 @pytest.mark.asyncio
-async def test_stdio_client_call_times_out_and_cleans_pending(monkeypatch):
-    sent = []
+async def test_stdio_client_call_times_out_and_cleans_pending(monkeypatch: pytest.MonkeyPatch) -> None:
+    sent: list[dict[str, Any]] = []
     client = ACPStdioClient("agent", [], rpc_timeout_sec=0.01)
     client._proc = object()
 
-    async def send(payload: dict):
+    async def send(payload: dict[str, Any]) -> None:
         sent.append(payload)
 
     monkeypatch.setattr(client, "_send", send)

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_sse_transport.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_sse_transport.py
@@ -23,6 +23,7 @@ def _make_transport(
     post_url: str | None = "http://localhost:8080/messages",
     **kwargs,
 ) -> MCPSSETransport:
+    kwargs.setdefault("allow_private_network", True)
     return MCPSSETransport(sse_url=sse_url, post_url=post_url, **kwargs)
 
 
@@ -357,7 +358,7 @@ async def test_sse_transport_reader_loop_tears_down_on_stream_end():
 @pytest.mark.asyncio
 async def test_sse_transport_discover_post_url():
     """_discover_post_url resolves relative URL against sse_url base."""
-    t = MCPSSETransport(sse_url="http://localhost:8080/sse")
+    t = MCPSSETransport(sse_url="http://localhost:8080/sse", allow_private_network=True)
 
     # Mock the HTTP client stream to return an endpoint event
     async def mock_stream_lines():
@@ -376,6 +377,42 @@ async def test_sse_transport_discover_post_url():
 
     url = await t._discover_post_url()
     assert url == "http://localhost:8080/messages"
+
+
+@pytest.mark.asyncio
+async def test_sse_transport_rejects_loopback_endpoint_before_client_creation():
+    t = MCPSSETransport(
+        sse_url="http://127.0.0.1:8080/sse",
+        post_url="http://127.0.0.1:8080/messages",
+    )
+
+    with patch.object(t, "_create_http_client") as create_client:
+        with pytest.raises(ValueError):
+            await t.connect()
+
+    create_client.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sse_transport_rejects_cross_origin_discovered_post_url():
+    t = MCPSSETransport(sse_url="https://mcp.example.com/sse")
+
+    async def mock_stream_lines():
+        yield "event: endpoint"
+        yield "data: https://evil.example.com/messages"
+        yield ""
+
+    mock_response = AsyncMock()
+    mock_response.aiter_lines = mock_stream_lines
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
+
+    mock_http = AsyncMock()
+    mock_http.stream = MagicMock(return_value=mock_response)
+    t._http_client = mock_http
+
+    with pytest.raises(ValueError, match="same origin"):
+        await t._discover_post_url()
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_sse_transport.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_sse_transport.py
@@ -395,7 +395,7 @@ async def test_sse_transport_rejects_loopback_endpoint_before_client_creation():
 
 @pytest.mark.asyncio
 async def test_sse_transport_rejects_cross_origin_discovered_post_url():
-    t = MCPSSETransport(sse_url="https://mcp.example.com/sse")
+    t = MCPSSETransport(sse_url="https://mcp.example.com/sse", allow_private_network=True)
 
     async def mock_stream_lines():
         yield "event: endpoint"

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_streamable_http_transport.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_streamable_http_transport.py
@@ -73,6 +73,7 @@ def transport():
         endpoint="http://localhost:8080/mcp",
         headers={"Authorization": "Bearer test"},
         timeout_sec=15,
+        allow_private_network=True,
     )
 
 
@@ -239,3 +240,14 @@ async def test_streamable_http_call_tool_not_connected(transport):
     """call_tool() raises RuntimeError when not connected."""
     with pytest.raises(RuntimeError, match="Not connected"):
         await transport.call_tool("echo", {})
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_rejects_loopback_endpoint_before_client_creation():
+    transport = MCPStreamableHTTPTransport(endpoint="http://127.0.0.1:8080/mcp")
+
+    with patch.object(transport, "_create_http_client") as create_client:
+        with pytest.raises(ValueError):
+            await transport.connect()
+
+    create_client.assert_not_called()

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_permission_tiers_sanitizers.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_permission_tiers_sanitizers.py
@@ -42,6 +42,10 @@ def test_policy_permission_tier_failure_log_is_sanitized(monkeypatch: pytest.Mon
         "get_shell_history",
         "list_terminal_sessions",
         "Bash(git:push --force)",
+        "read_and_write_file",
+        "get_and_update_profile",
+        "list_and_destroy_instances",
+        "find_and_patch_record",
     ],
 )
 def test_permission_tier_checks_destructive_tokens_before_auto_tokens(

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_permission_tiers_sanitizers.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_permission_tiers_sanitizers.py
@@ -31,3 +31,26 @@ def test_policy_permission_tier_failure_log_is_sanitized(monkeypatch: pytest.Mon
     assert "permission policy backend exploded" not in rendered
     assert "/tmp/acp-policy-secret-token" not in rendered
     assert "exc_info" not in rendered
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "tool_name",
+    [
+        "thread.delete",
+        "file_read_delete",
+        "get_shell_history",
+        "list_terminal_sessions",
+        "Bash(git:push --force)",
+    ],
+)
+def test_permission_tier_checks_destructive_tokens_before_auto_tokens(
+    tool_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.Agent_Client_Protocol.permission_tiers import determine_permission_tier
+    import tldw_Server_API.app.services.admin_acp_sessions_service as store_src
+
+    monkeypatch.setattr(store_src, "_store", None, raising=False)
+
+    assert determine_permission_tier(tool_name) == "individual"


### PR DESCRIPTION
## Change summary
TODO: Human requester must replace this with a human-written summary explaining what changed and why these implementation choices were made before this PR is marked ready for merge.

## AI-prepared technical summary
- Add ACP hardening helpers for launch validation, bounded queues/buffers, log redaction, and MCP URL validation.
- Block unsafe host-runner cwd/env/stdio-MCP surfaces by default unless explicitly enabled.
- Add RPC timeouts, sandbox SSH key persistence guard, fail-fast egress behavior, and regression coverage.

## Test plan
- [x] python -m pytest --confcutdir=tldw_Server_API/tests/Agent_Client_Protocol tldw_Server_API/tests/Agent_Client_Protocol/test_permission_tiers_sanitizers.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_stream_client.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_hardening_helpers.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_sse_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_streamable_http_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py -q
- [x] python -m bandit -r tldw_Server_API/app/core/Agent_Client_Protocol -f json -o /tmp/bandit_acp_hardening_worktree.json

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens ACP runner, transports, and sandbox with strict session launch validation, DNS-aware MCP SSRF checks, RPC timeouts, bounded buffers/queues, and redacted stderr to cut SSRF and secret leakage risk. Aligns with the hardening review by enforcing safer defaults, fail-closed cwd roots, and focused regression coverage.

- New Features
  - Validate session inputs: enforce cwd within allowed roots (fail if unset); block session env and inline stdio MCP servers by default (configurable via `ACPRunnerConfig`).
  - Enforce MCP HTTP/SSE safety: DNS-resolving host checks; block local/private endpoints by default; require `post_url` to match `sse_url` origin; fail before creating clients.
  - Add RPC timeouts with pending-future cleanup in stdio/stream clients; bound stream buffers and session update queues; truncate oversized updates.
  - Redact secrets and private keys in stderr/output with truncate-before-regex.
  - Permission tiers favor destructive tokens (delete/run/exec/etc.) over auto-approve substrings.
  - Sandbox: do not persist SSH private keys by default; fail fast on unsupported per-session egress allowlists.

- Migration
  - If needed, re-enable prior behavior via flags: `ACP_ALLOW_SESSION_ENV`, `ACP_ALLOW_INLINE_STDIO_MCP`, `ACP_ALLOW_PRIVATE_MCP_HTTP`, `ACP_ALLOW_CROSS_ORIGIN_SSE_POST`.
  - Set `ACP_ALLOWED_SESSION_CWD_ROOTS` to include permitted workspace roots.
  - Only set `ACP_SSH_PERSIST_PRIVATE_KEYS=true` if you must persist keys.
  - Remove `ACP_SANDBOX_ALLOWED_EGRESS_HOSTS`; use the core sandbox network policy instead.

<sup>Written for commit 680a7c514cf57be985519dfbd9c5bf11dea5d1f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

