### PR TITLE
Harden RAG review findings

### DIFF
--- a/backlog/tasks/task-9930 - Harden-RAG-review-findings-2026-06-23.md
+++ b/backlog/tasks/task-9930 - Harden-RAG-review-findings-2026-06-23.md
@@ -1,0 +1,65 @@
+---
+id: TASK-9930
+title: Harden RAG review findings 2026-06-23
+status: Done
+assignee: []
+created_date: 2026-06-23 18:53
+updated_date: 2026-06-24 04:33
+labels:
+- rag
+- security
+- review
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and address the validated RAG module review findings under tldw_Server_API/app/core/RAG. Scope is current module code, not git diffs. Findings verified and fixed: PGVector metadata order_by SQL injection, raw PII audit metadata, hard-coded anonymous security filtering / role hierarchy, mutable RAG cache document payloads, and unescaped PGVector wildcard collection matching.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PGVector metadata order_by validates/binds metadata keys and rejects unsafe keys.
+- [x] #2 RAG security audit metadata never stores raw query text or raw PII match text.
+- [x] #3 Security filtering uses the resolved request user where available and role sensitivity access is cumulative.
+- [x] #4 RAG cache document payloads are cloned on store and retrieval so later mutations do not poison cached results.
+- [x] #5 PGVector multi-collection wildcard matching escapes literal metacharacters and supports intended wildcards only.
+- [x] #6 Focused regression tests and Bandit touched-scope verification are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Initial task file TASK-2420 was created before edits, but an unrelated task-2420 file is now present in the task directory. This task records the completed RAG review-fix work without modifying the unrelated task.
+
+Plan: IMPLEMENTATION_PLAN_rag_review_fixes.md. Red verification: new unified helper pytest initially failed to import missing helpers before production changes. Focused production verification after fixes: python -m pytest tldw_Server_API/tests/VectorStores/unit/test_pgvector_adapter_helpers.py tldw_Server_API/tests/RAG_NEW/unit/test_security_filters_sanitizers.py tldw_Server_API/tests/RAG_NEW/unit/test_unified_pipeline_security_cache_helpers.py -q passed with 14 passed, 38 warnings. Bandit: python -m bandit -r tldw_Server_API/app/core/RAG/rag_service/vector_stores/pgvector_adapter.py tldw_Server_API/app/core/RAG/rag_service/security_filters.py tldw_Server_API/app/core/RAG/rag_service/unified_pipeline.py -f json -o /tmp/bandit_rag_review_fixes.json exited 0 with results=0 errors=0. git diff --check passed.
+
+Moved to isolated worktree .worktrees/rag-review-fixes-9930 on branch codex/rag-review-fixes-9930 from local dev. Worktree verification: source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/VectorStores/unit/test_pgvector_adapter_helpers.py tldw_Server_API/tests/RAG_NEW/unit/test_security_filters_sanitizers.py tldw_Server_API/tests/RAG_NEW/unit/test_unified_pipeline_security_cache_helpers.py -q passed with 14 passed, 41 warnings. Worktree Bandit: python -m bandit -r touched RAG source files -f json -o /tmp/bandit_rag_review_fixes_worktree.json exited 0 with results=0 errors=0. Worktree git diff --check passed.
+
+PR branch rebuilt directly on origin/dev after dropping local-only dev history. Final PR-range verification should compare origin/dev..HEAD and contain only the RAG fix/task files.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Verified and fixed the validated RAG review findings, then rebased PR #2472 on latest dev and addressed the current Qodo review comments. PGVector metadata order_by validates and binds metadata keys through the centralized InvalidMetadataOrderKeyError, and multi_search now normalizes collection patterns into the sanitized collection-name space while preserving only the intended star wildcard. Security query audit metadata stores query hash/length, PII counts, masked query, and PII type/offset metadata without raw query or match text. Access roles are cumulative, and unified pipeline security filtering resolves the request user before falling back to feedback user or anonymous. Cache hit/store boundaries now use type-aware clones that isolate mutable document metadata without duplicating embedding buffers. Focused regression coverage and touched-scope verification were updated for the PR feedback fixes.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Reopened to rebase draft PR #2472 on latest dev and evaluate/address current PR checks and review comments.
+PR #2472 feedback pass: rebased on latest origin/dev, validated Qodo review comments, moved InvalidMetadataOrderKeyError to core/exceptions.py, normalized PGVector collection glob patterns in sanitized collection-name space, added test type hints/docstrings and parameterized role access coverage, and replaced cache document deepcopy with type-aware cloning that preserves embedding references while isolating mutable metadata. Verification: focused pytest passed with 19 passed, 50 warnings; compileall passed for touched source files; Bandit touched-source JSON results=0 errors=0; git diff --check passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/core/RAG/rag_service/security_filters.py
+++ b/tldw_Server_API/app/core/RAG/rag_service/security_filters.py
@@ -412,8 +412,17 @@ class AccessController:
         self.user_permissions = {}
         self.document_acls = {}
         self.role_permissions = {
-            "admin": [SensitivityLevel.RESTRICTED],
-            "manager": [SensitivityLevel.CONFIDENTIAL, SensitivityLevel.INTERNAL],
+            "admin": [
+                SensitivityLevel.PUBLIC,
+                SensitivityLevel.INTERNAL,
+                SensitivityLevel.CONFIDENTIAL,
+                SensitivityLevel.RESTRICTED,
+            ],
+            "manager": [
+                SensitivityLevel.PUBLIC,
+                SensitivityLevel.INTERNAL,
+                SensitivityLevel.CONFIDENTIAL,
+            ],
             "employee": [SensitivityLevel.INTERNAL, SensitivityLevel.PUBLIC],
             "guest": [SensitivityLevel.PUBLIC]
         }
@@ -772,6 +781,22 @@ class SecurityFilters:
         self.access_controller = AccessController() if enable_access_control else None
         self.auditor = SecurityAuditor(audit_db_path) if enable_audit_logging else None
 
+    @staticmethod
+    def _query_hash(query: str) -> str:
+        """Return a stable audit identifier for query text without storing the text."""
+        return hashlib.sha256(query.encode("utf-8", errors="surrogatepass")).hexdigest()
+
+    @staticmethod
+    def _safe_pii_match_for_audit(match: PIIMatch) -> dict[str, Any]:
+        """Serialize a PII match without the matched text."""
+        return {
+            "type": match.pii_type.value,
+            "start": match.start,
+            "end": match.end,
+            "length": max(0, match.end - match.start),
+            "confidence": match.confidence,
+        }
+
     def process_query(
         self,
         query: str,
@@ -790,12 +815,15 @@ class SecurityFilters:
             Tuple of (processed_query, security_metadata)
         """
         metadata: dict[str, Any] = {
-            "original_query": query,
+            "query_hash": self._query_hash(query),
+            "query_length": len(query),
             "user_id": user_id,
             "pii_detected": [],
+            "pii_counts": {},
             "sensitivity": None
         }
         pii_detected: list[dict[str, Any]] = []
+        pii_matches: list[PIIMatch] = []
         sensitivity: SensitivityLevel = SensitivityLevel.PUBLIC
 
         processed_query = query
@@ -803,11 +831,17 @@ class SecurityFilters:
         # Detect PII
         if self.pii_detector:
             pii_matches = self.pii_detector.detect_pii(query)
-            pii_detected = [match.to_dict() for match in pii_matches]
+            pii_detected = [self._safe_pii_match_for_audit(match) for match in pii_matches]
             metadata["pii_detected"] = pii_detected
+            pii_counts: dict[str, int] = {}
+            for match in pii_matches:
+                pii_counts[match.pii_type.value] = pii_counts.get(match.pii_type.value, 0) + 1
+            metadata["pii_counts"] = pii_counts
 
             if mask_pii and pii_matches:
                 processed_query = self.pii_detector.mask_pii(query, pii_matches)
+            if pii_matches:
+                metadata["masked_query"] = self.pii_detector.mask_pii(query, pii_matches)
 
         # Classify content
         if self.content_filter:
@@ -821,7 +855,7 @@ class SecurityFilters:
                 action="query",
                 resource="search",
                 sensitivity=sensitivity,
-                pii_detected=[PIIType(m["type"]) for m in pii_detected],
+                pii_detected=[match.pii_type for match in pii_matches],
                 access_granted=True,
                 metadata=metadata
             )

--- a/tldw_Server_API/app/core/RAG/rag_service/unified_pipeline.py
+++ b/tldw_Server_API/app/core/RAG/rag_service/unified_pipeline.py
@@ -15,6 +15,7 @@ Design Philosophy:
 
 import asyncio
 import calendar
+import copy
 import hashlib
 import inspect
 import os
@@ -96,6 +97,46 @@ def _serialize_result_document(doc: Any) -> dict[str, Any]:
         "score": getattr(doc, "score", 0.0),
         "metadata": metadata,
     }
+
+
+def _clone_cached_document(doc: Any) -> Any:
+    """Return an isolated cache document without duplicating embedding buffers."""
+    if isinstance(doc, Document):
+        return replace(
+            doc,
+            metadata=copy.deepcopy(doc.metadata),
+            citations=copy.deepcopy(doc.citations),
+            source_document_metadata=copy.deepcopy(doc.source_document_metadata),
+            children_ids=list(doc.children_ids),
+            embedding=doc.embedding,
+        )
+
+    if isinstance(doc, dict):
+        cloned = dict(doc)
+        for field_name in ("metadata", "citations", "source_document_metadata"):
+            if field_name in cloned:
+                cloned[field_name] = copy.deepcopy(cloned[field_name])
+        if isinstance(cloned.get("children_ids"), list):
+            cloned["children_ids"] = list(cloned["children_ids"])
+        return cloned
+
+    return copy.deepcopy(doc)
+
+
+def _clone_cached_documents(documents: list[Any]) -> list[Any]:
+    """Return independent document instances for cache store/load boundaries."""
+    return [_clone_cached_document(doc) for doc in documents]
+
+
+def _resolve_security_user_id(user_id: Any, feedback_user_id: Any) -> str:
+    """Resolve the best available user identifier for security filtering."""
+    for candidate in (user_id, feedback_user_id):
+        if candidate is None:
+            continue
+        value = str(candidate).strip()
+        if value:
+            return value
+    return "anonymous"
 
 
 def _resolve_include_rerank_debug_documents(explicit_flag: Any) -> bool:
@@ -3156,12 +3197,12 @@ async def unified_rag_pipeline(
                             result.generated_answer = ans
                         docs = cached_documents.get("documents")
                         if isinstance(docs, list):
-                            result.documents = docs
+                            result.documents = _clone_cached_documents(docs)
                         if cached_documents.get("cached") is True:
                             result.metadata["cached_flag"] = True
                     elif isinstance(cached_documents, list):
                         # Backward compatibility: older cache entries stored document lists directly
-                        result.documents = cached_documents
+                        result.documents = _clone_cached_documents(cached_documents)
                     result.metadata.setdefault("cached_flag", True)
 
             result.timings["cache_check"] = time.time() - cache_start
@@ -4382,7 +4423,7 @@ async def unified_rag_pipeline(
                             ]
                             filtered_payloads = filter_documents(
                                 serialized_docs,
-                                user_id="anonymous",
+                                user_id=_resolve_security_user_id(user_id, feedback_user_id),
                                 max_sensitivity=sensitivity_value,
                                 mask_pii=bool(redact_pii),
                             )
@@ -6960,7 +7001,7 @@ async def unified_rag_pipeline(
                     set_fn = getattr(cache, 'set', None) or getattr(cache, 'add', None)
                     if set_fn:
                         cache_payload = {
-                            "documents": list(result.documents),
+                            "documents": _clone_cached_documents(list(result.documents)),
                             "answer": result.generated_answer,
                             "cached": True,
                         }

--- a/tldw_Server_API/app/core/RAG/rag_service/vector_stores/pgvector_adapter.py
+++ b/tldw_Server_API/app/core/RAG/rag_service/vector_stores/pgvector_adapter.py
@@ -8,11 +8,14 @@ Notes:
 """
 import asyncio
 import contextlib
+import fnmatch
 import re
 from typing import Any, Optional, cast
 
 from loguru import logger
 from prometheus_client import Counter, Histogram
+
+from tldw_Server_API.app.core.exceptions import InvalidMetadataOrderKeyError
 
 from .base import VectorSearchResult, VectorStoreAdapter, VectorStoreConfig
 
@@ -173,6 +176,36 @@ class PGVectorAdapter(VectorStoreAdapter):
         # Allow only alphanum and underscores; replace others with underscore
         safe = re.sub(r"[^A-Za-z0-9_]+", "_", name)
         return f"vs_{safe}"
+
+    def _metadata_order_expression(self, order_by: Optional[str]) -> tuple[str, list[Any]]:
+        """Return a safe ORDER BY expression and any bound expression params."""
+        if not order_by or not isinstance(order_by, str):
+            return "id", []
+        if order_by == "id":
+            return "id", []
+        if not order_by.startswith("metadata."):
+            return "id", []
+
+        key = order_by.split(".", 1)[1]
+        if not re.fullmatch(r"[A-Za-z0-9_-]{1,128}", key):
+            raise InvalidMetadataOrderKeyError(
+                "metadata order key must be 1-128 characters of letters, numbers, "
+                "underscore, or hyphen"
+            )
+        return "(metadata->>%s)", [key]
+
+    @staticmethod
+    def _normalize_collection_pattern(pattern: str) -> str:
+        """Normalize a collection glob into sanitized collection-name space."""
+        return re.sub(r"[^A-Za-z0-9_*]+", "_", pattern)
+
+    @staticmethod
+    def _matches_collection_pattern(pattern: str, collection_name: str) -> bool:
+        """Match collection globs while treating non-glob metacharacters literally."""
+        if not isinstance(pattern, str) or not pattern or len(pattern) > 128:
+            return False
+        normalized_pattern = PGVectorAdapter._normalize_collection_pattern(pattern)
+        return fnmatch.fnmatchcase(collection_name, normalized_pattern)
 
     def _borrow_conn(self):
         if self._pool is not None:
@@ -508,17 +541,11 @@ class PGVectorAdapter(VectorStoreAdapter):
             where_sql, params = self._build_where_from_filter(filter)
         else:
             where_sql, params = '', []
-        ob = 'id'
-        if order_by and isinstance(order_by, str):
-            if order_by.startswith('metadata.'):
-                key = order_by.split('.', 1)[1]
-                ob = f"(metadata->>'{key}')"
-            elif order_by == 'id':
-                ob = 'id'
+        ob, order_params = self._metadata_order_expression(order_by)
         odir = 'ASC' if str(order_dir).lower() == 'asc' else 'DESC'
         rows = await self._query(
             f"SELECT id, content, metadata FROM {tbl}{where_sql} ORDER BY {ob} {odir} LIMIT %s OFFSET %s",  # nosec B608
-            tuple(params + [int(limit), int(offset)]),
+            tuple(params + order_params + [int(limit), int(offset)]),
         )
         items = []
         for rid, content, metadata in rows:
@@ -541,17 +568,11 @@ class PGVectorAdapter(VectorStoreAdapter):
             where_sql, params = self._build_where_from_filter(filter)
         else:
             where_sql, params = '', []
-        ob = 'id'
-        if order_by and isinstance(order_by, str):
-            if order_by.startswith('metadata.'):
-                key = order_by.split('.', 1)[1]
-                ob = f"(metadata->>'{key}')"
-            elif order_by == 'id':
-                ob = 'id'
+        ob, order_params = self._metadata_order_expression(order_by)
         odir = 'ASC' if str(order_dir).lower() == 'asc' else 'DESC'
         rows = await self._query(
             f"SELECT id, content, metadata, embedding FROM {tbl}{where_sql} ORDER BY {ob} {odir} LIMIT %s OFFSET %s",  # nosec B608
-            tuple(params + [int(limit), int(offset)]),
+            tuple(params + order_params + [int(limit), int(offset)]),
         )
         items = []
         for rid, content, metadata, embedding in rows:
@@ -721,9 +742,8 @@ class PGVectorAdapter(VectorStoreAdapter):
         all_tables = await self.list_collections()
         results: list[VectorSearchResult] = []
         for pattern in collection_patterns:
-            regex = re.compile('^' + pattern.replace('*', '.*') + '$')
             for tbl in all_tables:
-                if regex.match(tbl):
+                if self._matches_collection_pattern(pattern, tbl):
                     results.extend(await self.search(tbl, query_vector, k=k, filter=filter))
         # Sort by score desc and trim
         results.sort(key=lambda r: r.score, reverse=True)

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -43,6 +43,10 @@ class BadRequestError(ValueError):
     """Raised when a caller provides invalid arguments for an operation."""
 
 
+class InvalidMetadataOrderKeyError(ValueError):
+    """Raised when a metadata order key cannot be safely used."""
+
+
 class RecipeEnqueueError(RuntimeError):
     """Raised when a recipe run cannot be enqueued into Jobs."""
 

--- a/tldw_Server_API/tests/RAG_NEW/unit/test_security_filters_sanitizers.py
+++ b/tldw_Server_API/tests/RAG_NEW/unit/test_security_filters_sanitizers.py
@@ -1,11 +1,19 @@
 """Sanitizer coverage for RAG security filter fallback logs."""
 
+import hashlib
+import json
 from pathlib import Path
 
 import pytest
 
 from tldw_Server_API.app.core.RAG.rag_service import security_filters
-from tldw_Server_API.app.core.RAG.rag_service.security_filters import PIIDetector, SecurityAuditor
+from tldw_Server_API.app.core.RAG.rag_service.security_filters import (
+    AccessController,
+    PIIDetector,
+    SecurityAuditor,
+    SecurityFilters,
+    SensitivityLevel,
+)
 
 
 pytestmark = pytest.mark.unit
@@ -136,3 +144,83 @@ def test_audit_delete_fallback_log_omits_path_and_exception_details(
 
     assert logger_stub.records[-1] == ("error", "Error deleting old records: RuntimeError")
     _assert_logs_are_sanitized(logger_stub)
+
+
+def test_process_query_audit_metadata_omits_raw_query_and_pii_text(tmp_path: Path) -> None:
+    """Verify query audit metadata excludes raw query and PII text."""
+    audit_path = tmp_path / "audit.db"
+    filters = SecurityFilters(audit_db_path=str(audit_path))
+    raw_email = "jane.doe@example.com"
+    query = f"Please find records for {raw_email} about confidential budget planning."
+
+    processed_query, metadata = filters.process_query(
+        query,
+        user_id="user-123",
+        mask_pii=True,
+    )
+
+    rendered_metadata = json.dumps(metadata)
+    assert raw_email not in processed_query
+    assert raw_email not in rendered_metadata
+    assert query not in rendered_metadata
+    assert "original_query" not in metadata
+    assert metadata["query_hash"] == hashlib.sha256(query.encode("utf-8")).hexdigest()
+    assert metadata["pii_detected"]
+    assert all("text" not in match for match in metadata["pii_detected"])
+
+    assert filters.auditor is not None
+    rows = filters.auditor.get_audit_trail(user_id="user-123", limit=1)
+    assert len(rows) == 1
+    audit_metadata_text = rows[0]["metadata"]
+    assert raw_email not in audit_metadata_text
+    assert query not in audit_metadata_text
+    audit_metadata = json.loads(audit_metadata_text)
+    assert "original_query" not in audit_metadata
+    assert all("text" not in match for match in audit_metadata["pii_detected"])
+
+
+@pytest.mark.parametrize(
+    ("role", "expected_access"),
+    [
+        (
+            "admin",
+            {
+                SensitivityLevel.PUBLIC: True,
+                SensitivityLevel.INTERNAL: True,
+                SensitivityLevel.CONFIDENTIAL: True,
+                SensitivityLevel.RESTRICTED: True,
+            },
+        ),
+        (
+            "manager",
+            {
+                SensitivityLevel.PUBLIC: True,
+                SensitivityLevel.INTERNAL: True,
+                SensitivityLevel.CONFIDENTIAL: True,
+                SensitivityLevel.RESTRICTED: False,
+            },
+        ),
+        (
+            "employee",
+            {
+                SensitivityLevel.PUBLIC: True,
+                SensitivityLevel.INTERNAL: True,
+                SensitivityLevel.CONFIDENTIAL: False,
+                SensitivityLevel.RESTRICTED: False,
+            },
+        ),
+    ],
+)
+def test_role_sensitivity_permissions_are_cumulative(
+    role: str,
+    expected_access: dict[SensitivityLevel, bool],
+) -> None:
+    """Verify each role grants cumulative access to expected sensitivity levels."""
+    controller = AccessController()
+    user_id = f"{role}-user"
+    controller.set_user_role(user_id, role)
+
+    assert {
+        level: controller.check_access(user_id, "doc", level)
+        for level in SensitivityLevel
+    } == expected_access

--- a/tldw_Server_API/tests/RAG_NEW/unit/test_unified_pipeline_security_cache_helpers.py
+++ b/tldw_Server_API/tests/RAG_NEW/unit/test_unified_pipeline_security_cache_helpers.py
@@ -1,0 +1,94 @@
+"""Focused coverage for unified pipeline security and cache helpers."""
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from tldw_Server_API.app.core.RAG.rag_service.types import Document
+from tldw_Server_API.app.core.RAG.rag_service.unified_pipeline import (
+    _clone_cached_documents,
+    _resolve_security_user_id,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_resolve_security_user_id_prefers_request_user_then_feedback_user() -> None:
+    """Verify security user resolution prefers request, feedback, then anonymous."""
+    scenarios = [
+        ("request-user", "feedback-user", "request-user"),
+        (None, "feedback-user", "feedback-user"),
+        ("", "feedback-user", "feedback-user"),
+        (None, None, "anonymous"),
+        ("   ", "", "anonymous"),
+    ]
+
+    assert [
+        _resolve_security_user_id(request_user, feedback_user)
+        for request_user, feedback_user, _expected in scenarios
+    ] == [expected for _request_user, _feedback_user, expected in scenarios]
+
+
+def test_clone_cached_documents_returns_independent_document_instances() -> None:
+    """Verify cached document clones protect mutable document fields."""
+    original = Document(
+        id="doc-1",
+        content="original content",
+        metadata={"nested": {"count": 1}},
+        score=0.7,
+    )
+
+    first_clone = _clone_cached_documents([original])
+    assert first_clone[0] is not original
+
+    first_clone[0].content = "redacted content"
+    first_clone[0].metadata["nested"]["count"] = 2
+
+    assert original.content == "original content"
+    assert original.metadata["nested"]["count"] == 1
+
+    second_clone = _clone_cached_documents(first_clone)
+    assert second_clone[0] is not first_clone[0]
+
+    second_clone[0].metadata["nested"]["count"] = 3
+    assert first_clone[0].metadata["nested"]["count"] == 2
+
+
+def test_clone_cached_documents_preserves_embedding_reference_without_deepcopy() -> None:
+    """Verify cache cloning avoids duplicating large embedding arrays."""
+    embedding = np.array([0.1, 0.2, 0.3])
+    original = Document(
+        id="doc-embedding",
+        content="content",
+        metadata={"nested": {"count": 1}},
+        score=0.5,
+        embedding=embedding,
+    )
+
+    cloned = _clone_cached_documents([original])[0]
+
+    assert isinstance(cloned, Document)
+    assert cloned is not original
+    assert cloned.embedding is embedding
+    cloned.metadata["nested"]["count"] = 2
+    assert original.metadata["nested"]["count"] == 1
+
+
+def test_clone_cached_documents_copies_dict_metadata_without_embedding_copy() -> None:
+    """Verify dict document clones isolate metadata but share embeddings."""
+    embedding = np.array([0.1, 0.2, 0.3])
+    original: dict[str, Any] = {
+        "id": "dict-doc",
+        "content": "content",
+        "metadata": {"nested": {"count": 1}},
+        "embedding": embedding,
+    }
+
+    cloned = _clone_cached_documents([original])[0]
+
+    assert cloned is not original
+    assert cloned["embedding"] is embedding
+    cloned["metadata"]["nested"]["count"] = 2
+    assert original["metadata"]["nested"]["count"] == 1

--- a/tldw_Server_API/tests/VectorStores/unit/test_pgvector_adapter_helpers.py
+++ b/tldw_Server_API/tests/VectorStores/unit/test_pgvector_adapter_helpers.py
@@ -1,12 +1,20 @@
+import asyncio
 import json
+from typing import Any
+
 import pytest
 
-from tldw_Server_API.app.core.RAG.rag_service.vector_stores.base import VectorStoreConfig, VectorStoreType
+from tldw_Server_API.app.core.exceptions import InvalidMetadataOrderKeyError
+from tldw_Server_API.app.core.RAG.rag_service.vector_stores.base import (
+    VectorStoreConfig,
+    VectorStoreType,
+)
 from tldw_Server_API.app.core.RAG.rag_service.vector_stores.pgvector_adapter import PGVectorAdapter
 
 
 @pytest.mark.unit
-def test_pg_list_vectors_paginated_builds_filter(monkeypatch):
+def test_pg_list_vectors_paginated_builds_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify paginated vector listing applies metadata filters."""
     cfg = VectorStoreConfig(
         store_type=VectorStoreType.PGVECTOR,
         connection_params={'dsn': 'postgresql://u:p@localhost:5432/db'},
@@ -15,9 +23,9 @@ def test_pg_list_vectors_paginated_builds_filter(monkeypatch):
     )
     adapter = PGVectorAdapter(cfg)
 
-    captured = []
+    captured: list[tuple[str, Any]] = []
 
-    async def fake_query(sql, params=None):
+    async def fake_query(sql: str, params: Any = None) -> list[tuple[Any, ...]]:
         captured.append((sql, params))
         # Return two rows
         if 'COUNT(*)' in sql:
@@ -27,7 +35,6 @@ def test_pg_list_vectors_paginated_builds_filter(monkeypatch):
     monkeypatch.setattr(adapter, '_query', fake_query)
 
     # Invoke with a metadata filter
-    import asyncio
     res = asyncio.run(
         adapter.list_vectors_paginated('store', limit=10, offset=0, filter={'genre': 'a'})
     )
@@ -38,7 +45,8 @@ def test_pg_list_vectors_paginated_builds_filter(monkeypatch):
 
 
 @pytest.mark.unit
-def test_pg_list_vectors_with_embeddings(monkeypatch):
+def test_pg_list_vectors_with_embeddings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify paginated vector listing includes embedding vectors."""
     cfg = VectorStoreConfig(
         store_type=VectorStoreType.PGVECTOR,
         connection_params={'dsn': 'postgresql://u:p@localhost:5432/db'},
@@ -47,17 +55,157 @@ def test_pg_list_vectors_with_embeddings(monkeypatch):
     )
     adapter = PGVectorAdapter(cfg)
 
-    async def fake_query(sql, params=None):
+    async def fake_query(sql: str, params: Any = None) -> list[tuple[Any, ...]]:
         if 'COUNT(*)' in sql:
             return [(1,)]
         return [("id1", "doc1", {"k": 1}, [0.1, 0.2, 0.3, 0.4])]
 
     monkeypatch.setattr(adapter, '_query', fake_query)
 
-    import asyncio
     res = asyncio.run(
         adapter.list_vectors_with_embeddings_paginated('store', limit=1, offset=0)
     )
     assert res['total'] == 1
     assert res['items'][0]['id'] == 'id1'
     assert isinstance(res['items'][0]['vector'], list)
+
+
+@pytest.mark.unit
+def test_pg_list_vectors_paginated_binds_metadata_order_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify metadata order keys are bound as query parameters."""
+    cfg = VectorStoreConfig(
+        store_type=VectorStoreType.PGVECTOR,
+        connection_params={'dsn': 'postgresql://u:p@localhost:5432/db'},
+        embedding_dim=8,
+        user_id='1'
+    )
+    adapter = PGVectorAdapter(cfg)
+    captured: list[tuple[str, Any]] = []
+
+    async def fake_query(sql: str, params: Any = None) -> list[tuple[Any, ...]]:
+        captured.append((sql, params))
+        if 'COUNT(*)' in sql:
+            return [(1,)]
+        return [("a", "doc a", {"score": "0.9"})]
+
+    monkeypatch.setattr(adapter, '_query', fake_query)
+
+    asyncio.run(
+        adapter.list_vectors_paginated(
+            'store',
+            limit=10,
+            offset=0,
+            order_by='metadata.score',
+        )
+    )
+
+    select_sql, select_params = captured[0]
+    assert "metadata->>'score'" not in select_sql
+    assert "metadata->>%s" in select_sql
+    assert select_params == ("score", 10, 0)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "method_name",
+    ["list_vectors_paginated", "list_vectors_with_embeddings_paginated"],
+)
+def test_pg_list_vectors_rejects_unsafe_metadata_order_key(
+    monkeypatch: pytest.MonkeyPatch,
+    method_name: str,
+) -> None:
+    """Verify unsafe metadata order keys are rejected before query execution."""
+    cfg = VectorStoreConfig(
+        store_type=VectorStoreType.PGVECTOR,
+        connection_params={'dsn': 'postgresql://u:p@localhost:5432/db'},
+        embedding_dim=8,
+        user_id='1'
+    )
+    adapter = PGVectorAdapter(cfg)
+
+    async def fake_query(sql: str, params: Any = None) -> list[tuple[Any, ...]]:
+        if 'COUNT(*)' in sql:
+            return [(0,)]
+        return []
+
+    monkeypatch.setattr(adapter, '_query', fake_query)
+
+    with pytest.raises(InvalidMetadataOrderKeyError, match="metadata order key"):
+        asyncio.run(
+            getattr(adapter, method_name)(
+                'store',
+                limit=10,
+                offset=0,
+                order_by="metadata.score') DESC; SELECT pg_sleep(10); --",
+            )
+        )
+
+
+@pytest.mark.unit
+def test_pg_multi_search_normalizes_patterns_to_sanitized_collection_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify namespace-style glob patterns match sanitized collection names."""
+    cfg = VectorStoreConfig(
+        store_type=VectorStoreType.PGVECTOR,
+        connection_params={'dsn': 'postgresql://u:p@localhost:5432/db'},
+        embedding_dim=4,
+        user_id='1'
+    )
+    adapter = PGVectorAdapter(cfg)
+    searched_collections: list[str] = []
+
+    async def fake_list_collections() -> list[str]:
+        return ["tenant_alpha", "tenant_beta", "tenantXalpha"]
+
+    async def fake_search(
+        collection_name: str,
+        query_vector: list[float],
+        k: int = 10,
+        filter: dict[str, Any] | None = None,
+    ) -> list[Any]:
+        searched_collections.append(collection_name)
+        return []
+
+    monkeypatch.setattr(adapter, 'list_collections', fake_list_collections)
+    monkeypatch.setattr(adapter, 'search', fake_search)
+
+    asyncio.run(adapter.multi_search(["tenant.*"], [0.1, 0.2, 0.3, 0.4], k=5))
+
+    assert searched_collections == ["tenant_alpha", "tenant_beta"]
+
+
+@pytest.mark.unit
+def test_pg_multi_search_treats_unsupported_glob_tokens_as_literals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify collection patterns only support the intended star wildcard."""
+    cfg = VectorStoreConfig(
+        store_type=VectorStoreType.PGVECTOR,
+        connection_params={'dsn': 'postgresql://u:p@localhost:5432/db'},
+        embedding_dim=4,
+        user_id='1'
+    )
+    adapter = PGVectorAdapter(cfg)
+    searched_collections: list[str] = []
+
+    async def fake_list_collections() -> list[str]:
+        return ["tenant_alpha", "tenant_beta", "tenant_ab_gamma"]
+
+    async def fake_search(
+        collection_name: str,
+        query_vector: list[float],
+        k: int = 10,
+        filter: dict[str, Any] | None = None,
+    ) -> list[Any]:
+        searched_collections.append(collection_name)
+        return []
+
+    monkeypatch.setattr(adapter, 'list_collections', fake_list_collections)
+    monkeypatch.setattr(adapter, 'search', fake_search)
+
+    asyncio.run(adapter.multi_search(["tenant[ab]*"], [0.1, 0.2, 0.3, 0.4], k=5))
+
+    assert searched_collections == ["tenant_ab_gamma"]


### PR DESCRIPTION
## Summary
- Harden PGVector metadata ordering by validating and binding metadata order keys through the centralized InvalidMetadataOrderKeyError.
- Normalize PGVector collection globs into the sanitized collection-name space while preserving only the intended star wildcard.
- Remove raw query/PII text from RAG security audit metadata, make role access cumulative, resolve request users for security filtering, and clone cached documents with metadata isolation without duplicating embedding buffers.
- Add focused regression coverage plus PR-feedback cleanup for test docstrings, type hints, and role-access assertions.

## Change summary (human-authored, required before merge)
Pending: requester must add the human-written Change summary explaining what changed and why before this draft is marked ready.

## Test Plan
- [x] /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/VectorStores/unit/test_pgvector_adapter_helpers.py tldw_Server_API/tests/RAG_NEW/unit/test_unified_pipeline_security_cache_helpers.py tldw_Server_API/tests/RAG_NEW/unit/test_security_filters_sanitizers.py -q (19 passed, 50 warnings)
- [x] /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m compileall tldw_Server_API/app/core/RAG/rag_service/vector_stores/pgvector_adapter.py tldw_Server_API/app/core/RAG/rag_service/unified_pipeline.py tldw_Server_API/app/core/exceptions.py
- [x] /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m bandit -r tldw_Server_API/app/core/RAG/rag_service/vector_stores/pgvector_adapter.py tldw_Server_API/app/core/RAG/rag_service/unified_pipeline.py tldw_Server_API/app/core/exceptions.py -f json -o /tmp/bandit_rag_review_fixes_pr_comments_final.json (results=0, errors=0)
- [x] git diff --check origin/dev..HEAD