### PR TITLE
fix(embeddings): harden reviewed failure modes

### DIFF
--- a/Docs/superpowers/plans/2026-06-28-pr2451-review-rebase.md
+++ b/Docs/superpowers/plans/2026-06-28-pr2451-review-rebase.md
@@ -1,0 +1,42 @@
+# PR 2451 Review Rebase Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebase PR 2451 onto current `dev` and address every active PR review comment.
+
+**Architecture:** Keep the existing Embeddings hardening approach. Add regression coverage beside the affected modules, then make the smallest production changes needed to fail closed without broad refactors.
+
+**Tech Stack:** FastAPI backend, Python, pytest, ChromaDB, Redis embeddings enqueue path, Backlog.md.
+
+---
+
+## Stage 1: Rebase And Review Inventory
+**Goal**: Work from the current `dev` base and enumerate active PR feedback.
+**Success Criteria**: Branch rebased, active review threads identified, CI guard status understood.
+**Tests**: `python Helper_Scripts/ci/check_shard_coverage.py --ci-file .github/workflows/ci.yml`
+**Status**: Complete
+
+## Stage 2: Regression Tests
+**Goal**: Add red tests for each still-actionable review issue.
+**Success Criteria**: Tests fail for Chroma string booleans, Kanban enqueue failure state, artifact path type rejection, singleton removal expectations, and DLQ cleanup coverage.
+**Tests**: Targeted pytest node ids for the new tests.
+**Status**: Complete
+
+## Stage 3: Production Fixes
+**Goal**: Implement minimal fixes that satisfy the tests and review comments.
+**Success Criteria**: String booleans parse correctly, malformed artifact paths raise non-retryable `EmbeddingsJobError`, Kanban root jobs are failed on enqueue errors, request signing/sharding no longer use modified singleton accessors, and DLQ encryption metadata is written without redundant branching.
+**Tests**: Targeted pytest files pass.
+**Status**: Complete
+
+## Stage 4: Verification And PR Cleanup
+**Goal**: Verify touched scope, record Backlog evidence, push the rebased branch, and resolve/comment on PR threads.
+**Success Criteria**: Targeted tests, compileall, shard coverage guard, and Bandit pass or have documented environment blockers; branch is pushed to PR 2451; active review threads are addressed.
+**Tests**: `pytest` targeted files, `python -m compileall` on touched modules, `python -m bandit -r` on touched production paths.
+**Status**: Complete
+
+Verification completed locally:
+- `python -m pytest tldw_Server_API/tests/ChromaDB/unit/test_chromadb_dimensions_and_list.py tldw_Server_API/tests/Embeddings_isolated/test_review_findings_hardening.py tldw_Server_API/tests/Embeddings_isolated/test_request_signing_nonce_security.py tldw_Server_API/tests/kanban/test_kanban_vector_search.py -q`
+- `python Helper_Scripts/ci/check_shard_coverage.py --ci-file .github/workflows/ci.yml`
+- `python -m compileall tldw_Server_API/app/core/Embeddings/ChromaDB_Library.py tldw_Server_API/app/core/DB_Management/kanban_vector_search.py tldw_Server_API/app/core/Embeddings/services/jobs_worker.py tldw_Server_API/app/core/Embeddings/request_signing.py tldw_Server_API/app/core/Embeddings/sharding.py tldw_Server_API/app/core/Embeddings/dlq_crypto.py`
+- `python -m bandit -r tldw_Server_API/app/core/Embeddings/ChromaDB_Library.py tldw_Server_API/app/core/DB_Management/kanban_vector_search.py tldw_Server_API/app/core/Embeddings/services/jobs_worker.py tldw_Server_API/app/core/Embeddings/request_signing.py tldw_Server_API/app/core/Embeddings/sharding.py tldw_Server_API/app/core/Embeddings/dlq_crypto.py -f json -o /tmp/bandit_pr2451.json`
+- `git diff --check`

--- a/IMPLEMENTATION_PLAN_embeddings_review_findings_9927.md
+++ b/IMPLEMENTATION_PLAN_embeddings_review_findings_9927.md
@@ -1,0 +1,29 @@
+## Stage 1: Verify and Capture Regressions
+**Goal**: Confirm the current Embeddings findings and add focused failing tests for the validated hot-path defects.
+**Success Criteria**: Tests demonstrate unsafe artifact paths, unsafe Chroma fallback/dimension behavior, orphaned Redis enqueue failures, DLQ encryption downgrade, and sensitive logging.
+**Tests**: Focused pytest cases under `tldw_Server_API/tests/Embeddings_isolated/` and `tldw_Server_API/tests/ChromaDB/unit/`.
+**Status**: Complete
+
+## Stage 2: Harden Artifact and Queue Boundaries
+**Goal**: Ensure job artifacts stay under the per-user artifact directory and Redis enqueue failures are surfaced to the root job.
+**Success Criteria**: Payload-provided artifact paths are rejected unless safely confined, generated artifact names are sanitized, and enqueue infrastructure failures do not leave root jobs queued without work.
+**Tests**: New/updated Embeddings job worker and jobs adapter tests.
+**Status**: Complete
+
+## Stage 3: Harden Chroma Storage Behavior
+**Goal**: Prevent silent in-memory fallback and implicit collection deletion on dimension mismatch.
+**Success Criteria**: Persistent Chroma initialization fails closed unless explicitly allowed, and dimension mismatches raise without deleting collections.
+**Tests**: New/updated ChromaDB unit tests.
+**Status**: Complete
+
+## Stage 4: Harden DLQ and Logging Privacy
+**Goal**: Fail closed for configured DLQ encryption when crypto is unavailable and remove sensitive payload text from logs.
+**Success Criteria**: DLQ encryption no longer returns `alg=none` for configured encryption, provider error logs omit response bodies, and vector search logs omit query text.
+**Tests**: New/updated Embeddings DLQ, connection pool, and ChromaDB logging tests.
+**Status**: Complete
+
+## Stage 5: Dead-Code Cleanup Notes and Verification
+**Goal**: Quarantine or document inactive sharding/request-signing helpers and run focused verification.
+**Success Criteria**: Runtime-facing inactive helpers are clearly marked or removed from active paths, focused tests pass, Bandit is run on touched Embeddings files, and TASK-9927 is updated with results.
+**Tests**: Focused pytest commands plus Bandit touched-scope scan.
+**Status**: Complete

--- a/backlog/tasks/task-12054 - Rebase-PR-2451-on-dev-and-address-review-comments.md
+++ b/backlog/tasks/task-12054 - Rebase-PR-2451-on-dev-and-address-review-comments.md
@@ -1,0 +1,62 @@
+---
+id: TASK-12054
+title: Rebase PR 2451 on dev and address review comments
+status: Done
+labels:
+- pr-review
+- embeddings
+priority: high
+references:
+- https://github.com/rmusser01/tldw_server/pull/2451
+modified_files:
+- Docs/superpowers/plans/2026-06-28-pr2451-review-rebase.md
+- backlog/tasks/task-12054 - Rebase-PR-2451-on-dev-and-address-review-comments.md
+- tldw_Server_API/app/core/Embeddings/ChromaDB_Library.py
+- tldw_Server_API/app/core/DB_Management/kanban_vector_search.py
+- tldw_Server_API/app/core/Embeddings/services/jobs_worker.py
+- tldw_Server_API/app/core/Embeddings/request_signing.py
+- tldw_Server_API/app/core/Embeddings/sharding.py
+- tldw_Server_API/app/core/Embeddings/dlq_crypto.py
+- tldw_Server_API/tests/ChromaDB/unit/test_chromadb_dimensions_and_list.py
+- tldw_Server_API/tests/Embeddings_isolated/test_review_findings_hardening.py
+- tldw_Server_API/tests/Embeddings_isolated/test_request_signing_nonce_security.py
+- tldw_Server_API/tests/kanban/test_kanban_vector_search.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase PR 2451 onto latest dev and remediate all active PR review comments/issues: Redis root-job failure handling, Chroma boolean parsing, artifact path type validation, singleton rule feedback, DLQ cleanup, and CI shard coverage guard if still applicable.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-28-pr2451-review-rebase.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Rebased PR branch onto origin/dev. Added red/green regression tests and fixes for active PR review findings: Chroma string boolean parsing, Kanban root-job failure on Redis enqueue errors, non-retryable artifact path type validation, request signer/shard manager singleton removal, and DLQ redundant branch cleanup. Local shard coverage guard passes after rebase.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR 2451 branch onto origin/dev and addressed the active PR review threads. Implemented string-safe Chroma stub/fallback flag parsing, Kanban root-job failure handling for Redis enqueue errors, non-retryable Embeddings artifact path type validation, request signer and shard manager factories without reviewed global singleton reuse, and DLQ encryption branch cleanup. Verification: targeted red tests failed before production changes and passed after; affected test files passed (62 tests); shard coverage guard passed; compileall passed on touched production modules; Bandit reported zero findings on touched production scope; git diff --check passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-9927 - Fix-validated-Embeddings-module-review-findings.md
+++ b/backlog/tasks/task-9927 - Fix-validated-Embeddings-module-review-findings.md
@@ -1,0 +1,76 @@
+---
+id: TASK-9927
+title: Fix validated Embeddings module review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 18:48'
+updated_date: '2026-06-23 18:52'
+labels:
+  - embeddings
+  - security
+  - reliability
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and address validated current-code findings from the Embeddings module review. Scope includes job artifact path confinement, Chroma persistent-client fallback behavior, Chroma dimension mismatch handling, Redis enqueue failure handling, DLQ encryption fail-closed behavior, sensitive log redaction, and inactive sharding/request-signing helper quarantine.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Job artifact paths cannot escape the per-user embeddings artifact directory.
+- [x] #2 Persistent Chroma client initialization fails closed unless stub mode or fallback is explicitly enabled.
+- [x] #3 Embedding dimension mismatches no longer delete existing collections implicitly.
+- [x] #4 Redis enqueue infrastructure errors fail the root job instead of leaving it orphaned.
+- [x] #5 Configured DLQ encryption never silently degrades to base64-only encoding.
+- [x] #6 Provider error and vector-search logs do not include sensitive payload text.
+- [x] #7 Inactive sharding/request-signing modules are quarantined from runtime use.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add regression tests that reproduce each validated hot-path issue.
+2. Implement the minimal code changes needed to make those tests pass.
+3. Run focused tests for Embeddings/ChromaDB paths.
+4. Run Bandit on touched Embeddings paths.
+5. Update task notes/final summary with verification evidence.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Validated findings and implemented focused fixes:
+- Confined embeddings job artifact identifiers and payload-provided artifact paths to the per-user artifact directory.
+- Made Redis idempotency infrastructure failures raise so the adapter fails the root job instead of orphaning it.
+- Made persistent Chroma fallback fail closed by default and made dimension mismatches non-destructive.
+- Removed sensitive provider response bodies and vector-search query text from logs.
+- Made configured DLQ encryption fail closed when AES-GCM is unavailable or a plaintext fallback is returned.
+- Gated inactive sharding and request-signing singleton helpers behind explicit configuration, including request-signing API-key manager key-file configuration.
+
+Verification:
+- Red runs observed expected regression failures before implementation, including artifact escape, Chroma fallback/deletion, Redis orphaning, DLQ downgrade, log leakage, sharding/request-signing singleton defaults, and request-signing API-key default generation.
+- source .venv/bin/activate && python -m pytest --confcutdir=tldw_Server_API/tests/Embeddings_isolated -q tldw_Server_API/tests/Embeddings_isolated/test_review_findings_hardening.py tldw_Server_API/tests/Embeddings_isolated/test_request_signing_nonce_security.py => 11 passed, 14 warnings.
+- source .venv/bin/activate && python -m pytest --confcutdir=tldw_Server_API/tests/ChromaDB -q tldw_Server_API/tests/ChromaDB/unit/test_chromadb_dimensions_and_list.py => 17 passed, 4 warnings.
+- source .venv/bin/activate && python -m compileall -q <touched files> => passed.
+- source .venv/bin/activate && python -m bandit -r <touched production files> -f json -o /tmp/bandit_embeddings_review_findings_9927.json => 0 findings.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed Embeddings review remediation. Hot-path security/reliability findings are fixed with regression coverage; inactive sharding/request-signing helper risks are quarantined behind explicit configuration. Focused tests, compileall, and Bandit passed on the touched scope.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/DB_Management/kanban_vector_search.py
+++ b/tldw_Server_API/app/core/DB_Management/kanban_vector_search.py
@@ -15,6 +15,7 @@ Metadata: card_id, board_id, list_id, due_date, priority, labels, created_at
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import os
 from typing import Any
@@ -331,12 +332,22 @@ class KanbanVectorSearch:
             stage_payload["parent_job_uuid"] = root_uuid
             stage_payload["user_id"] = str(self.user_id)
 
-            redis_pipeline.enqueue_content_job(
-                payload=stage_payload,
-                root_job_uuid=root_uuid,
-                force_regenerate=False,
-                require_redis=not redis_pipeline.allow_stub(),
-            )
+            try:
+                redis_pipeline.enqueue_content_job(
+                    payload=stage_payload,
+                    root_job_uuid=root_uuid,
+                    force_regenerate=False,
+                    require_redis=not redis_pipeline.allow_stub(),
+                )
+            except Exception:
+                with contextlib.suppress(Exception):
+                    jm.fail_job(
+                        int(root_job["id"]),
+                        error="Failed to enqueue kanban embeddings job to Redis",
+                        retryable=False,
+                        enforce=False,
+                    )
+                raise
 
             logger.debug(f"Queued embeddings for card {card_id} (user {self.user_id})")
             return True

--- a/tldw_Server_API/app/core/Embeddings/ChromaDB_Library.py
+++ b/tldw_Server_API/app/core/Embeddings/ChromaDB_Library.py
@@ -336,7 +336,7 @@ class ChromaDBManager:
                 or backend == "stub"
                 or _env_force_stub
             )
-            allow_stub_fallback = bool(chroma_client_settings_config.get("allow_stub_fallback", True))
+            allow_stub_fallback = bool(chroma_client_settings_config.get("allow_stub_fallback", False))
 
             if use_stub:
                 # Scope the stub client key by user and base dir to avoid cross-config leakage
@@ -1295,25 +1295,21 @@ class ChromaDBManager:
             try:
                 cleaned_metadatas = [self._clean_metadata(metadata) for metadata in metadatas]
 
-                # Dimension Check and Collection Recreation (if needed)
-                # This check is more robust if the collection stores its expected dimension in metadata
+                # Dimension checks are non-destructive. A mismatch means callers are mixing
+                # embedding models/dimensions in one collection and must choose a new collection.
                 collection_meta = target_collection.metadata
                 existing_dim_from_meta = None
                 if collection_meta and "embedding_dimension" in collection_meta:
                     existing_dim_from_meta = int(collection_meta["embedding_dimension"])
 
                 if existing_dim_from_meta and existing_dim_from_meta != new_embedding_dim:
-                    logger.warning(
+                    message = (
                         f"User '{self.user_id}': Embedding dimension mismatch for collection '{target_collection.name}'. "
                         f"Collection expected dim (from metadata): {existing_dim_from_meta}, New: {new_embedding_dim} "
-                        f"(from model_id '{embedding_model_id_for_dim_check or 'Unknown'}'). Recreating collection."
+                        f"(from model_id '{embedding_model_id_for_dim_check or 'Unknown'}')."
                     )
-                    self.client.delete_collection(name=target_collection.name)
-                    new_coll_meta = {"embedding_dimension": new_embedding_dim}
-                    if embedding_model_id_for_dim_check:
-                        new_coll_meta["source_model_id"] = embedding_model_id_for_dim_check
-                    target_collection = self.client.create_collection(name=target_collection.name,
-                                                                      metadata=new_coll_meta)
+                    logger.warning(message)
+                    raise ValueError(message)
                 elif not existing_dim_from_meta and target_collection.count() > 0:  # Has items but no dim in meta
                     # Fallback: get an existing embedding to check dimension
                     existing_item = target_collection.get(limit=1, include=['embeddings'])
@@ -1321,16 +1317,13 @@ class ChromaDBManager:
                     if embeddings_exist and len(existing_item['embeddings']) > 0:
                         existing_dim_from_sample = len(existing_item['embeddings'][0])
                         if existing_dim_from_sample != new_embedding_dim:
-                            logger.warning(
-                                f"User '{self.user_id}': Dim mismatch (sampled). Existing: {existing_dim_from_sample}, New: {new_embedding_dim}. Recreating '{target_collection.name}'."
+                            message = (
+                                f"User '{self.user_id}': Embedding dimension mismatch for collection "
+                                f"'{target_collection.name}'. Existing: {existing_dim_from_sample}, "
+                                f"New: {new_embedding_dim}."
                             )
-                            self.client.delete_collection(name=target_collection.name)
-                            new_coll_meta = {"embedding_dimension": new_embedding_dim}
-                            if embedding_model_id_for_dim_check:
-                                new_coll_meta[
-                                "source_model_id"] = embedding_model_id_for_dim_check
-                            target_collection = self.client.create_collection(name=target_collection.name,
-                                                                              metadata=new_coll_meta)
+                            logger.warning(message)
+                            raise ValueError(message)
 
                 # Batch upsert for potentially large number of embeddings
                 # ChromaDB's upsert handles batching internally, but if we had extremely large lists,
@@ -1383,6 +1376,8 @@ class ChromaDBManager:
                     f"User '{self.user_id}': ChromaDB error in store_in_chroma for collection '{target_collection.name}': {ce}",
                     exc_info=True)
                 raise RuntimeError(f"ChromaDB operation failed: {ce}") from ce
+            except ValueError:
+                raise
             except _CHROMA_NONCRITICAL_EXCEPTIONS as e:
                 import traceback
                 tb = traceback.format_exc()
@@ -1416,7 +1411,7 @@ class ChromaDBManager:
         with self._lock:
             try:
                 logger.info(
-                    f"User '{self.user_id}': Vector search in '{target_collection.name}' for query: '{query[:50]}...' "
+                    f"User '{self.user_id}': Vector search in '{target_collection.name}' "
                     f"using model_id '{query_embedding_model_id}'. k={k}, Filter: {where_filter is not None}."
                 )
 

--- a/tldw_Server_API/app/core/Embeddings/ChromaDB_Library.py
+++ b/tldw_Server_API/app/core/Embeddings/ChromaDB_Library.py
@@ -74,7 +74,7 @@ from tldw_Server_API.app.core.Embeddings.audit_adapter import (
     log_security_violation,
 )
 from tldw_Server_API.app.core.LLM_Calls.Summarization_General_Lib import analyze  # Assuming this is correct
-from tldw_Server_API.app.core.testing import env_flag_enabled
+from tldw_Server_API.app.core.testing import env_flag_enabled, is_truthy
 from tldw_Server_API.app.core.Utils.prompt_loader import load_prompt
 from tldw_Server_API.app.core.Utils.Utils import logger  # Assuming this is 'logging' aliased or a custom logger
 
@@ -331,12 +331,14 @@ class ChromaDBManager:
             backend = str(chroma_client_settings_config.get("backend", "persistent")).lower()
             # Honor explicit config, and also support CHROMADB_FORCE_STUB for tests/CI
             _env_force_stub = env_flag_enabled("CHROMADB_FORCE_STUB")
-            use_stub = bool(
-                chroma_client_settings_config.get("use_in_memory_stub", False)
+            use_stub = (
+                is_truthy(str(chroma_client_settings_config.get("use_in_memory_stub", "")).strip())
                 or backend == "stub"
                 or _env_force_stub
             )
-            allow_stub_fallback = bool(chroma_client_settings_config.get("allow_stub_fallback", False))
+            allow_stub_fallback = is_truthy(
+                str(chroma_client_settings_config.get("allow_stub_fallback", "")).strip()
+            )
 
             if use_stub:
                 # Scope the stub client key by user and base dir to avoid cross-config leakage

--- a/tldw_Server_API/app/core/Embeddings/connection_pool.py
+++ b/tldw_Server_API/app/core/Embeddings/connection_pool.py
@@ -176,13 +176,9 @@ class ConnectionPool:
 
                 status = int(getattr(resp, "status_code", 0))
                 if status >= 400:
-                    try:
-                        error_text = (resp.text or "")[:500]
-                    except Exception:
-                        error_text = ""
                     logger.error(
                         f"{self.provider} API error: "
-                        f"status={status}, body={error_text}"
+                        f"status={status}"
                     )
                     raise NetworkError(f"HTTP {status}")
 

--- a/tldw_Server_API/app/core/Embeddings/dlq_crypto.py
+++ b/tldw_Server_API/app/core/Embeddings/dlq_crypto.py
@@ -124,11 +124,10 @@ def encrypt_payload_if_configured(payload_obj: dict[str, Any]) -> str | None:
         obj = _aesgcm_encrypt(raw, key)
         if obj.get("alg") != "AESGCM":
             raise DLQEncryptionError("DLQ encryption unavailable: AES-GCM support is required")
-        if obj.get("alg") == "AESGCM":
-            obj["kdf"] = kdf_used
-            if kdf_used == "scrypt":
-                obj["salt"] = base64.b64encode(salt).decode("utf-8")
-                obj["kdf_params"] = _SCRYPT_PARAMS
+        obj["kdf"] = kdf_used
+        if kdf_used == "scrypt":
+            obj["salt"] = base64.b64encode(salt).decode("utf-8")
+            obj["kdf_params"] = _SCRYPT_PARAMS
         return json.dumps(obj)
     except (MemoryError, OSError, TypeError, ValueError) as exc:
         raise DLQEncryptionError("DLQ encryption failed") from exc

--- a/tldw_Server_API/app/core/Embeddings/dlq_crypto.py
+++ b/tldw_Server_API/app/core/Embeddings/dlq_crypto.py
@@ -2,7 +2,7 @@
 DLQ payload optional encryption helpers.
 
 Uses AES-GCM if `cryptography` is available and EMBEDDINGS_DLQ_ENCRYPTION_KEY is set.
-Falls back to base64 encoding when crypto is unavailable (marked alg=none).
+Configured encryption fails closed when AES-GCM is unavailable.
 """
 
 from __future__ import annotations
@@ -35,6 +35,10 @@ _SCRYPT_PARAMS = {
     "p": 1,
     "dklen": 32,
 }
+
+
+class DLQEncryptionError(RuntimeError):
+    """Raised when configured DLQ encryption cannot produce an encrypted payload."""
 
 
 def _derive_key_from_passphrase_legacy(passphrase: str) -> bytes:
@@ -70,8 +74,7 @@ def _aesgcm_encrypt(plaintext: bytes, key: bytes) -> dict[str, str]:
     try:
         from cryptography.hazmat.primitives.ciphers.aead import AESGCM  # type: ignore
     except ImportError:
-        # Fallback to base64-only marker
-        return {"alg": "none", "b64": base64.b64encode(plaintext).decode("utf-8")}
+        raise DLQEncryptionError("DLQ encryption unavailable: AES-GCM support is not installed")
     aesgcm = AESGCM(key)
     nonce = os.urandom(12)
     ct = aesgcm.encrypt(nonce, plaintext, associated_data=None)
@@ -109,7 +112,7 @@ def _aesgcm_decrypt(obj: dict[str, str], key: bytes) -> bytes | None:
 def encrypt_payload_if_configured(payload_obj: dict[str, Any]) -> str | None:
     """Return JSON string of encrypted blob when configured; else None.
 
-    When EMBEDDINGS_DLQ_ENCRYPTION_KEY is set, encrypts with AES-GCM (or base64 fallback).
+    When EMBEDDINGS_DLQ_ENCRYPTION_KEY is set, encrypts with AES-GCM.
     """
     key_str = os.getenv("EMBEDDINGS_DLQ_ENCRYPTION_KEY")
     if not key_str:
@@ -119,14 +122,16 @@ def encrypt_payload_if_configured(payload_obj: dict[str, Any]) -> str | None:
         key, kdf_used = _derive_key_from_passphrase(key_str, salt)
         raw = json.dumps(payload_obj, default=str).encode("utf-8")
         obj = _aesgcm_encrypt(raw, key)
+        if obj.get("alg") != "AESGCM":
+            raise DLQEncryptionError("DLQ encryption unavailable: AES-GCM support is required")
         if obj.get("alg") == "AESGCM":
             obj["kdf"] = kdf_used
             if kdf_used == "scrypt":
                 obj["salt"] = base64.b64encode(salt).decode("utf-8")
                 obj["kdf_params"] = _SCRYPT_PARAMS
         return json.dumps(obj)
-    except (MemoryError, OSError, TypeError, ValueError):
-        return None
+    except (MemoryError, OSError, TypeError, ValueError) as exc:
+        raise DLQEncryptionError("DLQ encryption failed") from exc
 
 
 def decrypt_payload_if_present(enc_json: str | None) -> dict[str, Any] | None:

--- a/tldw_Server_API/app/core/Embeddings/redis_pipeline.py
+++ b/tldw_Server_API/app/core/Embeddings/redis_pipeline.py
@@ -105,6 +105,10 @@ class RedisEmbeddingsQueues:
     dlq_prefix: str
 
 
+class RedisEnqueueError(RuntimeError):
+    """Raised when an embeddings Redis enqueue operation cannot be completed."""
+
+
 def load_queues() -> RedisEmbeddingsQueues:
     return RedisEmbeddingsQueues(
         streams={stage: stream_name(stage) for stage in _STAGE_STREAM_DEFAULTS},
@@ -179,7 +183,9 @@ def enqueue_chunking_job(
                     return None
             except Exception as exc:
                 logger.warning(f"Failed to set idempotency key for embeddings root {root_job_uuid}: {exc}")
-                return None
+                raise RedisEnqueueError(
+                    f"Failed to set Redis idempotency key for embeddings root {root_job_uuid}"
+                ) from exc
         return client.xadd(stream, _sanitize_stream_payload(payload))
     finally:
         if created_client:
@@ -226,7 +232,9 @@ def enqueue_content_job(
                     return None
             except Exception as exc:
                 logger.warning(f"Failed to set content idempotency key for embeddings root {root_job_uuid}: {exc}")
-                return None
+                raise RedisEnqueueError(
+                    f"Failed to set Redis idempotency key for embeddings root {root_job_uuid}"
+                ) from exc
         return client.xadd(stream, _sanitize_stream_payload(payload))
     finally:
         if created_client:

--- a/tldw_Server_API/app/core/Embeddings/request_signing.py
+++ b/tldw_Server_API/app/core/Embeddings/request_signing.py
@@ -401,20 +401,16 @@ class APIKeyManager:
 
 
 # Global instances
-_request_signer: Optional[RequestSigner] = None
 _nonce_manager: Optional[NonceManager] = None
 _api_key_manager: Optional[APIKeyManager] = None
 
 
-def get_request_signer() -> RequestSigner:
-    """Get or create the global request signer."""
-    global _request_signer
-    if _request_signer is None:
-        secret_key = (os.getenv("EMBEDDINGS_REQUEST_SIGNING_SECRET") or "").strip()
-        if not secret_key:
-            raise RuntimeError("Embeddings request signing secret is not configured")
-        _request_signer = RequestSigner(secret_key=secret_key)
-    return _request_signer
+def get_request_signer(secret_key: str | None = None) -> RequestSigner:
+    """Create a request signer from explicit or environment configuration."""
+    resolved_secret = (secret_key or os.getenv("EMBEDDINGS_REQUEST_SIGNING_SECRET") or "").strip()
+    if not resolved_secret:
+        raise RuntimeError("Embeddings request signing secret is not configured")
+    return RequestSigner(secret_key=resolved_secret)
 
 
 def get_nonce_manager() -> NonceManager:

--- a/tldw_Server_API/app/core/Embeddings/request_signing.py
+++ b/tldw_Server_API/app/core/Embeddings/request_signing.py
@@ -5,6 +5,7 @@ import base64
 import hashlib
 import hmac
 import json
+import os
 import secrets
 import threading
 import time
@@ -309,15 +310,8 @@ class APIKeyManager:
             except Exception as e:
                 logger.error(f"Failed to load API keys: {e}")
 
-        # Generate default key if none exist
         if not self.api_keys:
-            default_key = self.generate_api_key("default")
-            self.api_keys[default_key] = {
-                "name": "default",
-                "created_at": datetime.utcnow().isoformat(),
-                "permissions": ["read", "write"],
-                "rate_limit": "1000/hour"
-            }
+            raise RuntimeError("Embeddings request signing API key file loaded no keys")
 
     def generate_api_key(self, name: str) -> str:
         """
@@ -416,7 +410,10 @@ def get_request_signer() -> RequestSigner:
     """Get or create the global request signer."""
     global _request_signer
     if _request_signer is None:
-        _request_signer = RequestSigner()
+        secret_key = (os.getenv("EMBEDDINGS_REQUEST_SIGNING_SECRET") or "").strip()
+        if not secret_key:
+            raise RuntimeError("Embeddings request signing secret is not configured")
+        _request_signer = RequestSigner(secret_key=secret_key)
     return _request_signer
 
 
@@ -432,7 +429,10 @@ def get_api_key_manager() -> APIKeyManager:
     """Get or create the global API key manager."""
     global _api_key_manager
     if _api_key_manager is None:
-        _api_key_manager = APIKeyManager()
+        keys_file = (os.getenv("EMBEDDINGS_REQUEST_SIGNING_KEYS_FILE") or "").strip()
+        if not keys_file:
+            raise RuntimeError("Embeddings request signing API key file is not configured")
+        _api_key_manager = APIKeyManager(keys_file=keys_file)
     return _api_key_manager
 
 

--- a/tldw_Server_API/app/core/Embeddings/services/jobs_worker.py
+++ b/tldw_Server_API/app/core/Embeddings/services/jobs_worker.py
@@ -349,14 +349,19 @@ def _resolve_artifact_path(
     default_path: Path,
 ) -> Path:
     raw_value = payload.get(key)
-    candidate = Path(raw_value) if raw_value else default_path
-    if not candidate.is_absolute():
-        candidate = artifact_dir / candidate
-    artifact_root = artifact_dir.resolve()
-    resolved = candidate.resolve()
     try:
+        if raw_value in (None, ""):
+            candidate = default_path
+        elif isinstance(raw_value, (str, os.PathLike)):
+            candidate = Path(raw_value)
+        else:
+            raise TypeError(f"{key} must be a filesystem path string")
+        if not candidate.is_absolute():
+            candidate = artifact_dir / candidate
+        artifact_root = artifact_dir.resolve()
+        resolved = candidate.resolve()
         resolved.relative_to(artifact_root)
-    except ValueError as exc:
+    except (OSError, RuntimeError, TypeError, ValueError) as exc:
         raise EmbeddingsJobError(f"Invalid embeddings artifact path for {key}", retryable=False) from exc
     return resolved
 

--- a/tldw_Server_API/app/core/Embeddings/services/jobs_worker.py
+++ b/tldw_Server_API/app/core/Embeddings/services/jobs_worker.py
@@ -317,10 +317,48 @@ def _artifact_dir(
 ) -> Path:
     base_dir = DatabasePaths.get_user_vector_store_dir(user_id) / "embeddings_jobs"
     base_dir.mkdir(parents=True, exist_ok=True)
-    name = root_uuid or job_uuid or f"media_{media_id}"
-    path = base_dir / str(name)
+    name = _validate_artifact_identifier(root_uuid or job_uuid or f"media_{media_id}")
+    base_resolved = base_dir.resolve()
+    path = (base_dir / name).resolve()
+    try:
+        path.relative_to(base_resolved)
+    except ValueError as exc:
+        raise EmbeddingsJobError("Invalid embeddings artifact identifier", retryable=False) from exc
     path.mkdir(parents=True, exist_ok=True)
     return path
+
+
+def _validate_artifact_identifier(value: Any) -> str:
+    raw = str(value or "").strip()
+    if (
+        not raw
+        or raw in {".", ".."}
+        or ".." in raw
+        or "/" in raw
+        or "\\" in raw
+        or "\x00" in raw
+    ):
+        raise EmbeddingsJobError("Invalid embeddings artifact identifier", retryable=False)
+    return raw
+
+
+def _resolve_artifact_path(
+    artifact_dir: Path,
+    payload: dict[str, Any],
+    key: str,
+    default_path: Path,
+) -> Path:
+    raw_value = payload.get(key)
+    candidate = Path(raw_value) if raw_value else default_path
+    if not candidate.is_absolute():
+        candidate = artifact_dir / candidate
+    artifact_root = artifact_dir.resolve()
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(artifact_root)
+    except ValueError as exc:
+        raise EmbeddingsJobError(f"Invalid embeddings artifact path for {key}", retryable=False) from exc
+    return resolved
 
 
 def _chunk_artifact_path(base_dir: Path) -> Path:
@@ -492,7 +530,7 @@ async def _handle_chunking_job(
 ) -> tuple[dict[str, Any], bool]:
     force_regenerate = _coerce_bool(payload.get("force_regenerate"))
     artifact_dir = _artifact_dir(user_id, root_uuid, media_id, str(job.get("uuid") or job.get("id")))
-    chunks_path = Path(payload.get("chunks_path") or _chunk_artifact_path(artifact_dir))
+    chunks_path = _resolve_artifact_path(artifact_dir, payload, "chunks_path", _chunk_artifact_path(artifact_dir))
 
     if chunks_path.exists() and not force_regenerate:
         chunks = _read_json(chunks_path)
@@ -562,11 +600,16 @@ async def _handle_embedding_job(
 ) -> dict[str, Any]:
     force_regenerate = _coerce_bool(payload.get("force_regenerate"))
     artifact_dir = _artifact_dir(user_id, root_uuid, media_id, str(job.get("uuid") or job.get("id")))
-    chunks_path = Path(payload.get("chunks_path") or _chunk_artifact_path(artifact_dir))
+    chunks_path = _resolve_artifact_path(artifact_dir, payload, "chunks_path", _chunk_artifact_path(artifact_dir))
     if not chunks_path.exists():
         raise EmbeddingsJobError("Chunk artifacts missing for embedding stage", retryable=False)
 
-    embeddings_path = Path(payload.get("embeddings_path") or _embedding_artifact_path(artifact_dir))
+    embeddings_path = _resolve_artifact_path(
+        artifact_dir,
+        payload,
+        "embeddings_path",
+        _embedding_artifact_path(artifact_dir),
+    )
     if embeddings_path.exists() and not force_regenerate:
         stored = _read_json(embeddings_path)
         if isinstance(stored, dict):
@@ -670,9 +713,14 @@ async def _handle_storage_job(
 ) -> dict[str, Any]:
     force_regenerate = _coerce_bool(payload.get("force_regenerate"))
     artifact_dir = _artifact_dir(user_id, root_uuid, media_id, str(job.get("uuid") or job.get("id")))
-    chunks_path = Path(payload.get("chunks_path") or _chunk_artifact_path(artifact_dir))
-    embeddings_path = Path(payload.get("embeddings_path") or _embedding_artifact_path(artifact_dir))
-    storage_path = Path(payload.get("storage_path") or _storage_artifact_path(artifact_dir))
+    chunks_path = _resolve_artifact_path(artifact_dir, payload, "chunks_path", _chunk_artifact_path(artifact_dir))
+    embeddings_path = _resolve_artifact_path(
+        artifact_dir,
+        payload,
+        "embeddings_path",
+        _embedding_artifact_path(artifact_dir),
+    )
+    storage_path = _resolve_artifact_path(artifact_dir, payload, "storage_path", _storage_artifact_path(artifact_dir))
 
     if storage_path.exists() and not force_regenerate:
         stored = _read_json(storage_path)

--- a/tldw_Server_API/app/core/Embeddings/sharding.py
+++ b/tldw_Server_API/app/core/Embeddings/sharding.py
@@ -477,19 +477,12 @@ class EmbeddingShardManager:
         logger.info("Shard manager shutdown complete")
 
 
-# Global shard manager
-_shard_manager: Optional[EmbeddingShardManager] = None
-
-
 def get_shard_manager() -> EmbeddingShardManager:
-    """Get or create the global shard manager."""
-    global _shard_manager
+    """Create an experimental shard manager when explicitly enabled."""
     enabled = str(os.getenv("EMBEDDINGS_ENABLE_EXPERIMENTAL_SHARDING") or "").strip().lower()
     if enabled not in {"1", "true", "yes", "on"}:
         raise RuntimeError("Embeddings experimental sharding is disabled")
-    if _shard_manager is None:
-        _shard_manager = EmbeddingShardManager()
-    return _shard_manager
+    return EmbeddingShardManager()
 
 
 # Example configuration for sharding

--- a/tldw_Server_API/app/core/Embeddings/sharding.py
+++ b/tldw_Server_API/app/core/Embeddings/sharding.py
@@ -2,6 +2,7 @@
 # Sharding implementation for distributed embedding storage and retrieval
 
 import hashlib
+import os
 import threading
 from collections import defaultdict
 from dataclasses import dataclass
@@ -483,6 +484,9 @@ _shard_manager: Optional[EmbeddingShardManager] = None
 def get_shard_manager() -> EmbeddingShardManager:
     """Get or create the global shard manager."""
     global _shard_manager
+    enabled = str(os.getenv("EMBEDDINGS_ENABLE_EXPERIMENTAL_SHARDING") or "").strip().lower()
+    if enabled not in {"1", "true", "yes", "on"}:
+        raise RuntimeError("Embeddings experimental sharding is disabled")
     if _shard_manager is None:
         _shard_manager = EmbeddingShardManager()
     return _shard_manager

--- a/tldw_Server_API/tests/ChromaDB/unit/test_chromadb_dimensions_and_list.py
+++ b/tldw_Server_API/tests/ChromaDB/unit/test_chromadb_dimensions_and_list.py
@@ -20,7 +20,7 @@ def _make_manager_with_mock(mock_client, tmp_path):
     return mgr
 
 
-def test_dimension_metadata_mismatch_recreates_collection(tmp_path):
+def test_dimension_metadata_mismatch_rejects_without_deleting_collection(tmp_path):
 
 
     mock_client = MagicMock()
@@ -39,20 +39,22 @@ def test_dimension_metadata_mismatch_recreates_collection(tmp_path):
     ids = ["1", "2"]
     metas = [{"source": "t1"}, {"source": "t2"}]
 
-    mgr.store_in_chroma("dim_meta", texts, embeddings, ids, metas, embedding_model_id_for_dim_check="text-embedding-3-large")
+    with pytest.raises(ValueError, match="Embedding dimension mismatch"):
+        mgr.store_in_chroma(
+            "dim_meta",
+            texts,
+            embeddings,
+            ids,
+            metas,
+            embedding_model_id_for_dim_check="text-embedding-3-large",
+        )
 
-    # Expect deletion and recreation with new dimension metadata
-    mock_client.delete_collection.assert_called_with(name="dim_meta")
-    mock_client.create_collection.assert_called()
-    args, kwargs = mock_client.create_collection.call_args
-    assert kwargs.get("name") == "dim_meta"
-    assert kwargs.get("metadata")["embedding_dimension"] == 512
-    assert kwargs.get("metadata")["source_model_id"] == "text-embedding-3-large"
-    # Upsert invoked on the (current) collection
-    assert mock_coll.upsert.called
+    mock_client.delete_collection.assert_not_called()
+    mock_client.create_collection.assert_not_called()
+    mock_coll.upsert.assert_not_called()
 
 
-def test_dimension_sample_mismatch_recreates_collection(tmp_path):
+def test_dimension_sample_mismatch_rejects_without_deleting_collection(tmp_path):
 
 
     mock_client = MagicMock()
@@ -73,16 +75,36 @@ def test_dimension_sample_mismatch_recreates_collection(tmp_path):
     ids = ["id-x"]
     metas = [{"source": "unit"}]
 
-    mgr.store_in_chroma("dim_sample", texts, embeddings, ids, metas, embedding_model_id_for_dim_check="text-embedding-3-large")
+    with pytest.raises(ValueError, match="Embedding dimension mismatch"):
+        mgr.store_in_chroma(
+            "dim_sample",
+            texts,
+            embeddings,
+            ids,
+            metas,
+            embedding_model_id_for_dim_check="text-embedding-3-large",
+        )
 
-    # Expect recreation due to sampled dim mismatch
-    mock_client.delete_collection.assert_called_with(name="dim_sample")
-    mock_client.create_collection.assert_called()
-    args, kwargs = mock_client.create_collection.call_args
-    assert kwargs.get("name") == "dim_sample"
-    assert kwargs.get("metadata")["embedding_dimension"] == 256
-    assert kwargs.get("metadata")["source_model_id"] == "text-embedding-3-large"
-    assert mock_coll.upsert.called
+    mock_client.delete_collection.assert_not_called()
+    mock_client.create_collection.assert_not_called()
+    mock_coll.upsert.assert_not_called()
+
+
+def test_persistent_client_init_failure_fails_closed_by_default(monkeypatch, tmp_path):
+    from tldw_Server_API.app.core.Embeddings import ChromaDB_Library as cdl
+
+    def _raise_persistent_client(**_kwargs):
+        raise ValueError("persistent init failed")
+
+    monkeypatch.setattr(cdl.chromadb, "PersistentClient", _raise_persistent_client)
+    user_cfg = {
+        "USER_DB_BASE_DIR": str(tmp_path),
+        "embedding_config": {"default_model_id": "unused", "models": {}},
+        "chroma_client_settings": {"backend": "persistent"},
+    }
+
+    with pytest.raises(RuntimeError, match="ChromaDB client initialization failed"):
+        ChromaDBManager(user_id="fail_closed", user_embedding_config=user_cfg)
 
 
 def test_list_collections_propagates(mock_chroma_client, tmp_path):
@@ -343,6 +365,50 @@ def test_vector_search_passes_user_app_config(temp_chroma_path, monkeypatch):
     assert captured["kwargs"]["user_app_config"] == user_cfg
     assert "user_embedding_config" not in captured["kwargs"]
     mgr.close()
+
+
+@pytest.mark.unit
+def test_vector_search_log_omits_query_text(mock_chroma_client, tmp_path, monkeypatch):
+    from tldw_Server_API.app.core.Embeddings import ChromaDB_Library as cdl
+
+    logged_info: list[str] = []
+
+    class _Logger:
+        def info(self, message):
+            logged_info.append(str(message))
+
+        def debug(self, *_args, **_kwargs):
+            return None
+
+        def warning(self, *_args, **_kwargs):
+            return None
+
+        def error(self, *_args, **_kwargs):
+            return None
+
+    mock_coll = MagicMock()
+    mock_coll.name = "secret_collection"
+    mock_coll.query.return_value = {
+        "ids": [["doc-1"]],
+        "documents": [["stored doc"]],
+        "metadatas": [[{"source": "unit"}]],
+        "distances": [[0.1]],
+    }
+    mock_chroma_client.get_or_create_collection.return_value = mock_coll
+
+    monkeypatch.setattr(cdl, "logger", _Logger())
+    monkeypatch.setattr(cdl, "create_embedding", lambda text, user_app_config, model_id_override: [0.1, 0.2, 0.3])
+
+    mgr = _make_manager_with_mock(mock_chroma_client, tmp_path)
+    mgr.vector_search(
+        query="secret customer query text",
+        collection_name="secret_collection",
+        k=1,
+        embedding_model_id_override="manual",
+    )
+
+    assert logged_info
+    assert all("secret customer query text" not in message for message in logged_info)
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/ChromaDB/unit/test_chromadb_dimensions_and_list.py
+++ b/tldw_Server_API/tests/ChromaDB/unit/test_chromadb_dimensions_and_list.py
@@ -107,6 +107,47 @@ def test_persistent_client_init_failure_fails_closed_by_default(monkeypatch, tmp
         ChromaDBManager(user_id="fail_closed", user_embedding_config=user_cfg)
 
 
+def test_string_false_does_not_enable_in_memory_stub(monkeypatch, tmp_path):
+    from tldw_Server_API.app.core.Embeddings import ChromaDB_Library as cdl
+
+    def _raise_persistent_client(**_kwargs):
+        raise ValueError("persistent init attempted")
+
+    monkeypatch.setattr(cdl.chromadb, "PersistentClient", _raise_persistent_client)
+    user_cfg = {
+        "USER_DB_BASE_DIR": str(tmp_path),
+        "embedding_config": {"default_model_id": "unused", "models": {}},
+        "chroma_client_settings": {
+            "backend": "persistent",
+            "use_in_memory_stub": "false",
+            "allow_stub_fallback": False,
+        },
+    }
+
+    with pytest.raises(RuntimeError, match="ChromaDB client initialization failed"):
+        ChromaDBManager(user_id="string_false_stub", user_embedding_config=user_cfg)
+
+
+def test_string_false_does_not_enable_stub_fallback(monkeypatch, tmp_path):
+    from tldw_Server_API.app.core.Embeddings import ChromaDB_Library as cdl
+
+    def _raise_persistent_client(**_kwargs):
+        raise ValueError("persistent init failed")
+
+    monkeypatch.setattr(cdl.chromadb, "PersistentClient", _raise_persistent_client)
+    user_cfg = {
+        "USER_DB_BASE_DIR": str(tmp_path),
+        "embedding_config": {"default_model_id": "unused", "models": {}},
+        "chroma_client_settings": {
+            "backend": "persistent",
+            "allow_stub_fallback": "false",
+        },
+    }
+
+    with pytest.raises(RuntimeError, match="ChromaDB client initialization failed"):
+        ChromaDBManager(user_id="string_false_fallback", user_embedding_config=user_cfg)
+
+
 def test_list_collections_propagates(mock_chroma_client, tmp_path):
 
 

--- a/tldw_Server_API/tests/Embeddings_isolated/test_request_signing_nonce_security.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_request_signing_nonce_security.py
@@ -24,12 +24,8 @@ def test_invalid_signature_does_not_consume_nonce(monkeypatch):
         lambda **_kwargs: None,
     )
 
-    monkeypatch.setattr(
-        request_signing_module,
-        "_request_signer",
-        request_signing_module.RequestSigner(secret_key="k" * 32),
-        raising=False,
-    )
+    monkeypatch.setenv("EMBEDDINGS_REQUEST_SIGNING_SECRET", "k" * 32)
+    monkeypatch.setattr(request_signing_module, "_request_signer", None, raising=False)
     monkeypatch.setattr(
         request_signing_module,
         "_nonce_manager",
@@ -67,12 +63,8 @@ def test_valid_signature_replay_is_rejected(monkeypatch):
         lambda **_kwargs: None,
     )
 
-    monkeypatch.setattr(
-        request_signing_module,
-        "_request_signer",
-        request_signing_module.RequestSigner(secret_key="k" * 32),
-        raising=False,
-    )
+    monkeypatch.setenv("EMBEDDINGS_REQUEST_SIGNING_SECRET", "k" * 32)
+    monkeypatch.setattr(request_signing_module, "_request_signer", None, raising=False)
     monkeypatch.setattr(
         request_signing_module,
         "_nonce_manager",

--- a/tldw_Server_API/tests/Embeddings_isolated/test_review_findings_hardening.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_review_findings_hardening.py
@@ -1,0 +1,196 @@
+import base64
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+from tldw_Server_API.app.core.Embeddings import redis_pipeline
+from tldw_Server_API.app.core.Embeddings.connection_pool import ConnectionPool
+from tldw_Server_API.app.core.Embeddings.jobs_adapter import EmbeddingsJobsAdapter
+from tldw_Server_API.app.core.Embeddings.services import jobs_worker
+from tldw_Server_API.app.core.Jobs.manager import JobManager
+from tldw_Server_API.app.core.Jobs.migrations import ensure_jobs_tables
+from tldw_Server_API.app.core.exceptions import NetworkError
+
+
+def _setup_jobs_db(monkeypatch, tmp_path):
+    db_path = tmp_path / "jobs.db"
+    ensure_jobs_tables(db_path)
+    monkeypatch.setenv("JOBS_DB_PATH", str(db_path))
+    monkeypatch.delenv("JOBS_DB_URL", raising=False)
+    monkeypatch.setenv("EMBEDDINGS_JOBS_QUEUE", "default")
+    monkeypatch.setenv("EMBEDDINGS_ROOT_JOBS_QUEUE", "low")
+    monkeypatch.setenv("EMBEDDINGS_REDIS_ALLOW_STUB", "1")
+    return db_path
+
+
+@pytest.mark.unit
+def test_artifact_dir_rejects_path_traversal_identifier(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        DatabasePaths,
+        "get_user_vector_store_dir",
+        lambda user_id: tmp_path / f"user_{user_id}",
+    )
+
+    with pytest.raises(jobs_worker.EmbeddingsJobError, match="artifact identifier"):
+        jobs_worker._artifact_dir("user-1", "../escape", 42, "job-1")
+
+
+@pytest.mark.asyncio
+async def test_chunking_job_rejects_payload_artifact_path_escape(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        DatabasePaths,
+        "get_user_vector_store_dir",
+        lambda user_id: tmp_path / f"user_{user_id}",
+    )
+    monkeypatch.setattr(
+        jobs_worker,
+        "_load_media_content",
+        lambda media_id, user_id: {
+            "media_item": {"id": media_id, "title": "Doc"},
+            "content": {"content": "hello embeddings"},
+        },
+    )
+
+    outside_path = tmp_path / "outside" / "chunks.json"
+
+    with pytest.raises(jobs_worker.EmbeddingsJobError, match="artifact path"):
+        await jobs_worker._handle_chunking_job(
+            {"id": 1, "uuid": "job-1"},
+            {"chunks_path": str(outside_path)},
+            media_id=42,
+            user_id="user-1",
+            chunk_size=100,
+            chunk_overlap=0,
+            root_uuid="root-1",
+        )
+
+    assert not outside_path.exists()
+
+
+@pytest.mark.unit
+def test_embeddings_jobs_adapter_fails_root_when_idempotency_write_fails(monkeypatch, tmp_path):
+    db_path = _setup_jobs_db(monkeypatch, tmp_path)
+
+    class _FailingRedis:
+        def set(self, *_args, **_kwargs):
+            raise RuntimeError("redis unavailable")
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(redis_pipeline, "create_sync_redis_client", lambda **_kwargs: _FailingRedis())
+    adapter = EmbeddingsJobsAdapter()
+
+    with pytest.raises(RuntimeError, match="idempotency"):
+        adapter.create_job(
+            user_id="user1",
+            media_id=111,
+            embedding_model="model-a",
+            embedding_provider="provider-a",
+            chunk_size=1000,
+            chunk_overlap=200,
+            request_source="test",
+            force_regenerate=False,
+            stage="chunking",
+            embedding_priority=50,
+        )
+
+    jm = JobManager(db_path)
+    jobs = jm.list_jobs(domain="embeddings", owner_user_id="user1", limit=20)
+    assert len(jobs) == 1
+    assert jobs[0]["job_type"] == "embeddings_pipeline"
+    assert jobs[0]["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_connection_pool_http_error_log_omits_response_body(monkeypatch):
+    from tldw_Server_API.app.core.Embeddings import connection_pool as pool_mod
+
+    class _DummyResponse:
+        status_code = 503
+        text = "secret response body sk-test"
+        headers = {"content-type": "application/json"}
+
+        def json(self):
+            return {"ok": False}
+
+        async def aclose(self):
+            return None
+
+    class _Logger:
+        def __init__(self):
+            self.errors: list[str] = []
+
+        def info(self, *_args, **_kwargs):
+            return None
+
+        def error(self, message):
+            self.errors.append(str(message))
+
+    logger = _Logger()
+
+    async def _fake_afetch(**_kwargs):
+        return _DummyResponse()
+
+    monkeypatch.setattr(pool_mod, "logger", logger)
+    monkeypatch.setattr(pool_mod, "afetch", _fake_afetch)
+
+    pool = ConnectionPool(provider="test-provider", retry_attempts=1)
+    with pytest.raises(NetworkError):
+        await pool.request("POST", "https://example.invalid/embeddings")
+
+    assert logger.errors
+    assert all("secret response body" not in message for message in logger.errors)
+    assert all("sk-test" not in message for message in logger.errors)
+
+
+@pytest.mark.unit
+def test_dlq_crypto_configured_encryption_rejects_plaintext_fallback(monkeypatch):
+    monkeypatch.setenv("EMBEDDINGS_DLQ_ENCRYPTION_KEY", "test-passphrase")
+    from tldw_Server_API.app.core.Embeddings import dlq_crypto
+
+    monkeypatch.setattr(
+        dlq_crypto,
+        "_aesgcm_encrypt",
+        lambda plaintext, key: {
+            "alg": "none",
+            "b64": base64.b64encode(plaintext).decode("utf-8"),
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="DLQ encryption unavailable"):
+        dlq_crypto.encrypt_payload_if_configured({"secret": "value"})
+
+
+@pytest.mark.unit
+def test_shard_manager_requires_explicit_experimental_flag(monkeypatch):
+    from tldw_Server_API.app.core.Embeddings import sharding
+
+    monkeypatch.delenv("EMBEDDINGS_ENABLE_EXPERIMENTAL_SHARDING", raising=False)
+    monkeypatch.setattr(sharding, "_shard_manager", None)
+    monkeypatch.setattr(sharding, "EmbeddingShardManager", lambda: object())
+
+    with pytest.raises(RuntimeError, match="experimental sharding"):
+        sharding.get_shard_manager()
+
+
+@pytest.mark.unit
+def test_request_signer_singleton_requires_configured_secret(monkeypatch):
+    from tldw_Server_API.app.core.Embeddings import request_signing
+
+    monkeypatch.delenv("EMBEDDINGS_REQUEST_SIGNING_SECRET", raising=False)
+    monkeypatch.setattr(request_signing, "_request_signer", None)
+
+    with pytest.raises(RuntimeError, match="request signing secret"):
+        request_signing.get_request_signer()
+
+
+@pytest.mark.unit
+def test_request_signing_api_key_manager_requires_configured_key_file(monkeypatch):
+    from tldw_Server_API.app.core.Embeddings import request_signing
+
+    monkeypatch.delenv("EMBEDDINGS_REQUEST_SIGNING_KEYS_FILE", raising=False)
+    monkeypatch.setattr(request_signing, "_api_key_manager", None)
+
+    with pytest.raises(RuntimeError, match="API key file"):
+        request_signing.get_api_key_manager()

--- a/tldw_Server_API/tests/Embeddings_isolated/test_review_findings_hardening.py
+++ b/tldw_Server_API/tests/Embeddings_isolated/test_review_findings_hardening.py
@@ -68,6 +68,22 @@ async def test_chunking_job_rejects_payload_artifact_path_escape(monkeypatch, tm
 
 
 @pytest.mark.unit
+def test_artifact_path_rejects_non_string_payload_value(tmp_path):
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+
+    with pytest.raises(jobs_worker.EmbeddingsJobError, match="artifact path") as exc_info:
+        jobs_worker._resolve_artifact_path(
+            artifact_dir,
+            {"chunks_path": 42},
+            "chunks_path",
+            artifact_dir / "chunks.json",
+        )
+
+    assert exc_info.value.retryable is False
+
+
+@pytest.mark.unit
 def test_embeddings_jobs_adapter_fails_root_when_idempotency_write_fails(monkeypatch, tmp_path):
     db_path = _setup_jobs_db(monkeypatch, tmp_path)
 
@@ -167,7 +183,7 @@ def test_shard_manager_requires_explicit_experimental_flag(monkeypatch):
     from tldw_Server_API.app.core.Embeddings import sharding
 
     monkeypatch.delenv("EMBEDDINGS_ENABLE_EXPERIMENTAL_SHARDING", raising=False)
-    monkeypatch.setattr(sharding, "_shard_manager", None)
+    monkeypatch.setattr(sharding, "_shard_manager", None, raising=False)
     monkeypatch.setattr(sharding, "EmbeddingShardManager", lambda: object())
 
     with pytest.raises(RuntimeError, match="experimental sharding"):
@@ -175,14 +191,40 @@ def test_shard_manager_requires_explicit_experimental_flag(monkeypatch):
 
 
 @pytest.mark.unit
-def test_request_signer_singleton_requires_configured_secret(monkeypatch):
+def test_shard_manager_factory_does_not_reuse_global_singleton(monkeypatch):
+    from tldw_Server_API.app.core.Embeddings import sharding
+
+    monkeypatch.setenv("EMBEDDINGS_ENABLE_EXPERIMENTAL_SHARDING", "1")
+    monkeypatch.setattr(sharding, "_shard_manager", None, raising=False)
+    monkeypatch.setattr(sharding, "EmbeddingShardManager", lambda: object())
+
+    assert sharding.get_shard_manager() is not sharding.get_shard_manager()
+
+
+@pytest.mark.unit
+def test_request_signer_requires_configured_secret(monkeypatch):
     from tldw_Server_API.app.core.Embeddings import request_signing
 
     monkeypatch.delenv("EMBEDDINGS_REQUEST_SIGNING_SECRET", raising=False)
-    monkeypatch.setattr(request_signing, "_request_signer", None)
+    monkeypatch.setattr(request_signing, "_request_signer", None, raising=False)
 
     with pytest.raises(RuntimeError, match="request signing secret"):
         request_signing.get_request_signer()
+
+
+@pytest.mark.unit
+def test_request_signer_factory_does_not_reuse_global_singleton(monkeypatch):
+    from tldw_Server_API.app.core.Embeddings import request_signing
+
+    monkeypatch.setenv("EMBEDDINGS_REQUEST_SIGNING_SECRET", "configured-secret")
+    monkeypatch.setattr(request_signing, "_request_signer", None, raising=False)
+
+    first = request_signing.get_request_signer()
+    second = request_signing.get_request_signer()
+
+    assert first is not second
+    assert first.secret_key == "configured-secret"
+    assert second.secret_key == "configured-secret"
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/kanban/test_kanban_vector_search.py
+++ b/tldw_Server_API/tests/kanban/test_kanban_vector_search.py
@@ -281,6 +281,46 @@ class TestKanbanVectorSearchHelpers:
         assert stage_payload["card_id"] == 10
         assert stage_payload["card_version"] == 7
 
+    def test_index_card_fails_root_job_when_enqueue_fails(self, monkeypatch):
+        from tldw_Server_API.app.core.DB_Management import kanban_vector_search as kvs
+
+        instance = kvs.KanbanVectorSearch(
+            user_id="1",
+            embedding_config={"embedding_model": "test-model", "embedding_provider": "test-provider"},
+        )
+        instance._available = True
+        instance._manager = object()
+
+        captured: dict[str, object] = {}
+
+        class _StubJobManager:
+            def create_job(self, **_kwargs):
+                return {"id": 99, "uuid": "root-uuid"}
+
+            def fail_job(self, job_id, **kwargs):
+                captured["failed_job_id"] = job_id
+                captured["fail_kwargs"] = kwargs
+
+        def _raise_enqueue_error(**_kwargs):
+            raise kvs.redis_pipeline.RedisEnqueueError("redis unavailable")
+
+        monkeypatch.setattr(kvs, "_jobs_manager", lambda: _StubJobManager())
+        monkeypatch.setattr(kvs.redis_pipeline, "enqueue_content_job", _raise_enqueue_error)
+        monkeypatch.setattr(kvs.redis_pipeline, "allow_stub", lambda: False)
+        monkeypatch.delenv("TEST_MODE", raising=False)
+
+        card = {
+            "id": 10,
+            "title": "Queue Test",
+            "description": "Queue content",
+            "board_id": 1,
+            "list_id": 2,
+            "version": 7,
+        }
+        assert instance.index_card(card) is False
+        assert captured["failed_job_id"] == 99
+        assert captured["fail_kwargs"]["retryable"] is False
+
     def test_index_card_returns_false_when_unavailable(self, vector_search_instance):
 
         """Test that index_card returns False when vector search is unavailable."""


### PR DESCRIPTION
## Summary
- Harden validated Embeddings review findings around artifact path handling, Redis enqueue failures, Chroma dimension mismatches, DLQ encryption, request signing defaults, experimental sharding, and sensitive error logging.
- Add focused regression tests for the reviewed failure modes and update the ChromaDB dimension/list unit coverage.
- Move the completed fix set onto an isolated worktree branch rooted at dev.

## Test Plan
- source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest --confcutdir=tldw_Server_API/tests/Embeddings_isolated -q tldw_Server_API/tests/Embeddings_isolated/test_review_findings_hardening.py tldw_Server_API/tests/Embeddings_isolated/test_request_signing_nonce_security.py
- source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest --confcutdir=tldw_Server_API/tests/ChromaDB -q tldw_Server_API/tests/ChromaDB/unit/test_chromadb_dimensions_and_list.py
- source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m compileall -q touched Embeddings production files
- source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m bandit -r touched Embeddings production files -f json -o /tmp/bandit_embeddings_review_fixes_worktree_9927.json

## AI-Generated PR Merge Gate
A human-maintained Change summary explaining what changed and why is required before merge per repo policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Embeddings module to prevent path traversal, silent Chroma fallbacks, and sensitive data leaks; improved reliability on Redis enqueue paths and enforced explicit config for risky features. Meets TASK-9927 acceptance criteria with focused regression tests.

- **Bug Fixes**
  - Confined job artifacts to the per-user dir; reject traversal in `chunks_path`, `embeddings_path`, and `storage_path`.
  - Fail root jobs on Redis enqueue/idempotency errors to avoid orphaning work (Embeddings adapter and Kanban vector search).
  - Chroma: default stub fallback disabled; string booleans now parsed for `use_in_memory_stub` and `allow_stub_fallback`; persistent-client init failures fail closed; dimension mismatches are errors (no delete/recreate); omit query text from vector-search logs.
  - Stop logging provider response bodies on HTTP errors.
  - DLQ: require AES-GCM when configured; remove base64 “alg=none” fallback; raise on misconfig/failure.
  - Request signing: require `EMBEDDINGS_REQUEST_SIGNING_SECRET` and `EMBEDDINGS_REQUEST_SIGNING_KEYS_FILE`; no auto-generated defaults.
  - Experimental sharding is disabled unless `EMBEDDINGS_ENABLE_EXPERIMENTAL_SHARDING` is set.

- **Migration**
  - Set `EMBEDDINGS_REQUEST_SIGNING_SECRET` and `EMBEDDINGS_REQUEST_SIGNING_KEYS_FILE` to use request signing.
  - Opt in to experimental sharding with `EMBEDDINGS_ENABLE_EXPERIMENTAL_SHARDING` if needed.
  - Ensure AES-GCM (`cryptography`) is installed and `EMBEDDINGS_DLQ_ENCRYPTION_KEY` is set if DLQ encryption is enabled.
  - Update flows expecting implicit Chroma collection recreation; dimension mismatches now error. If you rely on stub mode, set `chroma_client_settings.allow_stub_fallback=true`.

<sup>Written for commit f0fdb0b95a8c894627085adf8597428a0f1829a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

