### PR TITLE
Harden Integrations weather provider

### DIFF
--- a/backlog/tasks/task-9999 - Harden-Integrations-weather-provider-review-findings.md
+++ b/backlog/tasks/task-9999 - Harden-Integrations-weather-provider-review-findings.md
@@ -1,0 +1,77 @@
+---
+id: TASK-9999
+title: Harden Integrations weather provider review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 18:55'
+updated_date: '2026-06-24 03:43'
+labels:
+  - integrations
+  - weather
+  - review-fix
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address validated review findings in tldw_Server_API/app/core/Integrations: avoid blocking async chat command execution, sanitize provider exception metadata, validate weather inputs before outbound requests, and refresh stale package documentation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Weather provider execution no longer blocks the async chat command event loop.
+- [x] #2 Provider failures returned to callers expose stable sanitized metadata without API keys or raw exception details.
+- [x] #3 Weather location and coordinate inputs are bounded and validated before outbound provider requests.
+- [x] #4 Integrations package docstring matches current responsibility.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused failing tests for non-blocking command dispatch, sanitized error metadata, and input validation.
+2. Patch weather provider validation/error handling and command router execution boundary.
+3. Refresh package docstring and remove local pycache artifacts.
+4. Run targeted pytest and Bandit; record results in TASK-9999.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added focused regression coverage for sanitized OpenWeather exception metadata, oversized location rejection, out-of-range coordinate rejection, and non-blocking weather command dispatch. The standard pytest invocation for the same files hung in parent conftest/app setup and cleanup; rerunning with `--confcutdir=tldw_Server_API/tests/Chat_NEW/unit` executed the unit tests directly and passed.
+
+Verification:
+- Red run before implementation: same focused files reported 4 failures for the new regressions.
+- `source .venv/bin/activate && python -m pytest --confcutdir=tldw_Server_API/tests/Chat_NEW/unit tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py -q` -> 30 passed.
+- Direct provider and command-router checks passed for sanitized metadata, input validation, and event-loop non-blocking behavior.
+- `source .venv/bin/activate && python -m py_compile ...` on touched Python files passed.
+- `git diff --check -- ...` on touched files passed.
+- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Integrations tldw_Server_API/app/core/Chat/command_router.py -f json -o /tmp/bandit_integrations_weather_hardening.json` -> 0 results.
+
+Rebase update:
+- Rebased PR #2468 onto `origin/dev` at `89e59499cd4250e4c6d05c29615ca19031596d57`.
+- PR comments checked: Gemini quota notice and CodeRabbit draft-skip notice only; no inline review comments or submitted review findings.
+- Post-rebase verification: focused pytest -> 32 passed; py_compile on touched Python files passed; `git diff --check origin/dev...HEAD` passed; Bandit on touched scope -> 0 results.
+
+Qodo review update:
+- Rebased PR #2468 onto `origin/dev` at `46595e31c0b1bd45e6a06422906eef5e405babc4`.
+- Addressed Qodo comments for the async weather test marker, timing-based assertion, missing SlowClient annotations, missing OpenWeather helper docstrings, and awaitable handler detection.
+- Post-review verification: focused pytest -> 33 passed; py_compile on touched Python and test files passed; `git diff --check` passed; Bandit on touched runtime scope -> 0 results.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened the Integrations weather provider by validating location and coordinate inputs before outbound requests, returning sanitized stable exception metadata, and refreshing the package docstring. Updated the `/weather` command handler to offload the synchronous provider call from the async event loop. Removed local Integrations `__pycache__` files and added regression tests for the accepted review findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Chat/command_router.py
+++ b/tldw_Server_API/app/core/Chat/command_router.py
@@ -25,12 +25,13 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
 import os
 import re
 import threading
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Awaitable, Callable, Optional
 
 from loguru import logger
 
@@ -286,7 +287,7 @@ class CommandResult:
     metadata: dict[str, Any]
 
 
-Handler = Callable[[CommandContext, Optional[str]], CommandResult]
+Handler = Callable[[CommandContext, Optional[str]], CommandResult | Awaitable[CommandResult]]
 
 
 @dataclass
@@ -518,7 +519,7 @@ async def async_dispatch_command(ctx: CommandContext, command: str, args: str | 
 
     try:
         res = spec.handler(ctx, args)
-        if asyncio.iscoroutine(res):  # future-proof if handlers become async
+        if inspect.isawaitable(res):  # future-proof if handlers become async
             res = await res  # type: ignore[assignment]
         if not isinstance(res, CommandResult):
             raise TypeError(f"Command handler for /{cmd} returned {type(res)}")
@@ -587,7 +588,7 @@ def _time_handler(ctx: CommandContext, args: str | None) -> CommandResult:
         return CommandResult(ok=False, command="time", content=f"Time lookup failed: {e}", metadata={"error": "time_error"})
 
 
-def _weather_handler(ctx: CommandContext, args: str | None) -> CommandResult:
+async def _weather_handler(ctx: CommandContext, args: str | None) -> CommandResult:
     location = (args or "").strip()
     if not location:
         location = _cfg_str("DEFAULT_LOCATION", "default_location", "").strip()
@@ -598,7 +599,7 @@ def _weather_handler(ctx: CommandContext, args: str | None) -> CommandResult:
         # Backward-compatible: some tests patch a zero-arg seam
         client = get_weather_client()
     try:
-        result = client.get_current(location=location or None)
+        result = await asyncio.to_thread(client.get_current, location=location or None)
         metadata = dict(getattr(result, "metadata", {}) or {})
         if result.ok:
             return CommandResult(ok=True, command="weather", content=result.summary, metadata=metadata)

--- a/tldw_Server_API/app/core/Integrations/__init__.py
+++ b/tldw_Server_API/app/core/Integrations/__init__.py
@@ -1,1 +1,1 @@
-"""Integrations package (stub for Stage 4)."""
+"""Core integration helpers for weather-backed chat commands."""

--- a/tldw_Server_API/app/core/Integrations/weather_providers.py
+++ b/tldw_Server_API/app/core/Integrations/weather_providers.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from math import isfinite
 from typing import Any
 
 import httpx
@@ -27,6 +28,12 @@ _WEATHER_NONCRITICAL_EXCEPTIONS = (
 
 # Test seam for controlled outbound behavior without patching httpx directly.
 http_client_factory = httpx.Client
+
+_MAX_LOCATION_CHARS = 120
+_MIN_LATITUDE = -90.0
+_MAX_LATITUDE = 90.0
+_MIN_LONGITUDE = -180.0
+_MAX_LONGITUDE = 180.0
 
 
 @dataclass
@@ -99,6 +106,64 @@ class OpenWeatherClient(WeatherClient):
             params["q"] = location
         return params
 
+    def _invalid_location_result(self) -> WeatherResult:
+        """Build the stable response for invalid location input."""
+        return WeatherResult(
+            ok=False,
+            summary="Weather information is unavailable for the requested location.",
+            metadata={
+                "provider": "openweather",
+                "error": "invalid_location",
+                "max_location_chars": _MAX_LOCATION_CHARS,
+            },
+        )
+
+    def _invalid_coordinates_result(self) -> WeatherResult:
+        """Build the stable response for invalid coordinate input."""
+        return WeatherResult(
+            ok=False,
+            summary="Weather information is unavailable for the requested coordinates.",
+            metadata={"provider": "openweather", "error": "invalid_coordinates"},
+        )
+
+    def _validate_inputs(
+        self,
+        *,
+        location: str | None,
+        lat: float | None,
+        lon: float | None,
+    ) -> tuple[str | None, float | None, float | None, WeatherResult | None]:
+        """Normalize and validate location and coordinate inputs before HTTP use."""
+        normalized_location: str | None = None
+        if location is not None:
+            if not isinstance(location, str):
+                return None, None, None, self._invalid_location_result()
+            normalized_location = location.strip() or None
+            if normalized_location and len(normalized_location) > _MAX_LOCATION_CHARS:
+                return None, None, None, self._invalid_location_result()
+
+        normalized_lat: float | None = None
+        normalized_lon: float | None = None
+        if lat is not None or lon is not None:
+            if lat is None or lon is None:
+                if normalized_location:
+                    return normalized_location, None, None, None
+                return None, None, None, self._invalid_coordinates_result()
+            try:
+                normalized_lat = float(lat)
+                normalized_lon = float(lon)
+            except (TypeError, ValueError):
+                return None, None, None, self._invalid_coordinates_result()
+            if (
+                not isfinite(normalized_lat)
+                or not isfinite(normalized_lon)
+                or not (_MIN_LATITUDE <= normalized_lat <= _MAX_LATITUDE)
+                or not (_MIN_LONGITUDE <= normalized_lon <= _MAX_LONGITUDE)
+            ):
+                return None, None, None, self._invalid_coordinates_result()
+
+        return normalized_location, normalized_lat, normalized_lon, None
+
     def _parse_summary(self, data: dict[str, Any], location_hint: str | None) -> tuple[str, dict[str, Any]]:
         weather_desc = ""
         weather = data.get("weather")
@@ -139,6 +204,10 @@ class OpenWeatherClient(WeatherClient):
         lat: float | None = None,
         lon: float | None = None,
     ) -> WeatherResult:
+        location, lat, lon, validation_error = self._validate_inputs(location=location, lat=lat, lon=lon)
+        if validation_error is not None:
+            return validation_error
+
         params = self._build_params(location=location, lat=lat, lon=lon)
         if "q" not in params and ("lat" not in params or "lon" not in params):
             return WeatherResult(
@@ -169,7 +238,11 @@ class OpenWeatherClient(WeatherClient):
             return WeatherResult(
                 ok=False,
                 summary=f"Weather information is unavailable for {location or 'your area'}.",
-                metadata={"provider": "openweather", "error": "exception", "details": str(exc)},
+                metadata={
+                    "provider": "openweather",
+                    "error": "exception",
+                    "exception_type": type(exc).__name__,
+                },
             )
 
 

--- a/tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py
+++ b/tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py
@@ -1,9 +1,11 @@
 from typing import Optional
 
 import asyncio
+import threading
 import pytest
 
 from tldw_Server_API.app.core.Chat import command_router
+from tldw_Server_API.app.core.Integrations import weather_providers
 
 
 @pytest.fixture(autouse=True)
@@ -72,6 +74,86 @@ async def test_weather_stub(monkeypatch):
     res = await command_router.async_dispatch_command(ctx, "weather", "Boston")
     assert res.ok
     assert "Sunny" in res.content
+
+
+@pytest.mark.unit
+def test_weather_provider_does_not_block_event_loop(monkeypatch):
+    monkeypatch.setenv("CHAT_COMMANDS_ENABLED", "1")
+    monkeypatch.setenv("CHAT_COMMANDS_RATE_LIMIT_USER", "100")
+    monkeypatch.setenv("CHAT_COMMANDS_RATE_LIMIT_GLOBAL", "100")
+
+    provider_thread_ids: list[int] = []
+
+    class SlowClient:
+        def get_current(
+            self,
+            location: Optional[str] = None,
+            lat: float | None = None,
+            lon: float | None = None,
+        ) -> weather_providers.WeatherResult:
+            provider_thread_ids.append(threading.get_ident())
+            return weather_providers.WeatherResult(
+                ok=True,
+                summary=f"Sunny at {location or 'somewhere'}",
+                metadata={"provider": "test", "lat": lat, "lon": lon},
+            )
+
+    monkeypatch.setattr(command_router, "get_weather_client", lambda ctx=None: SlowClient())
+    command_router._acquire_global_bucket("weather")
+    command_router._acquire_bucket("weather-nonblocking-user", "weather")
+
+    async def exercise() -> None:
+        event_loop_thread_id = threading.get_ident()
+        res = await command_router.async_dispatch_command(
+            command_router.CommandContext(user_id="weather-nonblocking-user"),
+            "weather",
+            "Boston",
+        )
+
+        assert provider_thread_ids
+        assert provider_thread_ids[0] != event_loop_thread_id
+        assert res.ok
+        assert "Sunny" in res.content
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.unit
+def test_async_dispatch_awaits_task_returning_handler(monkeypatch):
+    monkeypatch.setenv("CHAT_COMMANDS_ENABLED", "1")
+    monkeypatch.setenv("CHAT_COMMANDS_RATE_LIMIT_USER", "100")
+    monkeypatch.setenv("CHAT_COMMANDS_RATE_LIMIT_GLOBAL", "100")
+
+    async def build_result() -> command_router.CommandResult:
+        await asyncio.sleep(0)
+        return command_router.CommandResult(
+            ok=True,
+            command="taskresult",
+            content="task result",
+            metadata={},
+        )
+
+    def task_handler(
+        ctx: command_router.CommandContext,
+        args: Optional[str],
+    ) -> asyncio.Task[command_router.CommandResult]:
+        return asyncio.create_task(build_result())
+
+    async def exercise() -> command_router.CommandResult:
+        return await command_router.async_dispatch_command(
+            command_router.CommandContext(user_id="task-awaitable-user"),
+            "taskresult",
+            None,
+        )
+
+    command_router.register_command("taskresult", "task result", task_handler)
+    try:
+        res = asyncio.run(exercise())
+    finally:
+        command_router._registry.pop("taskresult", None)
+
+    assert res.ok
+    assert res.content == "task result"
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py
+++ b/tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py
@@ -88,6 +88,65 @@ def test_openweather_exception_path(monkeypatch):
 
 
 @pytest.mark.unit
+def test_openweather_exception_metadata_does_not_expose_raw_details(monkeypatch):
+    client = weather_providers.OpenWeatherClient(api_key="secret-key")
+
+    class RaisingClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        @staticmethod
+        def get(*args, **kwargs):
+            raise httpx.RequestError("failed with appid=secret-key")
+
+    monkeypatch.setattr(weather_providers, "http_client_factory", RaisingClient)
+
+    result = client.get_current(location="Boston")
+    combined = f"{result.summary} {result.metadata}"
+    assert not result.ok
+    assert result.metadata.get("error") == "exception"
+    assert result.metadata.get("exception_type") == "RequestError"
+    assert "details" not in result.metadata
+    assert "secret-key" not in combined
+
+
+@pytest.mark.unit
+def test_openweather_rejects_oversized_location_before_network(monkeypatch):
+    client = weather_providers.OpenWeatherClient(api_key="k")
+
+    class FailingClient:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("network should not be used for invalid input")
+
+    monkeypatch.setattr(weather_providers, "http_client_factory", FailingClient)
+
+    result = client.get_current(location="x" * 300)
+    assert not result.ok
+    assert result.metadata.get("error") == "invalid_location"
+
+
+@pytest.mark.unit
+def test_openweather_rejects_out_of_range_coordinates_before_network(monkeypatch):
+    client = weather_providers.OpenWeatherClient(api_key="k")
+
+    class FailingClient:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("network should not be used for invalid input")
+
+    monkeypatch.setattr(weather_providers, "http_client_factory", FailingClient)
+
+    result = client.get_current(lat=95.0, lon=0.0)
+    assert not result.ok
+    assert result.metadata.get("error") == "invalid_coordinates"
+
+
+@pytest.mark.unit
 def test_openweather_success_response(monkeypatch):
     client = weather_providers.OpenWeatherClient(api_key="k", units="metric")
 


### PR DESCRIPTION
## Change Summary

Human-authored change summary required before merge per project policy. This PR is intentionally draft until the requester adds that summary.

## What Changed

- Offload `/weather` provider calls from the async command-router event loop.
- Validate OpenWeather location and coordinate inputs before outbound requests.
- Return stable sanitized provider exception metadata without raw details or API keys.
- Refresh the Integrations package docstring and add focused regression coverage.
- Record the work in Backlog task `TASK-9999` due Backlog CLI/MCP conflicts in the dirty source workspace.

## Test Plan

- [x] `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest --confcutdir=tldw_Server_API/tests/Chat_NEW/unit tldw_Server_API/tests/Chat_NEW/unit/test_weather_providers.py tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py -q` — 32 passed.
- [x] `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m py_compile` on touched Python files.
- [x] `git diff --check` on touched files.
- [x] `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Integrations tldw_Server_API/app/core/Chat/command_router.py -f json -o /tmp/bandit_integrations_weather_hardening_worktree_post_rebase.json` — 0 findings.

## Notes

Standard pytest without `--confcutdir` previously hung in parent Chat_NEW conftest/app setup in the dirty source workspace; the isolated unit-scope run above passed in the clean worktree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the `/weather` integration to keep the async command router responsive and prevent leaking provider details. Validates inputs before network calls, sanitizes error metadata, and adds async/awaitable handler support with focused tests.

- **Bug Fixes**
  - Offload the provider call to a background thread via `asyncio.to_thread` to avoid blocking the event loop.
  - Validate location length and lat/lon presence/ranges before outbound requests; reject invalid inputs consistently.
  - Return stable, sanitized error metadata with `exception_type`; no raw details or API keys.

- **Refactors**
  - Allow command handlers to be async and await any awaitable (coroutine or `asyncio.Task`) via `inspect.isawaitable`; update the handler type and `_weather_handler`.
  - Refresh the `Integrations` package docstring.
  - Add unit tests for non-blocking dispatch, input validation, exception metadata, and awaitable handlers.

<sup>Written for commit bf780c934c46035cb7bd4fa4e71b593a12d947dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

