### PR TITLE
Harden Governance policy candidate loading

### DIFF
--- a/backlog/tasks/task-2415 - Harden-Governance-core-review-findings.md
+++ b/backlog/tasks/task-2415 - Harden-Governance-core-review-findings.md
@@ -1,0 +1,71 @@
+---
+id: TASK-2415
+title: Harden Governance core review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 14:39'
+updated_date: '2026-06-23 14:57'
+labels:
+  - governance
+  - review
+  - bugfix
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address validated current-code review findings in tldw_Server_API/app/core/Governance. Scope includes store-backed rule loading, strict candidate action validation, candidate updated_at preservation, gap scope dedupe hardening, and metadata category normalization.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 GovernanceService default runtime can load active candidates from GovernanceStore.
+- [x] #2 Invalid candidate actions fail safely instead of propagating unknown actions.
+- [x] #3 Mapping candidates preserve updated_at for resolver tie-breaking.
+- [x] #4 Gap dedupe cannot collide null scope with invalid sentinel values.
+- [x] #5 Null/non-string metadata category does not become category none.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused failing tests for each reviewed behavior.
+2. Implement the narrow GovernanceStore and GovernanceService fixes needed to pass those tests.
+3. Run focused Governance tests plus Bandit on the touched Governance source.
+4. Update this task with verification notes and final summary.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Manual Backlog task created because the Backlog MCP workflow was unavailable and the CLI create/list commands hung in this environment; user approved this temporary exception.
+
+Verification:
+- Red run before implementation: `python -m pytest tldw_Server_API/tests/Governance/test_governance_service.py tldw_Server_API/tests/Governance/test_governance_gap_dedupe.py -q` failed on the expected 6 reviewed defects.
+- Focused isolated unit run after fixes: `python -m pytest --confcutdir=tldw_Server_API/tests/Governance tldw_Server_API/tests/Governance/test_governance_service.py tldw_Server_API/tests/Governance/test_governance_gap_dedupe.py -q` passed, 12 passed.
+- Full isolated Governance unit run: `python -m pytest --confcutdir=tldw_Server_API/tests/Governance tldw_Server_API/tests/Governance -q` passed, 26 passed.
+- Direct MCP governance regression run: `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_governance_module.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_governance_preflight.py -q` passed, 15 passed.
+- Compile check passed for touched Governance source/tests with `python -m py_compile`.
+- Whitespace check passed with `git diff --check` on touched files.
+- Bandit completed on `tldw_Server_API/app/core/Governance` with 0 findings; report: `/tmp/bandit_governance_2415.json`.
+
+Known verification note: one repository-global pytest invocation and one single-test invocation were interrupted after pytest cleanup/import hooks stalled; the same behaviors were verified using the isolated `--confcutdir` unit invocation.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented store-backed governance rule candidates by default, added an additive `action` schema migration for existing governance databases, preserved rule timestamps for resolver tie-breaking, made malformed loaded candidate actions deny instead of propagating unknown actions, normalized blank text scopes and rejected invalid numeric scope sentinels, and fixed metadata category handling so null/non-string values do not become real categories. Added focused regression tests for each reviewed finding.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2415 - Harden-Governance-core-review-findings.md
+++ b/backlog/tasks/task-2415 - Harden-Governance-core-review-findings.md
@@ -3,12 +3,12 @@ id: TASK-2415
 title: Harden Governance core review findings
 status: Done
 assignee: []
-created_date: '2026-06-23 14:39'
-updated_date: '2026-06-23 14:57'
+created_date: 2026-06-23 14:39
+updated_date: 2026-06-24 03:46
 labels:
-  - governance
-  - review
-  - bugfix
+- governance
+- review
+- bugfix
 dependencies: []
 priority: high
 ---
@@ -42,7 +42,7 @@ Address validated current-code review findings in tldw_Server_API/app/core/Gover
 <!-- SECTION:NOTES:BEGIN -->
 Manual Backlog task created because the Backlog MCP workflow was unavailable and the CLI create/list commands hung in this environment; user approved this temporary exception.
 
-Verification:
+Verification before initial PR creation:
 - Red run before implementation: `python -m pytest tldw_Server_API/tests/Governance/test_governance_service.py tldw_Server_API/tests/Governance/test_governance_gap_dedupe.py -q` failed on the expected 6 reviewed defects.
 - Focused isolated unit run after fixes: `python -m pytest --confcutdir=tldw_Server_API/tests/Governance tldw_Server_API/tests/Governance/test_governance_service.py tldw_Server_API/tests/Governance/test_governance_gap_dedupe.py -q` passed, 12 passed.
 - Full isolated Governance unit run: `python -m pytest --confcutdir=tldw_Server_API/tests/Governance tldw_Server_API/tests/Governance -q` passed, 26 passed.
@@ -51,13 +51,23 @@ Verification:
 - Whitespace check passed with `git diff --check` on touched files.
 - Bandit completed on `tldw_Server_API/app/core/Governance` with 0 findings; report: `/tmp/bandit_governance_2415.json`.
 
-Known verification note: one repository-global pytest invocation and one single-test invocation were interrupted after pytest cleanup/import hooks stalled; the same behaviors were verified using the isolated `--confcutdir` unit invocation.
+PR #2456 review follow-up after rebase onto latest origin/dev:
+- Addressed review comments by centralizing `InvalidGovernanceCandidateError`, catching integer/timestamp conversion edge cases, adding helper docstrings, using name-based PRAGMA column access, logging knowledge-query candidate load failures, treating malformed metadata scope IDs as global candidate lookups, and removing duplicate async test markers.
+- Focused review regression run passed: `python -m pytest --confcutdir=tldw_Server_API/tests/Governance tldw_Server_API/tests/Governance/test_governance_service.py tldw_Server_API/tests/Governance/test_governance_gap_dedupe.py -q` passed, 15 passed.
+- Full isolated Governance unit run passed: `python -m pytest --confcutdir=tldw_Server_API/tests/Governance tldw_Server_API/tests/Governance -q` passed, 29 passed.
+- Direct MCP governance regression run passed: `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_governance_module.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_governance_preflight.py -q` passed, 15 passed.
+- Ruff check passed on touched Python files with `python -m ruff check`.
+- Compile check passed for touched Governance source/tests and `exceptions.py` with `python -m py_compile`.
+- Whitespace check passed with `git diff --check`.
+- Bandit completed on `tldw_Server_API/app/core/Governance` plus `tldw_Server_API/app/core/exceptions.py` with 0 findings; report: `/tmp/bandit_governance_pr2456_rebase.json`.
+
+Known verification note: one repository-global pytest invocation and one single-test invocation were interrupted during the initial fix pass after pytest cleanup/import hooks stalled; the same behaviors were verified using isolated `--confcutdir` unit invocations.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented store-backed governance rule candidates by default, added an additive `action` schema migration for existing governance databases, preserved rule timestamps for resolver tie-breaking, made malformed loaded candidate actions deny instead of propagating unknown actions, normalized blank text scopes and rejected invalid numeric scope sentinels, and fixed metadata category handling so null/non-string values do not become real categories. Added focused regression tests for each reviewed finding.
+Implemented store-backed governance rule candidates by default, added an additive `action` schema migration for existing governance databases, preserved rule timestamps for resolver tie-breaking, made malformed loaded candidate actions deny instead of propagating unknown actions, normalized blank text scopes and rejected invalid numeric scope sentinels, and fixed metadata category handling so null/non-string values do not become real categories. PR #2456 follow-up also centralized the candidate exception, hardened bool/overflow timestamp and integer coercion, made malformed caller metadata fail closed to global rule matching instead of warn fallback, added diagnostic logging for knowledge-query candidate load failures, removed duplicate async test markers, and added regression tests for the new review comments.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/core/Governance/service.py
+++ b/tldw_Server_API/app/core/Governance/service.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 import inspect
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Literal, Mapping, Protocol, cast
+from typing import Any, Literal, Protocol, cast
+
+from loguru import logger
+
+from tldw_Server_API.app.core.exceptions import InvalidGovernanceCandidateError
 
 from .resolver import resolve_effective_action
 from .types import CandidateAction, GovernanceAction, utc_now
@@ -32,10 +37,6 @@ _CATEGORY_PATTERNS: tuple[tuple[str, tuple[str, ...]], ...] = (
 )
 
 _VALID_ACTIONS = frozenset({"allow", "warn", "require_approval", "deny"})
-
-
-class InvalidGovernanceCandidateError(ValueError):
-    """Raised when a policy source returns a malformed governance candidate."""
 
 
 class _GapStoreProtocol(Protocol):
@@ -80,6 +81,7 @@ class GovernanceService:
 
     @staticmethod
     def _normalize_text(value: Any) -> str:
+        """Normalize arbitrary text-like values for matching and storage."""
         return " ".join(str(value or "").strip().split())
 
     def _resolve_category(
@@ -107,6 +109,7 @@ class GovernanceService:
 
     @staticmethod
     def _coerce_action(value: Any) -> GovernanceAction:
+        """Normalize a raw policy action and reject unknown action names."""
         normalized = GovernanceService._normalize_text(value).lower()
         action = _FALLBACK_ACTIONS.get(normalized, normalized)
         if action not in _VALID_ACTIONS:
@@ -115,19 +118,26 @@ class GovernanceService:
 
     @staticmethod
     def _coerce_int(value: Any, *, field: str) -> int:
+        """Convert a candidate integer field while rejecting malformed values."""
+        if isinstance(value, bool):
+            raise InvalidGovernanceCandidateError(f"invalid_candidate_{field}")
         try:
             return int(value)
-        except (TypeError, ValueError) as exc:
+        except (TypeError, ValueError, OverflowError) as exc:
             raise InvalidGovernanceCandidateError(f"invalid_candidate_{field}") from exc
 
     @staticmethod
     def _coerce_updated_at(value: Any) -> datetime:
+        """Normalize a candidate timestamp to timezone-aware UTC."""
         if value is None:
             return utc_now()
         if isinstance(value, datetime):
             parsed = value
         elif isinstance(value, (int, float)) and not isinstance(value, bool):
-            parsed = datetime.fromtimestamp(float(value), tz=timezone.utc)
+            try:
+                parsed = datetime.fromtimestamp(float(value), tz=timezone.utc)
+            except (OverflowError, OSError, ValueError) as exc:
+                raise InvalidGovernanceCandidateError("invalid_candidate_updated_at") from exc
         else:
             rendered = GovernanceService._normalize_text(value)
             if not rendered:
@@ -144,6 +154,7 @@ class GovernanceService:
 
     @staticmethod
     def _coerce_candidate(raw: CandidateAction | Mapping[str, Any]) -> CandidateAction:
+        """Convert a loader result into a resolver-ready candidate object."""
         if isinstance(raw, CandidateAction):
             GovernanceService._coerce_action(raw.action)
             return raw
@@ -157,6 +168,7 @@ class GovernanceService:
         )
 
     async def _load_candidates(self, **kwargs: Any) -> list[CandidateAction]:
+        """Load policy candidates from the configured loader and validate them."""
         if self._policy_loader is None:
             return []
 
@@ -202,7 +214,15 @@ class GovernanceService:
                 }
                 for candidate in candidates
             )
-        except (AttributeError, InvalidGovernanceCandidateError, RuntimeError, TypeError, ValueError):
+        except (AttributeError, InvalidGovernanceCandidateError, RuntimeError, TypeError, ValueError) as exc:
+            logger.warning(
+                "Governance knowledge candidate loading failed for category={} source={} "
+                "query_length={} error_type={}",
+                resolved_category,
+                category_source,
+                len(self._normalize_text(query)),
+                type(exc).__name__,
+            )
             rules = ()
 
         return GovernanceKnowledgeResult(

--- a/tldw_Server_API/app/core/Governance/service.py
+++ b/tldw_Server_API/app/core/Governance/service.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import inspect
 from dataclasses import dataclass, field
-from typing import Any, Literal, Mapping, Protocol
+from datetime import datetime, timezone
+from typing import Any, Literal, Mapping, Protocol, cast
 
 from .resolver import resolve_effective_action
-from .types import CandidateAction, GovernanceAction
+from .types import CandidateAction, GovernanceAction, utc_now
 
 CategorySource = Literal["explicit", "metadata", "pattern", "default"]
 
@@ -29,6 +30,12 @@ _CATEGORY_PATTERNS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("dependencies", ("dependency", "dependencies", "package", "library", "version")),
     ("compliance", ("compliance", "policy", "governance", "audit", "regulation")),
 )
+
+_VALID_ACTIONS = frozenset({"allow", "warn", "require_approval", "deny"})
+
+
+class InvalidGovernanceCandidateError(ValueError):
+    """Raised when a policy source returns a malformed governance candidate."""
 
 
 class _GapStoreProtocol(Protocol):
@@ -68,11 +75,11 @@ class GovernanceService:
         default_fallback_mode: str = "warn_only",
     ) -> None:
         self._store = store
-        self._policy_loader = policy_loader
+        self._policy_loader = policy_loader if policy_loader is not None else store
         self._default_fallback_mode = default_fallback_mode
 
     @staticmethod
-    def _normalize_text(value: str | None) -> str:
+    def _normalize_text(value: Any) -> str:
         return " ".join(str(value or "").strip().split())
 
     def _resolve_category(
@@ -87,8 +94,8 @@ class GovernanceService:
             return explicit, "explicit"
 
         metadata_category = ""
-        if metadata:
-            metadata_category = self._normalize_text(str(metadata.get("category", ""))).lower()
+        if metadata and isinstance(metadata.get("category"), str):
+            metadata_category = self._normalize_text(metadata.get("category")).lower()
         if metadata_category:
             return metadata_category, "metadata"
 
@@ -99,13 +106,52 @@ class GovernanceService:
         return "general", "default"
 
     @staticmethod
+    def _coerce_action(value: Any) -> GovernanceAction:
+        normalized = GovernanceService._normalize_text(value).lower()
+        action = _FALLBACK_ACTIONS.get(normalized, normalized)
+        if action not in _VALID_ACTIONS:
+            raise InvalidGovernanceCandidateError("invalid_candidate_action")
+        return cast(GovernanceAction, action)
+
+    @staticmethod
+    def _coerce_int(value: Any, *, field: str) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError) as exc:
+            raise InvalidGovernanceCandidateError(f"invalid_candidate_{field}") from exc
+
+    @staticmethod
+    def _coerce_updated_at(value: Any) -> datetime:
+        if value is None:
+            return utc_now()
+        if isinstance(value, datetime):
+            parsed = value
+        elif isinstance(value, (int, float)) and not isinstance(value, bool):
+            parsed = datetime.fromtimestamp(float(value), tz=timezone.utc)
+        else:
+            rendered = GovernanceService._normalize_text(value)
+            if not rendered:
+                return utc_now()
+            if rendered.endswith("Z"):
+                rendered = f"{rendered[:-1]}+00:00"
+            try:
+                parsed = datetime.fromisoformat(rendered)
+            except ValueError as exc:
+                raise InvalidGovernanceCandidateError("invalid_candidate_updated_at") from exc
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    @staticmethod
     def _coerce_candidate(raw: CandidateAction | Mapping[str, Any]) -> CandidateAction:
         if isinstance(raw, CandidateAction):
+            GovernanceService._coerce_action(raw.action)
             return raw
         return CandidateAction(
-            action=str(raw.get("action", "allow")),  # type: ignore[arg-type]
-            scope_level=int(raw.get("scope_level", 0)),
-            priority=int(raw.get("priority", 0)),
+            action=GovernanceService._coerce_action(raw.get("action", "allow")),
+            scope_level=GovernanceService._coerce_int(raw.get("scope_level", 0), field="scope_level"),
+            priority=GovernanceService._coerce_int(raw.get("priority", 0), field="priority"),
+            updated_at=GovernanceService._coerce_updated_at(raw.get("updated_at")),
             source_id=(None if raw.get("source_id") is None else str(raw.get("source_id"))),
             reason=(None if raw.get("reason") is None else str(raw.get("reason"))),
         )
@@ -156,7 +202,7 @@ class GovernanceService:
                 }
                 for candidate in candidates
             )
-        except (AttributeError, RuntimeError, TypeError, ValueError):
+        except (AttributeError, InvalidGovernanceCandidateError, RuntimeError, TypeError, ValueError):
             rules = ()
 
         return GovernanceKnowledgeResult(
@@ -199,6 +245,15 @@ class GovernanceService:
                 summary=summary,
                 category=resolved_category,
                 metadata=metadata or {},
+            )
+        except InvalidGovernanceCandidateError as exc:
+            return GovernanceValidationResult(
+                action="deny",
+                status="deny",
+                category=resolved_category,
+                category_source=category_source,
+                fallback_reason=str(exc) or "invalid_candidate",
+                matched_rules=(),
             )
         except (AttributeError, RuntimeError, TypeError, ValueError):
             fallback_action = self.resolve_fallback(effective_fallback_mode)

--- a/tldw_Server_API/app/core/Governance/store.py
+++ b/tldw_Server_API/app/core/Governance/store.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Mapping, Optional
+from typing import Any
 
 import aiosqlite
 
@@ -20,17 +21,17 @@ class GapRecord:
     question_fingerprint: str
     category: str
     status: str
-    org_id: Optional[int]
-    team_id: Optional[int]
-    persona_id: Optional[str]
-    workspace_id: Optional[str]
-    resolution_mode: Optional[str]
-    resolution_text: Optional[str]
+    org_id: int | None
+    team_id: int | None
+    persona_id: str | None
+    workspace_id: str | None
+    resolution_mode: str | None
+    resolution_text: str | None
     created_at: str
     updated_at: str
 
     @classmethod
-    def from_row(cls, row: aiosqlite.Row) -> "GapRecord":
+    def from_row(cls, row: aiosqlite.Row) -> GapRecord:
         return cls(
             id=int(row["id"]),
             question=str(row["question"]),
@@ -122,7 +123,7 @@ class GovernanceStore:
     async def _ensure_schema_columns(self, db: aiosqlite.Connection) -> None:
         """Apply lightweight additive migrations for existing governance DBs."""
         cursor = await db.execute("PRAGMA table_info(governance_rules)")
-        columns = {str(row[1]) for row in await cursor.fetchall()}
+        columns = {str(row["name"]) for row in await cursor.fetchall()}
         if "action" not in columns:
             await db.execute(
                 "ALTER TABLE governance_rules ADD COLUMN action TEXT NOT NULL DEFAULT 'warn'"
@@ -141,39 +142,47 @@ class GovernanceStore:
 
     @staticmethod
     def _normalize_text(text: Any) -> str:
+        """Normalize arbitrary text-like values by trimming repeated whitespace."""
         return " ".join(str(text or "").strip().split())
 
     @classmethod
     def _normalize_optional_scope_text(cls, text: str | None) -> str | None:
+        """Normalize optional text scope values and collapse blanks to None."""
         normalized = cls._normalize_text(text)
         return normalized or None
 
     @staticmethod
     def _validate_optional_scope_id(field: str, value: int | None) -> int | None:
+        """Validate optional numeric scope identifiers for persisted gap writes."""
         if value is None:
             return None
         if isinstance(value, bool):
             raise ValueError(f"{field} must be an integer")
-        normalized = int(value)
+        try:
+            normalized = int(value)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(f"{field} must be an integer") from exc
         if normalized < 0:
             raise ValueError(f"{field} must be non-negative")
         return normalized
 
     @classmethod
     def _coerce_metadata_scope_id(cls, field: str, metadata: Mapping[str, Any]) -> int | None:
+        """Extract optional candidate scope IDs, treating malformed caller metadata as global."""
         value = metadata.get(field)
         if value is None or value == "":
             return None
         if isinstance(value, bool):
-            raise ValueError(f"{field} must be an integer")
+            return None
         try:
             normalized = int(str(value))
-        except (TypeError, ValueError) as exc:
-            raise ValueError(f"{field} must be an integer") from exc
-        return cls._validate_optional_scope_id(field, normalized)
+            return cls._validate_optional_scope_id(field, normalized)
+        except (TypeError, ValueError, OverflowError):
+            return None
 
     @classmethod
     def _normalize_category(cls, category: str | None) -> str:
+        """Normalize candidate lookup category values with a general fallback."""
         return cls._normalize_text(category).lower() or "general"
 
     @classmethod
@@ -183,6 +192,7 @@ class GovernanceStore:
 
     @staticmethod
     def _scope_level(row: aiosqlite.Row) -> int:
+        """Resolve a deterministic specificity level for a governance rule row."""
         if row["workspace_id"] is not None:
             return 4
         if row["persona_id"] is not None:

--- a/tldw_Server_API/app/core/Governance/store.py
+++ b/tldw_Server_API/app/core/Governance/store.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 import aiosqlite
+
+_VALID_ACTIONS = frozenset({"allow", "warn", "require_approval", "deny"})
 
 
 @dataclass(frozen=True)
@@ -68,6 +70,7 @@ class GovernanceStore:
                     persona_id TEXT,
                     workspace_id TEXT,
                     category TEXT NOT NULL,
+                    action TEXT NOT NULL DEFAULT 'warn',
                     title TEXT NOT NULL DEFAULT '',
                     body_markdown TEXT NOT NULL DEFAULT '',
                     status TEXT NOT NULL DEFAULT 'active',
@@ -108,9 +111,22 @@ class GovernanceStore:
                     COALESCE(workspace_id, '')
                 )
                 WHERE status = 'open';
+
+                CREATE INDEX IF NOT EXISTS idx_governance_rules_active_category
+                ON governance_rules (status, category, priority, updated_at);
                 """
             )
+            await self._ensure_schema_columns(db)
             await db.commit()
+
+    async def _ensure_schema_columns(self, db: aiosqlite.Connection) -> None:
+        """Apply lightweight additive migrations for existing governance DBs."""
+        cursor = await db.execute("PRAGMA table_info(governance_rules)")
+        columns = {str(row[1]) for row in await cursor.fetchall()}
+        if "action" not in columns:
+            await db.execute(
+                "ALTER TABLE governance_rules ADD COLUMN action TEXT NOT NULL DEFAULT 'warn'"
+            )
 
     async def table_exists(self, table_name: str) -> bool:
         """Return True when a SQLite table exists."""
@@ -124,13 +140,117 @@ class GovernanceStore:
             return bool(row)
 
     @staticmethod
-    def _normalize_text(text: str) -> str:
+    def _normalize_text(text: Any) -> str:
         return " ".join(str(text or "").strip().split())
+
+    @classmethod
+    def _normalize_optional_scope_text(cls, text: str | None) -> str | None:
+        normalized = cls._normalize_text(text)
+        return normalized or None
+
+    @staticmethod
+    def _validate_optional_scope_id(field: str, value: int | None) -> int | None:
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            raise ValueError(f"{field} must be an integer")
+        normalized = int(value)
+        if normalized < 0:
+            raise ValueError(f"{field} must be non-negative")
+        return normalized
+
+    @classmethod
+    def _coerce_metadata_scope_id(cls, field: str, metadata: Mapping[str, Any]) -> int | None:
+        value = metadata.get(field)
+        if value is None or value == "":
+            return None
+        if isinstance(value, bool):
+            raise ValueError(f"{field} must be an integer")
+        try:
+            normalized = int(str(value))
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{field} must be an integer") from exc
+        return cls._validate_optional_scope_id(field, normalized)
+
+    @classmethod
+    def _normalize_category(cls, category: str | None) -> str:
+        return cls._normalize_text(category).lower() or "general"
 
     @classmethod
     def _question_fingerprint(cls, question: str) -> str:
         normalized = cls._normalize_text(question).lower()
         return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _scope_level(row: aiosqlite.Row) -> int:
+        if row["workspace_id"] is not None:
+            return 4
+        if row["persona_id"] is not None:
+            return 3
+        if row["team_id"] is not None:
+            return 2
+        if row["org_id"] is not None:
+            return 1
+        return 0
+
+    async def get_candidates(
+        self,
+        *,
+        surface: str | None = None,
+        summary: str | None = None,
+        category: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return active governance rule candidates for a category and optional scope."""
+        del surface, summary
+        metadata_map = metadata or {}
+        normalized_category = self._normalize_category(category)
+        org_id = self._coerce_metadata_scope_id("org_id", metadata_map)
+        team_id = self._coerce_metadata_scope_id("team_id", metadata_map)
+        persona_id = self._normalize_optional_scope_text(
+            None if metadata_map.get("persona_id") is None else str(metadata_map.get("persona_id"))
+        )
+        workspace_id = self._normalize_optional_scope_text(
+            None if metadata_map.get("workspace_id") is None else str(metadata_map.get("workspace_id"))
+        )
+
+        async with self._connect() as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                """
+                SELECT id, org_id, team_id, persona_id, workspace_id,
+                       category, action, title, priority, updated_at
+                FROM governance_rules
+                WHERE status = 'active'
+                  AND LOWER(category) IN (?, 'general')
+                  AND (effective_from IS NULL OR effective_from <= CURRENT_TIMESTAMP)
+                  AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
+                  AND (org_id IS NULL OR org_id = ?)
+                  AND (team_id IS NULL OR team_id = ?)
+                  AND (persona_id IS NULL OR persona_id = ?)
+                  AND (workspace_id IS NULL OR workspace_id = ?)
+                ORDER BY priority DESC, updated_at DESC, id ASC
+                """,
+                (normalized_category, org_id, team_id, persona_id, workspace_id),
+            )
+            rows = await cursor.fetchall()
+
+        candidates: list[dict[str, Any]] = []
+        for row in rows:
+            action = self._normalize_text(row["action"]).lower()
+            if action not in _VALID_ACTIONS:
+                action = "deny"
+            candidates.append(
+                {
+                    "action": action,
+                    "scope_level": self._scope_level(row),
+                    "priority": int(row["priority"]),
+                    "updated_at": str(row["updated_at"]),
+                    "source_id": f"governance_rules:{int(row['id'])}",
+                    "reason": self._normalize_text(row["title"]) or None,
+                }
+            )
+        return candidates
 
     async def upsert_open_gap(
         self,
@@ -146,6 +266,10 @@ class GovernanceStore:
         """Create or return an existing open gap for the same normalized question/scope."""
         normalized_question = self._normalize_text(question)
         normalized_category = self._normalize_text(category).lower()
+        normalized_org_id = self._validate_optional_scope_id("org_id", org_id)
+        normalized_team_id = self._validate_optional_scope_id("team_id", team_id)
+        normalized_persona_id = self._normalize_optional_scope_text(persona_id)
+        normalized_workspace_id = self._normalize_optional_scope_text(workspace_id)
         if not normalized_question:
             raise ValueError("question is required")
         if not normalized_category:
@@ -163,10 +287,10 @@ class GovernanceStore:
                     ) VALUES (?, ?, ?, ?, ?, ?, ?, 'open', ?)
                     """,
                     (
-                        org_id,
-                        team_id,
-                        persona_id,
-                        workspace_id,
+                        normalized_org_id,
+                        normalized_team_id,
+                        normalized_persona_id,
+                        normalized_workspace_id,
                         normalized_question,
                         fingerprint,
                         normalized_category,
@@ -197,10 +321,10 @@ class GovernanceStore:
                 (
                     fingerprint,
                     normalized_category,
-                    org_id,
-                    team_id,
-                    persona_id,
-                    workspace_id,
+                    normalized_org_id,
+                    normalized_team_id,
+                    normalized_persona_id,
+                    normalized_workspace_id,
                 ),
             )
             row = await cursor.fetchone()

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from loguru import logger
 
-from .exception_types import PromptCatalogError
+from .exception_types import PromptCatalogError  # noqa: F401 - re-exported for compatibility.
 
 if hasattr(status, "HTTP_422_UNPROCESSABLE_CONTENT"):
     DEFAULT_VALIDATION_STATUS = status.HTTP_422_UNPROCESSABLE_CONTENT
@@ -124,6 +124,10 @@ class AuditLogError(RuntimeError):
 
 class ValidationError(BadRequestError):
     """Raised when validation of input parameters fails."""
+
+
+class InvalidGovernanceCandidateError(ValueError):
+    """Raised when a policy source returns a malformed governance candidate."""
 
 
 class ResearchDiscoveryError(Exception):

--- a/tldw_Server_API/tests/Governance/test_governance_gap_dedupe.py
+++ b/tldw_Server_API/tests/Governance/test_governance_gap_dedupe.py
@@ -5,7 +5,6 @@ from tldw_Server_API.app.core.Governance.store import GovernanceStore
 pytestmark = pytest.mark.unit
 
 
-@pytest.mark.asyncio
 async def test_open_gap_upsert_deduplicates_same_fingerprint(tmp_path):
     db_path = tmp_path / "gov_gaps.db"
     store = GovernanceStore(sqlite_path=str(db_path))
@@ -29,7 +28,6 @@ async def test_open_gap_upsert_deduplicates_same_fingerprint(tmp_path):
     assert first.status == "open"
 
 
-@pytest.mark.asyncio
 async def test_open_gap_upsert_distinct_scope_creates_new_gap(tmp_path):
     db_path = tmp_path / "gov_gaps_scope.db"
     store = GovernanceStore(sqlite_path=str(db_path))
@@ -51,7 +49,6 @@ async def test_open_gap_upsert_distinct_scope_creates_new_gap(tmp_path):
     assert team_a.id != team_b.id
 
 
-@pytest.mark.asyncio
 async def test_open_gap_rejects_negative_numeric_scope_ids(tmp_path):
     db_path = tmp_path / "gov_gaps_negative_scope.db"
     store = GovernanceStore(sqlite_path=str(db_path))
@@ -65,7 +62,6 @@ async def test_open_gap_rejects_negative_numeric_scope_ids(tmp_path):
         )
 
 
-@pytest.mark.asyncio
 async def test_open_gap_rejects_boolean_numeric_scope_ids(tmp_path):
     db_path = tmp_path / "gov_gaps_boolean_scope.db"
     store = GovernanceStore(sqlite_path=str(db_path))
@@ -79,7 +75,6 @@ async def test_open_gap_rejects_boolean_numeric_scope_ids(tmp_path):
         )
 
 
-@pytest.mark.asyncio
 async def test_open_gap_normalizes_blank_text_scope_to_null(tmp_path):
     db_path = tmp_path / "gov_gaps_blank_scope.db"
     store = GovernanceStore(sqlite_path=str(db_path))

--- a/tldw_Server_API/tests/Governance/test_governance_gap_dedupe.py
+++ b/tldw_Server_API/tests/Governance/test_governance_gap_dedupe.py
@@ -50,3 +50,45 @@ async def test_open_gap_upsert_distinct_scope_creates_new_gap(tmp_path):
 
     assert team_a.id != team_b.id
 
+
+@pytest.mark.asyncio
+async def test_open_gap_rejects_negative_numeric_scope_ids(tmp_path):
+    db_path = tmp_path / "gov_gaps_negative_scope.db"
+    store = GovernanceStore(sqlite_path=str(db_path))
+    await store.ensure_schema()
+
+    with pytest.raises(ValueError, match="org_id must be non-negative"):
+        await store.upsert_open_gap(
+            question="How should shared policy apply?",
+            category="general",
+            org_id=-1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_open_gap_rejects_boolean_numeric_scope_ids(tmp_path):
+    db_path = tmp_path / "gov_gaps_boolean_scope.db"
+    store = GovernanceStore(sqlite_path=str(db_path))
+    await store.ensure_schema()
+
+    with pytest.raises(ValueError, match="team_id must be an integer"):
+        await store.upsert_open_gap(
+            question="How should shared policy apply?",
+            category="general",
+            team_id=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_open_gap_normalizes_blank_text_scope_to_null(tmp_path):
+    db_path = tmp_path / "gov_gaps_blank_scope.db"
+    store = GovernanceStore(sqlite_path=str(db_path))
+    await store.ensure_schema()
+
+    gap = await store.upsert_open_gap(
+        question="How should workspace policy apply?",
+        category="general",
+        workspace_id="   ",
+    )
+
+    assert gap.workspace_id is None

--- a/tldw_Server_API/tests/Governance/test_governance_service.py
+++ b/tldw_Server_API/tests/Governance/test_governance_service.py
@@ -47,7 +47,6 @@ class _FakePolicyLoader:
         return list(self.candidates)
 
 
-@pytest.mark.asyncio
 async def test_validate_change_uses_shared_fallback_mode():
     svc = GovernanceService(
         store=_FakeStore(),
@@ -64,7 +63,6 @@ async def test_validate_change_uses_shared_fallback_mode():
     assert out.fallback_reason == "backend_unavailable"
 
 
-@pytest.mark.asyncio
 async def test_query_knowledge_returns_category_source():
     svc = GovernanceService(store=_FakeStore(), policy_loader=_FakePolicyLoader(should_fail=False))
 
@@ -73,7 +71,6 @@ async def test_query_knowledge_returns_category_source():
     assert out.category_source in {"explicit", "metadata", "pattern", "default"}
 
 
-@pytest.mark.asyncio
 async def test_resolve_gap_uses_metadata_category_when_missing_explicit():
     store = _FakeStore()
     svc = GovernanceService(store=store, policy_loader=_FakePolicyLoader(should_fail=False))
@@ -90,7 +87,6 @@ async def test_resolve_gap_uses_metadata_category_when_missing_explicit():
     assert store.last_upsert["category"] == "security"
 
 
-@pytest.mark.asyncio
 async def test_validate_change_uses_store_backed_rules_by_default(tmp_path):
     db_path = tmp_path / "governance_rules.db"
     store = GovernanceStore(sqlite_path=str(db_path))
@@ -117,7 +113,6 @@ async def test_validate_change_uses_store_backed_rules_by_default(tmp_path):
     assert out.matched_rules == ("governance_rules:1",)
 
 
-@pytest.mark.asyncio
 async def test_validate_change_denies_invalid_candidate_action():
     svc = GovernanceService(
         store=_FakeStore(),
@@ -137,7 +132,72 @@ async def test_validate_change_denies_invalid_candidate_action():
     assert out.fallback_reason == "invalid_candidate_action"
 
 
-@pytest.mark.asyncio
+async def test_validate_change_denies_bool_candidate_int_field():
+    svc = GovernanceService(
+        store=_FakeStore(),
+        policy_loader=_FakePolicyLoader(
+            should_fail=False,
+            candidates=[{"action": "warn", "priority": True, "source_id": "bad-rule"}],
+        ),
+    )
+
+    out = await svc.validate_change(
+        surface="mcp_tool",
+        summary="Change package policy",
+        category="dependencies",
+    )
+
+    assert out.status == "deny"
+    assert out.fallback_reason == "invalid_candidate_priority"
+
+
+async def test_validate_change_denies_out_of_range_candidate_timestamp():
+    svc = GovernanceService(
+        store=_FakeStore(),
+        policy_loader=_FakePolicyLoader(
+            should_fail=False,
+            candidates=[{"action": "warn", "updated_at": float("inf"), "source_id": "bad-rule"}],
+        ),
+    )
+
+    out = await svc.validate_change(
+        surface="mcp_tool",
+        summary="Change package policy",
+        category="dependencies",
+    )
+
+    assert out.status == "deny"
+    assert out.fallback_reason == "invalid_candidate_updated_at"
+
+
+async def test_validate_change_treats_malformed_scope_metadata_as_global(tmp_path):
+    db_path = tmp_path / "governance_metadata_scope.db"
+    store = GovernanceStore(sqlite_path=str(db_path))
+    await store.ensure_schema()
+    async with store._connect() as db:
+        await db.execute(
+            """
+            INSERT INTO governance_rules (category, title, action, priority)
+            VALUES (?, ?, ?, ?)
+            """,
+            ("security", "Deny global security-sensitive changes", "deny", 5),
+        )
+        await db.commit()
+
+    svc = GovernanceService(store=store)
+
+    out = await svc.validate_change(
+        surface="mcp_tool",
+        summary="Rotate an admin auth token",
+        category="security",
+        metadata={"org_id": True},
+    )
+
+    assert out.status == "deny"
+    assert out.fallback_reason is None
+    assert out.matched_rules == ("governance_rules:1",)
+
+
 async def test_mapping_candidate_preserves_updated_at_for_tie_breaker():
     now = datetime.now(timezone.utc)
     svc = GovernanceService(
@@ -172,7 +232,6 @@ async def test_mapping_candidate_preserves_updated_at_for_tie_breaker():
     assert out.matched_rules == ("newer", "older")
 
 
-@pytest.mark.asyncio
 async def test_metadata_category_none_is_ignored():
     svc = GovernanceService(store=_FakeStore(), policy_loader=_FakePolicyLoader(should_fail=False))
 

--- a/tldw_Server_API/tests/Governance/test_governance_service.py
+++ b/tldw_Server_API/tests/Governance/test_governance_service.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import pytest
 
 from tldw_Server_API.app.core.Governance.service import GovernanceService
+from tldw_Server_API.app.core.Governance.store import GovernanceStore
 
 pytestmark = pytest.mark.unit
 
@@ -86,3 +88,95 @@ async def test_resolve_gap_uses_metadata_category_when_missing_explicit():
     assert gap.status == "open"
     assert store.last_upsert is not None
     assert store.last_upsert["category"] == "security"
+
+
+@pytest.mark.asyncio
+async def test_validate_change_uses_store_backed_rules_by_default(tmp_path):
+    db_path = tmp_path / "governance_rules.db"
+    store = GovernanceStore(sqlite_path=str(db_path))
+    await store.ensure_schema()
+    async with store._connect() as db:
+        await db.execute(
+            """
+            INSERT INTO governance_rules (category, title, action, priority)
+            VALUES (?, ?, ?, ?)
+            """,
+            ("security", "Deny security-sensitive changes", "deny", 5),
+        )
+        await db.commit()
+
+    svc = GovernanceService(store=store)
+
+    out = await svc.validate_change(
+        surface="mcp_tool",
+        summary="Rotate an admin auth token",
+        category="security",
+    )
+
+    assert out.status == "deny"
+    assert out.matched_rules == ("governance_rules:1",)
+
+
+@pytest.mark.asyncio
+async def test_validate_change_denies_invalid_candidate_action():
+    svc = GovernanceService(
+        store=_FakeStore(),
+        policy_loader=_FakePolicyLoader(
+            should_fail=False,
+            candidates=[{"action": "bogus", "scope_level": 1, "source_id": "bad-rule"}],
+        ),
+    )
+
+    out = await svc.validate_change(
+        surface="mcp_tool",
+        summary="Change package policy",
+        category="dependencies",
+    )
+
+    assert out.status == "deny"
+    assert out.fallback_reason == "invalid_candidate_action"
+
+
+@pytest.mark.asyncio
+async def test_mapping_candidate_preserves_updated_at_for_tie_breaker():
+    now = datetime.now(timezone.utc)
+    svc = GovernanceService(
+        store=_FakeStore(),
+        policy_loader=_FakePolicyLoader(
+            should_fail=False,
+            candidates=[
+                {
+                    "action": "warn",
+                    "scope_level": 2,
+                    "priority": 1,
+                    "updated_at": (now - timedelta(minutes=1)).isoformat(),
+                    "source_id": "newer",
+                },
+                {
+                    "action": "warn",
+                    "scope_level": 2,
+                    "priority": 1,
+                    "updated_at": (now - timedelta(minutes=5)).isoformat(),
+                    "source_id": "older",
+                },
+            ],
+        ),
+    )
+
+    out = await svc.validate_change(
+        surface="mcp_tool",
+        summary="Change audit policy",
+        category="compliance",
+    )
+
+    assert out.matched_rules == ("newer", "older")
+
+
+@pytest.mark.asyncio
+async def test_metadata_category_none_is_ignored():
+    svc = GovernanceService(store=_FakeStore(), policy_loader=_FakePolicyLoader(should_fail=False))
+
+    out = await svc.query_knowledge(query="general guidance", metadata={"category": None})
+
+    assert out.category == "general"
+    assert out.category_source == "default"


### PR DESCRIPTION
## Summary
- Loads active GovernanceStore rules by default for GovernanceService validation instead of silently allowing when no explicit loader is injected.
- Validates and normalizes candidate actions, preserves loaded updated_at values for resolver tie-breaking, and denies malformed candidate actions safely.
- Hardens gap scope normalization to avoid null/sentinel collisions and adds focused regression coverage plus Backlog tracking.

## Change summary
TODO (human requester before merge): Replace this section with a human-authored explanation of what changed and why these implementation choices were made.

## Verification
- source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest --confcutdir=tldw_Server_API/tests/Governance tldw_Server_API/tests/Governance -q
- source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_governance_module.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_governance_preflight.py -q
- source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m py_compile tldw_Server_API/app/core/Governance/service.py tldw_Server_API/app/core/Governance/store.py tldw_Server_API/tests/Governance/test_governance_service.py tldw_Server_API/tests/Governance/test_governance_gap_dedupe.py
- git diff --check
- source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Governance -f json -o /tmp/bandit_governance_pr.json

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened governance rule loading and validation. Default to store-backed active rules, enforce strict candidate schema, honor rule time windows, and fail closed on malformed inputs to prevent unsafe passes.

- **Bug Fixes**
  - Use GovernanceStore as the default policy loader for GovernanceService.
  - Add store-backed candidate loading: return active rules by category (with general fallback), scoped filters, and only within effective_from/expires_at windows; invalid rule actions default to safe deny.
  - Coerce and validate candidate fields: normalize action; reject bool/invalid ints for priority/scope_level; normalize updated_at to UTC and reject invalid timestamps; invalid candidates return a safe deny with a clear reason.
  - Preserve updated_at in candidates for resolver tie-breaking.
  - Normalize category from metadata only when it’s a string; null/non-string falls back to general.
  - Treat malformed metadata scope IDs as global lookups when loading candidates.
  - Harden gap dedupe: reject negative/boolean numeric scope IDs; trim blank text scopes to null to avoid collisions.
  - Log knowledge-query candidate load failures and return no matches instead of partial/malformed results.

- **Migration**
  - ensure_schema adds action column to governance_rules with default warn and creates an index for active lookups. No manual steps; applied on startup.

<sup>Written for commit 0342cd165249c6d6ca125cf07f93d442c80a5e1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

