### PR TITLE
fix: harden flashcards setup recovery

### DIFF
--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx
@@ -14,6 +14,7 @@ import {
 import type { TextAreaRef } from "antd/es/input/TextArea"
 import { Plus } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { Alert } from "@/components/ui/primitives"
 import { useAntdMessage } from "@/hooks/useAntdMessage"
 import {
   useDecksQuery,
@@ -141,6 +142,7 @@ export const FlashcardCreateDrawer: React.FC<
   // Inline deck creation state
   const [showInlineCreate, setShowInlineCreate] = React.useState(false)
   const [inlineDeckName, setInlineDeckName] = React.useState("")
+  const [createError, setCreateError] = React.useState<string | null>(null)
   const [templateValueModalOpen, setTemplateValueModalOpen] = React.useState(false)
   const [saveTemplateModalOpen, setSaveTemplateModalOpen] = React.useState(false)
   const [saveTemplateInitialValues, setSaveTemplateInitialValues] = React.useState<Partial<FlashcardTemplateCreate> | null>(null)
@@ -230,6 +232,7 @@ export const FlashcardCreateDrawer: React.FC<
       setSaveTemplateModalOpen(false)
       setSaveTemplateInitialValues(null)
       setInlineDeckName("")
+      setCreateError(null)
       inlineSchedulerDraft.resetToDefaults()
     }
   }, [form, initialDeckId, inlineSchedulerDraft.resetToDefaults, open])
@@ -267,6 +270,7 @@ export const FlashcardCreateDrawer: React.FC<
   // Create flashcard
   const handleCreate = async () => {
     try {
+      setCreateError(null)
       const values = await form.validateFields()
       await createMutation.mutateAsync(
         normalizeFlashcardTemplateFields({
@@ -281,6 +285,7 @@ export const FlashcardCreateDrawer: React.FC<
     } catch (e: unknown) {
       if (e && typeof e === "object" && "errorFields" in e) return // form validation
       const errorMessage = e instanceof Error ? e.message : "Create failed"
+      setCreateError(errorMessage)
       message.error(errorMessage)
     }
   }
@@ -288,6 +293,7 @@ export const FlashcardCreateDrawer: React.FC<
   // Create and add another
   const handleCreateAndAddAnother = async () => {
     try {
+      setCreateError(null)
       const values = await form.validateFields()
       await createMutation.mutateAsync(
         normalizeFlashcardTemplateFields({
@@ -301,6 +307,7 @@ export const FlashcardCreateDrawer: React.FC<
     } catch (e: unknown) {
       if (e && typeof e === "object" && "errorFields" in e) return
       const errorMessage = e instanceof Error ? e.message : "Create failed"
+      setCreateError(errorMessage)
       message.error(errorMessage)
     }
   }
@@ -436,6 +443,18 @@ export const FlashcardCreateDrawer: React.FC<
         </div>
       }
     >
+      {createError && (
+        <Alert
+          variant="error"
+          title={t("option:flashcards.createFailedTitle", {
+            defaultValue: "Could not create flashcard"
+          })}
+          data-testid="flashcards-create-error"
+          className="mb-4"
+        >
+          {createError}
+        </Alert>
+      )}
       <Form
         form={form}
         layout="vertical"

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.deck-reference.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.deck-reference.test.tsx
@@ -489,6 +489,10 @@ describe("FlashcardCreateDrawer deck reference section", () => {
     })
     rerender(<FlashcardCreateDrawer open onClose={onClose} onSuccess={onSuccess} />)
 
+    const createErrorAlert = screen.getByTestId("flashcards-create-error")
+    expect(createErrorAlert).toHaveAttribute("data-ds-component", "Alert")
+    expect(createErrorAlert).toHaveTextContent("Could not create flashcard")
+    expect(createErrorAlert).toHaveTextContent("Create service unavailable")
     expect(onClose).not.toHaveBeenCalled()
     expect(onSuccess).not.toHaveBeenCalled()
     expect((screen.getByPlaceholderText("Question or prompt...") as HTMLTextAreaElement).value).toBe(

--- a/apps/packages/ui/src/components/Flashcards/tabs/ImageOcclusionTransferPanel.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ImageOcclusionTransferPanel.tsx
@@ -367,6 +367,22 @@ export const ImageOcclusionTransferPanel: React.FC<ImageOcclusionTransferPanelPr
 
       const created = await createBulkMutation.mutateAsync(payload)
       const createdItems = normalizeCreatedItems(created.items)
+
+      if (createdItems.length === 0) {
+        const warningCopy = t("option:flashcards.occlusionSaveZeroCreated", {
+          defaultValue:
+            "No image occlusion cards were saved. Details are unavailable; review the drafts and retry."
+        })
+        setInlineAlert({ message: warningCopy, variant: "warning" })
+        message.warning(warningCopy)
+        onTransferAction?.({
+          area: "occlusion",
+          status: "warning",
+          message: warningCopy
+        })
+        return
+      }
+
       setDrafts([])
 
       const successCopy = t("option:flashcards.occlusionSaveSuccess", {

--- a/apps/packages/ui/src/components/Flashcards/tabs/ImportExport/ImportPanel.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ImportExport/ImportPanel.tsx
@@ -73,8 +73,11 @@ import {
 
 const { Text } = Typography
 
+const stripRequestContextSuffix = (message: string): string =>
+  message.replace(/\s+\((?:GET|POST|PUT|PATCH|DELETE)\s+[^)]+\)\s*$/i, "").trim()
+
 const isValidationImportErrorMessage = (message: string): boolean => {
-  const normalized = message.toLowerCase()
+  const normalized = stripRequestContextSuffix(message).toLowerCase()
   return [
     "missing required",
     "invalid",
@@ -83,7 +86,9 @@ const isValidationImportErrorMessage = (message: string): boolean => {
     "line too long",
     "maximum import",
     "parse",
-    "json"
+    "malformed json",
+    "invalid json",
+    "json parse"
   ].some((token) => normalized.includes(token))
 }
 

--- a/apps/packages/ui/src/components/Flashcards/tabs/ImportExport/ImportPanel.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ImportExport/ImportPanel.tsx
@@ -40,6 +40,7 @@ import {
   usePreviewStructuredQaImportMutation
 } from "../../hooks"
 import { useDeckSchedulerDraft } from "../../hooks/useDeckSchedulerDraft"
+import { extractFlashcardsErrorStatus } from "../../utils/error-taxonomy"
 import { getUtf8ByteLength } from "../../utils/field-byte-limit"
 import { formatSchedulerSummary } from "../../utils/scheduler-settings"
 import {
@@ -58,6 +59,7 @@ import {
   countDelimiterOccurrences,
   detectJsonImportFormat,
   estimateJsonItemCount,
+  guardInterpolatedText,
   getImportErrorGuidance,
   normalizeHeaderToken,
   normalizeImportLimits,
@@ -70,6 +72,34 @@ import {
 } from "./shared"
 
 const { Text } = Typography
+
+const isValidationImportErrorMessage = (message: string): boolean => {
+  const normalized = message.toLowerCase()
+  return [
+    "missing required",
+    "invalid",
+    "validation",
+    "field too long",
+    "line too long",
+    "maximum import",
+    "parse",
+    "json"
+  ].some((token) => normalized.includes(token))
+}
+
+const getImportFailureMessage = (error: unknown, fallback: string): string => {
+  if (error instanceof Error && error.message.trim()) return error.message
+  if (typeof error === "string" && error.trim()) return error
+  return fallback
+}
+
+const isValidationImportError = (error: unknown, message: string): boolean => {
+  const status = extractFlashcardsErrorStatus(error)
+  if (status !== undefined) {
+    return status === 400 || status === 422
+  }
+  return isValidationImportErrorMessage(message)
+}
 
 /**
  * Import panel for CSV/TSV flashcard import.
@@ -302,6 +332,114 @@ export const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
     return null
   }, [content, delimiter, hasHeader, importMode, selectedDelimiterLabel, t])
 
+  const buildCompletedImportResult = React.useCallback(
+    (imported: number, errors: FlashcardsImportError[]): ImportResultSummary => {
+      const skipped = errors.length
+      if (errors.length > 0 && imported > 0) {
+        return {
+          status: "partial",
+          imported,
+          skipped,
+          errors,
+          detailsAvailable: true,
+          title: t("option:flashcards.lastImportPartial", {
+            defaultValue: "Last import: {{imported}} imported, {{skipped}} skipped",
+            imported,
+            skipped
+          }),
+          detail: t("option:flashcards.lastImportPartialDetail", {
+            defaultValue:
+              "Some rows were skipped. Review the details below, fix those rows, then import them again."
+          })
+        }
+      }
+
+      if (errors.length > 0) {
+        return {
+          status: "validation-error",
+          imported,
+          skipped,
+          errors,
+          detailsAvailable: true,
+          title: t("option:flashcards.importValidationFailedTitle", {
+            defaultValue: "Import validation failed"
+          }),
+          detail: t("option:flashcards.importValidationFailedDetail", {
+            defaultValue:
+              "No cards were created. Review the details below, fix the payload, then import again."
+          })
+        }
+      }
+
+      if (imported > 0) {
+        return {
+          status: "success",
+          imported,
+          skipped,
+          errors,
+          detailsAvailable: true,
+          title: t("option:flashcards.lastImportSuccess", {
+            defaultValue: "Last import: {{imported}} cards imported",
+            imported
+          }),
+          detail: t("option:flashcards.lastImportSuccessDetail", {
+            defaultValue:
+              "Review imported cards in Manage, or use the undo notification if this import was accidental."
+          })
+        }
+      }
+
+      return {
+        status: "validation-error",
+        imported,
+        skipped,
+        errors,
+        detailsAvailable: false,
+        title: t("option:flashcards.importNoCardsTitle", {
+          defaultValue: "No cards imported"
+        }),
+        detail: t("option:flashcards.importNoCardsDetail", {
+          defaultValue:
+            "No cards were created and the API did not return row details. Your pasted content is still below so you can adjust it and retry."
+        })
+      }
+    },
+    [t]
+  )
+
+  const buildFailedImportResult = React.useCallback(
+    (error: unknown, fallbackMessage: string): ImportResultSummary => {
+      const errorMessage = getImportFailureMessage(error, fallbackMessage)
+      const isValidationError = isValidationImportError(error, errorMessage)
+      return {
+        status: isValidationError ? "validation-error" : "error",
+        imported: 0,
+        skipped: 0,
+        errors: [],
+        detailsAvailable: false,
+        title: isValidationError
+          ? t("option:flashcards.importValidationFailedTitle", {
+              defaultValue: "Import validation failed"
+            })
+          : t("option:flashcards.importFailedTitle", {
+              defaultValue: "Import failed"
+            }),
+        detail: isValidationError
+          ? t("option:flashcards.importValidationFailedRetryDetail", {
+              defaultValue:
+                "{{message}}. No cards were created. Your pasted content is still below. Fix the highlighted issue and import again.",
+              message: errorMessage
+            })
+          : t("option:flashcards.importFailedRetryDetail", {
+              defaultValue:
+                "{{message}}. No cards were created. Your pasted content is still below. Details are unavailable; check connection/API status and retry.",
+              message: errorMessage
+            })
+      }
+    },
+    [t]
+  )
+
   const detectedJsonImportFormat = React.useMemo(
     () => detectJsonImportFormat(content),
     [content]
@@ -336,6 +474,13 @@ export const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
       : importMode === "structured"
         ? false
         : estimatedImportItems >= LARGE_IMPORT_CONFIRM_THRESHOLD_ROWS
+  const importLimitsFallback = importLimits
+    ? [
+        `Limits: max ${importLimits.maxLines.toLocaleString()} lines`,
+        `${importLimits.maxLineLengthBytes.toLocaleString()} bytes per line`,
+        `${importLimits.maxFieldLengthBytes.toLocaleString()} bytes per field`
+      ].join(", ")
+    : ""
 
   const invalidateFlashcardQueries = React.useCallback(async () => {
     await qc.invalidateQueries({
@@ -381,7 +526,8 @@ export const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
         message: successCopy
       })
     } catch (e: unknown) {
-      const errorMessage = e instanceof Error ? e.message : "Structured preview failed"
+      const errorMessage = getImportFailureMessage(e, "Structured preview failed")
+      setLastResult(buildFailedImportResult(e, "Structured preview failed"))
       message.error(errorMessage)
       onTransferAction?.({
         area: "import",
@@ -389,7 +535,7 @@ export const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
         message: errorMessage
       })
     }
-  }, [content, message, onTransferAction, previewStructuredMutation, t])
+  }, [buildFailedImportResult, content, message, onTransferAction, previewStructuredMutation, t])
 
   const handleSaveStructuredDrafts = React.useCallback(async () => {
     const selectedDrafts = structuredDrafts.filter((draft) => draft.selected)
@@ -432,14 +578,31 @@ export const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
       const submittedDraftIds = new Set(savableDrafts.map((draft) => draft.id))
       const resultErrors = [...structuredPreviewErrors, ...skippedSaveErrors]
 
+      setLastResult(buildCompletedImportResult(createdItems.length, resultErrors))
+
+      if (createdItems.length === 0) {
+        const warningCopy =
+          resultErrors.length > 0
+            ? t("option:flashcards.structuredSaveZeroCreatedWithErrors", {
+                defaultValue:
+                  "No structured cards were saved. Review {{count}} errors below and retry.",
+                count: resultErrors.length
+              })
+            : t("option:flashcards.structuredSaveZeroCreated", {
+                defaultValue: "No structured cards were saved. Details are unavailable."
+              })
+        message.warning(warningCopy)
+        onTransferAction?.({
+          area: "import",
+          status: "warning",
+          message: warningCopy
+        })
+        return
+      }
+
       setStructuredDrafts((prev) =>
         prev.filter((draft) => !submittedDraftIds.has(draft.id))
       )
-      setLastResult({
-        imported: createdItems.length,
-        skipped: resultErrors.length,
-        errors: resultErrors
-      })
 
       const saveFeedbackCopy =
         resultErrors.length > 0
@@ -499,7 +662,8 @@ export const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
         })
       }
     } catch (e: unknown) {
-      const errorMessage = e instanceof Error ? e.message : "Structured save failed"
+      const errorMessage = getImportFailureMessage(e, "Structured save failed")
+      setLastResult(buildFailedImportResult(e, "Structured save failed"))
       message.error(errorMessage)
       onTransferAction?.({
         area: "import",
@@ -508,6 +672,8 @@ export const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
       })
     }
   }, [
+    buildCompletedImportResult,
+    buildFailedImportResult,
     createBulkMutation,
     invalidateFlashcardQueries,
     message,
@@ -559,11 +725,7 @@ export const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
       const errors = normalizeImportErrors(result.errors)
       const skipped = errors.length
 
-      setLastResult({
-        imported,
-        skipped,
-        errors
-      })
+      setLastResult(buildCompletedImportResult(imported, errors))
 
       if (errors.length > 0) {
         const warningCopy = t("option:flashcards.importResultWithErrors", {
@@ -578,7 +740,7 @@ export const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
           status: "warning",
           message: warningCopy
         })
-      } else {
+      } else if (imported > 0) {
         const successCopy = t("option:flashcards.importResultSuccess", {
           defaultValue: "Imported {{count}} cards.",
           count: imported
@@ -593,6 +755,16 @@ export const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
         if (importMode === "apkg") {
           setApkgFile(null)
         }
+      } else {
+        const warningCopy = t("option:flashcards.importNoCardsWarning", {
+          defaultValue: "No cards were imported. Details are unavailable."
+        })
+        message.warning(warningCopy)
+        onTransferAction?.({
+          area: "import",
+          status: "warning",
+          message: warningCopy
+        })
       }
 
       if (importedItems.length > 0) {
@@ -635,7 +807,8 @@ export const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
         })
       }
     } catch (e: unknown) {
-      const errorMessage = e instanceof Error ? e.message : "Import failed"
+      const errorMessage = getImportFailureMessage(e, "Import failed")
+      setLastResult(buildFailedImportResult(e, "Import failed"))
       message.error(errorMessage)
       onTransferAction?.({
         area: "import",
@@ -644,6 +817,8 @@ export const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
       })
     }
   }, [
+    buildCompletedImportResult,
+    buildFailedImportResult,
     content,
     delimiter,
     hasHeader,
@@ -1086,13 +1261,16 @@ export const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
       )}
       {importLimits && (
         <Text type="secondary" className="text-xs">
-          {t("option:flashcards.importLimitsValue", {
-            defaultValue:
-              "Limits: max {{maxLines}} lines, {{maxLineBytes}} bytes per line, {{maxFieldBytes}} bytes per field",
-            maxLines: importLimits.maxLines.toLocaleString(),
-            maxLineBytes: importLimits.maxLineLengthBytes.toLocaleString(),
-            maxFieldBytes: importLimits.maxFieldLengthBytes.toLocaleString()
-          })}
+          {guardInterpolatedText(
+            t("option:flashcards.importLimitsValue", {
+              defaultValue:
+                "Limits: max {{maxLines}} lines, {{maxLineBytes}} bytes per line, {{maxFieldBytes}} bytes per field",
+              maxLines: importLimits.maxLines.toLocaleString(),
+              maxLineBytes: importLimits.maxLineLengthBytes.toLocaleString(),
+              maxFieldBytes: importLimits.maxFieldLengthBytes.toLocaleString()
+            }),
+            importLimitsFallback
+          )}
         </Text>
       )}
       {importPreflightWarning && (
@@ -1314,20 +1492,23 @@ export const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferA
       {lastResult && (
         <Alert
           data-testid="flashcards-import-last-result"
-          variant={lastResult.errors.length > 0 ? "warning" : "success"}
-          title={
-            lastResult.errors.length > 0
-              ? t("option:flashcards.lastImportPartial", {
-                  defaultValue: "Last import: {{imported}} imported, {{skipped}} skipped",
-                  imported: lastResult.imported,
-                  skipped: lastResult.skipped
-                })
-              : t("option:flashcards.lastImportSuccess", {
-                  defaultValue: "Last import: {{imported}} cards imported",
-                  imported: lastResult.imported
-                })
+          variant={
+            lastResult.status === "success"
+              ? "success"
+              : lastResult.status === "error"
+                ? "error"
+                : "warning"
           }
+          title={lastResult.title}
         >
+          <Text className="block text-xs">{lastResult.detail}</Text>
+          {!lastResult.detailsAvailable && (
+            <Text type="secondary" className="mt-1 block text-xs">
+              {t("option:flashcards.importDetailsUnavailable", {
+                defaultValue: "Row-level details are unavailable for this result."
+              })}
+            </Text>
+          )}
           {lastResult.errors.length > 0 && (
             <div className="mt-1 space-y-1 text-xs">
               {lastResult.errors.slice(0, 6).map((err, idx) => {

--- a/apps/packages/ui/src/components/Flashcards/tabs/ImportExport/shared.ts
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ImportExport/shared.ts
@@ -4,9 +4,13 @@ import type { FlashcardsGenerateIntent } from "@/services/tldw/flashcards-genera
 import { getUtf8ByteLength } from "../../utils/field-byte-limit"
 
 export interface ImportResultSummary {
+  status: "success" | "partial" | "validation-error" | "error"
+  title: string
+  detail: string
   imported: number
   skipped: number
   errors: FlashcardsImportError[]
+  detailsAvailable: boolean
 }
 
 export interface ImportedCardReference {
@@ -82,6 +86,11 @@ export const IMPORT_HELP_ANCHORS = {
 
 const positiveNumberOrNull = (value: unknown): number | null =>
   typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null
+
+const UNRESOLVED_TEMPLATE_TOKEN_PATTERN = /\{\{[^}]+\}\}/
+
+export const guardInterpolatedText = (value: string, fallback: string): string =>
+  UNRESOLVED_TEMPLATE_TOKEN_PATTERN.test(value) ? fallback : value
 
 export const normalizeImportLimits = (value: unknown): NormalizedImportLimits | null => {
   if (!value || typeof value !== "object") return null

--- a/apps/packages/ui/src/components/Flashcards/tabs/ImportExportTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ImportExportTab.tsx
@@ -13,6 +13,7 @@ import { GeneratePanel } from "./ImportExport/GeneratePanel"
 import { ImportPanel } from "./ImportExport/ImportPanel"
 import { StudyPackPanel } from "./ImportExport/StudyPackPanel"
 import {
+  guardInterpolatedText,
   normalizeImportLimits,
   type TransferActionSummary,
   type TransferActionSummaryInput
@@ -94,13 +95,21 @@ export const ImportExportTab: React.FC<ImportExportTabProps> = ({
   const importLimitsText = React.useMemo(() => {
     const importLimits = normalizeImportLimits(limitsQuery.data)
     if (!importLimits) return null
-    return t("option:flashcards.transferSummaryLimitsValue", {
-      defaultValue:
-        "{{lines}} lines / {{lineBytes}} bytes per line / {{fieldBytes}} bytes per field",
-      lines: importLimits.maxLines.toLocaleString(),
-      lineBytes: importLimits.maxLineLengthBytes.toLocaleString(),
-      fieldBytes: importLimits.maxFieldLengthBytes.toLocaleString()
-    })
+    const fallback = [
+      `${importLimits.maxLines.toLocaleString()} lines`,
+      `${importLimits.maxLineLengthBytes.toLocaleString()} bytes per line`,
+      `${importLimits.maxFieldLengthBytes.toLocaleString()} bytes per field`
+    ].join(" / ")
+    return guardInterpolatedText(
+      t("option:flashcards.transferSummaryLimitsValue", {
+        defaultValue:
+          "{{lines}} lines / {{lineBytes}} bytes per line / {{fieldBytes}} bytes per field",
+        lines: importLimits.maxLines.toLocaleString(),
+        lineBytes: importLimits.maxLineLengthBytes.toLocaleString(),
+        fieldBytes: importLimits.maxFieldLengthBytes.toLocaleString()
+      }),
+      fallback
+    )
   }, [limitsQuery.data, t])
 
   React.useEffect(() => {
@@ -201,12 +210,17 @@ export const ImportExportTab: React.FC<ImportExportTabProps> = ({
             : t("option:flashcards.generateTitle", {
                 defaultValue: "Generate Flashcards"
               })
-    return t("option:flashcards.transferSummaryLastAction", {
-      defaultValue: "{{area}} · {{message}} · {{time}}",
-      area: areaLabel,
-      message: lastTransferAction.message,
-      time: new Date(lastTransferAction.at).toLocaleTimeString()
-    })
+    const actionTime = new Date(lastTransferAction.at).toLocaleTimeString()
+    const fallback = `${areaLabel} · ${lastTransferAction.message} · ${actionTime}`
+    return guardInterpolatedText(
+      t("option:flashcards.transferSummaryLastAction", {
+        defaultValue: "{{area}} · {{message}} · {{time}}",
+        area: areaLabel,
+        message: lastTransferAction.message,
+        time: actionTime
+      }),
+      fallback
+    )
   }, [lastTransferAction, t])
 
   return (

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx
@@ -241,6 +241,53 @@ describe("ImageOcclusionTransferPanel", () => {
     })
   })
 
+  it("keeps drafts and reports warning when bulk create returns zero saved cards without details", async () => {
+    createBulkMutateAsync.mockResolvedValueOnce({
+      items: [],
+      count: 0,
+      total: 0
+    })
+    const onTransferAction = vi.fn()
+
+    render(<ImageOcclusionTransferPanel onTransferAction={onTransferAction} />)
+
+    fireEvent.click(screen.getByTestId("mock-occlusion-panel-load"))
+    fireEvent.click(screen.getByTestId("flashcards-occlusion-generate-button"))
+
+    await waitFor(() => {
+      expect(uploadFlashcardAssetMock).toHaveBeenCalledTimes(3)
+    })
+
+    fireEvent.click(screen.getByTestId("flashcards-occlusion-save-button"))
+
+    await waitFor(() => {
+      expect(createBulkMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    expect(
+      screen.getByTestId("flashcards-occlusion-draft-front-occlusion-region-1")
+    ).toHaveValue("Identify the occluded region.\n\n![Prompt](flashcard-asset://prompt-asset)")
+    expect(
+      screen.getByTestId("flashcards-occlusion-draft-back-occlusion-region-1")
+    ).toHaveValue("Mitochondria\n\n![Answer](flashcard-asset://answer-asset)")
+    const warningText = await screen.findByText(
+      "No image occlusion cards were saved. Details are unavailable; review the drafts and retry."
+    )
+    expect(warningText.closest('[data-ds-component="Alert"]')).not.toBeNull()
+    expect(messageSpies.warning).toHaveBeenCalledWith(
+      "No image occlusion cards were saved. Details are unavailable; review the drafts and retry."
+    )
+    expect(messageSpies.success).not.toHaveBeenCalledWith(
+      "Saved 0 image occlusion cards."
+    )
+    expect(showUndoNotificationMock).not.toHaveBeenCalled()
+    expect(onTransferAction).toHaveBeenLastCalledWith({
+      area: "occlusion",
+      status: "warning",
+      message:
+        "No image occlusion cards were saved. Details are unavailable; review the drafts and retry."
+    })
+  })
+
   it("renders generation errors through the design-system alert", async () => {
     generateImageOcclusionAssetsMock.mockRejectedValueOnce(
       new Error("Unable to prepare image occlusion assets.")

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
@@ -39,7 +39,8 @@ const messageSpies = {
 }
 const showUndoNotificationMock = vi.fn()
 const invalidateQueriesMock = vi.fn()
-const { useQueryMock } = vi.hoisted(() => ({
+const { translationOverrides, useQueryMock } = vi.hoisted(() => ({
+  translationOverrides: new Map<string, string>(),
   useQueryMock: vi.fn()
 }))
 
@@ -74,6 +75,8 @@ vi.mock("react-i18next", () => ({
             defaultValue?: string
           }
     ) => {
+      const override = translationOverrides.get(key)
+      if (override !== undefined) return override
       if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
       if (defaultValueOrOptions?.defaultValue) {
         return defaultValueOrOptions.defaultValue.replace(
@@ -170,6 +173,7 @@ const openExportTask = () =>
 describe("ImportExportTab import result details", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    translationOverrides.clear()
     invalidateQueriesMock.mockReset()
     useQueryMock.mockReturnValue({
       data: 42,
@@ -748,6 +752,162 @@ describe("ImportExportTab import result details", () => {
     )
   })
 
+  it("keeps structured drafts editable when bulk save returns zero created cards without details", async () => {
+    const previewMutateAsync = vi.fn().mockResolvedValue({
+      detected_format: "qa_labels",
+      skipped_blocks: 0,
+      errors: [],
+      drafts: [
+        {
+          front: "What is ATP?",
+          back: "Primary energy currency.",
+          line_start: 1,
+          line_end: 2,
+          tags: []
+        }
+      ]
+    })
+    const createBulkMutateAsync = vi.fn().mockResolvedValue({
+      items: [],
+      count: 0,
+      total: 0
+    })
+    vi.mocked(usePreviewStructuredQaImportMutation).mockReturnValue({
+      mutateAsync: previewMutateAsync,
+      isPending: false
+    } as any)
+    vi.mocked(useCreateFlashcardsBulkMutation).mockReturnValue({
+      mutateAsync: createBulkMutateAsync,
+      isPending: false
+    } as any)
+
+    render(<ImportExportTab />)
+    await openImportTask()
+
+    const formatSelect = screen.getByTestId("flashcards-import-format")
+    fireEvent.mouseDown(
+      formatSelect.querySelector(".ant-select-selector") ?? formatSelect
+    )
+    fireEvent.click(screen.getByText("Structured Q&A"))
+
+    fireEvent.change(screen.getByTestId("flashcards-import-textarea"), {
+      target: { value: "Q: What is ATP?\nA: Primary energy currency." }
+    })
+    fireEvent.click(screen.getByTestId("flashcards-structured-preview-button"))
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("What is ATP?")).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByTestId("flashcards-structured-save-button"))
+
+    await waitFor(() => {
+      expect(createBulkMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    expect(screen.getByDisplayValue("What is ATP?")).toBeInTheDocument()
+    expect(screen.getByDisplayValue("Primary energy currency.")).toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-structured-draft-selected-0")).toBeChecked()
+    expect(messageSpies.success).not.toHaveBeenCalledWith("Saved 0 structured cards.")
+    expect(messageSpies.warning).toHaveBeenCalledWith(
+      "No structured cards were saved. Details are unavailable."
+    )
+    expect(showUndoNotificationMock).not.toHaveBeenCalled()
+    const result = screen.getByTestId("flashcards-import-last-result")
+    expect(result).toHaveTextContent("No cards imported")
+    expect(result).toHaveTextContent("Row-level details are unavailable")
+    expect(screen.getByTestId("flashcards-transfer-summary-last-action")).toHaveTextContent(
+      "Import Flashcards · No structured cards were saved. Details are unavailable."
+    )
+  })
+
+  it("keeps structured drafts editable when zero created cards still have local errors", async () => {
+    const previewMutateAsync = vi.fn().mockResolvedValue({
+      detected_format: "qa_labels",
+      skipped_blocks: 1,
+      errors: [{ line: 9, error: "Skipped unlabeled block" }],
+      drafts: [
+        {
+          front: "What is ATP?",
+          back: "Energy.",
+          line_start: 1,
+          line_end: 2,
+          tags: []
+        },
+        {
+          front: "What is glycolysis after repeated repetition?",
+          back: "Cytosolic glucose breakdown.",
+          line_start: 4,
+          line_end: 5,
+          tags: []
+        }
+      ]
+    })
+    const createBulkMutateAsync = vi.fn().mockResolvedValue({
+      items: [],
+      count: 0,
+      total: 0
+    })
+    vi.mocked(usePreviewStructuredQaImportMutation).mockReturnValue({
+      mutateAsync: previewMutateAsync,
+      isPending: false
+    } as any)
+    vi.mocked(useCreateFlashcardsBulkMutation).mockReturnValue({
+      mutateAsync: createBulkMutateAsync,
+      isPending: false
+    } as any)
+    vi.mocked(useImportLimitsQuery).mockReturnValue({
+      data: {
+        max_field_length: 16
+      }
+    } as any)
+
+    render(<ImportExportTab />)
+    await openImportTask()
+
+    const formatSelect = screen.getByTestId("flashcards-import-format")
+    fireEvent.mouseDown(
+      formatSelect.querySelector(".ant-select-selector") ?? formatSelect
+    )
+    fireEvent.click(screen.getByText("Structured Q&A"))
+
+    fireEvent.change(screen.getByTestId("flashcards-import-textarea"), {
+      target: { value: "Q: What is ATP?\nA: Energy.\n\nNotes without labels" }
+    })
+    fireEvent.click(screen.getByTestId("flashcards-structured-preview-button"))
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("What is ATP?")).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByTestId("flashcards-structured-save-button"))
+
+    await waitFor(() => {
+      expect(createBulkMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    expect(screen.getByDisplayValue("What is ATP?")).toBeInTheDocument()
+    expect(screen.getByDisplayValue("Energy.")).toBeInTheDocument()
+    expect(
+      screen.getByDisplayValue("What is glycolysis after repeated repetition?")
+    ).toBeInTheDocument()
+    expect(screen.getByDisplayValue("Cytosolic glucose breakdown.")).toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-structured-draft-selected-0")).toBeChecked()
+    expect(screen.getByTestId("flashcards-structured-draft-selected-1")).toBeChecked()
+    expect(messageSpies.success).not.toHaveBeenCalledWith(
+      "Saved 0 structured cards, skipped 2 drafts."
+    )
+    expect(messageSpies.warning).toHaveBeenCalledWith(
+      "No structured cards were saved. Review 2 errors below and retry."
+    )
+    expect(showUndoNotificationMock).not.toHaveBeenCalled()
+    const result = screen.getByTestId("flashcards-import-last-result")
+    expect(result).toHaveTextContent("Import validation failed")
+    expect(result).toHaveTextContent("Skipped unlabeled block")
+    expect(result).toHaveTextContent("Field too long: Front (> 16 bytes)")
+    expect(screen.getByTestId("flashcards-transfer-summary-last-action")).toHaveTextContent(
+      "Import Flashcards · No structured cards were saved. Review 2 errors below and retry."
+    )
+  })
+
   it("allows clearing the structured target deck without auto-restoring the first deck", async () => {
     vi.mocked(useDecksQuery).mockReturnValue({
       data: [
@@ -996,10 +1156,145 @@ describe("ImportExportTab import result details", () => {
     expect(limits).toHaveTextContent(`${(500).toLocaleString()} lines`)
     expect(limits).toHaveTextContent(`${(32768).toLocaleString()} bytes per line`)
     expect(limits).toHaveTextContent(`${(1048576).toLocaleString()} bytes per field`)
+    expect(limits).not.toHaveTextContent(
+      /\{\{(?:cards|bytes|lines|lineBytes|fieldBytes|maxLines|maxLineBytes|maxFieldBytes)\}\}/
+    )
     expect(screen.getByTestId("flashcards-transfer-summary-last-action")).toHaveTextContent(
       "No transfer actions yet in this session."
     )
   })
+
+  it("falls back to concrete import limit copy when a translation leaves placeholders unresolved", () => {
+    translationOverrides.set(
+      "option:flashcards.transferSummaryLimitsValue",
+      "{{maxLines}} lines / {{maxLineBytes}} bytes per line / {{maxFieldBytes}} bytes per field"
+    )
+    vi.mocked(useImportLimitsQuery).mockReturnValue({
+      data: {
+        max_lines: 500,
+        max_line_length: 32768,
+        max_field_length: 1048576
+      }
+    } as any)
+
+    render(<ImportExportTab />)
+
+    const limits = screen.getByTestId("flashcards-transfer-summary-limits")
+    expect(limits).toHaveTextContent("500 lines / 32,768 bytes per line / 1,048,576 bytes per field")
+    expect(limits).not.toHaveTextContent("{{maxLines}}")
+    expect(limits).not.toHaveTextContent("{{maxLineBytes}}")
+    expect(limits).not.toHaveTextContent("{{maxFieldBytes}}")
+  })
+
+  it("keeps invalid import payloads editable and shows retryable validation recovery", async () => {
+    const mutateAsync = vi.fn().mockRejectedValue(
+      new Error("Missing required field: Back on line 2")
+    )
+    vi.mocked(useImportFlashcardsMutation).mockReturnValue({
+      mutateAsync,
+      isPending: false
+    } as any)
+
+    render(<ImportExportTab />)
+    await openImportTask()
+
+    const invalidPayload = "Deck\tFront\tBack\nBiology\tQuestion\t"
+    fireEvent.change(screen.getByTestId("flashcards-import-textarea"), {
+      target: {
+        value: invalidPayload
+      }
+    })
+    fireEvent.click(screen.getByTestId("flashcards-import-button"))
+
+    const recoveryAlert = await screen.findByTestId("flashcards-import-last-result")
+    expect(recoveryAlert).toHaveAttribute("data-ds-component", "Alert")
+    expect(recoveryAlert).toHaveTextContent("Import validation failed")
+    expect(recoveryAlert).toHaveTextContent("Missing required field: Back on line 2")
+    expect(recoveryAlert).toHaveTextContent("No cards were created.")
+    expect(recoveryAlert).toHaveTextContent(
+      "Your pasted content is still below. Fix the highlighted issue and import again."
+    )
+    expect(screen.getByTestId("flashcards-import-textarea")).toHaveValue(invalidPayload)
+    expect(screen.getByTestId("flashcards-import-button")).toBeEnabled()
+    expect(screen.getByTestId("flashcards-import-button")).not.toHaveClass("ant-btn-loading")
+    expect(messageSpies.error).toHaveBeenCalledWith(
+      "Missing required field: Back on line 2"
+    )
+  })
+
+  it.each([400, 422])(
+    "classifies HTTP %i import rejection as validation",
+    async (status) => {
+      const error = Object.assign(
+        new Error("Missing required field: Back on line 2"),
+        { status }
+      )
+      const mutateAsync = vi.fn().mockRejectedValue(error)
+      vi.mocked(useImportFlashcardsMutation).mockReturnValue({
+        mutateAsync,
+        isPending: false
+      } as any)
+
+      render(<ImportExportTab />)
+      await openImportTask()
+
+      const invalidPayload = "Deck\tFront\tBack\nBiology\tQuestion\t"
+      fireEvent.change(screen.getByTestId("flashcards-import-textarea"), {
+        target: {
+          value: invalidPayload
+        }
+      })
+      fireEvent.click(screen.getByTestId("flashcards-import-button"))
+
+      const recoveryAlert = await screen.findByTestId("flashcards-import-last-result")
+      expect(recoveryAlert).toHaveTextContent("Import validation failed")
+      expect(recoveryAlert).toHaveTextContent(
+        "Your pasted content is still below. Fix the highlighted issue and import again."
+      )
+      expect(recoveryAlert).not.toHaveTextContent(
+        "Details are unavailable; check connection/API status and retry."
+      )
+      expect(screen.getByTestId("flashcards-import-textarea")).toHaveValue(invalidPayload)
+    }
+  )
+
+  it.each([
+    [401, "invalid API key"],
+    [403, "invalid API key"],
+    [500, "invalid response"]
+  ])(
+    "classifies HTTP %i import rejection as operational",
+    async (status, errorText) => {
+      const error = Object.assign(new Error(errorText), { status })
+      const mutateAsync = vi.fn().mockRejectedValue(error)
+      vi.mocked(useImportFlashcardsMutation).mockReturnValue({
+        mutateAsync,
+        isPending: false
+      } as any)
+
+      render(<ImportExportTab />)
+      await openImportTask()
+
+      const payload = "Deck\tFront\tBack\nBiology\tQuestion\tAnswer"
+      fireEvent.change(screen.getByTestId("flashcards-import-textarea"), {
+        target: {
+          value: payload
+        }
+      })
+      fireEvent.click(screen.getByTestId("flashcards-import-button"))
+
+      const recoveryAlert = await screen.findByTestId("flashcards-import-last-result")
+      expect(recoveryAlert).toHaveTextContent("Import failed")
+      expect(recoveryAlert).toHaveTextContent(errorText)
+      expect(recoveryAlert).toHaveTextContent(
+        "Details are unavailable; check connection/API status and retry."
+      )
+      expect(recoveryAlert).not.toHaveTextContent(
+        "Fix the highlighted issue and import again."
+      )
+      expect(screen.getByTestId("flashcards-import-textarea")).toHaveValue(payload)
+    }
+  )
 
   it("updates transfer summary after import actions", async () => {
     const mutateAsync = vi.fn().mockResolvedValue({

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx
@@ -1160,7 +1160,7 @@ describe("ImportExportTab import result details", () => {
       /\{\{(?:cards|bytes|lines|lineBytes|fieldBytes|maxLines|maxLineBytes|maxFieldBytes)\}\}/
     )
     expect(screen.getByTestId("flashcards-transfer-summary-last-action")).toHaveTextContent(
-      "No transfer actions yet in this session."
+      "No import/export actions yet in this session."
     )
   })
 
@@ -1295,6 +1295,45 @@ describe("ImportExportTab import result details", () => {
       expect(screen.getByTestId("flashcards-import-textarea")).toHaveValue(payload)
     }
   )
+
+  it("classifies status-less JSON endpoint request failures as operational", async () => {
+    const error = new Error("Failed to fetch (POST /api/v1/flashcards/import/json)")
+    const mutateAsync = vi.fn().mockRejectedValue(error)
+    vi.mocked(useImportFlashcardsJsonMutation).mockReturnValue({
+      mutateAsync,
+      isPending: false
+    } as any)
+
+    render(<ImportExportTab />)
+    await openImportTask()
+
+    const payload = JSON.stringify([{ front: "Question", back: "Answer" }])
+    const formatSelect = screen.getByTestId("flashcards-import-format")
+    fireEvent.mouseDown(
+      formatSelect.querySelector(".ant-select-selector") ?? formatSelect
+    )
+    fireEvent.click(screen.getByText("JSON / JSONL"))
+    fireEvent.change(screen.getByTestId("flashcards-import-textarea"), {
+      target: {
+        value: payload
+      }
+    })
+    fireEvent.click(screen.getByTestId("flashcards-import-button"))
+
+    const recoveryAlert = await screen.findByTestId("flashcards-import-last-result")
+    expect(recoveryAlert).toHaveTextContent("Import failed")
+    expect(recoveryAlert).toHaveTextContent(
+      "Failed to fetch (POST /api/v1/flashcards/import/json)"
+    )
+    expect(recoveryAlert).toHaveTextContent(
+      "Details are unavailable; check connection/API status and retry."
+    )
+    expect(recoveryAlert).not.toHaveTextContent("Import validation failed")
+    expect(recoveryAlert).not.toHaveTextContent(
+      "Fix the highlighted issue and import again."
+    )
+    expect(screen.getByTestId("flashcards-import-textarea")).toHaveValue(payload)
+  })
 
   it("updates transfer summary after import actions", async () => {
     const mutateAsync = vi.fn().mockResolvedValue({

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/__snapshots__/ImportExportTab.import-results.test.tsx.snap
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/__snapshots__/ImportExportTab.import-results.test.tsx.snap
@@ -46,6 +46,11 @@ exports[`ImportExportTab import result details > matches baseline snapshot for i
     <div
       class="text-sm text-warn mt-1"
     >
+      <span
+        class="ant-typography block text-xs css-dev-only-do-not-override-3uaqrl css-var-root"
+      >
+        Some rows were skipped. Review the details below, fix those rows, then import them again.
+      </span>
       <div
         class="mt-1 space-y-1 text-xs"
       >

--- a/backlog/tasks/task-2403 - Implement-flashcards-UX-PR-2-create-import-generate-reliability.md
+++ b/backlog/tasks/task-2403 - Implement-flashcards-UX-PR-2-create-import-generate-reliability.md
@@ -1,0 +1,85 @@
+---
+id: TASK-2403
+title: Implement flashcards UX PR 2 create import generate reliability
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-23 21:52'
+labels:
+  - ux
+  - flashcards
+  - frontend
+dependencies: []
+ordinal: 2403
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Task 2 from the flashcards UX remediation plan: create, import, and generate reliability. The PR 2 slice prevents false success states and preserves recovery paths after setup failures.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-23-flashcards-remaining-ux-remediation-plan.md#task-2-create-import-and-generate-reliability
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation notes:
+- Added regression coverage for concrete import limit counts and unresolved placeholder leakage in the transfer summary.
+- Added invalid import recovery coverage: rejected import keeps the pasted payload, renders an inline validation alert, and leaves the import button enabled.
+- Added create drawer failure coverage requiring an inline design-system Alert while preserving question/answer inputs.
+- Extended import result state handling with success, partial, validation-error, and API/network error branches. Rejected imports now render retry guidance and explicitly avoid invented row counts when details are unavailable.
+- Added placeholder guard for import/export transfer summary text and import limits text so unresolved {{...}} tokens fall back to concrete copy.
+- GeneratePanel was inspected and left unchanged because current contracts did not show a shared false-success issue; ImageOcclusionTransferPanel now handles zero-created/no-detail bulk saves with an inline retryable warning.
+- Linked plan file Docs/superpowers/plans/2026-06-23-flashcards-remaining-ux-remediation-plan.md was not present in this worktree; task requirements were taken from TASK-2403 and the user-provided Task 2 plan text.
+- Bandit N/A: frontend-only TypeScript/React changes, no Python touched.
+
+Verification:
+- RED: Focused Vitest initially reached tests and failed on missing flashcards-import-last-result recovery alert and missing flashcards-create-error inline alert.
+- PASS: git diff --check exited 0.
+- PASS: cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.deck-reference.test.tsx (2 files passed, 38 tests passed).
+
+Review follow-up 2026-06-23:
+- Fixed structured import bulk-save zero-created/no-detail responses so selected drafts remain editable/selected, no success toast is shown, no undo is registered, and transfer summary reports a warning.
+- Fixed image occlusion bulk-save zero-created/no-detail responses so drafts remain editable, an inline warning alert is shown, no success/undo is emitted, and transfer action status is warning.
+- Added focused regressions for both zero-created/no-detail false-success paths.
+
+Review follow-up verification:
+- RED: new structured import and image occlusion zero-created tests failed against 74c37b6265 because drafts were cleared and Saved 0 success paths fired.
+- PASS: git diff --check exited 0.
+- PASS: cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.deck-reference.test.tsx src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx (3 files passed, 44 tests passed).
+
+Second review follow-up 2026-06-23:
+- Fixed structured import bulk-save zero-created responses when preview/local validation errors exist so selected drafts remain editable/selected, row details stay visible, no undo is registered, and transfer summary reports a warning instead of Saved 0 copy.
+- Changed failed import classification to prefer HTTP status: 400/422 remain validation, while status-bearing 401/403/500 and other non-validation statuses are operational errors even when the message contains invalid/invalid response text.
+- Added direct unresolved-placeholder fallback coverage for transfer summary import limits.
+
+Second review follow-up verification:
+- RED: cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx failed 4 tests against 9d908856dd: structured zero-created/local-error draft preservation plus 401/403/500 operational classification.
+- PASS: git diff --check exited 0.
+- PASS: cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.deck-reference.test.tsx src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx (3 files passed, 51 tests passed).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the PR 2 reliability slice for flashcards create/import recovery, including both review follow-ups. Invalid imports, zero-created/no-detail structured saves, and zero-created structured saves with available preview/local validation errors now render honest warning/error states without clearing user input or selected drafts. Failed import classification now uses HTTP status first so 400/422 are validation and status-bearing auth/server/network-style failures are operational even when their text says invalid. Image occlusion zero-created/no-detail saves preserve drafts, show an inline warning, and avoid success/undo side effects. Create drawer mutation failures render an inline Alert while preserving form values and re-enabling create actions. Transfer summary import limits are guarded against unresolved i18n placeholders with direct fallback coverage. F01 placeholder leakage, F03 invalid import recovery, and F05 create failure/zero-created recovery are closed for the touched frontend paths.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2403 - Implement-flashcards-UX-PR-2-create-import-generate-reliability.md
+++ b/backlog/tasks/task-2403 - Implement-flashcards-UX-PR-2-create-import-generate-reliability.md
@@ -4,7 +4,7 @@ title: Implement flashcards UX PR 2 create import generate reliability
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-23 21:52'
+updated_date: '2026-06-23 22:07'
 labels:
   - ux
   - flashcards
@@ -66,12 +66,26 @@ Second review follow-up verification:
 - RED: cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx failed 4 tests against 9d908856dd: structured zero-created/local-error draft preservation plus 401/403/500 operational classification.
 - PASS: git diff --check exited 0.
 - PASS: cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.deck-reference.test.tsx src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx (3 files passed, 51 tests passed).
+
+Third review follow-up 2026-06-23:
+- Rebased PR #2466 on latest origin/dev.
+- Fixed status-less JSON import endpoint request failures so transport wrapper text such as "Failed to fetch (POST /api/v1/flashcards/import/json)" is treated as an operational/API error instead of a validation error caused by the endpoint path.
+- Removed the bare "json" validation token, stripped trailing request context before fallback message classification, and kept JSON validation matching to explicit malformed/invalid/parse phrases.
+- Updated a stale transfer-summary empty-state assertion to match the current "No import/export actions yet in this session." UI copy from the rebased component.
+- Added a regression that keeps the JSON payload editable and shows operational retry guidance for status-less JSON endpoint fetch failures.
+
+Third review follow-up verification:
+- RED: cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx -t "status-less JSON endpoint" failed against the rebased branch because the status-less JSON endpoint request failure rendered "Import validation failed".
+- PASS: cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx -t "status-less JSON endpoint" (1 test passed, 38 skipped).
+- PASS: cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ImportExportTab.import-results.test.tsx src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.deck-reference.test.tsx src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx (3 files passed, 53 tests passed).
+- PASS: git diff --check exited 0.
+- Bandit N/A: frontend-only TypeScript/React and Backlog markdown changes, no Python touched.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the PR 2 reliability slice for flashcards create/import recovery, including both review follow-ups. Invalid imports, zero-created/no-detail structured saves, and zero-created structured saves with available preview/local validation errors now render honest warning/error states without clearing user input or selected drafts. Failed import classification now uses HTTP status first so 400/422 are validation and status-bearing auth/server/network-style failures are operational even when their text says invalid. Image occlusion zero-created/no-detail saves preserve drafts, show an inline warning, and avoid success/undo side effects. Create drawer mutation failures render an inline Alert while preserving form values and re-enabling create actions. Transfer summary import limits are guarded against unresolved i18n placeholders with direct fallback coverage. F01 placeholder leakage, F03 invalid import recovery, and F05 create failure/zero-created recovery are closed for the touched frontend paths.
+Implemented the PR 2 reliability slice for flashcards create/import recovery, including review follow-ups. Invalid imports, zero-created/no-detail structured saves, and zero-created structured saves with available preview/local validation errors now render honest warning/error states without clearing user input or selected drafts. Failed import classification now uses HTTP status first so 400/422 are validation and status-bearing auth/server/network-style failures are operational even when their text says invalid. Status-less JSON endpoint transport failures are also operational because request-path suffixes are stripped and the bare "json" validation token was replaced with explicit malformed/invalid/parse JSON phrases. Image occlusion zero-created/no-detail saves preserve drafts, show an inline warning, and avoid success/undo side effects. Create drawer mutation failures render an inline Alert while preserving form values and re-enabling create actions. Transfer summary import limits are guarded against unresolved i18n placeholders with direct fallback coverage. F01 placeholder leakage, F03 invalid import recovery, and F05 create failure/zero-created recovery are closed for the touched frontend paths.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Hardens Flashcards create/import recovery so validation, operational failure, and zero-created cases do not look like success.
- Preserves user input and selected structured/image drafts after recoverable failures and adds explicit warning/error guidance.
- Backlog: TASK-2403.

## Test Plan
- git diff --check
- Focused Vitest passed: ImportExport import-results, FlashcardCreateDrawer deck-reference, ImageOcclusionTransferPanel: 3 files, 51 tests
- Red/green regressions recorded for zero-created and failed import classification paths

## Merge Note
- Project policy requires a human-authored Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens flashcards setup recovery: prevents false “success” on create/import, preserves input and drafts, and adds clear inline guidance. Addresses TASK-2403.

- **Bug Fixes**
  - Create drawer: inline error `Alert` on mutation failure; keep form values; actions stay enabled.
  - Structured import: classify results as success/partial/validation-error/error; keep pasted content and structured drafts on failure or zero-created (including when local/preview errors exist); no success toast/undo; last-result alert shows clear title/detail and notes when row details are unavailable.
  - Image occlusion save: treat zero-created/no-detail as a warning; keep drafts; no success toast/undo.
  - Failure classification: prefer HTTP status (400/422 = validation; others, including status-less JSON fetch failures, = operational); strip request-context suffixes; robust message fallback.
  - Copy safety: guard unresolved i18n placeholders in transfer summary limits/last-action text and Import panel limits via `guardInterpolatedText`.

<sup>Written for commit 99dcdfcded3535f93c9df22273108046e1ed2847. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

