### PR TITLE
Fix audiobook core review findings

### DIFF
--- a/IMPLEMENTATION_PLAN_audiobook_core_review_fixes.md
+++ b/IMPLEMENTATION_PLAN_audiobook_core_review_fixes.md
@@ -1,0 +1,29 @@
+## Stage 1: Parser Validation
+**Goal**: Reject or normalize invalid tag-derived chapter, speed, and timestamp data before it reaches worker orchestration.
+**Success Criteria**: Duplicate chapter IDs are made unique with warnings; invalid speeds and timestamps are dropped with warnings.
+**Tests**: Focused unit tests in `test_audiobook_tag_parser.py`.
+**Status**: Complete
+
+## Stage 2: Alignment Timeline Safety
+**Goal**: Prevent alignment anchors from producing non-monotonic adjusted word timings.
+**Success Criteria**: Later anchors before the last adjusted cue end are ignored and subtitle timelines remain ordered.
+**Tests**: Focused unit tests in `test_audiobook_alignment_anchors.py`.
+**Status**: Complete
+
+## Stage 3: Subtitle Text Safety
+**Goal**: Escape or sanitize cue text for SRT, VTT, and ASS output without breaking expected line wrapping.
+**Success Criteria**: Cue text cannot inject subtitle control markup or extra cue blocks.
+**Tests**: Focused unit tests in `test_audiobook_subtitle_generator.py`.
+**Status**: Complete
+
+## Stage 4: Subtitle Parser Tightening
+**Goal**: Only remove actual SRT/VTT timing lines while preserving ordinary dialogue containing arrows.
+**Success Criteria**: Dialogue text containing `-->` survives normalization, while timing metadata is still removed.
+**Tests**: Focused unit tests in `test_audiobook_parse_utils.py`.
+**Status**: Complete
+
+## Stage 5: Verification
+**Goal**: Run targeted tests and security scan for the touched audiobook core scope.
+**Success Criteria**: Targeted tests pass, Bandit reports no new actionable findings, and the backlog task records the result.
+**Tests**: `python -m pytest` for touched Audiobook unit tests plus Bandit on touched core files.
+**Status**: Complete

--- a/backlog/tasks/task-9923 - Fix-Audiobook-core-review-findings.md
+++ b/backlog/tasks/task-9923 - Fix-Audiobook-core-review-findings.md
@@ -1,0 +1,56 @@
+---
+id: TASK-9923
+title: Fix Audiobook core review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 18:31'
+updated_date: '2026-06-23 18:31'
+labels:
+  - audiobooks
+  - code-review
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address current-code review findings in tldw_Server_API/app/core/Audiobooks: duplicate chapter IDs, non-monotonic alignment anchors, unsafe subtitle cue text, loose tag marker validation, and overly broad subtitle timing-line detection.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Duplicate explicit and generated chapter IDs cannot collide silently
+- [x] #2 Multiple alignment anchors cannot produce a backwards subtitle timeline
+- [x] #3 Generated SRT, VTT, and ASS subtitle text is escaped or sanitized per format
+- [x] #4 Speed and timestamp tags reject invalid values with parser warnings
+- [x] #5 Subtitle parsing only strips real timing lines
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+See IMPLEMENTATION_PLAN_audiobook_core_review_fixes.md.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation completed inline after red tests confirmed the reviewed failures. Verification: direct core regression script passed; python -m compileall passed for touched runtime/test files; Bandit on touched runtime scope reported 0 findings. Pytest targeted commands were attempted, but the local harness stalled in setup/cleanup on this Python 3.14 environment after confirming red failures and two later passing tests.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed audiobook core review findings: chapter IDs are de-duplicated with warnings, speed/timestamp tags reject invalid values, alignment anchors cannot move later cues before adjusted prior cues, generated subtitle text is sanitized per SRT/VTT/ASS, and subtitle parsing only strips real timing lines.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-9923 - Fix-Audiobook-core-review-findings.md
+++ b/backlog/tasks/task-9923 - Fix-Audiobook-core-review-findings.md
@@ -3,11 +3,11 @@ id: TASK-9923
 title: Fix Audiobook core review findings
 status: Done
 assignee: []
-created_date: '2026-06-23 18:31'
-updated_date: '2026-06-23 18:31'
+created_date: 2026-06-23 18:31
+updated_date: 2026-06-24 01:39
 labels:
-  - audiobooks
-  - code-review
+- audiobooks
+- code-review
 dependencies: []
 priority: high
 ---
@@ -42,7 +42,7 @@ Implementation completed inline after red tests confirmed the reviewed failures.
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixed audiobook core review findings: chapter IDs are de-duplicated with warnings, speed/timestamp tags reject invalid values, alignment anchors cannot move later cues before adjusted prior cues, generated subtitle text is sanitized per SRT/VTT/ASS, and subtitle parsing only strips real timing lines.
+Fixed audiobook core review findings and PR #2443 review feedback: chapter IDs are de-duplicated with non-cascading warnings, speed/timestamp tags reject invalid values, alignment anchors cannot move later cues before adjusted prior cues, generated subtitle text is sanitized per SRT/VTT/ASS, subtitle parsing only strips real timing lines, worker metadata preserves chapter-planning warnings, and modified helpers include docstrings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -54,3 +54,10 @@ Fixed audiobook core review findings: chapter IDs are de-duplicated with warning
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+2026-06-24: Reopened to address PR #2443 review feedback after rebasing onto latest origin/dev. Action items: refine generated chapter collision warnings, add required docstrings, refresh worker tag marker metadata after warning mutation, and strip next-line timing candidates defensively.
+2026-06-24 PR #2443 review pass: rebased branch onto latest origin/dev and addressed review feedback. Generated chapter ID warnings now only report explicit-ID collisions instead of cascading from prior generated IDs. Added required docstrings to modified audiobook helpers, refreshed worker tag marker metadata after chapter planning mutates warnings, and stripped next-line timing candidates defensively. Verification: targeted Audiobooks unit subset passed (45 passed); compileall passed; Bandit on touched runtime scope reported 0 findings; git diff --check passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audiobooks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audiobooks.py
@@ -529,7 +529,11 @@ async def parse_audiobook_source(
 
     chapters: list[ChapterPreview] = []
     if tag_result.chapter_markers:
-        chapters = build_chapters_from_markers(normalized_text, tag_result.chapter_markers)
+        chapters = build_chapters_from_markers(
+            normalized_text,
+            tag_result.chapter_markers,
+            warnings=tag_result.warnings,
+        )
     elif request.detect_chapters:
         try:
             chapters = _detect_chapters(

--- a/tldw_Server_API/app/core/Audiobooks/alignment_utils.py
+++ b/tldw_Server_API/app/core/Audiobooks/alignment_utils.py
@@ -36,6 +36,7 @@ def apply_alignment_anchors(
 
     adjusted: list[AlignmentWord] = []
     active_delta = 0
+    last_adjusted_end: int | None = None
     next_anchor_idx = 0
     next_word_boundary = len(words)
     if valid_pairs:
@@ -46,7 +47,7 @@ def apply_alignment_anchors(
             anchor, word_index = valid_pairs[next_anchor_idx]
             next_anchor_idx += 1
             next_word_boundary = valid_pairs[next_anchor_idx][1] if next_anchor_idx < len(valid_pairs) else len(words)
-            if i > 0 and anchor.time_ms < words[i - 1].end_ms:
+            if last_adjusted_end is not None and anchor.time_ms < last_adjusted_end:
                 logger.warning("alignment anchor ignored: non-monotonic at {}", anchor.offset)
                 continue
             active_delta = anchor.time_ms - word.start_ms
@@ -58,6 +59,7 @@ def apply_alignment_anchors(
             new_start = max(0, new_start)
             new_end = max(new_start, new_end)
         adjusted.append(word.model_copy(update={"start_ms": new_start, "end_ms": new_end}))
+        last_adjusted_end = new_end
 
     return adjusted
 

--- a/tldw_Server_API/app/core/Audiobooks/subtitle_generator.py
+++ b/tldw_Server_API/app/core/Audiobooks/subtitle_generator.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import html
 import os
+import re
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from functools import lru_cache
@@ -18,6 +20,10 @@ from tldw_Server_API.app.api.v1.schemas.audiobook_schemas import (
 )
 from tldw_Server_API.app.core.config import get_config_value
 from tldw_Server_API.app.core.Utils.common import parse_boolean
+
+_ASS_OVERRIDE_RE = re.compile(r"\{[^}]*\}")
+_ASS_INLINE_CONTROL_RE = re.compile(r"\\[Nnh]")
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 
 
 @dataclass(frozen=True)
@@ -68,15 +74,16 @@ def generate_subtitles(
             raise ValueError("alignment end_ms must be >= start_ms")
         if mode == "highlight":
             word = cue_words[0]
+            safe_word = _sanitize_word_for_format(word.word, format)
             if format == "vtt":
-                text = f"<c.hl>{word.word}</c>"
+                text = f"<c.hl>{safe_word}</c>"
             elif format == "ass":
                 duration_cs = max(1, (end_ms - start_ms) // 10)
-                text = f"{{\\k{duration_cs}}}{word.word}"
+                text = f"{{\\k{duration_cs}}}{safe_word}"
             else:
-                text = word.word
+                text = safe_word
         else:
-            text = _render_text(cue_words, effective_max_chars, max_lines, line_sep)
+            text = _render_text(cue_words, effective_max_chars, max_lines, line_sep, format)
         if mode == "word_count":
             start_ms, end_ms = _clamp_cue_duration(start_ms, end_ms)
         rendered.append(SubtitleCue(index=idx, start_ms=start_ms, end_ms=end_ms, text=text))
@@ -293,8 +300,9 @@ def _render_text(
     max_chars: int | None,
     max_lines: int | None,
     line_sep: str,
+    format: SubtitleFormat,
 ) -> str:
-    tokens = [word.word for word in words]
+    tokens = [_sanitize_word_for_format(word.word, format) for word in words]
     if max_lines is not None and max_lines <= 0:
         raise ValueError("max_lines must be positive")
     if max_chars is not None and max_chars <= 0:
@@ -329,6 +337,28 @@ def _render_text(
         lines = lines[: max_lines - 1] + [merged]
     rendered = line_sep.join(lines).replace("\n\n", "\n").strip() if line_sep == "\n" else line_sep.join(lines).strip()
     return rendered
+
+
+def _sanitize_word_for_format(text: str, format: SubtitleFormat) -> str:
+    clean = _normalize_word_text(text)
+    if format == "vtt":
+        return html.escape(clean, quote=False)
+    if format == "ass":
+        clean = _ASS_OVERRIDE_RE.sub("", clean)
+        clean = _ASS_INLINE_CONTROL_RE.sub(" ", clean)
+        clean = clean.replace("\\", "")
+        clean = clean.replace("{", "(").replace("}", ")")
+        return " ".join(clean.split())
+    return clean.replace("-->", "-- >")
+
+
+def _normalize_word_text(text: str) -> str:
+    clean = str(text)
+    clean = clean.replace("\r\n", "\n").replace("\r", "\n")
+    clean = clean.replace("\u2028", "\n").replace("\u2029", "\n")
+    clean = _CONTROL_CHARS_RE.sub(" ", clean)
+    clean = clean.replace("\n", " ")
+    return " ".join(clean.split())
 
 
 def _format_srt(cues: Iterable[SubtitleCue]) -> str:

--- a/tldw_Server_API/app/core/Audiobooks/subtitle_generator.py
+++ b/tldw_Server_API/app/core/Audiobooks/subtitle_generator.py
@@ -302,6 +302,7 @@ def _render_text(
     line_sep: str,
     format: SubtitleFormat,
 ) -> str:
+    """Render sanitized alignment words into wrapped subtitle cue text."""
     tokens = [_sanitize_word_for_format(word.word, format) for word in words]
     if max_lines is not None and max_lines <= 0:
         raise ValueError("max_lines must be positive")
@@ -340,6 +341,7 @@ def _render_text(
 
 
 def _sanitize_word_for_format(text: str, format: SubtitleFormat) -> str:
+    """Sanitize a subtitle token for the target subtitle container format."""
     clean = _normalize_word_text(text)
     if format == "vtt":
         return html.escape(clean, quote=False)
@@ -353,6 +355,7 @@ def _sanitize_word_for_format(text: str, format: SubtitleFormat) -> str:
 
 
 def _normalize_word_text(text: str) -> str:
+    """Collapse control characters and line separators inside subtitle word text."""
     clean = str(text)
     clean = clean.replace("\r\n", "\n").replace("\r", "\n")
     clean = clean.replace("\u2028", "\n").replace("\u2029", "\n")

--- a/tldw_Server_API/app/core/Audiobooks/subtitle_parser.py
+++ b/tldw_Server_API/app/core/Audiobooks/subtitle_parser.py
@@ -61,7 +61,7 @@ def _parse_srt_vtt(text: str, *, kind: str) -> str:
             continue
         if not current:
             next_line = _peek_next_non_empty_line(idx + 1)
-            if next_line and _SRT_VTT_TIMING_RE.match(next_line):
+            if next_line and _SRT_VTT_TIMING_RE.match(next_line.strip()):
                 if kind == "vtt":
                     # Cue identifier line for VTT.
                     continue

--- a/tldw_Server_API/app/core/Audiobooks/subtitle_parser.py
+++ b/tldw_Server_API/app/core/Audiobooks/subtitle_parser.py
@@ -6,6 +6,10 @@ import re
 
 _ASS_DIALOGUE_RE = re.compile(r"^(dialogue|comment):", re.IGNORECASE)
 _ASS_TAG_RE = re.compile(r"\{[^}]*\}")
+_SUBTITLE_TIMESTAMP_RE = r"(?:\d{1,2}:)?\d{2}:\d{2}[,.]\d{1,3}"
+_SRT_VTT_TIMING_RE = re.compile(
+    rf"^{_SUBTITLE_TIMESTAMP_RE}\s+-->\s+{_SUBTITLE_TIMESTAMP_RE}(?:\s+.*)?$"
+)
 
 
 def normalize_subtitle_source(text: str, input_type: str) -> str:
@@ -52,12 +56,12 @@ def _parse_srt_vtt(text: str, *, kind: str) -> str:
             # Skip VTT blocks entirely when not in a cue block.
             skip_block = True
             continue
-        if "-->" in stripped:
+        if _SRT_VTT_TIMING_RE.match(stripped):
             # Timing line, ignore.
             continue
         if not current:
             next_line = _peek_next_non_empty_line(idx + 1)
-            if next_line and "-->" in next_line:
+            if next_line and _SRT_VTT_TIMING_RE.match(next_line):
                 if kind == "vtt":
                     # Cue identifier line for VTT.
                     continue

--- a/tldw_Server_API/app/core/Audiobooks/tag_parser.py
+++ b/tldw_Server_API/app/core/Audiobooks/tag_parser.py
@@ -162,12 +162,14 @@ def build_chapters_from_markers(
     *,
     warnings: list[str] | None = None,
 ) -> list[ChapterPreview]:
+    """Build chapter previews from tag markers while resolving ID collisions."""
     if not markers:
         return []
     length = len(text)
     ordered = sorted(markers, key=lambda m: m.offset)
     chapters: list[ChapterPreview] = []
     seen_ids: set[str] = set()
+    explicit_ids: set[str] = {marker.chapter_id for marker in ordered if marker.chapter_id}
     for idx, marker in enumerate(ordered):
         start = max(0, min(marker.offset, length))
         next_offset = length
@@ -179,7 +181,7 @@ def build_chapters_from_markers(
         if marker.chapter_id:
             chapter_id = _deduplicate_explicit_chapter_id(marker.chapter_id, seen_ids, warnings)
         else:
-            chapter_id = _next_generated_chapter_id(len(chapters) + 1, seen_ids, warnings)
+            chapter_id = _next_generated_chapter_id(len(chapters) + 1, seen_ids, explicit_ids, warnings)
         chapters.append(
             ChapterPreview(
                 chapter_id=chapter_id,
@@ -197,6 +199,7 @@ def _deduplicate_explicit_chapter_id(
     seen_ids: set[str],
     warnings: list[str] | None,
 ) -> str:
+    """Return a unique explicit chapter ID and warn when suffixing duplicates."""
     if chapter_id not in seen_ids:
         seen_ids.add(chapter_id)
         return chapter_id
@@ -213,13 +216,15 @@ def _deduplicate_explicit_chapter_id(
 def _next_generated_chapter_id(
     start_number: int,
     seen_ids: set[str],
+    explicit_ids: set[str],
     warnings: list[str] | None,
 ) -> str:
+    """Return the next generated chapter ID and warn only for explicit-ID skips."""
     number = max(1, start_number)
     candidate = f"ch_{number:03d}"
-    if candidate in seen_ids and warnings is not None:
-        warnings.append(f"generated_chapter_id_collision:{candidate}")
     while candidate in seen_ids:
+        if candidate in explicit_ids and warnings is not None:
+            warnings.append(f"generated_chapter_id_collision:{candidate}")
         number += 1
         candidate = f"ch_{number:03d}"
     seen_ids.add(candidate)

--- a/tldw_Server_API/app/core/Audiobooks/tag_parser.py
+++ b/tldw_Server_API/app/core/Audiobooks/tag_parser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import re
 from dataclasses import dataclass
 
@@ -9,6 +10,8 @@ from tldw_Server_API.app.api.v1.schemas.audiobook_schemas import ChapterPreview
 
 _TAG_LINE_RE = re.compile(r"^\[\[(.+)\]\]$")
 _CHAPTER_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+_MIN_SPEED = 0.25
+_MAX_SPEED = 4.0
 
 
 @dataclass(frozen=True)
@@ -110,6 +113,8 @@ def parse_tagged_text(text: str) -> TagParseResult:
             elif key == "speed":
                 try:
                     speed_value = float(value)
+                    if not math.isfinite(speed_value) or not (_MIN_SPEED <= speed_value <= _MAX_SPEED):
+                        raise ValueError
                     speed_markers.append(SpeedMarker(offset=offset, value=speed_value))
                 except ValueError:
                     warnings.append(f"invalid_speed:{value}")
@@ -151,12 +156,18 @@ def parse_tagged_text(text: str) -> TagParseResult:
     )
 
 
-def build_chapters_from_markers(text: str, markers: list[ChapterMarker]) -> list[ChapterPreview]:
+def build_chapters_from_markers(
+    text: str,
+    markers: list[ChapterMarker],
+    *,
+    warnings: list[str] | None = None,
+) -> list[ChapterPreview]:
     if not markers:
         return []
     length = len(text)
     ordered = sorted(markers, key=lambda m: m.offset)
     chapters: list[ChapterPreview] = []
+    seen_ids: set[str] = set()
     for idx, marker in enumerate(ordered):
         start = max(0, min(marker.offset, length))
         next_offset = length
@@ -165,7 +176,10 @@ def build_chapters_from_markers(text: str, markers: list[ChapterMarker]) -> list
         if start >= next_offset:
             continue
         chapter_text = text[start:next_offset]
-        chapter_id = marker.chapter_id or f"ch_{len(chapters) + 1:03d}"
+        if marker.chapter_id:
+            chapter_id = _deduplicate_explicit_chapter_id(marker.chapter_id, seen_ids, warnings)
+        else:
+            chapter_id = _next_generated_chapter_id(len(chapters) + 1, seen_ids, warnings)
         chapters.append(
             ChapterPreview(
                 chapter_id=chapter_id,
@@ -178,6 +192,40 @@ def build_chapters_from_markers(text: str, markers: list[ChapterMarker]) -> list
     return chapters
 
 
+def _deduplicate_explicit_chapter_id(
+    chapter_id: str,
+    seen_ids: set[str],
+    warnings: list[str] | None,
+) -> str:
+    if chapter_id not in seen_ids:
+        seen_ids.add(chapter_id)
+        return chapter_id
+    if warnings is not None:
+        warnings.append(f"duplicate_chapter_id:{chapter_id}")
+    suffix = 2
+    while f"{chapter_id}_{suffix}" in seen_ids:
+        suffix += 1
+    resolved = f"{chapter_id}_{suffix}"
+    seen_ids.add(resolved)
+    return resolved
+
+
+def _next_generated_chapter_id(
+    start_number: int,
+    seen_ids: set[str],
+    warnings: list[str] | None,
+) -> str:
+    number = max(1, start_number)
+    candidate = f"ch_{number:03d}"
+    if candidate in seen_ids and warnings is not None:
+        warnings.append(f"generated_chapter_id_collision:{candidate}")
+    while candidate in seen_ids:
+        number += 1
+        candidate = f"ch_{number:03d}"
+    seen_ids.add(candidate)
+    return candidate
+
+
 def _parse_timestamp_ms(value: str) -> int | None:
     match = re.match(r"^(\d{1,2}):(\d{2}):(\d{2})\.(\d{1,3})$", value)
     if not match:
@@ -185,5 +233,7 @@ def _parse_timestamp_ms(value: str) -> int | None:
     hours = int(match.group(1))
     minutes = int(match.group(2))
     seconds = int(match.group(3))
+    if minutes >= 60 or seconds >= 60:
+        return None
     millis = int(match.group(4).ljust(3, "0"))
     return ((hours * 60 + minutes) * 60 + seconds) * 1000 + millis

--- a/tldw_Server_API/app/services/audiobook_jobs_worker.py
+++ b/tldw_Server_API/app/services/audiobook_jobs_worker.py
@@ -702,6 +702,7 @@ def _build_chapter_plan(
     tag_result: TagParseResult | None = None,
     voice_profile: VoiceProfileConfig | None = None,
 ) -> list[ChapterPlanItem]:
+    """Build chapter work items from explicit specs, tags, or detected headings."""
     detected: list[ChapterPreview]
     if tag_result and tag_result.chapter_markers:
         detected = build_chapters_from_markers(
@@ -823,6 +824,12 @@ def _build_chapter_plan(
         for i, item in enumerate(plan)
     ]
     return plan
+
+
+def _refresh_tag_marker_metadata(metadata: dict[str, Any], tag_result: TagParseResult) -> None:
+    """Refresh copied tag metadata after chapter planning mutates warnings."""
+    if "tag_markers" in metadata:
+        metadata["tag_markers"] = tag_result.as_metadata()
 
 
 def _sanitize_source_ref(source: dict[str, Any]) -> dict[str, Any]:
@@ -1246,6 +1253,7 @@ async def process_audiobook_job(
                 tag_result=tag_result,
                 voice_profile=voice_profile,
             )
+            _refresh_tag_marker_metadata(source_metadata, tag_result)
 
             item_title = _resolve_item_title(item_metadata, source_metadata)
             item_tag = _build_item_tag(item_index, item_title)

--- a/tldw_Server_API/app/services/audiobook_jobs_worker.py
+++ b/tldw_Server_API/app/services/audiobook_jobs_worker.py
@@ -704,7 +704,11 @@ def _build_chapter_plan(
 ) -> list[ChapterPlanItem]:
     detected: list[ChapterPreview]
     if tag_result and tag_result.chapter_markers:
-        detected = build_chapters_from_markers(text, tag_result.chapter_markers)
+        detected = build_chapters_from_markers(
+            text,
+            tag_result.chapter_markers,
+            warnings=tag_result.warnings,
+        )
     else:
         detected = _detect_chapters(text, language=language, custom_pattern=custom_pattern)
     if not detected:

--- a/tldw_Server_API/tests/Audiobooks/unit/test_audiobook_alignment_anchors.py
+++ b/tldw_Server_API/tests/Audiobooks/unit/test_audiobook_alignment_anchors.py
@@ -29,6 +29,26 @@ def test_apply_alignment_anchors_shifts_target_block():
     assert adjusted[2].end_ms == 5950
 
 
+def test_apply_alignment_anchors_ignores_anchor_before_adjusted_previous_end():
+    words = [
+        AlignmentWord(word="one", start_ms=0, end_ms=100, char_start=0, char_end=3),
+        AlignmentWord(word="two", start_ms=200, end_ms=300, char_start=4, char_end=7),
+        AlignmentWord(word="three", start_ms=400, end_ms=500, char_start=8, char_end=13),
+    ]
+    anchors = [
+        AlignmentAnchor(offset=4, time_ms=1000),
+        AlignmentAnchor(offset=8, time_ms=350),
+    ]
+
+    adjusted = apply_alignment_anchors(words, anchors)
+
+    assert [(word.start_ms, word.end_ms) for word in adjusted] == [
+        (0, 100),
+        (1000, 1100),
+        (1200, 1300),
+    ]
+
+
 def test_scale_alignment_payload_scales_timestamps():
     payload_words = [
         AlignmentWord(word="Hello", start_ms=0, end_ms=400, char_start=0, char_end=5),

--- a/tldw_Server_API/tests/Audiobooks/unit/test_audiobook_parse_utils.py
+++ b/tldw_Server_API/tests/Audiobooks/unit/test_audiobook_parse_utils.py
@@ -98,6 +98,17 @@ Line without timing
     assert "Line without timing" in normalized
 
 
+def test_normalize_subtitles_preserves_dialogue_arrow_text():
+    srt_text = """1
+00:00:00,000 --> 00:00:01,000
+Walk A --> B.
+"""
+
+    normalized = _normalize_subtitles(srt_text, "srt")
+
+    assert normalized == "Walk A --> B."
+
+
 def test_detect_chapters_fallback_when_no_markers():
     text = "This is a plain paragraph with no chapter markers."
     chapters = _detect_chapters(text)

--- a/tldw_Server_API/tests/Audiobooks/unit/test_audiobook_subtitle_generator.py
+++ b/tldw_Server_API/tests/Audiobooks/unit/test_audiobook_subtitle_generator.py
@@ -186,6 +186,24 @@ def test_generate_vtt_highlight_adds_class_tag():
     assert "<c.hl>Hello</c>" in content
 
 
+def test_generate_vtt_highlight_escapes_word_markup():
+    alignment = AlignmentPayload(
+        engine="kokoro",
+        sample_rate=24000,
+        words=[AlignmentWord(word="<script&>", start_ms=0, end_ms=400)],
+    )
+
+    content = generate_subtitles(
+        alignment,
+        format="vtt",
+        mode="highlight",
+        variant="wide",
+    )
+
+    assert "<c.hl>&lt;script&amp;&gt;</c>" in content
+    assert "<script&>" not in content
+
+
 def test_generate_ass_highlight_adds_karaoke_tag():
     alignment = AlignmentPayload(
         engine="kokoro",
@@ -199,6 +217,51 @@ def test_generate_ass_highlight_adds_karaoke_tag():
         variant="wide",
     )
     assert "{\\k50}Hello" in content
+
+
+def test_generate_ass_sanitizes_override_tags_in_text():
+    alignment = AlignmentPayload(
+        engine="kokoro",
+        sample_rate=24000,
+        words=[AlignmentWord(word="{\\pos(0,0)}Hello\\Nthere", start_ms=0, end_ms=500)],
+    )
+
+    content = generate_subtitles(
+        alignment,
+        format="ass",
+        mode="word_count",
+        variant="wide",
+        words_per_cue=1,
+    )
+
+    assert "\\pos" not in content
+    assert "Hello there" in content
+
+
+def test_generate_srt_highlight_sanitizes_cue_breaking_text():
+    alignment = AlignmentPayload(
+        engine="kokoro",
+        sample_rate=24000,
+        words=[
+            AlignmentWord(
+                word="Line\n\n2\n00:00:02,000 --> 00:00:03,000",
+                start_ms=0,
+                end_ms=500,
+            )
+        ],
+    )
+
+    content = generate_subtitles(
+        alignment,
+        format="srt",
+        mode="highlight",
+        variant="wide",
+    )
+
+    blocks = [block for block in content.strip().split("\n\n") if block]
+    assert len(blocks) == 1
+    assert "-- >" in blocks[0]
+    assert "00:00:02,000 --> 00:00:03,000" not in blocks[0]
 
 
 def test_generate_rejects_negative_end_times():

--- a/tldw_Server_API/tests/Audiobooks/unit/test_audiobook_tag_parser.py
+++ b/tldw_Server_API/tests/Audiobooks/unit/test_audiobook_tag_parser.py
@@ -78,6 +78,22 @@ def test_build_chapters_from_markers_deduplicates_ids_with_warnings():
     assert "duplicate_chapter_id:ch_002" in warnings
 
 
+def test_generated_chapter_collision_warnings_do_not_cascade_from_generated_ids():
+    text = "One.\nTwo.\nThree.\nFour."
+    markers = [
+        ChapterMarker(offset=0, chapter_id="ch_002", title="One"),
+        ChapterMarker(offset=text.index("Two."), chapter_id=None, title="Two"),
+        ChapterMarker(offset=text.index("Three."), chapter_id=None, title="Three"),
+        ChapterMarker(offset=text.index("Four."), chapter_id=None, title="Four"),
+    ]
+    warnings: list[str] = []
+
+    chapters = build_chapters_from_markers(text, markers, warnings=warnings)
+
+    assert [chapter.chapter_id for chapter in chapters] == ["ch_002", "ch_003", "ch_004", "ch_005"]
+    assert warnings == ["generated_chapter_id_collision:ch_002"]
+
+
 def test_parse_tagged_text_rejects_invalid_speed_markers():
     raw = (
         "[[speed=nan]]\n"

--- a/tldw_Server_API/tests/Audiobooks/unit/test_audiobook_tag_parser.py
+++ b/tldw_Server_API/tests/Audiobooks/unit/test_audiobook_tag_parser.py
@@ -60,3 +60,53 @@ def test_build_chapters_from_markers_respects_offsets_and_ids():
     assert chapters[0].end_offset == text.index("Two.")
     assert chapters[1].chapter_id == "custom_id"
     assert chapters[1].start_offset == text.index("Two.")
+
+
+def test_build_chapters_from_markers_deduplicates_ids_with_warnings():
+    text = "One.\nTwo.\nThree."
+    markers = [
+        ChapterMarker(offset=0, chapter_id="ch_002", title="One"),
+        ChapterMarker(offset=text.index("Two."), chapter_id=None, title="Two"),
+        ChapterMarker(offset=text.index("Three."), chapter_id="ch_002", title="Three"),
+    ]
+    warnings: list[str] = []
+
+    chapters = build_chapters_from_markers(text, markers, warnings=warnings)
+
+    assert [chapter.chapter_id for chapter in chapters] == ["ch_002", "ch_003", "ch_002_2"]
+    assert "generated_chapter_id_collision:ch_002" in warnings
+    assert "duplicate_chapter_id:ch_002" in warnings
+
+
+def test_parse_tagged_text_rejects_invalid_speed_markers():
+    raw = (
+        "[[speed=nan]]\n"
+        "[[speed=inf]]\n"
+        "[[speed=0.1]]\n"
+        "[[speed=4.5]]\n"
+        "[[speed=1.25]]\n"
+        "Narration.\n"
+    )
+
+    result = parse_tagged_text(raw)
+
+    assert [marker.value for marker in result.speed_markers] == [1.25]
+    assert result.warnings.count("invalid_speed:nan") == 1
+    assert result.warnings.count("invalid_speed:inf") == 1
+    assert result.warnings.count("invalid_speed:0.1") == 1
+    assert result.warnings.count("invalid_speed:4.5") == 1
+
+
+def test_parse_tagged_text_rejects_out_of_range_timestamps():
+    raw = (
+        "[[ts=00:60:00.000]]\n"
+        "[[ts=00:00:60.000]]\n"
+        "[[ts=00:01:02.345]]\n"
+        "Narration.\n"
+    )
+
+    result = parse_tagged_text(raw)
+
+    assert [marker.time_ms for marker in result.ts_markers] == [62345]
+    assert "invalid_ts:00:60:00.000" in result.warnings
+    assert "invalid_ts:00:00:60.000" in result.warnings

--- a/tldw_Server_API/tests/Audiobooks/unit/test_audiobook_worker_plan_tags.py
+++ b/tldw_Server_API/tests/Audiobooks/unit/test_audiobook_worker_plan_tags.py
@@ -1,7 +1,11 @@
 import pytest
 
 from tldw_Server_API.app.core.Audiobooks.tag_parser import parse_tagged_text
-from tldw_Server_API.app.services.audiobook_jobs_worker import AudiobookJobError, _build_chapter_plan
+from tldw_Server_API.app.services.audiobook_jobs_worker import (
+    AudiobookJobError,
+    _build_chapter_plan,
+    _refresh_tag_marker_metadata,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -53,3 +57,21 @@ def test_build_chapter_plan_rejects_unknown_chapter_id():
     chapter_specs = [{"chapter_id": "ch_999", "include": True}]
     with pytest.raises(AudiobookJobError):
         _build_chapter_plan(tag_result.clean_text, chapter_specs, tag_result=tag_result)
+
+
+def test_refresh_tag_marker_metadata_preserves_chapter_plan_warnings():
+    raw = (
+        "[[chapter:id=ch_002]]\n"
+        "First text.\n"
+        "[[chapter:title=Generated]]\n"
+        "Second text.\n"
+    )
+    tag_result = parse_tagged_text(raw)
+    metadata = {"tag_markers": tag_result.as_metadata()}
+
+    _build_chapter_plan(tag_result.clean_text, None, tag_result=tag_result)
+    assert metadata["tag_markers"]["warnings"] == []
+
+    _refresh_tag_marker_metadata(metadata, tag_result)
+
+    assert metadata["tag_markers"]["warnings"] == ["generated_chapter_id_collision:ch_002"]


### PR DESCRIPTION
## Summary
- Harden audiobook tag parsing by rejecting invalid speeds/timestamps and de-duplicating chapter IDs with warnings.
- Sanitize generated VTT/ASS/SRT subtitle text and preserve dialogue text containing literal arrows during subtitle parsing.
- Prevent alignment anchors from producing non-monotonic adjusted word timings.

## Test Plan
- [x] /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest -q tldw_Server_API/tests/Audiobooks/unit/test_audiobook_tag_parser.py tldw_Server_API/tests/Audiobooks/unit/test_audiobook_alignment_anchors.py tldw_Server_API/tests/Audiobooks/unit/test_audiobook_subtitle_generator.py tldw_Server_API/tests/Audiobooks/unit/test_audiobook_parse_utils.py
- [x] /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m compileall -q touched Audiobooks runtime and test files
- [x] /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Audiobooks tldw_Server_API/app/api/v1/endpoints/audio/audiobooks.py tldw_Server_API/app/services/audiobook_jobs_worker.py -f json -o /tmp/bandit_audiobook_core_review_rebased.json
- [x] git diff --check origin/dev...HEAD

## Backlog
- TASK-9923

## Change summary
Pending human-authored change summary before this PR is marked ready, per the AI-generated PR merge policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened audiobook parsing, alignment, and subtitle handling to block invalid data and sanitize subtitle text. Completes TASK-9923 by fixing duplicate chapter IDs, invalid speeds/timestamps, unsafe subtitle text, and non‑monotonic anchors.

- **Bug Fixes**
  - Tag parser: reject non‑finite/out‑of‑range speeds and invalid timestamps; de‑duplicate explicit chapter IDs with suffixes; warn only when generated IDs skip explicit ones; propagate warnings to API/worker and refresh worker tag metadata.
  - Alignment: ignore anchors that would move timelines backwards to keep word times monotonic.
  - Subtitle generation: sanitize cue text for `vtt` (HTML‑escape), `ass` (strip override tags/controls), and `srt` (normalize control chars and break `-->`), preventing cue‑breaking injection.
  - Subtitle parsing: strictly detect and remove only SRT/VTT timing lines; preserve dialogue text containing `-->`.

<sup>Written for commit 1ac46404ed86ce92bc17102d5ed4e6942b1282a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

