### PR TITLE
Harden Persona review findings

### DIFF
--- a/backlog/tasks/task-2418 - Harden-Persona-module-review-findings.md
+++ b/backlog/tasks/task-2418 - Harden-Persona-module-review-findings.md
@@ -1,0 +1,78 @@
+---
+id: TASK-2418
+title: Harden Persona module review findings
+status: Done
+assignee: []
+created_date: 2026-06-23 18:23
+updated_date: 2026-06-24 04:24
+labels:
+- persona
+- security
+- review
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and address validated review findings in the current Persona core module code. Scope: native visual import cleanup, visual candidate terminal review state, Persona Live focus/idempotency consistency, visual export asset bounds, and connection-template log redaction.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Validated findings have focused regression tests.
+- [x] #2 Native visual import failures clean up partial packs/assets.
+- [x] #3 Visual candidate accept/reject terminal state is enforced.
+- [x] #4 Persona Live focus/idempotency consistency is hardened or invalidated with evidence.
+- [x] #5 Visual export enforces asset size bounds before loading/writing large files.
+- [x] #6 Connection template render errors do not log raw sensitive template values.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified findings and fixed validated issues.
+
+Red verification: focused regression run failed before fixes for native import cleanup, candidate terminal review state, stale live focus reconciliation, oversized export preflight, and template log redaction.
+
+Post-fix verification:
+- `python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability.py::test_export_pack_rejects_oversized_asset_before_archive_validation tldw_Server_API/tests/Persona/test_persona_visual_portability.py::test_import_commit_native_archive_cleans_up_failed_manifest_update tldw_Server_API/tests/Persona/test_persona_visuals_api.py::test_review_generated_candidate_terminal_status_cannot_be_changed tldw_Server_API/tests/Persona/test_persona_live_control_api.py::test_live_session_focus_reconciles_stale_focused_rows_after_missed_snapshot tldw_Server_API/tests/Persona/test_persona_connection_helpers.py::test_render_template_value_logs_warning_for_invalid_format -q --tb=short` passed 5 tests.
+- `python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py tldw_Server_API/tests/Persona/test_persona_live_control_api.py tldw_Server_API/tests/Persona/test_persona_connection_helpers.py -q --tb=short` passed 127 tests.
+- `git diff --check` passed.
+- `python -m bandit -r tldw_Server_API/app/core/Persona/visual_portability/importer.py tldw_Server_API/app/core/Persona/visual_portability/exporter.py tldw_Server_API/app/core/Persona/visual_service.py tldw_Server_API/app/core/Persona/live_control.py tldw_Server_API/app/core/Persona/connections.py tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py tldw_Server_API/app/api/v1/endpoints/persona.py -f json -o /tmp/bandit_persona_review_hardening.json` exited 0.
+
+Additional live-control verification: added a concurrent create-new idempotency regression that failed before the lock (`len(set(created)) == 2`) and passed after serializing create/resume with the process-local live-session mutation lock.
+
+Final current-code verification:
+- `python -m pytest tldw_Server_API/tests/Persona/test_persona_live_control_api.py::test_live_session_create_idempotency_serializes_concurrent_requests -q --tb=short` passed 1 test.
+- `python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py tldw_Server_API/tests/Persona/test_persona_live_control_api.py tldw_Server_API/tests/Persona/test_persona_connection_helpers.py -q --tb=short` passed 128 tests.
+- `git diff --check` passed.
+- Bandit over touched backend Persona/API/DB files exited 0.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR #2455 onto latest origin/dev, removing the unrelated inherited Claims commit from the PR diff. Addressed all validated review comments by hardening Persona Live focus conflict handling with retries, locking, and bounded reconciliation; adding the requested reconciliation comment and docstrings; using a Persona-specific export exception for new archive limit failures; and annotating/expanding regression tests. Verified with targeted tests, the 129-test focused Persona suite, git diff --check, and Bandit.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+- [x] #7 Focused tests pass.
+- [x] #8 Bandit runs on touched Python files.
+- [x] #9 Backlog task records verification and final summary.
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+PR #2455 follow-up: rebased onto latest origin/dev and validating review comments for remediation (focus conflict handling, exporter domain exception, missing docstrings, test type annotations, and focus reconciliation comment).
+PR #2455 review follow-up completed. Addressed validated comments: rebased the branch onto latest origin/dev and dropped the unrelated inherited Claims commit from the PR diff; added bounded optimistic-concurrency retries for Persona Live preference updates; serialized focus mutations with the live-session mutation lock; reconciled focused rows in bounded passes and reverts target focus before surfacing unreconciled conflicts; added an explanatory focus reconciliation comment; changed new export limit failures to PersonaVisualPackExportError; added missing docstrings; annotated new live-control regression tests; added a regression for conflicted focused-row cleanup. Verification: targeted review tests passed 4 tests; focused Persona suite passed 129 tests; git diff --check passed; Bandit over touched Persona/API/DB paths exited 0 with only existing nosec warnings in persona_state_store.py.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -2397,7 +2397,7 @@ def _persona_visual_service_error_to_http(exc: PersonaVisualServiceError) -> HTT
         status_code = status.HTTP_403_FORBIDDEN
     elif exc.code in {"upload_too_large"}:
         status_code = status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
-    elif exc.code in {"source_asset_missing", "source_asset_checksum_mismatch"}:
+    elif exc.code in {"source_asset_missing", "source_asset_checksum_mismatch", "candidate_status_conflict"}:
         status_code = status.HTTP_409_CONFLICT
     return HTTPException(
         status_code=status_code,

--- a/tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/persona_state_store.py
@@ -3490,20 +3490,39 @@ class PersonaStateStore:
         user_id: str,
         status: str,
         failure_reason: str | None = None,
+        expected_statuses: set[str] | None = None,
     ) -> dict[str, Any] | None:
         status_value = self._normalize_persona_visual_enum(
             status,
             allowed=self._ALLOWED_PERSONA_VISUAL_CANDIDATE_STATUSES,
             field_name="candidate status",
         )
+        expected_status_values: list[str] = []
+        if expected_statuses is not None:
+            for expected_status in sorted(expected_statuses):
+                expected_status_values.append(
+                    self._normalize_persona_visual_enum(
+                        expected_status,
+                        allowed=self._ALLOWED_PERSONA_VISUAL_CANDIDATE_STATUSES,
+                        field_name="candidate status",
+                    )
+                )
+            if not expected_status_values:
+                raise InputError("expected_statuses must not be empty when provided.")  # noqa: TRY003
         now = self._get_current_utc_timestamp_iso()
         bool_cast = bool if self.backend_type == BackendType.POSTGRESQL else int
+        status_predicate = ""
+        if expected_status_values:
+            placeholders = ", ".join("?" for _ in expected_status_values)
+            status_predicate = f" AND status IN ({placeholders})"
         query = (
             "UPDATE persona_visual_candidates "
             "SET status = ?, failure_reason = ?, last_modified = ?, version = version + 1 "
             "WHERE id = ? AND pack_id = ? AND persona_id = ? AND user_id = ? AND deleted = ?"
         )
-        params = (
+        # status_predicate contains only generated placeholder tokens.
+        query = f"{query}{status_predicate}"  # nosec B608
+        params = [
             status_value,
             self._normalize_nullable_text(failure_reason),
             now,
@@ -3512,7 +3531,9 @@ class PersonaStateStore:
             persona_id,
             user_id,
             bool_cast(False),
-        )
+        ]
+        params.extend(expected_status_values)
+        updated = False
         with self.transaction() as conn:
             self._require_active_persona_profile_owner(conn, persona_id=persona_id, user_id=user_id)
             self._require_persona_visual_pack_owner(
@@ -3521,8 +3542,12 @@ class PersonaStateStore:
                 persona_id=persona_id,
                 user_id=user_id,
             )
-            prepared_query, prepared_params = self._prepare_backend_statement(query, params)
-            conn.execute(prepared_query, prepared_params or ())
+            prepared_query, prepared_params = self._prepare_backend_statement(query, tuple(params))
+            cursor = conn.execute(prepared_query, prepared_params or ())
+            updated = cursor.rowcount > 0
+
+        if expected_status_values and not updated:
+            return None
 
         return self.get_persona_visual_candidate(
             candidate_id=candidate_id,

--- a/tldw_Server_API/app/core/Persona/connections.py
+++ b/tldw_Server_API/app/core/Persona/connections.py
@@ -14,6 +14,7 @@ from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import (
     key_hint_for_api_key,
     loads_envelope,
 )
+from tldw_Server_API.app.core.Persona.dialogue_tree_context import redact_sensitive_payload
 from tldw_Server_API.app.core.Security.egress import evaluate_url_policy
 
 
@@ -212,7 +213,7 @@ def render_template_value(value: str, context: dict[str, str]) -> str:
     except Exception as exc:  # noqa: BLE001
         logger.warning(
             "Failed to render persona connection template '{}': {}",
-            value,
+            redact_sensitive_payload(value),
             exc,
         )
         return rendered

--- a/tldw_Server_API/app/core/Persona/live_control.py
+++ b/tldw_Server_API/app/core/Persona/live_control.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from threading import RLock
 from typing import Any
 
-from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, ConflictError
 from tldw_Server_API.app.core.Persona.session_manager import SessionManager
 from tldw_Server_API.app.core.Persona.session_materialization import (
     DEFAULT_PERSONA_ID,
@@ -20,7 +20,10 @@ LIVE_CONTROL_PREFS_KEY = "persona_live_control"
 _TERMINAL_STATUSES = {"closed", "archived"}
 _CAPABILITIES = {"text": True, "voice": False, "browser_microphone_required": False}
 _generation_lock = RLock()
+_live_session_mutation_lock = RLock()
 _last_focus_generation = 0
+_PREFERENCE_UPDATE_RETRIES = 3
+_FOCUS_RECONCILIATION_PASSES = 3
 _SESSION_SCAN_PAGE_SIZE = 200
 _FOCUSED_SESSION_LOOKUP_LIMIT = 1000
 
@@ -127,10 +130,12 @@ def _update_preferences(db: CharactersRAGDB, *, row: dict[str, Any], user_id: st
     session_id = str(row.get("id") or "").strip()
     if not session_id:
         return
+    expected_version = row.get("version")
     db.update_persona_session(
         session_id=session_id,
         user_id=user_id,
         update_data={"preferences_json": preferences},
+        expected_version=int(expected_version) if expected_version is not None else None,
     )
 
 
@@ -145,13 +150,23 @@ def _update_live_control_preferences(
     session_id = str(row.get("id") or "").strip()
     if not session_id:
         return
-    fresh_row = db.get_persona_session(session_id, user_id=user_id, include_deleted=False) or row
-    _update_preferences(
-        db,
-        row=fresh_row,
-        user_id=user_id,
-        preferences=_live_preferences_patch(fresh_row, focus=focus, idempotency_key=idempotency_key),
-    )
+    last_conflict: ConflictError | None = None
+    latest_row = row
+    for _ in range(_PREFERENCE_UPDATE_RETRIES):
+        fresh_row = db.get_persona_session(session_id, user_id=user_id, include_deleted=False) or latest_row
+        try:
+            _update_preferences(
+                db,
+                row=fresh_row,
+                user_id=user_id,
+                preferences=_live_preferences_patch(fresh_row, focus=focus, idempotency_key=idempotency_key),
+            )
+            return
+        except ConflictError as exc:
+            last_conflict = exc
+            latest_row = db.get_persona_session(session_id, user_id=user_id, include_deleted=False) or fresh_row
+    if last_conflict is not None:
+        raise last_conflict
 
 
 def _load_owned_session_or_raise(db: CharactersRAGDB, *, user_id: str, session_id: str) -> dict[str, Any]:
@@ -309,7 +324,9 @@ def build_live_session_summary(
     return {
         "session_id": session_id,
         "persona_id": persona_id,
-        "persona_name": persona_name if persona_name is not None else _persona_name_for_row(db, row=row, user_id=user_id),
+        "persona_name": (
+            persona_name if persona_name is not None else _persona_name_for_row(db, row=row, user_id=user_id)
+        ),
         "lifecycle": lifecycle,
         "status": status,
         "is_focused": bool(is_focused),
@@ -345,6 +362,82 @@ def _focused_session_id(rows: list[dict[str, Any]]) -> str | None:
             winner_generation = generation
             winner_id = str(row.get("id") or "").strip() or None
     return winner_id
+
+
+def _clear_other_focused_sessions(
+    db: CharactersRAGDB,
+    *,
+    user_id: str,
+    target_session_id: str,
+    focused_rows: list[dict[str, Any]],
+) -> list[str]:
+    """Clear known non-target focused rows and report rows that still conflicted."""
+    conflicted_session_ids: list[str] = []
+    for existing in focused_rows:
+        existing_id = str(existing.get("id") or "").strip()
+        if not existing_id or existing_id == target_session_id:
+            continue
+        try:
+            _update_live_control_preferences(
+                db,
+                row=existing,
+                user_id=user_id,
+                focus={"focused": False},
+            )
+        except ConflictError:
+            conflicted_session_ids.append(existing_id)
+    return conflicted_session_ids
+
+
+def _non_target_focused_rows(rows: list[dict[str, Any]], *, target_session_id: str) -> list[dict[str, Any]]:
+    """Return focused rows that do not represent the desired target session."""
+    return [
+        row
+        for row in rows
+        if str(row.get("id") or "").strip() != target_session_id and _focus_metadata(row).get("focused")
+    ]
+
+
+def _reconcile_focused_sessions(
+    db: CharactersRAGDB,
+    *,
+    user_id: str,
+    target_session_id: str,
+    initially_focused_rows: list[dict[str, Any]],
+) -> None:
+    """Run bounded focus cleanup until only the target row remains focused."""
+    focused_rows = initially_focused_rows
+    for _ in range(_FOCUS_RECONCILIATION_PASSES):
+        _clear_other_focused_sessions(
+            db,
+            user_id=user_id,
+            target_session_id=target_session_id,
+            focused_rows=focused_rows,
+        )
+        remaining = _non_target_focused_rows(
+            _focused_session_rows(db, user_id=user_id),
+            target_session_id=target_session_id,
+        )
+        if not remaining:
+            return
+        focused_rows = remaining
+
+    target_row = db.get_persona_session(target_session_id, user_id=user_id, include_deleted=False)
+    if target_row is not None:
+        try:
+            _update_live_control_preferences(
+                db,
+                row=target_row,
+                user_id=user_id,
+                focus={"focused": False},
+            )
+        except ConflictError:
+            pass
+    raise ConflictError(
+        "Unable to reconcile focused Persona Live sessions.",
+        entity="persona_sessions",
+        entity_id=target_session_id,
+    )
 
 
 def list_live_session_summaries(
@@ -444,6 +537,31 @@ def create_or_resume_live_session(
     stream_registry: PersonaLiveStreamRegistry = persona_live_stream_registry,
 ) -> dict[str, Any]:
     """Create or resume a Persona Live session using the requested reuse policy and focus it."""
+    with _live_session_mutation_lock:
+        return _create_or_resume_live_session_unlocked(
+            db,
+            session_manager=session_manager,
+            user_id=user_id,
+            persona_id=persona_id,
+            reuse_policy=reuse_policy,
+            idempotency_key=idempotency_key,
+            surface=surface,
+            stream_registry=stream_registry,
+        )
+
+
+def _create_or_resume_live_session_unlocked(
+    db: CharactersRAGDB,
+    *,
+    session_manager: SessionManager,
+    user_id: str,
+    persona_id: str,
+    reuse_policy: str,
+    idempotency_key: str | None,
+    surface: str | None,
+    stream_registry: PersonaLiveStreamRegistry,
+) -> dict[str, Any]:
+    """Create or resume a live session while the caller holds the mutation lock."""
     resolved_persona_id = _resolve_live_control_persona_id(db, user_id=user_id, persona_id=persona_id)
     requested_key = str(idempotency_key or "").strip() or None
     row: dict[str, Any] | None = None
@@ -510,6 +628,23 @@ def focus_live_session(
     stream_registry: PersonaLiveStreamRegistry = persona_live_stream_registry,
 ) -> dict[str, Any]:
     """Mark one non-terminal Persona Live session as focused and clear prior focused rows."""
+    with _live_session_mutation_lock:
+        return _focus_live_session_unlocked(
+            db,
+            user_id=user_id,
+            session_id=session_id,
+            stream_registry=stream_registry,
+        )
+
+
+def _focus_live_session_unlocked(
+    db: CharactersRAGDB,
+    *,
+    user_id: str,
+    session_id: str,
+    stream_registry: PersonaLiveStreamRegistry,
+) -> dict[str, Any]:
+    """Focus a live session while the caller holds the mutation lock."""
     row = _load_owned_session_or_raise(db, user_id=user_id, session_id=session_id)
     if _is_terminal(row):
         raise ValueError("Cannot focus a terminal persona session.")
@@ -517,25 +652,20 @@ def focus_live_session(
     focused_at = _utc_now_iso()
     previously_focused_rows = _focused_session_rows(db, user_id=user_id)
     fresh_target_row = db.get_persona_session(session_id, user_id=user_id, include_deleted=False) or row
-    _update_preferences(
+    _update_live_control_preferences(
         db,
         row=fresh_target_row,
         user_id=user_id,
-        preferences=_live_preferences_patch(
-            fresh_target_row,
-            focus={"focused": True, "focused_at": focused_at, "focus_generation": generation},
-        ),
+        focus={"focused": True, "focused_at": focused_at, "focus_generation": generation},
     )
-    for existing in previously_focused_rows:
-        existing_id = str(existing.get("id") or "").strip()
-        if not existing_id or existing_id == session_id:
-            continue
-        _update_preferences(
-            db,
-            row=existing,
-            user_id=user_id,
-            preferences=_live_preferences_patch(existing, focus={"focused": False}),
-        )
+    # Reconcile the pre-focus snapshot first, then any rows that became focused
+    # during concurrent requests so only the target session remains focused.
+    _reconcile_focused_sessions(
+        db,
+        user_id=user_id,
+        target_session_id=session_id,
+        initially_focused_rows=previously_focused_rows,
+    )
     row = db.get_persona_session(session_id, user_id=user_id, include_deleted=False) or row
     return build_live_session_summary(
         db,

--- a/tldw_Server_API/app/core/Persona/visual_portability/exporter.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/exporter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import uuid
 import zipfile
 from collections.abc import Callable, Mapping
@@ -12,7 +13,11 @@ from typing import TYPE_CHECKING, Any
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Persona.visual_service import VISUAL_STORAGE_PREFIX
 
-from .archive import validate_archive_members
+from .archive import (
+    DEFAULT_MAX_ARCHIVE_SIZE_BYTES,
+    DEFAULT_MAX_MEMBER_SIZE_BYTES,
+    validate_archive_members,
+)
 from .constants import (
     ASSET_BYTES_STATUS_MISSING,
     ASSET_BYTES_STATUS_PRESENT,
@@ -31,6 +36,10 @@ from .models import PersonaVisualPackExportOptions, PersonaVisualPackExportResul
 
 if TYPE_CHECKING:
     from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+
+class PersonaVisualPackExportError(ValueError):
+    """Raised when Persona visual pack export cannot produce a valid archive."""
 
 
 class PersonaVisualPackExporter:
@@ -89,14 +98,8 @@ class PersonaVisualPackExporter:
                     "assets": asset_fingerprints,
                 }
                 payload_fingerprint = canonical_payload_fingerprint(fingerprint_payload)
-                metadata_payloads = {
-                    path: canonical_json_bytes(payload)
-                    for path, payload in sorted(sections.items())
-                }
-                checksums = {
-                    path: sha256_bytes(content)
-                    for path, content in metadata_payloads.items()
-                }
+                metadata_payloads = {path: canonical_json_bytes(payload) for path, payload in sorted(sections.items())}
+                checksums = {path: sha256_bytes(content) for path, content in metadata_payloads.items()}
                 checksums.update(asset_checksums)
                 manifest = self._archive_manifest(
                     pack=pack,
@@ -119,11 +122,11 @@ class PersonaVisualPackExporter:
                     "signatures/README.md": b"Signatures are reserved for future persona visual pack versions.\n",
                 }
                 _write_payloads_to_archive(archive, archive_payloads)
+            validate_archive_members(archive_path)
         except Exception:
             archive_path.unlink(missing_ok=True)
             raise
 
-        validate_archive_members(archive_path)
         archive_hash = sha256_file(archive_path)
         file_size_bytes = archive_path.stat().st_size
         self._progress(
@@ -150,23 +153,32 @@ class PersonaVisualPackExporter:
         exported_assets: list[dict[str, Any]] = []
         asset_checksums: dict[str, str] = {}
         asset_fingerprints: list[dict[str, Any]] = []
+        total_asset_bytes = 0
 
         for asset in assets:
             exported = self._export_asset_row(asset)
             asset_id = str(asset["id"])
             asset_path = self._asset_storage_path(asset)
             if asset_path.is_file():
-                asset_bytes = asset_path.read_bytes()
-                asset_sha256 = sha256_bytes(asset_bytes)
+                asset_size_bytes = asset_path.stat().st_size
+                if asset_size_bytes > DEFAULT_MAX_MEMBER_SIZE_BYTES:
+                    raise PersonaVisualPackExportError(f"asset_too_large:asset:{asset_id}")
+                total_asset_bytes += asset_size_bytes
+                if total_asset_bytes > DEFAULT_MAX_ARCHIVE_SIZE_BYTES:
+                    raise PersonaVisualPackExportError("archive_too_large")
                 expected_sha256 = str(asset.get("checksum_sha256") or "")
+                archive_path = self._asset_archive_path(asset)
+                asset_sha256 = _write_file_to_archive_with_sha256(
+                    archive,
+                    archive_path=archive_path,
+                    source_path=asset_path,
+                )
                 if expected_sha256 and asset_sha256 != expected_sha256:
                     raise ValueError(f"asset_checksum_mismatch:asset:{asset_id}")
-                archive_path = self._asset_archive_path(asset)
                 exported["asset_bytes_status"] = ASSET_BYTES_STATUS_PRESENT
                 exported["asset_path"] = archive_path
                 exported["asset_sha256"] = asset_sha256
-                exported["asset_size_bytes"] = len(asset_bytes)
-                archive.writestr(archive_path, asset_bytes)
+                exported["asset_size_bytes"] = asset_size_bytes
                 asset_checksums[archive_path] = asset_sha256
                 asset_fingerprints.append(
                     {
@@ -207,9 +219,7 @@ class PersonaVisualPackExporter:
             for path, checksum in sorted(checksums.items())
             if path.startswith("metadata/") or path.startswith("assets/")
         ]
-        assets_with_bytes = sum(
-            1 for asset in assets if asset.get("asset_bytes_status") == ASSET_BYTES_STATUS_PRESENT
-        )
+        assets_with_bytes = sum(1 for asset in assets if asset.get("asset_bytes_status") == ASSET_BYTES_STATUS_PRESENT)
         return {
             "schema_version": PERSONA_VISUAL_PACK_SCHEMA_VERSION,
             "exported_by": {"app": "tldw_server"},
@@ -227,9 +237,7 @@ class PersonaVisualPackExporter:
                 "missing_assets": len(assets) - assets_with_bytes,
             },
             "include_images": True,
-            "provenance_mode": (
-                "full" if options.include_full_provenance else "redacted"
-            ),
+            "provenance_mode": ("full" if options.include_full_provenance else "redacted"),
             "trust_hints": {
                 "source_owner_user_id": self.user_id,
                 "source_persona_id": pack["persona_id"],
@@ -243,7 +251,7 @@ class PersonaVisualPackExporter:
     def _asset_storage_path(self, asset: Mapping[str, Any]) -> Path:
         storage_key = str(asset.get("storage_key") or "")
         prefix = f"{VISUAL_STORAGE_PREFIX}/"
-        relative_key = storage_key[len(prefix):] if storage_key.startswith(prefix) else storage_key
+        relative_key = storage_key[len(prefix) :] if storage_key.startswith(prefix) else storage_key
         relative_path = _safe_relative_storage_path(relative_key)
         base = DatabasePaths.get_user_persona_visuals_dir(self.user_id).resolve(strict=False)
         target_path = (base / Path(*relative_path.parts)).resolve(strict=False)
@@ -258,14 +266,9 @@ class PersonaVisualPackExporter:
 
     def _archive_path(self, pack: Mapping[str, Any]) -> Path:
         self.staging_root.mkdir(parents=True, exist_ok=True)
-        safe_title = "".join(
-            char.lower() if char.isalnum() else "-"
-            for char in str(pack["title"]).strip()
-        ).strip("-")
+        safe_title = "".join(char.lower() if char.isalnum() else "-" for char in str(pack["title"]).strip()).strip("-")
         safe_title = safe_title[:64] or "persona-visual-pack"
-        return self.staging_root / (
-            f"{safe_title}-{uuid.uuid4().hex[:12]}{PERSONA_VISUAL_PACK_EXTENSION}"
-        )
+        return self.staging_root / (f"{safe_title}-{uuid.uuid4().hex[:12]}{PERSONA_VISUAL_PACK_EXTENSION}")
 
     def _export_pack_row(self, row: Mapping[str, Any]) -> dict[str, Any]:
         return {
@@ -307,10 +310,7 @@ class PersonaVisualPackExporter:
 
     def _readme_payload(self, pack: Mapping[str, Any]) -> bytes:
         title = str(pack.get("title") or "Persona Visual Pack")
-        return (
-            f"# {title}\n\n"
-            "This archive contains a tldw persona visual pack export.\n"
-        ).encode("utf-8")
+        return (f"# {title}\n\n" "This archive contains a tldw persona visual pack export.\n").encode("utf-8")
 
     def _progress(
         self,
@@ -328,6 +328,20 @@ def _write_payloads_to_archive(
 ) -> None:
     for path, payload in sorted(payloads.items()):
         archive.writestr(path, payload)
+
+
+def _write_file_to_archive_with_sha256(
+    archive: zipfile.ZipFile,
+    *,
+    archive_path: str,
+    source_path: Path,
+) -> str:
+    digest = hashlib.sha256()
+    with source_path.open("rb") as source, archive.open(archive_path, "w") as target:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+            target.write(chunk)
+    return digest.hexdigest()
 
 
 def _safe_relative_storage_path(relative_key: str) -> PurePosixPath:

--- a/tldw_Server_API/app/core/Persona/visual_portability/importer.py
+++ b/tldw_Server_API/app/core/Persona/visual_portability/importer.py
@@ -120,77 +120,86 @@ class PersonaVisualPackImporter:
                 progress=progress,
             )
 
-        with zipfile.ZipFile(archive_path, "r") as archive:
-            members = _archive_members_by_normalized_name(archive)
-            pack_payload = _read_required_json(archive, members, "metadata/pack.json")
-            assets_payload = _read_required_json(archive, members, "metadata/assets.json")
-            pack = _section_record(pack_payload, key="pack", path="metadata/pack.json")
-            assets = _section_list(assets_payload, key="assets", path="metadata/assets.json")
+        created_pack: dict[str, Any] | None = None
+        id_maps: dict[str, Any] = {"assets": {}, "packs": {}}
+        imported_assets: list[dict[str, Any]] = []
+        try:
+            with zipfile.ZipFile(archive_path, "r") as archive:
+                members = _archive_members_by_normalized_name(archive)
+                pack_payload = _read_required_json(archive, members, "metadata/pack.json")
+                assets_payload = _read_required_json(archive, members, "metadata/assets.json")
+                pack = _section_record(pack_payload, key="pack", path="metadata/pack.json")
+                assets = _section_list(assets_payload, key="assets", path="metadata/assets.json")
 
-            self._progress(progress, "creating_pack", {"target_persona_id": target_persona_id})
-            pack_title = _import_pack_title(title=title, pack=pack)
-            created_pack = self.db.create_persona_visual_pack(
-                persona_id=target_persona_id,
-                user_id=self.user_id,
-                title=pack_title,
-                renderer_type=str(pack.get("renderer_type") or "sprite_frames"),
-                manifest={
-                    "manifest_version": 1,
-                    "renderer_type": str(pack.get("renderer_type") or "sprite_frames"),
-                    "states": {},
-                    "animations": {},
-                },
-                provenance="imported",
-            )
-
-            id_maps: dict[str, Any] = {"assets": {}, "packs": {}}
-            if pack.get("source_pack_id") not in (None, ""):
-                id_maps["packs"][str(pack["source_pack_id"])] = str(created_pack["id"])
-
-            imported_assets = []
-            for asset in assets:
-                if asset.get("asset_bytes_status") != ASSET_BYTES_STATUS_PRESENT:
-                    continue
-                asset_path = normalize_member_name(str(asset.get("asset_path") or ""))
-                if asset_path not in members:
-                    raise ValueError(f"missing_asset_file: {asset_path}")
-                content = archive.read(members[asset_path])
-                imported = self.service.create_asset_from_upload(
+                self._progress(progress, "creating_pack", {"target_persona_id": target_persona_id})
+                pack_title = _import_pack_title(title=title, pack=pack)
+                created_pack = self.db.create_persona_visual_pack(
                     persona_id=target_persona_id,
                     user_id=self.user_id,
-                    pack_id=str(created_pack["id"]),
-                    content=content,
-                    mime_type=str(asset.get("mime_type") or "application/octet-stream"),
-                    original_filename=asset.get("original_filename"),
-                    asset_role=str(asset.get("asset_role") or "frame"),
+                    title=pack_title,
+                    renderer_type=str(pack.get("renderer_type") or "sprite_frames"),
+                    manifest={
+                        "manifest_version": 1,
+                        "renderer_type": str(pack.get("renderer_type") or "sprite_frames"),
+                        "states": {},
+                        "animations": {},
+                    },
                     provenance="imported",
                 )
-                source_asset_id = str(asset.get("source_asset_id") or "")
-                if source_asset_id:
-                    id_maps["assets"][source_asset_id] = str(imported["id"])
-                imported_assets.append(imported)
 
-        visual_manifest = pack.get("visual_manifest") if isinstance(pack.get("visual_manifest"), dict) else {}
-        remapped_manifest = remap_visual_manifest_assets(visual_manifest, id_maps["assets"])
-        asset_ids = {str(asset["id"]) for asset in imported_assets}
-        asset_dimensions = {
-            str(asset["id"]): (int(asset["width"]), int(asset["height"]))
-            for asset in imported_assets
-            if asset.get("width") is not None and asset.get("height") is not None
-        }
-        validation = validate_visual_manifest(
-            remapped_manifest,
-            available_asset_ids=asset_ids,
-            available_asset_dimensions=asset_dimensions,
-            require_activatable=False,
-        )
-        updated_pack = self.db.update_persona_visual_pack_manifest(
-            pack_id=str(created_pack["id"]),
-            persona_id=target_persona_id,
-            user_id=self.user_id,
-            manifest=validation.manifest,
-            expected_version=int(created_pack["version"]),
-        )
+                if pack.get("source_pack_id") not in (None, ""):
+                    id_maps["packs"][str(pack["source_pack_id"])] = str(created_pack["id"])
+
+                for asset in assets:
+                    if asset.get("asset_bytes_status") != ASSET_BYTES_STATUS_PRESENT:
+                        continue
+                    asset_path = normalize_member_name(str(asset.get("asset_path") or ""))
+                    if asset_path not in members:
+                        raise ValueError(f"missing_asset_file: {asset_path}")
+                    content = archive.read(members[asset_path])
+                    imported = self.service.create_asset_from_upload(
+                        persona_id=target_persona_id,
+                        user_id=self.user_id,
+                        pack_id=str(created_pack["id"]),
+                        content=content,
+                        mime_type=str(asset.get("mime_type") or "application/octet-stream"),
+                        original_filename=asset.get("original_filename"),
+                        asset_role=str(asset.get("asset_role") or "frame"),
+                        provenance="imported",
+                    )
+                    source_asset_id = str(asset.get("source_asset_id") or "")
+                    if source_asset_id:
+                        id_maps["assets"][source_asset_id] = str(imported["id"])
+                    imported_assets.append(imported)
+
+            visual_manifest = pack.get("visual_manifest") if isinstance(pack.get("visual_manifest"), dict) else {}
+            remapped_manifest = remap_visual_manifest_assets(visual_manifest, id_maps["assets"])
+            asset_ids = {str(asset["id"]) for asset in imported_assets}
+            asset_dimensions = {
+                str(asset["id"]): (int(asset["width"]), int(asset["height"]))
+                for asset in imported_assets
+                if asset.get("width") is not None and asset.get("height") is not None
+            }
+            validation = validate_visual_manifest(
+                remapped_manifest,
+                available_asset_ids=asset_ids,
+                available_asset_dimensions=asset_dimensions,
+                require_activatable=False,
+            )
+            updated_pack = self.db.update_persona_visual_pack_manifest(
+                pack_id=str(created_pack["id"]),
+                persona_id=target_persona_id,
+                user_id=self.user_id,
+                manifest=validation.manifest,
+                expected_version=int(created_pack["version"]),
+            )
+        except Exception:
+            if created_pack is not None:
+                self._cleanup_created_pack(
+                    pack_id=str(created_pack["id"]),
+                    target_persona_id=target_persona_id,
+                )
+            raise
         replaced_pack_id = None
         if replacement_pack is not None:
             replaced_pack_id = str(replacement_pack["id"])

--- a/tldw_Server_API/app/core/Persona/visual_service.py
+++ b/tldw_Server_API/app/core/Persona/visual_service.py
@@ -42,6 +42,7 @@ _IMAGE_VALIDATION_ERRORS = (
     ValueError,
     UnidentifiedImageError,
 )
+_REVIEWABLE_CANDIDATE_STATUSES = frozenset({"review"})
 
 
 class PersonaVisualServiceError(Exception):
@@ -438,6 +439,7 @@ class PersonaVisualService:
                 "Persona visual candidate not found for user.",
                 details={"candidate_id": candidate_id},
             )
+        self._ensure_candidate_reviewable(candidate)
         pack = self._db.get_persona_visual_pack(
             pack_id=pack_id,
             persona_id=persona_id,
@@ -452,9 +454,11 @@ class PersonaVisualService:
 
         merged_manifest = self._merge_candidate_patch(
             pack.get("manifest") if isinstance(pack.get("manifest"), dict) else {},
-            candidate.get("proposed_manifest_patch")
-            if isinstance(candidate.get("proposed_manifest_patch"), dict)
-            else {},
+            (
+                candidate.get("proposed_manifest_patch")
+                if isinstance(candidate.get("proposed_manifest_patch"), dict)
+                else {}
+            ),
         )
         assets = self._db.list_persona_visual_assets(
             pack_id=pack_id,
@@ -494,8 +498,17 @@ class PersonaVisualService:
             persona_id=persona_id,
             user_id=user_id,
             status="accepted",
+            expected_statuses=set(_REVIEWABLE_CANDIDATE_STATUSES),
         )
         if not updated:
+            latest = self._db.get_persona_visual_candidate(
+                candidate_id=candidate_id,
+                pack_id=pack_id,
+                persona_id=persona_id,
+                user_id=user_id,
+            )
+            if latest:
+                self._raise_candidate_status_conflict(latest)
             raise PersonaVisualServiceError(
                 "candidate_not_found",
                 "Persona visual candidate not found for user.",
@@ -513,6 +526,19 @@ class PersonaVisualService:
         status: str = "rejected",
         failure_reason: str | None = None,
     ) -> dict[str, Any]:
+        candidate = self._db.get_persona_visual_candidate(
+            candidate_id=candidate_id,
+            pack_id=pack_id,
+            persona_id=persona_id,
+            user_id=user_id,
+        )
+        if not candidate:
+            raise PersonaVisualServiceError(
+                "candidate_not_found",
+                "Persona visual candidate not found for user.",
+                details={"candidate_id": candidate_id},
+            )
+        self._ensure_candidate_reviewable(candidate)
         updated = self._db.update_persona_visual_candidate_status(
             candidate_id=candidate_id,
             pack_id=pack_id,
@@ -520,14 +546,40 @@ class PersonaVisualService:
             user_id=user_id,
             status=status,
             failure_reason=failure_reason,
+            expected_statuses=set(_REVIEWABLE_CANDIDATE_STATUSES),
         )
         if not updated:
+            latest = self._db.get_persona_visual_candidate(
+                candidate_id=candidate_id,
+                pack_id=pack_id,
+                persona_id=persona_id,
+                user_id=user_id,
+            )
+            if latest:
+                self._raise_candidate_status_conflict(latest)
             raise PersonaVisualServiceError(
                 "candidate_not_found",
                 "Persona visual candidate not found for user.",
                 details={"candidate_id": candidate_id},
             )
         return updated
+
+    def _ensure_candidate_reviewable(self, candidate: dict[str, Any]) -> None:
+        """Raise when a generated visual candidate has already reached a terminal state."""
+        if str(candidate.get("status") or "").strip() in _REVIEWABLE_CANDIDATE_STATUSES:
+            return
+        self._raise_candidate_status_conflict(candidate)
+
+    def _raise_candidate_status_conflict(self, candidate: dict[str, Any]) -> None:
+        """Raise a typed service error for terminal candidate review transitions."""
+        raise PersonaVisualServiceError(
+            "candidate_status_conflict",
+            "Persona visual candidate has already reached a terminal review status.",
+            details={
+                "candidate_id": str(candidate.get("id") or ""),
+                "status": str(candidate.get("status") or ""),
+            },
+        )
 
     @staticmethod
     def _merge_candidate_patch(
@@ -657,7 +709,7 @@ class PersonaVisualService:
 
     def _asset_storage_path(self, *, user_id: str, storage_key: str) -> Path:
         prefix = f"{VISUAL_STORAGE_PREFIX}/"
-        relative_key = storage_key[len(prefix):] if storage_key.startswith(prefix) else storage_key
+        relative_key = storage_key[len(prefix) :] if storage_key.startswith(prefix) else storage_key
         relative_path = Path(*Path(relative_key).parts)
         if relative_path.is_absolute() or ".." in relative_path.parts:
             raise PersonaVisualServiceError(

--- a/tldw_Server_API/tests/Persona/test_persona_connection_helpers.py
+++ b/tldw_Server_API/tests/Persona/test_persona_connection_helpers.py
@@ -15,8 +15,12 @@ def test_render_template_value_logs_warning_for_invalid_format(monkeypatch: pyte
         lambda message, *args: warnings.append(str(message).format(*args)),
     )
 
-    rendered = persona_connections.render_template_value("Bearer {secret", {"secret": "token"})
+    rendered = persona_connections.render_template_value(
+        "Bearer sk-live-literal {secret",
+        {"secret": "token"},
+    )
 
-    assert rendered == "Bearer {secret"
+    assert rendered == "Bearer sk-live-literal {secret"
     assert warnings
     assert "failed to render persona connection template" in warnings[0].lower()
+    assert "sk-live-literal" not in warnings[0]

--- a/tldw_Server_API/tests/Persona/test_persona_live_control_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_live_control_api.py
@@ -4,6 +4,7 @@ import json
 import queue
 import threading
 import time
+from typing import Any
 
 import pytest
 from fastapi import FastAPI
@@ -12,7 +13,7 @@ from fastapi.testclient import TestClient
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.endpoints import persona as persona_ep
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
-from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, ConflictError
 from tldw_Server_API.app.core.Persona import live_control as live_control_module
 from tldw_Server_API.app.core.Persona.exemplar_prompt_assembly import PersonaExemplarPromptAssembly
 from tldw_Server_API.app.core.Persona.exemplar_runtime import PersonaExemplarRuntimeContext
@@ -292,6 +293,56 @@ def test_live_session_create_new_honors_idempotency_key(monkeypatch, persona_db:
     assert first.json()["session"]["session_id"] == second.json()["session"]["session_id"]
 
 
+def test_live_session_create_idempotency_serializes_concurrent_requests(
+    monkeypatch: pytest.MonkeyPatch,
+    persona_db: CharactersRAGDB,
+) -> None:
+    _create_profile(persona_db, user_id="1", persona_id="persona_a")
+    original_materialize = live_control_module.materialize_persona_session
+    materialize_calls = 0
+    materialize_call_lock = threading.Lock()
+
+    def slow_materialize(*args: Any, **kwargs: Any) -> Any:
+        nonlocal materialize_calls
+        if not kwargs.get("resume_session_id"):
+            with materialize_call_lock:
+                materialize_calls += 1
+            time.sleep(0.2)
+        return original_materialize(*args, **kwargs)
+
+    monkeypatch.setattr(live_control_module, "materialize_persona_session", slow_materialize)
+    results: queue.Queue[dict[str, Any]] = queue.Queue()
+    errors: queue.Queue[BaseException] = queue.Queue()
+
+    def create_live_session() -> None:
+        try:
+            results.put(
+                live_control_module.create_or_resume_live_session(
+                    persona_db,
+                    session_manager=SessionManager(),
+                    user_id="1",
+                    persona_id="persona_a",
+                    reuse_policy="create_new",
+                    idempotency_key="same-create-key",
+                )
+            )
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            errors.put(exc)
+
+    threads = [threading.Thread(target=create_live_session) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not any(thread.is_alive() for thread in threads)
+    assert errors.empty(), list(errors.queue)
+    created = [results.get_nowait()["session_id"] for _ in range(results.qsize())]
+    assert len(created) == 2
+    assert len(set(created)) == 1
+    assert materialize_calls == 1
+
+
 def test_live_session_idempotency_key_ignores_stopped_session(monkeypatch, persona_db: CharactersRAGDB):
     monkeypatch.setattr(persona_ep, "get_session_manager", lambda: SessionManager())
 
@@ -450,6 +501,94 @@ def test_live_session_focus_a_then_b_only_marks_b_focused(monkeypatch, persona_d
     payload = listed.json()
     focused = [item for item in payload["sessions"] if item["is_focused"]]
     assert [item["session_id"] for item in focused] == ["sess-b"]
+
+
+def test_live_session_focus_reconciles_stale_focused_rows_after_missed_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    persona_db: CharactersRAGDB,
+) -> None:
+    monkeypatch.setattr(persona_ep, "get_session_manager", lambda: SessionManager())
+    _create_profile(persona_db, user_id="1", persona_id="persona_a")
+    _create_session(
+        persona_db,
+        user_id="1",
+        persona_id="persona_a",
+        session_id="sess-stale",
+        preferences={
+            "persona_live_control": {
+                "focus": {
+                    "focused": True,
+                    "focused_at": "2026-05-20T00:00:00+00:00",
+                    "focus_generation": 12,
+                }
+            }
+        },
+    )
+    _create_session(persona_db, user_id="1", persona_id="persona_a", session_id="sess-target")
+    original_focused_rows = live_control_module._focused_session_rows
+    call_count = 0
+
+    def stale_first_focus_snapshot(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return []
+        return original_focused_rows(*args, **kwargs)
+
+    monkeypatch.setattr(live_control_module, "_focused_session_rows", stale_first_focus_snapshot)
+
+    with _client_for_user(1, persona_db) as client:
+        response = client.post("/api/v1/persona/live/sessions/sess-target/focus")
+
+    assert response.status_code == 200, response.text
+    focused_rows = persona_db.list_focused_persona_sessions(user_id="1")
+    assert [row["id"] for row in focused_rows] == ["sess-target"]  # nosec B101
+
+
+def test_live_session_focus_retries_conflicted_clear_updates(
+    monkeypatch: pytest.MonkeyPatch,
+    persona_db: CharactersRAGDB,
+) -> None:
+    _create_profile(persona_db, user_id="1", persona_id="persona_a")
+    _create_session(
+        persona_db,
+        user_id="1",
+        persona_id="persona_a",
+        session_id="sess-old",
+        preferences={
+            "persona_live_control": {
+                "focus": {
+                    "focused": True,
+                    "focused_at": "2026-05-20T00:00:00+00:00",
+                    "focus_generation": 12,
+                }
+            }
+        },
+    )
+    _create_session(persona_db, user_id="1", persona_id="persona_a", session_id="sess-target")
+    original_update = persona_db.update_persona_session
+    conflict_seen = False
+
+    def conflict_once(*args: Any, **kwargs: Any) -> Any:
+        nonlocal conflict_seen
+        session_id = str(kwargs.get("session_id") or (args[0] if args else ""))
+        update_data = kwargs.get("update_data")
+        preferences = update_data.get("preferences_json") if isinstance(update_data, dict) else None
+        live = preferences.get("persona_live_control") if isinstance(preferences, dict) else None
+        focus = live.get("focus") if isinstance(live, dict) else None
+        if session_id == "sess-old" and isinstance(focus, dict) and focus.get("focused") is False and not conflict_seen:
+            conflict_seen = True
+            raise ConflictError("simulated stale focus row", entity="persona_sessions", entity_id=session_id)
+        return original_update(*args, **kwargs)
+
+    monkeypatch.setattr(persona_db, "update_persona_session", conflict_once)
+
+    summary = live_control_module.focus_live_session(persona_db, user_id="1", session_id="sess-target")
+
+    assert summary["is_focused"] is True
+    assert conflict_seen is True
+    focused_rows = persona_db.list_focused_persona_sessions(user_id="1")
+    assert [row["id"] for row in focused_rows] == ["sess-target"]  # nosec B101
 
 
 def test_live_session_focus_uses_utc_iso_focus_timestamp(monkeypatch, persona_db: CharactersRAGDB):

--- a/tldw_Server_API/tests/Persona/test_persona_visual_portability.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visual_portability.py
@@ -11,6 +11,7 @@ from PIL import Image
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Persona.visual_portability.archive import (
+    DEFAULT_MAX_MEMBER_SIZE_BYTES,
     validate_archive_members,
 )
 from tldw_Server_API.app.core.Persona.visual_portability.constants import (
@@ -22,6 +23,7 @@ from tldw_Server_API.app.core.Persona.visual_portability.constants import (
     REQUIRED_MEMBERS,
 )
 from tldw_Server_API.app.core.Persona.visual_portability.exporter import (
+    PersonaVisualPackExportError,
     PersonaVisualPackExporter,
 )
 from tldw_Server_API.app.core.Persona.visual_portability.fingerprints import (
@@ -35,7 +37,6 @@ from tldw_Server_API.app.core.Persona.visual_portability.preview import (
     PersonaVisualPackImportPreviewer,
 )
 from tldw_Server_API.app.core.Persona.visual_service import PersonaVisualService
-
 
 pytestmark = pytest.mark.unit
 
@@ -310,9 +311,7 @@ def _renderer_preview_archive(
         "counts": {
             "assets": len(assets),
             "assets_with_bytes": sum(
-                1
-                for asset in assets
-                if asset.get("asset_bytes_status") == ASSET_BYTES_STATUS_PRESENT
+                1 for asset in assets if asset.get("asset_bytes_status") == ASSET_BYTES_STATUS_PRESENT
             ),
         },
     }
@@ -330,10 +329,7 @@ def _renderer_preview_archive(
         "metadata/assets.json": _json_bytes({"assets": assets}),
         **asset_files,
     }
-    checksums = {
-        member_path: sha256_bytes(member_bytes)
-        for member_path, member_bytes in entries.items()
-    }
+    checksums = {member_path: sha256_bytes(member_bytes) for member_path, member_bytes in entries.items()}
     entries[CHECKSUMS_PATH] = _json_bytes(dict(sorted(checksums.items())))
 
     with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
@@ -567,7 +563,9 @@ def test_export_pack_writes_manifest_metadata_checksums_and_asset_bytes(
 
         pack_payload = json.loads(archive.read("metadata/pack.json"))["pack"]
         assert pack_payload["title"] == "Portable Visuals"  # nosec B101
-        assert pack_payload["visual_manifest"]["animations"]["idle"]["frames"][0]["asset_id"] == asset["id"]  # nosec B101
+        assert (
+            pack_payload["visual_manifest"]["animations"]["idle"]["frames"][0]["asset_id"] == asset["id"]
+        )  # nosec B101
 
         assets = json.loads(archive.read("metadata/assets.json"))["assets"]
         assert len(assets) == 1  # nosec B101
@@ -606,6 +604,41 @@ def test_export_pack_strict_mode_rejects_missing_asset_bytes(
             pack_id=str(pack["id"]),
             options=PersonaVisualPackExportOptions(strict=True),
         )
+
+
+def test_export_pack_rejects_oversized_asset_before_archive_validation(
+    db_instance: CharactersRAGDB,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    persona_id, pack, asset = _create_pack_with_asset(
+        db_instance,
+        visuals_root=tmp_path / "visuals",
+        monkeypatch=monkeypatch,
+    )
+    asset_path = Path(str(asset["storage_path"]))
+    with asset_path.open("wb") as handle:
+        handle.seek(DEFAULT_MAX_MEMBER_SIZE_BYTES)
+        handle.write(b"x")
+    db_instance.execute_query(
+        "UPDATE persona_visual_assets SET checksum_sha256 = '' WHERE id = ?",
+        (asset["id"],),
+    )
+    staging_root = tmp_path / "exports"
+    exporter = PersonaVisualPackExporter(
+        db=db_instance,
+        user_id="user-1",
+        staging_root=staging_root,
+    )
+
+    with pytest.raises(PersonaVisualPackExportError, match="asset_too_large"):
+        exporter.export_pack(
+            persona_id=persona_id,
+            pack_id=str(pack["id"]),
+            options=PersonaVisualPackExportOptions(),
+        )
+
+    assert list(staging_root.glob("*.tldw-persona-vpack")) == []  # nosec B101
 
 
 def test_import_preview_validates_archive_without_mutating_packs(
@@ -660,9 +693,7 @@ def test_import_preview_reports_target_pack_conflicts_and_choices(
         visuals_root=tmp_path / "visuals",
         monkeypatch=monkeypatch,
     )
-    target_persona_id = db_instance.create_persona_profile(
-        {"user_id": "user-1", "name": "Target Persona"}
-    )
+    target_persona_id = db_instance.create_persona_profile({"user_id": "user-1", "name": "Target Persona"})
     active_pack = db_instance.create_persona_visual_pack(
         persona_id=target_persona_id,
         user_id="user-1",
@@ -703,12 +734,8 @@ def test_import_preview_reports_target_pack_conflicts_and_choices(
         f"target_pack_title_match:{active_pack['id']}",
         f"target_pack_title_match:{draft_pack['id']}",
     }
-    active_conflict = next(
-        conflict for conflict in preview["conflicts"] if conflict["pack_id"] == active_pack["id"]
-    )
-    draft_conflict = next(
-        conflict for conflict in preview["conflicts"] if conflict["pack_id"] == draft_pack["id"]
-    )
+    active_conflict = next(conflict for conflict in preview["conflicts"] if conflict["pack_id"] == active_pack["id"])
+    draft_conflict = next(conflict for conflict in preview["conflicts"] if conflict["pack_id"] == draft_pack["id"])
     assert active_conflict["pack_status"] == "active"  # nosec B101
     assert active_conflict["allowed_choices"] == ["create_new"]  # nosec B101
     assert draft_conflict["pack_status"] == "draft"  # nosec B101
@@ -755,9 +782,7 @@ def test_import_preview_reports_missing_asset_bytes_as_warning(
     )
 
     assert preview["bundle_summary"]["missing_asset_items"] == 1  # nosec B101
-    assert preview["validation_warnings"] == [  # nosec B101
-        f"missing_asset_bytes:frame:{asset['id']}"
-    ]
+    assert preview["validation_warnings"] == [f"missing_asset_bytes:frame:{asset['id']}"]  # nosec B101
     exported_assets = preview["bundle_summary"]["assets"]
     assert exported_assets[0]["asset_bytes_status"] == ASSET_BYTES_STATUS_MISSING  # nosec B101
 
@@ -781,10 +806,7 @@ def test_import_preview_accepts_buddy_pipeline_packet_with_source_sheet_diagnost
     )
 
     summary = preview["bundle_summary"]
-    assets_by_id = {
-        asset["source_asset_id"]: asset
-        for asset in summary["assets"]
-    }
+    assets_by_id = {asset["source_asset_id"]: asset for asset in summary["assets"]}
     assert preview["status"] == "completed"  # nosec B101
     assert summary["renderer_type"] == "sprite_frames"  # nosec B101
     assert summary["asset_count"] == 5  # nosec B101
@@ -896,9 +918,7 @@ def test_import_commit_accepts_codex_pet_archive_as_inactive_draft(
     )
 
     _patch_visuals_dir(monkeypatch, tmp_path / "visuals")
-    persona_id = db_instance.create_persona_profile(
-        {"user_id": "user-1", "name": "Codex Pet Target"}
-    )
+    persona_id = db_instance.create_persona_profile({"user_id": "user-1", "name": "Codex Pet Target"})
     archive_path = _codex_pet_archive(tmp_path)
     preview_result = PersonaVisualPackImportPreviewer().create_preview(
         archive_path=archive_path,
@@ -972,9 +992,7 @@ def test_import_commit_codex_pet_cleans_up_failed_manifest_update(
     )
 
     _patch_visuals_dir(monkeypatch, tmp_path / "visuals")
-    persona_id = db_instance.create_persona_profile(
-        {"user_id": "user-1", "name": "Codex Pet Target"}
-    )
+    persona_id = db_instance.create_persona_profile({"user_id": "user-1", "name": "Codex Pet Target"})
     archive_path = _codex_pet_archive(tmp_path)
     preview_result = PersonaVisualPackImportPreviewer().create_preview(
         archive_path=archive_path,
@@ -1041,6 +1059,100 @@ def test_import_commit_codex_pet_cleans_up_failed_manifest_update(
     assert bool(asset_rows[0]["deleted"]) is True  # nosec B101
 
 
+def test_import_commit_native_archive_cleans_up_failed_manifest_update(
+    db_instance: CharactersRAGDB,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.DB_Management.PersonaVisualPortability_DB import (
+        PersonaVisualPortabilityRepository,
+    )
+    from tldw_Server_API.app.core.Persona.visual_portability.importer import (
+        PersonaVisualPackImporter,
+    )
+
+    _patch_visuals_dir(monkeypatch, tmp_path / "visuals")
+    source_persona_id, source_pack, _source_asset = _create_pack_with_asset(
+        db_instance,
+        visuals_root=tmp_path / "source-visuals",
+        monkeypatch=monkeypatch,
+    )
+    exporter = PersonaVisualPackExporter(
+        db=db_instance,
+        user_id="user-1",
+        staging_root=tmp_path / "exports",
+    )
+    export_result = exporter.export_pack(
+        persona_id=source_persona_id,
+        pack_id=str(source_pack["id"]),
+        options=PersonaVisualPackExportOptions(),
+    )
+    target_persona_id = db_instance.create_persona_profile({"user_id": "user-1", "name": "Native Import Target"})
+    preview_result = PersonaVisualPackImportPreviewer().create_preview(
+        archive_path=export_result.archive_path,
+        owner_user_id="user-1",
+        target_persona_id=target_persona_id,
+    )
+    repo = PersonaVisualPortabilityRepository.initialized(db_instance)
+    preview = repo.create_import_preview(
+        owner_user_id="user-1",
+        job_id="job-preview-native-cleanup",
+        status="completed",
+        stage="completed",
+        archive_path=str(export_result.archive_path),
+        archive_sha256=preview_result["archive_sha256"],
+        canonical_payload_fingerprint=preview_result["canonical_payload_fingerprint"],
+        schema_version=preview_result["schema_version"],
+        target_persona_id=target_persona_id,
+        bundle_summary=preview_result["bundle_summary"],
+        proposed_plan=preview_result["proposed_plan"],
+        required_choices=preview_result["required_choices"],
+    )
+    original_update = db_instance.update_persona_visual_pack_manifest
+
+    def fail_manifest_update(*args: object, **kwargs: object) -> object:
+        if kwargs.get("persona_id") == target_persona_id:
+            raise RuntimeError("injected native manifest failure")
+        return original_update(*args, **kwargs)
+
+    monkeypatch.setattr(db_instance, "update_persona_visual_pack_manifest", fail_manifest_update)
+
+    with pytest.raises(RuntimeError, match="injected native manifest failure"):
+        PersonaVisualPackImporter(
+            db=db_instance,
+            repo=repo,
+            user_id="user-1",
+        ).import_preview(
+            preview_id=str(preview["id"]),
+            target_persona_id=target_persona_id,
+            trust_mode="untrusted_import",
+        )
+
+    active_packs = db_instance.list_persona_visual_packs(
+        persona_id=target_persona_id,
+        user_id="user-1",
+    )
+    deleted_packs = db_instance.list_persona_visual_packs(
+        persona_id=target_persona_id,
+        user_id="user-1",
+        include_deleted=True,
+    )
+    asset_rows = db_instance.execute_query(
+        """
+        SELECT deleted
+          FROM persona_visual_assets
+         WHERE persona_id = ?
+           AND user_id = ?
+        """,
+        (target_persona_id, "user-1"),
+    ).fetchall()
+    assert active_packs == []  # nosec B101
+    assert len(deleted_packs) == 1  # nosec B101
+    assert deleted_packs[0]["deleted"] is True  # nosec B101
+    assert len(asset_rows) == 1  # nosec B101
+    assert bool(asset_rows[0]["deleted"]) is True  # nosec B101
+
+
 def test_import_preview_reports_v2_live2d_renderer_diagnostics_without_activation(
     tmp_path: Path,
 ) -> None:
@@ -1069,12 +1181,8 @@ def test_import_preview_reports_v2_live2d_renderer_diagnostics_without_activatio
     assert renderer_preview["can_commit"] is False  # nosec B101
     assert renderer_preview["activation_eligible"] is False  # nosec B101
     assert "runtime_adapter_not_implemented" in renderer_preview["blockers"]  # nosec B101
-    assert renderer_preview["normalized_role_categories"]["fallback_preview"] == [  # nosec B101
-        "asset-fallback"
-    ]
-    assert renderer_preview["normalized_role_categories"]["source_manifest"] == [  # nosec B101
-        "asset-model"
-    ]
+    assert renderer_preview["normalized_role_categories"]["fallback_preview"] == ["asset-fallback"]  # nosec B101
+    assert renderer_preview["normalized_role_categories"]["source_manifest"] == ["asset-model"]  # nosec B101
 
 
 @pytest.mark.parametrize("manifest_version", [2.0, "+2"])
@@ -1127,9 +1235,7 @@ def test_import_preview_reports_v2_missing_required_role_category(
     assert preview["status"] == "blocked"  # nosec B101
     assert "missing_required_role_category:fallback_preview" in renderer_preview["blockers"]  # nosec B101
     assert renderer_preview["normalized_role_categories"]["fallback_preview"] == []  # nosec B101
-    assert renderer_preview["normalized_role_categories"]["source_manifest"] == [  # nosec B101
-        "asset-model"
-    ]
+    assert renderer_preview["normalized_role_categories"]["source_manifest"] == ["asset-model"]  # nosec B101
 
 
 def test_import_preview_reports_v2_unknown_renderer_safely(
@@ -1159,9 +1265,7 @@ def test_import_preview_reports_v2_unknown_renderer_safely(
     assert preview["status"] == "blocked"  # nosec B101
     assert preview["proposed_plan"]["commit_eligible"] is False  # nosec B101
     assert renderer_preview["status"] == "unsupported_renderer"  # nosec B101
-    assert renderer_preview["blockers"] == [  # nosec B101
-        "unknown_renderer:unknown\\nrenderer\\\\token"
-    ]
+    assert renderer_preview["blockers"] == ["unknown_renderer:unknown\\nrenderer\\\\token"]  # nosec B101
     assert "\n" not in renderer_preview["blockers"][0]  # nosec B101
 
 

--- a/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_visuals_api.py
@@ -867,6 +867,60 @@ def test_accept_and_reject_generated_candidates(persona_db: CharactersRAGDB) -> 
         assert rejected_response.json()["failure_reason"] == "not useful"
 
 
+def test_review_generated_candidate_terminal_status_cannot_be_changed(
+    persona_db: CharactersRAGDB,
+) -> None:
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Candidate Terminal Persona")
+        pack = _create_visual_pack(client, persona_id)
+        asset = _upload_png(client, persona_id, pack["id"])
+        candidate = persona_db.create_persona_visual_candidate(
+            pack_id=pack["id"],
+            persona_id=persona_id,
+            user_id="1",
+            job_id="job-terminal",
+            proposed_manifest_patch={
+                "states": {"thinking": {"animation_id": "generated-thinking"}},
+                "animations": {
+                    "generated-thinking": {
+                        "asset_ids": [asset["id"]],
+                        "frame_rate": 1,
+                        "loop": True,
+                    }
+                },
+            },
+            generated_asset_ids=[asset["id"]],
+            prompt="make thinking",
+        )
+
+        accepted_response = client.post(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/{pack['id']}/candidates/{candidate['id']}/review",
+            json={"status": "accepted"},
+        )
+        reject_response = client.post(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/{pack['id']}/candidates/{candidate['id']}/review",
+            json={"status": "rejected", "failure_reason": "changed my mind"},
+        )
+
+        assert accepted_response.status_code == 200, accepted_response.text
+        assert reject_response.status_code == 409, reject_response.text
+        assert reject_response.json()["detail"]["code"] == "candidate_status_conflict"
+        stored_candidate = persona_db.get_persona_visual_candidate(
+            candidate_id=candidate["id"],
+            pack_id=pack["id"],
+            persona_id=persona_id,
+            user_id="1",
+        )
+        assert stored_candidate is not None
+        assert stored_candidate["status"] == "accepted"
+        assert stored_candidate["failure_reason"] is None
+        detail = client.get(
+            f"/api/v1/persona/profiles/{persona_id}/visual-packs/{pack['id']}"
+        )
+        assert detail.status_code == 200, detail.text
+        assert detail.json()["manifest"]["states"]["thinking"]["animation_id"] == "generated-thinking"
+
+
 def test_list_generated_candidates_returns_preview_asset_urls(persona_db: CharactersRAGDB) -> None:
     with _client_for_user(1, persona_db) as client:
         persona_id = _create_persona(client, name="Candidate List Persona")


### PR DESCRIPTION
## Summary
- Harden Persona native visual import cleanup, export preflighting, and asset streaming behavior.
- Serialize live session create/resume paths and return conflict responses for terminal candidate-review states.
- Redact sensitive connection-template values in logs and expand regression coverage.

## Test Plan
- [x] git diff --check
- [x] python -m bandit -r touched Persona paths -f json -o /tmp/bandit_persona_review_hardening_worktree.json
- [x] python -m pytest tldw_Server_API/tests/Persona/test_persona_visual_portability.py tldw_Server_API/tests/Persona/test_persona_visuals_api.py tldw_Server_API/tests/Persona/test_persona_live_control_api.py tldw_Server_API/tests/Persona/test_persona_connection_helpers.py -q --tb=short

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Persona visuals and live session flows to improve reliability and safety. Cleans up failed imports, enforces terminal review states, serializes live create/focus with conflict reconciliation, adds archive size limits, and redacts sensitive logs (addresses TASK-2418).

- **Bug Fixes**
  - Native import: on failure, delete the newly created pack and assets to avoid partial state.
  - Export: preflight asset and archive size limits; stream file writes with on-the-fly SHA-256; validate archive members; raise PersonaVisualPackExportError (`asset_too_large`, `archive_too_large`).
  - Candidate review: only allow transitions from “review”; return HTTP 409 on conflicts and surface `candidate_status_conflict`; DB update supports `expected_statuses`.
  - Live sessions: serialize create/resume and focus with a process-local lock; reconcile stale or conflicted focused rows in bounded passes; preference updates use optimistic version checks with retries.
  - Logging: redact sensitive connection template values in warnings.

<sup>Written for commit 6f3d5b2138a55cd0c6ff1936738c2e9f8e55e164. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

