### PR TITLE
Harden Local_LLM lifecycle and downloads

### DIFF
--- a/backlog/tasks/task-2420 - Harden-Local_LLM-lifecycle-and-downloads.md
+++ b/backlog/tasks/task-2420 - Harden-Local_LLM-lifecycle-and-downloads.md
@@ -1,0 +1,59 @@
+---
+id: TASK-2420
+title: Harden Local_LLM lifecycle and downloads
+status: Done
+assignee: []
+created_date: '2026-06-23 18:25'
+updated_date: '2026-06-23 19:01'
+labels:
+  - local-llm
+  - llamacpp
+  - security
+dependencies: []
+references:
+  - tldw_Server_API/app/core/Local_LLM
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and remediate Local_LLM review findings around llama.cpp acquisition SSRF protections, llamafile executable provenance, legacy process lifecycle locking, unmanaged PID termination, HuggingFace local-path/cache behavior, URL redaction, and HTTP status parsing. Continue moving llama.cpp lifecycle behavior toward the newer supervisor/process-runner path and consolidate duplicated llama.cpp argument formatting.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Validated findings are either fixed or documented as not applicable with evidence.
+- [x] #2 llama.cpp acquisition fetches revalidate redirect/final targets and private-network protections at worker download time.
+- [x] #3 Llamafile executable auto-download is opt-in and requires integrity verification before execution.
+- [x] #4 Legacy handlers no longer terminate arbitrary unmanaged PIDs and lifecycle state mutations are serialized.
+- [x] #5 Duplicated llama.cpp server argument formatting is consolidated for supervisor and legacy compatibility paths.
+- [x] #6 Focused tests, Bandit on touched scope, and relevant lint/import checks pass or are documented.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified the current Local_LLM code still contains the reviewed issues: acquisition payload validation does not re-run DNS checks and the httpx fetch follows redirects automatically; Llamafile start can auto-download the latest executable without required integrity verification; legacy LlamaCpp/Llamafile/Ollama PID stop paths can target unmanaged processes; legacy LlamaCpp/Llamafile lifecycle state lacks explicit locks; HuggingFace accepts arbitrary local model directories and caches variants without a bound; download failures can log raw URLs; HTTP status fallback regex is double-escaped. Plan: add failing focused regressions, consolidate llama.cpp argument formatting into a shared helper used by both supervisor runner and legacy handler, harden download/provenance behavior, remove unmanaged PID stops, add lifecycle locks, tighten HuggingFace path/cache behavior, and verify with focused pytest plus Bandit.
+
+Implemented shared llama.cpp server argument formatting, hardened acquisition redirect/final-target validation through the central HTTP client, required opt-in plus SHA-256 for llamafile executable auto-downloads, serialized legacy LlamaCpp/Llamafile lifecycle mutation, rejected unmanaged PID/port stops, tightened HuggingFace local path and loaded-model cache behavior, and redacted sensitive URLs/status parsing.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Verified and remediated the validated Local_LLM findings. Focused touched-file suite passed: python -m pytest -p no:unraisableexception tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_process_runner.py tldw_Server_API/tests/Local_LLM/test_http_utils.py tldw_Server_API/tests/Local_LLM/test_llamacpp_handler.py tldw_Server_API/tests/Local_LLM/test_llamafile_handler.py tldw_Server_API/tests/Local_LLM/test_ollama_handler.py tldw_Server_API/tests/Local_LLM/test_huggingface_handler_hardening.py -q (100 passed). Py_compile passed for touched Local_LLM modules. Bandit passed on tldw_Server_API/app/core/Local_LLM with 0 findings in /tmp/bandit_local_llm_2420.json; only unrelated handler_utils nosec warnings were emitted.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+- [x] #7 Focused tests pass.
+- [x] #8 Bandit runs on touched Python files.
+- [x] #9 Backlog task records verification and final summary.
+<!-- DOD:END -->

--- a/backlog/tasks/task-2420 - Harden-Local_LLM-lifecycle-and-downloads.md
+++ b/backlog/tasks/task-2420 - Harden-Local_LLM-lifecycle-and-downloads.md
@@ -3,15 +3,15 @@ id: TASK-2420
 title: Harden Local_LLM lifecycle and downloads
 status: Done
 assignee: []
-created_date: '2026-06-23 18:25'
-updated_date: '2026-06-23 19:01'
+created_date: 2026-06-23 18:25
+updated_date: 2026-06-24 03:46
 labels:
-  - local-llm
-  - llamacpp
-  - security
+- local-llm
+- llamacpp
+- security
 dependencies: []
 references:
-  - tldw_Server_API/app/core/Local_LLM
+- tldw_Server_API/app/core/Local_LLM
 priority: high
 ---
 
@@ -43,6 +43,7 @@ Implemented shared llama.cpp server argument formatting, hardened acquisition re
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Verified and remediated the validated Local_LLM findings. Focused touched-file suite passed: python -m pytest -p no:unraisableexception tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_process_runner.py tldw_Server_API/tests/Local_LLM/test_http_utils.py tldw_Server_API/tests/Local_LLM/test_llamacpp_handler.py tldw_Server_API/tests/Local_LLM/test_llamafile_handler.py tldw_Server_API/tests/Local_LLM/test_ollama_handler.py tldw_Server_API/tests/Local_LLM/test_huggingface_handler_hardening.py -q (100 passed). Py_compile passed for touched Local_LLM modules. Bandit passed on tldw_Server_API/app/core/Local_LLM with 0 findings in /tmp/bandit_local_llm_2420.json; only unrelated handler_utils nosec warnings were emitted.
+PR follow-up verification after rebase: `python -m py_compile tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py tldw_Server_API/app/core/Local_LLM/Ollama_Handler.py` passed. Focused suite passed: `python -m pytest -p no:unraisableexception tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_process_runner.py tldw_Server_API/tests/Local_LLM/test_http_utils.py tldw_Server_API/tests/Local_LLM/test_llamacpp_handler.py tldw_Server_API/tests/Local_LLM/test_llamafile_handler.py tldw_Server_API/tests/Local_LLM/test_ollama_handler.py tldw_Server_API/tests/Local_LLM/test_huggingface_handler_hardening.py -q` (102 passed). Bandit passed on `tldw_Server_API/app/core/Local_LLM` with 0 findings in `/tmp/bandit_local_llm_2420_rebase.json`.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -57,3 +58,10 @@ Verified and remediated the validated Local_LLM findings. Focused touched-file s
 - [x] #8 Bandit runs on touched Python files.
 - [x] #9 Backlog task records verification and final summary.
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Reopened for PR follow-up: rebase `codex/local-llm-hardening-2420` on latest `dev`, inspect PR comments/checks, address validated issues, re-run focused verification, and update PR branch.
+PR follow-up completed: rebased `codex/local-llm-hardening-2420` onto latest `origin/dev`, removed the unrelated Claims_Extraction design/task commit from the PR branch, and addressed the Qodo review findings. `_HttpxDownloadStream.__aenter__()` now offloads config loading and per-hop URL/DNS validation with `asyncio.to_thread`; `OllamaHandler.stop_server()` now terminates the handler-owned `asyncio.subprocess.Process` directly for managed PID/port stops instead of routing through the optional psutil PID helper.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/core/Local_LLM/Huggingface_Handler.py
+++ b/tldw_Server_API/app/core/Local_LLM/Huggingface_Handler.py
@@ -107,6 +107,36 @@ class HuggingFaceHandler(BaseLLMHandler):
     def _cache_key(self, model_name_or_path: str, quantization_config: Optional[dict]) -> tuple:
         return (model_name_or_path, self._freeze_config(quantization_config))
 
+    def _resolve_model_dir(self, model_name_or_path: str) -> Path | None:
+        candidate = Path(model_name_or_path).expanduser()
+        if candidate.is_dir():
+            try:
+                resolved = candidate.resolve()
+            except (OSError, RuntimeError, ValueError):
+                return None
+            if self._is_path_allowed(resolved) and (resolved / "config.json").exists():
+                return resolved
+            return None
+
+        local_model_path = (self.models_dir / model_name_or_path).expanduser()
+        try:
+            resolved_local = local_model_path.resolve()
+        except (OSError, RuntimeError, ValueError):
+            return None
+        if self._is_path_allowed(resolved_local) and (resolved_local / "config.json").exists():
+            return resolved_local
+        return None
+
+    def _enforce_cache_limit(self) -> None:
+        try:
+            max_loaded = int(getattr(self.config, "max_loaded_models", 1) or 1)
+        except (TypeError, ValueError):
+            max_loaded = 1
+        max_loaded = max(1, max_loaded)
+        while len(self.loaded_models) > max_loaded:
+            oldest_key = next(iter(self.loaded_models))
+            del self.loaded_models[oldest_key]
+
     async def list_models(self) -> list[str]:
         """Lists locally available Hugging Face models (directories in models_dir)."""
         if not self.models_dir.exists():
@@ -117,12 +147,7 @@ class HuggingFaceHandler(BaseLLMHandler):
 
     async def is_model_available(self, model_name: str) -> bool:
         """Checks if a model is available locally (either as a full path or in models_dir)."""
-        # Check if model_name is an absolute path to a model directory
-        if Path(model_name).is_dir() and (Path(model_name)/"config.json").exists():
-            return True
-        # Check if it's a name in our local models_dir
-        local_model_path = self.models_dir / model_name
-        return local_model_path.is_dir() and (local_model_path / "config.json").exists()
+        return self._resolve_model_dir(model_name) is not None
 
 
     async def download_model(self, model_identifier: str, save_directory: Optional[str] = None) -> str:
@@ -194,11 +219,9 @@ class HuggingFaceHandler(BaseLLMHandler):
         if cache_key in self.loaded_models:
             return self.loaded_models[cache_key]
 
-        actual_path = model_name_or_path
-        if not Path(actual_path).is_dir(): # If not a full path, assume it's in models_dir
-            actual_path = str(self.models_dir / model_name_or_path)
-            if not Path(actual_path).is_dir():
-                raise ModelNotFoundError(f"Model directory not found at {actual_path} or {model_name_or_path}")
+        actual_path = self._resolve_model_dir(model_name_or_path)
+        if actual_path is None:
+            raise ModelNotFoundError("Model directory was not found under allowed HuggingFace model paths.")
 
         self.logger.info(f"Loading model and tokenizer from: {actual_path}")
 
@@ -239,6 +262,7 @@ class HuggingFaceHandler(BaseLLMHandler):
         try:
             model, tokenizer = await asyncio.to_thread(_load)
             self.loaded_models[cache_key] = (model, tokenizer)
+            self._enforce_cache_limit()
             self.logger.info(f"Model and tokenizer for '{model_name_or_path}' loaded successfully.")
             return model, tokenizer
         except Exception as e:

--- a/tldw_Server_API/app/core/Local_LLM/LLM_Inference_Schemas.py
+++ b/tldw_Server_API/app/core/Local_LLM/LLM_Inference_Schemas.py
@@ -25,6 +25,8 @@ class HuggingFaceConfig(BaseHandlerConfig):
     models_dir: Path = Path("models/huggingface_models") # Default path
     default_device_map: str = "auto"
     default_torch_dtype: str = "torch.bfloat16" # Store as string, convert later
+    allowed_paths: Optional[list[Path]] = None
+    max_loaded_models: int = 1
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -39,6 +41,8 @@ class LlamafileConfig(BaseHandlerConfig):
     port_autoselect: bool = True
     port_probe_max: int = 10
     allowed_paths: Optional[list[Path]] = None
+    allow_executable_auto_download: bool = False
+    executable_sha256: Optional[str] = None
     http_timeout: float = 120.0  # HTTP request timeout in seconds
     readiness_timeout: float = 30.0  # Server readiness poll timeout in seconds
     stderr_read_timeout: float = 5.0  # Timeout for reading stderr during startup failures

--- a/tldw_Server_API/app/core/Local_LLM/LlamaCpp_Handler.py
+++ b/tldw_Server_API/app/core/Local_LLM/LlamaCpp_Handler.py
@@ -20,6 +20,7 @@ from tldw_Server_API.app.core.LLM_Calls.sse import (
     sse_done,
 )
 from tldw_Server_API.app.core.Local_LLM import handler_utils, http_utils
+from tldw_Server_API.app.core.Local_LLM.llamacpp_server_args import clean_server_args, server_arg_formatters
 
 # Local imports
 from .LLM_Base_Handler import BaseLLMHandler
@@ -94,6 +95,7 @@ class LlamaCppHandler(BaseLLMHandler):
         self._active_server_host: Optional[str] = None
         self._active_server_log_handle = None
         self._stream_tasks: list[asyncio.Task] = []
+        self._lifecycle_lock = asyncio.Lock()
 
         # Apply environment overrides for handler config
         handler_utils.apply_env_overrides(self.config)
@@ -233,27 +235,6 @@ class LlamaCppHandler(BaseLLMHandler):
                 task.cancel()
         self._stream_tasks = []
 
-    async def _stop_unmanaged_pid(self, pid: int) -> str:
-        try:
-            if platform.system() == "Windows":
-                await asyncio.to_thread(
-                    subprocess.run,
-                    ["taskkill", "/F", "/PID", str(pid)],
-                    check=True,
-                    capture_output=True,
-                )
-            else:
-                await asyncio.to_thread(os.kill, pid, signal.SIGTERM)
-            return f"Attempted to send SIGTERM to unmanaged llama.cpp server with PID {pid}."
-        except ProcessLookupError:
-            return f"No process found with PID {pid}."
-        except subprocess.CalledProcessError as e_taskkill:
-            self.logger.exception(f"taskkill failed for PID {pid}: {e_taskkill.stderr.decode()}")
-            return f"Failed to stop unmanaged PID {pid} with taskkill."
-        except Exception as e:
-            self.logger.error(f"Error stopping unmanaged PID {pid}: {e}", exc_info=True)
-            raise ServerError(f"Error stopping unmanaged PID {pid}: {e}") from e
-
     def _is_chat_endpoint(self, api_endpoint: str) -> bool:
         endpoint = f"/{api_endpoint.lstrip('/')}"
         return endpoint.lower().endswith("/chat/completions")
@@ -319,11 +300,12 @@ class LlamaCppHandler(BaseLLMHandler):
             raise ServerError("Model path must reference a GGUF file.")
         if not model_path.is_file():
             raise ModelNotFoundError(f"Model file {model_path.name} was not found.")
-        return await self._start_server_for_model_path(
-            model_path,
-            model_label=model_label or model_path.name,
-            server_args=server_args,
-        )
+        async with self._lifecycle_lock:
+            return await self._start_server_for_model_path(
+                model_path,
+                model_label=model_label or model_path.name,
+                server_args=server_args,
+            )
 
     async def _start_server_for_model_path(
         self,
@@ -353,7 +335,7 @@ class LlamaCppHandler(BaseLLMHandler):
             self.logger.info(
                 f"Stopping existing Llama.cpp server (PID: {self._active_server_process.pid}) to swap model.")
             try:
-                await self.stop_server()
+                await self._stop_server_unlocked()
             except ServerError as e:
                 # Restore previous state on stop failure
                 self.logger.warning(f"Failed to stop server for model swap: {e}. Restoring previous state.")
@@ -364,176 +346,10 @@ class LlamaCppHandler(BaseLLMHandler):
                 self._active_server_log_handle = prev_log_handle
                 raise ServerError(f"Model swap failed: could not stop existing server: {e}") from e
 
-        args = {k: v for k, v in (server_args or {}).items() if v is not None and v != ""}
+        args = clean_server_args(server_args)
         self._denylist_check(args)
 
-        # Allowlist of supported args (internal key -> formatter)
-        # Each formatter extends the command list with the mapped CLI args.
-        allowed_formatters: dict[str, Any] = {
-            "port": lambda v: ["--port", str(int(v))],
-            "host": lambda v: ["--host", str(v)],
-            "threads": lambda v: ["-t", str(int(v))],
-            "t": lambda v: ["-t", str(int(v))],
-            "threads_batch": lambda v: ["--threads-batch", str(int(v))],
-            "tb": lambda v: ["--threads-batch", str(int(v))],
-            "ctx_size": lambda v: ["-c", str(int(v))],
-            "c": lambda v: ["-c", str(int(v))],
-            "n_ctx": lambda v: ["-c", str(int(v))],
-            "n_gpu_layers": lambda v: ["-ngl", str(int(v))],
-            "ngl": lambda v: ["-ngl", str(int(v))],
-            "gpu_layers": lambda v: ["-ngl", str(int(v))],
-            "batch_size": lambda v: ["-b", str(int(v))],
-            "b": lambda v: ["-b", str(int(v))],
-            "n_batch": lambda v: ["-b", str(int(v))],
-            "ubatch_size": lambda v: ["--ubatch-size", str(int(v))],
-            "ub": lambda v: ["--ubatch-size", str(int(v))],
-            "n_ubatch": lambda v: ["--ubatch-size", str(int(v))],
-            "verbose": lambda v: (["--verbose"] if v else []),
-            "log_disable": lambda v: (["--log-disable"] if v else []),
-            # Extended safe flags
-            "no_mmap": lambda v: (["--no-mmap"] if v else []),
-            "mlock": lambda v: (["--mlock"] if v else []),
-            "main_gpu": lambda v: ["--main-gpu", str(int(v))],
-            "mg": lambda v: ["--main-gpu", str(int(v))],
-            "split_mode": lambda v: ["--split-mode", str(v)],
-            "sm": lambda v: ["--split-mode", str(v)],
-            "row_split": lambda v: (["--split-mode", "row"] if v else []),
-            # Additional extended flags
-            # Note: Some of these may be build-dependent in llama.cpp;
-            # keeping them in allowlist enables safe, explicit usage when supported.
-            "main_kv": lambda v: ["--main-kv", str(int(v))],
-            "no_kv_offload": lambda v: (["--no-kv-offload"] if v else []),
-            "cpu_moe": lambda v: (["--cpu-moe"] if v else []),
-            "n_cpu_moe": lambda v: ["--n-cpu-moe", str(int(v))],
-            # Rope scaling type (e.g., "linear", "yarn", etc.)
-            "rope_scaling_type": lambda v: ["--rope-scaling", str(v)],
-            "rope_scaling": lambda v: ["--rope-scaling", str(v)],
-            "tensor_split": lambda v: ["--tensor-split", ",".join(map(str, v))] if isinstance(v, (list, tuple)) else ["--tensor-split", str(v)],
-            "rope_freq_base": lambda v: ["--rope-freq-base", str(float(v))],
-            "rope_freq_scale": lambda v: ["--rope-freq-scale", str(float(v))],
-            # Aliases and additional safe toggles
-            "rope_scale": lambda v: ["--rope-freq-scale", str(float(v))],
-            "flash_attn": lambda v: (["--flash-attn", str(v)] if isinstance(v, str) else (["--flash-attn"] if v else [])),
-            "cont_batching": lambda v: (["--cont-batching"] if v else ["--no-cont-batching"]),
-            "no_cont_batching": lambda v: (["--no-cont-batching"] if v else []),
-            "context_shift": lambda v: (["--context-shift"] if v else ["--no-context-shift"]),
-            "streaming_llm": lambda v: (["--context-shift"] if v else []),
-            # LoRA support (repeatable)
-            "lora": lambda v: sum((["--lora", str(x)] for x in (v if isinstance(v, (list, tuple)) else [v])), []),
-            "lora_scaled": lambda v: (["--lora-scaled", str(v[0]), str(v[1])]
-                                      if isinstance(v, (list, tuple)) and len(v) == 2
-                                      else (["--lora-scaled", str(v)] if v is not None else [])),
-            "lora_base": lambda v: ["--lora-base", str(v)],
-            "control_vector": lambda v: ["--control-vector", str(v)],
-            # KV cache type hints
-            "cache_type_k": lambda v: ["--cache-type-k", str(v)],
-            "cache_type_v": lambda v: ["--cache-type-v", str(v)],
-            "cache_type": lambda v: ["--cache-type-k", str(v), "--cache-type-v", str(v)],
-            # Model download / HF
-            # Note: hf_token is intentionally NOT in allowlist (use HF_TOKEN env var instead)
-            "hf_repo": lambda v: ["--hf-repo", str(v)],
-            "hf_file": lambda v: ["--hf-file", str(v)],
-            "offline": lambda v: (["--offline"] if v else []),
-            # Chat / conversation toggles
-            "conversation": lambda v: (["--conversation"] if v else []),
-            "cnv": lambda v: (["--conversation"] if v else []),
-            "no_conversation": lambda v: (["--no-conversation"] if v else []),
-            "no_cnv": lambda v: (["--no-conversation"] if v else []),
-            "interactive": lambda v: (["--interactive"] if v else []),
-            "i": lambda v: (["--interactive"] if v else []),
-            "interactive_first": lambda v: (["--interactive-first"] if v else []),
-            "if": lambda v: (["--interactive-first"] if v else []),
-            "single_turn": lambda v: (["--single-turn"] if v else []),
-            "st": lambda v: (["--single-turn"] if v else []),
-            "jinja": lambda v: (["--jinja"] if v else []),
-            "chat_template": lambda v: ["--chat-template", str(v)],
-            "chat_template_file": lambda v: ["--chat-template-file", str(v)],
-            # Input/output control
-            "in_prefix": lambda v: ["--in-prefix", str(v)],
-            "in_suffix": lambda v: ["--in-suffix", str(v)],
-            "in_prefix_bos": lambda v: (["--in-prefix-bos"] if v else []),
-            "reverse_prompt": lambda v: ["--reverse-prompt", str(v)],
-            "r": lambda v: ["--reverse-prompt", str(v)],
-            # Text generation controls
-            "predict": lambda v: ["-n", str(int(v))],
-            "n": lambda v: ["-n", str(int(v))],
-            "keep": lambda v: ["--keep", str(int(v))],
-            "ignore_eos": lambda v: (["--ignore-eos"] if v else []),
-            "no_context_shift": lambda v: (["--no-context-shift"] if v else []),
-            # Sampling controls
-            "temp": lambda v: ["--temp", str(float(v))],
-            "seed": lambda v: ["-s", str(int(v))],
-            "dynatemp_range": lambda v: ["--dynatemp-range", str(float(v))],
-            "top_k": lambda v: ["--top-k", str(int(v))],
-            "top_p": lambda v: ["--top-p", str(float(v))],
-            "min_p": lambda v: ["--min-p", str(float(v))],
-            "typical": lambda v: ["--typical", str(float(v))],
-            # Repetition controls
-            "repeat_penalty": lambda v: ["--repeat-penalty", str(float(v))],
-            "repeat_last_n": lambda v: ["--repeat-last-n", str(int(v))],
-            "presence_penalty": lambda v: ["--presence-penalty", str(float(v))],
-            "frequency_penalty": lambda v: ["--frequency-penalty", str(float(v))],
-            # DRY sampling
-            "dry_multiplier": lambda v: ["--dry-multiplier", str(float(v))],
-            "dry_base": lambda v: ["--dry-base", str(float(v))],
-            "dry_allowed_length": lambda v: ["--dry-allowed-length", str(int(v))],
-            # Mirostat
-            "mirostat": lambda v: ["--mirostat", str(int(v))],
-            "mirostat_lr": lambda v: ["--mirostat-lr", str(float(v))],
-            "mirostat_ent": lambda v: ["--mirostat-ent", str(float(v))],
-            # CPU/GPU/NUMA
-            "cpu_mask": lambda v: ["--cpu-mask", str(v)],
-            "cpu_range": lambda v: ["--cpu-range", str(v)],
-            "numa": lambda v: (["--numa", str(v)] if isinstance(v, str) else (["--numa"] if v else [])),
-            # Structured generation
-            "grammar": lambda v: ["--grammar", str(v)],
-            "grammar_file": lambda v: ["--grammar-file", str(v)],
-            "json_schema": lambda v: ["--json-schema", str(v)],
-            "json_schema_file": lambda v: ["--json-schema-file", str(v)],
-            "j": lambda v: ["-j", str(v)],
-            # Reasoning
-            "reasoning_format": lambda v: ["--reasoning-format", str(v)],
-            "reasoning_budget": lambda v: ["--reasoning-budget", str(int(v))],
-            # Caching
-            "prompt_cache": lambda v: ["--prompt-cache", str(v)],
-            "prompt_cache_all": lambda v: (["--prompt-cache-all"] if v else []),
-            "prompt_cache_ro": lambda v: (["--prompt-cache-ro"] if v else []),
-            "cache_prompt": lambda v: (["--cache-prompt"] if v else ["--no-cache-prompt"]),
-            "cache_reuse": lambda v: ["--cache-reuse", str(int(v))],
-            # Server runtime
-            "parallel": lambda v: ["--parallel", str(int(v))],
-            "threads_http": lambda v: ["--threads-http", str(int(v))],
-            "timeout": lambda v: ["--timeout", str(int(v))],
-            # Multimodal
-            "mmproj": lambda v: ["--mmproj", str(v)],
-            "mmproj_url": lambda v: ["--mmproj-url", str(v)],
-            "mmproj_auto": lambda v: (["--mmproj-auto"] if v else ["--no-mmproj"]),
-            "no_mmproj": lambda v: (["--no-mmproj"] if v else []),
-            "mmproj_offload": lambda v: (["--mmproj-offload"] if v else ["--no-mmproj-offload"]),
-            "no_mmproj_offload": lambda v: (["--no-mmproj-offload"] if v else []),
-            "image_min_tokens": lambda v: ["--image-min-tokens", str(int(v))],
-            "image_max_tokens": lambda v: ["--image-max-tokens", str(int(v))],
-            # Speculative decoding
-            "model_draft": lambda v: ["--model-draft", str(v)],
-            "draft_max": lambda v: ["--draft-max", str(int(v))],
-            "draft_min": lambda v: ["--draft-min", str(int(v))],
-            "draft_p_min": lambda v: ["--draft-p-min", str(float(v))],
-            "ctx_size_draft": lambda v: ["--ctx-size-draft", str(int(v))],
-            "gpu_layers_draft": lambda v: ["--gpu-layers-draft", str(int(v))],
-            "cpu_moe_draft": lambda v: (["--cpu-moe-draft"] if v else []),
-            "n_cpu_moe_draft": lambda v: ["--n-cpu-moe-draft", str(int(v))],
-            # Logging
-            "log_file": lambda v: ["--log-file", str(v)],
-            "log_colors": lambda v: (["--log-colors"] if v else []),
-            "log_timestamps": lambda v: (["--log-timestamps"] if v else []),
-            "log_verbosity": lambda v: ["--log-verbosity", str(v)],
-            "no_perf": lambda v: (["--no-perf"] if v else []),
-            # System prompt/chat
-            "system_prompt": lambda v: ["--system-prompt", str(v)],
-            "sys": lambda v: ["--system-prompt", str(v)],
-            # Prompt convenience
-            "prompt": lambda v: ["-p", str(v)],
-        }
+        allowed_formatters = server_arg_formatters()
 
         def _coerce_port(value: Any, fallback: Any) -> int:
             if value is None or value == "":
@@ -587,7 +403,7 @@ class LlamaCppHandler(BaseLLMHandler):
             fmt = allowed_formatters.get(k)
             if fmt:
                 # Path safety for file arguments
-                if k in {"grammar_file", "json_schema_file", "chat_template_file", "prompt_cache", "log_file", "lora_base", "control_vector", "mmproj"}:
+                if k in {"grammar_file", "json_schema_file", "chat_template_file", "prompt_cache", "log_file", "lora_base", "control_vector", "mmproj", "model_draft"}:
                     p = Path(v)
                     if not self._is_path_allowed(p):
                         raise ServerError(f"File path for '{k}' must be under allowed directories.")
@@ -596,6 +412,10 @@ class LlamaCppHandler(BaseLLMHandler):
                     for item in vals:
                         if not self._is_path_allowed(Path(item)):
                             raise ServerError("LoRA path must be under allowed directories.")
+                if k == "lora_scaled":
+                    vals = v if isinstance(v, (list, tuple)) else [v]
+                    if vals and not self._is_path_allowed(Path(vals[0])):
+                        raise ServerError("LoRA path must be under allowed directories.")
                 command += fmt(v)
             elif getattr(self.config, "allow_unvalidated_args", False):
                 # Pass-through unknown args as --key value (bool True -> flag only)
@@ -696,11 +516,15 @@ class LlamaCppHandler(BaseLLMHandler):
             raise ServerError(f"Exception starting Llama.cpp server: {e}") from e
 
     async def stop_server(self, pid: Optional[int] = None, port: Optional[int] = None) -> str:
+        async with self._lifecycle_lock:
+            return await self._stop_server_unlocked(pid=pid, port=port)
+
+    async def _stop_server_unlocked(self, pid: Optional[int] = None, port: Optional[int] = None) -> str:
         if pid is not None:
             if self._active_server_process and pid == self._active_server_process.pid:
                 port = None
             else:
-                return await self._stop_unmanaged_pid(pid)
+                return f"No managed Llama.cpp server found with PID {pid}."
         if port is not None:
             if not self._active_server_process or self._active_server_port is None or int(port) != int(self._active_server_port):
                 return f"No managed Llama.cpp server found on port {port}."
@@ -715,70 +539,8 @@ class LlamaCppHandler(BaseLLMHandler):
 
         try:
             if process_to_stop.returncode is None:  # Still running
-                if platform.system() == "Windows":
-                    process_to_stop.terminate()
-                else:
-                    try:
-                        pgid = await asyncio.to_thread(
-                            self._signal_managed_process_group,
-                            process_to_stop,
-                            signal.SIGTERM,
-                        )
-                        self.logger.info(f"Sent SIGTERM to process group {pgid} (leader PID: {pid}).")
-                    except ProcessLookupError:
-                        self.logger.warning(f"Process {pid} not found for SIGTERM, likely already terminated.")
-                        process_to_stop.terminate()  # Fallback
-                    except _LLAMACPP_NONCRITICAL_EXCEPTIONS as e_pg:
-                        self.logger.warning(
-                            f"Failed to send SIGTERM to process group {pid}: {e_pg}. Falling back to PID.")
-                        process_to_stop.terminate()
-
-                try:
-                    await asyncio.wait_for(process_to_stop.wait(), timeout=10)
-                    self.logger.info(f"Llama.cpp server PID {pid} (Model: {model_name}) terminated gracefully.")
-                except asyncio.TimeoutError:
-                    self.logger.warning(
-                        f"Llama.cpp server PID {pid} (Model: {model_name}) did not terminate gracefully. Killing.")
-                    if platform.system() == "Windows":
-                        if hasattr(process_to_stop, "send_signal"):
-                            with contextlib.suppress(_LLAMACPP_NONCRITICAL_EXCEPTIONS):
-                                process_to_stop.send_signal(signal.CTRL_BREAK_EVENT)
-                        if hasattr(process_to_stop, "terminate"):
-                            process_to_stop.terminate()
-                        if hasattr(process_to_stop, "kill"):
-                            process_to_stop.kill()
-                    else:
-                        try:
-                            await asyncio.to_thread(
-                                self._signal_managed_process_group,
-                                process_to_stop,
-                                signal.SIGKILL,
-                            )
-                        except (ProcessLookupError, PermissionError, OSError) as e:
-                            # pgid may not be available if getpgid failed; log using pid
-                            self.logger.warning(
-                                f"Failed to kill process group for PID {pid}: {e}. Attempting PID SIGKILL fallback.")
-                            # Try direct SIGKILL to PID; if that fails, try process.kill() if available
-                            try:
-                                await asyncio.to_thread(os.kill, pid, signal.SIGKILL)
-                                self.logger.info(f"Sent SIGKILL to PID {pid} (fallback).")
-                            except ProcessLookupError:
-                                self.logger.warning(
-                                    f"PID {pid} already exited when attempting SIGKILL fallback.")
-                            except _LLAMACPP_NONCRITICAL_EXCEPTIONS as e_killpid:
-                                self.logger.debug(
-                                    f"os.kill fallback failed for PID {pid}: {e_killpid}; checking for process.kill()"
-                                )
-                                if hasattr(process_to_stop, "kill"):
-                                    try:
-                                        process_to_stop.kill()
-                                        self.logger.info(
-                                            f"Invoked process.kill() for PID {pid} (final fallback)."
-                                        )
-                                    except _LLAMACPP_NONCRITICAL_EXCEPTIONS as e_pkill:
-                                        self.logger.warning(
-                                            f"process.kill() failed for PID {pid}: {e_pkill}")
-                    await process_to_stop.wait()
+                await self._terminate_process(process_to_stop)
+                self.logger.info(f"Llama.cpp server PID {pid} (Model: {model_name}) terminated.")
             else:
                 self.logger.info(
                     f"Llama.cpp server PID {pid} (Model: {model_name}) was already stopped (return code: {process_to_stop.returncode}).")

--- a/tldw_Server_API/app/core/Local_LLM/Llamafile_Handler.py
+++ b/tldw_Server_API/app/core/Local_LLM/Llamafile_Handler.py
@@ -9,7 +9,8 @@ import os
 import platform
 import shutil
 import signal
-import subprocess
+# Used without shell for managed process flags, exceptions, and cleanup.
+import subprocess  # nosec B404
 import sys
 import tempfile
 import time
@@ -81,6 +82,7 @@ class LlamafileHandler(BaseLLMHandler):
         # Corrected type hint for asyncio.subprocess.Process
         self._active_servers: dict[int, asyncio.subprocess.Process] = {}
         self._stream_tasks: dict[int, list[asyncio.Task]] = {}
+        self._lifecycle_lock = asyncio.Lock()
 
         # Apply environment overrides
         handler_utils.apply_env_overrides(self.config)
@@ -242,11 +244,21 @@ class LlamafileHandler(BaseLLMHandler):
     async def download_latest_llamafile_executable(self, force_download: bool = False) -> Path:
         """Downloads the latest llamafile binary if not present or if force_download is True."""
         output_path = self.llamafile_exe_path
+        expected_sha256 = str(getattr(self.config, "executable_sha256", "") or "").strip().lower()
         self.logger.info(f"Checking for llamafile executable at {output_path}...")
         if output_path.exists() and not force_download:
+            if expected_sha256 and not await asyncio.to_thread(verify_checksum, str(output_path), expected_sha256):
+                raise ModelDownloadError("Existing llamafile executable failed checksum verification.")
             self.logger.debug(f"{output_path.name} already exists. Skipping download.")
             await asyncio.to_thread(os.chmod, output_path, 0o755)  # Ensure executable
             return output_path
+
+        if not getattr(self.config, "allow_executable_auto_download", False):
+            raise ModelDownloadError(
+                "Llamafile executable auto-download is disabled. Configure a local executable or enable it explicitly."
+            )
+        if not expected_sha256:
+            raise ModelDownloadError("Llamafile executable auto-download requires executable_sha256.")
 
         repo = "Mozilla-Ocho/llamafile"
         latest_release_url = f"https://api.github.com/repos/{repo}/releases/latest"
@@ -344,7 +356,7 @@ class LlamafileHandler(BaseLLMHandler):
                     raise ModelDownloadError(f"No suitable llamafile asset found for tag {tag_name}.")
 
                 self.logger.info(
-                    f"Found asset: {chosen_asset_name}. Downloading Llamafile from {asset_url} to {output_path}...")
+                    f"Found asset: {chosen_asset_name}. Downloading Llamafile from {http_utils.redacted_url(asset_url)} to {output_path}...")
 
                 # Ensure the target directory exists
                 output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -359,6 +371,9 @@ class LlamafileHandler(BaseLLMHandler):
                         tmp_zip_path.unlink(missing_ok=True)
                 else:
                     await async_stream_download(asset_url, str(output_path))
+                if not await asyncio.to_thread(verify_checksum, str(output_path), expected_sha256):
+                    output_path.unlink(missing_ok=True)
+                    raise ModelDownloadError("Checksum verification failed for downloaded llamafile executable.")
                 await asyncio.to_thread(os.chmod, output_path, 0o755)
                 self.logger.info(f"Downloaded {output_path.name} successfully.")
                 return output_path
@@ -408,7 +423,7 @@ class LlamafileHandler(BaseLLMHandler):
                 return model_path
 
         self.models_dir.mkdir(parents=True, exist_ok=True)  # Ensure models dir exists
-        self.logger.info(f"Downloading model: {model_name} from {model_url} to {model_path}")
+        self.logger.info(f"Downloading model: {model_name} from {http_utils.redacted_url(model_url)} to {model_path}")
         try:
             from tldw_Server_API.app.core.Local_LLM.http_utils import async_stream_download
             await async_stream_download(model_url, str(model_path))
@@ -442,6 +457,10 @@ class LlamafileHandler(BaseLLMHandler):
 
     # --- Server Management ---
     async def start_server(self, model_filename: str, server_args: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+        async with self._lifecycle_lock:
+            return await self._start_server_unlocked(model_filename, server_args=server_args)
+
+    async def _start_server_unlocked(self, model_filename: str, server_args: Optional[dict[str, Any]] = None) -> dict[str, Any]:
         llamafile_exe = await self.download_latest_llamafile_executable()
         if not llamafile_exe or not llamafile_exe.exists():
             raise ServerError("Llamafile executable not found or could not be downloaded.")
@@ -620,6 +639,10 @@ class LlamafileHandler(BaseLLMHandler):
             raise ServerError(f"Exception starting llamafile: {e}") from e
 
     async def stop_server(self, port: Optional[int] = None, pid: Optional[int] = None) -> str:
+        async with self._lifecycle_lock:
+            return await self._stop_server_unlocked(port=port, pid=pid)
+
+    async def _stop_server_unlocked(self, port: Optional[int] = None, pid: Optional[int] = None) -> str:
         process_to_stop: Optional[asyncio.subprocess.Process] = None
         port_to_clear = None
 
@@ -630,24 +653,7 @@ class LlamafileHandler(BaseLLMHandler):
                     port_to_clear = p
                     break
             if not process_to_stop:
-                self.logger.warning(
-                    f"PID {pid} not in managed servers. Attempting to terminate externally (best effort).")
-                try:
-                    # This part is synchronous and for unmanaged processes
-                    target_pid = int(pid)
-                    if platform.system() == "Windows":
-                        subprocess.run(['taskkill', '/F', '/PID', str(target_pid)], check=True, capture_output=True)
-                    else:
-                        os.kill(target_pid, signal.SIGTERM)  # Can use os.killpg if it was started in a group
-                    return f"Attempted to send SIGTERM to unmanaged llamafile server with PID {pid}."
-                except ProcessLookupError:
-                    return f"No process found with PID {pid}."
-                except subprocess.CalledProcessError as e_taskkill:
-                    self.logger.exception(f"taskkill failed for PID {pid}: {e_taskkill.stderr.decode()}")
-                    return f"Failed to stop unmanaged PID {pid} with taskkill."
-                except Exception as e:
-                    self.logger.error(f"Error stopping unmanaged PID {pid}: {e}", exc_info=True)
-                    raise ServerError(f"Error stopping unmanaged PID {pid}: {e}") from e
+                return f"No managed llamafile server found with PID {pid}."
         elif port:
             if port in self._active_servers:
                 process_to_stop = self._active_servers[port]
@@ -665,62 +671,9 @@ class LlamafileHandler(BaseLLMHandler):
         try:
             # Check if still running using returncode
             if process_to_stop.returncode is None:
-                if platform.system() == "Windows":
-                    process_to_stop.terminate()
-                else:
-                    try:
-                        # Get process group ID (pgid) to terminate the entire group
-                        pgid = await asyncio.to_thread(os.getpgid, current_pid)
-                        await asyncio.to_thread(os.killpg, pgid, signal.SIGTERM)
-                        self.logger.info(f"Sent SIGTERM to process group {pgid} (leader PID: {current_pid}).")
-                    except ProcessLookupError:  # Process might have died just now
-                        self.logger.warning(
-                            f"Process {current_pid} not found during getpgid, likely already terminated.")
-                        # Fallback to terminating just the PID if getpgid fails for other reasons
-                        process_to_stop.terminate()
-                        self.logger.info(f"Sent SIGTERM to process PID {current_pid} (fallback).")
-
-                try:
-                    await asyncio.wait_for(process_to_stop.wait(), timeout=10)
-                    self.logger.info(
-                        f"Llamafile server PID {current_pid} terminated gracefully (return code: {process_to_stop.returncode}).")
-                except asyncio.TimeoutError:
-                    self.logger.warning(
-                        f"Llamafile server PID {current_pid} did not terminate gracefully after SIGTERM. Killing.")
-                    if platform.system() == "Windows":
-                        process_to_stop.kill()
-                    else:
-                        try:
-                            pgid = await asyncio.to_thread(os.getpgid, current_pid)
-                            await asyncio.to_thread(os.killpg, pgid, signal.SIGKILL)
-                            self.logger.info(f"Sent SIGKILL to process group {pgid} (leader PID: {current_pid}).")
-                        except ProcessLookupError:
-                            self.logger.warning(f"Process {current_pid} not found during getpgid for SIGKILL.")
-                            # Fallback: try direct SIGKILL to PID; if that fails, try process.kill() if available
-                            try:
-                                await asyncio.to_thread(os.kill, current_pid, signal.SIGKILL)
-                                self.logger.info(f"Sent SIGKILL to process PID {current_pid} (fallback).")
-                            except ProcessLookupError:
-                                self.logger.warning(
-                                    f"Process {current_pid} already exited when attempting SIGKILL fallback.")
-                            except _LLAMAFILE_NONCRITICAL_EXCEPTIONS as e_killpid:
-                                self.logger.debug(
-                                    f"os.kill fallback failed for PID {current_pid}: {e_killpid}; "
-                                    f"checking for process.kill() availability"
-                                )
-                                if hasattr(process_to_stop, "kill"):
-                                    try:
-                                        process_to_stop.kill()
-                                        self.logger.info(
-                                            f"Invoked process.kill() for PID {current_pid} (final fallback)."
-                                        )
-                                    except _LLAMAFILE_NONCRITICAL_EXCEPTIONS as e_pkill:
-                                        self.logger.warning(
-                                            f"process.kill() failed for PID {current_pid}: {e_pkill}")
-
-                    await process_to_stop.wait()  # Ensure it's reaped
-                    self.logger.info(
-                        f"Llamafile server PID {current_pid} killed (return code: {process_to_stop.returncode}).")
+                await self._terminate_process(process_to_stop)
+                self.logger.info(
+                    f"Llamafile server PID {current_pid} terminated (return code: {process_to_stop.returncode}).")
             else:
                 self.logger.info(
                     f"Llamafile server PID {current_pid} was already stopped (return code: {process_to_stop.returncode}).")

--- a/tldw_Server_API/app/core/Local_LLM/Ollama_Handler.py
+++ b/tldw_Server_API/app/core/Local_LLM/Ollama_Handler.py
@@ -328,12 +328,14 @@ class OllamaHandler(BaseLLMHandler):
             self.logger.info(f"Attempting to stop Ollama server with PID {pid}")
             if not self._serve_process or self._serve_process.pid != pid:
                 return f"No managed Ollama server found with PID {pid}"
+            process = self._serve_process
             try:
-                await asyncio.to_thread(self._terminate_process, pid)
+                await self._terminate_managed_process(process)
                 self._clear_serve_process(pid)
                 return f"Attempted to stop Ollama server with PID {pid}"
             except ProcessLookupError:
                 self.logger.warning(f"No process found with PID {pid}")
+                self._clear_serve_process(pid)
                 return f"No process found with PID {pid}"
             except _OLLAMA_NONCRITICAL_EXCEPTIONS as e:
                 self.logger.error(f"Error stopping Ollama server PID {pid}")
@@ -346,9 +348,10 @@ class OllamaHandler(BaseLLMHandler):
                 or int(port) != int(self._serve_port)
             ):
                 return f"No managed Ollama server found on port {port}"
-            managed_pid = self._serve_process.pid
+            process = self._serve_process
+            managed_pid = process.pid
             try:
-                await asyncio.to_thread(self._terminate_process, managed_pid)
+                await self._terminate_managed_process(process)
                 self._clear_serve_process(managed_pid)
                 return f"Attempted to stop Ollama server (PID {managed_pid}) on port {port}"
             except ProcessLookupError:
@@ -369,26 +372,21 @@ class OllamaHandler(BaseLLMHandler):
             # self.logger.info(f"Ollama stop command output: {stdout}")
             return "General 'ollama stop' for a server is not a standard command. Please provide PID or manage via system services."
 
-    def _terminate_process(self, pid: int):
-        """Helper to terminate a process by PID. Requires psutil."""
-        if not PSUTIL_AVAILABLE:
-            raise ServerError("psutil not available; cannot terminate process by PID")
+    async def _terminate_managed_process(self, process: asyncio.subprocess.Process) -> None:
+        """Terminate only the subprocess object owned by this handler."""
+        if process.returncode is not None:
+            return
         try:
-            proc = psutil.Process(pid)
-            proc.terminate()  # Send SIGTERM
-            self.logger.info(f"Sent SIGTERM to process {pid}")
-            try:
-                proc.wait(timeout=5)  # Wait for termination
-                self.logger.info(f"Process {pid} terminated gracefully.")
-            except psutil.TimeoutExpired:
-                self.logger.warning(f"Process {pid} did not terminate after SIGTERM, sending SIGKILL.")
-                proc.kill()  # Send SIGKILL
-                proc.wait(timeout=5)
-                self.logger.info(f"Process {pid} killed.")
-        except psutil.NoSuchProcess:
-            raise ProcessLookupError(f"No process found with PID {pid}") from None
-        except _OLLAMA_PSUTIL_EXCEPTIONS as e:
-            raise ServerError(f"Failed to terminate process {pid}: {e}") from e
+            process.terminate()
+            self.logger.info(f"Sent SIGTERM to managed Ollama process {process.pid}")
+            await asyncio.wait_for(process.wait(), timeout=5)
+            self.logger.info(f"Managed Ollama process {process.pid} terminated gracefully.")
+        except asyncio.TimeoutError:
+            self.logger.warning(
+                f"Managed Ollama process {process.pid} did not terminate after SIGTERM, sending SIGKILL."
+            )
+            process.kill()
+            await asyncio.wait_for(process.wait(), timeout=5)
 
     async def inference(self, model_name: str, prompt: str, system_message: Optional[str] = None,
                         port: Optional[int] = None, host: str = "127.0.0.1",

--- a/tldw_Server_API/app/core/Local_LLM/Ollama_Handler.py
+++ b/tldw_Server_API/app/core/Local_LLM/Ollama_Handler.py
@@ -89,6 +89,8 @@ class OllamaHandler(BaseLLMHandler):
         super().__init__(config, global_app_config)
         self.config: OllamaConfig  # For type hinting
         self._serve_process: Optional[asyncio.subprocess.Process] = None
+        self._serve_host: Optional[str] = None
+        self._serve_port: Optional[int] = None
         self._serve_stream_tasks: list[asyncio.Task] = []
 
     async def _drain_stream(self, stream, label: str) -> None:
@@ -124,6 +126,8 @@ class OllamaHandler(BaseLLMHandler):
         if self._serve_process and (pid is None or self._serve_process.pid == pid):
             self._stop_stream_drainers()
             self._serve_process = None
+            self._serve_host = None
+            self._serve_port = None
     async def is_ollama_installed(self) -> bool:
         """Checks if the 'ollama' executable is available."""
         return await asyncio.to_thread(shutil.which, 'ollama') is not None
@@ -298,6 +302,8 @@ class OllamaHandler(BaseLLMHandler):
             pid = process.pid
             self.logger.info(f"Ollama server process started with PID {pid} on {host}:{port}. May run in background.")
             self._serve_process = process
+            self._serve_host = host
+            self._serve_port = int(port)
             self._start_stream_drainers(process)
             return {"status": "started", "pid": pid, "host": host, "port": port}
 
@@ -312,16 +318,16 @@ class OllamaHandler(BaseLLMHandler):
     async def stop_server(self, pid: Optional[int] = None, port: Optional[int] = None) -> str:
         """
         Stops the Ollama server.
-        If PID is given, it attempts to terminate that specific process.
-        If port is given, it attempts to find and terminate the process listening on that port.
-        Stopping `ollama serve` can be tricky as it might be managed by systemd.
-        This function primarily targets processes started by this library or manually.
+        PID and port stops are limited to the process started by this handler.
+        External Ollama services should be managed by their owning service manager.
         """
         if not await self.is_ollama_installed():
             return "Ollama is not installed."
 
         if pid:
             self.logger.info(f"Attempting to stop Ollama server with PID {pid}")
+            if not self._serve_process or self._serve_process.pid != pid:
+                return f"No managed Ollama server found with PID {pid}"
             try:
                 await asyncio.to_thread(self._terminate_process, pid)
                 self._clear_serve_process(pid)
@@ -333,25 +339,23 @@ class OllamaHandler(BaseLLMHandler):
                 self.logger.error(f"Error stopping Ollama server PID {pid}")
                 return f"Error stopping Ollama server PID {pid}"
         elif port:
-            if not PSUTIL_AVAILABLE:
-                return "Cannot stop by port: psutil not available. Please provide PID instead."
             self.logger.info(f"Attempting to stop Ollama server listening on port {port}")
-            found_pid = None
+            if (
+                not self._serve_process
+                or self._serve_port is None
+                or int(port) != int(self._serve_port)
+            ):
+                return f"No managed Ollama server found on port {port}"
+            managed_pid = self._serve_process.pid
             try:
-                for conn in await asyncio.to_thread(psutil.net_connections):
-                    if conn.status == psutil.CONN_LISTEN and conn.laddr.port == int(port):
-                        if conn.pid:
-                            proc_info = await asyncio.to_thread(psutil.Process, conn.pid)
-                            if "ollama" in proc_info.name().lower():
-                                found_pid = conn.pid
-                                break
-                if found_pid:
-                    await asyncio.to_thread(self._terminate_process, found_pid)
-                    self._clear_serve_process(found_pid)
-                    return f"Attempted to stop Ollama server (PID {found_pid}) on port {port}"
-                else:
-                    return f"No Ollama server found listening on port {port}"
-            except _OLLAMA_PSUTIL_EXCEPTIONS as e:
+                await asyncio.to_thread(self._terminate_process, managed_pid)
+                self._clear_serve_process(managed_pid)
+                return f"Attempted to stop Ollama server (PID {managed_pid}) on port {port}"
+            except ProcessLookupError:
+                self.logger.warning(f"No process found with PID {managed_pid}")
+                self._clear_serve_process(managed_pid)
+                return f"No process found with PID {managed_pid}"
+            except _OLLAMA_NONCRITICAL_EXCEPTIONS:
                 self.logger.error(f"Error stopping Ollama server on port {port}")
                 return f"Error stopping Ollama server on port {port}"
         else:

--- a/tldw_Server_API/app/core/Local_LLM/http_utils.py
+++ b/tldw_Server_API/app/core/Local_LLM/http_utils.py
@@ -10,6 +10,7 @@ import asyncio
 import re
 from collections.abc import Iterable
 from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from loguru import logger
 
@@ -27,6 +28,22 @@ from tldw_Server_API.app.core.http_client import (
 DEFAULT_TIMEOUT: float = 120.0
 DEFAULT_RETRIES: int = 2
 DEFAULT_BACKOFF: float = 0.75
+_SECRET_QUERY_KEYS = {
+    "access_token",
+    "apikey",
+    "api_key",
+    "auth",
+    "authorization",
+    "key",
+    "password",
+    "secret",
+    "sig",
+    "signature",
+    "token",
+    "x-amz-credential",
+    "x-amz-security-token",
+    "x-amz-signature",
+}
 
 
 def _is_httpx_async_client(client: Any) -> bool:
@@ -52,7 +69,7 @@ def get_http_status_from_exception(exc: Exception) -> int | None:
             except (TypeError, ValueError):
                 pass
     if isinstance(exc, NetworkError):
-        match = re.search(r"HTTP\\s+(\\d{3})", str(exc))
+        match = re.search(r"HTTP\s+(\d{3})", str(exc))
         if match:
             try:
                 return int(match.group(1))
@@ -83,6 +100,35 @@ def is_network_error(exc: Exception) -> bool:
     if module.startswith("requests"):
         return "RequestException" in name or "Timeout" in name or "ConnectionError" in name
     return False
+
+
+def redacted_url(url: str) -> str:
+    """Return a log-safe URL string without credentials or sensitive query values."""
+    value = str(url or "").strip()
+    if not value:
+        return ""
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return "<invalid-url>"
+    if not parsed.scheme or not parsed.netloc:
+        return value
+
+    host = parsed.hostname or ""
+    netloc = host
+    if ":" in host and not host.startswith("["):
+        netloc = f"[{host}]"
+    if parsed.port is not None:
+        netloc = f"{netloc}:{parsed.port}"
+    query = urlencode(
+        [
+            (key, val)
+            for key, val in parse_qsl(parsed.query, keep_blank_values=True)
+            if key.strip().lower() not in _SECRET_QUERY_KEYS
+        ],
+        doseq=True,
+    )
+    return urlunsplit((parsed.scheme, netloc, parsed.path, query, ""))
 
 
 def redact_cmd_args(
@@ -247,5 +293,5 @@ async def async_stream_download(
     try:
         await adownload(url=url, dest=dest_path, retry=policy)
     except Exception as e:
-        logger.error(f"Download failed for {url}: {e}")
+        logger.error(f"Download failed for {redacted_url(url)}: {e}")
         raise

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py
@@ -13,7 +13,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
-from urllib.parse import SplitResult, parse_qsl, unquote, urlencode, urlsplit, urlunsplit
+from urllib.parse import SplitResult, parse_qsl, unquote, urlencode, urljoin, urlsplit, urlunsplit
 
 import httpx
 
@@ -21,6 +21,7 @@ from tldw_Server_API.app.api.v1.schemas.llamacpp_admin_schemas import (
     LlamaCppAsset,
     LlamaCppAssetDownloadRequest,
 )
+from tldw_Server_API.app.core import http_client
 from tldw_Server_API.app.core.config import load_comprehensive_config
 from tldw_Server_API.app.core.Local_LLM import handler_utils, llamacpp_inventory_service
 from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
@@ -47,6 +48,7 @@ _SECRET_QUERY_KEYS = {
 _SAFE_JOB_ID_RE = re.compile(r"[^a-zA-Z0-9_.-]+")
 _DEFAULT_DOWNLOAD_TIMEOUT_SECONDS = 60.0
 _DEFAULT_MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024 * 1024
+_MAX_DOWNLOAD_REDIRECTS = 5
 
 ProgressCallback = Callable[[dict[str, Any]], Awaitable[None] | None]
 CancelCheck = Callable[[], bool]
@@ -108,7 +110,7 @@ def validate_download_payload(
         raise ServerError("Invalid llama.cpp acquisition job payload.")
     config = saved_config if saved_config is not None else _read_saved_config()
     warnings = _string_list(payload.get("warnings"))
-    source_url = _validate_payload_source_url(str(payload.get("source_url") or ""), config)
+    source_url = _validate_source_url(str(payload.get("source_url") or ""), config, warnings)
     destination_raw = str(payload.get("destination_path") or "").strip()
     if not destination_raw:
         raise ServerError("Download destination path is required.")
@@ -319,36 +321,6 @@ def _validate_source_url(url: str, saved_config: dict[str, Any], warnings: list[
     if _is_local_hostname(host) and not allow_private:
         raise ServerError("Download URL host resolves to a local or private network address.")
     _validate_host_addresses(host, allow_private=allow_private, warnings=warnings)
-    return _normalized_source_url(parsed, port=port)
-
-
-def _validate_payload_source_url(url: str, saved_config: dict[str, Any]) -> str:
-    """Validate a queued download URL without DNS lookups and return its sanitized form."""
-
-    raw_url = str(url or "").strip()
-    if not raw_url:
-        raise ServerError("Download URL is required.")
-    try:
-        parsed = urlsplit(raw_url)
-        port = parsed.port
-    except ValueError as exc:
-        raise ServerError("Download URL is invalid.") from exc
-    scheme = parsed.scheme.lower()
-    if scheme not in _DOWNLOAD_SCHEMES:
-        raise ServerError("Download URL scheme must be http or https.")
-    if not parsed.hostname:
-        raise ServerError("Download URL host is required.")
-    if parsed.username is not None or parsed.password is not None:
-        raise ServerError("Download URL credentials are not supported.")
-    if any(_is_secret_query_key(key) for key, _val in parse_qsl(parsed.query, keep_blank_values=True)):
-        raise ServerError("Download URL contains unsupported sensitive query parameters.")
-    allow_private = bool(_config_bool(saved_config.get("allow_private_downloads")))
-    host = parsed.hostname.strip().lower()
-    if _is_local_hostname(host) and not allow_private:
-        raise ServerError("Download URL host resolves to a local or private network address.")
-    literal = _ip_address_or_none(host)
-    if literal is not None:
-        _reject_private_address(literal, allow_private=allow_private)
     return _normalized_source_url(parsed, port=port)
 
 
@@ -638,10 +610,27 @@ class _HttpxDownloadStream:
         self.total_bytes: int | None = None
 
     async def __aenter__(self) -> _HttpxDownloadStream:
-        self._client = httpx.AsyncClient(timeout=self._timeout_seconds, follow_redirects=True)
-        self._response_cm = self._client.stream("GET", self._url)
-        self._response = await self._response_cm.__aenter__()
-        self._response.raise_for_status()
+        self._client = http_client.create_async_client(timeout=self._timeout_seconds)
+        config = _read_saved_config()
+        warnings: list[str] = []
+        next_url = self._url
+        for _redirect_count in range(_MAX_DOWNLOAD_REDIRECTS + 1):
+            next_url = _validate_source_url(next_url, config, warnings)
+            self._response_cm = self._client.stream("GET", next_url)
+            self._response = await self._response_cm.__aenter__()
+            if self._is_redirect(self._response):
+                location = self._response.headers.get("location")
+                await self._response_cm.__aexit__(None, None, None)
+                self._response_cm = None
+                self._response = None
+                if not location:
+                    raise LlamaCppDownloadError("Download redirect did not include a Location header.")
+                next_url = urljoin(next_url, location)
+                continue
+            self._response.raise_for_status()
+            break
+        else:
+            raise LlamaCppDownloadError("Download exceeded the maximum redirect count.")
         self.total_bytes = _content_length(self._response.headers.get("content-length"))
         return self
 
@@ -657,6 +646,10 @@ class _HttpxDownloadStream:
             raise LlamaCppDownloadError("Download stream was not opened.")
         async for chunk in self._response.aiter_bytes():
             yield chunk
+
+    @staticmethod
+    def _is_redirect(response: httpx.Response) -> bool:
+        return response.status_code in {301, 302, 303, 307, 308}
 
 
 def _content_length(value: str | None) -> int | None:

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py
@@ -611,11 +611,11 @@ class _HttpxDownloadStream:
 
     async def __aenter__(self) -> _HttpxDownloadStream:
         self._client = http_client.create_async_client(timeout=self._timeout_seconds)
-        config = _read_saved_config()
+        config = await asyncio.to_thread(_read_saved_config)
         warnings: list[str] = []
         next_url = self._url
         for _redirect_count in range(_MAX_DOWNLOAD_REDIRECTS + 1):
-            next_url = _validate_source_url(next_url, config, warnings)
+            next_url = await asyncio.to_thread(_validate_source_url, next_url, config, warnings)
             self._response_cm = self._client.stream("GET", next_url)
             self._response = await self._response_cm.__aenter__()
             if self._is_redirect(self._response):

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_process_runner.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_process_runner.py
@@ -7,11 +7,12 @@ import contextlib
 import os
 import platform
 import signal
-import subprocess  # nosec B404 - used without shell for llama-server process control
+# Used without shell for managed llama-server process control.
+import subprocess  # nosec B404
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 from loguru import logger
 
@@ -25,31 +26,19 @@ from tldw_Server_API.app.core.Local_LLM.llamacpp_runtime_models import (
     LlamaCppRuntime,
     LlamaCppRuntimeState,
 )
+from tldw_Server_API.app.core.Local_LLM.llamacpp_server_args import (
+    CORE_SERVER_ARG_KEYS,
+    PATH_ARG_KEYS,
+    RESERVED_STRUCTURED_ARG_KEYS,
+    clean_server_args,
+    server_arg_formatters,
+)
 
 _MAX_LOG_LINES = 1000
 _MAX_LOG_BYTES = 256 * 1024
-_PATH_ARG_KEYS = {
-    "grammar_file",
-    "json_schema_file",
-    "chat_template_file",
-    "prompt_cache",
-    "log_file",
-    "lora_base",
-    "control_vector",
-    "mmproj",
-    "model_draft",
-}
-_CORE_SERVER_ARG_KEYS = {
-    "threads",
-    "t",
-    "ctx_size",
-    "c",
-    "n_ctx",
-    "n_gpu_layers",
-    "ngl",
-    "gpu_layers",
-}
-_RESERVED_STRUCTURED_ARG_KEYS = {"host", "port", "model", "m"}
+_PATH_ARG_KEYS = PATH_ARG_KEYS
+_CORE_SERVER_ARG_KEYS = CORE_SERVER_ARG_KEYS
+_RESERVED_STRUCTURED_ARG_KEYS = RESERVED_STRUCTURED_ARG_KEYS
 
 
 async def wait_for_http_ready(*args: Any, **kwargs: Any) -> bool:
@@ -61,158 +50,8 @@ def _utc_now() -> str:
     return datetime.now(UTC).isoformat()
 
 
-def _flatten_repeatable(flag: str, value: Any) -> list[str]:
-    values = value if isinstance(value, (list, tuple)) else [value]
-    command: list[str] = []
-    for item in values:
-        command.extend([flag, str(item)])
-    return command
-
-
-def _server_arg_formatters() -> dict[str, Callable[[Any], list[str]]]:
-    """Return the supported llama-server args used by the Admin UI and V1 APIs.
-
-    TODO(TASK-397): consolidate this map with LlamaCppHandler once the new
-    supervisor owns the default-profile compatibility path.
-    """
-    return {
-        "threads": lambda v: ["-t", str(int(v))],
-        "t": lambda v: ["-t", str(int(v))],
-        "threads_batch": lambda v: ["--threads-batch", str(int(v))],
-        "tb": lambda v: ["--threads-batch", str(int(v))],
-        "ctx_size": lambda v: ["-c", str(int(v))],
-        "c": lambda v: ["-c", str(int(v))],
-        "n_ctx": lambda v: ["-c", str(int(v))],
-        "n_gpu_layers": lambda v: ["-ngl", str(int(v))],
-        "ngl": lambda v: ["-ngl", str(int(v))],
-        "gpu_layers": lambda v: ["-ngl", str(int(v))],
-        "batch_size": lambda v: ["-b", str(int(v))],
-        "b": lambda v: ["-b", str(int(v))],
-        "n_batch": lambda v: ["-b", str(int(v))],
-        "ubatch_size": lambda v: ["--ubatch-size", str(int(v))],
-        "ub": lambda v: ["--ubatch-size", str(int(v))],
-        "n_ubatch": lambda v: ["--ubatch-size", str(int(v))],
-        "verbose": lambda v: ["--verbose"] if v else [],
-        "log_disable": lambda v: ["--log-disable"] if v else [],
-        "no_mmap": lambda v: ["--no-mmap"] if v else [],
-        "mlock": lambda v: ["--mlock"] if v else [],
-        "main_gpu": lambda v: ["--main-gpu", str(int(v))],
-        "mg": lambda v: ["--main-gpu", str(int(v))],
-        "split_mode": lambda v: ["--split-mode", str(v)],
-        "sm": lambda v: ["--split-mode", str(v)],
-        "row_split": lambda v: ["--split-mode", "row"] if v else [],
-        "main_kv": lambda v: ["--main-kv", str(int(v))],
-        "no_kv_offload": lambda v: ["--no-kv-offload"] if v else [],
-        "cpu_moe": lambda v: ["--cpu-moe"] if v else [],
-        "n_cpu_moe": lambda v: ["--n-cpu-moe", str(int(v))],
-        "rope_scaling_type": lambda v: ["--rope-scaling", str(v)],
-        "rope_scaling": lambda v: ["--rope-scaling", str(v)],
-        "tensor_split": lambda v: ["--tensor-split", ",".join(map(str, v))]
-        if isinstance(v, (list, tuple))
-        else ["--tensor-split", str(v)],
-        "rope_freq_base": lambda v: ["--rope-freq-base", str(float(v))],
-        "rope_freq_scale": lambda v: ["--rope-freq-scale", str(float(v))],
-        "rope_scale": lambda v: ["--rope-freq-scale", str(float(v))],
-        "flash_attn": lambda v: ["--flash-attn", str(v)] if isinstance(v, str) else (["--flash-attn"] if v else []),
-        "cont_batching": lambda v: ["--cont-batching"] if v else ["--no-cont-batching"],
-        "no_cont_batching": lambda v: ["--no-cont-batching"] if v else [],
-        "context_shift": lambda v: ["--context-shift"] if v else ["--no-context-shift"],
-        "streaming_llm": lambda v: ["--context-shift"] if v else [],
-        "lora": lambda v: _flatten_repeatable("--lora", v),
-        "lora_scaled": lambda v: ["--lora-scaled", str(v[0]), str(v[1])]
-        if isinstance(v, (list, tuple)) and len(v) == 2
-        else (["--lora-scaled", str(v)] if v is not None else []),
-        "lora_base": lambda v: ["--lora-base", str(v)],
-        "control_vector": lambda v: ["--control-vector", str(v)],
-        "cache_type_k": lambda v: ["--cache-type-k", str(v)],
-        "cache_type_v": lambda v: ["--cache-type-v", str(v)],
-        "cache_type": lambda v: ["--cache-type-k", str(v), "--cache-type-v", str(v)],
-        "hf_repo": lambda v: ["--hf-repo", str(v)],
-        "hf_file": lambda v: ["--hf-file", str(v)],
-        "offline": lambda v: ["--offline"] if v else [],
-        "conversation": lambda v: ["--conversation"] if v else [],
-        "cnv": lambda v: ["--conversation"] if v else [],
-        "no_conversation": lambda v: ["--no-conversation"] if v else [],
-        "no_cnv": lambda v: ["--no-conversation"] if v else [],
-        "interactive": lambda v: ["--interactive"] if v else [],
-        "i": lambda v: ["--interactive"] if v else [],
-        "interactive_first": lambda v: ["--interactive-first"] if v else [],
-        "if": lambda v: ["--interactive-first"] if v else [],
-        "single_turn": lambda v: ["--single-turn"] if v else [],
-        "st": lambda v: ["--single-turn"] if v else [],
-        "jinja": lambda v: ["--jinja"] if v else [],
-        "chat_template": lambda v: ["--chat-template", str(v)],
-        "chat_template_file": lambda v: ["--chat-template-file", str(v)],
-        "in_prefix": lambda v: ["--in-prefix", str(v)],
-        "in_suffix": lambda v: ["--in-suffix", str(v)],
-        "in_prefix_bos": lambda v: ["--in-prefix-bos"] if v else [],
-        "reverse_prompt": lambda v: ["--reverse-prompt", str(v)],
-        "r": lambda v: ["--reverse-prompt", str(v)],
-        "predict": lambda v: ["-n", str(int(v))],
-        "n": lambda v: ["-n", str(int(v))],
-        "keep": lambda v: ["--keep", str(int(v))],
-        "ignore_eos": lambda v: ["--ignore-eos"] if v else [],
-        "no_context_shift": lambda v: ["--no-context-shift"] if v else [],
-        "temp": lambda v: ["--temp", str(float(v))],
-        "seed": lambda v: ["-s", str(int(v))],
-        "dynatemp_range": lambda v: ["--dynatemp-range", str(float(v))],
-        "top_k": lambda v: ["--top-k", str(int(v))],
-        "top_p": lambda v: ["--top-p", str(float(v))],
-        "min_p": lambda v: ["--min-p", str(float(v))],
-        "typical": lambda v: ["--typical", str(float(v))],
-        "repeat_penalty": lambda v: ["--repeat-penalty", str(float(v))],
-        "repeat_last_n": lambda v: ["--repeat-last-n", str(int(v))],
-        "presence_penalty": lambda v: ["--presence-penalty", str(float(v))],
-        "frequency_penalty": lambda v: ["--frequency-penalty", str(float(v))],
-        "dry_multiplier": lambda v: ["--dry-multiplier", str(float(v))],
-        "dry_base": lambda v: ["--dry-base", str(float(v))],
-        "dry_allowed_length": lambda v: ["--dry-allowed-length", str(int(v))],
-        "mirostat": lambda v: ["--mirostat", str(int(v))],
-        "mirostat_lr": lambda v: ["--mirostat-lr", str(float(v))],
-        "mirostat_ent": lambda v: ["--mirostat-ent", str(float(v))],
-        "cpu_mask": lambda v: ["--cpu-mask", str(v)],
-        "cpu_range": lambda v: ["--cpu-range", str(v)],
-        "numa": lambda v: ["--numa", str(v)] if isinstance(v, str) else (["--numa"] if v else []),
-        "grammar": lambda v: ["--grammar", str(v)],
-        "grammar_file": lambda v: ["--grammar-file", str(v)],
-        "json_schema": lambda v: ["--json-schema", str(v)],
-        "json_schema_file": lambda v: ["--json-schema-file", str(v)],
-        "j": lambda v: ["-j", str(v)],
-        "reasoning_format": lambda v: ["--reasoning-format", str(v)],
-        "reasoning_budget": lambda v: ["--reasoning-budget", str(int(v))],
-        "prompt_cache": lambda v: ["--prompt-cache", str(v)],
-        "prompt_cache_all": lambda v: ["--prompt-cache-all"] if v else [],
-        "prompt_cache_ro": lambda v: ["--prompt-cache-ro"] if v else [],
-        "cache_prompt": lambda v: ["--cache-prompt"] if v else ["--no-cache-prompt"],
-        "cache_reuse": lambda v: ["--cache-reuse", str(int(v))],
-        "parallel": lambda v: ["--parallel", str(int(v))],
-        "threads_http": lambda v: ["--threads-http", str(int(v))],
-        "timeout": lambda v: ["--timeout", str(int(v))],
-        "mmproj": lambda v: ["--mmproj", str(v)],
-        "mmproj_url": lambda v: ["--mmproj-url", str(v)],
-        "mmproj_auto": lambda v: ["--mmproj-auto"] if v else ["--no-mmproj"],
-        "no_mmproj": lambda v: ["--no-mmproj"] if v else [],
-        "mmproj_offload": lambda v: ["--mmproj-offload"] if v else ["--no-mmproj-offload"],
-        "no_mmproj_offload": lambda v: ["--no-mmproj-offload"] if v else [],
-        "image_min_tokens": lambda v: ["--image-min-tokens", str(int(v))],
-        "image_max_tokens": lambda v: ["--image-max-tokens", str(int(v))],
-        "model_draft": lambda v: ["--model-draft", str(v)],
-        "draft_max": lambda v: ["--draft-max", str(int(v))],
-        "draft_min": lambda v: ["--draft-min", str(int(v))],
-        "draft_p_min": lambda v: ["--draft-p-min", str(float(v))],
-        "ctx_size_draft": lambda v: ["--ctx-size-draft", str(int(v))],
-        "gpu_layers_draft": lambda v: ["--gpu-layers-draft", str(int(v))],
-        "cpu_moe_draft": lambda v: ["--cpu-moe-draft"] if v else [],
-        "n_cpu_moe_draft": lambda v: ["--n-cpu-moe-draft", str(int(v))],
-        "log_file": lambda v: ["--log-file", str(v)],
-        "log_colors": lambda v: ["--log-colors"] if v else [],
-        "log_timestamps": lambda v: ["--log-timestamps"] if v else [],
-        "log_verbosity": lambda v: ["--log-verbosity", str(v)],
-        "no_perf": lambda v: ["--no-perf"] if v else [],
-        "system_prompt": lambda v: ["--system-prompt", str(v)],
-        "sys": lambda v: ["--system-prompt", str(v)],
-        "prompt": lambda v: ["-p", str(v)],
-    }
+_server_arg_formatters = server_arg_formatters
+_clean_server_args = clean_server_args
 
 
 def validate_profile_server_args(
@@ -262,10 +101,6 @@ def validate_profile_server_args(
             continue
         if key in core_keys:
             continue
-
-
-def _clean_server_args(server_args: dict[str, Any]) -> dict[str, Any]:
-    return {key: value for key, value in server_args.items() if value is not None and value != ""}
 
 
 def _is_config_path_allowed(config: LlamaCppConfig, path: Path) -> bool:
@@ -490,7 +325,7 @@ class LlamaCppProcessRunner:
                 if platform.system() == "Windows":
                     process.terminate()
                 else:
-                    os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+                    self._signal_managed_process_group(process, signal.SIGTERM)
         self._stop_stream_drainers()
         self._close_log_handle()
         self._process = None
@@ -755,8 +590,7 @@ class LlamaCppProcessRunner:
             process.terminate()
         else:
             try:
-                pgid = await asyncio.to_thread(os.getpgid, process.pid)
-                await asyncio.to_thread(os.killpg, pgid, signal.SIGTERM)
+                await asyncio.to_thread(self._signal_managed_process_group, process, signal.SIGTERM)
             except ProcessLookupError:
                 process.terminate()
             except Exception:
@@ -768,12 +602,26 @@ class LlamaCppProcessRunner:
                 process.kill()
             else:
                 try:
-                    pgid = await asyncio.to_thread(os.getpgid, process.pid)
-                    await asyncio.to_thread(os.killpg, pgid, signal.SIGKILL)
+                    await asyncio.to_thread(self._signal_managed_process_group, process, signal.SIGKILL)
                 except Exception:
                     process.kill()
             await process.wait()
         self._exit_code = process.returncode
+
+    @staticmethod
+    def _signal_managed_process_group(process: asyncio.subprocess.Process, sig: signal.Signals) -> int:
+        pid = getattr(process, "pid", None)
+        if not isinstance(pid, int) or pid <= 1:
+            raise ProcessLookupError(f"Refusing unsafe process group signal for PID {pid!r}")
+
+        pgid = os.getpgid(pid)
+        if pgid != pid:
+            raise PermissionError(f"Refusing to signal non-leader process group {pgid} for PID {pid}")
+        if pgid == os.getpgrp():
+            raise PermissionError("Refusing to signal current process group")
+
+        os.killpg(pgid, sig)
+        return pgid
 
     def _close_log_handle(self) -> None:
         if self._log_handle is not None:

--- a/tldw_Server_API/app/core/Local_LLM/llamacpp_server_args.py
+++ b/tldw_Server_API/app/core/Local_LLM/llamacpp_server_args.py
@@ -1,0 +1,187 @@
+"""Shared llama.cpp server argument formatting helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+
+CORE_SERVER_ARG_KEYS: set[str] = {
+    "threads",
+    "t",
+    "ctx_size",
+    "c",
+    "n_ctx",
+    "n_gpu_layers",
+    "ngl",
+    "gpu_layers",
+}
+
+RESERVED_STRUCTURED_ARG_KEYS: set[str] = {"model", "model_path", "m", "host", "port"}
+
+PATH_ARG_KEYS: set[str] = {
+    "grammar_file",
+    "json_schema_file",
+    "chat_template_file",
+    "prompt_cache",
+    "log_file",
+    "lora_base",
+    "control_vector",
+    "mmproj",
+    "model_draft",
+}
+
+
+def flatten_repeatable(flag: str, value: Any) -> list[str]:
+    values = value if isinstance(value, (list, tuple)) else [value]
+    command: list[str] = []
+    for item in values:
+        command.extend([flag, str(item)])
+    return command
+
+
+def clean_server_args(server_args: dict[str, Any] | None) -> dict[str, Any]:
+    return {key: value for key, value in (server_args or {}).items() if value is not None and value != ""}
+
+
+def server_arg_formatters() -> dict[str, Callable[[Any], list[str]]]:
+    """Return supported llama-server arg formatters shared by legacy and supervisor paths."""
+
+    return {
+        "threads": lambda v: ["-t", str(int(v))],
+        "t": lambda v: ["-t", str(int(v))],
+        "threads_batch": lambda v: ["--threads-batch", str(int(v))],
+        "tb": lambda v: ["--threads-batch", str(int(v))],
+        "ctx_size": lambda v: ["-c", str(int(v))],
+        "c": lambda v: ["-c", str(int(v))],
+        "n_ctx": lambda v: ["-c", str(int(v))],
+        "n_gpu_layers": lambda v: ["-ngl", str(int(v))],
+        "ngl": lambda v: ["-ngl", str(int(v))],
+        "gpu_layers": lambda v: ["-ngl", str(int(v))],
+        "batch_size": lambda v: ["-b", str(int(v))],
+        "b": lambda v: ["-b", str(int(v))],
+        "n_batch": lambda v: ["-b", str(int(v))],
+        "ubatch_size": lambda v: ["--ubatch-size", str(int(v))],
+        "ub": lambda v: ["--ubatch-size", str(int(v))],
+        "n_ubatch": lambda v: ["--ubatch-size", str(int(v))],
+        "verbose": lambda v: ["--verbose"] if v else [],
+        "log_disable": lambda v: ["--log-disable"] if v else [],
+        "no_mmap": lambda v: ["--no-mmap"] if v else [],
+        "mlock": lambda v: ["--mlock"] if v else [],
+        "main_gpu": lambda v: ["--main-gpu", str(int(v))],
+        "mg": lambda v: ["--main-gpu", str(int(v))],
+        "split_mode": lambda v: ["--split-mode", str(v)],
+        "sm": lambda v: ["--split-mode", str(v)],
+        "row_split": lambda v: ["--split-mode", "row"] if v else [],
+        "main_kv": lambda v: ["--main-kv", str(int(v))],
+        "no_kv_offload": lambda v: ["--no-kv-offload"] if v else [],
+        "cpu_moe": lambda v: ["--cpu-moe"] if v else [],
+        "n_cpu_moe": lambda v: ["--n-cpu-moe", str(int(v))],
+        "rope_scaling_type": lambda v: ["--rope-scaling", str(v)],
+        "rope_scaling": lambda v: ["--rope-scaling", str(v)],
+        "tensor_split": lambda v: ["--tensor-split", ",".join(map(str, v))]
+        if isinstance(v, (list, tuple))
+        else ["--tensor-split", str(v)],
+        "rope_freq_base": lambda v: ["--rope-freq-base", str(float(v))],
+        "rope_freq_scale": lambda v: ["--rope-freq-scale", str(float(v))],
+        "rope_scale": lambda v: ["--rope-freq-scale", str(float(v))],
+        "flash_attn": lambda v: ["--flash-attn", str(v)] if isinstance(v, str) else (["--flash-attn"] if v else []),
+        "cont_batching": lambda v: ["--cont-batching"] if v else ["--no-cont-batching"],
+        "no_cont_batching": lambda v: ["--no-cont-batching"] if v else [],
+        "context_shift": lambda v: ["--context-shift"] if v else ["--no-context-shift"],
+        "streaming_llm": lambda v: ["--context-shift"] if v else [],
+        "lora": lambda v: flatten_repeatable("--lora", v),
+        "lora_scaled": lambda v: ["--lora-scaled", str(v[0]), str(v[1])]
+        if isinstance(v, (list, tuple)) and len(v) == 2
+        else (["--lora-scaled", str(v)] if v is not None else []),
+        "lora_base": lambda v: ["--lora-base", str(v)],
+        "control_vector": lambda v: ["--control-vector", str(v)],
+        "cache_type_k": lambda v: ["--cache-type-k", str(v)],
+        "cache_type_v": lambda v: ["--cache-type-v", str(v)],
+        "cache_type": lambda v: ["--cache-type-k", str(v), "--cache-type-v", str(v)],
+        "hf_repo": lambda v: ["--hf-repo", str(v)],
+        "hf_file": lambda v: ["--hf-file", str(v)],
+        "offline": lambda v: ["--offline"] if v else [],
+        "conversation": lambda v: ["--conversation"] if v else [],
+        "cnv": lambda v: ["--conversation"] if v else [],
+        "no_conversation": lambda v: ["--no-conversation"] if v else [],
+        "no_cnv": lambda v: ["--no-conversation"] if v else [],
+        "interactive": lambda v: ["--interactive"] if v else [],
+        "i": lambda v: ["--interactive"] if v else [],
+        "interactive_first": lambda v: ["--interactive-first"] if v else [],
+        "if": lambda v: ["--interactive-first"] if v else [],
+        "single_turn": lambda v: ["--single-turn"] if v else [],
+        "st": lambda v: ["--single-turn"] if v else [],
+        "jinja": lambda v: ["--jinja"] if v else [],
+        "chat_template": lambda v: ["--chat-template", str(v)],
+        "chat_template_file": lambda v: ["--chat-template-file", str(v)],
+        "in_prefix": lambda v: ["--in-prefix", str(v)],
+        "in_suffix": lambda v: ["--in-suffix", str(v)],
+        "in_prefix_bos": lambda v: ["--in-prefix-bos"] if v else [],
+        "reverse_prompt": lambda v: ["--reverse-prompt", str(v)],
+        "r": lambda v: ["--reverse-prompt", str(v)],
+        "predict": lambda v: ["-n", str(int(v))],
+        "n": lambda v: ["-n", str(int(v))],
+        "keep": lambda v: ["--keep", str(int(v))],
+        "ignore_eos": lambda v: ["--ignore-eos"] if v else [],
+        "no_context_shift": lambda v: ["--no-context-shift"] if v else [],
+        "temp": lambda v: ["--temp", str(float(v))],
+        "seed": lambda v: ["-s", str(int(v))],
+        "dynatemp_range": lambda v: ["--dynatemp-range", str(float(v))],
+        "top_k": lambda v: ["--top-k", str(int(v))],
+        "top_p": lambda v: ["--top-p", str(float(v))],
+        "min_p": lambda v: ["--min-p", str(float(v))],
+        "typical": lambda v: ["--typical", str(float(v))],
+        "repeat_penalty": lambda v: ["--repeat-penalty", str(float(v))],
+        "repeat_last_n": lambda v: ["--repeat-last-n", str(int(v))],
+        "presence_penalty": lambda v: ["--presence-penalty", str(float(v))],
+        "frequency_penalty": lambda v: ["--frequency-penalty", str(float(v))],
+        "dry_multiplier": lambda v: ["--dry-multiplier", str(float(v))],
+        "dry_base": lambda v: ["--dry-base", str(float(v))],
+        "dry_allowed_length": lambda v: ["--dry-allowed-length", str(int(v))],
+        "mirostat": lambda v: ["--mirostat", str(int(v))],
+        "mirostat_lr": lambda v: ["--mirostat-lr", str(float(v))],
+        "mirostat_ent": lambda v: ["--mirostat-ent", str(float(v))],
+        "cpu_mask": lambda v: ["--cpu-mask", str(v)],
+        "cpu_range": lambda v: ["--cpu-range", str(v)],
+        "numa": lambda v: ["--numa", str(v)] if isinstance(v, str) else (["--numa"] if v else []),
+        "grammar": lambda v: ["--grammar", str(v)],
+        "grammar_file": lambda v: ["--grammar-file", str(v)],
+        "json_schema": lambda v: ["--json-schema", str(v)],
+        "json_schema_file": lambda v: ["--json-schema-file", str(v)],
+        "j": lambda v: ["-j", str(v)],
+        "reasoning_format": lambda v: ["--reasoning-format", str(v)],
+        "reasoning_budget": lambda v: ["--reasoning-budget", str(int(v))],
+        "prompt_cache": lambda v: ["--prompt-cache", str(v)],
+        "prompt_cache_all": lambda v: ["--prompt-cache-all"] if v else [],
+        "prompt_cache_ro": lambda v: ["--prompt-cache-ro"] if v else [],
+        "cache_prompt": lambda v: ["--cache-prompt"] if v else ["--no-cache-prompt"],
+        "cache_reuse": lambda v: ["--cache-reuse", str(int(v))],
+        "parallel": lambda v: ["--parallel", str(int(v))],
+        "threads_http": lambda v: ["--threads-http", str(int(v))],
+        "timeout": lambda v: ["--timeout", str(int(v))],
+        "mmproj": lambda v: ["--mmproj", str(v)],
+        "mmproj_url": lambda v: ["--mmproj-url", str(v)],
+        "mmproj_auto": lambda v: ["--mmproj-auto"] if v else ["--no-mmproj"],
+        "no_mmproj": lambda v: ["--no-mmproj"] if v else [],
+        "mmproj_offload": lambda v: ["--mmproj-offload"] if v else ["--no-mmproj-offload"],
+        "no_mmproj_offload": lambda v: ["--no-mmproj-offload"] if v else [],
+        "image_min_tokens": lambda v: ["--image-min-tokens", str(int(v))],
+        "image_max_tokens": lambda v: ["--image-max-tokens", str(int(v))],
+        "model_draft": lambda v: ["--model-draft", str(v)],
+        "draft_max": lambda v: ["--draft-max", str(int(v))],
+        "draft_min": lambda v: ["--draft-min", str(int(v))],
+        "draft_p_min": lambda v: ["--draft-p-min", str(float(v))],
+        "ctx_size_draft": lambda v: ["--ctx-size-draft", str(int(v))],
+        "gpu_layers_draft": lambda v: ["--gpu-layers-draft", str(int(v))],
+        "cpu_moe_draft": lambda v: ["--cpu-moe-draft"] if v else [],
+        "n_cpu_moe_draft": lambda v: ["--n-cpu-moe-draft", str(int(v))],
+        "log_file": lambda v: ["--log-file", str(v)],
+        "log_colors": lambda v: ["--log-colors"] if v else [],
+        "log_timestamps": lambda v: ["--log-timestamps"] if v else [],
+        "log_verbosity": lambda v: ["--log-verbosity", str(v)],
+        "no_perf": lambda v: ["--no-perf"] if v else [],
+        "system_prompt": lambda v: ["--system-prompt", str(v)],
+        "sys": lambda v: ["--system-prompt", str(v)],
+        "prompt": lambda v: ["-p", str(v)],
+    }

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 from pathlib import Path
 
+import httpx
 import pytest
 
 
@@ -109,6 +110,80 @@ def test_validate_download_request_fails_closed_when_dns_cannot_be_verified(monk
 
     with pytest.raises(ServerError, match="resolve|verify"):
         llamacpp_acquisition_service.validate_download_request(payload, _saved_config(models_dir))
+
+
+@pytest.mark.unit
+def test_validate_download_payload_rechecks_dns_before_worker_download(monkeypatch, tmp_path: Path) -> None:
+    from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    destination = models_dir / "model.gguf"
+    payload = {
+        "source_url": "https://example.com/model.gguf",
+        "destination_path": str(destination),
+        "register_asset": True,
+    }
+    monkeypatch.setattr(
+        llamacpp_acquisition_service.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [(None, None, None, None, ("127.0.0.1", 0))],
+    )
+
+    with pytest.raises(ServerError, match="private|local|loopback"):
+        llamacpp_acquisition_service.validate_download_payload(payload, _saved_config(models_dir))
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_download_to_partial_rejects_redirect_to_private_target(monkeypatch, tmp_path: Path) -> None:
+    from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
+    from tldw_Server_API.app.core import http_client
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    partial_path = models_dir / "model.gguf.partial"
+    validated = llamacpp_acquisition_service.LlamaCppValidatedDownload(
+        source_url="https://example.com/model.gguf",
+        source_label="example.com/model.gguf",
+        destination_path=models_dir / "model.gguf",
+    )
+
+    def fake_getaddrinfo(host: str, *_args, **_kwargs):
+        if host == "example.com":
+            return [(None, None, None, None, ("93.184.216.34", 0))]
+        if host == "127.0.0.1":
+            return [(None, None, None, None, ("127.0.0.1", 0))]
+        raise AssertionError(f"unexpected host lookup: {host}")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "example.com":
+            return httpx.Response(
+                302,
+                headers={"location": "http://127.0.0.1/internal-model.gguf"},
+                request=request,
+            )
+        return httpx.Response(200, content=b"internal", request=request)
+
+    transport = httpx.MockTransport(handler)
+
+    def fake_async_client(**kwargs):
+        return httpx.AsyncClient(
+            transport=transport,
+            timeout=kwargs.get("timeout"),
+            follow_redirects=False,
+        )
+
+    monkeypatch.setattr(llamacpp_acquisition_service.socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(llamacpp_acquisition_service, "_read_saved_config", lambda: _saved_config(models_dir))
+    monkeypatch.setattr(http_client, "create_async_client", fake_async_client)
+
+    with pytest.raises(ServerError, match="private|local|loopback"):
+        await llamacpp_acquisition_service.download_to_partial(validated, partial_path)
+
+    assert not partial_path.exists()
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py
@@ -187,6 +187,58 @@ async def test_download_to_partial_rejects_redirect_to_private_target(monkeypatc
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_download_to_partial_offloads_config_and_url_validation(monkeypatch, tmp_path: Path) -> None:
+    import threading
+
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service
+    from tldw_Server_API.app.core import http_client
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    partial_path = models_dir / "model.gguf.partial"
+    validated = llamacpp_acquisition_service.LlamaCppValidatedDownload(
+        source_url="https://example.com/model.gguf",
+        source_label="example.com/model.gguf",
+        destination_path=models_dir / "model.gguf",
+    )
+    event_loop_thread = threading.get_ident()
+    calls: list[str] = []
+
+    def fake_read_saved_config() -> dict[str, object]:
+        assert threading.get_ident() != event_loop_thread
+        calls.append("config")
+        return _saved_config(models_dir)
+
+    def fake_validate_source_url(url: str, config: dict[str, object], warnings: list[str]) -> str:
+        assert threading.get_ident() != event_loop_thread
+        calls.append("validate")
+        return url
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"model-bytes", request=request)
+
+    transport = httpx.MockTransport(handler)
+
+    def fake_async_client(**kwargs):
+        return httpx.AsyncClient(
+            transport=transport,
+            timeout=kwargs.get("timeout"),
+            follow_redirects=False,
+        )
+
+    monkeypatch.setattr(llamacpp_acquisition_service, "_read_saved_config", fake_read_saved_config)
+    monkeypatch.setattr(llamacpp_acquisition_service, "_validate_source_url", fake_validate_source_url)
+    monkeypatch.setattr(http_client, "create_async_client", fake_async_client)
+
+    bytes_written = await llamacpp_acquisition_service.download_to_partial(validated, partial_path)
+
+    assert bytes_written == len(b"model-bytes")
+    assert partial_path.read_bytes() == b"model-bytes"
+    assert calls == ["config", "validate"]
+
+
+@pytest.mark.unit
 def test_validate_download_request_rejects_malformed_port(monkeypatch, tmp_path: Path) -> None:
     from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Exceptions import ServerError
     from tldw_Server_API.app.core.Local_LLM import llamacpp_acquisition_service

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_process_runner.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_process_runner.py
@@ -83,6 +83,13 @@ def make_model(config: LlamaCppConfig, name: str = "model.gguf") -> Path:
     return model_path
 
 
+def test_runner_uses_shared_server_arg_formatter_map() -> None:
+    from tldw_Server_API.app.core.Local_LLM import llamacpp_process_runner as runner_module
+    from tldw_Server_API.app.core.Local_LLM.llamacpp_server_args import server_arg_formatters
+
+    assert runner_module._server_arg_formatters is server_arg_formatters
+
+
 def profile(
     profile_id: str,
     *,

--- a/tldw_Server_API/tests/Local_LLM/test_http_utils.py
+++ b/tldw_Server_API/tests/Local_LLM/test_http_utils.py
@@ -3,11 +3,13 @@ import httpx
 import pytest
 
 from tldw_Server_API.app.core.Local_LLM.http_utils import (
+    get_http_status_from_exception,
     request_json,
     redact_cmd_args,
+    redacted_url,
     wait_for_http_ready,
 )
-from tldw_Server_API.app.core.exceptions import JSONDecodeError
+from tldw_Server_API.app.core.exceptions import JSONDecodeError, NetworkError
 
 
 def _build_client(status_codes: list[int], payload: dict | None = None) -> tuple[httpx.AsyncClient, dict[str, int]]:
@@ -98,6 +100,21 @@ def test_redact_cmd_args_non_sensitive_equals():
     args = ["cmd", "--model=gpt-4", "--port=8080"]
     result = redact_cmd_args(args)
     assert result == ["cmd", "--model=gpt-4", "--port=8080"]
+
+
+def test_get_http_status_from_network_error_text():
+    """NetworkError fallback parsing should recognize plain HTTP status text."""
+    assert get_http_status_from_exception(NetworkError("HTTP 503 from local backend")) == 503
+
+
+def test_redacted_url_removes_credentials_and_sensitive_query_values():
+    """URL logging helper should keep useful location context without secrets."""
+    result = redacted_url("https://user:pass@example.com/model.gguf?token=secret&download=1")
+    assert "user" not in result
+    assert "pass" not in result
+    assert "secret" not in result
+    assert "token=" not in result
+    assert "download=1" in result
 
 
 # --- Tests for wait_for_http_ready improvements ---

--- a/tldw_Server_API/tests/Local_LLM/test_huggingface_handler_hardening.py
+++ b/tldw_Server_API/tests/Local_LLM/test_huggingface_handler_hardening.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.Local_LLM.Huggingface_Handler import HuggingFaceHandler
+from tldw_Server_API.app.core.Local_LLM.LLM_Inference_Schemas import HuggingFaceConfig
+
+
+@pytest.mark.asyncio
+async def test_hf_is_model_available_rejects_outside_local_path(tmp_path: Path) -> None:
+    models_dir = tmp_path / "models"
+    outside_dir = tmp_path / "outside"
+    models_dir.mkdir()
+    outside_dir.mkdir()
+    (outside_dir / "config.json").write_text("{}", encoding="utf-8")
+
+    handler = HuggingFaceHandler(HuggingFaceConfig(models_dir=models_dir), global_app_config={})
+
+    assert await handler.is_model_available(str(outside_dir)) is False
+
+
+@pytest.mark.asyncio
+async def test_hf_loaded_model_cache_respects_configured_limit(monkeypatch, tmp_path: Path) -> None:
+    models_dir = tmp_path / "models"
+    for name in ("first", "second"):
+        model_dir = models_dir / name
+        model_dir.mkdir(parents=True)
+        (model_dir / "config.json").write_text("{}", encoding="utf-8")
+
+    cfg = HuggingFaceConfig(models_dir=models_dir, max_loaded_models=1)
+    handler = HuggingFaceHandler(cfg, global_app_config={})
+
+    class FakeTorch:
+        bfloat16 = object()
+        float16 = object()
+        float32 = object()
+
+        class cuda:
+            @staticmethod
+            def is_available() -> bool:
+                return False
+
+    class FakeTokenizer:
+        @staticmethod
+        def from_pretrained(_path: str):
+            return object()
+
+    class FakeModel:
+        @staticmethod
+        def from_pretrained(_path: str, **_kwargs):
+            return object()
+
+    monkeypatch.setattr(
+        handler,
+        "_ensure_hf_dependencies",
+        lambda: (FakeTorch, FakeModel, FakeTokenizer, lambda **kwargs: kwargs, None),
+    )
+
+    first_model, _first_tokenizer = await handler._load_model_and_tokenizer("first")
+    second_model, _second_tokenizer = await handler._load_model_and_tokenizer("second")
+
+    assert first_model is not second_model
+    assert len(handler.loaded_models) == 1
+    assert next(iter(handler.loaded_models))[0] == "second"

--- a/tldw_Server_API/tests/Local_LLM/test_llamacpp_handler.py
+++ b/tldw_Server_API/tests/Local_LLM/test_llamacpp_handler.py
@@ -493,6 +493,20 @@ async def test_llamacpp_stop_server_by_pid(monkeypatch, tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_llamacpp_stop_server_rejects_unmanaged_pid(monkeypatch, tmp_path: Path):
+    exe = tmp_path / "llama_server"
+    exe.write_text("#!/bin/sh\n")
+    model_dir = tmp_path / "models"
+    model_dir.mkdir()
+    cfg = LlamaCppConfig(executable_path=exe, models_dir=model_dir)
+    handler = LlamaCppHandler(cfg, global_app_config={})
+
+    msg = await handler.stop_server(pid=424242)
+
+    assert "no managed" in msg.lower()
+
+
+@pytest.mark.asyncio
 async def test_llamacpp_start_server_not_ready(monkeypatch, tmp_path: Path):
     exe = tmp_path / "llama_server"
     exe.write_text("#!/bin/sh\n")

--- a/tldw_Server_API/tests/Local_LLM/test_llamafile_handler.py
+++ b/tldw_Server_API/tests/Local_LLM/test_llamafile_handler.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import platform
 import zipfile
 from pathlib import Path
@@ -66,6 +67,39 @@ async def test_llamafile_start_server_redacts_api_key(monkeypatch, tmp_path: Pat
     assert res["status"] == "started"
     assert "REDACTED" in res["command"]
     assert "supersecret" not in res["command"]
+
+
+@pytest.mark.asyncio
+async def test_llamafile_executable_download_requires_opt_in_and_sha256(monkeypatch, tmp_path: Path):
+    llama_dir = tmp_path / "llamafile"
+    model_dir = tmp_path / "models"
+    llama_dir.mkdir()
+    model_dir.mkdir()
+
+    cfg = LlamafileConfig(llamafile_dir=llama_dir, models_dir=model_dir)
+    handler = LlamafileHandler(cfg, global_app_config={})
+
+    async def fake_request_json(*_args, **_kwargs):
+        return {
+            "tag_name": "v1.0",
+            "assets": [
+                {
+                    "name": "llamafile-linux-arm64",
+                    "browser_download_url": "https://example.com/llamafile",
+                }
+            ],
+        }
+
+    async def fake_download(*_args, **_kwargs):
+        raise AssertionError("remote executable download should fail before network fetch")
+
+    import tldw_Server_API.app.core.Local_LLM.http_utils as http_utils
+
+    monkeypatch.setattr(http_utils, "request_json", fake_request_json)
+    monkeypatch.setattr(http_utils, "async_stream_download", fake_download)
+
+    with pytest.raises(ModelDownloadError, match="auto-download|sha256|checksum"):
+        await handler.download_latest_llamafile_executable()
 
 
 @pytest.mark.asyncio
@@ -158,6 +192,24 @@ async def test_llamafile_stop_timeout(monkeypatch, tmp_path: Path):
 
     msg = await handler.stop_server(port=5555)
     assert "stopped" in msg.lower() or "terminated" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_llamafile_stop_server_rejects_unmanaged_pid(monkeypatch, tmp_path: Path):
+    llama_dir = tmp_path / "llamafile"
+    llama_dir.mkdir()
+    cfg = LlamafileConfig(llamafile_dir=llama_dir, models_dir=tmp_path)
+    handler = LlamafileHandler(cfg, global_app_config={})
+
+    def fail_kill(*_args, **_kwargs):
+        raise AssertionError("unmanaged PID termination must not be attempted")
+
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr("os.kill", fail_kill)
+
+    msg = await handler.stop_server(pid=424242)
+
+    assert "no managed" in msg.lower()
 
 
 @pytest.mark.asyncio
@@ -469,7 +521,12 @@ async def test_llamafile_inference_drops_timeout(monkeypatch, tmp_path: Path):
 async def test_llamafile_download_selects_exe_asset(monkeypatch, tmp_path: Path):
     llama_dir = tmp_path / "llamafile"
     llama_dir.mkdir()
-    cfg = LlamafileConfig(llamafile_dir=llama_dir, models_dir=tmp_path)
+    cfg = LlamafileConfig(
+        llamafile_dir=llama_dir,
+        models_dir=tmp_path,
+        allow_executable_auto_download=True,
+        executable_sha256=hashlib.sha256(b"binary").hexdigest(),
+    )
     handler = LlamafileHandler(cfg, global_app_config={})
     handler.llamafile_exe_path = llama_dir / "llamafile.exe"
 
@@ -501,7 +558,7 @@ async def test_llamafile_download_selects_exe_asset(monkeypatch, tmp_path: Path)
 
     async def fake_download(url, dest_path):
         downloads.append(url)
-        Path(dest_path).write_text("binary")
+        Path(dest_path).write_bytes(b"binary")
 
     import tldw_Server_API.app.core.Local_LLM.Llamafile_Handler as lf_mod
     import tldw_Server_API.app.core.Local_LLM.http_utils as http_utils
@@ -522,7 +579,12 @@ async def test_llamafile_download_selects_exe_asset(monkeypatch, tmp_path: Path)
 async def test_llamafile_download_extracts_zip_asset(monkeypatch, tmp_path: Path):
     llama_dir = tmp_path / "llamafile"
     llama_dir.mkdir()
-    cfg = LlamafileConfig(llamafile_dir=llama_dir, models_dir=tmp_path)
+    cfg = LlamafileConfig(
+        llamafile_dir=llama_dir,
+        models_dir=tmp_path,
+        allow_executable_auto_download=True,
+        executable_sha256=hashlib.sha256(b"binary").hexdigest(),
+    )
     handler = LlamafileHandler(cfg, global_app_config={})
     handler.llamafile_exe_path = llama_dir / "llamafile.exe"
 

--- a/tldw_Server_API/tests/Local_LLM/test_ollama_handler.py
+++ b/tldw_Server_API/tests/Local_LLM/test_ollama_handler.py
@@ -124,10 +124,10 @@ async def test_ollama_stop_server_pid_failure_is_sanitized(monkeypatch):
     monkeypatch.setattr(handler, "is_ollama_installed", lambda: asyncio.sleep(0, result=True))
     handler._serve_process = SimpleNamespace(pid=123)
 
-    def fail_terminate(_pid):
+    async def fail_terminate(_process):
         raise RuntimeError("termination failed at /private/ollama.pid")
 
-    monkeypatch.setattr(handler, "_terminate_process", fail_terminate)
+    monkeypatch.setattr(handler, "_terminate_managed_process", fail_terminate)
 
     result = await handler.stop_server(pid=123)
 
@@ -143,10 +143,10 @@ async def test_ollama_stop_server_rejects_unmanaged_pid(monkeypatch):
 
     monkeypatch.setattr(handler, "is_ollama_installed", lambda: asyncio.sleep(0, result=True))
 
-    def fail_terminate(_pid):
+    async def fail_terminate(_process):
         raise AssertionError("unmanaged PID termination must not be attempted")
 
-    monkeypatch.setattr(handler, "_terminate_process", fail_terminate)
+    monkeypatch.setattr(handler, "_terminate_managed_process", fail_terminate)
 
     result = await handler.stop_server(pid=424242)
 
@@ -162,10 +162,10 @@ async def test_ollama_stop_server_port_failure_is_sanitized(monkeypatch):
     handler._serve_process = SimpleNamespace(pid=456)
     handler._serve_port = 11434
 
-    def fail_terminate(_pid):
+    async def fail_terminate(_process):
         raise RuntimeError("port stop failed at /private/ollama.sock")
 
-    monkeypatch.setattr(handler, "_terminate_process", fail_terminate)
+    monkeypatch.setattr(handler, "_terminate_managed_process", fail_terminate)
 
     result = await handler.stop_server(port=11434)
 
@@ -181,11 +181,50 @@ async def test_ollama_stop_server_rejects_unmanaged_port(monkeypatch):
 
     monkeypatch.setattr(handler, "is_ollama_installed", lambda: asyncio.sleep(0, result=True))
 
-    def fail_terminate(_pid):
+    async def fail_terminate(_process):
         raise AssertionError("unmanaged port termination must not be attempted")
 
-    monkeypatch.setattr(handler, "_terminate_process", fail_terminate)
+    monkeypatch.setattr(handler, "_terminate_managed_process", fail_terminate)
 
     result = await handler.stop_server(port=11434)
 
     assert "no managed" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_ollama_stop_server_uses_managed_process_without_psutil(monkeypatch):
+    cfg = OllamaConfig()
+    handler = OllamaHandler(cfg, global_app_config={})
+
+    monkeypatch.setattr(handler, "is_ollama_installed", lambda: asyncio.sleep(0, result=True))
+
+    import tldw_Server_API.app.core.Local_LLM.Ollama_Handler as ol_mod
+
+    monkeypatch.setattr(ol_mod, "PSUTIL_AVAILABLE", False)
+
+    class DummyManagedProcess:
+        pid = 123
+        returncode = None
+        terminated = False
+        killed = False
+
+        def terminate(self):
+            self.terminated = True
+
+        def kill(self):
+            self.killed = True
+            self.returncode = -9
+
+        async def wait(self):
+            self.returncode = 0
+            return 0
+
+    process = DummyManagedProcess()
+    handler._serve_process = process
+
+    result = await handler.stop_server(pid=123)
+
+    assert result == "Attempted to stop Ollama server with PID 123"
+    assert process.terminated is True
+    assert process.killed is False
+    assert handler._serve_process is None

--- a/tldw_Server_API/tests/Local_LLM/test_ollama_handler.py
+++ b/tldw_Server_API/tests/Local_LLM/test_ollama_handler.py
@@ -122,6 +122,7 @@ async def test_ollama_stop_server_pid_failure_is_sanitized(monkeypatch):
     handler = OllamaHandler(cfg, global_app_config={})
 
     monkeypatch.setattr(handler, "is_ollama_installed", lambda: asyncio.sleep(0, result=True))
+    handler._serve_process = SimpleNamespace(pid=123)
 
     def fail_terminate(_pid):
         raise RuntimeError("termination failed at /private/ollama.pid")
@@ -136,23 +137,55 @@ async def test_ollama_stop_server_pid_failure_is_sanitized(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_ollama_stop_server_rejects_unmanaged_pid(monkeypatch):
+    cfg = OllamaConfig()
+    handler = OllamaHandler(cfg, global_app_config={})
+
+    monkeypatch.setattr(handler, "is_ollama_installed", lambda: asyncio.sleep(0, result=True))
+
+    def fail_terminate(_pid):
+        raise AssertionError("unmanaged PID termination must not be attempted")
+
+    monkeypatch.setattr(handler, "_terminate_process", fail_terminate)
+
+    result = await handler.stop_server(pid=424242)
+
+    assert "no managed" in result.lower()
+
+
+@pytest.mark.asyncio
 async def test_ollama_stop_server_port_failure_is_sanitized(monkeypatch):
     cfg = OllamaConfig()
     handler = OllamaHandler(cfg, global_app_config={})
 
-    import tldw_Server_API.app.core.Local_LLM.Ollama_Handler as ol_mod
-
-    def fail_net_connections():
-        raise RuntimeError("port lookup failed at /private/ollama.sock")
-
-    fake_psutil = SimpleNamespace(CONN_LISTEN="LISTEN", net_connections=fail_net_connections)
-
     monkeypatch.setattr(handler, "is_ollama_installed", lambda: asyncio.sleep(0, result=True))
-    monkeypatch.setattr(ol_mod, "PSUTIL_AVAILABLE", True)
-    monkeypatch.setattr(ol_mod, "psutil", fake_psutil)
+    handler._serve_process = SimpleNamespace(pid=456)
+    handler._serve_port = 11434
+
+    def fail_terminate(_pid):
+        raise RuntimeError("port stop failed at /private/ollama.sock")
+
+    monkeypatch.setattr(handler, "_terminate_process", fail_terminate)
 
     result = await handler.stop_server(port=11434)
 
     assert result == "Error stopping Ollama server on port 11434"
-    assert "port lookup failed" not in result
+    assert "port stop failed" not in result
     assert "/private/ollama.sock" not in result
+
+
+@pytest.mark.asyncio
+async def test_ollama_stop_server_rejects_unmanaged_port(monkeypatch):
+    cfg = OllamaConfig()
+    handler = OllamaHandler(cfg, global_app_config={})
+
+    monkeypatch.setattr(handler, "is_ollama_installed", lambda: asyncio.sleep(0, result=True))
+
+    def fail_terminate(_pid):
+        raise AssertionError("unmanaged port termination must not be attempted")
+
+    monkeypatch.setattr(handler, "_terminate_process", fail_terminate)
+
+    result = await handler.stop_server(port=11434)
+
+    assert "no managed" in result.lower()


### PR DESCRIPTION
## Summary
- Harden llama.cpp acquisition downloads with worker-time URL and redirect validation.
- Require opt-in plus SHA-256 verification for llamafile executable auto-downloads.
- Consolidate llama.cpp server argument formatting and retire unmanaged PID/port stops from legacy handlers.
- Address PR review feedback: offload acquisition config/URL/DNS validation from the event loop and stop Ollama managed processes through the handler-owned subprocess handle instead of optional psutil PID termination.
- Rebased on latest dev and removed the unrelated Claims_Extraction design/task commit from this PR branch.

## Human Change Summary
TODO: Human requester must fill this in before merge per the project AI-generated PR policy.

## Test Plan
- python -m py_compile tldw_Server_API/app/core/Local_LLM/llamacpp_acquisition_service.py tldw_Server_API/app/core/Local_LLM/Ollama_Handler.py
- python -m pytest -p no:unraisableexception tldw_Server_API/tests/LLM_Local/test_llamacpp_acquisition_service.py tldw_Server_API/tests/LLM_Local/test_llamacpp_process_runner.py tldw_Server_API/tests/Local_LLM/test_http_utils.py tldw_Server_API/tests/Local_LLM/test_llamacpp_handler.py tldw_Server_API/tests/Local_LLM/test_llamafile_handler.py tldw_Server_API/tests/Local_LLM/test_ollama_handler.py tldw_Server_API/tests/Local_LLM/test_huggingface_handler_hardening.py -q (102 passed)
- python -m bandit -r tldw_Server_API/app/core/Local_LLM -f json -o /tmp/bandit_local_llm_2420_rebase.json (0 findings)