### PR TITLE
Harden Evaluations core review findings

### DIFF
--- a/backlog/tasks/task-9935 - Harden-Evaluations-core-review-findings.md
+++ b/backlog/tasks/task-9935 - Harden-Evaluations-core-review-findings.md
@@ -1,0 +1,73 @@
+---
+id: TASK-9935
+title: Harden Evaluations core review findings
+status: Done
+assignee: []
+created_date: 2026-06-23 21:41
+updated_date: 2026-06-24 03:54
+labels:
+- evaluations
+- security
+- hardening
+dependencies: []
+priority: high
+modified_files:
+- tldw_Server_API/app/core/Evaluations/eval_runner.py
+- tldw_Server_API/app/core/Evaluations/recipe_runs_jobs_worker.py
+- tldw_Server_API/app/core/Evaluations/recipe_runs_service.py
+- tldw_Server_API/app/core/Evaluations/recipes/rag_answer_quality.py
+- tldw_Server_API/app/core/Evaluations/synthetic_eval_repository.py
+- tldw_Server_API/app/core/Evaluations/synthetic_eval_service.py
+- tldw_Server_API/app/core/Evaluations/user_rate_limiter.py
+- tldw_Server_API/app/core/Evaluations/webhook_manager.py
+- tldw_Server_API/app/core/Evaluations/webhook_security.py
+- tldw_Server_API/tests/Evaluations/test_evaluations_core_hardening.py
+- tldw_Server_API/tests/Evaluations/test_recipe_runs_service.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and address validated current-code review findings in tldw_Server_API/app/core/Evaluations, including dataset ownership, webhook SSRF, persistence failure handling, recipe-run secret storage, synthetic eval queue ownership, cost limit atomicity, webhook domain matching, and stale adapter registration. This replaces the earlier collided TASK-2414 allocation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Validated findings have regression tests that fail before fixes and pass after fixes.
+- [x] #2 Cross-user data access paths are owner-scoped for evaluations datasets and synthetic eval drafts.
+- [x] #3 Webhook delivery paths use a single hardened validation/delivery flow or reject unsafe direct URLs.
+- [x] #4 Sensitive per-run API keys are not persisted plaintext in recipe run metadata.
+- [x] #5 Touched scope passes focused tests and Bandit scan.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Starting verified, test-first remediation for Evaluations core review findings. Earlier TASK-2414 output was ignored because that ID resolves to an unrelated Image Generation task in this worktree.
+
+Verification complete. Focused tests: source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Evaluations/test_evaluations_core_hardening.py tldw_Server_API/tests/Evaluations/test_recipe_runs_service.py::test_recipe_service_redacts_sensitive_run_config_in_public_metadata tldw_Server_API/tests/Evaluations/unit/test_user_rate_limiter_minute_exact_and_reset.py -q -> 13 passed. Bandit: source .venv/bin/activate && python -m bandit -r <touched Evaluations core files> -f json -o /tmp/bandit_evaluations_9935.json -> 0 results. Documentation was not updated because the fixes are internal hardening behavior with regression tests.
+
+Clean worktree PR verification on codex/evaluations-core-hardening-9935: focused pytest set passed with 13 passed; Bandit JSON report /tmp/bandit_evaluations_9935_clean_worktree.json reported 0 results; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Validated and fixed the Evaluations core review findings. Added regression coverage for cross-user dataset/synthetic draft ownership, webhook SSRF and DNS rebinding-safe delivery, persistence failure surfacing, recipe-run secret retention, domain boundary matching, stale adapter registration, and atomic daily cost reservation. Runtime changes scope dataset and synthetic sample lookups by owner, resolve webhook delivery to a validated IP target with Host preservation, avoid durable plaintext recipe-run secrets, raise on failed evaluation result persistence, stop registering the unimplemented PostgreSQL adapter, and make rate-limit cost reservation/write atomic. Verification: 13 focused tests passed and Bandit reported 0 findings on touched core files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Rebased PR #2460 branch on latest origin/dev and addressed validated Gemini/Qodo review comments: removed in-memory recipe run secret config storage in favor of BYOK-encrypted durable metadata, preserved candidate_api_keys through rag_answer_quality normalization for worker execution, moved webhook DNS resolution and rate-limit SQLite writes off the async event loop, preserved HTTPS webhook hostnames for TLS verification, fixed mixed IPv4/IPv6 private-network checks, normalized leading-dot domains, required synthetic workflow user scope for owner-filtered operations, and explicitly closed SQLite connections in the rate limiter. Verification: compileall on touched files passed; targeted review regressions passed (5 passed); expanded hardening/recipe/rate-limiter tests passed (32 passed); recipe service + worker suites passed (43 passed); Bandit on touched Evaluations core files reported 0 findings.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/core/Evaluations/db_adapter.py
+++ b/tldw_Server_API/app/core/Evaluations/db_adapter.py
@@ -406,7 +406,6 @@ class DatabaseAdapterFactory:
 
     _adapters = {
         DatabaseType.SQLITE: SQLiteAdapter,
-        DatabaseType.POSTGRESQL: PostgreSQLAdapter,
     }
 
     @classmethod

--- a/tldw_Server_API/app/core/Evaluations/eval_runner.py
+++ b/tldw_Server_API/app/core/Evaluations/eval_runner.py
@@ -54,6 +54,7 @@ from tldw_Server_API.app.core.Evaluations.run_state import (
     can_transition_run_status,
     normalize_run_status,
 )
+from tldw_Server_API.app.core.Evaluations.webhook_security import webhook_validator
 from tldw_Server_API.app.core.RAG.rag_custom_metrics import get_custom_metrics
 from tldw_Server_API.app.core.RAG.rag_service.unified_pipeline import unified_rag_pipeline
 from tldw_Server_API.app.core.RAG.rag_service.vector_stores import (
@@ -1237,7 +1238,8 @@ class EvaluationRunner:
         # Get from evaluation's dataset
         dataset_id = evaluation.get("dataset_id")
         if dataset_id:
-            dataset = self.db.get_dataset(dataset_id)
+            created_by = eval_config.get("created_by") or evaluation.get("created_by")
+            dataset = self.db.get_dataset(dataset_id, created_by=created_by)
             if dataset:
                 return dataset["samples"]
 
@@ -2356,7 +2358,16 @@ class EvaluationRunner:
                 "results_url": f"/api/v1/runs/{run_id}/results",
                 "summary": summary,
             }
-            resp = await afetch(method="POST", url=webhook_url, json=payload, timeout=10, retry=RetryPolicy(attempts=1))
+            delivery_url, host_headers = await webhook_validator.resolve_safe_delivery_target_async(webhook_url)
+            resp = await afetch(
+                method="POST",
+                url=delivery_url,
+                json=payload,
+                headers=host_headers,
+                timeout=10,
+                allow_redirects=False,
+                retry=RetryPolicy(attempts=1),
+            )
             if resp.status_code >= 400:
                 try:
                     resp.raise_for_status()

--- a/tldw_Server_API/app/core/Evaluations/recipe_runs_jobs_worker.py
+++ b/tldw_Server_API/app/core/Evaluations/recipe_runs_jobs_worker.py
@@ -42,6 +42,7 @@ from tldw_Server_API.app.core.Evaluations.recipe_runs_jobs import (
 )
 from tldw_Server_API.app.core.Evaluations.recipe_runs_service import (
     RecipeRunsService,
+    decrypt_recipe_run_config_from_metadata,
     get_recipe_runs_service_for_user,
 )
 from tldw_Server_API.app.core.Jobs.manager import JobManager
@@ -113,7 +114,27 @@ def _parse_json_list(value: Any) -> list[Any]:
 
 def _run_config_for_execution(record: Any) -> dict[str, Any]:
     metadata = getattr(record, "metadata", {}) or {}
-    return dict(metadata.get("run_config_internal") or metadata.get("run_config") or {})
+    encrypted_config = decrypt_recipe_run_config_from_metadata(metadata)
+    if encrypted_config is not None:
+        return encrypted_config
+
+    run_config = dict(metadata.get("run_config") or {})
+    if _contains_redacted_value(run_config):
+        raise ValueError(
+            "Recipe run secret-bearing config is encrypted but cannot be decrypted. "
+            "Configure BYOK_ENCRYPTION_KEY for recipe worker execution."
+        )
+    return run_config
+
+
+def _contains_redacted_value(value: Any) -> bool:
+    if value == "[REDACTED]":
+        return True
+    if isinstance(value, dict):
+        return any(_contains_redacted_value(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_redacted_value(item) for item in value)
+    return False
 
 
 def _resolve_embeddings_dataset(record: Any, db: EvaluationsDatabase, user_id: str | None) -> list[dict[str, Any]]:
@@ -1195,7 +1216,6 @@ def handle_recipe_run_job(
             metadata=failed_metadata,
         )
         raise job_error from exc
-
     logger.info("Recipe run job completed: run_id={} job_id={}", run_id, job_id)
     return {
         "status": "completed",

--- a/tldw_Server_API/app/core/Evaluations/recipe_runs_service.py
+++ b/tldw_Server_API/app/core/Evaluations/recipe_runs_service.py
@@ -19,6 +19,10 @@ from tldw_Server_API.app.api.v1.schemas.evaluation_recipe_schemas import (
 )
 from tldw_Server_API.app.api.v1.schemas.evaluation_schemas_unified import RunStatus
 from tldw_Server_API.app.core.AuthNZ.settings import is_single_user_mode
+from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import (
+    decrypt_byok_payload,
+    encrypt_byok_payload,
+)
 from tldw_Server_API.app.core.DB_Management.Evaluations_DB import EvaluationsDatabase
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Evaluations.recipes.dataset_snapshot import (
@@ -32,6 +36,7 @@ from tldw_Server_API.app.core.Evaluations.recipes.registry import (
 from tldw_Server_API.app.core.Evaluations.recipes.reporting import RecipeRunReport
 
 RECIPE_RUN_REUSE_ENTITY_TYPE = "recipe_run_reuse"
+RUN_CONFIG_ENCRYPTED_METADATA_KEY = "run_config_encrypted"
 _SENSITIVE_RUN_CONFIG_KEYS = {
     "api_key",
     "api_keys",
@@ -50,6 +55,38 @@ REQUIRED_RECOMMENDATION_SLOTS: tuple[str, ...] = (
     "best_cheap",
     "best_local",
 )
+
+
+def _clone_json_like(value: dict[str, Any]) -> dict[str, Any]:
+    try:
+        return json.loads(json.dumps(value))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return dict(value)
+
+
+def encrypt_recipe_run_config_for_metadata(run_config: dict[str, Any]) -> dict[str, Any]:
+    """Encrypt a full recipe run config for durable worker-side execution."""
+
+    try:
+        return encrypt_byok_payload({"run_config": _clone_json_like(run_config)})
+    except ValueError as exc:
+        raise ValueError(
+            "Recipe run config contains sensitive values; configure BYOK_ENCRYPTION_KEY "
+            "so it can be stored encrypted for worker retries."
+        ) from exc
+
+
+def decrypt_recipe_run_config_from_metadata(metadata: dict[str, Any]) -> dict[str, Any] | None:
+    """Decrypt a full recipe run config from persisted metadata when present."""
+
+    envelope = metadata.get(RUN_CONFIG_ENCRYPTED_METADATA_KEY)
+    if not isinstance(envelope, dict):
+        return None
+    payload = decrypt_byok_payload(envelope)
+    run_config = payload.get("run_config")
+    if not isinstance(run_config, dict):
+        raise ValueError("Encrypted recipe run config payload is malformed.")
+    return _clone_json_like(run_config)
 
 
 class RecipeDefinitionNotFoundError(LookupError):
@@ -259,27 +296,32 @@ class RecipeRunsService:
                 self._record_reuse_mapping(reusable.run_id, reuse_hash)
                 return self.get_run(reusable.run_id)
 
+        run_metadata = {
+            "run_config": self._sanitize_run_config_for_metadata(normalized_run_config),
+            "reuse_hash": reuse_hash,
+            "dataset_mode": validation["dataset_mode"],
+            "dataset_id": dataset_id,
+            "inline_dataset": (
+                self._normalize_dataset_samples(dataset)
+                if dataset_id is None and dataset is not None
+                else None
+            ),
+            "owner_user_id": self.user_id,
+            "recipe_validation": validation_metadata,
+            "review_sample": validation_metadata.get("review_sample"),
+        }
+        if self._run_config_contains_sensitive_value(normalized_run_config):
+            run_metadata[RUN_CONFIG_ENCRYPTED_METADATA_KEY] = encrypt_recipe_run_config_for_metadata(
+                normalized_run_config
+            )
+
         run_id = self.db.create_recipe_run(
             recipe_id=manifest.recipe_id,
             recipe_version=manifest.recipe_version,
             status=RunStatus.PENDING,
             dataset_snapshot_ref=validation["dataset_snapshot_ref"],
             dataset_content_hash=validation["dataset_content_hash"],
-            metadata={
-                "run_config": self._sanitize_run_config_for_metadata(normalized_run_config),
-                "run_config_internal": normalized_run_config,
-                "reuse_hash": reuse_hash,
-                "dataset_mode": validation["dataset_mode"],
-                "dataset_id": dataset_id,
-                "inline_dataset": (
-                    self._normalize_dataset_samples(dataset)
-                    if dataset_id is None and dataset is not None
-                    else None
-                ),
-                "owner_user_id": self.user_id,
-                "recipe_validation": validation_metadata,
-                "review_sample": validation_metadata.get("review_sample"),
-            },
+            metadata=run_metadata,
         )
         self._record_reuse_mapping(run_id, reuse_hash)
         return self.get_run(run_id)
@@ -584,7 +626,24 @@ class RecipeRunsService:
     def _public_record(self, record: RecipeRunRecord) -> RecipeRunRecord:
         metadata = dict(record.metadata or {})
         metadata.pop("run_config_internal", None)
+        metadata.pop(RUN_CONFIG_ENCRYPTED_METADATA_KEY, None)
         return record.model_copy(update={"metadata": metadata})
+
+    def _run_config_contains_sensitive_value(self, value: Any, *, key_name: str | None = None) -> bool:
+        if key_name:
+            lowered = key_name.lower()
+            if lowered in _SENSITIVE_RUN_CONFIG_KEYS or lowered.endswith(
+                ("_api_key", "_token", "_secret", "_password")
+            ):
+                return True
+        if isinstance(value, dict):
+            return any(
+                self._run_config_contains_sensitive_value(item, key_name=str(key))
+                for key, item in value.items()
+            )
+        if isinstance(value, list):
+            return any(self._run_config_contains_sensitive_value(item) for item in value)
+        return False
 
     def _sanitize_run_config_for_metadata(self, value: Any) -> Any:
         if isinstance(value, dict):

--- a/tldw_Server_API/app/core/Evaluations/recipes/rag_answer_quality.py
+++ b/tldw_Server_API/app/core/Evaluations/recipes/rag_answer_quality.py
@@ -198,6 +198,7 @@ class RAGAnswerQualityRecipe(RecipeDefinition):
         }
         prompts = self._normalize_prompt_mapping(run_config.get("prompts"))
         judge_config = self._normalize_mapping(run_config.get("judge_config"), field_name="run_config.judge_config")
+        candidate_api_keys = self._normalize_candidate_api_keys(run_config.get("candidate_api_keys"))
         execution_policy = self._normalize_mapping(
             run_config.get("execution_policy"),
             field_name="run_config.execution_policy",
@@ -206,6 +207,8 @@ class RAGAnswerQualityRecipe(RecipeDefinition):
             normalized["prompts"] = prompts
         if judge_config:
             normalized["judge_config"] = judge_config
+        if candidate_api_keys:
+            normalized["candidate_api_keys"] = candidate_api_keys
         if execution_policy:
             normalized["execution_policy"] = execution_policy
 
@@ -550,6 +553,17 @@ class RAGAnswerQualityRecipe(RecipeDefinition):
             str(key): str(prompt)
             for key, prompt in prompts.items()
             if str(key).strip() and str(prompt).strip()
+        }
+
+    def _normalize_candidate_api_keys(self, value: Any) -> dict[str, str]:
+        candidate_api_keys = self._normalize_mapping(
+            value,
+            field_name="run_config.candidate_api_keys",
+        )
+        return {
+            str(provider).strip(): str(api_key).strip()
+            for provider, api_key in candidate_api_keys.items()
+            if str(provider).strip() and str(api_key).strip()
         }
 
     def _normalize_live_retrieval_config(self, run_config: Mapping[str, Any]) -> dict[str, Any]:

--- a/tldw_Server_API/app/core/Evaluations/synthetic_eval_repository.py
+++ b/tldw_Server_API/app/core/Evaluations/synthetic_eval_repository.py
@@ -55,6 +55,7 @@ def _draft_sample_filter_clause(
     review_state: str | SyntheticEvalReviewState | None = None,
     source_kind: str | None = None,
     generation_batch_id: str | None = None,
+    created_by: str | None = None,
 ) -> tuple[str, list[Any]]:
     query = " WHERE 1=1"
     params: list[Any] = []
@@ -75,6 +76,13 @@ def _draft_sample_filter_clause(
     if generation_batch_id:
         query += " AND CAST(sample_metadata_json AS TEXT) LIKE ?"
         params.append(f'%\"generation_batch_id\":{_json_dumps(generation_batch_id)}%')
+    if created_by is not None:
+        normalized_created_by = str(created_by).strip()
+        if not normalized_created_by:
+            query += " AND 1=0"
+        else:
+            query += " AND created_by = ?"
+            params.append(normalized_created_by)
     return query, params
 
 
@@ -150,16 +158,24 @@ class SyntheticEvalRepository:
                 ),
             )
             conn.commit()
-        return self.get_draft_sample(sample_id) or {}
+        return self.get_draft_sample(sample_id, created_by=created_by) or {}
 
-    def get_draft_sample(self, sample_id: str) -> dict[str, Any] | None:
+    def get_draft_sample(self, sample_id: str, *, created_by: str | None = None) -> dict[str, Any] | None:
         """Fetch a persisted synthetic draft sample."""
 
         with self._db.get_connection() as conn:
             cursor = conn.cursor()
+            query = "SELECT * FROM synthetic_eval_draft_samples WHERE sample_id = ?"
+            params: list[Any] = [sample_id]
+            if created_by is not None:
+                normalized_created_by = str(created_by).strip()
+                if not normalized_created_by:
+                    return None
+                query += " AND created_by = ?"
+                params.append(normalized_created_by)
             cursor.execute(
-                "SELECT * FROM synthetic_eval_draft_samples WHERE sample_id = ?",
-                (sample_id,),
+                query,
+                params,
             )
             row = cursor.fetchone()
         if not row:
@@ -177,6 +193,7 @@ class SyntheticEvalRepository:
         review_state: str | SyntheticEvalReviewState | None = None,
         source_kind: str | None = None,
         generation_batch_id: str | None = None,
+        created_by: str | None = None,
         limit: int | None = None,
         offset: int = 0,
     ) -> list[dict[str, Any]]:
@@ -187,6 +204,7 @@ class SyntheticEvalRepository:
             review_state=review_state,
             source_kind=source_kind,
             generation_batch_id=generation_batch_id,
+            created_by=created_by,
         )
         # where_clause is assembled from fixed predicates and bound parameters.
         query = "SELECT * FROM synthetic_eval_draft_samples" + where_clause  # nosec B608
@@ -217,6 +235,7 @@ class SyntheticEvalRepository:
         review_state: str | SyntheticEvalReviewState | None = None,
         source_kind: str | None = None,
         generation_batch_id: str | None = None,
+        created_by: str | None = None,
         limit: int = 50,
         offset: int = 0,
     ) -> list[dict[str, Any]]:
@@ -227,6 +246,7 @@ class SyntheticEvalRepository:
             review_state=review_state,
             source_kind=source_kind,
             generation_batch_id=generation_batch_id,
+            created_by=created_by,
             limit=limit,
             offset=offset,
         )
@@ -239,6 +259,7 @@ class SyntheticEvalRepository:
         review_state: str | SyntheticEvalReviewState | None = None,
         source_kind: str | None = None,
         generation_batch_id: str | None = None,
+        created_by: str | None = None,
     ) -> int:
         """Count matching synthetic draft samples before pagination."""
 
@@ -247,6 +268,7 @@ class SyntheticEvalRepository:
             review_state=review_state,
             source_kind=source_kind,
             generation_batch_id=generation_batch_id,
+            created_by=created_by,
         )
         # where_clause is assembled from fixed predicates and bound parameters.
         query = "SELECT COUNT(*) AS total FROM synthetic_eval_draft_samples" + where_clause  # nosec B608
@@ -264,18 +286,18 @@ class SyntheticEvalRepository:
         value = row_dict.get("total") if row_dict else row[0]
         return int(value or 0)
 
-    def get_draft_samples(self, sample_ids: list[str]) -> list[dict[str, Any]]:
+    def get_draft_samples(self, sample_ids: list[str], *, created_by: str | None = None) -> list[dict[str, Any]]:
         """Fetch multiple draft samples in caller-provided order."""
 
         ordered: list[dict[str, Any]] = []
         for sample_id in sample_ids:
-            ordered.append(self.require_draft_sample(sample_id))
+            ordered.append(self.require_draft_sample(sample_id, created_by=created_by))
         return ordered
 
-    def require_draft_sample(self, sample_id: str) -> dict[str, Any]:
+    def require_draft_sample(self, sample_id: str, *, created_by: str | None = None) -> dict[str, Any]:
         """Return a sample or raise when it does not exist."""
 
-        sample = self.get_draft_sample(sample_id)
+        sample = self.get_draft_sample(sample_id, created_by=created_by)
         if sample is None:
             raise ValueError("sample does not exist")
         return sample
@@ -305,11 +327,12 @@ class SyntheticEvalRepository:
         notes: str | None = None,
         action_payload: dict[str, Any] | None = None,
         resulting_review_state: str | SyntheticEvalReviewState | None = None,
+        created_by: str | None = None,
     ) -> dict[str, Any]:
         """Append a review action and update the sample's current review state."""
 
         normalized_action = SyntheticEvalReviewActionType(action)
-        sample = self.require_draft_sample(sample_id)
+        sample = self.require_draft_sample(sample_id, created_by=created_by)
         if resulting_review_state is None:
             if normalized_action in {
                 SyntheticEvalReviewActionType.EDIT_AND_APPROVE,
@@ -441,10 +464,11 @@ class SyntheticEvalRepository:
         promoted_by: str | None = None,
         promotion_reason: str | None = None,
         promotion_metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
     ) -> dict[str, Any]:
         """Persist a dataset promotion record for an approved draft sample."""
 
-        sample = self.require_draft_sample(sample_id)
+        sample = self.require_draft_sample(sample_id, created_by=created_by)
         if sample.get("review_state") != SyntheticEvalReviewState.APPROVED.value:
             raise ValueError("sample must be approved before promotion")
 

--- a/tldw_Server_API/app/core/Evaluations/synthetic_eval_service.py
+++ b/tldw_Server_API/app/core/Evaluations/synthetic_eval_service.py
@@ -280,6 +280,11 @@ class SyntheticEvalWorkflowService:
             repository=self.repository
         )
 
+    def _owner_scope(self) -> str:
+        if not self.user_id:
+            raise ValueError("user_id is required for owner-scoped synthetic eval workflow operations.")
+        return self.user_id
+
     def generate_draft_batch(self, **kwargs: Any) -> SyntheticEvalGenerationResult:
         """Proxy through to the shared generation service."""
 
@@ -299,11 +304,13 @@ class SyntheticEvalWorkflowService:
     ) -> dict[str, Any]:
         """Return a filtered synthetic review queue."""
 
+        owner_scope = self._owner_scope()
         rows = self.repository.list_draft_samples(
             recipe_kind=recipe_kind,
             review_state=review_state,
             source_kind=source_kind,
             generation_batch_id=generation_batch_id,
+            created_by=owner_scope,
             limit=limit,
             offset=offset,
         )
@@ -312,6 +319,7 @@ class SyntheticEvalWorkflowService:
             review_state=review_state,
             source_kind=source_kind,
             generation_batch_id=generation_batch_id,
+            created_by=owner_scope,
         )
         return {
             "data": rows,
@@ -330,13 +338,15 @@ class SyntheticEvalWorkflowService:
     ) -> dict[str, Any]:
         """Apply a review action to a draft sample."""
 
+        owner_scope = self._owner_scope()
         return self.repository.record_review_action(
             sample_id=sample_id,
             action=action,
-            reviewer_id=reviewer_id or self.user_id or None,
+            reviewer_id=reviewer_id or owner_scope,
             notes=notes,
             action_payload=action_payload,
             resulting_review_state=resulting_review_state,
+            created_by=owner_scope,
         )
 
     def promote_samples(
@@ -354,7 +364,8 @@ class SyntheticEvalWorkflowService:
         if not sample_ids:
             raise ValueError("sample_ids must contain at least one sample.")
 
-        samples = self.repository.get_draft_samples(sample_ids)
+        owner_scope = self._owner_scope()
+        samples = self.repository.get_draft_samples(sample_ids, created_by=owner_scope)
         recipe_kinds = {str(sample.get("recipe_kind") or "").strip() for sample in samples}
         if "" in recipe_kinds:
             raise ValueError("all promoted samples must include a recipe_kind")
@@ -372,7 +383,7 @@ class SyntheticEvalWorkflowService:
             },
         )
 
-        owner = promoted_by or self.user_id or None
+        owner = promoted_by or owner_scope
         dataset_id = self.db.create_dataset(
             name=dataset_name,
             description=dataset_description,
@@ -395,6 +406,7 @@ class SyntheticEvalWorkflowService:
                 promoted_by=owner,
                 promotion_reason=promotion_reason,
                 promotion_metadata={"dataset_name": dataset_name},
+                created_by=owner_scope,
             )
             promotion_ids.append(str(promotion.get("promotion_id") or ""))
 

--- a/tldw_Server_API/app/core/Evaluations/unified_evaluation_service.py
+++ b/tldw_Server_API/app/core/Evaluations/unified_evaluation_service.py
@@ -317,6 +317,14 @@ class UnifiedEvaluationService:
                     description=f"Dataset for {name}",
                     created_by=created_by
                 )
+            elif dataset_id:
+                existing_dataset = self.db.get_dataset(
+                    dataset_id,
+                    created_by=created_by,
+                    include_samples=False,
+                )
+                if not existing_dataset:
+                    raise ValueError(f"Dataset {dataset_id} not found")
 
             # Create evaluation
             eval_id = self.db.create_evaluation(
@@ -1505,7 +1513,7 @@ class UnifiedEvaluationService:
 
         except _UNIFIED_EVAL_NONCRITICAL_EXCEPTIONS as e:
             logger.error(f"Failed to store evaluation result: {e}")
-            return f"temp_{int(time.time())}"
+            raise
 
     async def get_metrics_summary(self) -> dict[str, Any]:
         """Get evaluation metrics summary"""

--- a/tldw_Server_API/app/core/Evaluations/user_rate_limiter.py
+++ b/tldw_Server_API/app/core/Evaluations/user_rate_limiter.py
@@ -321,50 +321,59 @@ class UserRateLimiter:
                         "rate_limit_source": "resource_governor",
                     }
 
-                # Enforce cost caps locally (RG does not handle cost limits).
-                cost_ok, cost_meta = await self._check_cost_limits(user_id, estimated_cost, config)
-                if not cost_ok:
-                    return False, cost_meta
-
-                # Record the request (usage + ledger shadow writes).
-                try:
-                    await self._record_request(user_id, endpoint, tokens_requested, estimated_cost)
-                except _USER_RATE_LIMIT_NONCRITICAL_EXCEPTIONS:
-                    # Best-effort only; never block allow path.
-                    pass
+                # Enforce cost caps locally (RG does not handle cost limits)
+                # and reserve the estimated request usage atomically.
+                usage_ok, usage_meta = await self._reserve_request_usage(
+                    user_id,
+                    endpoint,
+                    tokens_requested,
+                    estimated_cost,
+                    config,
+                )
+                if not usage_ok:
+                    return False, usage_meta
 
                 metadata: dict[str, Any] = {
                     "policy_id": rg_decision.get("policy_id", policy_id),
                     "rate_limit_source": "resource_governor",
                 }
+                metadata.update(usage_meta)
                 return True, metadata
 
             _log_rg_evals_fallback("rg_decision_unavailable")
             _emit_evals_legacy_deprecation("rg_decision_unavailable")
             # Fail-open for eval/token caps; still enforce cost.
-            cost_ok, cost_meta = await self._check_cost_limits(user_id, estimated_cost, config)
-            if not cost_ok:
-                return False, cost_meta
-            try:
-                await self._record_request(user_id, endpoint, tokens_requested, estimated_cost)
-            except _USER_RATE_LIMIT_NONCRITICAL_EXCEPTIONS:
-                pass
+            usage_ok, usage_meta = await self._reserve_request_usage(
+                user_id,
+                endpoint,
+                tokens_requested,
+                estimated_cost,
+                config,
+            )
+            if not usage_ok:
+                return False, usage_meta
             return True, {
                 "policy_id": policy_id,
                 "rate_limit_source": "resource_governor",
+                **usage_meta,
             }
 
         # RG disabled or CUSTOM tier → skip minute/daily checks (Phase 2),
         # enforce cost caps only.
         _emit_evals_legacy_deprecation("rg_disabled_or_custom_tier")
-        cost_ok, cost_meta = await self._check_cost_limits(user_id, estimated_cost, config)
-        if not cost_ok:
-            return False, cost_meta
-
-        await self._record_request(user_id, endpoint, tokens_requested, estimated_cost)
+        usage_ok, usage_meta = await self._reserve_request_usage(
+            user_id,
+            endpoint,
+            tokens_requested,
+            estimated_cost,
+            config,
+        )
+        if not usage_ok:
+            return False, usage_meta
         return True, {
             "rate_limit_source": "legacy_cost_only",
             "tier": config.tier.value,
+            **usage_meta,
         }
 
     async def _get_user_config(self, user_id: str) -> RateLimitConfig:
@@ -564,7 +573,11 @@ class UserRateLimiter:
             total_cost = float(row[0] or 0.0) if row else 0.0
 
         if total_cost + cost > float(config.max_cost_per_day):
-            reset_at = datetime.combine(today + timedelta(days=1), datetime.min.time())
+            reset_at = datetime.combine(
+                today + timedelta(days=1),
+                datetime.min.time(),
+                tzinfo=timezone.utc,
+            )
             retry_after = max(1, int((reset_at - datetime.now(timezone.utc)).total_seconds()))
             return False, {
                 "error": "Daily cost limit exceeded",
@@ -579,6 +592,102 @@ class UserRateLimiter:
             "cost_remaining": float(config.max_cost_per_day) - total_cost - cost,
         }
 
+    async def _reserve_request_usage(
+        self,
+        user_id: str,
+        endpoint: str,
+        tokens_used: int,
+        cost: float,
+        config: RateLimitConfig,
+    ) -> tuple[bool, dict[str, Any]]:
+        """Atomically enforce cost caps and record estimated request usage."""
+        allowed, metadata, now, normalized_tokens = await asyncio.to_thread(
+            self._reserve_request_usage_sync,
+            user_id,
+            endpoint,
+            tokens_used,
+            cost,
+            config,
+        )
+        if not allowed:
+            return False, metadata
+
+        await self._shadow_write_daily_usage(
+            user_id=user_id,
+            endpoint=endpoint,
+            now=now,
+            tokens_used=normalized_tokens,
+        )
+        return True, metadata
+
+    def _reserve_request_usage_sync(
+        self,
+        user_id: str,
+        endpoint: str,
+        tokens_used: int,
+        cost: float,
+        config: RateLimitConfig,
+    ) -> tuple[bool, dict[str, Any], datetime, int]:
+        now = datetime.now(timezone.utc)
+        today = now.date()
+        try:
+            normalized_cost = float(cost or 0.0)
+        except _USER_RATE_LIMIT_NONCRITICAL_EXCEPTIONS:
+            normalized_cost = 0.0
+        normalized_tokens = max(0, int(tokens_used or 0))
+        cost_remaining: Optional[float] = None
+
+        conn = sqlite3.connect(self.db_path, timeout=30.0)
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                if normalized_cost > 0:
+                    cursor = conn.cursor()
+                    cursor.execute(
+                        "SELECT total_cost FROM daily_usage WHERE user_id = ? AND date = ?",
+                        (user_id, str(today)),
+                    )
+                    row = cursor.fetchone()
+                    total_cost = float(row[0] or 0.0) if row else 0.0
+                    daily_limit = float(config.max_cost_per_day)
+                    if total_cost + normalized_cost > daily_limit:
+                        conn.rollback()
+                        reset_at = datetime.combine(
+                            today + timedelta(days=1),
+                            datetime.min.time(),
+                            tzinfo=timezone.utc,
+                        )
+                        retry_after = max(1, int((reset_at - datetime.now(timezone.utc)).total_seconds()))
+                        return False, {
+                            "error": "Daily cost limit exceeded",
+                            "limit": config.max_cost_per_day,
+                            "used": total_cost,
+                            "requested": normalized_cost,
+                            "retry_after": retry_after,
+                            "resets_at": reset_at.isoformat(),
+                        }, now, normalized_tokens
+                    cost_remaining = daily_limit - total_cost - normalized_cost
+
+                self._write_request_usage(
+                    conn,
+                    user_id=user_id,
+                    endpoint=endpoint,
+                    now=now,
+                    today=today,
+                    tokens_used=normalized_tokens,
+                    cost=normalized_cost,
+                )
+                conn.commit()
+            except _USER_RATE_LIMIT_NONCRITICAL_EXCEPTIONS:
+                conn.rollback()
+                raise
+        finally:
+            conn.close()
+
+        if cost_remaining is None:
+            return True, {}, now, normalized_tokens
+        return True, {"cost_remaining": cost_remaining}, now, normalized_tokens
+
     async def _record_request(
         self,
         user_id: str,
@@ -587,28 +696,83 @@ class UserRateLimiter:
         cost: float
     ):
         """Record a request for tracking."""
+        now, normalized_tokens = await asyncio.to_thread(
+            self._record_request_sync,
+            user_id,
+            endpoint,
+            tokens_used,
+            cost,
+        )
+        await self._shadow_write_daily_usage(
+            user_id=user_id,
+            endpoint=endpoint,
+            now=now,
+            tokens_used=normalized_tokens,
+        )
+
+    def _record_request_sync(
+        self,
+        user_id: str,
+        endpoint: str,
+        tokens_used: int,
+        cost: float,
+    ) -> tuple[datetime, int]:
         now = datetime.now(timezone.utc)
         today = now.date()
+        normalized_tokens = max(0, int(tokens_used or 0))
+        normalized_cost = float(cost or 0.0)
 
-        with sqlite3.connect(self.db_path) as conn:
-            # Record in tracking table
-            conn.execute(
-                "INSERT INTO rate_limit_tracking (user_id, endpoint, timestamp, tokens_used, cost) VALUES (?, ?, ?, ?, ?)",
-                (user_id, endpoint, now.isoformat(), tokens_used, cost)
+        conn = sqlite3.connect(self.db_path)
+        try:
+            self._write_request_usage(
+                conn,
+                user_id=user_id,
+                endpoint=endpoint,
+                now=now,
+                today=today,
+                tokens_used=normalized_tokens,
+                cost=normalized_cost,
             )
-
-            # Update daily usage
-            conn.execute("""
-                INSERT INTO daily_usage (user_id, date, total_evaluations, total_tokens, total_cost)
-                VALUES (?, ?, 1, ?, ?)
-                ON CONFLICT(user_id, date) DO UPDATE SET
-                    total_evaluations = total_evaluations + 1,
-                    total_tokens = total_tokens + ?,
-                    total_cost = total_cost + ?
-            """, (user_id, str(today), tokens_used, cost, tokens_used, cost))
-
             conn.commit()
+        finally:
+            conn.close()
+        return now, normalized_tokens
 
+    @staticmethod
+    def _write_request_usage(
+        conn: sqlite3.Connection,
+        *,
+        user_id: str,
+        endpoint: str,
+        now: datetime,
+        today: Any,
+        tokens_used: int,
+        cost: float,
+    ) -> None:
+        # Record in tracking table
+        conn.execute(
+            "INSERT INTO rate_limit_tracking (user_id, endpoint, timestamp, tokens_used, cost) VALUES (?, ?, ?, ?, ?)",
+            (user_id, endpoint, now.isoformat(), tokens_used, cost)
+        )
+
+        # Update daily usage
+        conn.execute("""
+            INSERT INTO daily_usage (user_id, date, total_evaluations, total_tokens, total_cost)
+            VALUES (?, ?, 1, ?, ?)
+            ON CONFLICT(user_id, date) DO UPDATE SET
+                total_evaluations = total_evaluations + 1,
+                total_tokens = total_tokens + ?,
+                total_cost = total_cost + ?
+        """, (user_id, str(today), tokens_used, cost, tokens_used, cost))
+
+    async def _shadow_write_daily_usage(
+        self,
+        *,
+        user_id: str,
+        endpoint: str,
+        now: datetime,
+        tokens_used: int,
+    ) -> None:
         # Shadow-write daily usage into the shared ResourceDailyLedger so RG can
         # enforce tokens/evaluations caps cross-module in v1.1.
         try:

--- a/tldw_Server_API/app/core/Evaluations/webhook_manager.py
+++ b/tldw_Server_API/app/core/Evaluations/webhook_manager.py
@@ -627,67 +627,15 @@ class WebhookManager:
         url = webhook["url"]
         secret = webhook["secret"]
 
-        # Validate URL before delivery to prevent SSRF
-        import ipaddress
-        import socket
-        from urllib.parse import urlparse
-
         # In tests, skip DNS validation to keep runs deterministic.
         from tldw_Server_API.app.core.testing import is_test_mode as _is_test_mode
         testing_env = (_is_test_mode() or "PYTEST_CURRENT_TEST" in os.environ)
         skip_dns = testing_env
+        delivery_url = url
+        host_headers: dict[str, str] = {}
         if not skip_dns:
             try:
-                parsed_url = urlparse(url)
-                if parsed_url.hostname:
-                    # Check if hostname is an IP address
-                    try:
-                        ip_addr = ipaddress.ip_address(parsed_url.hostname)
-                        # Check against private networks
-                        private_networks = [
-                            ipaddress.IPv4Network("10.0.0.0/8"),
-                            ipaddress.IPv4Network("172.16.0.0/12"),
-                            ipaddress.IPv4Network("192.168.0.0/16"),
-                            ipaddress.IPv4Network("169.254.0.0/16"),
-                            ipaddress.IPv4Network("127.0.0.0/8"),
-                            ipaddress.IPv6Network("::1/128"),
-                            ipaddress.IPv6Network("fc00::/7"),
-                            ipaddress.IPv6Network("fe80::/10"),
-                        ]
-                        for network in private_networks:
-                            if ip_addr in network:
-                                logger.error(f"Webhook URL points to private network: {url}")
-                                self._update_webhook_stats(webhook_id, success=False, error="URL points to private network")
-                                return
-                    except ValueError:
-                        # Not an IP, resolve hostname
-                        try:
-                            resolved_ips = socket.getaddrinfo(parsed_url.hostname, None)
-                            for addr_info in resolved_ips:
-                                ip_str = addr_info[4][0]
-                                try:
-                                    ip_addr = ipaddress.ip_address(ip_str)
-                                    private_networks = [
-                                        ipaddress.IPv4Network("10.0.0.0/8"),
-                                        ipaddress.IPv4Network("172.16.0.0/12"),
-                                        ipaddress.IPv4Network("192.168.0.0/16"),
-                                        ipaddress.IPv4Network("169.254.0.0/16"),
-                                        ipaddress.IPv4Network("127.0.0.0/8"),
-                                        ipaddress.IPv6Network("::1/128"),
-                                        ipaddress.IPv6Network("fc00::/7"),
-                                        ipaddress.IPv6Network("fe80::/10"),
-                                    ]
-                                    for network in private_networks:
-                                        if ip_addr in network:
-                                            logger.error(f"Webhook hostname resolves to private IP: {url}")
-                                            self._update_webhook_stats(webhook_id, success=False, error="Hostname resolves to private IP")
-                                            return
-                                except ValueError:
-                                    pass
-                        except socket.gaierror:
-                            logger.error(f"Failed to resolve webhook hostname: {url}")
-                            self._update_webhook_stats(webhook_id, success=False, error="DNS resolution failed")
-                            return
+                delivery_url, host_headers = await webhook_validator.resolve_safe_delivery_target_async(url)
             except _WEBHOOK_MANAGER_NONCRITICAL_EXCEPTIONS as e:
                 logger.error(f"URL validation failed: {e}")
                 self._update_webhook_stats(webhook_id, success=False, error=f"URL validation failed: {str(e)}")
@@ -721,6 +669,7 @@ class WebhookManager:
                     "X-Webhook-Event": payload.event,
                     "X-Webhook-Delivery": str(delivery_id)
                 }
+                headers.update(host_headers)
                 start_time = datetime.now()
 
                 try:
@@ -729,7 +678,7 @@ class WebhookManager:
                     timeout = 5
                 resp = await afetch(
                     method="POST",
-                    url=url,
+                    url=delivery_url,
                     data=payload_json,
                     headers=headers,
                     timeout=timeout,

--- a/tldw_Server_API/app/core/Evaluations/webhook_security.py
+++ b/tldw_Server_API/app/core/Evaluations/webhook_security.py
@@ -13,7 +13,7 @@ import ssl
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Optional
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlparse, urlunparse
 
 from loguru import logger
 
@@ -94,8 +94,16 @@ class WebhookSecurityValidator:
         self.max_url_length = get_config("webhooks.security.max_url_length", 2048)
 
         # Domain filtering
-        self.allowed_domains = set(get_config("webhooks.security.allowed_domains", []))
-        self.blocked_domains = set(get_config("webhooks.security.blocked_domains", []))
+        self.allowed_domains = {
+            self._normalize_domain(domain)
+            for domain in get_config("webhooks.security.allowed_domains", [])
+            if domain
+        }
+        self.blocked_domains = {
+            self._normalize_domain(domain)
+            for domain in get_config("webhooks.security.blocked_domains", [])
+            if domain
+        }
 
         # Rate limiting
         self.max_webhooks_per_user = get_config("webhooks.registration_limits.per_user_max", 10)
@@ -130,6 +138,82 @@ class WebhookSecurityValidator:
             11211, # Memcached
             27017, # MongoDB
         }
+
+    def resolve_safe_delivery_target(self, url: str) -> tuple[str, dict[str, str]]:
+        """Resolve a webhook URL to a delivery target.
+
+        HTTP delivery uses the resolved IP address and preserves the original
+        host in a Host header. HTTPS keeps the original URL after validating
+        resolved addresses so TLS SNI and certificate validation still use the
+        hostname.
+        """
+
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"}:
+            raise ValueError("Webhook URL scheme must be http or https")
+        if not parsed.hostname:
+            raise ValueError("Webhook URL must include a hostname")
+        if parsed.username or parsed.password:
+            raise ValueError("Webhook URL credentials are not allowed")
+
+        hostname = parsed.hostname
+        try:
+            ip_addr = ipaddress.ip_address(hostname)
+            self._raise_if_private_ip(ip_addr)
+            safe_ip = str(ip_addr)
+        except ValueError as direct_ip_error:
+            safe_ips: list[str] = []
+            try:
+                resolved_ips = socket.getaddrinfo(hostname, parsed.port)
+            except socket.gaierror as e:
+                raise ValueError(f"DNS resolution failed: {str(e)}") from e
+
+            for addr_info in resolved_ips:
+                ip_str = addr_info[4][0]
+                try:
+                    ip_addr = ipaddress.ip_address(ip_str)
+                except ValueError:
+                    continue
+                try:
+                    self._raise_if_private_ip(ip_addr)
+                except ValueError as private_error:
+                    raise private_error from direct_ip_error
+                safe_ips.append(str(ip_addr))
+
+            if not safe_ips:
+                raise ValueError("No valid IPs found for hostname")
+            safe_ip = safe_ips[0]
+
+        if parsed.scheme == "https":
+            return url, {}
+
+        if parsed.port:
+            netloc = f"[{safe_ip}]:{parsed.port}" if ":" in safe_ip else f"{safe_ip}:{parsed.port}"
+        else:
+            netloc = f"[{safe_ip}]" if ":" in safe_ip else safe_ip
+
+        delivery_url = urlunparse((
+            parsed.scheme,
+            netloc,
+            parsed.path,
+            parsed.params,
+            parsed.query,
+            parsed.fragment,
+        ))
+        host_header = hostname
+        if parsed.port:
+            host_header = f"{hostname}:{parsed.port}"
+        return delivery_url, {"Host": host_header}
+
+    async def resolve_safe_delivery_target_async(self, url: str) -> tuple[str, dict[str, str]]:
+        """Resolve a webhook delivery target without blocking the event loop."""
+
+        return await asyncio.to_thread(self.resolve_safe_delivery_target, url)
+
+    def _raise_if_private_ip(self, ip_addr: ipaddress._BaseAddress) -> None:
+        for network in self.private_networks:
+            if ip_addr.version == network.version and ip_addr in network:
+                raise ValueError(f"Hostname resolves to private IP: {ip_addr}")
 
     async def validate_webhook_url(
         self,
@@ -359,11 +443,13 @@ class WebhookSecurityValidator:
         errors = []
         warnings = []
         metadata = {"domain_status": "unknown"}
+        normalized_hostname = self._normalize_domain(hostname)
 
         # Check blocked domains
         if self.blocked_domains:
             for blocked_domain in self.blocked_domains:
-                if hostname.endswith(blocked_domain) or hostname == blocked_domain:
+                normalized_domain = self._normalize_domain(blocked_domain)
+                if normalized_domain and self._domain_matches(normalized_hostname, normalized_domain):
                     errors.append(WebhookValidationError(
                         code="BLOCKED_DOMAIN",
                         message=f"Domain is blocked: {hostname}",
@@ -377,7 +463,8 @@ class WebhookSecurityValidator:
         if self.allowed_domains and metadata["domain_status"] != "blocked":
             domain_allowed = False
             for allowed_domain in self.allowed_domains:
-                if hostname.endswith(allowed_domain) or hostname == allowed_domain:
+                normalized_domain = self._normalize_domain(allowed_domain)
+                if normalized_domain and self._domain_matches(normalized_hostname, normalized_domain):
                     domain_allowed = True
                     metadata["domain_status"] = "allowed"
                     break
@@ -399,6 +486,14 @@ class WebhookSecurityValidator:
             "warnings": warnings,
             "metadata": metadata
         }
+
+    @staticmethod
+    def _normalize_domain(domain: str) -> str:
+        return str(domain).strip().lower().strip(".")
+
+    @staticmethod
+    def _domain_matches(hostname: str, domain: str) -> bool:
+        return hostname == domain or hostname.endswith(f".{domain}")
 
     def _validate_path(self, path: str, warnings: list[WebhookValidationError]):
         """Validate URL path for potential issues."""

--- a/tldw_Server_API/tests/Evaluations/test_evaluations_core_hardening.py
+++ b/tldw_Server_API/tests/Evaluations/test_evaluations_core_hardening.py
@@ -1,0 +1,370 @@
+"""Regression coverage for Evaluations core hardening findings."""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tldw_Server_API.app.api.v1.schemas.synthetic_eval_schemas import (
+    SyntheticEvalProvenance,
+    SyntheticEvalReviewActionType,
+    SyntheticEvalReviewState,
+)
+from tldw_Server_API.app.core.DB_Management.Evaluations_DB import EvaluationsDatabase
+from tldw_Server_API.app.core.Evaluations.db_adapter import (
+    DatabaseAdapterFactory,
+    DatabaseConfig,
+    DatabaseType,
+)
+from tldw_Server_API.app.core.Evaluations.eval_runner import EvaluationRunner
+from tldw_Server_API.app.core.Evaluations.synthetic_eval_service import SyntheticEvalWorkflowService
+from tldw_Server_API.app.core.Evaluations.unified_evaluation_service import UnifiedEvaluationService
+from tldw_Server_API.app.core.Evaluations.user_rate_limiter import UserRateLimiter, UserTier
+from tldw_Server_API.app.core.Evaluations.webhook_manager import WebhookPayload, WebhookManager
+from tldw_Server_API.app.core.Evaluations.webhook_security import WebhookSecurityValidator
+
+
+@pytest.mark.asyncio
+async def test_create_evaluation_rejects_dataset_owned_by_another_user(temp_db_path) -> None:
+    service = UnifiedEvaluationService(db_path=str(temp_db_path), enable_webhooks=False)
+
+    dataset_id = service.db.create_dataset(
+        name="private-dataset",
+        samples=[{"input": {"text": "tenant-a secret"}, "expected": {"text": "ok"}}],
+        created_by="user-a",
+    )
+
+    with pytest.raises(ValueError, match="Dataset .* not found"):
+        await service.create_evaluation(
+            name="cross-owner",
+            eval_type="exact_match",
+            eval_spec={"metrics": ["exact_match"]},
+            dataset_id=dataset_id,
+            created_by="user-b",
+        )
+
+
+@pytest.mark.asyncio
+async def test_store_evaluation_result_raises_when_standard_persistence_fails(temp_db_path, monkeypatch) -> None:
+    service = UnifiedEvaluationService(db_path=str(temp_db_path), enable_webhooks=False)
+
+    def _fail_create_evaluation(*_args, **_kwargs):
+        raise RuntimeError("db create failed")
+
+    monkeypatch.setattr(service.db, "create_evaluation", _fail_create_evaluation)
+
+    with pytest.raises(RuntimeError, match="db create failed"):
+        await service._store_evaluation_result(
+            "geval",
+            input_data={"transcript": "input", "summary": "summary"},
+            results={"score": 0.5},
+            metadata={"user_id": "user-a"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_runner_does_not_load_dataset_owned_by_another_user(temp_db_path) -> None:
+    runner = EvaluationRunner(str(temp_db_path), max_concurrent_evals=1, eval_timeout=5)
+    dataset_id = runner.db.create_dataset(
+        name="private-dataset",
+        samples=[{"input": {"text": "tenant-a secret"}, "expected": {"text": "ok"}}],
+        created_by="user-a",
+    )
+    eval_id = runner.db.create_evaluation(
+        name="bad-reference",
+        eval_type="exact_match",
+        eval_spec={"metrics": ["exact_match"]},
+        dataset_id=dataset_id,
+        created_by="user-b",
+    )
+    evaluation = runner.db.get_evaluation(eval_id, created_by="user-b")
+
+    with pytest.raises(ValueError, match="No samples found"):
+        await runner._get_samples(evaluation, {"created_by": "user-b"})
+
+
+def _synthetic_service(db: EvaluationsDatabase, user_id: str) -> SyntheticEvalWorkflowService:
+    return SyntheticEvalWorkflowService(db=db, user_id=user_id)
+
+
+def _create_synthetic_sample(
+    service: SyntheticEvalWorkflowService,
+    *,
+    sample_id: str,
+    created_by: str,
+    review_state: str = SyntheticEvalReviewState.DRAFT.value,
+) -> None:
+    service.repository.create_draft_sample(
+        sample_id=sample_id,
+        recipe_kind="rag_retrieval_tuning",
+        sample_payload={"query": sample_id},
+        provenance=SyntheticEvalProvenance.SYNTHETIC_FROM_CORPUS.value,
+        review_state=review_state,
+        created_by=created_by,
+    )
+
+
+def test_synthetic_queue_lists_only_current_users_draft_samples(tmp_path) -> None:
+    db = EvaluationsDatabase(str(tmp_path / "evaluations.db"))
+    service_a = _synthetic_service(db, "user-a")
+    service_b = _synthetic_service(db, "user-b")
+    _create_synthetic_sample(service_a, sample_id="sample-a", created_by="user-a")
+    _create_synthetic_sample(service_b, sample_id="sample-b", created_by="user-b")
+
+    queue = service_b.list_queue()
+
+    assert [row["sample_id"] for row in queue["data"]] == ["sample-b"]  # nosec B101
+    assert queue["total"] == 1  # nosec B101
+
+
+def test_synthetic_review_rejects_sample_owned_by_another_user(tmp_path) -> None:
+    db = EvaluationsDatabase(str(tmp_path / "evaluations.db"))
+    service_a = _synthetic_service(db, "user-a")
+    service_b = _synthetic_service(db, "user-b")
+    _create_synthetic_sample(service_a, sample_id="sample-a", created_by="user-a")
+
+    with pytest.raises(ValueError, match="sample does not exist"):
+        service_b.review_sample(
+            "sample-a",
+            action=SyntheticEvalReviewActionType.APPROVE.value,
+        )
+
+
+def test_synthetic_promotion_rejects_sample_owned_by_another_user(tmp_path) -> None:
+    db = EvaluationsDatabase(str(tmp_path / "evaluations.db"))
+    service_a = _synthetic_service(db, "user-a")
+    service_b = _synthetic_service(db, "user-b")
+    _create_synthetic_sample(
+        service_a,
+        sample_id="sample-a",
+        created_by="user-a",
+        review_state=SyntheticEvalReviewState.APPROVED.value,
+    )
+
+    with pytest.raises(ValueError, match="sample does not exist"):
+        service_b.promote_samples(
+            sample_ids=["sample-a"],
+            dataset_name="should-not-promote",
+        )
+
+
+@pytest.mark.asyncio
+async def test_runner_direct_webhook_rejects_private_targets_without_posting(temp_db_path) -> None:
+    runner = EvaluationRunner(str(temp_db_path), max_concurrent_evals=1, eval_timeout=5)
+
+    with patch(
+        "tldw_Server_API.app.core.Evaluations.eval_runner.afetch",
+        new_callable=AsyncMock,
+    ) as mock_fetch:
+        mock_fetch.return_value = SimpleNamespace(status_code=200, text="ok")
+        await runner._send_webhook(
+            "http://127.0.0.1/webhook",
+            "run-private",
+            "eval-private",
+            "completed",
+            {"ok": True},
+        )
+
+    mock_fetch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_registered_webhook_delivery_uses_resolved_safe_target(temp_db_path, monkeypatch) -> None:
+    manager = WebhookManager(str(temp_db_path))
+    original_url = "http://attacker.test/webhook"
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    webhook = {
+        "id": 1,
+        "url": original_url,
+        "secret": "test-secret",
+        "retry_count": 1,
+        "timeout_seconds": 5,
+    }
+    payload = WebhookPayload(
+        event="evaluation.completed",
+        evaluation_id="eval-safe",
+        timestamp="2026-06-23T00:00:00+00:00",
+        data={"score": 1.0},
+    )
+
+    async def _ok_fetch(**kwargs):
+        return SimpleNamespace(status_code=200, text="ok")
+
+    with (
+        patch.object(manager, "_create_delivery_record", return_value=1),
+        patch.object(manager, "_update_delivery_record", MagicMock()),
+        patch.object(manager, "_update_webhook_stats", MagicMock()),
+        patch("tldw_Server_API.app.core.testing.is_test_mode", return_value=False),
+        patch(
+            "socket.getaddrinfo",
+            return_value=[(None, None, None, None, ("93.184.216.34", 80))],
+        ),
+        patch(
+            "tldw_Server_API.app.core.Evaluations.webhook_manager.afetch",
+            new=AsyncMock(side_effect=_ok_fetch),
+        ) as mock_fetch,
+    ):
+        await manager._deliver_webhook(webhook, payload)
+
+    mock_fetch.assert_awaited_once()
+    _, kwargs = mock_fetch.await_args
+    assert kwargs["url"] == "http://93.184.216.34/webhook"  # nosec B101
+    assert kwargs["headers"]["Host"] == "attacker.test"  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_registered_https_webhook_delivery_preserves_hostname_for_tls(temp_db_path, monkeypatch) -> None:
+    manager = WebhookManager(str(temp_db_path))
+    original_url = "https://example.test/webhook"
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    webhook = {
+        "id": 1,
+        "url": original_url,
+        "secret": "test-secret",
+        "retry_count": 1,
+        "timeout_seconds": 5,
+    }
+    payload = WebhookPayload(
+        event="evaluation.completed",
+        evaluation_id="eval-safe",
+        timestamp="2026-06-23T00:00:00+00:00",
+        data={"score": 1.0},
+    )
+
+    async def _ok_fetch(**kwargs):
+        return SimpleNamespace(status_code=200, text="ok")
+
+    with (
+        patch.object(manager, "_create_delivery_record", return_value=1),
+        patch.object(manager, "_update_delivery_record", MagicMock()),
+        patch.object(manager, "_update_webhook_stats", MagicMock()),
+        patch("tldw_Server_API.app.core.testing.is_test_mode", return_value=False),
+        patch(
+            "socket.getaddrinfo",
+            return_value=[(None, None, None, None, ("93.184.216.34", 443))],
+        ),
+        patch(
+            "tldw_Server_API.app.core.Evaluations.webhook_manager.afetch",
+            new=AsyncMock(side_effect=_ok_fetch),
+        ) as mock_fetch,
+    ):
+        await manager._deliver_webhook(webhook, payload)
+
+    mock_fetch.assert_awaited_once()
+    _, kwargs = mock_fetch.await_args
+    assert kwargs["url"] == original_url  # nosec B101
+    assert "Host" not in kwargs["headers"]  # nosec B101
+
+
+@pytest.mark.asyncio
+async def test_webhook_domain_filters_match_label_boundaries(monkeypatch) -> None:
+    validator = WebhookSecurityValidator()
+    monkeypatch.setattr(
+        "socket.getaddrinfo",
+        lambda *_args, **_kwargs: [(None, None, None, None, ("93.184.216.34", 80))],
+    )
+
+    validator.blocked_domains = {"example.com"}
+    validator.allowed_domains = set()
+    result = await validator.validate_webhook_url(
+        "http://badexample.com/webhook",
+        user_id="user-a",
+        check_connectivity=False,
+    )
+    assert result.valid  # nosec B101
+    assert not any(error.code == "BLOCKED_DOMAIN" for error in result.errors)  # nosec B101
+
+    validator.blocked_domains = set()
+    validator.allowed_domains = {".example.com"}
+    result = await validator.validate_webhook_url(
+        "http://badexample.com/webhook",
+        user_id="user-a",
+        check_connectivity=False,
+    )
+    assert not result.valid  # nosec B101
+    assert any(error.code == "DOMAIN_NOT_ALLOWED" for error in result.errors)  # nosec B101
+
+    result = await validator.validate_webhook_url(
+        "http://api.example.com/webhook",
+        user_id="user-a",
+        check_connectivity=False,
+    )
+    assert result.valid  # nosec B101
+    assert result.metadata["domain_status"] == "allowed"  # nosec B101
+
+
+def test_webhook_private_ip_check_handles_mixed_ip_versions() -> None:
+    validator = WebhookSecurityValidator()
+
+    validator._raise_if_private_ip(ipaddress.ip_address("2001:4860:4860::8888"))
+
+    with pytest.raises(ValueError, match="private IP"):
+        validator._raise_if_private_ip(ipaddress.ip_address("::1"))
+
+
+def test_postgresql_adapter_is_not_constructible_until_implemented() -> None:
+    with pytest.raises(ValueError, match="Unsupported database type"):
+        DatabaseAdapterFactory.create(
+            DatabaseConfig(
+                db_type=DatabaseType.POSTGRESQL,
+                connection_string="postgresql://user:pass@example.com/evaluations",
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_cost_reservation_is_atomic(tmp_path, monkeypatch) -> None:
+    limiter = UserRateLimiter(db_path=str(tmp_path / "rate_limits.db"))
+    user_id = "cost-user"
+    endpoint = "/api/v1/evaluations/geval"
+    await limiter.upgrade_user_tier(
+        user_id=user_id,
+        new_tier=UserTier.CUSTOM,
+        custom_limits={
+            "evaluations_per_minute": 100,
+            "batch_evaluations_per_minute": 100,
+            "evaluations_per_day": 100,
+            "total_tokens_per_day": 100_000,
+            "burst_size": 0,
+            "max_cost_per_day": 0.05,
+            "max_cost_per_month": 10.0,
+        },
+    )
+
+    barrier = asyncio.Event()
+    waiters = 0
+    original_record_request = limiter._record_request
+
+    async def _delayed_record_request(*args, **kwargs):
+        nonlocal waiters
+        waiters += 1
+        if waiters == 2:
+            barrier.set()
+        await asyncio.wait_for(barrier.wait(), timeout=1)
+        return await original_record_request(*args, **kwargs)
+
+    monkeypatch.setattr(limiter, "_record_request", _delayed_record_request)
+
+    results = await asyncio.gather(
+        limiter.check_rate_limit(user_id, endpoint, estimated_cost=0.04),
+        limiter.check_rate_limit(user_id, endpoint, estimated_cost=0.04),
+    )
+
+    allowed_count = sum(1 for allowed, _metadata in results if allowed)
+    denied_metadata = [metadata for allowed, metadata in results if not allowed]
+    assert allowed_count == 1  # nosec B101
+    assert len(denied_metadata) == 1  # nosec B101
+    assert denied_metadata[0]["error"] == "Daily cost limit exceeded"  # nosec B101
+
+
+def test_synthetic_workflow_requires_user_for_owner_scoped_operations(tmp_path) -> None:
+    db = EvaluationsDatabase(str(tmp_path / "evaluations.db"))
+    service = SyntheticEvalWorkflowService(db=db, user_id=None)
+
+    with pytest.raises(ValueError, match="user_id is required"):
+        service.list_queue()

--- a/tldw_Server_API/tests/Evaluations/test_recipe_runs_service.py
+++ b/tldw_Server_API/tests/Evaluations/test_recipe_runs_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 from typing import Any
 
 import pytest
@@ -18,6 +19,19 @@ from tldw_Server_API.app.core.Evaluations.recipe_runs_service import (
 from tldw_Server_API.app.core.Evaluations.recipes.base import RecipeDefinition
 from tldw_Server_API.app.core.Evaluations.recipes.registry import RecipeRegistry
 from tldw_Server_API.app.core.Evaluations.recipes.dataset_snapshot import build_dataset_content_hash
+
+
+@pytest.fixture
+def recipe_run_config_encryption_key(monkeypatch):
+    """Configure a deterministic BYOK encryption key for recipe-run config tests."""
+
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    monkeypatch.setenv("BYOK_ENCRYPTION_KEY", base64.b64encode(b"r" * 32).decode("ascii"))
+    monkeypatch.delenv("BYOK_SECONDARY_ENCRYPTION_KEY", raising=False)
+    reset_settings()
+    yield
+    reset_settings()
 
 
 def _inline_dataset() -> list[dict[str, Any]]:
@@ -1163,7 +1177,10 @@ def test_find_latest_completed_run_by_reuse_hash_does_not_refetch_full_record(tm
     assert record.status is RunStatus.COMPLETED
 
 
-def test_recipe_service_redacts_sensitive_run_config_in_public_metadata(tmp_path) -> None:
+def test_recipe_service_redacts_sensitive_run_config_in_public_metadata(
+    tmp_path,
+    recipe_run_config_encryption_key,
+) -> None:
     db, service, _ = _service(tmp_path)
     record = service.create_run(
         "rag_answer_quality",
@@ -1184,10 +1201,24 @@ def test_recipe_service_redacts_sensitive_run_config_in_public_metadata(tmp_path
 
     assert record.metadata["run_config"]["judge_config"]["api_key"] == "[REDACTED]"
     assert "run_config_internal" not in record.metadata
+    assert "run_config_encrypted" not in record.metadata
 
     raw_record = db.get_recipe_run(record.run_id)
     assert raw_record is not None
-    assert raw_record.metadata["run_config_internal"]["judge_config"]["api_key"] == "sk-judge-secret"
+    assert "run_config_internal" not in raw_record.metadata
+    assert "run_config_encrypted" in raw_record.metadata
+    raw_metadata = repr(raw_record.metadata)
+    assert "sk-judge-secret" not in raw_metadata
+    assert "sk-live-secret" not in raw_metadata
+    assert "ollama-local-secret" not in raw_metadata
+
+    from tldw_Server_API.app.core.Evaluations.recipe_runs_jobs_worker import (
+        _run_config_for_execution,
+    )
+
+    execution_config = _run_config_for_execution(raw_record)
+    assert execution_config["judge_config"]["api_key"] == "sk-judge-secret"
+    assert execution_config["candidate_api_keys"]["openai"] == "sk-live-secret"
 
 
 def test_recipe_service_get_run_rejects_other_users_run(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- Scope Evaluations dataset and synthetic draft operations by owner to prevent cross-user access.
- Harden webhook egress by resolving safe delivery targets, preserving Host headers, and fixing domain boundary matching.
- Surface persistence failures, avoid durable plaintext recipe-run secrets, remove the unimplemented PostgreSQL adapter from the default registry, and make cost reservation atomic.

## Verification
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Evaluations/test_evaluations_core_hardening.py tldw_Server_API/tests/Evaluations/test_recipe_runs_service.py::test_recipe_service_redacts_sensitive_run_config_in_public_metadata tldw_Server_API/tests/Evaluations/unit/test_user_rate_limiter_minute_exact_and_reset.py -q` -> 13 passed
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m bandit -r <touched Evaluations core files> -f json -o /tmp/bandit_evaluations_9935_clean_worktree.json` -> 0 results
- `git diff --check` -> passed

Backlog: TASK-9935

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Evaluations core to enforce tenant boundaries, secure webhook delivery, encrypt recipe-run secrets for safe retries, and make daily cost reservations atomic. Also raises on result persistence failures and removes the unimplemented `POSTGRESQL` adapter. Addresses TASK-9935.

- **Bug Fixes**
  - Enforce owner scoping for datasets and synthetic drafts/queue actions; block cross-user access.
  - Webhooks: resolve to validated public IPs, block private networks, fix domain-boundary matching; HTTP delivers to resolved IP with preserved Host; HTTPS preserves hostname for TLS; redirects disabled.
  - Encrypt secret-bearing recipe run configs with BYOK for durable storage; redact public metadata; workers decrypt for execution and fail if the key is missing.
  - Raise on evaluation result persistence failures.
  - Rate limiting: atomic daily cost reservation with UTC reset times; include cost_remaining in metadata.
  - Remove `DatabaseType.POSTGRESQL` from the factory until implemented.

- **Migration**
  - Configure BYOK via BYOK_ENCRYPTION_KEY so workers can decrypt stored recipe-run configs; do not rely on plaintext secrets in metadata.
  - Ensure webhook targets resolve to public IPs, use bare domains, and accept preserved Host headers (HTTP); HTTPS endpoints must present valid certs for their hostname.
  - If you used the factory with `POSTGRESQL`, switch to SQLite or implement a real adapter before re-enabling.

<sup>Written for commit 9fa008d6ecf108dedb9d5ab1ba38d04959370d74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

