### PR TITLE
Harden Personalization review findings

### DIFF
--- a/backlog/tasks/task-2419 - Harden-Personalization-module-review-findings.md
+++ b/backlog/tasks/task-2419 - Harden-Personalization-module-review-findings.md
@@ -1,14 +1,14 @@
 ---
 id: TASK-2419
 title: Harden Personalization module review findings
-status: In Progress
+status: Done
 assignee: []
-created_date: '2026-06-23 19:00'
-updated_date: '2026-06-24 04:45'
+created_date: 2026-06-23 19:00
+updated_date: 2026-06-24 20:07
 labels:
-  - personalization
-  - security
-  - review-fix
+- personalization
+- security
+- review-fix
 dependencies: []
 priority: high
 ---
@@ -61,7 +61,7 @@ Verify and fix validated Personalization companion module review findings. Scope
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Hardened the Personalization companion module by centralizing storage ID resolution, reducing retained free-text metadata, validating reflection job inputs, and preserving non-leaky but actionable capture logs. Added legacy DB fallback handling for text-user storage IDs, structured sanitized capture-failure logs, regression coverage for each behavior change, and updated the reading activity bridge expectation to the safer preview metadata contract.
+Hardened the Personalization companion module by centralizing storage ID resolution, reducing retained free-text metadata, validating reflection job inputs, preserving non-leaky but actionable capture logs, and addressing the latest PR feedback after rebasing on dev. The latest fixes ensure reflection jobs open collection data by storage-safe ID, legacy text-user DB fallback only accepts DBs that contain the matching logical profile, and consolidation enumerates storage/logical user pairs so DB access and personalization queries use the correct identifiers.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -72,3 +72,12 @@ Hardened the Personalization companion module by centralizing storage ID resolut
 - [x] #4 Final summary added
 - [x] #5 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Addressed latest PR review feedback by opening the companion reflection job Collections DB with the storage-safe user ID.
+- Addressed latest PR review feedback by validating that an existing legacy companion personalization DB contains a matching logical profile before using its legacy storage ID.
+- Addressed latest PR review feedback by pairing consolidation storage directories with logical profile IDs from the personalization DB, so DB access uses storage IDs while event/card operations use logical user IDs.
+- Latest verification after rebasing on dev: focused Personalization suite 54 passed; derivations/dependency/lifecycle tests 9 passed; Collections bridge 3 passed; Bandit on touched Personalization/API dependency/consolidation paths reported 0 findings and 0 errors in /tmp/bandit_personalization_review_latest.json.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-2419 - Harden-Personalization-module-review-findings.md
+++ b/backlog/tasks/task-2419 - Harden-Personalization-module-review-findings.md
@@ -1,0 +1,72 @@
+---
+id: TASK-2419
+title: Harden Personalization module review findings
+status: In Progress
+assignee: []
+created_date: '2026-06-23 19:00'
+updated_date: '2026-06-23 19:45'
+labels:
+  - personalization
+  - security
+  - review-fix
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and fix validated Personalization companion module review findings. Scope: consistent companion storage user ID resolution, bounded/sanitized activity metadata retention, reflection job type and cadence validation, and actionable logging for activity capture failures.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Validated review findings are fixed or explicitly documented as not applicable
+- [x] #2 Focused regression tests cover each behavior change
+- [x] #3 Touched Personalization/API dependency tests pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+- Verify each review finding against current code and tests before making behavior changes.
+- Add failing regression tests for validated behavior bugs.
+- Implement the smallest compatible fixes in the Personalization module and API dependency boundary.
+- Run focused tests plus Bandit on touched code and record results.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Validated and fixed inconsistent text user ID storage resolution across companion activity capture, context loading, API dependency creation, reflection jobs, lifecycle-compatible helpers, and personalization consolidation.
+- Validated and fixed raw free-text retention for reading item notes and reading highlight quote/note metadata by storing bounded previews, character counts, digests, and truncation flags.
+- Validated and fixed reflection job cadence handling by normalizing supported cadences before slot/dedupe generation and rejecting unknown cadences.
+- Validated and fixed reflection worker dispatch by rejecting unknown job types instead of treating them as reflection jobs.
+- Validated and improved non-fatal activity capture logging with sanitized exception class reasons; exception messages and paths remain omitted.
+- Reviewed the broad adapter-file P3 concern and lifecycle no-op scopes as maintainability/iteration items rather than correctness or security defects for this fix. No broad split was done in this task.
+<!-- SECTION:NOTES:END -->
+
+## Verification
+
+<!-- SECTION:VERIFICATION:BEGIN -->
+- `source .venv/bin/activate && python -m pytest --confcutdir=tldw_Server_API/tests/Personalization tldw_Server_API/tests/Personalization/test_companion_activity_adapters.py tldw_Server_API/tests/Personalization/test_companion_activity_db.py tldw_Server_API/tests/Personalization/test_companion_context.py tldw_Server_API/tests/Personalization/test_companion_reflection_jobs.py tldw_Server_API/tests/Personalization/test_companion_user_ids.py -q` - 48 passed.
+- `env SINGLE_USER_TEST_API_KEY=test-single-user-key SINGLE_USER_API_KEY=test-single-user-key /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest --confcutdir=tldw_Server_API/tests/Collections tldw_Server_API/tests/Collections/test_companion_reading_activity_bridge.py -q` - 3 passed in the isolated worktree.
+- `source .venv/bin/activate && python -m pytest --confcutdir=tldw_Server_API/tests/Personalization tldw_Server_API/tests/Personalization/test_companion_derivations.py tldw_Server_API/tests/API_Deps/test_personalization_deps_sanitization.py -q` - 4 passed.
+- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Personalization tldw_Server_API/app/api/v1/API_Deps/personalization_deps.py tldw_Server_API/app/services/personalization_consolidation.py -f json -o /tmp/bandit_personalization_review.json` - 0 findings, 0 errors.
+- Running the same focused tests without `--confcutdir` timed out before test execution in the global autouse fixture while importing the full app. The traceback pointed to `tldw_Server_API/tests/conftest.py` importing `tldw_Server_API.app.main`, not to the touched Personalization code.
+<!-- SECTION:VERIFICATION:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened the Personalization companion module by centralizing storage ID resolution, reducing retained free-text metadata, validating reflection job inputs, and preserving non-leaky but actionable capture logs. Added regression coverage for each behavior change and updated the reading activity bridge expectation to the safer preview metadata contract.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Bandit run for touched code when applicable or document environment skip
+- [x] #4 Final summary added
+- [x] #5 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2419 - Harden-Personalization-module-review-findings.md
+++ b/backlog/tasks/task-2419 - Harden-Personalization-module-review-findings.md
@@ -4,7 +4,7 @@ title: Harden Personalization module review findings
 status: In Progress
 assignee: []
 created_date: '2026-06-23 19:00'
-updated_date: '2026-06-23 19:45'
+updated_date: '2026-06-24 04:45'
 labels:
   - personalization
   - security
@@ -43,23 +43,25 @@ Verify and fix validated Personalization companion module review findings. Scope
 - Validated and fixed reflection job cadence handling by normalizing supported cadences before slot/dedupe generation and rejecting unknown cadences.
 - Validated and fixed reflection worker dispatch by rejecting unknown job types instead of treating them as reflection jobs.
 - Validated and improved non-fatal activity capture logging with sanitized exception class reasons; exception messages and paths remain omitted.
+- Addressed PR review feedback by adding structured activity-capture log context, sanitized traceback frame summaries, and event/user/dedupe references without logging raw exception messages or paths.
+- Addressed PR review feedback by adding legacy text-user storage ID candidates and a read-only existing-DB resolver so older personalization DBs remain discoverable without creating new directories during lookup.
 - Reviewed the broad adapter-file P3 concern and lifecycle no-op scopes as maintainability/iteration items rather than correctness or security defects for this fix. No broad split was done in this task.
 <!-- SECTION:NOTES:END -->
 
 ## Verification
 
 <!-- SECTION:VERIFICATION:BEGIN -->
-- `source .venv/bin/activate && python -m pytest --confcutdir=tldw_Server_API/tests/Personalization tldw_Server_API/tests/Personalization/test_companion_activity_adapters.py tldw_Server_API/tests/Personalization/test_companion_activity_db.py tldw_Server_API/tests/Personalization/test_companion_context.py tldw_Server_API/tests/Personalization/test_companion_reflection_jobs.py tldw_Server_API/tests/Personalization/test_companion_user_ids.py -q` - 48 passed.
+- `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest --confcutdir=tldw_Server_API/tests/Personalization tldw_Server_API/tests/Personalization/test_companion_activity_adapters.py tldw_Server_API/tests/Personalization/test_companion_activity_db.py tldw_Server_API/tests/Personalization/test_companion_context.py tldw_Server_API/tests/Personalization/test_companion_reflection_jobs.py tldw_Server_API/tests/Personalization/test_companion_user_ids.py -q` - 52 passed.
 - `env SINGLE_USER_TEST_API_KEY=test-single-user-key SINGLE_USER_API_KEY=test-single-user-key /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest --confcutdir=tldw_Server_API/tests/Collections tldw_Server_API/tests/Collections/test_companion_reading_activity_bridge.py -q` - 3 passed in the isolated worktree.
-- `source .venv/bin/activate && python -m pytest --confcutdir=tldw_Server_API/tests/Personalization tldw_Server_API/tests/Personalization/test_companion_derivations.py tldw_Server_API/tests/API_Deps/test_personalization_deps_sanitization.py -q` - 4 passed.
-- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Personalization tldw_Server_API/app/api/v1/API_Deps/personalization_deps.py tldw_Server_API/app/services/personalization_consolidation.py -f json -o /tmp/bandit_personalization_review.json` - 0 findings, 0 errors.
+- `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest --confcutdir=tldw_Server_API/tests/Personalization tldw_Server_API/tests/Personalization/test_companion_derivations.py tldw_Server_API/tests/API_Deps/test_personalization_deps_sanitization.py tldw_Server_API/tests/Personalization/test_companion_lifecycle.py -q` - 8 passed.
+- `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Personalization tldw_Server_API/app/api/v1/API_Deps/personalization_deps.py tldw_Server_API/app/services/personalization_consolidation.py -f json -o /tmp/bandit_personalization_review_pr_comments.json` - 0 findings, 0 errors.
 - Running the same focused tests without `--confcutdir` timed out before test execution in the global autouse fixture while importing the full app. The traceback pointed to `tldw_Server_API/tests/conftest.py` importing `tldw_Server_API.app.main`, not to the touched Personalization code.
 <!-- SECTION:VERIFICATION:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Hardened the Personalization companion module by centralizing storage ID resolution, reducing retained free-text metadata, validating reflection job inputs, and preserving non-leaky but actionable capture logs. Added regression coverage for each behavior change and updated the reading activity bridge expectation to the safer preview metadata contract.
+Hardened the Personalization companion module by centralizing storage ID resolution, reducing retained free-text metadata, validating reflection job inputs, and preserving non-leaky but actionable capture logs. Added legacy DB fallback handling for text-user storage IDs, structured sanitized capture-failure logs, regression coverage for each behavior change, and updated the reading activity bridge expectation to the safer preview metadata contract.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/API_Deps/personalization_deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/personalization_deps.py
@@ -10,31 +10,18 @@ from fastapi import Depends, Request
 from loguru import logger
 
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
-from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.DB_Management.Personalization_DB import (
     PersonalizationDB,
     UsageEvent,
+)
+from tldw_Server_API.app.core.Personalization.companion_user_ids import (
+    resolve_companion_storage_user_id,
 )
 
 
 def get_personalization_db_for_user(user: User = Depends(get_request_user)) -> PersonalizationDB:
     """Return a PersonalizationDB instance bound to the current user's DB path."""
-    # Accept both numeric and string IDs in tests/single-user flows
-    try:
-        uid = int(user.id)
-    except Exception:
-        # Derive a stable numeric from string id (e.g., "test_user")
-        try:
-            import hashlib
-            # Deterministic non-crypto ID derivation for non-integer test/single-user IDs.
-            # `usedforsecurity=False` keeps behavior while making intent explicit.
-            try:
-                digest = hashlib.sha1(str(user.id).encode("utf-8"), usedforsecurity=False).digest()
-            except TypeError:  # pragma: no cover - compatibility fallback
-                digest = hashlib.sha1(str(user.id).encode("utf-8")).digest()  # nosec B324
-            uid = int.from_bytes(digest[:4], byteorder="big", signed=False)
-        except Exception:
-            uid = 0
+    uid = resolve_companion_storage_user_id(user.id)
     return PersonalizationDB.for_user(uid)
 
 

--- a/tldw_Server_API/app/api/v1/API_Deps/personalization_deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/personalization_deps.py
@@ -15,13 +15,13 @@ from tldw_Server_API.app.core.DB_Management.Personalization_DB import (
     UsageEvent,
 )
 from tldw_Server_API.app.core.Personalization.companion_user_ids import (
-    resolve_companion_storage_user_id,
+    resolve_existing_companion_storage_user_id,
 )
 
 
 def get_personalization_db_for_user(user: User = Depends(get_request_user)) -> PersonalizationDB:
     """Return a PersonalizationDB instance bound to the current user's DB path."""
-    uid = resolve_companion_storage_user_id(user.id)
+    uid = resolve_existing_companion_storage_user_id(user.id)
     return PersonalizationDB.for_user(uid)
 
 

--- a/tldw_Server_API/app/core/Personalization/companion_activity.py
+++ b/tldw_Server_API/app/core/Personalization/companion_activity.py
@@ -11,6 +11,9 @@ from loguru import logger
 
 from tldw_Server_API.app.core.DB_Management.Personalization_DB import PersonalizationDB
 from tldw_Server_API.app.core.feature_flags import is_personalization_enabled
+from tldw_Server_API.app.core.Personalization.companion_user_ids import (
+    resolve_companion_storage_user_id,
+)
 
 
 def _open_db_for_user(user_id: str | int) -> tuple[PersonalizationDB, str]:
@@ -18,7 +21,8 @@ def _open_db_for_user(user_id: str | int) -> tuple[PersonalizationDB, str]:
     normalized_user_id = str(user_id or "").strip()
     if not normalized_user_id:
         raise ValueError("user_id is required")
-    return PersonalizationDB.for_user(user_id), normalized_user_id
+    storage_user_id = resolve_companion_storage_user_id(normalized_user_id)
+    return PersonalizationDB.for_user(storage_user_id), normalized_user_id
 
 
 def _profile_opted_in(db: PersonalizationDB, user_id: str) -> bool:
@@ -52,6 +56,10 @@ def _payload_fingerprint(payload: dict[str, Any] | None) -> str:
     except Exception:
         serialized = json.dumps({"unserializable": True}, sort_keys=True, ensure_ascii=True)
     return hashlib.sha1(serialized.encode("utf-8"), usedforsecurity=False).hexdigest()[:12]
+
+
+def _exception_reason(exc: BaseException) -> str:
+    return type(exc).__name__
 
 
 def record_companion_activity(
@@ -91,10 +99,10 @@ def record_companion_activity(
         if _unique_conflict(exc):
             logger.debug("companion activity duplicate skipped: {}", dedupe_key)
             return None
-        logger.debug("companion activity insert skipped")
+        logger.debug("companion activity insert skipped: reason={}", _exception_reason(exc))
         return None
-    except Exception:
-        logger.debug("companion activity capture skipped")
+    except Exception as exc:
+        logger.debug("companion activity capture skipped: reason={}", _exception_reason(exc))
         return None
 
 
@@ -127,8 +135,8 @@ def record_companion_activity_events_bulk(
             user_id=normalized_user_id,
             events=safe_events,
         )
-    except Exception:
-        logger.warning("companion activity bulk capture skipped")
+    except Exception as exc:
+        logger.warning("companion activity bulk capture skipped: reason={}", _exception_reason(exc))
         return []
 
 
@@ -141,6 +149,32 @@ def _truncate_text(value: str | None, *, max_length: int) -> str | None:
     if len(normalized) <= max_length:
         return normalized
     return normalized[: max_length - 3].rstrip() + "..."
+
+
+def _retained_text_metadata(field_name: str, value: Any, *, max_chars: int = 240) -> dict[str, Any]:
+    text = " ".join(str(value or "").strip().split())
+    if not text:
+        return {
+            f"{field_name}_preview": None,
+            f"{field_name}_char_count": 0,
+            f"{field_name}_digest": "na",
+            f"{field_name}_truncated": False,
+        }
+    digest = hashlib.sha1(text.encode("utf-8"), usedforsecurity=False).hexdigest()[:16]
+    safe_limit = max(8, int(max_chars))
+    suffix = "... [truncated]"
+    if len(text) <= safe_limit:
+        preview = text
+    elif safe_limit <= len(suffix):
+        preview = text[:safe_limit]
+    else:
+        preview = f"{text[: safe_limit - len(suffix)]}{suffix}"
+    return {
+        f"{field_name}_preview": preview,
+        f"{field_name}_char_count": len(text),
+        f"{field_name}_digest": digest,
+        f"{field_name}_truncated": len(text) > safe_limit,
+    }
 
 
 def _normalize_companion_tags(tags: list[str] | None) -> list[str]:
@@ -256,7 +290,7 @@ def record_reading_item_updated(*, user_id: str | int | None, item: Any) -> str 
             "title": getattr(item, "title", None),
             "status": getattr(item, "status", None),
             "favorite": bool(getattr(item, "favorite", False)),
-            "notes": getattr(item, "notes", None),
+            **_retained_text_metadata("notes", getattr(item, "notes", None)),
         },
     )
 
@@ -366,8 +400,8 @@ def _reading_highlight_metadata(highlight: Any, *, item_title: str | None = None
         "item_id": getattr(highlight, "item_id", None),
         "title": item_title,
         "item_title": item_title,
-        "quote": getattr(highlight, "quote", None),
-        "note": getattr(highlight, "note", None),
+        **_retained_text_metadata("quote", getattr(highlight, "quote", None)),
+        **_retained_text_metadata("note", getattr(highlight, "note", None)),
         "color": getattr(highlight, "color", None),
         "state": getattr(highlight, "state", None),
         "anchor_strategy": getattr(highlight, "anchor_strategy", None),

--- a/tldw_Server_API/app/core/Personalization/companion_activity.py
+++ b/tldw_Server_API/app/core/Personalization/companion_activity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import sqlite3
+import traceback
 from typing import Any
 
 from loguru import logger
@@ -12,7 +13,7 @@ from loguru import logger
 from tldw_Server_API.app.core.DB_Management.Personalization_DB import PersonalizationDB
 from tldw_Server_API.app.core.feature_flags import is_personalization_enabled
 from tldw_Server_API.app.core.Personalization.companion_user_ids import (
-    resolve_companion_storage_user_id,
+    resolve_existing_companion_storage_user_id,
 )
 
 
@@ -21,7 +22,7 @@ def _open_db_for_user(user_id: str | int) -> tuple[PersonalizationDB, str]:
     normalized_user_id = str(user_id or "").strip()
     if not normalized_user_id:
         raise ValueError("user_id is required")
-    storage_user_id = resolve_companion_storage_user_id(normalized_user_id)
+    storage_user_id = resolve_existing_companion_storage_user_id(normalized_user_id)
     return PersonalizationDB.for_user(storage_user_id), normalized_user_id
 
 
@@ -62,6 +63,65 @@ def _exception_reason(exc: BaseException) -> str:
     return type(exc).__name__
 
 
+def _log_ref(value: Any) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        return "na"
+    return hashlib.sha1(normalized.encode("utf-8"), usedforsecurity=False).hexdigest()[:12]
+
+
+def _traceback_summary(exc: BaseException) -> list[dict[str, Any]]:
+    frames = traceback.extract_tb(exc.__traceback__)
+    return [
+        {"function": frame.name, "line": frame.lineno}
+        for frame in frames[-4:]
+    ]
+
+
+def _log_activity_exception(
+    *,
+    level: str,
+    message: str,
+    exc: BaseException,
+    operation: str,
+    user_id: str | int | None,
+    event_type: str | None = None,
+    source_type: str | None = None,
+    source_id: str | int | None = None,
+    dedupe_key: str | None = None,
+    event_count: int | None = None,
+) -> None:
+    reason = _exception_reason(exc)
+    context = {
+        "operation": operation,
+        "reason": reason,
+        "user_ref": _log_ref(user_id),
+        "event_type": event_type or "na",
+        "source_type": source_type or "na",
+        "source_ref": _log_ref(source_id),
+        "dedupe_ref": _log_ref(dedupe_key),
+        "event_count": event_count,
+        "trace": _traceback_summary(exc),
+    }
+    logger.bind(**context).log(
+        level,
+        (
+            "{}: reason={} operation={} user_ref={} event_type={} "
+            "source_type={} source_ref={} dedupe_ref={} event_count={} trace={}"
+        ),
+        message,
+        reason,
+        context["operation"],
+        context["user_ref"],
+        context["event_type"],
+        context["source_type"],
+        context["source_ref"],
+        context["dedupe_ref"],
+        context["event_count"],
+        context["trace"],
+    )
+
+
 def record_companion_activity(
     *,
     user_id: str | int | None,
@@ -99,10 +159,30 @@ def record_companion_activity(
         if _unique_conflict(exc):
             logger.debug("companion activity duplicate skipped: {}", dedupe_key)
             return None
-        logger.debug("companion activity insert skipped: reason={}", _exception_reason(exc))
+        _log_activity_exception(
+            level="DEBUG",
+            message="companion activity insert skipped",
+            exc=exc,
+            operation="record_companion_activity.insert",
+            user_id=user_id,
+            event_type=event_type,
+            source_type=source_type,
+            source_id=source_id,
+            dedupe_key=dedupe_key,
+        )
         return None
     except Exception as exc:
-        logger.debug("companion activity capture skipped: reason={}", _exception_reason(exc))
+        _log_activity_exception(
+            level="DEBUG",
+            message="companion activity capture skipped",
+            exc=exc,
+            operation="record_companion_activity",
+            user_id=user_id,
+            event_type=event_type,
+            source_type=source_type,
+            source_id=source_id,
+            dedupe_key=dedupe_key,
+        )
         return None
 
 
@@ -136,7 +216,14 @@ def record_companion_activity_events_bulk(
             events=safe_events,
         )
     except Exception as exc:
-        logger.warning("companion activity bulk capture skipped: reason={}", _exception_reason(exc))
+        _log_activity_exception(
+            level="WARNING",
+            message="companion activity bulk capture skipped",
+            exc=exc,
+            operation="record_companion_activity_events_bulk",
+            user_id=normalized_user_id or user_id,
+            event_count=len(events),
+        )
         return []
 
 

--- a/tldw_Server_API/app/core/Personalization/companion_context.py
+++ b/tldw_Server_API/app/core/Personalization/companion_context.py
@@ -12,7 +12,7 @@ from tldw_Server_API.app.core.DB_Management.Personalization_DB import Personaliz
 from tldw_Server_API.app.core.feature_flags import is_personalization_enabled
 from tldw_Server_API.app.core.Personalization.companion_relevance import rank_companion_candidates
 from tldw_Server_API.app.core.Personalization.companion_user_ids import (
-    resolve_companion_storage_user_id,
+    resolve_existing_companion_storage_user_id,
 )
 
 _MAX_COMPANION_CONTEXT_TOTAL_CHARS = 1_200
@@ -142,7 +142,7 @@ def _load_ranked_companion_candidates(
 ) -> dict[str, Any]:
     personalization_db = db
     if personalization_db is None:
-        personalization_db = PersonalizationDB.for_user(resolve_companion_storage_user_id(user_id))
+        personalization_db = PersonalizationDB.for_user(resolve_existing_companion_storage_user_id(user_id))
     profile = personalization_db.get_or_create_profile(user_id)
     if not bool(profile.get("enabled", 0)):
         return {

--- a/tldw_Server_API/app/core/Personalization/companion_context.py
+++ b/tldw_Server_API/app/core/Personalization/companion_context.py
@@ -9,9 +9,11 @@ from typing import Any
 from loguru import logger
 
 from tldw_Server_API.app.core.DB_Management.Personalization_DB import PersonalizationDB
-from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.feature_flags import is_personalization_enabled
 from tldw_Server_API.app.core.Personalization.companion_relevance import rank_companion_candidates
+from tldw_Server_API.app.core.Personalization.companion_user_ids import (
+    resolve_companion_storage_user_id,
+)
 
 _MAX_COMPANION_CONTEXT_TOTAL_CHARS = 1_200
 _MAX_COMPANION_CONTEXT_ITEM_CHARS = 240
@@ -140,7 +142,7 @@ def _load_ranked_companion_candidates(
 ) -> dict[str, Any]:
     personalization_db = db
     if personalization_db is None:
-        personalization_db = PersonalizationDB.for_user(user_id)
+        personalization_db = PersonalizationDB.for_user(resolve_companion_storage_user_id(user_id))
     profile = personalization_db.get_or_create_profile(user_id)
     if not bool(profile.get("enabled", 0)):
         return {

--- a/tldw_Server_API/app/core/Personalization/companion_lifecycle.py
+++ b/tldw_Server_API/app/core/Personalization/companion_lifecycle.py
@@ -10,7 +10,7 @@ from tldw_Server_API.app.core.DB_Management.Personalization_DB import Personaliz
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Personalization.companion_derivations import derive_companion_knowledge_cards
 from tldw_Server_API.app.core.Personalization.companion_user_ids import (
-    resolve_companion_storage_user_id,
+    resolve_existing_companion_storage_user_id,
 )
 
 
@@ -43,7 +43,7 @@ def _resolve_personalization_db(
     """Return the provided personalization DB or open the default DB for the user."""
     if personalization_db is not None:
         return personalization_db
-    storage_user_id = resolve_companion_storage_user_id(user_id)
+    storage_user_id = resolve_existing_companion_storage_user_id(user_id)
     return PersonalizationDB.for_user(storage_user_id)
 
 

--- a/tldw_Server_API/app/core/Personalization/companion_reflection_jobs.py
+++ b/tldw_Server_API/app/core/Personalization/companion_reflection_jobs.py
@@ -404,7 +404,7 @@ def run_companion_reflection_job(
     current_time = _coerce_now(_parse_iso_datetime(scheduled_for) or now)
     storage_user_id = resolve_existing_companion_storage_user_id(normalized_user_id)
     db = personalization_db or PersonalizationDB.for_user(storage_user_id)
-    cdb = collections_db or CollectionsDatabase.for_user(user_id=normalized_user_id)
+    cdb = collections_db or CollectionsDatabase.for_user(user_id=storage_user_id)
     profile = db.get_or_create_profile(normalized_user_id)
 
     enabled, reason = companion_reflection_enabled_for_profile(profile, normalized_cadence)

--- a/tldw_Server_API/app/core/Personalization/companion_reflection_jobs.py
+++ b/tldw_Server_API/app/core/Personalization/companion_reflection_jobs.py
@@ -24,6 +24,7 @@ from tldw_Server_API.app.core.Personalization.companion_user_ids import (
 COMPANION_REFLECTION_DOMAIN = "companion"
 COMPANION_REFLECTION_JOB_TYPE = "companion_reflection"
 COMPANION_REBUILD_JOB_TYPE = "companion_rebuild"
+_COMPANION_REFLECTION_CADENCES = frozenset({"daily", "weekly"})
 
 
 def companion_reflection_queue() -> str:
@@ -84,6 +85,13 @@ def _parse_hhmm(raw: Any) -> tuple[int, int] | None:
     return hour, minute
 
 
+def _normalize_reflection_cadence(cadence: str | None) -> str | None:
+    normalized = str(cadence or "").strip().lower() or "daily"
+    if normalized not in _COMPANION_REFLECTION_CADENCES:
+        return None
+    return normalized
+
+
 def _quiet_hours_active(profile: dict[str, Any], now: datetime) -> bool:
     start = _parse_hhmm(profile.get("quiet_hours_start"))
     end = _parse_hhmm(profile.get("quiet_hours_end"))
@@ -110,7 +118,9 @@ def companion_reflection_enabled_for_profile(
         return False, "proactive_disabled"
     if not bool(profile.get("companion_reflections_enabled", 1)):
         return False, "companion_reflections_disabled"
-    normalized_cadence = str(cadence or "").strip().lower()
+    normalized_cadence = _normalize_reflection_cadence(cadence)
+    if normalized_cadence is None:
+        return False, "invalid_cadence"
     if normalized_cadence == "daily" and not bool(profile.get("companion_daily_reflections_enabled", 1)):
         return False, "daily_reflections_disabled"
     if normalized_cadence == "weekly" and not bool(profile.get("companion_weekly_reflections_enabled", 1)):
@@ -388,20 +398,23 @@ def run_companion_reflection_job(
 ) -> dict[str, Any]:
     """Generate one companion reflection for the given cadence slot."""
     normalized_user_id = str(user_id)
+    normalized_cadence = _normalize_reflection_cadence(cadence)
+    if normalized_cadence is None:
+        return {"status": "skipped", "reason": "invalid_cadence"}
     current_time = _coerce_now(_parse_iso_datetime(scheduled_for) or now)
     storage_user_id = resolve_companion_storage_user_id(normalized_user_id)
     db = personalization_db or PersonalizationDB.for_user(storage_user_id)
     cdb = collections_db or CollectionsDatabase.for_user(user_id=normalized_user_id)
     profile = db.get_or_create_profile(normalized_user_id)
 
-    enabled, reason = companion_reflection_enabled_for_profile(profile, cadence)
+    enabled, reason = companion_reflection_enabled_for_profile(profile, normalized_cadence)
     if not enabled:
         return {"status": "skipped", "reason": reason}
     if _quiet_hours_active(profile, current_time):
         return {"status": "skipped", "reason": "quiet_hours"}
 
-    slot_key = _reflection_slot_key(cadence, current_time)
-    dedupe_key = f"companion.reflection:{cadence}:{slot_key}"
+    slot_key = _reflection_slot_key(normalized_cadence, current_time)
+    dedupe_key = f"companion.reflection:{normalized_cadence}:{slot_key}"
     recent_rows, _total = db.list_companion_activity_events(normalized_user_id, limit=100, offset=0)
     recent_reflections = _recent_reflection_summaries(rows=recent_rows, current_slot_key=slot_key)
     activity_rows = [row for row in recent_rows if row["source_type"] != "companion_reflection"]
@@ -415,14 +428,14 @@ def run_companion_reflection_job(
         if str(goal.get("status") or "").lower() in {"active", "paused"}
     ]
     title, metadata, provenance, tags = _build_reflection_payload(
-        cadence=cadence,
+        cadence=normalized_cadence,
         cards=cards,
         goals=goals,
         activity_rows=activity_rows,
         now=current_time,
     )
     delivery = classify_companion_reflection_delivery(
-        cadence=cadence,
+        cadence=normalized_cadence,
         activity_count=len(activity_rows),
         theme_key=str(metadata.get("theme_key") or ""),
         signal_strength=float(metadata.get("signal_strength") or 0.0),
@@ -464,7 +477,7 @@ def run_companion_reflection_job(
             source_job_type=COMPANION_REFLECTION_JOB_TYPE,
             link_type="companion_reflection",
             link_id=reflection_id,
-            dedupe_key=f"companion_reflection:{cadence}:{slot_key}",
+            dedupe_key=f"companion_reflection:{normalized_cadence}:{slot_key}",
         )
     return {
         "status": "completed",
@@ -485,6 +498,12 @@ async def handle_companion_reflection_job(job: dict[str, Any]) -> dict[str, Any]
             user_id=user_id,
             scope=scope,
         )
+    if job_type and job_type != COMPANION_REFLECTION_JOB_TYPE:
+        return {
+            "status": "skipped",
+            "reason": "unsupported_job_type",
+            "job_type": job_type,
+        }
     cadence = str(payload.get("cadence") or "daily").strip().lower() or "daily"
     scheduled_for = payload.get("scheduled_for")
     return await asyncio.to_thread(

--- a/tldw_Server_API/app/core/Personalization/companion_reflection_jobs.py
+++ b/tldw_Server_API/app/core/Personalization/companion_reflection_jobs.py
@@ -17,7 +17,7 @@ from tldw_Server_API.app.core.Personalization.companion_proactive import (
     classify_companion_reflection_delivery,
 )
 from tldw_Server_API.app.core.Personalization.companion_user_ids import (
-    resolve_companion_storage_user_id,
+    resolve_existing_companion_storage_user_id,
 )
 
 
@@ -402,7 +402,7 @@ def run_companion_reflection_job(
     if normalized_cadence is None:
         return {"status": "skipped", "reason": "invalid_cadence"}
     current_time = _coerce_now(_parse_iso_datetime(scheduled_for) or now)
-    storage_user_id = resolve_companion_storage_user_id(normalized_user_id)
+    storage_user_id = resolve_existing_companion_storage_user_id(normalized_user_id)
     db = personalization_db or PersonalizationDB.for_user(storage_user_id)
     cdb = collections_db or CollectionsDatabase.for_user(user_id=normalized_user_id)
     profile = db.get_or_create_profile(normalized_user_id)

--- a/tldw_Server_API/app/core/Personalization/companion_user_ids.py
+++ b/tldw_Server_API/app/core/Personalization/companion_user_ids.py
@@ -2,16 +2,24 @@ from __future__ import annotations
 
 """Helpers for resolving companion storage IDs from logical user identities."""
 
+import hashlib
 import hmac
+
+from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 
 _COMPANION_STORAGE_ID_NAMESPACE = b"tldw-companion-storage-user-id"
 
 
-def resolve_companion_storage_user_id(user_id: str | int) -> str:
-    """Return the stable storage key used for companion personalization DB paths."""
+def _normalized_raw_user_id(user_id: str | int) -> str:
     raw = str(user_id).strip()
     if not raw:
         raise ValueError("user_id must not be empty")
+    return raw
+
+
+def resolve_companion_storage_user_id(user_id: str | int) -> str:
+    """Return the stable storage key used for companion personalization DB paths."""
+    raw = _normalized_raw_user_id(user_id)
     try:
         return str(int(raw))
     except (TypeError, ValueError):
@@ -26,4 +34,69 @@ def resolve_companion_storage_user_id(user_id: str | int) -> str:
         return str(storage_id)
 
 
-__all__ = ["resolve_companion_storage_user_id"]
+def _legacy_companion_hmac32_storage_user_id(raw_user_id: str) -> str:
+    digest = hmac.digest(
+        _COMPANION_STORAGE_ID_NAMESPACE,
+        raw_user_id.encode("utf-8"),
+        "sha256",
+    )
+    return str(int.from_bytes(digest[:4], byteorder="big", signed=False))
+
+
+def _legacy_api_sha1_32_storage_user_id(raw_user_id: str) -> str:
+    digest = hashlib.sha1(raw_user_id.encode("utf-8"), usedforsecurity=False).digest()
+    return str(int.from_bytes(digest[:4], byteorder="big", signed=False))
+
+
+def resolve_legacy_companion_storage_user_ids(user_id: str | int) -> list[str]:
+    """Return legacy companion storage keys that may contain existing DBs."""
+    raw = _normalized_raw_user_id(user_id)
+    try:
+        str(int(raw))
+    except (TypeError, ValueError):
+        legacy_ids = [
+            _legacy_companion_hmac32_storage_user_id(raw),
+            _legacy_api_sha1_32_storage_user_id(raw),
+        ]
+        return [candidate for candidate in dict.fromkeys(legacy_ids) if candidate != "0"]
+    return []
+
+
+def resolve_companion_storage_user_id_candidates(user_id: str | int) -> list[str]:
+    """Return preferred and legacy storage keys for companion DB lookup."""
+    preferred = resolve_companion_storage_user_id(user_id)
+    candidates = [preferred, *resolve_legacy_companion_storage_user_ids(user_id)]
+    return list(dict.fromkeys(candidates))
+
+
+def _personalization_db_exists(storage_user_id: str) -> bool:
+    db_path = (
+        DatabasePaths.resolve_user_base_directory(storage_user_id)
+        / DatabasePaths.PERSONALIZATION_DB_NAME
+    )
+    return db_path.is_file()
+
+
+def resolve_existing_companion_storage_user_id(user_id: str | int) -> str:
+    """Return the storage key for an existing companion DB, falling back to new key.
+
+    The lookup is intentionally read-only: it resolves candidate paths without
+    creating user directories, so checking legacy locations cannot create
+    partial storage trees as a side effect.
+    """
+    candidates = resolve_companion_storage_user_id_candidates(user_id)
+    preferred = candidates[0]
+    if _personalization_db_exists(preferred):
+        return preferred
+    for candidate in candidates[1:]:
+        if _personalization_db_exists(candidate):
+            return candidate
+    return preferred
+
+
+__all__ = [
+    "resolve_companion_storage_user_id",
+    "resolve_companion_storage_user_id_candidates",
+    "resolve_existing_companion_storage_user_id",
+    "resolve_legacy_companion_storage_user_ids",
+]

--- a/tldw_Server_API/app/core/Personalization/companion_user_ids.py
+++ b/tldw_Server_API/app/core/Personalization/companion_user_ids.py
@@ -20,7 +20,10 @@ def resolve_companion_storage_user_id(user_id: str | int) -> str:
             raw.encode("utf-8"),
             "sha256",
         )
-        return str(int.from_bytes(digest[:4], byteorder="big", signed=False))
+        storage_id = int.from_bytes(digest[:16], byteorder="big", signed=False)
+        if storage_id <= 0:
+            storage_id = int.from_bytes(digest, byteorder="big", signed=False)
+        return str(storage_id)
 
 
 __all__ = ["resolve_companion_storage_user_id"]

--- a/tldw_Server_API/app/core/Personalization/companion_user_ids.py
+++ b/tldw_Server_API/app/core/Personalization/companion_user_ids.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import sqlite3
+from pathlib import Path
 
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 
@@ -69,12 +71,33 @@ def resolve_companion_storage_user_id_candidates(user_id: str | int) -> list[str
     return list(dict.fromkeys(candidates))
 
 
-def _personalization_db_exists(storage_user_id: str) -> bool:
-    db_path = (
+def _personalization_db_path(storage_user_id: str) -> Path:
+    return (
         DatabasePaths.resolve_user_base_directory(storage_user_id)
         / DatabasePaths.PERSONALIZATION_DB_NAME
     )
-    return db_path.is_file()
+
+
+def _personalization_db_exists(storage_user_id: str) -> bool:
+    return _personalization_db_path(storage_user_id).is_file()
+
+
+def _personalization_db_has_profile(storage_user_id: str, logical_user_id: str) -> bool:
+    db_path = _personalization_db_path(storage_user_id)
+    if not db_path.is_file():
+        return False
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            row = conn.execute(
+                "SELECT 1 FROM profiles WHERE user_id = ? LIMIT 1",
+                (logical_user_id,),
+            ).fetchone()
+            return row is not None
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return False
 
 
 def resolve_existing_companion_storage_user_id(user_id: str | int) -> str:
@@ -84,12 +107,13 @@ def resolve_existing_companion_storage_user_id(user_id: str | int) -> str:
     creating user directories, so checking legacy locations cannot create
     partial storage trees as a side effect.
     """
-    candidates = resolve_companion_storage_user_id_candidates(user_id)
+    raw = _normalized_raw_user_id(user_id)
+    candidates = resolve_companion_storage_user_id_candidates(raw)
     preferred = candidates[0]
     if _personalization_db_exists(preferred):
         return preferred
     for candidate in candidates[1:]:
-        if _personalization_db_exists(candidate):
+        if _personalization_db_has_profile(candidate, raw):
             return candidate
     return preferred
 

--- a/tldw_Server_API/app/services/personalization_consolidation.py
+++ b/tldw_Server_API/app/services/personalization_consolidation.py
@@ -7,7 +7,6 @@ Stage 1 scaffold: topic scoring from event tags, no embedding integration yet.
 from __future__ import annotations
 
 import asyncio
-import hashlib
 from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -19,6 +18,7 @@ from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.DB_Management.Personalization_DB import PersonalizationDB
 from tldw_Server_API.app.core.Metrics import get_metrics_registry
 from tldw_Server_API.app.core.Personalization.companion_derivations import derive_companion_knowledge_cards
+from tldw_Server_API.app.core.Personalization.companion_user_ids import resolve_companion_storage_user_id
 
 _PERSONALIZATION_CONSOLIDATION_NONCRITICAL_EXCEPTIONS = (
     asyncio.CancelledError,
@@ -33,13 +33,9 @@ _PERSONALIZATION_CONSOLIDATION_NONCRITICAL_EXCEPTIONS = (
 )
 
 
-def _resolve_user_id_to_int(user_id: str) -> int:
-    """Convert a user_id string to a numeric value, mirroring personalization_deps logic."""
-    try:
-        return int(user_id)
-    except (ValueError, TypeError):
-        digest = hashlib.sha1(str(user_id).encode("utf-8"), usedforsecurity=False).digest()
-        return int.from_bytes(digest[:4], byteorder="big", signed=False)
+def _resolve_user_storage_id(user_id: str) -> str:
+    """Return the shared personalization storage id for logical user ids."""
+    return resolve_companion_storage_user_id(user_id)
 
 
 @dataclass
@@ -212,8 +208,8 @@ class PersonalizationConsolidationService:
 
     @staticmethod
     def _get_user_db(user_id: str) -> PersonalizationDB:
-        uid_int = _resolve_user_id_to_int(user_id)
-        return PersonalizationDB.for_user(uid_int)
+        storage_user_id = _resolve_user_storage_id(user_id)
+        return PersonalizationDB.for_user(storage_user_id)
 
     @staticmethod
     def _score_topics_from_events(events: list[dict]) -> dict[str, float]:

--- a/tldw_Server_API/app/services/personalization_consolidation.py
+++ b/tldw_Server_API/app/services/personalization_consolidation.py
@@ -45,6 +45,12 @@ class ConsolidationConfig:
     interval_seconds: int = 1800  # default 30 minutes
 
 
+@dataclass(frozen=True)
+class ConsolidationTarget:
+    logical_user_id: str
+    storage_user_id: str
+
+
 class PersonalizationConsolidationService:
     def __init__(self, config: ConsolidationConfig | None = None):
         self.config = config or ConsolidationConfig()
@@ -97,11 +103,14 @@ class PersonalizationConsolidationService:
         while not self._shutdown.is_set():
             try:
                 logger.debug("Consolidation tick")
-                user_ids = self._enumerate_user_ids()
-                for uid in user_ids:
+                targets = self._enumerate_user_targets()
+                for target in targets:
                     if self._shutdown.is_set():
                         break
-                    self._consolidate_user(str(uid))
+                    self._consolidate_user(
+                        target.logical_user_id,
+                        storage_user_id=target.storage_user_id,
+                    )
             except _PERSONALIZATION_CONSOLIDATION_NONCRITICAL_EXCEPTIONS as e:
                 logger.warning(f"Consolidation loop error (scaffold): {e}")
                 try:
@@ -116,9 +125,9 @@ class PersonalizationConsolidationService:
             except asyncio.TimeoutError:
                 continue
 
-    def _consolidate_user(self, user_id: str) -> None:
+    def _consolidate_user(self, user_id: str, *, storage_user_id: str | None = None) -> None:
         """Consolidate per-user topics from recent events."""
-        db = self._get_user_db(user_id)
+        db = self._get_user_db(user_id, storage_user_id=storage_user_id)
         # Use public thread-safe method instead of bypassing the lock
         events = db.list_recent_events(user_id)
         scores = self._score_topics_from_events(events)
@@ -202,6 +211,86 @@ class PersonalizationConsolidationService:
 
         return sorted(set(uids))
 
+    @staticmethod
+    def _enumerate_user_targets() -> list[ConsolidationTarget]:
+        """Return logical users paired with the storage IDs that own their DBs."""
+        try:
+            base = DatabasePaths.get_user_db_base_dir()
+        except _PERSONALIZATION_CONSOLIDATION_NONCRITICAL_EXCEPTIONS as exc:
+            logger.debug(f"personalization: failed to resolve user db base dir: {exc}")
+            try:
+                get_metrics_registry().increment(
+                    "app_warning_events_total",
+                    labels={"component": "personalization", "event": "user_db_dir_read_failed"},
+                )
+            except _PERSONALIZATION_CONSOLIDATION_NONCRITICAL_EXCEPTIONS:
+                logger.debug("metrics increment failed for personalization user_db_dir_read_failed")
+            return []
+
+        targets: list[ConsolidationTarget] = []
+        for path in base.iterdir():
+            if not path.is_dir():
+                continue
+            storage_user_id = path.name
+            if not storage_user_id.isdigit():
+                logger.debug(f"personalization: skipping non-int user dir {storage_user_id}")
+                try:
+                    get_metrics_registry().increment(
+                        "app_warning_events_total",
+                        labels={"component": "personalization", "event": "invalid_user_dir_name"},
+                    )
+                except _PERSONALIZATION_CONSOLIDATION_NONCRITICAL_EXCEPTIONS:
+                    logger.debug("metrics increment failed for personalization invalid_user_dir_name")
+                continue
+            db_path = path / DatabasePaths.PERSONALIZATION_DB_NAME
+            if not db_path.is_file():
+                continue
+            try:
+                db = PersonalizationDB.for_path(db_path)
+                logical_user_ids = db.list_profile_user_ids()
+            except _PERSONALIZATION_CONSOLIDATION_NONCRITICAL_EXCEPTIONS as exc:
+                logger.debug(f"personalization: failed to inspect profile ids for {storage_user_id}: {exc}")
+                try:
+                    get_metrics_registry().increment(
+                        "app_warning_events_total",
+                        labels={"component": "personalization", "event": "profile_id_scan_failed"},
+                    )
+                except _PERSONALIZATION_CONSOLIDATION_NONCRITICAL_EXCEPTIONS:
+                    logger.debug("metrics increment failed for personalization profile_id_scan_failed")
+                continue
+            for logical_user_id in logical_user_ids:
+                targets.append(
+                    ConsolidationTarget(
+                        logical_user_id=str(logical_user_id),
+                        storage_user_id=storage_user_id,
+                    )
+                )
+
+        if not targets:
+            try:
+                logical_user_id = str(DatabasePaths.get_single_user_id())
+                targets = [
+                    ConsolidationTarget(
+                        logical_user_id=logical_user_id,
+                        storage_user_id=_resolve_user_storage_id(logical_user_id),
+                    )
+                ]
+            except _PERSONALIZATION_CONSOLIDATION_NONCRITICAL_EXCEPTIONS as exc:
+                logger.debug(f"personalization: failed to derive single_user_id: {exc}")
+                try:
+                    get_metrics_registry().increment(
+                        "app_warning_events_total",
+                        labels={"component": "personalization", "event": "single_user_id_fallback_failed"},
+                    )
+                except _PERSONALIZATION_CONSOLIDATION_NONCRITICAL_EXCEPTIONS:
+                    logger.debug("metrics increment failed for personalization single_user_id_fallback_failed")
+                targets = []
+
+        return sorted(
+            {target for target in targets},
+            key=lambda target: (target.logical_user_id, target.storage_user_id),
+        )
+
     def get_status(self) -> dict:
         """Return service status including last consolidation ticks."""
         running = bool(self._task and not self._task.done())
@@ -209,8 +298,8 @@ class PersonalizationConsolidationService:
         return {"running": running, "last_ticks": last, "user_count": len(self._last_tick)}
 
     @staticmethod
-    def _get_user_db(user_id: str) -> PersonalizationDB:
-        storage_user_id = _resolve_user_storage_id(user_id)
+    def _get_user_db(user_id: str, *, storage_user_id: str | None = None) -> PersonalizationDB:
+        storage_user_id = storage_user_id or _resolve_user_storage_id(user_id)
         return PersonalizationDB.for_user(storage_user_id)
 
     @staticmethod

--- a/tldw_Server_API/app/services/personalization_consolidation.py
+++ b/tldw_Server_API/app/services/personalization_consolidation.py
@@ -18,7 +18,9 @@ from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.DB_Management.Personalization_DB import PersonalizationDB
 from tldw_Server_API.app.core.Metrics import get_metrics_registry
 from tldw_Server_API.app.core.Personalization.companion_derivations import derive_companion_knowledge_cards
-from tldw_Server_API.app.core.Personalization.companion_user_ids import resolve_companion_storage_user_id
+from tldw_Server_API.app.core.Personalization.companion_user_ids import (
+    resolve_existing_companion_storage_user_id,
+)
 
 _PERSONALIZATION_CONSOLIDATION_NONCRITICAL_EXCEPTIONS = (
     asyncio.CancelledError,
@@ -35,7 +37,7 @@ _PERSONALIZATION_CONSOLIDATION_NONCRITICAL_EXCEPTIONS = (
 
 def _resolve_user_storage_id(user_id: str) -> str:
     """Return the shared personalization storage id for logical user ids."""
-    return resolve_companion_storage_user_id(user_id)
+    return resolve_existing_companion_storage_user_id(user_id)
 
 
 @dataclass

--- a/tldw_Server_API/tests/Collections/test_companion_reading_activity_bridge.py
+++ b/tldw_Server_API/tests/Collections/test_companion_reading_activity_bridge.py
@@ -248,7 +248,9 @@ def test_reading_note_links_and_highlights_record_companion_activity(
     )
     assert highlight_create_event["source_type"] == "reading_highlight"
     assert highlight_create_event["source_id"] == str(highlight_id)
-    assert highlight_create_event["metadata"]["quote"] == "Important sentence"
+    assert highlight_create_event["metadata"]["quote_preview"] == "Important sentence"
+    assert highlight_create_event["metadata"]["quote_char_count"] == len("Important sentence")
+    assert "quote" not in highlight_create_event["metadata"]
     assert highlight_create_event["metadata"]["item_title"] == "Annotated Article"
     assert highlight_create_event["provenance"]["route"] == f"/api/v1/reading/items/{item_id}/highlight"
 
@@ -256,4 +258,5 @@ def test_reading_note_links_and_highlights_record_companion_activity(
         event for event in events if event["event_type"] == "reading_highlight_deleted"
     )
     assert highlight_delete_event["metadata"]["item_id"] == item_id
-    assert highlight_delete_event["metadata"]["quote"] == "Important sentence"
+    assert highlight_delete_event["metadata"]["quote_preview"] == "Important sentence"
+    assert "quote" not in highlight_delete_event["metadata"]

--- a/tldw_Server_API/tests/Personalization/test_companion_activity_adapters.py
+++ b/tldw_Server_API/tests/Personalization/test_companion_activity_adapters.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import sqlite3
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -19,6 +20,8 @@ from tldw_Server_API.app.core.Personalization.companion_activity import (
     record_persona_session_started,
     record_persona_session_summarized,
     record_persona_tool_executed,
+    record_reading_highlight_created,
+    record_reading_item_updated,
     record_reminder_task_deleted,
     record_reminder_task_updated,
     record_watchlist_item_added,
@@ -27,6 +30,7 @@ from tldw_Server_API.app.core.Personalization.companion_activity import (
     record_watchlist_source_restored,
     record_watchlist_source_updated,
 )
+from tldw_Server_API.app.core.Personalization.companion_user_ids import resolve_companion_storage_user_id
 from tldw_Server_API.app.core.config import settings
 
 
@@ -116,6 +120,41 @@ def test_record_companion_activity_requires_opt_in_and_dedupes(companion_db_env)
     assert total_after_duplicate == 1
 
 
+def test_record_companion_activity_uses_resolved_storage_user_id_for_text_users(monkeypatch):
+    class _FakeDB:
+        def get_or_create_profile(self, user_id: str) -> dict[str, int]:
+            return {"enabled": 1}
+
+        def insert_companion_activity_event(self, **kwargs: Any) -> str:
+            assert kwargs["user_id"] == "user-alpha"
+            return "evt-1"
+
+    opened_user_ids: list[str] = []
+
+    def _fake_for_user(cls, user_id: str | int) -> _FakeDB:
+        opened_user_ids.append(str(user_id))
+        return _FakeDB()
+
+    monkeypatch.setattr(companion_activity_module, "is_personalization_enabled", lambda: True)
+    monkeypatch.setattr(
+        companion_activity_module.PersonalizationDB,
+        "for_user",
+        classmethod(_fake_for_user),
+    )
+
+    result = record_companion_activity(
+        user_id="user-alpha",
+        event_type="reading_item_saved",
+        source_type="reading_item",
+        source_id="123",
+        surface="api.reading",
+        dedupe_key="reading.save:123",
+    )
+
+    assert result == "evt-1"
+    assert opened_user_ids == [resolve_companion_storage_user_id("user-alpha")]
+
+
 def test_insert_companion_activity_events_bulk_skips_duplicate_dedupe_keys(companion_db_env):
     user_id = "77-bulk"
     db = PersonalizationDB(str(DatabasePaths.get_personalization_db_path(user_id)))
@@ -149,6 +188,81 @@ def test_insert_companion_activity_events_bulk_skips_duplicate_dedupe_keys(compa
     rows, total = db.list_companion_activity_events(user_id, limit=10)
     assert total == 1
     assert rows[0]["source_id"] == "n1"
+
+
+def test_record_reading_item_updated_retains_notes_preview_not_full_text(monkeypatch):
+    captured: dict[str, Any] = {}
+    long_notes = "sensitive " * 80
+
+    def _capture_activity(**kwargs: Any) -> str:
+        captured.update(kwargs)
+        return "evt-note"
+
+    monkeypatch.setattr(companion_activity_module, "record_companion_activity", _capture_activity)
+
+    result = record_reading_item_updated(
+        user_id="1",
+        item=SimpleNamespace(
+            id=123,
+            updated_at="2026-06-23T12:00:00Z",
+            created_at=None,
+            tags=[],
+            title="Reading item",
+            status="active",
+            favorite=False,
+            notes=long_notes,
+        ),
+    )
+
+    metadata = captured["metadata"]
+    assert result == "evt-note"
+    assert "notes" not in metadata
+    assert metadata["notes_preview"].endswith("... [truncated]")
+    assert len(metadata["notes_preview"]) <= 240
+    assert metadata["notes_char_count"] == len(long_notes.strip())
+    assert metadata["notes_digest"]
+
+
+def test_record_reading_highlight_created_retains_quote_and_note_previews(monkeypatch):
+    captured: dict[str, Any] = {}
+    quote = "important quote " * 40
+    note = "private annotation " * 40
+
+    def _capture_activity(**kwargs: Any) -> str:
+        captured.update(kwargs)
+        return "evt-highlight"
+
+    monkeypatch.setattr(companion_activity_module, "record_companion_activity", _capture_activity)
+
+    result = record_reading_highlight_created(
+        user_id="1",
+        highlight=SimpleNamespace(
+            id=99,
+            item_id=123,
+            created_at="2026-06-23T12:00:00Z",
+            quote=quote,
+            note=note,
+            color="yellow",
+            state="active",
+            anchor_strategy="offset",
+            start_offset=0,
+            end_offset=10,
+        ),
+        item_title="Reading item",
+    )
+
+    metadata = captured["metadata"]
+    assert result == "evt-highlight"
+    assert "quote" not in metadata
+    assert "note" not in metadata
+    assert metadata["quote_preview"].endswith("... [truncated]")
+    assert metadata["note_preview"].endswith("... [truncated]")
+    assert len(metadata["quote_preview"]) <= 240
+    assert len(metadata["note_preview"]) <= 240
+    assert metadata["quote_char_count"] == len(quote.strip())
+    assert metadata["note_char_count"] == len(note.strip())
+    assert metadata["quote_digest"]
+    assert metadata["note_digest"]
 
 
 def test_insert_companion_activity_events_bulk_keeps_unique_rows_when_one_conflicts(companion_db_env):
@@ -299,6 +413,7 @@ def test_record_companion_activity_capture_skip_log_omits_exception_text(monkeyp
     assert result is None
     log_text = "\n".join(messages)
     assert "companion activity capture skipped" in log_text
+    assert "RuntimeError" in log_text
     assert "companion backend exploded" not in log_text
     assert "/private/companion.db" not in log_text
 
@@ -334,6 +449,7 @@ def test_record_companion_activity_insert_skip_log_omits_exception_text(monkeypa
     assert result is None
     log_text = "\n".join(messages)
     assert "companion activity insert skipped" in log_text
+    assert "IntegrityError" in log_text
     assert "database disk image is malformed" not in log_text
     assert "/private/companion.db" not in log_text
 
@@ -368,6 +484,7 @@ def test_record_companion_activity_bulk_capture_skip_log_omits_exception_text(mo
     assert result == []
     log_text = "\n".join(messages)
     assert "companion activity bulk capture skipped" in log_text
+    assert "RuntimeError" in log_text
     assert "companion backend exploded" not in log_text
     assert "/private/companion.db" not in log_text
 
@@ -701,7 +818,9 @@ def test_persona_activity_adapters_accept_surface_overrides_and_normalize_invali
     companion_db_env,
 ):
     user_id = "81b"
-    db = PersonalizationDB(str(DatabasePaths.get_personalization_db_path(user_id)))
+    db = PersonalizationDB(
+        str(DatabasePaths.get_personalization_db_path(resolve_companion_storage_user_id(user_id)))
+    )
     db.update_profile(user_id, enabled=1)
 
     started = record_persona_session_started(

--- a/tldw_Server_API/tests/Personalization/test_companion_activity_adapters.py
+++ b/tldw_Server_API/tests/Personalization/test_companion_activity_adapters.py
@@ -30,7 +30,10 @@ from tldw_Server_API.app.core.Personalization.companion_activity import (
     record_watchlist_source_restored,
     record_watchlist_source_updated,
 )
-from tldw_Server_API.app.core.Personalization.companion_user_ids import resolve_companion_storage_user_id
+from tldw_Server_API.app.core.Personalization.companion_user_ids import (
+    resolve_companion_storage_user_id,
+    resolve_legacy_companion_storage_user_ids,
+)
 from tldw_Server_API.app.core.config import settings
 
 
@@ -153,6 +156,34 @@ def test_record_companion_activity_uses_resolved_storage_user_id_for_text_users(
 
     assert result == "evt-1"
     assert opened_user_ids == [resolve_companion_storage_user_id("user-alpha")]
+
+
+def test_record_companion_activity_uses_existing_legacy_storage_db_for_text_users(
+    companion_db_env,
+    monkeypatch,
+):
+    user_id = "user-alpha"
+    preferred_storage_id = resolve_companion_storage_user_id(user_id)
+    legacy_storage_id = resolve_legacy_companion_storage_user_ids(user_id)[0]
+    legacy_db = PersonalizationDB(str(DatabasePaths.get_personalization_db_path(legacy_storage_id)))
+    legacy_db.update_profile(user_id, enabled=1)
+    monkeypatch.setattr(companion_activity_module, "is_personalization_enabled", lambda: True)
+
+    result = record_companion_activity(
+        user_id=user_id,
+        event_type="reading_item_saved",
+        source_type="reading_item",
+        source_id="123",
+        surface="api.reading",
+        dedupe_key="reading.save:123",
+        metadata={"title": "Legacy DB item"},
+    )
+
+    assert result
+    rows, total = legacy_db.list_companion_activity_events(user_id, limit=10)
+    assert total == 1
+    assert rows[0]["metadata"]["title"] == "Legacy DB item"
+    assert not (companion_db_env / preferred_storage_id).exists()
 
 
 def test_insert_companion_activity_events_bulk_skips_duplicate_dedupe_keys(companion_db_env):
@@ -414,6 +445,10 @@ def test_record_companion_activity_capture_skip_log_omits_exception_text(monkeyp
     log_text = "\n".join(messages)
     assert "companion activity capture skipped" in log_text
     assert "RuntimeError" in log_text
+    assert "operation=record_companion_activity" in log_text
+    assert "event_type=reading_item_saved" in log_text
+    assert "source_type=reading_item" in log_text
+    assert "trace=[" in log_text
     assert "companion backend exploded" not in log_text
     assert "/private/companion.db" not in log_text
 
@@ -450,6 +485,10 @@ def test_record_companion_activity_insert_skip_log_omits_exception_text(monkeypa
     log_text = "\n".join(messages)
     assert "companion activity insert skipped" in log_text
     assert "IntegrityError" in log_text
+    assert "operation=record_companion_activity.insert" in log_text
+    assert "event_type=reading_item_saved" in log_text
+    assert "source_type=reading_item" in log_text
+    assert "trace=[" in log_text
     assert "database disk image is malformed" not in log_text
     assert "/private/companion.db" not in log_text
 
@@ -485,6 +524,9 @@ def test_record_companion_activity_bulk_capture_skip_log_omits_exception_text(mo
     log_text = "\n".join(messages)
     assert "companion activity bulk capture skipped" in log_text
     assert "RuntimeError" in log_text
+    assert "operation=record_companion_activity_events_bulk" in log_text
+    assert "event_count=1" in log_text
+    assert "trace=[" in log_text
     assert "companion backend exploded" not in log_text
     assert "/private/companion.db" not in log_text
 

--- a/tldw_Server_API/tests/Personalization/test_companion_activity_db.py
+++ b/tldw_Server_API/tests/Personalization/test_companion_activity_db.py
@@ -7,6 +7,7 @@ import pytest
 import tldw_Server_API.app.api.v1.API_Deps.personalization_deps as personalization_deps
 import tldw_Server_API.app.core.DB_Management.Personalization_DB as personalization_db_module
 from tldw_Server_API.app.core.DB_Management.Personalization_DB import PersonalizationDB
+from tldw_Server_API.app.core.Personalization.companion_user_ids import resolve_companion_storage_user_id
 
 
 pytestmark = pytest.mark.unit
@@ -55,6 +56,29 @@ def test_personalization_dependency_uses_safe_for_user_factory(monkeypatch):
     )
 
     assert result is sentinel
+
+
+def test_personalization_dependency_uses_shared_storage_id_for_text_users(monkeypatch):
+    sentinel = object()
+    opened_user_ids: list[str] = []
+
+    def _fake_for_user(cls, user_id: str | int):
+        opened_user_ids.append(str(user_id))
+        return sentinel
+
+    monkeypatch.setattr(
+        personalization_deps.PersonalizationDB,
+        "for_user",
+        classmethod(_fake_for_user),
+        raising=False,
+    )
+
+    result = personalization_deps.get_personalization_db_for_user(
+        user=SimpleNamespace(id="user-alpha")
+    )
+
+    assert result is sentinel
+    assert opened_user_ids == [resolve_companion_storage_user_id("user-alpha")]
 
 
 def test_personalization_db_constructor_does_not_resolve_input_path(monkeypatch, tmp_path) -> None:

--- a/tldw_Server_API/tests/Personalization/test_companion_context.py
+++ b/tldw_Server_API/tests/Personalization/test_companion_context.py
@@ -5,6 +5,7 @@ import pytest
 
 from tldw_Server_API.app.core.DB_Management.Personalization_DB import PersonalizationDB
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+from tldw_Server_API.app.core.Personalization.companion_user_ids import resolve_companion_storage_user_id
 from tldw_Server_API.app.core.Personalization.companion_context import load_companion_context
 from tldw_Server_API.app.core.config import settings
 
@@ -79,6 +80,34 @@ def test_load_companion_context_returns_compact_knowledge_and_explicit_activity(
     assert payload["activity_lines"] == [
         "- Pytest Patterns (reading item saved)"
     ]
+
+
+def test_load_companion_context_uses_resolved_storage_user_id_for_text_users(monkeypatch):
+    class _FakeDB:
+        def get_or_create_profile(self, user_id_value):
+            assert user_id_value == "user-alpha"
+            return {"enabled": 0}
+
+    opened_user_ids: list[str] = []
+
+    def _fake_for_user(cls, user_id_value):
+        opened_user_ids.append(str(user_id_value))
+        return _FakeDB()
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Personalization.companion_context.PersonalizationDB.for_user",
+        classmethod(_fake_for_user),
+    )
+
+    payload = load_companion_context(user_id="user-alpha")
+
+    assert payload == {
+        "knowledge_lines": [],
+        "activity_lines": [],
+        "card_count": 0,
+        "activity_count": 0,
+    }
+    assert opened_user_ids == [resolve_companion_storage_user_id("user-alpha")]
 
 
 def test_load_companion_context_returns_empty_when_profile_disabled(companion_context_env):

--- a/tldw_Server_API/tests/Personalization/test_companion_derivations.py
+++ b/tldw_Server_API/tests/Personalization/test_companion_derivations.py
@@ -6,6 +6,9 @@ import pytest
 from tldw_Server_API.app.core.DB_Management.Personalization_DB import PersonalizationDB
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Personalization.companion_derivations import derive_companion_knowledge_cards
+from tldw_Server_API.app.core.Personalization.companion_user_ids import (
+    resolve_companion_storage_user_id,
+)
 from tldw_Server_API.app.core.config import settings
 from tldw_Server_API.app.services.personalization_consolidation import PersonalizationConsolidationService
 
@@ -154,6 +157,43 @@ def test_consolidation_upserts_companion_knowledge_cards(companion_derivations_e
     assert "source_focus" in card_types
     project_card = next(card for card in cards if card["card_type"] == "project_focus")
     assert "security" in project_card["summary"]
+
+
+def test_consolidation_pairs_storage_dirs_with_logical_profile_ids(companion_derivations_env):
+    user_id = "user-alpha"
+    storage_user_id = resolve_companion_storage_user_id(user_id)
+    db = PersonalizationDB(str(DatabasePaths.get_personalization_db_path(storage_user_id)))
+    db.update_profile(user_id, enabled=1)
+    _insert_event(
+        db,
+        user_id=user_id,
+        event_type="reading_item_saved",
+        source_id="501",
+        tags=["storage-safe", "research"],
+        title="Storage-safe profile event",
+    )
+    _insert_event(
+        db,
+        user_id=user_id,
+        event_type="reading_item_updated",
+        source_id="502",
+        tags=["storage-safe", "research"],
+        title="Storage-safe follow-up",
+    )
+
+    service = PersonalizationConsolidationService()
+    targets = service._enumerate_user_targets()
+
+    assert [
+        (target.logical_user_id, target.storage_user_id)
+        for target in targets
+    ] == [(user_id, storage_user_id)]
+
+    service._consolidate_user(user_id, storage_user_id=storage_user_id)
+
+    cards = db.list_companion_knowledge_cards(user_id)
+    assert cards
+    assert not db.list_companion_knowledge_cards(storage_user_id)
 
 
 def test_derive_companion_knowledge_cards_emits_multiple_card_families(companion_derivations_env):

--- a/tldw_Server_API/tests/Personalization/test_companion_reflection_jobs.py
+++ b/tldw_Server_API/tests/Personalization/test_companion_reflection_jobs.py
@@ -10,6 +10,7 @@ from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDat
 from tldw_Server_API.app.core.DB_Management.Personalization_DB import PersonalizationDB
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Personalization.companion_user_ids import (
+    resolve_existing_companion_storage_user_id,
     resolve_legacy_companion_storage_user_ids,
 )
 from tldw_Server_API.app.core.Personalization.companion_reflection_jobs import (
@@ -329,6 +330,34 @@ def test_companion_reflection_job_rejects_unknown_cadence(
     assert result == {"status": "skipped", "reason": "invalid_cadence"}
     rows, _total = personalization_db.list_companion_activity_events("1", limit=20, offset=0)
     assert not any(row["event_type"] == "companion_reflection_generated" for row in rows)
+
+
+def test_companion_reflection_job_opens_collections_db_with_storage_user_id(
+    companion_reflection_env,
+    monkeypatch,
+) -> None:
+    user_id = "user-alpha"
+    storage_user_id = resolve_existing_companion_storage_user_id(user_id)
+    personalization_db = PersonalizationDB(
+        str(DatabasePaths.get_personalization_db_path(storage_user_id))
+    )
+    personalization_db.update_profile(user_id, enabled=0)
+    opened_collection_user_ids: list[str] = []
+
+    def _fake_for_user(cls, user_id):
+        opened_collection_user_ids.append(str(user_id))
+        return object()
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Personalization.companion_reflection_jobs.CollectionsDatabase.for_user",
+        classmethod(_fake_for_user),
+    )
+
+    result = run_companion_reflection_job(user_id=user_id, cadence="daily")
+
+    assert result["status"] == "skipped"
+    assert result["reason"] == "disabled"
+    assert opened_collection_user_ids == [storage_user_id]
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Personalization/test_companion_reflection_jobs.py
+++ b/tldw_Server_API/tests/Personalization/test_companion_reflection_jobs.py
@@ -10,7 +10,7 @@ from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDat
 from tldw_Server_API.app.core.DB_Management.Personalization_DB import PersonalizationDB
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Personalization.companion_user_ids import (
-    resolve_companion_storage_user_id,
+    resolve_legacy_companion_storage_user_ids,
 )
 from tldw_Server_API.app.core.Personalization.companion_reflection_jobs import (
     COMPANION_REBUILD_JOB_TYPE,
@@ -42,7 +42,7 @@ def companion_reflection_env(monkeypatch, tmp_path) -> Iterator[Path]:
 
 
 def _legacy_storage_user_id(user_id: str) -> str:
-    return resolve_companion_storage_user_id(user_id)
+    return resolve_legacy_companion_storage_user_ids(user_id)[0]
 
 
 def _seed_companion_context(user_id: str) -> tuple[PersonalizationDB, CollectionsDatabase]:

--- a/tldw_Server_API/tests/Personalization/test_companion_reflection_jobs.py
+++ b/tldw_Server_API/tests/Personalization/test_companion_reflection_jobs.py
@@ -282,6 +282,73 @@ def test_companion_reflection_job_reuses_existing_reflection_outside_recent_wind
     assert len(reflections) == 1
 
 
+def test_companion_reflection_job_normalizes_cadence_before_deduping(
+    companion_reflection_env,
+) -> None:
+    personalization_db, collections_db = _seed_companion_context("1")
+    now = datetime(2026, 3, 10, 16, 0, tzinfo=timezone.utc)
+
+    first = run_companion_reflection_job(
+        user_id="1",
+        cadence=" Weekly ",
+        now=now,
+        personalization_db=personalization_db,
+        collections_db=collections_db,
+    )
+    second = run_companion_reflection_job(
+        user_id="1",
+        cadence="weekly",
+        now=now,
+        personalization_db=personalization_db,
+        collections_db=collections_db,
+    )
+
+    assert first["status"] == "completed"
+    assert second["status"] == "completed"
+    assert second["reflection_id"] == first["reflection_id"]
+    rows, _total = personalization_db.list_companion_activity_events("1", limit=20, offset=0)
+    reflections = [row for row in rows if row["event_type"] == "companion_reflection_generated"]
+    assert len(reflections) == 1
+    assert reflections[0]["metadata"]["cadence"] == "weekly"
+    assert reflections[0]["source_id"] == "2026-W11"
+
+
+def test_companion_reflection_job_rejects_unknown_cadence(
+    companion_reflection_env,
+) -> None:
+    personalization_db, collections_db = _seed_companion_context("1")
+
+    result = run_companion_reflection_job(
+        user_id="1",
+        cadence="monthly",
+        now=datetime(2026, 3, 10, 16, 0, tzinfo=timezone.utc),
+        personalization_db=personalization_db,
+        collections_db=collections_db,
+    )
+
+    assert result == {"status": "skipped", "reason": "invalid_cadence"}
+    rows, _total = personalization_db.list_companion_activity_events("1", limit=20, offset=0)
+    assert not any(row["event_type"] == "companion_reflection_generated" for row in rows)
+
+
+@pytest.mark.asyncio
+async def test_handle_companion_reflection_job_rejects_unknown_job_type(
+    companion_reflection_env,
+) -> None:
+    result = await handle_companion_reflection_job(
+        {
+            "job_type": "companion_archive",
+            "payload": {"user_id": "1", "cadence": "daily"},
+        }
+    )
+
+    assert result == {
+        "status": "skipped",
+        "reason": "unsupported_job_type",
+        "job_type": "companion_archive",
+    }
+
+
 @pytest.mark.asyncio
 async def test_handle_companion_job_dispatches_rebuild_scope(companion_reflection_env) -> None:
     personalization_db = PersonalizationDB(str(DatabasePaths.get_personalization_db_path("1")))

--- a/tldw_Server_API/tests/Personalization/test_companion_user_ids.py
+++ b/tldw_Server_API/tests/Personalization/test_companion_user_ids.py
@@ -13,3 +13,4 @@ def test_resolve_companion_storage_user_id_derives_stable_numeric_key_for_text_i
 
     assert left == right
     assert left.isdigit()
+    assert int(left) > 2**32

--- a/tldw_Server_API/tests/Personalization/test_companion_user_ids.py
+++ b/tldw_Server_API/tests/Personalization/test_companion_user_ids.py
@@ -1,6 +1,11 @@
 from tldw_Server_API.app.core.Personalization.companion_user_ids import (
+    resolve_existing_companion_storage_user_id,
     resolve_companion_storage_user_id,
+    resolve_legacy_companion_storage_user_ids,
 )
+from tldw_Server_API.app.core.config import settings
+from tldw_Server_API.app.core.DB_Management.Personalization_DB import PersonalizationDB
+from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 
 
 def test_resolve_companion_storage_user_id_preserves_numeric_ids() -> None:
@@ -14,3 +19,76 @@ def test_resolve_companion_storage_user_id_derives_stable_numeric_key_for_text_i
     assert left == right
     assert left.isdigit()
     assert int(left) > 2**32
+
+
+def test_resolve_legacy_companion_storage_user_ids_returns_older_text_derivations() -> None:
+    preferred = resolve_companion_storage_user_id("user@example.com")
+    legacy = resolve_legacy_companion_storage_user_ids("user@example.com")
+
+    assert len(legacy) == 2
+    assert preferred not in legacy
+    assert all(candidate.isdigit() for candidate in legacy)
+    assert all(0 < int(candidate) <= 2**32 - 1 for candidate in legacy)
+
+
+def test_resolve_existing_companion_storage_user_id_finds_legacy_db_without_creating_new_dir(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    base_dir = tmp_path / "user_dbs"
+    base_dir.mkdir()
+    prev_base_dir = settings.get("USER_DB_BASE_DIR")
+    settings.USER_DB_BASE_DIR = str(base_dir)
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(base_dir))
+    try:
+        user_id = "user@example.com"
+        preferred = resolve_companion_storage_user_id(user_id)
+        legacy = resolve_legacy_companion_storage_user_ids(user_id)[0]
+        legacy_db = PersonalizationDB(str(DatabasePaths.get_personalization_db_path(legacy)))
+        legacy_db.update_profile(user_id, enabled=1)
+
+        resolved = resolve_existing_companion_storage_user_id(user_id)
+
+        assert resolved == legacy
+        assert not (base_dir / preferred).exists()
+    finally:
+        if prev_base_dir is not None:
+            settings.USER_DB_BASE_DIR = prev_base_dir
+        else:
+            try:
+                del settings.USER_DB_BASE_DIR
+            except AttributeError:
+                pass
+
+
+def test_resolve_existing_companion_storage_user_id_prefers_existing_new_db(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    base_dir = tmp_path / "user_dbs"
+    base_dir.mkdir()
+    prev_base_dir = settings.get("USER_DB_BASE_DIR")
+    settings.USER_DB_BASE_DIR = str(base_dir)
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(base_dir))
+    try:
+        user_id = "user@example.com"
+        preferred = resolve_companion_storage_user_id(user_id)
+        legacy = resolve_legacy_companion_storage_user_ids(user_id)[0]
+        PersonalizationDB(str(DatabasePaths.get_personalization_db_path(legacy))).update_profile(
+            user_id,
+            enabled=1,
+        )
+        PersonalizationDB(str(DatabasePaths.get_personalization_db_path(preferred))).update_profile(
+            user_id,
+            enabled=1,
+        )
+
+        assert resolve_existing_companion_storage_user_id(user_id) == preferred
+    finally:
+        if prev_base_dir is not None:
+            settings.USER_DB_BASE_DIR = prev_base_dir
+        else:
+            try:
+                del settings.USER_DB_BASE_DIR
+            except AttributeError:
+                pass

--- a/tldw_Server_API/tests/Personalization/test_companion_user_ids.py
+++ b/tldw_Server_API/tests/Personalization/test_companion_user_ids.py
@@ -61,6 +61,36 @@ def test_resolve_existing_companion_storage_user_id_finds_legacy_db_without_crea
                 pass
 
 
+def test_resolve_existing_companion_storage_user_id_ignores_legacy_db_for_other_user(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    base_dir = tmp_path / "user_dbs"
+    base_dir.mkdir()
+    prev_base_dir = settings.get("USER_DB_BASE_DIR")
+    settings.USER_DB_BASE_DIR = str(base_dir)
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(base_dir))
+    try:
+        user_id = "user@example.com"
+        preferred = resolve_companion_storage_user_id(user_id)
+        legacy = resolve_legacy_companion_storage_user_ids(user_id)[0]
+        legacy_db = PersonalizationDB(str(DatabasePaths.get_personalization_db_path(legacy)))
+        legacy_db.update_profile("other-user@example.com", enabled=1)
+
+        resolved = resolve_existing_companion_storage_user_id(user_id)
+
+        assert resolved == preferred
+        assert not (base_dir / preferred).exists()
+    finally:
+        if prev_base_dir is not None:
+            settings.USER_DB_BASE_DIR = prev_base_dir
+        else:
+            try:
+                del settings.USER_DB_BASE_DIR
+            except AttributeError:
+                pass
+
+
 def test_resolve_existing_companion_storage_user_id_prefers_existing_new_db(
     monkeypatch,
     tmp_path,


### PR DESCRIPTION
## Change summary

TODO: Human requester must replace this section before merge with a human-authored summary explaining what changed and why these implementation choices were made.

## AI-prepared notes

- Centralized companion Personalization storage ID resolution for text user IDs and applied it consistently across activity capture, context loading, API dependency creation, and consolidation.
- Reduced retained reading activity free-text metadata to bounded previews, counts, digests, and truncation flags.
- Hardened reflection jobs by validating job types and normalizing/rejecting unsupported cadences.
- Added sanitized activity capture logging and regression coverage for the validated review findings.

## Verification

- `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest --confcutdir=tldw_Server_API/tests/Personalization tldw_Server_API/tests/Personalization/test_companion_activity_adapters.py tldw_Server_API/tests/Personalization/test_companion_activity_db.py tldw_Server_API/tests/Personalization/test_companion_context.py tldw_Server_API/tests/Personalization/test_companion_reflection_jobs.py tldw_Server_API/tests/Personalization/test_companion_user_ids.py -q` - 48 passed.
- `env SINGLE_USER_TEST_API_KEY=test-single-user-key SINGLE_USER_API_KEY=test-single-user-key /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest --confcutdir=tldw_Server_API/tests/Collections tldw_Server_API/tests/Collections/test_companion_reading_activity_bridge.py -q` - 3 passed.
- `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest --confcutdir=tldw_Server_API/tests/Personalization tldw_Server_API/tests/Personalization/test_companion_derivations.py tldw_Server_API/tests/API_Deps/test_personalization_deps_sanitization.py -q` - 4 passed.
- `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Personalization tldw_Server_API/app/api/v1/API_Deps/personalization_deps.py tldw_Server_API/app/services/personalization_consolidation.py -f json -o /tmp/bandit_personalization_review_pr.json` - 0 findings, 0 errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Personalization module by centralizing storage user ID resolution with a read-only legacy DB fallback, tightening retained text, validating reflection jobs, and adding sanitized logs. Consolidation, activity capture, context, API deps, and reflections now use storage-safe IDs tied to the correct logical profiles. Addresses TASK-2419.

- **Bug Fixes**
  - Storage IDs: resolved via a read-only resolver that prefers existing legacy DBs only when the profile matches; applied across activity capture, context loading, API deps, lifecycle, consolidation, and reflections (Collections DB opens with the storage-safe ID; no directories created during lookup).
  - Text retention: replaced raw notes/highlight text with previews, char counts, digests, and truncation flags; removed full free text and updated the reading bridge.
  - Reflections: normalized cadence to daily/weekly, rejected unknown cadences with an explicit reason, keyed dedupe by normalized cadence, and `handle_companion_reflection_job` skips unsupported job types.
  - Logging: added structured, sanitized activity-capture logs with exception class, hashed refs, and compact trace summaries; omitted exception messages and file paths.

<sup>Written for commit 770f48d45df0d1ff2fddd09acb39e8316cb67241. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

