### PR TITLE
Harden External_Sources connector sync

### DIFF
--- a/backlog/tasks/task-9928 - Harden-External_Sources-review-findings.md
+++ b/backlog/tasks/task-9928 - Harden-External_Sources-review-findings.md
@@ -1,0 +1,114 @@
+---
+id: TASK-9928
+title: Harden External_Sources review findings
+status: Done
+assignee: []
+created_date: 2026-06-23 18:50
+updated_date: 2026-06-24 04:06
+labels: []
+dependencies: []
+priority: high
+modified_files:
+- tldw_Server_API/app/core/External_Sources/connector_base.py
+- tldw_Server_API/app/core/External_Sources/connectors_service.py
+- tldw_Server_API/app/core/External_Sources/notion.py
+- tldw_Server_API/app/services/connectors_worker.py
+- tldw_Server_API/app/core/exceptions.py
+- tldw_Server_API/tests/External_Sources/test_connectors_service_sanitizers.py
+- tldw_Server_API/tests/External_Sources/test_connectors_worker_file_sync.py
+- tldw_Server_API/tests/External_Sources/test_notion_connector_sanitizers.py
+- tldw_Server_API/tests/External_Sources/test_sync_adapter_contract.py
+- tldw_Server_API/tests/External_Sources/test_token_refresh_envelope.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track remediation for External_Sources code review findings: file-sync delta create/restore handling, atomic OAuth state consumption, fail-closed connector job creation, token encryption posture, Notion Markdown sanitization, and explicit unsupported base connector capabilities.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 File-sync provider deltas create first-seen files and restore archived/orphaned bindings
+- [x] #2 OAuth state consumption is atomic and single-use
+- [x] #3 Connector job creation failures surface instead of returning fake queued jobs
+- [x] #4 Connector secrets fail closed when encryption is required
+- [x] #5 Notion Markdown output escapes unsafe text and image URLs
+- [x] #6 Base connector unsupported capabilities raise explicitly
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Completed; temporary implementation plan file removed after verification per repository guidance.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Touched production files:
+- tldw_Server_API/app/core/External_Sources/connector_base.py
+- tldw_Server_API/app/core/External_Sources/connectors_service.py
+- tldw_Server_API/app/core/External_Sources/notion.py
+- tldw_Server_API/app/services/connectors_worker.py
+
+Added focused regression coverage in External_Sources tests for delta reconciliation, OAuth state replay, fail-closed job creation/token storage, Notion rendering sanitization, and base connector contract behavior.
+
+Verification:
+- python -m py_compile on touched production files
+- ULTRA_MINIMAL_APP=1 python -m pytest -p no:unraisableexception tldw_Server_API/tests/External_Sources/test_connectors_worker_file_sync.py tldw_Server_API/tests/External_Sources/test_connectors_service_sanitizers.py tldw_Server_API/tests/External_Sources/test_token_refresh_envelope.py tldw_Server_API/tests/External_Sources/test_notion_connector_sanitizers.py tldw_Server_API/tests/External_Sources/test_sync_adapter_contract.py tldw_Server_API/tests/External_Sources/test_reference_manager_storage.py tldw_Server_API/tests/External_Sources/test_policy_and_connectors.py::test_notion_download_renders_nested_blocks -q --tb=short (25 passed)
+- python -m bandit -r touched production files -f json -o /tmp/bandit_external_sources_9928.json (0 findings)
+
+Known skip: full default pytest import path timed out in unrelated optional-router app import; rerun used ULTRA_MINIMAL_APP=1 to keep verification scoped to these unit tests.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened External_Sources review findings and addressed PR #2454 comments, including PR Compliance ID 224214 docstring cleanup for the Notion sanitization helpers and connector secret helper focus area. Verification includes AST docstring checks, compile, focused tests, and Bandit with 0 findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+PR #2454 remediation started after automated review comments. Scope: rebase on latest origin/dev; handle Notion code literal rendering, safe URL parsing, SQLite commit fallback, docstrings/type hints/custom exception review items; refresh verification and push updated branch.
+PR #2454 remediation completed after rebasing on latest origin/dev. Addressed automated review comments by preserving literal Notion code block text, using collision-free inline code spans, guarding malformed Markdown image URLs, avoiding the missing-commit-method await failure, adding docstrings/type hints for touched helpers, and replacing connector-domain RuntimeError raises with ConnectorServiceError.
+
+Verification after remediation:
+- python -m py_compile tldw_Server_API/app/core/External_Sources/connector_base.py tldw_Server_API/app/core/External_Sources/connectors_service.py tldw_Server_API/app/core/External_Sources/notion.py tldw_Server_API/app/services/connectors_worker.py tldw_Server_API/app/core/exceptions.py (passed)
+- ULTRA_MINIMAL_APP=1 python -m pytest -p no:unraisableexception tldw_Server_API/tests/External_Sources/test_connectors_worker_file_sync.py tldw_Server_API/tests/External_Sources/test_connectors_service_sanitizers.py tldw_Server_API/tests/External_Sources/test_token_refresh_envelope.py tldw_Server_API/tests/External_Sources/test_notion_connector_sanitizers.py tldw_Server_API/tests/External_Sources/test_sync_adapter_contract.py tldw_Server_API/tests/External_Sources/test_reference_manager_storage.py tldw_Server_API/tests/External_Sources/test_policy_and_connectors.py::test_notion_download_renders_nested_blocks -q --tb=short (29 passed)
+- python -m bandit -r touched production files including exceptions.py -f json -o /tmp/bandit_external_sources_pr2454_rebase.json (0 findings)
+Final latest-dev rebase verification after origin/dev advanced again:
+- Rebased onto origin/dev e18a86bb0186862e5ff408049d18ee882d3a8269.
+- python -m py_compile touched production files including exceptions.py (passed)
+- ULTRA_MINIMAL_APP=1 focused External_Sources pytest slice (29 passed)
+- Bandit JSON at /tmp/bandit_external_sources_pr2454_rebase_latest.json reported 0 findings.
+Second latest-dev rebase verification after origin/dev advanced again:
+- Rebased onto origin/dev 5851988ca9f8f485048d84eee19396f4cc1926ec.
+- python -m py_compile touched production files including exceptions.py (passed)
+- ULTRA_MINIMAL_APP=1 focused External_Sources pytest slice (29 passed)
+- Bandit JSON at /tmp/bandit_external_sources_pr2454_rebase_5851988.json reported 0 findings.
+Third latest-dev rebase verification after origin/dev advanced again:
+- Rebased onto origin/dev 54eadfcdb2a612e3b517ead4a4686fbaba5d34a1.
+- python -m py_compile touched production files including exceptions.py (passed)
+- ULTRA_MINIMAL_APP=1 focused External_Sources pytest slice (29 passed)
+- Bandit JSON at /tmp/bandit_external_sources_pr2454_rebase_54eadfc.json reported 0 findings.
+Follow-up docstring compliance cleanup: verifying PR Compliance ID 224214 against the Notion sanitization helper area and connector secret helper area. The named helpers already have docstrings; adding docstrings for nearby focus-window functions surfaced by AST scan to avoid follow-up compliance noise.
+Docstring compliance follow-up completed for PR Compliance ID 224214. Added first-statement docstrings for nearby focus-window functions that the AST scan surfaced in addition to the already-documented Notion sanitization and connector secret helpers.
+
+Verification for docstring follow-up:
+- AST docstring scan over Notion lines 1-90 and connectors_service lines 120-180 found docstrings for all functions in those windows.
+- python -m py_compile tldw_Server_API/app/core/External_Sources/notion.py tldw_Server_API/app/core/External_Sources/connectors_service.py (passed)
+- ULTRA_MINIMAL_APP=1 focused pytest for test_connectors_service_sanitizers.py and test_notion_connector_sanitizers.py (12 passed)
+- Bandit JSON at /tmp/bandit_external_sources_docstrings_224214.json reported 0 findings.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/core/External_Sources/connector_base.py
+++ b/tldw_Server_API/app/core/External_Sources/connector_base.py
@@ -36,10 +36,10 @@ class BaseConnector(ABC):
         page_size: int = 50,
         cursor: str | None = None,
     ) -> tuple[list[dict[str, Any]], str | None]:
-        """List folders/pages/databases; scaffold returns empty list."""
+        """List folders/pages/databases when implemented by a provider."""
         _ = page_size
         _ = cursor
-        return [], None
+        raise NotImplementedError(f"{self.name} does not support source listing")
 
     async def list_files(
         self,
@@ -49,15 +49,15 @@ class BaseConnector(ABC):
         page_size: int = 50,
         cursor: str | None = None,
     ) -> tuple[list[dict[str, Any]], str | None]:
-        """List files under a folder/page; scaffold returns empty list."""
+        """List files under a folder/page when implemented by a provider."""
         _ = page_size
         _ = cursor
-        return [], None
+        raise NotImplementedError(f"{self.name} does not support file listing")
 
     async def download_file(self, account: dict[str, Any], file_id: str, **kwargs: Any) -> bytes:
-        """Download file contents; scaffold returns empty bytes."""
+        """Download file contents when implemented by a provider."""
         _ = kwargs
-        return b""
+        raise NotImplementedError(f"{self.name} does not support file download")
 
     async def list_children(
         self,

--- a/tldw_Server_API/app/core/External_Sources/connectors_service.py
+++ b/tldw_Server_API/app/core/External_Sources/connectors_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import os
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -15,6 +16,7 @@ from tldw_Server_API.app.core.External_Sources.notion import NotionConnector
 from tldw_Server_API.app.core.External_Sources.onedrive import OneDriveConnector
 from tldw_Server_API.app.core.External_Sources.sync_adapter import FileSyncAdapter
 from tldw_Server_API.app.core.External_Sources.zotero import ZoteroConnector
+from tldw_Server_API.app.core.exceptions import ConnectorServiceError
 
 _CONNECTORS_NONCRITICAL_EXCEPTIONS = (
     AssertionError,
@@ -84,6 +86,8 @@ _EXTERNAL_ITEM_BINDING_FIELDS = (
     "access_revoked_at",
     "provider_metadata",
 )
+_TRUTHY_ENV_VALUES = frozenset({"1", "true", "t", "yes", "y", "on"})
+
 
 def _utc_now_text() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
@@ -118,6 +122,7 @@ def _row_to_dict(row: Any) -> dict[str, Any]:
 
 
 def _json_loads(value: Any, default: Any) -> Any:
+    """Decode JSON-like connector values, returning default on empty or invalid input."""
     if value in (None, ""):
         return default
     if isinstance(value, (dict, list)):
@@ -128,7 +133,48 @@ def _json_loads(value: Any, default: Any) -> Any:
         return default
 
 
+def _env_truthy(name: str) -> bool:
+    """Return whether an environment variable is set to a truthy value."""
+    return str(os.getenv(name, "")).strip().lower() in _TRUTHY_ENV_VALUES
+
+
+def _connector_secret_encryption_required() -> bool:
+    """Return whether connector secrets must be encrypted before persistence."""
+    auth_mode = str(os.getenv("AUTH_MODE", "")).strip().lower()
+    return (
+        _env_truthy("CONNECTORS_REQUIRE_TOKEN_ENCRYPTION")
+        or auth_mode == "multi_user"
+        or _env_truthy("tldw_production")
+        or _env_truthy("TLDW_PRODUCTION")
+    )
+
+
+def _raise_required_connector_secret_encryption() -> None:
+    """Raise the fail-closed connector encryption error without leaking secrets."""
+    logger.warning("Connector secret encryption is required but unavailable")
+    raise ConnectorServiceError("Connector secret encryption is required but unavailable")
+
+
+def _encrypt_connector_secret_payload(payload: dict[str, Any], *, failure_log: str) -> dict[str, Any] | None:
+    """Encrypt connector secret payloads or fail closed when policy requires it."""
+    try:
+        from tldw_Server_API.app.core.Security.crypto import encrypt_json_blob
+
+        envelope = encrypt_json_blob(dict(payload or {}))
+        if envelope:
+            return envelope
+    except _CONNECTORS_NONCRITICAL_EXCEPTIONS:
+        if _connector_secret_encryption_required():
+            _raise_required_connector_secret_encryption()
+        logger.debug(failure_log)
+        return None
+    if _connector_secret_encryption_required():
+        _raise_required_connector_secret_encryption()
+    return None
+
+
 def _provider_metadata_from_tokens(tokens: dict[str, Any] | None) -> dict[str, Any]:
+    """Extract non-secret provider metadata fields from an OAuth token payload."""
     metadata: dict[str, Any] = {}
     for key, value in dict(tokens or {}).items():
         if value in (None, ""):
@@ -181,14 +227,12 @@ def _normalize_reference_item_row(row: Any) -> dict[str, Any] | None:
 def _protect_oauth_state_metadata(metadata: dict[str, Any] | None) -> dict[str, Any] | None:
     if not metadata:
         return None
-    try:
-        from tldw_Server_API.app.core.Security.crypto import encrypt_json_blob
-
-        envelope = encrypt_json_blob(dict(metadata))
-        if envelope:
-            return envelope
-    except _CONNECTORS_NONCRITICAL_EXCEPTIONS:
-        logger.debug("Failed to encrypt oauth state metadata")
+    envelope = _encrypt_connector_secret_payload(
+        dict(metadata),
+        failure_log="Failed to encrypt oauth state metadata",
+    )
+    if envelope:
+        return envelope
     return dict(metadata)
 
 
@@ -539,7 +583,7 @@ async def consume_oauth_state(
     await _ensure_tables(db)
     is_pg = _is_postgres_connection(db)
     cutoff_dt, cutoff_str = _oauth_state_cutoff(max_age_minutes)
-    row = await _fetch_oauth_state_row(
+    row = await _consume_oauth_state_row(
         db,
         is_pg=is_pg,
         state=state,
@@ -550,16 +594,10 @@ async def consume_oauth_state(
     )
     if not row:
         return False
-    await _delete_oauth_state_row(
-        db,
-        is_pg=is_pg,
-        state=state,
-        user_id=user_id,
-    )
     return _normalize_oauth_state_row(row) or True
 
 
-async def _fetch_oauth_state_row(
+async def _consume_oauth_state_row(
     db,
     *,
     is_pg: bool,
@@ -572,39 +610,25 @@ async def _fetch_oauth_state_row(
     if is_pg:
         return await db.fetchrow(
             """
-            SELECT state, provider, metadata, created_at FROM external_oauth_state
+            DELETE FROM external_oauth_state
             WHERE state = $1 AND user_id = $2 AND provider = $3 AND created_at >= $4
+            RETURNING state, provider, metadata, created_at
             """,
             state, user_id, provider, cutoff_dt,
         )
     cur = await db.execute(
         """
-        SELECT state, provider, metadata, created_at FROM external_oauth_state
+        DELETE FROM external_oauth_state
         WHERE state = ? AND user_id = ? AND provider = ? AND created_at >= ?
+        RETURNING state, provider, metadata, created_at
         """,
         (state, user_id, provider, cutoff_str),
     )
-    return await cur.fetchone()
-
-
-async def _delete_oauth_state_row(
-    db,
-    *,
-    is_pg: bool,
-    state: str,
-    user_id: int,
-) -> None:
-    if is_pg:
-        await db.execute(
-            "DELETE FROM external_oauth_state WHERE state = $1 AND user_id = $2",
-            state, user_id,
-        )
-        return
-    await db.execute(
-        "DELETE FROM external_oauth_state WHERE state = ? AND user_id = ?",
-        (state, user_id),
-    )
-    await getattr(db, "commit", lambda: None)()
+    row = await cur.fetchone()
+    commit_fn = getattr(db, "commit", None)
+    if commit_fn is not None:
+        await commit_fn()
+    return row
 
 
 async def create_account(db, user_id: int, provider: str, display_name: str, email: str | None, tokens: dict[str, Any]) -> dict[str, Any]:
@@ -613,16 +637,13 @@ async def create_account(db, user_id: int, provider: str, display_name: str, ema
     provider_metadata = _provider_metadata_from_tokens(tokens)
     # Securely envelope tokens if crypto is configured; fallback to storing access token raw
     import json as _json
-    try:
-        from tldw_Server_API.app.core.Security.crypto import encrypt_json_blob
-        env = encrypt_json_blob(dict(tokens or {}))
-        access_token_store = _json.dumps(env) if env else str(tokens.get("access_token") or "")
-        refresh_token_store = None  # envelope contains refresh
-        tokens.get("scope") or None
-    except _CONNECTORS_NONCRITICAL_EXCEPTIONS:
-        access_token_store = str(tokens.get("access_token") or "")
-        refresh_token_store = tokens.get("refresh_token")
-        tokens.get("scope") or None
+    env = _encrypt_connector_secret_payload(
+        dict(tokens or {}),
+        failure_log="Failed to encrypt connector account tokens",
+    )
+    access_token_store = _json.dumps(env) if env else str(tokens.get("access_token") or "")
+    refresh_token_store = None if env else tokens.get("refresh_token")
+    tokens.get("scope") or None
 
     if is_pg:
         row = await db.fetchrow(
@@ -765,19 +786,16 @@ async def update_account_tokens(db, user_id: int, account_id: int, new_tokens: d
     provider_metadata_value = existing_provider_metadata | _provider_metadata_from_tokens(new_tokens)
     refresh_token_value = new_tokens.get("refresh_token") or existing_refresh
     # Build storage values similar to create_account
-    try:
-        from tldw_Server_API.app.core.Security.crypto import encrypt_json_blob
-        envelope_payload = dict(existing.get("tokens") or {})
-        envelope_payload.update(dict(new_tokens or {}))
-        envelope_payload["refresh_token"] = refresh_token_value
-        env = encrypt_json_blob(envelope_payload)
-        access_token_store = _json.dumps(env) if env else str(new_tokens.get("access_token") or "")
-        refresh_token_store = None
-        scopes_store = new_tokens.get("scope") or None
-    except _CONNECTORS_NONCRITICAL_EXCEPTIONS:
-        access_token_store = str(new_tokens.get("access_token") or "")
-        refresh_token_store = refresh_token_value
-        scopes_store = new_tokens.get("scope") or None
+    envelope_payload = dict(existing.get("tokens") or {})
+    envelope_payload.update(dict(new_tokens or {}))
+    envelope_payload["refresh_token"] = refresh_token_value
+    env = _encrypt_connector_secret_payload(
+        envelope_payload,
+        failure_log="Failed to encrypt connector account tokens",
+    )
+    access_token_store = _json.dumps(env) if env else str(new_tokens.get("access_token") or "")
+    refresh_token_store = None if env else refresh_token_value
+    scopes_store = new_tokens.get("scope") or None
 
     if is_pg:
         # Ensure ownership
@@ -2587,16 +2605,6 @@ async def create_import_job(
                 if _job_is_active(active_job):
                     return _format_connectors_job(active_job or {}, source_id=source_id, default_type=job_type)
         return _format_connectors_job(job, source_id=source_id, default_type=job_type)
-    except _CONNECTORS_NONCRITICAL_EXCEPTIONS:
+    except _CONNECTORS_NONCRITICAL_EXCEPTIONS as exc:
         logger.warning("Failed to create connectors job via JobManager")
-        # Fallback to synthetic ID
-        import uuid
-        jid = uuid.uuid4().hex
-        return {
-            "id": jid,
-            "source_id": source_id,
-            "type": job_type,
-            "status": "queued",
-            "progress_pct": 0,
-            "counts": {"processed": 0, "skipped": 0, "failed": 0},
-        }
+        raise ConnectorServiceError("Failed to create connectors job") from exc

--- a/tldw_Server_API/app/core/External_Sources/notion.py
+++ b/tldw_Server_API/app/core/External_Sources/notion.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import html
 import os
+import re
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 from loguru import logger
 
@@ -10,11 +12,75 @@ from tldw_Server_API.app.core.http_client import afetch
 
 from .connector_base import BaseConnector
 
+_MARKDOWN_SPECIAL_CHARS = re.compile(r"([\\`*_{}\[\]()#+\-.!|])")
+_JAVASCRIPT_SCHEME = re.compile(r"(?i)\bjavascript\s*:")
+_SAFE_CODE_LANGUAGE = re.compile(r"[^A-Za-z0-9_+.#-]")
+_BACKTICK_RUN = re.compile(r"`+")
+
+
+def _neutralize_unsafe_text_schemes(value: str) -> str:
+    """Neutralize unsafe URL-like schemes in text rendered as Markdown."""
+    return _JAVASCRIPT_SCHEME.sub("javascript&#58;", value)
+
+
+def _escape_markdown_text(value: Any) -> str:
+    """Escape user-controlled text that will be emitted into Markdown prose."""
+    text = html.escape(str(value or ""), quote=False)
+    text = _neutralize_unsafe_text_schemes(text)
+    return _MARKDOWN_SPECIAL_CHARS.sub(r"\\\1", text)
+
+
+def _escape_html_text(value: Any) -> str:
+    """Escape user-controlled text that will be emitted into raw HTML."""
+    return _neutralize_unsafe_text_schemes(html.escape(str(value or ""), quote=True))
+
+
+def _rich_text_plain_text(rich: list[dict[str, Any]]) -> str:
+    """Collapse Notion rich text fragments into literal plain text."""
+    return "".join(str(part.get("plain_text") or "") for part in rich or [])
+
+
+def _safe_markdown_url(value: Any) -> str | None:
+    """Return a Markdown-safe image URL or None when it should be omitted."""
+    url = str(value or "").strip()
+    if not url or any(char.isspace() for char in url) or any(char in url for char in "<>"):
+        return None
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme.lower() not in {"http", "https"}:
+            return None
+        _ = parsed.port
+    except ValueError:
+        return None
+    return url.replace(")", "%29")
+
+
+def _sanitize_code_language(value: Any) -> str:
+    """Remove characters that can break a Markdown code fence info string."""
+    return _SAFE_CODE_LANGUAGE.sub("", str(value or "").strip())
+
+
+def _code_fence_for(text: str) -> str:
+    """Return a code fence long enough to wrap text containing backticks."""
+    max_run = max((len(match.group(0)) for match in _BACKTICK_RUN.finditer(text)), default=0)
+    return "`" * max(3, max_run + 1)
+
+
+def _inline_code_span(value: Any) -> str:
+    """Return a Markdown code span that cannot collide with contained backticks."""
+    text = str(value or "")
+    max_run = max((len(match.group(0)) for match in _BACKTICK_RUN.finditer(text)), default=0)
+    delimiter = "`" * max(1, max_run + 1)
+    if text.startswith(("`", " ")) or text.endswith(("`", " ")):
+        return f"{delimiter} {text} {delimiter}"
+    return f"{delimiter}{text}{delimiter}"
+
 
 class NotionConnector(BaseConnector):
     name = "notion"
 
     def __init__(self, client_id: str | None = None, client_secret: str | None = None, redirect_base: str | None = None):
+        """Initialize the Notion connector with explicit or environment credentials."""
         super().__init__(
             client_id=client_id or os.getenv("CONNECTOR_NOTION_CLIENT_ID"),
             client_secret=client_secret or os.getenv("CONNECTOR_NOTION_SECRET"),
@@ -22,6 +88,7 @@ class NotionConnector(BaseConnector):
         )
 
     def authorize_url(self, state: str | None = None, scopes: list[str] | None = None, redirect_path: str = "/api/v1/connectors/providers/notion/callback") -> str:
+        """Build a Notion OAuth authorization URL for the configured redirect."""
         redirect_uri = f"{self.redirect_base}{redirect_path}"
         if not self.client_id:
             return f"{redirect_uri}?scaffold=1&state={state or ''}"
@@ -186,16 +253,18 @@ class NotionConnector(BaseConnector):
         def _rich_text_to_md(rich: list[dict[str, Any]]) -> str:
             out = []
             for p in rich or []:
-                txt = p.get("plain_text") or ""
+                raw_txt = p.get("plain_text") or ""
                 ann = (p.get("annotations") or {})
                 if ann.get("code"):
-                    txt = f"`{txt}`"
-                if ann.get("bold"):
-                    txt = f"**{txt}**"
-                if ann.get("italic"):
-                    txt = f"*{txt}*"
-                if ann.get("strikethrough"):
-                    txt = f"~~{txt}~~"
+                    txt = _inline_code_span(raw_txt)
+                else:
+                    txt = _escape_markdown_text(raw_txt)
+                    if ann.get("bold"):
+                        txt = f"**{txt}**"
+                    if ann.get("italic"):
+                        txt = f"*{txt}*"
+                    if ann.get("strikethrough"):
+                        txt = f"~~{txt}~~"
                 out.append(txt)
             return "".join(out)
 
@@ -225,7 +294,7 @@ class NotionConnector(BaseConnector):
                         lines.extend(await _render_block(kb, depth + 1))
             # Toggle
             elif t == "toggle":
-                text = _rich_text_to_md(bt.get("rich_text") or [])
+                text = "".join(_escape_html_text(p.get("plain_text") or "") for p in bt.get("rich_text") or [])
                 lines.append(f"<details><summary>{text}</summary>")
                 if b.get("has_children"):
                     kids = await _fetch_children(b.get("id"))
@@ -234,9 +303,10 @@ class NotionConnector(BaseConnector):
                 lines.append("</details>")
             # Code block
             elif t == "code":
-                lang = (bt.get("language") or "").strip() or ""
-                text = _rich_text_to_md(bt.get("rich_text") or [])
-                lines.append(f"```{lang}\n{text}\n```")
+                lang = _sanitize_code_language(bt.get("language"))
+                text = _rich_text_plain_text(bt.get("rich_text") or [])
+                fence = _code_fence_for(text)
+                lines.append(f"{fence}{lang}\n{text}\n{fence}")
             # Quote
             elif t == "quote":
                 text = _rich_text_to_md(bt.get("rich_text") or [])
@@ -245,7 +315,7 @@ class NotionConnector(BaseConnector):
             elif t == "callout":
                 text = _rich_text_to_md(bt.get("rich_text") or [])
                 emoji = (bt.get("icon") or {}).get("emoji") if isinstance(bt.get("icon"), dict) else None
-                prefix = f"{emoji} " if emoji else ""
+                prefix = f"{_escape_markdown_text(emoji)} " if emoji else ""
                 lines.append(f"> {prefix}{text}")
             # Table (render table and its rows)
             elif t == "table":
@@ -278,13 +348,14 @@ class NotionConnector(BaseConnector):
                 elif bt.get("type") == "file":
                     src = (bt.get("file") or {}).get("url")
                 alt = cap or "image"
-                if src:
-                    lines.append(f"![{alt}]({src})")
+                safe_src = _safe_markdown_url(src)
+                if safe_src:
+                    lines.append(f"![{alt}]({safe_src})")
                 else:
                     lines.append(f"![{alt}]")
             # Unsupported types: render a placeholder and children if any
             else:
-                typename = t or "unknown"
+                typename = re.sub(r"[^A-Za-z0-9_:-]", "", str(t or "unknown")) or "unknown"
                 lines.append(f"<!-- unsupported block: {typename} -->")
                 if b.get("has_children"):
                     kids = await _fetch_children(b.get("id"))

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -162,6 +162,10 @@ class ReferenceImportError(RuntimeError):
     """Raised when a reference-manager item cannot be persisted correctly."""
 
 
+class ConnectorServiceError(RuntimeError):
+    """Raised when External_Sources connector service operations fail."""
+
+
 class StructuredOutputParseError(ValueError):
     """Base error for structured-output parsing/normalization failures.
 

--- a/tldw_Server_API/app/services/connectors_worker.py
+++ b/tldw_Server_API/app/services/connectors_worker.py
@@ -8,11 +8,15 @@ import html
 import json
 import os
 import re
+from dataclasses import replace
 from datetime import datetime, timezone
 from fnmatch import fnmatch
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
+
+if TYPE_CHECKING:
+    from tldw_Server_API.app.core.External_Sources.sync_adapter import FileSyncChange
 
 try:
     from tldw_Server_API.app.core.Jobs.manager import JobManager
@@ -41,6 +45,7 @@ _CONNECTOR_NONCRITICAL_EXCEPTIONS = (
 
 DOMAIN = "connectors"
 _EMAIL_SYNC_METRICS_REGISTERED = False
+_FILE_SYNC_RESTORABLE_STATUSES = frozenset({"archived_upstream_removed", "orphaned"})
 
 
 def _email_sync_metric_labels(
@@ -473,6 +478,20 @@ def _file_sync_cursor_kind(provider: str) -> str | None:
     if normalized == "onedrive":
         return "graph_delta_link"
     return None
+
+
+def _normalize_file_sync_delta_event(
+    change: FileSyncChange,
+    binding: dict[str, Any] | None,
+) -> FileSyncChange:
+    if change.event_type != "content_updated":
+        return change
+    if not binding:
+        return replace(change, event_type="created")
+    sync_status = str(binding.get("sync_status") or "active").strip().lower()
+    if sync_status in _FILE_SYNC_RESTORABLE_STATUSES:
+        return replace(change, event_type="restored")
+    return change
 
 
 def _determine_drive_export_mime(
@@ -1214,6 +1233,7 @@ async def _process_import_job(
                         external_id=change.remote_id,
                     )
 
+                change = _normalize_file_sync_delta_event(change, binding)
                 if not binding and change.event_type != "created":
                     logger.warning(
                         "Skipping file sync change without binding for provider={} source_id={} remote_id={}",

--- a/tldw_Server_API/tests/External_Sources/test_connectors_service_sanitizers.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_service_sanitizers.py
@@ -4,6 +4,7 @@ import pytest
 
 from tldw_Server_API.app.core.External_Sources import connectors_service as svc
 from tldw_Server_API.app.core.Security import crypto
+from tldw_Server_API.app.core.exceptions import ConnectorServiceError
 
 
 pytestmark = pytest.mark.unit
@@ -36,6 +37,9 @@ def test_protect_oauth_state_metadata_sanitizes_encryption_fallback_log(monkeypa
     def _fail_encrypt(_metadata):
         raise RuntimeError("connectors crypto exploded /private/connectors.db")
 
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.delenv("CONNECTORS_REQUIRE_TOKEN_ENCRYPTION", raising=False)
+    monkeypatch.delenv("tldw_production", raising=False)
     monkeypatch.setattr(svc, "logger", fake_logger)
     monkeypatch.setattr(crypto, "encrypt_json_blob", _fail_encrypt)
 
@@ -46,6 +50,22 @@ def test_protect_oauth_state_metadata_sanitizes_encryption_fallback_log(monkeypa
         fake_logger,
         "Failed to encrypt oauth state metadata",
     )
+
+
+def test_protect_oauth_state_metadata_requires_encryption_in_multi_user(monkeypatch):
+    fake_logger = MagicMock()
+
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.delenv("CONNECTORS_REQUIRE_TOKEN_ENCRYPTION", raising=False)
+    monkeypatch.delenv("tldw_production", raising=False)
+    monkeypatch.delenv("WORKFLOWS_ARTIFACT_ENC_KEY", raising=False)
+    monkeypatch.setattr(svc, "logger", fake_logger)
+    monkeypatch.setattr(crypto, "encrypt_json_blob", lambda _metadata: None)
+
+    with pytest.raises(ConnectorServiceError, match="Connector secret encryption is required"):
+        svc._protect_oauth_state_metadata({"oauth_token_secret": "temp-secret"})
+
+    fake_logger.warning.assert_called_once_with("Connector secret encryption is required but unavailable")
 
 
 def test_unprotect_oauth_state_metadata_sanitizes_decryption_fallback_log(monkeypatch):
@@ -89,7 +109,104 @@ async def test_ensure_tables_sanitizes_failure_log_and_reraises(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_create_import_job_sanitizes_job_manager_fallback_log(monkeypatch):
+async def test_consume_oauth_state_consumes_postgres_row_atomically(monkeypatch):
+    class _FakePg:
+        _is_sqlite = False
+
+        def __init__(self):
+            self.delete_rows = [
+                {
+                    "state": "state-token",
+                    "provider": "zotero",
+                    "metadata": {"nonce": "only-once"},
+                    "created_at": "2026-05-01 00:00:00",
+                }
+            ]
+            self.delete_calls = 0
+            self.select_calls = 0
+
+        async def fetchrow(self, sql, *args):
+            sql_head = " ".join(str(sql).split()).upper()
+            if sql_head.startswith("SELECT"):
+                self.select_calls += 1
+                return {
+                    "state": "state-token",
+                    "provider": "zotero",
+                    "metadata": {"nonce": "stale-select"},
+                    "created_at": "2026-05-01 00:00:00",
+                }
+            if sql_head.startswith("DELETE"):
+                self.delete_calls += 1
+                return self.delete_rows.pop(0) if self.delete_rows else None
+            raise AssertionError(f"unexpected query: {sql}")
+
+        async def execute(self, *args, **kwargs):
+            return None
+
+    async def _noop_ensure_tables(_db):
+        return None
+
+    db = _FakePg()
+    monkeypatch.setattr(svc, "_ensure_tables", _noop_ensure_tables)
+
+    first = await svc.consume_oauth_state(
+        db,
+        user_id=7,
+        provider="zotero",
+        state="state-token",
+    )
+    second = await svc.consume_oauth_state(
+        db,
+        user_id=7,
+        provider="zotero",
+        state="state-token",
+    )
+
+    assert first is not False
+    assert first["nonce"] == "only-once"
+    assert second is False
+    assert db.delete_calls == 2
+    assert db.select_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_consume_oauth_state_sqlite_without_commit_method_still_returns_row(monkeypatch):
+    class _Cursor:
+        async def fetchone(self):
+            return {
+                "state": "state-token",
+                "provider": "zotero",
+                "metadata": {"nonce": "no-commit"},
+                "created_at": "2026-05-01 00:00:00",
+            }
+
+    class _NoCommitSqlite:
+        _is_sqlite = True
+
+        async def execute(self, sql, args=None):
+            assert "DELETE FROM external_oauth_state" in sql
+            assert "RETURNING state, provider, metadata, created_at" in sql
+            assert args[:3] == ("state-token", 7, "zotero")
+            return _Cursor()
+
+    async def _noop_ensure_tables(_db):
+        return None
+
+    monkeypatch.setattr(svc, "_ensure_tables", _noop_ensure_tables)
+
+    result = await svc.consume_oauth_state(
+        _NoCommitSqlite(),
+        user_id=7,
+        provider="zotero",
+        state="state-token",
+    )
+
+    assert result is not False
+    assert result["nonce"] == "no-commit"
+
+
+@pytest.mark.asyncio
+async def test_create_import_job_sanitizes_job_manager_failure_log(monkeypatch):
     class _Pool:
         pass
 
@@ -108,13 +225,9 @@ async def test_create_import_job_sanitizes_job_manager_fallback_log(monkeypatch)
     monkeypatch.setattr(auth_database, "get_db_pool", _get_db_pool)
     monkeypatch.setattr(jobs_manager, "JobManager", _FailingJobManager)
 
-    result = await svc.create_import_job(user_id=7, source_id=42, job_type="import")
+    with pytest.raises(ConnectorServiceError, match="Failed to create connectors job"):
+        await svc.create_import_job(user_id=7, source_id=42, job_type="import")
 
-    assert result["source_id"] == 42
-    assert result["type"] == "import"
-    assert result["status"] == "queued"
-    assert result["progress_pct"] == 0
-    assert result["counts"] == {"processed": 0, "skipped": 0, "failed": 0}
     _assert_sanitized_warning(
         fake_logger,
         "Failed to create connectors job via JobManager",

--- a/tldw_Server_API/tests/External_Sources/test_connectors_worker_file_sync.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_worker_file_sync.py
@@ -1,9 +1,21 @@
 from __future__ import annotations
 
+import inspect
+
 import pytest
 
 from tldw_Server_API.app.core.External_Sources.sync_adapter import FileSyncChange
 from tldw_Server_API.app.core.External_Sources.sync_coordinator import SyncReconcileResult
+
+
+@pytest.mark.unit
+def test_normalize_file_sync_delta_event_has_type_hints():
+    import tldw_Server_API.app.services.connectors_worker as worker
+
+    signature = inspect.signature(worker._normalize_file_sync_delta_event)
+
+    assert signature.parameters["change"].annotation is not inspect.Signature.empty
+    assert signature.return_annotation is not inspect.Signature.empty
 
 
 @pytest.mark.asyncio
@@ -235,7 +247,8 @@ async def test_worker_drive_incremental_sync_uses_delta_feed_and_advances_cursor
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_worker_drive_created_delta_without_binding_still_reconciles(monkeypatch):
+@pytest.mark.parametrize("delta_event_type", ["created", "content_updated"])
+async def test_worker_drive_created_delta_without_binding_still_reconciles(monkeypatch, delta_event_type):
     import tldw_Server_API.app.services.connectors_worker as worker
 
     class FakeJM:
@@ -270,7 +283,7 @@ async def test_worker_drive_created_delta_without_binding_still_reconciles(monke
             return (
                 [
                     FileSyncChange(
-                        event_type="created",
+                        event_type=delta_event_type,
                         remote_id="file-new",
                         remote_name="new-file.txt",
                         remote_parent_id="folder-1",
@@ -404,6 +417,191 @@ async def test_worker_drive_created_delta_without_binding_still_reconciles(monke
     assert reconcile_calls[0]["change"].event_type == "created"
     assert reconcile_calls[0]["content"].text == "Brand new drive sync body"
     assert reconcile_calls[0]["job_id"] == "5678"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_worker_drive_content_update_for_archived_binding_reconciles_as_restore(monkeypatch):
+    import tldw_Server_API.app.services.connectors_worker as worker
+
+    class FakeJM:
+        def __init__(self):
+            self.completed = None
+
+        def renew_job_lease(self, *args, **kwargs):
+            return None
+
+        def complete_job(
+            self,
+            jid,
+            result=None,
+            worker_id=None,
+            lease_id=None,
+            completion_token=None,
+        ):
+            self.completed = {"jid": jid, "result": result}
+
+    class FakeDriveConn:
+        download_calls: list[str] = []
+
+        async def list_files(self, *args, **kwargs):
+            raise AssertionError("delta sync should not fall back to recursive traversal")
+
+        async def list_changes(
+            self,
+            account,
+            *,
+            cursor: str | None = None,
+            page_size: int = 100,
+        ):
+            assert account["tokens"]["access_token"] == "tok"
+            return (
+                [
+                    FileSyncChange(
+                        event_type="content_updated",
+                        remote_id="file-restore",
+                        remote_name="restored-file.txt",
+                        remote_parent_id="folder-1",
+                        remote_path="/finance/restored-file.txt",
+                        remote_revision="rev-3",
+                        remote_hash="hash-restored",
+                        metadata={
+                            "mime_type": "text/plain",
+                            "size": 64,
+                            "modified_at": "2026-03-06T12:00:00Z",
+                        },
+                    )
+                ],
+                None,
+                "cursor-2",
+            )
+
+        async def download_or_export(self, account, remote_id, *, metadata=None):
+            type(self).download_calls.append(remote_id)
+            raise AssertionError("restored bindings should be reconciled before content download")
+
+    class _DummyTx:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _DummyPool:
+        def transaction(self):
+            return _DummyTx()
+
+    async def _fake_get_db_pool():
+        return _DummyPool()
+
+    async def _fake_get_source_by_id(db, user_id, source_id):
+        return {
+            "id": source_id,
+            "provider": "drive",
+            "account_id": 123,
+            "remote_id": "root",
+            "type": "folder",
+            "path": "/",
+            "options": {"recursive": True},
+            "email": "sync@example.com",
+        }
+
+    async def _fake_get_account_tokens(db, user_id, account_id):
+        return {"access_token": "tok"}
+
+    async def _fake_get_source_sync_state(db, *, source_id):
+        return {"source_id": source_id, "cursor": "cursor-1", "cursor_kind": "drive_start_page_token"}
+
+    async def _fake_upsert_source_sync_state(db, *, source_id, **updates):
+        return {"source_id": source_id, **updates}
+
+    async def _fake_get_external_item_binding(db, *, source_id, provider, external_id):
+        assert external_id == "file-restore"
+        return {
+            "id": 5,
+            "source_id": source_id,
+            "provider": provider,
+            "external_id": external_id,
+            "media_id": 88,
+            "version": "rev-2",
+            "hash": "hash-old",
+            "sync_status": "archived_upstream_removed",
+        }
+
+    reconcile_calls: list[dict[str, object]] = []
+
+    async def _fake_reconcile_file_change(
+        connectors_db,
+        media_db,
+        *,
+        source_id,
+        provider,
+        change,
+        content=None,
+        job_id=None,
+    ):
+        reconcile_calls.append(
+            {
+                "source_id": source_id,
+                "provider": provider,
+                "change": change,
+                "content": content,
+                "job_id": job_id,
+            }
+        )
+        return SyncReconcileResult(
+            action="restored",
+            media_id=88,
+            binding_id=5,
+            current_version_number=1,
+            sync_status="active",
+        )
+
+    class _FakeMDB:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    import tldw_Server_API.app.core.AuthNZ.database as dbmod
+    import tldw_Server_API.app.core.AuthNZ.orgs_teams as orgs
+    import tldw_Server_API.app.core.External_Sources as ext_pkg
+    import tldw_Server_API.app.core.External_Sources.connectors_service as svc
+    import tldw_Server_API.app.core.External_Sources.sync_coordinator as sync_coordinator
+
+    monkeypatch.setattr(ext_pkg, "get_connector_by_name", lambda name: FakeDriveConn())
+    monkeypatch.setattr(dbmod, "get_db_pool", _fake_get_db_pool)
+    monkeypatch.setattr(svc, "get_source_by_id", _fake_get_source_by_id)
+    monkeypatch.setattr(svc, "get_account_tokens", _fake_get_account_tokens)
+    monkeypatch.setattr(svc, "get_source_sync_state", _fake_get_source_sync_state)
+    monkeypatch.setattr(svc, "upsert_source_sync_state", _fake_upsert_source_sync_state)
+    monkeypatch.setattr(svc, "get_external_item_binding", _fake_get_external_item_binding)
+    monkeypatch.setattr(sync_coordinator, "reconcile_file_change", _fake_reconcile_file_change)
+    monkeypatch.setattr(
+        worker,
+        "create_media_database",
+        lambda client_id, db_path=None: _FakeMDB(client_id, db_path=db_path),
+        raising=False,
+    )
+    monkeypatch.setattr(orgs, "list_memberships_for_user", lambda user_id: [])
+
+    jm = FakeJM()
+
+    await worker._process_import_job(
+        jm,
+        jid=5679,
+        lease_id="lease-1",
+        worker_id="worker-1",
+        source_id=99,
+        user_id=42,
+    )
+
+    assert jm.completed is not None
+    assert jm.completed["result"]["processed"] == 1
+    assert FakeDriveConn.download_calls == []
+    assert len(reconcile_calls) == 1
+    assert reconcile_calls[0]["change"].event_type == "restored"
+    assert reconcile_calls[0]["content"] is None
+    assert reconcile_calls[0]["job_id"] == "5679"
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/External_Sources/test_notion_connector_sanitizers.py
+++ b/tldw_Server_API/tests/External_Sources/test_notion_connector_sanitizers.py
@@ -112,3 +112,171 @@ async def test_list_sources_sanitizes_search_result_title_fallback_log(monkeypat
         }
     ]
     _assert_sanitized_debug(fake_logger, "Notion connector failed to extract search result title")
+
+
+@pytest.mark.asyncio
+async def test_download_file_escapes_markdown_html_and_unsafe_image_urls(monkeypatch):
+    async def _fake_afetch(**_kwargs):
+        return _Response(
+            {
+                "results": [
+                    {
+                        "object": "block",
+                        "id": "paragraph-1",
+                        "type": "paragraph",
+                        "paragraph": {
+                            "rich_text": [
+                                {
+                                    "plain_text": "hello <script>alert(1)</script> [x](javascript:alert(2))",
+                                    "annotations": {},
+                                }
+                            ],
+                        },
+                    },
+                    {
+                        "object": "block",
+                        "id": "toggle-1",
+                        "type": "toggle",
+                        "toggle": {
+                            "rich_text": [
+                                {
+                                    "plain_text": "</summary><script>alert(3)</script>",
+                                    "annotations": {},
+                                }
+                            ],
+                        },
+                    },
+                    {
+                        "object": "block",
+                        "id": "code-1",
+                        "type": "code",
+                        "code": {
+                            "language": "py`on<script>",
+                            "rich_text": [
+                                {
+                                    "plain_text": "```\nprint('x')\n```",
+                                    "annotations": {},
+                                }
+                            ],
+                        },
+                    },
+                    {
+                        "object": "block",
+                        "id": "image-1",
+                        "type": "image",
+                        "image": {
+                            "type": "external",
+                            "external": {"url": "javascript:alert(4)"},
+                            "caption": [
+                                {
+                                    "plain_text": "<bad alt>",
+                                    "annotations": {},
+                                }
+                            ],
+                        },
+                    },
+                    {
+                        "object": "block",
+                        "id": "image-2",
+                        "type": "image",
+                        "image": {
+                            "type": "external",
+                            "external": {"url": "http://[::1"},
+                            "caption": [
+                                {
+                                    "plain_text": "broken",
+                                    "annotations": {},
+                                }
+                            ],
+                        },
+                    },
+                ],
+                "has_more": False,
+                "next_cursor": None,
+            }
+        )
+
+    monkeypatch.setattr(notion_mod, "afetch", _fake_afetch)
+
+    connector = NotionConnector(client_id="client", client_secret="secret", redirect_base="http://localhost")
+    markdown = (await connector.download_file({"access_token": "token"}, "page-1")).decode("utf-8")
+
+    assert "<script" not in markdown.lower()
+    assert "</summary><script" not in markdown.lower()
+    assert "](javascript:" not in markdown.lower()
+    assert "\\[x\\]" in markdown
+    assert "![&lt;bad alt&gt;](javascript:" not in markdown.lower()
+    assert "![broken](http://[::1" not in markdown
+    assert "![broken]" in markdown
+    assert "````" in markdown
+
+
+@pytest.mark.asyncio
+async def test_download_file_preserves_literal_code_block_text(monkeypatch):
+    async def _fake_afetch(**_kwargs):
+        return _Response(
+            {
+                "results": [
+                    {
+                        "object": "block",
+                        "id": "code-1",
+                        "type": "code",
+                        "code": {
+                            "language": "python",
+                            "rich_text": [
+                                {
+                                    "plain_text": "if left < right:\n    url = 'javascript:alert(1)'",
+                                    "annotations": {},
+                                }
+                            ],
+                        },
+                    },
+                ],
+                "has_more": False,
+                "next_cursor": None,
+            }
+        )
+
+    monkeypatch.setattr(notion_mod, "afetch", _fake_afetch)
+
+    connector = NotionConnector(client_id="client", client_secret="secret", redirect_base="http://localhost")
+    markdown = (await connector.download_file({"access_token": "token"}, "page-1")).decode("utf-8")
+
+    assert "if left < right:" in markdown
+    assert "javascript:alert(1)" in markdown
+    assert "&lt;" not in markdown
+    assert "javascript&#58;" not in markdown
+
+
+@pytest.mark.asyncio
+async def test_download_file_uses_collision_free_inline_code_span(monkeypatch):
+    async def _fake_afetch(**_kwargs):
+        return _Response(
+            {
+                "results": [
+                    {
+                        "object": "block",
+                        "id": "paragraph-1",
+                        "type": "paragraph",
+                        "paragraph": {
+                            "rich_text": [
+                                {
+                                    "plain_text": "`tick` [x](javascript:alert(1))",
+                                    "annotations": {"code": True},
+                                }
+                            ],
+                        },
+                    },
+                ],
+                "has_more": False,
+                "next_cursor": None,
+            }
+        )
+
+    monkeypatch.setattr(notion_mod, "afetch", _fake_afetch)
+
+    connector = NotionConnector(client_id="client", client_secret="secret", redirect_base="http://localhost")
+    markdown = (await connector.download_file({"access_token": "token"}, "page-1")).decode("utf-8")
+
+    assert markdown.strip() == "`` `tick` [x](javascript:alert(1)) ``"
+    assert "\\`" not in markdown

--- a/tldw_Server_API/tests/External_Sources/test_sync_adapter_contract.py
+++ b/tldw_Server_API/tests/External_Sources/test_sync_adapter_contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tldw_Server_API.app.core.External_Sources import connectors_service as svc
+from tldw_Server_API.app.core.External_Sources.connector_base import BaseConnector
 from tldw_Server_API.app.core.External_Sources.sync_adapter import (
     FileSyncAdapter,
     FileSyncChange,
@@ -31,3 +32,33 @@ def test_get_file_sync_connector_by_name_restricts_to_file_sync_providers() -> N
 
     with pytest.raises(ValueError, match="does not support file sync"):
         svc.get_file_sync_connector_by_name("gmail")
+
+
+class _MinimalConnector(BaseConnector):
+    name = "minimal"
+
+    def authorize_url(
+        self,
+        state: str | None = None,
+        scopes: list[str] | None = None,
+        redirect_path: str = "/api/v1/connectors/callback",
+    ) -> str:
+        return "https://example.test/oauth"
+
+    async def exchange_code(self, code: str, redirect_uri: str) -> dict[str, object]:
+        return {"access_token": code, "redirect_uri": redirect_uri}
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_base_connector_unsupported_capabilities_raise() -> None:
+    connector = _MinimalConnector()
+
+    with pytest.raises(NotImplementedError, match="does not support source listing"):
+        await connector.list_sources({})
+
+    with pytest.raises(NotImplementedError, match="does not support file listing"):
+        await connector.list_files({}, "parent-1")
+
+    with pytest.raises(NotImplementedError, match="does not support file download"):
+        await connector.download_file({}, "file-1")

--- a/tldw_Server_API/tests/External_Sources/test_token_refresh_envelope.py
+++ b/tldw_Server_API/tests/External_Sources/test_token_refresh_envelope.py
@@ -10,6 +10,7 @@ async def test_update_account_tokens_encrypted_env(monkeypatch, tmp_path):
 
     # Enable encryption
     # Valid base64-encoded 32-byte key (AES-256)
+    monkeypatch.setenv("AUTH_MODE", "single_user")
     monkeypatch.setenv("WORKFLOWS_ARTIFACT_ENC_KEY", "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=")
 
     import aiosqlite
@@ -53,6 +54,9 @@ async def test_update_account_tokens_encrypted_env(monkeypatch, tmp_path):
 async def test_update_account_tokens_plaintext_without_env(monkeypatch, tmp_path):
     from tldw_Server_API.app.core.External_Sources import connectors_service as svc
     # Ensure encryption disabled
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.delenv("CONNECTORS_REQUIRE_TOKEN_ENCRYPTION", raising=False)
+    monkeypatch.delenv("tldw_production", raising=False)
     monkeypatch.delenv("WORKFLOWS_ARTIFACT_ENC_KEY", raising=False)
 
     import aiosqlite
@@ -74,3 +78,35 @@ async def test_update_account_tokens_plaintext_without_env(monkeypatch, tmp_path
         # get_account_tokens reflects new value
         toks = await svc.get_account_tokens(db, 1, account_id)
         assert toks.get("access_token") == "n2"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_create_account_requires_encryption_in_multi_user(monkeypatch, tmp_path):
+    from tldw_Server_API.app.core.External_Sources import connectors_service as svc
+    from tldw_Server_API.app.core.Security import crypto
+
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.delenv("CONNECTORS_REQUIRE_TOKEN_ENCRYPTION", raising=False)
+    monkeypatch.delenv("tldw_production", raising=False)
+    monkeypatch.delenv("WORKFLOWS_ARTIFACT_ENC_KEY", raising=False)
+    monkeypatch.setattr(crypto, "encrypt_json_blob", lambda _tokens: None)
+
+    import aiosqlite
+    db_path = tmp_path / "required-encryption.db"
+    async with aiosqlite.connect(str(db_path)) as db:
+        from tldw_Server_API.app.core.exceptions import ConnectorServiceError
+
+        with pytest.raises(ConnectorServiceError, match="Connector secret encryption is required"):
+            await svc.create_account(
+                db,
+                user_id=1,
+                provider="drive",
+                display_name="Drive",
+                email="user@example.com",
+                tokens={"access_token": "at1", "refresh_token": "rt1"},
+            )
+
+        cur = await db.execute("SELECT COUNT(*) FROM external_accounts")
+        row = await cur.fetchone()
+        assert row[0] == 0


### PR DESCRIPTION
## Summary
- Normalize Drive/OneDrive `content_updated` deltas into create/restore actions when bindings are missing or archived.
- Make connector service paths fail closed for OAuth state replay, job creation failures, and required token/state encryption.
- Sanitize Notion Markdown output and make unsupported base connector capabilities explicit.

## Test Plan
- `python -m py_compile tldw_Server_API/app/core/External_Sources/connector_base.py tldw_Server_API/app/core/External_Sources/connectors_service.py tldw_Server_API/app/core/External_Sources/notion.py tldw_Server_API/app/services/connectors_worker.py`
- `ULTRA_MINIMAL_APP=1 python -m pytest -p no:unraisableexception tldw_Server_API/tests/External_Sources/test_connectors_worker_file_sync.py tldw_Server_API/tests/External_Sources/test_connectors_service_sanitizers.py tldw_Server_API/tests/External_Sources/test_token_refresh_envelope.py tldw_Server_API/tests/External_Sources/test_notion_connector_sanitizers.py tldw_Server_API/tests/External_Sources/test_sync_adapter_contract.py tldw_Server_API/tests/External_Sources/test_reference_manager_storage.py tldw_Server_API/tests/External_Sources/test_policy_and_connectors.py::test_notion_download_renders_nested_blocks -q --tb=short`
- `python -m bandit -r tldw_Server_API/app/core/External_Sources/connector_base.py tldw_Server_API/app/core/External_Sources/connectors_service.py tldw_Server_API/app/core/External_Sources/notion.py tldw_Server_API/app/services/connectors_worker.py -f json -o /tmp/bandit_external_sources_clean_pr.json`

## Notes
- Backlog task: TASK-9928
- Full default pytest app import path previously timed out in unrelated optional-router startup; targeted verification used `ULTRA_MINIMAL_APP=1` to scope unit-test app imports.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened External_Sources sync and Notion rendering for safety and correctness. Addresses TASK-9928 with atomic single-use OAuth state consumption, fail-closed token/state encryption policy, safer Markdown, and stricter job/connector errors.

- **Bug Fixes**
  - Drive/OneDrive: map `content_updated` to `created` when no binding, and to `restored` when binding is archived/orphaned.
  - OAuth state is single-use via `DELETE … RETURNING` on Postgres and SQLite; SQLite no-commit fallback handled.
  - Job creation now raises `ConnectorServiceError`; no synthetic “queued” jobs.
  - Base connector methods raise `NotImplementedError` for unsupported capabilities.

- **Hardening**
  - Token/state encryption envelopes used when available; fail closed when required by `AUTH_MODE=multi_user`, `CONNECTORS_REQUIRE_TOKEN_ENCRYPTION`, `tldw_production`/`TLDW_PRODUCTION`.
  - Introduced `ConnectorServiceError` and fail-closed helpers for connector-domain failures.
  - Notion Markdown: preserve literal code block text, use collision‑free inline code spans, sanitize code fence languages, escape Markdown/HTML, neutralize `javascript:` links, and allow only safe `http/https` image URLs.

<sup>Written for commit bd076975a9db66be091ba705b38cdc91117df312. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

