### PR TITLE
Harden audit module review findings

### DIFF
--- a/backlog/tasks/task-2409 - Harden-audit-module-review-findings.md
+++ b/backlog/tasks/task-2409 - Harden-audit-module-review-findings.md
@@ -4,7 +4,7 @@ title: Harden audit module review findings
 status: Done
 assignee: []
 created_date: '2026-06-23 18:11'
-updated_date: '2026-06-24 01:06'
+updated_date: '2026-06-24 01:22'
 labels:
   - audit
   - security
@@ -66,6 +66,14 @@ Post-review verification in PR worktree:
 - focused review regression subset: 8 passed, 13 warnings
 - touched audit test files: 106 passed, 1 xfailed, 332 warnings
 - Bandit audit module scan: 0 findings (/tmp/bandit_audit_module_hardening_pr2440.json)
+
+2026-06-24: Rebased PR #2440 onto latest origin/dev (4fb8eafd5) and clarified the cancellation propagation test by restoring the original audit DB reader before forcing count_events/export_events/get_security_summary to raise from flush(). This addresses the remaining Gemini test-isolation comment while preserving the existing count_events flush behavior.
+
+Rebased PR verification:
+- py_compile on touched audit files: passed
+- focused review regression subset: 8 passed, 13 warnings
+- touched audit test files: 106 passed, 1 xfailed, 332 warnings
+- Bandit audit module scan: 0 findings (/tmp/bandit_audit_module_hardening_pr2440_rebased.json)
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2409 - Harden-audit-module-review-findings.md
+++ b/backlog/tasks/task-2409 - Harden-audit-module-review-findings.md
@@ -1,0 +1,77 @@
+---
+id: TASK-2409
+title: Harden audit module review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 18:11'
+updated_date: '2026-06-23 18:31'
+labels:
+  - audit
+  - security
+  - review
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the current tldw_Server_API/app/core/Audit module findings from the audit module review. Scope: CSV export formula injection, cancellation propagation, PII metadata key redaction, stale reads from buffered events, hash-chain consistency across service instances, shared migration checkpoint resume behavior, and README drift.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 CSV exports neutralize spreadsheet formulas in user-controlled string fields.
+- [x] #2 Cancellation is propagated instead of being wrapped as a normal audit read/export error.
+- [x] #3 PII redaction covers metadata keys as well as values.
+- [x] #4 Read APIs flush buffered events before querying summaries/exports.
+- [x] #5 Hash chaining remains valid when multiple service instances write sequentially to the same shared DB.
+- [x] #6 Shared audit migration resumes by source row identity and does not skip late older timestamp rows.
+- [x] #7 Audit README matches the current public helper surface.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Completed stages:
+1. Added focused regression tests for all accepted audit review findings.
+2. Hardened UnifiedAuditService CSV export, cancellation propagation, PII redaction, read flushing, and hash chaining.
+3. Fixed shared audit migration resume semantics and README drift.
+4. Ran focused tests and Bandit.
+
+Temporary plan file IMPLEMENTATION_PLAN_audit_module_hardening.md was completed and removed per repository instructions.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-06-23: Started implementation. Using TDD for focused regression coverage before production changes.
+
+2026-06-23: Created IMPLEMENTATION_PLAN_audit_module_hardening.md with four stages.
+
+2026-06-23: Implemented audit hardening fixes. Added focused regression coverage for CSV formula neutralization, cancellation propagation, metadata key PII redaction, buffered query/security summary reads, multi-instance hash-chain continuity, and late older timestamp migration resume. Updated README helper references. Temporary implementation plan completed and removed per repo instructions.
+
+Verification:
+- source .venv/bin/activate && python -m py_compile tldw_Server_API/app/core/Audit/unified_audit_service.py tldw_Server_API/app/core/Audit/audit_shared_migration.py tldw_Server_API/tests/Audit/test_unified_audit_service.py tldw_Server_API/tests/Audit/test_audit_shared_migration.py: passed
+- source .venv/bin/activate && python -m pytest -q --confcutdir=tldw_Server_API/tests/Audit [7 focused new audit regressions]: 7 passed, 11 warnings
+- source .venv/bin/activate && python -m pytest -q --confcutdir=tldw_Server_API/tests/Audit tldw_Server_API/tests/Audit/test_unified_audit_service.py tldw_Server_API/tests/Audit/test_audit_shared_migration.py: 106 passed, 1 xfailed, 332 warnings
+- source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Audit -f json -o /tmp/bandit_audit_module_hardening.json: 0 findings
+
+Known limitation: running the same focused tests with the repository parent conftest loaded blocked during an unrelated character_chat_sessions FastAPI import before audit test bodies ran. A broader tldw_Server_API/tests/Audit run with parent conftest excluded was interrupted after 19 passing tests because endpoint tests were slow/teardown did not return promptly.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the audit review findings in the current module code. CSV exports now neutralize spreadsheet formulas across in-memory, streaming, and file paths; cancellation is no longer part of the broad noncritical exception bucket; PII redaction covers metadata keys; query_events and get_security_summary flush buffered events before reading; hash-chain writes reload the current persisted chain head; shared migration resume includes appended older-timestamp rows; and README helper references match the current service API. Added focused regression tests for each behavior and ran py_compile, targeted pytest coverage, and Bandit with zero findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2409 - Harden-audit-module-review-findings.md
+++ b/backlog/tasks/task-2409 - Harden-audit-module-review-findings.md
@@ -4,7 +4,7 @@ title: Harden audit module review findings
 status: Done
 assignee: []
 created_date: '2026-06-23 18:11'
-updated_date: '2026-06-23 18:31'
+updated_date: '2026-06-24 01:06'
 labels:
   - audit
   - security
@@ -58,6 +58,14 @@ Verification:
 - source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Audit -f json -o /tmp/bandit_audit_module_hardening.json: 0 findings
 
 Known limitation: running the same focused tests with the repository parent conftest loaded blocked during an unrelated character_chat_sessions FastAPI import before audit test bodies ran. A broader tldw_Server_API/tests/Audit run with parent conftest excluded was interrupted after 19 passing tests because endpoint tests were slow/teardown did not return promptly.
+
+2026-06-24: Addressed PR #2440 automated review comments. Added docstring for _neutralize_csv_row; included newline-prefixed CSV formula neutralization with test coverage; made metadata key redaction collision-safe with stable suffixes; changed normal migration resume to rowid-only with a rowid-reuse/source-reset fallback; added third-pass migration idempotency assertions; added get_security_summary cancellation coverage; made the security-summary flush test keep the event buffered before read; replaced blocking Path.read_text in async test with asyncio.to_thread; wrapped flush and fallback replay chain writes in BEGIN IMMEDIATE transaction boundaries with rollback on failure.
+
+Post-review verification in PR worktree:
+- py_compile on touched audit files: passed
+- focused review regression subset: 8 passed, 13 warnings
+- touched audit test files: 106 passed, 1 xfailed, 332 warnings
+- Bandit audit module scan: 0 findings (/tmp/bandit_audit_module_hardening_pr2440.json)
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/app/core/Audit/README.md
+++ b/tldw_Server_API/app/core/Audit/README.md
@@ -93,8 +93,8 @@ contextual fields automatically. Similar helpers can be added for domain-specifi
 events-mirror the pattern so tests can stub them easily.
 
 ### Export & Reporting
-The service exposes `export_events(...)` (CSV/JSONL), `get_daily_stats(...)`,
-`get_recent_events(...)`, and other query helpers used by the API endpoints in
+The service exposes `query_events(...)`, `count_events(...)`, `export_events(...)`
+(CSV/JSONL), `get_security_summary(...)`, and other query helpers used by the API endpoints in
 `app/api/v1/endpoints/audit.py`. Keep export code async (it uses the same pooled
 connection and locks) to avoid blocking the event loop.
 

--- a/tldw_Server_API/app/core/Audit/audit_shared_migration.py
+++ b/tldw_Server_API/app/core/Audit/audit_shared_migration.py
@@ -743,15 +743,18 @@ async def _migrate_source(
                     last_event_id = None
                     last_timestamp = None
 
-            if last_timestamp:
+            if last_rowid > 0 and last_timestamp:
                 query = (
                     "SELECT rowid, * FROM audit_events "
-                    "WHERE (timestamp > ? OR (timestamp = ? AND event_id > ?)) "
-                    "ORDER BY timestamp, event_id"
+                    "WHERE rowid > ? OR (timestamp > ? OR (timestamp = ? AND event_id > ?)) "
+                    "ORDER BY rowid"
                 )
-                params = (last_timestamp, last_timestamp, last_event_id or "")
+                params = (last_rowid, last_timestamp, last_timestamp, last_event_id or "")
+            elif last_rowid > 0:
+                query = "SELECT rowid, * FROM audit_events WHERE rowid > ? ORDER BY rowid"
+                params = (last_rowid,)
             else:
-                query = "SELECT rowid, * FROM audit_events ORDER BY timestamp, event_id"
+                query = "SELECT rowid, * FROM audit_events ORDER BY rowid"
                 params = ()
 
             async with source_db.execute(query, params) as cur:

--- a/tldw_Server_API/app/core/Audit/audit_shared_migration.py
+++ b/tldw_Server_API/app/core/Audit/audit_shared_migration.py
@@ -743,16 +743,40 @@ async def _migrate_source(
                     last_event_id = None
                     last_timestamp = None
 
-            if last_rowid > 0 and last_timestamp:
-                query = (
-                    "SELECT rowid, * FROM audit_events "
-                    "WHERE rowid > ? OR (timestamp > ? OR (timestamp = ? AND event_id > ?)) "
-                    "ORDER BY rowid"
-                )
-                params = (last_rowid, last_timestamp, last_timestamp, last_event_id or "")
-            elif last_rowid > 0:
+            if last_rowid > 0 and last_event_id:
+                try:
+                    async with source_db.execute(
+                        "SELECT event_id FROM audit_events WHERE rowid = ?",
+                        (last_rowid,),
+                    ) as cur:
+                        checkpoint_row = await cur.fetchone()
+                    if checkpoint_row and str(checkpoint_row["event_id"]) != last_event_id:
+                        # Source rowids were reused or the source was rebuilt; fall back to a full
+                        # scan and rely on event_id de-duplication to preserve correctness.
+                        last_rowid = 0
+                        last_event_id = None
+                        last_timestamp = None
+                    elif checkpoint_row is None:
+                        async with source_db.execute("SELECT MAX(rowid) FROM audit_events") as cur:
+                            max_row = await cur.fetchone()
+                        max_rowid = int(max_row[0]) if max_row and max_row[0] is not None else None
+                        if max_rowid is not None and max_rowid <= last_rowid:
+                            last_rowid = 0
+                            last_event_id = None
+                            last_timestamp = None
+                except _AUDIT_DB_EXCEPTIONS:
+                    pass
+
+            if last_rowid > 0:
                 query = "SELECT rowid, * FROM audit_events WHERE rowid > ? ORDER BY rowid"
                 params = (last_rowid,)
+            elif last_timestamp:
+                query = (
+                    "SELECT rowid, * FROM audit_events "
+                    "WHERE timestamp > ? OR (timestamp = ? AND event_id > ?) "
+                    "ORDER BY timestamp, event_id"
+                )
+                params = (last_timestamp, last_timestamp, last_event_id or "")
             else:
                 query = "SELECT rowid, * FROM audit_events ORDER BY rowid"
                 params = ()

--- a/tldw_Server_API/app/core/Audit/unified_audit_service.py
+++ b/tldw_Server_API/app/core/Audit/unified_audit_service.py
@@ -120,7 +120,7 @@ _VALID_STORAGE_MODES = {"per_user", "shared"}
 _SYSTEM_TENANT_ID = "system"
 _UNIDENTIFIED_TENANT_ID = "unidentified_user"
 _AUDIT_SHARED_SCHEMA_VERSION = 1
-_CSV_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
+_CSV_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r", "\n")
 
 try:
     import fcntl  # type: ignore
@@ -228,6 +228,7 @@ def _neutralize_csv_formula(value: Any) -> Any:
 
 
 def _neutralize_csv_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Return a CSV-safe copy of a row without mutating caller-owned data."""
     return {key: _neutralize_csv_formula(value) for key, value in row.items()}
 
 
@@ -681,7 +682,12 @@ class PIIDetector:
                 redacted: dict[Any, Any] = {}
                 for key, value in data.items():
                     safe_key = self._redact_value(key, placeholder_format) if isinstance(key, str) else key
-                    redacted[safe_key] = self.redact_obj(value, placeholder_format)
+                    unique_key = safe_key
+                    suffix = 2
+                    while unique_key in redacted:
+                        unique_key = f"{safe_key}__{suffix}"
+                        suffix += 1
+                    redacted[unique_key] = self.redact_obj(value, placeholder_format)
                 return redacted
             if isinstance(data, list):
                 return [self.redact_obj(v, placeholder_format) for v in data]
@@ -1161,6 +1167,20 @@ class UnifiedAuditService:
         if not row:
             return ""
         return str(row[0] or "")
+
+    @asynccontextmanager
+    async def _immediate_write_transaction(self, db: aiosqlite.Connection) -> AsyncGenerator[None, None]:
+        """Hold SQLite's writer lock from chain-head read through commit."""
+        await db.execute("BEGIN IMMEDIATE")
+        committed = False
+        try:
+            yield
+            await db.commit()
+            committed = True
+        finally:
+            if not committed:
+                with suppress(_AUDIT_NONCRITICAL_EXCEPTIONS):
+                    await db.rollback()
 
 
     def _build_event_columns(self) -> list[str]:
@@ -2499,42 +2519,44 @@ class UnifiedAuditService:
                                 db.row_factory = aiosqlite.Row
                             except _AUDIT_NONCRITICAL_EXCEPTIONS:
                                 pass
-                            new_events = await self._filter_new_events(db, events)
-                            if not new_events:
-                                return True
-                            # Prepare batch data
-                            records = [event.to_dict() for event in new_events]
-                            self._ensure_record_tenant_ids(records)
-                            previous_hash = await self._load_last_chain_hash_from_db(db)
-                            committed_chain_hash = self._apply_chain_hashes(
-                                records,
-                                previous_hash=previous_hash,
-                            )
-                            await db.executemany(self._event_insert_sql, records)
-                            await self._update_daily_stats(db, new_events)
-                            await db.commit()
+                            committed_chain_hash = self._last_chain_hash
+                            async with self._immediate_write_transaction(db):
+                                new_events = await self._filter_new_events(db, events)
+                                if not new_events:
+                                    return True
+                                # Prepare batch data
+                                records = [event.to_dict() for event in new_events]
+                                self._ensure_record_tenant_ids(records)
+                                previous_hash = await self._load_last_chain_hash_from_db(db)
+                                committed_chain_hash = self._apply_chain_hashes(
+                                    records,
+                                    previous_hash=previous_hash,
+                                )
+                                await db.executemany(self._event_insert_sql, records)
+                                await self._update_daily_stats(db, new_events)
                             self._last_chain_hash = committed_chain_hash
                     else:
                         db = await self._ensure_db_pool()
                         async with self._db_lock:
-                            new_events = await self._filter_new_events(db, events)
-                            if not new_events:
-                                return True
-                            # Prepare batch data
-                            records = [event.to_dict() for event in new_events]
+                            committed_chain_hash = self._last_chain_hash
+                            async with self._immediate_write_transaction(db):
+                                new_events = await self._filter_new_events(db, events)
+                                if not new_events:
+                                    return True
+                                # Prepare batch data
+                                records = [event.to_dict() for event in new_events]
 
-                            # Batch insert
-                            self._ensure_record_tenant_ids(records)
-                            previous_hash = await self._load_last_chain_hash_from_db(db)
-                            committed_chain_hash = self._apply_chain_hashes(
-                                records,
-                                previous_hash=previous_hash,
-                            )
-                            await db.executemany(self._event_insert_sql, records)
+                                # Batch insert
+                                self._ensure_record_tenant_ids(records)
+                                previous_hash = await self._load_last_chain_hash_from_db(db)
+                                committed_chain_hash = self._apply_chain_hashes(
+                                    records,
+                                    previous_hash=previous_hash,
+                                )
+                                await db.executemany(self._event_insert_sql, records)
 
-                            # Update daily statistics
-                            await self._update_daily_stats(db, new_events)
-                            await db.commit()
+                                # Update daily statistics
+                                await self._update_daily_stats(db, new_events)
                             self._last_chain_hash = committed_chain_hash
 
                     # Success
@@ -2951,48 +2973,49 @@ class UnifiedAuditService:
 
                 async def _do_write() -> int:
                     nonlocal replay_chain_hash
-                    record_ids = [str(r.get("event_id")) for r in records_chunk if r.get("event_id")]
-                    existing_ids = await self._fetch_existing_event_ids(db, record_ids)
-                    seen: set[str] = set()
-                    filtered_records: list[dict[str, Any]] = []
-                    for record in records_chunk:
-                        event_id = record.get("event_id")
-                        if not event_id:
-                            continue
-                        event_id = str(event_id)
-                        if event_id in existing_ids or event_id in seen:
-                            continue
-                        seen.add(event_id)
-                        filtered_records.append(record)
-
-                    if not filtered_records:
-                        return 0
-
-                    for record in filtered_records:
-                        record["pii_detected"] = _coerce_bool(record.get("pii_detected"), False)
-
-                    self._ensure_record_tenant_ids(filtered_records)
-                    previous_hash = await self._load_last_chain_hash_from_db(db)
-                    committed_chain_hash = self._apply_chain_hashes(
-                        filtered_records,
-                        previous_hash=previous_hash,
-                    )
-                    await db.executemany(self._event_insert_sql, filtered_records)
-                    if stats_events:
-                        filtered_stats: list[AuditEvent] = []
-                        stats_seen: set[str] = set()
-                        for ev in stats_events:
-                            if not ev.event_id:
+                    committed_chain_hash = replay_chain_hash
+                    async with self._immediate_write_transaction(db):
+                        record_ids = [str(r.get("event_id")) for r in records_chunk if r.get("event_id")]
+                        existing_ids = await self._fetch_existing_event_ids(db, record_ids)
+                        seen: set[str] = set()
+                        filtered_records: list[dict[str, Any]] = []
+                        for record in records_chunk:
+                            event_id = record.get("event_id")
+                            if not event_id:
                                 continue
-                            if ev.event_id in existing_ids or ev.event_id not in seen:
+                            event_id = str(event_id)
+                            if event_id in existing_ids or event_id in seen:
                                 continue
-                            if ev.event_id in stats_seen:
-                                continue
-                            stats_seen.add(ev.event_id)
-                            filtered_stats.append(ev)
-                        if filtered_stats:
-                            await self._update_daily_stats(db, filtered_stats)
-                    await db.commit()
+                            seen.add(event_id)
+                            filtered_records.append(record)
+
+                        if not filtered_records:
+                            return 0
+
+                        for record in filtered_records:
+                            record["pii_detected"] = _coerce_bool(record.get("pii_detected"), False)
+
+                        self._ensure_record_tenant_ids(filtered_records)
+                        previous_hash = await self._load_last_chain_hash_from_db(db)
+                        committed_chain_hash = self._apply_chain_hashes(
+                            filtered_records,
+                            previous_hash=previous_hash,
+                        )
+                        await db.executemany(self._event_insert_sql, filtered_records)
+                        if stats_events:
+                            filtered_stats: list[AuditEvent] = []
+                            stats_seen: set[str] = set()
+                            for ev in stats_events:
+                                if not ev.event_id:
+                                    continue
+                                if ev.event_id in existing_ids or ev.event_id not in seen:
+                                    continue
+                                if ev.event_id in stats_seen:
+                                    continue
+                                stats_seen.add(ev.event_id)
+                                filtered_stats.append(ev)
+                            if filtered_stats:
+                                await self._update_daily_stats(db, filtered_stats)
                     replay_chain_hash = committed_chain_hash
                     self._last_chain_hash = committed_chain_hash
                     return len(filtered_records)

--- a/tldw_Server_API/app/core/Audit/unified_audit_service.py
+++ b/tldw_Server_API/app/core/Audit/unified_audit_service.py
@@ -71,7 +71,6 @@ _AUDIT_NONCRITICAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
     json.JSONDecodeError,
     csv.Error,
     aiosqlite.Error,
-    asyncio.CancelledError,
 )
 
 
@@ -121,6 +120,7 @@ _VALID_STORAGE_MODES = {"per_user", "shared"}
 _SYSTEM_TENANT_ID = "system"
 _UNIDENTIFIED_TENANT_ID = "unidentified_user"
 _AUDIT_SHARED_SCHEMA_VERSION = 1
+_CSV_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
 
 try:
     import fcntl  # type: ignore
@@ -218,6 +218,17 @@ def _normalize_storage_mode(raw: Any) -> str:
         return "per_user"
     mode = str(raw).strip().lower()
     return mode if mode in _VALID_STORAGE_MODES else "per_user"
+
+
+def _neutralize_csv_formula(value: Any) -> Any:
+    """Prevent spreadsheet formula execution for exported string cells."""
+    if isinstance(value, str) and value and value[0] in _CSV_FORMULA_PREFIXES:
+        return "'" + value
+    return value
+
+
+def _neutralize_csv_row(row: dict[str, Any]) -> dict[str, Any]:
+    return {key: _neutralize_csv_formula(value) for key, value in row.items()}
 
 
 def _resolve_storage_mode(explicit: Optional[str] = None) -> str:
@@ -667,7 +678,11 @@ class PIIDetector:
         """Recursively redact PII from nested dict/list/tuple/set structures and strings."""
         try:
             if isinstance(data, dict):
-                return {k: self.redact_obj(v, placeholder_format) for k, v in data.items()}
+                redacted: dict[Any, Any] = {}
+                for key, value in data.items():
+                    safe_key = self._redact_value(key, placeholder_format) if isinstance(key, str) else key
+                    redacted[safe_key] = self.redact_obj(value, placeholder_format)
+                return redacted
             if isinstance(data, list):
                 return [self.redact_obj(v, placeholder_format) for v in data]
             if isinstance(data, tuple):
@@ -1129,19 +1144,24 @@ class UnifiedAuditService:
         """Resume the tamper-evident chain from the most recently inserted event."""
         try:
             async with self._read_db() as db:
-                async with db.execute(
-                    "SELECT chain_hash FROM audit_events "
-                    "WHERE chain_hash IS NOT NULL AND chain_hash != '' "
-                    "ORDER BY rowid DESC LIMIT 1"
-                ) as cursor:
-                    row = await cursor.fetchone()
+                return await self._load_last_chain_hash_from_db(db)
         except _AUDIT_NONCRITICAL_EXCEPTIONS as exc:
             logger.warning(f"Failed to resume audit hash chain: {exc}")
             return ""
 
+    async def _load_last_chain_hash_from_db(self, db: aiosqlite.Connection) -> str:
+        """Read the persisted hash-chain head from an existing connection."""
+        async with db.execute(
+            "SELECT chain_hash FROM audit_events "
+            "WHERE chain_hash IS NOT NULL AND chain_hash != '' "
+            "ORDER BY rowid DESC LIMIT 1"
+        ) as cursor:
+            row = await cursor.fetchone()
+
         if not row:
             return ""
         return str(row[0] or "")
+
 
     def _build_event_columns(self) -> list[str]:
         columns = [
@@ -2485,9 +2505,10 @@ class UnifiedAuditService:
                             # Prepare batch data
                             records = [event.to_dict() for event in new_events]
                             self._ensure_record_tenant_ids(records)
+                            previous_hash = await self._load_last_chain_hash_from_db(db)
                             committed_chain_hash = self._apply_chain_hashes(
                                 records,
-                                previous_hash=self._last_chain_hash,
+                                previous_hash=previous_hash,
                             )
                             await db.executemany(self._event_insert_sql, records)
                             await self._update_daily_stats(db, new_events)
@@ -2504,9 +2525,10 @@ class UnifiedAuditService:
 
                             # Batch insert
                             self._ensure_record_tenant_ids(records)
+                            previous_hash = await self._load_last_chain_hash_from_db(db)
                             committed_chain_hash = self._apply_chain_hashes(
                                 records,
-                                previous_hash=self._last_chain_hash,
+                                previous_hash=previous_hash,
                             )
                             await db.executemany(self._event_insert_sql, records)
 
@@ -2950,9 +2972,10 @@ class UnifiedAuditService:
                         record["pii_detected"] = _coerce_bool(record.get("pii_detected"), False)
 
                     self._ensure_record_tenant_ids(filtered_records)
+                    previous_hash = await self._load_last_chain_hash_from_db(db)
                     committed_chain_hash = self._apply_chain_hashes(
                         filtered_records,
-                        previous_hash=replay_chain_hash,
+                        previous_hash=previous_hash,
                     )
                     await db.executemany(self._event_insert_sql, filtered_records)
                     if stats_events:
@@ -3132,6 +3155,14 @@ class UnifiedAuditService:
     ) -> list[dict[str, Any]]:
         """Query audit events with filters"""
         self._touch()
+        try:
+            await self.flush(raise_on_failure=True)
+        except asyncio.CancelledError:
+            raise
+        except _AUDIT_NONCRITICAL_EXCEPTIONS as e:
+            logger.error(f"Failed to flush before query: {e}")
+            raise AuditReadError("Failed to flush audit buffer before query") from e
+
         base_query, params = self._build_events_query(
             start_time=start_time,
             end_time=end_time,
@@ -3155,6 +3186,8 @@ class UnifiedAuditService:
             async with self._read_db() as db, db.execute(query, params) as cursor:
                 rows = await cursor.fetchall()
                 return [dict(row) for row in rows]
+        except asyncio.CancelledError:
+            raise
         except _AUDIT_NONCRITICAL_EXCEPTIONS as e:
             logger.error(f"Failed to query audit events: {e}")
             raise AuditReadError("Failed to query audit events") from e
@@ -3198,6 +3231,8 @@ class UnifiedAuditService:
             async with self._read_db() as db, db.execute(query, params) as cursor:
                 row = await cursor.fetchone()
                 return int(row[0]) if row else 0
+        except asyncio.CancelledError:
+            raise
         except _AUDIT_NONCRITICAL_EXCEPTIONS as e:
             logger.error(f"Failed to count audit events: {e}")
             raise AuditReadError("Failed to count audit events") from e
@@ -3249,6 +3284,8 @@ class UnifiedAuditService:
         self._touch()
         try:
             await self.flush(raise_on_failure=True)
+        except asyncio.CancelledError:
+            raise
         except _AUDIT_NONCRITICAL_EXCEPTIONS as e:
             logger.error(f"Failed to flush before export: {e}")
             raise AuditReadError("Failed to flush audit buffer before export") from e
@@ -3338,7 +3375,7 @@ class UnifiedAuditService:
                     for r in chunk:
                         if max_rows is not None and rows_written >= max_rows:
                             break
-                        writer.writerow(r)
+                        writer.writerow(_neutralize_csv_row(r))
                         rows_written += 1
                     cursor_ts, cursor_event_id = self._cursor_from_row(chunk[-1])
                     if (
@@ -3370,7 +3407,7 @@ class UnifiedAuditService:
                     for r in rows:
                         if max_rows is not None and written >= max_rows:
                             break
-                        writer.writerow(r)
+                        writer.writerow(_neutralize_csv_row(r))
                         written += 1
                     chunk_str = buf.getvalue()
                     if chunk_str:
@@ -3556,7 +3593,7 @@ class UnifiedAuditService:
             writer = csv.DictWriter(buf, fieldnames=CSV_HEADERS, extrasaction="ignore")
             writer.writeheader()
             for r in rows:
-                writer.writerow(r)
+                writer.writerow(_neutralize_csv_row(r))
             return buf.getvalue()
 
         if file_path is None:
@@ -3668,6 +3705,15 @@ class UnifiedAuditService:
             Dictionary with summary stats: high_risk_events, failure_events,
             unique_security_users, top_failing_ips
         """
+        self._touch()
+        try:
+            await self.flush(raise_on_failure=True)
+        except asyncio.CancelledError:
+            raise
+        except _AUDIT_NONCRITICAL_EXCEPTIONS as e:
+            logger.error(f"Failed to flush before security summary: {e}")
+            raise AuditReadError("Failed to flush audit buffer before security summary") from e
+
         start_time = datetime.now(timezone.utc) - timedelta(hours=hours)
         start_iso = start_time.isoformat()
         cat = AuditEventCategory.SECURITY.value
@@ -3761,8 +3807,14 @@ class UnifiedAuditService:
                 "total_events": total_events,
             }
 
-        async with self._read_db() as db:
-            return await _summarize(db)
+        try:
+            async with self._read_db() as db:
+                return await _summarize(db)
+        except asyncio.CancelledError:
+            raise
+        except _AUDIT_NONCRITICAL_EXCEPTIONS as e:
+            logger.error(f"Failed to summarize security audit events: {e}")
+            raise AuditReadError("Failed to summarize security audit events") from e
 
     def decode_row_fields(self, row: dict[str, Any]) -> dict[str, Any]:
         """Return a copy of a row dict with JSON fields decoded.

--- a/tldw_Server_API/tests/Audit/test_audit_shared_migration.py
+++ b/tldw_Server_API/tests/Audit/test_audit_shared_migration.py
@@ -324,6 +324,17 @@ async def test_migration_resume_includes_late_older_timestamp_rows(tmp_path):
     event_ids = {row["event_id"] for row in rows}
     assert {"evt-first", "evt-second", "evt-late-older"} <= event_ids
 
+    report3 = await migrate_to_shared_audit_db(
+        shared_db_path=shared_db_path,
+        user_db_base_dir=user_base,
+        default_db_path=None,
+        system_tenant_id="system",
+        chunk_size=100,
+    )
+    source_counts3 = next(c for c in report3.sources if c.source.label == f"user:{user_id}")
+    assert source_counts3.events_read == 0
+    assert source_counts3.events_inserted == 0
+
 
 @pytest.mark.asyncio
 async def test_migration_checkpoint_handles_empty_timestamp_resume(tmp_path, monkeypatch):

--- a/tldw_Server_API/tests/Audit/test_audit_shared_migration.py
+++ b/tldw_Server_API/tests/Audit/test_audit_shared_migration.py
@@ -257,6 +257,75 @@ async def test_migration_resume_checkpoint(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_migration_resume_includes_late_older_timestamp_rows(tmp_path):
+    """Resume should not skip appended source rows whose timestamps are older."""
+    user_base = tmp_path / "user_dbs"
+    user_id = "212"
+    user_db_path = user_base / user_id / "audit" / "unified_audit.db"
+    shared_db_path = tmp_path / "Databases" / "audit_shared.db"
+    user_db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    svc_user = UnifiedAuditService(
+        db_path=str(user_db_path),
+        storage_mode="per_user",
+        enable_pii_detection=False,
+        enable_risk_scoring=False,
+        buffer_size=1,
+        flush_interval=0.1,
+    )
+    await svc_user.initialize(start_background_tasks=False)
+    await svc_user.stop()
+
+    async with aiosqlite.connect(user_db_path) as db:
+        await db.execute(
+            "INSERT INTO audit_events (event_id, timestamp, category, event_type, severity) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("evt-first", "2025-01-02T00:00:00+00:00", "api_call", "api.request", "info"),
+        )
+        await db.execute(
+            "INSERT INTO audit_events (event_id, timestamp, category, event_type, severity) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("evt-second", "2025-01-03T00:00:00+00:00", "api_call", "api.request", "info"),
+        )
+        await db.commit()
+
+    report1 = await migrate_to_shared_audit_db(
+        shared_db_path=shared_db_path,
+        user_db_base_dir=user_base,
+        default_db_path=None,
+        system_tenant_id="system",
+        chunk_size=100,
+    )
+    assert report1.total_events_inserted == 2
+
+    async with aiosqlite.connect(user_db_path) as db:
+        await db.execute(
+            "INSERT INTO audit_events (event_id, timestamp, category, event_type, severity) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("evt-late-older", "2025-01-01T00:00:00+00:00", "api_call", "api.request", "info"),
+        )
+        await db.commit()
+
+    report2 = await migrate_to_shared_audit_db(
+        shared_db_path=shared_db_path,
+        user_db_base_dir=user_base,
+        default_db_path=None,
+        system_tenant_id="system",
+        chunk_size=100,
+    )
+    source_counts = next(c for c in report2.sources if c.source.label == f"user:{user_id}")
+    assert source_counts.events_read == 1
+    assert source_counts.events_inserted == 1
+
+    async with aiosqlite.connect(shared_db_path) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute("SELECT event_id FROM audit_events") as cur:
+            rows = await cur.fetchall()
+    event_ids = {row["event_id"] for row in rows}
+    assert {"evt-first", "evt-second", "evt-late-older"} <= event_ids
+
+
+@pytest.mark.asyncio
 async def test_migration_checkpoint_handles_empty_timestamp_resume(tmp_path, monkeypatch):
     user_base = tmp_path / "user_dbs"
     user_id = "909"

--- a/tldw_Server_API/tests/Audit/test_unified_audit_service.py
+++ b/tldw_Server_API/tests/Audit/test_unified_audit_service.py
@@ -2472,6 +2472,7 @@ async def test_export_events_raises_on_read_failure(audit_service, monkeypatch):
 @pytest.mark.asyncio
 async def test_read_methods_propagate_cancellation(audit_service, monkeypatch):
     """Task cancellation should not be wrapped as an audit read/export failure."""
+    original_read_db = audit_service._read_db
 
     @asynccontextmanager
     async def _cancelled_read_db():
@@ -2485,6 +2486,7 @@ async def test_read_methods_propagate_cancellation(audit_service, monkeypatch):
     with pytest.raises(asyncio.CancelledError):
         await audit_service.query_events(user_id="cancelled-query-user")
 
+    monkeypatch.setattr(audit_service, "_read_db", original_read_db)
     monkeypatch.setattr(audit_service, "flush", _cancelled_flush)
     with pytest.raises(asyncio.CancelledError):
         await audit_service.count_events(user_id="cancelled-count-user")

--- a/tldw_Server_API/tests/Audit/test_unified_audit_service.py
+++ b/tldw_Server_API/tests/Audit/test_unified_audit_service.py
@@ -168,6 +168,7 @@ class TestPIIDetection:
             context=context,
             metadata={
                 "owner@example.com": "present in key",
+                "second@example.org": "second value",
                 "nested": {
                     "(555) 123-4567": "phone key",
                 },
@@ -182,8 +183,14 @@ class TestPIIDetection:
         stringified = json.dumps(meta)
 
         assert "owner@example.com" not in stringified
+        assert "second@example.org" not in stringified
         assert "(555) 123-4567" not in stringified
         assert "[EMAIL_REDACTED]" in meta
+        assert "[EMAIL_REDACTED]__2" in meta
+        assert sorted([meta["[EMAIL_REDACTED]"], meta["[EMAIL_REDACTED]__2"]]) == [
+            "present in key",
+            "second value",
+        ]
         nested_keys = list(meta["nested"])
         assert all("(555) 123-4567" not in key for key in nested_keys)
         assert any("[PHONE_REDACTED]" in key for key in nested_keys)
@@ -2488,6 +2495,8 @@ async def test_read_methods_propagate_cancellation(audit_service, monkeypatch):
             stream=False,
             max_rows=10,
         )
+    with pytest.raises(asyncio.CancelledError):
+        await audit_service.get_security_summary(hours=1)
 
 
 @pytest.mark.asyncio
@@ -2859,7 +2868,7 @@ async def test_security_summary_flushes_buffered_events(tmp_path):
     service = UnifiedAuditService(
         db_path=str(db_path),
         enable_pii_detection=False,
-        enable_risk_scoring=True,
+        enable_risk_scoring=False,
         buffer_size=100,
         flush_interval=60.0,
     )
@@ -2871,6 +2880,7 @@ async def test_security_summary_flushes_buffered_events(tmp_path):
             action="blocked_access",
             result="failure",
         )
+        assert len(service.event_buffer) == 1
 
         summary = await service.get_security_summary(hours=1)
 
@@ -2897,7 +2907,7 @@ async def test_csv_export_neutralizes_spreadsheet_formulas(tmp_path):
         await service.log_event(
             AuditEventType.DATA_EXPORT,
             context=AuditContext(user_id="csv-formula-user"),
-            resource_type="sheet",
+            resource_type="\n=SUM(1,1)",
             resource_id="+SUM(1,1)",
             action="=HYPERLINK(\"http://example.test\",\"x\")",
         )
@@ -2912,6 +2922,7 @@ async def test_csv_export_neutralizes_spreadsheet_formulas(tmp_path):
         rows = list(csv.DictReader(StringIO(content)))
         row = next(r for r in rows if r["context_user_id"] == "csv-formula-user")
         assert row["action"].startswith("'=")
+        assert row["resource_type"].startswith("'\n=")
         assert row["resource_id"].startswith("'+")
 
         output_path = tmp_path / "audit_export.csv"
@@ -2923,9 +2934,11 @@ async def test_csv_export_neutralizes_spreadsheet_formulas(tmp_path):
             max_rows=10,
         )
         assert written == 1
-        rows = list(csv.DictReader(StringIO(output_path.read_text(encoding="utf-8"))))
+        file_content = await asyncio.to_thread(output_path.read_text, encoding="utf-8")
+        rows = list(csv.DictReader(StringIO(file_content)))
         row = rows[0]
         assert row["action"].startswith("'=")
+        assert row["resource_type"].startswith("'\n=")
         assert row["resource_id"].startswith("'+")
 
         stream = await service.export_events(
@@ -2939,6 +2952,7 @@ async def test_csv_export_neutralizes_spreadsheet_formulas(tmp_path):
         rows = list(csv.DictReader(StringIO(streamed)))
         row = rows[0]
         assert row["action"].startswith("'=")
+        assert row["resource_type"].startswith("'\n=")
         assert row["resource_id"].startswith("'+")
     finally:
         await service.stop()

--- a/tldw_Server_API/tests/Audit/test_unified_audit_service.py
+++ b/tldw_Server_API/tests/Audit/test_unified_audit_service.py
@@ -6,9 +6,11 @@ testing the new unified audit service without references to deprecated modules.
 """
 
 import asyncio
+import csv
 import hashlib
 import json
 from contextlib import asynccontextmanager
+from io import StringIO
 import tempfile
 import sqlite3
 from datetime import datetime, timedelta, timezone
@@ -156,6 +158,35 @@ class TestPIIDetection:
         stringified = json.dumps(red_meta)
         assert api_key not in stringified
         assert card not in stringified
+
+    @pytest.mark.asyncio
+    async def test_recursive_redaction_includes_metadata_keys(self, audit_service):
+        """PII in metadata keys should be redacted before storage/export."""
+        context = AuditContext(user_id="key_redaction_user")
+        await audit_service.log_event(
+            event_type=AuditEventType.DATA_WRITE,
+            context=context,
+            metadata={
+                "owner@example.com": "present in key",
+                "nested": {
+                    "(555) 123-4567": "phone key",
+                },
+            },
+        )
+        await audit_service.flush()
+
+        events = await audit_service.query_events(user_id="key_redaction_user")
+        assert events, "No audit events returned"
+        meta_raw = events[0]["metadata"]
+        meta = json.loads(meta_raw) if isinstance(meta_raw, str) else meta_raw
+        stringified = json.dumps(meta)
+
+        assert "owner@example.com" not in stringified
+        assert "(555) 123-4567" not in stringified
+        assert "[EMAIL_REDACTED]" in meta
+        nested_keys = list(meta["nested"])
+        assert all("(555) 123-4567" not in key for key in nested_keys)
+        assert any("[PHONE_REDACTED]" in key for key in nested_keys)
 
     @pytest.mark.asyncio
     async def test_redaction_handles_dataclass_metadata_values(self, audit_service):
@@ -2430,6 +2461,35 @@ async def test_export_events_raises_on_read_failure(audit_service, monkeypatch):
             max_rows=10,
         )
 
+
+@pytest.mark.asyncio
+async def test_read_methods_propagate_cancellation(audit_service, monkeypatch):
+    """Task cancellation should not be wrapped as an audit read/export failure."""
+
+    @asynccontextmanager
+    async def _cancelled_read_db():
+        raise asyncio.CancelledError()
+        yield
+
+    async def _cancelled_flush(*_args, **_kwargs):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(audit_service, "_read_db", _cancelled_read_db)
+    with pytest.raises(asyncio.CancelledError):
+        await audit_service.query_events(user_id="cancelled-query-user")
+
+    monkeypatch.setattr(audit_service, "flush", _cancelled_flush)
+    with pytest.raises(asyncio.CancelledError):
+        await audit_service.count_events(user_id="cancelled-count-user")
+    with pytest.raises(asyncio.CancelledError):
+        await audit_service.export_events(
+            format="json",
+            user_id="cancelled-export-user",
+            stream=False,
+            max_rows=10,
+        )
+
+
 @pytest.mark.asyncio
 async def test_legacy_migration_allows_new_events_with_chain_hash(tmp_path):
     """A migrated legacy table should accept fresh writes with chain hashes."""
@@ -2763,3 +2823,183 @@ async def test_export_events_flushes_buffered_events(tmp_path):
         assert service.event_buffer == []
     finally:
         await service.stop()
+
+
+@pytest.mark.asyncio
+async def test_query_events_flushes_buffered_events(tmp_path):
+    """Queries should include buffered events without waiting for periodic flush."""
+    db_path = tmp_path / "query_flushes_buffer.db"
+    service = UnifiedAuditService(
+        db_path=str(db_path),
+        enable_pii_detection=False,
+        enable_risk_scoring=False,
+        buffer_size=100,
+        flush_interval=60.0,
+    )
+    await service.initialize(start_background_tasks=False)
+    try:
+        await service.log_event(
+            AuditEventType.DATA_READ,
+            context=AuditContext(user_id="buffered-query-user"),
+            resource_id="query-me",
+        )
+
+        events = await service.query_events(user_id="buffered-query-user")
+
+        assert any(row.get("resource_id") == "query-me" for row in events)
+        assert service.event_buffer == []
+    finally:
+        await service.stop()
+
+
+@pytest.mark.asyncio
+async def test_security_summary_flushes_buffered_events(tmp_path):
+    """Security summaries should include buffered security events."""
+    db_path = tmp_path / "summary_flushes_buffer.db"
+    service = UnifiedAuditService(
+        db_path=str(db_path),
+        enable_pii_detection=False,
+        enable_risk_scoring=True,
+        buffer_size=100,
+        flush_interval=60.0,
+    )
+    await service.initialize(start_background_tasks=False)
+    try:
+        await service.log_event(
+            AuditEventType.SECURITY_VIOLATION,
+            context=AuditContext(user_id="summary-user", ip_address="203.0.113.10"),
+            action="blocked_access",
+            result="failure",
+        )
+
+        summary = await service.get_security_summary(hours=1)
+
+        assert summary["total_events"] == 1
+        assert summary["failure_events"] == 1
+        assert service.event_buffer == []
+    finally:
+        await service.stop()
+
+
+@pytest.mark.asyncio
+async def test_csv_export_neutralizes_spreadsheet_formulas(tmp_path):
+    """CSV exports should neutralize formula-like user-controlled values."""
+    db_path = tmp_path / "csv_formula_export.db"
+    service = UnifiedAuditService(
+        db_path=str(db_path),
+        enable_pii_detection=False,
+        enable_risk_scoring=False,
+        buffer_size=1,
+        flush_interval=60.0,
+    )
+    await service.initialize(start_background_tasks=False)
+    try:
+        await service.log_event(
+            AuditEventType.DATA_EXPORT,
+            context=AuditContext(user_id="csv-formula-user"),
+            resource_type="sheet",
+            resource_id="+SUM(1,1)",
+            action="=HYPERLINK(\"http://example.test\",\"x\")",
+        )
+        await service.flush()
+
+        content = await service.export_events(
+            user_id="csv-formula-user",
+            format="csv",
+            stream=False,
+            max_rows=10,
+        )
+        rows = list(csv.DictReader(StringIO(content)))
+        row = next(r for r in rows if r["context_user_id"] == "csv-formula-user")
+        assert row["action"].startswith("'=")
+        assert row["resource_id"].startswith("'+")
+
+        output_path = tmp_path / "audit_export.csv"
+        written = await service.export_events(
+            user_id="csv-formula-user",
+            format="csv",
+            file_path=output_path,
+            chunk_size=1,
+            max_rows=10,
+        )
+        assert written == 1
+        rows = list(csv.DictReader(StringIO(output_path.read_text(encoding="utf-8"))))
+        row = rows[0]
+        assert row["action"].startswith("'=")
+        assert row["resource_id"].startswith("'+")
+
+        stream = await service.export_events(
+            user_id="csv-formula-user",
+            format="csv",
+            stream=True,
+            chunk_size=1,
+            max_rows=10,
+        )
+        streamed = "".join([part async for part in stream])
+        rows = list(csv.DictReader(StringIO(streamed)))
+        row = rows[0]
+        assert row["action"].startswith("'=")
+        assert row["resource_id"].startswith("'+")
+    finally:
+        await service.stop()
+
+
+@pytest.mark.asyncio
+async def test_hash_chain_uses_latest_persisted_head_for_multiple_instances(tmp_path):
+    """Sequential writers with stale in-memory heads should still form one chain."""
+    db_path = tmp_path / "multi_instance_chain.db"
+    service1 = UnifiedAuditService(
+        db_path=str(db_path),
+        enable_pii_detection=False,
+        enable_risk_scoring=False,
+        buffer_size=10,
+        flush_interval=60.0,
+    )
+    service2 = UnifiedAuditService(
+        db_path=str(db_path),
+        enable_pii_detection=False,
+        enable_risk_scoring=False,
+        buffer_size=10,
+        flush_interval=60.0,
+    )
+    await service1.initialize(start_background_tasks=False)
+    await service2.initialize(start_background_tasks=False)
+    try:
+        await service1.log_event(
+            AuditEventType.DATA_READ,
+            context=AuditContext(user_id="multi-chain-user"),
+            action="first_read",
+        )
+        await service1.flush(raise_on_failure=True)
+
+        await service2.log_event(
+            AuditEventType.DATA_READ,
+            context=AuditContext(user_id="multi-chain-user"),
+            action="second_read",
+        )
+        await service2.flush(raise_on_failure=True)
+
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT action, context_user_id, timestamp, event_type, chain_hash "
+                "FROM audit_events WHERE context_user_id = ? ORDER BY rowid ASC",
+                ("multi-chain-user",),
+            ) as cur:
+                rows = [dict(r) for r in await cur.fetchall()]
+
+        assert [row["action"] for row in rows] == ["first_read", "second_read"]
+        result = verify_audit_chain([
+            {
+                "action": row.get("action", ""),
+                "user_id": row.get("context_user_id"),
+                "timestamp": row.get("timestamp", ""),
+                "detail": row.get("event_type", ""),
+                "chain_hash": row.get("chain_hash", ""),
+            }
+            for row in rows
+        ])
+        assert result["valid"] is True, result
+    finally:
+        await service2.stop()
+        await service1.stop()


### PR DESCRIPTION
## Summary

- What changed:
bugfix audit 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the audit module to resolve review findings (Linear TASK-2409): CSV exports neutralize spreadsheet formulas, reads flush buffers and propagate cancellation, and hash chaining and shared migration are reliable across instances. Updated README and added focused regression tests.

- **Bug Fixes**
  - CSV exports neutralize formula prefixes (=, +, -, @, tab, newline) across in-memory, streaming, and file writes.
  - PII redaction now covers metadata keys and preserves key uniqueness with stable suffixes.
  - query_events, count_events, export_events, and get_security_summary flush buffered events first; cancellations are re-raised instead of wrapped.
  - Hash-chain writes read the latest persisted head and run inside BEGIN IMMEDIATE transactions; replay writes follow the same pattern.
  - Shared migration resumes by rowid with fallback for rowid reuse and includes late older-timestamp rows.

<sup>Written for commit 41b67a1cbd4d39dcfdc30b5273ba8271865b1862. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

