### PR TITLE
fix: clarify flashcards bulk recovery feedback

### DIFF
--- a/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
@@ -171,6 +171,30 @@ export const ManageTab: React.FC<ManageTabProps> = ({
     },
     [message]
   )
+  const formatCardCount = React.useCallback(
+    (count: number) => {
+      const noun =
+        count === 1
+          ? t("option:flashcards.cardLowercase", { defaultValue: "card" })
+          : t("option:flashcards.cardsLowercase", { defaultValue: "cards" })
+      return `${count} ${noun}`
+    },
+    [t]
+  )
+  const warnBulkPartialFailure = React.useCallback(
+    (verb: string, successCount: number, failedCount: number) => {
+      message.warning(
+        t("option:flashcards.bulkPartialFailure", {
+          defaultValue:
+            "{{verb}} {{successLabel}}; {{failed}} failed. Failed cards remain selected so you can retry.",
+          verb,
+          successLabel: formatCardCount(successCount),
+          failed: failedCount
+        })
+      )
+    },
+    [formatCardCount, message, t]
+  )
 
   // Track pending deletions for soft-delete with undo + trash view
   const [pendingDeletions, setPendingDeletions] = React.useState<Record<string, PendingDeletion>>({})
@@ -405,6 +429,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
   const [selectedIds, setSelectedIds] = React.useState<Set<string>>(new Set())
   const [previewOpen, setPreviewOpen] = React.useState<Set<string>>(new Set())
   const [selectAllAcross, setSelectAllAcross] = React.useState<boolean>(false)
+  const [selectedIdsMaySpanPages, setSelectedIdsMaySpanPages] = React.useState(false)
 
   const updatePendingDeletions = React.useCallback(
     (updater: (prev: Record<string, PendingDeletion>) => Record<string, PendingDeletion>) => {
@@ -527,15 +552,24 @@ export const ManageTab: React.FC<ManageTabProps> = ({
   }, [mQueryInput, mQuery])
 
   React.useEffect(() => {
-    if (!selectAllAcross) {
+    if (!selectAllAcross && !selectedIdsMaySpanPages) {
       setSelectedIds(new Set())
     }
-  }, [page, pageSize, selectAllAcross])
+  }, [page, pageSize, selectAllAcross, selectedIdsMaySpanPages])
 
   React.useEffect(() => {
     setSelectedIds(new Set())
     setSelectAllAcross(false)
-  }, [mDeckId, normalizedManageQuery, mTags, mDue, mSort])
+    setSelectedIdsMaySpanPages(false)
+  }, [
+    mDeckId,
+    normalizedManageQuery,
+    mTags,
+    mDue,
+    mSort,
+    selectedWorkspaceId,
+    showWorkspaceDecks
+  ])
 
   React.useEffect(() => {
     return () => {
@@ -548,28 +582,34 @@ export const ManageTab: React.FC<ManageTabProps> = ({
 
   const toggleSelect = (uuid: string, checked: boolean) => {
     if (selectAllAcross) return
-    setSelectedIds((prev) => {
-      const next = new Set(prev)
-      if (checked) next.add(uuid)
-      else next.delete(uuid)
-      return next
-    })
+    const next = new Set(selectedIds)
+    if (checked) next.add(uuid)
+    else next.delete(uuid)
+    const selectedVisibleCount = visibleItems.reduce(
+      (count, item) => count + (next.has(item.uuid) ? 1 : 0),
+      0
+    )
+    setSelectedIdsMaySpanPages(next.size > selectedVisibleCount)
+    setSelectedIds(next)
   }
 
   const selectAllOnPage = () => {
     const ids = visibleItems.map((i) => i.uuid)
     setSelectAllAcross(false)
-    setSelectedIds(new Set([...(selectedIds || new Set()), ...ids]))
+    setSelectedIdsMaySpanPages(false)
+    setSelectedIds(new Set(ids))
   }
 
   const clearSelection = React.useCallback(() => {
     setSelectedIds(new Set())
     setSelectAllAcross(false)
+    setSelectedIdsMaySpanPages(false)
   }, [])
 
   const selectAllAcrossResults = () => {
     if (selectAllAcrossDisabled) return
     setSelectAllAcross(true)
+    setSelectedIdsMaySpanPages(false)
     setSelectedIds(new Set())
   }
 
@@ -606,6 +646,24 @@ export const ManageTab: React.FC<ManageTabProps> = ({
   const allOnPageSelected = pageCount > 0 && selectedOnPageCount === pageCount
   const someOnPageSelected = selectedOnPageCount > 0 && selectedOnPageCount < pageCount
   const selectAllAcrossDisabled = isDocumentMode && documentQuery.isTruncated
+  const selectionScopeLabel = selectedIdsMaySpanPages
+    ? t("option:flashcards.selectedFailedForRetry", {
+        defaultValue: "failed cards selected for retry"
+      })
+    : selectAllAcross
+      ? t("option:flashcards.selectedAcrossAll", {
+          defaultValue: "selected across all results"
+        })
+      : t("option:flashcards.selectedOnPage", {
+          defaultValue: "selected on this page"
+        })
+  const selectionBadgeTitle = selectedIdsMaySpanPages
+    ? t("option:flashcards.failedCardsForRetry", {
+        defaultValue: "Failed cards selected for retry"
+      })
+    : selectAllAcross
+      ? t("option:flashcards.allResults", { defaultValue: "All results" })
+      : t("option:flashcards.thisPage", { defaultValue: "This page" })
   const isNoCardFirstRun =
     viewMode === "cards" &&
     !isDocumentMode &&
@@ -733,7 +791,21 @@ export const ManageTab: React.FC<ManageTabProps> = ({
 
   async function getSelectedItems(): Promise<Flashcard[]> {
     if (!selectAllAcross) {
-      return visibleItems.filter((i) => selectedIds.has(i.uuid))
+      const selectedVisibleItems = visibleItems.filter((i) => selectedIds.has(i.uuid))
+      if (!selectedIdsMaySpanPages || selectedVisibleItems.length === selectedIds.size) {
+        return selectedVisibleItems
+      }
+      const selectedItemsByUuid = new Map(
+        selectedVisibleItems.map((item) => [item.uuid, item])
+      )
+      const missingIds = [...selectedIds].filter((uuid) => !selectedItemsByUuid.has(uuid))
+      await processInChunks(missingIds, BULK_MUTATION_CHUNK_SIZE, async (chunk) => {
+        const results = await Promise.all(chunk.map((uuid) => getFlashcard(uuid)))
+        results.forEach((item) => {
+          selectedItemsByUuid.set(item.uuid, item)
+        })
+      })
+      return [...selectedItemsByUuid.values()]
     }
     const all = await fetchAllItemsAcrossFilters()
     return all
@@ -837,6 +909,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
       }
 
       let changedCount = 0
+      const failedIds = new Set<string>()
       await processInChunks(
         selectedItems,
         BULK_MUTATION_CHUNK_SIZE,
@@ -867,17 +940,37 @@ export const ManageTab: React.FC<ManageTabProps> = ({
               changedCount += 1
             })
           )
-          const failures = results.filter((result) => result.status === "rejected")
-          if (failures.length > 0) {
-            console.warn(`${failures.length} bulk tag updates failed in chunk`)
+          let chunkFailures = 0
+          results.forEach((result, index) => {
+            if (result.status === "rejected") {
+              failedIds.add(chunk[index].uuid)
+              chunkFailures += 1
+            }
+          })
+          if (chunkFailures > 0) {
+            console.warn(`${chunkFailures} bulk tag updates failed in chunk`)
           }
         }
       )
 
-      clearSelection()
       setBulkTagOpen(false)
       setBulkTagInput("")
       await qc.invalidateQueries({ queryKey: ["flashcards:list"] })
+
+      const failedCount = failedIds.size
+      if (failedCount > 0) {
+        setSelectAllAcross(false)
+        setSelectedIdsMaySpanPages(true)
+        setSelectedIds(new Set(failedIds))
+        warnBulkPartialFailure(
+          t("option:flashcards.bulkPartialUpdated", { defaultValue: "Updated" }),
+          changedCount,
+          failedCount
+        )
+        return
+      }
+
+      clearSelection()
 
       if (changedCount === 0) {
         message.info(
@@ -1275,6 +1368,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
     try {
       const undoSnapshots: MoveUndoSnapshot[] = []
       let movedCount = 0
+      let failedCount = 0
       if (moveCard) {
         const full = await getFlashcard(moveCard.uuid)
         const previousDeckId = full.deck_id ?? null
@@ -1291,6 +1385,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
           movedCount += 1
         }
       } else {
+        const failedIds = new Set<string>()
         if (moveDeckId == null) {
           message.error(
             t("option:flashcards.bulkMoveSelectDeck", {
@@ -1323,20 +1418,41 @@ export const ManageTab: React.FC<ManageTabProps> = ({
                   movedCount += 1
                 })
               )
-              const failures = results.filter((r) => r.status === "rejected")
-              if (failures.length > 0) {
-                console.warn(`${failures.length} move updates failed in chunk`)
+              let chunkFailures = 0
+              results.forEach((result, index) => {
+                if (result.status === "rejected") {
+                  failedIds.add(chunk[index].uuid)
+                  chunkFailures += 1
+                }
+              })
+              if (chunkFailures > 0) {
+                console.warn(`${chunkFailures} move updates failed in chunk`)
               }
             }
           )
         }
-        clearSelection()
+        if (failedIds.size > 0) {
+          setSelectAllAcross(false)
+          setSelectedIdsMaySpanPages(true)
+          setSelectedIds(new Set(failedIds))
+        } else {
+          clearSelection()
+        }
+        failedCount = failedIds.size
       }
       setMoveOpen(false)
       setMoveCard(null)
       setMoveDeckId(null)
       await qc.invalidateQueries({ queryKey: ["flashcards:list"] })
       if (movedCount === 0) {
+        if (failedCount > 0) {
+          warnBulkPartialFailure(
+            t("option:flashcards.bulkPartialMoved", { defaultValue: "Moved" }),
+            0,
+            failedCount
+          )
+          return
+        }
         message.info(
           t("option:flashcards.bulkMoveNoChanges", {
             defaultValue: "No cards needed moving."
@@ -1385,7 +1501,15 @@ export const ManageTab: React.FC<ManageTabProps> = ({
           await qc.invalidateQueries({ queryKey: ["flashcards:list"] })
         }
       })
-      message.success(t("common:updated", { defaultValue: "Updated" }))
+      if (failedCount > 0) {
+        warnBulkPartialFailure(
+          t("option:flashcards.bulkPartialMoved", { defaultValue: "Moved" }),
+          movedCount,
+          failedCount
+        )
+      } else {
+        message.success(t("common:updated", { defaultValue: "Updated" }))
+      }
     } catch (e: unknown) {
       reportUiError(
         e,
@@ -2028,16 +2152,10 @@ export const ManageTab: React.FC<ManageTabProps> = ({
                   showZero={false}
                   className="mr-1"
                   style={{ backgroundColor: selectAllAcross ? "rgb(var(--color-primary))" : "rgb(var(--color-success))" }}
-                  title={selectAllAcross ? t("option:flashcards.allResults", { defaultValue: "All results" }) : t("option:flashcards.thisPage", { defaultValue: "This page" })}
+                  title={selectionBadgeTitle}
                 />
                 <span className="text-text-muted flex items-center gap-1">
-                  {selectAllAcross
-                    ? t("option:flashcards.selectedAcrossAll", {
-                        defaultValue: "selected across all results"
-                      })
-                    : t("option:flashcards.selectedOnPage", {
-                        defaultValue: "selected on this page"
-                      })}
+                  {selectionScopeLabel}
                 </span>
                 {!selectAllAcross && selectedCount > 0 && totalCount > selectedCount && (
                   <button
@@ -2503,9 +2621,15 @@ export const ManageTab: React.FC<ManageTabProps> = ({
             style={{ backgroundColor: selectAllAcross ? "rgb(var(--color-primary))" : "rgb(var(--color-success))" }}
           />
           <span className="text-sm text-text-muted">
-            {selectAllAcross
-              ? t("option:flashcards.selectedAcrossAll", { defaultValue: "selected across all results" })
-              : t("option:flashcards.selected", { defaultValue: "selected" })}
+            {selectedIdsMaySpanPages
+              ? t("option:flashcards.selectedFailedForRetry", {
+                  defaultValue: "failed cards selected for retry"
+                })
+              : selectAllAcross
+                ? t("option:flashcards.selectedAcrossAll", {
+                    defaultValue: "selected across all results"
+                  })
+                : t("option:flashcards.selected", { defaultValue: "selected" })}
           </span>
           <div className="h-4 w-px bg-border" />
           <Space>
@@ -2534,6 +2658,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
 
       <Modal
         open={bulkTagOpen}
+        destroyOnHidden
         title={
           bulkTagMode === "add"
             ? t("option:flashcards.bulkAddTagTitle", {

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.undo-stage3.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.undo-stage3.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ManageTab } from "../ManageTab"
 import { clearSetting } from "@/services/settings/registry"
@@ -455,7 +455,8 @@ describe("ManageTab stage3 undo controls", () => {
     )
 
     fireEvent.click(screen.getByTestId(`flashcard-item-${sampleCard.uuid}-select`))
-    fireEvent.click(screen.getByRole("button", { name: "Add tag" }))
+    const bulkActionBar = document.querySelector(".fixed.bottom-4") as HTMLElement
+    fireEvent.click(within(bulkActionBar).getByRole("button", { name: "Add tag" }))
     fireEvent.change(screen.getByTestId("flashcards-bulk-tag-input"), {
       target: { value: "chemistry chapter-1" }
     })
@@ -470,6 +471,288 @@ describe("ManageTab stage3 undo controls", () => {
       tags: ["biology", "chemistry", "chapter-1"],
       expected_version: 11
     })
+  }, 15000)
+
+  it("keeps failed cards selected and warns when bulk tag updates partially fail", async () => {
+    const cards = buildSampleCards(2)
+    vi.mocked(useManageQuery).mockReturnValue({
+      data: {
+        items: cards,
+        count: cards.length,
+        total: cards.length
+      },
+      isFetching: false
+    } as any)
+    vi.mocked(getFlashcard)
+      .mockResolvedValueOnce({
+        ...cards[0],
+        version: 11,
+        tags: ["biology"]
+      })
+      .mockResolvedValueOnce({
+        ...cards[1],
+        version: 12,
+        tags: ["biology"]
+      })
+    vi.mocked(updateFlashcard)
+      .mockResolvedValueOnce(undefined as any)
+      .mockRejectedValueOnce(new Error("save failed"))
+
+    render(
+      <ManageTab
+        onNavigateToImport={() => {}}
+        onReviewCard={() => {}}
+        isActive={false}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId("flashcard-item-card-undo-1-select"))
+    fireEvent.click(screen.getByTestId("flashcard-item-card-undo-2-select"))
+    const retryBulkActionBar = document.querySelector(".fixed.bottom-4") as HTMLElement
+    fireEvent.click(within(retryBulkActionBar).getByRole("button", { name: "Add tag" }))
+    fireEvent.change(screen.getByTestId("flashcards-bulk-tag-input"), {
+      target: { value: "chemistry" }
+    })
+    const addTagButtons = screen.getAllByRole("button", { name: "Add tag" })
+    fireEvent.click(addTagButtons[addTagButtons.length - 1])
+
+    await waitFor(() => {
+      expect(messageSpies.warning).toHaveBeenCalledWith(
+        "Updated 1 card; 1 failed. Failed cards remain selected so you can retry."
+      )
+    })
+    expect(messageSpies.success).not.toHaveBeenCalled()
+    expect(screen.getByTestId("flashcard-item-card-undo-1-select")).not.toBeChecked()
+    expect(screen.getByTestId("flashcard-item-card-undo-2-select")).toBeChecked()
+  }, 15000)
+
+  it("retries failed off-page cards after select-all-across bulk tag partial failure", async () => {
+    const cards = buildSampleCards(2)
+    vi.mocked(useManageQuery).mockReturnValue({
+      data: {
+        items: [cards[0]],
+        count: 1,
+        total: cards.length
+      },
+      isFetching: false
+    } as any)
+    vi.mocked(listFlashcards).mockResolvedValue({
+      items: cards,
+      total: cards.length,
+      page: 1,
+      page_size: cards.length
+    } as any)
+    vi.mocked(getFlashcard).mockImplementation(async (uuid) => {
+      const card = cards.find((item) => item.uuid === uuid)
+      if (!card) throw new Error("card not found")
+      return {
+        ...card,
+        version: card.uuid === cards[0].uuid ? 11 : 12,
+        tags: ["biology"]
+      }
+    })
+    let offPageAttempts = 0
+    vi.mocked(updateFlashcard).mockImplementation(async (uuid) => {
+      if (uuid === cards[1].uuid) {
+        offPageAttempts += 1
+        if (offPageAttempts === 1) {
+          throw new Error("save failed")
+        }
+      }
+      return undefined as any
+    })
+
+    render(
+      <ManageTab
+        onNavigateToImport={() => {}}
+        onReviewCard={() => {}}
+        isActive={false}
+      />
+    )
+
+    fireEvent.click(screen.getByLabelText("Select all cards on this page"))
+    fireEvent.click(screen.getByTestId("flashcards-select-all-across"))
+    fireEvent.click(screen.getByRole("button", { name: "Add tag" }))
+    let bulkTagInputs = screen.getAllByTestId("flashcards-bulk-tag-input")
+    let activeBulkTagInput = bulkTagInputs[bulkTagInputs.length - 1]
+    fireEvent.change(activeBulkTagInput, {
+      target: { value: "chemistry" }
+    })
+    const retryAddTagButtons = screen.getAllByRole("button", { name: "Add tag" })
+    fireEvent.click(retryAddTagButtons[retryAddTagButtons.length - 1])
+
+    await waitFor(() => {
+      expect(messageSpies.warning).toHaveBeenCalledWith(
+        "Updated 1 card; 1 failed. Failed cards remain selected so you can retry."
+      )
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("flashcard-item-card-undo-1-select")).not.toBeChecked()
+    })
+    await waitFor(() => {
+      expect(screen.getAllByText("failed cards selected for retry").length).toBeGreaterThan(0)
+    })
+
+    const retryBulkActionBar = document.querySelector(".fixed.bottom-4") as HTMLElement
+    fireEvent.click(within(retryBulkActionBar).getByRole("button", { name: "Add tag" }))
+    bulkTagInputs = screen.getAllByTestId("flashcards-bulk-tag-input")
+    activeBulkTagInput = bulkTagInputs[bulkTagInputs.length - 1]
+    fireEvent.change(activeBulkTagInput, {
+      target: { value: "chemistry" }
+    })
+    fireEvent.keyDown(activeBulkTagInput, { key: "Enter", code: "Enter" })
+
+    await waitFor(() => {
+      expect(updateFlashcard).toHaveBeenCalledTimes(3)
+    })
+    expect(vi.mocked(updateFlashcard).mock.calls[2][0]).toBe(cards[1].uuid)
+    expect(listFlashcards).toHaveBeenCalledTimes(1)
+    expect(messageSpies.info).not.toHaveBeenCalledWith("No cards selected.")
+  }, 15000)
+
+  it("keeps off-page retry selections when a visible card is toggled", async () => {
+    const cards = buildSampleCards(2)
+    vi.mocked(useManageQuery).mockReturnValue({
+      data: {
+        items: [cards[0]],
+        count: 1,
+        total: cards.length
+      },
+      isFetching: false
+    } as any)
+    vi.mocked(listFlashcards).mockResolvedValue({
+      items: cards,
+      total: cards.length,
+      page: 1,
+      page_size: cards.length
+    } as any)
+    vi.mocked(getFlashcard).mockImplementation(async (uuid) => {
+      const card = cards.find((item) => item.uuid === uuid)
+      if (!card) throw new Error("card not found")
+      return {
+        ...card,
+        version: card.uuid === cards[0].uuid ? 11 : 12,
+        tags: ["biology"]
+      }
+    })
+    let offPageAttempts = 0
+    vi.mocked(updateFlashcard).mockImplementation(async (uuid) => {
+      if (uuid === cards[1].uuid) {
+        offPageAttempts += 1
+        if (offPageAttempts === 1) {
+          throw new Error("save failed")
+        }
+      }
+      return undefined as any
+    })
+
+    render(
+      <ManageTab
+        onNavigateToImport={() => {}}
+        onReviewCard={() => {}}
+        isActive={false}
+      />
+    )
+
+    fireEvent.click(screen.getByLabelText("Select all cards on this page"))
+    fireEvent.click(screen.getByTestId("flashcards-select-all-across"))
+    fireEvent.click(screen.getByRole("button", { name: "Add tag" }))
+    let bulkTagInputs = screen.getAllByTestId("flashcards-bulk-tag-input")
+    let activeBulkTagInput = bulkTagInputs[bulkTagInputs.length - 1]
+    fireEvent.change(activeBulkTagInput, {
+      target: { value: "chemistry" }
+    })
+    let addTagButtons = screen.getAllByRole("button", { name: "Add tag" })
+    fireEvent.click(addTagButtons[addTagButtons.length - 1])
+
+    await waitFor(() => {
+      expect(screen.getAllByText("failed cards selected for retry").length).toBeGreaterThan(0)
+    })
+
+    fireEvent.click(screen.getByTestId("flashcard-item-card-undo-1-select"))
+
+    const retryBulkActionBar = document.querySelector(".fixed.bottom-4") as HTMLElement
+    fireEvent.click(within(retryBulkActionBar).getByRole("button", { name: "Add tag" }))
+    bulkTagInputs = screen.getAllByTestId("flashcards-bulk-tag-input")
+    activeBulkTagInput = bulkTagInputs[bulkTagInputs.length - 1]
+    fireEvent.change(activeBulkTagInput, {
+      target: { value: "chemistry" }
+    })
+    addTagButtons = screen.getAllByRole("button", { name: "Add tag" })
+    fireEvent.click(addTagButtons[addTagButtons.length - 1])
+
+    await waitFor(() => {
+      expect(updateFlashcard).toHaveBeenCalledTimes(4)
+    })
+    expect(vi.mocked(updateFlashcard).mock.calls.slice(2).map(([uuid]) => uuid)).toEqual([
+      cards[0].uuid,
+      cards[1].uuid
+    ])
+    expect(listFlashcards).toHaveBeenCalledTimes(1)
+  }, 15000)
+
+  it("clears failed retry selection when workspace scope changes", async () => {
+    const cards = buildSampleCards(2)
+    vi.mocked(useManageQuery).mockReturnValue({
+      data: {
+        items: [cards[0]],
+        count: 1,
+        total: cards.length
+      },
+      isFetching: false
+    } as any)
+    vi.mocked(listFlashcards).mockResolvedValue({
+      items: cards,
+      total: cards.length,
+      page: 1,
+      page_size: cards.length
+    } as any)
+    vi.mocked(getFlashcard)
+      .mockResolvedValueOnce({
+        ...cards[0],
+        version: 11,
+        tags: ["biology"]
+      })
+      .mockResolvedValueOnce({
+        ...cards[1],
+        version: 12,
+        tags: ["biology"]
+      })
+    vi.mocked(updateFlashcard).mockImplementation(async (uuid) => {
+      if (uuid === cards[1].uuid) {
+        throw new Error("save failed")
+      }
+      return undefined as any
+    })
+
+    render(
+      <ManageTab
+        onNavigateToImport={() => {}}
+        onReviewCard={() => {}}
+        isActive={false}
+      />
+    )
+
+    fireEvent.click(screen.getByLabelText("Select all cards on this page"))
+    fireEvent.click(screen.getByTestId("flashcards-select-all-across"))
+    fireEvent.click(screen.getByRole("button", { name: "Add tag" }))
+    const bulkTagInput = screen.getByTestId("flashcards-bulk-tag-input")
+    fireEvent.change(bulkTagInput, {
+      target: { value: "chemistry" }
+    })
+    const addTagButtons = screen.getAllByRole("button", { name: "Add tag" })
+    fireEvent.click(addTagButtons[addTagButtons.length - 1])
+
+    await waitFor(() => {
+      expect(screen.getAllByText("failed cards selected for retry").length).toBeGreaterThan(0)
+    })
+
+    fireEvent.click(screen.getByTestId("flashcards-manage-show-workspace-decks"))
+
+    await waitFor(() => {
+      expect(screen.queryAllByText("failed cards selected for retry")).toHaveLength(0)
+    })
+    expect(document.querySelector(".fixed.bottom-4")).toBeNull()
   }, 15000)
 
   it("applies bulk remove tag to selected cards case-insensitively", async () => {
@@ -504,6 +787,59 @@ describe("ManageTab stage3 undo controls", () => {
       tags: ["biology"],
       expected_version: 14
     })
+  }, 15000)
+
+  it("keeps failed cards selected and warns when bulk move partially fails", async () => {
+    const cards = buildSampleCards(2)
+    vi.mocked(useManageQuery).mockReturnValue({
+      data: {
+        items: cards,
+        count: cards.length,
+        total: cards.length
+      },
+      isFetching: false
+    } as any)
+    vi.mocked(getFlashcard)
+      .mockResolvedValueOnce({
+        ...cards[0],
+        version: 21,
+        deck_id: 1
+      })
+      .mockResolvedValueOnce({
+        ...cards[1],
+        version: 22,
+        deck_id: 1
+      })
+    vi.mocked(updateFlashcard)
+      .mockResolvedValueOnce(undefined as any)
+      .mockRejectedValueOnce(new Error("move failed"))
+
+    render(
+      <ManageTab
+        onNavigateToImport={() => {}}
+        onReviewCard={() => {}}
+        isActive={false}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId("flashcard-item-card-undo-1-select"))
+    fireEvent.click(screen.getByTestId("flashcard-item-card-undo-2-select"))
+    fireEvent.click(screen.getByRole("button", { name: "Move" }))
+    const comboboxes = screen.getAllByRole("combobox")
+    fireEvent.mouseDown(comboboxes[comboboxes.length - 1])
+    fireEvent.click(screen.getByText("Deck 2"))
+    const moveButtons = screen.getAllByRole("button", { name: "Move" })
+    fireEvent.click(moveButtons[moveButtons.length - 1])
+
+    await waitFor(() => {
+      expect(messageSpies.warning).toHaveBeenCalledWith(
+        "Moved 1 card; 1 failed. Failed cards remain selected so you can retry."
+      )
+    })
+    expect(messageSpies.success).not.toHaveBeenCalled()
+    expect(showUndoNotificationMock).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId("flashcard-item-card-undo-1-select")).not.toBeChecked()
+    expect(screen.getByTestId("flashcard-item-card-undo-2-select")).toBeChecked()
   }, 15000)
 
   it("renders large bulk delete warning with the design-system Alert", async () => {

--- a/backlog/tasks/task-2405 - Implement-flashcards-UX-PR-4-errors-empty-states-and-feedback.md
+++ b/backlog/tasks/task-2405 - Implement-flashcards-UX-PR-4-errors-empty-states-and-feedback.md
@@ -1,0 +1,70 @@
+---
+id: TASK-2405
+title: Implement flashcards UX PR 4 errors empty states and feedback
+status: Done
+labels:
+- ux
+- flashcards
+- frontend
+ordinal: 2405
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Task 4 from the flashcards UX remediation plan: improve error messaging, empty-state hierarchy, and user feedback across flashcards flows before the final responsive/docs phases.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Flashcards operations surface clear success, partial failure, retry, and recovery guidance where applicable.
+- [x] #2 No-card and filtered-empty states emphasize the correct next action without exposing irrelevant expert chrome.
+- [x] #3 Visible feedback distinguishes loading, success, failure, and unavailable states for affected create/import/generate/review flows.
+- [x] #4 Focused tests cover the updated states and copy.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implementation notes:
+- Added partial-failure handling for Manage bulk tag updates. Successful cards are no longer presented as a clean success when other selected cards fail; failed cards remain selected and the warning tells the user they can retry.
+- Added matching partial-failure handling for Manage bulk move operations while preserving undo for successfully moved cards.
+- Code review fix: failed selections produced by select-all-across now remain retryable even when the failed card is off the visible page; the retry path fetches selected failed IDs from the full filtered result set.
+- Second code review fix: changing workspace scope now clears the failed-card retry selection so stale off-scope cards are not advertised as retryable.
+- Third code review fix: rebased PR #2469 on latest origin/dev, resolved the ManageTab selection reset conflict, preserved retry selections when users toggle visible cards, and changed off-page retry reconstruction to fetch only the missing selected UUIDs instead of refetching all filtered results.
+- Labeled the failed-selection recovery state as "failed cards selected for retry" in the selection summary and floating action bar.
+- Kept existing first-run and filtered-empty Manage states intact; origin/dev already had the no-card expert-chrome reduction and tests.
+- Removed temporary dependency changes after test execution. The worktree still needs the known local `antd` symlink retarget only while running focused Vitest.
+- Bandit N/A: frontend-only TypeScript/React changes, no Python touched.
+
+Verification:
+- RED: `cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ManageTab.undo-stage3.test.tsx` failed 2 tests because partial tag/move failures only logged console warnings and did not keep failed cards selected.
+- PASS: `cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ManageTab.undo-stage3.test.tsx` (1 file passed, 10 tests passed).
+- PASS: `cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ManageTab.undo-stage3.test.tsx src/components/Flashcards/tabs/__tests__/ManageTab.first-time.test.tsx src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx` (3 files passed, 24 tests passed).
+- REVIEW-FIX RED: `cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ManageTab.undo-stage3.test.tsx` failed the off-page select-all-across retry regression before the selection-scope fix.
+- REVIEW-FIX PASS: `cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ManageTab.undo-stage3.test.tsx` (1 file passed, 11 tests passed).
+- REVIEW-FIX PASS: `cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ManageTab.undo-stage3.test.tsx src/components/Flashcards/tabs/__tests__/ManageTab.first-time.test.tsx src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx` (3 files passed, 25 tests passed).
+- REVIEW-FIX RED: `cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ManageTab.undo-stage3.test.tsx` failed the workspace-scope reset regression before workspace visibility and selected-workspace changes were added to the selection reset dependencies.
+- REVIEW-FIX PASS: `cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ManageTab.undo-stage3.test.tsx` (1 file passed, 12 tests passed).
+- REVIEW-FIX PASS: `cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ManageTab.undo-stage3.test.tsx src/components/Flashcards/tabs/__tests__/ManageTab.first-time.test.tsx src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx` (3 files passed, 26 tests passed).
+- THIRD REVIEW-FIX PASS: `cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ManageTab.undo-stage3.test.tsx` (1 file passed, 13 tests passed).
+- THIRD REVIEW-FIX PASS: `cd apps/packages/ui && bunx vitest run src/components/Flashcards/tabs/__tests__/ManageTab.undo-stage3.test.tsx src/components/Flashcards/tabs/__tests__/ManageTab.first-time.test.tsx src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx` (3 files passed, 27 tests passed).
+- THIRD REVIEW-FIX PASS: `git diff --check`.
+- THIRD REVIEW-FIX Bandit N/A: frontend-only TypeScript/React and Backlog markdown changes, no Python touched.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Manage bulk tag and bulk move now report partial failures as warnings with retry guidance, leave failed cards selected for recovery, and avoid clean success messages when only part of the operation completed. Failed selections from select-all-across remain retryable across result pages, visible-card toggles no longer drop off-page retry IDs, retry fetches only the missing selected UUIDs, and workspace scope changes clear stale failed retry selections. Existing first-time and filtered-empty Manage behavior remains covered by focused tests.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Reports Manage bulk tag/move partial failures as warning states with retry guidance instead of clean success.
- Keeps failed cards selected for recovery, including select-all-across/off-page cases, and clears stale retry selections on workspace scope changes.
- Backlog: TASK-2405.

## Test Plan
- Focused Vitest passed: ManageTab undo-stage3, first-time, scheduling-metadata: 3 files, 26 tests
- Red/green regressions recorded for partial failures, off-page retry, and workspace-scope reset

## Merge Note
- Project policy requires a human-authored Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies bulk recovery feedback in the Flashcards Manage tab: partial failures now warn with counts, and failed cards stay selected for quick retry, including off-page cases. Satisfies TASK-2405’s requirement for clearer error and recovery feedback.

- **Bug Fixes**
  - Show warnings with counts for partial failures in bulk tag/move; no false “success”.
  - Keep failed cards selected for retry, with a “failed cards selected for retry” label.
  - Off-page retries fetch only missing selected cards, not the full result set.
  - Preserve off-page retry selections when toggling a visible card.
  - Clear stale retry selections on workspace scope/visibility changes; added focused tests.

<sup>Written for commit fb570dcca3305843394e70e9565a61279b7df60b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

