### PR TITLE
Harden Collections reading module

### DIFF
--- a/backlog/tasks/task-2412 - Harden-Collections-reading-module-review-findings.md
+++ b/backlog/tasks/task-2412 - Harden-Collections-reading-module-review-findings.md
@@ -1,0 +1,63 @@
+---
+id: TASK-2412
+title: Harden Collections reading module review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 18:13'
+updated_date: '2026-06-23 18:42'
+labels:
+  - collections
+  - security
+  - reliability
+dependencies: []
+references:
+  - tldw_Server_API/app/core/Collections/reading_service.py
+  - tldw_Server_API/app/core/Collections/reading_importers.py
+  - tldw_Server_API/app/core/Collections/reading_import_jobs.py
+  - tldw_Server_API/app/core/Collections/reading_digest_jobs.py
+  - tldw_Server_API/app/core/Collections/embedding_queue.py
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the accepted review findings for the Collections reading module: bound persisted/queued reading content, reject or inert unsafe URL schemes in imports and digest output, centralize reading status validation, harden import size env parsing, and extract focused helpers from ReadingService without changing public endpoint shapes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Reading content and embedding job payloads are bounded by explicit limits with regression tests.
+- [x] #2 Imported non-http(s) URLs are rejected or skipped, and digest renderers do not emit active links for unsafe schemes.
+- [x] #3 Save/update/import reading status paths use one validation/normalization contract.
+- [x] #4 READING_IMPORT_MAX_BYTES uses safe env parsing and cannot fail module import on invalid values.
+- [x] #5 ReadingService retains its public facade while archive/import responsibilities move behind smaller helpers.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented bounded reading metadata and embedding job payloads, shared reading status normalization, http/https import filtering, inert unsafe digest links, safe READING_IMPORT_MAX_BYTES parsing, and ReadingArchiveService/ReadingImportService helpers behind ReadingService.
+
+Verification: direct behavioral script passed for digest unsafe-link rendering, invalid import env fallback, embedding payload truncation, save/update status normalization, bounded metadata, helper wiring, and non-http import skip. compileall passed for touched Collections code/tests. git diff --check passed. Bandit on touched Collections files produced 0 findings at /tmp/bandit_task_2412_collections.json.
+
+Focused pytest limitation: targeted pytest timed out during repo-wide autouse fixture setup before executing the Collections test body. Timeout stack was in tests/conftest.py importing character_chat_sessions -> Research/RAG -> nltk/scipy, not in the changed Collections code.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened the Collections reading module against the review findings: content is bounded before metadata/job persistence, unsafe imported/digest URLs are not active, reading statuses share one normalization contract, invalid import-size env values no longer break imports, and ReadingService delegates archive/import responsibilities to focused helpers. Verification passed via direct behavioral checks, compileall, diff whitespace check, and Bandit; focused pytest remains blocked by unrelated global fixture bootstrap timeout.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+- [ ] #7 Focused pytest coverage passes for Collections reading service/import/digest/embedding queue behavior.
+- [x] #8 Bandit runs clean on touched Collections files.
+<!-- DOD:END -->

--- a/backlog/tasks/task-2412 - Harden-Collections-reading-module-review-findings.md
+++ b/backlog/tasks/task-2412 - Harden-Collections-reading-module-review-findings.md
@@ -3,19 +3,19 @@ id: TASK-2412
 title: Harden Collections reading module review findings
 status: Done
 assignee: []
-created_date: '2026-06-23 18:13'
-updated_date: '2026-06-23 18:42'
+created_date: 2026-06-23 18:13
+updated_date: 2026-06-24 03:48
 labels:
-  - collections
-  - security
-  - reliability
+- collections
+- security
+- reliability
 dependencies: []
 references:
-  - tldw_Server_API/app/core/Collections/reading_service.py
-  - tldw_Server_API/app/core/Collections/reading_importers.py
-  - tldw_Server_API/app/core/Collections/reading_import_jobs.py
-  - tldw_Server_API/app/core/Collections/reading_digest_jobs.py
-  - tldw_Server_API/app/core/Collections/embedding_queue.py
+- tldw_Server_API/app/core/Collections/reading_service.py
+- tldw_Server_API/app/core/Collections/reading_importers.py
+- tldw_Server_API/app/core/Collections/reading_import_jobs.py
+- tldw_Server_API/app/core/Collections/reading_digest_jobs.py
+- tldw_Server_API/app/core/Collections/embedding_queue.py
 priority: high
 ---
 
@@ -61,3 +61,9 @@ Hardened the Collections reading module against the review findings: content is 
 - [ ] #7 Focused pytest coverage passes for Collections reading service/import/digest/embedding queue behavior.
 - [x] #8 Bandit runs clean on touched Collections files.
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Review follow-up: addressed PR comments by adding docstrings to new helpers, adding type hints/docstrings to new tests, hardening default markdown digest rendering against link/summary injection, and verifying skipped import counts still count unsupported raw URLs once. Verification before commit: git diff --check passed; compileall on touched files passed; Bandit on touched Collections core files reported 0 findings; direct behavior checks passed for markdown escaping, embedding content bounding, unsupported URL skip count, and invalid import-size env fallback.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/core/Collections/embedding_queue.py
+++ b/tldw_Server_API/app/core/Collections/embedding_queue.py
@@ -9,6 +9,25 @@ from loguru import logger
 from tldw_Server_API.app.core.Embeddings import redis_pipeline
 from tldw_Server_API.app.core.Jobs.manager import JobManager
 from tldw_Server_API.app.core.testing import is_test_mode
+from tldw_Server_API.app.core.Collections.utils import truncate_text_hard
+
+
+def _env_int(name: str, default: int, *, minimum: int | None = None) -> int:
+    raw = os.getenv(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    try:
+        value = int(str(raw).strip())
+    except (TypeError, ValueError):
+        logger.warning("Invalid integer for {}: {!r}; using default={}", name, raw, default)
+        return default
+    if minimum is not None and value < minimum:
+        logger.warning("Out-of-range integer for {}: {}; minimum={}; using default={}", name, value, minimum, default)
+        return default
+    return value
+
+
+EMBEDDING_JOB_CONTENT_MAX_CHARS = _env_int("EMBEDDING_JOB_CONTENT_MAX_CHARS", 200_000, minimum=0)
 
 
 def _jobs_queue() -> str:
@@ -56,15 +75,23 @@ async def enqueue_embeddings_job_for_item(
     text = (content or "").strip()
     if not text:
         return
+    bounded_text, content_truncated, original_len = truncate_text_hard(text, EMBEDDING_JOB_CONTENT_MAX_CHARS)
+    if not bounded_text:
+        return
 
     try:
         jm = _jobs_manager()
         stage_queue = _jobs_queue()
         root_queue = _root_jobs_queue(stage_queue)
+        payload_metadata = dict(metadata or {})
+        if content_truncated:
+            payload_metadata["content_truncated"] = True
+            payload_metadata["content_char_count"] = original_len
+            payload_metadata["content_max_chars"] = EMBEDDING_JOB_CONTENT_MAX_CHARS
         payload = {
             "item_id": int(item_id),
-            "content": text,
-            "metadata": metadata or {},
+            "content": bounded_text,
+            "metadata": payload_metadata,
             "current_stage": "content",
             "request_source": "collections",
         }

--- a/tldw_Server_API/app/core/Collections/embedding_queue.py
+++ b/tldw_Server_API/app/core/Collections/embedding_queue.py
@@ -13,6 +13,7 @@ from tldw_Server_API.app.core.Collections.utils import truncate_text_hard
 
 
 def _env_int(name: str, default: int, *, minimum: int | None = None) -> int:
+    """Read an integer environment variable with fallback validation."""
     raw = os.getenv(name)
     if raw is None or str(raw).strip() == "":
         return default

--- a/tldw_Server_API/app/core/Collections/reading_digest_jobs.py
+++ b/tldw_Server_API/app/core/Collections/reading_digest_jobs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import sqlite3
 from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
@@ -62,6 +63,8 @@ READING_DIGEST_SUGGESTIONS_MAX_LIMIT = _env_int("READING_DIGEST_SUGGESTIONS_MAX_
 READING_DIGEST_SUGGESTIONS_MAX_CANDIDATES = _env_int("READING_DIGEST_SUGGESTIONS_MAX_CANDIDATES", 200)
 
 _SUGGESTION_ALLOWED_STATUSES = {"saved", "reading", "read", "archived"}
+_MARKDOWN_ESCAPE_RE = re.compile(r"([\\`*_{}\[\]()#+\-.!])")
+_DANGEROUS_MARKDOWN_SCHEME_RE = re.compile(r"\b(javascript|vbscript|data):", re.IGNORECASE)
 
 
 def reading_digest_queue() -> str:
@@ -314,31 +317,45 @@ def _resolve_retention_until(retention_days: int | None) -> str | None:
     return (datetime.now(tz=timezone.utc) + timedelta(days=days)).isoformat()
 
 
+def _escape_markdown_text(value: Any) -> str:
+    """Escape untrusted text before interpolating it into Markdown."""
+    text = str(value or "").replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
+    escaped = _MARKDOWN_ESCAPE_RE.sub(r"\\\1", text)
+    return _DANGEROUS_MARKDOWN_SCHEME_RE.sub(lambda match: f"{match.group(1)}&#58;", escaped)
+
+
+def _is_safe_markdown_url(value: str) -> bool:
+    """Return True when value is safe to use inside a Markdown autolink target."""
+    return is_supported_reading_url(value) and not any(ch.isspace() or ord(ch) < 32 or ch in "<>\"'" for ch in value)
+
+
 def _render_default_markdown(
     title: str,
     items: list[dict[str, Any]],
     suggestions: list[dict[str, Any]] | None = None,
 ) -> str:
-    lines = [f"# {title}", ""]
+    lines = [f"# {_escape_markdown_text(title)}", ""]
     for idx, itm in enumerate(items, 1):
-        entry_title = itm.get("title") or f"Item {idx}"
+        entry_title = _escape_markdown_text(itm.get("title") or f"Item {idx}")
         url = str(itm.get("url") or "").strip()
-        line = f"{idx}. [{entry_title}]({url})" if url else f"{idx}. {entry_title}"
-        if url and not is_supported_reading_url(url):
+        if url and _is_safe_markdown_url(url):
+            line = f"{idx}. [{entry_title}](<{url}>)"
+        else:
             line = f"{idx}. {entry_title}"
-        summary = itm.get("summary") or ""
+        summary = _escape_markdown_text(itm.get("summary") or "")
         if summary:
             line += f" - {summary}"
         lines.append(line)
     if suggestions:
         lines.extend(["", "## Suggested reads", ""])
         for idx, itm in enumerate(suggestions, 1):
-            entry_title = itm.get("title") or f"Suggestion {idx}"
+            entry_title = _escape_markdown_text(itm.get("title") or f"Suggestion {idx}")
             url = str(itm.get("url") or "").strip()
-            line = f"{idx}. [{entry_title}]({url})" if url else f"{idx}. {entry_title}"
-            if url and not is_supported_reading_url(url):
+            if url and _is_safe_markdown_url(url):
+                line = f"{idx}. [{entry_title}](<{url}>)"
+            else:
                 line = f"{idx}. {entry_title}"
-            summary = itm.get("summary") or ""
+            summary = _escape_markdown_text(itm.get("summary") or "")
             if summary:
                 line += f" - {summary}"
             lines.append(line)

--- a/tldw_Server_API/app/core/Collections/reading_digest_jobs.py
+++ b/tldw_Server_API/app/core/Collections/reading_digest_jobs.py
@@ -12,6 +12,7 @@ from typing import Any
 from loguru import logger
 
 from tldw_Server_API.app.core.Collections.reading_service import ReadingService
+from tldw_Server_API.app.core.Collections.utils import is_supported_reading_url
 from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.exceptions import ReadingDigestJobError
@@ -321,8 +322,10 @@ def _render_default_markdown(
     lines = [f"# {title}", ""]
     for idx, itm in enumerate(items, 1):
         entry_title = itm.get("title") or f"Item {idx}"
-        url = itm.get("url")
+        url = str(itm.get("url") or "").strip()
         line = f"{idx}. [{entry_title}]({url})" if url else f"{idx}. {entry_title}"
+        if url and not is_supported_reading_url(url):
+            line = f"{idx}. {entry_title}"
         summary = itm.get("summary") or ""
         if summary:
             line += f" - {summary}"
@@ -331,8 +334,10 @@ def _render_default_markdown(
         lines.extend(["", "## Suggested reads", ""])
         for idx, itm in enumerate(suggestions, 1):
             entry_title = itm.get("title") or f"Suggestion {idx}"
-            url = itm.get("url")
+            url = str(itm.get("url") or "").strip()
             line = f"{idx}. [{entry_title}]({url})" if url else f"{idx}. {entry_title}"
+            if url and not is_supported_reading_url(url):
+                line = f"{idx}. {entry_title}"
             summary = itm.get("summary") or ""
             if summary:
                 line += f" - {summary}"
@@ -349,8 +354,8 @@ def _render_default_html(
     for idx, itm in enumerate(items, 1):
         entry_title = escape(itm.get("title") or f"Item {idx}")
         summary = escape(itm.get("summary") or "")
-        url = itm.get("url")
-        entry = f'<li><a href="{escape(url)}">{entry_title}</a>' if url else f"<li>{entry_title}"
+        url = str(itm.get("url") or "").strip()
+        entry = f'<li><a href="{escape(url)}">{entry_title}</a>' if is_supported_reading_url(url) else f"<li>{entry_title}"
         if summary:
             entry += f" - {summary}"
         entry += "</li>"
@@ -361,8 +366,8 @@ def _render_default_html(
         for idx, itm in enumerate(suggestions, 1):
             entry_title = escape(itm.get("title") or f"Suggestion {idx}")
             summary = escape(itm.get("summary") or "")
-            url = itm.get("url")
-            entry = f'<li><a href="{escape(url)}">{entry_title}</a>' if url else f"<li>{entry_title}"
+            url = str(itm.get("url") or "").strip()
+            entry = f'<li><a href="{escape(url)}">{entry_title}</a>' if is_supported_reading_url(url) else f"<li>{entry_title}"
             if summary:
                 entry += f" - {summary}"
             entry += "</li>"

--- a/tldw_Server_API/app/core/Collections/reading_import_jobs.py
+++ b/tldw_Server_API/app/core/Collections/reading_import_jobs.py
@@ -26,6 +26,7 @@ READING_IMPORT_JOB_TYPE = "reading_import"
 
 
 def _env_int(name: str, default: int, *, minimum: int | None = None) -> int:
+    """Read an integer environment variable with fallback validation."""
     raw = os.getenv(name)
     if raw is None or str(raw).strip() == "":
         return default

--- a/tldw_Server_API/app/core/Collections/reading_import_jobs.py
+++ b/tldw_Server_API/app/core/Collections/reading_import_jobs.py
@@ -23,7 +23,24 @@ from tldw_Server_API.app.core.testing import is_truthy
 
 READING_IMPORT_DOMAIN = "reading"
 READING_IMPORT_JOB_TYPE = "reading_import"
-MAX_READING_IMPORT_BYTES = int(os.getenv("READING_IMPORT_MAX_BYTES", str(10 * 1024 * 1024)))
+
+
+def _env_int(name: str, default: int, *, minimum: int | None = None) -> int:
+    raw = os.getenv(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    try:
+        value = int(str(raw).strip())
+    except (TypeError, ValueError):
+        logger.warning("Invalid integer for {}: {!r}; using default={}", name, raw, default)
+        return default
+    if minimum is not None and value < minimum:
+        logger.warning("Out-of-range integer for {}: {}; minimum={}; using default={}", name, value, minimum, default)
+        return default
+    return value
+
+
+MAX_READING_IMPORT_BYTES = _env_int("READING_IMPORT_MAX_BYTES", 10 * 1024 * 1024, minimum=1)
 
 
 class ReadingImportJobError(RuntimeError):

--- a/tldw_Server_API/app/core/Collections/reading_importers.py
+++ b/tldw_Server_API/app/core/Collections/reading_importers.py
@@ -9,6 +9,11 @@ from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import unquote, urlparse
 
+from tldw_Server_API.app.core.Collections.utils import (
+    is_supported_reading_url,
+    normalize_reading_status,
+)
+
 try:
     from tldw_Server_API.app.core.Web_Scraping.url_utils import normalize_for_crawl
 except Exception:  # pragma: no cover - import fallback for isolated tests
@@ -212,10 +217,7 @@ def _truthy(value: Any) -> bool:
 
 
 def _normalize_status(value: str | None) -> str:
-    text = str(value or "").strip().lower()
-    if text in _READING_STATUS_PRIORITY:
-        return text
-    return "saved"
+    return normalize_reading_status(value)
 
 
 def _merge_status(left: str | None, right: str | None) -> str:
@@ -231,12 +233,13 @@ def _normalize_import_url(url: str) -> str:
     if not raw:
         return ""
     if normalize_for_crawl is None:
-        return raw
+        return raw if is_supported_reading_url(raw) else ""
     try:
         normalized = normalize_for_crawl(raw, raw)
     except Exception:
         normalized = raw
-    return normalized or raw
+    candidate = normalized or raw
+    return candidate if is_supported_reading_url(candidate) else ""
 
 
 def _title_from_url(url: str) -> str | None:

--- a/tldw_Server_API/app/core/Collections/reading_service.py
+++ b/tldw_Server_API/app/core/Collections/reading_service.py
@@ -147,6 +147,7 @@ def _safe_filename_fragment(raw: str, max_len: int = 64) -> str:
 
 
 def _add_bounded_metadata_text(metadata: dict[str, object], key: str, value: str | None, limit: int) -> None:
+    """Store bounded metadata text plus truncation diagnostics."""
     bounded, truncated, original_len = truncate_text_hard(value, limit)
     if bounded:
         metadata[key] = bounded

--- a/tldw_Server_API/app/core/Collections/reading_service.py
+++ b/tldw_Server_API/app/core/Collections/reading_service.py
@@ -16,7 +16,14 @@ from loguru import logger
 
 from tldw_Server_API.app.core.Collections.embedding_queue import enqueue_embeddings_job_for_item
 from tldw_Server_API.app.core.Collections.reading_importers import ReadingImportItem, normalize_import_items
-from tldw_Server_API.app.core.Collections.utils import hash_text_sha256, truncate_text, word_count
+from tldw_Server_API.app.core.Collections.utils import (
+    hash_text_sha256,
+    is_supported_reading_url,
+    normalize_reading_status,
+    truncate_text,
+    truncate_text_hard,
+    word_count,
+)
 from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase, ContentItemRow
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.exceptions import (
@@ -52,6 +59,8 @@ def _env_int(name: str, default: int, *, minimum: int | None = None) -> int:
 READING_DEFAULT_STATUS = "saved"
 READING_ARCHIVE_MAX_BYTES = _env_int("READING_ARCHIVE_MAX_BYTES", 5 * 1024 * 1024, minimum=0)
 READING_ARCHIVE_RETENTION_DAYS = _env_int("READING_ARCHIVE_RETENTION_DAYS", 30, minimum=0)
+READING_CONTENT_METADATA_MAX_CHARS = _env_int("READING_CONTENT_METADATA_MAX_CHARS", 50_000, minimum=0)
+READING_CLEAN_HTML_METADATA_MAX_CHARS = _env_int("READING_CLEAN_HTML_METADATA_MAX_CHARS", 50_000, minimum=0)
 
 _READING_SERVICE_NONCRITICAL_EXCEPTIONS = (
     AssertionError,
@@ -137,6 +146,17 @@ def _safe_filename_fragment(raw: str, max_len: int = 64) -> str:
     return text[:max_len]
 
 
+def _add_bounded_metadata_text(metadata: dict[str, object], key: str, value: str | None, limit: int) -> None:
+    bounded, truncated, original_len = truncate_text_hard(value, limit)
+    if bounded:
+        metadata[key] = bounded
+    if value:
+        metadata[f"{key}_char_count"] = original_len
+        if truncated:
+            metadata[f"{key}_truncated"] = True
+            metadata[f"{key}_max_chars"] = limit
+
+
 @dataclass
 class ReadingSaveResult:
     item: ContentItemRow
@@ -156,12 +176,159 @@ class ReadingImportResult:
     errors: list[str]
 
 
+class ReadingArchiveService:
+    """Create reading archive artifacts for saved items."""
+
+    def __init__(self, *, user_id: int, collections: CollectionsDatabase) -> None:
+        self.user_id = user_id
+        self.collections = collections
+
+    @staticmethod
+    def resolve_archive_retention() -> str | None:
+        try:
+            days = max(0, int(READING_ARCHIVE_RETENTION_DAYS))
+        except (TypeError, ValueError):
+            return None
+        if days <= 0:
+            return None
+        expires = datetime.now(tz=timezone.utc) + timedelta(days=days)
+        return expires.isoformat()
+
+    async def create_archive_artifact(
+        self,
+        *,
+        item_id: int,
+        title: str,
+        url: str | None,
+        body_text: str,
+        media_item_id: int | None,
+    ) -> tuple[int | None, str | None]:
+        text_value = (body_text or "").strip()
+        if not text_value:
+            return None, "archive_no_content"
+        content = f"# {title}\n\n{url or ''}\n\n{text_value}\n"
+        content_bytes = content.encode("utf-8")
+        if READING_ARCHIVE_MAX_BYTES > 0 and len(content_bytes) > READING_ARCHIVE_MAX_BYTES:
+            return None, "archive_too_large"
+
+        timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
+        safe_title = _safe_filename_fragment(title, max_len=40)
+        filename = f"reading_archive_{item_id}_{safe_title}_{timestamp}.md"
+        outputs_dir = DatabasePaths.get_user_outputs_dir(self.user_id)
+        await asyncio.to_thread(outputs_dir.mkdir, parents=True, exist_ok=True)
+        path = outputs_dir / filename
+        await asyncio.to_thread(path.write_text, content, encoding="utf-8")
+
+        metadata = {
+            "item_id": item_id,
+            "url": url,
+            "canonical_url": url,
+            "source": "save_url",
+            "format": "md",
+            "title": title,
+        }
+        output_row = self.collections.create_output_artifact(
+            type_="reading_archive",
+            title=f"{title} (archive {timestamp})",
+            format_="md",
+            storage_path=filename,
+            metadata_json=json.dumps(metadata, ensure_ascii=False),
+            media_item_id=media_item_id,
+            retention_until=self.resolve_archive_retention(),
+        )
+        return int(output_row.id), None
+
+
+class ReadingImportService:
+    """Normalize and persist reading-list import items."""
+
+    def __init__(self, *, collections: CollectionsDatabase, normalize_url: Any) -> None:
+        self.collections = collections
+        self._normalize_url = normalize_url
+
+    def import_items(
+        self,
+        *,
+        items: list[ReadingImportItem],
+        merge_tags: bool = True,
+        origin_type: str = "import",
+    ) -> ReadingImportResult:
+        skipped = sum(
+            1
+            for item in items
+            if not is_supported_reading_url(str(getattr(item, "url", "") or "").strip())
+        )
+        normalized = normalize_import_items(items)
+        imported = 0
+        updated = 0
+        errors: list[str] = []
+
+        for item in normalized:
+            url = item.url.strip() if item.url else ""
+            if not url or not is_supported_reading_url(url):
+                skipped += 1
+                continue
+            normalized_url = self._normalize_url(url, "reading_import")
+            if not is_supported_reading_url(normalized_url):
+                skipped += 1
+                continue
+            parsed = urlparse(normalized_url)
+            domain = parsed.netloc.lower() if parsed.netloc else None
+            status = normalize_reading_status(item.status)
+            read_at = item.read_at
+            if status == "read" and not read_at:
+                read_at = _utcnow_iso()
+            tags = item.tags or []
+            metadata_payload = {"source": "reading_import"}
+            metadata_payload.update(item.metadata or {})
+            if normalized_url != url:
+                metadata_payload.setdefault("import_original_url", url)
+            try:
+                row = self.collections.upsert_content_item(
+                    origin="reading",
+                    origin_type=origin_type,
+                    origin_id=None,
+                    url=normalized_url,
+                    canonical_url=normalized_url,
+                    domain=domain,
+                    title=item.title or normalized_url,
+                    summary=None,
+                    notes=item.notes,
+                    content_hash=None,
+                    word_count=None,
+                    published_at=None,
+                    status=status,
+                    favorite=item.favorite,
+                    metadata=metadata_payload,
+                    media_id=None,
+                    job_id=None,
+                    run_id=None,
+                    source_id=None,
+                    read_at=read_at,
+                    tags=tags,
+                    merge_tags=merge_tags,
+                    preserve_existing_on_null=True,
+                )
+                if row.is_new:
+                    imported += 1
+                else:
+                    updated += 1
+            except _READING_SERVICE_NONCRITICAL_EXCEPTIONS as exc:
+                errors.append(f"{url}: {exc}")
+        return ReadingImportResult(imported=imported, updated=updated, skipped=skipped, errors=errors)
+
+
 class ReadingService:
     """Utilities for Reading List capture and updates."""
 
     def __init__(self, user_id: int | str) -> None:
         self.user_id = int(user_id)
         self.collections = CollectionsDatabase.for_user(self.user_id)
+        self._archive_service = ReadingArchiveService(user_id=self.user_id, collections=self.collections)
+        self._import_service = ReadingImportService(
+            collections=self.collections,
+            normalize_url=self._normalize_url,
+        )
 
     @staticmethod
     def _normalize_url(value: str, source: str) -> str:
@@ -406,14 +573,7 @@ class ReadingService:
 
     @staticmethod
     def _resolve_archive_retention() -> str | None:
-        try:
-            days = max(0, int(READING_ARCHIVE_RETENTION_DAYS))
-        except (TypeError, ValueError):
-            return None
-        if days <= 0:
-            return None
-        expires = datetime.now(tz=timezone.utc) + timedelta(days=days)
-        return expires.isoformat()
+        return ReadingArchiveService.resolve_archive_retention()
 
     async def _create_archive_artifact(
         self,
@@ -424,40 +584,13 @@ class ReadingService:
         body_text: str,
         media_item_id: int | None,
     ) -> tuple[int | None, str | None]:
-        text_value = (body_text or "").strip()
-        if not text_value:
-            return None, "archive_no_content"
-        content = f"# {title}\n\n{url or ''}\n\n{text_value}\n"
-        content_bytes = content.encode("utf-8")
-        if READING_ARCHIVE_MAX_BYTES > 0 and len(content_bytes) > READING_ARCHIVE_MAX_BYTES:
-            return None, "archive_too_large"
-
-        timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
-        safe_title = _safe_filename_fragment(title, max_len=40)
-        filename = f"reading_archive_{item_id}_{safe_title}_{timestamp}.md"
-        outputs_dir = DatabasePaths.get_user_outputs_dir(self.user_id)
-        await asyncio.to_thread(outputs_dir.mkdir, parents=True, exist_ok=True)
-        path = outputs_dir / filename
-        await asyncio.to_thread(path.write_text, content, encoding="utf-8")
-
-        metadata = {
-            "item_id": item_id,
-            "url": url,
-            "canonical_url": url,
-            "source": "save_url",
-            "format": "md",
-            "title": title,
-        }
-        output_row = self.collections.create_output_artifact(
-            type_="reading_archive",
-            title=f"{title} (archive {timestamp})",
-            format_="md",
-            storage_path=filename,
-            metadata_json=json.dumps(metadata, ensure_ascii=False),
+        return await self._archive_service.create_archive_artifact(
+            item_id=item_id,
+            title=title,
+            url=url,
+            body_text=body_text,
             media_item_id=media_item_id,
-            retention_until=self._resolve_archive_retention(),
         )
-        return int(output_row.id), None
 
     async def save_url(
         self,
@@ -474,7 +607,7 @@ class ReadingService:
         archive_mode: str = "use_default",
     ) -> ReadingSaveResult:
         """Fetch, dedupe, and persist a reading item."""
-        normalized_status = (status or READING_DEFAULT_STATUS).lower()
+        normalized_status = normalize_reading_status(status, default=READING_DEFAULT_STATUS)
         tags = [t for t in (tags or []) if t]
         archive_requested = self._resolve_archive_requested(archive_mode)
         try:
@@ -528,18 +661,21 @@ class ReadingService:
             metadata_payload["fetch_status"] = article.get("status_code")
         if media_uuid:
             metadata_payload["media_uuid"] = media_uuid
-        if article.get("clean_html"):
-            metadata_payload["clean_html"] = article.get("clean_html")
-        if content:
-            metadata_payload["text"] = content
+        if metadata:
+            metadata_payload.update(metadata)
+        _add_bounded_metadata_text(
+            metadata_payload,
+            "clean_html",
+            str(article.get("clean_html") or "") if article.get("clean_html") else None,
+            READING_CLEAN_HTML_METADATA_MAX_CHARS,
+        )
+        _add_bounded_metadata_text(metadata_payload, "text", content, READING_CONTENT_METADATA_MAX_CHARS)
         if content_word_count:
             metadata_payload["reading_time_seconds"] = max(1, int(content_word_count / 200 * 60))
         if fetch_error:
             metadata_payload["fetch_error"] = fetch_error
         else:
             metadata_payload["fetch_error"] = None
-        if metadata:
-            metadata_payload.update(metadata)
 
         item_row = self.collections.upsert_content_item(
             origin="reading",
@@ -825,6 +961,7 @@ class ReadingService:
         metadata: dict[str, object] | None = None,
     ) -> ContentItemRow:
         normalized_tags = tags if tags is None else [t for t in tags if t]
+        normalized_status = normalize_reading_status(status) if status is not None else None
         metadata = metadata or {}
         read_at: str | None = None
         clear_read_at = False
@@ -833,8 +970,7 @@ class ReadingService:
                 current = self.collections.get_content_item(item_id)
             except KeyError:
                 raise
-            status_lower = status.lower()
-            if status_lower == "read":
+            if normalized_status == "read":
                 if not current.read_at:
                     read_at = _utcnow_iso()
             else:
@@ -843,7 +979,7 @@ class ReadingService:
 
         return self.collections.update_content_item(
             item_id,
-            status=status,
+            status=normalized_status,
             favorite=favorite,
             tags=normalized_tags,
             notes=notes,
@@ -863,61 +999,8 @@ class ReadingService:
         merge_tags: bool = True,
         origin_type: str = "import",
     ) -> ReadingImportResult:
-        normalized = normalize_import_items(items)
-        imported = 0
-        updated = 0
-        skipped = 0
-        errors: list[str] = []
-
-        for item in normalized:
-            url = item.url.strip() if item.url else ""
-            if not url:
-                skipped += 1
-                continue
-            normalized_url = self._normalize_url(url, "reading_import")
-            parsed = urlparse(normalized_url)
-            domain = parsed.netloc.lower() if parsed.netloc else None
-            status = (item.status or "saved").strip().lower()
-            if status not in {"saved", "reading", "read", "archived"}:
-                status = "saved"
-            read_at = item.read_at
-            if status == "read" and not read_at:
-                read_at = _utcnow_iso()
-            tags = item.tags or []
-            metadata_payload = {"source": "reading_import"}
-            metadata_payload.update(item.metadata or {})
-            if normalized_url != url:
-                metadata_payload.setdefault("import_original_url", url)
-            try:
-                row = self.collections.upsert_content_item(
-                    origin="reading",
-                    origin_type=origin_type,
-                    origin_id=None,
-                    url=normalized_url,
-                    canonical_url=normalized_url,
-                    domain=domain,
-                    title=item.title or normalized_url,
-                    summary=None,
-                    notes=item.notes,
-                    content_hash=None,
-                    word_count=None,
-                    published_at=None,
-                    status=status,
-                    favorite=item.favorite,
-                    metadata=metadata_payload,
-                    media_id=None,
-                    job_id=None,
-                    run_id=None,
-                    source_id=None,
-                    read_at=read_at,
-                    tags=tags,
-                    merge_tags=merge_tags,
-                    preserve_existing_on_null=True,
-                )
-                if row.is_new:
-                    imported += 1
-                else:
-                    updated += 1
-            except _READING_SERVICE_NONCRITICAL_EXCEPTIONS as exc:
-                errors.append(f"{url}: {exc}")
-        return ReadingImportResult(imported=imported, updated=updated, skipped=skipped, errors=errors)
+        return self._import_service.import_items(
+            items=items,
+            merge_tags=merge_tags,
+            origin_type=origin_type,
+        )

--- a/tldw_Server_API/app/core/Collections/utils.py
+++ b/tldw_Server_API/app/core/Collections/utils.py
@@ -31,6 +31,7 @@ def truncate_text_hard(value: str | None, limit: int) -> tuple[str | None, bool,
 
 
 def normalize_reading_status(value: str | None, default: str = "saved") -> str:
+    """Normalize untrusted reading status values to the allowed set."""
     text = str(value or default).strip().lower()
     if text in READING_ALLOWED_STATUSES:
         return text
@@ -39,6 +40,7 @@ def normalize_reading_status(value: str | None, default: str = "saved") -> str:
 
 
 def is_supported_reading_url(value: str | None) -> bool:
+    """Return True when value is an absolute http(s) reading URL."""
     if not value:
         return False
     parsed = urlparse(str(value).strip())

--- a/tldw_Server_API/app/core/Collections/utils.py
+++ b/tldw_Server_API/app/core/Collections/utils.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 import hashlib
 import re
+from urllib.parse import urlparse
+
+
+READING_ALLOWED_STATUSES = frozenset({"saved", "reading", "read", "archived"})
 
 
 def truncate_text(value: str | None, limit: int = 400) -> str | None:
@@ -11,6 +15,34 @@ def truncate_text(value: str | None, limit: int = 400) -> str | None:
     if len(stripped) <= limit:
         return stripped
     return stripped[: max(0, limit - 3)].rstrip() + "..."
+
+
+def truncate_text_hard(value: str | None, limit: int) -> tuple[str | None, bool, int]:
+    """Return text capped to limit without exceeding the requested length."""
+    if value is None:
+        return None, False, 0
+    text = str(value)
+    original_len = len(text)
+    if limit <= 0:
+        return None, bool(text), original_len
+    if original_len <= limit:
+        return text, False, original_len
+    return text[:limit], True, original_len
+
+
+def normalize_reading_status(value: str | None, default: str = "saved") -> str:
+    text = str(value or default).strip().lower()
+    if text in READING_ALLOWED_STATUSES:
+        return text
+    fallback = str(default or "saved").strip().lower()
+    return fallback if fallback in READING_ALLOWED_STATUSES else "saved"
+
+
+def is_supported_reading_url(value: str | None) -> bool:
+    if not value:
+        return False
+    parsed = urlparse(str(value).strip())
+    return parsed.scheme.lower() in {"http", "https"} and bool(parsed.netloc)
 
 
 def hash_text_sha256(value: str | None) -> str | None:

--- a/tldw_Server_API/tests/Collections/test_embedding_queue.py
+++ b/tldw_Server_API/tests/Collections/test_embedding_queue.py
@@ -46,6 +46,36 @@ async def test_enqueue_embeddings_job_uses_manager(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_enqueue_embeddings_job_bounds_payload_content(monkeypatch):
+    captured = {}
+    enqueue = {}
+
+    class FakeManager:
+        def create_job(self, **kwargs):
+            captured["job_kwargs"] = kwargs
+            return {"id": 123, "uuid": "root-123"}
+
+    _disable_test_mode(monkeypatch)
+    monkeypatch.setattr(embedding_queue, "_jobs_manager", lambda: FakeManager())
+    monkeypatch.setattr(embedding_queue, "EMBEDDING_JOB_CONTENT_MAX_CHARS", 12)
+    monkeypatch.setattr(redis_pipeline, "allow_stub", lambda: True)
+    monkeypatch.setattr(redis_pipeline, "enqueue_content_job", lambda **kwargs: enqueue.update(kwargs) or "stream-1")
+
+    await enqueue_embeddings_job_for_item(
+        user_id=123,
+        item_id=456,
+        content="A" * 80,
+        metadata={"origin": "reading"},
+    )
+
+    payload = captured["job_kwargs"]["payload"]
+    assert len(payload["content"]) <= 12
+    assert payload["metadata"]["content_truncated"] is True
+    assert payload["metadata"]["content_char_count"] == 80
+    assert enqueue["payload"]["metadata"]["content_truncated"] is True
+
+
+@pytest.mark.asyncio
 async def test_enqueue_embeddings_skips_empty_content(monkeypatch):
     called = {}
 

--- a/tldw_Server_API/tests/Collections/test_embedding_queue.py
+++ b/tldw_Server_API/tests/Collections/test_embedding_queue.py
@@ -1,4 +1,6 @@
 import asyncio
+from typing import Any
+
 import pytest
 
 from tldw_Server_API.app.core.Collections import embedding_queue
@@ -46,12 +48,13 @@ async def test_enqueue_embeddings_job_uses_manager(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_enqueue_embeddings_job_bounds_payload_content(monkeypatch):
-    captured = {}
-    enqueue = {}
+async def test_enqueue_embeddings_job_bounds_payload_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Embedding jobs cap payload content and include truncation metadata."""
+    captured: dict[str, Any] = {}
+    enqueue: dict[str, Any] = {}
 
     class FakeManager:
-        def create_job(self, **kwargs):
+        def create_job(self, **kwargs: Any) -> dict[str, object]:
             captured["job_kwargs"] = kwargs
             return {"id": 123, "uuid": "root-123"}
 

--- a/tldw_Server_API/tests/Collections/test_reading_digests.py
+++ b/tldw_Server_API/tests/Collections/test_reading_digests.py
@@ -17,6 +17,8 @@ from tldw_Server_API.app.core.Collections.reading_digest_jobs import (
     READING_DIGEST_DOMAIN,
     READING_DIGEST_JOB_TYPE,
     _normalize_suggestions_config,
+    _render_default_html,
+    _render_default_markdown,
     _score_suggestion_candidate,
     handle_reading_digest_job,
     reading_digest_queue,
@@ -162,6 +164,18 @@ def test_reading_digest_suggestions_flags_accept_y():
     assert cfg["include_archived"] is True
     assert "read" in cfg["status"]
     assert "archived" in cfg["status"]
+
+
+def test_default_digest_renderers_do_not_link_unsafe_urls():
+    items = [{"title": "Unsafe", "url": "javascript:alert(1)", "summary": "Summary"}]
+
+    html = _render_default_html("Digest", items)
+    markdown = _render_default_markdown("Digest", items)
+
+    assert 'href="javascript:alert(1)"' not in html
+    assert "[Unsafe](javascript:alert(1))" not in markdown
+    assert "Unsafe" in html
+    assert "Unsafe" in markdown
 
 
 def test_reading_digest_schedule_crud(client_with_user):

--- a/tldw_Server_API/tests/Collections/test_reading_digests.py
+++ b/tldw_Server_API/tests/Collections/test_reading_digests.py
@@ -166,14 +166,23 @@ def test_reading_digest_suggestions_flags_accept_y():
     assert "archived" in cfg["status"]
 
 
-def test_default_digest_renderers_do_not_link_unsafe_urls():
-    items = [{"title": "Unsafe", "url": "javascript:alert(1)", "summary": "Summary"}]
+def test_default_digest_renderers_do_not_link_unsafe_urls() -> None:
+    """Default digest renderers keep unsafe URLs and markdown injection inert."""
+    items = [
+        {
+            "title": "Unsafe](javascript:alert(1))",
+            "url": "javascript:alert(1)",
+            "summary": "Summary [bad](javascript:alert(2))",
+        }
+    ]
 
     html = _render_default_html("Digest", items)
     markdown = _render_default_markdown("Digest", items)
 
     assert 'href="javascript:alert(1)"' not in html
-    assert "[Unsafe](javascript:alert(1))" not in markdown
+    assert "](javascript:alert(1))" not in markdown
+    assert "[bad](javascript:alert(2))" not in markdown
+    assert "javascript:" not in markdown
     assert "Unsafe" in html
     assert "Unsafe" in markdown
 

--- a/tldw_Server_API/tests/Collections/test_reading_import_export.py
+++ b/tldw_Server_API/tests/Collections/test_reading_import_export.py
@@ -68,7 +68,8 @@ def test_parse_instapaper_export():
     assert item.notes == "Note A"
 
 
-def test_reading_import_max_bytes_invalid_env_uses_default(monkeypatch):
+def test_reading_import_max_bytes_invalid_env_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invalid READING_IMPORT_MAX_BYTES falls back without import-time failure."""
     monkeypatch.setenv("READING_IMPORT_MAX_BYTES", "not-an-int")
     reloaded = importlib.reload(reading_import_jobs_module)
     try:

--- a/tldw_Server_API/tests/Collections/test_reading_import_export.py
+++ b/tldw_Server_API/tests/Collections/test_reading_import_export.py
@@ -18,6 +18,7 @@ from tldw_Server_API.app.core.Collections.reading_import_jobs import (
     resolve_reading_import_file,
     stage_reading_import_file,
 )
+import tldw_Server_API.app.core.Collections.reading_import_jobs as reading_import_jobs_module
 from tldw_Server_API.app.core.Collections.reading_importers import (
     parse_instapaper_export,
     parse_pocket_export,
@@ -65,6 +66,16 @@ def test_parse_instapaper_export():
     assert set(item.tags) == {"tag1", "tag2"}
     assert item.status == "archived"
     assert item.notes == "Note A"
+
+
+def test_reading_import_max_bytes_invalid_env_uses_default(monkeypatch):
+    monkeypatch.setenv("READING_IMPORT_MAX_BYTES", "not-an-int")
+    reloaded = importlib.reload(reading_import_jobs_module)
+    try:
+        assert reloaded.MAX_READING_IMPORT_BYTES == 10 * 1024 * 1024
+    finally:
+        monkeypatch.delenv("READING_IMPORT_MAX_BYTES", raising=False)
+        importlib.reload(reading_import_jobs_module)
 
 
 @pytest.mark.usefixtures("client_with_user")

--- a/tldw_Server_API/tests/Collections/test_reading_service.py
+++ b/tldw_Server_API/tests/Collections/test_reading_service.py
@@ -88,6 +88,24 @@ async def test_reading_save_and_list(reading_env):
 
 
 @pytest.mark.asyncio
+async def test_reading_save_bounds_metadata_text(reading_env, monkeypatch):
+    monkeypatch.setattr(reading_service_module, "READING_CONTENT_METADATA_MAX_CHARS", 24)
+    service = ReadingService(TEST_USER_ID + 20)
+    content = "A" * 100
+
+    result = await service.save_url(
+        url="https://example.org/large-metadata",
+        title_override="Large Metadata",
+        content_override=content,
+    )
+
+    metadata = json.loads(result.item.metadata_json or "{}")
+    assert len(metadata["text"]) <= 24
+    assert metadata["text_truncated"] is True
+    assert metadata["text_char_count"] == len(content)
+
+
+@pytest.mark.asyncio
 async def test_reading_save_merges_tags_on_duplicate(reading_env):
     service = ReadingService(TEST_USER_ID + 10)
     first = await service.save_url(
@@ -109,6 +127,21 @@ async def test_reading_save_merges_tags_on_duplicate(reading_env):
         content_override="Dupe content body.",
     )
     assert set(second.item.tags) == {"alpha", "beta"}
+
+
+@pytest.mark.asyncio
+async def test_reading_status_is_normalized_on_save_and_update(reading_env):
+    service = ReadingService(TEST_USER_ID + 21)
+    saved = await service.save_url(
+        url="https://example.org/status-normalized",
+        status="not-a-status",
+        title_override="Status Normalized",
+        content_override="Status body.",
+    )
+    assert saved.item.status == "saved"
+
+    updated = service.update_item(saved.item.id, status="also-invalid")
+    assert updated.status == "saved"
 
 
 @pytest.mark.asyncio
@@ -140,6 +173,13 @@ async def test_reading_update_status_and_filters(reading_env):
     assert any(row.id == save_result.item.id for row in rows)
 
 
+def test_reading_service_uses_focused_helpers(reading_env):
+    service = ReadingService(TEST_USER_ID + 22)
+
+    assert type(service._archive_service).__name__ == "ReadingArchiveService"
+    assert type(service._import_service).__name__ == "ReadingImportService"
+
+
 def test_reading_import_items_normalize_domain_and_read_at(reading_env):
     service = ReadingService(TEST_USER_ID + 11)
     result = service.import_items(
@@ -166,6 +206,39 @@ def test_reading_import_items_normalize_domain_and_read_at(reading_env):
     assert row.domain == "example.org"
     assert row.status == "read"
     assert row.read_at is not None
+
+
+def test_reading_import_skips_non_http_urls(reading_env):
+    service = ReadingService(TEST_USER_ID + 23)
+    result = service.import_items(
+        items=[
+            ReadingImportItem(
+                url="javascript:alert(1)",
+                title="Bad link",
+                tags=[],
+                status="saved",
+                favorite=False,
+                notes=None,
+                read_at=None,
+                metadata={},
+            ),
+            ReadingImportItem(
+                url="https://example.org/good",
+                title="Good link",
+                tags=[],
+                status="saved",
+                favorite=False,
+                notes=None,
+                read_at=None,
+                metadata={},
+            ),
+        ]
+    )
+
+    rows, total = service.list_items(page=1, size=10)
+    assert result.skipped == 1
+    assert total == 1
+    assert rows[0].url == "https://example.org/good"
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Collections/test_reading_service.py
+++ b/tldw_Server_API/tests/Collections/test_reading_service.py
@@ -88,7 +88,8 @@ async def test_reading_save_and_list(reading_env):
 
 
 @pytest.mark.asyncio
-async def test_reading_save_bounds_metadata_text(reading_env, monkeypatch):
+async def test_reading_save_bounds_metadata_text(reading_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Saving long reading content stores bounded metadata text with diagnostics."""
     monkeypatch.setattr(reading_service_module, "READING_CONTENT_METADATA_MAX_CHARS", 24)
     service = ReadingService(TEST_USER_ID + 20)
     content = "A" * 100
@@ -130,7 +131,8 @@ async def test_reading_save_merges_tags_on_duplicate(reading_env):
 
 
 @pytest.mark.asyncio
-async def test_reading_status_is_normalized_on_save_and_update(reading_env):
+async def test_reading_status_is_normalized_on_save_and_update(reading_env: Path) -> None:
+    """Invalid save/update reading statuses normalize to the default status."""
     service = ReadingService(TEST_USER_ID + 21)
     saved = await service.save_url(
         url="https://example.org/status-normalized",
@@ -173,7 +175,8 @@ async def test_reading_update_status_and_filters(reading_env):
     assert any(row.id == save_result.item.id for row in rows)
 
 
-def test_reading_service_uses_focused_helpers(reading_env):
+def test_reading_service_uses_focused_helpers(reading_env: Path) -> None:
+    """ReadingService wires focused archive and import helper services."""
     service = ReadingService(TEST_USER_ID + 22)
 
     assert type(service._archive_service).__name__ == "ReadingArchiveService"
@@ -208,7 +211,8 @@ def test_reading_import_items_normalize_domain_and_read_at(reading_env):
     assert row.read_at is not None
 
 
-def test_reading_import_skips_non_http_urls(reading_env):
+def test_reading_import_skips_non_http_urls(reading_env: Path) -> None:
+    """Reading imports skip unsupported URL schemes while preserving valid rows."""
     service = ReadingService(TEST_USER_ID + 23)
     result = service.import_items(
         items=[


### PR DESCRIPTION
## Summary
- Bound reading metadata and embedding job payloads with explicit truncation metadata.
- Skip non-http(s) reading imports and render unsafe digest URLs as plain text.
- Centralize reading status normalization, harden import-size env parsing, and move archive/import work behind focused ReadingService helpers.

## Verification
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m compileall -q tldw_Server_API/app/core/Collections tldw_Server_API/tests/Collections/test_reading_service.py tldw_Server_API/tests/Collections/test_embedding_queue.py tldw_Server_API/tests/Collections/test_reading_digests.py tldw_Server_API/tests/Collections/test_reading_import_export.py`
- `git diff --check -- ...` for touched Collections and Backlog files
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Collections/reading_service.py tldw_Server_API/app/core/Collections/reading_importers.py tldw_Server_API/app/core/Collections/reading_import_jobs.py tldw_Server_API/app/core/Collections/reading_digest_jobs.py tldw_Server_API/app/core/Collections/embedding_queue.py tldw_Server_API/app/core/Collections/utils.py -f json -o /tmp/bandit_task_2412_collections_pr_branch.json` (0 findings)
- Direct behavioral checks passed for unsafe digest links, invalid import env fallback, embedding payload truncation, save/update status normalization, bounded metadata, helper wiring, and non-http import skip.

## Test Caveat
Focused pytest timed out before executing the Collections test body because a repo-wide autouse fixture imported `character_chat_sessions -> Research/RAG -> nltk/scipy` during setup. The timeout stack did not enter the changed Collections code.

## Change Summary Required
This PR was materially authored by AI. Per project policy, a human requester must replace this section with a human-written Change summary that explains both what changed and why these implementation choices were made before marking the PR ready for merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Collections reading module to bound metadata and embedding payloads, neutralize unsafe links in imports and digests, and unify status handling. Split archive/import into focused services with robust env parsing, with no public API changes.

- **Bug Fixes**
  - Skip non-http(s) import URLs; digest renderers escape Markdown and only link safe http(s) URLs in Markdown and HTML.
  - Cap metadata `text` and `clean_html` with truncation flags/counts; bound embedding job content with truncation metadata under `EMBEDDING_JOB_CONTENT_MAX_CHARS`.
  - Safely parse `READING_IMPORT_MAX_BYTES` and `EMBEDDING_JOB_CONTENT_MAX_CHARS` with fallbacks; invalid env values no longer break imports.
  - Normalize statuses on save/update/import via a shared helper; auto-set `read_at` when status is `read`.

- **Refactors**
  - Added `ReadingArchiveService` and `ReadingImportService`; `ReadingService` delegates archive/import logic and retention resolution.
  - Centralized helpers: `is_supported_reading_url`, `normalize_reading_status`, `truncate_text_hard`; introduced `READING_CONTENT_METADATA_MAX_CHARS` and `READING_CLEAN_HTML_METADATA_MAX_CHARS` to bound metadata.

<sup>Written for commit fe2af20a73cae3e582b4903082611af4e6364e1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

