### PR TITLE
fix: improve flashcards first-time setup

### DIFF
--- a/apps/packages/ui/src/components/Flashcards/FlashcardsManager.tsx
+++ b/apps/packages/ui/src/components/Flashcards/FlashcardsManager.tsx
@@ -1,9 +1,16 @@
 import React from "react"
-import { Button, Space, Tabs, Tooltip } from "antd"
+import { Button, Card, Empty, Space, Tabs, Tooltip, Typography } from "antd"
 import { HelpCircle } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { useLocation, useNavigate } from "react-router-dom"
-import { ReviewTab, ManageTab, ImportExportTab, SchedulerTab, TemplatesTab } from "./tabs"
+import {
+  ReviewTab,
+  ManageTab,
+  ImportExportTab,
+  SchedulerTab,
+  TemplatesTab,
+  type TransferTaskKey
+} from "./tabs"
 import { KeyboardShortcutsModal } from "./components"
 import { useDecksQuery, type UseFlashcardQueriesOptions } from "./hooks"
 import type { Flashcard } from "@/services/flashcards"
@@ -13,6 +20,8 @@ import {
   buildQuizAssessmentRouteFromFlashcards,
   parseFlashcardsStudyIntentFromLocation
 } from "@/services/tldw/quiz-flashcards-handoff"
+
+const { Text } = Typography
 
 const parseInitialFlashcardsTab = (locationLike: { search?: string; hash?: string }): string | null => {
   const search = locationLike.search || ""
@@ -74,7 +83,7 @@ export const FlashcardsManager: React.FC = () => {
     includeWorkspaceItems: currentStudyIntent?.forceShowWorkspaceItems ?? false
   }), [currentStudyIntent?.forceShowWorkspaceItems])
   const { data: initialDecks } = useDecksQuery(deckVisibilityOptions)
-  const showSchedulerTab = initialDecks === undefined || initialDecks.length > 0
+  const hasNoInitialDecks = initialDecks !== undefined && initialDecks.length === 0
   const [reviewDeckId, setReviewDeckId] = React.useState<number | null | undefined>(
     currentStudyIntent?.deckId ?? undefined
   )
@@ -110,10 +119,19 @@ export const FlashcardsManager: React.FC = () => {
     deckId: number
     key: string
   } | null>(null)
+  const [transferTaskHandoff, setTransferTaskHandoff] = React.useState<{
+    task: TransferTaskKey
+    key: string
+  } | null>(null)
   const deckHandoffCounterRef = React.useRef(0)
+  const transferTaskHandoffCounterRef = React.useRef(0)
   const nextDeckHandoffKey = React.useCallback((prefix: string, deckId: number) => {
     deckHandoffCounterRef.current += 1
     return `${prefix}:${deckId}:${deckHandoffCounterRef.current}`
+  }, [])
+  const nextTransferTaskHandoffKey = React.useCallback((task: TransferTaskKey) => {
+    transferTaskHandoffCounterRef.current += 1
+    return `${task}:${transferTaskHandoffCounterRef.current}`
   }, [])
   const clearDeckHandoffs = React.useCallback(() => {
     setManageDeckHandoff(null)
@@ -163,6 +181,12 @@ export const FlashcardsManager: React.FC = () => {
     const nextTab =
       currentTab ?? (currentGenerateIntent || currentStudyPackIntent ? "importExport" : null)
     if (nextTab) {
+      if (
+        nextTab === "importExport" &&
+        (currentTab === "importExport" || currentGenerateIntent || currentStudyPackIntent)
+      ) {
+        setTransferTaskHandoff(null)
+      }
       setActiveTab(nextTab)
     }
     if (currentStudyIntent?.deckId !== undefined) {
@@ -171,13 +195,10 @@ export const FlashcardsManager: React.FC = () => {
   }, [applyReviewDeckChange, currentGenerateIntent, currentStudyIntent?.deckId, currentStudyPackIntent, currentTab])
 
   React.useEffect(() => {
-    if (!showSchedulerTab && activeTab === "scheduler") {
-      if (schedulerDirty) {
-        discardSchedulerChanges()
-      }
-      setActiveTab("review")
+    if (hasNoInitialDecks && activeTab === "scheduler" && schedulerDirty) {
+      discardSchedulerChanges()
     }
-  }, [activeTab, discardSchedulerChanges, schedulerDirty, showSchedulerTab])
+  }, [activeTab, discardSchedulerChanges, hasNoInitialDecks, schedulerDirty])
 
   const handleReviewCard = React.useCallback(
     (card: Flashcard) => {
@@ -221,6 +242,29 @@ export const FlashcardsManager: React.FC = () => {
     },
     [applyReviewDeckChange, nextDeckHandoffKey]
   )
+  const requestTransferTask = React.useCallback(
+    (task: TransferTaskKey) => {
+      setTransferTaskHandoff({
+        task,
+        key: nextTransferTaskHandoffKey(task)
+      })
+    },
+    [nextTransferTaskHandoffKey]
+  )
+  const navigateToTransferTask = React.useCallback(
+    (task: TransferTaskKey) => {
+      clearDeckHandoffs()
+      requestTransferTask(task)
+      setActiveTab("importExport")
+    },
+    [clearDeckHandoffs, requestTransferTask]
+  )
+  const navigateToImportTask = React.useCallback(() => {
+    navigateToTransferTask("import")
+  }, [navigateToTransferTask])
+  const navigateToGenerateTask = React.useCallback(() => {
+    navigateToTransferTask("create")
+  }, [navigateToTransferTask])
   const navigateToExportDeck = React.useCallback(
     (deckId: number) => {
       applyReviewDeckChange(deckId)
@@ -228,9 +272,10 @@ export const FlashcardsManager: React.FC = () => {
         deckId,
         key: nextDeckHandoffKey("export", deckId)
       })
+      requestTransferTask("export")
       setActiveTab("importExport")
     },
-    [applyReviewDeckChange, nextDeckHandoffKey]
+    [applyReviewDeckChange, nextDeckHandoffKey, requestTransferTask]
   )
 
   const quizCtaRoute = React.useMemo(() => {
@@ -244,16 +289,13 @@ export const FlashcardsManager: React.FC = () => {
     })
   }, [currentStudyIntent?.attemptId, currentStudyIntent?.deckId, currentStudyIntent?.forceShowWorkspaceItems, currentStudyIntent?.quizId, reviewDeckId])
   const canOpenQuizCta = currentStudyIntent?.quizId !== undefined
-  const effectiveActiveTab =
-    !showSchedulerTab && activeTab === "scheduler" ? "review" : activeTab
+  const effectiveActiveTab = activeTab
   const effectiveSchedulerDeckId = schedulerDeckHandoff?.deckId ?? schedulerHandoffDeckId
   const effectiveSchedulerHandoffKey =
     schedulerDeckHandoff?.key ?? schedulerHandoffKey
 
   const handleTabChange = React.useCallback(
     (nextTab: string) => {
-      if (nextTab === "scheduler" && !showSchedulerTab) return
-
       if (activeTab === "scheduler" && nextTab !== "scheduler" && schedulerDirty) {
         const shouldDiscard = window.confirm(
           t("option:flashcards.schedulerDiscardChangesPrompt", {
@@ -264,9 +306,49 @@ export const FlashcardsManager: React.FC = () => {
         discardSchedulerChanges()
       }
 
+      if (nextTab === "importExport") {
+        setTransferTaskHandoff(null)
+      }
+
       setActiveTab(nextTab)
     },
-    [activeTab, discardSchedulerChanges, schedulerDirty, showSchedulerTab, t]
+    [activeTab, discardSchedulerChanges, schedulerDirty, t]
+  )
+
+  const schedulerEmptyPreview = (
+    <Card size="small" data-testid="flashcards-scheduler-empty-preview">
+      <Empty
+        image={Empty.PRESENTED_IMAGE_SIMPLE}
+        description={
+          <Space orientation="vertical" size={8} align="center">
+            <Text strong>
+              {t("option:flashcards.schedulerEmptyTitle", {
+                defaultValue: "Create a deck before tuning scheduler rules."
+              })}
+            </Text>
+            <Text type="secondary" className="max-w-xl text-center">
+              {t("option:flashcards.schedulerEmptyDescription", {
+                defaultValue:
+                  "Scheduler policies control review timing per deck. Start with a new deck, or import and generate cards first."
+              })}
+            </Text>
+          </Space>
+        }
+      >
+        <Space wrap>
+          <Button type="primary" onClick={routeToCreateEntryPoint}>
+            {t("option:flashcards.schedulerEmptyCreateDeck", {
+              defaultValue: "Create a deck"
+            })}
+          </Button>
+          <Button onClick={navigateToImportTask}>
+            {t("option:flashcards.schedulerEmptyImportGenerate", {
+              defaultValue: "Import or generate cards"
+            })}
+          </Button>
+        </Space>
+      </Empty>
+    </Card>
   )
 
   return (
@@ -326,7 +408,8 @@ export const FlashcardsManager: React.FC = () => {
             children: (
               <ReviewTab
                 onNavigateToCreate={routeToCreateEntryPoint}
-                onNavigateToImport={() => setActiveTab("importExport")}
+                onNavigateToImport={navigateToImportTask}
+                onNavigateToGenerate={navigateToGenerateTask}
                 reviewDeckId={reviewDeckId}
                 onReviewDeckChange={applyReviewDeckChange}
                 reviewOverrideCard={reviewOverrideCard}
@@ -344,7 +427,8 @@ export const FlashcardsManager: React.FC = () => {
             label: t("option:flashcards.tabManage", { defaultValue: "Manage" }),
             children: (
               <ManageTab
-                onNavigateToImport={() => setActiveTab("importExport")}
+                onNavigateToImport={navigateToImportTask}
+                onNavigateToGenerate={navigateToGenerateTask}
                 onReviewCard={handleReviewCard}
                 openCreateSignal={openCreateSignal}
                 isActive={effectiveActiveTab === "cards"}
@@ -370,6 +454,8 @@ export const FlashcardsManager: React.FC = () => {
               <ImportExportTab
                 generateIntent={currentGenerateIntent}
                 studyPackIntent={currentStudyPackIntent}
+                initialTask={transferTaskHandoff?.task ?? null}
+                initialTaskHandoffKey={transferTaskHandoff?.key ?? null}
                 initialExportDeckId={exportDeckHandoff?.deckId ?? null}
                 initialExportDeckHandoffKey={exportDeckHandoff?.key ?? null}
               />
@@ -380,24 +466,22 @@ export const FlashcardsManager: React.FC = () => {
             label: t("option:flashcards.tabTemplates", { defaultValue: "Templates" }),
             children: <TemplatesTab />
           },
-          ...(showSchedulerTab
-            ? [
-                {
-                  key: "scheduler",
-                  label: t("option:flashcards.tabScheduler", { defaultValue: "Scheduler" }),
-                  children: (
-                    <SchedulerTab
-                      isActive={effectiveActiveTab === "scheduler"}
-                      initialDeckId={effectiveSchedulerDeckId}
-                      initialDeckHandoffKey={effectiveSchedulerHandoffKey}
-                      deckVisibilityOptions={deckVisibilityOptions}
-                      onDirtyChange={setSchedulerDirty}
-                      discardSignal={schedulerDiscardSignal}
-                    />
-                  )
-                }
-              ]
-            : [])
+          {
+            key: "scheduler",
+            label: t("option:flashcards.tabScheduler", { defaultValue: "Scheduler" }),
+            children: hasNoInitialDecks ? (
+              schedulerEmptyPreview
+            ) : (
+              <SchedulerTab
+                isActive={effectiveActiveTab === "scheduler"}
+                initialDeckId={effectiveSchedulerDeckId}
+                initialDeckHandoffKey={effectiveSchedulerHandoffKey}
+                deckVisibilityOptions={deckVisibilityOptions}
+                onDirtyChange={setSchedulerDirty}
+                discardSignal={schedulerDiscardSignal}
+              />
+            )
+          }
         ]}
       />
 

--- a/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { FlashcardsManager } from "../FlashcardsManager"
 
@@ -56,6 +56,8 @@ vi.mock("../hooks", () => ({
 vi.mock("../tabs", () => ({
   ReviewTab: (props: {
     onNavigateToCreate: () => void
+    onNavigateToImport: () => void
+    onNavigateToGenerate?: () => void
     reviewDeckId?: number | null
     onReviewDeckChange: (deckId: number | null | undefined) => void
     onNavigateToManageDeck?: (deckId: number) => void
@@ -64,6 +66,8 @@ vi.mock("../tabs", () => ({
   }) => (
     <div data-testid="mock-review-tab">
       <button onClick={props.onNavigateToCreate}>Route Create</button>
+      <button onClick={props.onNavigateToImport}>Route Import</button>
+      <button onClick={() => props.onNavigateToGenerate?.()}>Route Generate</button>
       <button onClick={() => props.onReviewDeckChange(12)}>Select Deck 12</button>
       <button onClick={() => props.onReviewDeckChange(21)}>Select Deck 21</button>
       <button onClick={() => props.onReviewDeckChange(undefined)}>Clear Deck</button>
@@ -77,6 +81,7 @@ vi.mock("../tabs", () => ({
   ),
   ManageTab: (props: {
     onNavigateToImport: () => void
+    onNavigateToGenerate?: () => void
     onReviewCard: (card: { deck_id: number }) => void
     openCreateSignal?: number
     initialDeckId?: number
@@ -88,6 +93,7 @@ vi.mock("../tabs", () => ({
   }) => (
     <div data-testid="mock-manage-tab">
       <button onClick={props.onNavigateToImport}>Route Import</button>
+      <button onClick={() => props.onNavigateToGenerate?.()}>Route Generate</button>
       <button onClick={() => props.onReviewCard({ deck_id: 21 })}>Review Managed Card 21</button>
       <button onClick={() => props.onCreateHandoffConsumed?.()}>Consume Create Handoff</button>
       <span data-testid="mock-open-create-signal">{String(props.openCreateSignal ?? 0)}</span>
@@ -101,11 +107,15 @@ vi.mock("../tabs", () => ({
     </div>
   ),
   ImportExportTab: (props: {
+    initialTask?: "create" | "import" | "export" | null
+    initialTaskHandoffKey?: string | null
     initialExportDeckId?: number | null
     initialExportDeckHandoffKey?: string | null
   }) => (
     <div data-testid="mock-transfer-tab">
       Import / Export panel
+      <span data-testid="mock-transfer-initial-task">{String(props.initialTask ?? "")}</span>
+      <span data-testid="mock-transfer-task-handoff-key">{String(props.initialTaskHandoffKey ?? "")}</span>
       <span data-testid="mock-export-initial-deck-id">{String(props.initialExportDeckId ?? "")}</span>
       <span data-testid="mock-export-handoff-key">{String(props.initialExportDeckHandoffKey ?? "")}</span>
     </div>
@@ -418,7 +428,7 @@ describe("FlashcardsManager consistency standards", () => {
     expect(mocks.translationKeys).not.toContain("option:flashcards.tabImportExport")
   })
 
-  it("defaults empty accounts to Study and keeps import/export available without implying LLM-only import", () => {
+  it("defaults zero-deck users to Study and keeps Scheduler discoverable", () => {
     mocks.decks = []
     window.history.replaceState({}, "", "/flashcards")
 
@@ -428,7 +438,7 @@ describe("FlashcardsManager consistency standards", () => {
     expect(screen.getByText("Import / Export")).toBeInTheDocument()
     expect(screen.queryByText("LLM")).not.toBeInTheDocument()
     expect(screen.getByText("Templates")).toBeInTheDocument()
-    expect(screen.queryByText("Scheduler")).not.toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: /scheduler/i })).toBeInTheDocument()
     expect(screen.queryByTestId("mock-scheduler-tab")).not.toBeInTheDocument()
   })
 
@@ -484,8 +494,8 @@ describe("FlashcardsManager consistency standards", () => {
 
     expect(screen.getByText("Templates")).toBeInTheDocument()
     expect(screen.getByTestId("mock-templates-tab")).toBeInTheDocument()
-    expect(screen.queryByRole("tab", { name: /scheduler/i })).not.toBeInTheDocument()
-    expect(screen.queryByText("Scheduler")).not.toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: /scheduler/i })).toBeInTheDocument()
+    expect(screen.queryByTestId("mock-scheduler-tab")).not.toBeInTheDocument()
   })
 
   it("requests workspace decks when study links include workspace items", () => {
@@ -504,13 +514,18 @@ describe("FlashcardsManager consistency standards", () => {
     )
   })
 
-  it("clamps scheduler deep-links to Study when Scheduler is hidden", () => {
+  it("opens a Scheduler preview for zero-deck Scheduler deep-links", () => {
     mocks.decks = []
     window.history.replaceState({}, "", "/flashcards?tab=scheduler&deck_id=9")
 
     render(<FlashcardsManager />)
 
-    expect(screen.getByTestId("mock-review-tab")).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: /scheduler/i })).toHaveAttribute("aria-selected", "true")
+    expect(screen.getByTestId("flashcards-scheduler-empty-preview")).toHaveTextContent(
+      /create a deck/i
+    )
+    expect(screen.getByRole("button", { name: /create a deck/i })).toBeInTheDocument()
+    expect(screen.queryByTestId("mock-review-tab")).not.toBeInTheDocument()
     expect(screen.queryByTestId("mock-scheduler-tab")).not.toBeInTheDocument()
   })
 
@@ -521,6 +536,47 @@ describe("FlashcardsManager consistency standards", () => {
     fireEvent.click(screen.getByText("Route Create"))
     expect(screen.getByTestId("mock-manage-tab")).toBeInTheDocument()
     expect(screen.getByTestId("mock-open-create-signal")).toHaveTextContent("1")
+  })
+
+  it("routes Study import CTA to the Import file task", () => {
+    window.history.replaceState({}, "", "/flashcards")
+    render(<FlashcardsManager />)
+
+    fireEvent.click(within(screen.getByTestId("mock-review-tab")).getByText("Route Import"))
+
+    expect(screen.getByTestId("mock-transfer-tab")).toBeInTheDocument()
+    expect(screen.getByTestId("mock-transfer-initial-task")).toHaveTextContent("import")
+    expect(screen.getByTestId("mock-transfer-task-handoff-key")).toHaveTextContent("import:")
+  })
+
+  it("routes Study generate CTA to the Create and generate task", () => {
+    window.history.replaceState({}, "", "/flashcards")
+    render(<FlashcardsManager />)
+
+    fireEvent.click(within(screen.getByTestId("mock-review-tab")).getByText("Route Generate"))
+
+    expect(screen.getByTestId("mock-transfer-tab")).toBeInTheDocument()
+    expect(screen.getByTestId("mock-transfer-initial-task")).toHaveTextContent("create")
+    expect(screen.getByTestId("mock-transfer-task-handoff-key")).toHaveTextContent("create:")
+  })
+
+  it("routes Manage empty-state transfer CTAs to distinct transfer tasks", () => {
+    window.history.replaceState({}, "", "/flashcards")
+    render(<FlashcardsManager />)
+
+    fireEvent.click(screen.getByText("Manage"))
+    fireEvent.click(within(screen.getByTestId("mock-manage-tab")).getByText("Route Import"))
+
+    expect(screen.getByTestId("mock-transfer-tab")).toBeInTheDocument()
+    expect(screen.getByTestId("mock-transfer-initial-task")).toHaveTextContent("import")
+    expect(screen.getByTestId("mock-transfer-task-handoff-key")).toHaveTextContent("import:")
+
+    fireEvent.click(screen.getByText("Manage"))
+    fireEvent.click(within(screen.getByTestId("mock-manage-tab")).getByText("Route Generate"))
+
+    expect(screen.getByTestId("mock-transfer-tab")).toBeInTheDocument()
+    expect(screen.getByTestId("mock-transfer-initial-task")).toHaveTextContent("create")
+    expect(screen.getByTestId("mock-transfer-task-handoff-key")).toHaveTextContent("create:")
   })
 
   it("passes the selected Study deck to the Manage create drawer handoff", () => {
@@ -627,7 +683,8 @@ describe("FlashcardsManager consistency standards", () => {
     confirmSpy.mockRestore()
   })
 
-  it("discards scheduler draft state when Scheduler is auto-hidden", async () => {
+  it("discards scheduler draft state when Scheduler is replaced by the zero-deck preview", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm")
     window.history.replaceState({}, "", "/flashcards")
     const { rerender } = render(<FlashcardsManager />)
 
@@ -639,14 +696,14 @@ describe("FlashcardsManager consistency standards", () => {
     rerender(<FlashcardsManager />)
 
     await waitFor(() => {
-      expect(screen.queryByTestId("mock-scheduler-tab")).not.toBeInTheDocument()
+      expect(screen.getByTestId("flashcards-scheduler-empty-preview")).toBeInTheDocument()
     })
 
-    mocks.decks = [{ id: 1, name: "Biology" }]
-    rerender(<FlashcardsManager />)
-    fireEvent.click(screen.getByText("Scheduler"))
+    fireEvent.click(screen.getByText("Manage"))
 
-    expect(screen.getByTestId("mock-scheduler-discard-signal")).toHaveTextContent("1")
-    expect(screen.getByTestId("mock-scheduler-draft-state")).toHaveTextContent("clean")
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(screen.getByTestId("mock-manage-tab")).toBeInTheDocument()
+
+    confirmSpy.mockRestore()
   })
 })

--- a/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx
@@ -442,11 +442,11 @@ describe("FlashcardsManager consistency standards", () => {
     expect(screen.queryByTestId("mock-scheduler-tab")).not.toBeInTheDocument()
   })
 
-  it("documents current zero-deck behavior before first-time IA remediation", async () => {
+  it("documents zero-deck behavior after first-time IA remediation", async () => {
     renderFlashcardsManager({ decks: [] })
 
     expect(await screen.findByText("Import / Export")).toBeInTheDocument()
-    expect(screen.queryByText("Scheduler")).not.toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: /scheduler/i })).toBeInTheDocument()
   })
 
   it("still opens Import / Export first for explicit generate and study-pack intents", () => {

--- a/apps/packages/ui/src/components/Flashcards/hooks/__tests__/useFlashcardQueries.tag-suggestions.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/hooks/__tests__/useFlashcardQueries.tag-suggestions.test.tsx
@@ -3,7 +3,7 @@ import { renderHook, waitFor } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { useGlobalFlashcardTagSuggestionsQuery } from "../useFlashcardQueries"
+import { useGlobalFlashcardTagSuggestionsQuery, useManageQuery } from "../useFlashcardQueries"
 import {
   listFlashcardTagSuggestions,
   listFlashcards,
@@ -95,5 +95,51 @@ describe("useGlobalFlashcardTagSuggestionsQuery", () => {
 
     expect(listFlashcardTagSuggestions).not.toHaveBeenCalled()
     expect(listFlashcards).not.toHaveBeenCalled()
+  })
+})
+
+describe("useManageQuery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("normalizes whitespace around search text for cache keys and list requests", async () => {
+    vi.mocked(listFlashcards).mockResolvedValue({
+      items: [],
+      count: 0,
+      total: 0
+    })
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false }
+      }
+    })
+
+    const { result } = renderHook(
+      () =>
+        useManageQuery({
+          query: "  mitochondria  ",
+          page: 1,
+          pageSize: 20
+        }),
+      { wrapper: buildWrapper(queryClient) }
+    )
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(listFlashcards).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: "mitochondria"
+      })
+    )
+
+    const manageQuery = queryClient
+      .getQueryCache()
+      .getAll()
+      .find((query) => query.queryKey[0] === "flashcards:list")
+
+    expect(manageQuery?.queryKey[2]).toBe("mitochondria")
   })
 })

--- a/apps/packages/ui/src/components/Flashcards/hooks/useFlashcardDocumentQuery.ts
+++ b/apps/packages/ui/src/components/Flashcards/hooks/useFlashcardDocumentQuery.ts
@@ -9,6 +9,7 @@ import {
   applyManageClientSort,
   cardHasAllTags,
   getManageServerOrderBy,
+  normalizeManageQuery,
   normalizeManageTags,
   type DueStatus,
   type UseFlashcardQueriesOptions,
@@ -55,7 +56,7 @@ export const getFlashcardDocumentQueryKey = (
 ) => [
   "flashcards:document",
   params.deckId ?? null,
-  params.query ?? "",
+  normalizeManageQuery(params.query) ?? "",
   (resolved?.normalizedTags ?? normalizeManageTags(params.tags, params.tag)).join("|"),
   resolved?.dueStatus ?? params.dueStatus ?? "all",
   resolved?.sortBy ?? params.sortBy ?? "due",
@@ -78,7 +79,7 @@ async function fetchSingleTagDocumentPage(
 ): Promise<FlashcardDocumentPage> {
   const response = await listFlashcards({
     deck_id: params.deckId ?? undefined,
-    q: params.query || undefined,
+    q: normalizeManageQuery(params.query),
     tag: params.primaryTag || undefined,
     due_status: params.dueStatus,
     limit: params.pageSize,
@@ -116,7 +117,7 @@ async function fetchMultiTagDocumentPage(
   while (offset < DOCUMENT_MAX_SCAN && matched.length < targetCount) {
     const response = await listFlashcards({
       deck_id: params.deckId ?? undefined,
-      q: params.query || undefined,
+      q: normalizeManageQuery(params.query),
       tag: params.primaryTag,
       due_status: params.dueStatus,
       limit: DOCUMENT_SCAN_PAGE_SIZE,
@@ -168,6 +169,7 @@ export function useFlashcardDocumentQuery(
 ) {
   const { flashcardsEnabled } = useFlashcardsEnabled()
   const normalizedTags = normalizeManageTags(params.tags, params.tag)
+  const normalizedQuery = normalizeManageQuery(params.query)
   const primaryTag = normalizedTags[0]
   const dueStatus = params.dueStatus ?? "all"
   const sortBy = params.sortBy ?? "due"
@@ -192,7 +194,7 @@ export function useFlashcardDocumentQuery(
         return fetchMultiTagDocumentPage(
           {
             deckId: params.deckId,
-            query: params.query,
+            query: normalizedQuery,
             dueStatus,
             sortBy,
             pageSize,
@@ -207,7 +209,7 @@ export function useFlashcardDocumentQuery(
       return fetchSingleTagDocumentPage(
         {
           deckId: params.deckId,
-          query: params.query,
+          query: normalizedQuery,
           dueStatus,
           sortBy,
           pageSize,

--- a/apps/packages/ui/src/components/Flashcards/hooks/useFlashcardQueries.ts
+++ b/apps/packages/ui/src/components/Flashcards/hooks/useFlashcardQueries.ts
@@ -471,6 +471,11 @@ export const normalizeManageTags = (
   return normalized
 }
 
+export const normalizeManageQuery = (query?: string | null): string | undefined => {
+  const normalized = String(query ?? "").trim()
+  return normalized || undefined
+}
+
 export const cardHasAllTags = (card: Flashcard, normalizedTags: string[]): boolean => {
   if (normalizedTags.length === 0) return true
   const cardTags = new Set((card.tags || []).map((tag) => String(tag || "").trim().toLowerCase()))
@@ -491,6 +496,7 @@ export function useManageQuery(params: ManageQueryParams, options?: UseFlashcard
     page = 1,
     pageSize = 20
   } = params
+  const normalizedQuery = normalizeManageQuery(query)
   const normalizedTags = normalizeManageTags(tags, tag)
   const primaryTag = normalizedTags[0]
 
@@ -498,7 +504,7 @@ export function useManageQuery(params: ManageQueryParams, options?: UseFlashcard
     queryKey: [
       "flashcards:list",
       deckId,
-      query,
+      normalizedQuery ?? "",
       normalizedTags.join("|"),
       dueStatus,
       sortBy,
@@ -516,7 +522,7 @@ export function useManageQuery(params: ManageQueryParams, options?: UseFlashcard
         while (offset < MAX_SCAN) {
           const chunk = await listFlashcards({
             deck_id: deckId ?? undefined,
-            q: query || undefined,
+            q: normalizedQuery,
             tag: primaryTag,
             due_status: dueStatus,
             limit: PAGE_SCAN_SIZE,
@@ -543,7 +549,7 @@ export function useManageQuery(params: ManageQueryParams, options?: UseFlashcard
 
       const response = await listFlashcards({
         deck_id: deckId ?? undefined,
-        q: query || undefined,
+        q: normalizedQuery,
         tag: primaryTag,
         due_status: dueStatus,
         limit: pageSize,

--- a/apps/packages/ui/src/components/Flashcards/tabs/ImportExportTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ImportExportTab.tsx
@@ -18,8 +18,8 @@ import {
   type TransferActionSummaryInput
 } from "./ImportExport/shared"
 
-const { Text } = Typography
-type TransferTaskKey = "create" | "import" | "export"
+const { Text, Title } = Typography
+export type TransferTaskKey = "create" | "import" | "export"
 
 const getGenerateIntentToken = (
   intent: FlashcardsGenerateIntent | null | undefined
@@ -65,6 +65,8 @@ const getExportHandoffToken = (
 type ImportExportTabProps = {
   generateIntent?: FlashcardsGenerateIntent | null
   studyPackIntent?: StudyPackIntent | null
+  initialTask?: TransferTaskKey | null
+  initialTaskHandoffKey?: string | null
   initialExportDeckId?: number | null
   initialExportDeckHandoffKey?: string | null
 }
@@ -72,19 +74,22 @@ type ImportExportTabProps = {
 export const ImportExportTab: React.FC<ImportExportTabProps> = ({
   generateIntent,
   studyPackIntent,
+  initialTask = null,
+  initialTaskHandoffKey = null,
   initialExportDeckId = null,
   initialExportDeckHandoffKey = null
 }) => {
   const { t } = useTranslation(["option", "common"])
   const limitsQuery = useImportLimitsQuery()
   const [activeTask, setActiveTask] = React.useState<TransferTaskKey>(() =>
-    initialExportDeckId != null && initialExportDeckHandoffKey ? "export" : "create"
+    initialTask ?? (initialExportDeckId != null && initialExportDeckHandoffKey ? "export" : "create")
   )
   const [lastTransferAction, setLastTransferAction] =
     React.useState<TransferActionSummary | null>(null)
   const [studyPackDrawerOpen, setStudyPackDrawerOpen] = React.useState(false)
   const seenGenerateIntentTokenRef = React.useRef<string | null>(null)
   const seenStudyPackIntentTokenRef = React.useRef<string | null>(null)
+  const seenTaskHandoffTokenRef = React.useRef<string | null>(null)
   const seenExportHandoffTokenRef = React.useRef<string | null>(null)
   const importLimitsText = React.useMemo(() => {
     const importLimits = normalizeImportLimits(limitsQuery.data)
@@ -122,6 +127,18 @@ export const ImportExportTab: React.FC<ImportExportTabProps> = ({
     seenGenerateIntentTokenRef.current = token
     setActiveTask("create")
   }, [generateIntent])
+
+  React.useEffect(() => {
+    if (!initialTask || !initialTaskHandoffKey) {
+      seenTaskHandoffTokenRef.current = null
+      return
+    }
+    const token = `${initialTask}:${initialTaskHandoffKey}`
+    if (token === seenTaskHandoffTokenRef.current) return
+
+    seenTaskHandoffTokenRef.current = token
+    setActiveTask(initialTask)
+  }, [initialTask, initialTaskHandoffKey])
 
   React.useEffect(() => {
     const token = getExportHandoffToken(initialExportDeckId, initialExportDeckHandoffKey)
@@ -169,7 +186,7 @@ export const ImportExportTab: React.FC<ImportExportTabProps> = ({
   const lastTransferActionText = React.useMemo(() => {
     if (!lastTransferAction) {
       return t("option:flashcards.transferSummaryNoAction", {
-        defaultValue: "No transfer actions yet in this session."
+        defaultValue: "No import/export actions yet in this session."
       })
     }
     const areaLabel =
@@ -210,120 +227,158 @@ export const ImportExportTab: React.FC<ImportExportTabProps> = ({
           onChange={(value) => setActiveTask(value as TransferTaskKey)}
         />
       </Card>
-      <Card
-        title={t("option:flashcards.transferSummaryTitle", {
-          defaultValue: "Import/export summary"
-        })}
-        data-testid="flashcards-transfer-summary"
+      <section
+        aria-labelledby="flashcards-create-generate-heading"
+        data-testid="flashcards-create-generate-section"
+        role="region"
       >
-        <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
-          <div data-testid="flashcards-transfer-summary-formats">
-            <Text strong className="block">
-              {t("option:flashcards.transferSummaryFormatsLabel", {
-                defaultValue: "Supported formats"
-              })}
-            </Text>
-            <Text type="secondary">
-              {t("option:flashcards.transferSummaryFormatsValue", {
-                defaultValue:
-                  "Import: CSV, TSV, JSON, JSONL, Structured Q&A, APKG · Author: Generate, Image Occlusion · Export: TSV, CSV, JSON, APKG"
-              })}
-            </Text>
-          </div>
-          <div data-testid="flashcards-transfer-summary-limits">
-            <Text strong className="block">
-              {t("option:flashcards.transferSummaryLimitsLabel", {
-                defaultValue: "Current import limits"
-              })}
-            </Text>
-            <Text type="secondary">
-              {importLimitsText
-                ? importLimitsText
-                : t("option:flashcards.transferSummaryLimitsUnknown", {
-                    defaultValue: "Limits unavailable"
-                  })}
-            </Text>
-          </div>
-          <div data-testid="flashcards-transfer-summary-last-action">
-            <Text strong className="block">
-              {t("option:flashcards.transferSummaryLastActionLabel", {
-                defaultValue: "Last action"
-              })}
-            </Text>
-            <Text
-              type={
-                lastTransferAction?.status === "error"
-                  ? "danger"
-                  : lastTransferAction?.status === "warning"
-                    ? "warning"
-                    : "secondary"
-              }
-            >
-              {lastTransferActionText}
-            </Text>
-          </div>
+        <div className="mb-2">
+          <Title id="flashcards-create-generate-heading" level={5} className="!mb-0">
+            {t("option:flashcards.createGenerateSectionTitle", {
+              defaultValue: "Create and generate"
+            })}
+          </Title>
+          <Text type="secondary">
+            {t("option:flashcards.createGenerateSectionDescription", {
+              defaultValue: "Start new study material from study packs, source text, or images."
+            })}
+          </Text>
         </div>
-      </Card>
-      <section
-        className={
-          activeTask === "create" ? "grid gap-4 grid-cols-1 xl:grid-cols-2" : "hidden"
-        }
-        data-testid="flashcards-create-task-panel"
-      >
-        <Card
-          className="xl:col-span-2"
-          title={t("option:flashcards.studyPackLauncherTitle", {
-            defaultValue: "Study packs"
-          })}
-          data-testid="flashcards-study-pack-launcher"
+        <section
+          className={
+            activeTask === "create" ? "grid gap-4 grid-cols-1 xl:grid-cols-2" : "hidden"
+          }
+          data-testid="flashcards-create-task-panel"
         >
-          <StudyPackPanel onLaunch={() => setStudyPackDrawerOpen(true)} />
-        </Card>
-        <Card
-          title={t("option:flashcards.generateTitle", {
-            defaultValue: "Generate Flashcards"
-          })}
-        >
-          <GeneratePanel
-            initialIntent={generateIntent || null}
-            onTransferAction={handleTransferAction}
-          />
-        </Card>
-        <Card
-          title={t("option:flashcards.occlusionTitle", {
-            defaultValue: "Image Occlusion"
-          })}
-        >
-          <ImageOcclusionTransferPanel onTransferAction={handleTransferAction} />
-        </Card>
+          <Card
+            className="xl:col-span-2"
+            title={t("option:flashcards.studyPackLauncherTitle", {
+              defaultValue: "Study packs"
+            })}
+            data-testid="flashcards-study-pack-launcher"
+          >
+            <StudyPackPanel onLaunch={() => setStudyPackDrawerOpen(true)} />
+          </Card>
+          <Card
+            title={t("option:flashcards.generateTitle", {
+              defaultValue: "Generate Flashcards"
+            })}
+          >
+            <GeneratePanel
+              initialIntent={generateIntent || null}
+              onTransferAction={handleTransferAction}
+            />
+          </Card>
+          <Card
+            title={t("option:flashcards.occlusionTitle", {
+              defaultValue: "Image Occlusion"
+            })}
+          >
+            <ImageOcclusionTransferPanel onTransferAction={handleTransferAction} />
+          </Card>
+        </section>
       </section>
       <section
-        className={activeTask === "import" ? "" : "hidden"}
-        data-testid="flashcards-import-task-panel"
+        aria-labelledby="flashcards-import-export-heading"
+        data-testid="flashcards-import-export-section"
+        role="region"
       >
+        <div className="mb-2">
+          <Title id="flashcards-import-export-heading" level={5} className="!mb-0">
+            {t("option:flashcards.importExportSectionTitle", {
+              defaultValue: "Import and export"
+            })}
+          </Title>
+          <Text type="secondary">
+            {t("option:flashcards.importExportSectionDescription", {
+              defaultValue: "Move cards in and out without changing the flashcards route."
+            })}
+          </Text>
+        </div>
         <Card
-          title={t("option:flashcards.importTitle", {
-            defaultValue: "Import Flashcards"
+          title={t("option:flashcards.transferSummaryTitle", {
+            defaultValue: "Import/export summary"
           })}
+          data-testid="flashcards-transfer-summary"
+          size="small"
+          className="mb-4"
         >
-          <ImportPanel onTransferAction={handleTransferAction} />
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+            <div data-testid="flashcards-transfer-summary-formats">
+              <Text strong className="block">
+                {t("option:flashcards.transferSummaryFormatsLabel", {
+                  defaultValue: "Supported formats"
+                })}
+              </Text>
+              <Text type="secondary">
+                {t("option:flashcards.transferSummaryFormatsValue", {
+                  defaultValue:
+                    "Import: CSV, TSV, JSON, JSONL, Structured Q&A, APKG · Author: Generate, Image Occlusion · Export: TSV, CSV, JSON, APKG"
+                })}
+              </Text>
+            </div>
+            <div data-testid="flashcards-transfer-summary-limits">
+              <Text strong className="block">
+                {t("option:flashcards.transferSummaryLimitsLabel", {
+                  defaultValue: "Current import limits"
+                })}
+              </Text>
+              <Text type="secondary">
+                {importLimitsText
+                  ? importLimitsText
+                  : t("option:flashcards.transferSummaryLimitsUnknown", {
+                      defaultValue: "Limits unavailable"
+                    })}
+              </Text>
+            </div>
+            <div data-testid="flashcards-transfer-summary-last-action">
+              <Text strong className="block">
+                {t("option:flashcards.transferSummaryLastActionLabel", {
+                  defaultValue: "Last action"
+                })}
+              </Text>
+              <Text
+                type={
+                  lastTransferAction?.status === "error"
+                    ? "danger"
+                    : lastTransferAction?.status === "warning"
+                      ? "warning"
+                      : "secondary"
+                }
+              >
+                {lastTransferActionText}
+              </Text>
+            </div>
+          </div>
         </Card>
-      </section>
-      <section
-        className={activeTask === "export" ? "" : "hidden"}
-        data-testid="flashcards-export-task-panel"
-      >
-        <Card
-          title={t("option:flashcards.exportTitle", {
-            defaultValue: "Export Flashcards"
-          })}
+        <section
+          className={activeTask === "import" ? "" : "hidden"}
+          data-testid="flashcards-import-task-panel"
         >
-          <ExportPanel
-            onTransferAction={handleTransferAction}
-            initialDeckId={initialExportDeckId}
-            initialDeckHandoffKey={initialExportDeckHandoffKey}
-          />
-        </Card>
+          <Card
+            title={t("option:flashcards.importTitle", {
+              defaultValue: "Import Flashcards"
+            })}
+          >
+            <ImportPanel onTransferAction={handleTransferAction} />
+          </Card>
+        </section>
+        <section
+          className={activeTask === "export" ? "" : "hidden"}
+          data-testid="flashcards-export-task-panel"
+        >
+          <Card
+            title={t("option:flashcards.exportTitle", {
+              defaultValue: "Export Flashcards"
+            })}
+          >
+            <ExportPanel
+              onTransferAction={handleTransferAction}
+              initialDeckId={initialExportDeckId}
+              initialDeckHandoffKey={initialExportDeckHandoffKey}
+            />
+          </Card>
+        </section>
       </section>
       <StudyPackCreateDrawer
         open={studyPackDrawerOpen}

--- a/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
@@ -103,6 +103,7 @@ type MoveUndoSnapshot = {
 
 interface ManageTabProps {
   onNavigateToImport: () => void
+  onNavigateToGenerate?: () => void
   onReviewCard: (card: Flashcard) => void
   openCreateSignal?: number
   isActive: boolean
@@ -130,6 +131,7 @@ export const buildFlashcardsWorkspaceVisibilityOptions = (
  */
 export const ManageTab: React.FC<ManageTabProps> = ({
   onNavigateToImport,
+  onNavigateToGenerate,
   onReviewCard,
   openCreateSignal,
   isActive,
@@ -284,8 +286,15 @@ export const ManageTab: React.FC<ManageTabProps> = ({
     [mSort]
   )
 
-  // Check if any filters are active
-  const hasActiveFilters = !!(mQuery || mTags.length > 0 || mDeckId != null || mDue !== "all")
+  // Check if any manage filters are active
+  const hasActiveFilters = !!(
+    mQuery.trim() ||
+    mTags.length > 0 ||
+    mDue !== "all" ||
+    mDeckId != null ||
+    selectedWorkspaceId != null ||
+    showWorkspaceDecks
+  )
 
   // Clear all filters
   const clearAllFilters = () => {
@@ -294,6 +303,8 @@ export const ManageTab: React.FC<ManageTabProps> = ({
     setMTags([])
     setMTagInput("")
     setMDeckId(undefined)
+    setShowWorkspaceDecks(false)
+    setSelectedWorkspaceId(null)
     setMDue("all")
     setMSort("due")
     setPage(1)
@@ -2066,7 +2077,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
                 <Empty
                   description={t("option:flashcards.noCardsTitle", {
                     defaultValue:
-                      mQuery || mTags.length > 0 || mDeckId != null || mDue !== "all"
+                      hasActiveFilters
                         ? "No cards match your filters"
                         : "No flashcards yet"
                   })}
@@ -2075,13 +2086,13 @@ export const ManageTab: React.FC<ManageTabProps> = ({
                     <Text type="secondary">
                       {t("option:flashcards.noCardsDescription", {
                         defaultValue:
-                          mQuery || mTags.length > 0 || mDeckId != null || mDue !== "all"
+                          hasActiveFilters
                             ? "Try adjusting your search, deck, tag, or due filters."
                             : "Create cards from your notes and media, or import an existing deck."
                       })}
                     </Text>
                     <Space>
-                      {mQuery || mTags.length > 0 || mDeckId != null || mDue !== "all" ? (
+                      {hasActiveFilters ? (
                         <Button onClick={clearAllFilters}>
                           {t("option:flashcards.clearFilters", {
                             defaultValue: "Clear filters"
@@ -2107,7 +2118,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
                             })}
                           </Button>
                           <Button
-                            onClick={onNavigateToImport}
+                            onClick={onNavigateToGenerate ?? onNavigateToImport}
                             data-testid="flashcards-manage-empty-generate-cta"
                           >
                             {t("option:flashcards.noCardsGenerateCta", {

--- a/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
@@ -286,9 +286,11 @@ export const ManageTab: React.FC<ManageTabProps> = ({
     [mSort]
   )
 
+  const normalizedManageQuery = mQuery.trim()
+
   // Check if any manage filters are active
   const hasActiveFilters = !!(
-    mQuery.trim() ||
+    normalizedManageQuery ||
     mTags.length > 0 ||
     mDue !== "all" ||
     mDeckId != null ||
@@ -443,7 +445,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
 
   const manageQuery = useManageQuery({
     deckId: mDeckId,
-    query: mQuery,
+    query: normalizedManageQuery,
     tags: mTags,
     dueStatus: mDue,
     sortBy: mSort,
@@ -454,7 +456,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
   const documentQuery = useFlashcardDocumentQuery(
     {
       deckId: mDeckId,
-      query: mQuery,
+      query: normalizedManageQuery,
       tags: mTags,
       dueStatus: mDue,
       sortBy: documentSort,
@@ -468,21 +470,29 @@ export const ManageTab: React.FC<ManageTabProps> = ({
   const documentFilterContext = React.useMemo(
     () => ({
       deckId: mDeckId,
-      query: mQuery,
+      query: normalizedManageQuery,
       tags: mTags,
       dueStatus: mDue,
       sortBy: documentSort,
       workspaceId: selectedWorkspaceId,
       includeWorkspaceItems: selectedWorkspaceId == null ? showWorkspaceDecks : false
     }),
-    [documentSort, mDeckId, mDue, mQuery, mTags, selectedWorkspaceId, showWorkspaceDecks]
+    [
+      documentSort,
+      mDeckId,
+      mDue,
+      normalizedManageQuery,
+      mTags,
+      selectedWorkspaceId,
+      showWorkspaceDecks
+    ]
   )
   const documentQueryKey = React.useMemo(
     () =>
       getFlashcardDocumentQueryKey(
         {
           deckId: mDeckId,
-          query: mQuery,
+          query: normalizedManageQuery,
           tags: mTags,
           dueStatus: mDue,
           sortBy: documentSort,
@@ -496,7 +506,15 @@ export const ManageTab: React.FC<ManageTabProps> = ({
           includeWorkspaceItems: selectedWorkspaceId == null ? showWorkspaceDecks : false
         }
       ),
-    [documentSort, mDeckId, mDue, mQuery, mTags, selectedWorkspaceId, showWorkspaceDecks]
+    [
+      documentSort,
+      mDeckId,
+      mDue,
+      normalizedManageQuery,
+      mTags,
+      selectedWorkspaceId,
+      showWorkspaceDecks
+    ]
   )
 
   React.useEffect(() => {
@@ -517,7 +535,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
   React.useEffect(() => {
     setSelectedIds(new Set())
     setSelectAllAcross(false)
-  }, [mDeckId, mQuery, mTags, mDue, mSort])
+  }, [mDeckId, normalizedManageQuery, mTags, mDue, mSort])
 
   React.useEffect(() => {
     return () => {
@@ -659,7 +677,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
   // Reset focused index when page or filters change
   React.useEffect(() => {
     setFocusedIndex(-1)
-  }, [page, pageSize, listDensity, mDeckId, mQuery, mTags, mDue, mSort])
+  }, [page, pageSize, listDensity, mDeckId, normalizedManageQuery, mTags, mDue, mSort])
 
   async function fetchAllItemsAcrossFilters(): Promise<Flashcard[]> {
     const items: Flashcard[] = []
@@ -683,7 +701,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
     ) {
       const res = await listFlashcards({
         deck_id: mDeckId ?? undefined,
-        q: mQuery || undefined,
+        q: normalizedManageQuery || undefined,
         tag: primaryTag,
         due_status: mDue,
         workspace_id: selectedWorkspaceId ?? undefined,

--- a/apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx
@@ -81,6 +81,7 @@ const CRAM_AVAILABILITY_LIMIT = 1
 interface ReviewTabProps {
   onNavigateToCreate: () => void
   onNavigateToImport: () => void
+  onNavigateToGenerate?: () => void
   reviewDeckId: number | null | undefined
   onReviewDeckChange: (deckId: number | null | undefined) => void
   reviewOverrideCard?: Flashcard | null
@@ -109,6 +110,7 @@ interface ReviewFailureState {
 export const ReviewTab: React.FC<ReviewTabProps> = ({
   onNavigateToCreate,
   onNavigateToImport,
+  onNavigateToGenerate,
   reviewDeckId,
   onReviewDeckChange,
   reviewOverrideCard,
@@ -1715,12 +1717,6 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
                                 "Rate recall with Again/Hard/Good/Easy so the next review is scheduled automatically."
                             })}
                           </li>
-                          <li className="text-text-muted">
-                            {t("option:flashcards.onboardingStepLlmNote", {
-                              defaultValue:
-                                "Card generation and the study assistant require an LLM provider (configure in Settings)."
-                            })}
-                          </li>
                         </ol>
                         <Text
                           type="secondary"
@@ -1794,7 +1790,7 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
                       })}
                     </Button>
                     <Button
-                      onClick={onNavigateToImport}
+                      onClick={onNavigateToGenerate ?? onNavigateToImport}
                       data-testid="flashcards-review-empty-generate-cta"
                     >
                       {t("option:flashcards.generateFromTextCta", {

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.decomposition.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.decomposition.test.tsx
@@ -133,6 +133,27 @@ describe("ImportExportTab decomposition", () => {
     expect(screen.getByTestId("mock-image-occlusion-panel")).toBeVisible()
   })
 
+  it("groups setup work into accessible task-first sections", () => {
+    mocks.useImportLimitsQuery.mockReturnValue({
+      data: null
+    })
+
+    render(<ImportExportTab />)
+
+    expect(
+      screen.getByRole("region", {
+        name: "Create and generate"
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("region", {
+        name: "Import and export"
+      })
+    ).toBeInTheDocument()
+    expect(screen.getByText("Import/export summary")).toBeInTheDocument()
+    expect(screen.queryByText("Transfer summary")).not.toBeInTheDocument()
+  })
+
   it("labels the task switcher with all available transfer tasks", () => {
     mocks.useImportLimitsQuery.mockReturnValue({
       data: null
@@ -166,6 +187,43 @@ describe("ImportExportTab decomposition", () => {
     expect(screen.getByTestId("flashcards-export-task-panel")).not.toHaveClass("hidden")
     expect(screen.getByTestId("flashcards-create-task-panel")).toHaveClass("hidden")
     expect(screen.getByTestId("flashcards-import-task-panel")).toHaveClass("hidden")
+  })
+
+  it("opens the import task when an import handoff is present", () => {
+    mocks.useImportLimitsQuery.mockReturnValue({
+      data: null
+    })
+
+    render(<ImportExportTab initialTask="import" initialTaskHandoffKey="first-run-import" />)
+
+    expect(screen.getByTestId("flashcards-import-task-panel")).toBeVisible()
+    expect(screen.getByTestId("flashcards-import-task-panel")).not.toHaveClass("hidden")
+    expect(screen.getByTestId("flashcards-create-task-panel")).toHaveClass("hidden")
+    expect(screen.getByTestId("flashcards-export-task-panel")).toHaveClass("hidden")
+  })
+
+  it("switches to the create task when a later create handoff arrives", async () => {
+    mocks.useImportLimitsQuery.mockReturnValue({
+      data: null
+    })
+
+    const { rerender } = render(
+      <ImportExportTab initialTask="import" initialTaskHandoffKey="first-run-import" />
+    )
+
+    expect(screen.getByTestId("flashcards-import-task-panel")).not.toHaveClass("hidden")
+
+    rerender(
+      <ImportExportTab initialTask="create" initialTaskHandoffKey="first-run-generate" />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("flashcards-create-task-panel")).not.toHaveClass(
+        "hidden"
+      )
+      expect(screen.getByTestId("flashcards-import-task-panel")).toHaveClass("hidden")
+      expect(screen.getByTestId("flashcards-export-task-panel")).toHaveClass("hidden")
+    })
   })
 
   it("opens the export task when a deck export handoff is present", () => {

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.empty-state.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.empty-state.test.tsx
@@ -1,0 +1,282 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import type React from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ManageTab } from "../ManageTab"
+import {
+  useCardsKeyboardNav,
+  useDecksQuery,
+  useDeleteFlashcardMutation,
+  useFlashcardDocumentQuery,
+  useManageQuery,
+  useResetFlashcardSchedulingMutation,
+  useTagSuggestionsQuery,
+  useUpdateDeckMutation,
+  useUpdateFlashcardsBulkMutation,
+  useUpdateFlashcardMutation
+} from "../../hooks"
+
+const { trackShortcutHintTelemetryMock } = vi.hoisted(() => ({
+  trackShortcutHintTelemetryMock: vi.fn().mockResolvedValue(undefined)
+}))
+const { trackErrorRecoveryTelemetryMock } = vi.hoisted(() => ({
+  trackErrorRecoveryTelemetryMock: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      defaultValueOrOptions?:
+        | string
+        | {
+            defaultValue?: string
+          }
+    ) => {
+      if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
+      if (defaultValueOrOptions?.defaultValue) return defaultValueOrOptions.defaultValue
+      return key
+    }
+  })
+}))
+
+vi.mock("@/utils/flashcards-shortcut-hint-telemetry", () => ({
+  trackFlashcardsShortcutHintTelemetry: trackShortcutHintTelemetryMock
+}))
+
+vi.mock("@/utils/chunk-processing", () => ({
+  processInChunks: vi.fn(
+    async <T,>(
+      items: T[],
+      chunkSizeOrWorker: number | ((chunk: T[]) => Promise<void>),
+      maybeWorker?: (chunk: T[]) => Promise<void>
+    ) => {
+      const worker =
+        typeof chunkSizeOrWorker === "function" ? chunkSizeOrWorker : maybeWorker
+      if (worker) await worker(items)
+    }
+  )
+}))
+
+vi.mock("@/utils/flashcards-error-recovery-telemetry", () => ({
+  trackFlashcardsErrorRecoveryTelemetry: trackErrorRecoveryTelemetryMock
+}))
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-query")>("@tanstack/react-query")
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      invalidateQueries: vi.fn()
+    })
+  }
+})
+
+vi.mock("@/hooks/useAntdMessage", () => ({
+  useAntdMessage: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    loading: vi.fn(),
+    open: vi.fn(),
+    destroy: vi.fn()
+  })
+}))
+
+vi.mock("@/hooks/useUndoNotification", () => ({
+  useUndoNotification: () => ({
+    showUndoNotification: vi.fn()
+  })
+}))
+
+vi.mock("@/components/Common/confirm-danger", () => ({
+  useConfirmDanger: () => vi.fn().mockResolvedValue(true)
+}))
+
+vi.mock("../../hooks", () => ({
+  DOCUMENT_VIEW_SUPPORTED_SORTS: ["due", "created"],
+  getFlashcardDocumentQueryKey: vi.fn(() => ["flashcards:document", 1]),
+  useDecksQuery: vi.fn(),
+  useManageQuery: vi.fn(),
+  useFlashcardDocumentQuery: vi.fn(),
+  useTagSuggestionsQuery: vi.fn(),
+  useUpdateDeckMutation: vi.fn(),
+  useUpdateFlashcardMutation: vi.fn(),
+  useUpdateFlashcardsBulkMutation: vi.fn(),
+  useResetFlashcardSchedulingMutation: vi.fn(),
+  useDeleteFlashcardMutation: vi.fn(),
+  useCardsKeyboardNav: vi.fn(),
+  useDebouncedFormField: vi.fn(() => undefined),
+  getManageServerOrderBy: vi.fn(() => "due_at")
+}))
+
+vi.mock("../../components", () => ({
+  FlashcardMarkdownSnippet: ({ content }: { content: string }) => <div>{content}</div>,
+  MarkdownWithBoundary: ({ content }: { content: string }) => <div>{content}</div>,
+  FlashcardActionsMenu: () => null,
+  FlashcardEditDrawer: () => null,
+  FlashcardCreateDrawer: () => null
+}))
+
+vi.mock("@/services/flashcards", () => ({
+  getFlashcard: vi.fn(),
+  updateFlashcard: vi.fn(),
+  createFlashcard: vi.fn(),
+  deleteFlashcard: vi.fn(),
+  listFlashcards: vi.fn()
+}))
+
+vi.mock("../../utils/error-taxonomy", () => ({
+  formatFlashcardsUiErrorMessage: vi.fn(() => "Action failed"),
+  mapFlashcardsUiError: vi.fn(() => ({
+    code: "FLASHCARDS_UNKNOWN",
+    message: "Action failed",
+    actionLabel: "Retry",
+    rawMessage: "Action failed"
+  }))
+}))
+
+vi.mock("../../hooks/useFlashcardsShortcutHintDensity", () => ({
+  useFlashcardsShortcutHintDensity: () => ["expanded", vi.fn()]
+}))
+
+if (!(globalThis as any).ResizeObserver) {
+  ;(globalThis as any).ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+}
+
+if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn()
+    }))
+  })
+}
+
+const renderManageTab = (props: Partial<React.ComponentProps<typeof ManageTab>> = {}) =>
+  render(
+    <ManageTab
+      onNavigateToImport={() => {}}
+      onReviewCard={() => {}}
+      isActive
+      {...props}
+    />
+  )
+
+describe("ManageTab no-card empty state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useDecksQuery).mockReturnValue({
+      data: [
+        {
+          id: 1,
+          name: "Biology",
+          description: null,
+          deleted: false,
+          client_id: "test",
+          workspace_id: "workspace-a",
+          version: 1
+        }
+      ],
+      isLoading: false
+    } as any)
+    vi.mocked(useManageQuery).mockReturnValue({
+      data: {
+        items: [],
+        count: 0,
+        total: 0
+      },
+      isFetching: false
+    } as any)
+    vi.mocked(useFlashcardDocumentQuery).mockReturnValue({
+      items: [],
+      isFetching: false,
+      isLoading: false,
+      isTruncated: false,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      supportedSorts: ["due", "created"],
+      data: {
+        pages: []
+      }
+    } as any)
+    vi.mocked(useTagSuggestionsQuery).mockReturnValue({
+      data: [],
+      isLoading: false
+    } as any)
+    vi.mocked(useUpdateFlashcardMutation).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false
+    } as any)
+    vi.mocked(useUpdateDeckMutation).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false
+    } as any)
+    vi.mocked(useUpdateFlashcardsBulkMutation).mockReturnValue({
+      mutateAsync: vi.fn().mockResolvedValue({
+        results: []
+      }),
+      isPending: false
+    } as any)
+    vi.mocked(useResetFlashcardSchedulingMutation).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false
+    } as any)
+    vi.mocked(useDeleteFlashcardMutation).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false
+    } as any)
+    vi.mocked(useCardsKeyboardNav).mockImplementation(() => undefined)
+  })
+
+  it("shows create, import, and generate actions before filter chrome for a true first run", () => {
+    renderManageTab()
+
+    expect(screen.getByText("No flashcards yet")).toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-manage-empty-create-cta")).toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-manage-empty-import-cta")).toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-manage-empty-generate-cta")).toBeInTheDocument()
+    expect(screen.queryByTestId("flashcards-manage-search")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("flashcards-density-toggle")).not.toBeInTheDocument()
+  })
+
+  it("routes import and generate empty-state actions through distinct callbacks", () => {
+    const onNavigateToImport = vi.fn()
+    const onNavigateToGenerate = vi.fn()
+
+    renderManageTab({
+      onNavigateToImport,
+      onNavigateToGenerate
+    })
+
+    fireEvent.click(screen.getByTestId("flashcards-manage-empty-import-cta"))
+    fireEvent.click(screen.getByTestId("flashcards-manage-empty-generate-cta"))
+
+    expect(onNavigateToImport).toHaveBeenCalledTimes(1)
+    expect(onNavigateToGenerate).toHaveBeenCalledTimes(1)
+  })
+
+  it("treats workspace deck visibility as an active empty-result filter", () => {
+    renderManageTab({
+      initialShowWorkspaceDecks: true
+    })
+
+    expect(screen.getByText("No cards match your filters")).toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-manage-search")).toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-manage-show-workspace-decks")).toBeChecked()
+    expect(screen.getByTestId("flashcards-density-toggle")).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx
@@ -318,11 +318,13 @@ describe("ReviewTab create CTA visibility", () => {
   it("shows first-run onboarding guidance with create/import/generate actions", () => {
     const onNavigateToCreate = vi.fn()
     const onNavigateToImport = vi.fn()
+    const onNavigateToGenerate = vi.fn()
 
     render(
       <ReviewTab
         onNavigateToCreate={onNavigateToCreate}
         onNavigateToImport={onNavigateToImport}
+        onNavigateToGenerate={onNavigateToGenerate}
         reviewDeckId={undefined}
         onReviewDeckChange={() => {}}
         isActive
@@ -335,6 +337,10 @@ describe("ReviewTab create CTA visibility", () => {
       "Alert"
     )
     expect(onboardingGuide).toHaveAttribute("aria-live", "off")
+    expect(within(onboardingGuide).queryByText(/LLM provider/i)).not.toBeInTheDocument()
+    expect(
+      within(onboardingGuide).queryByText(/require.*provider/i)
+    ).not.toBeInTheDocument()
     expect(screen.getByTestId("flashcards-review-scheduler-preview")).toHaveTextContent(
       "Scheduler"
     )
@@ -348,7 +354,8 @@ describe("ReviewTab create CTA visibility", () => {
     fireEvent.click(screen.getByTestId("flashcards-review-empty-generate-cta"))
 
     expect(onNavigateToCreate).toHaveBeenCalledTimes(1)
-    expect(onNavigateToImport).toHaveBeenCalledTimes(2)
+    expect(onNavigateToImport).toHaveBeenCalledTimes(1)
+    expect(onNavigateToGenerate).toHaveBeenCalledTimes(1)
   })
 
   it("persists onboarding dismissal across remounts", async () => {

--- a/backlog/tasks/task-2402 - Implement-flashcards-UX-PR-1-first-time-setup-and-IA.md
+++ b/backlog/tasks/task-2402 - Implement-flashcards-UX-PR-1-first-time-setup-and-IA.md
@@ -1,0 +1,97 @@
+---
+id: TASK-2402
+title: Implement flashcards UX PR 1 first-time setup and IA
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-23 20:47'
+labels:
+  - ux
+  - flashcards
+dependencies: []
+documentation:
+  - >-
+    Review fix requested 2026-06-23: remove provider-required copy from Review
+    first-time onboarding while preserving Generate/Assistant provider-gating
+    surfaces.
+  - >-
+    Code-quality review fix requested 2026-06-23: make first-run import CTAs
+    hand off to the Import file task while generate CTAs intentionally open
+    Create/generate
+  - preserving the public importExport tab key.
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Task 1 from flashcards remaining UX remediation plan: improve first-time setup, make Scheduler discoverable for zero-deck users, refine Manage empty state ordering, and reorganize Import/Export information architecture.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Task 1 first-time flashcards UX remediation.
+
+Changed:
+- FlashcardsManager keeps Scheduler visible for zero-deck users and renders a Scheduler empty preview for zero-deck Scheduler deep links with create/import actions.
+- ManageTab treats query, tags, due status, selected deck, selected workspace, and workspace-deck visibility as active filters; true first-run no-card state shows create/import/generate actions before expert chrome.
+- ImportExportTab keeps the `importExport` route key while adding accessible task-first sections for Create and generate plus Import and export, with compact Import/export summary copy.
+- Updated/added targeted component tests for zero-deck IA, Manage no-card filter behavior, and Import/Export section decomposition.
+
+Verification:
+- Red run after test changes reached expected assertion failures: Scheduler hidden, workspace visibility not active, and missing Import/Export section labels.
+- `bunx vitest run src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx src/components/Flashcards/tabs/__tests__/ManageTab.empty-state.test.tsx src/components/Flashcards/tabs/__tests__/ImportExportTab.decomposition.test.tsx` passed: 3 files, 42 tests.
+- `git diff --check` passed.
+
+Bandit: N/A, frontend-only TypeScript/React changes.
+
+Known skips/blockers:
+- Clean worktree dependency symlinks require a temporary ignored `apps/node_modules` link to the main checkout's installed Bun cache for Vitest resolution. The link was removed before staging and is not committed.
+- No backend Python touched; no backend tests run.
+
+Review fix follow-up:
+- Removed provider-required copy from the Review first-time onboarding guide.
+- Added focused ReviewTab coverage asserting the onboarding guide does not render provider-required copy.
+- Re-ran provider-gating tests for Generate and Assistant surfaces to confirm those messages remain intact.
+
+Review fix verification:
+- Red run: `bunx vitest run src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx` failed on the new onboarding assertion because the guide still rendered `LLM provider` copy.
+- Green run: `bunx vitest run src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx src/components/Flashcards/tabs/__tests__/ImportExportTab.llm-gating.test.tsx` passed: 3 files, 36 tests.
+- `git diff --check` passed after the review fix.
+- Bandit remains N/A, frontend-only TypeScript/React changes.
+- Temporary ignored `apps/node_modules` symlink was used for Vitest resolution and removed before staging.
+
+Code-quality review fix follow-up:
+- Added an explicit tokened ImportExport inner-task handoff while keeping the public `importExport` tab key stable.
+- Split first-run import and generate callbacks in ReviewTab and ManageTab so import CTAs open Import file and generate CTAs open Create/generate.
+- Preserved generate intent, study-pack intent, and deck export handoff behavior with focused ImportExportTab coverage.
+
+Code-quality review fix verification:
+- Red run after test changes: `bunx vitest run src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx src/components/Flashcards/tabs/__tests__/ManageTab.empty-state.test.tsx src/components/Flashcards/tabs/__tests__/ImportExportTab.decomposition.test.tsx` reached expected failures for empty import task handoffs and shared import/generate callbacks after adding the temporary ignored `apps/node_modules` symlink.
+- Green run: same `bunx vitest run ...` command passed: 4 files, 70 tests.
+- `git diff --check` passed.
+- Bandit remains N/A, frontend-only TypeScript/React changes.
+- Temporary ignored `apps/node_modules` symlink was used for Vitest resolution and removed before staging.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2402 - Implement-flashcards-UX-PR-1-first-time-setup-and-IA.md
+++ b/backlog/tasks/task-2402 - Implement-flashcards-UX-PR-1-first-time-setup-and-IA.md
@@ -19,6 +19,10 @@ documentation:
     hand off to the Import file task while generate CTAs intentionally open
     Create/generate
   - preserving the public importExport tab key.
+  - >-
+    Review fix requested 2026-06-24: normalize Manage search query
+    whitespace consistently across cache keys, list requests, document-mode
+    queries, and bulk list requests.
 ---
 
 ## Description
@@ -84,6 +88,19 @@ Code-quality review fix verification:
 - `git diff --check` passed.
 - Bandit remains N/A, frontend-only TypeScript/React changes.
 - Temporary ignored `apps/node_modules` symlink was used for Vitest resolution and removed before staging.
+
+Whitespace-query review fix follow-up:
+- Rebased PR #2465 onto latest `origin/dev`.
+- Added a regression test proving `useManageQuery` trims whitespace for both React Query cache keys and `listFlashcards` request params.
+- Normalized Manage search text in `useManageQuery`, document-mode queries, ManageTab filter/query-key inputs, and bulk list requests so whitespace-only search state cannot diverge between UI and backend queries.
+- Updated a stale zero-deck Scheduler assertion to match this PR's Scheduler-discoverability behavior after rebasing.
+
+Whitespace-query review fix verification:
+- Red run: `bunx vitest run src/components/Flashcards/hooks/__tests__/useFlashcardQueries.tag-suggestions.test.tsx` failed because `listFlashcards` received `q: "  mitochondria  "`.
+- Green run: same hook test passed: 1 file, 3 tests.
+- Focused PR slice: `bunx vitest run src/components/Flashcards/hooks/__tests__/useFlashcardQueries.tag-suggestions.test.tsx src/components/Flashcards/hooks/__tests__/useFlashcardDocumentQuery.test.ts src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx src/components/Flashcards/tabs/__tests__/ManageTab.empty-state.test.tsx src/components/Flashcards/tabs/__tests__/ImportExportTab.decomposition.test.tsx src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx` passed: 6 files, 78 tests.
+- `git diff --check` passed.
+- Bandit remains N/A, frontend-only TypeScript/React and Backlog metadata changes.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Keeps first-run users on clearer Study/Manage/Scheduler paths and makes Scheduler discoverable without a deck.
- Splits Create & Import into task-first sections while preserving the public importExport tab key and handoff behavior.
- Backlog: TASK-2402.

## Test Plan
- git diff --check
- Focused Vitest: FlashcardsManager consistency, ReviewTab create CTA, ManageTab empty state, ImportExport decomposition passed: 4 files, 70 tests
- Provider-gating follow-up tests passed: 3 files, 36 tests

## Merge Note
- Project policy requires a human-authored Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves first-time flashcards setup and IA: Scheduler tab stays visible and shows an empty preview for zero-deck users (including deep-links), Import/Export is task-first with tokened handoffs, and empty states guide create/import/generate. Normalizes Manage search whitespace across cache keys, document-mode, and list/bulk requests. Addresses TASK-2402.

- **New Features**
  - Scheduler: tab always visible; zero-deck preview with Create/Import actions; safely discards draft state on preview.
  - Import/Export: keeps `importExport` route key; adds “Create and generate” and “Import and export” sections; supports tokened handoffs for `create`/`import`/`export`; import CTAs open Import, generate CTAs open Create.
  - Manage: treats workspace visibility/selection as active filters; true first-run shows create/import/generate before filters; clear-all resets workspace toggles.
  - Review: separates import vs generate CTAs; removes provider-required copy from first-run onboarding.

- **Bug Fixes**
  - Manage search: trims whitespace consistently for React Query keys, document-mode queries, and list/bulk requests; adds tests verifying normalized query behavior.

<sup>Written for commit 1c96643e7b3d083cb2c6ef7dea0c637d2084de32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

