### PR TITLE
Harden Chatbooks import and job admission

### DIFF
--- a/backlog/tasks/task-2408 - Harden-Chatbooks-review-findings.md
+++ b/backlog/tasks/task-2408 - Harden-Chatbooks-review-findings.md
@@ -1,0 +1,60 @@
+---
+id: TASK-2408
+title: Harden Chatbooks review findings
+status: Done
+assignee: []
+created_date: 2026-06-23 18:11
+updated_date: 2026-06-24 03:32
+labels:
+- chatbooks
+- security
+- review
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and address validated Chatbooks module review findings: v1.1 manifest path integrity, cancellation handling, quota admission races, unreachable Prompt Studio paths, service decomposition cleanup where practical, and OpenWebUI import bounds.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Validated high-severity findings have regression tests.
+- [x] #2 Chatbook v1.1 imports consume only verified manifest-resolved payload paths.
+- [x] #3 Async cancellation is not swallowed by generic recoverable exception handling.
+- [x] #4 Quota/concurrency admission is enforced atomically or documented as deferred with a concrete task if broader Jobs changes are required.
+- [x] #5 Unreachable legacy code and unused helpers are removed where safe.
+- [x] #6 Verification includes focused pytest and Bandit on touched scope.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Chatbooks fixes for v1.1 explicit import paths, cancellation propagation, OpenWebUI JSON/SQLite import bounds, async quota admission, and safe legacy cleanup. Async Chatbooks export/import now checks tier quota and inserts the pending Chatbooks job row inside one database transaction; endpoint preflight remains for fast feedback. Updated stale v1.1 async test from the removed Prompt Studio path to the current core Jobs payload path.
+
+Documentation update not required: changes harden existing Chatbooks behavior and are covered by regression tests/task notes without changing public request or response schemas.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Validated and addressed the Chatbooks review findings and follow-up PR comments. Fixed v1.1 manifest path usage, cancellation propagation, OpenWebUI JSON/SQLite import bounds, async and sync quota admission, structured quota errors, PostgreSQL admission locking, and manifest path indexing. Full Chatbooks pytest suite and Bandit on touched code passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Post-PR review comments addressed on rebased dev: synchronous export/import now run service-level Chatbooks quota admission; quota rejections surface as structured QuotaExceededError instead of endpoint string matching; PostgreSQL count-and-insert admission takes a per-user advisory transaction lock; manifest import file resolution uses a single explicit-path index for the import; async export accepts content_selections=None as an empty selection.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/chatbooks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chatbooks.py
@@ -40,7 +40,7 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, ge
 from ....core.Chatbooks.chatbook_models import ContentType, ExportJob, ExportStatus
 from ....core.Chatbooks.chatbook_service import ChatbookService
 from ....core.Chatbooks.chatbook_validators import ChatbookValidator
-from ....core.Chatbooks.exceptions import JobError
+from ....core.Chatbooks.exceptions import JobError, QuotaExceededError
 from ....core.Chatbooks.quota_manager import QuotaManager
 from ....core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from ....core.DB_Management.db_path_utils import DatabasePaths
@@ -331,7 +331,7 @@ def get_chatbook_service(
 ) -> ChatbookService:
     """Get chatbook service for the current user."""
     user_int = user.id_int if hasattr(user, "id_int") else None
-    return ChatbookService(user.id, db, user_id_int=user_int)
+    return ChatbookService(user.id, db, user_id_int=user_int, user_tier=getattr(user, "tier", "free"))
 
 
 @router.get("/health", summary="Chatbooks service health")
@@ -514,6 +514,8 @@ async def create_chatbook(
 
     except HTTPException:
         raise
+    except QuotaExceededError as exc:
+        raise HTTPException(status_code=429, detail=str(exc)) from None
     except _CHATBOOKS_NONCRITICAL_EXCEPTIONS:
         # Log full traceback to aid debugging intermittent 500s in CI
         get_ps_logger(
@@ -894,6 +896,8 @@ async def import_chatbook(
 
     except HTTPException:
         raise
+    except QuotaExceededError as exc:
+        raise HTTPException(status_code=429, detail=str(exc)) from None
     except _CHATBOOKS_NONCRITICAL_EXCEPTIONS:
         get_ps_logger(
             request_id=ensure_request_id(request),

--- a/tldw_Server_API/app/core/Chatbooks/chatbook_service.py
+++ b/tldw_Server_API/app/core/Chatbooks/chatbook_service.py
@@ -27,7 +27,7 @@ import os
 import shutil
 import zipfile
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from collections.abc import Callable
 from typing import Any
 from uuid import NAMESPACE_URL, uuid4, uuid5
@@ -78,6 +78,7 @@ from .exceptions import (
     ExportError,
     FileOperationError,
     JobError,
+    QuotaExceededError,
     SecurityError,
     ValidationError,
 )
@@ -109,6 +110,7 @@ from .openwebui_hydration import (
     resolve_openwebui_file_path,
     validate_openwebui_data_root,
 )
+from .quota_manager import QuotaManager, UNLIMITED_QUOTA
 
 _CHATBOOK_NONCRITICAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
     ArchiveError,
@@ -130,7 +132,6 @@ _CHATBOOK_NONCRITICAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
     ValueError,
     json.JSONDecodeError,
     zipfile.BadZipFile,
-    asyncio.CancelledError,
 )
 _OPENWEBUI_FOLDER_MIRROR_EXCEPTIONS: tuple[type[BaseException], ...] = (
     *_CHATBOOK_NONCRITICAL_EXCEPTIONS,
@@ -139,6 +140,7 @@ _OPENWEBUI_FOLDER_MIRROR_EXCEPTIONS: tuple[type[BaseException], ...] = (
 
 _CHATBOOK_TEMPLATE_MODES = {"pass_through", "render_on_export", "render_on_import"}
 MAX_OPENWEBUI_HYDRATION_RESPONSE_ITEMS = 1000
+ManifestImportPathIndex = dict[tuple[str, str], tuple[str | None, str]]
 
 try:  # Prompts database is optional in some deployments
     from ..DB_Management.Prompts_DB import PromptsDatabase  # type: ignore
@@ -173,6 +175,14 @@ except _CHATBOOK_NONCRITICAL_EXCEPTIONS:  # pragma: no cover
 
 class ChatbookService:
     """Service for creating and importing chatbooks with user isolation."""
+
+    _IMPORT_PAYLOAD_FALLBACK_TEMPLATES = {
+        ContentType.CONVERSATION: "content/conversations/conversation_{id}.json",
+        ContentType.NOTE: "content/notes/note_{id}.md",
+        ContentType.CHARACTER: "content/characters/character_{id}.json",
+        ContentType.WORLD_BOOK: "content/world_books/world_book_{id}.json",
+        ContentType.DICTIONARY: "content/dictionaries/dictionary_{id}.json",
+    }
 
     @staticmethod
     def _is_unsafe_archive_path(member_path: str) -> bool:
@@ -212,6 +222,83 @@ class ChatbookService:
                 return True
 
         return False
+
+    @staticmethod
+    def _normalize_manifest_archive_path(raw_path: str) -> str | None:
+        """Normalize a manifest archive path and reject absolute/traversal paths."""
+        if not isinstance(raw_path, str) or not raw_path:
+            return None
+        normalized = raw_path.replace("\\", "/")
+        pure_path = PurePosixPath(normalized)
+        if pure_path.is_absolute() or not pure_path.parts:
+            return None
+        if any(part in {"", ".", ".."} or "\x00" in part for part in pure_path.parts):
+            return None
+        return pure_path.as_posix()
+
+    @staticmethod
+    def _content_type_value(value: Any) -> str | None:
+        if value is None:
+            return None
+        raw_value = getattr(value, "value", value)
+        return raw_value if isinstance(raw_value, str) else None
+
+    def _build_manifest_import_path_index(self, manifest: ChatbookManifest) -> ManifestImportPathIndex:
+        """Index explicit manifest payload paths by content type and item id."""
+        index: ManifestImportPathIndex = {}
+        for item in manifest.content_items:
+            item_id = str(getattr(item, "id", "") or "")
+            type_value = self._content_type_value(getattr(item, "type", None))
+            explicit_path = getattr(item, "file_path", None)
+            if not item_id or not type_value or not explicit_path:
+                continue
+            explicit_path_text = str(explicit_path)
+            index[(type_value, item_id)] = (
+                self._normalize_manifest_archive_path(explicit_path_text),
+                explicit_path_text,
+            )
+        return index
+
+    def _resolve_manifest_import_file(
+        self,
+        extract_dir: Path,
+        manifest: ChatbookManifest,
+        content_type: ContentType,
+        item_id: str,
+        manifest_path_index: ManifestImportPathIndex | None = None,
+    ) -> tuple[Path | None, str]:
+        """
+        Resolve the exact payload path for an import item from the manifest.
+
+        v1.1 validation verifies content item ``file_path`` entries when present;
+        import must consume the same path instead of reconstructing fallback names.
+        """
+        item_id_text = str(item_id)
+        fallback_template = self._IMPORT_PAYLOAD_FALLBACK_TEMPLATES.get(content_type)
+        rel_path = fallback_template.format(id=item_id_text) if fallback_template else ""
+
+        path_index = (
+            manifest_path_index
+            if manifest_path_index is not None
+            else self._build_manifest_import_path_index(manifest)
+        )
+        explicit_entry = path_index.get((content_type.value, item_id_text))
+        if explicit_entry is not None:
+            normalized, display_path = explicit_entry
+            if normalized is None:
+                return None, display_path
+            rel_path = normalized
+
+        if not rel_path:
+            return None, item_id_text
+
+        try:
+            base_path = extract_dir.resolve()
+            candidate = (base_path / rel_path).resolve()
+            candidate.relative_to(base_path)
+        except (OSError, ValueError):
+            return None, rel_path
+        return candidate, rel_path
 
     @staticmethod
     def _get_env_int(name: str, default: int) -> int:
@@ -470,7 +557,13 @@ class ChatbookService:
                 safe_name = "chatbook"
         return f"{safe_name}{suffix}"
 
-    def __init__(self, user_id: str | int, db: CharactersRAGDB, user_id_int: int | None = None):
+    def __init__(
+        self,
+        user_id: str | int,
+        db: CharactersRAGDB,
+        user_id_int: int | None = None,
+        user_tier: str = "free",
+    ):
         """
         Initialize the chatbook service for a specific user.
 
@@ -478,6 +571,7 @@ class ChatbookService:
             user_id: User identifier (string or integer)
             db: User's ChaChaNotes database instance
             user_id_int: Optional integer form of the user id for cross-database access
+            user_tier: User quota tier
         """
         self.user_id_raw = user_id
         self.user_id = str(user_id)
@@ -492,6 +586,7 @@ class ChatbookService:
                 self.user_id_int = int(self.user_id)
             except (TypeError, ValueError):
                 self.user_id_int = None
+        self.user_tier = user_tier
         self.db = db
 
         # Track TODOs once per session so we comply with PRD while exposing gaps
@@ -522,8 +617,6 @@ class ChatbookService:
             logger.warning("Chatbooks jobs backend override ignored; only core Jobs is supported now.")
         self._jobs_backend = "core"
 
-        # Legacy Prompt Studio adapter placeholder (no longer used; core Jobs only)
-        self._ps_job_adapter = None
         self._jobs_adapter = None
         self._jobs_db_path: Path | None = None
         try:
@@ -1274,7 +1367,7 @@ class ChatbookService:
         self,
         name: str,
         description: str,
-        content_selections: dict[ContentType, list[str]],
+        content_selections: dict[ContentType, list[str]] | None,
         author: str | None = None,
         include_media: bool = False,
         media_quality: str = "compressed",
@@ -1307,32 +1400,14 @@ class ChatbookService:
             Tuple of (success, message, job_id or file_path)
         """
         format_version = self._coerce_format_version(format_version)
+        content_selections = content_selections or {}
+
+        if not async_mode:
+            self._check_chatbook_job_admission_with_lock("export")
+
         if async_mode:
             # Create job and run asynchronously
-            # If using Prompt Studio backend, create PS job first and reuse its id
-            job_id = None
-            if self._jobs_backend == "prompt_studio" and self._ps_job_adapter is not None:
-                payload = {
-                    "domain": "chatbooks",
-                    "job_type": "export",
-                    "user_id": self.user_id,
-                    "name": name,
-                    "include_media": include_media,
-                    "include_embeddings": include_embeddings,
-                    "include_generated_content": include_generated_content,
-                    "tags": tags or [],
-                    "categories": categories or [],
-                    "format_version": format_version.value,
-                }
-                try:
-                    ps_job = self._ps_job_adapter.create_export_job(payload, request_id=request_id)
-                    if ps_job and ps_job.get("id") is not None:
-                        job_id = str(ps_job["id"])  # mirror PS id
-                except _CHATBOOK_NONCRITICAL_EXCEPTIONS as e:
-                    logger.warning(f"Failed to create PS export job, falling back to core: {e}")
-                    job_id = None
-            if job_id is None:
-                job_id = str(uuid4())
+            job_id = str(uuid4())
             job = ExportJob(
                 job_id=job_id,
                 user_id=self.user_id,
@@ -1340,60 +1415,54 @@ class ChatbookService:
                 chatbook_name=name
             )
 
-            # Store job in database
-            self._save_export_job(job)
+            # Store job in database after atomically reserving Chatbooks quota.
+            self._save_export_job_with_quota(job)
 
-            # Start async processing depending on backend
-            if self._jobs_backend == "core":
-                # Enqueue into core Jobs and start worker if needed
-                job_created = None
-                enqueue_error: str | None = None
+            # Enqueue into core Jobs and start worker if needed
+            job_created = None
+            enqueue_error: str | None = None
+            try:
+                from tldw_Server_API.app.core.Jobs.manager import JobManager
+                if not hasattr(self, "_core_jobs"):
+                    self._core_jobs = JobManager()
+                payload = {
+                    "action": "export",
+                    "chatbooks_job_id": job_id,
+                    "name": name,
+                    "description": description,
+                    "content_selections": {k.value if hasattr(k, 'value') else str(k): v for k, v in content_selections.items()},
+                    "author": author,
+                    "include_media": include_media,
+                    "media_quality": media_quality,
+                    "include_embeddings": include_embeddings,
+                    "include_generated_content": include_generated_content,
+                    "tags": tags or [],
+                    "categories": categories or [],
+                    "format_version": format_version.value if hasattr(format_version, "value") else str(format_version),
+                }
+                job_created = self._core_jobs.create_job(
+                    domain="chatbooks",
+                    queue="default",
+                    job_type="export",
+                    payload=payload,
+                    owner_user_id=self.user_id,
+                    priority=5,
+                    max_retries=3,
+                    request_id=request_id,
+                )
+            except _CHATBOOK_NONCRITICAL_EXCEPTIONS as e:
+                enqueue_error = str(e)
+                logger.warning(f"Failed to enqueue export job into core Jobs: {e}")
+            if not job_created:
+                err_msg = enqueue_error or "Failed to enqueue export job"
+                job.status = ExportStatus.FAILED
+                job.completed_at = datetime.now(timezone.utc)
+                job.error_message = err_msg
                 try:
-                    from tldw_Server_API.app.core.Jobs.manager import JobManager
-                    if not hasattr(self, "_core_jobs"):
-                        self._core_jobs = JobManager()
-                    payload = {
-                        "action": "export",
-                        "chatbooks_job_id": job_id,
-                        "name": name,
-                        "description": description,
-                        "content_selections": {k.value if hasattr(k, 'value') else str(k): v for k, v in content_selections.items()},
-                        "author": author,
-                        "include_media": include_media,
-                        "media_quality": media_quality,
-                        "include_embeddings": include_embeddings,
-                        "include_generated_content": include_generated_content,
-                        "tags": tags or [],
-                        "categories": categories or [],
-                        "format_version": format_version.value if hasattr(format_version, "value") else str(format_version),
-                    }
-                    job_created = self._core_jobs.create_job(
-                        domain="chatbooks",
-                        queue="default",
-                        job_type="export",
-                        payload=payload,
-                        owner_user_id=self.user_id,
-                        priority=5,
-                        max_retries=3,
-                        request_id=request_id,
-                    )
-                except _CHATBOOK_NONCRITICAL_EXCEPTIONS as e:
-                    enqueue_error = str(e)
-                    logger.warning(f"Failed to enqueue export job into core Jobs: {e}")
-                if not job_created:
-                    err_msg = enqueue_error or "Failed to enqueue export job"
-                    job.status = ExportStatus.FAILED
-                    job.completed_at = datetime.now(timezone.utc)
-                    job.error_message = err_msg
-                    try:
-                        self._save_export_job(job)
-                    except _CHATBOOK_NONCRITICAL_EXCEPTIONS as save_err:
-                        logger.warning(f"Failed to persist failed export job state: {save_err}")
-                    return False, f"Export job failed to enqueue: {err_msg}", job_id
-            elif self._jobs_backend == "prompt_studio":
-                # Do not start local processing when using Prompt Studio backend.
-                # PS worker (external) is responsible for running the job.
-                pass
+                    self._save_export_job(job)
+                except _CHATBOOK_NONCRITICAL_EXCEPTIONS as save_err:
+                    logger.warning(f"Failed to persist failed export job state: {save_err}")
+                return False, f"Export job failed to enqueue: {err_msg}", job_id
 
             return True, f"Export job started: {job_id}", job_id
         else:
@@ -1404,41 +1473,6 @@ class ChatbookService:
                 include_generated_content, tags, categories,
                 format_version=format_version,
             )
-
-    def _with_transaction(self, func, *args, **kwargs):
-        """Execute a function within a database transaction."""
-        conn = None
-        try:
-            # Get connection and start transaction
-            conn = self.db.get_connection() if hasattr(self.db, 'get_connection') else None
-            if conn:
-                conn.execute("BEGIN TRANSACTION")
-
-            # Execute the function
-            result = func(*args, **kwargs)
-
-            # Commit if we have a connection
-            if conn:
-                conn.execute("COMMIT")
-
-            return result
-
-        except _CHATBOOK_NONCRITICAL_EXCEPTIONS as e:
-            # Rollback on error
-            if conn:
-                try:
-                    conn.execute("ROLLBACK")
-                except _CHATBOOK_NONCRITICAL_EXCEPTIONS as e2:
-                    logger.warning(f"Transaction rollback failed: error={e2}")
-            logger.error(f"Transaction rolled back: {e}")
-            raise
-        finally:
-            # Close connection
-            if conn:
-                try:
-                    conn.close()
-                except _CHATBOOK_NONCRITICAL_EXCEPTIONS as e3:
-                    logger.warning(f"Connection close failed after transaction: error={e3}")
 
     async def continue_chatbook_export(
         self,
@@ -1813,12 +1847,6 @@ class ChatbookService:
             job.status = ExportStatus.IN_PROGRESS
             job.started_at = datetime.now(timezone.utc)
             self._save_export_job(job)
-            # PS backend: reflect processing
-            if getattr(self, "_jobs_backend", "core") == "prompt_studio" and getattr(self, "_ps_job_adapter", None) is not None:
-                try:
-                    self._ps_job_adapter.update_status(int(job.job_id), "in_progress")
-                except _CHATBOOK_NONCRITICAL_EXCEPTIONS as e:
-                    logger.debug(f"PS adapter update_status failed for export job {job.job_id}: {e}")
 
             # Create chatbook using the sync wrapper (could be made truly async)
             success, message, file_path = await self._create_chatbook_sync_wrapper(
@@ -1832,12 +1860,6 @@ class ChatbookService:
                 # Update job with success; respect cancellation
                 latest = self._get_export_job(job.job_id)
                 if latest and latest.status == ExportStatus.CANCELLED:
-                    # PS backend: reflect cancellation terminal state
-                    if getattr(self, "_jobs_backend", "core") == "prompt_studio" and getattr(self, "_ps_job_adapter", None) is not None:
-                        try:
-                            self._ps_job_adapter.update_status(int(job.job_id), "cancelled")
-                        except _CHATBOOK_NONCRITICAL_EXCEPTIONS as e:
-                            logger.debug(f"PS adapter update_status (cancelled) failed for export job {job.job_id}: {e}")
                     return
                 job.status = ExportStatus.COMPLETED
                 now_utc = datetime.now(timezone.utc)
@@ -1853,15 +1875,6 @@ class ChatbookService:
                 job.status = ExportStatus.FAILED
                 job.completed_at = datetime.now(timezone.utc)
                 job.error_message = message
-            # PS backend: reflect terminal state
-            if getattr(self, "_jobs_backend", "core") == "prompt_studio" and getattr(self, "_ps_job_adapter", None) is not None:
-                try:
-                    if job.status == ExportStatus.COMPLETED:
-                        self._ps_job_adapter.update_status(int(job.job_id), "completed", result={"path": job.output_path})
-                    elif job.status == ExportStatus.FAILED:
-                        self._ps_job_adapter.update_status(int(job.job_id), "failed", error_message=job.error_message)
-                except _CHATBOOK_NONCRITICAL_EXCEPTIONS as e:
-                    logger.debug(f"PS adapter update_status (completion) failed for export job {job.job_id}: {e}")
             self._save_export_job(job)
 
         except _CHATBOOK_NONCRITICAL_EXCEPTIONS as e:
@@ -1870,11 +1883,6 @@ class ChatbookService:
             job.completed_at = datetime.now(timezone.utc)
             job.error_message = str(e)
             self._save_export_job(job)
-            if getattr(self, "_jobs_backend", "core") == "prompt_studio" and getattr(self, "_ps_job_adapter", None) is not None:
-                try:
-                    self._ps_job_adapter.update_status(int(job.job_id), "failed", error_message=str(e))
-                except _CHATBOOK_NONCRITICAL_EXCEPTIONS as ps_err:
-                    logger.debug(f"PS adapter update_status (failed) failed for export job {job.job_id}: {ps_err}")
 
     async def import_chatbook(
         self,
@@ -1989,31 +1997,12 @@ class ChatbookService:
             return False, detail, None
         file_token = self._build_import_file_token(resolved_path)
 
+        if not async_mode:
+            self._check_chatbook_job_admission_with_lock("import")
+
         if async_mode:
             # Create job and run asynchronously
-            job_id = None
-            if getattr(self, "_jobs_backend", "core") == "prompt_studio" and getattr(self, "_ps_job_adapter", None) is not None:
-                payload = {
-                    "domain": "chatbooks",
-                    "job_type": "import",
-                    "user_id": self.user_id,
-                    "path": file_token,
-                    "file_token": file_token,
-                    "source_format": source_format_value,
-                    "selected_openwebui_user_id": selected_openwebui_user_id,
-                    "import_media": import_media,
-                    "import_embeddings": import_embeddings,
-                    "conflict_resolution": str(conflict_resolution.value if hasattr(conflict_resolution, 'value') else conflict_resolution),
-                }
-                try:
-                    ps_job = self._ps_job_adapter.create_import_job(payload, request_id=request_id)
-                    if ps_job and ps_job.get("id") is not None:
-                        job_id = str(ps_job["id"])  # mirror PS id
-                except _CHATBOOK_NONCRITICAL_EXCEPTIONS as e:
-                    logger.warning(f"Failed to create PS import job, falling back to core: {e}")
-                    job_id = None
-            if job_id is None:
-                job_id = str(uuid4())
+            job_id = str(uuid4())
             job = ImportJob(
                 job_id=job_id,
                 user_id=self.user_id,
@@ -2021,60 +2010,51 @@ class ChatbookService:
                 chatbook_path=file_token
             )
 
-            # Store job in database
-            self._save_import_job(job)
+            # Store job in database after atomically reserving Chatbooks quota.
+            self._save_import_job_with_quota(job)
 
-            # Start async task
-            if self._jobs_backend == "core":
-                job_created = None
-                enqueue_error: str | None = None
+            # Start async task through core Jobs.
+            job_created = None
+            enqueue_error: str | None = None
+            try:
+                from tldw_Server_API.app.core.Jobs.manager import JobManager
+                if not hasattr(self, "_core_jobs"):
+                    self._core_jobs = JobManager()
+                payload = {
+                    "action": "import",
+                    "chatbooks_job_id": job_id,
+                    "file_token": file_token,
+                    "source_format": source_format_value,
+                    "selected_openwebui_user_id": selected_openwebui_user_id,
+                    "content_selections": {k.value if hasattr(k, 'value') else str(k): v for k, v in (content_selections or {}).items()},
+                    "conflict_resolution": conflict_resolution.value if hasattr(conflict_resolution, 'value') else str(conflict_resolution),
+                    "prefix_imported": bool(prefix_imported),
+                    "import_media": bool(import_media),
+                    "import_embeddings": bool(import_embeddings),
+                }
+                job_created = self._core_jobs.create_job(
+                    domain="chatbooks",
+                    queue="default",
+                    job_type="import",
+                    payload=payload,
+                    owner_user_id=self.user_id,
+                    priority=5,
+                    max_retries=3,
+                    request_id=request_id,
+                )
+            except _CHATBOOK_NONCRITICAL_EXCEPTIONS as e:
+                enqueue_error = str(e)
+                logger.warning(f"Failed to enqueue import job into core Jobs: {e}")
+            if not job_created:
+                err_msg = enqueue_error or "Failed to enqueue import job"
+                job.status = ImportStatus.FAILED
+                job.completed_at = datetime.now(timezone.utc)
+                job.error_message = err_msg
                 try:
-                    from tldw_Server_API.app.core.Jobs.manager import JobManager
-                    if not hasattr(self, "_core_jobs"):
-                        self._core_jobs = JobManager()
-                    payload = {
-                        "action": "import",
-                        "chatbooks_job_id": job_id,
-                        "file_token": file_token,
-                        "source_format": source_format_value,
-                        "selected_openwebui_user_id": selected_openwebui_user_id,
-                        "content_selections": {k.value if hasattr(k, 'value') else str(k): v for k, v in (content_selections or {}).items()},
-                        "conflict_resolution": conflict_resolution.value if hasattr(conflict_resolution, 'value') else str(conflict_resolution),
-                        "prefix_imported": bool(prefix_imported),
-                        "import_media": bool(import_media),
-                        "import_embeddings": bool(import_embeddings),
-                    }
-                    job_created = self._core_jobs.create_job(
-                        domain="chatbooks",
-                        queue="default",
-                        job_type="import",
-                        payload=payload,
-                        owner_user_id=self.user_id,
-                        priority=5,
-                        max_retries=3,
-                        request_id=request_id,
-                    )
-                except _CHATBOOK_NONCRITICAL_EXCEPTIONS as e:
-                    enqueue_error = str(e)
-                    logger.warning(f"Failed to enqueue import job into core Jobs: {e}")
-                if not job_created:
-                    err_msg = enqueue_error or "Failed to enqueue import job"
-                    job.status = ImportStatus.FAILED
-                    job.completed_at = datetime.now(timezone.utc)
-                    job.error_message = err_msg
-                    try:
-                        self._save_import_job(job)
-                    except _CHATBOOK_NONCRITICAL_EXCEPTIONS as save_err:
-                        logger.warning(f"Failed to persist failed import job state: {save_err}")
-                    return False, f"Import job failed to enqueue: {err_msg}", job_id
-            else:
-                task = asyncio.create_task(self._import_chatbook_async(
-                    job_id, str(resolved_path), content_selections,
-                    conflict_resolution, prefix_imported,
-                    import_media, import_embeddings
-                ))
-                self._tasks[job_id] = task
-                task.add_done_callback(lambda _t: self._tasks.pop(job_id, None))
+                    self._save_import_job(job)
+                except _CHATBOOK_NONCRITICAL_EXCEPTIONS as save_err:
+                    logger.warning(f"Failed to persist failed import job state: {save_err}")
+                return False, f"Import job failed to enqueue: {err_msg}", job_id
 
             return True, f"Import job started: {job_id}", job_id
         else:
@@ -2248,6 +2228,7 @@ class ChatbookService:
                     )
                 content_selections.pop(ct, None)
 
+            manifest_path_index = self._build_manifest_import_path_index(manifest)
             character_id_map: dict[str, int] = {}
             imported_items: dict[str, int] = {}
 
@@ -2272,6 +2253,7 @@ class ChatbookService:
                     content_selections[ContentType.CHARACTER],
                     conflict_resolution, prefix_imported,
                     import_status,
+                    manifest_path_index=manifest_path_index,
                     character_id_map=character_id_map
                 )
 
@@ -2283,7 +2265,8 @@ class ChatbookService:
                     extract_dir, manifest,
                     content_selections[ContentType.WORLD_BOOK],
                     conflict_resolution, prefix_imported,
-                    import_status
+                    import_status,
+                    manifest_path_index=manifest_path_index,
                 )
 
             # Import dictionaries
@@ -2294,7 +2277,8 @@ class ChatbookService:
                     extract_dir, manifest,
                     content_selections[ContentType.DICTIONARY],
                     conflict_resolution, prefix_imported,
-                    import_status
+                    import_status,
+                    manifest_path_index=manifest_path_index,
                 )
 
             # Import conversations
@@ -2306,6 +2290,7 @@ class ChatbookService:
                     content_selections[ContentType.CONVERSATION],
                     conflict_resolution, prefix_imported,
                     import_status,
+                    manifest_path_index=manifest_path_index,
                     character_id_map=character_id_map
                 )
 
@@ -2317,7 +2302,8 @@ class ChatbookService:
                     extract_dir, manifest,
                     content_selections[ContentType.NOTE],
                     conflict_resolution, prefix_imported,
-                    import_status
+                    import_status,
+                    manifest_path_index=manifest_path_index,
                 )
 
             # Note: We do NOT delete the original import file - the caller owns it
@@ -2374,11 +2360,6 @@ class ChatbookService:
             job.status = ImportStatus.IN_PROGRESS
             job.started_at = datetime.now(timezone.utc)
             self._save_import_job(job)
-            if getattr(self, "_jobs_backend", "core") == "prompt_studio" and getattr(self, "_ps_job_adapter", None) is not None:
-                try:
-                    self._ps_job_adapter.update_status(int(job.job_id), "in_progress")
-                except _CHATBOOK_NONCRITICAL_EXCEPTIONS as e:
-                    logger.debug(f"PS adapter update_status failed for import job {job.job_id}: {e}")
 
             # Import chatbook synchronously using thread pool
             success, message, _ = await asyncio.to_thread(
@@ -2391,11 +2372,6 @@ class ChatbookService:
             if success:
                 latest = self._get_import_job(job.job_id)
                 if latest and latest.status == ImportStatus.CANCELLED:
-                    if getattr(self, "_jobs_backend", "core") == "prompt_studio" and getattr(self, "_ps_job_adapter", None) is not None:
-                        try:
-                            self._ps_job_adapter.update_status(int(job.job_id), "cancelled")
-                        except _CHATBOOK_NONCRITICAL_EXCEPTIONS as e:
-                            logger.debug(f"PS adapter update_status (cancelled) failed for import job {job.job_id}: {e}")
                     return
                 job.status = ImportStatus.COMPLETED
             else:
@@ -2404,25 +2380,12 @@ class ChatbookService:
 
             job.completed_at = datetime.now(timezone.utc)
             self._save_import_job(job)
-            if getattr(self, "_jobs_backend", "core") == "prompt_studio" and getattr(self, "_ps_job_adapter", None) is not None:
-                try:
-                    if job.status == ImportStatus.COMPLETED:
-                        self._ps_job_adapter.update_status(int(job.job_id), "completed")
-                    elif job.status == ImportStatus.FAILED:
-                        self._ps_job_adapter.update_status(int(job.job_id), "failed", error_message=job.error_message)
-                except _CHATBOOK_NONCRITICAL_EXCEPTIONS as e:
-                    logger.debug(f"PS adapter update_status (completion) failed for import job {job.job_id}: {e}")
 
         except _CHATBOOK_NONCRITICAL_EXCEPTIONS as e:
             job.status = ImportStatus.FAILED
             job.completed_at = datetime.now(timezone.utc)
             job.error_message = str(e)
             self._save_import_job(job)
-            if getattr(self, "_jobs_backend", "core") == "prompt_studio" and getattr(self, "_ps_job_adapter", None) is not None:
-                try:
-                    self._ps_job_adapter.update_status(int(job.job_id), "failed", error_message=str(e))
-                except _CHATBOOK_NONCRITICAL_EXCEPTIONS as ps_err:
-                    logger.debug(f"PS adapter update_status (failed) failed for import job {job.job_id}: {ps_err}")
         finally:
             # Ensure original import archive is removed for async mode
             try:
@@ -3480,26 +3443,7 @@ class ChatbookService:
     def get_export_job(self, job_id: str) -> ExportJob | None:
         """Get export job status."""
         job = self._get_export_job(job_id)
-        # If using PS backend, reflect PS status for live view
-        if job and getattr(self, "_jobs_backend", "core") == "prompt_studio" and getattr(self, "_ps_job_adapter", None) is not None:
-            try:
-                ps_id = int(job_id)
-                ps_job = self._ps_job_adapter.get(ps_id)
-                if ps_job and isinstance(ps_job, dict):
-                    ps_status = str(ps_job.get("status", "")).lower()
-                    status_map = {
-                        "queued": ExportStatus.PENDING,
-                        "processing": ExportStatus.IN_PROGRESS,
-                        "completed": ExportStatus.COMPLETED,
-                        "failed": ExportStatus.FAILED,
-                        "cancelled": ExportStatus.CANCELLED,
-                    }
-                    mapped = status_map.get(ps_status)
-                    if mapped and job.status not in {ExportStatus.COMPLETED, ExportStatus.FAILED}:
-                        job.status = mapped
-            except _CHATBOOK_NONCRITICAL_EXCEPTIONS:
-                pass
-        if job and getattr(self, "_jobs_backend", "core") == "core" and getattr(self, "_jobs_adapter", None) is not None:
+        if job and getattr(self, "_jobs_adapter", None) is not None:
             with contextlib.suppress(_CHATBOOK_NONCRITICAL_EXCEPTIONS):
                 self._jobs_adapter.apply_export_status(job)
         return job
@@ -3507,25 +3451,7 @@ class ChatbookService:
     def get_import_job(self, job_id: str) -> ImportJob | None:
         """Get import job status."""
         job = self._get_import_job(job_id)
-        if job and getattr(self, "_jobs_backend", "core") == "prompt_studio" and getattr(self, "_ps_job_adapter", None) is not None:
-            try:
-                ps_id = int(job_id)
-                ps_job = self._ps_job_adapter.get(ps_id)
-                if ps_job and isinstance(ps_job, dict):
-                    ps_status = str(ps_job.get("status", "")).lower()
-                    status_map = {
-                        "queued": ImportStatus.PENDING,
-                        "processing": ImportStatus.IN_PROGRESS,
-                        "completed": ImportStatus.COMPLETED,
-                        "failed": ImportStatus.FAILED,
-                        "cancelled": ImportStatus.CANCELLED,
-                    }
-                    mapped = status_map.get(ps_status)
-                    if mapped and job.status not in {ImportStatus.COMPLETED, ImportStatus.FAILED}:
-                        job.status = mapped
-            except _CHATBOOK_NONCRITICAL_EXCEPTIONS:
-                pass
-        if job and getattr(self, "_jobs_backend", "core") == "core" and getattr(self, "_jobs_adapter", None) is not None:
+        if job and getattr(self, "_jobs_adapter", None) is not None:
             with contextlib.suppress(_CHATBOOK_NONCRITICAL_EXCEPTIONS):
                 self._jobs_adapter.apply_import_status(job)
         return job
@@ -3626,25 +3552,6 @@ class ChatbookService:
                         expires_at=ChatbookService._parse_timestamp(row[14]) if len(row) > 14 else None,
                         metadata={}  # Initialize empty metadata
                     )
-                # Reflect PS status if applicable
-                if getattr(self, "_jobs_backend", "core") == "prompt_studio" and getattr(self, "_ps_job_adapter", None) is not None:
-                    try:
-                        ps_id = int(job.job_id)
-                        ps_job = self._ps_job_adapter.get(ps_id)
-                        if ps_job and isinstance(ps_job, dict):
-                            ps_status = str(ps_job.get("status", "")).lower()
-                            status_map = {
-                                "queued": ExportStatus.PENDING,
-                                "processing": ExportStatus.IN_PROGRESS,
-                                "completed": ExportStatus.COMPLETED,
-                                "failed": ExportStatus.FAILED,
-                                "cancelled": ExportStatus.CANCELLED,
-                            }
-                            mapped = status_map.get(ps_status)
-                            if mapped and job.status not in {ExportStatus.COMPLETED, ExportStatus.FAILED}:
-                                job.status = mapped
-                    except _CHATBOOK_NONCRITICAL_EXCEPTIONS:
-                        pass
                 jobs.append(job)
 
             if getattr(self, "_jobs_backend", "core") == "core" and getattr(self, "_jobs_adapter", None) is not None:
@@ -3760,24 +3667,6 @@ class ChatbookService:
                         conflicts=json.loads(row[14]) if len(row) > 14 and row[14] else [],
                         warnings=json.loads(row[15]) if len(row) > 15 and row[15] else []
                     )
-                if getattr(self, "_jobs_backend", "core") == "prompt_studio" and getattr(self, "_ps_job_adapter", None) is not None:
-                    try:
-                        ps_id = int(job.job_id)
-                        ps_job = self._ps_job_adapter.get(ps_id)
-                        if ps_job and isinstance(ps_job, dict):
-                            ps_status = str(ps_job.get("status", "")).lower()
-                            status_map = {
-                                "queued": ImportStatus.PENDING,
-                                "processing": ImportStatus.IN_PROGRESS,
-                                "completed": ImportStatus.COMPLETED,
-                                "failed": ImportStatus.FAILED,
-                                "cancelled": ImportStatus.CANCELLED,
-                            }
-                            mapped = status_map.get(ps_status)
-                            if mapped and job.status not in {ImportStatus.COMPLETED, ImportStatus.FAILED}:
-                                job.status = mapped
-                    except _CHATBOOK_NONCRITICAL_EXCEPTIONS:
-                        pass
                 jobs.append(job)
 
             if getattr(self, "_jobs_backend", "core") == "core" and getattr(self, "_jobs_adapter", None) is not None:
@@ -4994,21 +4883,33 @@ class ChatbookService:
         conflict_resolution: ConflictResolution,
         prefix_imported: bool,
         status: ImportJob,
+        manifest_path_index: ManifestImportPathIndex | None = None,
         character_id_map: dict[str, int] | None = None
     ):
         """Import conversations from chatbook."""
-        conv_dir = extract_dir / "content" / "conversations"
         max_img_bytes = self._get_max_message_image_bytes()
+        if manifest_path_index is None:
+            manifest_path_index = self._build_manifest_import_path_index(manifest)
 
         for conv_id in conversation_ids:
             status.processed_items += 1
 
             try:
                 # Load conversation file
-                conv_file = conv_dir / f"conversation_{conv_id}.json"
+                conv_file, conv_path = self._resolve_manifest_import_file(
+                    extract_dir,
+                    manifest,
+                    ContentType.CONVERSATION,
+                    conv_id,
+                    manifest_path_index,
+                )
+                if conv_file is None:
+                    status.failed_items += 1
+                    status.warnings.append(f"Unsafe conversation file path: {conv_path}")
+                    continue
                 if not conv_file.exists():
                     status.failed_items += 1
-                    status.warnings.append(f"Conversation file not found: {conv_file.name}")
+                    status.warnings.append(f"Conversation file not found: {conv_path}")
                     continue
 
                 with open(conv_file, encoding='utf-8') as f:
@@ -5150,11 +5051,13 @@ class ChatbookService:
         note_ids: list[str],
         conflict_resolution: ConflictResolution,
         prefix_imported: bool,
-        status: ImportJob
+        status: ImportJob,
+        manifest_path_index: ManifestImportPathIndex | None = None,
     ):
         """Import notes from chatbook."""
-        notes_dir = extract_dir / "content" / "notes"
         template_settings = self._resolve_template_settings(manifest)
+        if manifest_path_index is None:
+            manifest_path_index = self._build_manifest_import_path_index(manifest)
 
         def _parse_yaml_scalar(text: str) -> str:
             if not text:
@@ -5185,10 +5088,20 @@ class ChatbookService:
 
             try:
                 # Find note file
-                note_file = notes_dir / f"note_{note_id}.md"
+                note_file, note_path = self._resolve_manifest_import_file(
+                    extract_dir,
+                    manifest,
+                    ContentType.NOTE,
+                    note_id,
+                    manifest_path_index,
+                )
+                if note_file is None:
+                    status.failed_items += 1
+                    status.warnings.append(f"Unsafe note file path: {note_path}")
+                    continue
                 if not note_file.exists():
                     status.failed_items += 1
-                    status.warnings.append(f"Note file not found: {note_file.name}")
+                    status.warnings.append(f"Note file not found: {note_path}")
                     continue
 
                 # Parse markdown with frontmatter
@@ -5264,20 +5177,32 @@ class ChatbookService:
         conflict_resolution: ConflictResolution,
         prefix_imported: bool,
         status: ImportJob,
+        manifest_path_index: ManifestImportPathIndex | None = None,
         character_id_map: dict[str, int] | None = None
     ):
         """Import character cards from chatbook."""
-        chars_dir = extract_dir / "content" / "characters"
+        if manifest_path_index is None:
+            manifest_path_index = self._build_manifest_import_path_index(manifest)
 
         for char_id in character_ids:
             status.processed_items += 1
 
             try:
                 # Load character file
-                char_file = chars_dir / f"character_{char_id}.json"
+                char_file, char_path = self._resolve_manifest_import_file(
+                    extract_dir,
+                    manifest,
+                    ContentType.CHARACTER,
+                    char_id,
+                    manifest_path_index,
+                )
+                if char_file is None:
+                    status.failed_items += 1
+                    status.warnings.append(f"Unsafe character file path: {char_path}")
+                    continue
                 if not char_file.exists():
                     status.failed_items += 1
-                    status.warnings.append(f"Character file not found: {char_file.name}")
+                    status.warnings.append(f"Character file not found: {char_path}")
                     continue
 
                 with open(char_file, encoding='utf-8') as f:
@@ -5328,24 +5253,35 @@ class ChatbookService:
         world_book_ids: list[str],
         conflict_resolution: ConflictResolution,
         prefix_imported: bool,
-        status: ImportJob
+        status: ImportJob,
+        manifest_path_index: ManifestImportPathIndex | None = None,
     ):
         """Import world books from chatbook."""
-        wb_dir = extract_dir / "content" / "world_books"
-
         # Import the world book service
         from ..Character_Chat.world_book_manager import WorldBookService
         wb_service = WorldBookService(self.db)
+        if manifest_path_index is None:
+            manifest_path_index = self._build_manifest_import_path_index(manifest)
 
         for wb_id in world_book_ids:
             status.processed_items += 1
 
             try:
                 # Load world book file
-                wb_file = wb_dir / f"world_book_{wb_id}.json"
+                wb_file, wb_path = self._resolve_manifest_import_file(
+                    extract_dir,
+                    manifest,
+                    ContentType.WORLD_BOOK,
+                    wb_id,
+                    manifest_path_index,
+                )
+                if wb_file is None:
+                    status.failed_items += 1
+                    status.warnings.append(f"Unsafe world book file path: {wb_path}")
+                    continue
                 if not wb_file.exists():
                     status.failed_items += 1
-                    status.warnings.append(f"World book file not found: {wb_file.name}")
+                    status.warnings.append(f"World book file not found: {wb_path}")
                     continue
 
                 with open(wb_file, encoding='utf-8') as f:
@@ -5385,12 +5321,14 @@ class ChatbookService:
         dictionary_ids: list[str],
         conflict_resolution: ConflictResolution,
         prefix_imported: bool,
-        status: ImportJob
+        status: ImportJob,
+        manifest_path_index: ManifestImportPathIndex | None = None,
     ):
         """Import chat dictionaries from chatbook."""
-        dict_dir = extract_dir / "content" / "dictionaries"
         template_settings = self._resolve_template_settings(manifest)
         strict_dict_import = self._truthy_env("CHATBOOKS_IMPORT_DICT_STRICT", False)
+        if manifest_path_index is None:
+            manifest_path_index = self._build_manifest_import_path_index(manifest)
 
         # Import the dictionary service
         from ..Character_Chat.chat_dictionary import ChatDictionaryService
@@ -5401,10 +5339,20 @@ class ChatbookService:
 
             try:
                 # Load dictionary file
-                dict_file = dict_dir / f"dictionary_{dict_id}.json"
+                dict_file, dict_path = self._resolve_manifest_import_file(
+                    extract_dir,
+                    manifest,
+                    ContentType.DICTIONARY,
+                    dict_id,
+                    manifest_path_index,
+                )
+                if dict_file is None:
+                    status.failed_items += 1
+                    status.warnings.append(f"Unsafe dictionary file path: {dict_path}")
+                    continue
                 if not dict_file.exists():
                     status.failed_items += 1
-                    status.warnings.append(f"Dictionary file not found: {dict_file.name}")
+                    status.warnings.append(f"Dictionary file not found: {dict_path}")
                     continue
 
                 with open(dict_file, encoding='utf-8') as f:
@@ -5586,10 +5534,127 @@ class ChatbookService:
 
     # Database helper methods
 
-    def _save_export_job(self, job: ExportJob):
+    def _cursor_count(self, cursor: Any) -> int:
+        """Read a COUNT(*) result from supported cursor/list row shapes."""
+        if hasattr(cursor, "fetchone"):
+            row = cursor.fetchone()
+        elif isinstance(cursor, list) and cursor:
+            row = cursor[0]
+        else:
+            row = None
+        if not row:
+            return 0
+        if isinstance(row, dict):
+            return int(row.get("c", row.get("COUNT(1)", row.get("COUNT(*)", 0))) or 0)
+        if hasattr(row, "keys"):
+            try:
+                return int(row["c"])
+            except _CHATBOOK_NONCRITICAL_EXCEPTIONS:
+                try:
+                    return int(row["COUNT(1)"])
+                except _CHATBOOK_NONCRITICAL_EXCEPTIONS:
+                    return int(row[0])
+        return int(row[0])
+
+    def _count_operations_today_for_quota(self, operation_type: str) -> int:
+        start = datetime.now(timezone.utc).date().isoformat()
+        if operation_type == "export":
+            cursor = self.db.execute_query(
+                "SELECT COUNT(1) AS c FROM export_jobs WHERE user_id = ? AND created_at >= ?",
+                (self.user_id, start),
+            )
+        else:
+            cursor = self.db.execute_query(
+                "SELECT COUNT(1) AS c FROM import_jobs WHERE user_id = ? AND created_at >= ?",
+                (self.user_id, start),
+            )
+        return self._cursor_count(cursor)
+
+    def _count_active_jobs_for_quota(self) -> int:
+        export_cursor = self.db.execute_query(
+            "SELECT COUNT(1) AS c FROM export_jobs WHERE user_id = ? AND status IN (?, ?)",
+            (self.user_id, ExportStatus.PENDING.value, ExportStatus.IN_PROGRESS.value),
+        )
+        import_cursor = self.db.execute_query(
+            "SELECT COUNT(1) AS c FROM import_jobs WHERE user_id = ? AND status IN (?, ?, ?)",
+            (
+                self.user_id,
+                ImportStatus.PENDING.value,
+                ImportStatus.VALIDATING.value,
+                ImportStatus.IN_PROGRESS.value,
+            ),
+        )
+        return self._cursor_count(export_cursor) + self._cursor_count(import_cursor)
+
+    def _uses_postgres_backend(self) -> bool:
+        backend_type = getattr(self.db, "backend_type", None)
+        backend_value = getattr(backend_type, "value", backend_type)
+        return str(backend_value).strip().lower() in {"postgres", "postgresql"}
+
+    def _acquire_chatbook_quota_admission_lock(self) -> None:
+        if not self._uses_postgres_backend():
+            return
+        self.db.execute_query(
+            "SELECT pg_advisory_xact_lock(hashtext(?), hashtext(?))",
+            ("chatbooks_quota", str(self.user_id)),
+        )
+
+    def _check_chatbook_job_admission(self, operation_type: str) -> None:
+        quota_manager = QuotaManager(self.user_id, self.user_tier, db=self.db)
+        if quota_manager._quotas_disabled:
+            return
+
+        if operation_type == "export":
+            operation_limit = quota_manager.quotas["max_exports_per_day"]
+            limit_message = f"Daily export limit ({operation_limit}) reached. Try again tomorrow."
+            quota_type = "daily_export"
+        else:
+            operation_limit = quota_manager.quotas["max_imports_per_day"]
+            limit_message = f"Daily import limit ({operation_limit}) reached. Try again tomorrow."
+            quota_type = "daily_import"
+
+        if operation_limit != UNLIMITED_QUOTA:
+            operations_today = self._count_operations_today_for_quota(operation_type)
+            if operations_today >= operation_limit:
+                raise QuotaExceededError(
+                    limit_message,
+                    quota_type=quota_type,
+                    limit=operation_limit,
+                    current=operations_today,
+                )
+
+        concurrent_limit = quota_manager.quotas["max_concurrent_jobs"]
+        if concurrent_limit != UNLIMITED_QUOTA:
+            active_jobs = self._count_active_jobs_for_quota()
+            if active_jobs >= concurrent_limit:
+                raise QuotaExceededError(
+                    f"Maximum concurrent jobs ({concurrent_limit}) reached. Wait for current jobs to complete.",
+                    quota_type="concurrent_jobs",
+                    limit=concurrent_limit,
+                    current=active_jobs,
+                )
+
+    def _check_chatbook_job_admission_with_lock(self, operation_type: str) -> None:
+        with self.db.transaction():
+            self._acquire_chatbook_quota_admission_lock()
+            self._check_chatbook_job_admission(operation_type)
+
+    def _save_export_job_with_quota(self, job: ExportJob) -> None:
+        with self.db.transaction():
+            self._acquire_chatbook_quota_admission_lock()
+            self._check_chatbook_job_admission("export")
+            self._save_export_job(job, commit=False)
+
+    def _save_import_job_with_quota(self, job: ImportJob) -> None:
+        with self.db.transaction():
+            self._acquire_chatbook_quota_admission_lock()
+            self._check_chatbook_job_admission("import")
+            self._save_import_job(job, commit=False)
+
+    def _save_export_job(self, job: ExportJob, *, commit: bool = True):
         """Save export job to database.
 
-        Note: Uses execute_query with commit=True which handles its own transaction.
+        Note: Uses execute_query with commit=True by default, which handles its own transaction.
         Previous _with_transaction wrapper was removed because it created a separate
         connection that didn't share the transaction with execute_query's connection.
         """
@@ -5610,7 +5675,7 @@ class ChatbookService:
                 job.error_message, job.progress_percentage, job.total_items,
                 job.processed_items, job.file_size_bytes, job.download_url,
                 job.expires_at.strftime('%Y-%m-%d %H:%M:%S.%f') if job.expires_at else None
-            ), commit=True)
+            ), commit=commit)
         except _CHATBOOK_NONCRITICAL_EXCEPTIONS as e:
             logger.error(f"Error saving export job: {e}")
             raise
@@ -5758,10 +5823,10 @@ class ChatbookService:
             logger.error(f"Traceback: {traceback.format_exc()}")
             return None
 
-    def _save_import_job(self, job: ImportJob):
+    def _save_import_job(self, job: ImportJob, *, commit: bool = True):
         """Save import job to database.
 
-        Note: Uses execute_query with commit=True which handles its own transaction.
+        Note: Uses execute_query with commit=True by default, which handles its own transaction.
         Previous _with_transaction wrapper was removed because it created a separate
         connection that didn't share the transaction with execute_query's connection.
         """
@@ -5782,7 +5847,7 @@ class ChatbookService:
                 job.error_message, job.progress_percentage, job.total_items,
                 job.processed_items, job.successful_items, job.failed_items,
                 job.skipped_items, json.dumps(job.conflicts), json.dumps(job.warnings)
-            ), commit=True)
+            ), commit=commit)
         except _CHATBOOK_NONCRITICAL_EXCEPTIONS as e:
             logger.error(f"Error saving import job: {e}")
             raise
@@ -5987,28 +6052,23 @@ class ChatbookService:
         if task:
             with contextlib.suppress(_CHATBOOK_NONCRITICAL_EXCEPTIONS):
                 task.cancel()
-        # PS backend cancel
-        if getattr(self, "_jobs_backend", "core") == "prompt_studio" and getattr(self, "_ps_job_adapter", None) is not None:
-            with contextlib.suppress(_CHATBOOK_NONCRITICAL_EXCEPTIONS):
-                self._ps_job_adapter.cancel(int(job_id))
         # Core backend: cancel queued or request cancel for processing in core Jobs
-        if getattr(self, "_jobs_backend", "core") == "core":
-            try:
-                from tldw_Server_API.app.core.Jobs.manager import JobManager
-                jm = getattr(self, "_core_jobs", None) or JobManager()
-                # scan recent jobs for this user and domain
-                for st in ("queued", "processing"):
-                    jobs = jm.list_jobs(domain="chatbooks", queue="default", status=st, owner_user_id=self.user_id, limit=50)
-                    for j in jobs:
-                        try:
-                            payload = j.get("payload") or {}
-                            job_uuid = str(j.get("uuid") or j.get("id"))
-                            if payload.get("chatbooks_job_id") == job_id or job_uuid == job_id:
-                                jm.cancel_job(int(j["id"]))
-                        except _CHATBOOK_NONCRITICAL_EXCEPTIONS:
-                            pass
-            except _CHATBOOK_NONCRITICAL_EXCEPTIONS:
-                pass
+        try:
+            from tldw_Server_API.app.core.Jobs.manager import JobManager
+            jm = getattr(self, "_core_jobs", None) or JobManager()
+            # scan recent jobs for this user and domain
+            for st in ("queued", "processing"):
+                jobs = jm.list_jobs(domain="chatbooks", queue="default", status=st, owner_user_id=self.user_id, limit=50)
+                for j in jobs:
+                    try:
+                        payload = j.get("payload") or {}
+                        job_uuid = str(j.get("uuid") or j.get("id"))
+                        if payload.get("chatbooks_job_id") == job_id or job_uuid == job_id:
+                            jm.cancel_job(int(j["id"]))
+                    except _CHATBOOK_NONCRITICAL_EXCEPTIONS:
+                        pass
+        except _CHATBOOK_NONCRITICAL_EXCEPTIONS:
+            pass
 
         # Audit is performed at the API layer.
 
@@ -6027,25 +6087,21 @@ class ChatbookService:
         if task:
             with contextlib.suppress(_CHATBOOK_NONCRITICAL_EXCEPTIONS):
                 task.cancel()
-        if getattr(self, "_jobs_backend", "core") == "prompt_studio" and getattr(self, "_ps_job_adapter", None) is not None:
-            with contextlib.suppress(_CHATBOOK_NONCRITICAL_EXCEPTIONS):
-                self._ps_job_adapter.cancel(int(job_id))
-        if getattr(self, "_jobs_backend", "core") == "core":
-            try:
-                from tldw_Server_API.app.core.Jobs.manager import JobManager
-                jm = getattr(self, "_core_jobs", None) or JobManager()
-                for st in ("queued", "processing"):
-                    jobs = jm.list_jobs(domain="chatbooks", queue="default", status=st, owner_user_id=self.user_id, limit=50)
-                    for j in jobs:
-                        try:
-                            payload = j.get("payload") or {}
-                            job_uuid = str(j.get("uuid") or j.get("id"))
-                            if payload.get("chatbooks_job_id") == job_id or job_uuid == job_id:
-                                jm.cancel_job(int(j["id"]))
-                        except _CHATBOOK_NONCRITICAL_EXCEPTIONS:
-                            pass
-            except _CHATBOOK_NONCRITICAL_EXCEPTIONS:
-                pass
+        try:
+            from tldw_Server_API.app.core.Jobs.manager import JobManager
+            jm = getattr(self, "_core_jobs", None) or JobManager()
+            for st in ("queued", "processing"):
+                jobs = jm.list_jobs(domain="chatbooks", queue="default", status=st, owner_user_id=self.user_id, limit=50)
+                for j in jobs:
+                    try:
+                        payload = j.get("payload") or {}
+                        job_uuid = str(j.get("uuid") or j.get("id"))
+                        if payload.get("chatbooks_job_id") == job_id or job_uuid == job_id:
+                            jm.cancel_job(int(j["id"]))
+                    except _CHATBOOK_NONCRITICAL_EXCEPTIONS:
+                        pass
+        except _CHATBOOK_NONCRITICAL_EXCEPTIONS:
+            pass
         return True
 
     def delete_export_job(self, job_id: str, delete_file: bool = True) -> bool:
@@ -6445,7 +6501,7 @@ class ChatbookService:
                 "total_imports": 0
             }
 
-    # Removed legacy JobQueueShim handlers; Chatbooks uses in-process tasks (core) or PS adapter (prompt_studio).
+    # Removed legacy JobQueueShim handlers; Chatbooks uses core Jobs.
 
     def _create_chatbook_archive(self, work_dir: Path, output_path: Path) -> bool:
         """Create ZIP archive from work directory."""

--- a/tldw_Server_API/app/core/Chatbooks/import_adapters/openwebui.py
+++ b/tldw_Server_API/app/core/Chatbooks/import_adapters/openwebui.py
@@ -18,6 +18,11 @@ _ATTACHMENT_KEYS = (
     "file_ids",
     "fileIds",
 )
+MAX_OPENWEBUI_JSON_BYTES = 100 * 1024 * 1024
+MAX_OPENWEBUI_CHATS = 10_000
+MAX_OPENWEBUI_MESSAGES_PER_CHAT = 20_000
+MAX_OPENWEBUI_TOTAL_MESSAGES = 200_000
+MAX_OPENWEBUI_PREVIEW_ITEMS = 1_000
 
 
 @dataclass(frozen=True)
@@ -226,9 +231,22 @@ def _is_branched(messages: list[OpenWebUIMessagePlan]) -> bool:
     return root_count > 1
 
 
-def load_openwebui_export(file_path: str | Path) -> OpenWebUIParsedExport:
+def load_openwebui_export(
+    file_path: str | Path,
+    *,
+    max_bytes: int = MAX_OPENWEBUI_JSON_BYTES,
+    max_chats: int = MAX_OPENWEBUI_CHATS,
+    max_messages_per_chat: int = MAX_OPENWEBUI_MESSAGES_PER_CHAT,
+    max_total_messages: int = MAX_OPENWEBUI_TOTAL_MESSAGES,
+) -> OpenWebUIParsedExport:
     """Load and normalize an OpenWebUI chat export JSON file."""
     path = Path(file_path)
+    try:
+        if max_bytes > 0 and path.stat().st_size > max_bytes:
+            raise ValueError(f"OpenWebUI JSON export is too large; maximum is {max_bytes} bytes")
+    except OSError as exc:
+        raise ValueError("Unable to read OpenWebUI JSON export") from exc
+
     try:
         with path.open("r", encoding="utf-8") as handle:
             raw_data = json.load(handle)
@@ -239,10 +257,13 @@ def load_openwebui_export(file_path: str | Path) -> OpenWebUIParsedExport:
 
     if not isinstance(raw_data, list):
         raise ValueError("OpenWebUI export top-level JSON value must be an array")
+    if max_chats > 0 and len(raw_data) > max_chats:
+        raise ValueError(f"OpenWebUI export has too many OpenWebUI chats; maximum is {max_chats}")
 
     chats: list[OpenWebUIConversationPlan] = []
     warnings: list[str] = []
     malformed_chat_count = 0
+    total_messages = 0
 
     for index, item in enumerate(raw_data):
         extracted = _extract_chat_payload(item)
@@ -266,6 +287,16 @@ def load_openwebui_export(file_path: str | Path) -> OpenWebUIParsedExport:
                 chat_warnings.append(f"Message {source_key} is malformed and was skipped.")
                 continue
             messages.append(message)
+            if max_messages_per_chat > 0 and len(messages) > max_messages_per_chat:
+                raise ValueError(
+                    f"OpenWebUI chat at index {index} has too many OpenWebUI messages; "
+                    f"maximum is {max_messages_per_chat}"
+                )
+            total_messages += 1
+            if max_total_messages > 0 and total_messages > max_total_messages:
+                raise ValueError(
+                    f"OpenWebUI export has too many OpenWebUI messages; maximum is {max_total_messages}"
+                )
 
         current_id = _coerce_optional_text(history.get("currentId") or history.get("current_id"))
         attachment_count = sum(len(message.attachment_refs) for message in messages)
@@ -301,17 +332,31 @@ def load_openwebui_export(file_path: str | Path) -> OpenWebUIParsedExport:
 def preview_openwebui_export(
     file_path: str | Path,
     duplicate_lookup: Callable[[str], bool] | None = None,
+    *,
+    max_bytes: int = MAX_OPENWEBUI_JSON_BYTES,
+    max_chats: int = MAX_OPENWEBUI_CHATS,
+    max_messages_per_chat: int = MAX_OPENWEBUI_MESSAGES_PER_CHAT,
+    max_total_messages: int = MAX_OPENWEBUI_TOTAL_MESSAGES,
+    max_preview_items: int = MAX_OPENWEBUI_PREVIEW_ITEMS,
 ) -> OpenWebUIImportPreview:
     """Build a preview for an OpenWebUI chat export JSON file."""
-    parsed = load_openwebui_export(file_path)
+    parsed = load_openwebui_export(
+        file_path,
+        max_bytes=max_bytes,
+        max_chats=max_chats,
+        max_messages_per_chat=max_messages_per_chat,
+        max_total_messages=max_total_messages,
+    )
     duplicate_lookup = duplicate_lookup or (lambda _external_ref: False)
 
     items: list[OpenWebUIPreviewChatItem] = []
     duplicate_chat_count = 0
-    for chat in parsed.chats:
+    for index, chat in enumerate(parsed.chats):
         duplicate = bool(duplicate_lookup(chat.external_ref))
         if duplicate:
             duplicate_chat_count += 1
+        if max_preview_items > 0 and index >= max_preview_items:
+            continue
         items.append(
             OpenWebUIPreviewChatItem(
                 external_ref=chat.external_ref,
@@ -323,6 +368,12 @@ def preview_openwebui_export(
             )
         )
 
+    warnings = list(parsed.warnings)
+    if max_preview_items > 0 and len(parsed.chats) > max_preview_items:
+        warnings.append(
+            f"OpenWebUI preview items truncated to {max_preview_items} of {len(parsed.chats)} chats."
+        )
+
     return OpenWebUIImportPreview(
         chat_count=len(parsed.chats),
         message_count=sum(len(chat.messages) for chat in parsed.chats),
@@ -330,6 +381,6 @@ def preview_openwebui_export(
         duplicate_chat_count=duplicate_chat_count,
         attachment_reference_count=sum(chat.attachment_reference_count for chat in parsed.chats),
         malformed_chat_count=parsed.malformed_chat_count,
-        warnings=list(parsed.warnings),
+        warnings=warnings,
         items=items,
     )

--- a/tldw_Server_API/app/core/Chatbooks/import_adapters/openwebui_db.py
+++ b/tldw_Server_API/app/core/Chatbooks/import_adapters/openwebui_db.py
@@ -28,6 +28,11 @@ from .openwebui import (
 UNFILED_FOLDER_PATH = ["Unfiled"]
 MAX_PREVIEW_WARNINGS_PER_USER = 100
 MAX_PREVIEW_WARNINGS_TOTAL = 500
+MAX_OPENWEBUI_DB_BYTES = 512 * 1024 * 1024
+MAX_OPENWEBUI_DB_USERS = 1_000
+MAX_OPENWEBUI_DB_CHATS_PER_USER = 10_000
+MAX_OPENWEBUI_DB_MESSAGES_PER_CHAT = 20_000
+MAX_OPENWEBUI_DB_TOTAL_MESSAGES_PER_USER = 200_000
 
 
 @dataclass
@@ -127,14 +132,53 @@ class OpenWebUIDatabaseExtractionResult:
     warnings: list[str] = field(default_factory=list)
 
 
+def _check_db_file_size(file_path: str | Path, max_bytes: int) -> None:
+    if max_bytes <= 0:
+        return
+    try:
+        if Path(file_path).stat().st_size > max_bytes:
+            raise ValueError(f"OpenWebUI database is too large; maximum is {max_bytes} bytes")
+    except OSError as exc:
+        raise ValueError("Unable to read OpenWebUI database") from exc
+
+
+def _enforce_message_limits(
+    chat_plan: OpenWebUIConversationPlan,
+    *,
+    user_id: str,
+    current_total: int,
+    max_messages_per_chat: int,
+    max_total_messages: int,
+) -> None:
+    message_count = len(chat_plan.messages)
+    if max_messages_per_chat > 0 and message_count > max_messages_per_chat:
+        raise ValueError(
+            f"OpenWebUI chat {chat_plan.external_ref} for user {user_id} has too many OpenWebUI messages; "
+            f"maximum is {max_messages_per_chat}"
+        )
+    if max_total_messages > 0 and current_total + message_count > max_total_messages:
+        raise ValueError(
+            f"OpenWebUI user {user_id} has too many OpenWebUI messages; maximum is {max_total_messages}"
+        )
+
+
 def preview_openwebui_db(
     file_path: str | Path,
     duplicate_lookup: Callable[[str], bool] | None = None,
+    *,
+    max_bytes: int = MAX_OPENWEBUI_DB_BYTES,
+    max_users: int = MAX_OPENWEBUI_DB_USERS,
+    max_chats_per_user: int = MAX_OPENWEBUI_DB_CHATS_PER_USER,
+    max_messages_per_chat: int = MAX_OPENWEBUI_DB_MESSAGES_PER_CHAT,
+    max_total_messages_per_user: int = MAX_OPENWEBUI_DB_TOTAL_MESSAGES_PER_USER,
 ) -> OpenWebUIDatabasePreview:
     """Build a per-user preview for an uploaded OpenWebUI SQLite database."""
     duplicate_lookup = duplicate_lookup or (lambda _external_ref: False)
+    _check_db_file_size(file_path, max_bytes)
     with _open_validated_db(file_path) as conn:
         users = _load_users(conn)
+        if max_users > 0 and len(users) > max_users:
+            raise ValueError(f"OpenWebUI database has too many users; maximum is {max_users}")
         user_previews: list[OpenWebUIDatabaseUserPreview] = []
         warnings = _PreviewWarningAccumulator(
             MAX_PREVIEW_WARNINGS_TOTAL,
@@ -154,8 +198,15 @@ def preview_openwebui_db(
             archived_chat_count = 0
             pinned_chat_count = 0
             attachment_reference_count = 0
+            scanned_chat_count = 0
 
             for chat_row in _iter_chats_for_user(conn, user_id):
+                scanned_chat_count += 1
+                if max_chats_per_user > 0 and scanned_chat_count > max_chats_per_user:
+                    raise ValueError(
+                        f"OpenWebUI user {user_id} has too many OpenWebUI chats; "
+                        f"maximum is {max_chats_per_user}"
+                    )
                 if _sqlite_truthy(chat_row["archived"]):
                     archived_chat_count += 1
                 if _sqlite_truthy(chat_row["pinned"]):
@@ -165,6 +216,13 @@ def preview_openwebui_db(
                     user_warnings.extend(chat_warnings)
                     warnings.extend(chat_warnings)
                     continue
+                _enforce_message_limits(
+                    chat_plan,
+                    user_id=user_id,
+                    current_total=message_count,
+                    max_messages_per_chat=max_messages_per_chat,
+                    max_total_messages=max_total_messages_per_user,
+                )
                 user_warnings.extend(chat_warnings)
                 warnings.extend(chat_warnings)
                 folder_plan = _folder_plan_for_chat(chat_row, folders)
@@ -201,11 +259,16 @@ def extract_openwebui_db_user(
     file_path: str | Path,
     *,
     selected_user_id: str,
+    max_bytes: int = MAX_OPENWEBUI_DB_BYTES,
+    max_chats: int = MAX_OPENWEBUI_DB_CHATS_PER_USER,
+    max_messages_per_chat: int = MAX_OPENWEBUI_DB_MESSAGES_PER_CHAT,
+    max_total_messages: int = MAX_OPENWEBUI_DB_TOTAL_MESSAGES_PER_USER,
 ) -> OpenWebUIDatabaseExtractionResult:
     """Extract normalized conversations for one selected OpenWebUI source user."""
     if not selected_user_id or not str(selected_user_id).strip():
         raise ValueError("selected_user_id is required for OpenWebUI database imports")
 
+    _check_db_file_size(file_path, max_bytes)
     with _open_validated_db(file_path) as conn:
         user = _load_user(conn, selected_user_id)
         if user is None:
@@ -215,8 +278,16 @@ def extract_openwebui_db_user(
         chats: list[OpenWebUIConversationPlan] = []
         folder_plans_by_external_ref: dict[str, OpenWebUIDatabaseFolderPlan] = {}
         warnings: list[str] = []
+        scanned_chat_count = 0
+        total_messages = 0
 
         for chat_row in _iter_chats_for_user(conn, selected_user_id):
+            scanned_chat_count += 1
+            if max_chats > 0 and scanned_chat_count > max_chats:
+                raise ValueError(
+                    f"OpenWebUI user {selected_user_id} has too many OpenWebUI chats; "
+                    f"maximum is {max_chats}"
+                )
             chat_plan, chat_warnings = _conversation_plan_from_chat_row(
                 chat_row,
                 source_user_id=selected_user_id,
@@ -224,6 +295,14 @@ def extract_openwebui_db_user(
             warnings.extend(chat_warnings)
             if chat_plan is None:
                 continue
+            _enforce_message_limits(
+                chat_plan,
+                user_id=selected_user_id,
+                current_total=total_messages,
+                max_messages_per_chat=max_messages_per_chat,
+                max_total_messages=max_total_messages,
+            )
+            total_messages += len(chat_plan.messages)
 
             folder_plan = _folder_plan_for_chat(chat_row, folders)
             warnings.extend(folder_plan.warnings)

--- a/tldw_Server_API/app/core/Chatbooks/quota_manager.py
+++ b/tldw_Server_API/app/core/Chatbooks/quota_manager.py
@@ -378,15 +378,16 @@ class QuotaManager:
         # Prefer database-backed counts when available
         try:
             if self.db is not None and hasattr(self.db, 'execute_query'):
-                active_statuses = ('pending', 'in_progress')
+                export_active_statuses = ('pending', 'in_progress')
+                import_active_statuses = ('pending', 'validating', 'in_progress')
                 # Count both export and import active jobs
                 c1 = self.db.execute_query(
                     "SELECT COUNT(1) FROM export_jobs WHERE user_id = ? AND status IN (?, ?)",
-                    (self.user_id, *active_statuses)
+                    (self.user_id, *export_active_statuses)
                 )
                 c2 = self.db.execute_query(
-                    "SELECT COUNT(1) FROM import_jobs WHERE user_id = ? AND status IN (?, ?)",
-                    (self.user_id, *active_statuses)
+                    "SELECT COUNT(1) FROM import_jobs WHERE user_id = ? AND status IN (?, ?, ?)",
+                    (self.user_id, *import_active_statuses)
                 )
                 def _to_int(cur):
                     if hasattr(cur, 'fetchone'):

--- a/tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py
+++ b/tldw_Server_API/app/core/Chatbooks/services/jobs_worker.py
@@ -466,9 +466,6 @@ async def _handle_job(job: dict[str, Any]) -> dict[str, Any]:
 
 
 async def main() -> None:
-    if os.getenv("CHATBOOKS_JOBS_BACKEND") == "prompt_studio":
-        logger.warning("CHATBOOKS_JOBS_BACKEND is prompt_studio; chatbooks Jobs worker expects core backend")
-
     worker_id = (os.getenv("CHATBOOKS_JOBS_WORKER_ID") or f"chatbooks-jobs-{os.getpid()}").strip()
     queue = (os.getenv("CHATBOOKS_JOBS_QUEUE") or "default").strip() or "default"
 

--- a/tldw_Server_API/tests/Chatbooks/test_chatbook_service.py
+++ b/tldw_Server_API/tests/Chatbooks/test_chatbook_service.py
@@ -10,13 +10,14 @@ job management, conflict resolution, and user isolation.
 """
 
 import pytest
+import asyncio
 import json
 import tempfile
 import zipfile
 import os
 import shutil
 from unittest.mock import MagicMock, patch, AsyncMock
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import uuid4
 from pathlib import Path
 
@@ -33,6 +34,7 @@ from tldw_Server_API.app.core.Chatbooks.chatbook_models import (
     ContentType,
     ConflictResolution,
 )
+from tldw_Server_API.app.core.Chatbooks.exceptions import QuotaExceededError
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 
 
@@ -158,6 +160,18 @@ class TestChatbookService:
         # Check job was saved - looking for INSERT OR REPLACE
         call_args = mock_db.execute_query.call_args[0]
         assert "INSERT OR REPLACE INTO export_jobs" in call_args[0]
+
+    @pytest.mark.asyncio
+    async def test_create_chatbook_sync_wrapper_reraises_cancelled_error(self, service):
+        """Task cancellation should not be converted into a failed export result."""
+        service._collect_notes = MagicMock(side_effect=asyncio.CancelledError())
+
+        with pytest.raises(asyncio.CancelledError):
+            await service._create_chatbook_sync_wrapper(
+                name="Cancelled Export",
+                description="cancel test",
+                content_selections={ContentType.NOTE: ["note-1"]},
+            )
 
     def test_get_media_db_uses_shared_factory_and_caches_result(self, mock_db, tmp_path, monkeypatch):
         """Media DB lookup should use the shared factory and cache the instance."""
@@ -782,6 +796,126 @@ class TestChatbookService:
             "status": "pending",
             "content_summary": {},
         }
+
+    @pytest.mark.asyncio
+    async def test_async_export_rejects_when_concurrent_quota_is_full(self, tmp_path, monkeypatch):
+        """Async export admission checks and inserts the Chatbooks job atomically."""
+        monkeypatch.delenv("CHATBOOKS_DISABLE_QUOTAS", raising=False)
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        monkeypatch.delenv("TEST_MODE", raising=False)
+        monkeypatch.delenv("TESTING", raising=False)
+        monkeypatch.setenv("USER_DB_BASE_DIR", str(tmp_path))
+
+        db = CharactersRAGDB(db_path=str(tmp_path / "quota.db"), client_id="quota-test")
+        service = ChatbookService(user_id="123", db=db, user_tier="free")
+
+        for index in range(2):
+            service._save_export_job(
+                ExportJob(
+                    job_id=f"existing-{index}",
+                    user_id="123",
+                    status=ExportStatus.PENDING,
+                    chatbook_name=f"Existing {index}",
+                    created_at=datetime.now(timezone.utc),
+                )
+            )
+
+        with pytest.raises(QuotaExceededError) as exc_info:
+            await service.create_chatbook(
+                name="Over quota",
+                description="Should be rejected",
+                content_selections={},
+                async_mode=True,
+            )
+
+        assert "Maximum concurrent jobs (2)" in str(exc_info.value)
+        assert exc_info.value.context["quota_type"] == "concurrent_jobs"
+        assert exc_info.value.context["limit"] == 2
+        assert service.count_export_jobs(status=ExportStatus.PENDING.value) == 2
+
+    @pytest.mark.asyncio
+    async def test_sync_export_rejects_when_concurrent_quota_is_full(self, tmp_path, monkeypatch):
+        """Sync export uses the same Chatbooks admission check before building an archive."""
+        monkeypatch.delenv("CHATBOOKS_DISABLE_QUOTAS", raising=False)
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        monkeypatch.delenv("TEST_MODE", raising=False)
+        monkeypatch.delenv("TESTING", raising=False)
+        monkeypatch.setenv("USER_DB_BASE_DIR", str(tmp_path))
+
+        db = CharactersRAGDB(db_path=str(tmp_path / "sync-quota.db"), client_id="sync-quota-test")
+        service = ChatbookService(user_id="123", db=db, user_tier="free")
+
+        for index in range(2):
+            service._save_export_job(
+                ExportJob(
+                    job_id=f"existing-sync-{index}",
+                    user_id="123",
+                    status=ExportStatus.PENDING,
+                    chatbook_name=f"Existing sync {index}",
+                    created_at=datetime.now(timezone.utc),
+                )
+            )
+
+        with pytest.raises(QuotaExceededError) as exc_info:
+            await service.create_chatbook(
+                name="Over sync quota",
+                description="Should be rejected before archive work",
+                content_selections={},
+                async_mode=False,
+            )
+
+        assert "Maximum concurrent jobs (2)" in str(exc_info.value)
+        assert service.count_export_jobs(status=ExportStatus.PENDING.value) == 2
+
+    def test_postgres_quota_admission_lock_precedes_job_insert(self, monkeypatch):
+        """Postgres quota admission serializes count-and-insert with an advisory transaction lock."""
+        monkeypatch.delenv("CHATBOOKS_DISABLE_QUOTAS", raising=False)
+
+        class _BackendType:
+            value = "postgresql"
+
+        class _Transaction:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        class _PostgresQuotaDB:
+            backend_type = _BackendType()
+
+            def __init__(self):
+                self.calls = []
+
+            def transaction(self):
+                return _Transaction()
+
+            def execute_query(self, query, params=None, *, commit=False, script=False):
+                self.calls.append((query, params, commit, script))
+                if "COUNT(1)" in query:
+                    return [(0,)]
+                return []
+
+        db = _PostgresQuotaDB()
+        service = object.__new__(ChatbookService)
+        service.user_id = "123"
+        service.user_tier = "free"
+        service.db = db
+
+        service._save_export_job_with_quota(
+            ExportJob(
+                job_id="new-export",
+                user_id="123",
+                status=ExportStatus.PENDING,
+                chatbook_name="New export",
+                created_at=datetime.now(timezone.utc),
+            )
+        )
+
+        queries = [call[0] for call in db.calls]
+        lock_index = next(index for index, query in enumerate(queries) if "pg_advisory_xact_lock" in query)
+        insert_index = next(index for index, query in enumerate(queries) if "INSERT OR REPLACE INTO export_jobs" in query)
+        assert lock_index < insert_index
 
     def test_import_skips_unsupported_content_types(self, service, tmp_path):
         """Unsupported content types should be skipped with warnings."""

--- a/tldw_Server_API/tests/Chatbooks/test_chatbooks_export_sync.py
+++ b/tldw_Server_API/tests/Chatbooks/test_chatbooks_export_sync.py
@@ -18,6 +18,14 @@ class _DummyConn:
         return None
 
 
+class _DummyTransaction:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
 class _DummyCursor:
     def __init__(self, rows):
         self._rows = rows
@@ -35,6 +43,9 @@ class FakeDB:
 
     def get_connection(self):
         return _DummyConn()
+
+    def transaction(self):
+        return _DummyTransaction()
 
     def execute_query(self, sql, params=(), commit=False):
         sql_norm = " ".join(str(sql).strip().split()).lower()

--- a/tldw_Server_API/tests/Chatbooks/test_chatbooks_import_validation.py
+++ b/tldw_Server_API/tests/Chatbooks/test_chatbooks_import_validation.py
@@ -378,6 +378,103 @@ def test_v1_1_import_rejects_missing_payload_inventory_entry_before_writes(servi
     service.db.add_note.assert_not_called()
 
 
+def test_v1_1_import_uses_verified_explicit_content_item_path(service):
+    verified_path = "content/custom/verified_note.md"
+    fallback_path = "content/notes/note_1.md"
+    verified_payload = b"---\ntitle: Verified Note\n---\n\nVerified body"
+    fallback_payload = b"---\ntitle: Fallback Note\n---\n\nUnverified fallback body"
+    verified_hash = f"sha256:{hashlib.sha256(verified_payload).hexdigest()}"
+
+    manifest = {
+        "version": "1.1.0",
+        "name": "Explicit Path Import",
+        "description": "Importer must use the same path validated by inventory.",
+        "author": None,
+        "created_at": "2026-06-18T12:00:00+00:00",
+        "updated_at": "2026-06-18T12:00:00+00:00",
+        "export_id": "explicit-path-import",
+        "content_items": [
+            {
+                "id": "1",
+                "type": "note",
+                "title": "Verified Note",
+                "description": None,
+                "created_at": None,
+                "updated_at": None,
+                "tags": [],
+                "metadata": {},
+                "file_path": verified_path,
+                "checksum": verified_hash,
+            }
+        ],
+        "relationships": [],
+        "configuration": {
+            "include_media": False,
+            "include_embeddings": False,
+            "include_generated_content": True,
+            "media_quality": "compressed",
+            "max_file_size_mb": 100,
+        },
+        "statistics": {
+            "total_conversations": 0,
+            "total_notes": 1,
+            "total_characters": 0,
+            "total_media_items": 0,
+            "total_prompts": 0,
+            "total_evaluations": 0,
+            "total_embeddings": 0,
+            "total_world_books": 0,
+            "total_dictionaries": 0,
+            "total_documents": 0,
+            "total_size_bytes": len(verified_payload),
+        },
+        "metadata": {"tags": [], "categories": [], "language": "en", "license": None},
+        "user_info": {"user_id": "test_user"},
+        "features_used": ["file_inventory", "integrity_metadata"],
+        "producer": {"name": "tldw_server"},
+        "source_instance": {},
+        "compatibility": {
+            "min_reader_version": "1.0.0",
+            "recommended_reader_version": "1.1.0",
+        },
+        "file_inventory": [
+            {
+                "path": verified_path,
+                "media_type": "text/markdown",
+                "size_bytes": len(verified_payload),
+                "integrity": {
+                    "status": "verified",
+                    "algorithm": "sha256",
+                    "value": verified_hash,
+                },
+                "role": "payload",
+                "content_item_ids": ["1"],
+            }
+        ],
+    }
+
+    archive_path = service.import_dir / "explicit_path_import.chatbook"
+    with zipfile.ZipFile(archive_path, "w") as zf:
+        zf.writestr(verified_path, verified_payload)
+        zf.writestr(fallback_path, fallback_payload)
+        zf.writestr("manifest.json", json.dumps(manifest))
+
+    service.db.add_note = MagicMock(return_value=123)
+
+    success, message, details = service._import_chatbook_sync(
+        file_path=str(archive_path),
+        content_selections=None,
+        conflict_resolution=ConflictResolution.SKIP,
+        prefix_imported=False,
+        import_media=False,
+        import_embeddings=False,
+    )
+
+    assert success is True, message
+    assert details == {"imported_items": {"note": 1}, "warnings": []}
+    service.db.add_note.assert_called_once_with(title="Verified Note", content="Verified body")
+
+
 def test_v1_1_import_rejects_null_file_path_missing_fallback_inventory_before_writes(service):
     readme_payload = b"# Import Validation\n"
     readme_hash = f"sha256:{hashlib.sha256(readme_payload).hexdigest()}"

--- a/tldw_Server_API/tests/Chatbooks/test_chatbooks_manifest_v1_1_contract.py
+++ b/tldw_Server_API/tests/Chatbooks/test_chatbooks_manifest_v1_1_contract.py
@@ -3,6 +3,7 @@ import json
 import shutil
 import zipfile
 from pathlib import Path
+from unittest.mock import patch
 
 import jsonschema
 import pytest
@@ -169,28 +170,46 @@ async def test_create_chatbook_export_canonicalizes_legacy_v1_manifest_version(c
     assert manifest["version"] == "1.0.0"
 
 
-async def test_prompt_studio_export_payload_includes_format_version(chatbook_v1_1_service):
+async def test_core_jobs_export_payload_includes_format_version(chatbook_v1_1_service):
     captured_payload = {}
 
-    class _PromptStudioAdapter:
-        def create_export_job(self, payload, request_id=None):
-            captured_payload.update(payload)
-            return {"id": 123}
+    def _capture_create_job(_self, **kwargs):
+        captured_payload.update(kwargs["payload"])
+        return {"uuid": "core-job-123"}
 
-    chatbook_v1_1_service._jobs_backend = "prompt_studio"
-    chatbook_v1_1_service._ps_job_adapter = _PromptStudioAdapter()
-
-    success, _message, job_id = await chatbook_v1_1_service.create_chatbook(
-        name="v1.1 async",
-        description="v1.1 async",
-        content_selections={},
-        format_version=ChatbookVersion.V1_1,
-        async_mode=True,
-    )
+    with patch("tldw_Server_API.app.core.Jobs.manager.JobManager.create_job", new=_capture_create_job):
+        success, _message, job_id = await chatbook_v1_1_service.create_chatbook(
+            name="v1.1 async",
+            description="v1.1 async",
+            content_selections={},
+            format_version=ChatbookVersion.V1_1,
+            async_mode=True,
+        )
 
     assert success is True
-    assert job_id == "123"
+    assert captured_payload["chatbooks_job_id"] == job_id
     assert captured_payload["format_version"] == "1.1.0"
+
+
+async def test_core_jobs_export_payload_accepts_none_content_selections(chatbook_v1_1_service):
+    captured_payload = {}
+
+    def _capture_create_job(_self, **kwargs):
+        captured_payload.update(kwargs["payload"])
+        return {"uuid": "core-job-123"}
+
+    with patch("tldw_Server_API.app.core.Jobs.manager.JobManager.create_job", new=_capture_create_job):
+        success, _message, job_id = await chatbook_v1_1_service.create_chatbook(
+            name="v1.1 async",
+            description="v1.1 async",
+            content_selections=None,
+            format_version=ChatbookVersion.V1_1,
+            async_mode=True,
+        )
+
+    assert success is True
+    assert captured_payload["chatbooks_job_id"] == job_id
+    assert captured_payload["content_selections"] == {}
 
 
 async def test_core_jobs_worker_forwards_format_version_to_archive_creation():

--- a/tldw_Server_API/tests/Chatbooks/test_openwebui_db_import_adapter.py
+++ b/tldw_Server_API/tests/Chatbooks/test_openwebui_db_import_adapter.py
@@ -326,6 +326,20 @@ def test_preview_openwebui_db_lists_users_counts_and_hides_content(tmp_path):
     assert "bob private content" not in json.dumps(data)
 
 
+def test_preview_openwebui_db_rejects_too_many_chats_per_user(tmp_path):
+    db_path = _write_openwebui_db(
+        tmp_path / "too-many-chats.db",
+        users=[{"id": "user-a", "name": "Alice"}],
+        chats=[
+            {"id": "chat-a", "user_id": "user-a", "title": "A", "chat": _message_tree()},
+            {"id": "chat-b", "user_id": "user-a", "title": "B", "chat": _message_tree()},
+        ],
+    )
+
+    with pytest.raises(ValueError, match="too many OpenWebUI chats"):
+        preview_openwebui_db(db_path, max_chats_per_user=1)
+
+
 def test_extract_openwebui_db_user_imports_only_selected_user_and_folder_plan(tmp_path):
     db_path = _standard_db(tmp_path)
 
@@ -350,6 +364,13 @@ def test_extract_openwebui_db_user_imports_only_selected_user_and_folder_plan(tm
     assert folder_plan.source_folder_id == "folder-child"
     assert folder_plan.source_path == ["Research", "Papers"]
     assert any("folder.items" in warning for warning in result.warnings)
+
+
+def test_extract_openwebui_db_user_rejects_too_many_messages(tmp_path):
+    db_path = _standard_db(tmp_path)
+
+    with pytest.raises(ValueError, match="too many OpenWebUI messages"):
+        extract_openwebui_db_user(db_path, selected_user_id="user-a", max_total_messages=2)
 
 
 def test_extract_openwebui_db_user_routes_folder_cycles_to_unfiled(tmp_path):

--- a/tldw_Server_API/tests/Chatbooks/test_openwebui_import_adapter.py
+++ b/tldw_Server_API/tests/Chatbooks/test_openwebui_import_adapter.py
@@ -130,6 +130,42 @@ def test_load_openwebui_export_rejects_non_array_root(tmp_path):
         load_openwebui_export(export_path)
 
 
+def test_load_openwebui_export_rejects_too_many_chats(tmp_path):
+    export_path = tmp_path / "too-many-chats.json"
+    payload = _standard_export() + _standard_export()
+    export_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="too many OpenWebUI chats"):
+        load_openwebui_export(export_path, max_chats=1)
+
+
+def test_load_openwebui_export_rejects_too_many_messages(tmp_path):
+    export_path = tmp_path / "too-many-messages.json"
+    export = _standard_export()
+    export[0]["chat"]["history"]["messages"]["extra"] = {
+        "id": "extra",
+        "role": "user",
+        "content": "extra",
+    }
+    export_path.write_text(json.dumps(export), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="too many OpenWebUI messages"):
+        load_openwebui_export(export_path, max_messages_per_chat=3)
+
+
+def test_preview_openwebui_export_truncates_preview_items(tmp_path):
+    export_path = tmp_path / "preview-truncated.json"
+    payload = _standard_export() + _standard_export()
+    payload[1]["id"] = "chat-second"
+    export_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    preview = preview_openwebui_export(export_path, max_preview_items=1)
+
+    assert preview.chat_count == 2
+    assert len(preview.items) == 1
+    assert any("truncated" in warning.lower() for warning in preview.warnings)
+
+
 def test_load_openwebui_export_rejects_non_utf8_json(tmp_path):
     export_path = tmp_path / "bad-encoding.json"
     export_path.write_bytes(b"\xff\xfe")


### PR DESCRIPTION
## Summary
- Harden v1.1 Chatbooks imports so import routines consume manifest-resolved payload paths that were validated.
- Preserve async cancellation semantics and remove dead legacy Prompt Studio Chatbooks job handling.
- Add bounded OpenWebUI JSON/SQLite import parsing and transactional async Chatbooks quota admission.

## Verification
- `python -m pytest --confcutdir=tldw_Server_API/tests/Chatbooks ... -q` (`9 passed`)
- `python -m py_compile ...`
- `python -m bandit -r ... -f json` (`0` findings)
- `git diff --check origin/dev..HEAD`

## Change summary
TODO: Human requester must replace this with a human-written Change summary before this PR is marked ready for merge, per project policy.