### PR TITLE
Harden image generation adapters

### DIFF
--- a/IMPLEMENTATION_PLAN_image_generation_hardening_2414.md
+++ b/IMPLEMENTATION_PLAN_image_generation_hardening_2414.md
@@ -1,0 +1,29 @@
+## Stage 1: Request Boundary Regressions
+**Goal**: Capture the reviewed Image Generation failures with focused tests before implementation.
+**Success Criteria**: Tests fail for unsafe SwarmUI URL handling, workflow request validation, blocking adapter dispatch, bounded output extraction, Stable Diffusion log redaction, and reference-image metadata reuse.
+**Tests**: `tests/Image_Generation/`, `tests/Workflows/adapters/test_content_adapters.py`, and `tests/Files/test_files_image_endpoint.py` focused regressions.
+**Status**: Complete
+
+## Stage 2: Shared Image Output and Validation Helpers
+**Goal**: Centralize image output validation, byte caps, and request validation so file artifacts and workflows enforce the same constraints.
+**Success Criteria**: Provider output extraction rejects oversized or unknown image payloads before returning results; workflow requests reject invalid dimensions, steps, formats, and disallowed extra params.
+**Tests**: Focused Image Generation adapter and workflow tests pass.
+**Status**: Complete
+
+## Stage 3: Provider Adapter Hardening
+**Goal**: Harden provider-specific risks without changing public behavior for valid requests.
+**Success Criteria**: SwarmUI blocks off-origin image URLs with cookies, Stable Diffusion no longer logs prompts/paths/secrets, and remote image URL extraction honors the shared output cap.
+**Tests**: SwarmUI, Stable Diffusion, OpenRouter, Novita, Together, and Model Studio focused tests pass.
+**Status**: Complete
+
+## Stage 4: Reference Image Listing Efficiency
+**Goal**: Avoid unnecessary reference-image storage reads and full decodes during picker listing.
+**Success Criteria**: Candidate rows expose stored file size, oversized rows are skipped before storage access, and dimension probing reads image headers without forcing a full decode while preserving fallback behavior.
+**Tests**: Reference-image unit tests and files reference-image endpoint tests pass.
+**Status**: Complete
+
+## Stage 5: Verification and Task Closeout
+**Goal**: Verify focused behavior, security scan touched code, and record results in Backlog.
+**Success Criteria**: Focused tests and Bandit complete with no new findings in touched scope, and `TASK-2414` has final notes.
+**Tests**: Focused pytest commands plus Bandit over touched source files.
+**Status**: Complete

--- a/backlog/tasks/task-2414 - Harden-Image-Generation-review-findings.md
+++ b/backlog/tasks/task-2414 - Harden-Image-Generation-review-findings.md
@@ -1,0 +1,68 @@
+---
+id: TASK-2414
+title: Harden Image Generation review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 18:17'
+updated_date: '2026-06-23 21:57'
+labels:
+  - backend
+  - image-generation
+  - security
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address Image Generation module review findings: SwarmUI URL/token leakage, blocking workflow adapter calls, missing workflow validation, unbounded image output handling, sensitive Stable Diffusion logging, and expensive reference-image listing.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 SwarmUI image URL fetches do not send swarm_token to off-origin URLs and block unsafe remote hosts
+- [x] #2 Workflow image generation validates request bounds and extra params consistently with file artifacts
+- [x] #3 Workflow image generation does not block the event loop while adapters run
+- [x] #4 Image extraction enforces output byte limits and image format validation before returning results
+- [x] #5 Stable Diffusion adapter logs and errors avoid prompt/path/secret leakage
+- [x] #6 Reference-image candidate listing avoids full image decode when metadata is available
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation plan: IMPLEMENTATION_PLAN_image_generation_hardening_2414.md
+
+Implemented shared Image Generation request validation for workflows and file artifacts, shared image output byte/magic validation, SwarmUI same-origin URL enforcement before authenticated image fetches, workflow off-event-loop backend generation, stable-diffusion log/error redaction, default inline byte cap enforcement, and reference image listing file-size/header optimizations.
+
+Verification:
+- Red regressions initially failed for workflow threading/validation, byte caps, stable-diffusion redaction, and oversized reference rows.
+- source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Image_Generation/test_openrouter_image_adapter.py tldw_Server_API/tests/Image_Generation/test_together_image_adapter.py tldw_Server_API/tests/Image_Generation/test_novita_image_adapter.py tldw_Server_API/tests/Image_Generation/test_modelstudio_image_adapter.py tldw_Server_API/tests/Image_Generation/test_swarmui_adapter.py tldw_Server_API/tests/Image_Generation/test_image_format_utils.py tldw_Server_API/tests/Image_Generation/test_stable_diffusion_cpp_adapter.py tldw_Server_API/tests/Image_Generation/test_reference_images.py -q => 34 passed.
+- source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/adapters/test_content_adapters.py::TestImageGenAdapter::test_image_gen_adapter_uses_thread_for_backend_generation tldw_Server_API/tests/Workflows/adapters/test_content_adapters.py::TestImageGenAdapter::test_image_gen_adapter_rejects_invalid_generation_params -q => 2 passed.
+- source .venv/bin/activate && python -m pytest tldw_Server_API/tests/FileArtifacts/test_image_adapter_allowlist.py tldw_Server_API/tests/Files/test_files_image_endpoint.py tldw_Server_API/tests/Image_Generation/test_image_generation_config_defaults.py tldw_Server_API/tests/Image_Generation/test_image_reference_capabilities.py -q => 39 passed.
+- git diff --check => passed.
+- source .venv/bin/activate && python -m bandit -r touched source scope -f json -o /tmp/bandit_image_generation_2414.json => 0 findings.
+
+Worktree PR prep verification on branch codex/image-generation-hardening-2414 at .worktrees/image-generation-hardening-2414:
+- Image Generation provider/reference suite: 34 passed.
+- Workflow/FileArtifacts/files endpoint/config/reference capability suite: 38 passed.
+- git diff --check: passed.
+- Bandit touched source scope: 0 findings.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened Image Generation review findings end to end: unsafe SwarmUI authenticated image fetches are blocked off-origin; workflows now validate image params and run backend generation in a worker thread; provider output extraction enforces byte caps and actual PNG/JPEG/WebP bytes; stable-diffusion logging/errors no longer expose prompts, paths, or secret CLI values; reference image candidate listing skips oversized rows before storage access and avoids full image decode for dimensions. Focused tests and Bandit passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2414 - Harden-Image-Generation-review-findings.md
+++ b/backlog/tasks/task-2414 - Harden-Image-Generation-review-findings.md
@@ -3,12 +3,12 @@ id: TASK-2414
 title: Harden Image Generation review findings
 status: Done
 assignee: []
-created_date: '2026-06-23 18:17'
-updated_date: '2026-06-23 21:57'
+created_date: 2026-06-23 18:17
+updated_date: 2026-06-24 03:52
 labels:
-  - backend
-  - image-generation
-  - security
+- backend
+- image-generation
+- security
 dependencies: []
 priority: high
 ---
@@ -66,3 +66,9 @@ Hardened Image Generation review findings end to end: unsafe SwarmUI authenticat
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+PR #2462 rebase/review update: rebased codex/image-generation-hardening-2414 onto latest origin/dev (46595e31c) and removed unrelated Claims Extraction docs commit from the PR branch. Addressed unresolved Gemini/Qodo review threads: data URL base64 whitespace handling, bounded streaming remote image fetch without relying on Content-Length, workflow falsy numeric parameter validation, shared cfg_scale finite/positive validation, and inline Bandit suppression justifications. Verification: focused regression tests 6 passed; Image Generation provider/reference suite 36 passed; workflow/FileArtifacts/files/config/reference suite 38 passed; git diff --check passed; Bandit touched source scope 0 findings.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/core/File_Artifacts/adapters/image_adapter.py
+++ b/tldw_Server_API/app/core/File_Artifacts/adapters/image_adapter.py
@@ -165,7 +165,6 @@ class ImageAdapter:
             ValidationIssue(code=issue.code, message=issue.message, path=issue.path)
             for issue in validate_image_generation_request(structured, config=config)
         ]
-        self._validate_cfg_scale(structured.get("cfg_scale"), issues)
         return issues
 
     def export(self, structured: dict[str, Any], *, format: str) -> ExportResult:
@@ -301,27 +300,6 @@ class ImageAdapter:
         if not math.isfinite(candidate):
             raise FileArtifactsValidationError("image_params_invalid")
         return candidate
-
-    @staticmethod
-    def _validate_cfg_scale(value: Any, issues: list[ValidationIssue]) -> None:
-        if value is None:
-            return
-        if isinstance(value, bool):
-            issues.append(
-                ValidationIssue(code="image_params_invalid", message="cfg_scale must be finite", path="cfg_scale")
-            )
-            return
-        try:
-            candidate = float(value)
-        except (TypeError, ValueError):
-            issues.append(
-                ValidationIssue(code="image_params_invalid", message="cfg_scale must be finite", path="cfg_scale")
-            )
-            return
-        if not math.isfinite(candidate):
-            issues.append(
-                ValidationIssue(code="image_params_invalid", message="cfg_scale must be finite", path="cfg_scale")
-            )
 
     @staticmethod
     def _positive_int_or_none(value: Any) -> int | None:

--- a/tldw_Server_API/app/core/File_Artifacts/adapters/image_adapter.py
+++ b/tldw_Server_API/app/core/File_Artifacts/adapters/image_adapter.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+import math
 from contextvars import ContextVar, Token
+from dataclasses import dataclass
 from typing import Any
 
 from loguru import logger
@@ -27,6 +28,10 @@ from tldw_Server_API.app.core.Image_Generation.reference_images import (
 from tldw_Server_API.app.core.Image_Generation.prompt_refinement import (
     normalize_prompt_refinement_mode,
     refine_image_prompt,
+)
+from tldw_Server_API.app.core.Image_Generation.request_validation import (
+    allowed_extra_params_for_backend,
+    validate_image_generation_request,
 )
 
 
@@ -155,58 +160,12 @@ class ImageAdapter:
         return structured
 
     def validate(self, structured: dict[str, Any]) -> list[ValidationIssue]:
-        issues: list[ValidationIssue] = []
         config = get_image_generation_config()
-
-        prompt = structured.get("prompt")
-        if isinstance(prompt, str) and len(prompt) > config.max_prompt_length:
-            issues.append(
-                ValidationIssue(
-                    code="image_params_invalid",
-                    message="prompt exceeds max length",
-                    path="prompt",
-                )
-            )
-
-        width = structured.get("width")
-        height = structured.get("height")
-        if width is not None and (width <= 0 or width > config.max_width):
-            issues.append(
-                ValidationIssue(
-                    code="image_params_invalid",
-                    message="width out of range",
-                    path="width",
-                )
-            )
-        if height is not None and (height <= 0 or height > config.max_height):
-            issues.append(
-                ValidationIssue(
-                    code="image_params_invalid",
-                    message="height out of range",
-                    path="height",
-                )
-            )
-        if isinstance(width, int) and isinstance(height, int) and width * height > config.max_pixels:
-            issues.append(
-                ValidationIssue(
-                    code="image_params_invalid",
-                    message="image dimensions exceed max pixels",
-                    path="width,height",
-                )
-            )
-
-        steps = structured.get("steps")
-        if steps is not None and (steps <= 0 or steps > config.max_steps):
-            issues.append(
-                ValidationIssue(
-                    code="image_params_invalid",
-                    message="steps out of range",
-                    path="steps",
-                )
-            )
-
-        self._validate_extra_params(structured, config, issues)
-
+        issues = [
+            ValidationIssue(code=issue.code, message=issue.message, path=issue.path)
+            for issue in validate_image_generation_request(structured, config=config)
+        ]
+        self._validate_cfg_scale(structured.get("cfg_scale"), issues)
         return issues
 
     def export(self, structured: dict[str, Any], *, format: str) -> ExportResult:
@@ -333,10 +292,36 @@ class ImageAdapter:
     def _float_or_none(value: Any) -> float | None:
         if value is None:
             return None
+        if isinstance(value, bool):
+            raise FileArtifactsValidationError("image_params_invalid")
         try:
-            return float(value)
+            candidate = float(value)
         except (TypeError, ValueError):
             raise FileArtifactsValidationError("image_params_invalid") from None
+        if not math.isfinite(candidate):
+            raise FileArtifactsValidationError("image_params_invalid")
+        return candidate
+
+    @staticmethod
+    def _validate_cfg_scale(value: Any, issues: list[ValidationIssue]) -> None:
+        if value is None:
+            return
+        if isinstance(value, bool):
+            issues.append(
+                ValidationIssue(code="image_params_invalid", message="cfg_scale must be finite", path="cfg_scale")
+            )
+            return
+        try:
+            candidate = float(value)
+        except (TypeError, ValueError):
+            issues.append(
+                ValidationIssue(code="image_params_invalid", message="cfg_scale must be finite", path="cfg_scale")
+            )
+            return
+        if not math.isfinite(candidate):
+            issues.append(
+                ValidationIssue(code="image_params_invalid", message="cfg_scale must be finite", path="cfg_scale")
+            )
 
     @staticmethod
     def _positive_int_or_none(value: Any) -> int | None:
@@ -354,19 +339,7 @@ class ImageAdapter:
 
     @staticmethod
     def _allowed_extra_params(backend: str, config) -> set[str]:
-        if backend == "stable_diffusion_cpp":
-            return set(config.sd_cpp_allowed_extra_params or [])
-        if backend == "swarmui":
-            return set(config.swarmui_allowed_extra_params or [])
-        if backend == "openrouter":
-            return set(config.openrouter_image_allowed_extra_params or [])
-        if backend == "novita":
-            return set(config.novita_image_allowed_extra_params or [])
-        if backend == "together":
-            return set(config.together_image_allowed_extra_params or [])
-        if backend == "modelstudio":
-            return set(config.modelstudio_image_allowed_extra_params or [])
-        return set()
+        return allowed_extra_params_for_backend(backend, config)
 
     def _validate_extra_params(
         self,
@@ -374,44 +347,8 @@ class ImageAdapter:
         config,
         issues: list[ValidationIssue],
     ) -> None:
-        extra_params = structured.get("extra_params") or {}
-        if not extra_params:
-            return
-        backend = str(structured.get("backend") or "").strip()
-        allowlist = self._allowed_extra_params(backend, config)
-        exempt_control_keys: set[str] = set()
-        if backend == "modelstudio":
-            # `mode` is a local backend control knob, not a passthrough upstream parameter.
-            exempt_control_keys.add("mode")
-        keys_to_validate = [key for key in extra_params if key not in exempt_control_keys]
-        if not keys_to_validate:
-            return
-        if not allowlist:
-            for key in keys_to_validate:
-                issues.append(
-                    ValidationIssue(
-                        code="image_params_invalid",
-                        message="extra_params key not allowlisted",
-                        path=f"extra_params.{key}",
-                    )
-                )
-            return
-        for key in keys_to_validate:
-            if key not in allowlist:
-                issues.append(
-                    ValidationIssue(
-                        code="image_params_invalid",
-                        message="extra_params key not allowlisted",
-                        path=f"extra_params.{key}",
-                    )
-                )
-        if "cli_args" in extra_params and "cli_args" in allowlist:
-            cli_args = extra_params.get("cli_args")
-            if not isinstance(cli_args, (list, tuple)):
-                issues.append(
-                    ValidationIssue(
-                        code="image_params_invalid",
-                        message="cli_args must be a list",
-                        path="extra_params.cli_args",
-                    )
-                )
+        issues.extend(
+            ValidationIssue(code=issue.code, message=issue.message, path=issue.path)
+            for issue in validate_image_generation_request(structured, config=config)
+            if issue.path.startswith("extra_params")
+        )

--- a/tldw_Server_API/app/core/Image_Generation/adapters/image_format_utils.py
+++ b/tldw_Server_API/app/core/Image_Generation/adapters/image_format_utils.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import base64
 import binascii
-import contextlib
 import io
 from pathlib import Path
 from typing import Any
 
-from tldw_Server_API.app.core.http_client import fetch
+from tldw_Server_API.app.core.http_client import (
+    DEFAULT_MAX_REDIRECTS,
+    _resolve_redirect_url,
+    _validate_egress_or_raise,
+    create_client,
+)
 from tldw_Server_API.app.core.Image_Generation.capabilities import ResolvedReferenceImage
 from tldw_Server_API.app.core.Image_Generation.exceptions import ImageGenerationError
 
@@ -28,9 +32,10 @@ def decode_data_url(data_url: str, *, max_bytes: int | None = None) -> tuple[byt
     content_type = meta.split(";", 1)[0] or content_type if ";" in meta else meta or content_type
     if ";base64" not in header:
         raise ImageGenerationError("unsupported data URL encoding")
-    _enforce_base64_encoded_limit(encoded, max_bytes)
+    encoded_clean = "".join(encoded.split())
+    _enforce_base64_encoded_limit(encoded_clean, max_bytes)
     try:
-        content = base64.b64decode(encoded, validate=True)
+        content = base64.b64decode(encoded_clean, validate=True)
     except (binascii.Error, TypeError, ValueError) as exc:
         raise ImageGenerationError("invalid base64 data") from exc
     _enforce_max_bytes(content, max_bytes)
@@ -194,49 +199,46 @@ def fetch_image_bytes(
     cookies: dict[str, Any] | None = None,
     max_bytes: int | None = None,
 ) -> tuple[bytes, str]:
+    current_url = url
     try:
-        response = fetch(
-            method="GET",
-            url=url,
-            headers=headers,
-            cookies=cookies,
-            timeout=timeout,
-        )
+        with create_client(timeout=timeout) as client:
+            for _redirect_count in range(DEFAULT_MAX_REDIRECTS + 1):
+                _validate_egress_or_raise(current_url)
+                with client.stream(
+                    "GET",
+                    current_url,
+                    headers=headers,
+                    cookies=cookies,
+                    timeout=timeout,
+                    follow_redirects=False,
+                ) as response:
+                    status = int(getattr(response, "status_code", 0) or 0)
+                    if status in {301, 302, 303, 307, 308}:
+                        location = response.headers.get("location") or response.headers.get("Location")
+                        if not location:
+                            raise ImageGenerationError("image fetch failed: redirect without location")
+                        next_url = _resolve_redirect_url(str(getattr(response, "url", current_url)), str(location))
+                        if not next_url:
+                            raise ImageGenerationError("image fetch failed: invalid redirect")
+                        current_url = next_url
+                        continue
+                    if status >= 400:
+                        raise ImageGenerationError(f"image fetch failed with status {status}")
+
+                    headers_obj = getattr(response, "headers", {}) or {}
+                    _reject_declared_oversize(headers_obj, max_bytes)
+                    content = _read_stream_with_limit(response.iter_bytes(), max_bytes)
+                    content_type = (
+                        headers_obj.get("content-type")
+                        or headers_obj.get("Content-Type")
+                        or "application/octet-stream"
+                    )
+                    return content, content_type.split(";", 1)[0].strip().lower()
+            raise ImageGenerationError("image fetch failed: too many redirects")
+    except ImageGenerationError:
+        raise
     except Exception as exc:
         raise ImageGenerationError(f"image fetch failed: {exc}") from exc
-
-    try:
-        status = getattr(response, "status_code", None) or response.status_code
-    except Exception:
-        status = None
-    if status and int(status) >= 400:
-        with contextlib.suppress(Exception):
-            response.close()
-        raise ImageGenerationError(f"image fetch failed with status {status}")
-
-    headers_obj = getattr(response, "headers", {}) or {}
-    content_length = headers_obj.get("content-length") or headers_obj.get("Content-Length")
-    if max_bytes is not None and content_length is not None:
-        try:
-            if int(str(content_length).strip()) > max_bytes:
-                with contextlib.suppress(Exception):
-                    response.close()
-                raise ImageGenerationError("image content too large")
-        except ValueError:
-            pass
-
-    try:
-        content = response.content
-    except Exception as exc:
-        with contextlib.suppress(Exception):
-            response.close()
-        raise ImageGenerationError(f"image fetch failed: {exc}") from exc
-
-    _enforce_max_bytes(content, max_bytes)
-    content_type = headers_obj.get("content-type") or headers_obj.get("Content-Type") or "application/octet-stream"
-    with contextlib.suppress(Exception):
-        response.close()
-    return content, content_type.split(";", 1)[0].strip().lower()
 
 
 def _enforce_base64_encoded_limit(encoded: str, max_bytes: int | None) -> None:
@@ -253,12 +255,46 @@ def _enforce_base64_encoded_limit(encoded: str, max_bytes: int | None) -> None:
         raise ImageGenerationError("image content too large")
 
 
-def _enforce_max_bytes(content: bytes, max_bytes: int | None) -> None:
-    if max_bytes is None:
+def _reject_declared_oversize(headers: Any, max_bytes: int | None) -> None:
+    limit = _positive_byte_limit(max_bytes)
+    if limit is None:
         return
+    content_length = headers.get("content-length") or headers.get("Content-Length")
+    if content_length is None:
+        return
+    try:
+        declared_size = int(str(content_length).strip())
+    except ValueError:
+        return
+    if declared_size > limit:
+        raise ImageGenerationError("image content too large")
+
+
+def _read_stream_with_limit(chunks: Any, max_bytes: int | None) -> bytes:
+    limit = _positive_byte_limit(max_bytes)
+    total = 0
+    parts: list[bytes] = []
+    for chunk in chunks:
+        if not chunk:
+            continue
+        total += len(chunk)
+        if limit is not None and total > limit:
+            raise ImageGenerationError("image content too large")
+        parts.append(chunk)
+    return b"".join(parts)
+
+
+def _enforce_max_bytes(content: bytes, max_bytes: int | None) -> None:
+    limit = _positive_byte_limit(max_bytes)
+    if limit is not None and len(content) > limit:
+        raise ImageGenerationError("image content too large")
+
+
+def _positive_byte_limit(max_bytes: int | None) -> int | None:
+    if max_bytes is None:
+        return None
     try:
         limit = int(max_bytes)
     except (TypeError, ValueError):
-        return
-    if limit > 0 and len(content) > limit:
-        raise ImageGenerationError("image content too large")
+        return None
+    return limit if limit > 0 else None

--- a/tldw_Server_API/app/core/Image_Generation/adapters/image_format_utils.py
+++ b/tldw_Server_API/app/core/Image_Generation/adapters/image_format_utils.py
@@ -19,7 +19,7 @@ except Exception:  # pragma: no cover - optional dependency guard
     Image = None  # type: ignore
 
 
-def decode_data_url(data_url: str) -> tuple[bytes, str]:
+def decode_data_url(data_url: str, *, max_bytes: int | None = None) -> tuple[bytes, str]:
     header, _, encoded = data_url.partition(",")
     if not header.startswith("data:"):
         raise ImageGenerationError("invalid data URL")
@@ -28,21 +28,26 @@ def decode_data_url(data_url: str) -> tuple[bytes, str]:
     content_type = meta.split(";", 1)[0] or content_type if ";" in meta else meta or content_type
     if ";base64" not in header:
         raise ImageGenerationError("unsupported data URL encoding")
+    _enforce_base64_encoded_limit(encoded, max_bytes)
     try:
-        content = base64.b64decode(encoded)
+        content = base64.b64decode(encoded, validate=True)
     except (binascii.Error, TypeError, ValueError) as exc:
         raise ImageGenerationError("invalid base64 data") from exc
+    _enforce_max_bytes(content, max_bytes)
     return content, content_type
 
 
-def decode_base64_image(encoded: str) -> bytes:
+def decode_base64_image(encoded: str, *, max_bytes: int | None = None) -> bytes:
+    _enforce_base64_encoded_limit(encoded, max_bytes)
     try:
-        return base64.b64decode(encoded, validate=True)
+        content = base64.b64decode(encoded, validate=True)
     except (binascii.Error, TypeError, ValueError) as exc:
         raise ImageGenerationError("invalid base64 image data") from exc
+    _enforce_max_bytes(content, max_bytes)
+    return content
 
 
-def maybe_decode_base64_image(encoded: str | None) -> bytes | None:
+def maybe_decode_base64_image(encoded: str | None, *, max_bytes: int | None = None) -> bytes | None:
     if not isinstance(encoded, str):
         return None
     raw = encoded.strip()
@@ -50,16 +55,21 @@ def maybe_decode_base64_image(encoded: str | None) -> bytes | None:
         return None
     if raw.startswith("data:"):
         try:
-            content, _content_type = decode_data_url(raw)
+            content, _content_type = decode_data_url(raw, max_bytes=max_bytes)
             return content
-        except ImageGenerationError:
+        except ImageGenerationError as exc:
+            if "too large" in str(exc):
+                raise
             return None
     if any(ch.isspace() for ch in raw):
         return None
+    _enforce_base64_encoded_limit(raw, max_bytes)
     try:
-        return base64.b64decode(raw, validate=True)
+        content = base64.b64decode(raw, validate=True)
     except (binascii.Error, TypeError, ValueError):
         return None
+    _enforce_max_bytes(content, max_bytes)
+    return content
 
 
 def reference_image_data_url(reference_image: ResolvedReferenceImage) -> str:
@@ -125,11 +135,11 @@ def maybe_convert_format(
     requested_format: str,
 ) -> tuple[bytes, str]:
     if requested_format == actual_format:
-        return content, content_type
+        return content, content_type or content_type_for_format(requested_format)
     if requested_format not in {"png", "jpg", "webp"}:
         raise ImageGenerationError(f"unsupported output format: {requested_format}")
-    if actual_format is None and requested_format == "png":
-        return content, content_type or "image/png"
+    if actual_format is None:
+        raise ImageGenerationError("invalid image content")
     if Image is None:
         raise ImageGenerationError("Pillow is required for image format conversion")
     try:
@@ -151,17 +161,45 @@ def maybe_convert_format(
     return converted, content_type_for_format(requested_format)
 
 
+def validate_and_convert_image_output(
+    content: bytes,
+    content_type: str,
+    requested_format: str,
+    *,
+    max_bytes: int | None = None,
+) -> tuple[bytes, str]:
+    """Validate actual image bytes, enforce size caps, and convert when requested."""
+
+    _enforce_max_bytes(content, max_bytes)
+    output_format = "jpg" if requested_format == "jpeg" else requested_format
+    actual_format = format_from_bytes(content)
+    if actual_format is None:
+        raise ImageGenerationError("invalid image content")
+    actual_content_type = content_type_for_format(actual_format)
+    converted, converted_content_type = maybe_convert_format(
+        content,
+        actual_content_type,
+        actual_format,
+        output_format,
+    )
+    _enforce_max_bytes(converted, max_bytes)
+    return converted, converted_content_type
+
+
 def fetch_image_bytes(
     url: str,
     *,
     timeout: int | float,
     headers: dict[str, Any] | None = None,
+    cookies: dict[str, Any] | None = None,
+    max_bytes: int | None = None,
 ) -> tuple[bytes, str]:
     try:
         response = fetch(
             method="GET",
             url=url,
             headers=headers,
+            cookies=cookies,
             timeout=timeout,
         )
     except Exception as exc:
@@ -176,6 +214,17 @@ def fetch_image_bytes(
             response.close()
         raise ImageGenerationError(f"image fetch failed with status {status}")
 
+    headers_obj = getattr(response, "headers", {}) or {}
+    content_length = headers_obj.get("content-length") or headers_obj.get("Content-Length")
+    if max_bytes is not None and content_length is not None:
+        try:
+            if int(str(content_length).strip()) > max_bytes:
+                with contextlib.suppress(Exception):
+                    response.close()
+                raise ImageGenerationError("image content too large")
+        except ValueError:
+            pass
+
     try:
         content = response.content
     except Exception as exc:
@@ -183,7 +232,33 @@ def fetch_image_bytes(
             response.close()
         raise ImageGenerationError(f"image fetch failed: {exc}") from exc
 
-    content_type = response.headers.get("content-type", "application/octet-stream")
+    _enforce_max_bytes(content, max_bytes)
+    content_type = headers_obj.get("content-type") or headers_obj.get("Content-Type") or "application/octet-stream"
     with contextlib.suppress(Exception):
         response.close()
     return content, content_type.split(";", 1)[0].strip().lower()
+
+
+def _enforce_base64_encoded_limit(encoded: str, max_bytes: int | None) -> None:
+    if max_bytes is None:
+        return
+    try:
+        limit = int(max_bytes)
+    except (TypeError, ValueError):
+        return
+    if limit <= 0:
+        return
+    max_encoded_chars = ((limit + 2) // 3) * 4
+    if len(encoded.strip()) > max_encoded_chars:
+        raise ImageGenerationError("image content too large")
+
+
+def _enforce_max_bytes(content: bytes, max_bytes: int | None) -> None:
+    if max_bytes is None:
+        return
+    try:
+        limit = int(max_bytes)
+    except (TypeError, ValueError):
+        return
+    if limit > 0 and len(content) > limit:
+        raise ImageGenerationError("image content too large")

--- a/tldw_Server_API/app/core/Image_Generation/adapters/modelstudio_image_adapter.py
+++ b/tldw_Server_API/app/core/Image_Generation/adapters/modelstudio_image_adapter.py
@@ -15,11 +15,9 @@ from tldw_Server_API.app.core.Image_Generation.adapters.image_format_utils impor
     decode_base64_image,
     decode_data_url,
     fetch_image_bytes,
-    format_from_bytes,
-    format_from_content_type,
-    maybe_convert_format,
     maybe_decode_base64_image,
     reference_image_data_url,
+    validate_and_convert_image_output,
 )
 from tldw_Server_API.app.core.Image_Generation.capabilities import resolve_reference_image_capability
 from tldw_Server_API.app.core.Image_Generation.config import (
@@ -29,6 +27,7 @@ from tldw_Server_API.app.core.Image_Generation.config import (
     get_image_generation_config,
 )
 from tldw_Server_API.app.core.Image_Generation.exceptions import ImageBackendUnavailableError, ImageGenerationError
+from tldw_Server_API.app.core.Image_Generation.request_validation import effective_inline_max_bytes
 
 
 class ModelStudioImageAdapter:
@@ -75,11 +74,17 @@ class ModelStudioImageAdapter:
                 raise ImageGenerationError("Model Studio generation failed in auto mode") from async_exc
         return self._finalize_result(content, content_type, output_format)
 
-    @staticmethod
-    def _finalize_result(content: bytes, content_type: str, output_format: str) -> ImageGenResult:
-        actual_format = format_from_content_type(content_type) or format_from_bytes(content)
-        content, content_type = maybe_convert_format(content, content_type, actual_format, output_format)
+    def _finalize_result(self, content: bytes, content_type: str, output_format: str) -> ImageGenResult:
+        content, content_type = validate_and_convert_image_output(
+            content,
+            content_type,
+            output_format,
+            max_bytes=self._max_output_bytes(),
+        )
         return ImageGenResult(content=content, content_type=content_type, bytes_len=len(content))
+
+    def _max_output_bytes(self) -> int:
+        return effective_inline_max_bytes(self._config)
 
     def _generate_sync(self, request: ImageGenRequest) -> tuple[bytes, str]:
         api_key = self._resolve_api_key()
@@ -325,7 +330,7 @@ class ModelStudioImageAdapter:
             for key in ("b64_json", "image_base64", "base64", "image_b64"):
                 value = node.get(key)
                 if isinstance(value, str) and value.strip():
-                    return decode_base64_image(value.strip()), "image/png"
+                    return decode_base64_image(value.strip(), max_bytes=self._max_output_bytes()), "image/png"
 
             for key in ("image_url", "url", "image"):
                 if key in node:
@@ -365,15 +370,16 @@ class ModelStudioImageAdapter:
         if not raw:
             return None
         if raw.startswith("data:"):
-            return decode_data_url(raw)
+            return decode_data_url(raw, max_bytes=self._max_output_bytes())
         if raw.startswith("http://") or raw.startswith("https://"):
             if not self._is_allowed_remote_image_url(raw):
                 raise ImageGenerationError("Model Studio returned unsupported image URL host")
             return fetch_image_bytes(
                 raw,
                 timeout=self._config.modelstudio_image_timeout_seconds or DEFAULT_MODELSTUDIO_IMAGE_TIMEOUT_SECONDS,
+                max_bytes=self._max_output_bytes(),
             )
-        decoded = maybe_decode_base64_image(raw)
+        decoded = maybe_decode_base64_image(raw, max_bytes=self._max_output_bytes())
         if decoded is not None:
             return decoded, "image/png"
         return None

--- a/tldw_Server_API/app/core/Image_Generation/adapters/novita_image_adapter.py
+++ b/tldw_Server_API/app/core/Image_Generation/adapters/novita_image_adapter.py
@@ -12,10 +12,8 @@ from tldw_Server_API.app.core.Image_Generation.adapters.image_format_utils impor
     decode_base64_image,
     decode_data_url,
     fetch_image_bytes,
-    format_from_bytes,
-    format_from_content_type,
-    maybe_convert_format,
     maybe_decode_base64_image,
+    validate_and_convert_image_output,
 )
 from tldw_Server_API.app.core.Image_Generation.config import (
     DEFAULT_NOVITA_IMAGE_BASE_URL,
@@ -24,6 +22,7 @@ from tldw_Server_API.app.core.Image_Generation.config import (
     get_image_generation_config,
 )
 from tldw_Server_API.app.core.Image_Generation.exceptions import ImageBackendUnavailableError, ImageGenerationError
+from tldw_Server_API.app.core.Image_Generation.request_validation import effective_inline_max_bytes
 
 
 class NovitaImageAdapter:
@@ -49,9 +48,16 @@ class NovitaImageAdapter:
         result_payload = self._poll_task_result(base_url, api_key, task_id)
 
         content, content_type = self._extract_image_content(result_payload)
-        actual_format = format_from_content_type(content_type) or format_from_bytes(content)
-        content, content_type = maybe_convert_format(content, content_type, actual_format, output_format)
+        content, content_type = validate_and_convert_image_output(
+            content,
+            content_type,
+            output_format,
+            max_bytes=self._max_output_bytes(),
+        )
         return ImageGenResult(content=content, content_type=content_type, bytes_len=len(content))
+
+    def _max_output_bytes(self) -> int:
+        return effective_inline_max_bytes(self._config)
 
     def _resolve_api_key(self) -> str:
         api_key = (self._config.novita_image_api_key or "").strip()
@@ -218,7 +224,7 @@ class NovitaImageAdapter:
             for key in ("b64_json", "image_base64", "base64", "image_b64"):
                 value = node.get(key)
                 if isinstance(value, str) and value.strip():
-                    return decode_base64_image(value.strip()), "image/png"
+                    return decode_base64_image(value.strip(), max_bytes=self._max_output_bytes()), "image/png"
             for key in ("image_url", "url", "image"):
                 if key in node:
                     extracted = self._extract_from_link_value(node.get(key))
@@ -254,13 +260,14 @@ class NovitaImageAdapter:
         if not raw:
             return None
         if raw.startswith("data:"):
-            return decode_data_url(raw)
+            return decode_data_url(raw, max_bytes=self._max_output_bytes())
         if raw.startswith("http://") or raw.startswith("https://"):
             return fetch_image_bytes(
                 raw,
                 timeout=self._config.novita_image_timeout_seconds or DEFAULT_NOVITA_IMAGE_TIMEOUT_SECONDS,
+                max_bytes=self._max_output_bytes(),
             )
-        decoded = maybe_decode_base64_image(raw)
+        decoded = maybe_decode_base64_image(raw, max_bytes=self._max_output_bytes())
         if decoded is not None:
             return decoded, "image/png"
         return None

--- a/tldw_Server_API/app/core/Image_Generation/adapters/openrouter_image_adapter.py
+++ b/tldw_Server_API/app/core/Image_Generation/adapters/openrouter_image_adapter.py
@@ -12,10 +12,8 @@ from tldw_Server_API.app.core.Image_Generation.adapters.image_format_utils impor
     decode_base64_image,
     decode_data_url,
     fetch_image_bytes,
-    format_from_bytes,
-    format_from_content_type,
-    maybe_convert_format,
     maybe_decode_base64_image,
+    validate_and_convert_image_output,
 )
 from tldw_Server_API.app.core.Image_Generation.config import (
     DEFAULT_OPENROUTER_IMAGE_BASE_URL,
@@ -24,6 +22,7 @@ from tldw_Server_API.app.core.Image_Generation.config import (
     get_image_generation_config,
 )
 from tldw_Server_API.app.core.Image_Generation.exceptions import ImageBackendUnavailableError, ImageGenerationError
+from tldw_Server_API.app.core.Image_Generation.request_validation import effective_inline_max_bytes
 
 
 class OpenRouterImageAdapter:
@@ -55,9 +54,16 @@ class OpenRouterImageAdapter:
             raise ImageGenerationError(f"OpenRouter request failed: {exc}") from exc
 
         content, content_type = self._extract_image_content(data)
-        actual_format = format_from_content_type(content_type) or format_from_bytes(content)
-        content, content_type = maybe_convert_format(content, content_type, actual_format, output_format)
+        content, content_type = validate_and_convert_image_output(
+            content,
+            content_type,
+            output_format,
+            max_bytes=self._max_output_bytes(),
+        )
         return ImageGenResult(content=content, content_type=content_type, bytes_len=len(content))
+
+    def _max_output_bytes(self) -> int:
+        return effective_inline_max_bytes(self._config)
 
     def _resolve_api_key(self) -> str:
         api_key = (self._config.openrouter_image_api_key or "").strip()
@@ -145,7 +151,7 @@ class OpenRouterImageAdapter:
             for key in ("b64_json", "image_base64", "base64", "image_b64"):
                 value = node.get(key)
                 if isinstance(value, str) and value.strip():
-                    return decode_base64_image(value.strip()), "image/png"
+                    return decode_base64_image(value.strip(), max_bytes=self._max_output_bytes()), "image/png"
 
             for key in ("image_url", "url", "image"):
                 if key in node:
@@ -185,13 +191,14 @@ class OpenRouterImageAdapter:
         if not raw:
             return None
         if raw.startswith("data:"):
-            return decode_data_url(raw)
+            return decode_data_url(raw, max_bytes=self._max_output_bytes())
         if raw.startswith("http://") or raw.startswith("https://"):
             return fetch_image_bytes(
                 raw,
                 timeout=self._config.openrouter_image_timeout_seconds or DEFAULT_OPENROUTER_IMAGE_TIMEOUT_SECONDS,
+                max_bytes=self._max_output_bytes(),
             )
-        decoded = maybe_decode_base64_image(raw)
+        decoded = maybe_decode_base64_image(raw, max_bytes=self._max_output_bytes())
         if decoded is not None:
             return decoded, "image/png"
         return None

--- a/tldw_Server_API/app/core/Image_Generation/adapters/stable_diffusion_cpp_adapter.py
+++ b/tldw_Server_API/app/core/Image_Generation/adapters/stable_diffusion_cpp_adapter.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-import subprocess
+# The adapter intentionally invokes a configured local stable-diffusion.cpp binary.
+import subprocess  # nosec B404
 import tempfile
 from pathlib import Path
 
 from loguru import logger
 
 from tldw_Server_API.app.core.Image_Generation.adapters.base import ImageGenRequest, ImageGenResult
+from tldw_Server_API.app.core.Image_Generation.adapters.image_format_utils import validate_and_convert_image_output
 from tldw_Server_API.app.core.Image_Generation.config import (
     DEFAULT_SD_CPP_CFG_SCALE,
     DEFAULT_SD_CPP_SAMPLER,
@@ -16,6 +18,7 @@ from tldw_Server_API.app.core.Image_Generation.config import (
     get_image_generation_config,
 )
 from tldw_Server_API.app.core.Image_Generation.exceptions import ImageBackendUnavailableError, ImageGenerationError
+from tldw_Server_API.app.core.Image_Generation.request_validation import effective_inline_max_bytes
 
 
 class StableDiffusionCppAdapter:
@@ -77,9 +80,19 @@ class StableDiffusionCppAdapter:
                 extra_params=extra_params,
                 device=self._config.sd_cpp_device,
             )
-            logger.info("stable-diffusion.cpp: running {}", " ".join(cmd))
+            logger.info(
+                "stable-diffusion.cpp: running backend binary={} model_flag={} width={} height={} steps={} format={} extra_keys={}",
+                binary_path.name,
+                model_flag,
+                width,
+                height,
+                steps,
+                output_format,
+                sorted(str(key) for key in extra_params),
+            )
             try:
-                result = subprocess.run(
+                # `cmd` is an argv list for the configured local binary; shell execution is not used.
+                result = subprocess.run(  # nosec B603
                     cmd,
                     cwd=str(binary_path.parent),
                     capture_output=True,
@@ -90,9 +103,12 @@ class StableDiffusionCppAdapter:
                 raise ImageGenerationError("stable-diffusion.cpp timed out") from exc
 
             if result.returncode != 0:
-                stderr_tail = (result.stderr or "").strip().splitlines()[-5:]
-                detail = "\n".join(stderr_tail) if stderr_tail else "unknown error"
-                raise ImageGenerationError(f"stable-diffusion.cpp failed: {detail}")
+                logger.warning(
+                    "stable-diffusion.cpp failed exit_code={} stderr_lines={}",
+                    result.returncode,
+                    len((result.stderr or "").splitlines()),
+                )
+                raise ImageGenerationError("stable-diffusion.cpp failed")
 
             if not output_path.exists():
                 raise ImageGenerationError("stable-diffusion.cpp did not produce output")
@@ -100,6 +116,12 @@ class StableDiffusionCppAdapter:
             content = output_path.read_bytes()
 
         content_type = _content_type_for_format(output_format)
+        content, content_type = validate_and_convert_image_output(
+            content,
+            content_type,
+            output_format,
+            max_bytes=effective_inline_max_bytes(self._config),
+        )
         return ImageGenResult(content=content, content_type=content_type, bytes_len=len(content))
 
     @staticmethod

--- a/tldw_Server_API/app/core/Image_Generation/adapters/stable_diffusion_cpp_adapter.py
+++ b/tldw_Server_API/app/core/Image_Generation/adapters/stable_diffusion_cpp_adapter.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-# The adapter intentionally invokes a configured local stable-diffusion.cpp binary.
-import subprocess  # nosec B404
+import subprocess  # nosec B404 # Required for configured local stable-diffusion.cpp binary invocation.
 import tempfile
 from pathlib import Path
 
@@ -91,8 +90,7 @@ class StableDiffusionCppAdapter:
                 sorted(str(key) for key in extra_params),
             )
             try:
-                # `cmd` is an argv list for the configured local binary; shell execution is not used.
-                result = subprocess.run(  # nosec B603
+                result = subprocess.run(  # nosec B603 # cmd is an argv list for a configured local binary; shell=False.
                     cmd,
                     cwd=str(binary_path.parent),
                     capture_output=True,

--- a/tldw_Server_API/app/core/Image_Generation/adapters/swarmui_adapter.py
+++ b/tldw_Server_API/app/core/Image_Generation/adapters/swarmui_adapter.py
@@ -2,27 +2,25 @@
 
 from __future__ import annotations
 
-import base64
-import contextlib
-import io
 from typing import Any
 from urllib.parse import quote, urlparse
 
 from loguru import logger
 
-from tldw_Server_API.app.core.http_client import fetch, fetch_json
+from tldw_Server_API.app.core.http_client import fetch_json
 from tldw_Server_API.app.core.Image_Generation.adapters.base import ImageGenRequest, ImageGenResult
+from tldw_Server_API.app.core.Image_Generation.adapters.image_format_utils import (
+    decode_data_url as decode_shared_data_url,
+    fetch_image_bytes as fetch_shared_image_bytes,
+    validate_and_convert_image_output,
+)
 from tldw_Server_API.app.core.Image_Generation.config import (
     DEFAULT_SWARMUI_BASE_URL,
     DEFAULT_SWARMUI_TIMEOUT_SECONDS,
     get_image_generation_config,
 )
 from tldw_Server_API.app.core.Image_Generation.exceptions import ImageBackendUnavailableError, ImageGenerationError
-
-try:
-    from PIL import Image
-except Exception:  # pragma: no cover - optional dependency guard
-    Image = None  # type: ignore
+from tldw_Server_API.app.core.Image_Generation.request_validation import effective_inline_max_bytes
 
 
 class SwarmUIAdapter:
@@ -50,15 +48,23 @@ class SwarmUIAdapter:
             raise ImageGenerationError("SwarmUI did not return any images")
 
         if image_ref.startswith("data:"):
-            content, content_type = _decode_data_url(image_ref)
-            fmt = _format_from_content_type(content_type)
-            content, content_type = _maybe_convert_format(content, content_type, fmt, output_format)
+            content, content_type = decode_shared_data_url(image_ref, max_bytes=self._max_output_bytes())
+            content, content_type = validate_and_convert_image_output(
+                content,
+                content_type,
+                output_format,
+                max_bytes=self._max_output_bytes(),
+            )
             return ImageGenResult(content=content, content_type=content_type, bytes_len=len(content))
 
         image_url = self._resolve_image_url(base_url, image_ref)
         content, content_type = self._fetch_image_bytes(image_url)
-        fmt = _format_from_content_type(content_type) or _format_from_url(image_ref)
-        content, content_type = _maybe_convert_format(content, content_type, fmt, output_format)
+        content, content_type = validate_and_convert_image_output(
+            content,
+            content_type,
+            output_format,
+            max_bytes=self._max_output_bytes(),
+        )
         return ImageGenResult(content=content, content_type=content_type, bytes_len=len(content))
 
     def _resolve_base_url(self) -> str:
@@ -74,6 +80,9 @@ class SwarmUIAdapter:
         if not token:
             return None
         return {"swarm_token": token}
+
+    def _max_output_bytes(self) -> int:
+        return effective_inline_max_bytes(self._config)
 
     def _ensure_session(self, base_url: str) -> str:
         if self._session_id:
@@ -174,121 +183,45 @@ class SwarmUIAdapter:
     @staticmethod
     def _resolve_image_url(base_url: str, image_ref: str) -> str:
         if image_ref.startswith("http://") or image_ref.startswith("https://"):
+            if not SwarmUIAdapter._same_origin(base_url, image_ref):
+                raise ImageGenerationError("SwarmUI returned off-origin image URL")
             return image_ref
         parsed = urlparse(image_ref)
         if parsed.scheme in {"http", "https"}:
+            if not SwarmUIAdapter._same_origin(base_url, image_ref):
+                raise ImageGenerationError("SwarmUI returned off-origin image URL")
             return image_ref
         path = image_ref.lstrip("/")
         encoded_path = "/".join(quote(part) for part in path.split("/"))
         return f"{base_url.rstrip('/')}/{encoded_path}"
 
+    @staticmethod
+    def _same_origin(base_url: str, target_url: str) -> bool:
+        base = urlparse(base_url)
+        target = urlparse(target_url)
+        return (
+            base.scheme.lower() == target.scheme.lower()
+            and (base.hostname or "").lower() == (target.hostname or "").lower()
+            and SwarmUIAdapter._origin_port(base) == SwarmUIAdapter._origin_port(target)
+        )
+
+    @staticmethod
+    def _origin_port(parsed) -> int | None:
+        if parsed.port is not None:
+            return int(parsed.port)
+        if parsed.scheme.lower() == "https":
+            return 443
+        if parsed.scheme.lower() == "http":
+            return 80
+        return None
+
     def _fetch_image_bytes(self, url: str) -> tuple[bytes, str]:
         try:
-            response = fetch(
-                method="GET",
-                url=url,
+            return fetch_shared_image_bytes(
+                url,
                 cookies=self._cookies(),
                 timeout=self._config.swarmui_timeout_seconds or DEFAULT_SWARMUI_TIMEOUT_SECONDS,
+                max_bytes=self._max_output_bytes(),
             )
         except Exception as exc:
             raise ImageGenerationError(f"SwarmUI image fetch failed: {exc}") from exc
-        try:
-            status = getattr(response, "status_code", None) or response.status_code
-        except Exception:
-            status = None
-        if status and int(status) >= 400:
-            with contextlib.suppress(Exception):
-                response.close()
-            raise ImageGenerationError(f"SwarmUI image fetch failed with status {status}")
-        try:
-            content = response.content
-        except Exception as exc:
-            with contextlib.suppress(Exception):
-                response.close()
-            raise ImageGenerationError(f"SwarmUI image fetch failed: {exc}") from exc
-        content_type = response.headers.get("content-type", "application/octet-stream")
-        with contextlib.suppress(Exception):
-            response.close()
-        return content, content_type.split(";")[0].strip().lower()
-
-
-def _decode_data_url(data_url: str) -> tuple[bytes, str]:
-    header, _, encoded = data_url.partition(",")
-    if not header.startswith("data:"):
-        raise ImageGenerationError("invalid data URL")
-    meta = header[5:]
-    content_type = "application/octet-stream"
-    content_type = meta.split(";", 1)[0] or content_type if ";" in meta else meta or content_type
-    if ";base64" not in header:
-        raise ImageGenerationError("unsupported data URL encoding")
-    try:
-        content = base64.b64decode(encoded)
-    except Exception as exc:
-        raise ImageGenerationError("invalid base64 data") from exc
-    return content, content_type
-
-
-def _format_from_content_type(content_type: str) -> str | None:
-    if not content_type:
-        return None
-    ctype = content_type.split(";", 1)[0].strip().lower()
-    if ctype == "image/png":
-        return "png"
-    if ctype == "image/jpeg":
-        return "jpg"
-    if ctype == "image/webp":
-        return "webp"
-    return None
-
-
-def _format_from_url(url: str) -> str | None:
-    lowered = url.lower()
-    if lowered.endswith(".png"):
-        return "png"
-    if lowered.endswith(".jpg") or lowered.endswith(".jpeg"):
-        return "jpg"
-    if lowered.endswith(".webp"):
-        return "webp"
-    return None
-
-
-def _maybe_convert_format(
-    content: bytes,
-    content_type: str,
-    actual_format: str | None,
-    requested_format: str,
-) -> tuple[bytes, str]:
-    if requested_format == actual_format:
-        return content, content_type
-    if requested_format not in {"png", "jpg"}:
-        raise ImageGenerationError(f"unsupported output format: {requested_format}")
-    # If we don't know the actual format and PNG was requested, keep as-is.
-    if actual_format is None and requested_format == "png":
-        return content, content_type
-    converted = _convert_image_bytes(content, requested_format)
-    return converted, _content_type_for_format(requested_format)
-
-
-def _convert_image_bytes(content: bytes, target_format: str) -> bytes:
-    if Image is None:
-        raise ImageGenerationError("Pillow is required for image format conversion")
-    try:
-        with Image.open(io.BytesIO(content)) as img:
-            if target_format == "jpg" and img.mode not in {"RGB"}:
-                img = img.convert("RGB")
-            buf = io.BytesIO()
-            save_format = "JPEG" if target_format == "jpg" else "PNG"
-            img.save(buf, format=save_format)
-            return buf.getvalue()
-    except Exception as exc:
-        raise ImageGenerationError(f"failed to convert image: {exc}") from exc
-
-
-def _content_type_for_format(fmt: str) -> str:
-    if fmt == "png":
-        return "image/png"
-    if fmt == "jpg":
-        return "image/jpeg"
-    if fmt == "webp":
-        return "image/webp"
-    return "application/octet-stream"

--- a/tldw_Server_API/app/core/Image_Generation/adapters/together_image_adapter.py
+++ b/tldw_Server_API/app/core/Image_Generation/adapters/together_image_adapter.py
@@ -11,10 +11,8 @@ from tldw_Server_API.app.core.Image_Generation.adapters.image_format_utils impor
     decode_base64_image,
     decode_data_url,
     fetch_image_bytes,
-    format_from_bytes,
-    format_from_content_type,
-    maybe_convert_format,
     maybe_decode_base64_image,
+    validate_and_convert_image_output,
 )
 from tldw_Server_API.app.core.Image_Generation.config import (
     DEFAULT_TOGETHER_IMAGE_BASE_URL,
@@ -23,6 +21,7 @@ from tldw_Server_API.app.core.Image_Generation.config import (
     get_image_generation_config,
 )
 from tldw_Server_API.app.core.Image_Generation.exceptions import ImageBackendUnavailableError, ImageGenerationError
+from tldw_Server_API.app.core.Image_Generation.request_validation import effective_inline_max_bytes
 
 
 class TogetherImageAdapter:
@@ -54,9 +53,16 @@ class TogetherImageAdapter:
             raise ImageGenerationError(f"Together image request failed: {exc}") from exc
 
         content, content_type = self._extract_image_content(data)
-        actual_format = format_from_content_type(content_type) or format_from_bytes(content)
-        content, content_type = maybe_convert_format(content, content_type, actual_format, output_format)
+        content, content_type = validate_and_convert_image_output(
+            content,
+            content_type,
+            output_format,
+            max_bytes=self._max_output_bytes(),
+        )
         return ImageGenResult(content=content, content_type=content_type, bytes_len=len(content))
+
+    def _max_output_bytes(self) -> int:
+        return effective_inline_max_bytes(self._config)
 
     def _resolve_api_key(self) -> str:
         api_key = (self._config.together_image_api_key or "").strip()
@@ -138,7 +144,7 @@ class TogetherImageAdapter:
             for key in ("b64_json", "image_base64", "base64", "image_b64"):
                 value = node.get(key)
                 if isinstance(value, str) and value.strip():
-                    return decode_base64_image(value.strip()), "image/png"
+                    return decode_base64_image(value.strip(), max_bytes=self._max_output_bytes()), "image/png"
             for key in ("url", "image_url", "image"):
                 if key in node:
                     extracted = self._extract_from_link_value(node.get(key))
@@ -174,13 +180,14 @@ class TogetherImageAdapter:
         if not raw:
             return None
         if raw.startswith("data:"):
-            return decode_data_url(raw)
+            return decode_data_url(raw, max_bytes=self._max_output_bytes())
         if raw.startswith("http://") or raw.startswith("https://"):
             return fetch_image_bytes(
                 raw,
                 timeout=self._config.together_image_timeout_seconds or DEFAULT_TOGETHER_IMAGE_TIMEOUT_SECONDS,
+                max_bytes=self._max_output_bytes(),
             )
-        decoded = maybe_decode_base64_image(raw)
+        decoded = maybe_decode_base64_image(raw, max_bytes=self._max_output_bytes())
         if decoded is not None:
             return decoded, "image/png"
         return None

--- a/tldw_Server_API/app/core/Image_Generation/config.py
+++ b/tldw_Server_API/app/core/Image_Generation/config.py
@@ -205,9 +205,9 @@ def get_image_generation_config(*, reload: bool = False) -> ImageGenerationConfi
         enabled_backends = []
 
     inline_max_bytes_raw = _get_config_value(section, "inline_max_bytes")
-    inline_max_bytes = None
+    inline_max_bytes = DEFAULT_INLINE_MAX_BYTES
     if inline_max_bytes_raw is not None:
-        inline_max_bytes = _coerce_int(inline_max_bytes_raw, DEFAULT_INLINE_MAX_BYTES)
+        inline_max_bytes = max(1, _coerce_int(inline_max_bytes_raw, DEFAULT_INLINE_MAX_BYTES))
 
     config = ImageGenerationConfig(
         default_backend=default_backend,

--- a/tldw_Server_API/app/core/Image_Generation/reference_images.py
+++ b/tldw_Server_API/app/core/Image_Generation/reference_images.py
@@ -10,6 +10,8 @@ from PIL import Image
 
 from tldw_Server_API.app.core.DB_Management.media_db.runtime.validation import MediaDbLike
 from tldw_Server_API.app.core.Image_Generation.capabilities import ResolvedReferenceImage
+from tldw_Server_API.app.core.Image_Generation.config import get_image_generation_config
+from tldw_Server_API.app.core.Image_Generation.request_validation import effective_inline_max_bytes
 from tldw_Server_API.app.core.Storage import get_storage_backend
 from tldw_Server_API.app.core.Storage.storage_interface import StorageBackend, StorageError
 from tldw_Server_API.app.core.exceptions import FileArtifactsValidationError
@@ -39,6 +41,7 @@ class ManagedReferenceImageRow:
     storage_path: str
     filename: str | None
     mime_type: str
+    file_size: int | None
     created_at: str
 
 
@@ -67,6 +70,7 @@ class ManagedReferenceImageRepository:
                 mf.storage_path AS storage_path,
                 mf.original_filename AS filename,
                 mf.mime_type AS mime_type,
+                mf.file_size AS file_size,
                 mf.created_at AS created_at
             FROM MediaFiles mf
             INNER JOIN Media m ON m.id = mf.media_id
@@ -98,6 +102,7 @@ class ManagedReferenceImageRepository:
                 storage_path=str(row["storage_path"]),
                 filename=row["filename"],
                 mime_type=str(row["mime_type"]),
+                file_size=int(row["file_size"]) if row["file_size"] is not None else None,
                 created_at=str(row["created_at"]),
             )
             for row in rows
@@ -112,10 +117,18 @@ def _probe_dimensions(image_bytes: bytes) -> tuple[int | None, int | None]:
     try:
         with Image.open(io.BytesIO(image_bytes)) as image:
             width, height = image.size
-            image.load()
+            image.verify()
             return int(width), int(height)
     except Exception as exc:
         raise FileArtifactsValidationError("reference_image_invalid") from exc
+
+
+def _reference_image_max_bytes() -> int:
+    return effective_inline_max_bytes(get_image_generation_config())
+
+
+def _is_known_oversized(row: ManagedReferenceImageRow, max_bytes: int) -> bool:
+    return row.file_size is not None and row.file_size > max_bytes
 
 
 def _sanitize_path_component(component: str) -> str:
@@ -148,6 +161,7 @@ async def _load_durable_bytes(
     user_id: str | int,
     media_id: int,
     storage_path: str,
+    max_bytes: int | None = None,
 ) -> bytes:
     _validate_owned_media_storage_path(user_id=user_id, media_id=media_id, storage_path=storage_path)
     try:
@@ -169,6 +183,8 @@ async def _load_durable_bytes(
         raise FileArtifactsValidationError("reference_image_invalid") from exc
     if not isinstance(content, bytes) or not content:
         raise FileArtifactsValidationError("reference_image_invalid")
+    if max_bytes is not None and len(content) > max_bytes:
+        raise FileArtifactsValidationError("reference_image_invalid")
     return content
 
 
@@ -183,12 +199,16 @@ async def resolve_reference_image(
 
     repo = ManagedReferenceImageRepository(media_db, user_id=user_id)
     row = repo.get_candidate_row(file_id)
+    max_bytes = _reference_image_max_bytes()
+    if _is_known_oversized(row, max_bytes):
+        raise FileArtifactsValidationError("reference_image_invalid")
     storage_backend = storage or get_storage_backend()
     content = await _load_durable_bytes(
         storage_backend,
         user_id=user_id,
         media_id=row.media_id,
         storage_path=row.storage_path,
+        max_bytes=max_bytes,
     )
     width, height = _probe_dimensions(content)
     return ResolvedReferenceImage(
@@ -214,6 +234,7 @@ async def list_reference_image_candidates(
 
     repo = ManagedReferenceImageRepository(media_db, user_id=user_id)
     storage_backend = storage or get_storage_backend()
+    max_bytes = _reference_image_max_bytes()
     items: list[ReferenceImageCandidate] = []
     offset = 0
     while len(items) < limit:
@@ -222,12 +243,15 @@ async def list_reference_image_candidates(
         if not rows:
             break
         for row in rows:
+            if _is_known_oversized(row, max_bytes):
+                continue
             try:
                 content = await _load_durable_bytes(
                     storage_backend,
                     user_id=user_id,
                     media_id=row.media_id,
                     storage_path=row.storage_path,
+                    max_bytes=max_bytes,
                 )
                 width, height = _probe_dimensions(content)
             except FileArtifactsValidationError:

--- a/tldw_Server_API/app/core/Image_Generation/request_validation.py
+++ b/tldw_Server_API/app/core/Image_Generation/request_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Any
 
@@ -87,6 +88,7 @@ def validate_image_generation_request(
     max_steps = _positive_int_attr(config, "max_steps", DEFAULT_MAX_STEPS)
     _validate_int_bound(issues, steps, path="steps", max_value=max_steps)
 
+    _validate_positive_finite_float(issues, structured.get("cfg_scale"), path="cfg_scale")
     _validate_extra_params(structured, config, issues)
     return issues
 
@@ -123,6 +125,26 @@ def _validate_int_bound(
         issues.append(_issue(f"{path} out of range", path))
         return False
     return True
+
+
+def _validate_positive_finite_float(
+    issues: list[ImageGenerationValidationIssue],
+    value: Any,
+    *,
+    path: str,
+) -> None:
+    if value is None:
+        return
+    if isinstance(value, bool):
+        issues.append(_issue(f"{path} must be a finite positive number", path))
+        return
+    try:
+        candidate = float(value)
+    except (TypeError, ValueError):
+        issues.append(_issue(f"{path} must be a finite positive number", path))
+        return
+    if not math.isfinite(candidate) or candidate <= 0:
+        issues.append(_issue(f"{path} must be a finite positive number", path))
 
 
 def _validate_extra_params(

--- a/tldw_Server_API/app/core/Image_Generation/request_validation.py
+++ b/tldw_Server_API/app/core/Image_Generation/request_validation.py
@@ -1,0 +1,156 @@
+"""Shared request validation helpers for image-generation entry points."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from tldw_Server_API.app.core.Image_Generation.config import (
+    DEFAULT_INLINE_MAX_BYTES,
+    DEFAULT_MAX_HEIGHT,
+    DEFAULT_MAX_PIXELS,
+    DEFAULT_MAX_PROMPT_LENGTH,
+    DEFAULT_MAX_STEPS,
+    DEFAULT_MAX_WIDTH,
+    get_image_generation_config,
+)
+
+
+@dataclass(frozen=True)
+class ImageGenerationValidationIssue:
+    code: str
+    message: str
+    path: str
+
+
+def effective_inline_max_bytes(config: Any | None = None) -> int:
+    """Return a positive byte cap for inline/remote image payloads."""
+
+    if config is None:
+        config = get_image_generation_config()
+    raw = getattr(config, "inline_max_bytes", None)
+    if raw is None:
+        return DEFAULT_INLINE_MAX_BYTES
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_INLINE_MAX_BYTES
+    return value if value > 0 else DEFAULT_INLINE_MAX_BYTES
+
+
+def allowed_extra_params_for_backend(backend: str, config: Any) -> set[str]:
+    """Return configured passthrough allowlist keys for an image backend."""
+
+    backend_name = str(backend or "").strip().lower()
+    attr_by_backend = {
+        "stable_diffusion_cpp": "sd_cpp_allowed_extra_params",
+        "swarmui": "swarmui_allowed_extra_params",
+        "openrouter": "openrouter_image_allowed_extra_params",
+        "novita": "novita_image_allowed_extra_params",
+        "together": "together_image_allowed_extra_params",
+        "modelstudio": "modelstudio_image_allowed_extra_params",
+    }
+    attr = attr_by_backend.get(backend_name)
+    if not attr:
+        return set()
+    return {str(item).strip() for item in getattr(config, attr, []) or [] if str(item).strip()}
+
+
+def validate_image_generation_request(
+    structured: dict[str, Any],
+    *,
+    config: Any | None = None,
+) -> list[ImageGenerationValidationIssue]:
+    """Validate shared image-generation bounds and backend passthrough controls."""
+
+    if config is None:
+        config = get_image_generation_config()
+
+    issues: list[ImageGenerationValidationIssue] = []
+    prompt = structured.get("prompt")
+    max_prompt_length = _positive_int_attr(config, "max_prompt_length", DEFAULT_MAX_PROMPT_LENGTH)
+    if isinstance(prompt, str) and len(prompt) > max_prompt_length:
+        issues.append(_issue("prompt exceeds max length", "prompt"))
+
+    width = structured.get("width")
+    height = structured.get("height")
+    max_width = _positive_int_attr(config, "max_width", DEFAULT_MAX_WIDTH)
+    max_height = _positive_int_attr(config, "max_height", DEFAULT_MAX_HEIGHT)
+    max_pixels = _positive_int_attr(config, "max_pixels", DEFAULT_MAX_PIXELS)
+
+    width_ok = _validate_int_bound(issues, width, path="width", max_value=max_width)
+    height_ok = _validate_int_bound(issues, height, path="height", max_value=max_height)
+    if width_ok and height_ok and isinstance(width, int) and isinstance(height, int) and width * height > max_pixels:
+        issues.append(_issue("image dimensions exceed max pixels", "width,height"))
+
+    steps = structured.get("steps")
+    max_steps = _positive_int_attr(config, "max_steps", DEFAULT_MAX_STEPS)
+    _validate_int_bound(issues, steps, path="steps", max_value=max_steps)
+
+    _validate_extra_params(structured, config, issues)
+    return issues
+
+
+def _issue(message: str, path: str) -> ImageGenerationValidationIssue:
+    return ImageGenerationValidationIssue(
+        code="image_params_invalid",
+        message=message,
+        path=path,
+    )
+
+
+def _positive_int_attr(config: Any, attr: str, default: int) -> int:
+    try:
+        value = int(getattr(config, attr, default))
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+def _validate_int_bound(
+    issues: list[ImageGenerationValidationIssue],
+    value: Any,
+    *,
+    path: str,
+    max_value: int,
+) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, bool) or not isinstance(value, int):
+        issues.append(_issue(f"{path} must be an integer", path))
+        return False
+    if value <= 0 or value > max_value:
+        issues.append(_issue(f"{path} out of range", path))
+        return False
+    return True
+
+
+def _validate_extra_params(
+    structured: dict[str, Any],
+    config: Any,
+    issues: list[ImageGenerationValidationIssue],
+) -> None:
+    extra_params = structured.get("extra_params") or {}
+    if not extra_params:
+        return
+    if not isinstance(extra_params, dict):
+        issues.append(_issue("extra_params must be an object", "extra_params"))
+        return
+
+    backend = str(structured.get("backend") or "").strip().lower()
+    allowlist = allowed_extra_params_for_backend(backend, config)
+    exempt_control_keys: set[str] = set()
+    if backend == "modelstudio":
+        exempt_control_keys.add("mode")
+
+    keys_to_validate = [key for key in extra_params if key not in exempt_control_keys]
+    if not keys_to_validate:
+        return
+    for key in keys_to_validate:
+        if key not in allowlist:
+            issues.append(_issue("extra_params key not allowlisted", f"extra_params.{key}"))
+
+    if "cli_args" in extra_params and "cli_args" in allowlist:
+        cli_args = extra_params.get("cli_args")
+        if not isinstance(cli_args, (list, tuple)):
+            issues.append(_issue("cli_args must be a list", "extra_params.cli_args"))

--- a/tldw_Server_API/app/core/Workflows/adapters/content/_config.py
+++ b/tldw_Server_API/app/core/Workflows/adapters/content/_config.py
@@ -44,15 +44,21 @@ class ImageGenConfig(BaseAdapterConfig):
     """Config for image generation adapter."""
 
     prompt: str = Field(..., description="Image generation prompt (templated)")
-    provider: Literal["openai", "stability", "midjourney", "local"] = Field(
-        "openai", description="Image generation provider"
-    )
-    model: str | None = Field(None, description="Model to use (e.g., dall-e-3)")
-    size: str = Field("1024x1024", description="Image size (e.g., '1024x1024')")
-    quality: Literal["standard", "hd"] = Field("standard", description="Image quality")
-    style: str | None = Field(None, description="Style preset")
+    backend: str = Field("stable_diffusion_cpp", description="Image generation backend")
     negative_prompt: str | None = Field(None, description="Negative prompt")
-    num_images: int = Field(1, ge=1, le=4, description="Number of images to generate")
+    width: int = Field(512, ge=1, description="Image width in pixels")
+    height: int = Field(512, ge=1, description="Image height in pixels")
+    steps: int = Field(20, ge=1, description="Sampling steps")
+    cfg_scale: float = Field(7.0, gt=0, description="Classifier-free guidance scale")
+    seed: int | None = Field(None, description="Optional deterministic seed")
+    sampler: str | None = Field(None, description="Optional sampler name")
+    model: str | None = Field(None, description="Optional backend model override")
+    format: Literal["png", "jpg", "jpeg", "webp"] = Field("png", description="Output image format")
+    extra_params: dict[str, Any] | None = Field(None, description="Backend-specific allowlisted parameters")
+    prompt_refinement: bool | Literal["off", "auto", "basic"] | None = Field(
+        None,
+        description="Prompt refinement mode",
+    )
 
 
 class ImageDescribeConfig(BaseAdapterConfig):

--- a/tldw_Server_API/app/core/Workflows/adapters/content/image.py
+++ b/tldw_Server_API/app/core/Workflows/adapters/content/image.py
@@ -8,6 +8,7 @@ This module includes adapters for image operations:
 from __future__ import annotations
 
 import base64
+import asyncio
 import time
 import uuid
 from typing import Any
@@ -110,6 +111,7 @@ async def run_image_gen_adapter(config: dict[str, Any], context: dict[str, Any])
         normalize_prompt_refinement_mode,
         refine_image_prompt,
     )
+    from tldw_Server_API.app.core.Image_Generation.request_validation import validate_image_generation_request
 
     image_generation_cfg = get_image_generation_config()
     prompt_refinement_mode = normalize_prompt_refinement_mode(config.get("prompt_refinement"))
@@ -126,24 +128,51 @@ async def run_image_gen_adapter(config: dict[str, Any], context: dict[str, Any])
         negative_prompt = apply_template_to_string(str(neg_prompt_t), context) or str(neg_prompt_t)
 
     # Parameters
-    backend = str(config.get("backend") or "stable_diffusion_cpp").strip().lower()
-    width = int(config.get("width") or 512)
-    height = int(config.get("height") or 512)
-    steps = int(config.get("steps") or 20)
-    cfg_scale = float(config.get("cfg_scale") or 7.0)
-    seed = config.get("seed")
-    if seed is not None:
-        try:
+    try:
+        backend = str(config.get("backend") or "stable_diffusion_cpp").strip().lower()
+        width = int(config.get("width") or 512)
+        height = int(config.get("height") or 512)
+        steps = int(config.get("steps") or 20)
+        cfg_scale = float(config.get("cfg_scale") or 7.0)
+        seed = config.get("seed")
+        if seed is not None:
             seed = int(seed)
-        except Exception:
-            seed = None
-    sampler = config.get("sampler")
-    model = config.get("model")
-    img_format = str(config.get("format") or "png").strip().lower()
-    if img_format not in ("png", "jpg", "jpeg", "webp"):
-        img_format = "png"
+        sampler = config.get("sampler")
+        model = config.get("model")
+        img_format = str(config.get("format") or "png").strip().lower()
+        if img_format == "jpeg":
+            img_format = "jpg"
+        if img_format not in ("png", "jpg", "webp"):
+            img_format = "png"
+        extra_params = config.get("extra_params") or {}
+        if not isinstance(extra_params, dict):
+            return {"error": "image_params_invalid"}
+        extra_params = dict(extra_params)
+    except (TypeError, ValueError):
+        return {"error": "image_params_invalid"}
+
     save_artifact = config.get("save_artifact")
     save_artifact = True if save_artifact is None else bool(save_artifact)
+
+    validation_issues = validate_image_generation_request(
+        {
+            "backend": backend,
+            "prompt": prompt,
+            "width": width,
+            "height": height,
+            "steps": steps,
+            "extra_params": extra_params,
+        },
+        config=image_generation_cfg,
+    )
+    if validation_issues:
+        return {
+            "error": "image_params_invalid",
+            "validation_errors": [
+                {"code": issue.code, "message": issue.message, "path": issue.path}
+                for issue in validation_issues
+            ],
+        }
 
     # Test mode simulation
     if is_test_mode():
@@ -197,12 +226,12 @@ async def run_image_gen_adapter(config: dict[str, Any], context: dict[str, Any])
             sampler=sampler,
             model=model,
             format=img_format,
-            extra_params=dict(config.get("extra_params") or {}),
+            extra_params=extra_params,
         )
 
         # Generate
         start_ts = time.time()
-        result = adapter.generate(request)
+        result = await asyncio.to_thread(adapter.generate, request)
         duration_ms = (time.time() - start_ts) * 1000
 
         # Save image artifact

--- a/tldw_Server_API/app/core/Workflows/adapters/content/image.py
+++ b/tldw_Server_API/app/core/Workflows/adapters/content/image.py
@@ -130,12 +130,14 @@ async def run_image_gen_adapter(config: dict[str, Any], context: dict[str, Any])
     # Parameters
     try:
         backend = str(config.get("backend") or "stable_diffusion_cpp").strip().lower()
-        width = int(config.get("width") or 512)
-        height = int(config.get("height") or 512)
-        steps = int(config.get("steps") or 20)
-        cfg_scale = float(config.get("cfg_scale") or 7.0)
+        width = _coerce_int_param(config.get("width"), 512)
+        height = _coerce_int_param(config.get("height"), 512)
+        steps = _coerce_int_param(config.get("steps"), 20)
+        cfg_scale = _coerce_float_param(config.get("cfg_scale"), 7.0)
         seed = config.get("seed")
         if seed is not None:
+            if isinstance(seed, bool):
+                return {"error": "image_params_invalid"}
             seed = int(seed)
         sampler = config.get("sampler")
         model = config.get("model")
@@ -144,7 +146,8 @@ async def run_image_gen_adapter(config: dict[str, Any], context: dict[str, Any])
             img_format = "jpg"
         if img_format not in ("png", "jpg", "webp"):
             img_format = "png"
-        extra_params = config.get("extra_params") or {}
+        extra_params = config.get("extra_params")
+        extra_params = {} if extra_params is None else extra_params
         if not isinstance(extra_params, dict):
             return {"error": "image_params_invalid"}
         extra_params = dict(extra_params)
@@ -161,6 +164,7 @@ async def run_image_gen_adapter(config: dict[str, Any], context: dict[str, Any])
             "width": width,
             "height": height,
             "steps": steps,
+            "cfg_scale": cfg_scale,
             "extra_params": extra_params,
         },
         config=image_generation_cfg,
@@ -299,6 +303,22 @@ async def run_image_gen_adapter(config: dict[str, Any], context: dict[str, Any])
     except Exception:
         logger.exception("Image gen adapter error")
         return {"error": "image_gen_error"}
+
+
+def _coerce_int_param(value: Any, default: int) -> int:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        raise ValueError("boolean is not a valid integer parameter")
+    return int(value)
+
+
+def _coerce_float_param(value: Any, default: float) -> float:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        raise ValueError("boolean is not a valid float parameter")
+    return float(value)
 
 
 @registry.register(

--- a/tldw_Server_API/tests/Image_Generation/test_image_format_utils.py
+++ b/tldw_Server_API/tests/Image_Generation/test_image_format_utils.py
@@ -1,0 +1,44 @@
+import base64
+
+import pytest
+
+from tldw_Server_API.app.core.Image_Generation.adapters import image_format_utils
+from tldw_Server_API.app.core.Image_Generation.exceptions import ImageGenerationError
+
+
+def test_fetch_image_bytes_rejects_content_length_over_max(monkeypatch):
+    class FakeResponse:
+        status_code = 200
+        headers = {
+            "content-length": "10",
+            "content-type": "image/png",
+        }
+
+        @property
+        def content(self):
+            raise AssertionError("oversized responses should be rejected before content is read")
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(image_format_utils, "fetch", lambda **_kwargs: FakeResponse())
+
+    with pytest.raises(ImageGenerationError, match="too large"):
+        image_format_utils.fetch_image_bytes("https://cdn.example/image.png", timeout=1, max_bytes=3)
+
+
+def test_decode_base64_image_rejects_content_over_max():
+    encoded = base64.b64encode(b"1234").decode("ascii")
+
+    with pytest.raises(ImageGenerationError, match="too large"):
+        image_format_utils.decode_base64_image(encoded, max_bytes=3)
+
+
+def test_validate_and_convert_image_output_rejects_unknown_png_bytes():
+    with pytest.raises(ImageGenerationError, match="invalid image content"):
+        image_format_utils.validate_and_convert_image_output(
+            b"hello",
+            "image/png",
+            "png",
+            max_bytes=4_000_000,
+        )

--- a/tldw_Server_API/tests/Image_Generation/test_image_format_utils.py
+++ b/tldw_Server_API/tests/Image_Generation/test_image_format_utils.py
@@ -6,25 +6,89 @@ from tldw_Server_API.app.core.Image_Generation.adapters import image_format_util
 from tldw_Server_API.app.core.Image_Generation.exceptions import ImageGenerationError
 
 
+class _FakeStreamResponse:
+    def __init__(self, *, headers, chunks):
+        self.status_code = 200
+        self.headers = headers
+        self.url = "https://cdn.example/image.png"
+        self._chunks = chunks
+        self.closed = False
+        self.content_accessed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc_info):
+        self.closed = True
+        return False
+
+    @property
+    def content(self):
+        self.content_accessed = True
+        raise AssertionError("streaming fetch should not access response.content")
+
+    def iter_bytes(self):
+        yield from self._chunks
+
+
+class _FakeStreamClient:
+    def __init__(self, response):
+        self.response = response
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc_info):
+        return False
+
+    def stream(self, *_args, **_kwargs):
+        return self.response
+
+
+def _patch_stream_client(monkeypatch, response):
+    monkeypatch.setattr(image_format_utils, "_validate_egress_or_raise", lambda _url: None)
+    monkeypatch.setattr(image_format_utils, "create_client", lambda **_kwargs: _FakeStreamClient(response))
+
+
+def test_decode_data_url_allows_base64_whitespace():
+    encoded = base64.b64encode(b"image-bytes").decode("ascii")
+    spaced = f"{encoded[:4]}\n {encoded[4:]}"
+
+    content, content_type = image_format_utils.decode_data_url(f"data:image/png;base64,{spaced}")
+
+    assert content == b"image-bytes"
+    assert content_type == "image/png"
+
+
 def test_fetch_image_bytes_rejects_content_length_over_max(monkeypatch):
-    class FakeResponse:
-        status_code = 200
-        headers = {
+    response = _FakeStreamResponse(
+        headers={
             "content-length": "10",
             "content-type": "image/png",
-        }
-
-        @property
-        def content(self):
-            raise AssertionError("oversized responses should be rejected before content is read")
-
-        def close(self):
-            return None
-
-    monkeypatch.setattr(image_format_utils, "fetch", lambda **_kwargs: FakeResponse())
+        },
+        chunks=[b"oversized"],
+    )
+    _patch_stream_client(monkeypatch, response)
 
     with pytest.raises(ImageGenerationError, match="too large"):
         image_format_utils.fetch_image_bytes("https://cdn.example/image.png", timeout=1, max_bytes=3)
+
+    assert response.closed is True
+    assert response.content_accessed is False
+
+
+def test_fetch_image_bytes_rejects_stream_over_max_without_content_length(monkeypatch):
+    response = _FakeStreamResponse(
+        headers={"content-type": "image/png"},
+        chunks=[b"12", b"34"],
+    )
+    _patch_stream_client(monkeypatch, response)
+
+    with pytest.raises(ImageGenerationError, match="too large"):
+        image_format_utils.fetch_image_bytes("https://cdn.example/image.png", timeout=1, max_bytes=3)
+
+    assert response.closed is True
+    assert response.content_accessed is False
 
 
 def test_decode_base64_image_rejects_content_over_max():

--- a/tldw_Server_API/tests/Image_Generation/test_modelstudio_image_adapter.py
+++ b/tldw_Server_API/tests/Image_Generation/test_modelstudio_image_adapter.py
@@ -9,6 +9,8 @@ from tldw_Server_API.app.core.Image_Generation.capabilities import ResolvedRefer
 from tldw_Server_API.app.core.Image_Generation.config import ImageGenerationConfig
 from tldw_Server_API.app.core.Image_Generation.exceptions import ImageGenerationError
 
+PNG_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+
 
 def _make_config(**overrides) -> ImageGenerationConfig:
     base = dict(
@@ -158,7 +160,7 @@ def test_modelstudio_generate_sync_data_url(monkeypatch):
                     {
                         "message": {
                             "content": [
-                                {"image_url": "data:image/png;base64,aGVsbG8="},
+                                {"image_url": f"data:image/png;base64,{PNG_B64}"},
                             ]
                         }
                     }
@@ -170,9 +172,9 @@ def test_modelstudio_generate_sync_data_url(monkeypatch):
 
     adapter = modelstudio_module.ModelStudioImageAdapter()
     result = adapter.generate(_make_request())
-    assert result.content == b"hello"
+    assert result.content.startswith(b"\x89PNG\r\n\x1a\n")
     assert result.content_type == "image/png"
-    assert result.bytes_len == 5
+    assert result.bytes_len == len(result.content)
     assert captured["method"] == "POST"
     assert captured["url"].endswith("/services/aigc/multimodal-generation/generation")
 

--- a/tldw_Server_API/tests/Image_Generation/test_novita_image_adapter.py
+++ b/tldw_Server_API/tests/Image_Generation/test_novita_image_adapter.py
@@ -5,6 +5,8 @@ from tldw_Server_API.app.core.Image_Generation.adapters import novita_image_adap
 from tldw_Server_API.app.core.Image_Generation.config import ImageGenerationConfig
 from tldw_Server_API.app.core.Image_Generation.exceptions import ImageGenerationError
 
+PNG_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+
 
 def _make_config(**overrides) -> ImageGenerationConfig:
     base = dict(
@@ -97,7 +99,7 @@ def test_novita_generate_async_polling_success(monkeypatch):
             poll_counter["count"] += 1
             if poll_counter["count"] == 1:
                 return {"status": "pending"}
-            return {"status": "success", "images": [{"image_base64": "aGVsbG8="}]}
+            return {"status": "success", "images": [{"image_base64": PNG_B64}]}
         raise AssertionError("unexpected request")
 
     monkeypatch.setattr(novita_module, "fetch_json", fake_fetch_json)
@@ -105,9 +107,9 @@ def test_novita_generate_async_polling_success(monkeypatch):
 
     adapter = novita_module.NovitaImageAdapter()
     result = adapter.generate(_make_request())
-    assert result.content == b"hello"
+    assert result.content.startswith(b"\x89PNG\r\n\x1a\n")
     assert result.content_type == "image/png"
-    assert result.bytes_len == 5
+    assert result.bytes_len == len(result.content)
     assert poll_counter["count"] == 2
     assert any(call[1].endswith("/v3/async/txt2img") for call in calls)
     assert any(call[1].endswith("/v3/async/task-result") for call in calls)

--- a/tldw_Server_API/tests/Image_Generation/test_openrouter_image_adapter.py
+++ b/tldw_Server_API/tests/Image_Generation/test_openrouter_image_adapter.py
@@ -2,6 +2,8 @@ from tldw_Server_API.app.core.Image_Generation.adapters.base import ImageGenRequ
 from tldw_Server_API.app.core.Image_Generation.adapters import openrouter_image_adapter as openrouter_module
 from tldw_Server_API.app.core.Image_Generation.config import ImageGenerationConfig
 
+PNG_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+
 
 def _make_config(**overrides) -> ImageGenerationConfig:
     base = dict(
@@ -96,7 +98,7 @@ def test_openrouter_generate_data_url(monkeypatch):
                     "message": {
                         "images": [
                             {
-                                "image_url": "data:image/png;base64,aGVsbG8=",
+                                "image_url": f"data:image/png;base64,{PNG_B64}",
                             }
                         ]
                     }
@@ -108,9 +110,9 @@ def test_openrouter_generate_data_url(monkeypatch):
 
     adapter = openrouter_module.OpenRouterImageAdapter()
     result = adapter.generate(_make_request())
-    assert result.content == b"hello"
+    assert result.content.startswith(b"\x89PNG\r\n\x1a\n")
     assert result.content_type == "image/png"
-    assert result.bytes_len == 5
+    assert result.bytes_len == len(result.content)
     assert captured["method"] == "POST"
     assert captured["url"].endswith("/chat/completions")
     assert captured["json"]["modalities"] == ["image", "text"]
@@ -142,7 +144,7 @@ def test_openrouter_generate_image_url(monkeypatch):
     monkeypatch.setattr(
         openrouter_module,
         "fetch_image_bytes",
-        lambda url, timeout: (b"\x89PNG\r\n\x1a\nabc", "image/png"),
+        lambda url, timeout, **kwargs: (b"\x89PNG\r\n\x1a\nabc", "image/png"),
     )
 
     adapter = openrouter_module.OpenRouterImageAdapter()

--- a/tldw_Server_API/tests/Image_Generation/test_reference_images.py
+++ b/tldw_Server_API/tests/Image_Generation/test_reference_images.py
@@ -1,11 +1,13 @@
 from io import BytesIO
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from PIL import Image
 
 from tldw_Server_API.app.core.DB_Management.media_db.native_class import MediaDatabase
 from tldw_Server_API.app.core.exceptions import FileArtifactsValidationError
+from tldw_Server_API.app.core.Image_Generation import reference_images as reference_images_module
 from tldw_Server_API.app.core.Image_Generation.reference_images import (
     ReferenceImageOperationalError,
     list_reference_image_candidates,
@@ -89,6 +91,14 @@ class ReadFailingStorage:
 
     async def retrieve(self, path: str) -> ReadFailingHandle:
         return ReadFailingHandle()
+
+
+class MustNotReadStorage:
+    async def exists(self, path: str) -> bool:
+        raise AssertionError("oversized reference candidate should not hit storage")
+
+    async def retrieve(self, path: str):
+        raise AssertionError("oversized reference candidate should not hit storage")
 
 
 @pytest.mark.asyncio
@@ -444,3 +454,35 @@ async def test_list_reference_image_candidates_pages_past_newer_invalid_rows(med
     candidates = await list_reference_image_candidates(media_db, user_id="777", limit=1, storage=storage)
 
     assert [(candidate.file_id, candidate.title) for candidate in candidates] == [(1, "Old valid image")]
+
+
+@pytest.mark.asyncio
+async def test_list_reference_image_candidates_skips_oversized_rows_before_storage(
+    monkeypatch,
+    media_db: MediaDatabase,
+) -> None:
+    monkeypatch.setattr(
+        reference_images_module,
+        "get_image_generation_config",
+        lambda: SimpleNamespace(inline_max_bytes=3),
+        raising=False,
+    )
+
+    media_id = _create_test_image_media(
+        media_db,
+        title="Oversized image",
+        content="image content",
+        content_hash="image-hash-oversized",
+    )
+    media_db.insert_media_file(
+        media_id=media_id,
+        file_type="original",
+        storage_path=f"777/media/{media_id}/oversized.png",
+        original_filename="oversized.png",
+        file_size=10,
+        mime_type="image/png",
+    )
+
+    candidates = await list_reference_image_candidates(media_db, user_id="777", storage=MustNotReadStorage())
+
+    assert candidates == []

--- a/tldw_Server_API/tests/Image_Generation/test_stable_diffusion_cpp_adapter.py
+++ b/tldw_Server_API/tests/Image_Generation/test_stable_diffusion_cpp_adapter.py
@@ -1,0 +1,121 @@
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_Server_API.app.core.Image_Generation.adapters import stable_diffusion_cpp_adapter as stable_module
+from tldw_Server_API.app.core.Image_Generation.adapters.base import ImageGenRequest
+from tldw_Server_API.app.core.Image_Generation.config import ImageGenerationConfig
+from tldw_Server_API.app.core.Image_Generation.exceptions import ImageGenerationError
+
+
+def _make_config(**overrides) -> ImageGenerationConfig:
+    base = dict(
+        default_backend="stable_diffusion_cpp",
+        enabled_backends=["stable_diffusion_cpp"],
+        max_width=1024,
+        max_height=1024,
+        max_pixels=1024 * 1024,
+        max_steps=50,
+        max_prompt_length=1000,
+        inline_max_bytes=4000000,
+        sd_cpp_diffusion_model_path=None,
+        sd_cpp_llm_path=None,
+        sd_cpp_binary_path=None,
+        sd_cpp_model_path=None,
+        sd_cpp_vae_path=None,
+        sd_cpp_lora_paths=[],
+        sd_cpp_allowed_extra_params=[],
+        sd_cpp_default_steps=25,
+        sd_cpp_default_cfg_scale=7.5,
+        sd_cpp_default_sampler="euler_a",
+        sd_cpp_device="auto",
+        sd_cpp_timeout_seconds=120,
+        swarmui_base_url=None,
+        swarmui_default_model=None,
+        swarmui_swarm_token=None,
+        swarmui_allowed_extra_params=[],
+        swarmui_timeout_seconds=120,
+        openrouter_image_base_url=None,
+        openrouter_image_api_key=None,
+        openrouter_image_default_model=None,
+        openrouter_image_allowed_extra_params=[],
+        openrouter_image_timeout_seconds=120,
+        novita_image_base_url=None,
+        novita_image_api_key=None,
+        novita_image_default_model=None,
+        novita_image_allowed_extra_params=[],
+        novita_image_timeout_seconds=180,
+        novita_image_poll_interval_seconds=2,
+        together_image_base_url=None,
+        together_image_api_key=None,
+        together_image_default_model=None,
+        together_image_allowed_extra_params=[],
+        together_image_timeout_seconds=120,
+        modelstudio_image_base_url=None,
+        modelstudio_image_api_key=None,
+        modelstudio_image_default_model=None,
+        modelstudio_image_region="sg",
+        modelstudio_image_mode="auto",
+        modelstudio_image_poll_interval_seconds=2,
+        modelstudio_image_timeout_seconds=180,
+        modelstudio_image_allowed_extra_params=[],
+    )
+    base.update(overrides)
+    return ImageGenerationConfig(**base)
+
+
+def test_stable_diffusion_failure_redacts_prompt_paths_and_tokens(monkeypatch, tmp_path):
+    binary_path = tmp_path / "sd"
+    model_path = tmp_path / "secret-model.gguf"
+    binary_path.write_text("#!/bin/sh\n", encoding="utf-8")
+    model_path.write_text("model", encoding="utf-8")
+    secret_prompt = "confidential prompt token-123"
+
+    cfg = _make_config(
+        sd_cpp_binary_path=str(binary_path),
+        sd_cpp_model_path=str(model_path),
+        sd_cpp_allowed_extra_params=["cli_args"],
+    )
+    monkeypatch.setattr(stable_module, "get_image_generation_config", lambda: cfg)
+
+    def fake_run(*_args, **_kwargs):
+        return SimpleNamespace(
+            returncode=1,
+            stderr=f"failed for {secret_prompt} using {model_path} and token-123",
+        )
+
+    monkeypatch.setattr(stable_module.subprocess, "run", fake_run)
+
+    logs: list[str] = []
+    sink_id = stable_module.logger.add(logs.append, format="{message}")
+    try:
+        adapter = stable_module.StableDiffusionCppAdapter()
+        with pytest.raises(ImageGenerationError) as exc_info:
+            adapter.generate(
+                ImageGenRequest(
+                    backend="stable_diffusion_cpp",
+                    prompt=secret_prompt,
+                    negative_prompt=None,
+                    width=512,
+                    height=512,
+                    steps=20,
+                    cfg_scale=7.5,
+                    seed=None,
+                    sampler=None,
+                    model=None,
+                    format="png",
+                    extra_params={"cli_args": ["--api-key", "token-123"]},
+                    request_id=None,
+                )
+            )
+    finally:
+        stable_module.logger.remove(sink_id)
+
+    error_text = str(exc_info.value)
+    log_text = "\n".join(logs)
+    assert secret_prompt not in error_text
+    assert str(model_path) not in error_text
+    assert "token-123" not in error_text
+    assert secret_prompt not in log_text
+    assert str(model_path) not in log_text
+    assert "token-123" not in log_text

--- a/tldw_Server_API/tests/Image_Generation/test_swarmui_adapter.py
+++ b/tldw_Server_API/tests/Image_Generation/test_swarmui_adapter.py
@@ -1,6 +1,11 @@
+import pytest
+
 import tldw_Server_API.app.core.Image_Generation.adapters.swarmui_adapter as swarmui_module
 from tldw_Server_API.app.core.Image_Generation.adapters.base import ImageGenRequest
 from tldw_Server_API.app.core.Image_Generation.config import ImageGenerationConfig
+from tldw_Server_API.app.core.Image_Generation.exceptions import ImageGenerationError
+
+PNG_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
 
 
 def _make_config(**overrides) -> ImageGenerationConfig:
@@ -92,21 +97,35 @@ def test_swarmui_generate_data_url(monkeypatch):
         if url.endswith("/API/GenerateText2Image"):
             assert json["prompt"] == "hello"
             assert json["negativeprompt"] == "nope"
-            return {"images": ["data:image/png;base64,aGVsbG8="]}
+            return {"images": [f"data:image/png;base64,{PNG_B64}"]}
         raise AssertionError("unexpected URL")
 
-    def fake_fetch(*args, **kwargs):
-        raise AssertionError("fetch should not be called for data URLs")
-
     monkeypatch.setattr(swarmui_module, "fetch_json", fake_fetch_json)
-    monkeypatch.setattr(swarmui_module, "fetch", fake_fetch)
 
     adapter = swarmui_module.SwarmUIAdapter()
     result = adapter.generate(_make_request())
-    assert result.content == b"hello"
+    assert result.content.startswith(b"\x89PNG\r\n\x1a\n")
     assert result.content_type == "image/png"
-    assert result.bytes_len == 5
+    assert result.bytes_len == len(result.content)
     assert len(calls) == 2
+
+
+def test_swarmui_rejects_off_origin_image_url_with_token(monkeypatch):
+    cfg = _make_config(swarmui_swarm_token="secret-token")
+    monkeypatch.setattr(swarmui_module, "get_image_generation_config", lambda: cfg)
+
+    def fake_fetch_json(method, url, json, **kwargs):
+        if url.endswith("/API/GetNewSession"):
+            return {"session_id": "sess"}
+        if url.endswith("/API/GenerateText2Image"):
+            return {"images": ["https://attacker.example/out.png"]}
+        raise AssertionError("unexpected URL")
+
+    monkeypatch.setattr(swarmui_module, "fetch_json", fake_fetch_json)
+
+    adapter = swarmui_module.SwarmUIAdapter()
+    with pytest.raises(ImageGenerationError, match="off-origin"):
+        adapter.generate(_make_request())
 
 
 def test_swarmui_invalid_session_refresh(monkeypatch):
@@ -127,24 +146,16 @@ def test_swarmui_invalid_session_refresh(monkeypatch):
             return {"images": ["View/local/raw/test.png"]}
         raise AssertionError("unexpected URL")
 
-    class _FakeResponse:
-        status_code = 200
-        headers = {"content-type": "image/png"}
-        content = b"\x89PNG"  # minimal header
-
-        def close(self):
-            return None
-
-    def fake_fetch(method, url, **kwargs):
+    def fake_fetch_image_bytes(url, **kwargs):
         assert url.endswith("/View/local/raw/test.png")
-        return _FakeResponse()
+        return b"\x89PNG\r\n\x1a\nabc", "image/png"
 
     monkeypatch.setattr(swarmui_module, "fetch_json", fake_fetch_json)
-    monkeypatch.setattr(swarmui_module, "fetch", fake_fetch)
+    monkeypatch.setattr(swarmui_module, "fetch_shared_image_bytes", fake_fetch_image_bytes)
 
     adapter = swarmui_module.SwarmUIAdapter()
     result = adapter.generate(_make_request())
-    assert result.content == b"\x89PNG"
+    assert result.content.startswith(b"\x89PNG\r\n\x1a\n")
     assert result.content_type == "image/png"
     assert len(session_calls) == 2
     assert len(generate_calls) == 2
@@ -167,7 +178,6 @@ def test_swarmui_converts_to_jpg(monkeypatch):
         raise AssertionError("unexpected URL")
 
     monkeypatch.setattr(swarmui_module, "fetch_json", fake_fetch_json)
-    monkeypatch.setattr(swarmui_module, "fetch", lambda *args, **kwargs: None)
 
     adapter = swarmui_module.SwarmUIAdapter()
     result = adapter.generate(_make_request(format="jpg"))

--- a/tldw_Server_API/tests/Image_Generation/test_together_image_adapter.py
+++ b/tldw_Server_API/tests/Image_Generation/test_together_image_adapter.py
@@ -2,6 +2,8 @@ from tldw_Server_API.app.core.Image_Generation.adapters.base import ImageGenRequ
 from tldw_Server_API.app.core.Image_Generation.adapters import together_image_adapter as together_module
 from tldw_Server_API.app.core.Image_Generation.config import ImageGenerationConfig
 
+PNG_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+
 
 def _make_config(**overrides) -> ImageGenerationConfig:
     base = dict(
@@ -90,15 +92,15 @@ def test_together_generate_b64_json(monkeypatch):
         captured["url"] = url
         captured["headers"] = headers
         captured["json"] = json
-        return {"data": [{"b64_json": "aGVsbG8="}]}
+        return {"data": [{"b64_json": PNG_B64}]}
 
     monkeypatch.setattr(together_module, "fetch_json", fake_fetch_json)
 
     adapter = together_module.TogetherImageAdapter()
     result = adapter.generate(_make_request())
-    assert result.content == b"hello"
+    assert result.content.startswith(b"\x89PNG\r\n\x1a\n")
     assert result.content_type == "image/png"
-    assert result.bytes_len == 5
+    assert result.bytes_len == len(result.content)
     assert captured["method"] == "POST"
     assert captured["url"].endswith("/images/generations")
     assert captured["json"]["response_format"] == "b64_json"
@@ -116,7 +118,7 @@ def test_together_generate_from_image_url(monkeypatch):
     monkeypatch.setattr(
         together_module,
         "fetch_image_bytes",
-        lambda url, timeout: (b"\x89PNG\r\n\x1a\nxyz", "image/png"),
+        lambda url, timeout, **kwargs: (b"\x89PNG\r\n\x1a\nxyz", "image/png"),
     )
 
     adapter = together_module.TogetherImageAdapter()

--- a/tldw_Server_API/tests/Workflows/adapters/test_content_adapters.py
+++ b/tldw_Server_API/tests/Workflows/adapters/test_content_adapters.py
@@ -542,6 +542,202 @@ class TestImageGenAdapter:
 
         assert result == {"error": "image_gen_error"}
 
+    @pytest.mark.asyncio
+    async def test_image_gen_adapter_uses_thread_for_backend_generation(self, monkeypatch, tmp_path, base_context):
+        """Backend generation is synchronous and must run off the event loop."""
+        monkeypatch.delenv("TEST_MODE", raising=False)
+        monkeypatch.delenv("TLDW_TEST_MODE", raising=False)
+
+        from tldw_Server_API.app.core.Image_Generation.adapters.base import ImageGenResult
+        from tldw_Server_API.app.core.Image_Generation.config import ImageGenerationConfig
+        from tldw_Server_API.app.core.Workflows.adapters.content import run_image_gen_adapter
+        from tldw_Server_API.app.core.Workflows.adapters.content import image as image_module
+
+        cfg = ImageGenerationConfig(
+            default_backend="stable_diffusion_cpp",
+            enabled_backends=["stable_diffusion_cpp"],
+            max_width=1024,
+            max_height=1024,
+            max_pixels=1024 * 1024,
+            max_steps=50,
+            max_prompt_length=1000,
+            inline_max_bytes=4000000,
+            sd_cpp_diffusion_model_path=None,
+            sd_cpp_llm_path=None,
+            sd_cpp_binary_path=None,
+            sd_cpp_model_path=None,
+            sd_cpp_vae_path=None,
+            sd_cpp_lora_paths=[],
+            sd_cpp_allowed_extra_params=[],
+            sd_cpp_default_steps=25,
+            sd_cpp_default_cfg_scale=7.5,
+            sd_cpp_default_sampler="euler_a",
+            sd_cpp_device="auto",
+            sd_cpp_timeout_seconds=120,
+            swarmui_base_url=None,
+            swarmui_default_model=None,
+            swarmui_swarm_token=None,
+            swarmui_allowed_extra_params=[],
+            swarmui_timeout_seconds=120,
+            openrouter_image_base_url=None,
+            openrouter_image_api_key=None,
+            openrouter_image_default_model=None,
+            openrouter_image_allowed_extra_params=[],
+            openrouter_image_timeout_seconds=120,
+            novita_image_base_url=None,
+            novita_image_api_key=None,
+            novita_image_default_model=None,
+            novita_image_allowed_extra_params=[],
+            novita_image_timeout_seconds=180,
+            novita_image_poll_interval_seconds=2,
+            together_image_base_url=None,
+            together_image_api_key=None,
+            together_image_default_model=None,
+            together_image_allowed_extra_params=[],
+            together_image_timeout_seconds=120,
+            modelstudio_image_base_url=None,
+            modelstudio_image_api_key=None,
+            modelstudio_image_default_model=None,
+            modelstudio_image_region="sg",
+            modelstudio_image_mode="auto",
+            modelstudio_image_poll_interval_seconds=2,
+            modelstudio_image_timeout_seconds=180,
+            modelstudio_image_allowed_extra_params=[],
+        )
+
+        class FakeAdapter:
+            def __init__(self) -> None:
+                self.requests = []
+
+            def generate(self, request):
+                self.requests.append(request)
+                return ImageGenResult(content=b"\x89PNG\r\n\x1a\nabc", content_type="image/png", bytes_len=11)
+
+        adapter = FakeAdapter()
+
+        class FakeRegistry:
+            def resolve_backend(self, backend):
+                return backend
+
+            def get_adapter(self, backend):
+                return adapter
+
+        to_thread_calls = []
+
+        async def fake_to_thread(func, *args, **kwargs):
+            to_thread_calls.append((func, args, kwargs))
+            return func(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "tldw_Server_API.app.core.Image_Generation.config.get_image_generation_config",
+            lambda: cfg,
+        )
+        monkeypatch.setattr(
+            "tldw_Server_API.app.core.Image_Generation.adapter_registry.get_registry",
+            lambda: FakeRegistry(),
+        )
+        monkeypatch.setattr(image_module, "is_test_mode", lambda: False)
+        monkeypatch.setattr(image_module, "resolve_artifacts_dir", lambda _step_run_id: tmp_path)
+        monkeypatch.setattr(
+            image_module,
+            "asyncio",
+            type("AsyncioStub", (), {"to_thread": staticmethod(fake_to_thread)}),
+            raising=False,
+        )
+
+        result = await run_image_gen_adapter({"prompt": "A clean test image", "prompt_refinement": "off"}, base_context)
+
+        assert result["count"] == 1
+        assert to_thread_calls
+        assert adapter.requests[0].prompt == "A clean test image"
+
+    @pytest.mark.asyncio
+    async def test_image_gen_adapter_rejects_invalid_generation_params(self, monkeypatch, base_context):
+        """Workflow image generation uses the same bounds and extra-param allowlist as other entry points."""
+        monkeypatch.delenv("TEST_MODE", raising=False)
+        monkeypatch.delenv("TLDW_TEST_MODE", raising=False)
+
+        from tldw_Server_API.app.core.Image_Generation.config import ImageGenerationConfig
+        from tldw_Server_API.app.core.Workflows.adapters.content import run_image_gen_adapter
+        from tldw_Server_API.app.core.Workflows.adapters.content import image as image_module
+
+        cfg = ImageGenerationConfig(
+            default_backend="stable_diffusion_cpp",
+            enabled_backends=["stable_diffusion_cpp"],
+            max_width=512,
+            max_height=512,
+            max_pixels=512 * 512,
+            max_steps=50,
+            max_prompt_length=1000,
+            inline_max_bytes=4000000,
+            sd_cpp_diffusion_model_path=None,
+            sd_cpp_llm_path=None,
+            sd_cpp_binary_path=None,
+            sd_cpp_model_path=None,
+            sd_cpp_vae_path=None,
+            sd_cpp_lora_paths=[],
+            sd_cpp_allowed_extra_params=[],
+            sd_cpp_default_steps=25,
+            sd_cpp_default_cfg_scale=7.5,
+            sd_cpp_default_sampler="euler_a",
+            sd_cpp_device="auto",
+            sd_cpp_timeout_seconds=120,
+            swarmui_base_url=None,
+            swarmui_default_model=None,
+            swarmui_swarm_token=None,
+            swarmui_allowed_extra_params=[],
+            swarmui_timeout_seconds=120,
+            openrouter_image_base_url=None,
+            openrouter_image_api_key=None,
+            openrouter_image_default_model=None,
+            openrouter_image_allowed_extra_params=[],
+            openrouter_image_timeout_seconds=120,
+            novita_image_base_url=None,
+            novita_image_api_key=None,
+            novita_image_default_model=None,
+            novita_image_allowed_extra_params=[],
+            novita_image_timeout_seconds=180,
+            novita_image_poll_interval_seconds=2,
+            together_image_base_url=None,
+            together_image_api_key=None,
+            together_image_default_model=None,
+            together_image_allowed_extra_params=[],
+            together_image_timeout_seconds=120,
+            modelstudio_image_base_url=None,
+            modelstudio_image_api_key=None,
+            modelstudio_image_default_model=None,
+            modelstudio_image_region="sg",
+            modelstudio_image_mode="auto",
+            modelstudio_image_poll_interval_seconds=2,
+            modelstudio_image_timeout_seconds=180,
+            modelstudio_image_allowed_extra_params=[],
+        )
+
+        class FailingRegistry:
+            def resolve_backend(self, backend):
+                raise AssertionError("registry should not be reached for invalid params")
+
+        monkeypatch.setattr(
+            "tldw_Server_API.app.core.Image_Generation.config.get_image_generation_config",
+            lambda: cfg,
+        )
+        monkeypatch.setattr(
+            "tldw_Server_API.app.core.Image_Generation.adapter_registry.get_registry",
+            lambda: FailingRegistry(),
+        )
+        monkeypatch.setattr(image_module, "is_test_mode", lambda: False)
+
+        result = await run_image_gen_adapter(
+            {
+                "prompt": "A clean test image",
+                "width": 2048,
+                "extra_params": {"cli_args": ["--unsafe"]},
+            },
+            base_context,
+        )
+
+        assert result["error"] == "image_params_invalid"
+
 
 # =============================================================================
 # Test: run_image_describe_adapter

--- a/tldw_Server_API/tests/Workflows/adapters/test_content_adapters.py
+++ b/tldw_Server_API/tests/Workflows/adapters/test_content_adapters.py
@@ -738,6 +738,22 @@ class TestImageGenAdapter:
 
         assert result["error"] == "image_params_invalid"
 
+        invalid_cases = [
+            {"width": 0},
+            {"height": False},
+            {"cfg_scale": float("nan")},
+            {"cfg_scale": 0},
+        ]
+        for invalid_config in invalid_cases:
+            result = await run_image_gen_adapter(
+                {
+                    "prompt": "A clean test image",
+                    **invalid_config,
+                },
+                base_context,
+            )
+            assert result["error"] == "image_params_invalid"
+
 
 # =============================================================================
 # Test: run_image_describe_adapter


### PR DESCRIPTION
## Summary
- Harden Image Generation request validation for user-supplied parameters and workflow adapter inputs.
- Tighten provider/image format handling across OpenRouter, Together, Novita, ModelStudio, SwarmUI, and stable-diffusion.cpp paths.
- Add focused regression coverage for image format decoding, reference-image capabilities, file artifact allowlisting, and workflow validation.

## Test Plan
- [x] /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Image_Generation/test_openrouter_image_adapter.py tldw_Server_API/tests/Image_Generation/test_together_image_adapter.py tldw_Server_API/tests/Image_Generation/test_novita_image_adapter.py tldw_Server_API/tests/Image_Generation/test_modelstudio_image_adapter.py tldw_Server_API/tests/Image_Generation/test_swarmui_adapter.py tldw_Server_API/tests/Image_Generation/test_image_format_utils.py tldw_Server_API/tests/Image_Generation/test_stable_diffusion_cpp_adapter.py tldw_Server_API/tests/Image_Generation/test_reference_images.py -q — 34 passed
- [x] /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Workflows/adapters/test_content_adapters.py::TestImageGenAdapter::test_image_gen_adapter_uses_thread_for_backend_generation tldw_Server_API/tests/Workflows/adapters/test_content_adapters.py::TestImageGenAdapter::test_image_gen_adapter_rejects_invalid_generation_params tldw_Server_API/tests/FileArtifacts/test_image_adapter_allowlist.py tldw_Server_API/tests/Files/test_files_image_endpoint.py tldw_Server_API/tests/Image_Generation/test_image_generation_config_defaults.py tldw_Server_API/tests/Image_Generation/test_image_reference_capabilities.py -q — 38 passed
- [x] git diff --check
- [x] python -m bandit on touched Image Generation/Workflow/FileArtifacts source scope — 0 findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened image generation across adapters with shared request validation and strict image byte/format enforcement. Adds bounded streaming fetches and same‑origin checks, prevents secret leakage in `stable-diffusion.cpp`, and makes workflow image generation non-blocking. Addresses TASK-2414 acceptance criteria.

- **Bug Fixes**
  - Validate prompt length, width/height/steps, and finite positive `cfg_scale` uniformly; allowlist `extra_params` per backend (`openrouter`, `together`, `novita`, `modelstudio`, `swarmui`, `stable_diffusion_cpp`).
  - Enforce byte caps for inline/base64/data-URL inputs and stream remote image fetches with limits; verify real PNG/JPG/WebP bytes before returning or converting.
  - Block `SwarmUI` off-origin image URLs; never send `swarm_token` to other origins.
  - Redact prompts, paths, and tokens in `stable-diffusion.cpp` logs/errors; keep clear failure signals.
  - Skip oversized reference-image rows using stored `file_size`; cap bytes on load; probe dimensions via header verification.
  - Workflow image generation validates inputs consistently and runs in a worker thread to avoid blocking.

- **Refactors**
  - Added shared `request_validation` and `image_format_utils.validate_and_convert_image_output`; implemented redirect-aware, egress-checked, bounded `fetch_image_bytes`.
  - Defaulted `inline_max_bytes` to a positive value and introduced `effective_inline_max_bytes`; centralized backend extra-param allowlisting.

<sup>Written for commit 0e50869f50dd0e44d60a842325635b25f3413fb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

