### PR TITLE
Harden PrivilegeMaps review findings

### DIFF
--- a/Docs/superpowers/specs/2026-06-23-claims-extraction-hardening-refactor-design.md
+++ b/Docs/superpowers/specs/2026-06-23-claims-extraction-hardening-refactor-design.md
@@ -1,0 +1,76 @@
+# Claims_Extraction Hardening and Refactor Design
+
+## Goal
+
+Harden the validated Claims_Extraction review findings with focused regression tests, then prepare a staged refactor plan that reduces module coupling without changing the public API surface.
+
+Backlog task: TASK-9934.
+
+## Validated Findings
+
+The hardening pass addresses these current-code findings:
+
+- Rebuild workers soft-delete existing claims before replacement storage succeeds.
+- Shared claims exception tuples include `asyncio.CancelledError`, allowing cancellation to be swallowed.
+- Ingestion LLM timeout uses a `ThreadPoolExecutor` context that still waits for stuck workers during shutdown.
+- Runtime config resolvers bound minimum values but not the same maximum values enforced by the settings API.
+- Review notification HTML interpolates claim text and metadata without escaping.
+- Claims dashboard analytics accepts an owner scope but does not apply it consistently.
+- FVA adjudication score metrics run in the branch where no adjudication exists.
+- Notification webhook retries spawn daemon threads without local backpressure.
+
+## Hardening Design
+
+The fix pass stays narrow and behavior-focused. It adds failing regression tests before production changes and avoids broad file moves.
+
+Rebuild replacement will fail closed. If non-empty extraction produces zero stored claims, the rebuild task will raise and be counted as failed instead of deleting active claims and logging success. Where possible, delete and insert should run under one Media DB transaction or a DB helper that preserves old active claims until replacement storage is confirmed.
+
+Cancellation handling will remove `asyncio.CancelledError` from Claims_Extraction noncritical exception tuples. Async paths that encounter cancellation will re-raise it instead of falling back to heuristic extraction, default verification, or empty analytics payloads.
+
+The LLM timeout path will avoid `ThreadPoolExecutor` context-manager shutdown semantics after timeout. The implementation should either use a provider/client timeout or explicitly shut down the executor with `wait=False` and `cancel_futures=True` so the caller returns promptly.
+
+Runtime safety will enforce a maximum context window and extraction pass count in `runtime_config`, matching the settings service caps. This protects direct config and environment paths, not only API updates.
+
+Review notification email HTML will escape all interpolated values with `html.escape`. Plain text bodies remain readable and unescaped.
+
+Dashboard analytics will apply owner scope consistently to claims, review-log, per-media, and orphan-cluster queries. In single-user SQLite paths this should preserve current results; in shared/admin paths it prevents ambiguous cross-owner totals.
+
+FVA metrics will record adjudication scores only after adjudication exists. The no-anti-context branch will only count wasted falsification.
+
+Notification dispatch will use a small bounded local dispatcher for the immediate fix. Full Jobs/Scheduler migration is deferred to the refactor plan because it changes operational contracts and persistence expectations.
+
+## Refactor Direction
+
+The follow-up refactor should split by responsibility while keeping imports and endpoint behavior stable:
+
+- `claims_analytics_service.py`: dashboard aggregation, status trends, latency, per-media stats, cluster analytics, and owner-scope SQL helpers.
+- `claims_notification_dispatcher.py`: review and alert notification dispatch, bounded retry execution, and delivery helpers.
+- `claims_rebuild_orchestrator.py`: rebuild task orchestration and atomic replacement semantics.
+- `claims_runtime_limits.py` or expanded `runtime_config.py`: shared bounds and config normalization for extraction runtime settings.
+
+`claims_service.py` should remain the public service facade during the first refactor stage. Endpoint modules should not need new imports until the extracted helpers are stable.
+
+## Testing Design
+
+Regression tests should extend existing Claims tests rather than create a new harness:
+
+- Rebuild tests in `tldw_Server_API/tests/Claims/test_claims_rebuild_service_failure.py`.
+- Runtime config bounds in `tldw_Server_API/tests/Claims/test_claims_runtime_config.py`.
+- Review notification escaping and dispatcher behavior in `tldw_Server_API/tests/Claims/test_claims_review_notifications.py`.
+- Dashboard owner scoping in `tldw_Server_API/tests/Claims/test_claims_dashboard_analytics.py`.
+- FVA metric branch behavior in `tldw_Server_API/tests/Claims_Extraction/test_fva_pipeline.py`.
+- Cancellation propagation tests near the claims engine/service paths they exercise.
+- Timeout behavior with a fake executor or provider call that proves the function returns after timeout without waiting for the worker body to finish.
+
+Touched code must run targeted pytest checks, Bandit on the touched Claims_Extraction scope, and any narrower tests needed by changed DB helpers.
+
+## Out of Scope
+
+This pass does not rename public API endpoints, change claim schemas, rewrite extraction strategies, or migrate notification delivery to Jobs. Those are follow-up refactor tasks once the hardened behavior is verified.
+
+## Spec Review
+
+- Placeholder scan: no placeholders remain.
+- Consistency check: the hardening design and testing design cover each validated finding.
+- Scope check: the immediate fix pass is separate from the larger refactor.
+- Ambiguity check: notification delivery uses a bounded local dispatcher now; Jobs migration is deferred.

--- a/IMPLEMENTATION_PLAN_privilege_maps_review_hardening_2422.md
+++ b/IMPLEMENTATION_PLAN_privilege_maps_review_hardening_2422.md
@@ -1,0 +1,25 @@
+# PrivilegeMaps Review Hardening Implementation Plan
+
+## Stage 1: Transaction Portability
+**Goal**: Make snapshot and trend writes safe on PostgreSQL-backed AuthNZ pools.
+**Success Criteria**: Transaction-scoped SQL uses backend-appropriate placeholders; focused tests prove no raw `?` placeholders reach asyncpg-style connections.
+**Tests**: Add unit coverage in `tldw_Server_API/tests/Privileges/test_privilege_snapshot_store.py` and `tldw_Server_API/tests/Privileges/test_privilege_trends.py` with fake PostgreSQL transaction connections.
+**Status**: Complete
+
+## Stage 2: Effective Permission Semantics
+**Goal**: Align PrivilegeMaps user hydration with AuthNZ RBAC semantics.
+**Success Criteria**: Expired roles are ignored, expired direct permission overrides are ignored, explicit deny overrides subtract role-derived permissions, and multi-user fetch failures fail closed instead of synthesizing admin data.
+**Tests**: Extend `tldw_Server_API/tests/Privileges/test_privilege_service_sqlite.py` for expired/denied permissions and multi-user failure behavior.
+**Status**: Complete
+
+## Stage 3: Scope, Snapshot, and Detail Safety
+**Goal**: Fix privilege-map scoping and bounded output behavior.
+**Success Criteria**: Inactive org/team memberships are excluded, sync snapshot IDs are collision-resistant, org trend snapshots carry org scope, detail generation stops before unbounded matrix materialization, and unused role helper code is removed.
+**Tests**: Extend `tldw_Server_API/tests/Privileges/test_privilege_service_sqlite.py`, `tldw_Server_API/tests/Privileges/test_privilege_endpoints.py`, and service unit coverage for pagination caps and org trend metadata.
+**Status**: Complete
+
+## Stage 4: Verification and Tracking
+**Goal**: Prove the fixes and record closeout.
+**Success Criteria**: Focused tests pass, Bandit runs on touched Python files, Backlog task `TASK-2422` records verification and final summary.
+**Tests**: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Privileges -v`; targeted tests first during TDD; Bandit on touched Python files.
+**Status**: Complete

--- a/backlog/tasks/task-2422 - Harden-PrivilegeMaps-module-review-findings.md
+++ b/backlog/tasks/task-2422 - Harden-PrivilegeMaps-module-review-findings.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-2422
 title: Harden PrivilegeMaps module review findings
-status: In Progress
+status: Done
 assignee: []
 created_date: 2026-06-23 18:26
-updated_date: 2026-06-24 19:40
+updated_date: 2026-06-24 19:49
 labels:
 - authnz
 - privilege-maps
@@ -16,6 +16,12 @@ references:
 - tldw_Server_API/app/core/PrivilegeMaps/trends.py
 - tldw_Server_API/app/api/v1/endpoints/privileges.py
 priority: high
+modified_files:
+- tldw_Server_API/app/core/PrivilegeMaps/db_utils.py
+- tldw_Server_API/app/core/PrivilegeMaps/service.py
+- tldw_Server_API/tests/Privileges/test_privilege_endpoints.py
+- tldw_Server_API/tests/Privileges/test_privilege_service_sqlite.py
+- tldw_Server_API/tests/Privileges/test_privilege_snapshot_store.py
 ---
 
 ## Description
@@ -70,4 +76,10 @@ Hardened PrivilegeMaps against the review findings: transaction writes now norma
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Reopened to address PR #2461 review comments after initial push: rebase on latest dev, harden placeholder conversion around literal question marks, treat NULL active flags as inactive, clean up endpoint test formatting, and respond to the DB_Management boundary comment.
+PR #2461 follow-up verification completed after rebasing on latest dev:
+- source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Privileges/test_privilege_service_sqlite.py tldw_Server_API/tests/Privileges/test_privilege_snapshot_store.py tldw_Server_API/tests/Privileges/test_privilege_trends.py tldw_Server_API/tests/Privileges/test_privilege_role_normalization.py -q -> 15 passed
+- source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Privileges -q -> 42 passed
+- source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/PrivilegeMaps tldw_Server_API/app/api/v1/endpoints/privileges.py -f json -o /tmp/bandit_privilege_maps_2422_pr2461.json -> 0 findings
+- git diff --check -> clean
+Resolved review comments: robust PostgreSQL placeholder conversion skips SQL literals/identifiers/comments, NULL active flags are treated as inactive for users/teams/orgs, endpoint test signature was formatted. DB_Management boundary comment was addressed with PR discussion because a full PrivilegeMaps persistence relocation is broader than this hardening PR.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-2422 - Harden-PrivilegeMaps-module-review-findings.md
+++ b/backlog/tasks/task-2422 - Harden-PrivilegeMaps-module-review-findings.md
@@ -1,0 +1,67 @@
+---
+id: TASK-2422
+title: Harden PrivilegeMaps module review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 18:26'
+updated_date: '2026-06-23 18:58'
+labels:
+  - authnz
+  - privilege-maps
+  - review-fix
+dependencies: []
+references:
+  - tldw_Server_API/app/core/PrivilegeMaps/service.py
+  - tldw_Server_API/app/core/PrivilegeMaps/snapshots.py
+  - tldw_Server_API/app/core/PrivilegeMaps/trends.py
+  - tldw_Server_API/app/api/v1/endpoints/privileges.py
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address code review findings in PrivilegeMaps: Postgres-safe snapshot/trend writes, RBAC parity for effective permissions, fail-closed user fetch behavior, collision-safe snapshot IDs, active membership filtering, bounded detail generation, org-scoped trends, and removal of an unused helper.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+- [x] #7 Focused tests pass.
+- [x] #8 Bandit runs on touched Python files.
+- [x] #9 Backlog task records verification and final summary.
+<!-- DOD:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Postgres-backed snapshot and trend stores use normalized parameter handling inside transactions.
+- [x] #2 PrivilegeMaps effective permissions honor expired roles, expired overrides, and explicit deny overrides.
+- [x] #3 Multi-user DB failures do not fall back to synthetic admin/full-scope privilege data.
+- [x] #4 Snapshot creation uses collision-safe IDs and no longer overwrites concurrent sync snapshots.
+- [x] #5 Org/team maps ignore inactive memberships and inactive teams/orgs.
+- [x] #6 Detail views avoid unbounded matrix materialization beyond the configured cap.
+- [x] #7 Org trend history is scoped by org_id when org filters are used.
+- [x] #8 Unused PrivilegeMapService role helper is removed.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation plan: IMPLEMENTATION_PLAN_privilege_maps_review_hardening_2422.md
+
+Verification completed:
+- source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Privileges -q -> 40 passed
+- source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/PrivilegeMaps tldw_Server_API/app/api/v1/endpoints/privileges.py -f json -o /tmp/bandit_privilege_maps_2422.json -> 0 findings
+Known skips/blockers: none.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened PrivilegeMaps against the review findings: transaction writes now normalize placeholders for raw PostgreSQL transactions; effective permissions honor expiry and explicit denies; multi-user loading fails closed; sync snapshot IDs are UUID-based; org/team filters ignore inactive memberships/entities; detail generation caps materialization; org trends carry org_id; the unused role helper was removed. Added regression coverage across service, endpoint, snapshot, trend, and role-resolution tests.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-2422 - Harden-PrivilegeMaps-module-review-findings.md
+++ b/backlog/tasks/task-2422 - Harden-PrivilegeMaps-module-review-findings.md
@@ -1,20 +1,20 @@
 ---
 id: TASK-2422
 title: Harden PrivilegeMaps module review findings
-status: Done
+status: In Progress
 assignee: []
-created_date: '2026-06-23 18:26'
-updated_date: '2026-06-23 18:58'
+created_date: 2026-06-23 18:26
+updated_date: 2026-06-24 19:40
 labels:
-  - authnz
-  - privilege-maps
-  - review-fix
+- authnz
+- privilege-maps
+- review-fix
 dependencies: []
 references:
-  - tldw_Server_API/app/core/PrivilegeMaps/service.py
-  - tldw_Server_API/app/core/PrivilegeMaps/snapshots.py
-  - tldw_Server_API/app/core/PrivilegeMaps/trends.py
-  - tldw_Server_API/app/api/v1/endpoints/privileges.py
+- tldw_Server_API/app/core/PrivilegeMaps/service.py
+- tldw_Server_API/app/core/PrivilegeMaps/snapshots.py
+- tldw_Server_API/app/core/PrivilegeMaps/trends.py
+- tldw_Server_API/app/api/v1/endpoints/privileges.py
 priority: high
 ---
 
@@ -65,3 +65,9 @@ Known skips/blockers: none.
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Hardened PrivilegeMaps against the review findings: transaction writes now normalize placeholders for raw PostgreSQL transactions; effective permissions honor expiry and explicit denies; multi-user loading fails closed; sync snapshot IDs are UUID-based; org/team filters ignore inactive memberships/entities; detail generation caps materialization; org trends carry org_id; the unused role helper was removed. Added regression coverage across service, endpoint, snapshot, trend, and role-resolution tests.
 <!-- SECTION:FINAL_SUMMARY:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Reopened to address PR #2461 review comments after initial push: rebase on latest dev, harden placeholder conversion around literal question marks, treat NULL active flags as inactive, clean up endpoint test formatting, and respond to the DB_Management boundary comment.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-9934 - Harden-Claims_Extraction-review-findings-and-refactor-design.md
+++ b/backlog/tasks/task-9934 - Harden-Claims_Extraction-review-findings-and-refactor-design.md
@@ -1,0 +1,41 @@
+---
+id: TASK-9934
+title: Harden Claims_Extraction review findings and refactor design
+status: In Progress
+assignee: []
+created_date: '2026-06-23 21:39'
+labels:
+  - claims
+  - review-hardening
+  - refactor
+dependencies: []
+references:
+  - tldw_Server_API/app/core/Claims_Extraction
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and address validated Claims_Extraction review findings, then capture a focused refactor design for the module.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Validated review findings are covered by failing-first regression tests before production changes.
+- [ ] #2 Rebuild storage failure cannot soft-delete existing claims and report success.
+- [ ] #3 Claims cancellation propagates instead of being swallowed by noncritical exception handling.
+- [ ] #4 LLM extraction timeout returns promptly without waiting on stuck worker shutdown.
+- [ ] #5 Runtime limits, HTML escaping, analytics scoping, FVA metrics, and notification dispatch reliability are hardened.
+- [ ] #6 A focused Claims_Extraction refactor design spec is written for follow-up modularization.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/privileges.py
+++ b/tldw_Server_API/app/api/v1/endpoints/privileges.py
@@ -498,7 +498,7 @@ async def create_privilege_snapshot(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
     generated_at = datetime.now(timezone.utc)
-    snapshot_id = f"snap-{generated_at.strftime('%Y%m%d-%H%M%S')}"
+    snapshot_id = f"snap-{uuid4()}"
     summary_model = PrivilegeSnapshotSummary(**summary_data)
     detail_items = service.build_snapshot_detail(
         snapshot_users,

--- a/tldw_Server_API/app/core/PrivilegeMaps/db_utils.py
+++ b/tldw_Server_API/app/core/PrivilegeMaps/db_utils.py
@@ -10,16 +10,78 @@ def _uses_postgres(pool: Any) -> bool:
 
 
 def _question_marks_to_dollar_params(query: str, param_count: int) -> str:
-    if "?" not in query or "$" in query:
+    if "?" not in query:
         return query
-    if query.count("?") != param_count:
-        return query
-    parts = query.split("?")
+
     rebuilt: list[str] = []
-    for index, part in enumerate(parts[:-1], start=1):
-        rebuilt.append(part)
-        rebuilt.append(f"${index}")
-    rebuilt.append(parts[-1])
+    placeholder_index = 0
+    index = 0
+    length = len(query)
+
+    while index < length:
+        char = query[index]
+
+        if char == "'":
+            start = index
+            index += 1
+            while index < length:
+                if query[index] == "'":
+                    if index + 1 < length and query[index + 1] == "'":
+                        index += 2
+                        continue
+                    index += 1
+                    break
+                index += 1
+            rebuilt.append(query[start:index])
+            continue
+
+        if char == '"':
+            start = index
+            index += 1
+            while index < length:
+                if query[index] == '"':
+                    if index + 1 < length and query[index + 1] == '"':
+                        index += 2
+                        continue
+                    index += 1
+                    break
+                index += 1
+            rebuilt.append(query[start:index])
+            continue
+
+        if char == "-" and index + 1 < length and query[index + 1] == "-":
+            start = index
+            index += 2
+            while index < length and query[index] not in "\r\n":
+                index += 1
+            rebuilt.append(query[start:index])
+            continue
+
+        if char == "/" and index + 1 < length and query[index + 1] == "*":
+            start = index
+            index += 2
+            while index + 1 < length:
+                if query[index] == "*" and query[index + 1] == "/":
+                    index += 2
+                    break
+                index += 1
+            rebuilt.append(query[start:index])
+            continue
+
+        if char == "$" and index + 1 < length and query[index + 1].isdigit():
+            return query
+
+        if char == "?":
+            placeholder_index += 1
+            rebuilt.append(f"${placeholder_index}")
+            index += 1
+            continue
+
+        rebuilt.append(char)
+        index += 1
+
+    if placeholder_index != param_count:
+        return query
     return "".join(rebuilt)
 
 

--- a/tldw_Server_API/app/core/PrivilegeMaps/db_utils.py
+++ b/tldw_Server_API/app/core/PrivilegeMaps/db_utils.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+
+def _uses_postgres(pool: Any) -> bool:
+    backend_type = str(getattr(pool, "backend_type", "") or "").lower()
+    return backend_type == "postgres" or getattr(pool, "pool", None) is not None
+
+
+def _question_marks_to_dollar_params(query: str, param_count: int) -> str:
+    if "?" not in query or "$" in query:
+        return query
+    if query.count("?") != param_count:
+        return query
+    parts = query.split("?")
+    rebuilt: list[str] = []
+    for index, part in enumerate(parts[:-1], start=1):
+        rebuilt.append(part)
+        rebuilt.append(f"${index}")
+    rebuilt.append(parts[-1])
+    return "".join(rebuilt)
+
+
+async def execute_transaction_sql(
+    pool: Any,
+    conn: Any,
+    query: str,
+    params: Sequence[Any] | None = None,
+) -> Any:
+    """Execute SQL on a raw transaction connection with backend-aware placeholders."""
+    if params is None:
+        return await conn.execute(query)
+
+    param_tuple = tuple(params)
+    if _uses_postgres(pool):
+        query = _question_marks_to_dollar_params(query, len(param_tuple))
+        return await conn.execute(query, *param_tuple)
+    return await conn.execute(query, param_tuple)

--- a/tldw_Server_API/app/core/PrivilegeMaps/service.py
+++ b/tldw_Server_API/app/core/PrivilegeMaps/service.py
@@ -14,7 +14,7 @@ from loguru import logger
 from tldw_Server_API.app.api.v1.utils.pagination import build_page_pagination_meta
 from tldw_Server_API.app.core.AuthNZ.database import DatabasePool, get_db_pool
 from tldw_Server_API.app.core.AuthNZ.privilege_catalog import PrivilegeCatalog, ScopeEntry, load_catalog
-from tldw_Server_API.app.core.AuthNZ.settings import is_single_user_profile_mode
+from tldw_Server_API.app.core.AuthNZ.settings import is_single_user_mode, is_single_user_profile_mode
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import get_single_user_instance
 from tldw_Server_API.app.core.PrivilegeMaps.cache import get_privilege_cache
 from tldw_Server_API.app.core.PrivilegeMaps.introspection import (
@@ -135,14 +135,17 @@ class PrivilegeMapService:
         scope: str,
         group_by: str,
         team_id: str | None,
+        org_id: str | None,
         users_signature: str,
     ) -> str:
         team_component = str(team_id or "__none__")
+        org_component = str(org_id or "__none__")
         return "::".join(
             [
                 scope,
                 group_by,
                 team_component,
+                org_component,
                 users_signature,
                 self._route_signature,
                 self.catalog.version,
@@ -188,6 +191,7 @@ class PrivilegeMapService:
             scope="org",
             group_by=group_by,
             team_id=None,
+            org_id=org_id,
             users_signature=users_signature,
         )
         cached = self._summary_cache.get(cache_key)
@@ -213,6 +217,7 @@ class PrivilegeMapService:
                     buckets=buckets,
                     generated_at=generated_at,
                     team_id=None,
+                    org_id=org_id,
                 )
             except _PRIVILEGE_MAP_NONCRITICAL_EXCEPTIONS as exc:
                 logger.debug("Unable to record privilege trend snapshot: {}", exc)
@@ -228,6 +233,7 @@ class PrivilegeMapService:
                 generated_at=generated_at,
                 since=since,
                 team_id=None,
+                org_id=org_id,
             )
 
         return {
@@ -241,6 +247,7 @@ class PrivilegeMapService:
                     "group_by": group_by,
                     "include_trends": include_trends,
                     "since": since.isoformat() if since else None,
+                    "org_id": org_id,
                 }
             },
         }
@@ -277,6 +284,7 @@ class PrivilegeMapService:
             scope="team",
             group_by=group_by,
             team_id=team_id,
+            org_id=None,
             users_signature=users_signature,
         )
         cached = self._summary_cache.get(cache_key)
@@ -300,6 +308,7 @@ class PrivilegeMapService:
                     buckets=buckets,
                     generated_at=generated_at,
                     team_id=team_id,
+                    org_id=None,
                 )
             except _PRIVILEGE_MAP_NONCRITICAL_EXCEPTIONS as exc:
                 logger.debug("Unable to record team privilege trend snapshot: {}", exc)
@@ -315,6 +324,7 @@ class PrivilegeMapService:
                 generated_at=generated_at,
                 since=since,
                 team_id=team_id,
+                org_id=None,
             )
 
         return {
@@ -533,7 +543,7 @@ class PrivilegeMapService:
             base_users: dict[str, dict[str, Any]] = {}
             for row in rows:
                 record = self._row_to_dict(row)
-                if not record or not record.get("is_active", 1):
+                if not record or not self._truthy(record.get("is_active", 1)):
                     continue
                 user_id = str(record.get("id"))
                 base_users[user_id] = {
@@ -553,8 +563,13 @@ class PrivilegeMapService:
                 roles = payload.get("roles") or [payload.get("primary_role")]
                 roles = sorted({role for role in roles if role})
                 permissions = {perm for perm in payload.get("permissions", set()) if perm}
+                denied_permissions = {perm for perm in payload.get("denied_permissions", set()) if perm}
                 feature_flags = self._feature_flags_for_user(roles, permissions)
-                allowed_scopes = self._resolve_scopes_for_user(roles, permissions)
+                allowed_scopes = self._resolve_scopes_for_user(
+                    roles,
+                    permissions,
+                    denied_permissions=denied_permissions,
+                )
                 primary_role = roles[0] if roles else payload.get("primary_role", "user")
                 users.append(
                     {
@@ -565,10 +580,14 @@ class PrivilegeMapService:
                         "permissions": sorted(permissions),
                         "feature_flags": feature_flags,
                         "allowed_scopes": allowed_scopes,
+                        "denied_permissions": sorted(denied_permissions),
                     }
                 )
             return users
         except _PRIVILEGE_MAP_NONCRITICAL_EXCEPTIONS as exc:
+            if not is_single_user_mode():
+                logger.warning("Unable to load multi-user privilege dataset: {}", exc)
+                raise
             logger.debug("Falling back to single-user privilege dataset: {}", exc)
 
         # Fallback: single-user-style profile or empty DB
@@ -600,7 +619,8 @@ class PrivilegeMapService:
             rows = await pool.fetchall(
                 """
                 SELECT tm.team_id, tm.user_id, tm.role AS membership_role,
-                       t.name AS team_name, t.org_id
+                       tm.status AS membership_status,
+                       t.name AS team_name, t.org_id, t.is_active AS team_is_active
                 FROM team_members tm
                 JOIN teams t ON tm.team_id = t.id
                 """
@@ -608,7 +628,11 @@ class PrivilegeMapService:
             memberships: list[dict[str, Any]] = []
             for row in rows:
                 record = self._row_to_dict(row)
-                if record:
+                if (
+                    record
+                    and self._is_active_status(record.get("membership_status"))
+                    and self._truthy(record.get("team_is_active", 1))
+                ):
                     memberships.append(record)
             return memberships
         except _PRIVILEGE_MAP_NONCRITICAL_EXCEPTIONS as exc:
@@ -620,14 +644,21 @@ class PrivilegeMapService:
             pool: DatabasePool = await get_db_pool()
             rows = await pool.fetchall(
                 """
-                SELECT om.org_id, om.user_id, om.role AS membership_role
+                SELECT om.org_id, om.user_id, om.role AS membership_role,
+                       om.status AS membership_status,
+                       o.is_active AS org_is_active
                 FROM org_members om
+                JOIN organizations o ON om.org_id = o.id
                 """
             )
             memberships: list[dict[str, Any]] = []
             for row in rows:
                 record = self._row_to_dict(row)
-                if record:
+                if (
+                    record
+                    and self._is_active_status(record.get("membership_status"))
+                    and self._truthy(record.get("org_is_active", 1))
+                ):
                     memberships.append(record)
             return memberships
         except _PRIVILEGE_MAP_NONCRITICAL_EXCEPTIONS as exc:
@@ -675,7 +706,7 @@ class PrivilegeMapService:
         try:
             rows = await pool.fetchall(
                 """
-                SELECT ur.user_id, r.name AS role_name
+                SELECT ur.user_id, r.name AS role_name, ur.expires_at
                 FROM user_roles ur
                 JOIN roles r ON ur.role_id = r.id
                 """
@@ -686,7 +717,11 @@ class PrivilegeMapService:
                     continue
                 user_id = str(record.get("user_id"))
                 role_name = record.get("role_name")
-                if user_id in base_users and role_name:
+                if (
+                    user_id in base_users
+                    and role_name
+                    and self._not_expired(record.get("expires_at"))
+                ):
                     role_assignments[user_id].add(role_name)
         except _PRIVILEGE_MAP_NONCRITICAL_EXCEPTIONS as exc:
             logger.debug("Unable to load role assignments: {}", exc)
@@ -712,11 +747,12 @@ class PrivilegeMapService:
         except _PRIVILEGE_MAP_NONCRITICAL_EXCEPTIONS as exc:
             logger.debug("Unable to load role permissions: {}", exc)
 
-        user_permissions_direct: dict[str, set[str]] = defaultdict(set)
+        user_permissions_allow: dict[str, set[str]] = defaultdict(set)
+        user_permissions_deny: dict[str, set[str]] = defaultdict(set)
         try:
             rows = await pool.fetchall(
                 """
-                SELECT up.user_id, p.name AS permission_name, up.granted
+                SELECT up.user_id, p.name AS permission_name, up.granted, up.expires_at
                 FROM user_permissions up
                 JOIN permissions p ON up.permission_id = p.id
                 """
@@ -725,23 +761,29 @@ class PrivilegeMapService:
                 record = self._row_to_dict(row)
                 if not record:
                     continue
-                granted = record.get("granted")
-                if granted is not None and not bool(granted):
-                    continue
                 user_id = str(record.get("user_id"))
                 permission_name = record.get("permission_name")
-                if user_id in base_users and permission_name:
-                    user_permissions_direct[user_id].add(permission_name)
+                if user_id not in base_users or not permission_name:
+                    continue
+                if not self._not_expired(record.get("expires_at")):
+                    continue
+                if self._truthy(record.get("granted"), default=True):
+                    user_permissions_allow[user_id].add(permission_name)
+                else:
+                    user_permissions_deny[user_id].add(permission_name)
         except _PRIVILEGE_MAP_NONCRITICAL_EXCEPTIONS as exc:
             logger.debug("Unable to load direct user permissions: {}", exc)
 
         for user_id, payload in base_users.items():
             roles = sorted(role_assignments.get(user_id, set())) or [payload.get("primary_role")]
             payload["roles"] = roles
-            perms: set[str] = set(user_permissions_direct.get(user_id, set()))
+            perms: set[str] = set(user_permissions_allow.get(user_id, set()))
             for role in roles:
                 perms.update(role_permissions.get(role, set()))
+            denied_permissions = set(user_permissions_deny.get(user_id, set()))
+            perms.difference_update(denied_permissions)
             payload["permissions"] = perms
+            payload["denied_permissions"] = denied_permissions
 
     def _feature_flags_for_user(
         self,
@@ -777,13 +819,20 @@ class PrivilegeMapService:
         self,
         roles: Sequence[str],
         permissions: Sequence[str],
+        *,
+        denied_permissions: Sequence[str] | None = None,
     ) -> set[str]:
         normalized_roles = [role.lower() for role in roles if role]
         role_set = set(normalized_roles)
         perm_set = {perm.lower() for perm in permissions if perm}
+        denied_perm_set = {perm.lower() for perm in denied_permissions or () if perm}
 
         if role_set & self._admin_roles:
-            return {scope.id for scope in self.catalog.scopes}
+            return {
+                scope.id
+                for scope in self.catalog.scopes
+                if not (denied_perm_set & self._permission_candidates_for_scope(scope.id))
+            }
 
         allowed: set[str] = set()
         for scope in self.catalog.scopes:
@@ -797,20 +846,24 @@ class PrivilegeMapService:
                     break
 
             if not granted:
-                candidate_permissions = {
-                    scope.id.lower(),
-                    scope.id.replace(".", "_").lower(),
-                    f"scope:{scope.id}".lower(),
-                    f"scope.{scope.id}".lower(),
-                    f"{scope.id}:read".lower(),
-                    f"{scope.id}:write".lower(),
-                }
+                candidate_permissions = self._permission_candidates_for_scope(scope.id)
                 if perm_set & candidate_permissions:
                     granted = True
 
-            if granted:
+            if granted and not (denied_perm_set & self._permission_candidates_for_scope(scope.id)):
                 allowed.add(scope.id)
         return allowed
+
+    @staticmethod
+    def _permission_candidates_for_scope(scope_id: str) -> set[str]:
+        return {
+            scope_id.lower(),
+            scope_id.replace(".", "_").lower(),
+            f"scope:{scope_id}".lower(),
+            f"scope.{scope_id}".lower(),
+            f"{scope_id}:read".lower(),
+            f"{scope_id}:write".lower(),
+        }
 
     def _scopes_from_ids(self, scope_ids: Sequence[str]) -> list[ScopeEntry]:
         return [self._scope_lookup[sid] for sid in scope_ids if sid in self._scope_lookup]
@@ -951,14 +1004,6 @@ class PrivilegeMapService:
             )
         return results
 
-    def _scopes_for_role(self, role: str | None) -> list[ScopeEntry]:
-        normalized = (role or "user").lower()
-        if normalized in self._admin_roles:
-            return list(self.catalog.scopes)
-        if normalized in self._role_scope_map:
-            return self._role_scope_map[normalized]
-        return []
-
     def _build_detail_items(
         self,
         users: Sequence[dict[str, Any]],
@@ -1024,6 +1069,13 @@ class PrivilegeMapService:
                         source_module = None
                         if route_meta.endpoint:
                             source_module = route_meta.endpoint.rsplit(".", 1)[0]
+
+                        if len(items) >= MAX_DETAIL_ROWS:
+                            logger.warning(
+                                "Privilege detail generation reached configured cap of {} rows",
+                                MAX_DETAIL_ROWS,
+                            )
+                            return items
 
                         items.append(
                             {
@@ -1092,6 +1144,7 @@ class PrivilegeMapService:
         buckets: Sequence[dict[str, Any]],
         generated_at: datetime,
         team_id: str | None,
+        org_id: str | None,
     ) -> None:
         if not buckets:
             return
@@ -1103,6 +1156,7 @@ class PrivilegeMapService:
             generated_at=normalized_ts,
             buckets=buckets,
             team_id=team_id,
+            org_id=org_id,
         )
 
     async def _build_trends(
@@ -1114,6 +1168,7 @@ class PrivilegeMapService:
         generated_at: datetime,
         since: datetime | None,
         team_id: str | None,
+        org_id: str | None,
     ) -> list[dict[str, Any]]:
         if not buckets:
             return []
@@ -1141,10 +1196,47 @@ class PrivilegeMapService:
                 window_start=window_start,
                 window_end=window_end,
                 team_id=team_id,
+                org_id=org_id,
             )
         except _PRIVILEGE_MAP_NONCRITICAL_EXCEPTIONS as exc:
             logger.debug("Privilege trend computation failed: {}", exc)
             return []
+
+    @staticmethod
+    def _truthy(value: Any, *, default: bool = True) -> bool:
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            return value != 0
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if not normalized:
+                return default
+            return normalized not in {"0", "false", "f", "no", "n", "off", "inactive", "disabled"}
+        return bool(value)
+
+    @staticmethod
+    def _is_active_status(value: Any) -> bool:
+        return str(value or "active").strip().lower() == "active"
+
+    @classmethod
+    def _not_expired(cls, value: Any) -> bool:
+        if value is None:
+            return True
+        if isinstance(value, datetime):
+            expires_at = value
+        else:
+            raw = str(value).strip()
+            if not raw:
+                return True
+            try:
+                expires_at = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            except _PRIVILEGE_MAP_COERCE_EXCEPTIONS:
+                return False
+        expires_at = cls._normalize_timestamp(expires_at)
+        return expires_at > datetime.now(timezone.utc)
 
     def _build_recommended_actions(
         self, items: Sequence[dict[str, Any]]

--- a/tldw_Server_API/app/core/PrivilegeMaps/service.py
+++ b/tldw_Server_API/app/core/PrivilegeMaps/service.py
@@ -543,7 +543,10 @@ class PrivilegeMapService:
             base_users: dict[str, dict[str, Any]] = {}
             for row in rows:
                 record = self._row_to_dict(row)
-                if not record or not self._truthy(record.get("is_active", 1)):
+                if not record or not self._truthy(
+                    record.get("is_active", 1),
+                    default=False,
+                ):
                     continue
                 user_id = str(record.get("id"))
                 base_users[user_id] = {
@@ -631,7 +634,7 @@ class PrivilegeMapService:
                 if (
                     record
                     and self._is_active_status(record.get("membership_status"))
-                    and self._truthy(record.get("team_is_active", 1))
+                    and self._truthy(record.get("team_is_active", 1), default=False)
                 ):
                     memberships.append(record)
             return memberships
@@ -657,7 +660,7 @@ class PrivilegeMapService:
                 if (
                     record
                     and self._is_active_status(record.get("membership_status"))
-                    and self._truthy(record.get("org_is_active", 1))
+                    and self._truthy(record.get("org_is_active", 1), default=False)
                 ):
                     memberships.append(record)
             return memberships

--- a/tldw_Server_API/app/core/PrivilegeMaps/snapshots.py
+++ b/tldw_Server_API/app/core/PrivilegeMaps/snapshots.py
@@ -12,6 +12,7 @@ from loguru import logger
 from tldw_Server_API.app.api.v1.utils.pagination import build_page_pagination_meta
 from tldw_Server_API.app.core.AuthNZ.database import DatabasePool, get_db_pool
 from tldw_Server_API.app.core.AuthNZ.exceptions import TransactionError
+from tldw_Server_API.app.core.PrivilegeMaps.db_utils import execute_transaction_sql
 
 MAX_SNAPSHOT_DETAIL_ROWS = 50_000
 DETAIL_INSERT_BATCH_SIZE = 500
@@ -209,7 +210,9 @@ class PrivilegeSnapshotStore:
                 )
 
         async with pool.transaction() as conn:
-            await conn.execute(
+            await execute_transaction_sql(
+                pool,
+                conn,
                 """
                 INSERT INTO privilege_snapshots (
                     snapshot_id,
@@ -249,20 +252,22 @@ class PrivilegeSnapshotStore:
                     now_iso,
                 ),
             )
-            await conn.execute(
+            await execute_transaction_sql(
+                pool,
+                conn,
                 "DELETE FROM privilege_snapshot_details WHERE snapshot_id = ?",
                 (snapshot_id,),
             )
             if detail_payload:
-                await self._insert_snapshot_details(conn, snapshot_id, detail_payload, now_iso)
+                await self._insert_snapshot_details(pool, conn, snapshot_id, detail_payload, now_iso)
 
     async def clear(self) -> None:
         pool = await self._get_pool()
         await self._ensure_schema(pool)
         try:
             async with pool.transaction() as conn:
-                await conn.execute("DELETE FROM privilege_snapshots")
-                await conn.execute("DELETE FROM privilege_snapshot_details")
+                await execute_transaction_sql(pool, conn, "DELETE FROM privilege_snapshots")
+                await execute_transaction_sql(pool, conn, "DELETE FROM privilege_snapshot_details")
         except TransactionError as exc:
             detail = str(exc).lower()
             if "no such table" in detail:
@@ -272,6 +277,7 @@ class PrivilegeSnapshotStore:
 
     async def _insert_snapshot_details(
         self,
+        pool: DatabasePool,
         conn: Any,
         snapshot_id: str,
         detail_rows: Sequence[dict[str, Any]],
@@ -282,7 +288,9 @@ class PrivilegeSnapshotStore:
             chunk = detail_rows[chunk_start : chunk_start + DETAIL_INSERT_BATCH_SIZE]
             for item in chunk:
                 row_json = self._encode_detail_item(item)
-                await conn.execute(
+                await execute_transaction_sql(
+                    pool,
+                    conn,
                     """
                     INSERT INTO privilege_snapshot_details (
                         snapshot_id,

--- a/tldw_Server_API/app/core/PrivilegeMaps/trends.py
+++ b/tldw_Server_API/app/core/PrivilegeMaps/trends.py
@@ -10,6 +10,7 @@ from typing import Any
 from loguru import logger
 
 from tldw_Server_API.app.core.AuthNZ.database import DatabasePool, get_db_pool
+from tldw_Server_API.app.core.PrivilegeMaps.db_utils import execute_transaction_sql
 
 
 @dataclass
@@ -61,7 +62,9 @@ class PrivilegeTrendStore:
                 }
                 metadata_json = json.dumps(metadata, default=str) if metadata else None
                 # Deduplicate exact timestamp snapshots for same bucket.
-                await conn.execute(
+                await execute_transaction_sql(
+                    pool,
+                    conn,
                     """
                     DELETE FROM privilege_trend_history
                     WHERE scope = ?
@@ -80,7 +83,9 @@ class PrivilegeTrendStore:
                         timestamp,
                     ),
                 )
-                await conn.execute(
+                await execute_transaction_sql(
+                    pool,
+                    conn,
                     """
                     INSERT INTO privilege_trend_history (
                         scope,
@@ -236,7 +241,9 @@ class PrivilegeTrendStore:
         await self._ensure_schema(pool)
         cutoff_iso = self._to_iso(cutoff)
         async with pool.transaction() as conn:
-            result = await conn.execute(
+            result = await execute_transaction_sql(
+                pool,
+                conn,
                 "DELETE FROM privilege_trend_history WHERE generated_at < ?",
                 (cutoff_iso,),
             )

--- a/tldw_Server_API/tests/Privileges/test_privilege_endpoints.py
+++ b/tldw_Server_API/tests/Privileges/test_privilege_endpoints.py
@@ -20,7 +20,17 @@ class InMemoryTrendStore:
     def __init__(self) -> None:
         self.snapshots = []
 
-    async def record_snapshot(self, *, scope, group_by, catalog_version, generated_at, buckets, team_id=None, org_id=None):  # type: ignore[no-untyped-def]
+    async def record_snapshot(
+        self,
+        *,
+        scope,
+        group_by,
+        catalog_version,
+        generated_at,
+        buckets,
+        team_id=None,
+        org_id=None,
+    ):  # type: ignore[no-untyped-def]
         self.snapshots.append((scope, group_by, generated_at, buckets, team_id, org_id))
 
     async def compute_trends(self, *, scope, group_by, bucket_counts, window_start, window_end, team_id=None, org_id=None):  # type: ignore[no-untyped-def]

--- a/tldw_Server_API/tests/Privileges/test_privilege_endpoints.py
+++ b/tldw_Server_API/tests/Privileges/test_privilege_endpoints.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+from tldw_Server_API.app.api.v1.endpoints import privileges as privileges_endpoint
 from tldw_Server_API.app.main import app as fastapi_app
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
@@ -19,8 +20,8 @@ class InMemoryTrendStore:
     def __init__(self) -> None:
         self.snapshots = []
 
-    async def record_snapshot(self, *, scope, group_by, catalog_version, generated_at, buckets, team_id=None):  # type: ignore[no-untyped-def]
-        self.snapshots.append((scope, group_by, generated_at, buckets, team_id))
+    async def record_snapshot(self, *, scope, group_by, catalog_version, generated_at, buckets, team_id=None, org_id=None):  # type: ignore[no-untyped-def]
+        self.snapshots.append((scope, group_by, generated_at, buckets, team_id, org_id))
 
     async def compute_trends(self, *, scope, group_by, bucket_counts, window_start, window_end, team_id=None, org_id=None):  # type: ignore[no-untyped-def]
         trends = []
@@ -496,6 +497,28 @@ def test_create_snapshot_org(privilege_test_client: TestClient):
     payload = response.json()
     assert payload["target_scope"] == "org"
     assert payload["summary"]["users"] >= 1
+
+
+def test_create_snapshot_sync_ids_are_collision_resistant(privilege_test_client: TestClient, monkeypatch):
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2026, 1, 1, 12, 0, 0, tzinfo=tz or timezone.utc)
+
+    monkeypatch.setattr(privileges_endpoint, "datetime", FixedDateTime)
+
+    first = privilege_test_client.post(
+        "/api/v1/privileges/snapshots",
+        json={"target_scope": "org", "org_id": "acme"},
+    )
+    second = privilege_test_client.post(
+        "/api/v1/privileges/snapshots",
+        json={"target_scope": "org", "org_id": "acme"},
+    )
+
+    assert first.status_code == 201
+    assert second.status_code == 201
+    assert first.json()["snapshot_id"] != second.json()["snapshot_id"]
 
 
 def test_org_requires_admin_claim(privilege_test_client: TestClient):

--- a/tldw_Server_API/tests/Privileges/test_privilege_role_normalization.py
+++ b/tldw_Server_API/tests/Privileges/test_privilege_role_normalization.py
@@ -48,6 +48,20 @@ def test_scope_resolution_normalizes_role_case():
     assert "rag.search" in scopes
 
 
+def test_scope_resolution_applies_explicit_denies_to_admin_roles():
+
+    catalog = _build_catalog()
+    service = PrivilegeMapService(route_registry={}, catalog=catalog)
+
+    scopes = service._resolve_scopes_for_user(
+        ["admin"],
+        [],
+        denied_permissions=["rag.search"],
+    )
+
+    assert "rag.search" not in scopes
+
+
 def test_group_by_role_normalizes_case():
 
     catalog = _build_catalog()

--- a/tldw_Server_API/tests/Privileges/test_privilege_service_sqlite.py
+++ b/tldw_Server_API/tests/Privileges/test_privilege_service_sqlite.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
+import tldw_Server_API.app.core.PrivilegeMaps.service as service_module
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
 from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+from tldw_Server_API.app.core.AuthNZ.privilege_catalog import PrivilegeCatalog
 from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+from tldw_Server_API.app.core.PrivilegeMaps.introspection import RouteMetadata
 from tldw_Server_API.app.core.PrivilegeMaps.service import PrivilegeMapService
 
 
@@ -14,6 +18,39 @@ async def _fetch_id(pool, query: str, value: str) -> int:
     result = await pool.fetchval(query, (value,))
     assert result is not None, f"Expected ID for query {query} with value {value}"
     return int(result)
+
+
+def _test_catalog(scope_ids: list[str], *, version: str = "test-privileges") -> PrivilegeCatalog:
+    return PrivilegeCatalog.model_validate(
+        {
+            "version": version,
+            "updated_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+            "rate_limit_classes": [
+                {
+                    "id": "standard",
+                    "requests_per_min": 60,
+                    "burst": 10,
+                    "notes": None,
+                }
+            ],
+            "feature_flags": [],
+            "ownership_predicates": [],
+            "scopes": [
+                {
+                    "id": scope_id,
+                    "description": f"{scope_id} test scope",
+                    "resource_tags": ["test"],
+                    "sensitivity_tier": "low",
+                    "rate_limit_class": "standard",
+                    "default_roles": [],
+                    "feature_flag_id": None,
+                    "ownership_predicates": [],
+                    "doc_url": None,
+                }
+                for scope_id in scope_ids
+            ],
+        }
+    )
 
 
 @pytest.mark.asyncio
@@ -199,6 +236,120 @@ async def test_privilege_service_honors_authnz_role_mappings(tmp_path, monkeypat
 
 
 @pytest.mark.asyncio
+async def test_privilege_service_honors_expiry_and_explicit_permission_denies(tmp_path, monkeypatch):
+    db_path = tmp_path / "authnz-effective-permissions.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-effective-permissions-123456")
+    monkeypatch.setenv("TEST_MODE", "true")
+
+    reset_settings()
+    await reset_db_pool()
+    ensure_authnz_tables(Path(db_path))
+
+    pool = await get_db_pool()
+    async with pool.transaction() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (username, email, password_hash, is_active, role)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            ("effective-user", "effective@example.com", "hashed", 1, "viewer"),
+        )
+        for role_name in ["active-role", "expired-role"]:
+            await conn.execute(
+                "INSERT OR IGNORE INTO roles (name, description, is_system) VALUES (?, ?, 0)",
+                (role_name, f"{role_name} role"),
+            )
+        for permission_name in [
+            "scope.active",
+            "scope.denied",
+            "scope.expired_role",
+            "scope.expired_allow",
+        ]:
+            await conn.execute(
+                "INSERT OR IGNORE INTO permissions (name, description, category) VALUES (?, ?, ?)",
+                (permission_name, f"{permission_name} permission", "test"),
+            )
+
+    user_id = await _fetch_id(pool, "SELECT id FROM users WHERE username = ?", "effective-user")
+    active_role_id = await _fetch_id(pool, "SELECT id FROM roles WHERE name = ?", "active-role")
+    expired_role_id = await _fetch_id(pool, "SELECT id FROM roles WHERE name = ?", "expired-role")
+    permission_ids = {
+        name: await _fetch_id(pool, "SELECT id FROM permissions WHERE name = ?", name)
+        for name in ["scope.active", "scope.denied", "scope.expired_role", "scope.expired_allow"]
+    }
+
+    async with pool.transaction() as conn:
+        await conn.execute(
+            "INSERT OR IGNORE INTO user_roles (user_id, role_id) VALUES (?, ?)",
+            (user_id, active_role_id),
+        )
+        await conn.execute(
+            "INSERT OR REPLACE INTO user_roles (user_id, role_id, expires_at) VALUES (?, ?, ?)",
+            (user_id, expired_role_id, "2000-01-01T00:00:00+00:00"),
+        )
+        await conn.execute(
+            "INSERT OR IGNORE INTO role_permissions (role_id, permission_id) VALUES (?, ?)",
+            (active_role_id, permission_ids["scope.denied"]),
+        )
+        await conn.execute(
+            "INSERT OR IGNORE INTO role_permissions (role_id, permission_id) VALUES (?, ?)",
+            (expired_role_id, permission_ids["scope.expired_role"]),
+        )
+        await conn.execute(
+            "INSERT OR REPLACE INTO user_permissions (user_id, permission_id, granted) VALUES (?, ?, 1)",
+            (user_id, permission_ids["scope.active"]),
+        )
+        await conn.execute(
+            "INSERT OR REPLACE INTO user_permissions (user_id, permission_id, granted) VALUES (?, ?, 0)",
+            (user_id, permission_ids["scope.denied"]),
+        )
+        await conn.execute(
+            """
+            INSERT OR REPLACE INTO user_permissions (user_id, permission_id, granted, expires_at)
+            VALUES (?, ?, 1, ?)
+            """,
+            (user_id, permission_ids["scope.expired_allow"], "2000-01-01T00:00:00+00:00"),
+        )
+
+    service = PrivilegeMapService(
+        route_registry={},
+        catalog=_test_catalog(
+            ["scope.active", "scope.denied", "scope.expired_role", "scope.expired_allow"],
+            version="test-effective-permissions",
+        ),
+    )
+    users = await service._fetch_users()
+    effective_user = next(user for user in users if user["username"] == "effective-user")
+
+    assert effective_user["roles"] == ["active-role"]
+    assert set(effective_user["permissions"]) == {"scope.active"}
+    assert effective_user["allowed_scopes"] == {"scope.active"}
+
+    await reset_db_pool()
+    reset_settings()
+
+
+@pytest.mark.asyncio
+async def test_privilege_service_multi_user_fetch_failure_fails_closed(monkeypatch):
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-fetch-failure-123456")
+    reset_settings()
+
+    async def broken_pool():
+        raise RuntimeError("authnz database unavailable")
+
+    monkeypatch.setattr(service_module, "get_db_pool", broken_pool)
+    service = PrivilegeMapService(route_registry={}, catalog=_test_catalog(["scope.active"]))
+
+    with pytest.raises(RuntimeError, match="authnz database unavailable"):
+        await service._fetch_users()
+
+    reset_settings()
+
+
+@pytest.mark.asyncio
 async def test_privilege_service_org_filter_uses_org_members(tmp_path, monkeypatch):
     db_path = tmp_path / "authnz-org.db"
     monkeypatch.setenv("AUTH_MODE", "multi_user")
@@ -243,20 +394,30 @@ async def test_privilege_service_org_filter_uses_org_members(tmp_path, monkeypat
     org2_id = await _fetch_id(pool, "SELECT id FROM organizations WHERE slug = ?", "org-two")
 
     async with pool.transaction() as conn:
-        for user_id in [user1_id, user2_id]:
-            await conn.execute(
-                """
-                INSERT OR IGNORE INTO org_members (org_id, user_id, role, status)
-                VALUES (?, ?, ?, ?)
-                """,
-                (org1_id, user_id, "member", "active"),
-            )
+        await conn.execute(
+            """
+            INSERT OR IGNORE INTO org_members (org_id, user_id, role, status)
+            VALUES (?, ?, ?, ?)
+            """,
+            (org1_id, user1_id, "member", "active"),
+        )
+        await conn.execute(
+            """
+            INSERT OR IGNORE INTO org_members (org_id, user_id, role, status)
+            VALUES (?, ?, ?, ?)
+            """,
+            (org1_id, user2_id, "member", "suspended"),
+        )
         await conn.execute(
             """
             INSERT OR IGNORE INTO org_members (org_id, user_id, role, status)
             VALUES (?, ?, ?, ?)
             """,
             (org2_id, user3_id, "member", "active"),
+        )
+        await conn.execute(
+            "UPDATE organizations SET is_active = 0 WHERE id = ?",
+            (org2_id,),
         )
 
     service = PrivilegeMapService()
@@ -267,8 +428,17 @@ async def test_privilege_service_org_filter_uses_org_members(tmp_path, monkeypat
         team_id=None,
         user_ids=None,
     )
-    assert summary_org1["users"] == 2
-    assert len(org1_users) == 2
+    assert summary_org1["users"] == 1
+    assert {user["username"] for user in org1_users} == {"org-user-1"}
+
+    summary_org2, org2_users = await service.build_snapshot_summary(
+        target_scope="org",
+        org_id=str(org2_id),
+        team_id=None,
+        user_ids=None,
+    )
+    assert summary_org2["users"] == 0
+    assert len(org2_users) == 0
 
     summary_org_none, org_none_users = await service.build_snapshot_summary(
         target_scope="org",
@@ -281,3 +451,196 @@ async def test_privilege_service_org_filter_uses_org_members(tmp_path, monkeypat
 
     await reset_db_pool()
     reset_settings()
+
+
+@pytest.mark.asyncio
+async def test_privilege_service_team_filter_uses_active_memberships_and_teams(tmp_path, monkeypatch):
+    db_path = tmp_path / "authnz-team-filter.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-team-filter-123456")
+    monkeypatch.setenv("TEST_MODE", "true")
+
+    reset_settings()
+    await reset_db_pool()
+    ensure_authnz_tables(Path(db_path))
+
+    pool = await get_db_pool()
+    async with pool.transaction() as conn:
+        for username, email in [
+            ("team-user-1", "team1@example.com"),
+            ("team-user-2", "team2@example.com"),
+        ]:
+            await conn.execute(
+                """
+                INSERT INTO users (username, email, password_hash, is_active, role)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (username, email, "hashed", 1, "viewer"),
+            )
+
+    user1_id = await _fetch_id(pool, "SELECT id FROM users WHERE username = ?", "team-user-1")
+    user2_id = await _fetch_id(pool, "SELECT id FROM users WHERE username = ?", "team-user-2")
+
+    async with pool.transaction() as conn:
+        await conn.execute(
+            "INSERT INTO organizations (name, slug, owner_user_id) VALUES (?, ?, ?)",
+            ("Team Org", "team-org", user1_id),
+        )
+
+    org_id = await _fetch_id(pool, "SELECT id FROM organizations WHERE slug = ?", "team-org")
+
+    async with pool.transaction() as conn:
+        await conn.execute(
+            "INSERT INTO teams (org_id, name, slug, is_active) VALUES (?, ?, ?, 1)",
+            (org_id, "Active Team", "active-team"),
+        )
+        await conn.execute(
+            "INSERT INTO teams (org_id, name, slug, is_active) VALUES (?, ?, ?, 0)",
+            (org_id, "Inactive Team", "inactive-team"),
+        )
+
+    active_team_id = await _fetch_id(pool, "SELECT id FROM teams WHERE slug = ?", "active-team")
+    inactive_team_id = await _fetch_id(pool, "SELECT id FROM teams WHERE slug = ?", "inactive-team")
+
+    async with pool.transaction() as conn:
+        await conn.execute(
+            "INSERT OR IGNORE INTO team_members (team_id, user_id, role, status) VALUES (?, ?, ?, ?)",
+            (active_team_id, user1_id, "member", "active"),
+        )
+        await conn.execute(
+            "INSERT OR IGNORE INTO team_members (team_id, user_id, role, status) VALUES (?, ?, ?, ?)",
+            (active_team_id, user2_id, "member", "suspended"),
+        )
+        await conn.execute(
+            "INSERT OR IGNORE INTO team_members (team_id, user_id, role, status) VALUES (?, ?, ?, ?)",
+            (inactive_team_id, user2_id, "member", "active"),
+        )
+
+    service = PrivilegeMapService()
+    active_summary, active_users = await service.build_snapshot_summary(
+        target_scope="team",
+        org_id=None,
+        team_id=str(active_team_id),
+        user_ids=None,
+    )
+    assert active_summary["users"] == 1
+    assert {user["username"] for user in active_users} == {"team-user-1"}
+
+    inactive_summary, inactive_users = await service.build_snapshot_summary(
+        target_scope="team",
+        org_id=None,
+        team_id=str(inactive_team_id),
+        user_ids=None,
+    )
+    assert inactive_summary["users"] == 0
+    assert inactive_users == []
+
+    await reset_db_pool()
+    reset_settings()
+
+
+def test_privilege_detail_generation_stops_at_configured_cap(monkeypatch):
+    monkeypatch.setattr(service_module, "MAX_DETAIL_ROWS", 2)
+    catalog = _test_catalog(["scope.active"], version="test-detail-cap")
+    service = PrivilegeMapService(
+        catalog=catalog,
+        route_registry={
+            "scope.active": [
+                RouteMetadata(
+                    path="/unit/detail-cap",
+                    methods=("GET", "POST", "DELETE"),
+                    name="detail_cap",
+                    tags=("test",),
+                    endpoint="tests.detail_cap",
+                )
+            ]
+        },
+    )
+
+    items = service.build_snapshot_detail(
+        [
+            {
+                "id": "user-1",
+                "username": "cap-user",
+                "primary_role": "viewer",
+                "roles": ["viewer"],
+                "permissions": [],
+                "feature_flags": set(),
+                "allowed_scopes": {"scope.active"},
+            }
+        ]
+    )
+
+    assert len(items) == 2
+
+
+@pytest.mark.asyncio
+async def test_privilege_org_trends_are_scoped_to_org_id(monkeypatch):
+    class RecordingTrendStore:
+        def __init__(self) -> None:
+            self.recorded_org_ids: list[str | None] = []
+            self.computed_org_ids: list[str | None] = []
+
+        async def record_snapshot(
+            self,
+            *,
+            scope,
+            group_by,
+            catalog_version,
+            generated_at,
+            buckets,
+            team_id=None,
+            org_id=None,
+        ):
+            self.recorded_org_ids.append(org_id)
+
+        async def compute_trends(
+            self,
+            *,
+            scope,
+            group_by,
+            bucket_counts,
+            window_start,
+            window_end,
+            team_id=None,
+            org_id=None,
+        ):
+            self.computed_org_ids.append(org_id)
+            return []
+
+    trend_store = RecordingTrendStore()
+    service = PrivilegeMapService(
+        route_registry={},
+        catalog=_test_catalog(["scope.active"], version="test-org-trends"),
+        trend_store=trend_store,
+    )
+
+    async def fetch_users():
+        return [
+            {
+                "id": "user-1",
+                "username": "org-user",
+                "primary_role": "viewer",
+                "roles": ["viewer"],
+                "permissions": [],
+                "feature_flags": set(),
+                "allowed_scopes": {"scope.active"},
+            }
+        ]
+
+    async def fetch_org_memberships():
+        return [{"org_id": "acme", "user_id": "user-1", "membership_role": "member"}]
+
+    monkeypatch.setattr(service, "_fetch_users", fetch_users)
+    monkeypatch.setattr(service, "_fetch_org_memberships", fetch_org_memberships)
+
+    await service.get_org_summary(
+        group_by="role",
+        include_trends=True,
+        since=None,
+        org_id="acme",
+    )
+
+    assert trend_store.recorded_org_ids == ["acme"]
+    assert trend_store.computed_org_ids == ["acme"]

--- a/tldw_Server_API/tests/Privileges/test_privilege_service_sqlite.py
+++ b/tldw_Server_API/tests/Privileges/test_privilege_service_sqlite.py
@@ -375,10 +375,18 @@ async def test_privilege_service_org_filter_uses_org_members(tmp_path, monkeypat
                 """,
                 (username, email, "hashed", 1, primary_role),
             )
+        await conn.execute(
+            """
+            INSERT INTO users (username, email, password_hash, is_active, role)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            ("org-user-4", "org4@example.com", "hashed", None, "viewer"),
+        )
 
     user1_id = await _fetch_id(pool, "SELECT id FROM users WHERE username = ?", "org-user-1")
     user2_id = await _fetch_id(pool, "SELECT id FROM users WHERE username = ?", "org-user-2")
     user3_id = await _fetch_id(pool, "SELECT id FROM users WHERE username = ?", "org-user-3")
+    user4_id = await _fetch_id(pool, "SELECT id FROM users WHERE username = ?", "org-user-4")
 
     async with pool.transaction() as conn:
         await conn.execute(
@@ -413,10 +421,17 @@ async def test_privilege_service_org_filter_uses_org_members(tmp_path, monkeypat
             INSERT OR IGNORE INTO org_members (org_id, user_id, role, status)
             VALUES (?, ?, ?, ?)
             """,
+            (org1_id, user4_id, "member", "active"),
+        )
+        await conn.execute(
+            """
+            INSERT OR IGNORE INTO org_members (org_id, user_id, role, status)
+            VALUES (?, ?, ?, ?)
+            """,
             (org2_id, user3_id, "member", "active"),
         )
         await conn.execute(
-            "UPDATE organizations SET is_active = 0 WHERE id = ?",
+            "UPDATE organizations SET is_active = NULL WHERE id = ?",
             (org2_id,),
         )
 
@@ -496,8 +511,8 @@ async def test_privilege_service_team_filter_uses_active_memberships_and_teams(t
             (org_id, "Active Team", "active-team"),
         )
         await conn.execute(
-            "INSERT INTO teams (org_id, name, slug, is_active) VALUES (?, ?, ?, 0)",
-            (org_id, "Inactive Team", "inactive-team"),
+            "INSERT INTO teams (org_id, name, slug, is_active) VALUES (?, ?, ?, ?)",
+            (org_id, "Inactive Team", "inactive-team", None),
         )
 
     active_team_id = await _fetch_id(pool, "SELECT id FROM teams WHERE slug = ?", "active-team")

--- a/tldw_Server_API/tests/Privileges/test_privilege_snapshot_store.py
+++ b/tldw_Server_API/tests/Privileges/test_privilege_snapshot_store.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 
+from tldw_Server_API.app.core.PrivilegeMaps.db_utils import _question_marks_to_dollar_params
 from tldw_Server_API.app.core.PrivilegeMaps.snapshots import PrivilegeSnapshotStore
 
 
@@ -30,6 +31,28 @@ class _FakePostgresPool:
     @asynccontextmanager
     async def transaction(self):
         yield self.connection
+
+
+def test_question_mark_conversion_ignores_sql_literals_identifiers_and_comments() -> None:
+    query = (
+        "SELECT '?' AS literal, \"column?name\" "
+        "FROM privilege_snapshots "
+        "WHERE snapshot_id = ? AND generated_by = ? -- ? comment\n"
+        "AND catalog_version = ?"
+    )
+
+    assert _question_marks_to_dollar_params(query, 3) == (
+        "SELECT '?' AS literal, \"column?name\" "
+        "FROM privilege_snapshots "
+        "WHERE snapshot_id = $1 AND generated_by = $2 -- ? comment\n"
+        "AND catalog_version = $3"
+    )
+
+
+def test_question_mark_conversion_returns_original_on_placeholder_count_mismatch() -> None:
+    query = "SELECT '?' AS literal FROM privilege_snapshots WHERE snapshot_id = ?"
+
+    assert _question_marks_to_dollar_params(query, 2) == query
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Privileges/test_privilege_snapshot_store.py
+++ b/tldw_Server_API/tests/Privileges/test_privilege_snapshot_store.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.PrivilegeMaps.snapshots import PrivilegeSnapshotStore
+
+
+class _FakePostgresConnection:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+
+    async def execute(self, query: str, *args: Any) -> str:
+        if "?" in query:
+            raise AssertionError("raw question-mark placeholder reached PostgreSQL transaction")
+        self.executed.append((query, args))
+        return "OK"
+
+
+class _FakePostgresPool:
+    backend_type = "postgres"
+
+    def __init__(self) -> None:
+        self.pool = object()
+        self.connection = _FakePostgresConnection()
+
+    @asynccontextmanager
+    async def transaction(self):
+        yield self.connection
+
+
+@pytest.mark.asyncio
+async def test_snapshot_store_transactions_normalize_postgres_placeholders() -> None:
+    pool = _FakePostgresPool()
+    store = PrivilegeSnapshotStore(pool=pool)  # type: ignore[arg-type]
+    store._initialized = True  # noqa: SLF001 - keep this unit test scoped to write SQL
+
+    await store.add_snapshot(
+        {
+            "snapshot_id": "snap-unit",
+            "generated_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+            "generated_by": "user-1",
+            "target_scope": "user",
+            "org_id": None,
+            "team_id": None,
+            "catalog_version": "unit",
+            "summary": {"users": 1, "scopes": 1, "scope_ids": ["media.ingest"]},
+        },
+        detail_items=[
+            {
+                "user_id": "user-1",
+                "endpoint": "/api/v1/media/process",
+                "method": "POST",
+                "privilege_scope_id": "media.ingest",
+                "status": "allowed",
+            }
+        ],
+    )
+
+    assert any("$1" in query for query, _args in pool.connection.executed)

--- a/tldw_Server_API/tests/Privileges/test_privilege_trends.py
+++ b/tldw_Server_API/tests/Privileges/test_privilege_trends.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.PrivilegeMaps.trends import PrivilegeTrendStore
+
+
+class _FakePostgresConnection:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+
+    async def execute(self, query: str, *args: Any) -> str:
+        if "?" in query:
+            raise AssertionError("raw question-mark placeholder reached PostgreSQL transaction")
+        self.executed.append((query, args))
+        return "OK"
+
+
+class _FakePostgresPool:
+    backend_type = "postgres"
+
+    def __init__(self) -> None:
+        self.pool = object()
+        self.connection = _FakePostgresConnection()
+
+    @asynccontextmanager
+    async def transaction(self):
+        yield self.connection
+
+
+@pytest.mark.asyncio
+async def test_trend_store_transactions_normalize_postgres_placeholders() -> None:
+    pool = _FakePostgresPool()
+    store = PrivilegeTrendStore(pool=pool)  # type: ignore[arg-type]
+    store._initialized = True  # noqa: SLF001 - keep this unit test scoped to write SQL
+
+    await store.record_snapshot(
+        scope="org",
+        group_by="role",
+        catalog_version="unit",
+        generated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        buckets=[
+            {
+                "key": "admin",
+                "users": 1,
+                "endpoints": 2,
+                "scopes": 3,
+            }
+        ],
+        org_id="org-1",
+    )
+
+    assert any("$1" in query for query, _args in pool.connection.executed)


### PR DESCRIPTION
## Summary
- Harden PrivilegeMaps transaction writes for PostgreSQL-backed AuthNZ pools.
- Align effective permission hydration with expiry and explicit deny semantics, including fail-closed multi-user loading.
- Add collision-safe sync snapshot IDs, active org/team scoping, bounded detail generation, org-scoped trends, and regression coverage.

## Verification
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Privileges/test_privilege_service_sqlite.py tldw_Server_API/tests/Privileges/test_privilege_role_normalization.py tldw_Server_API/tests/Privileges/test_privilege_snapshot_store.py tldw_Server_API/tests/Privileges/test_privilege_trends.py -q` -> 13 passed in the PR worktree.
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/PrivilegeMaps tldw_Server_API/app/api/v1/endpoints/privileges.py -f json -o /tmp/bandit_privilege_maps_2422_worktree.json` -> 0 findings.

## Change summary
TODO: Human requester must replace this section with a human-written summary before marking the PR ready for merge, per repo policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens `PrivilegeMaps` with PostgreSQL-safe transaction writes, corrected effective-permission semantics (expiry and explicit denies), scoped org/team outputs, and bounded detail to prevent bad data and collisions. Fulfills TASK-2422 acceptance criteria.

- **Bug Fixes**
  - PostgreSQL transactions: `execute_transaction_sql` converts `?` to `$n` and skips literals/identifiers/comments; applied to snapshot and trend stores.
  - Effective permissions: ignore expired roles/overrides; explicit denies subtract permissions (including admin); multi-user fetch failures now fail closed.
  - Scoping: exclude inactive orgs/teams and suspended memberships; treat NULL active flags as inactive.
  - Trends: propagate `org_id` to recording, history, and caching; deduplicate identical timestamps per bucket.
  - Snapshots: use UUID-based `snapshot_id` to avoid sync-time collisions.
  - Detail: cap materialization by `MAX_DETAIL_ROWS`.
  - Added focused regression tests (transactions, trends org-scope, snapshot UUIDs, permission semantics, endpoints); Bandit clean.

<sup>Written for commit 9c7d3093241e6fd86bd1046221339ec8fc8b50bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

