### PR TITLE
test: refresh flashcards ux harness

### DIFF
--- a/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx
@@ -170,6 +170,16 @@ if (!(globalThis as any).ResizeObserver) {
   }
 }
 
+const renderFlashcardsManager = ({
+  decks = mocks.decks
+}: {
+  decks?: Array<{ id: number; name: string }>
+} = {}) => {
+  mocks.decks = decks
+  window.history.replaceState({}, "", "/flashcards")
+  return render(<FlashcardsManager />)
+}
+
 describe("FlashcardsManager consistency standards", () => {
   mocks.useDecksQuery.mockImplementation(() => ({
     data: mocks.decks,
@@ -420,6 +430,13 @@ describe("FlashcardsManager consistency standards", () => {
     expect(screen.getByText("Templates")).toBeInTheDocument()
     expect(screen.queryByText("Scheduler")).not.toBeInTheDocument()
     expect(screen.queryByTestId("mock-scheduler-tab")).not.toBeInTheDocument()
+  })
+
+  it("documents current zero-deck behavior before first-time IA remediation", async () => {
+    renderFlashcardsManager({ decks: [] })
+
+    expect(await screen.findByText("Import / Export")).toBeInTheDocument()
+    expect(screen.queryByText("Scheduler")).not.toBeInTheDocument()
   })
 
   it("still opens Import / Export first for explicit generate and study-pack intents", () => {

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.deck-reference.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.deck-reference.test.tsx
@@ -301,6 +301,32 @@ describe("FlashcardCreateDrawer deck reference section", () => {
       expect(screen.getByText("Existing cards in this deck")).toBeInTheDocument()
     })
     expect(screen.getByText("Biology deck")).toBeInTheDocument()
+    expect(vi.mocked(useFlashcardDeckRecentCardsQuery)).toHaveBeenLastCalledWith(
+      12,
+      expect.objectContaining({
+        enabled: false,
+        limit: 6
+      })
+    )
+
+    await expandReferenceSection()
+
+    expect(vi.mocked(useFlashcardDeckRecentCardsQuery)).toHaveBeenLastCalledWith(
+      12,
+      expect.objectContaining({
+        enabled: true,
+        limit: 6
+      })
+    )
+    expect(vi.mocked(useFlashcardDeckSearchQuery)).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        deckId: 12,
+        query: ""
+      }),
+      expect.objectContaining({
+        enabled: false
+      })
+    )
   })
 
   it("forwards workspace visibility options to the drawer deck reference hooks", async () => {

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
@@ -417,31 +417,6 @@ describe("ImportExportTab import result details", () => {
     expect(screen.getByDisplayValue(invalidPayload)).toBeInTheDocument()
   })
 
-  it.skip(
-    "fixme: Implement flashcards UX PR 2 create import generate reliability should show inline invalid import alert",
-    async () => {
-      const invalidPayload = "invalid import payload"
-      vi.mocked(useImportFlashcardsMutation).mockReturnValue({
-        mutateAsync: vi.fn().mockRejectedValue(new Error("Invalid import payload")),
-        isPending: false
-      } as any)
-
-      render(<ImportExportTab />)
-      await openImportTask()
-
-      fireEvent.change(screen.getByTestId("flashcards-import-textarea"), {
-        target: { value: invalidPayload }
-      })
-      fireEvent.click(screen.getByRole("button", { name: /^import$/i }))
-
-      expect(await screen.findByRole("alert")).toHaveTextContent(
-        /invalid|failed|could not import/i
-      )
-      expect(screen.getByRole("button", { name: /^import$/i })).toBeEnabled()
-      expect(screen.getByDisplayValue(invalidPayload)).toBeInTheDocument()
-    }
-  )
-
   it("requires confirmation before importing very large batches", async () => {
     const mutateAsync = vi.fn().mockResolvedValue({
       imported: 0,

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
@@ -395,6 +395,53 @@ describe("ImportExportTab import result details", () => {
     ).toBeInTheDocument()
   })
 
+  it("documents current invalid import failure preserving input and exiting loading", async () => {
+    const invalidPayload = "invalid import payload"
+    vi.mocked(useImportFlashcardsMutation).mockReturnValue({
+      mutateAsync: vi.fn().mockRejectedValue(new Error("Invalid import payload")),
+      isPending: false
+    } as any)
+
+    render(<ImportExportTab />)
+    await openImportTask()
+
+    fireEvent.change(screen.getByTestId("flashcards-import-textarea"), {
+      target: { value: invalidPayload }
+    })
+    fireEvent.click(screen.getByRole("button", { name: /^import$/i }))
+
+    await waitFor(() => {
+      expect(messageSpies.error).toHaveBeenCalledWith("Invalid import payload")
+    })
+    expect(screen.getByRole("button", { name: /^import$/i })).toBeEnabled()
+    expect(screen.getByDisplayValue(invalidPayload)).toBeInTheDocument()
+  })
+
+  it.skip(
+    "fixme: Implement flashcards UX PR 2 create import generate reliability should show inline invalid import alert",
+    async () => {
+      const invalidPayload = "invalid import payload"
+      vi.mocked(useImportFlashcardsMutation).mockReturnValue({
+        mutateAsync: vi.fn().mockRejectedValue(new Error("Invalid import payload")),
+        isPending: false
+      } as any)
+
+      render(<ImportExportTab />)
+      await openImportTask()
+
+      fireEvent.change(screen.getByTestId("flashcards-import-textarea"), {
+        target: { value: invalidPayload }
+      })
+      fireEvent.click(screen.getByRole("button", { name: /^import$/i }))
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        /invalid|failed|could not import/i
+      )
+      expect(screen.getByRole("button", { name: /^import$/i })).toBeEnabled()
+      expect(screen.getByDisplayValue(invalidPayload)).toBeInTheDocument()
+    }
+  )
+
   it("requires confirmation before importing very large batches", async () => {
     const mutateAsync = vi.fn().mockResolvedValue({
       imported: 0,

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import { ReviewTab } from "../ReviewTab"
 import { clearSetting } from "@/services/settings/registry"
@@ -436,6 +437,74 @@ describe("ReviewTab create CTA visibility", () => {
     expect(topbarPrimaryButtons).toHaveLength(
       FLASHCARDS_LAYOUT_GUARDRAILS.review.maxTopbarPrimaryCtas.active
     )
+  })
+
+  it("keeps a visible re-rate action after rating an active review card", async () => {
+    const user = userEvent.setup()
+    let currentCard = createReviewCard({
+      uuid: "active-card-1",
+      deck_id: 11,
+      front: "Question",
+      back: "Answer"
+    })
+    const nextCard = createReviewCard({
+      uuid: "active-card-2",
+      deck_id: 11,
+      front: "Next question",
+      back: "Next answer",
+      version: 3
+    })
+
+    vi.mocked(useDecksQuery).mockReturnValue({
+      data: [{ id: 11, name: "Biology" }],
+      isLoading: false
+    } as any)
+    vi.mocked(useReviewQuery).mockImplementation(
+      () =>
+        ({
+          data: currentCard,
+          isLoading: false,
+          isFetching: false,
+          refetch: vi.fn().mockResolvedValue(undefined)
+        }) as any
+    )
+    vi.mocked(useReviewFlashcardMutation).mockReturnValue({
+      mutateAsync: vi.fn().mockImplementation(async () => {
+        currentCard = nextCard
+        return {
+          uuid: "active-card-1",
+          ef: 2.6,
+          interval_days: 2,
+          repetitions: 2,
+          lapses: 0,
+          due_at: "2026-02-20T09:30:00.000Z",
+          version: 2
+        }
+      }),
+      isPending: false
+    } as any)
+    vi.mocked(useDueCountsQuery).mockReturnValue({
+      data: { due: 2, new: 0, learning: 0, total: 2 },
+      refetch: vi.fn().mockResolvedValue(undefined)
+    } as any)
+    vi.mocked(useHasCardsQuery).mockReturnValue({
+      data: true
+    } as any)
+
+    render(
+      <ReviewTab
+        onNavigateToCreate={() => {}}
+        onNavigateToImport={() => {}}
+        reviewDeckId={11}
+        onReviewDeckChange={() => {}}
+        isActive
+      />
+    )
+
+    expect(await screen.findByRole("button", { name: /show answer/i })).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: /show answer/i }))
+    await user.click(screen.getByRole("button", { name: /good/i }))
+    expect(await screen.findByRole("button", { name: /re-rate last card/i })).toBeInTheDocument()
   })
 
   it("shows due counts in deck selector labels when available", () => {

--- a/apps/tldw-frontend/e2e/utils/helpers.ts
+++ b/apps/tldw-frontend/e2e/utils/helpers.ts
@@ -4,11 +4,20 @@
 import { expect, type Locator, type Page, type Route } from '@playwright/test';
 import { resolveE2eApiKey } from './e2e-auth';
 
-const E2E_SERVER_URL =
+const RAW_E2E_SERVER_URL =
   process.env.TLDW_SERVER_URL ||
   process.env.TLDW_E2E_SERVER_URL ||
   process.env.E2E_TEST_BASE_URL ||
   'http://127.0.0.1:8000';
+
+const normalizeOrigin = (value: string): string => value.replace(/\/$/, '');
+
+const normalizeHttpOrigin = (value: string): string => {
+  const origin = normalizeOrigin(value.trim());
+  return /^https?:\/\//i.test(origin) ? origin : `http://${origin}`;
+};
+
+const E2E_SERVER_URL = normalizeHttpOrigin(RAW_E2E_SERVER_URL);
 
 /**
  * Environment configuration for tests
@@ -20,11 +29,9 @@ export const TEST_CONFIG = {
   allowOffline: process.env.TLDW_E2E_ALLOW_OFFLINE !== '0',
 };
 
-const normalizeOrigin = (value: string): string => value.replace(/\/$/, '');
-
 const resolveSeedServerUrl = (cfg: Partial<typeof TEST_CONFIG>): string => {
   if (typeof cfg.serverUrl === 'string' && cfg.serverUrl.trim().length > 0) {
-    return normalizeOrigin(cfg.serverUrl.trim());
+    return normalizeHttpOrigin(cfg.serverUrl);
   }
   if (typeof cfg.webUrl === 'string' && cfg.webUrl.trim().length > 0) {
     return normalizeOrigin(cfg.webUrl.trim());

--- a/apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
@@ -9,9 +9,181 @@
  *   /api/v1/flashcards        (cards CRUD, review, generate, import, export)
  *   /api/v1/flashcards/decks  (deck CRUD)
  */
-import { type Page, type Locator, expect } from '@playwright/test';
+import { type APIRequestContext, type Page, type Locator, expect } from '@playwright/test';
 import { BasePage, type InteractiveElement } from './BasePage';
-import { waitForAppShell, waitForConnection, dismissConnectionModals } from '../helpers';
+import {
+  waitForAppShell,
+  waitForConnection,
+  dismissConnectionModals,
+  TEST_CONFIG,
+} from '../helpers';
+
+export const FLASHCARDS_E2E_PREFIX = 'codex-flashcards-ux';
+
+export function makeFlashcardsRunId(): string {
+  return `${FLASHCARDS_E2E_PREFIX}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export type FlashcardsSeedRecord = {
+  runId: string;
+  deckName: string;
+  cardFront: string;
+  cardBack: string;
+};
+
+export function buildFlashcardsSeedRecord(
+  runId = makeFlashcardsRunId()
+): FlashcardsSeedRecord {
+  return {
+    runId,
+    deckName: `${runId}-deck`,
+    cardFront: `${runId} front`,
+    cardBack: `${runId} back`,
+  };
+}
+
+type FlashcardsCleanupDeck = {
+  id?: number;
+  name?: string;
+  version?: number;
+};
+
+type FlashcardsCleanupCard = {
+  uuid?: string;
+  front?: string | null;
+  back?: string | null;
+  tags?: string[] | null;
+  version?: number;
+};
+
+function flashcardsApiUrl(path: string): string {
+  return `${TEST_CONFIG.serverUrl.replace(/\/$/, '')}${path}`;
+}
+
+function flashcardsApiHeaders(): Record<string, string> {
+  return {
+    'X-API-Key': TEST_CONFIG.apiKey,
+  };
+}
+
+export async function assertFlashcardsBackendReady(
+  request: APIRequestContext
+): Promise<void> {
+  const response = await request.get(flashcardsApiUrl('/api/v1/health'), {
+    headers: flashcardsApiHeaders(),
+  });
+
+  if (!response.ok()) {
+    throw new Error(
+      `Flashcards backend preflight failed: ${response.status()} ${await response.text()}`
+    );
+  }
+
+  const flashcardsResponse = await request.get(
+    flashcardsApiUrl('/api/v1/flashcards/decks?limit=1&include_deleted=false'),
+    { headers: flashcardsApiHeaders() }
+  );
+
+  if (!flashcardsResponse.ok()) {
+    throw new Error(
+      `Flashcards API preflight failed: ${flashcardsResponse.status()} ${await flashcardsResponse.text()}`
+    );
+  }
+}
+
+const startsWithFlashcardsRunPrefix = (value: unknown): boolean =>
+  typeof value === 'string' && value.startsWith(`${FLASHCARDS_E2E_PREFIX}-`);
+
+async function cleanupFlashcardCard(
+  request: APIRequestContext,
+  card: FlashcardsCleanupCard
+): Promise<void> {
+  if (!card.uuid || typeof card.version !== 'number') return;
+
+  const response = await request.delete(
+    flashcardsApiUrl(
+      `/api/v1/flashcards/${encodeURIComponent(card.uuid)}?expected_version=${card.version}`
+    ),
+    { headers: flashcardsApiHeaders() }
+  );
+
+  if (!response.ok() && response.status() !== 404 && response.status() !== 409) {
+    throw new Error(
+      `Failed to cleanup flashcard card ${card.uuid}: ${response.status()} ${await response.text()}`
+    );
+  }
+}
+
+async function cleanupFlashcardDeck(
+  request: APIRequestContext,
+  deck: FlashcardsCleanupDeck
+): Promise<void> {
+  if (typeof deck.id !== 'number' || typeof deck.version !== 'number') return;
+
+  const response = await request.delete(
+    flashcardsApiUrl(
+      `/api/v1/flashcards/decks/${deck.id}?expected_version=${deck.version}`
+    ),
+    { headers: flashcardsApiHeaders() }
+  );
+
+  if (!response.ok() && response.status() !== 404 && response.status() !== 409) {
+    throw new Error(
+      `Failed to cleanup flashcard deck ${deck.id}: ${response.status()} ${await response.text()}`
+    );
+  }
+}
+
+export async function cleanupFlashcardsRunRecords(
+  request: APIRequestContext,
+  _testTitle?: string
+): Promise<void> {
+  try {
+    await assertFlashcardsBackendReady(request);
+  } catch {
+    return;
+  }
+
+  const cardResponse = await request.get(
+    flashcardsApiUrl(
+      `/api/v1/flashcards?q=${encodeURIComponent(FLASHCARDS_E2E_PREFIX)}&limit=1000&due_status=all`
+    ),
+    { headers: flashcardsApiHeaders() }
+  );
+
+  if (cardResponse.ok()) {
+    const payload = (await cardResponse.json().catch(() => ({}))) as {
+      items?: FlashcardsCleanupCard[];
+    };
+    const cards = Array.isArray(payload.items) ? payload.items : [];
+
+    for (const card of cards) {
+      if (
+        startsWithFlashcardsRunPrefix(card.front) ||
+        startsWithFlashcardsRunPrefix(card.back) ||
+        card.tags?.some(startsWithFlashcardsRunPrefix)
+      ) {
+        await cleanupFlashcardCard(request, card);
+      }
+    }
+  }
+
+  const deckResponse = await request.get(
+    flashcardsApiUrl('/api/v1/flashcards/decks?limit=1000&include_deleted=false'),
+    { headers: flashcardsApiHeaders() }
+  );
+
+  if (!deckResponse.ok()) return;
+
+  const decks = (await deckResponse.json().catch(() => [])) as FlashcardsCleanupDeck[];
+  if (!Array.isArray(decks)) return;
+
+  for (const deck of decks) {
+    if (startsWithFlashcardsRunPrefix(deck.name)) {
+      await cleanupFlashcardDeck(request, deck);
+    }
+  }
+}
 
 export class FlashcardsPage extends BasePage {
   constructor(page: Page) {

--- a/apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
@@ -20,8 +20,22 @@ import {
 
 export const FLASHCARDS_E2E_PREFIX = 'codex-flashcards-ux';
 
-export function makeFlashcardsRunId(): string {
-  return `${FLASHCARDS_E2E_PREFIX}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+function hashFlashcardsRunSeed(seed: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < seed.length; index += 1) {
+    hash ^= seed.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+export function makeFlashcardsRunId(seed: string): string {
+  const normalizedSeed = seed
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+  return `${FLASHCARDS_E2E_PREFIX}-${normalizedSeed || 'run'}-${hashFlashcardsRunSeed(seed)}`;
 }
 
 export type FlashcardsSeedRecord = {
@@ -32,7 +46,7 @@ export type FlashcardsSeedRecord = {
 };
 
 export function buildFlashcardsSeedRecord(
-  runId = makeFlashcardsRunId()
+  runId: string
 ): FlashcardsSeedRecord {
   return {
     runId,
@@ -91,8 +105,16 @@ export async function assertFlashcardsBackendReady(
   }
 }
 
-const startsWithFlashcardsRunPrefix = (value: unknown): boolean =>
-  typeof value === 'string' && value.startsWith(`${FLASHCARDS_E2E_PREFIX}-`);
+const startsWithFlashcardsRunId = (value: unknown, runId: string): boolean =>
+  typeof value === 'string' && value.startsWith(runId);
+
+function warnFlashcardsCleanup(message: string, error?: unknown): void {
+  if (error === undefined) {
+    console.warn(`[flashcards:e2e:cleanup] ${message}`);
+    return;
+  }
+  console.warn(`[flashcards:e2e:cleanup] ${message}`, error);
+}
 
 async function cleanupFlashcardCard(
   request: APIRequestContext,
@@ -100,17 +122,21 @@ async function cleanupFlashcardCard(
 ): Promise<void> {
   if (!card.uuid || typeof card.version !== 'number') return;
 
-  const response = await request.delete(
-    flashcardsApiUrl(
-      `/api/v1/flashcards/${encodeURIComponent(card.uuid)}?expected_version=${card.version}`
-    ),
-    { headers: flashcardsApiHeaders() }
-  );
-
-  if (!response.ok() && response.status() !== 404 && response.status() !== 409) {
-    throw new Error(
-      `Failed to cleanup flashcard card ${card.uuid}: ${response.status()} ${await response.text()}`
+  try {
+    const response = await request.delete(
+      flashcardsApiUrl(
+        `/api/v1/flashcards/${encodeURIComponent(card.uuid)}?expected_version=${card.version}`
+      ),
+      { headers: flashcardsApiHeaders() }
     );
+
+    if (!response.ok() && response.status() !== 404 && response.status() !== 409) {
+      warnFlashcardsCleanup(
+        `Failed to cleanup flashcard card ${card.uuid}: ${response.status()} ${await response.text()}`
+      );
+    }
+  } catch (error) {
+    warnFlashcardsCleanup(`Failed to cleanup flashcard card ${card.uuid}`, error);
   }
 }
 
@@ -120,69 +146,95 @@ async function cleanupFlashcardDeck(
 ): Promise<void> {
   if (typeof deck.id !== 'number' || typeof deck.version !== 'number') return;
 
-  const response = await request.delete(
-    flashcardsApiUrl(
-      `/api/v1/flashcards/decks/${deck.id}?expected_version=${deck.version}`
-    ),
-    { headers: flashcardsApiHeaders() }
-  );
-
-  if (!response.ok() && response.status() !== 404 && response.status() !== 409) {
-    throw new Error(
-      `Failed to cleanup flashcard deck ${deck.id}: ${response.status()} ${await response.text()}`
+  try {
+    const response = await request.delete(
+      flashcardsApiUrl(
+        `/api/v1/flashcards/decks/${deck.id}?expected_version=${deck.version}`
+      ),
+      { headers: flashcardsApiHeaders() }
     );
+
+    if (!response.ok() && response.status() !== 404 && response.status() !== 409) {
+      warnFlashcardsCleanup(
+        `Failed to cleanup flashcard deck ${deck.id}: ${response.status()} ${await response.text()}`
+      );
+    }
+  } catch (error) {
+    warnFlashcardsCleanup(`Failed to cleanup flashcard deck ${deck.id}`, error);
   }
 }
 
 export async function cleanupFlashcardsRunRecords(
   request: APIRequestContext,
-  _testTitle?: string
+  runId: string
 ): Promise<void> {
   try {
     await assertFlashcardsBackendReady(request);
-  } catch {
+  } catch (error) {
+    warnFlashcardsCleanup(`Skipping cleanup for ${runId}; backend preflight failed`, error);
     return;
   }
 
-  const cardResponse = await request.get(
-    flashcardsApiUrl(
-      `/api/v1/flashcards?q=${encodeURIComponent(FLASHCARDS_E2E_PREFIX)}&limit=1000&due_status=all`
-    ),
-    { headers: flashcardsApiHeaders() }
-  );
+  let cardResponse;
+  try {
+    cardResponse = await request.get(
+      flashcardsApiUrl(
+        `/api/v1/flashcards?q=${encodeURIComponent(runId)}&limit=1000&due_status=all`
+      ),
+      { headers: flashcardsApiHeaders() }
+    );
+  } catch (error) {
+    warnFlashcardsCleanup(`Failed to list flashcards for cleanup run ${runId}`, error);
+    return;
+  }
 
   if (cardResponse.ok()) {
     const payload = (await cardResponse.json().catch(() => ({}))) as {
       items?: FlashcardsCleanupCard[];
     };
     const cards = Array.isArray(payload.items) ? payload.items : [];
-
-    for (const card of cards) {
-      if (
-        startsWithFlashcardsRunPrefix(card.front) ||
-        startsWithFlashcardsRunPrefix(card.back) ||
-        card.tags?.some(startsWithFlashcardsRunPrefix)
-      ) {
-        await cleanupFlashcardCard(request, card);
-      }
-    }
+    await Promise.allSettled(
+      cards
+        .filter(
+          card =>
+            startsWithFlashcardsRunId(card.front, runId) ||
+            startsWithFlashcardsRunId(card.back, runId) ||
+            card.tags?.some(tag => startsWithFlashcardsRunId(tag, runId))
+        )
+        .map(card => cleanupFlashcardCard(request, card))
+    );
+  } else {
+    warnFlashcardsCleanup(
+      `Failed to list flashcards for cleanup run ${runId}: ${cardResponse.status()} ${await cardResponse.text()}`
+    );
   }
 
-  const deckResponse = await request.get(
-    flashcardsApiUrl('/api/v1/flashcards/decks?limit=1000&include_deleted=false'),
-    { headers: flashcardsApiHeaders() }
-  );
+  let deckResponse;
+  try {
+    deckResponse = await request.get(
+      flashcardsApiUrl('/api/v1/flashcards/decks?limit=1000&include_deleted=false'),
+      { headers: flashcardsApiHeaders() }
+    );
+  } catch (error) {
+    warnFlashcardsCleanup(`Failed to list decks for cleanup run ${runId}`, error);
+    return;
+  }
 
-  if (!deckResponse.ok()) return;
+  if (!deckResponse.ok()) {
+    warnFlashcardsCleanup(
+      `Failed to list decks for cleanup run ${runId}: ${deckResponse.status()} ${await deckResponse.text()}`
+    );
+    return;
+  }
 
   const decks = (await deckResponse.json().catch(() => [])) as FlashcardsCleanupDeck[];
   if (!Array.isArray(decks)) return;
 
-  for (const deck of decks) {
-    if (startsWithFlashcardsRunPrefix(deck.name)) {
-      await cleanupFlashcardDeck(request, deck);
-    }
-  }
+  await Promise.allSettled(
+    decks
+      .filter(deck => startsWithFlashcardsRunId(deck.name, runId))
+      .map(deck => cleanupFlashcardDeck(request, deck))
+  );
 }
 
 export class FlashcardsPage extends BasePage {

--- a/apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
@@ -9,6 +9,7 @@
  *
  * Run: npx playwright test e2e/workflows/tier-2-features/flashcards.spec.ts
  */
+import { type APIRequestContext } from '@playwright/test';
 import {
   test,
   expect,
@@ -16,7 +17,13 @@ import {
   assertNoCriticalErrors,
 } from '../../utils/fixtures';
 import { expectApiCall } from '../../utils/api-assertions';
-import { FlashcardsPage } from '../../utils/page-objects';
+import {
+  FlashcardsPage,
+  FLASHCARDS_E2E_PREFIX,
+  assertFlashcardsBackendReady,
+  buildFlashcardsSeedRecord,
+  cleanupFlashcardsRunRecords,
+} from '../../utils/page-objects/FlashcardsPage';
 import {
   dispatchKeyboardShortcut,
   seedAuth,
@@ -121,12 +128,27 @@ async function cleanupFlashcardDeck(deck: SeededDeck): Promise<void> {
   }
 }
 
+async function skipIfFlashcardsBackendUnavailable(
+  request: APIRequestContext
+): Promise<void> {
+  try {
+    await assertFlashcardsBackendReady(request);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    test.skip(true, `Flashcards backend is not available: ${message}`);
+  }
+}
+
 test.describe('Flashcards', () => {
   let flashcards: FlashcardsPage;
 
   test.beforeEach(async ({ page }) => {
     await seedAuth(page);
     flashcards = new FlashcardsPage(page);
+  });
+
+  test.afterEach(async ({ request }, testInfo) => {
+    await cleanupFlashcardsRunRecords(request, testInfo.title);
   });
 
   // =========================================================================
@@ -196,10 +218,12 @@ test.describe('Flashcards', () => {
 
     test('flashcards Phase 1 evidence: empty first entry stays on Study with setup actions', async ({
       authedPage,
+      request,
       serverInfo,
       diagnostics,
     }) => {
       skipIfServerUnavailable(serverInfo);
+      await skipIfFlashcardsBackendUnavailable(request);
 
       await authedPage.route(/\/api\/v1\/flashcards\/decks(?:\?.*)?$/, async route => {
         if (route.request().method() !== 'GET') return route.fallback();
@@ -296,16 +320,18 @@ test.describe('Flashcards', () => {
 
     test('flashcards Phase 0 evidence: reviews a seeded card with keyboard reveal and rating', async ({
       authedPage,
+      request,
       serverInfo,
       diagnostics,
     }) => {
       test.setTimeout(120_000);
       skipIfServerUnavailable(serverInfo);
+      await skipIfFlashcardsBackendUnavailable(request);
 
-      const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-      const deck = await createFlashcardDeck(`E2E Phase0 Review ${runId}`);
-      const front = `Phase 0 front ${runId}`;
-      const back = `Phase 0 back ${runId}`;
+      const seed = buildFlashcardsSeedRecord();
+      const deck = await createFlashcardDeck(seed.deckName);
+      const front = seed.cardFront;
+      const back = seed.cardBack;
 
       await createFlashcardCard({
         deckId: deck.id,
@@ -362,15 +388,17 @@ test.describe('Flashcards', () => {
 
     test('should flip the review prompt side for a selected deck', async ({
       authedPage,
+      request,
       serverInfo,
       diagnostics,
     }) => {
       skipIfServerUnavailable(serverInfo);
+      await skipIfFlashcardsBackendUnavailable(request);
 
-      const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-      const deck = await createFlashcardDeck(`E2E Review Orientation ${runId}`);
-      const front = `Front prompt ${runId}`;
-      const back = `Back answer ${runId}`;
+      const seed = buildFlashcardsSeedRecord();
+      const deck = await createFlashcardDeck(seed.deckName);
+      const front = seed.cardFront;
+      const back = seed.cardBack;
 
       await createFlashcardCard({
         deckId: deck.id,
@@ -417,15 +445,17 @@ test.describe('Flashcards', () => {
 
     test('should review a seeded card using only keyboard shortcuts', async ({
       authedPage,
+      request,
       serverInfo,
       diagnostics,
     }) => {
       skipIfServerUnavailable(serverInfo);
+      await skipIfFlashcardsBackendUnavailable(request);
 
-      const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-      const deck = await createFlashcardDeck(`E2E Keyboard Review ${runId}`);
-      const front = `Keyboard front ${runId}`;
-      const back = `Keyboard back ${runId}`;
+      const seed = buildFlashcardsSeedRecord();
+      const deck = await createFlashcardDeck(seed.deckName);
+      const front = seed.cardFront;
+      const back = seed.cardBack;
 
       await createFlashcardCard({
         deckId: deck.id,
@@ -550,8 +580,13 @@ test.describe('Flashcards', () => {
   test.describe('Manage Tab', () => {
     test('should show search, deck filter, and FAB create button', async ({
       authedPage,
+      request,
+      serverInfo,
       diagnostics,
     }) => {
+      skipIfServerUnavailable(serverInfo);
+      await skipIfFlashcardsBackendUnavailable(request);
+
       flashcards = new FlashcardsPage(authedPage);
       await flashcards.goto();
       await flashcards.assertPageReady();
@@ -571,10 +606,12 @@ test.describe('Flashcards', () => {
 
     test('should fire flashcards list API when searching', async ({
       authedPage,
+      request,
       serverInfo,
       diagnostics,
     }) => {
       skipIfServerUnavailable(serverInfo);
+      await skipIfFlashcardsBackendUnavailable(request);
 
       flashcards = new FlashcardsPage(authedPage);
       await flashcards.goto();
@@ -613,14 +650,16 @@ test.describe('Flashcards', () => {
 
     test('creates a flashcard from the drawer and shows it in Manage', async ({
       authedPage,
+      request,
       serverInfo,
       diagnostics,
     }) => {
       skipIfServerUnavailable(serverInfo);
+      await skipIfFlashcardsBackendUnavailable(request);
 
-      const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-      const front = `Drawer-created front ${runId}`;
-      const back = `Drawer-created back ${runId}`;
+      const seed = buildFlashcardsSeedRecord();
+      const front = seed.cardFront;
+      const back = seed.cardBack;
 
       flashcards = new FlashcardsPage(authedPage);
       await flashcards.gotoPath('/flashcards?tab=manage');
@@ -660,27 +699,29 @@ test.describe('Flashcards', () => {
 
     test('should allow selecting existing tag suggestions in create and edit drawers', async ({
       authedPage,
+      request,
       serverInfo,
       diagnostics,
     }) => {
       test.setTimeout(120_000);
       skipIfServerUnavailable(serverInfo);
+      await skipIfFlashcardsBackendUnavailable(request);
 
-      const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-      const deck = await createFlashcardDeck(`E2E Flashcard Tags ${runId}`);
-      const createSuggestionTag = `bio-create-${runId}`;
-      const editSuggestionTag = `bio-edit-${runId}`;
+      const seed = buildFlashcardsSeedRecord();
+      const deck = await createFlashcardDeck(seed.deckName);
+      const createSuggestionTag = `${seed.runId}-bio-create`;
+      const editSuggestionTag = `${seed.runId}-bio-edit`;
 
       await createFlashcardCard({
         deckId: deck.id,
-        front: `Suggestion source ${runId}`,
+        front: `${seed.runId} suggestion source`,
         back: 'Seeds global tag suggestions',
         tags: [createSuggestionTag, editSuggestionTag],
       });
 
       const knownCard = await createFlashcardCard({
         deckId: deck.id,
-        front: `Known card ${runId}`,
+        front: `${seed.runId} known card`,
         back: 'Used for edit drawer verification',
       });
 
@@ -712,7 +753,7 @@ test.describe('Flashcards', () => {
       await createTagOption.click();
       await expect(flashcards.createTagPicker).toContainText(createSuggestionTag);
 
-      await authedPage.getByPlaceholder('Question or prompt...').fill(`Created via UI ${runId}`);
+      await authedPage.getByPlaceholder('Question or prompt...').fill(`${seed.runId} created via UI`);
       await authedPage.getByPlaceholder('Answer...').fill('Created tag suggestion answer');
 
       const createResponsePromise = authedPage.waitForResponse((response) => {
@@ -784,10 +825,12 @@ test.describe('Flashcards', () => {
   test.describe('Export', () => {
     test('should fire GET /api/v1/flashcards/export when Export button is clicked', async ({
       authedPage,
+      request,
       serverInfo,
       diagnostics,
     }) => {
       skipIfServerUnavailable(serverInfo);
+      await skipIfFlashcardsBackendUnavailable(request);
 
       flashcards = new FlashcardsPage(authedPage);
       await flashcards.goto();
@@ -880,15 +923,16 @@ test.describe('Flashcards', () => {
 
     test(
       'flashcards Phase 0 evidence: invalid delimited import does not show zero-card success or get stuck (TASK-537)',
-      async ({ authedPage, serverInfo }) => {
+      async ({ authedPage, request, serverInfo }) => {
         skipIfServerUnavailable(serverInfo);
+        await skipIfFlashcardsBackendUnavailable(request);
 
         flashcards = new FlashcardsPage(authedPage);
         await flashcards.gotoPath('/flashcards?tab=importExport');
         await flashcards.assertPageReady();
 
         await flashcards.openImportTask();
-        await flashcards.importTextarea.fill('Deck\tFront\tBack\nBroken\t\t');
+        await flashcards.importTextarea.fill(`Deck\tFront\tBack\n${FLASHCARDS_E2E_PREFIX}-invalid\t\t`);
         await flashcards.importButton.click();
 
         await expect(flashcards.importResultAlert).toBeVisible({ timeout: 20_000 });
@@ -946,14 +990,16 @@ test.describe('Flashcards', () => {
   test.describe('Direct Handoffs', () => {
     test('flashcards Phase 0 evidence: quiz handoff preserves selected review deck context', async ({
       authedPage,
+      request,
       serverInfo,
       diagnostics,
     }) => {
       test.setTimeout(90_000);
       skipIfServerUnavailable(serverInfo);
+      await skipIfFlashcardsBackendUnavailable(request);
 
-      const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-      const deck = await createFlashcardDeck(`E2E Quiz Handoff ${runId}`);
+      const seed = buildFlashcardsSeedRecord();
+      const deck = await createFlashcardDeck(seed.deckName);
 
       try {
         flashcards = new FlashcardsPage(authedPage);

--- a/apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
@@ -9,7 +9,7 @@
  *
  * Run: npx playwright test e2e/workflows/tier-2-features/flashcards.spec.ts
  */
-import { type APIRequestContext } from '@playwright/test';
+import { type APIRequestContext, type TestInfo } from '@playwright/test';
 import {
   test,
   expect,
@@ -23,6 +23,7 @@ import {
   assertFlashcardsBackendReady,
   buildFlashcardsSeedRecord,
   cleanupFlashcardsRunRecords,
+  makeFlashcardsRunId,
 } from '../../utils/page-objects/FlashcardsPage';
 import {
   dispatchKeyboardShortcut,
@@ -115,17 +116,37 @@ async function cleanupFlashcardDeck(deck: SeededDeck): Promise<void> {
       }
     );
 
-    expect(
-      response.ok,
-      `Failed to cleanup flashcard deck ${deck.id} at version ${expectedVersion}: ${response.status} ${response.statusText}`
-    ).toBeTruthy();
+    if (!response.ok && response.status !== 404 && response.status !== 409) {
+      console.warn(
+        `Failed to cleanup flashcard deck ${deck.id} at version ${expectedVersion}: ${response.status} ${response.statusText}`
+      );
+    }
   } catch (error) {
     console.error(
       `Failed to cleanup flashcard deck ${deck.id} at version ${expectedVersion} from ${TEST_CONFIG.serverUrl}`,
       error
     );
-    throw error;
   }
+}
+
+function flashcardsRunIdForTest(testInfo: TestInfo): string {
+  const maybeTitlePath = (
+    testInfo as TestInfo & { titlePath?: string[] | (() => string[]) }
+  ).titlePath;
+  const titlePath = Array.isArray(maybeTitlePath)
+    ? maybeTitlePath
+    : typeof maybeTitlePath === 'function'
+      ? maybeTitlePath()
+      : [testInfo.title];
+
+  return makeFlashcardsRunId(
+    [
+      testInfo.project.name,
+      ...titlePath,
+      `repeat-${testInfo.repeatEachIndex}`,
+      `retry-${testInfo.retry}`,
+    ].join('-')
+  );
 }
 
 async function skipIfFlashcardsBackendUnavailable(
@@ -148,7 +169,17 @@ test.describe('Flashcards', () => {
   });
 
   test.afterEach(async ({ request }, testInfo) => {
-    await cleanupFlashcardsRunRecords(request, testInfo.title);
+    const runId = flashcardsRunIdForTest(testInfo);
+    try {
+      await cleanupFlashcardsRunRecords(request, runId);
+    } catch (error) {
+      const message = error instanceof Error ? error.stack ?? error.message : String(error);
+      console.warn(`[flashcards:e2e:cleanup] Cleanup failed for ${runId}`, error);
+      await testInfo.attach('flashcards-cleanup-warning.txt', {
+        body: message,
+        contentType: 'text/plain',
+      });
+    }
   });
 
   // =========================================================================
@@ -323,12 +354,12 @@ test.describe('Flashcards', () => {
       request,
       serverInfo,
       diagnostics,
-    }) => {
+    }, testInfo) => {
       test.setTimeout(120_000);
       skipIfServerUnavailable(serverInfo);
       await skipIfFlashcardsBackendUnavailable(request);
 
-      const seed = buildFlashcardsSeedRecord();
+      const seed = buildFlashcardsSeedRecord(flashcardsRunIdForTest(testInfo));
       const deck = await createFlashcardDeck(seed.deckName);
       const front = seed.cardFront;
       const back = seed.cardBack;
@@ -391,11 +422,11 @@ test.describe('Flashcards', () => {
       request,
       serverInfo,
       diagnostics,
-    }) => {
+    }, testInfo) => {
       skipIfServerUnavailable(serverInfo);
       await skipIfFlashcardsBackendUnavailable(request);
 
-      const seed = buildFlashcardsSeedRecord();
+      const seed = buildFlashcardsSeedRecord(flashcardsRunIdForTest(testInfo));
       const deck = await createFlashcardDeck(seed.deckName);
       const front = seed.cardFront;
       const back = seed.cardBack;
@@ -448,11 +479,11 @@ test.describe('Flashcards', () => {
       request,
       serverInfo,
       diagnostics,
-    }) => {
+    }, testInfo) => {
       skipIfServerUnavailable(serverInfo);
       await skipIfFlashcardsBackendUnavailable(request);
 
-      const seed = buildFlashcardsSeedRecord();
+      const seed = buildFlashcardsSeedRecord(flashcardsRunIdForTest(testInfo));
       const deck = await createFlashcardDeck(seed.deckName);
       const front = seed.cardFront;
       const back = seed.cardBack;
@@ -653,11 +684,11 @@ test.describe('Flashcards', () => {
       request,
       serverInfo,
       diagnostics,
-    }) => {
+    }, testInfo) => {
       skipIfServerUnavailable(serverInfo);
       await skipIfFlashcardsBackendUnavailable(request);
 
-      const seed = buildFlashcardsSeedRecord();
+      const seed = buildFlashcardsSeedRecord(flashcardsRunIdForTest(testInfo));
       const front = seed.cardFront;
       const back = seed.cardBack;
 
@@ -702,12 +733,12 @@ test.describe('Flashcards', () => {
       request,
       serverInfo,
       diagnostics,
-    }) => {
+    }, testInfo) => {
       test.setTimeout(120_000);
       skipIfServerUnavailable(serverInfo);
       await skipIfFlashcardsBackendUnavailable(request);
 
-      const seed = buildFlashcardsSeedRecord();
+      const seed = buildFlashcardsSeedRecord(flashcardsRunIdForTest(testInfo));
       const deck = await createFlashcardDeck(seed.deckName);
       const createSuggestionTag = `${seed.runId}-bio-create`;
       const editSuggestionTag = `${seed.runId}-bio-edit`;
@@ -993,12 +1024,12 @@ test.describe('Flashcards', () => {
       request,
       serverInfo,
       diagnostics,
-    }) => {
+    }, testInfo) => {
       test.setTimeout(90_000);
       skipIfServerUnavailable(serverInfo);
       await skipIfFlashcardsBackendUnavailable(request);
 
-      const seed = buildFlashcardsSeedRecord();
+      const seed = buildFlashcardsSeedRecord(flashcardsRunIdForTest(testInfo));
       const deck = await createFlashcardDeck(seed.deckName);
 
       try {

--- a/apps/tldw-frontend/playwright.config.ts
+++ b/apps/tldw-frontend/playwright.config.ts
@@ -4,11 +4,12 @@ const rawBaseUrl = process.env.TLDW_WEB_URL || 'http://localhost:8080';
 const baseURL = rawBaseUrl.replace('127.0.0.1', 'localhost');
 const webCommand = process.env.TLDW_WEB_CMD || 'bun run dev -- -p 8080';
 const shouldAutoStart = process.env.TLDW_WEB_AUTOSTART !== 'false';
-const defaultApiUrl =
+const rawApiUrl =
   process.env.NEXT_PUBLIC_API_URL ||
   process.env.TLDW_SERVER_URL ||
   process.env.TLDW_E2E_SERVER_URL ||
   'http://127.0.0.1:8000';
+const defaultApiUrl = /^https?:\/\//i.test(rawApiUrl) ? rawApiUrl : `http://${rawApiUrl}`;
 const webServerEnv = {
   ...Object.fromEntries(
     Object.entries(process.env).filter(

--- a/backlog/tasks/task-2401 - Implement-flashcards-UX-PR-0-evidence-and-harness-refresh.md
+++ b/backlog/tasks/task-2401 - Implement-flashcards-UX-PR-0-evidence-and-harness-refresh.md
@@ -1,0 +1,75 @@
+---
+id: TASK-2401
+title: Implement flashcards UX PR 0 evidence and harness refresh
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-23 17:21'
+labels:
+  - ux
+  - flashcards
+  - tests
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+<!-- SECTION:DESCRIPTION:BEGIN -->
+<!-- SECTION:DESCRIPTION:END -->
+
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-23-flashcards-remaining-ux-remediation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented PR 0 flashcards UX evidence and harness refresh.
+
+Changed:
+- Added deterministic E2E seed IDs and prefix-safe cleanup helpers.
+- Normalized E2E backend URLs so the documented TLDW_E2E_SERVER_URL=127.0.0.1:8000 command resolves to http://127.0.0.1:8000.
+- Added authenticated flashcards API preflight and skip gating for backend-dependent Playwright cases.
+- Added current-state component coverage for zero-deck IA, invalid import failure recovery, visible review re-rate, and create-drawer deck-reference lazy loading.
+
+Verification:
+- git diff --check: passed.
+- URL normalization check: passed and printed http://127.0.0.1:8000.
+- Focused Vitest command: 4 files passed, 91 tests passed, 1 skipped.
+- Playwright flashcards workflow: 9 passed, 11 backend-dependent cases skipped when backend/flashcards preflight unavailable.
+- Spec compliance review: approved.
+- Code quality review: approved.
+
+Bandit: not applicable; this PR slice touched frontend/E2E TypeScript and Backlog metadata only.
+
+Notes:
+- The clean PR worktree already had an unrelated TASK-2354 from origin/dev, so TASK-2401 is the non-conflicting worktree Backlog record committed with this slice.
+- The worktree dependency layout has a broken tracked antd symlink target; verification temporarily repointed it to an installed cache target and restored it before staging.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2401 - Implement-flashcards-UX-PR-0-evidence-and-harness-refresh.md
+++ b/backlog/tasks/task-2401 - Implement-flashcards-UX-PR-0-evidence-and-harness-refresh.md
@@ -15,9 +15,7 @@ dependencies: []
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-<!-- SECTION:DESCRIPTION:BEGIN -->
-<!-- SECTION:DESCRIPTION:END -->
-
+Refresh the Flashcards UX evidence and test harness before behavior remediation work.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -62,6 +60,20 @@ Bandit: not applicable; this PR slice touched frontend/E2E TypeScript and Backlo
 Notes:
 - The clean PR worktree already had an unrelated TASK-2354 from origin/dev, so TASK-2401 is the non-conflicting worktree Backlog record committed with this slice.
 - The worktree dependency layout has a broken tracked antd symlink target; verification temporarily repointed it to an installed cache target and restored it before staging.
+
+Review follow-up:
+- Rebased PR #2464 onto latest `origin/dev`.
+- Removed the skipped future invalid-import inline alert test from PR0 instead of carrying disabled coverage.
+- Replaced random/time-based E2E run IDs with deterministic IDs derived from Playwright test metadata plus a stable hash suffix.
+- Scoped cleanup to the exact per-test run ID and made teardown cleanup best-effort with warnings instead of thrown failures.
+- Fixed duplicate DESCRIPTION section markers in this Backlog task.
+
+Review follow-up verification:
+- Targeted grep for skipped tests, random/time IDs, no-arg seed calls, and old cleanup helpers: no matches.
+- git diff --check: passed.
+- Focused Vitest flashcards suite: 4 files passed, 91 tests passed.
+- Playwright flashcards workflow: 9 passed, 11 backend-dependent cases skipped because the local backend preflight was unavailable; cleanup warnings did not fail teardown.
+- Bandit: not applicable; review follow-up touched frontend/E2E TypeScript and Backlog metadata only.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Refreshes Flashcards E2E/page-object helpers, backend preflight gating, and deterministic cleanup for the UX closeout series.
- Adds component guard coverage for zero-deck IA, invalid import recovery, visible re-rate, and create-drawer deck reference loading.
- Backlog: TASK-2401.

## Test Plan
- git diff --check
- Focused Vitest: 4 files, 91 passed, 1 skipped
- Playwright flashcards workflow: 9 passed, 11 backend-dependent cases skipped when preflight unavailable

## Merge Note
- Project policy requires a human-authored Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the Flashcards E2E harness and component tests to stabilize backend-dependent flows and document current UX states. Satisfies TASK-2401 PR‑0 evidence with deterministic per-test seeds and safer cleanup.

- **New Features**
  - Authenticated backend preflight with per-test skip gating for flashcards specs.
  - Deterministic run IDs from Playwright metadata plus stable hash; prefix-based API cleanup scoped to each test.
  - Added coverage for zero-deck IA, invalid import recovery (input preserved, loading exits), visible re-rate after rating, and lazy deck-reference loading in the create drawer.

- **Refactors**
  - Normalized E2E server URLs to accept bare hosts by auto-prefixing http in helpers and Playwright config.
  - Expanded `FlashcardsPage` with API helpers, seed builders, and best-effort teardown cleanup (warnings instead of failures).
  - Updated workflows to use shared seed/cleanup utilities to reduce flakiness.

<sup>Written for commit afd29f3138ec4a16dd79172c3bdb0c73dd265a88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

