### PR TITLE
Draft: Harden Meetings module review findings

### DIFF
--- a/Docs/superpowers/plans/2026-06-23-meetings-review-hardening.md
+++ b/Docs/superpowers/plans/2026-06-23-meetings-review-hardening.md
@@ -1,0 +1,54 @@
+# Meetings Review Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the validated Meetings module review findings for SSE framing, session transition races, finalize include validation, and finalization idempotency.
+
+**Architecture:** Keep API behavior in the existing Meetings endpoint and service boundaries. Add persistence support in `Meetings_DB.py` only where service-level fixes need atomic database behavior.
+
+**Tech Stack:** FastAPI, Pydantic, SQLite, pytest, Bandit.
+
+---
+
+## Stage 1: Regression Tests
+**Goal:** Capture the reviewed failure modes before production code changes.
+**Success Criteria:** New focused tests fail for the current implementation for the expected reasons.
+**Tests:** Targeted pytest selections for stream framing, session transitions, and finalize behavior.
+**Status:** Complete
+
+- [x] Add an SSE framing test in `tldw_Server_API/tests/Meetings/test_meetings_events_sse.py` showing newline-bearing `id` and `type` values cannot create extra SSE control lines.
+- [x] Add a session service race test in `tldw_Server_API/tests/Meetings/test_meetings_session_service.py` showing a stale transition is rejected when the stored status changes between read and update.
+- [x] Add finalize API tests in `tldw_Server_API/tests/Meetings/test_meetings_ingest_finalize_api.py` showing unsupported final artifact kinds return `400`, do not write partial artifacts, and repeated commits do not create duplicate final artifacts.
+- [x] Run the new tests and record the red failures in Backlog task `TASK-9924`.
+
+## Stage 2: SSE and Transition Fixes
+**Goal:** Make event framing safe and status transitions atomic.
+**Success Criteria:** SSE field injection test and stale transition test pass.
+**Tests:** `test_meetings_events_sse.py` and `test_meetings_session_service.py`.
+**Status:** Complete
+
+- [x] Update `tldw_Server_API/app/core/Meetings/stream_adapter.py` to sanitize SSE `id` and `event` control fields while keeping the JSON payload unchanged.
+- [x] Update `tldw_Server_API/app/core/DB_Management/Meetings_DB.py` so `update_session_status` can require an expected current status.
+- [x] Update `tldw_Server_API/app/core/Meetings/session_service.py` to pass the expected status and reject stale transitions.
+- [x] Run the focused tests for this stage.
+
+## Stage 3: Finalization Contract Fixes
+**Goal:** Validate finalizable artifact kinds and make final artifact writes atomic and idempotent.
+**Success Criteria:** Unsupported kinds are rejected before writes, explicit empty include lists do not fall back to defaults, and repeated commits leave one current artifact per kind/version.
+**Tests:** `test_meetings_ingest_finalize_api.py`.
+**Status:** Complete
+
+- [x] Update `tldw_Server_API/app/core/Meetings/artifact_service.py` to distinguish `include is None` from an explicit list, reject unsupported final artifact kinds, and preserve requested order without duplicates.
+- [x] Add a bulk replacement helper in `tldw_Server_API/app/core/DB_Management/Meetings_DB.py` that validates all artifacts before replacing `(session_id, kind, version)` rows in one transaction.
+- [x] Use the bulk replacement helper from final artifact generation.
+- [x] Run the focused finalization tests.
+
+## Stage 4: Verification and Task Finalization
+**Goal:** Verify the touched scope and update project tracking.
+**Success Criteria:** Focused Meetings tests pass, Bandit completes for touched source, and Backlog task `TASK-9924` records results.
+**Tests:** Focused pytest command plus Bandit on touched Meetings/DB source.
+**Status:** Complete
+
+- [x] Run focused Meetings pytest selections.
+- [x] Run Bandit on touched source files.
+- [x] Update `TASK-9924` with notes, checked acceptance criteria, final summary, and any known skips.

--- a/backlog/tasks/task-9924 - Fix-Meetings-module-review-findings.md
+++ b/backlog/tasks/task-9924 - Fix-Meetings-module-review-findings.md
@@ -4,7 +4,7 @@ title: Fix Meetings module review findings
 status: Done
 assignee: []
 created_date: '2026-06-23 18:40'
-updated_date: '2026-06-23 18:41'
+updated_date: '2026-06-24 03:33'
 labels:
   - meetings
   - review-hardening
@@ -36,6 +36,8 @@ Docs/superpowers/plans/2026-06-23-meetings-review-hardening.md
 
 <!-- SECTION:NOTES:BEGIN -->
 Replacement task created after an ID collision caused the original Meetings task file to disappear. Red checks: new SSE, stale-transition, unsupported finalize kind, empty include, and repeated-finalize tests failed against the prior implementation for expected reasons. Green checks: focused Meetings suite passed with --confcutdir=tldw_Server_API/tests/Meetings: 37 passed, 6 warnings in 18.23s. Security: Bandit on touched Meetings/API/DB source wrote /tmp/bandit_meetings_review_hardening.json with results_count=0 and no errors. Known skip: did not run test_meetings_routes_smoke.py because the developer guide calls out environment-specific heavy import crashes for that smoke path; focused endpoint coverage was run instead.
+
+PR: https://github.com/rmusser01/tldw_server/pull/2476
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-9924 - Fix-Meetings-module-review-findings.md
+++ b/backlog/tasks/task-9924 - Fix-Meetings-module-review-findings.md
@@ -4,7 +4,7 @@ title: Fix Meetings module review findings
 status: Done
 assignee: []
 created_date: '2026-06-23 18:40'
-updated_date: '2026-06-24 03:33'
+updated_date: '2026-06-24 03:46'
 labels:
   - meetings
   - review-hardening
@@ -38,6 +38,8 @@ Docs/superpowers/plans/2026-06-23-meetings-review-hardening.md
 Replacement task created after an ID collision caused the original Meetings task file to disappear. Red checks: new SSE, stale-transition, unsupported finalize kind, empty include, and repeated-finalize tests failed against the prior implementation for expected reasons. Green checks: focused Meetings suite passed with --confcutdir=tldw_Server_API/tests/Meetings: 37 passed, 6 warnings in 18.23s. Security: Bandit on touched Meetings/API/DB source wrote /tmp/bandit_meetings_review_hardening.json with results_count=0 and no errors. Known skip: did not run test_meetings_routes_smoke.py because the developer guide calls out environment-specific heavy import crashes for that smoke path; focused endpoint coverage was run instead.
 
 PR: https://github.com/rmusser01/tldw_server/pull/2476
+
+2026-06-24 rebase follow-up: Rebased `codex/meetings-review-hardening` onto latest `origin/dev` (`46595e31c`). PR review triage found no line comments or submitted reviews; issue comments were non-actionable bot status messages (Gemini quota, CodeRabbit skipped draft review). Re-ran focused Meetings suite on the rebased branch: 37 passed, 6 warnings in 2.42s. Re-ran Bandit on touched Meetings/API/DB source: `/tmp/bandit_meetings_review_hardening_worktree_rebase.json`, results empty and no errors.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-9924 - Fix-Meetings-module-review-findings.md
+++ b/backlog/tasks/task-9924 - Fix-Meetings-module-review-findings.md
@@ -4,7 +4,7 @@ title: Fix Meetings module review findings
 status: Done
 assignee: []
 created_date: '2026-06-23 18:40'
-updated_date: '2026-06-24 03:46'
+updated_date: '2026-06-24 04:19'
 labels:
   - meetings
   - review-hardening
@@ -40,12 +40,14 @@ Replacement task created after an ID collision caused the original Meetings task
 PR: https://github.com/rmusser01/tldw_server/pull/2476
 
 2026-06-24 rebase follow-up: Rebased `codex/meetings-review-hardening` onto latest `origin/dev` (`46595e31c`). PR review triage found no line comments or submitted reviews; issue comments were non-actionable bot status messages (Gemini quota, CodeRabbit skipped draft review). Re-ran focused Meetings suite on the rebased branch: 37 passed, 6 warnings in 2.42s. Re-ran Bandit on touched Meetings/API/DB source: `/tmp/bandit_meetings_review_hardening_worktree_rebase.json`, results empty and no errors.
+
+2026-06-24 PR comment follow-up: Rebased onto latest `origin/dev` (`3f3221aa8`). Addressed Qodo comments by adding docstrings to new helpers, adding explicit type hints to the new tests and nested helper, and fixing `include=[]` finalization so existing final artifacts are cleared transactionally. Red/green evidence: `test_finalize_session_empty_include_clears_existing_final_artifacts` failed before the fix with four stale artifacts remaining, then passed after the DB replacement-scope change. Verification: focused Meetings suite passed, 38 passed and 6 warnings in 4.82s. Security: Bandit on touched Meetings/API/DB source wrote `/tmp/bandit_meetings_review_hardening_pr_comments.json` with empty results and no errors.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixed Meetings review findings by sanitizing SSE control fields, making service-driven status transitions conditional on the validated current status, rejecting unsupported final artifact kinds before writes, preserving explicit empty include lists, and replacing generated final artifacts atomically/idempotently. Added regression coverage for each behavior and verified the focused Meetings suite plus Bandit on touched source.
+Fixed Meetings review findings by sanitizing SSE control fields, making service-driven status transitions conditional on the validated current status, rejecting unsupported final artifact kinds before writes, preserving explicit empty include lists, and replacing generated final artifacts atomically/idempotently. Follow-up review comments were addressed by documenting new helpers, typing new tests, and clearing stale persisted final artifacts when `include=[]` is used after prior finalization. Added regression coverage and verified the focused Meetings suite plus Bandit on touched source.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-9924 - Fix-Meetings-module-review-findings.md
+++ b/backlog/tasks/task-9924 - Fix-Meetings-module-review-findings.md
@@ -1,0 +1,55 @@
+---
+id: TASK-9924
+title: Fix Meetings module review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 18:40'
+updated_date: '2026-06-23 18:41'
+labels:
+  - meetings
+  - review-hardening
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address validated Meetings module review findings: sanitize SSE framing fields, make status transitions atomic, validate finalizable artifact kinds, and make finalization atomic/idempotent.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 SSE framing cannot be injected with newline-bearing event ids or event types.
+- [x] #2 Session status transitions are atomic and reject stale concurrent transitions.
+- [x] #3 Finalize include values reject unsupported final artifact kinds instead of silently skipping them.
+- [x] #4 Repeated finalize calls do not create duplicate final artifacts and partial artifact writes are avoided.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-23-meetings-review-hardening.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Replacement task created after an ID collision caused the original Meetings task file to disappear. Red checks: new SSE, stale-transition, unsupported finalize kind, empty include, and repeated-finalize tests failed against the prior implementation for expected reasons. Green checks: focused Meetings suite passed with --confcutdir=tldw_Server_API/tests/Meetings: 37 passed, 6 warnings in 18.23s. Security: Bandit on touched Meetings/API/DB source wrote /tmp/bandit_meetings_review_hardening.json with results_count=0 and no errors. Known skip: did not run test_meetings_routes_smoke.py because the developer guide calls out environment-specific heavy import crashes for that smoke path; focused endpoint coverage was run instead.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed Meetings review findings by sanitizing SSE control fields, making service-driven status transitions conditional on the validated current status, rejecting unsupported final artifact kinds before writes, preserving explicit empty include lists, and replacing generated final artifacts atomically/idempotently. Added regression coverage for each behavior and verified the focused Meetings suite plus Bandit on touched source.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/meetings.py
+++ b/tldw_Server_API/app/api/v1/endpoints/meetings.py
@@ -319,7 +319,7 @@ def finalize_session(
         artifacts = artifact_service.generate_final_artifacts(
             session_id=session_id,
             transcript_text=payload.transcript_text,
-            include=list(payload.include) if payload.include else None,
+            include=list(payload.include) if payload.include is not None else None,
         )
     except KeyError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Meeting session not found") from exc

--- a/tldw_Server_API/app/core/DB_Management/Meetings_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Meetings_DB.py
@@ -496,19 +496,41 @@ class MeetingsDatabase:
         session_id: str,
         status: str,
         user_id: int | str | None = None,
+        expected_status: str | None = None,
     ) -> bool:
         resolved_user_id = self._resolve_user_id(user_id)
         normalized_status = self._validate_status(status)
+        normalized_expected_status = (
+            self._validate_status(expected_status)
+            if expected_status is not None
+            else None
+        )
         now = self._utcnow_iso()
         with self.transaction() as conn:
-            cursor = conn.execute(
-                """
-                UPDATE meeting_sessions
-                SET status = ?, updated_at = ?
-                WHERE id = ? AND user_id = ?
-                """,
-                (normalized_status, now, str(session_id), resolved_user_id),
-            )
+            if normalized_expected_status is not None:
+                cursor = conn.execute(
+                    """
+                    UPDATE meeting_sessions
+                    SET status = ?, updated_at = ?
+                    WHERE id = ? AND user_id = ? AND status = ?
+                    """,
+                    (
+                        normalized_status,
+                        now,
+                        str(session_id),
+                        resolved_user_id,
+                        normalized_expected_status,
+                    ),
+                )
+            else:
+                cursor = conn.execute(
+                    """
+                    UPDATE meeting_sessions
+                    SET status = ?, updated_at = ?
+                    WHERE id = ? AND user_id = ?
+                    """,
+                    (normalized_status, now, str(session_id), resolved_user_id),
+                )
             return int(cursor.rowcount or 0) > 0
 
     def create_template(
@@ -629,6 +651,79 @@ class MeetingsDatabase:
                 ),
             )
         return artifact_id
+
+    def replace_artifacts(
+        self,
+        *,
+        session_id: str,
+        artifacts: list[dict[str, Any]],
+        user_id: int | str | None = None,
+    ) -> list[str]:
+        resolved_user_id = self._resolve_user_id(user_id)
+        prepared: list[tuple[str, str, str, str, int, str]] = []
+
+        for artifact in artifacts:
+            normalized_kind = self._validate_artifact_kind(str(artifact.get("kind") or ""))
+            clean_format = str(artifact.get("format") or "").strip()
+            if not clean_format:
+                raise InputError("artifact format is required")
+            payload_json = artifact.get("payload_json")
+            if not isinstance(payload_json, dict):
+                raise InputError("artifact payload_json must be an object")
+            version = max(1, int(artifact.get("version") or 1))
+            prepared.append(
+                (
+                    f"art_{uuid.uuid4().hex}",
+                    str(session_id),
+                    normalized_kind,
+                    clean_format,
+                    version,
+                    json.dumps(payload_json),
+                )
+            )
+
+        now = self._utcnow_iso()
+        with self.transaction() as conn:
+            session_row = conn.execute(
+                """
+                SELECT 1
+                FROM meeting_sessions
+                WHERE id = ? AND user_id = ?
+                """,
+                (str(session_id), resolved_user_id),
+            ).fetchone()
+            if session_row is None:
+                raise KeyError(f"meeting session not found: {session_id}")
+
+            for _artifact_id, prepared_session_id, kind, _format, version, _payload in prepared:
+                conn.execute(
+                    """
+                    DELETE FROM meeting_artifacts
+                    WHERE user_id = ? AND session_id = ? AND kind = ? AND version = ?
+                    """,
+                    (resolved_user_id, prepared_session_id, kind, version),
+                )
+
+            for artifact_id, prepared_session_id, kind, format_, version, payload in prepared:
+                conn.execute(
+                    """
+                    INSERT INTO meeting_artifacts (
+                        id, user_id, session_id, kind, format, payload_json, version, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        artifact_id,
+                        resolved_user_id,
+                        prepared_session_id,
+                        kind,
+                        format_,
+                        payload,
+                        version,
+                        now,
+                    ),
+                )
+
+        return [artifact_id for artifact_id, *_rest in prepared]
 
     def get_artifact(self, artifact_id: str, user_id: int | str | None = None) -> dict[str, Any] | None:
         resolved_user_id = self._resolve_user_id(user_id)

--- a/tldw_Server_API/app/core/DB_Management/Meetings_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Meetings_DB.py
@@ -657,8 +657,20 @@ class MeetingsDatabase:
         *,
         session_id: str,
         artifacts: list[dict[str, Any]],
+        replace_kinds: list[str] | None = None,
+        replace_version: int = 1,
         user_id: int | str | None = None,
     ) -> list[str]:
+        """Atomically replace artifact rows for a session and return new IDs.
+
+        Each artifact must provide a valid kind, non-empty format, object
+        payload_json, and optional version. By default, only the `(kind,
+        version)` pairs present in `artifacts` are deleted before inserting the
+        new rows. `replace_kinds` widens the deletion scope to those validated
+        kinds at `replace_version`, which lets callers intentionally replace a
+        prior generated artifact set with an empty result in the same
+        transaction.
+        """
         resolved_user_id = self._resolve_user_id(user_id)
         prepared: list[tuple[str, str, str, str, int, str]] = []
 
@@ -682,6 +694,23 @@ class MeetingsDatabase:
                 )
             )
 
+        if replace_kinds is None:
+            delete_targets = [
+                (kind, version)
+                for _id, _session_id, kind, _format, version, _payload in prepared
+            ]
+        else:
+            scoped_version = max(1, int(replace_version))
+            delete_targets: list[tuple[str, int]] = []
+            seen_targets: set[tuple[str, int]] = set()
+            for kind in replace_kinds:
+                normalized_kind = self._validate_artifact_kind(str(kind or ""))
+                target = (normalized_kind, scoped_version)
+                if target in seen_targets:
+                    continue
+                seen_targets.add(target)
+                delete_targets.append(target)
+
         now = self._utcnow_iso()
         with self.transaction() as conn:
             session_row = conn.execute(
@@ -695,13 +724,13 @@ class MeetingsDatabase:
             if session_row is None:
                 raise KeyError(f"meeting session not found: {session_id}")
 
-            for _artifact_id, prepared_session_id, kind, _format, version, _payload in prepared:
+            for kind, version in delete_targets:
                 conn.execute(
                     """
                     DELETE FROM meeting_artifacts
                     WHERE user_id = ? AND session_id = ? AND kind = ? AND version = ?
                     """,
-                    (resolved_user_id, prepared_session_id, kind, version),
+                    (resolved_user_id, str(session_id), kind, version),
                 )
 
             for artifact_id, prepared_session_id, kind, format_, version, payload in prepared:

--- a/tldw_Server_API/app/core/Meetings/artifact_service.py
+++ b/tldw_Server_API/app/core/Meetings/artifact_service.py
@@ -8,6 +8,7 @@ from typing import Any
 from tldw_Server_API.app.core.DB_Management.Meetings_DB import MeetingsDatabase
 
 _DEFAULT_FINAL_KINDS: tuple[str, ...] = ("summary", "action_items", "decisions", "speaker_stats")
+_FINALIZABLE_KINDS = set(_DEFAULT_FINAL_KINDS)
 
 
 class MeetingArtifactService:
@@ -56,23 +57,36 @@ class MeetingArtifactService:
         if self._db.get_session(session_id=session_id) is None:
             raise KeyError(f"meeting session not found: {session_id}")
 
-        requested_kinds = include or list(_DEFAULT_FINAL_KINDS)
         payloads = self._build_finalize_payloads(clean_transcript)
+        requested_kinds = self._normalize_requested_kinds(include=include)
+        unsupported = [kind for kind in requested_kinds if kind not in _FINALIZABLE_KINDS]
+        if unsupported:
+            raise ValueError(f"meeting artifact kinds are not finalizable: {', '.join(unsupported)}")
 
-        artifacts: list[dict[str, Any]] = []
-        for kind in requested_kinds:
+        artifact_specs = [
+            {
+                "kind": kind,
+                "format": "json",
+                "payload_json": payloads[kind],
+                "version": 1,
+            }
+            for kind in requested_kinds
+        ]
+        artifact_ids = self._db.replace_artifacts(session_id=session_id, artifacts=artifact_specs)
+        return [self.get_artifact(artifact_id=artifact_id) for artifact_id in artifact_ids]
+
+    @staticmethod
+    def _normalize_requested_kinds(*, include: list[str] | None) -> list[str]:
+        raw_kinds = list(_DEFAULT_FINAL_KINDS) if include is None else include
+        requested_kinds: list[str] = []
+        seen: set[str] = set()
+        for kind in raw_kinds:
             normalized_kind = str(kind).strip().lower()
-            if normalized_kind not in payloads:
+            if not normalized_kind or normalized_kind in seen:
                 continue
-            artifacts.append(
-                self.create_artifact(
-                    session_id=session_id,
-                    kind=normalized_kind,
-                    format="json",
-                    payload_json=payloads[normalized_kind],
-                )
-            )
-        return artifacts
+            seen.add(normalized_kind)
+            requested_kinds.append(normalized_kind)
+        return requested_kinds
 
     @staticmethod
     def _build_finalize_payloads(transcript_text: str) -> dict[str, dict[str, Any]]:

--- a/tldw_Server_API/app/core/Meetings/artifact_service.py
+++ b/tldw_Server_API/app/core/Meetings/artifact_service.py
@@ -72,11 +72,25 @@ class MeetingArtifactService:
             }
             for kind in requested_kinds
         ]
-        artifact_ids = self._db.replace_artifacts(session_id=session_id, artifacts=artifact_specs)
+        replace_kinds = requested_kinds
+        if include is not None and not requested_kinds:
+            replace_kinds = list(_DEFAULT_FINAL_KINDS)
+        artifact_ids = self._db.replace_artifacts(
+            session_id=session_id,
+            artifacts=artifact_specs,
+            replace_kinds=replace_kinds,
+            replace_version=1,
+        )
         return [self.get_artifact(artifact_id=artifact_id) for artifact_id in artifact_ids]
 
     @staticmethod
     def _normalize_requested_kinds(*, include: list[str] | None) -> list[str]:
+        """Return ordered, lower-cased, de-duplicated final artifact kinds.
+
+        `None` requests the default final artifact set. An explicit list,
+        including an empty list, is preserved as the caller's requested scope
+        after trimming blank values and dropping duplicates.
+        """
         raw_kinds = list(_DEFAULT_FINAL_KINDS) if include is None else include
         requested_kinds: list[str] = []
         seen: set[str] = set()

--- a/tldw_Server_API/app/core/Meetings/session_service.py
+++ b/tldw_Server_API/app/core/Meetings/session_service.py
@@ -62,7 +62,20 @@ class MeetingSessionService:
                 f"Invalid meeting session status transition: {current_status!r} -> {target_status!r}"
             )
 
-        updated = self._db.update_session_status(session_id=session_id, status=target_status)
+        updated = self._db.update_session_status(
+            session_id=session_id,
+            status=target_status,
+            expected_status=current_status,
+        )
         if not updated:
-            raise KeyError(f"meeting session not found: {session_id}")
+            latest = self._db.get_session(session_id=session_id)
+            if latest is None:
+                raise KeyError(f"meeting session not found: {session_id}")
+            latest_status = str(latest.get("status") or "").strip().lower()
+            if latest_status == target_status:
+                return latest
+            raise ValueError(
+                "Meeting session status changed concurrently: "
+                f"{current_status!r} -> {latest_status!r}; requested {target_status!r}"
+            )
         return self.get_session(session_id=session_id)

--- a/tldw_Server_API/app/core/Meetings/stream_adapter.py
+++ b/tldw_Server_API/app/core/Meetings/stream_adapter.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import json
+import re
 import uuid
 from datetime import datetime, timezone
 from typing import Any
+
+_SSE_CONTROL_FIELD_PATTERN = re.compile(r"[^A-Za-z0-9_.:-]+")
+_SSE_CONTROL_FIELD_MAX_LENGTH = 256
 
 
 def utcnow_iso() -> str:
@@ -29,6 +33,18 @@ def build_meeting_event(
     }
 
 
+def _sanitize_sse_control_field(value: Any, *, default: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return default
+    text = re.sub(r"[\r\n]+", "_", text)
+    text = _SSE_CONTROL_FIELD_PATTERN.sub("_", text)
+    text = text[:_SSE_CONTROL_FIELD_MAX_LENGTH].strip("_")
+    return text or default
+
+
 def to_sse_frame(event: dict[str, Any]) -> str:
     payload = json.dumps(event, separators=(",", ":"), default=str)
-    return f"id: {event.get('id','')}\nevent: {event.get('type','event')}\ndata: {payload}\n\n"
+    event_id = _sanitize_sse_control_field(event.get("id"), default="")
+    event_type = _sanitize_sse_control_field(event.get("type"), default="event")
+    return f"id: {event_id}\nevent: {event_type}\ndata: {payload}\n\n"

--- a/tldw_Server_API/app/core/Meetings/stream_adapter.py
+++ b/tldw_Server_API/app/core/Meetings/stream_adapter.py
@@ -34,6 +34,7 @@ def build_meeting_event(
 
 
 def _sanitize_sse_control_field(value: Any, *, default: str) -> str:
+    """Normalize an SSE id/event field so it cannot inject new frame lines."""
     text = str(value or "").strip()
     if not text:
         return default

--- a/tldw_Server_API/tests/Meetings/test_meetings_events_sse.py
+++ b/tldw_Server_API/tests/Meetings/test_meetings_events_sse.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.core.Meetings.stream_adapter import to_sse_frame
 
@@ -8,7 +9,7 @@ from tldw_Server_API.app.core.Meetings.stream_adapter import to_sse_frame
 pytestmark = pytest.mark.unit
 
 
-def _create_session(meetings_api_client) -> str:
+def _create_session(meetings_api_client: TestClient) -> str:
     resp = meetings_api_client.post(
         "/api/v1/meetings/sessions",
         json={"title": "SSE Session", "meeting_type": "standup"},
@@ -17,7 +18,7 @@ def _create_session(meetings_api_client) -> str:
     return resp.json()["id"]
 
 
-def test_sse_events_streams_structured_frames(meetings_api_client):
+def test_sse_events_streams_structured_frames(meetings_api_client: TestClient) -> None:
     session_id = _create_session(meetings_api_client)
     resp = meetings_api_client.get(f"/api/v1/meetings/sessions/{session_id}/events")
     assert resp.status_code == 200
@@ -26,7 +27,7 @@ def test_sse_events_streams_structured_frames(meetings_api_client):
     assert "\"session_id\"" in resp.text
 
 
-def test_sse_frame_sanitizes_control_fields():
+def test_sse_frame_sanitizes_control_fields() -> None:
     frame = to_sse_frame(
         {
             "id": "evt-1\nretry: 0",

--- a/tldw_Server_API/tests/Meetings/test_meetings_events_sse.py
+++ b/tldw_Server_API/tests/Meetings/test_meetings_events_sse.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import pytest
 
+from tldw_Server_API.app.core.Meetings.stream_adapter import to_sse_frame
+
 
 pytestmark = pytest.mark.unit
 
@@ -22,3 +24,21 @@ def test_sse_events_streams_structured_frames(meetings_api_client):
     assert "text/event-stream" in resp.headers.get("content-type", "")
     assert "event:" in resp.text
     assert "\"session_id\"" in resp.text
+
+
+def test_sse_frame_sanitizes_control_fields():
+    frame = to_sse_frame(
+        {
+            "id": "evt-1\nretry: 0",
+            "type": "transcript.final\ndata: forged",
+            "session_id": "sess_1",
+            "timestamp": "2026-06-23T00:00:00+00:00",
+            "data": {"text": "hello"},
+        }
+    )
+
+    lines = frame.splitlines()
+    assert lines[0] == "id: evt-1_retry:_0"
+    assert lines[1] == "event: transcript.final_data:_forged"
+    assert all(line != "retry: 0" for line in lines)
+    assert all(line != "data: forged" for line in lines)

--- a/tldw_Server_API/tests/Meetings/test_meetings_ingest_finalize_api.py
+++ b/tldw_Server_API/tests/Meetings/test_meetings_ingest_finalize_api.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import pytest
+from fastapi.testclient import TestClient
 
 
 pytestmark = pytest.mark.unit
 
 
-def _create_session(meetings_api_client) -> str:
+def _create_session(meetings_api_client: TestClient) -> str:
     resp = meetings_api_client.post(
         "/api/v1/meetings/sessions",
         json={"title": "Finalize Session", "meeting_type": "standup"},
@@ -15,7 +16,7 @@ def _create_session(meetings_api_client) -> str:
     return resp.json()["id"]
 
 
-def test_finalize_session_generates_summary_and_actions(meetings_api_client):
+def test_finalize_session_generates_summary_and_actions(meetings_api_client: TestClient) -> None:
     session_id = _create_session(meetings_api_client)
     transcript = (
         "Team discussed blockers. TODO: Alice will update the API docs. "
@@ -41,7 +42,9 @@ def test_finalize_session_generates_summary_and_actions(meetings_api_client):
     assert artifacts_by_kind["decisions"]["payload_json"]["items"] == []
 
 
-def test_finalize_session_rejects_unsupported_final_kind_without_partial_artifacts(meetings_api_client):
+def test_finalize_session_rejects_unsupported_final_kind_without_partial_artifacts(
+    meetings_api_client: TestClient,
+) -> None:
     session_id = _create_session(meetings_api_client)
 
     commit_resp = meetings_api_client.post(
@@ -60,7 +63,7 @@ def test_finalize_session_rejects_unsupported_final_kind_without_partial_artifac
     assert artifacts_resp.json() == []
 
 
-def test_finalize_session_respects_empty_include_list(meetings_api_client):
+def test_finalize_session_respects_empty_include_list(meetings_api_client: TestClient) -> None:
     session_id = _create_session(meetings_api_client)
 
     commit_resp = meetings_api_client.post(
@@ -76,7 +79,33 @@ def test_finalize_session_respects_empty_include_list(meetings_api_client):
     assert artifacts_resp.json() == []
 
 
-def test_finalize_session_replaces_existing_final_artifacts(meetings_api_client):
+def test_finalize_session_empty_include_clears_existing_final_artifacts(
+    meetings_api_client: TestClient,
+) -> None:
+    session_id = _create_session(meetings_api_client)
+    transcript = "Team discussed blockers. TODO: Alice will update the API docs."
+
+    create_resp = meetings_api_client.post(
+        f"/api/v1/meetings/sessions/{session_id}/commit",
+        json={"transcript_text": transcript},
+    )
+    assert create_resp.status_code == 200
+    assert create_resp.json()["artifacts"]
+
+    clear_resp = meetings_api_client.post(
+        f"/api/v1/meetings/sessions/{session_id}/commit",
+        json={"transcript_text": transcript, "include": []},
+    )
+
+    assert clear_resp.status_code == 200
+    assert clear_resp.json()["artifacts"] == []
+
+    artifacts_resp = meetings_api_client.get(f"/api/v1/meetings/sessions/{session_id}/artifacts")
+    assert artifacts_resp.status_code == 200
+    assert artifacts_resp.json() == []
+
+
+def test_finalize_session_replaces_existing_final_artifacts(meetings_api_client: TestClient) -> None:
     session_id = _create_session(meetings_api_client)
     transcript = "Team discussed blockers. TODO: Alice will update the API docs."
 

--- a/tldw_Server_API/tests/Meetings/test_meetings_ingest_finalize_api.py
+++ b/tldw_Server_API/tests/Meetings/test_meetings_ingest_finalize_api.py
@@ -39,3 +39,61 @@ def test_finalize_session_generates_summary_and_actions(meetings_api_client):
         "Bob will validate deployment checklist",
     ]
     assert artifacts_by_kind["decisions"]["payload_json"]["items"] == []
+
+
+def test_finalize_session_rejects_unsupported_final_kind_without_partial_artifacts(meetings_api_client):
+    session_id = _create_session(meetings_api_client)
+
+    commit_resp = meetings_api_client.post(
+        f"/api/v1/meetings/sessions/{session_id}/commit",
+        json={
+            "transcript_text": "Team discussed launch readiness.",
+            "include": ["summary", "sentiment"],
+        },
+    )
+
+    assert commit_resp.status_code == 400
+    assert "not finalizable" in commit_resp.json()["detail"]
+
+    artifacts_resp = meetings_api_client.get(f"/api/v1/meetings/sessions/{session_id}/artifacts")
+    assert artifacts_resp.status_code == 200
+    assert artifacts_resp.json() == []
+
+
+def test_finalize_session_respects_empty_include_list(meetings_api_client):
+    session_id = _create_session(meetings_api_client)
+
+    commit_resp = meetings_api_client.post(
+        f"/api/v1/meetings/sessions/{session_id}/commit",
+        json={"transcript_text": "Team discussed launch readiness.", "include": []},
+    )
+
+    assert commit_resp.status_code == 200
+    assert commit_resp.json()["artifacts"] == []
+
+    artifacts_resp = meetings_api_client.get(f"/api/v1/meetings/sessions/{session_id}/artifacts")
+    assert artifacts_resp.status_code == 200
+    assert artifacts_resp.json() == []
+
+
+def test_finalize_session_replaces_existing_final_artifacts(meetings_api_client):
+    session_id = _create_session(meetings_api_client)
+    transcript = "Team discussed blockers. TODO: Alice will update the API docs."
+
+    first_resp = meetings_api_client.post(
+        f"/api/v1/meetings/sessions/{session_id}/commit",
+        json={"transcript_text": transcript},
+    )
+    second_resp = meetings_api_client.post(
+        f"/api/v1/meetings/sessions/{session_id}/commit",
+        json={"transcript_text": transcript},
+    )
+
+    assert first_resp.status_code == 200
+    assert second_resp.status_code == 200
+
+    artifacts_resp = meetings_api_client.get(f"/api/v1/meetings/sessions/{session_id}/artifacts")
+    assert artifacts_resp.status_code == 200
+    artifacts = artifacts_resp.json()
+    kinds = [artifact["kind"] for artifact in artifacts]
+    assert sorted(kinds) == ["action_items", "decisions", "speaker_stats", "summary"]

--- a/tldw_Server_API/tests/Meetings/test_meetings_session_service.py
+++ b/tldw_Server_API/tests/Meetings/test_meetings_session_service.py
@@ -38,3 +38,24 @@ def test_session_state_machine_allows_valid_transition(session_service):
 def test_session_transition_raises_for_missing_session(session_service):
     with pytest.raises(KeyError):
         session_service.transition(session_id="sess_missing", to_status="live")
+
+
+def test_session_transition_rejects_stale_current_status(session_service, monkeypatch):
+    created = session_service.create_session(title="Race Review", meeting_type="standup")
+    real_update = session_service._db.update_session_status
+
+    def racing_update(*, session_id, status, user_id=None, expected_status=None):
+        if expected_status == "scheduled":
+            assert real_update(session_id=session_id, status="processing", user_id=user_id) is True
+        kwargs = {"session_id": session_id, "status": status, "user_id": user_id}
+        if expected_status is not None:
+            kwargs["expected_status"] = expected_status
+        return real_update(**kwargs)
+
+    monkeypatch.setattr(session_service._db, "update_session_status", racing_update)
+
+    with pytest.raises(ValueError, match="changed concurrently"):
+        session_service.transition(session_id=created["id"], to_status="live")
+
+    row = session_service.get_session(session_id=created["id"])
+    assert row["status"] == "processing"

--- a/tldw_Server_API/tests/Meetings/test_meetings_session_service.py
+++ b/tldw_Server_API/tests/Meetings/test_meetings_session_service.py
@@ -40,17 +40,28 @@ def test_session_transition_raises_for_missing_session(session_service):
         session_service.transition(session_id="sess_missing", to_status="live")
 
 
-def test_session_transition_rejects_stale_current_status(session_service, monkeypatch):
+def test_session_transition_rejects_stale_current_status(
+    session_service: MeetingSessionService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     created = session_service.create_session(title="Race Review", meeting_type="standup")
     real_update = session_service._db.update_session_status
 
-    def racing_update(*, session_id, status, user_id=None, expected_status=None):
+    def racing_update(
+        *,
+        session_id: str,
+        status: str,
+        user_id: int | str | None = None,
+        expected_status: str | None = None,
+    ) -> bool:
         if expected_status == "scheduled":
             assert real_update(session_id=session_id, status="processing", user_id=user_id) is True
-        kwargs = {"session_id": session_id, "status": status, "user_id": user_id}
-        if expected_status is not None:
-            kwargs["expected_status"] = expected_status
-        return real_update(**kwargs)
+        return real_update(
+            session_id=session_id,
+            status=status,
+            user_id=user_id,
+            expected_status=expected_status,
+        )
 
     monkeypatch.setattr(session_service._db, "update_session_status", racing_update)
 


### PR DESCRIPTION
Draft PR for Meetings review hardening. Human-written Change summary required before this is marked ready or merge-ready per Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md. Summary: sanitizes Meetings SSE control fields; makes service-driven status transitions conditional on the validated current status; rejects unsupported final artifact kinds before writes; preserves explicit empty include lists; replaces generated final artifacts atomically and idempotently. Test plan: focused Meetings suite passed (37 passed, 6 warnings); Bandit touched-source scan reported 0 findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Meetings module to block SSE control-field injection, make status transitions atomic with expected status, and make finalization safe, idempotent, and able to clear prior artifacts when `include=[]`. Preserves explicit empty includes and rejects unsupported final artifact kinds before any writes.

- **Bug Fixes**
  - Sanitized SSE `id`/`event` with regex, newline stripping, and length cap to prevent injection; added focused tests.
  - Made status transitions conditional via `expected_status` in `Meetings_DB.update_session_status`; `session_service.transition` rejects stale races and returns the latest row if already at target.
  - Finalization validates kinds against the allowed set, preserves caller order without dups, distinguishes `include=None` from `[]`, and atomically replaces artifacts via `Meetings_DB.replace_artifacts`; `include=[]` now clears existing default final artifacts; repeated commits replace without duplicates.
  - Endpoint only sends `include=None` when omitted by the client; tests expanded for sanitize/clear/replace; Bandit on touched code reports 0 findings.

- **Docs**
  - Added plan and task notes (`TASK-9924`) with PR link, rebase follow-ups, and fixes from review (docstrings, type hints, and the `include=[]` clearing change).

<sup>Written for commit 484ffd7497fff88560f2c4ee32e861c1cc27eb22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

