### PR TITLE
Harden Data Tables worker generation

### DIFF
--- a/tldw_Server_API/app/core/Data_Tables/jobs_worker.py
+++ b/tldw_Server_API/app/core/Data_Tables/jobs_worker.py
@@ -204,13 +204,15 @@ def _resolve_worker_user_id(
     payload: dict[str, Any],
     table_row: dict[str, Any] | None,
 ) -> str:
+    """Resolve and validate the user id that owns the target table."""
     payload_owner = str(payload.get("user_id") or "").strip()
     job_owner = str(job.get("owner_user_id") or "").strip()
     table_owner = str((table_row or {}).get("client_id") or "").strip()
+    effective_owner = payload_owner or job_owner
 
+    if table_row is not None and table_owner and effective_owner and effective_owner != table_owner:
+        raise DataTablesJobError("owner_mismatch", retryable=False)
     if payload_owner:
-        if table_row is not None and table_owner and payload_owner != table_owner:
-            raise DataTablesJobError("owner_mismatch", retryable=False)
         if table_row is None and job_owner and payload_owner != job_owner:
             raise DataTablesJobError("owner_mismatch", retryable=False)
         return payload_owner
@@ -302,6 +304,7 @@ def _normalize_column_key(value: str) -> str:
 
 
 def _dedupe_column_names(names: Sequence[str]) -> list[str]:
+    """Return unique column names while preserving original labels where possible."""
     counts: dict[str, int] = {}
     used: set[str] = set()
     output: list[str] = []
@@ -852,6 +855,7 @@ def _mark_table_for_job_error(
     user_id: str,
     exc: Exception,
 ) -> None:
+    """Persist table state for worker errors, keeping retryable failures queued."""
     retryable = bool(getattr(exc, "retryable", False))
     db.update_data_table(
         table_id,
@@ -859,6 +863,18 @@ def _mark_table_for_job_error(
         last_error=str(exc),
         owner_user_id=user_id,
     )
+
+
+def _drain_late_llm_future(future: asyncio.Future[Any]) -> None:
+    """Consume late executor completion after timeout without blocking the worker."""
+    if future.cancelled():
+        return
+    try:
+        future.exception()
+    except asyncio.CancelledError:
+        return
+    except Exception as exc:
+        logger.debug("data_tables worker: late LLM future completed with error: {}", exc)
 
 
 def _is_job_cancelled(jm: JobManager, job_id: int) -> bool:
@@ -894,7 +910,15 @@ async def _handle_job(job: dict[str, Any], jm: JobManager) -> dict[str, Any]:
         table_row = db.get_data_table(table_id, include_deleted=True, owner_user_id=user_id)
         if not table_row or int(table_row.get("deleted") or 0):
             raise DataTablesJobError("data_table_not_found", retryable=False)
-        user_id = _resolve_worker_user_id(job, payload, table_row)
+        resolved_user_id = _resolve_worker_user_id(job, payload, table_row)
+        if resolved_user_id != user_id:
+            user_id = resolved_user_id
+            db = _get_media_db(user_id)
+            table_row = db.get_data_table(table_id, include_deleted=True, owner_user_id=user_id)
+            if not table_row or int(table_row.get("deleted") or 0):
+                raise DataTablesJobError("data_table_not_found", retryable=False)
+        else:
+            user_id = resolved_user_id
 
         chacha_db: CharactersRAGDB | None = None
 
@@ -1048,6 +1072,7 @@ async def _handle_job(job: dict[str, Any], jm: JobManager) -> dict[str, Any]:
 
         messages_payload = [{"role": "user", "content": llm_prompt}]
         response_format = {"type": "json_object"}
+        timeout = _LLM_TIMEOUT_SECONDS if _LLM_TIMEOUT_SECONDS > 0 else None
 
         def _call_llm():
             adapter = _get_adapter(provider)
@@ -1062,22 +1087,22 @@ async def _handle_job(job: dict[str, Any], jm: JobManager) -> dict[str, Any]:
                     "model": model_to_use,
                     "temperature": _LLM_TEMPERATURE,
                     "max_tokens": _LLM_MAX_TOKENS,
-                    "timeout": _LLM_TIMEOUT_SECONDS if _LLM_TIMEOUT_SECONDS > 0 else None,
                     "response_format": response_format,
                     "app_config": app_config,
-                }
+                },
+                timeout=timeout,
             )
 
         start = time.time()
         loop = asyncio.get_running_loop()
         llm_future = loop.run_in_executor(None, _call_llm)
-        timeout = _LLM_TIMEOUT_SECONDS if _LLM_TIMEOUT_SECONDS > 0 else None
         try:
             if timeout is None:
                 raw_response = await llm_future
             else:
-                raw_response = await asyncio.wait_for(llm_future, timeout=timeout)
+                raw_response = await asyncio.wait_for(asyncio.shield(llm_future), timeout=timeout)
         except asyncio.TimeoutError as exc:
+            llm_future.add_done_callback(_drain_late_llm_future)
             llm_future.cancel()
             jm.update_job_progress(job_id, progress_percent=55.0, progress_message="llm_timeout")
             raise DataTablesJobError("llm_timeout", retryable=True) from exc

--- a/tldw_Server_API/app/core/Data_Tables/jobs_worker.py
+++ b/tldw_Server_API/app/core/Data_Tables/jobs_worker.py
@@ -100,6 +100,12 @@ _CHAT_MAX_MESSAGES = int(os.getenv("DATA_TABLES_CHAT_MAX_MESSAGES", "1500") or "
 _LLM_MAX_TOKENS = int(os.getenv("DATA_TABLES_LLM_MAX_TOKENS", "2000") or "2000")
 _LLM_TEMPERATURE = float(os.getenv("DATA_TABLES_LLM_TEMPERATURE", "0.2") or "0.2")
 _LLM_TIMEOUT_SECONDS = int(os.getenv("DATA_TABLES_LLM_TIMEOUT", "300") or "300")
+_MAX_RAG_TOP_K = max(1, int(os.getenv("DATA_TABLES_RAG_MAX_TOP_K", "50") or "50"))
+_MAX_RAG_SNAPSHOT_CHUNKS = max(
+    1,
+    int(os.getenv("DATA_TABLES_RAG_MAX_SNAPSHOT_CHUNKS", str(_MAX_RAG_TOP_K)) or str(_MAX_RAG_TOP_K)),
+)
+_ALLOWED_RAG_SOURCES = {"media_db", "notes", "characters"}
 
 _PROMPT_TEMPLATE = """You are a data table generator.
 
@@ -193,6 +199,27 @@ def _normalize_user_id(job: dict[str, Any], payload: dict[str, Any]) -> str:
     return str(owner)
 
 
+def _resolve_worker_user_id(
+    job: dict[str, Any],
+    payload: dict[str, Any],
+    table_row: dict[str, Any] | None,
+) -> str:
+    payload_owner = str(payload.get("user_id") or "").strip()
+    job_owner = str(job.get("owner_user_id") or "").strip()
+    table_owner = str((table_row or {}).get("client_id") or "").strip()
+
+    if payload_owner:
+        if table_row is not None and table_owner and payload_owner != table_owner:
+            raise DataTablesJobError("owner_mismatch", retryable=False)
+        if table_row is None and job_owner and payload_owner != job_owner:
+            raise DataTablesJobError("owner_mismatch", retryable=False)
+        return payload_owner
+
+    if job_owner:
+        return job_owner
+    return str(DatabasePaths.get_single_user_id())
+
+
 def _normalize_payload(raw: Any) -> dict[str, Any]:
     if isinstance(raw, dict):
         return dict(raw)
@@ -276,16 +303,27 @@ def _normalize_column_key(value: str) -> str:
 
 def _dedupe_column_names(names: Sequence[str]) -> list[str]:
     counts: dict[str, int] = {}
+    used: set[str] = set()
     output: list[str] = []
     for name in names:
         base = str(name or "").strip() or "Column"
         key = _normalize_column_key(base)
-        if key not in counts:
-            counts[key] = 1
-            output.append(base)
-            continue
-        counts[key] += 1
-        output.append(f"{base} ({counts[key]})")
+        next_count = counts.get(key, 0) + 1
+        if key not in used:
+            candidate = base
+            candidate_key = key
+            counts[key] = max(next_count, 1)
+        else:
+            while True:
+                candidate = f"{base} ({next_count})"
+                candidate_key = _normalize_column_key(candidate)
+                counts[key] = next_count
+                if candidate_key not in used:
+                    break
+                next_count += 1
+        used.add(candidate_key)
+        counts.setdefault(candidate_key, 1)
+        output.append(candidate)
     return output
 
 
@@ -507,7 +545,7 @@ def _normalize_rag_sources(raw_sources: Any) -> list[str]:
             normalized.append("notes")
         elif name in {"characters", "chats", "character_cards"}:
             normalized.append("characters")
-        else:
+        elif name in _ALLOWED_RAG_SOURCES:
             normalized.append(name)
     return normalized or ["media_db"]
 
@@ -536,6 +574,8 @@ def _build_rag_snapshot(
 ) -> dict[str, Any]:
     chunks: list[dict[str, Any]] = []
     for idx, doc in enumerate(documents, start=1):
+        if len(chunks) >= _MAX_RAG_SNAPSHOT_CHUNKS:
+            break
         doc_id, content, metadata, score = _normalize_rag_document(doc)
         if not content:
             continue
@@ -763,8 +803,18 @@ async def _resolve_rag_query_source(
     sources = _normalize_rag_sources(retrieval_params.get("sources"))
     search_mode = str(retrieval_params.get("search_mode") or "hybrid")
     fts_level = str(retrieval_params.get("fts_level") or "chunk")
-    top_k = _coerce_int(retrieval_params.get("top_k"), 10)
-    min_score = _coerce_float(retrieval_params.get("min_score"), 0.0)
+    top_k = max(1, min(_coerce_int(retrieval_params.get("top_k"), 10), _MAX_RAG_TOP_K))
+    min_score = max(0.0, _coerce_float(retrieval_params.get("min_score"), 0.0))
+    bounded_retrieval_params = dict(retrieval_params)
+    bounded_retrieval_params.update(
+        {
+            "sources": sources,
+            "search_mode": search_mode,
+            "fts_level": fts_level,
+            "top_k": top_k,
+            "min_score": min_score,
+        }
+    )
 
     result = await unified_rag_pipeline(
         query=query,
@@ -790,9 +840,25 @@ async def _resolve_rag_query_source(
         documents = list(result.documents or [])
     elif isinstance(result, dict):
         documents = list(result.get("documents") or [])
-    snapshot = _build_rag_snapshot(query=query, retrieval_params=retrieval_params, documents=documents)
+    snapshot = _build_rag_snapshot(query=query, retrieval_params=bounded_retrieval_params, documents=documents)
     text = _extract_text_from_snapshot(snapshot) or ""
     return text, snapshot
+
+
+def _mark_table_for_job_error(
+    db: Any,
+    *,
+    table_id: int,
+    user_id: str,
+    exc: Exception,
+) -> None:
+    retryable = bool(getattr(exc, "retryable", False))
+    db.update_data_table(
+        table_id,
+        status="queued" if retryable else "failed",
+        last_error=str(exc),
+        owner_user_id=user_id,
+    )
 
 
 def _is_job_cancelled(jm: JobManager, job_id: int) -> bool:
@@ -825,10 +891,18 @@ async def _handle_job(job: dict[str, Any], jm: JobManager) -> dict[str, Any]:
         max_rows = _resolve_max_rows(payload)
 
         db = _get_media_db(user_id)
-        chacha_db = _get_chacha_db(user_id)
         table_row = db.get_data_table(table_id, include_deleted=True, owner_user_id=user_id)
         if not table_row or int(table_row.get("deleted") or 0):
             raise DataTablesJobError("data_table_not_found", retryable=False)
+        user_id = _resolve_worker_user_id(job, payload, table_row)
+
+        chacha_db: CharactersRAGDB | None = None
+
+        def _ensure_chacha_db() -> CharactersRAGDB:
+            nonlocal chacha_db
+            if chacha_db is None:
+                chacha_db = _get_chacha_db(user_id)
+            return chacha_db
 
         if not prompt:
             prompt = str(table_row.get("prompt") or "").strip()
@@ -907,7 +981,7 @@ async def _handle_job(job: dict[str, Any], jm: JobManager) -> dict[str, Any]:
 
             if source_type == "chat":
                 if not text:
-                    text = _extract_chat_text(chacha_db, source_id)
+                    text = _extract_chat_text(_ensure_chacha_db(), source_id)
             elif source_type == "document":
                 if not text:
                     try:
@@ -921,7 +995,7 @@ async def _handle_job(job: dict[str, Any], jm: JobManager) -> dict[str, Any]:
                     text, updated_snapshot = await _resolve_rag_query_source(
                         query=query,
                         media_db=db,
-                        chacha_db=chacha_db,
+                        chacha_db=_ensure_chacha_db(),
                         retrieval_params=dict(retrieval_params or {}),
                         user_id=user_id,
                     )
@@ -988,6 +1062,7 @@ async def _handle_job(job: dict[str, Any], jm: JobManager) -> dict[str, Any]:
                     "model": model_to_use,
                     "temperature": _LLM_TEMPERATURE,
                     "max_tokens": _LLM_MAX_TOKENS,
+                    "timeout": _LLM_TIMEOUT_SECONDS if _LLM_TIMEOUT_SECONDS > 0 else None,
                     "response_format": response_format,
                     "app_config": app_config,
                 }
@@ -1004,15 +1079,6 @@ async def _handle_job(job: dict[str, Any], jm: JobManager) -> dict[str, Any]:
                 raw_response = await asyncio.wait_for(llm_future, timeout=timeout)
         except asyncio.TimeoutError as exc:
             llm_future.cancel()
-            try:
-                await llm_future
-            except asyncio.CancelledError:
-                pass
-            except DATA_TABLES_RUNTIME_EXCEPTIONS as cleanup_exc:
-                logger.debug(
-                    "data_tables worker: error awaiting cancelled LLM future: {}",
-                    cleanup_exc,
-                )
             jm.update_job_progress(job_id, progress_percent=55.0, progress_message="llm_timeout")
             raise DataTablesJobError("llm_timeout", retryable=True) from exc
         logger.info(
@@ -1094,7 +1160,7 @@ async def _handle_job(job: dict[str, Any], jm: JobManager) -> dict[str, Any]:
     except DataTablesJobError as exc:
         if db is not None and table_id > 0:
             try:
-                db.update_data_table(table_id, status="failed", last_error=str(exc), owner_user_id=user_id)
+                _mark_table_for_job_error(db, table_id=table_id, user_id=user_id, exc=exc)
             except DATA_TABLES_DB_EXCEPTIONS as reset_exc:
                 logger.debug(
                     "data_tables worker: failed to update table status for {}: {}",

--- a/tldw_Server_API/tests/DataTables/test_data_tables_worker.py
+++ b/tldw_Server_API/tests/DataTables/test_data_tables_worker.py
@@ -1,5 +1,5 @@
+import asyncio
 import json
-import time
 
 import pytest
 
@@ -16,7 +16,7 @@ class _StubAdapter:
     def __init__(self, payload):
         self._payload = payload
 
-    def chat(self, _request):
+    def chat(self, _request, *, timeout=None):
         return {"choices": [{"message": {"content": json.dumps(self._payload)}}]}
 
 
@@ -318,7 +318,6 @@ def test_dedupe_column_names_handles_suffix_collisions():
     assert len({jobs_worker._normalize_column_key(name) for name in deduped}) == len(deduped)
 
 
-@pytest.mark.asyncio
 async def test_rag_query_source_clamps_retrieval_and_snapshot(monkeypatch, tmp_path):
     captured: dict[str, object] = {}
 
@@ -384,13 +383,23 @@ def test_resolve_worker_user_id_allows_table_owner_payload():
     assert user_id == "test_client"
 
 
-class _SlowAdapter:
-    def chat(self, _request):
-        time.sleep(0.2)
+def test_resolve_worker_user_id_rejects_job_owner_mismatch_without_payload():
+    with pytest.raises(DataTablesJobError) as exc:
+        jobs_worker._resolve_worker_user_id(
+            {"owner_user_id": "wrong-owner"},
+            {},
+            {"client_id": "test_client"},
+        )
+
+    assert "owner_mismatch" in str(exc.value)
+    assert exc.value.retryable is False
+
+
+class _TimeoutAdapter:
+    def chat(self, _request, *, timeout=None):
         return {"choices": [{"message": {"content": "{}"}}]}
 
 
-@pytest.mark.asyncio
 async def test_retryable_llm_timeout_keeps_table_retriable(monkeypatch, tmp_path):
     media_path = tmp_path / "media.db"
     chacha_path = tmp_path / "chacha.db"
@@ -409,7 +418,11 @@ async def test_retryable_llm_timeout_keeps_table_retriable(monkeypatch, tmp_path
     )
     table_id = int(table.get("id"))
 
-    monkeypatch.setattr(jobs_worker, "_get_adapter", lambda _provider: _SlowAdapter())
+    async def _raise_timeout(_future, timeout=None):
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(jobs_worker.asyncio, "wait_for", _raise_timeout)
+    monkeypatch.setattr(jobs_worker, "_get_adapter", lambda _provider: _TimeoutAdapter())
     monkeypatch.setattr(jobs_worker, "_resolve_model", lambda *_args, **_kwargs: "test-model")
     monkeypatch.setattr(jobs_worker, "provider_requires_api_key", lambda _p: False)
     monkeypatch.setattr(jobs_worker, "resolve_provider_api_key", lambda *_a, **_k: ("", {}))
@@ -446,7 +459,6 @@ async def test_retryable_llm_timeout_keeps_table_retriable(monkeypatch, tmp_path
     assert refreshed["last_error"] == "llm_timeout"
 
 
-@pytest.mark.asyncio
 async def test_llm_request_includes_adapter_timeout(monkeypatch, tmp_path):
     media_path = tmp_path / "media.db"
     chacha_path = tmp_path / "chacha.db"
@@ -456,10 +468,12 @@ async def test_llm_request_includes_adapter_timeout(monkeypatch, tmp_path):
     monkeypatch.setattr(jobs_worker, "get_user_chacha_db_path", lambda _user_id: str(chacha_path))
 
     seen_request: dict[str, object] = {}
+    seen_timeout: dict[str, object] = {}
 
     class CapturingAdapter:
-        def chat(self, request):
+        def chat(self, request, *, timeout=None):
             seen_request.update(request)
+            seen_timeout["value"] = timeout
             return {
                 "choices": [
                     {
@@ -513,4 +527,5 @@ async def test_llm_request_includes_adapter_timeout(monkeypatch, tmp_path):
     result = await jobs_worker._handle_job(job, JobManager())
 
     assert result["row_count"] == 1
-    assert seen_request["timeout"] == 12
+    assert "timeout" not in seen_request
+    assert seen_timeout["value"] == 12

--- a/tldw_Server_API/tests/DataTables/test_data_tables_worker.py
+++ b/tldw_Server_API/tests/DataTables/test_data_tables_worker.py
@@ -1,4 +1,5 @@
 import json
+import time
 
 import pytest
 
@@ -308,3 +309,208 @@ def test_extract_media_text_sanitizes_latest_transcription_failure_log(monkeypat
         logger_stub,
         "data_tables: get_latest_transcription failed while extracting media text",
     )
+
+
+def test_dedupe_column_names_handles_suffix_collisions():
+    deduped = jobs_worker._dedupe_column_names(["Name", "name", "name (2)", "NAME"])
+
+    assert deduped == ["Name", "name (2)", "name (2) (2)", "NAME (3)"]
+    assert len({jobs_worker._normalize_column_key(name) for name in deduped}) == len(deduped)
+
+
+@pytest.mark.asyncio
+async def test_rag_query_source_clamps_retrieval_and_snapshot(monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+
+    documents = [
+        {
+            "id": f"chunk-{idx}",
+            "content": f"content {idx}",
+            "metadata": {"media_id": idx, "title": f"Title {idx}"},
+            "score": 1.0,
+        }
+        for idx in range(75)
+    ]
+
+    async def fake_unified_rag_pipeline(**kwargs):
+        captured.update(kwargs)
+        return {"documents": documents}
+
+    monkeypatch.setattr(jobs_worker, "unified_rag_pipeline", fake_unified_rag_pipeline)
+    monkeypatch.setattr(jobs_worker, "get_user_chacha_db_path", lambda _user_id: str(tmp_path / "chacha.db"))
+
+    class MediaDbStub:
+        db_path_str = str(tmp_path / "media.db")
+
+    text, snapshot = await jobs_worker._resolve_rag_query_source(
+        query="summarize",
+        media_db=MediaDbStub(),
+        chacha_db=object(),
+        retrieval_params={
+            "sources": ["media_db", "notes", "not-a-source"],
+            "top_k": 9999,
+            "min_score": -5,
+        },
+        user_id="1",
+    )
+
+    assert captured["sources"] == ["media_db", "notes"]
+    assert captured["top_k"] == 50
+    assert captured["min_score"] == 0.0
+    assert len(snapshot["chunks"]) == 50
+    assert "content 49" in text
+    assert "content 50" not in text
+
+
+def test_resolve_worker_user_id_rejects_forged_payload_owner():
+    with pytest.raises(DataTablesJobError) as exc:
+        jobs_worker._resolve_worker_user_id(
+            {"owner_user_id": "1"},
+            {"user_id": "evil-owner"},
+            {"client_id": "test_client"},
+        )
+
+    assert "owner_mismatch" in str(exc.value)
+    assert exc.value.retryable is False
+
+
+def test_resolve_worker_user_id_allows_table_owner_payload():
+    user_id = jobs_worker._resolve_worker_user_id(
+        {"owner_user_id": "1"},
+        {"user_id": "test_client"},
+        {"client_id": "test_client"},
+    )
+
+    assert user_id == "test_client"
+
+
+class _SlowAdapter:
+    def chat(self, _request):
+        time.sleep(0.2)
+        return {"choices": [{"message": {"content": "{}"}}]}
+
+
+@pytest.mark.asyncio
+async def test_retryable_llm_timeout_keeps_table_retriable(monkeypatch, tmp_path):
+    media_path = tmp_path / "media.db"
+    chacha_path = tmp_path / "chacha.db"
+    jobs_worker._MEDIA_DB_CACHE.clear()
+    jobs_worker._CHACHA_DB_CACHE.clear()
+    monkeypatch.setattr(jobs_worker, "get_user_media_db_path", lambda _user_id: str(media_path))
+    monkeypatch.setattr(jobs_worker, "get_user_chacha_db_path", lambda _user_id: str(chacha_path))
+
+    db = MediaDatabase(db_path=str(media_path), client_id="1")
+    table = db.create_data_table(
+        name="Timeout Table",
+        prompt="Summarize chunks",
+        description="unit",
+        status="queued",
+        row_count=0,
+    )
+    table_id = int(table.get("id"))
+
+    monkeypatch.setattr(jobs_worker, "_get_adapter", lambda _provider: _SlowAdapter())
+    monkeypatch.setattr(jobs_worker, "_resolve_model", lambda *_args, **_kwargs: "test-model")
+    monkeypatch.setattr(jobs_worker, "provider_requires_api_key", lambda _p: False)
+    monkeypatch.setattr(jobs_worker, "resolve_provider_api_key", lambda *_a, **_k: ("", {}))
+    monkeypatch.setattr(jobs_worker, "DEFAULT_LLM_PROVIDER", "openai")
+    monkeypatch.setattr(jobs_worker, "load_and_log_configs", lambda: {})
+    monkeypatch.setattr(jobs_worker, "_LLM_TIMEOUT_SECONDS", 0.01)
+
+    job = {
+        "id": 1,
+        "job_type": "data_table_generate",
+        "owner_user_id": "1",
+        "payload": {
+            "table_id": table_id,
+            "table_uuid": table.get("uuid"),
+            "prompt": "Summarize chunks",
+            "sources": [
+                {
+                    "source_type": "rag_query",
+                    "source_id": "summarize",
+                    "snapshot": {"chunks": [{"chunk_text": "alpha beta"}]},
+                }
+            ],
+            "max_rows": 5,
+        },
+    }
+
+    jm = JobManager()
+    with pytest.raises(DataTablesJobError) as exc:
+        await jobs_worker._handle_job(job, jm)
+
+    assert exc.value.retryable is True
+    refreshed = db.get_data_table(table_id, include_deleted=True)
+    assert refreshed["status"] == "queued"
+    assert refreshed["last_error"] == "llm_timeout"
+
+
+@pytest.mark.asyncio
+async def test_llm_request_includes_adapter_timeout(monkeypatch, tmp_path):
+    media_path = tmp_path / "media.db"
+    chacha_path = tmp_path / "chacha.db"
+    jobs_worker._MEDIA_DB_CACHE.clear()
+    jobs_worker._CHACHA_DB_CACHE.clear()
+    monkeypatch.setattr(jobs_worker, "get_user_media_db_path", lambda _user_id: str(media_path))
+    monkeypatch.setattr(jobs_worker, "get_user_chacha_db_path", lambda _user_id: str(chacha_path))
+
+    seen_request: dict[str, object] = {}
+
+    class CapturingAdapter:
+        def chat(self, request):
+            seen_request.update(request)
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "content": json.dumps(
+                                {
+                                    "columns": [{"name": "Term", "type": "text"}],
+                                    "rows": [["alpha"]],
+                                }
+                            )
+                        }
+                    }
+                ]
+            }
+
+    db = MediaDatabase(db_path=str(media_path), client_id="1")
+    table = db.create_data_table(
+        name="Timeout Config Table",
+        prompt="Summarize chunks",
+        description="unit",
+        status="queued",
+        row_count=0,
+    )
+
+    monkeypatch.setattr(jobs_worker, "_get_adapter", lambda _provider: CapturingAdapter())
+    monkeypatch.setattr(jobs_worker, "_resolve_model", lambda *_args, **_kwargs: "test-model")
+    monkeypatch.setattr(jobs_worker, "provider_requires_api_key", lambda _p: False)
+    monkeypatch.setattr(jobs_worker, "resolve_provider_api_key", lambda *_a, **_k: ("", {}))
+    monkeypatch.setattr(jobs_worker, "DEFAULT_LLM_PROVIDER", "openai")
+    monkeypatch.setattr(jobs_worker, "load_and_log_configs", lambda: {})
+    monkeypatch.setattr(jobs_worker, "_LLM_TIMEOUT_SECONDS", 12)
+
+    job = {
+        "id": 1,
+        "job_type": "data_table_generate",
+        "owner_user_id": "1",
+        "payload": {
+            "table_id": int(table.get("id")),
+            "table_uuid": table.get("uuid"),
+            "prompt": "Summarize chunks",
+            "sources": [
+                {
+                    "source_type": "rag_query",
+                    "source_id": "summarize",
+                    "snapshot": {"chunks": [{"chunk_text": "alpha beta"}]},
+                }
+            ],
+        },
+    }
+
+    result = await jobs_worker._handle_job(job, JobManager())
+
+    assert result["row_count"] == 1
+    assert seen_request["timeout"] == 12


### PR DESCRIPTION
## Summary
- Harden the Data Tables Jobs worker against unbounded RAG retrieval and snapshot growth by clamping retrieval parameters, dropping unknown RAG sources, and capping stored chunks.
- Validate worker payload ownership against the actual table row before generation, preserve retryable table state on transient worker failures, and avoid duplicate column names from suffix collisions.
- Pass LLM timeouts as adapter kwargs, keep timeout cleanup non-blocking, and address reviewer feedback around ownership validation, docstrings, and deterministic tests.

## Verification
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m compileall -q tldw_Server_API/app/core/Data_Tables/jobs_worker.py tldw_Server_API/tests/DataTables/test_data_tables_worker.py`
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/DataTables/test_data_tables_worker.py` - 18 passed
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Data_Tables/jobs_worker.py -f json -o /tmp/bandit_data_tables_worker_pr_rebase.json` - 0 findings

## Review Follow-up
- Rebased on latest `origin/dev` and replied to all existing inline review comments.

## Merge Note
- Project policy requires a human-authored `Change summary` before merge. This PR body intentionally does not claim to satisfy that human-authored merge gate.