### PR TITLE
fix: clarify flashcards review recovery

### DIFF
--- a/apps/packages/ui/src/components/Flashcards/components/KeyboardShortcutsModal.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/KeyboardShortcutsModal.tsx
@@ -45,7 +45,7 @@ export const KeyboardShortcutsModal: React.FC<KeyboardShortcutsModalProps> = ({
       {
         keys: ["Ctrl+Z", "⌘Z"],
         description: t("option:flashcards.shortcutUndoVisibleControl", {
-          defaultValue: "Re-rate last card while the undo button is visible"
+          defaultValue: "Re-rate last card when the Re-rate button is available"
         })
       }
     ]

--- a/apps/packages/ui/src/components/Flashcards/components/ReviewProgress.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/ReviewProgress.tsx
@@ -8,6 +8,8 @@ interface ReviewProgressProps {
   deckName?: string
   availableNowCount?: number
   scheduledDueCount?: number
+  newCount?: number
+  learningCount?: number
 }
 
 export const ReviewProgress: React.FC<ReviewProgressProps> = ({
@@ -15,7 +17,9 @@ export const ReviewProgress: React.FC<ReviewProgressProps> = ({
   reviewedCount,
   deckName,
   availableNowCount,
-  scheduledDueCount
+  scheduledDueCount,
+  newCount,
+  learningCount
 }) => {
   const { t } = useTranslation(["option"])
   const remaining = Math.max(0, dueCount - reviewedCount)
@@ -36,10 +40,26 @@ export const ReviewProgress: React.FC<ReviewProgressProps> = ({
       })
     )
   }
+  if (typeof newCount === "number") {
+    statusMessageParts.push(
+      t("option:flashcards.newQueueCount", {
+        defaultValue: "new: {{count}}",
+        count: newCount
+      })
+    )
+  }
+  if (typeof learningCount === "number") {
+    statusMessageParts.push(
+      t("option:flashcards.learningQueueCount", {
+        defaultValue: "learning: {{count}}",
+        count: learningCount
+      })
+    )
+  }
   if (typeof scheduledDueCount === "number") {
     statusMessageParts.push(
-      t("option:flashcards.scheduledDueCount", {
-        defaultValue: "Scheduled due: {{count}}",
+      t("option:flashcards.dueQueueCount", {
+        defaultValue: "due: {{count}}",
         count: scheduledDueCount
       })
     )
@@ -60,6 +80,9 @@ export const ReviewProgress: React.FC<ReviewProgressProps> = ({
       <span className="sr-only">{statusMessage}</span>
 
       <div className="flex items-center gap-2">
+        <span className="text-sm font-medium text-text" aria-hidden="true">
+          {t("option:flashcards.studyQueue", { defaultValue: "Study queue" })}
+        </span>
         <span className="text-2xl font-bold text-primary" aria-hidden="true">{remaining}</span>
         <span className="text-sm text-text-muted" aria-hidden="true">
           {t("option:flashcards.cardsRemaining", { defaultValue: "cards remaining" })}
@@ -81,12 +104,34 @@ export const ReviewProgress: React.FC<ReviewProgressProps> = ({
           </div>
         </>
       )}
+      {typeof newCount === "number" && (
+        <>
+          <div className="h-8 w-px bg-border" aria-hidden="true" />
+          <div className="text-sm text-text-muted" aria-hidden="true">
+            {t("option:flashcards.newQueueCount", {
+              defaultValue: "new: {{count}}",
+              count: newCount
+            })}
+          </div>
+        </>
+      )}
+      {typeof learningCount === "number" && (
+        <>
+          <div className="h-8 w-px bg-border" aria-hidden="true" />
+          <div className="text-sm text-text-muted" aria-hidden="true">
+            {t("option:flashcards.learningQueueCount", {
+              defaultValue: "learning: {{count}}",
+              count: learningCount
+            })}
+          </div>
+        </>
+      )}
       {typeof scheduledDueCount === "number" && (
         <>
           <div className="h-8 w-px bg-border" aria-hidden="true" />
           <div className="text-sm text-text-muted" aria-hidden="true">
-            {t("option:flashcards.scheduledDueCount", {
-              defaultValue: "Scheduled due: {{count}}",
+            {t("option:flashcards.dueQueueCount", {
+              defaultValue: "due: {{count}}",
               count: scheduledDueCount
             })}
           </div>

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/KeyboardShortcutsModal.rating-scale.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/KeyboardShortcutsModal.rating-scale.test.tsx
@@ -77,6 +77,6 @@ describe("KeyboardShortcutsModal rating scale guidance", () => {
 
     expect(screen.getByText("Show answer")).toBeInTheDocument()
     expect(screen.getByText("Rate with Again, Hard, Good, or Easy")).toBeInTheDocument()
-    expect(screen.getByText("Re-rate last card while the undo button is visible")).toBeInTheDocument()
+    expect(screen.getByText("Re-rate last card when the Re-rate button is available")).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/ReviewProgress.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/ReviewProgress.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { ReviewProgress } from "../ReviewProgress"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      defaultValueOrOptions?:
+        | string
+        | {
+            defaultValue?: string
+          }
+    ) => {
+      if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
+      if (defaultValueOrOptions?.defaultValue) {
+        return defaultValueOrOptions.defaultValue.replace(
+          /\{\{(\w+)\}\}/g,
+          (_match, token: string) =>
+            String((defaultValueOrOptions as Record<string, unknown>)[token] ?? `{{${token}}}`)
+        )
+      }
+      return key
+    }
+  })
+}))
+
+describe("ReviewProgress queue language", () => {
+  it("labels the available study queue and shows bucket counts separately", () => {
+    render(
+      <ReviewProgress
+        dueCount={6}
+        reviewedCount={2}
+        deckName="Biology"
+        availableNowCount={6}
+        scheduledDueCount={3}
+        newCount={2}
+        learningCount={1}
+      />
+    )
+
+    const progress = screen.getByTestId("flashcards-review-progress")
+
+    expect(progress).toHaveTextContent("Study queue")
+    expect(progress).toHaveTextContent("Available now: 6")
+    expect(progress).toHaveTextContent("new: 2")
+    expect(progress).toHaveTextContent("learning: 1")
+    expect(progress).toHaveTextContent("due: 3")
+    expect(progress).not.toHaveTextContent("Scheduled due")
+  })
+})

--- a/apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx
@@ -12,7 +12,7 @@ import {
   Tooltip,
   Typography
 } from "antd"
-import { X, Minus, Check, Star, Calendar, Undo2 } from "lucide-react"
+import { X, Minus, Check, Star, Calendar, Undo2, HelpCircle } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { Alert } from "@/components/ui/primitives"
@@ -152,6 +152,7 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
 
   // State
   const [showAnswer, setShowAnswer] = React.useState(false)
+  const [assistantOpen, setAssistantOpen] = React.useState(false)
   const [reviewedCount, setReviewedCount] = React.useState(0)
   const [localOverrideCard, setLocalOverrideCard] = React.useState<Flashcard | null>(null)
   const [editDrawerOpen, setEditDrawerOpen] = React.useState(false)
@@ -281,13 +282,19 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
   const availableNowCount =
     reviewMode === "cram"
       ? cramQueue.length
-      : dueCountsQuery.data
-        ? (dueCountsQuery.data.due ?? 0) +
-          (dueCountsQuery.data.new ?? 0) +
-          (dueCountsQuery.data.learning ?? 0)
-        : undefined
+      : dueCountsQuery.data?.total
+  const newQueueCount = reviewMode === "cram" ? undefined : dueCountsQuery.data?.new
+  const learningQueueCount =
+    reviewMode === "cram" ? undefined : dueCountsQuery.data?.learning
   const isCramMode = reviewMode === "cram"
-  const showTopBarCreateCta = !activeCard && !canShowAllDeckDashboard
+  const isCompletionRecoveryState =
+    !activeCard &&
+    hasCardsQuery.data === true &&
+    !canShowAllDeckDashboard &&
+    !isReviewCardLoading &&
+    !isCramQueueLoading
+  const showTopBarCreateCta =
+    !activeCard && !canShowAllDeckDashboard && !isCompletionRecoveryState
   const handleDashboardReviewDeck = React.useCallback(
     (deckId: number) => {
       onReviewDeckChange(deckId)
@@ -901,6 +908,7 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
   }, [])
 
   React.useEffect(() => {
+    setAssistantOpen(false)
     if (autoRevealAnswerRef.current) {
       autoRevealAnswerRef.current = false
       setShowAnswer(true)
@@ -1247,7 +1255,7 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
         </div>
       )}
 
-      {!activeCard && (
+      {!activeCard && !isCompletionRecoveryState && (
         <DeckStudyDashboard
           decks={availableDecks}
           deckProgress={deckDashboardAnalyticsQuery.data?.decks}
@@ -1276,6 +1284,8 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
           deckName={currentDeckName}
           availableNowCount={availableNowCount}
           scheduledDueCount={scheduledDueCount}
+          newCount={newQueueCount}
+          learningCount={learningQueueCount}
         />
       )}
 
@@ -1374,22 +1384,41 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
               </div>
             )}
 
-            <div className="relative">
-              <FlashcardStudyAssistantPanel
-                key={activeCard.uuid}
-                cardUuid={activeCard.uuid}
-                threadVersion={assistantQuery.data?.thread.version ?? null}
-                messages={assistantQuery.data?.messages ?? []}
-                availableActions={assistantQuery.data?.available_actions ?? null}
-                assistantContext={assistantQuery.data}
-                isLoading={assistantQuery.isLoading}
-                isError={assistantQuery.isError}
-                queryError={assistantQuery.error}
-                isResponding={assistantRespondMutation.isPending}
-                onReloadContext={() => assistantQuery.refetch()}
-                onRespond={handleAssistantRespond}
-                defaultExpanded={showAnswer}
-              />
+            <div className="relative flex flex-col gap-2">
+              <div>
+                <Button
+                  type="default"
+                  icon={<HelpCircle className="size-4" />}
+                  onClick={() => setAssistantOpen((open) => !open)}
+                  aria-expanded={assistantOpen}
+                  data-testid="flashcards-review-assistant-toggle"
+                >
+                  {assistantOpen
+                    ? t("option:flashcards.hideReviewHelp", {
+                        defaultValue: "Hide help"
+                      })
+                    : t("option:flashcards.needReviewHelp", {
+                        defaultValue: "Need help?"
+                      })}
+                </Button>
+              </div>
+              {assistantOpen && (
+                <FlashcardStudyAssistantPanel
+                  key={activeCard.uuid}
+                  cardUuid={activeCard.uuid}
+                  threadVersion={assistantQuery.data?.thread.version ?? null}
+                  messages={assistantQuery.data?.messages ?? []}
+                  availableActions={assistantQuery.data?.available_actions ?? null}
+                  assistantContext={assistantQuery.data}
+                  isLoading={assistantQuery.isLoading}
+                  isError={assistantQuery.isError}
+                  queryError={assistantQuery.error}
+                  isResponding={assistantRespondMutation.isPending}
+                  onReloadContext={() => assistantQuery.refetch()}
+                  onRespond={handleAssistantRespond}
+                  defaultExpanded={showAnswer}
+                />
+              )}
               <FeatureHint
                 featureKey="flashcards_study_assistant_discovery"
                 title={t("option:flashcards.studyAssistantHintTitle", {
@@ -1897,6 +1926,16 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
                         defaultValue: "Create card"
                       })}
                     </Button>
+                    {reviewDeckId != null && onNavigateToManageDeck && (
+                      <Button
+                        onClick={() => onNavigateToManageDeck(reviewDeckId)}
+                        data-testid="flashcards-review-manage-deck"
+                      >
+                        {t("option:flashcards.manageDeckCards", {
+                          defaultValue: "Manage deck/cards"
+                        })}
+                      </Button>
+                    )}
                     {reviewDeckId != null && (
                       <Button
                         onClick={() => {

--- a/apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx
@@ -287,12 +287,17 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
   const learningQueueCount =
     reviewMode === "cram" ? undefined : dueCountsQuery.data?.learning
   const isCramMode = reviewMode === "cram"
+  const isCramCompletionRecoveryState =
+    isCramMode &&
+    !activeCard &&
+    !cramTagFilter &&
+    !isCramQueueLoading &&
+    cramQueue.length === 0
   const isCompletionRecoveryState =
     !activeCard &&
     hasCardsQuery.data === true &&
     !canShowAllDeckDashboard &&
-    !isReviewCardLoading &&
-    !isCramQueueLoading
+    (isDueModeCaughtUp || isCramCompletionRecoveryState)
   const showTopBarCreateCta =
     !activeCard && !canShowAllDeckDashboard && !isCompletionRecoveryState
   const handleDashboardReviewDeck = React.useCallback(

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx
@@ -139,6 +139,7 @@ if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
 
 describe("ReviewTab study assistant panel", () => {
   let assistantQueryState: any
+  let activeReviewCard: any
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -152,30 +153,31 @@ describe("ReviewTab study assistant panel", () => {
       isLoading: false
     } as any)
     vi.mocked(useCramQueueQuery).mockReturnValue({ data: [] } as any)
-    vi.mocked(useReviewQuery).mockReturnValue({
-      data: {
-        uuid: "card-1",
-        deck_id: 1,
-        front: "What filters blood?",
-        back: "The glomerulus.",
-        notes: null,
-        extra: null,
-        is_cloze: false,
-        tags: ["renal"],
-        ef: 2.5,
-        interval_days: 2,
-        repetitions: 1,
-        lapses: 0,
-        due_at: null,
-        last_reviewed_at: null,
-        last_modified: null,
-        deleted: false,
-        client_id: "test",
-        version: 2,
-        model_type: "basic",
-        reverse: false
-      }
-    } as any)
+    activeReviewCard = {
+      uuid: "card-1",
+      deck_id: 1,
+      front: "What filters blood?",
+      back: "The glomerulus.",
+      notes: null,
+      extra: null,
+      is_cloze: false,
+      tags: ["renal"],
+      ef: 2.5,
+      interval_days: 2,
+      repetitions: 1,
+      lapses: 0,
+      due_at: null,
+      last_reviewed_at: null,
+      last_modified: null,
+      deleted: false,
+      client_id: "test",
+      version: 2,
+      model_type: "basic",
+      reverse: false
+    }
+    vi.mocked(useReviewQuery).mockImplementation(() => ({
+      data: activeReviewCard
+    } as any))
     vi.mocked(useReviewFlashcardMutation).mockReturnValue({
       mutateAsync: vi.fn(),
       isPending: false
@@ -310,8 +312,54 @@ describe("ReviewTab study assistant panel", () => {
       />
     )
 
+  const openReviewHelp = () => {
+    fireEvent.click(screen.getByTestId("flashcards-review-assistant-toggle"))
+  }
+
+  const openAssistantPanel = () => {
+    openReviewHelp()
+    fireEvent.click(screen.getByTestId("flashcards-study-assistant-toggle"))
+  }
+
+  it("keeps review recall first and resets explicit help when the active card changes", async () => {
+    const { rerender } = renderReviewTab()
+
+    expect(screen.getByRole("button", { name: "Show answer (Space)" })).toBeInTheDocument()
+    expect(screen.queryByTestId("flashcards-review-study-assistant")).not.toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-review-assistant-toggle")).toHaveTextContent("Need help?")
+
+    openReviewHelp()
+
+    expect(screen.getByTestId("flashcards-review-study-assistant")).toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-review-assistant-toggle")).toHaveTextContent("Hide help")
+
+    activeReviewCard = {
+      ...activeReviewCard,
+      uuid: "card-2",
+      front: "What reabsorbs glucose?",
+      back: "The proximal tubule."
+    }
+    rerender(
+      <ReviewTab
+        onNavigateToCreate={() => {}}
+        onNavigateToImport={() => {}}
+        reviewDeckId={1}
+        onReviewDeckChange={() => {}}
+        isActive
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("flashcards-review-study-assistant")).not.toBeInTheDocument()
+    })
+    expect(screen.getByTestId("flashcards-review-assistant-toggle")).toHaveTextContent("Need help?")
+    expect(screen.getByText("What reabsorbs glucose?")).toBeInTheDocument()
+  })
+
   it("keeps assistant actions collapsed before answer reveal and expands on demand", () => {
     renderReviewTab()
+
+    openReviewHelp()
 
     expect(screen.getByTestId("flashcards-review-study-assistant")).toBeInTheDocument()
     expect(screen.getByText("Need help understanding this card?")).toBeInTheDocument()
@@ -332,7 +380,7 @@ describe("ReviewTab study assistant panel", () => {
     })
     renderReviewTab()
 
-    fireEvent.click(screen.getByTestId("flashcards-study-assistant-toggle"))
+    openAssistantPanel()
     fireEvent.click(screen.getByRole("button", { name: "Explain" }))
 
     await waitFor(() => {
@@ -349,7 +397,7 @@ describe("ReviewTab study assistant panel", () => {
     })
     renderReviewTab()
 
-    fireEvent.click(screen.getByTestId("flashcards-study-assistant-toggle"))
+    openAssistantPanel()
     fireEvent.click(screen.getByRole("button", { name: "Fact-check me" }))
     expect(assistantMutateAsync).not.toHaveBeenCalled()
     expect(screen.getByText("Confirm transcript")).toBeInTheDocument()
@@ -374,7 +422,7 @@ describe("ReviewTab study assistant panel", () => {
   it("stops voice capture and clears the transcript when the assistant is collapsed", () => {
     const { rerender } = renderReviewTab()
 
-    fireEvent.click(screen.getByTestId("flashcards-study-assistant-toggle"))
+    openAssistantPanel()
     fireEvent.click(screen.getByRole("button", { name: "Fact-check me" }))
 
     expect(speechRecognitionState.start).toHaveBeenCalledTimes(1)
@@ -404,7 +452,7 @@ describe("ReviewTab study assistant panel", () => {
   it("plays back assistant replies on demand", async () => {
     renderReviewTab()
 
-    fireEvent.click(screen.getByTestId("flashcards-study-assistant-toggle"))
+    openAssistantPanel()
     fireEvent.click(screen.getByRole("button", { name: "Play reply" }))
 
     await waitFor(() => {
@@ -418,7 +466,7 @@ describe("ReviewTab study assistant panel", () => {
     assistantMutateAsync.mockRejectedValue(new Error("assistant failed"))
     renderReviewTab()
 
-    fireEvent.click(screen.getByTestId("flashcards-study-assistant-toggle"))
+    openAssistantPanel()
     fireEvent.click(screen.getByRole("button", { name: "Explain" }))
 
     await waitFor(() => {
@@ -444,7 +492,7 @@ describe("ReviewTab study assistant panel", () => {
       })
     renderReviewTab()
 
-    fireEvent.click(screen.getByTestId("flashcards-study-assistant-toggle"))
+    openAssistantPanel()
     fireEvent.click(screen.getByRole("button", { name: "Explain" }))
 
     await waitFor(() => {
@@ -470,7 +518,7 @@ describe("ReviewTab study assistant panel", () => {
     )
     renderReviewTab()
 
-    fireEvent.click(screen.getByTestId("flashcards-study-assistant-toggle"))
+    openAssistantPanel()
     fireEvent.click(screen.getByRole("button", { name: "Explain" }))
 
     await waitFor(() => {
@@ -494,7 +542,7 @@ describe("ReviewTab study assistant panel", () => {
       })
     renderReviewTab()
 
-    fireEvent.click(screen.getByTestId("flashcards-study-assistant-toggle"))
+    openAssistantPanel()
     fireEvent.click(screen.getByRole("button", { name: "Fact-check me" }))
     fireEvent.change(screen.getByLabelText("Transcript"), {
       target: { value: "I think the glomerulus filters blood." }
@@ -592,7 +640,7 @@ describe("ReviewTab study assistant panel", () => {
     })
     renderReviewTab()
 
-    fireEvent.click(screen.getByTestId("flashcards-study-assistant-toggle"))
+    openAssistantPanel()
     fireEvent.click(screen.getByRole("button", { name: "Explain" }))
 
     await waitFor(() => {

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx
@@ -1053,7 +1053,9 @@ describe("ReviewTab create CTA visibility", () => {
     expect(screen.queryByRole("button", { name: /Practice again/i })).not.toBeInTheDocument()
   })
 
-  it("offers completion actions for practice again and selected-deck scheduling", () => {
+  it("offers completion actions for recovery, creation, management, and scheduling", () => {
+    const onNavigateToCreate = vi.fn()
+    const onNavigateToManageDeck = vi.fn()
     vi.mocked(useHasCardsQuery).mockReturnValue({ data: true } as any)
     vi.mocked(useDueCountsQuery).mockReturnValue({
       data: { due: 0, new: 0, learning: 0, total: 0 }
@@ -1088,17 +1090,35 @@ describe("ReviewTab create CTA visibility", () => {
 
     render(
       <ReviewTab
-        onNavigateToCreate={() => {}}
+        onNavigateToCreate={onNavigateToCreate}
         onNavigateToImport={() => {}}
         reviewDeckId={11}
         onReviewDeckChange={() => {}}
         isActive
+        onNavigateToManageDeck={onNavigateToManageDeck}
       />
     )
 
     expect(vi.mocked(useCramQueueQuery).mock.calls.at(-1)?.[2]).toEqual(
       expect.objectContaining({ enabled: true, limit: 1 })
     )
+
+    const completionCard = screen.getByTestId("flashcards-review-empty-card")
+    expect(completionCard).toHaveTextContent("You're all caught up!")
+    expect(completionCard).toHaveTextContent("No cards are due for review. Great job!")
+    expect(within(completionCard).getByRole("button", { name: "Practice again" })).toBeInTheDocument()
+    expect(within(completionCard).getByRole("button", { name: "Create card" })).toBeInTheDocument()
+    expect(within(completionCard).getByRole("button", { name: "Manage deck/cards" })).toBeInTheDocument()
+    expect(within(completionCard).getByRole("button", { name: "Open scheduler" })).toBeInTheDocument()
+    expect(screen.queryByTestId("flashcards-review-create-cta")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("flashcards-deck-study-dashboard")).not.toBeInTheDocument()
+    expect(screen.getAllByRole("button", { name: "Create card" })).toHaveLength(1)
+
+    fireEvent.click(within(completionCard).getByRole("button", { name: "Create card" }))
+    expect(onNavigateToCreate).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(within(completionCard).getByRole("button", { name: "Manage deck/cards" }))
+    expect(onNavigateToManageDeck).toHaveBeenCalledWith(11)
 
     fireEvent.click(screen.getByTestId("flashcards-review-open-scheduler"))
     const schedulerRoute = navigateMock.mock.calls.at(-1)?.[0]
@@ -1183,10 +1203,19 @@ describe("ReviewTab create CTA visibility", () => {
     )
 
     expect(screen.getByTestId("flashcards-review-progress")).toHaveTextContent(
+      "Study queue"
+    )
+    expect(screen.getByTestId("flashcards-review-progress")).toHaveTextContent(
       "Available now: 1"
     )
     expect(screen.getByTestId("flashcards-review-progress")).toHaveTextContent(
-      "Scheduled due: 0"
+      "new: 1"
+    )
+    expect(screen.getByTestId("flashcards-review-progress")).toHaveTextContent(
+      "due: 0"
+    )
+    expect(screen.getByTestId("flashcards-review-progress")).not.toHaveTextContent(
+      "Scheduled due"
     )
   })
 

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx
@@ -1162,6 +1162,64 @@ describe("ReviewTab create CTA visibility", () => {
     )
   })
 
+  it("keeps deck navigation available when a cram tag filter has no matches", () => {
+    vi.mocked(useDecksQuery).mockReturnValue({
+      data: [{ id: 11, name: "Biology" }],
+      isLoading: false
+    } as any)
+    vi.mocked(useHasCardsQuery).mockReturnValue({ data: true } as any)
+    vi.mocked(useDueCountsQuery).mockReturnValue({
+      data: { due: 0, new: 0, learning: 0, total: 0 }
+    } as any)
+    vi.mocked(useCramQueueQuery).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false
+    } as any)
+    vi.mocked(useReviewAnalyticsSummaryQuery).mockReturnValue({
+      data: {
+        reviewed_today: 0,
+        retention_rate_today: null,
+        lapse_rate_today: null,
+        avg_answer_time_ms_today: null,
+        study_streak_days: 0,
+        generated_at: "2026-02-18T12:00:00.000Z",
+        decks: [
+          {
+            deck_id: 11,
+            deck_name: "Biology",
+            total: 20,
+            new: 2,
+            learning: 1,
+            due: 0,
+            mature: 17
+          }
+        ]
+      },
+      isLoading: false
+    } as any)
+
+    render(
+      <ReviewTab
+        onNavigateToCreate={() => {}}
+        onNavigateToImport={() => {}}
+        reviewDeckId={11}
+        onReviewDeckChange={() => {}}
+        isActive
+      />
+    )
+
+    fireEvent.click(screen.getByText("Cram"))
+    fireEvent.change(screen.getByTestId("flashcards-review-cram-tag"), {
+      target: { value: "biology" }
+    })
+
+    const emptyCard = screen.getByTestId("flashcards-review-empty-card")
+    expect(emptyCard).toHaveTextContent("No cards match this cram tag filter.")
+    expect(screen.getByTestId("flashcards-review-create-cta")).toBeInTheDocument()
+    expect(screen.getByTestId("flashcards-deck-study-dashboard")).toBeInTheDocument()
+  })
+
   it("distinguishes scheduled due cards from the available study queue", () => {
     vi.mocked(useReviewQuery).mockReturnValue({
       data: {

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/__snapshots__/ReviewTab.create-cta.test.tsx.snap
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/__snapshots__/ReviewTab.create-cta.test.tsx.snap
@@ -233,100 +233,48 @@ exports[`ReviewTab create CTA visibility > matches baseline snapshot for active 
         </div>
       </div>
       <div
-        class="relative"
+        class="relative flex flex-col gap-2"
       >
-        <div
-          class="ant-card ant-card-bordered ant-card-small css-dev-only-do-not-override-3uaqrl css-var-root"
-          data-testid="flashcards-review-study-assistant"
-        >
-          <div
-            class="ant-card-head"
+        <div>
+          <button
+            aria-expanded="false"
+            class="ant-btn css-dev-only-do-not-override-3uaqrl css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+            data-testid="flashcards-review-assistant-toggle"
+            type="button"
           >
-            <div
-              class="ant-card-head-wrapper"
+            <span
+              class="ant-btn-icon"
             >
-              <div
-                class="ant-card-head-title"
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-circle-question-mark size-4"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <div
-                  class="flex items-center gap-2"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="lucide lucide-sparkles size-4 text-primary"
-                    fill="none"
-                    height="24"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
-                    />
-                    <path
-                      d="M20 2v4"
-                    />
-                    <path
-                      d="M22 4h-4"
-                    />
-                    <circle
-                      cx="4"
-                      cy="20"
-                      r="2"
-                    />
-                  </svg>
-                  <span>
-                    Study assistant
-                  </span>
-                </div>
-              </div>
-              <div
-                class="ant-card-extra"
-              >
-                <button
-                  aria-expanded="false"
-                  class="ant-btn css-dev-only-do-not-override-3uaqrl css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-sm"
-                  data-testid="flashcards-study-assistant-toggle"
-                  type="button"
-                >
-                  <span>
-                    Open assistant
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-          <div
-            class="ant-card-body"
-          >
-            <div
-              class="ant-space css-dev-only-do-not-override-3uaqrl ant-space-vertical w-full css-var-root"
-              style="column-gap: 8px; row-gap: 8px;"
-            >
-              <div
-                class="ant-space-item"
-              >
-                <span
-                  class="ant-typography ant-typography-secondary css-dev-only-do-not-override-3uaqrl css-var-root"
-                >
-                  Need help understanding this card?
-                </span>
-              </div>
-              <div
-                class="ant-space-item"
-              >
-                <span
-                  class="ant-typography ant-typography-secondary text-xs css-dev-only-do-not-override-3uaqrl css-var-root"
-                >
-                  Open the assistant when you want an explanation, mnemonic, or fact-check without leaving review.
-                </span>
-              </div>
-            </div>
-          </div>
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="10"
+                />
+                <path
+                  d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"
+                />
+                <path
+                  d="M12 17h.01"
+                />
+              </svg>
+            </span>
+            <span>
+              Need help?
+            </span>
+          </button>
         </div>
         <div
           aria-live="polite"
@@ -628,15 +576,6 @@ exports[`ReviewTab create CTA visibility > matches baseline snapshot for caught-
       </label>
     </div>
   </div>
-  <button
-    class="ant-btn css-dev-only-do-not-override-3uaqrl css-var-root ant-btn-primary ant-btn-color-primary ant-btn-variant-solid min-h-11"
-    data-testid="flashcards-review-create-cta"
-    type="button"
-  >
-    <span>
-      Create card
-    </span>
-  </button>
 </div>
 `;
 

--- a/backlog/tasks/task-2404 - Implement-flashcards-UX-PR-3-review-comprehension-and-recovery.md
+++ b/backlog/tasks/task-2404 - Implement-flashcards-UX-PR-3-review-comprehension-and-recovery.md
@@ -51,18 +51,24 @@ Implementation notes:
 - Spec review fix: suppressed the top-bar create CTA and deck study dashboard during the completed-review recovery card so the recovery state exposes a single action surface.
 - Removed out-of-scope dependency artifact edits from interrupted worker attempts before committing.
 - Bandit N/A: frontend-only TypeScript/React changes, no Python touched.
+- Review follow-up 2026-06-23: rebased PR #2467 on latest origin/dev and narrowed completed-review recovery detection to actual completion states. Due mode now reuses `isDueModeCaughtUp`, while cram mode only uses the recovery card when the cram queue is exhausted without an active tag filter. Cram tag filters with no matching cards keep deck navigation and the top-bar create action available.
 
 Verification:
 - RED/PATCH: Focused Vitest initially failed the active-card snapshot after replacing the always-visible assistant panel with the explicit Need help toggle; updated the snapshot for the intended UI change.
 - SPEC-FIX PASS: `cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx src/components/Flashcards/components/__tests__/ReviewProgress.test.tsx src/components/Flashcards/components/__tests__/KeyboardShortcutsModal.rating-scale.test.tsx` (4 files passed, 36 tests passed).
 - INITIAL PASS: `cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx src/components/Flashcards/components/__tests__/ReviewProgress.test.tsx src/components/Flashcards/components/__tests__/KeyboardShortcutsModal.rating-scale.test.tsx` (4 files passed, 36 tests passed).
 - PASS: `git diff --check`.
+- REVIEW RED: `cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx -t "cram tag filter"` failed against the rebased branch because the cram tag-empty state hid `flashcards-review-create-cta`.
+- REVIEW PASS: `cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx -t "cram tag filter"` (1 test passed, 23 skipped).
+- REVIEW PASS: `cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx src/components/Flashcards/components/__tests__/ReviewProgress.test.tsx src/components/Flashcards/components/__tests__/KeyboardShortcutsModal.rating-scale.test.tsx` (4 files passed, 38 tests passed).
+- REVIEW PASS: `git diff --check`.
+- REVIEW Bandit N/A: frontend-only TypeScript/React and Backlog markdown changes, no Python touched.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented the PR 3 review-comprehension slice. Review mode now stays recall-first by hiding the study assistant behind an explicit help toggle that resets on card changes. Completion recovery actions are pinned by tests, progress copy now separates queue buckets, and shortcut guidance now matches the visible Re-rate control availability. Focused review, assistant, progress, and shortcut tests pass.
+Implemented the PR 3 review-comprehension slice. Review mode now stays recall-first by hiding the study assistant behind an explicit help toggle that resets on card changes. Completion recovery actions are pinned by tests, progress copy now separates queue buckets, and shortcut guidance now matches the visible Re-rate control availability. Review follow-up narrowed completion recovery gating so non-completion empty states, including cram tag filters with no matches, keep deck navigation available. Focused review, assistant, progress, and shortcut tests pass.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2404 - Implement-flashcards-UX-PR-3-review-comprehension-and-recovery.md
+++ b/backlog/tasks/task-2404 - Implement-flashcards-UX-PR-3-review-comprehension-and-recovery.md
@@ -1,0 +1,76 @@
+---
+id: TASK-2404
+title: Implement flashcards UX PR 3 review comprehension and recovery
+status: Done
+labels:
+- ux
+- flashcards
+- frontend
+ordinal: 2404
+modified_files:
+- apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx
+- apps/packages/ui/src/components/Flashcards/components/FlashcardStudyAssistantPanel.tsx
+- apps/packages/ui/src/components/Flashcards/components/ReviewProgress.tsx
+- apps/packages/ui/src/components/Flashcards/components/KeyboardShortcutsModal.tsx
+- apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx
+- apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx
+- apps/packages/ui/src/components/Flashcards/components/__tests__/ReviewProgress.test.tsx
+- apps/packages/ui/src/components/Flashcards/components/__tests__/KeyboardShortcutsModal.rating-scale.test.tsx
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Task 3 from the flashcards UX remediation plan: review comprehension and recovery.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- Assistant is secondary during recall and is hidden until the user opens help.
+- Review completion offers recovery actions: practice again when applicable, create card, manage deck/cards, and open scheduler.
+- Progress language explains the study queue without contradicting due/new/learning counts.
+- Shortcut copy matches visible controls or clearly describes when accelerators are available.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Task 3 from Docs/superpowers/plans/2026-06-23-flashcards-remaining-ux-remediation-plan.md: Review Comprehension And Recovery.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implementation notes:
+- Added an explicit `Need help?` / `Hide help` review assistant toggle so the assistant stays secondary during recall.
+- Reset the explicit assistant-open state whenever the active card UUID changes.
+- Preserved the existing assistant query, reload, response, context, and feature-hint wiring; no `FlashcardStudyAssistantPanel` API changes were required.
+- Strengthened completion recovery actions with tested Create card, Manage deck/cards, Open scheduler, and Practice again affordances when applicable.
+- Updated review progress language to label the Study queue and show available, new, learning, and due bucket counts separately instead of relying on misleading scheduled-due copy.
+- Updated keyboard shortcut copy so Ctrl/Cmd+Z refers to the visible Re-rate button availability.
+- Spec review fix: suppressed the top-bar create CTA and deck study dashboard during the completed-review recovery card so the recovery state exposes a single action surface.
+- Removed out-of-scope dependency artifact edits from interrupted worker attempts before committing.
+- Bandit N/A: frontend-only TypeScript/React changes, no Python touched.
+
+Verification:
+- RED/PATCH: Focused Vitest initially failed the active-card snapshot after replacing the always-visible assistant panel with the explicit Need help toggle; updated the snapshot for the intended UI change.
+- SPEC-FIX PASS: `cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx src/components/Flashcards/components/__tests__/ReviewProgress.test.tsx src/components/Flashcards/components/__tests__/KeyboardShortcutsModal.rating-scale.test.tsx` (4 files passed, 36 tests passed).
+- INITIAL PASS: `cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ReviewTab.create-cta.test.tsx src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx src/components/Flashcards/components/__tests__/ReviewProgress.test.tsx src/components/Flashcards/components/__tests__/KeyboardShortcutsModal.rating-scale.test.tsx` (4 files passed, 36 tests passed).
+- PASS: `git diff --check`.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the PR 3 review-comprehension slice. Review mode now stays recall-first by hiding the study assistant behind an explicit help toggle that resets on card changes. Completion recovery actions are pinned by tests, progress copy now separates queue buckets, and shortcut guidance now matches the visible Re-rate control availability. Focused review, assistant, progress, and shortcut tests pass.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Makes review recall-first by placing assistant help behind an explicit toggle that resets on card changes.
- Clarifies review progress buckets, rating/shortcut copy, and completion recovery actions.
- Backlog: TASK-2404.

## Test Plan
- git diff --check
- Focused Vitest passed: ReviewTab create CTA, ReviewTab assistant, ReviewProgress, KeyboardShortcutsModal rating-scale: 4 files, 36 tests
- Spec-review fix included and reverified with the same focused suite

## Merge Note
- Project policy requires a human-authored Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make flashcard review recall-first by hiding the study assistant behind an explicit, per-card toggle. Clarifies progress and narrows completion recovery to only show when truly caught up (TASK-2404).

- **New Features**
  - Add "Need help?" / "Hide help" toggle for the study assistant; closed by default and resets per card.
  - Label "Study queue" and show counts for available, new, learning, and due.
  - Completion: show recovery actions (Practice again, Create card, Manage deck/cards, Open scheduler) and hide the top-bar create CTA/dashboard; only when truly completed (due caught up, or cram exhausted without a tag filter). Empty cram tag filters keep deck navigation and Create CTA.
  - Update Ctrl/Cmd+Z shortcut text to say "when the Re-rate button is available".

<sup>Written for commit eddde0e7d83c730a19187a6565df889fbde5d87c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

