### PR TITLE
Harden audio core review findings

### DIFF
--- a/Docs/superpowers/plans/2026-06-23-audio-core-review-hardening.md
+++ b/Docs/superpowers/plans/2026-06-23-audio-core-review-hardening.md
@@ -1,0 +1,60 @@
+# Audio Core Review Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Verify and fix validated security, quota, streaming, tokenizer, and helper-ownership findings from the `tldw_Server_API/app/core/Audio` review.
+
+**Architecture:** Keep `core.Audio` as the owner of shared audio service behavior. Endpoint shims may preserve test/backwards-compat patch points, but they should delegate to core implementations rather than duplicating logic. Fixes must fail closed for unsafe auth and local model-loading policy, while preserving explicit compatibility switches where existing clients may depend on legacy behavior.
+
+**Tech Stack:** Python, FastAPI WebSockets, pytest, Loguru, Backlog.md task `TASK-2407`.
+
+---
+
+## Stage 1: Verify Findings
+**Goal**: Confirm each review item still applies to current code.
+**Success Criteria**: Each finding is marked validated or not applicable in task notes.
+**Tests**: Static call-path checks with `rg` and targeted source reads.
+**Status**: Complete
+
+- [x] Check WebSocket auth query-token paths in `tldw_Server_API/app/core/Audio/streaming_service.py`.
+- [x] Check quota exception tuples in `tldw_Server_API/app/core/Audio/quota_helpers.py` and their fail-open callers.
+- [x] Check `_stream_tts_to_websocket` task cancellation behavior.
+- [x] Check tokenizer loader local-only fallback behavior and endpoint-controlled model inputs.
+- [x] Check tokenizer malformed payload behavior.
+- [x] Check BYOK and fail-open helper duplication between core and audio endpoint shims.
+
+## Stage 2: Write Failing Tests
+**Goal**: Add focused tests for validated behavior before production edits.
+**Success Criteria**: New tests fail for the expected reasons on current code.
+**Tests**: Targeted pytest invocations for audio core tests.
+**Status**: Complete
+
+- [x] Add tests proving query-token auth is rejected by default but can be enabled by an explicit compatibility flag.
+- [x] Add tests proving `NameError` is not in expected DB/Redis quota exceptions.
+- [x] Add a test proving TTS streaming cancels the producer when the WebSocket send path fails.
+- [x] Add tests proving tokenizer local-only loading does not fall back to download-capable calls.
+- [x] Add tests proving invalid base64, odd raw PCM, and invalid sample rates become HTTP 400 errors.
+- [x] Add tests proving endpoint BYOK wrappers delegate to the core helper.
+
+## Stage 3: Implement Fixes
+**Goal**: Make the smallest production changes that satisfy the failing tests.
+**Success Criteria**: All new tests pass without broad refactors.
+**Tests**: Same targeted pytest invocations from Stage 2.
+**Status**: Complete
+
+- [x] Gate WebSocket `?token=` auth behind `AUDIO_WS_ALLOW_QUERY_TOKEN_AUTH`.
+- [x] Remove `NameError` from quota exception tuples.
+- [x] Cancel the TTS producer when the consumer finishes early, while letting normal producer completion drain queued audio.
+- [x] Enforce tokenizer local-only policy by failing closed when a backend cannot honor it.
+- [x] Convert malformed tokenizer inputs into structured 400 errors.
+- [x] Delegate endpoint BYOK helper wrappers to `core.Audio.tts_service._resolve_tts_byok`.
+
+## Stage 4: Verification and Cleanup
+**Goal**: Prove the fixes and update tracking records.
+**Success Criteria**: Targeted tests, Bandit on touched scope, and task notes are complete.
+**Tests**: `python -m pytest` for touched audio tests and `python -m bandit` for touched source files.
+**Status**: Complete
+
+- [x] Run targeted pytest commands for new and impacted audio tests.
+- [x] Run Bandit on touched source paths.
+- [x] Update Backlog task `TASK-2407` with verification results and final summary.

--- a/backlog/tasks/task-2407 - Harden-audio-core-review-findings.md
+++ b/backlog/tasks/task-2407 - Harden-audio-core-review-findings.md
@@ -4,7 +4,7 @@ title: Harden audio core review findings
 status: Done
 assignee: []
 created_date: '2026-06-23 18:11'
-updated_date: '2026-06-23 18:47'
+updated_date: '2026-06-24 01:43'
 labels:
   - audio
   - security
@@ -52,6 +52,12 @@ Final verification refresh after tokenizer loader-function refinement:
 - py_compile passed for updated tokenizer source and tests.
 - Focused tokenizer pytest with parent conftest cut off passed: 6 passed in 1.74s.
 - Bandit rerun on touched audio source scope completed with 0 results and 0 errors (/tmp/bandit_audio_core_2407.json).
+
+PR review follow-up:
+- Added docstrings for new stream/tokenizer helper functions flagged by Qodo.
+- Preserved parent cancellation by re-raising asyncio.CancelledError in producer/consumer paths before broad noncritical handlers.
+- Added regression tests for parent cancellation during TTS stream cleanup and failed completion-sentinel enqueue cancelling the consumer instead of hanging.
+- Focused audio pytest after follow-up: 8 passed in 3.62s.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2407 - Harden-audio-core-review-findings.md
+++ b/backlog/tasks/task-2407 - Harden-audio-core-review-findings.md
@@ -1,0 +1,71 @@
+---
+id: TASK-2407
+title: Harden audio core review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 18:11'
+updated_date: '2026-06-23 18:47'
+labels:
+  - audio
+  - security
+  - review
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and address validated findings from the current-code review of tldw_Server_API/app/core/Audio. Scope includes WebSocket auth token handling, quota fail-open exception classes, TTS WebSocket producer cancellation, tokenizer loader local-only enforcement, tokenizer payload validation, and duplicate audio helper ownership.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Validated findings are either fixed with tests or documented as not applicable.
+- [x] #2 WebSocket audio auth no longer accepts long-lived credentials in query strings by default.
+- [x] #3 Quota fail-open exception tuples do not catch programmer errors such as NameError.
+- [x] #4 TTS WebSocket producer cancels promptly when the consumer exits or send fails.
+- [x] #5 Tokenizer model loading honors auto_download/local-only policy and rejects malformed payloads with 400-level errors.
+- [x] #6 Duplicate helper ownership is resolved or clearly delegated to core implementations.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-23-audio-core-review-hardening.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created implementation plan: Docs/superpowers/plans/2026-06-23-audio-core-review-hardening.md
+
+Verification results:
+- py_compile passed for touched audio source and tests.
+- Direct executable checks passed for query-token auth gating, quota exception tuples, TTS producer cancellation and normal queue drain, tokenizer local-only enforcement, malformed tokenizer payload errors, and endpoint BYOK delegation.
+- Focused pytest with parent conftest cut off passed: Audio/test_audio_streaming_service_core.py plus fail-open/BYOK tests, 6 passed in 35.20s.
+- Focused tokenizer pytest with parent conftest cut off passed: 5 passed in 6.56s.
+- Full selected pytest using repository-global conftest was interrupted after 154s because app lifecycle startup/teardown stalled in pytest cleanup; no assertion failures were observed before interruption.
+- Bandit on touched audio source scope completed with 0 results and 0 errors (/tmp/bandit_audio_core_2407.json).
+
+Final verification refresh after tokenizer loader-function refinement:
+- py_compile passed for updated tokenizer source and tests.
+- Focused tokenizer pytest with parent conftest cut off passed: 6 passed in 1.74s.
+- Bandit rerun on touched audio source scope completed with 0 results and 0 errors (/tmp/bandit_audio_core_2407.json).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Validated and fixed all reviewed audio-core findings: disabled WebSocket query-token credentials by default behind AUDIO_WS_ALLOW_QUERY_TOKEN_AUTH, removed NameError from quota fail-open exception tuples, fixed TTS WebSocket producer/consumer cancellation without truncating normal streams, made tokenizer loading fail closed when local-only cannot be enforced, mapped malformed tokenizer inputs to structured HTTP 400 responses, sanitized BYOK user-id logging, and delegated the aggregate endpoint BYOK wrapper to the core TTS helper. Added focused regression coverage for each validated behavior.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2407 - Harden-audio-core-review-findings.md
+++ b/backlog/tasks/task-2407 - Harden-audio-core-review-findings.md
@@ -3,12 +3,12 @@ id: TASK-2407
 title: Harden audio core review findings
 status: Done
 assignee: []
-created_date: '2026-06-23 18:11'
-updated_date: '2026-06-24 01:43'
+created_date: 2026-06-23 18:11
+updated_date: 2026-06-24 03:31
 labels:
-  - audio
-  - security
-  - review
+- audio
+- security
+- review
 dependencies: []
 priority: high
 ---
@@ -75,3 +75,16 @@ Validated and fixed all reviewed audio-core findings: disabled WebSocket query-t
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+PR review follow-up 2:
+- Verified the completed-consumer observation gap is still present in the producer-done branch of streaming_service.py.
+- Applying the minimal fix to observe consumer_task when it is already in the done set.
+Follow-up verification:
+- py_compile passed for streaming_service.py and test_audio_streaming_service_core.py.
+- Focused audio pytest passed: 9 passed in 1.95s.
+- git diff --check passed.
+- Bandit touched audio scope completed with 0 results and 0 errors (/tmp/bandit_audio_core_2446_observe_consumer.json).
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio.py
@@ -5,9 +5,8 @@ import importlib
 import os
 from typing import Any, Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 from loguru import logger
-from starlette import status
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import get_usage_event_logger
@@ -106,14 +105,6 @@ get_tts_service = audio_tts.get_tts_service
 get_usage_event_logger = get_usage_event_logger
 check_rate_limit = check_rate_limit
 
-# Shared helper re-exports used in tests
-from tldw_Server_API.app.core.Audio.tts_service import (
-    _tts_fallback_resolver,
-)
-from tldw_Server_API.app.core.AuthNZ.byok_runtime import (
-    record_byok_missing_credentials,
-    resolve_byok_credentials,
-)
 from tldw_Server_API.app.core.config import load_comprehensive_config as _load_comprehensive_config
 
 # Re-export config loader for tests to monkeypatch
@@ -128,51 +119,14 @@ async def _resolve_tts_byok(
     force_oauth_refresh: bool = False,
 ):
     """Wrapper to preserve audio.py patch points for BYOK resolution."""
-    user_id_int = None
-    try:
-        user_id_int = getattr(current_user, "id_int", None)
-        if user_id_int is None:
-            raw_id = getattr(current_user, "id", None)
-            if raw_id is not None:
-                user_id_int = int(raw_id)
-    except (AttributeError, TypeError, ValueError):
-        logger.debug("Failed to extract user_id from current_user")
-        user_id_int = None
+    from tldw_Server_API.app.core.Audio import tts_service as core_tts_service
 
-    tts_overrides = None
-    byok_tts_resolution = None
-    if provider_hint:
-        resolver = resolve_byok_credentials
-        try:
-            from tldw_Server_API.app.api.v1.endpoints import audio as _audio_pkg
-
-            resolver = getattr(_audio_pkg, "resolve_byok_credentials", resolve_byok_credentials)
-        except Exception:
-            resolver = resolve_byok_credentials
-        byok_tts_resolution = await resolver(
-            provider_hint,
-            user_id=user_id_int,
-            request=request,
-            fallback_resolver=_tts_fallback_resolver,
-            force_oauth_refresh=force_oauth_refresh,
-        )
-        if byok_tts_resolution.uses_byok:
-            tts_overrides = {"api_key": byok_tts_resolution.api_key}
-            base_url = byok_tts_resolution.credential_fields.get("base_url")
-            if isinstance(base_url, str) and base_url.strip():
-                tts_overrides["base_url"] = base_url.strip()
-        elif not byok_tts_resolution.api_key:
-            if provider_hint in {"openai", "elevenlabs"}:
-                record_byok_missing_credentials(provider_hint, operation="audio_tts")
-                raise HTTPException(
-                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                    detail={
-                        "error_code": "missing_provider_credentials",
-                        "message": f"TTS provider '{provider_hint}' requires an API key.",
-                    },
-                )
-
-    return user_id_int, tts_overrides, byok_tts_resolution
+    return await core_tts_service._resolve_tts_byok(
+        provider_hint=provider_hint,
+        current_user=current_user,
+        request=request,
+        force_oauth_refresh=force_oauth_refresh,
+    )
 
 
 def _get_failopen_cap_minutes() -> float:

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_streaming.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_streaming.py
@@ -844,21 +844,22 @@ ws_router = APIRouter()
 
 @ws_router.websocket("/stream/transcribe")
 async def websocket_transcribe(
-    websocket: WebSocket, token: Optional[str] = Query(None)  # Get token from query parameter
+    websocket: WebSocket, token: Optional[str] = Query(None)  # Legacy query-token auth; disabled by default.
 ):
     """
     Handle a WebSocket connection to perform real-time streaming audio transcription.
 
-    Accepts a WebSocket and an optional query token. Authentication is supported via:
-    - Multi-user: X-API-KEY header, Authorization: Bearer <JWT>, `token` query parameter (API key or JWT), or an initial auth message.
-    - Single-user: API key via header, `token` query parameter, or an initial auth message; an IP allowlist may be enforced.
+    Accepts a WebSocket. Authentication is supported via:
+    - Multi-user: X-API-KEY header, Authorization: Bearer <JWT>, or an initial auth message.
+    - Single-user: API key via header or an initial auth message; an IP allowlist may be enforced.
+    - Legacy `token` query-string auth is accepted only when AUDIO_WS_ALLOW_QUERY_TOKEN_AUTH is enabled.
     Supported incoming message types: "auth" (for token-based auth), "config" (streaming configuration), "audio" (base64-encoded audio chunks), and "commit" (finalize current utterance).
     Outgoing message types include partial updates ("partial"), interim/final transcriptions ("transcription"), the final transcript ("full_transcript"), and structured error frames ("error").
     Per-user limits are enforced (concurrent streams and daily minute quotas); when a quota is exceeded the server sends an "error" with `code="quota_exceeded"` and closes the connection with code 4003 (or 1008 when `AUDIO_WS_QUOTA_CLOSE_1008=1`). A compatibility alias `error_type` is included when `AUDIO_WS_COMPAT_ERROR_TYPE=1` (default).
     A server-side default streaming configuration is used if the client does not provide one before audio arrives.
     Parameters:
         websocket (WebSocket): The active WebSocket connection.
-        token (Optional[str]): Optional API key or JWT token supplied via the query string for both multi-user and single-user authentication.
+        token (Optional[str]): Legacy API key or JWT query-string token, ignored unless AUDIO_WS_ALLOW_QUERY_TOKEN_AUTH is enabled.
     """
     # Create a lightweight WebSocketStream for uniform metrics on outer error paths
     _outer_stream = None
@@ -1567,9 +1568,9 @@ async def websocket_audio_chat_stream(
       - Streaming TTS audio back (binary frames)
 
     Authentication:
-      - Multi-user: `X-API-KEY` header, `Authorization: Bearer <JWT>`, `token` query parameter (API key or JWT),
-        or an initial auth message frame (JWT).
-      - Single-user: API key via header, `token` query parameter, or an initial auth message; optional IP allowlist.
+      - Multi-user: `X-API-KEY` header, `Authorization: Bearer <JWT>`, or an initial auth message frame (JWT).
+      - Single-user: API key via header or an initial auth message; optional IP allowlist.
+      - Legacy `token` query-string auth is accepted only when AUDIO_WS_ALLOW_QUERY_TOKEN_AUTH is enabled.
     """
     await websocket.accept()
 
@@ -3002,8 +3003,9 @@ async def websocket_tts(
     WebSocket TTS streaming endpoint: accepts a prompt frame and streams audio bytes.
 
     Authentication mirrors `_audio_ws_authenticate`:
-    - Multi-user: `X-API-KEY` header, `Authorization: Bearer <JWT>`, or `token` query parameter (API key or JWT).
-    - Single-user: fixed API key via header, `token` query parameter, or initial auth message; optional IP allowlist.
+    - Multi-user: `X-API-KEY` header, `Authorization: Bearer <JWT>`, or initial auth message.
+    - Single-user: fixed API key via header or initial auth message; optional IP allowlist.
+    - Legacy `token` query-string auth is accepted only when AUDIO_WS_ALLOW_QUERY_TOKEN_AUTH is enabled.
     """
     await websocket.accept()
 

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_tokenizer.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_tokenizer.py
@@ -108,7 +108,7 @@ async def encode_audio_tokenizer(
                 status_code=400,
                 detail=_http_error_detail("Invalid JSON payload", request_id, exc=exc),
             ) from exc
-        audio_bytes = _decode_base64_payload(payload.audio_base64)
+        audio_bytes = _decode_base64_payload(payload.audio_base64, request_id=request_id)
         tokenizer_model = payload.tokenizer_model or tokenizer_model
         token_format = payload.token_format or token_format
         sample_rate_hint = payload.sample_rate
@@ -211,7 +211,7 @@ async def decode_audio_tokenizer(
     tokenizer_model = payload.tokenizer_model or settings["tokenizer_model"]
 
     if isinstance(payload.tokens, str):
-        token_bytes = _decode_base64_payload(payload.tokens)
+        token_bytes = _decode_base64_payload(payload.tokens, request_id=request_id)
         _enforce_payload_limit(token_bytes, settings["tokenizer_max_payload_mb"], request_id)
         tokens = np.frombuffer(token_bytes, dtype=np.int32).tolist()
     elif isinstance(payload.tokens, list):

--- a/tldw_Server_API/app/core/Audio/quota_helpers.py
+++ b/tldw_Server_API/app/core/Audio/quota_helpers.py
@@ -24,8 +24,8 @@ try:
 except ImportError:  # pragma: no cover
     AuthNZDatabaseError = None  # type: ignore
 
-# Build precise exception tuples we’ll catch in quota-limit helpers
-EXPECTED_DB_EXC = (NameError,)  # NameError if optional imports are unavailable
+# Build precise exception tuples we’ll catch in quota-limit helpers.
+EXPECTED_DB_EXC = ()
 if hasattr(sqlite3, "Error"):
     EXPECTED_DB_EXC = (*EXPECTED_DB_EXC, sqlite3.Error)  # type: ignore[attr-defined]
 if asyncpg and hasattr(asyncpg, "PostgresError"):
@@ -35,7 +35,7 @@ if aiosqlite and hasattr(aiosqlite, "Error"):
 if AuthNZDatabaseError is not None:
     EXPECTED_DB_EXC = (*EXPECTED_DB_EXC, AuthNZDatabaseError)  # type: ignore
 
-EXPECTED_REDIS_EXC = (NameError,)
+EXPECTED_REDIS_EXC = ()
 if redis_exceptions and hasattr(redis_exceptions, "RedisError"):
     EXPECTED_REDIS_EXC = (*EXPECTED_REDIS_EXC, redis_exceptions.RedisError)  # type: ignore[attr-defined]
 

--- a/tldw_Server_API/app/core/Audio/streaming_service.py
+++ b/tldw_Server_API/app/core/Audio/streaming_service.py
@@ -311,6 +311,8 @@ async def _stream_tts_to_websocket(
                     _observe_task_result(consumer_task, "consumer")
                 else:
                     await _cancel_task(consumer_task, "consumer")
+            elif consumer_task in done:
+                _observe_task_result(consumer_task, "consumer")
         elif consumer_task in done:
             _observe_task_result(consumer_task, "consumer")
             if producer_task in pending:

--- a/tldw_Server_API/app/core/Audio/streaming_service.py
+++ b/tldw_Server_API/app/core/Audio/streaming_service.py
@@ -89,6 +89,11 @@ def _get_tts_ws_queue_maxsize() -> int:
     return max(2, min(256, parsed))
 
 
+def _allow_query_token_auth() -> bool:
+    """Return True only when legacy WebSocket query-token auth is explicitly enabled."""
+    return is_truthy(os.getenv("AUDIO_WS_ALLOW_QUERY_TOKEN_AUTH", "0"))
+
+
 # Register audio fail-open metrics (idempotent if already registered)
 try:
     _reg = get_metrics_registry()
@@ -147,7 +152,7 @@ async def _stream_tts_to_websocket(
     QueueFull = getattr(aio, "QueueFull", asyncio.QueueFull)
     create_task = getattr(aio, "create_task", asyncio.create_task)
     wait = getattr(aio, "wait", asyncio.wait)
-    FIRST_EXCEPTION = getattr(aio, "FIRST_EXCEPTION", asyncio.FIRST_EXCEPTION)
+    FIRST_COMPLETED = getattr(aio, "FIRST_COMPLETED", asyncio.FIRST_COMPLETED)
     queue: asyncio.Queue[Optional[bytes]] = Queue(maxsize=_get_tts_ws_queue_maxsize())
     provider_label = (provider or getattr(speech_req, "model", None) or "default").lower()
     underrun_labels = {"provider": provider_label}
@@ -239,20 +244,49 @@ async def _stream_tts_to_websocket(
     producer_task = create_task(_producer())
     consumer_task = create_task(_consumer())
 
+    async def _cancel_task(task: Any, task_name: str) -> None:
+        if task.done():
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            logger.debug(f"{route} {task_name} task cancelled")
+        except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as wait_exc:
+            logger.debug(f"{route} wait for {task_name} task failed after cancel: error={wait_exc}")
+
+    def _observe_task_result(task: Any, task_name: str) -> None:
+        if not task.done():
+            return
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            logger.debug(f"{route} {task_name} task cancelled")
+        except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as done_exc:
+            logger.debug(f"{route} {task_name} task returned error: error={done_exc}")
+
     try:
-        _done, pending = await wait(
+        done, pending = await wait(
             {producer_task, consumer_task},
-            return_when=FIRST_EXCEPTION,
+            return_when=FIRST_COMPLETED,
         )
-        for task in pending:
-            task.cancel()
-            try:
-                await task
-            except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as wait_exc:
-                logger.debug(f"{route} wait for pending task failed after cancel: error={wait_exc}")
+        if producer_task in done:
+            _observe_task_result(producer_task, "producer")
+            if consumer_task in pending:
+                try:
+                    await consumer_task
+                except asyncio.CancelledError:
+                    raise
+                except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as wait_exc:
+                    logger.debug(f"{route} wait for consumer task failed: error={wait_exc}")
+                _observe_task_result(consumer_task, "consumer")
+        elif consumer_task in done:
+            _observe_task_result(consumer_task, "consumer")
+            if producer_task in pending:
+                await _cancel_task(producer_task, "producer")
     finally:
-        producer_task.cancel()
-        consumer_task.cancel()
+        await _cancel_task(producer_task, "producer")
+        await _cancel_task(consumer_task, "consumer")
 
 
 async def _audio_ws_authenticate(
@@ -445,9 +479,10 @@ async def _audio_ws_authenticate(
         except Exception as exc:  # noqa: BLE001
             logger.debug(f"Failed to read X-API-KEY header: {exc}")
             x_api_key = None
-        # Query-string token support (multi-user): allow `?token=` as an API key
-        # source when no X-API-KEY header is present.
-        if not x_api_key:
+        # Legacy query-string token support is disabled by default because URLs
+        # are frequently captured in logs and browser history.
+        allow_query_token_auth = _allow_query_token_auth()
+        if not x_api_key and allow_query_token_auth:
             try:
                 query_token = websocket.query_params.get("token") if hasattr(websocket, "query_params") else None
             except Exception as exc:  # noqa: BLE001
@@ -538,8 +573,9 @@ async def _audio_ws_authenticate(
             parts = auth_header.split()
             if len(parts) == 2 and parts[0].lower() == "bearer":
                 bearer = parts[1]
-        if not bearer:
-            # Fallback: support `?token=` as a JWT bearer source in multi-user mode.
+        if not bearer and allow_query_token_auth:
+            # Legacy fallback: support `?token=` as a JWT bearer source only
+            # when explicitly enabled.
             try:
                 query_token = websocket.query_params.get("token") if hasattr(websocket, "query_params") else None
             except Exception as exc:  # noqa: BLE001
@@ -615,11 +651,13 @@ async def _audio_ws_authenticate(
     header_bearer = None
     if auth_header and auth_header.lower().startswith("bearer "):
         header_bearer = auth_header.split(" ", 1)[1].strip()
-    try:
-        query_token = websocket.query_params.get("token") if hasattr(websocket, "query_params") else None
-    except Exception as exc:  # noqa: BLE001
-        logger.debug(f"Failed to read query token: {exc}")
-        query_token = None
+    query_token = None
+    if _allow_query_token_auth():
+        try:
+            query_token = websocket.query_params.get("token") if hasattr(websocket, "query_params") else None
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(f"Failed to read query token: {exc}")
+            query_token = None
 
     if (
         (header_api_key and header_api_key == expected_key)

--- a/tldw_Server_API/app/core/Audio/streaming_service.py
+++ b/tldw_Server_API/app/core/Audio/streaming_service.py
@@ -157,8 +157,10 @@ async def _stream_tts_to_websocket(
     provider_label = (provider or getattr(speech_req, "model", None) or "default").lower()
     underrun_labels = {"provider": provider_label}
     error_labels = {"component": component_label, "provider": provider_label}
+    sentinel_enqueued = False
 
     async def _producer() -> None:
+        nonlocal sentinel_enqueued
         try:
             generate_kwargs: dict[str, Any] = {
                 "provider": provider,
@@ -194,6 +196,8 @@ async def _stream_tts_to_websocket(
                         logger.debug(f"{route} queue recovery after full failed: error={m_err}")
                         with contextlib.suppress(_AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS):
                             reg.increment("audio_stream_errors_total", 1, labels=error_labels)
+        except asyncio.CancelledError:
+            raise
         except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as exc:
             try:
                 reg.increment("audio_stream_errors_total", 1, labels=error_labels)
@@ -202,11 +206,16 @@ async def _stream_tts_to_websocket(
             if error_handler is not None:
                 try:
                     await error_handler(exc)
+                except asyncio.CancelledError:
+                    raise
                 except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as send_exc:
                     logger.debug(f"{route} error handler failed: error={send_exc}")
         finally:
             try:
                 await queue.put(None)
+                sentinel_enqueued = True
+            except asyncio.CancelledError:
+                raise
             except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as q_err:
                 logger.debug(f"{route} queue sentinel enqueue failed: error={q_err}")
 
@@ -220,6 +229,8 @@ async def _stream_tts_to_websocket(
                     await websocket.send_bytes(item)
                     if outer_stream:
                         outer_stream.mark_activity()
+                except asyncio.CancelledError:
+                    raise
                 except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as exc:
                     try:
                         reg.increment("audio_stream_errors_total", 1, labels=error_labels)
@@ -227,14 +238,20 @@ async def _stream_tts_to_websocket(
                         logger.debug(f"{route} consumer metrics update failed: error={m_err}")
                     try:
                         await websocket.close(code=1011)
+                    except asyncio.CancelledError:
+                        raise
                     except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as close_exc:
                         logger.debug(f"{route} websocket close in consumer failed: error={close_exc}")
                     if error_handler is not None:
                         try:
                             await error_handler(exc)
+                        except asyncio.CancelledError:
+                            raise
                         except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as send_exc:
                             logger.debug(f"{route} consumer error handler failed: error={send_exc}")
                     break
+        except asyncio.CancelledError:
+            raise
         except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS:
             try:
                 reg.increment("audio_stream_errors_total", 1, labels=error_labels)
@@ -245,25 +262,36 @@ async def _stream_tts_to_websocket(
     consumer_task = create_task(_consumer())
 
     async def _cancel_task(task: Any, task_name: str) -> None:
+        """Cancel one child task while preserving cancellation of this stream."""
         if task.done():
             return
         task.cancel()
         try:
             await task
         except asyncio.CancelledError:
+            current = asyncio.current_task()
+            if current is not None and current.cancelling():
+                raise
             logger.debug(f"{route} {task_name} task cancelled")
         except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as wait_exc:
             logger.debug(f"{route} wait for {task_name} task failed after cancel: error={wait_exc}")
 
-    def _observe_task_result(task: Any, task_name: str) -> None:
+    def _observe_task_result(task: Any, task_name: str) -> bool:
+        """Return whether a completed task exited without a handled stream error."""
         if not task.done():
-            return
+            return False
         try:
             task.result()
         except asyncio.CancelledError:
+            current = asyncio.current_task()
+            if current is not None and current.cancelling():
+                raise
             logger.debug(f"{route} {task_name} task cancelled")
+            return False
         except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as done_exc:
             logger.debug(f"{route} {task_name} task returned error: error={done_exc}")
+            return False
+        return True
 
     try:
         done, pending = await wait(
@@ -271,22 +299,34 @@ async def _stream_tts_to_websocket(
             return_when=FIRST_COMPLETED,
         )
         if producer_task in done:
-            _observe_task_result(producer_task, "producer")
+            producer_ok = _observe_task_result(producer_task, "producer")
             if consumer_task in pending:
-                try:
-                    await consumer_task
-                except asyncio.CancelledError:
-                    raise
-                except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as wait_exc:
-                    logger.debug(f"{route} wait for consumer task failed: error={wait_exc}")
-                _observe_task_result(consumer_task, "consumer")
+                if producer_ok and sentinel_enqueued:
+                    try:
+                        await consumer_task
+                    except asyncio.CancelledError:
+                        raise
+                    except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as wait_exc:
+                        logger.debug(f"{route} wait for consumer task failed: error={wait_exc}")
+                    _observe_task_result(consumer_task, "consumer")
+                else:
+                    await _cancel_task(consumer_task, "consumer")
         elif consumer_task in done:
             _observe_task_result(consumer_task, "consumer")
             if producer_task in pending:
                 await _cancel_task(producer_task, "producer")
     finally:
-        await _cancel_task(producer_task, "producer")
-        await _cancel_task(consumer_task, "consumer")
+        cleanup_cancelled = False
+        for task, task_name in ((producer_task, "producer"), (consumer_task, "consumer")):
+            try:
+                await _cancel_task(task, task_name)
+            except asyncio.CancelledError:
+                cleanup_cancelled = True
+                logger.debug(f"{route} parent cancellation while cleaning up {task_name} task")
+            except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as cleanup_exc:
+                logger.debug(f"{route} cleanup for {task_name} task failed: error={cleanup_exc}")
+        if cleanup_cancelled:
+            raise asyncio.CancelledError
 
 
 async def _audio_ws_authenticate(

--- a/tldw_Server_API/app/core/Audio/tokenizer_service.py
+++ b/tldw_Server_API/app/core/Audio/tokenizer_service.py
@@ -1,6 +1,8 @@
 import base64
+import binascii
 import importlib
 import io
+from inspect import Parameter, signature
 from typing import Any, Optional
 
 import numpy as np
@@ -46,11 +48,17 @@ def _get_qwen3_tokenizer_settings() -> dict[str, Any]:
     }
 
 
-def _decode_base64_payload(raw: str) -> bytes:
+def _decode_base64_payload(raw: str, request_id: Optional[str] = None) -> bytes:
     payload = raw
     if "," in payload:
         payload = payload.split(",", 1)[1]
-    return base64.b64decode(payload, validate=True)
+    try:
+        return base64.b64decode(payload, validate=True)
+    except (binascii.Error, TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=_http_error_detail("Invalid base64 payload", request_id, exc=exc),
+        ) from exc
 
 
 def _enforce_payload_limit(payload_bytes: bytes, max_payload_mb: int, request_id: Optional[str]) -> None:
@@ -97,14 +105,48 @@ def _read_audio_from_bytes(
                     request_id,
                 ),
             ) from None
-        pcm = np.frombuffer(audio_bytes, dtype=np.int16)
+        try:
+            sample_rate = int(sample_rate_hint)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=_http_error_detail("Invalid sample_rate for raw PCM", request_id, exc=exc),
+            ) from exc
+        if sample_rate <= 0:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=_http_error_detail("sample_rate must be a positive integer for raw PCM", request_id),
+            )
+        if len(audio_bytes) % np.dtype(np.int16).itemsize != 0:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=_http_error_detail("Raw PCM payload length must be a multiple of 2 bytes", request_id),
+            )
+        try:
+            pcm = np.frombuffer(audio_bytes, dtype=np.int16)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=_http_error_detail("Invalid raw PCM payload", request_id, exc=exc),
+            ) from exc
         audio_data = pcm.astype(np.float32) / 32768.0
-        sample_rate = int(sample_rate_hint)
 
     if audio_data.ndim > 1:
         audio_data = np.mean(audio_data, axis=1)
-    duration_seconds = float(len(audio_data)) / float(sample_rate or 24000)
-    return audio_data, int(sample_rate), duration_seconds
+    try:
+        sample_rate_int = int(sample_rate)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=_http_error_detail("Decoded audio sample rate is invalid", request_id, exc=exc),
+        ) from exc
+    if sample_rate_int <= 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=_http_error_detail("Decoded audio sample rate must be positive", request_id),
+        )
+    duration_seconds = float(len(audio_data)) / float(sample_rate_int)
+    return audio_data, sample_rate_int, duration_seconds
 
 
 def _resolve_tokenizer_sample_rate(tokenizer: Any, fallback: int) -> int:
@@ -129,12 +171,29 @@ def _resolve_tokenizer_frame_rate(tokenizer: Any) -> Optional[float]:
     return None
 
 
+def _callable_supports_keyword(fn: Any, keyword: str) -> bool:
+    try:
+        params = signature(fn).parameters.values()
+    except (TypeError, ValueError):
+        return False
+    return any(param.kind == Parameter.VAR_KEYWORD or param.name == keyword for param in params)
+
+
+def _local_only_not_supported() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="Tokenizer backend cannot enforce local-only model loading",
+    )
+
+
 def _instantiate_tokenizer(tokenizer_cls: Any, model_id: str, allow_download: bool) -> Any:
     if hasattr(tokenizer_cls, "from_pretrained"):
-        try:
-            return tokenizer_cls.from_pretrained(model_id, local_files_only=not allow_download)
-        except TypeError:
-            return tokenizer_cls.from_pretrained(model_id)
+        from_pretrained = tokenizer_cls.from_pretrained
+        if _callable_supports_keyword(from_pretrained, "local_files_only"):
+            return from_pretrained(model_id, local_files_only=not allow_download)
+        if not allow_download:
+            raise _local_only_not_supported()
+        return from_pretrained(model_id)
     try:
         return tokenizer_cls(model_id)
     except TypeError:
@@ -158,6 +217,10 @@ def _load_qwen3_tokenizer(model_id: str, allow_download: bool) -> Any:
     for fn_name in ("load_tokenizer", "get_tokenizer", "create_tokenizer"):
         fn = getattr(module, fn_name, None)
         if callable(fn):
+            if _callable_supports_keyword(fn, "local_files_only"):
+                return fn(model_id, local_files_only=not allow_download)
+            if not allow_download:
+                raise _local_only_not_supported()
             try:
                 return fn(model_id)
             except Exception:

--- a/tldw_Server_API/app/core/Audio/tokenizer_service.py
+++ b/tldw_Server_API/app/core/Audio/tokenizer_service.py
@@ -172,6 +172,7 @@ def _resolve_tokenizer_frame_rate(tokenizer: Any) -> Optional[float]:
 
 
 def _callable_supports_keyword(fn: Any, keyword: str) -> bool:
+    """Return whether a callable explicitly accepts the named keyword."""
     try:
         params = signature(fn).parameters.values()
     except (TypeError, ValueError):
@@ -180,6 +181,7 @@ def _callable_supports_keyword(fn: Any, keyword: str) -> bool:
 
 
 def _local_only_not_supported() -> HTTPException:
+    """Build the fail-closed response for backends without local-only loading."""
     return HTTPException(
         status_code=status.HTTP_501_NOT_IMPLEMENTED,
         detail="Tokenizer backend cannot enforce local-only model loading",

--- a/tldw_Server_API/app/core/Audio/tts_service.py
+++ b/tldw_Server_API/app/core/Audio/tts_service.py
@@ -234,8 +234,8 @@ async def _resolve_tts_byok(
             raw_id = getattr(current_user, "id", None)
             if raw_id is not None:
                 user_id_int = int(raw_id)
-    except (AttributeError, TypeError, ValueError) as exc:
-        logger.debug(f"Failed to extract user_id from current_user: {exc}")
+    except (AttributeError, TypeError, ValueError):
+        logger.debug("Failed to extract user_id from current_user")
         user_id_int = None
 
     tts_overrides: Optional[dict[str, Any]] = None

--- a/tldw_Server_API/tests/Audio/test_audio_streaming_service_core.py
+++ b/tldw_Server_API/tests/Audio/test_audio_streaming_service_core.py
@@ -225,6 +225,49 @@ async def test_stream_tts_to_websocket_drains_queue_when_producer_finishes():
 
 
 @pytest.mark.asyncio
+async def test_stream_tts_to_websocket_observes_consumer_when_both_tasks_done():
+    class OneChunkTTSService:
+        async def generate_speech(self, *_args, **_kwargs):  # noqa: ARG002
+            yield b"first-chunk"
+
+    class FailingWebSocket:
+        async def send_bytes(self, _data: bytes):
+            raise ZeroDivisionError("consumer task failed")
+
+    class DummyRegistry:
+        def increment(self, *_args, **_kwargs):  # noqa: ARG002
+            return None
+
+    async def wait_for_both(tasks, return_when=None):  # noqa: ARG001
+        await asyncio.gather(*tasks, return_exceptions=True)
+        return set(tasks), set()
+
+    fake_asyncio = SimpleNamespace(
+        Queue=asyncio.Queue,
+        QueueFull=asyncio.QueueFull,
+        create_task=asyncio.create_task,
+        wait=wait_for_both,
+        FIRST_COMPLETED=asyncio.FIRST_COMPLETED,
+    )
+
+    with pytest.raises(ZeroDivisionError, match="consumer task failed"):
+        await asyncio.wait_for(
+            streaming_service._stream_tts_to_websocket(
+                websocket=FailingWebSocket(),
+                speech_req=SimpleNamespace(model="test-model"),
+                tts_service=OneChunkTTSService(),
+                provider="test-provider",
+                outer_stream=None,
+                reg=DummyRegistry(),
+                route="audio.stream.tts",
+                component_label="audio_tts_ws",
+                asyncio_module=fake_asyncio,
+            ),
+            timeout=0.5,
+        )
+
+
+@pytest.mark.asyncio
 async def test_stream_tts_to_websocket_cancels_consumer_when_completion_signal_fails():
     consumer_cancelled = asyncio.Event()
 

--- a/tldw_Server_API/tests/Audio/test_audio_streaming_service_core.py
+++ b/tldw_Server_API/tests/Audio/test_audio_streaming_service_core.py
@@ -140,6 +140,53 @@ async def test_stream_tts_to_websocket_cancels_producer_when_consumer_send_fails
 
 
 @pytest.mark.asyncio
+async def test_stream_tts_to_websocket_propagates_parent_cancellation_during_cleanup():
+    class SlowCancelTTSService:
+        def __init__(self):
+            self.cleanup_started = asyncio.Event()
+
+        async def generate_speech(self, *_args, **_kwargs):  # noqa: ARG002
+            try:
+                yield b"first-chunk"
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                self.cleanup_started.set()
+                await asyncio.sleep(0.2)
+                raise
+
+    class FailingWebSocket:
+        async def send_bytes(self, _data: bytes):
+            raise RuntimeError("client disconnected while reading stream")
+
+        async def close(self, code=1000, reason=None):  # noqa: ARG002
+            return None
+
+    class DummyRegistry:
+        def increment(self, *_args, **_kwargs):  # noqa: ARG002
+            return None
+
+    service = SlowCancelTTSService()
+    stream_task = asyncio.create_task(
+        streaming_service._stream_tts_to_websocket(
+            websocket=FailingWebSocket(),
+            speech_req=SimpleNamespace(model="test-model"),
+            tts_service=service,
+            provider="test-provider",
+            outer_stream=None,
+            reg=DummyRegistry(),
+            route="audio.stream.tts",
+            component_label="audio_tts_ws",
+        )
+    )
+
+    await asyncio.wait_for(service.cleanup_started.wait(), timeout=0.5)
+    stream_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(stream_task, timeout=0.5)
+
+
+@pytest.mark.asyncio
 async def test_stream_tts_to_websocket_drains_queue_when_producer_finishes():
     class FastTTSService:
         async def generate_speech(self, *_args, **_kwargs):  # noqa: ARG002
@@ -175,3 +222,67 @@ async def test_stream_tts_to_websocket_drains_queue_when_producer_finishes():
     )
 
     assert websocket.sent == [b"first-chunk", b"second-chunk"]
+
+
+@pytest.mark.asyncio
+async def test_stream_tts_to_websocket_cancels_consumer_when_completion_signal_fails():
+    consumer_cancelled = asyncio.Event()
+
+    class BrokenSentinelQueue:
+        def __init__(self, maxsize=0):  # noqa: ARG002
+            self.items = []
+
+        def put_nowait(self, item):
+            self.items.append(item)
+
+        async def put(self, item):
+            if item is None:
+                raise RuntimeError("sentinel enqueue failed")
+            self.items.append(item)
+
+        async def get(self):
+            if self.items:
+                return self.items.pop(0)
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                consumer_cancelled.set()
+                raise
+
+    class EmptyTTSService:
+        async def generate_speech(self, *_args, **_kwargs):  # noqa: ARG002
+            if False:
+                yield b"unreachable"
+
+    class PassiveWebSocket:
+        async def send_bytes(self, _data: bytes):
+            return None
+
+    class DummyRegistry:
+        def increment(self, *_args, **_kwargs):  # noqa: ARG002
+            return None
+
+    fake_asyncio = SimpleNamespace(
+        Queue=BrokenSentinelQueue,
+        QueueFull=asyncio.QueueFull,
+        create_task=asyncio.create_task,
+        wait=asyncio.wait,
+        FIRST_COMPLETED=asyncio.FIRST_COMPLETED,
+    )
+
+    await asyncio.wait_for(
+        streaming_service._stream_tts_to_websocket(
+            websocket=PassiveWebSocket(),
+            speech_req=SimpleNamespace(model="test-model"),
+            tts_service=EmptyTTSService(),
+            provider="test-provider",
+            outer_stream=None,
+            reg=DummyRegistry(),
+            route="audio.stream.tts",
+            component_label="audio_tts_ws",
+            asyncio_module=fake_asyncio,
+        ),
+        timeout=0.5,
+    )
+
+    assert consumer_cancelled.is_set()

--- a/tldw_Server_API/tests/Audio/test_audio_streaming_service_core.py
+++ b/tldw_Server_API/tests/Audio/test_audio_streaming_service_core.py
@@ -1,0 +1,177 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_Server_API.app.core.Audio import streaming_service
+
+
+pytestmark = pytest.mark.unit
+
+
+class DummyWebSocket:
+    def __init__(self):
+        self.headers = {}
+        self.query_params = {}
+        self.client = SimpleNamespace(host="127.0.0.1")
+        self.state = SimpleNamespace()
+        self.closed = False
+        self.close_code = None
+        self.sent_json = []
+
+    async def receive_text(self):
+        raise RuntimeError("no auth frame")
+
+    async def send_json(self, payload):
+        self.sent_json.append(payload)
+
+    async def send_bytes(self, _data: bytes):
+        return None
+
+    async def close(self, code=1000, reason=None):  # noqa: ARG002
+        self.closed = True
+        self.close_code = code
+
+
+@pytest.mark.asyncio
+async def test_audio_ws_query_token_auth_rejected_by_default(monkeypatch: pytest.MonkeyPatch):
+    from tldw_Server_API.app.core.AuthNZ import ip_allowlist, settings as auth_settings
+
+    ws = DummyWebSocket()
+    ws.query_params = {"token": "single-user-secret"}
+
+    monkeypatch.delenv("AUDIO_WS_ALLOW_QUERY_TOKEN_AUTH", raising=False)
+    monkeypatch.setattr(streaming_service, "is_multi_user_mode", lambda: False)
+    monkeypatch.setattr(
+        auth_settings,
+        "get_settings",
+        lambda: SimpleNamespace(
+            SINGLE_USER_API_KEY="single-user-secret",
+            SINGLE_USER_ALLOWED_IPS=[],
+            SINGLE_USER_FIXED_ID=1,
+        ),
+    )
+    monkeypatch.setattr(ip_allowlist, "resolve_client_ip", lambda *_args, **_kwargs: "127.0.0.1")
+
+    auth_ok, user_id = await streaming_service._audio_ws_authenticate(
+        ws,
+        None,
+        endpoint_id="audio.stream.tts",
+        ws_path="/api/v1/audio/stream/tts",
+    )
+
+    assert (auth_ok, user_id) == (False, None)
+    assert ws.closed is True
+
+
+@pytest.mark.asyncio
+async def test_audio_ws_query_token_auth_can_be_enabled_explicitly(monkeypatch: pytest.MonkeyPatch):
+    from tldw_Server_API.app.core.AuthNZ import ip_allowlist, settings as auth_settings
+
+    ws = DummyWebSocket()
+    ws.query_params = {"token": "single-user-secret"}
+
+    monkeypatch.setenv("AUDIO_WS_ALLOW_QUERY_TOKEN_AUTH", "1")
+    monkeypatch.setattr(streaming_service, "is_multi_user_mode", lambda: False)
+    monkeypatch.setattr(
+        auth_settings,
+        "get_settings",
+        lambda: SimpleNamespace(
+            SINGLE_USER_API_KEY="single-user-secret",
+            SINGLE_USER_ALLOWED_IPS=[],
+            SINGLE_USER_FIXED_ID=1,
+        ),
+    )
+    monkeypatch.setattr(ip_allowlist, "resolve_client_ip", lambda *_args, **_kwargs: "127.0.0.1")
+
+    auth_ok, user_id = await streaming_service._audio_ws_authenticate(
+        ws,
+        None,
+        endpoint_id="audio.stream.tts",
+        ws_path="/api/v1/audio/stream/tts",
+    )
+
+    assert (auth_ok, user_id) == (True, 1)
+    assert ws.closed is False
+
+
+@pytest.mark.asyncio
+async def test_stream_tts_to_websocket_cancels_producer_when_consumer_send_fails():
+    class HangingTTSService:
+        def __init__(self):
+            self.cancelled = asyncio.Event()
+
+        async def generate_speech(self, *_args, **_kwargs):  # noqa: ARG002
+            try:
+                yield b"first-chunk"
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                self.cancelled.set()
+                raise
+
+    class FailingWebSocket:
+        async def send_bytes(self, _data: bytes):
+            raise RuntimeError("client disconnected while reading stream")
+
+        async def close(self, code=1000, reason=None):  # noqa: ARG002
+            return None
+
+    class DummyRegistry:
+        def increment(self, *_args, **_kwargs):  # noqa: ARG002
+            return None
+
+    service = HangingTTSService()
+
+    await asyncio.wait_for(
+        streaming_service._stream_tts_to_websocket(
+            websocket=FailingWebSocket(),
+            speech_req=SimpleNamespace(model="test-model"),
+            tts_service=service,
+            provider="test-provider",
+            outer_stream=None,
+            reg=DummyRegistry(),
+            route="audio.stream.tts",
+            component_label="audio_tts_ws",
+        ),
+        timeout=0.25,
+    )
+
+    assert service.cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_stream_tts_to_websocket_drains_queue_when_producer_finishes():
+    class FastTTSService:
+        async def generate_speech(self, *_args, **_kwargs):  # noqa: ARG002
+            yield b"first-chunk"
+            yield b"second-chunk"
+
+    class SlowWebSocket:
+        def __init__(self):
+            self.sent = []
+
+        async def send_bytes(self, data: bytes):
+            await asyncio.sleep(0.01)
+            self.sent.append(data)
+
+    class DummyRegistry:
+        def increment(self, *_args, **_kwargs):  # noqa: ARG002
+            return None
+
+    websocket = SlowWebSocket()
+
+    await asyncio.wait_for(
+        streaming_service._stream_tts_to_websocket(
+            websocket=websocket,
+            speech_req=SimpleNamespace(model="test-model"),
+            tts_service=FastTTSService(),
+            provider="test-provider",
+            outer_stream=None,
+            reg=DummyRegistry(),
+            route="audio.stream.tts",
+            component_label="audio_tts_ws",
+        ),
+        timeout=0.5,
+    )
+
+    assert websocket.sent == [b"first-chunk", b"second-chunk"]

--- a/tldw_Server_API/tests/Audio/test_failopen_cap_minutes.py
+++ b/tldw_Server_API/tests/Audio/test_failopen_cap_minutes.py
@@ -100,6 +100,13 @@ def test_failopen_default_when_no_env_or_config(monkeypatch):
     assert abs(mod._get_failopen_cap_minutes() - 5.0) < 1e-6
 
 
+def test_expected_quota_exceptions_do_not_catch_programmer_errors():
+    from tldw_Server_API.app.core.Audio import quota_helpers
+
+    assert NameError not in quota_helpers.EXPECTED_DB_EXC
+    assert NameError not in quota_helpers.EXPECTED_REDIS_EXC
+
+
 def test_failopen_env_overrides(monkeypatch):
 
 
@@ -287,6 +294,41 @@ async def test_aggregate_resolve_tts_byok_user_id_failure_log_is_sanitized(monke
 
     assert result == (None, None, None)
     _assert_sanitized_debug_log(logger_stub, "Failed to extract user_id from current_user")
+
+
+@pytest.mark.asyncio
+async def test_aggregate_resolve_tts_byok_delegates_to_core(monkeypatch):
+    from tldw_Server_API.app.core.Audio import tts_service
+
+    mod = _import_audio_aggregate_module(monkeypatch, cfg=_fake_cfg({}))
+    calls = []
+
+    async def _core_resolver(**kwargs):
+        calls.append(kwargs)
+        return 42, {"api_key": "resolved"}, types.SimpleNamespace(uses_byok=True)
+
+    monkeypatch.setattr(tts_service, "_resolve_tts_byok", _core_resolver)
+
+    request = object()
+    user = types.SimpleNamespace(id=7)
+
+    result = await mod._resolve_tts_byok(
+        provider_hint=None,
+        current_user=user,
+        request=request,
+        force_oauth_refresh=True,
+    )
+
+    assert result[0] == 42
+    assert result[1] == {"api_key": "resolved"}
+    assert calls == [
+        {
+            "provider_hint": None,
+            "current_user": user,
+            "request": request,
+            "force_oauth_refresh": True,
+        }
+    ]
 
 
 def test_aggregate_quota_helper_import_logs_are_sanitized(monkeypatch):

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tokenizer_service_qwen3.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tokenizer_service_qwen3.py
@@ -82,6 +82,88 @@ def test_load_qwen3_tokenizer_uses_from_pretrained_when_available(monkeypatch):
     assert tokenizer.local_files_only is False
 
 
+def test_load_qwen3_tokenizer_fails_closed_when_local_only_not_supported(monkeypatch):
+    module = types.ModuleType("qwen_tts")
+
+    class DownloadOnlyTokenizer:
+        @classmethod
+        def from_pretrained(cls, model_id):
+            instance = cls()
+            instance.model = model_id
+            return instance
+
+    module.Qwen3TTSTokenizer = DownloadOnlyTokenizer
+    monkeypatch.setitem(sys.modules, "qwen_tts", module)
+
+    with pytest.raises(HTTPException) as exc_info:
+        tokenizer_service._load_qwen3_tokenizer("Qwen/Qwen3-TTS-Tokenizer-12Hz", allow_download=False)
+
+    assert exc_info.value.status_code == 501
+    assert "local-only" in str(exc_info.value.detail)
+
+    tokenizer = tokenizer_service._load_qwen3_tokenizer("Qwen/Qwen3-TTS-Tokenizer-12Hz", allow_download=True)
+    assert tokenizer.model == "Qwen/Qwen3-TTS-Tokenizer-12Hz"
+
+
+def test_load_qwen3_tokenizer_loader_function_fails_closed_without_download_permission(monkeypatch):
+    module = types.ModuleType("qwen_tts")
+
+    def load_tokenizer(model_id):
+        return {"model": model_id}
+
+    module.load_tokenizer = load_tokenizer
+    monkeypatch.setitem(sys.modules, "qwen_tts", module)
+
+    with pytest.raises(HTTPException) as exc_info:
+        tokenizer_service._load_qwen3_tokenizer("Qwen/Qwen3-TTS-Tokenizer-12Hz", allow_download=False)
+
+    assert exc_info.value.status_code == 501
+    assert "local-only" in str(exc_info.value.detail)
+
+    tokenizer = tokenizer_service._load_qwen3_tokenizer("Qwen/Qwen3-TTS-Tokenizer-12Hz", allow_download=True)
+    assert tokenizer == {"model": "Qwen/Qwen3-TTS-Tokenizer-12Hz"}
+
+
+def test_load_qwen3_tokenizer_loader_function_honors_local_files_only(monkeypatch):
+    module = types.ModuleType("qwen_tts")
+
+    def load_tokenizer(model_id, local_files_only=False):
+        return {"model": model_id, "local_files_only": local_files_only}
+
+    module.load_tokenizer = load_tokenizer
+    monkeypatch.setitem(sys.modules, "qwen_tts", module)
+
+    tokenizer = tokenizer_service._load_qwen3_tokenizer("Qwen/Qwen3-TTS-Tokenizer-12Hz", allow_download=False)
+    assert tokenizer == {"model": "Qwen/Qwen3-TTS-Tokenizer-12Hz", "local_files_only": True}
+
+    tokenizer = tokenizer_service._load_qwen3_tokenizer("Qwen/Qwen3-TTS-Tokenizer-12Hz", allow_download=True)
+    assert tokenizer == {"model": "Qwen/Qwen3-TTS-Tokenizer-12Hz", "local_files_only": False}
+
+
+def test_decode_base64_payload_rejects_invalid_input():
+    with pytest.raises(HTTPException) as exc_info:
+        tokenizer_service._decode_base64_payload("not valid base64", request_id="req-tokenizer")
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail["request_id"] == "req-tokenizer"
+
+
+def test_read_audio_from_raw_pcm_rejects_invalid_sample_rate():
+    with pytest.raises(HTTPException) as exc_info:
+        tokenizer_service._read_audio_from_bytes(b"\x00\x00", sample_rate_hint=0, request_id="req-tokenizer")
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail["request_id"] == "req-tokenizer"
+
+
+def test_read_audio_from_raw_pcm_rejects_odd_byte_length():
+    with pytest.raises(HTTPException) as exc_info:
+        tokenizer_service._read_audio_from_bytes(b"\x00", sample_rate_hint=24000, request_id="req-tokenizer")
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail["request_id"] == "req-tokenizer"
+
+
 def test_load_qwen3_tokenizer_sanitizes_missing_package_detail(monkeypatch):
     def _raise_missing_package(name):
         assert name == "qwen_tts"


### PR DESCRIPTION
## Summary
- Disable legacy WebSocket query-token auth by default behind `AUDIO_WS_ALLOW_QUERY_TOKEN_AUTH` and update endpoint auth docs.
- Harden audio quota fail-open exceptions, TTS WebSocket producer/consumer cancellation, tokenizer local-only loading, tokenizer malformed payload handling, and BYOK helper ownership.
- Add focused regression tests plus Backlog/plan tracking for the validated audio-core review findings.

## Verification
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m py_compile ...` for touched source/tests
- `python -m pytest -q --confcutdir=tldw_Server_API/tests/Audio ...` (`6 passed`)
- `python -m pytest -q --confcutdir=tldw_Server_API/tests/TTS_NEW/unit ...` (`6 passed`)
- `python -m bandit -r tldw_Server_API/app/core/Audio tldw_Server_API/app/api/v1/endpoints/audio/audio.py tldw_Server_API/app/api/v1/endpoints/audio/audio_tokenizer.py tldw_Server_API/app/api/v1/endpoints/audio/audio_streaming.py -f json -o /tmp/bandit_audio_core_2407_worktree_rebased.json` (`0` findings)
- `git diff --check`

## Change summary
Human-authored Change summary required before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks down audio core security and stability: disables legacy WebSocket query-token auth by default, hardens TTS stream lifecycle, and tightens tokenizer and quota error handling. Delegates BYOK resolution to core and adds focused regression tests.

- **Bug Fixes**
  - WebSocket auth: `?token=` gated behind `AUDIO_WS_ALLOW_QUERY_TOKEN_AUTH`; prefer headers or an initial auth frame.
  - Quota: removed `NameError` from expected DB/Redis exceptions to prevent fail-open on programmer errors.
  - TTS streaming: cancels producer on consumer send failure, observes consumer completion, drains the queue when the completion sentinel is enqueued, cancels the consumer if sentinel enqueue fails, and propagates parent cancellation during cleanup.
  - Tokenizer: strict base64 decoding with request IDs and clear 400s; raw PCM byte-length and positive sample-rate checks; local-only loading fails closed (501) when backends can’t enforce `local_files_only`.
  - BYOK: endpoint wrapper now delegates to `core.Audio.tts_service._resolve_tts_byok`; debug logs sanitized.

- **Migration**
  - If clients use `?token=` for WebSocket auth, set `AUDIO_WS_ALLOW_QUERY_TOKEN_AUTH=1` or switch to `X-API-KEY`/`Authorization` header or an initial auth frame.
  - For tokenizer local-only usage, use backends that support `local_files_only` or allow downloads; otherwise requests may return 501.

<sup>Written for commit ceb6d818aa6d31e869129afad05bcdaf6d5c466c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

