### PR TITLE
Harden AuthNZ review findings

### DIFF
--- a/backlog/tasks/task-2406 - Address-AuthNZ-review-hardening-findings.md
+++ b/backlog/tasks/task-2406 - Address-AuthNZ-review-hardening-findings.md
@@ -1,0 +1,43 @@
+---
+id: TASK-2406
+title: Address AuthNZ review hardening findings
+status: Done
+assignee: []
+created_date: '2026-06-23 18:10'
+updated_date: '2026-06-23 18:48'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and remediate validated AuthNZ review findings: OIDC authorization URL validation, OIDC JSON response caps, OAuth callback base URL hardening, mock email token redaction, and any confirmed low-risk cleanup.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Focused tests fail before fixes and pass after fixes; validated findings are addressed or documented as not applicable; Bandit runs over touched AuthNZ scope; Backlog task records verification.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified and addressed AuthNZ review findings. Implemented HTTPS/no-fragment validation for OIDC provider URLs, bounded OIDC discovery/token/JWKS JSON fetches, actual-body max_bytes enforcement in HTTP JSON helpers, PUBLIC_WEB_BASE_URL-based federation callback construction, mock redaction for token-bearing auth emails, and replacement of billing_repo production assert with an explicit ValueError. Verification: OIDC service focused tests 6 passed; HTTP JSON size-limit focused tests 3 passed; mock email redaction focused tests 2 passed; federation callback helper test 1 passed; production files py_compile passed. Bandit on touched source files reported only existing low-confidence B106 literal-string noise in auth.py; rerun with B106 skipped reported 0 findings. Full FastAPI endpoint redirect test was attempted with a longer timeout but remained in app startup for several minutes and was interrupted before the test body; helper-level coverage verifies the callback URL construction behavior directly.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+All validated AuthNZ findings were fixed with focused tests and source verification. Remaining note: the full FastAPI endpoint redirect test did not complete locally because app startup stayed in router/schema initialization for several minutes; direct helper coverage for PUBLIC_WEB_BASE_URL callback construction passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2406 - Address-AuthNZ-review-hardening-findings.md
+++ b/backlog/tasks/task-2406 - Address-AuthNZ-review-hardening-findings.md
@@ -4,7 +4,7 @@ title: Address AuthNZ review hardening findings
 status: Done
 assignee: []
 created_date: '2026-06-23 18:10'
-updated_date: '2026-06-23 18:48'
+updated_date: '2026-06-24 01:45'
 labels: []
 dependencies: []
 ---
@@ -24,12 +24,16 @@ Verify and remediate validated AuthNZ review findings: OIDC authorization URL va
 
 <!-- SECTION:NOTES:BEGIN -->
 Verified and addressed AuthNZ review findings. Implemented HTTPS/no-fragment validation for OIDC provider URLs, bounded OIDC discovery/token/JWKS JSON fetches, actual-body max_bytes enforcement in HTTP JSON helpers, PUBLIC_WEB_BASE_URL-based federation callback construction, mock redaction for token-bearing auth emails, and replacement of billing_repo production assert with an explicit ValueError. Verification: OIDC service focused tests 6 passed; HTTP JSON size-limit focused tests 3 passed; mock email redaction focused tests 2 passed; federation callback helper test 1 passed; production files py_compile passed. Bandit on touched source files reported only existing low-confidence B106 literal-string noise in auth.py; rerun with B106 skipped reported 0 findings. Full FastAPI endpoint redirect test was attempted with a longer timeout but remained in app startup for several minutes and was interrupted before the test body; helper-level coverage verifies the callback URL construction behavior directly.
+
+Follow-up: rebase PR #2444 onto latest dev and address all actionable PR comments/check findings.
+
+PR #2444 follow-up: rebased onto fetched latest dev, dropped unrelated Claims_Extraction commit from branch diff, and addressed actionable review comments. Fixes include docstrings on new helpers, typed new tests/stubs, async-safe mock email test file reads, OIDC authorization query key de-duplication, robust PUBLIC_WEB_BASE_URL callback URI construction, and callback token exchange redirect_uri validation against the helper-built URI.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-All validated AuthNZ findings were fixed with focused tests and source verification. Remaining note: the full FastAPI endpoint redirect test did not complete locally because app startup stayed in router/schema initialization for several minutes; direct helper coverage for PUBLIC_WEB_BASE_URL callback construction passed.
+PR #2444 is rebased onto latest dev and review feedback has been addressed with focused verification. Known note remains: full app endpoint startup is too slow locally, so callback behavior is covered by helper-level and focused AuthNZ tests.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/endpoints/auth.py
+++ b/tldw_Server_API/app/api/v1/endpoints/auth.py
@@ -14,7 +14,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from importlib import import_module
 from typing import Any, Optional
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlunsplit
 
 #
 # 3rd-party imports
@@ -210,6 +210,7 @@ async def _resolve_federation_provider(
 
 
 def _build_federation_redirect_uri(request: Request, provider_slug: str) -> str:
+    """Build the callback redirect URI, replacing request authority with public base when configured."""
     callback_url = request.url_for("federation_callback", provider_slug=provider_slug)
     public_web_base_url = str(getattr(get_settings(), "PUBLIC_WEB_BASE_URL", "") or "").strip()
     if not public_web_base_url:
@@ -235,7 +236,21 @@ def _build_federation_redirect_uri(request: Request, provider_slug: str) -> str:
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="PUBLIC_WEB_BASE_URL is invalid",
         )
-    return f"{public_web_base_url.rstrip('/')}{callback_url.path}"
+
+    callback_parsed = urlsplit(str(callback_url))
+    base_path = (parsed.path or "").rstrip("/")
+    callback_path = callback_parsed.path or "/"
+    if base_path and base_path != "/" and callback_path != base_path and not callback_path.startswith(f"{base_path}/"):
+        callback_path = f"{base_path}{callback_path}"
+    return urlunsplit(
+        (
+            parsed.scheme.lower(),
+            parsed.netloc,
+            callback_path,
+            callback_parsed.query,
+            "",
+        )
+    )
 
 
 def _get_email_service():
@@ -549,12 +564,18 @@ async def federation_callback(
             detail="OIDC state provider mismatch",
         )
 
-    redirect_uri = str(state_record.get("redirect_uri") or "").strip()
+    state_redirect_uri = str(state_record.get("redirect_uri") or "").strip()
     code_verifier = str(state_record.get("code_verifier") or "").strip()
-    if not redirect_uri or not code_verifier:
+    if not state_redirect_uri or not code_verifier:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="OIDC state is incomplete",
+        )
+    redirect_uri = _build_federation_redirect_uri(request, provider_slug)
+    if state_redirect_uri != redirect_uri:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="OIDC state redirect_uri mismatch",
         )
 
     oidc_service = get_oidc_federation_service_dep()

--- a/tldw_Server_API/app/api/v1/endpoints/auth.py
+++ b/tldw_Server_API/app/api/v1/endpoints/auth.py
@@ -14,6 +14,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from importlib import import_module
 from typing import Any, Optional
+from urllib.parse import urlsplit
 
 #
 # 3rd-party imports
@@ -206,6 +207,35 @@ async def _resolve_federation_provider(
         owner_scope_type="global",
         owner_scope_id=None,
     )
+
+
+def _build_federation_redirect_uri(request: Request, provider_slug: str) -> str:
+    callback_url = request.url_for("federation_callback", provider_slug=provider_slug)
+    public_web_base_url = str(getattr(get_settings(), "PUBLIC_WEB_BASE_URL", "") or "").strip()
+    if not public_web_base_url:
+        return str(callback_url)
+
+    try:
+        parsed = urlsplit(public_web_base_url)
+        _ = parsed.port
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="PUBLIC_WEB_BASE_URL is invalid",
+        ) from exc
+    if (
+        parsed.scheme.lower() not in {"http", "https"}
+        or not parsed.netloc
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="PUBLIC_WEB_BASE_URL is invalid",
+        )
+    return f"{public_web_base_url.rstrip('/')}{callback_url.path}"
 
 
 def _get_email_service():
@@ -424,7 +454,7 @@ async def federation_login(
             detail="Identity provider not found",
         )
 
-    redirect_uri = str(request.url_for("federation_callback", provider_slug=provider_slug))
+    redirect_uri = _build_federation_redirect_uri(request, provider_slug)
     oidc_service = get_oidc_federation_service_dep()
     try:
         auth_request = await oidc_service.build_authorization_request(

--- a/tldw_Server_API/app/core/AuthNZ/email_service.py
+++ b/tldw_Server_API/app/core/AuthNZ/email_service.py
@@ -688,13 +688,18 @@ class EmailService:
     def _redact_mock_email_body(body: str) -> str:
         """Redact token-bearing content before mock transport persists it."""
         redacted = re.sub(
-            r"([?&]token=)([^&\"'\\s<]+)",
+            r"([?&]token=)([^&\"'\s<]+)",
             r"\1[REDACTED]",
             body,
         )
         redacted = re.sub(
-            r"(?im)(manual token:\s*)(\S+)",
+            r"(?im)((?:manual token|copy this token(?: into the extension)?):\s*)(\S+)",
             r"\1[REDACTED]",
+            redacted,
+        )
+        redacted = re.sub(
+            r"(?is)(<div\s+class=[\"']code-box[\"'][^>]*>)(.*?)(</div>)",
+            r"\1[REDACTED]\3",
             redacted,
         )
         return redacted
@@ -798,7 +803,14 @@ class EmailService:
         text_body = text_template.render(**template_data)
         subject = Template(EMAIL_TEMPLATES["password_reset"]["subject"]).render(**template_data)
 
-        return await self.send_email(to_email, subject, html_body, text_body, _template="password_reset")
+        return await self.send_email(
+            to_email,
+            subject,
+            html_body,
+            text_body,
+            redact_mock_tokens=True,
+            _template="password_reset",
+        )
 
     async def send_verification_email(
         self,
@@ -831,7 +843,14 @@ class EmailService:
         text_body = text_template.render(**template_data)
         subject = Template(EMAIL_TEMPLATES["email_verification"]["subject"]).render(**template_data)
 
-        return await self.send_email(to_email, subject, html_body, text_body, _template="email_verification")
+        return await self.send_email(
+            to_email,
+            subject,
+            html_body,
+            text_body,
+            redact_mock_tokens=True,
+            _template="email_verification",
+        )
 
     async def send_magic_link_email(
         self,
@@ -868,7 +887,14 @@ class EmailService:
         text_body = text_template.render(**template_data)
         subject = Template(EMAIL_TEMPLATES["magic_link"]["subject"]).render(**template_data)
 
-        return await self.send_email(to_email, subject, html_body, text_body, _template="magic_link")
+        return await self.send_email(
+            to_email,
+            subject,
+            html_body,
+            text_body,
+            redact_mock_tokens=True,
+            _template="magic_link",
+        )
 
     async def send_admin_reauth_email(
         self,
@@ -940,7 +966,14 @@ class EmailService:
         text_body = text_template.render(**template_data)
         subject = Template(EMAIL_TEMPLATES["user_invitation"]["subject"]).render(**template_data)
 
-        return await self.send_email(to_email, subject, html_body, text_body, _template="user_invitation")
+        return await self.send_email(
+            to_email,
+            subject,
+            html_body,
+            text_body,
+            redact_mock_tokens=True,
+            _template="user_invitation",
+        )
 
     async def send_mfa_enabled_email(
         self,

--- a/tldw_Server_API/app/core/AuthNZ/federation/oidc_service.py
+++ b/tldw_Server_API/app/core/AuthNZ/federation/oidc_service.py
@@ -59,6 +59,7 @@ OIDC_JWKS_MAX_BYTES = 256 * 1024
 
 
 def _validate_oidc_provider_url(field_name: str, value: Any) -> str | None:
+    """Validate and normalize trusted OIDC provider endpoint URLs."""
     text = _coerce_nonempty_string(value)
     if not text:
         return None
@@ -89,8 +90,10 @@ def _validate_oidc_provider_url(field_name: str, value: Any) -> str | None:
 
 
 def _append_query_params(url: str, params: dict[str, str]) -> str:
+    """Append query parameters while replacing any existing keys being set."""
     parsed = urlsplit(url)
     query_items = parse_qsl(parsed.query, keep_blank_values=True)
+    query_items = [item for item in query_items if item[0] not in params]
     query_items.extend(params.items())
     return urlunsplit(
         (

--- a/tldw_Server_API/app/core/AuthNZ/federation/oidc_service.py
+++ b/tldw_Server_API/app/core/AuthNZ/federation/oidc_service.py
@@ -7,7 +7,7 @@ import secrets
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from jose import jwt
 from jose.exceptions import JWTError
@@ -53,6 +53,54 @@ _ASYMMETRIC_JWT_ALGS_BY_KTY: dict[str, set[str]] = {
     "OKP": {"EdDSA"},
     "RSA": {"PS256", "PS384", "PS512", "RS256", "RS384", "RS512"},
 }
+OIDC_DISCOVERY_MAX_BYTES = 128 * 1024
+OIDC_TOKEN_RESPONSE_MAX_BYTES = 64 * 1024
+OIDC_JWKS_MAX_BYTES = 256 * 1024
+
+
+def _validate_oidc_provider_url(field_name: str, value: Any) -> str | None:
+    text = _coerce_nonempty_string(value)
+    if not text:
+        return None
+    try:
+        parsed = urlsplit(text)
+        _ = parsed.port
+    except ValueError as exc:
+        raise ValueError(f"OIDC provider {field_name} is invalid") from exc
+
+    if parsed.scheme.lower() != "https":
+        raise ValueError(f"OIDC provider {field_name} must use https")
+    if not parsed.hostname:
+        raise ValueError(f"OIDC provider {field_name} must include a hostname")
+    if parsed.username or parsed.password:
+        raise ValueError(f"OIDC provider {field_name} must not include credentials")
+    if parsed.fragment:
+        raise ValueError(f"OIDC provider {field_name} must not include a URL fragment")
+
+    return urlunsplit(
+        (
+            parsed.scheme.lower(),
+            parsed.netloc,
+            parsed.path or "/",
+            parsed.query,
+            "",
+        )
+    )
+
+
+def _append_query_params(url: str, params: dict[str, str]) -> str:
+    parsed = urlsplit(url)
+    query_items = parse_qsl(parsed.query, keep_blank_values=True)
+    query_items.extend(params.items())
+    return urlunsplit(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            parsed.path,
+            urlencode(query_items),
+            "",
+        )
+    )
 
 
 def _parse_byok_secret_ref(secret_ref: str) -> tuple[str, int, str] | None:
@@ -168,10 +216,14 @@ class OIDCFederationService:
     state_ttl_seconds: int = 600
 
     async def _fetch_discovery_document(self, provider: dict[str, Any]) -> dict[str, Any]:
-        discovery_url = _coerce_nonempty_string(provider.get("discovery_url"))
+        discovery_url = _validate_oidc_provider_url("discovery_url", provider.get("discovery_url"))
         if not discovery_url:
             return {}
-        discovery = await afetch_json(method="GET", url=discovery_url)
+        discovery = await afetch_json(
+            method="GET",
+            url=discovery_url,
+            max_bytes=OIDC_DISCOVERY_MAX_BYTES,
+        )
         if not isinstance(discovery, dict):
             raise ValueError("OIDC discovery response is invalid")
         explicit_issuer = _coerce_nonempty_string(provider.get("issuer"))
@@ -193,6 +245,8 @@ class OIDCFederationService:
         *,
         touch_secret_refs: bool = True,
     ) -> dict[str, Any]:
+        if _coerce_nonempty_string(provider.get("discovery_url")):
+            _validate_oidc_provider_url("discovery_url", provider.get("discovery_url"))
         discovery = (
             await self._fetch_discovery_document(provider)
             if self._provider_requires_discovery(provider)
@@ -217,6 +271,8 @@ class OIDCFederationService:
                 or _coerce_string_set(discovery.get("id_token_signing_alg_values_supported"))
             ),
         }
+        for field_name in ("authorization_url", "token_url", "jwks_url"):
+            resolved[field_name] = _validate_oidc_provider_url(field_name, resolved.get(field_name))
         return resolved
 
     async def inspect_provider_configuration(
@@ -339,7 +395,7 @@ class OIDCFederationService:
         }
 
         return {
-            "auth_url": f"{authorization_url}?{urlencode(query)}",
+            "auth_url": _append_query_params(str(authorization_url), query),
             "state": state,
             "nonce": nonce,
             "code_verifier": code_verifier,
@@ -381,13 +437,18 @@ class OIDCFederationService:
             method="POST",
             url=token_url,
             data=form_data,
+            max_bytes=OIDC_TOKEN_RESPONSE_MAX_BYTES,
         )
 
         id_token = _coerce_nonempty_string(token_payload.get("id_token"))
         if not id_token:
             raise ValueError("OIDC token response is missing id_token")
 
-        jwks_payload = await afetch_json(method="GET", url=jwks_url)
+        jwks_payload = await afetch_json(
+            method="GET",
+            url=jwks_url,
+            max_bytes=OIDC_JWKS_MAX_BYTES,
+        )
         jwk = self._resolve_jwk_for_token(id_token, jwks_payload)
         allowed_algorithms = self._resolve_allowed_signing_algorithms(
             provider_runtime_config=runtime_config,

--- a/tldw_Server_API/app/core/AuthNZ/repos/billing_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/billing_repo.py
@@ -452,9 +452,9 @@ class AuthnzBillingRepo:
         if not updates:
             return await self.get_org_subscription(org_id)
 
-        # SECURITY: Verify column names are in the allowed whitelist before dynamic SQL
-        # This assertion should never fail since we filtered above, but provides defense-in-depth
-        assert all(k in allowed_fields for k in updates), "Invalid column name in updates"
+        # SECURITY: Verify column names are in the allowed whitelist before dynamic SQL.
+        if any(k not in allowed_fields for k in updates):
+            raise ValueError("Invalid column name in updates")
 
         try:
             async with self.db_pool.transaction() as conn:

--- a/tldw_Server_API/app/core/http_client.py
+++ b/tldw_Server_API/app/core/http_client.py
@@ -873,6 +873,7 @@ def _raise_if_json_response_exceeds_limit(
     content: bytes,
     max_bytes: int | None,
 ) -> None:
+    """Raise when JSON response metadata or actual body exceeds the configured limit."""
     if max_bytes is None:
         return
 

--- a/tldw_Server_API/app/core/http_client.py
+++ b/tldw_Server_API/app/core/http_client.py
@@ -867,6 +867,28 @@ def _sanitize_url_for_logs(u: str | Any) -> str:
         return s
 
 
+def _raise_if_json_response_exceeds_limit(
+    *,
+    headers: Any,
+    content: bytes,
+    max_bytes: int | None,
+) -> None:
+    if max_bytes is None:
+        return
+
+    content_length = headers.get("content-length")
+    if content_length:
+        try:
+            declared_length = int(content_length)
+        except (TypeError, ValueError) as exc:
+            raise JSONDecodeError("Invalid content-length header") from exc
+        if declared_length > max_bytes:
+            raise JSONDecodeError("Response exceeds max_bytes limit")  # noqa: TRY003
+
+    if len(content) > max_bytes:
+        raise JSONDecodeError("Response exceeds max_bytes limit")  # noqa: TRY003
+
+
 def _url_parts(u: str | Any) -> tuple[str, str, str]:
     """Return (scheme, host, path) for logging; redacts query by omission."""
     try:
@@ -3335,10 +3357,15 @@ async def afetch_json(
         await r.aclose()
         raise JSONDecodeError("Response is not application/json")  # noqa: TRY003
     if max_bytes is not None:
-        clen = r.headers.get("content-length")
-        if clen and int(clen) > max_bytes:
+        try:
+            _raise_if_json_response_exceeds_limit(
+                headers=r.headers,
+                content=r.content,
+                max_bytes=max_bytes,
+            )
+        except JSONDecodeError:
             await r.aclose()
-            raise JSONDecodeError("Response exceeds max_bytes limit")  # noqa: TRY003
+            raise
     try:
         data = r.json()
     except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS as e:
@@ -3362,10 +3389,15 @@ def fetch_json(
         r.close()
         raise JSONDecodeError("Response is not application/json")  # noqa: TRY003
     if max_bytes is not None:
-        clen = r.headers.get("content-length")
-        if clen and int(clen) > max_bytes:
+        try:
+            _raise_if_json_response_exceeds_limit(
+                headers=r.headers,
+                content=r.content,
+                max_bytes=max_bytes,
+            )
+        except JSONDecodeError:
             r.close()
-            raise JSONDecodeError("Response exceeds max_bytes limit")  # noqa: TRY003
+            raise
     try:
         data = r.json()
     except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS as e:

--- a/tldw_Server_API/tests/AuthNZ/unit/test_email_service.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_email_service.py
@@ -292,3 +292,46 @@ class TestTemplateEmailSending:
         assert "token=[REDACTED]" in email_data["text_body"]
         assert "token=[REDACTED]" in email_data["html_body"]
         assert "body omitted from persisted mock output" in html_body
+
+    @pytest.mark.asyncio
+    async def test_mock_token_bearing_auth_emails_redact_saved_mock_output(self, email_service, tmp_path):
+        """All token-bearing auth templates should redact mock output by default."""
+        await email_service.send_password_reset_email(
+            to_email="user@test.com",
+            username="testuser",
+            reset_token="reset-token-secret",
+            ip_address="192.168.1.1",
+            base_url="https://example.com",
+        )
+        await email_service.send_verification_email(
+            to_email="user@test.com",
+            username="testuser",
+            verification_token="verify-token-secret",
+            base_url="https://example.com",
+        )
+        await email_service.send_magic_link_email(
+            to_email="user@test.com",
+            magic_token="magic-token-secret",
+            expires_in_minutes=15,
+            username="testuser",
+            base_url="https://example.com",
+        )
+        await email_service.send_user_invitation_email(
+            to_email="invitee@test.com",
+            invite_token="invite-token-secret",
+            role="user",
+            base_url="https://example.com",
+        )
+
+        saved_bodies = []
+        for path in tmp_path.glob("*.json"):
+            email_data = json.loads(path.read_text())
+            saved_bodies.append(email_data["text_body"])
+            saved_bodies.append(email_data["html_body"])
+        combined = "\n".join(saved_bodies)
+
+        assert "reset-token-secret" not in combined
+        assert "verify-token-secret" not in combined
+        assert "magic-token-secret" not in combined
+        assert "invite-token-secret" not in combined
+        assert combined.count("token=[REDACTED]") >= 4

--- a/tldw_Server_API/tests/AuthNZ/unit/test_email_service.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_email_service.py
@@ -7,6 +7,7 @@ Tests cover:
 - SMTP error handling
 - Header injection prevention
 """
+import asyncio
 import json
 import pytest
 import os
@@ -294,7 +295,11 @@ class TestTemplateEmailSending:
         assert "body omitted from persisted mock output" in html_body
 
     @pytest.mark.asyncio
-    async def test_mock_token_bearing_auth_emails_redact_saved_mock_output(self, email_service, tmp_path):
+    async def test_mock_token_bearing_auth_emails_redact_saved_mock_output(
+        self,
+        email_service: EmailService,
+        tmp_path: Path,
+    ) -> None:
         """All token-bearing auth templates should redact mock output by default."""
         await email_service.send_password_reset_email(
             to_email="user@test.com",
@@ -323,9 +328,9 @@ class TestTemplateEmailSending:
             base_url="https://example.com",
         )
 
-        saved_bodies = []
+        saved_bodies: list[str] = []
         for path in tmp_path.glob("*.json"):
-            email_data = json.loads(path.read_text())
+            email_data = json.loads(await asyncio.to_thread(path.read_text))
             saved_bodies.append(email_data["text_body"])
             saved_bodies.append(email_data["html_body"])
         combined = "\n".join(saved_bodies)

--- a/tldw_Server_API/tests/AuthNZ_Federation/test_oidc_login_flow.py
+++ b/tldw_Server_API/tests/AuthNZ_Federation/test_oidc_login_flow.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from types import SimpleNamespace
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -18,6 +19,27 @@ from tldw_Server_API.app.core.AuthNZ.settings import Settings, reset_settings
 
 
 pytestmark = pytest.mark.integration
+
+
+def test_build_federation_redirect_uri_uses_public_base_without_request_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("JWT_SECRET_KEY", "x" * 32)
+    monkeypatch.setenv("PUBLIC_WEB_BASE_URL", "https://app.example.com")
+    reset_settings()
+
+    from tldw_Server_API.app.api.v1.endpoints.auth import _build_federation_redirect_uri
+
+    def _url_for(name: str, *, provider_slug: str):
+        assert name == "federation_callback"
+        return SimpleNamespace(path=f"/api/v1/auth/federation/{provider_slug}/callback")
+
+    request = SimpleNamespace(url_for=_url_for)
+
+    assert _build_federation_redirect_uri(request, "corp") == (
+        "https://app.example.com/api/v1/auth/federation/corp/callback"
+    )
 
 
 @pytest.fixture
@@ -123,6 +145,52 @@ def test_federation_login_redirects_to_provider_authorization_url(
     assert len(query["code_challenge"][0]) >= 32
     assert len(query["state"][0]) >= 20
     assert query["redirect_uri"] == ["http://testserver/api/v1/auth/federation/corp/callback"]
+
+
+def test_federation_login_uses_public_web_base_url_for_redirect_uri(
+    federation_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PUBLIC_WEB_BASE_URL", "https://app.example.com")
+    reset_settings()
+
+    create_response = federation_client.post(
+        "/api/v1/admin/identity/providers",
+        json={
+            "slug": "corp-public-base",
+            "provider_type": "oidc",
+            "owner_scope_type": "global",
+            "enabled": True,
+            "display_name": "Corp SSO",
+            "issuer": "https://issuer.example.com",
+            "authorization_url": "https://issuer.example.com/oauth2/authorize",
+            "token_url": "https://issuer.example.com/oauth2/token",
+            "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+            "client_id": "client-123",
+            "claim_mapping": {
+                "subject": "sub",
+                "email": "email",
+                "username": "preferred_username",
+            },
+            "provisioning_policy": {
+                "jit_create": True,
+                "allow_email_account_linking": True,
+            },
+        },
+    )
+    assert create_response.status_code == 200, create_response.text
+
+    response = federation_client.get(
+        "/api/v1/auth/federation/corp-public-base/login",
+        headers={"host": "attacker.example"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 307, response.text
+
+    query = parse_qs(urlparse(response.headers["location"]).query)
+    assert query["redirect_uri"] == [
+        "https://app.example.com/api/v1/auth/federation/corp-public-base/callback"
+    ]
 
 
 def test_federation_callback_supports_org_scoped_provider_resolution(

--- a/tldw_Server_API/tests/AuthNZ_Federation/test_oidc_login_flow.py
+++ b/tldw_Server_API/tests/AuthNZ_Federation/test_oidc_login_flow.py
@@ -8,6 +8,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
+from starlette.datastructures import URL
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     check_auth_rate_limit,
@@ -31,9 +32,9 @@ def test_build_federation_redirect_uri_uses_public_base_without_request_host(
 
     from tldw_Server_API.app.api.v1.endpoints.auth import _build_federation_redirect_uri
 
-    def _url_for(name: str, *, provider_slug: str):
+    def _url_for(name: str, *, provider_slug: str) -> URL:
         assert name == "federation_callback"
-        return SimpleNamespace(path=f"/api/v1/auth/federation/{provider_slug}/callback")
+        return URL(f"http://attacker.example/api/v1/auth/federation/{provider_slug}/callback")
 
     request = SimpleNamespace(url_for=_url_for)
 

--- a/tldw_Server_API/tests/AuthNZ_Federation/test_oidc_service.py
+++ b/tldw_Server_API/tests/AuthNZ_Federation/test_oidc_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -15,9 +16,9 @@ pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
 
 def _install_fetch_json_stub(
     monkeypatch: pytest.MonkeyPatch,
-    responses: dict[tuple[str, str], dict],
+    responses: dict[tuple[str, str], dict[str, Any]],
 ) -> None:
-    async def _fake_afetch_json(*, method: str, url: str, **kwargs) -> dict:  # noqa: ANN003
+    async def _fake_afetch_json(*, method: str, url: str, **kwargs: Any) -> dict[str, Any]:
         return dict(responses[(method.upper(), url)])
 
     monkeypatch.setattr(oidc_module, "afetch_json", _fake_afetch_json, raising=False)
@@ -169,6 +170,31 @@ async def test_build_authorization_request_rejects_unsafe_discovered_authorizati
 
 
 @pytest.mark.asyncio
+async def test_build_authorization_request_replaces_conflicting_authorization_query_params() -> None:
+    auth_request = await OIDCFederationService().build_authorization_request(
+        provider={
+            "issuer": "https://issuer.example.com",
+            "authorization_url": (
+                "https://issuer.example.com/oauth2/authorize?"
+                "prompt=login&client_id=stale-client&redirect_uri=https%3A%2F%2Fstale.example%2Fcallback&state=stale"
+            ),
+            "token_url": "https://issuer.example.com/oauth2/token",
+            "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+            "client_id": "client-123",
+        },
+        redirect_uri="http://testserver/callback",
+    )
+
+    query = parse_qs(urlparse(auth_request["auth_url"]).query)
+
+    assert query["prompt"] == ["login"]
+    assert query["client_id"] == ["client-123"]
+    assert query["redirect_uri"] == ["http://testserver/callback"]
+    assert query["state"] == [auth_request["state"]]
+    assert all(len(query[key]) == 1 for key in ("client_id", "redirect_uri", "state"))
+
+
+@pytest.mark.asyncio
 async def test_oidc_json_fetches_use_response_size_caps(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -190,7 +216,7 @@ async def test_oidc_json_fetches_use_response_size_caps(
     )
     seen_max_bytes: dict[tuple[str, str], int | None] = {}
 
-    async def _fake_afetch_json(*, method: str, url: str, **kwargs) -> dict:  # noqa: ANN003
+    async def _fake_afetch_json(*, method: str, url: str, **kwargs: Any) -> dict[str, Any]:
         key = (method.upper(), url)
         seen_max_bytes[key] = kwargs.get("max_bytes")
         if key == ("GET", discovery_url):

--- a/tldw_Server_API/tests/AuthNZ_Federation/test_oidc_service.py
+++ b/tldw_Server_API/tests/AuthNZ_Federation/test_oidc_service.py
@@ -114,6 +114,126 @@ async def test_build_authorization_request_uses_discovery_authorization_endpoint
     assert query["response_type"] == ["code"]
 
 
+@pytest.mark.parametrize(
+    "authorization_url",
+    [
+        "http://issuer.example.com/oauth2/authorize",
+        "javascript:alert(1)",
+        "https://",
+        "https://issuer.example.com/oauth2/authorize#fragment",
+    ],
+)
+@pytest.mark.asyncio
+async def test_build_authorization_request_rejects_unsafe_authorization_url(
+    authorization_url: str,
+) -> None:
+    with pytest.raises(ValueError, match="authorization_url"):
+        await OIDCFederationService().build_authorization_request(
+            provider={
+                "issuer": "https://issuer.example.com",
+                "authorization_url": authorization_url,
+                "token_url": "https://issuer.example.com/oauth2/token",
+                "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+                "client_id": "client-123",
+            },
+            redirect_uri="http://testserver/callback",
+        )
+
+
+@pytest.mark.asyncio
+async def test_build_authorization_request_rejects_unsafe_discovered_authorization_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    discovery_url = "https://issuer.example.com/.well-known/openid-configuration"
+    _install_fetch_json_stub(
+        monkeypatch,
+        {
+            ("GET", discovery_url): {
+                "issuer": "https://issuer.example.com",
+                "authorization_endpoint": "http://issuer.example.com/oauth2/authorize",
+                "token_endpoint": "https://issuer.example.com/oauth2/token",
+                "jwks_uri": "https://issuer.example.com/.well-known/jwks.json",
+            }
+        },
+    )
+
+    with pytest.raises(ValueError, match="authorization_url"):
+        await OIDCFederationService().build_authorization_request(
+            provider={
+                "issuer": "https://issuer.example.com",
+                "discovery_url": discovery_url,
+                "client_id": "client-123",
+            },
+            redirect_uri="http://testserver/callback",
+        )
+
+
+@pytest.mark.asyncio
+async def test_oidc_json_fetches_use_response_size_caps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    private_pem, jwk = _rsa_signing_material()
+    discovery_url = "https://issuer.example.com/.well-known/openid-configuration"
+    token_url = "https://issuer.example.com/oauth2/token"
+    jwks_url = "https://issuer.example.com/.well-known/jwks.json"
+    id_token = jwt.encode(
+        {
+            "sub": "external-user-capped",
+            "email": "capped@example.com",
+            "iss": "https://issuer.example.com",
+            "aud": "client-123",
+            "nonce": "nonce-capped",
+        },
+        private_pem,
+        algorithm="RS256",
+        headers={"kid": "oidc-key-1"},
+    )
+    seen_max_bytes: dict[tuple[str, str], int | None] = {}
+
+    async def _fake_afetch_json(*, method: str, url: str, **kwargs) -> dict:  # noqa: ANN003
+        key = (method.upper(), url)
+        seen_max_bytes[key] = kwargs.get("max_bytes")
+        if key == ("GET", discovery_url):
+            return {
+                "issuer": "https://issuer.example.com",
+                "authorization_endpoint": "https://issuer.example.com/oauth2/authorize",
+                "token_endpoint": token_url,
+                "jwks_uri": jwks_url,
+            }
+        if key == ("POST", token_url):
+            return {"id_token": id_token}
+        if key == ("GET", jwks_url):
+            return {"keys": [jwk]}
+        raise AssertionError(f"Unexpected OIDC fetch: {method} {url}")
+
+    monkeypatch.setattr(oidc_module, "afetch_json", _fake_afetch_json, raising=False)
+
+    await OIDCFederationService().build_authorization_request(
+        provider={
+            "issuer": "https://issuer.example.com",
+            "discovery_url": discovery_url,
+            "client_id": "client-123",
+        },
+        redirect_uri="http://testserver/callback",
+    )
+    await OIDCFederationService().exchange_authorization_code(
+        provider={
+            "issuer": "https://issuer.example.com",
+            "token_url": token_url,
+            "jwks_url": jwks_url,
+            "client_id": "client-123",
+        },
+        code="code-capped",
+        redirect_uri="http://testserver/callback",
+        code_verifier="verifier-capped",
+        nonce="nonce-capped",
+    )
+
+    assert seen_max_bytes[("GET", discovery_url)] == oidc_module.OIDC_DISCOVERY_MAX_BYTES
+    assert seen_max_bytes[("POST", token_url)] == oidc_module.OIDC_TOKEN_RESPONSE_MAX_BYTES
+    assert seen_max_bytes[("GET", jwks_url)] == oidc_module.OIDC_JWKS_MAX_BYTES
+
+
 @pytest.mark.asyncio
 async def test_exchange_authorization_code_uses_discovery_and_jwks_to_verify_signature(
     monkeypatch: pytest.MonkeyPatch,

--- a/tldw_Server_API/tests/http_client/test_http_client.py
+++ b/tldw_Server_API/tests/http_client/test_http_client.py
@@ -199,6 +199,69 @@ def test_json_max_bytes_guard():
 
 
 @requires_httpx
+def test_json_max_bytes_guard_uses_actual_body_despite_short_content_length():
+    import httpx
+    from tldw_Server_API.app.core.http_client import fetch_json, create_client
+    from tldw_Server_API.app.core.exceptions import JSONDecodeError
+
+    content = b"{" + b" \n" * 1024 + b"}"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            request=request,
+            content=content,
+            headers={"Content-Type": "application/json", "Content-Length": "2"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = create_client(transport=transport)
+    try:
+        with pytest.raises(JSONDecodeError):
+            fetch_json(
+                method="GET",
+                url="http://93.184.216.34/json",
+                client=client,
+                require_json_ct=True,
+                max_bytes=10,
+            )
+    finally:
+        client.close()
+
+
+@requires_httpx
+@pytest.mark.asyncio
+async def test_async_json_max_bytes_guard_uses_actual_body_despite_short_content_length():
+    import httpx
+    from tldw_Server_API.app.core.http_client import afetch_json, create_async_client
+    from tldw_Server_API.app.core.exceptions import JSONDecodeError
+
+    content = b"{" + b" \n" * 1024 + b"}"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            request=request,
+            content=content,
+            headers={"Content-Type": "application/json", "Content-Length": "2"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = create_async_client(transport=transport)
+    try:
+        with pytest.raises(JSONDecodeError):
+            await afetch_json(
+                method="GET",
+                url="http://93.184.216.34/json",
+                client=client,
+                require_json_ct=True,
+                max_bytes=10,
+            )
+    finally:
+        await client.aclose()
+
+
+@requires_httpx
 @pytest.mark.asyncio
 async def test_stream_cancellation_propagates():
     import httpx


### PR DESCRIPTION
## Summary
- Validate OIDC provider/discovery URLs before redirect and token/JWKS fetches, add explicit OIDC JSON response caps, and de-duplicate OAuth query keys when building authorization URLs.
- Build federation callback URLs from validated PUBLIC_WEB_BASE_URL, preserve generated callback paths robustly, and validate callback token exchange redirect_uri against that helper-built URI.
- Redact token-bearing mock auth emails by default, replace the billing repository production assert with an explicit runtime check, and address review feedback on docstrings/type hints/async test I/O.

## Test Plan
- [x] source ../../.venv/bin/activate && python -m pytest -q --confcutdir=tldw_Server_API/tests/AuthNZ_Federation tldw_Server_API/tests/AuthNZ_Federation/test_oidc_service.py::test_build_authorization_request_rejects_unsafe_authorization_url tldw_Server_API/tests/AuthNZ_Federation/test_oidc_service.py::test_build_authorization_request_rejects_unsafe_discovered_authorization_endpoint tldw_Server_API/tests/AuthNZ_Federation/test_oidc_service.py::test_build_authorization_request_replaces_conflicting_authorization_query_params tldw_Server_API/tests/AuthNZ_Federation/test_oidc_service.py::test_oidc_json_fetches_use_response_size_caps tldw_Server_API/tests/AuthNZ_Federation/test_oidc_login_flow.py::test_build_federation_redirect_uri_uses_public_base_without_request_host
- [x] source ../../.venv/bin/activate && python -m pytest -q --confcutdir=tldw_Server_API/tests/http_client tldw_Server_API/tests/http_client/test_http_client.py::test_json_max_bytes_guard tldw_Server_API/tests/http_client/test_http_client.py::test_json_max_bytes_guard_uses_actual_body_despite_short_content_length tldw_Server_API/tests/http_client/test_http_client.py::test_async_json_max_bytes_guard_uses_actual_body_despite_short_content_length
- [x] source ../../.venv/bin/activate && python -m pytest -q --confcutdir=tldw_Server_API/tests/AuthNZ/unit tldw_Server_API/tests/AuthNZ/unit/test_email_service.py::TestTemplateEmailSending::test_mock_token_bearing_auth_emails_redact_saved_mock_output tldw_Server_API/tests/AuthNZ/unit/test_email_service.py::TestTemplateEmailSending::test_mock_admin_reauth_email_redacts_token_in_saved_mock_output
- [x] source ../../.venv/bin/activate && python -m py_compile tldw_Server_API/app/core/AuthNZ/federation/oidc_service.py tldw_Server_API/app/api/v1/endpoints/auth.py tldw_Server_API/app/core/http_client.py tldw_Server_API/app/core/AuthNZ/email_service.py tldw_Server_API/app/core/AuthNZ/repos/billing_repo.py
- [x] git diff --check FETCH_HEAD..HEAD
- [x] source ../../.venv/bin/activate && python -m bandit tldw_Server_API/app/core/AuthNZ/federation/oidc_service.py tldw_Server_API/app/api/v1/endpoints/auth.py tldw_Server_API/app/core/http_client.py tldw_Server_API/app/core/AuthNZ/email_service.py tldw_Server_API/app/core/AuthNZ/repos/billing_repo.py --skip B106 -f json -o /tmp/bandit_authnz_2444_review_skip_b106.json

Note: full Bandit includes existing low-confidence B106 literal-string noise in auth.py; the focused scan with that known noise skipped reports zero findings. Full FastAPI endpoint startup remains too slow locally, so callback behavior is covered by helper-level/focused AuthNZ tests.