### PR TITLE
Harden Notes Graph review findings

### DIFF
--- a/backlog/tasks/task-9931 - Harden-Notes-Graph-review-findings.md
+++ b/backlog/tasks/task-9931 - Harden-Notes-Graph-review-findings.md
@@ -1,0 +1,61 @@
+---
+id: TASK-9931
+title: Harden Notes Graph review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 18:54'
+updated_date: '2026-06-24 04:23'
+labels:
+  - notes-graph
+  - security
+  - review
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address validated review findings in tldw_Server_API/app/core/Notes_Graph and related endpoint/DB support. The compacted context mentioned TASK-2418, but that ID belongs to an unrelated Persona task in this checkout; this task records the Notes Graph work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Graph requests clamp effective max_nodes, max_edges, and max_degree before traversal.
+- [x] #2 allow_heavy graph requests require elevated notes.graph.admin permission before larger caps are honored.
+- [x] #3 Graph cursor pagination validates cursor payloads and advances within a large neighbor list.
+- [x] #4 Tag and source filters use direct seed lookups instead of sampling recent notes.
+- [x] #5 Graph node ordering and timezone-aware time filtering are deterministic.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Plan: add failing regression coverage, harden service and endpoint limit handling, add direct tag/source seed DB lookups, run focused pytest and Bandit verification.
+
+Implemented request cap clamping before traversal, gated elevated allow_heavy limits behind notes.graph.admin/admin/*, validated graph cursor payloads, preserved neighbor offsets across cursor pages, added direct tag/source graph seed queries, ordered note nodes deterministically, and normalized timezone-aware time filters to UTC before comparison.
+
+Verification: py_compile on touched Python files passed. TEST_MODE=1 MINIMAL_TEST_APP=1 ULTRA_MINIMAL_APP=1 python -m pytest tldw_Server_API/tests/Notes_Graph/unit/test_graph_service.py tldw_Server_API/tests/Notes_Graph/unit/test_graph_db_queries.py -q => 62 passed. python -m pytest tldw_Server_API/tests/Notes_Graph/integration/test_graph_endpoint.py::test_allow_heavy_requires_graph_admin_permission -q => 1 passed. Bandit on touched backend Python files => 0 findings.
+
+Worktree PR prep verification on branch codex/notes-graph-review-hardening: py_compile passed, focused Notes Graph unit/DB tests passed (62 passed), endpoint allow_heavy permission regression passed (1 passed), Bandit JSON output had 0 results, and git diff --check passed.
+
+PR review follow-up: rebased codex/notes-graph-review-hardening onto origin/dev, dropped the unrelated local-only Claims_Extraction design commit from the branch, addressed Qodo comments for _to_utc_naive typing, AuthNZ-compatible heavy graph admin detection, and deterministic tag/source edge ordering. Verification after follow-up: py_compile passed, focused Notes Graph unit/DB tests passed (63 passed), endpoint heavy-permission tests passed (8 passed), Bandit had 0 findings, and git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened Notes Graph against the validated review findings: bounded graph expansion, admin-only heavy graph caps, valid advancing cursors, complete tag/source seed lookup queries, deterministic ordering, and correct timezone instant comparisons. Added focused regression coverage and recorded passing pytest/Bandit verification.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+- [x] #7 Focused regression tests pass.
+- [x] #8 Bandit runs clean on touched backend Python files.
+<!-- DOD:END -->

--- a/tldw_Server_API/Config_Files/privilege_catalog.yaml
+++ b/tldw_Server_API/Config_Files/privilege_catalog.yaml
@@ -1250,6 +1250,20 @@ scopes:
     ownership_predicates:
       - same_org
     doc_url: https://docs.example.com/privileges/notes-graph-write
+  - id: notes.graph.admin
+    description: Use elevated Notes Graph query limits.
+    resource_tags:
+      - notes
+      - graph
+      - admin
+    sensitivity_tier: moderate
+    rate_limit_class: standard
+    default_roles:
+      - admin
+    feature_flag_id: null
+    ownership_predicates:
+      - same_org
+    doc_url: https://docs.example.com/privileges/notes-graph-admin
   - id: notes.graph.suggest
     description: Suggest candidate graph links (LLM/heuristic).
     resource_tags:

--- a/tldw_Server_API/app/api/v1/endpoints/notes_graph.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes_graph.py
@@ -13,7 +13,12 @@ from tldw_Server_API.app.api.v1.schemas.notes_graph import (
     NoteGraphRequest,
     NoteLinkCreate,
 )
-from tldw_Server_API.app.core.AuthNZ.permissions import NOTES_GRAPH_READ, NOTES_GRAPH_WRITE
+from tldw_Server_API.app.core.AuthNZ.permissions import (
+    NOTES_GRAPH_ADMIN,
+    NOTES_GRAPH_READ,
+    NOTES_GRAPH_WRITE,
+    SYSTEM_CONFIGURE,
+)
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     CharactersRAGDB,
     CharactersRAGDBError,
@@ -63,6 +68,32 @@ def _normalize_edge_id(raw_id: Optional[str]) -> str:
             raise HTTPException(status_code=400, detail=f"Invalid UUID format: {value}") from None
         return value
     return text
+
+
+def _can_use_heavy_graph_limits(user: User) -> bool:
+    roles = {str(role).strip().lower() for role in (getattr(user, "roles", []) or [])}
+    legacy_role = str(getattr(user, "role", "") or "").strip().lower()
+    if legacy_role:
+        roles.add(legacy_role)
+    permissions = {str(perm).strip().lower() for perm in (getattr(user, "permissions", []) or [])}
+    admin_permissions = {"*", SYSTEM_CONFIGURE.lower(), NOTES_GRAPH_ADMIN.lower()}
+    return bool(
+        getattr(user, "is_admin", False)
+        or getattr(user, "is_superuser", False)
+        or "admin" in roles
+        or bool(permissions & admin_permissions)
+    )
+
+
+def _enforce_heavy_graph_permission(req: NoteGraphRequest, current_user: User) -> bool:
+    if not req.allow_heavy:
+        return False
+    if _can_use_heavy_graph_limits(current_user):
+        return True
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=f"{NOTES_GRAPH_ADMIN} permission is required for allow_heavy graph requests",
+    )
 
 
 @router.get(
@@ -122,7 +153,12 @@ async def get_notes_graph(
             req.edge_types = parsed or None
         if getattr(req, "center_note_id", None):
             req.center_note_id = _normalize_note_id(req.center_note_id)
-        service = NoteGraphService(user_id=str(current_user.id_str), db=db)
+        heavy_limits_allowed = _enforce_heavy_graph_permission(req, current_user)
+        service = NoteGraphService(
+            user_id=str(current_user.id_str),
+            db=db,
+            allow_heavy_limits=heavy_limits_allowed,
+        )
         graph = service.generate_graph(req)
         if req.format == GraphFormat.cytoscape:
             return to_cytoscape(graph)
@@ -187,7 +223,12 @@ async def get_note_neighbors(
         normalized_note_id = _normalize_note_id(note_id)
         req.center_note_id = normalized_note_id
         req.radius = 1
-        service = NoteGraphService(user_id=str(current_user.id_str), db=db)
+        heavy_limits_allowed = _enforce_heavy_graph_permission(req, current_user)
+        service = NoteGraphService(
+            user_id=str(current_user.id_str),
+            db=db,
+            allow_heavy_limits=heavy_limits_allowed,
+        )
         graph = service.generate_graph(req)
         if req.format == GraphFormat.cytoscape:
             return to_cytoscape(graph)

--- a/tldw_Server_API/app/core/AuthNZ/permissions.py
+++ b/tldw_Server_API/app/core/AuthNZ/permissions.py
@@ -314,6 +314,7 @@ CHAT_WORKFLOWS_RUN = "chat_workflows.run"
 # Notes / graph permissions
 NOTES_GRAPH_READ = "notes.graph.read"
 NOTES_GRAPH_WRITE = "notes.graph.write"
+NOTES_GRAPH_ADMIN = "notes.graph.admin"
 
 # Evaluations permissions
 EVALS_MANAGE = "evals.manage"

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -30117,6 +30117,8 @@ for _note_store_method in (
     "list_deleted_notes",
     "get_notes_batch",
     "get_all_note_ids_for_graph",
+    "get_note_ids_by_tag_for_graph",
+    "get_note_ids_by_source_for_graph",
     "get_note_tag_edges",
     "count_notes",
     "count_deleted_notes",

--- a/tldw_Server_API/app/core/DB_Management/chacha/note_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/note_store.py
@@ -557,6 +557,112 @@ class NoteStore:
         cur = self._db.execute_query(query, tuple(params))
         return [row[0] for row in cur.fetchall()]
 
+    @staticmethod
+    def _normalize_graph_tag_filter(tag: str) -> str:
+        text = str(tag or "").strip()
+        if text.lower().startswith("tag:"):
+            return text[4:].strip()
+        return text
+
+    @staticmethod
+    def _parse_graph_source_filter(source: str) -> tuple[str, str | None]:
+        text = str(source or "").strip()
+        if text.lower().startswith("source:"):
+            text = text[len("source:"):]
+        if ":" in text:
+            src, external_ref = text.split(":", 1)
+            return src.strip(), external_ref.strip() or None
+        return text.strip(), None
+
+    def get_note_ids_by_tag_for_graph(
+        self,
+        tag: str,
+        include_deleted: bool = True,
+        limit: int = 500,
+    ) -> list[str]:
+        """Return graph seed note IDs for a tag, ordered by last_modified DESC, id ASC."""
+        normalized_tag = self._normalize_graph_tag_filter(tag)
+        if not normalized_tag or limit <= 0:
+            return []
+
+        if include_deleted:
+            query = (
+                "SELECT DISTINCT n.id, n.last_modified "
+                "FROM notes n "
+                "JOIN note_keywords nk ON nk.note_id = n.id "
+                "JOIN keywords k ON k.id = nk.keyword_id "
+                "WHERE LOWER(k.keyword) = LOWER(?) AND k.deleted = ? "
+                "ORDER BY n.last_modified DESC, n.id ASC LIMIT ?"
+            )
+            params: list[Any] = [normalized_tag, self._deleted_value(False), limit]
+        else:
+            query = (
+                "SELECT DISTINCT n.id, n.last_modified "
+                "FROM notes n "
+                "JOIN note_keywords nk ON nk.note_id = n.id "
+                "JOIN keywords k ON k.id = nk.keyword_id "
+                "WHERE LOWER(k.keyword) = LOWER(?) AND k.deleted = ? AND n.deleted = ? "
+                "ORDER BY n.last_modified DESC, n.id ASC LIMIT ?"
+            )
+            params = [
+                normalized_tag,
+                self._deleted_value(False),
+                self._deleted_value(False),
+                limit,
+            ]
+        cur = self._db.execute_query(query, tuple(params))
+        return [row[0] for row in cur.fetchall()]
+
+    def get_note_ids_by_source_for_graph(
+        self,
+        source: str,
+        include_deleted: bool = True,
+        limit: int = 500,
+    ) -> list[str]:
+        """Return graph seed note IDs for a source, ordered by last_modified DESC, id ASC."""
+        src, external_ref = self._parse_graph_source_filter(source)
+        if not src or limit <= 0:
+            return []
+
+        if external_ref is not None and not include_deleted:
+            query = (
+                "SELECT DISTINCT n.id, n.last_modified "
+                "FROM notes n "
+                "JOIN conversations c ON c.id = n.conversation_id "
+                "WHERE c.source = ? AND c.external_ref = ? AND n.deleted = ? "
+                "ORDER BY n.last_modified DESC, n.id ASC LIMIT ?"
+            )
+            params: list[Any] = [src, external_ref, self._deleted_value(False), limit]
+        elif external_ref is not None:
+            query = (
+                "SELECT DISTINCT n.id, n.last_modified "
+                "FROM notes n "
+                "JOIN conversations c ON c.id = n.conversation_id "
+                "WHERE c.source = ? AND c.external_ref = ? "
+                "ORDER BY n.last_modified DESC, n.id ASC LIMIT ?"
+            )
+            params = [src, external_ref, limit]
+        elif not include_deleted:
+            query = (
+                "SELECT DISTINCT n.id, n.last_modified "
+                "FROM notes n "
+                "JOIN conversations c ON c.id = n.conversation_id "
+                "WHERE c.source = ? AND n.deleted = ? "
+                "ORDER BY n.last_modified DESC, n.id ASC LIMIT ?"
+            )
+            params = [src, self._deleted_value(False), limit]
+        else:
+            query = (
+                "SELECT DISTINCT n.id, n.last_modified "
+                "FROM notes n "
+                "JOIN conversations c ON c.id = n.conversation_id "
+                "WHERE c.source = ? "
+                "ORDER BY n.last_modified DESC, n.id ASC LIMIT ?"
+            )
+            params = [src, limit]
+        cur = self._db.execute_query(query, tuple(params))
+        return [row[0] for row in cur.fetchall()]
+
     def get_note_tag_edges(self, note_ids: list[str]) -> list[dict[str, Any]]:
         """Return (note_id, keyword_id, keyword) for notes with active keywords."""
         if not note_ids:
@@ -568,7 +674,8 @@ class NoteStore:
                 f"SELECT nk.note_id, k.id AS keyword_id, k.keyword "  # nosec B608
                 f"FROM note_keywords nk "
                 f"JOIN keywords k ON k.id = nk.keyword_id "
-                f"WHERE nk.note_id IN ({ph}) AND k.deleted = ?"
+                f"WHERE nk.note_id IN ({ph}) AND k.deleted = ? "
+                f"ORDER BY nk.note_id ASC, k.id ASC"
             )
             cur = self._db.execute_query(query, tuple([*batch, self._deleted_value(False)]))
             for row in cur.fetchall():
@@ -643,7 +750,8 @@ class NoteStore:
                 f"SELECT n.id AS note_id, c.id AS conversation_id, c.source, c.external_ref "  # nosec B608
                 f"FROM notes n "
                 f"JOIN conversations c ON c.id = n.conversation_id "
-                f"WHERE n.id IN ({ph}) AND c.source IS NOT NULL"
+                f"WHERE n.id IN ({ph}) AND c.source IS NOT NULL "
+                f"ORDER BY n.id ASC, c.source ASC, c.external_ref ASC"
             )
             cur = self._db.execute_query(query, tuple(batch))
             for row in cur.fetchall():

--- a/tldw_Server_API/app/core/Notes_Graph/graph_service.py
+++ b/tldw_Server_API/app/core/Notes_Graph/graph_service.py
@@ -8,6 +8,7 @@ import json
 import os
 import time
 from collections import deque
+from datetime import datetime, timezone
 
 from loguru import logger
 
@@ -95,8 +96,13 @@ def _metrics_observe(name: str, value: float, labels: dict[str, str] | None = No
 # Cursor helpers
 # ---------------------------------------------------------------------------
 
-def _encode_cursor(layer: int, pos: int, last_id: str) -> str:
-    payload = json.dumps({"layer": layer, "pos": pos, "last_id": last_id})
+def _encode_cursor(layer: int, pos: int, last_id: str, neighbor_pos: int = 0) -> str:
+    payload = json.dumps({
+        "layer": layer,
+        "pos": pos,
+        "last_id": last_id,
+        "neighbor_pos": neighbor_pos,
+    })
     return base64.urlsafe_b64encode(payload.encode()).decode()
 
 
@@ -104,9 +110,25 @@ def _decode_cursor(raw: str | None) -> dict | None:
     if not raw:
         return None
     try:
-        return json.loads(base64.urlsafe_b64decode(raw.encode()).decode())
-    except Exception:
-        return None
+        payload = json.loads(base64.urlsafe_b64decode(raw.encode()).decode())
+    except Exception as exc:
+        raise InputError("Invalid graph cursor") from exc
+    if not isinstance(payload, dict):
+        raise InputError("Invalid graph cursor")
+    for field in ("layer", "pos", "last_id"):
+        if field not in payload:
+            raise InputError("Invalid graph cursor")
+    try:
+        payload["layer"] = int(payload["layer"])
+        payload["pos"] = int(payload["pos"])
+        payload["neighbor_pos"] = int(payload.get("neighbor_pos", 0))
+    except (TypeError, ValueError) as exc:
+        raise InputError("Invalid graph cursor") from exc
+    if payload["layer"] < 0 or payload["pos"] < 0 or payload["neighbor_pos"] < 0:
+        raise InputError("Invalid graph cursor")
+    if not isinstance(payload["last_id"], str):
+        raise InputError("Invalid graph cursor")
+    return payload
 
 
 # ---------------------------------------------------------------------------
@@ -152,10 +174,12 @@ class NoteGraphService:
         user_id: str,
         db: CharactersRAGDB,
         cache: GraphCache | None = None,
+        allow_heavy_limits: bool = False,
     ) -> None:
         self._user_id = user_id
         self._db = db
         self._cache = cache
+        self._allow_heavy_limits = allow_heavy_limits
 
     # ------------------------------------------------------------------
     # Main entry
@@ -165,22 +189,8 @@ class NoteGraphService:
         """Build and return a bounded note graph."""
         t0 = time.monotonic()
 
-        # 1. Resolve effective limits
-        radius_cap_applied = False
-        eff_max_nodes = req.max_nodes or MAX_NODES()
-        eff_max_edges = req.max_edges or MAX_EDGES()
-        eff_max_degree = req.max_degree or MAX_DEGREE()
-
-        if req.radius == 2:
-            if eff_max_nodes > _R2_MAX_NODES:
-                eff_max_nodes = _R2_MAX_NODES
-                radius_cap_applied = True
-            if eff_max_edges > _R2_MAX_EDGES:
-                eff_max_edges = _R2_MAX_EDGES
-                radius_cap_applied = True
-            if eff_max_degree > _R2_MAX_DEGREE:
-                eff_max_degree = _R2_MAX_DEGREE
-                radius_cap_applied = True
+        # 1. Resolve effective limits before any graph expansion work.
+        eff_max_nodes, eff_max_edges, eff_max_degree, radius_cap_applied = self._resolve_effective_limits(req)
 
         # 2. Check cache
         if self._cache is not None:
@@ -197,6 +207,7 @@ class NoteGraphService:
                     "max_nodes": eff_max_nodes,
                     "max_edges": eff_max_edges,
                     "max_degree": eff_max_degree,
+                    "allow_heavy": req.allow_heavy and self._allow_heavy_limits,
                     "cursor": req.cursor,
                 },
             )
@@ -217,10 +228,10 @@ class NoteGraphService:
         )
 
         # 5. Fetch note data
-        note_rows = self._db.get_notes_batch(list(note_ids), include_deleted=True)
+        note_rows = self._db.get_notes_batch(note_ids, include_deleted=True)
         note_map: dict[str, dict] = {r["id"]: r for r in note_rows}
         # Prune IDs that don't actually exist
-        note_ids = set(note_map.keys())
+        note_ids = [nid for nid in note_ids if nid in note_map]
 
         # 5b. Validate center note exists
         if req.center_note_id and req.center_note_id not in note_map:
@@ -229,6 +240,8 @@ class NoteGraphService:
         # 6. Apply time-range filter
         if req.time_range:
             note_ids = self._apply_time_range(note_ids, note_map, req)
+        note_ids = self._order_note_ids(note_ids, note_map)
+        note_id_set = set(note_ids)
 
         # 7. Determine which edge types to compute
         wanted = set(req.edge_types) if req.edge_types else set(EdgeType)
@@ -241,7 +254,7 @@ class NoteGraphService:
         # Manual edges
         if EdgeType.manual in wanted:
             for e in manual_edges:
-                if e["from_note_id"] in note_ids and e["to_note_id"] in note_ids:
+                if e["from_note_id"] in note_id_set and e["to_note_id"] in note_id_set:
                     edges.append(GraphEdge(
                         id=f"e:{e['edge_id']}",
                         source=e["from_note_id"],
@@ -253,7 +266,7 @@ class NoteGraphService:
 
         # Wikilinks + backlinks
         if EdgeType.wikilink in wanted or EdgeType.backlink in wanted:
-            wl_edges, bl_edges = self._compute_wikilink_edges(note_ids, note_map, wanted)
+            wl_edges, bl_edges = self._compute_wikilink_edges(note_ids, note_id_set, note_map, wanted)
             edges.extend(wl_edges)
             edges.extend(bl_edges)
 
@@ -316,6 +329,7 @@ class NoteGraphService:
                         note_node_map[edge.source].primary_source_id = edge.target
 
         # 11. Pruning
+        edges = self._order_edges(edges)
         all_nodes: list[GraphNode] = list(note_node_map.values()) + list(tag_nodes.values()) + list(source_nodes.values())
         all_nodes, edges, truncated, truncated_by = self._apply_pruning(
             all_nodes, edges, eff_max_nodes, eff_max_edges, eff_max_degree,
@@ -327,7 +341,10 @@ class NoteGraphService:
         has_more = False
         if cursor_info and cursor_info.get("has_more"):
             cursor_str = _encode_cursor(
-                cursor_info["layer"], cursor_info["pos"], cursor_info["last_id"],
+                cursor_info["layer"],
+                cursor_info["pos"],
+                cursor_info["last_id"],
+                cursor_info.get("neighbor_pos", 0),
             )
             has_more = True
 
@@ -373,6 +390,43 @@ class NoteGraphService:
         return response
 
     # ------------------------------------------------------------------
+    # Limit resolution
+    # ------------------------------------------------------------------
+
+    def _resolve_effective_limits(self, req: NoteGraphRequest) -> tuple[int, int, int, bool]:
+        """Clamp caller-requested limits before DB traversal begins."""
+        default_max_nodes = MAX_NODES()
+        default_max_edges = MAX_EDGES()
+        default_max_degree = MAX_DEGREE()
+
+        heavy_allowed = bool(req.allow_heavy and self._allow_heavy_limits)
+        hard_max_nodes = default_max_nodes * 2 if heavy_allowed else default_max_nodes
+        hard_max_edges = default_max_edges * 2 if heavy_allowed else default_max_edges
+        hard_max_degree = default_max_degree * 2 if heavy_allowed else default_max_degree
+
+        requested_max_nodes = req.max_nodes if req.max_nodes is not None else default_max_nodes
+        requested_max_edges = req.max_edges if req.max_edges is not None else default_max_edges
+        requested_max_degree = req.max_degree if req.max_degree is not None else default_max_degree
+
+        eff_max_nodes = min(requested_max_nodes, hard_max_nodes)
+        eff_max_edges = min(requested_max_edges, hard_max_edges)
+        eff_max_degree = min(requested_max_degree, hard_max_degree)
+
+        radius_cap_applied = False
+        if req.radius == 2 and not heavy_allowed:
+            if eff_max_nodes > _R2_MAX_NODES:
+                eff_max_nodes = _R2_MAX_NODES
+                radius_cap_applied = True
+            if eff_max_edges > _R2_MAX_EDGES:
+                eff_max_edges = _R2_MAX_EDGES
+                radius_cap_applied = True
+            if eff_max_degree > _R2_MAX_DEGREE:
+                eff_max_degree = _R2_MAX_DEGREE
+                radius_cap_applied = True
+
+        return eff_max_nodes, eff_max_edges, eff_max_degree, radius_cap_applied
+
+    # ------------------------------------------------------------------
     # Seed set
     # ------------------------------------------------------------------
 
@@ -382,26 +436,18 @@ class NoteGraphService:
             return [req.center_note_id]
 
         if req.tag:
-            # Find notes with this tag
-            all_tags = self._db.get_note_tag_edges(
-                self._db.get_all_note_ids_for_graph(include_deleted=True, limit=max_nodes * 2)
+            return self._db.get_note_ids_by_tag_for_graph(
+                req.tag,
+                include_deleted=True,
+                limit=max_nodes,
             )
-            matching = [t["note_id"] for t in all_tags if t["keyword"].lower() == req.tag.lower()]
-            if not matching:
-                return []
-            return list(dict.fromkeys(matching))[:max_nodes]
 
         if req.source:
-            all_ids = self._db.get_all_note_ids_for_graph(include_deleted=True, limit=max_nodes * 2)
-            source_info = self._db.get_note_source_info(all_ids)
-            matching = [
-                s["note_id"] for s in source_info
-                if _source_node_id(s["source"], s.get("external_ref")) == req.source
-                or s["source"] == req.source
-            ]
-            if not matching:
-                return []
-            return list(dict.fromkeys(matching))[:max_nodes]
+            return self._db.get_note_ids_by_source_for_graph(
+                req.source,
+                include_deleted=True,
+                limit=max_nodes,
+            )
 
         # Seedless: full graph if small enough
         total = self._db.count_user_notes(include_deleted=True)
@@ -410,12 +456,12 @@ class NoteGraphService:
         if total <= max_nodes:
             return self._db.get_all_note_ids_for_graph(include_deleted=True, limit=max_nodes)
 
-        if req.allow_heavy:
+        if req.allow_heavy and self._allow_heavy_limits:
             return self._db.get_all_note_ids_for_graph(include_deleted=True, limit=max_nodes)
 
         raise InputError(  # noqa: TRY003
             f"Too many notes ({total}) for seedless graph. "
-            f"Provide center_note_id, tag, or source filter, or set allow_heavy=true."
+            f"Provide center_note_id, tag, or source filter, or request allow_heavy with elevated graph permission."
         )
 
     # ------------------------------------------------------------------
@@ -429,9 +475,10 @@ class NoteGraphService:
         max_nodes: int,
         max_degree: int,
         req: NoteGraphRequest,
-    ) -> tuple[set[str], list[dict], bool, list[str], dict | None]:
+    ) -> tuple[list[str], list[dict], bool, list[str], dict | None]:
         """Layer-by-layer BFS from seeds, collecting note IDs and manual edges."""
         visited: set[str] = set()
+        visited_order: list[str] = []
         all_edges: list[dict] = []
         edge_ids_seen: set[str] = set()
         truncated = False
@@ -445,6 +492,7 @@ class NoteGraphService:
             cur = None
         start_layer = cur["layer"] if cur else 0
         start_pos = cur["pos"] if cur else 0
+        start_neighbor_pos = cur["neighbor_pos"] if cur else 0
 
         frontier: deque[str] = deque()
 
@@ -457,6 +505,7 @@ class NoteGraphService:
                 break
             if sid not in visited:
                 visited.add(sid)
+                visited_order.append(sid)
                 frontier.append(sid)
 
         for layer in range(radius):
@@ -501,6 +550,7 @@ class NoteGraphService:
 
                 # Sort neighbors: deterministic
                 neighbors = sorted(set(neighbors))
+                neighbor_start = start_neighbor_pos if layer == start_layer and idx == start_pos else 0
 
                 # Enforce max_degree per node
                 if len(neighbors) > max_degree:
@@ -509,16 +559,23 @@ class NoteGraphService:
                     if "max_degree" not in truncated_by:
                         truncated_by.append("max_degree")
 
-                for nb in neighbors:
+                for neighbor_idx, nb in enumerate(neighbors[neighbor_start:], start=neighbor_start):
                     if nb in visited:
                         continue
                     if len(visited) >= max_nodes:
                         truncated = True
                         if "max_nodes" not in truncated_by:
                             truncated_by.append("max_nodes")
-                        cursor_info = {"layer": layer, "pos": idx, "last_id": nid, "has_more": True}
+                        cursor_info = {
+                            "layer": layer,
+                            "pos": idx,
+                            "last_id": nid,
+                            "neighbor_pos": neighbor_idx,
+                            "has_more": True,
+                        }
                         break
                     visited.add(nb)
+                    visited_order.append(nb)
                     next_frontier.append(nb)
 
                 if truncated and "max_nodes" in truncated_by:
@@ -526,7 +583,7 @@ class NoteGraphService:
 
             frontier = next_frontier
 
-        return visited, all_edges, truncated, truncated_by, cursor_info
+        return visited_order, all_edges, truncated, truncated_by, cursor_info
 
     # ------------------------------------------------------------------
     # Derived edges
@@ -534,7 +591,8 @@ class NoteGraphService:
 
     def _compute_wikilink_edges(
         self,
-        note_ids: set[str],
+        note_ids: list[str],
+        note_id_set: set[str],
         note_map: dict[str, dict],
         wanted: set[EdgeType],
     ) -> tuple[list[GraphEdge], list[GraphEdge]]:
@@ -553,7 +611,7 @@ class NoteGraphService:
             refs = extract_wikilinks(content)
             for ref in refs:
                 target = ref.target_note_id
-                if target not in note_ids:
+                if target not in note_id_set:
                     continue
                 if target == nid:
                     continue
@@ -587,7 +645,7 @@ class NoteGraphService:
         return wl_edges, bl_edges
 
     def _compute_tag_edges(
-        self, note_ids: set[str],
+        self, note_ids: list[str],
     ) -> tuple[list[GraphEdge], dict[str, GraphNode]]:
         """Compute tag_membership edges and tag nodes."""
         tag_data = self._db.get_note_tag_edges(list(note_ids))
@@ -638,7 +696,7 @@ class NoteGraphService:
         return edges, tag_nodes
 
     def _compute_source_edges(
-        self, note_ids: set[str],
+        self, note_ids: list[str],
     ) -> tuple[list[GraphEdge], dict[str, GraphNode]]:
         """Compute source_membership edges and source nodes."""
         source_data = self._db.get_note_source_info(list(note_ids))
@@ -681,10 +739,10 @@ class NoteGraphService:
 
     def _apply_time_range(
         self,
-        note_ids: set[str],
+        note_ids: list[str],
         note_map: dict[str, dict],
         req: NoteGraphRequest,
-    ) -> set[str]:
+    ) -> list[str]:
         """Filter notes by time range. Maps updated_at → last_modified."""
         tr = req.time_range
         if not tr:
@@ -693,39 +751,64 @@ class NoteGraphService:
         # Map field name
         field = "last_modified" if req.time_range_field == "updated_at" else "created_at"
 
-        filtered: set[str] = set()
+        filtered: list[str] = []
+        start_naive = self._to_utc_naive(tr.start) if tr.start else None
+        end_naive = self._to_utc_naive(tr.end) if tr.end else None
         for nid in note_ids:
             row = note_map.get(nid)
             if not row:
                 continue
             val = row.get(field)
             if val is None:
-                filtered.add(nid)
+                filtered.append(nid)
                 continue
-            # Parse if string
-            if isinstance(val, str):
-                from datetime import datetime
-                try:
-                    ts = datetime.fromisoformat(val.replace("Z", "+00:00"))
-                except (ValueError, TypeError):
-                    filtered.add(nid)
-                    continue
-            else:
-                ts = val
+            ts_naive = self._to_utc_naive(val)
+            if ts_naive is None:
+                filtered.append(nid)
+                continue
 
-            # Make naive for comparison if needed
-            ts_naive = ts.replace(tzinfo=None) if hasattr(ts, "replace") else ts
-
-            if tr.start:
-                start_naive = tr.start.replace(tzinfo=None) if tr.start.tzinfo else tr.start
+            if start_naive:
                 if ts_naive < start_naive:
                     continue
-            if tr.end:
-                end_naive = tr.end.replace(tzinfo=None) if tr.end.tzinfo else tr.end
+            if end_naive:
                 if ts_naive > end_naive:
                     continue
-            filtered.add(nid)
+            filtered.append(nid)
         return filtered
+
+    @staticmethod
+    def _to_utc_naive(value: str | datetime | None) -> datetime | None:
+        """Normalize datetimes to UTC-naive values for consistent comparisons."""
+        if value is None:
+            return None
+        if isinstance(value, str):
+            try:
+                value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except (ValueError, TypeError):
+                return None
+        if not isinstance(value, datetime):
+            return None
+        if value.tzinfo is not None:
+            return value.astimezone(timezone.utc).replace(tzinfo=None)
+        return value
+
+    def _order_note_ids(self, note_ids: list[str], note_map: dict[str, dict]) -> list[str]:
+        """Order note IDs by updated timestamp descending, then ID ascending."""
+        def _sort_key(note_id: str) -> tuple[float, str]:
+            row = note_map.get(note_id, {})
+            ts = self._to_utc_naive(row.get("last_modified"))
+            sort_ts = ts.replace(tzinfo=timezone.utc).timestamp() if ts is not None else 0.0
+            return (-sort_ts, note_id)
+
+        return sorted(dict.fromkeys(note_ids), key=_sort_key)
+
+    @staticmethod
+    def _order_edges(edges: list[GraphEdge]) -> list[GraphEdge]:
+        """Order edges deterministically before order-sensitive pruning."""
+        return sorted(
+            edges,
+            key=lambda edge: (edge.type.value, edge.id, edge.source, edge.target),
+        )
 
     # ------------------------------------------------------------------
     # Pruning

--- a/tldw_Server_API/tests/Notes_Graph/integration/test_graph_endpoint.py
+++ b/tldw_Server_API/tests/Notes_Graph/integration/test_graph_endpoint.py
@@ -14,6 +14,7 @@ from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_u
 from tldw_Server_API.app.core.AuthNZ.jwt_service import JWTService
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings, reset_settings
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.api.v1.endpoints.notes_graph import _can_use_heavy_graph_limits
 
 pytestmark = pytest.mark.integration
 
@@ -78,6 +79,19 @@ def client_and_db(tmp_path, monkeypatch):
 
 def _headers():
     return {"Authorization": f"Bearer {_make_token('notes')}"}
+
+
+def _graph_user(**overrides) -> User:
+    data = {
+        "id": 1,
+        "username": "tester",
+        "email": "t@e.com",
+        "is_active": True,
+        "roles": ["user"],
+        "permissions": ["notes.graph.read"],
+    }
+    data.update(overrides)
+    return User(**data)
 
 
 def _create_note(client, title="N", content="body"):
@@ -205,6 +219,37 @@ def test_seedless_small_collection(client_and_db):
     data = resp.json()
     note_ids = {n["id"] for n in data["nodes"] if n["type"] == "note"}
     assert {n1, n2, n3} <= note_ids
+
+
+def test_allow_heavy_requires_graph_admin_permission(client_and_db):
+    client, db = client_and_db
+    h = _headers()
+    n1 = _create_note(client, "Heavy", "heavy content")
+
+    resp = client.get(
+        "/api/v1/notes/graph",
+        params={"center_note_id": n1, "allow_heavy": "true", "max_nodes": 1000},
+        headers=h,
+    )
+
+    assert resp.status_code == 403
+    assert "notes.graph.admin" in resp.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    "user",
+    [
+        _graph_user(role="admin", roles=[], permissions=[]),
+        _graph_user(is_admin=True, roles=[], permissions=[]),
+        _graph_user(is_superuser=True, roles=[], permissions=[]),
+        _graph_user(roles=["Admin"], permissions=[]),
+        _graph_user(roles=[], permissions=["SYSTEM.CONFIGURE"]),
+        _graph_user(roles=[], permissions=["notes.graph.admin"]),
+        _graph_user(roles=[], permissions=["*"]),
+    ],
+)
+def test_heavy_graph_permission_accepts_authnz_admin_signals(user):
+    assert _can_use_heavy_graph_limits(user) is True
 
 
 def test_edge_type_filter(client_and_db):

--- a/tldw_Server_API/tests/Notes_Graph/unit/test_graph_db_queries.py
+++ b/tldw_Server_API/tests/Notes_Graph/unit/test_graph_db_queries.py
@@ -131,6 +131,39 @@ class TestGetNoteTagEdges:
         assert rows == []
 
 
+class TestGraphSeedLookups:
+    def test_get_note_ids_by_tag_for_graph_finds_older_match_with_limit(self, db):
+        for index in range(5):
+            _make_note(db, title=f"Recent {index}")
+        matching = _make_note(db, title="Older tagged")
+        kw_id = db.add_keyword("deep-tag")
+        db.link_note_to_keyword(matching, kw_id)
+
+        rows = db.get_note_ids_by_tag_for_graph("deep-tag", limit=1)
+
+        assert rows == [matching]
+
+    def test_get_note_ids_by_source_for_graph_accepts_canonical_source_id(self, db):
+        character_id = db.add_character_card({"name": "Graph Source Character"})
+        conversation_id = db.add_conversation(
+            {
+                "character_id": character_id,
+                "title": "Source Conversation",
+                "source": "youtube",
+                "external_ref": "video-123",
+            }
+        )
+        matching = db.add_note(
+            title="Sourced note",
+            content="body",
+            conversation_id=conversation_id,
+        )
+
+        rows = db.get_note_ids_by_source_for_graph("source:youtube:video-123", limit=5)
+
+        assert rows == [matching]
+
+
 # ---------- count_notes_per_tag ----------
 
 class TestCountNotesPerTag:

--- a/tldw_Server_API/tests/Notes_Graph/unit/test_graph_service.py
+++ b/tldw_Server_API/tests/Notes_Graph/unit/test_graph_service.py
@@ -1,5 +1,7 @@
 """Tests for NoteGraphService."""
 
+import base64
+import json
 import uuid
 from unittest.mock import MagicMock, patch
 
@@ -26,7 +28,8 @@ def _uid():
 
 
 def _mock_db(notes=None, edges=None, tag_edges=None, tag_counts=None,
-             source_info=None, note_count=0, all_ids=None):
+             source_info=None, note_count=0, all_ids=None,
+             tag_seed_ids=None, source_seed_ids=None):
     """Build a MagicMock CharactersRAGDB with graph helpers."""
     db = MagicMock()
     _notes = notes or []
@@ -59,6 +62,37 @@ def _mock_db(notes=None, edges=None, tag_edges=None, tag_counts=None,
     def count_user_notes(include_deleted=True):
         return note_count
 
+    def get_note_ids_by_tag_for_graph(tag, include_deleted=True, limit=500):
+        if tag_seed_ids is not None:
+            return list(tag_seed_ids)[:limit]
+        if tag_edges is None:
+            return []
+        tagged = [
+            row["note_id"]
+            for row in tag_edges
+            if str(row.get("keyword", "")).lower() == str(tag).lower()
+        ]
+        return tagged[:limit]
+
+    def get_note_ids_by_source_for_graph(source, include_deleted=True, limit=500):
+        if source_seed_ids is not None:
+            return list(source_seed_ids)[:limit]
+        if source_info is None:
+            return []
+        source_text = str(source)
+        if source_text.startswith("source:"):
+            source_text = source_text[len("source:"):]
+        parts = source_text.split(":", 1)
+        wanted_source = parts[0]
+        wanted_ref = parts[1] if len(parts) == 2 else None
+        sourced = [
+            row["note_id"]
+            for row in source_info
+            if row.get("source") == wanted_source
+            and (wanted_ref is None or row.get("external_ref") == wanted_ref)
+        ]
+        return sourced[:limit]
+
     db.get_notes_batch = MagicMock(side_effect=get_notes_batch)
     db.get_manual_edges_for_notes = MagicMock(side_effect=get_manual_edges_for_notes)
     db.get_all_note_ids_for_graph = MagicMock(side_effect=get_all_note_ids_for_graph)
@@ -66,6 +100,8 @@ def _mock_db(notes=None, edges=None, tag_edges=None, tag_counts=None,
     db.count_notes_per_tag = MagicMock(side_effect=count_notes_per_tag)
     db.get_note_source_info = MagicMock(side_effect=get_note_source_info)
     db.count_user_notes = MagicMock(side_effect=count_user_notes)
+    db.get_note_ids_by_tag_for_graph = MagicMock(side_effect=get_note_ids_by_tag_for_graph)
+    db.get_note_ids_by_source_for_graph = MagicMock(side_effect=get_note_ids_by_source_for_graph)
     return db
 
 
@@ -158,6 +194,59 @@ class TestTagFilterSeeds:
         note_ids = {n.id for n in resp.nodes if n.type == "note"}
         assert n1 in note_ids
         assert n2 in note_ids
+
+    def test_uses_direct_tag_seed_lookup_beyond_recent_window(self):
+        matching = _uid()
+        recent_unrelated = [_uid(), _uid()]
+        notes = [_note(matching, title="Older tagged note")]
+        db = _mock_db(
+            notes=notes,
+            note_count=500,
+            all_ids=recent_unrelated,
+            tag_seed_ids=[matching],
+        )
+        svc = NoteGraphService(user_id="u1", db=db)
+        req = NoteGraphRequest(tag="ml", radius=1)
+
+        resp = svc.generate_graph(req)
+
+        note_ids = {n.id for n in resp.nodes if n.type == "note"}
+        assert matching in note_ids
+        db.get_note_ids_by_tag_for_graph.assert_called_once_with(
+            "ml", include_deleted=True, limit=300,
+        )
+
+
+class TestSourceFilterSeeds:
+    def test_uses_direct_source_seed_lookup_beyond_recent_window(self):
+        matching = _uid()
+        recent_unrelated = [_uid(), _uid()]
+        notes = [_note(matching, title="Older sourced note")]
+        source_info = [
+            {
+                "note_id": matching,
+                "conversation_id": _uid(),
+                "source": "youtube",
+                "external_ref": "abc123",
+            }
+        ]
+        db = _mock_db(
+            notes=notes,
+            source_info=source_info,
+            note_count=500,
+            all_ids=recent_unrelated,
+            source_seed_ids=[matching],
+        )
+        svc = NoteGraphService(user_id="u1", db=db)
+        req = NoteGraphRequest(source="source:youtube:abc123", radius=1)
+
+        resp = svc.generate_graph(req)
+
+        note_ids = {n.id for n in resp.nodes if n.type == "note"}
+        assert matching in note_ids
+        db.get_note_ids_by_source_for_graph.assert_called_once_with(
+            "source:youtube:abc123", include_deleted=True, limit=300,
+        )
 
 
 class TestWikilinkEdges:
@@ -281,6 +370,28 @@ class TestMaxDegreeEnforced:
         assert note_count <= 4
 
 
+class TestLimitHardCaps:
+    def test_non_heavy_request_limits_are_clamped_to_configured_caps(self, monkeypatch):
+        monkeypatch.setenv("NOTES_GRAPH_MAX_NODES", "3")
+        monkeypatch.setenv("NOTES_GRAPH_MAX_EDGES", "4")
+        monkeypatch.setenv("NOTES_GRAPH_MAX_DEGREE", "2")
+        n1 = _uid()
+        db = _mock_db(notes=[_note(n1)], note_count=1, all_ids=[n1])
+        svc = NoteGraphService(user_id="u1", db=db)
+        req = NoteGraphRequest(
+            radius=1,
+            max_nodes=999,
+            max_edges=999,
+            max_degree=999,
+        )
+
+        resp = svc.generate_graph(req)
+
+        assert resp.limits.max_nodes == 3
+        assert resp.limits.max_edges == 4
+        assert resp.limits.max_degree == 2
+
+
 class TestMaxNodesTruncation:
     def test_truncated_true(self):
         center = _uid()
@@ -307,6 +418,36 @@ class TestRadius2Caps:
         assert resp.limits.max_edges == 800
         assert resp.limits.max_degree == 20
         assert resp.radius_cap_applied is True
+
+
+class TestCursorPagination:
+    def test_cursor_advances_within_large_neighbor_list(self):
+        center = _uid()
+        neighbors = sorted(_uid() for _ in range(5))
+        notes = [_note(center)] + [_note(n) for n in neighbors]
+        edges = [_manual_edge(center, n) for n in neighbors]
+        db = _mock_db(notes=notes, edges=edges, note_count=6)
+        svc = NoteGraphService(user_id="u1", db=db)
+
+        first = svc.generate_graph(NoteGraphRequest(center_note_id=center, radius=1, max_nodes=3))
+        second = svc.generate_graph(
+            NoteGraphRequest(center_note_id=center, radius=1, max_nodes=3, cursor=first.cursor)
+        )
+
+        first_neighbors = {n.id for n in first.nodes if n.type == "note"} - {center}
+        second_neighbors = {n.id for n in second.nodes if n.type == "note"} - {center}
+        assert first.has_more is True
+        assert second_neighbors
+        assert first_neighbors.isdisjoint(second_neighbors)
+
+    def test_malformed_cursor_shape_raises_input_error(self):
+        raw = base64.urlsafe_b64encode(json.dumps({"layer": 0}).encode()).decode()
+        n1 = _uid()
+        db = _mock_db(notes=[_note(n1)], note_count=1, all_ids=[n1])
+        svc = NoteGraphService(user_id="u1", db=db)
+
+        with pytest.raises(InputError, match="Invalid graph cursor"):
+            svc.generate_graph(NoteGraphRequest(center_note_id=n1, radius=1, cursor=raw))
 
 
 class TestEdgeTypeFilter:
@@ -381,6 +522,67 @@ class TestDeterministicOrdering:
         r2 = svc.generate_graph(req)
         assert [n.id for n in r1.nodes] == [n.id for n in r2.nodes]
         assert [e.id for e in r1.edges] == [e.id for e in r2.edges]
+
+    def test_note_nodes_are_ordered_by_updated_at_desc_then_id(self):
+        ids = [_uid() for _ in range(5)]
+        notes = []
+        for index, nid in enumerate(ids):
+            notes.append({
+                "id": nid,
+                "title": f"N{index}",
+                "content": "body",
+                "created_at": "2025-01-01T00:00:00",
+                "last_modified": f"2025-06-0{index + 1}T00:00:00",
+                "deleted": 0,
+                "conversation_id": None,
+            })
+        expected = [n["id"] for n in sorted(
+            notes,
+            key=lambda row: (row["last_modified"], row["id"]),
+            reverse=True,
+        )]
+        db = _mock_db(notes=notes, note_count=len(notes), all_ids=ids)
+        svc = NoteGraphService(user_id="u1", db=db)
+
+        resp = svc.generate_graph(NoteGraphRequest(radius=1, edge_types=[EdgeType.manual]))
+
+        assert [n.id for n in resp.nodes if n.type == "note"] == expected
+
+    def test_tag_and_source_edge_order_does_not_depend_on_db_row_order(self):
+        n1, n2 = sorted([_uid(), _uid()])
+        notes = [_note(n1), _note(n2)]
+        tag_edges = [
+            {"note_id": n2, "keyword_id": 2, "keyword": "zeta"},
+            {"note_id": n1, "keyword_id": 1, "keyword": "alpha"},
+        ]
+        source_info = [
+            {"note_id": n2, "conversation_id": _uid(), "source": "youtube", "external_ref": "b"},
+            {"note_id": n1, "conversation_id": _uid(), "source": "article", "external_ref": "a"},
+        ]
+        db_unsorted = _mock_db(
+            notes=notes,
+            tag_edges=tag_edges,
+            source_info=source_info,
+            note_count=2,
+            all_ids=[n2, n1],
+        )
+        db_reversed = _mock_db(
+            notes=notes,
+            tag_edges=list(reversed(tag_edges)),
+            source_info=list(reversed(source_info)),
+            note_count=2,
+            all_ids=[n2, n1],
+        )
+        req = NoteGraphRequest(
+            radius=1,
+            edge_types=[EdgeType.tag_membership, EdgeType.source_membership],
+            max_edges=3,
+        )
+
+        first = NoteGraphService(user_id="u1", db=db_unsorted).generate_graph(req)
+        second = NoteGraphService(user_id="u1", db=db_reversed).generate_graph(req)
+
+        assert [edge.id for edge in first.edges] == [edge.id for edge in second.edges]
 
 
 class TestEmptyGraph:
@@ -516,14 +718,48 @@ class TestTimeRangeFilter:
         note_ids = {n.id for n in resp.nodes if n.type == "note"}
         assert n1 in note_ids
 
+    def test_timezone_aware_range_compares_by_instant(self):
+        n1 = _uid()
+        notes = [
+            {
+                "id": n1, "title": "Before absolute start", "content": "x",
+                "created_at": "2026-01-01T07:30:00+00:00",
+                "last_modified": "2026-01-01T07:30:00+00:00",
+                "deleted": 0, "conversation_id": None,
+            },
+        ]
+        db = _mock_db(notes=notes, note_count=1, all_ids=[n1])
+        svc = NoteGraphService(user_id="u1", db=db)
+        req = NoteGraphRequest(
+            radius=1,
+            time_range=TimeRange(start="2026-01-01T00:00:00-08:00"),
+            time_range_field="updated_at",
+        )
+
+        resp = svc.generate_graph(req)
+
+        note_ids = {n.id for n in resp.nodes if n.type == "note"}
+        assert n1 not in note_ids
+
 
 class TestAllowHeavy:
-    def test_allow_heavy_returns_graph(self):
-        """When allow_heavy=True and note count exceeds max_nodes, return capped graph."""
+    def test_allow_heavy_without_elevated_permission_still_rejects_large_seedless_graph(self):
+        """The endpoint grants allow_heavy_limits only after a permission check."""
         ids = [_uid() for _ in range(10)]
         notes = [_note(i) for i in ids]
         db = _mock_db(notes=notes, note_count=500, all_ids=ids)
         svc = NoteGraphService(user_id="u1", db=db)
+        req = NoteGraphRequest(radius=1, allow_heavy=True)
+
+        with pytest.raises(InputError):
+            svc.generate_graph(req)
+
+    def test_allow_heavy_returns_graph_when_elevated_limits_are_authorized(self):
+        """When allow_heavy is authorized and note count exceeds max_nodes, return capped graph."""
+        ids = [_uid() for _ in range(10)]
+        notes = [_note(i) for i in ids]
+        db = _mock_db(notes=notes, note_count=500, all_ids=ids)
+        svc = NoteGraphService(user_id="u1", db=db, allow_heavy_limits=True)
         req = NoteGraphRequest(radius=1, allow_heavy=True)
         resp = svc.generate_graph(req)
         # Should not raise; returns notes up to max_nodes


### PR DESCRIPTION
Summary: Harden Notes Graph limits, heavy-query authorization, cursor handling, tag/source seed lookups, deterministic ordering, and timezone filtering. Tests: py_compile touched files; focused Notes Graph unit/DB tests (62 passed); endpoint allow_heavy permission regression (1 passed); Bandit 0 findings; git diff --check. Change summary: human requester must complete this section before merge per the AI-generated PR policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Notes Graph: clamped limits, admin‑gated heavy queries (2× caps when authorized), validated cursor pagination, direct tag/source seeds, deterministic node/edge ordering, and UTC‑aware time filters. Satisfies TASK-9931 and adds `notes.graph.admin`.

- **New Features**
  - Added `notes.graph.admin` permission and endpoint enforcement; heavy limits only when authorized (accepts admin role, `is_admin`/`is_superuser`, `SYSTEM.CONFIGURE`, or `*`).
  - Direct seed lookups via `get_note_ids_by_tag_for_graph` and `get_note_ids_by_source_for_graph`, ordered by `last_modified` desc then id.

- **Bug Fixes**
  - Clamp `max_nodes`/`max_edges`/`max_degree` before traversal; stricter radius=2 caps unless heavy limits are authorized.
  - Cursor validation with clear errors; encodes `neighbor_pos` so pagination continues within large neighbor lists.
  - Deterministic node and edge ordering; tag/source edge order is stable and pruning is order‑safe.
  - Time-range filters compare instants in UTC; `updated_at` correctly maps to `last_modified`.

<sup>Written for commit 05d9f2d6bba18f5205c5ba8abc6009e4ddbd2932. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

