### PR TITLE
Fix Character_Chat review findings

### DIFF
--- a/backlog/tasks/task-2404 - Verify-and-fix-Character_Chat-review-findings.md
+++ b/backlog/tasks/task-2404 - Verify-and-fix-Character_Chat-review-findings.md
@@ -1,0 +1,53 @@
+---
+id: TASK-2404
+title: Verify and fix Character_Chat review findings
+status: Done
+assignee: []
+created_date: 2026-06-23 18:10
+updated_date: 2026-06-24 01:47
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify the static review findings for tldw_Server_API/app/core/Character_Chat and address the validated issues with focused tests and security verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Each review finding is verified against current code and documented in task notes; validated Character_Chat issues are fixed with focused regression tests; touched scope tests pass; Bandit runs on touched Character_Chat paths
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red-test verification: targeted pytest collected 8 tests; 7 failed for intended old behavior and 1 parser case passed because embedded-array fallback already handled that input. Failures covered memory prompt contract, world-book timeout compile/match path, V3 validation, core message cap, bulk regex validation, and workflow adapter signature drift. The run hung during cleanup and was interrupted after failure details were captured.
+
+Implementation completed. Fixed memory extraction JSON-object contract, world-book regex runtime timeout usage, V3 card validation bounds, core post_message message-cap enforcement, bulk dictionary explicit-regex validation, workflow character_chat message adapter signature drift, and stale facade module line counts. Verification: red tests observed first; post-fix pytest 6 targeted Character_Chat tests passed; workflow adapter regression passed; direct ChatDictionaryService bulk regex check raised re.error; py_compile passed for touched prod/test files; git diff --check passed for touched paths. Bandit ran on touched production files and reported three pre-existing LOW findings in unchanged chat_dictionary.py lines 348, 3148, and 3173; no new Bandit finding is in the changed hunks. Limitation: tldw_Server_API/tests/Character_Chat/test_chat_dictionary_legacy.py::TestChatDictionaryService::test_bulk_add_entries_rejects_invalid_explicit_regex timed out during global app fixture setup before the test body, so direct service verification was used for that case.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Verified and addressed the validated Character_Chat review findings with focused regression coverage and security verification notes. Known verification limitation: the legacy chat dictionary pytest path times out in this local app setup before running the test body; direct service verification passed for the same behavior.
+Rebased PR #2449 follow-up onto latest origin/dev and addressed all validated review comments with focused regression coverage. Remaining Bandit output is limited to previously documented low-severity unchanged-line findings in chat_dictionary.py.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Reopened for PR #2449 follow-up: rebase onto latest origin/dev and address Gemini/Qodo review comments around message-limit semantics, memory parsing fallback, adapter DB offloading/error context, regex timeout exception handling, max_tokens coercion, and message-limit race mitigation.
+PR #2449 follow-up completed after rebasing onto latest origin/dev. Addressed validated Gemini/Qodo comments: user-message-only core limit enforcement, in-process per-conversation serialization for user message count+insert, explicit memory parser fallback for embedded JSON objects, adapter preflight limit check before LLM calls, sync DB offloading via asyncio.to_thread, contextual write errors, defensive regex timeout exception handling, and max_tokens coercion. Verification: py_compile passed for touched files; focused pytest passed 14 tests; direct ChatDictionaryService invalid explicit regex check passed; git diff --check passed; Bandit on touched production paths reported only the known LOW unchanged-line chat_dictionary.py findings at lines 348, 3148, and 3173.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/core/Character_Chat/Character_Chat_Lib_facade.py
+++ b/tldw_Server_API/app/core/Character_Chat/Character_Chat_Lib_facade.py
@@ -113,7 +113,7 @@ from .modules.character_templates import (
 MODULE_STRUCTURE = {
     "character_utils.py": {
         "description": "Utility functions for text processing and UI helpers",
-        "lines": "~150",
+        "lines": "~220",
         "functions": [
             "replace_placeholders",
             "replace_user_placeholder",
@@ -123,7 +123,7 @@ MODULE_STRUCTURE = {
     },
     "character_io.py": {
         "description": "Import/export operations for character cards",
-        "lines": "~600",
+        "lines": "~1439",
         "functions": [
             "extract_json_from_image_file",
             "import_character_card_from_json_string",
@@ -134,7 +134,7 @@ MODULE_STRUCTURE = {
     },
     "character_validation.py": {
         "description": "Validation and parsing for different card formats",
-        "lines": "~500",
+        "lines": "~727",
         "functions": [
             "parse_v1_card",
             "parse_v2_card",
@@ -149,7 +149,7 @@ MODULE_STRUCTURE = {
     },
     "character_db.py": {
         "description": "Database CRUD operations for characters",
-        "lines": "~700",
+        "lines": "~448",
         "functions": [
             "_prepare_character_data_for_db_storage",
             "create_new_character_from_data",
@@ -163,7 +163,7 @@ MODULE_STRUCTURE = {
     },
     "character_chat.py": {
         "description": "Chat session and message management",
-        "lines": "~700",
+        "lines": "~1555",
         "functions": [
             "process_db_messages_to_ui_history",
             "process_db_messages_to_rich_ui_history",
@@ -185,7 +185,7 @@ MODULE_STRUCTURE = {
     },
     "character_templates.py": {
         "description": "Character template management",
-        "lines": "~200",
+        "lines": "~130",
         "functions": [
             "get_character_template",
             "list_character_templates",

--- a/tldw_Server_API/app/core/Character_Chat/ccv3_parser.py
+++ b/tldw_Server_API/app/core/Character_Chat/ccv3_parser.py
@@ -13,6 +13,14 @@ from typing import Any, Optional
 
 from loguru import logger
 
+from tldw_Server_API.app.core.Character_Chat.modules.character_validation import (
+    MAX_V2_ALTERNATE_GREETINGS,
+    MAX_V2_TAG_LENGTH,
+    MAX_V2_TAGS,
+    MAX_V2_TEXT_FIELD_LENGTHS,
+    validate_character_book,
+)
+
 
 def validate_v3_card(card_data: dict[str, Any]) -> tuple[bool, list[str]]:
     errors: list[str] = []
@@ -22,10 +30,76 @@ def validate_v3_card(card_data: dict[str, Any]) -> tuple[bool, list[str]]:
         if not isinstance(data, dict):
             errors.append("'data' node must be a dictionary for v3")
             return False, errors
-        # Required core fields for successful mapping
-        for f in ["name", "description", "first_mes"]:
-            if f not in data or data[f] is None:
-                errors.append(f"Missing required field '{f}' in v3 data")
+        required_fields = {
+            "name": str,
+            "description": str,
+            "first_mes": str,
+        }
+        for field, expected_type in required_fields.items():
+            if field not in data or data[field] is None:
+                errors.append(f"Missing required field '{field}' in v3 data")
+            elif not isinstance(data[field], expected_type):
+                errors.append(f"Field '{field}' must be of type '{expected_type.__name__}'.")
+
+        if isinstance(data.get("name"), str) and not data["name"].strip():
+            errors.append("Field 'name' cannot be blank.")
+
+        optional_fields = {
+            "personality": str,
+            "scenario": str,
+            "mes_example": str,
+            "creator_notes": str,
+            "system_prompt": str,
+            "post_history_instructions": str,
+            "alternate_greetings": list,
+            "tags": list,
+            "creator": str,
+            "character_version": str,
+            "extensions": dict,
+        }
+        for field, expected_type in optional_fields.items():
+            if field in data and not isinstance(data[field], expected_type):
+                errors.append(f"Field '{field}' must be of type '{expected_type.__name__}'.")
+
+        for field_name, max_len in MAX_V2_TEXT_FIELD_LENGTHS.items():
+            field_value = data.get(field_name)
+            if isinstance(field_value, str) and len(field_value) > max_len:
+                errors.append(f"Field '{field_name}' exceeds max length of {max_len} characters.")
+
+        alternate_greetings = data.get("alternate_greetings")
+        if isinstance(alternate_greetings, list):
+            if len(alternate_greetings) > MAX_V2_ALTERNATE_GREETINGS:
+                errors.append(
+                    f"Field 'alternate_greetings' exceeds max entries of {MAX_V2_ALTERNATE_GREETINGS}."
+                )
+            for idx, greeting in enumerate(alternate_greetings):
+                if not isinstance(greeting, str):
+                    errors.append(f"Field 'alternate_greetings[{idx}]' must be of type 'str'.")
+                    continue
+                if len(greeting) > MAX_V2_TEXT_FIELD_LENGTHS["first_mes"]:
+                    errors.append(
+                        f"Field 'alternate_greetings[{idx}]' exceeds max length of "
+                        f"{MAX_V2_TEXT_FIELD_LENGTHS['first_mes']} characters."
+                    )
+
+        tags = data.get("tags")
+        if isinstance(tags, list):
+            if len(tags) > MAX_V2_TAGS:
+                errors.append(f"Field 'tags' exceeds max entries of {MAX_V2_TAGS}.")
+            for idx, tag in enumerate(tags):
+                if not isinstance(tag, str):
+                    errors.append(f"Field 'tags[{idx}]' must be of type 'str'.")
+                    continue
+                if len(tag) > MAX_V2_TAG_LENGTH:
+                    errors.append(f"Field 'tags[{idx}]' exceeds max length of {MAX_V2_TAG_LENGTH} characters.")
+
+        if "character_book" in data:
+            if not isinstance(data["character_book"], dict):
+                errors.append("Field 'character_book' must be a dictionary.")
+            else:
+                is_valid_book, book_errors = validate_character_book(data["character_book"])
+                if not is_valid_book:
+                    errors.extend(book_errors)
         return (len(errors) == 0), errors
     except Exception as e:
         logger.error(f"Unexpected error validating v3 card: {e}")
@@ -34,6 +108,11 @@ def validate_v3_card(card_data: dict[str, Any]) -> tuple[bool, list[str]]:
 
 def parse_v3_card(card_data: dict[str, Any]) -> Optional[dict[str, Any]]:
     try:
+        is_valid, errors = validate_v3_card(card_data)
+        if not is_valid:
+            logger.warning("Invalid v3 character card: {}", "; ".join(errors))
+            return None
+
         data = card_data.get("data", card_data)
         if not isinstance(data, dict):
             return None

--- a/tldw_Server_API/app/core/Character_Chat/chat_dictionary.py
+++ b/tldw_Server_API/app/core/Character_Chat/chat_dictionary.py
@@ -3592,6 +3592,9 @@ class ChatDictionaryService:
                     # Validate pattern
                     test_entry = ChatDictionaryEntry(pattern, replacement)
                     is_regex = True if entry_type == "regex" else bool(test_entry.is_regex)
+                    if is_regex and not _is_compiled_regex(test_entry.key):
+                        test_entry.is_regex = True
+                        test_entry._compile_regex_pattern(test_entry.key_pattern_str)
                     timed_effects_json = json.dumps(timed_effects)
                     conn.execute(
                         """
@@ -3643,6 +3646,8 @@ class ChatDictionaryService:
 
             return _BulkAddResult(added_count)
 
+        except re.error:
+            raise
         except _CHAT_DICTIONARY_NONCRITICAL_EXCEPTIONS as e:
             logger.error(f"Error adding bulk entries: {e}")
             raise CharactersRAGDBError(f"Error adding bulk entries: {e}") from e

--- a/tldw_Server_API/app/core/Character_Chat/modules/character_chat.py
+++ b/tldw_Server_API/app/core/Character_Chat/modules/character_chat.py
@@ -9,9 +9,11 @@ facade.
 import base64
 import random
 import re
+import threading
 import time
 from collections import Counter
 from collections.abc import Iterable
+from contextlib import nullcontext
 from datetime import datetime, timezone
 from typing import Any, Optional, Union
 
@@ -19,6 +21,7 @@ from loguru import logger
 from PIL import Image
 
 from tldw_Server_API.app.core.Character_Chat.constants import MAX_PERSIST_CONTENT_LENGTH
+from tldw_Server_API.app.core.Character_Chat.character_limits import check_message_limit
 from tldw_Server_API.app.core.config import settings
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     CharactersRAGDB,
@@ -40,6 +43,16 @@ _CHAR_CHAT_NONCRITICAL_EXCEPTIONS = (
     ConflictError,
     InputError,
 )
+
+_MESSAGE_LIMIT_LOCKS: dict[str, threading.Lock] = {}
+_MESSAGE_LIMIT_LOCKS_GUARD = threading.Lock()
+
+
+def _get_message_limit_lock(conversation_id: str) -> threading.Lock:
+    """Serialize per-conversation message-limit preflight and insert in this process."""
+    with _MESSAGE_LIMIT_LOCKS_GUARD:
+        return _MESSAGE_LIMIT_LOCKS.setdefault(str(conversation_id), threading.Lock())
+
 
 from .character_db import load_character_and_image
 from .character_utils import (
@@ -1209,8 +1222,34 @@ def post_message_to_conversation(
         "image_mime_type": image_mime_type,
     }
 
+    limit_context = _get_message_limit_lock(conversation_id) if is_user_message else nullcontext()
     try:
-        message_id = db.add_message(msg_payload)
+        with limit_context:
+            if is_user_message:
+                try:
+                    current_message_count = db.count_messages_for_conversation(conversation_id)
+                except _CHAR_CHAT_NONCRITICAL_EXCEPTIONS as exc:
+                    logger.error(
+                        "Failed to count messages for conversation {} before posting: {}",
+                        conversation_id,
+                        exc,
+                    )
+                    raise CharactersRAGDBError(
+                        f"Failed to count messages for conversation {conversation_id}"
+                    ) from exc
+                check_message_limit(conversation_id, current_message_count + 1)
+
+            message_id = db.add_message(msg_payload)
+    except (CharactersRAGDBError, InputError, ConflictError) as exc:
+        logger.error(
+            "Error posting message from '{}' to conversation {}: {}",
+            sender_name,
+            conversation_id,
+            exc,
+        )
+        raise
+
+    try:
         if message_id:
             logger.info(
                 "Posted message ID {} from '{}' to conversation {}.",

--- a/tldw_Server_API/app/core/Character_Chat/modules/character_memory_extraction.py
+++ b/tldw_Server_API/app/core/Character_Chat/modules/character_memory_extraction.py
@@ -31,9 +31,9 @@ _EXTRACTION_SYSTEM_PROMPT = (
     "- content: concise statement (1-2 sentences max)\n"
     "- salience: float 0.0-1.0 indicating importance (0.8+ = very important)\n\n"
     "Already known memories (do not duplicate):\n{existing_memories}\n\n"
-    "Respond ONLY with a JSON array:\n"
-    "[{{\"category\": \"...\", \"content\": \"...\", \"salience\": 0.8}}]\n"
-    "If nothing new, respond: []"
+    "Respond ONLY with a JSON object:\n"
+    "{{\"memories\": [{{\"category\": \"...\", \"content\": \"...\", \"salience\": 0.8}}]}}\n"
+    "If nothing new, respond: {{\"memories\": []}}"
 )
 
 
@@ -104,26 +104,36 @@ def parse_extraction_response(raw_text: str) -> list[dict[str, Any]]:
     if fence_match:
         text = fence_match.group(1).strip()
 
+    def _coerce_memory_payload(parsed: Any) -> tuple[bool, list[dict[str, Any]]]:
+        if isinstance(parsed, list):
+            return True, _validate_memory_list(parsed)
+        if isinstance(parsed, dict):
+            memories = parsed.get("memories")
+            if isinstance(memories, list):
+                return True, _validate_memory_list(memories)
+        return False, []
+
     # Try direct parse
     try:
         parsed = json.loads(text)
-        if isinstance(parsed, list):
-            return _validate_memory_list(parsed)
+        is_memory_payload, memories = _coerce_memory_payload(parsed)
+        if is_memory_payload:
+            return memories
     except json.JSONDecodeError:
         pass
 
-    # Try to find a JSON array in the text
-    bracket_start = text.find("[")
-    bracket_end = text.rfind("]")
-    if bracket_start != -1 and bracket_end > bracket_start:
+    # Try to recover a JSON object/array embedded in surrounding LLM text.
+    decoder = json.JSONDecoder()
+    for match in re.finditer(r"[\[{]", text):
         try:
-            parsed = json.loads(text[bracket_start : bracket_end + 1])
-            if isinstance(parsed, list):
-                return _validate_memory_list(parsed)
+            parsed, _ = decoder.raw_decode(text[match.start():])
         except json.JSONDecodeError:
-            pass
+            continue
+        is_memory_payload, memories = _coerce_memory_payload(parsed)
+        if is_memory_payload:
+            return memories
 
-    logger.warning("Failed to parse extraction response as JSON array")
+    logger.warning("Failed to parse extraction response as JSON memory payload")
     return []
 
 

--- a/tldw_Server_API/app/core/Character_Chat/world_book_manager.py
+++ b/tldw_Server_API/app/core/Character_Chat/world_book_manager.py
@@ -31,6 +31,7 @@ import sqlite3
 from datetime import datetime
 from typing import Any, Optional, Union
 
+import regex as _regex
 from loguru import logger
 
 try:
@@ -43,6 +44,7 @@ except ImportError:
 from tldw_Server_API.app.core.Character_Chat.constants import (
     MAX_BOOK_CACHE_SIZE,
     MAX_ENTRY_CACHE_SIZE,
+    MAX_REGEX_MATCH_TIME_MS,
     MAX_RECURSIVE_DEPTH,
     safe_parse_json_dict,
     safe_parse_json_list,
@@ -50,6 +52,7 @@ from tldw_Server_API.app.core.Character_Chat.constants import (
 
 # Import shared regex safety utilities
 from tldw_Server_API.app.core.Character_Chat.regex_safety import (
+    safe_compile_regex as _safe_compile_regex,
     validate_regex_safety as _validate_regex_safety,
 )
 from tldw_Server_API.app.core.DB_Management.backends.base import BackendType
@@ -69,6 +72,7 @@ _WORLD_BOOK_ENTRY_UPDATE_FIELDS = frozenset({
     "keywords", "content", "priority", "enabled", "case_sensitive",
     "regex_match", "whole_word_match", "metadata", "last_modified"
 })
+_REGEX_TIMEOUT_ERROR = getattr(_regex, "TimeoutError", TimeoutError)
 
 _WORLD_BOOK_NONCRITICAL_EXCEPTIONS = (
     AssertionError,
@@ -260,14 +264,14 @@ class WorldBookEntry:
         # Compile patterns for efficient matching
         self._patterns = self._compile_patterns()
 
-    def _compile_patterns(self) -> list[tuple[re.Pattern, str]]:
+    def _compile_patterns(self) -> list[tuple[Any, str]]:
         """
         Compile keyword patterns for matching.
 
         For regex patterns, validates against potential ReDoS vulnerabilities
         before compilation. Dangerous patterns are rejected with a warning.
         """
-        patterns: list[tuple[re.Pattern, str]] = []
+        patterns: list[tuple[Any, str]] = []
 
         for keyword in self.keywords:
             if self.regex_match:
@@ -284,7 +288,7 @@ class WorldBookEntry:
                 # Use keyword as regex directly
                 try:
                     flags = 0 if self.case_sensitive else re.IGNORECASE
-                    pattern = re.compile(keyword, flags)
+                    pattern = _safe_compile_regex(keyword, flags)
                     patterns.append((pattern, keyword))
                 except re.error as e:
                     logger.warning("Invalid regex pattern '{}': {}", keyword, e)
@@ -297,6 +301,20 @@ class WorldBookEntry:
                 patterns.append((re.compile(pattern_str, flags), keyword))
 
         return patterns
+
+    def _search_pattern(self, pattern: Any, text: str):
+        """Search *text* with runtime timeout for user-provided regex entries."""
+        try:
+            if self.regex_match:
+                return pattern.search(text, timeout=MAX_REGEX_MATCH_TIME_MS / 1000.0)
+            return pattern.search(text)
+        except (TimeoutError, _REGEX_TIMEOUT_ERROR):
+            logger.warning(
+                "World book regex pattern timed out after {}ms for entry {}",
+                MAX_REGEX_MATCH_TIME_MS,
+                self.entry_id,
+            )
+            return None
 
     def matches(self, text: str) -> bool:
         """
@@ -311,7 +329,7 @@ class WorldBookEntry:
         if not self.enabled or not self._patterns:
             return False
 
-        return any(pattern.search(text) for pattern, _keyword in self._patterns)
+        return any(self._search_pattern(pattern, text) for pattern, _keyword in self._patterns)
 
     def get_first_match_info(self, text: str) -> Optional[dict[str, Any]]:
         """Return the first matching keyword and reason, if any."""
@@ -319,7 +337,7 @@ class WorldBookEntry:
             return None
 
         for pattern, keyword in self._patterns:
-            if pattern.search(text):
+            if self._search_pattern(pattern, text):
                 return {
                     "reason": "regex_match" if self.regex_match else "keyword_match",
                     "keyword": keyword,
@@ -342,7 +360,7 @@ class WorldBookEntry:
 
         count = 0
         for pattern, _keyword in self._patterns:
-            if pattern.search(text):
+            if self._search_pattern(pattern, text):
                 count += 1
 
         return count

--- a/tldw_Server_API/app/core/Workflows/adapters/integration/messaging.py
+++ b/tldw_Server_API/app/core/Workflows/adapters/integration/messaging.py
@@ -8,12 +8,14 @@ This module includes adapters for application-specific integrations:
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
 import os
 from pathlib import Path
 from typing import Any
 
+from fastapi import HTTPException
 from loguru import logger
 
 from tldw_Server_API.app.core.Chat.prompt_template_manager import apply_template_to_string
@@ -54,6 +56,50 @@ def _safe_kanban_error_detail(exc: Exception) -> str:
     if isinstance(exc, ConflictError):
         return "Kanban conflict"
     return "Kanban operation failed"
+
+
+def _extract_character_chat_response_text(response: Any) -> str:
+    """Extract assistant text from common chat adapter response shapes."""
+    if response is None:
+        return ""
+    if isinstance(response, str):
+        return response
+    if isinstance(response, dict):
+        choices = response.get("choices")
+        if isinstance(choices, list) and choices:
+            first_choice = choices[0]
+            if isinstance(first_choice, dict):
+                message = first_choice.get("message")
+                if isinstance(message, dict):
+                    content = message.get("content")
+                    if content is not None:
+                        return str(content)
+                text = first_choice.get("text")
+                if text is not None:
+                    return str(text)
+        for key in ("response", "content", "text"):
+            value = response.get(key)
+            if value is not None:
+                return str(value)
+    return str(response)
+
+
+def _coerce_optional_positive_int(value: Any, field: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return None
+    if isinstance(value, bool):
+        raise AdapterError(f"invalid_{field}")
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError) as exc:
+        raise AdapterError(f"invalid_{field}") from exc
+    if coerced <= 0:
+        raise AdapterError(f"invalid_{field}")
+    return coerced
 
 
 @registry.register(
@@ -765,12 +811,19 @@ async def run_character_chat_adapter(config: dict[str, Any], context: dict[str, 
         return {"error": f"unknown_action:{action}", "simulated": True}
 
     try:
+        from tldw_Server_API.app.core.Chat.chat_service import perform_chat_api_call_async
+        from tldw_Server_API.app.core.Character_Chat.character_limits import check_message_limit
         from tldw_Server_API.app.core.Character_Chat.modules.character_chat import (
             load_chat_and_character,
             post_message_to_conversation,
             start_new_chat_session,
         )
-        from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+        from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+            CharactersRAGDB,
+            CharactersRAGDBError as CharacterDBError,
+            ConflictError as CharacterConflictError,
+            InputError as CharacterInputError,
+        )
 
         # Initialize user's character DB
         try:
@@ -779,7 +832,7 @@ async def run_character_chat_adapter(config: dict[str, Any], context: dict[str, 
         except (OverflowError, TypeError, ValueError):
             db_path = Path("Databases") / "user_databases" / user_id / "ChaChaNotes.db"
 
-        db = CharactersRAGDB(db_path=db_path, client_id="workflow_engine")
+        db = await asyncio.to_thread(CharactersRAGDB, db_path=db_path, client_id="workflow_engine")
 
         if action == "start":
             character_id = config.get("character_id")
@@ -788,7 +841,8 @@ async def run_character_chat_adapter(config: dict[str, Any], context: dict[str, 
 
             custom_title = _render(config.get("title")) if config.get("title") else None
 
-            conversation_id, char_data, initial_history, _ = start_new_chat_session(
+            conversation_id, char_data, initial_history, _ = await asyncio.to_thread(
+                start_new_chat_session,
                 db=db,
                 character_id=int(character_id),
                 user_name=user_name,
@@ -796,7 +850,7 @@ async def run_character_chat_adapter(config: dict[str, Any], context: dict[str, 
             )
 
             if not conversation_id:
-                return {"error": "failed_to_start_chat_session"}
+                return {"error": "failed_to_start_chat_session", "character_id": character_id}
 
             char_name = char_data.get("name", "Character") if char_data else "Character"
             greeting = ""
@@ -816,7 +870,8 @@ async def run_character_chat_adapter(config: dict[str, Any], context: dict[str, 
             if not conversation_id:
                 return {"error": "missing_conversation_id"}
 
-            char_data, history, _ = load_chat_and_character(
+            char_data, history, _ = await asyncio.to_thread(
+                load_chat_and_character,
                 db=db,
                 conversation_id_str=str(conversation_id),
                 user_name=user_name,
@@ -852,35 +907,128 @@ async def run_character_chat_adapter(config: dict[str, Any], context: dict[str, 
             if not message:
                 return {"error": "missing_message"}
 
-            api_name = _render(config.get("api_name") or config.get("api_provider") or "openai")
+            api_name = _render(config.get("api_name") or config.get("api_provider") or config.get("provider") or "openai")
             temperature = float(config.get("temperature") or 0.8)
-
-            # Post message and get response
-            result = await post_message_to_conversation(
-                db=db,
-                conversation_id=str(conversation_id),
-                user_message=message,
-                user_name=user_name,
-                api_name=api_name,
-                temperature=temperature,
+            model = _render(config.get("model")) if config.get("model") else None
+            max_tokens = _coerce_optional_positive_int(
+                _render(config.get("max_tokens")) if config.get("max_tokens") is not None else None,
+                "max_tokens",
             )
+            system_prompt = _render(config.get("system_prompt")) if config.get("system_prompt") else None
 
-            if result is None:
-                return {"error": "failed_to_post_message"}
+            char_data, history, _ = await asyncio.to_thread(
+                load_chat_and_character,
+                db=db,
+                conversation_id_str=str(conversation_id),
+                user_name=user_name,
+            )
+            if char_data is None:
+                return {"error": "conversation_not_found", "conversation_id": conversation_id}
 
-            response_text = result.get("response") or result.get("content") or ""
-            char_name = result.get("character_name") or "Character"
+            char_name = char_data.get("name", "Character") if char_data else "Character"
+            messages_payload: list[dict[str, str]] = []
+            for user_msg, char_msg in history:
+                if user_msg:
+                    messages_payload.append({"role": "user", "content": str(user_msg)})
+                if char_msg:
+                    messages_payload.append({"role": "assistant", "content": str(char_msg)})
+            messages_payload.append({"role": "user", "content": message})
+
+            try:
+                current_message_count = await asyncio.to_thread(
+                    db.count_messages_for_conversation,
+                    str(conversation_id),
+                )
+                check_message_limit(str(conversation_id), current_message_count + 1)
+            except HTTPException as exc:
+                return {
+                    "error": "message_limit_exceeded",
+                    "conversation_id": conversation_id,
+                    "detail": str(exc.detail),
+                }
+            except (CharacterDBError, CharacterConflictError, CharacterInputError, AttributeError, RuntimeError, TypeError, ValueError) as exc:
+                logger.error(
+                    "Failed to check message limit before workflow character chat call for conversation {}: {}",
+                    conversation_id,
+                    exc,
+                )
+                return {"error": "failed_to_check_message_limit", "conversation_id": conversation_id}
+
+            effective_system_prompt = system_prompt or (char_data.get("system_prompt") if char_data else None)
+            llm_response = await perform_chat_api_call_async(
+                api_endpoint=api_name,
+                messages_payload=messages_payload,
+                system_message=effective_system_prompt,
+                model=model,
+                temp=temperature,
+                max_tokens=max_tokens,
+            )
+            response_text = _extract_character_chat_response_text(llm_response).strip()
+
+            try:
+                user_message_id = await asyncio.to_thread(
+                    post_message_to_conversation,
+                    db=db,
+                    conversation_id=str(conversation_id),
+                    character_name=char_name,
+                    message_content=message,
+                    is_user_message=True,
+                )
+            except HTTPException as exc:
+                if exc.status_code == 403:
+                    return {
+                        "error": "message_limit_exceeded",
+                        "conversation_id": conversation_id,
+                        "detail": str(exc.detail),
+                    }
+                logger.error(
+                    "Failed to post workflow user message for conversation {}: {}",
+                    conversation_id,
+                    exc,
+                )
+                return {"error": "failed_to_post_message", "conversation_id": conversation_id, "message_role": "user"}
+            except (CharacterDBError, CharacterConflictError, CharacterInputError, RuntimeError, TypeError, ValueError) as exc:
+                logger.error(
+                    "Failed to post workflow user message for conversation {}: {}",
+                    conversation_id,
+                    exc,
+                )
+                return {"error": "failed_to_post_message", "conversation_id": conversation_id, "message_role": "user"}
+            if not user_message_id:
+                return {"error": "failed_to_post_message", "conversation_id": conversation_id, "message_role": "user"}
+
+            try:
+                assistant_message_id = await asyncio.to_thread(
+                    post_message_to_conversation,
+                    db=db,
+                    conversation_id=str(conversation_id),
+                    character_name=char_name,
+                    message_content=response_text or " ",
+                    is_user_message=False,
+                    parent_message_id=user_message_id,
+                )
+            except (CharacterDBError, CharacterConflictError, CharacterInputError, HTTPException, RuntimeError, TypeError, ValueError) as exc:
+                logger.error(
+                    "Failed to post workflow assistant message for conversation {}: {}",
+                    conversation_id,
+                    exc,
+                )
+                return {"error": "failed_to_post_message", "conversation_id": conversation_id, "message_role": "assistant"}
+            if not assistant_message_id:
+                return {"error": "failed_to_post_message", "conversation_id": conversation_id, "message_role": "assistant"}
 
             return {
                 "response": response_text,
                 "text": response_text,  # Alias for downstream steps
                 "conversation_id": conversation_id,
                 "character_name": char_name,
-                "turn_count": result.get("turn_count", 0),
+                "turn_count": len(messages_payload) + 1,
             }
 
         return {"error": f"unknown_action:{action}"}
 
+    except AdapterError as exc:
+        return {"error": _safe_adapter_error_message(exc)}
     except (AttributeError, ImportError, ModuleNotFoundError, OSError, RuntimeError, TypeError, ValueError):
         logger.exception("Character chat adapter error")
         return {"error": "character_chat_error"}

--- a/tldw_Server_API/tests/Character_Chat/test_chat_dictionary_legacy.py
+++ b/tldw_Server_API/tests/Character_Chat/test_chat_dictionary_legacy.py
@@ -165,6 +165,20 @@ class TestChatDictionaryService:
         assert "test" in insert_call[0][1]
         assert "replaced" in insert_call[0][1]
 
+    def test_bulk_add_entries_rejects_invalid_explicit_regex(self, service):
+        """Explicit regex entries added in bulk should be validated before insert."""
+        with pytest.raises(re.error):
+            service.bulk_add_entries(
+                1,
+                [
+                    {
+                        "pattern": "(",
+                        "replacement": "broken",
+                        "type": "regex",
+                    }
+                ],
+            )
+
     def test_process_text_literal_replacement(self, service, mock_db):
         """Test processing text with literal string replacement."""
         # Setup mock connection to return entries

--- a/tldw_Server_API/tests/Character_Chat/test_world_book_manager_legacy.py
+++ b/tldw_Server_API/tests/Character_Chat/test_world_book_manager_legacy.py
@@ -19,6 +19,7 @@ from tldw_Server_API.app.core.Character_Chat.world_book_manager import (
     WorldBookEntry,
     BoundedDict,
 )
+from tldw_Server_API.app.core.Character_Chat.constants import MAX_REGEX_MATCH_TIME_MS
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, InputError
 
 
@@ -54,6 +55,58 @@ def service(mock_db):
 
 class TestWorldBookService:
     """Test suite for WorldBookService."""
+
+    def test_regex_entry_matches_with_runtime_timeout(self, monkeypatch):
+        import tldw_Server_API.app.core.Character_Chat.world_book_manager as world_book_manager
+
+        observed_timeouts: list[float | None] = []
+
+        class FakePattern:
+            def search(self, _text: str, *, timeout: float | None = None):
+                observed_timeouts.append(timeout)
+                return True
+
+        def fake_safe_compile_regex(_pattern: str, flags: int = 0):
+            assert flags == 0
+            return FakePattern()
+
+        monkeypatch.setattr(world_book_manager, "_safe_compile_regex", fake_safe_compile_regex)
+
+        entry = WorldBookEntry(
+            entry_id=1,
+            world_book_id=1,
+            keywords=["hero"],
+            content="Hero lore",
+            regex_match=True,
+            case_sensitive=True,
+        )
+
+        assert entry.matches("the hero arrives")
+        assert observed_timeouts == [MAX_REGEX_MATCH_TIME_MS / 1000.0]
+
+    def test_regex_entry_timeout_variant_fails_closed(self, monkeypatch):
+        import tldw_Server_API.app.core.Character_Chat.world_book_manager as world_book_manager
+
+        class FakeRegexTimeout(Exception):
+            pass
+
+        class FakePattern:
+            def search(self, _text: str, *, timeout: float | None = None):
+                raise FakeRegexTimeout("timed out")
+
+        monkeypatch.setattr(world_book_manager, "_safe_compile_regex", lambda *_args, **_kwargs: FakePattern())
+        monkeypatch.setattr(world_book_manager, "_REGEX_TIMEOUT_ERROR", FakeRegexTimeout)
+
+        entry = WorldBookEntry(
+            entry_id=1,
+            world_book_id=1,
+            keywords=["hero"],
+            content="Hero lore",
+            regex_match=True,
+            case_sensitive=True,
+        )
+
+        assert entry.matches("the hero arrives") is False
 
     def test_init_creates_tables(self, mock_db):
         """Test that initialization creates necessary tables."""

--- a/tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_memory.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_memory.py
@@ -105,6 +105,8 @@ class TestBuildExtractionPrompt:
         ]
         system_msg, _ = build_extraction_prompt([], "Luna", "Alex", existing)
         assert "[fact] User is an engineer" in system_msg
+        assert "JSON object" in system_msg
+        assert '"memories"' in system_msg
 
 
 class TestParseExtractionResponse:
@@ -121,6 +123,19 @@ class TestParseExtractionResponse:
         assert result[0]["category"] == "fact"
         assert result[0]["content"] == "User is 30"
         assert result[0]["salience"] == 0.8
+
+    def test_json_object_with_memories_array(self):
+        from tldw_Server_API.app.core.Character_Chat.modules.character_memory_extraction import (
+            parse_extraction_response,
+        )
+        raw = json.dumps({
+            "memories": [
+                {"category": "fact", "content": "User is 30", "salience": 0.8},
+            ],
+        })
+        result = parse_extraction_response(raw)
+        assert len(result) == 1
+        assert result[0]["content"] == "User is 30"
 
     def test_markdown_fenced(self):
         from tldw_Server_API.app.core.Character_Chat.modules.character_memory_extraction import (
@@ -151,6 +166,25 @@ class TestParseExtractionResponse:
         result = parse_extraction_response(raw)
         assert len(result) == 1
         assert result[0]["content"] == "Likes tea"
+
+    def test_embedded_json_object_with_memories_array(self):
+        from tldw_Server_API.app.core.Character_Chat.modules.character_memory_extraction import (
+            parse_extraction_response,
+        )
+        raw = (
+            'Here are the memories: {"memories": '
+            '[{"category": "preference", "content": "Likes green tea"}]} done.'
+        )
+        result = parse_extraction_response(raw)
+        assert len(result) == 1
+        assert result[0]["content"] == "Likes green tea"
+
+    def test_json_object_without_memories_returns_empty_list(self):
+        from tldw_Server_API.app.core.Character_Chat.modules.character_memory_extraction import (
+            parse_extraction_response,
+        )
+
+        assert parse_extraction_response('{"items": []}') == []
 
     def test_invalid_category_normalized(self):
         from tldw_Server_API.app.core.Character_Chat.modules.character_memory_extraction import (

--- a/tldw_Server_API/tests/Characters/test_ccv3_parser.py
+++ b/tldw_Server_API/tests/Characters/test_ccv3_parser.py
@@ -4,6 +4,7 @@ import pytest
 
 from tldw_Server_API.app.core.Character_Chat.ccv3_parser import validate_v3_card, parse_v3_card
 from tldw_Server_API.app.core.Character_Chat.modules.character_io import import_character_card_from_json_string
+from tldw_Server_API.app.core.Character_Chat.modules.character_validation import MAX_V2_TEXT_FIELD_LENGTHS
 
 
 def test_ccv3_validate_and_parse_happy_path():
@@ -46,6 +47,40 @@ def test_ccv3_missing_required_fields_returns_none():
     parsed = import_character_card_from_json_string(json.dumps(card))
     # Validation fails; importer should fall through and not produce a usable card
     assert parsed is None
+
+
+def test_ccv3_rejects_overlong_name():
+    card = {
+        "spec": "chara_card_v3",
+        "spec_version": "3.0",
+        "data": {
+            "name": "A" * (MAX_V2_TEXT_FIELD_LENGTHS["name"] + 1),
+            "description": "Too much name",
+            "first_mes": "Hello",
+        },
+    }
+
+    ok, errs = validate_v3_card(card)
+    assert not ok
+    assert any("name" in err for err in errs)
+    assert import_character_card_from_json_string(json.dumps(card)) is None
+
+
+def test_ccv3_rejects_wrong_field_type():
+    card = {
+        "spec": "chara_card_v3",
+        "spec_version": "3.0",
+        "data": {
+            "name": "Bad Type",
+            "description": ["not", "text"],
+            "first_mes": "Hello",
+        },
+    }
+
+    ok, errs = validate_v3_card(card)
+    assert not ok
+    assert any("description" in err for err in errs)
+    assert import_character_card_from_json_string(json.dumps(card)) is None
 
 
 @pytest.mark.parametrize("image_key", ["char_image", "image"])

--- a/tldw_Server_API/tests/Characters/test_character_chat_lib.py
+++ b/tldw_Server_API/tests/Characters/test_character_chat_lib.py
@@ -2155,6 +2155,65 @@ def test_post_message_rejects_oversized_content(db, monkeypatch):
         )
 
 
+def test_post_message_enforces_message_limit(db, monkeypatch):
+    from fastapi import HTTPException
+
+    from tldw_Server_API.app.core.Character_Chat import character_limits as limits
+
+    monkeypatch.setenv("MAX_MESSAGES_PER_CHAT", "1")
+    monkeypatch.setattr(limits, "_limits", None)
+
+    char_id = db.add_character_card({"name": "LimitChar"})
+    conv_id = db.add_conversation({"character_id": char_id, "title": "Limit Chat"})
+
+    assert post_message_to_conversation(
+        db,
+        conv_id,
+        "LimitChar",
+        "first",
+        is_user_message=True,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        post_message_to_conversation(
+            db,
+            conv_id,
+            "LimitChar",
+            "second",
+            is_user_message=True,
+        )
+
+    assert exc_info.value.status_code == 403
+
+
+def test_post_message_does_not_limit_assistant_response(db, monkeypatch):
+    from tldw_Server_API.app.core.Character_Chat import character_limits as limits
+
+    monkeypatch.setenv("MAX_MESSAGES_PER_CHAT", "1")
+    monkeypatch.setattr(limits, "_limits", None)
+
+    char_id = db.add_character_card({"name": "LimitChar"})
+    conv_id = db.add_conversation({"character_id": char_id, "title": "Limit Chat"})
+
+    user_message_id = post_message_to_conversation(
+        db,
+        conv_id,
+        "LimitChar",
+        "first",
+        is_user_message=True,
+    )
+    assistant_message_id = post_message_to_conversation(
+        db,
+        conv_id,
+        "LimitChar",
+        "assistant reply",
+        is_user_message=False,
+        parent_message_id=user_message_id,
+    )
+
+    assert assistant_message_id
+
+
 def test_load_chat_history_respects_message_limit(db, monkeypatch):
     from tldw_Server_API.app.core.Character_Chat import character_limits as limits
 

--- a/tldw_Server_API/tests/Workflows/adapters/test_integration_adapters.py
+++ b/tldw_Server_API/tests/Workflows/adapters/test_integration_adapters.py
@@ -1621,6 +1621,292 @@ async def test_character_chat_adapter_message_test_mode_y(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_character_chat_adapter_message_uses_current_core_writer(monkeypatch):
+    """Non-test mode message action should use the current low-level message writer contract."""
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    monkeypatch.delenv("TLDW_TEST_MODE", raising=False)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Workflows.adapters.integration.messaging.is_test_mode",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Workflows.adapters.integration.messaging.DatabasePaths.get_chacha_db_path",
+        lambda _user_id: Path(":memory:"),
+    )
+
+    offloaded: list[Any] = []
+
+    async def fake_to_thread(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        offloaded.append(func)
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Workflows.adapters.integration.messaging.asyncio.to_thread",
+        fake_to_thread,
+    )
+
+    fake_db = MagicMock()
+    fake_db.count_messages_for_conversation.return_value = 2
+    posts: list[dict[str, Any]] = []
+
+    def fake_load_chat_and_character(db: object, conversation_id_str: str, user_name: str):
+        assert db is fake_db
+        assert conversation_id_str == "conv-123"
+        assert user_name == "Dana"
+        return (
+            {"name": "Luna", "system_prompt": "Stay in character."},
+            [("Earlier user message", "Earlier assistant reply")],
+            None,
+        )
+
+    def fake_post_message_to_conversation(
+        db: object,
+        conversation_id: str,
+        character_name: str,
+        message_content: str,
+        is_user_message: bool,
+        **_kwargs: Any,
+    ) -> str:
+        assert db is fake_db
+        posts.append(
+            {
+                "conversation_id": conversation_id,
+                "character_name": character_name,
+                "message_content": message_content,
+                "is_user_message": is_user_message,
+            }
+        )
+        return f"msg-{len(posts)}"
+
+    async def fake_perform_chat_api_call_async(**kwargs: Any):
+        assert kwargs["api_endpoint"] == "openai"
+        assert kwargs["model"] == "gpt-test"
+        assert kwargs["temp"] == 0.4
+        assert kwargs["max_tokens"] == 256
+        assert kwargs["system_message"] == "Stay in character."
+        assert kwargs["messages_payload"] == [
+            {"role": "user", "content": "Earlier user message"},
+            {"role": "assistant", "content": "Earlier assistant reply"},
+            {"role": "user", "content": "Hello!"},
+        ]
+        return {"choices": [{"message": {"content": "Hello from Luna"}}]}
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB.CharactersRAGDB",
+        lambda *_args, **_kwargs: fake_db,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Character_Chat.modules.character_chat.load_chat_and_character",
+        fake_load_chat_and_character,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Character_Chat.modules.character_chat.post_message_to_conversation",
+        fake_post_message_to_conversation,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Chat.chat_service.perform_chat_api_call_async",
+        fake_perform_chat_api_call_async,
+    )
+
+    from tldw_Server_API.app.core.Workflows.adapters.integration import run_character_chat_adapter
+
+    result = await run_character_chat_adapter(
+        {
+            "action": "message",
+            "conversation_id": "conv-123",
+            "message": "Hello!",
+            "api_name": "openai",
+            "model": "gpt-test",
+            "max_tokens": "256",
+            "temperature": 0.4,
+            "user_name": "Dana",
+        },
+        {"user_id": "1"},
+    )
+
+    assert result == {
+        "response": "Hello from Luna",
+        "text": "Hello from Luna",
+        "conversation_id": "conv-123",
+        "character_name": "Luna",
+        "turn_count": 4,
+    }
+    assert posts == [
+        {
+            "conversation_id": "conv-123",
+            "character_name": "Luna",
+            "message_content": "Hello!",
+            "is_user_message": True,
+        },
+        {
+            "conversation_id": "conv-123",
+            "character_name": "Luna",
+            "message_content": "Hello from Luna",
+            "is_user_message": False,
+        },
+    ]
+    fake_db.count_messages_for_conversation.assert_called_once_with("conv-123")
+    assert fake_load_chat_and_character in offloaded
+    assert offloaded.count(fake_post_message_to_conversation) == 2
+
+
+@pytest.mark.asyncio
+async def test_character_chat_adapter_message_preflights_limit_before_llm(monkeypatch):
+    """Message action should fail fast on message limit before spending an LLM call."""
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    monkeypatch.delenv("TLDW_TEST_MODE", raising=False)
+    monkeypatch.setenv("MAX_MESSAGES_PER_CHAT", "1")
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Workflows.adapters.integration.messaging.is_test_mode",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Workflows.adapters.integration.messaging.DatabasePaths.get_chacha_db_path",
+        lambda _user_id: Path(":memory:"),
+    )
+
+    from tldw_Server_API.app.core.Character_Chat import character_limits as limits
+
+    monkeypatch.setattr(limits, "_limits", None)
+    fake_db = MagicMock()
+    fake_db.count_messages_for_conversation.return_value = 1
+    llm_called = False
+    post_called = False
+
+    def fake_load_chat_and_character(db: object, conversation_id_str: str, user_name: str):
+        return ({"name": "Luna"}, [], None)
+
+    async def fake_perform_chat_api_call_async(**_kwargs: Any):
+        nonlocal llm_called
+        llm_called = True
+        return {"choices": [{"message": {"content": "Hello"}}]}
+
+    def fake_post_message_to_conversation(**_kwargs: Any):
+        nonlocal post_called
+        post_called = True
+        return "msg-1"
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB.CharactersRAGDB",
+        lambda *_args, **_kwargs: fake_db,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Character_Chat.modules.character_chat.load_chat_and_character",
+        fake_load_chat_and_character,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Character_Chat.modules.character_chat.post_message_to_conversation",
+        fake_post_message_to_conversation,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Chat.chat_service.perform_chat_api_call_async",
+        fake_perform_chat_api_call_async,
+    )
+
+    from tldw_Server_API.app.core.Workflows.adapters.integration import run_character_chat_adapter
+
+    result = await run_character_chat_adapter(
+        {"action": "message", "conversation_id": "conv-123", "message": "Hello!"},
+        {"user_id": "1"},
+    )
+
+    assert result["error"] == "message_limit_exceeded"
+    assert result["conversation_id"] == "conv-123"
+    assert llm_called is False
+    assert post_called is False
+
+
+@pytest.mark.asyncio
+async def test_character_chat_adapter_invalid_max_tokens_is_sanitized(monkeypatch):
+    """Invalid max_tokens should be rejected before it reaches provider payloads."""
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    monkeypatch.delenv("TLDW_TEST_MODE", raising=False)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Workflows.adapters.integration.messaging.is_test_mode",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Workflows.adapters.integration.messaging.DatabasePaths.get_chacha_db_path",
+        lambda _user_id: Path(":memory:"),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB.CharactersRAGDB",
+        lambda *_args, **_kwargs: MagicMock(),
+    )
+
+    from tldw_Server_API.app.core.Workflows.adapters.integration import run_character_chat_adapter
+
+    result = await run_character_chat_adapter(
+        {
+            "action": "message",
+            "conversation_id": "conv-123",
+            "message": "Hello!",
+            "max_tokens": "many",
+        },
+        {"user_id": "1"},
+    )
+
+    assert result == {"error": "invalid_max_tokens"}
+
+
+@pytest.mark.asyncio
+async def test_character_chat_adapter_post_failure_includes_context(monkeypatch):
+    """Write failures should identify the conversation and message role."""
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    monkeypatch.delenv("TLDW_TEST_MODE", raising=False)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Workflows.adapters.integration.messaging.is_test_mode",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Workflows.adapters.integration.messaging.DatabasePaths.get_chacha_db_path",
+        lambda _user_id: Path(":memory:"),
+    )
+
+    fake_db = MagicMock()
+    fake_db.count_messages_for_conversation.return_value = 0
+
+    def fake_load_chat_and_character(db: object, conversation_id_str: str, user_name: str):
+        return ({"name": "Luna"}, [], None)
+
+    async def fake_perform_chat_api_call_async(**_kwargs: Any):
+        return {"choices": [{"message": {"content": "Hello from Luna"}}]}
+
+    def fake_post_message_to_conversation(**_kwargs: Any):
+        return None
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB.CharactersRAGDB",
+        lambda *_args, **_kwargs: fake_db,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Character_Chat.modules.character_chat.load_chat_and_character",
+        fake_load_chat_and_character,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Character_Chat.modules.character_chat.post_message_to_conversation",
+        fake_post_message_to_conversation,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Chat.chat_service.perform_chat_api_call_async",
+        fake_perform_chat_api_call_async,
+    )
+
+    from tldw_Server_API.app.core.Workflows.adapters.integration import run_character_chat_adapter
+
+    result = await run_character_chat_adapter(
+        {"action": "message", "conversation_id": "conv-123", "message": "Hello!"},
+        {"user_id": "1"},
+    )
+
+    assert result == {
+        "error": "failed_to_post_message",
+        "conversation_id": "conv-123",
+        "message_role": "user",
+    }
+
+
+@pytest.mark.asyncio
 async def test_character_chat_adapter_load_test_mode(monkeypatch):
     """Test Character chat adapter load in test mode."""
     monkeypatch.setenv("TEST_MODE", "1")


### PR DESCRIPTION
## Summary
- Fix Character_Chat memory extraction to request and parse the JSON object contract.
- Harden world-book and chat-dictionary regex handling, plus V3 card validation.
- Enforce conversation message limits and repair the workflow character_chat adapter against the current core writer contract.

## Test Plan
- [x] Python compile check on touched production and test files
- [x] Focused pytest run: 7 passed
- [x] Direct chat dictionary regex regression check
- [x] Whitespace check against origin/dev
- [x] Bandit on touched production paths; only existing low-severity findings in unchanged chat_dictionary.py lines 348, 3148, and 3173

Refs TASK-2404

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Character_Chat review findings by enforcing user-message limits, hardening regex handling, tightening v3 card validation, and aligning memory extraction to a JSON-object contract. Addresses TASK-2404 with focused tests to prevent regressions.

- **Bug Fixes**
  - Memory extraction: prompt now requests a JSON object with a "memories" array; parser accepts object or legacy array, recovers embedded JSON, and returns [] when missing "memories".
  - Regex hardening: world-book uses safe compile and timeout-bounded search (fails closed on timeout); chat dictionary bulk-add validates/compiles explicit regex and raises on invalid patterns before insert.
  - V3 card validation: strict type/length checks, limits tags/alternate greetings, validates `character_book`; invalid v3 cards are rejected early.
  - Conversation flow: enforces per-chat user-message limits under a per-conversation lock; workflow character_chat adapter preflights the limit before LLM calls, builds messages from history, offloads DB I/O via `asyncio.to_thread`, posts user/assistant messages separately, normalizes provider responses, and sanitizes `max_tokens`.

<sup>Written for commit 765eea5f26a88f867ef98da08fa5632bcdea3bdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

