### PR TITLE
Harden Notes Studio review findings

### DIFF
--- a/IMPLEMENTATION_PLAN_notes_module_review_hardening_9932.md
+++ b/IMPLEMENTATION_PLAN_notes_module_review_hardening_9932.md
@@ -1,0 +1,29 @@
+## Stage 1: Regression Tests
+**Goal**: Capture the reviewed Notes Studio and search safety issues before implementation.
+**Success Criteria**: Tests fail for stale Studio regenerate, invalid diagram section IDs, bounded request inputs, bounded keyword tokens, and workflow cleanup.
+**Tests**:
+- `tldw_Server_API/tests/Notes_NEW/unit/test_notes_studio_service.py`
+- `tldw_Server_API/tests/Notes_NEW/integration/test_notes_studio_api.py`
+- `tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py`
+- `tldw_Server_API/tests/Workflows/adapters/test_knowledge_adapters.py`
+**Status**: Complete
+
+## Stage 2: Notes Studio Safety Fixes
+**Goal**: Prevent scope broadening, stale editor overwrites, and diagram sidecar clobbering.
+**Success Criteria**: Studio regenerate requires caller concurrency state, invalid diagram section IDs are rejected, and diagram updates only mutate the manifest after generation.
+**Tests**: Targeted Notes Studio unit and API tests pass.
+**Status**: Complete
+
+## Stage 3: Input Bounds and Resource Cleanup
+**Goal**: Bound request/input fan-out and ensure workflow-created NotesInteropService instances are closed.
+**Success Criteria**: Studio schemas enforce size/cardinality limits, keyword search rejects excessive tokens, and workflow notes CRUD closes cached DB handles.
+**Tests**: Targeted Notes API and workflow adapter tests pass.
+**Status**: Complete
+
+## Stage 4: Verification and Finalization
+**Goal**: Verify touched scope and record Backlog results.
+**Success Criteria**: Targeted tests and Bandit on touched code complete with results captured in `TASK-9932`.
+**Tests**:
+- `python -m pytest ...` targeted commands
+- `python -m bandit -r <touched_paths> -f json -o /tmp/bandit_notes_module_review_hardening_9932.json`
+**Status**: Complete

--- a/backlog/tasks/task-9932 - Harden-Notes-module-review-findings.md
+++ b/backlog/tasks/task-9932 - Harden-Notes-module-review-findings.md
@@ -4,7 +4,7 @@ title: Harden Notes module review findings
 status: Done
 assignee: []
 created_date: 2026-06-23 18:55
-updated_date: 2026-06-24 03:36
+updated_date: 2026-06-24 04:31
 labels:
 - notes
 - review
@@ -62,4 +62,5 @@ Hardened the Notes module review findings. Notes Studio regenerate now requires 
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 PR: https://github.com/rmusser01/tldw_server/pull/2478
+Rebased PR #2478 onto origin/dev at 0ca69b4b4 and dropped unrelated Claims_Extraction planning commit from the PR diff. Addressed Qodo review feedback: replaced the dynamic f-string SQL WHERE construction in update_note_studio_diagram_manifest with a static parameterized predicate, and corrected the raw keyword-token error message to report the 100 raw-token cap. Final verification on rebased branch: Notes Studio service tests 14 passed; Notes keyword-token regression tests 2 passed; Notes Studio API tests 11 passed; workflow notes adapter cleanup test 1 passed; compileall on touched app files passed; Bandit report /tmp/bandit_notes_module_review_hardening_9932_final_rebase.json reported 0 results and 0 errors.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-9932 - Harden-Notes-module-review-findings.md
+++ b/backlog/tasks/task-9932 - Harden-Notes-module-review-findings.md
@@ -3,12 +3,12 @@ id: TASK-9932
 title: Harden Notes module review findings
 status: Done
 assignee: []
-created_date: '2026-06-23 18:55'
-updated_date: '2026-06-23 18:57'
+created_date: 2026-06-23 18:55
+updated_date: 2026-06-24 03:36
 labels:
-  - notes
-  - review
-  - security
+- notes
+- review
+- security
 dependencies: []
 priority: high
 ---
@@ -57,3 +57,9 @@ Hardened the Notes module review findings. Notes Studio regenerate now requires 
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+PR: https://github.com/rmusser01/tldw_server/pull/2478
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-9932 - Harden-Notes-module-review-findings.md
+++ b/backlog/tasks/task-9932 - Harden-Notes-module-review-findings.md
@@ -1,0 +1,59 @@
+---
+id: TASK-9932
+title: Harden Notes module review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 18:55'
+updated_date: '2026-06-23 18:57'
+labels:
+  - notes
+  - review
+  - security
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the Notes module review findings under tldw_Server_API/app/core/: reject invalid Studio diagram sections, require optimistic concurrency for Studio regenerate, avoid diagram sidecar clobbering, bound Studio and keyword-search inputs, and close workflow NotesInteropService connections.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Invalid Notes Studio diagram source_section_ids are rejected instead of broadening to all sections.
+- [x] #2 Notes Studio regenerate requires caller expected_version and rejects stale versions.
+- [x] #3 Diagram manifest updates only mutate diagram_manifest_json and detect concurrent sidecar changes.
+- [x] #4 Notes Studio request fields and keyword token search inputs are bounded.
+- [x] #5 Workflow notes adapter closes NotesInteropService user DB connections.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+IMPLEMENTATION_PLAN_notes_module_review_hardening_9932.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Notes module review hardening: Studio regenerate now requires expected_version and rejects stale editor writes; diagram source_section_ids are validated; diagram manifest persistence updates only diagram_manifest_json with sidecar compare-and-swap; Studio request fields and keyword token search are bounded; workflow notes adapter closes NotesInteropService connections; NotesStudioService imports workflow adapters lazily; focused Studio API tests use deterministic adapters to avoid pulling the workflow/RAG stack.
+
+Verification: source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Notes_NEW/unit/test_notes_studio_service.py -q -> 14 passed, 41 warnings. source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Notes_NEW/integration/test_notes_studio_api.py -q -> 11 passed, 30 warnings. source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py::test_search_notes_rejects_excessive_keyword_tokens -q -> 1 passed, 10 warnings. source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/adapters/test_knowledge_adapters.py::test_notes_adapter_create_production_mode -q -> 1 passed, 10 warnings. source .venv/bin/activate && python -m compileall -q <touched app files> -> passed. Bandit report: /tmp/bandit_notes_module_review_hardening_9932.json -> 0 results, 0 errors, 0 skipped. No external documentation update was needed for this internal hardening.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened the Notes module review findings. Notes Studio regenerate now requires expected_version and rejects stale editor writes; diagram source section IDs are validated; diagram manifest writes use a narrow compare-and-swap update that only mutates diagram_manifest_json; Studio request schemas and keyword-token search inputs have bounds; workflow notes CRUD closes NotesInteropService connections. Focused regression tests pass and Bandit reported no findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/notes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes.py
@@ -1029,7 +1029,7 @@ def _normalize_keyword_tokens(tokens: Optional[list[str]]) -> list[str]:
     if len(tokens) > _NOTES_KEYWORD_TOKEN_MAX_RAW_COUNT:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Too many keyword tokens; maximum is {_NOTES_KEYWORD_TOKEN_MAX_COUNT}.",
+            detail=f"Too many keyword tokens; maximum raw tokens is {_NOTES_KEYWORD_TOKEN_MAX_RAW_COUNT}.",
         )
     seen: set[str] = set()
     out: list[str] = []

--- a/tldw_Server_API/app/api/v1/endpoints/notes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes.py
@@ -1018,9 +1018,19 @@ def _build_import_note_companion_event(
     )
 
 
+_NOTES_KEYWORD_TOKEN_MAX_COUNT = 20
+_NOTES_KEYWORD_TOKEN_MAX_RAW_COUNT = 100
+_NOTES_KEYWORD_TOKEN_MAX_LENGTH = 100
+
+
 def _normalize_keyword_tokens(tokens: Optional[list[str]]) -> list[str]:
     if not tokens:
         return []
+    if len(tokens) > _NOTES_KEYWORD_TOKEN_MAX_RAW_COUNT:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Too many keyword tokens; maximum is {_NOTES_KEYWORD_TOKEN_MAX_COUNT}.",
+        )
     seen: set[str] = set()
     out: list[str] = []
     for token in tokens:
@@ -1029,9 +1039,19 @@ def _normalize_keyword_tokens(tokens: Optional[list[str]]) -> list[str]:
         text = str(token).strip()
         if not text:
             continue
+        if len(text) > _NOTES_KEYWORD_TOKEN_MAX_LENGTH:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Keyword tokens must be {_NOTES_KEYWORD_TOKEN_MAX_LENGTH} characters or fewer.",
+            )
         key = text.lower()
         if key in seen:
             continue
+        if len(out) >= _NOTES_KEYWORD_TOKEN_MAX_COUNT:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Too many keyword tokens; maximum is {_NOTES_KEYWORD_TOKEN_MAX_COUNT}.",
+            )
         seen.add(key)
         out.append(key)
     return out
@@ -3353,7 +3373,7 @@ async def derive_note_studio_endpoint(
 )
 async def regenerate_note_studio_endpoint(
         note_id: str,
-        regenerate_in: NoteStudioRegenerateRequest | None = Body(default=None),
+        regenerate_in: NoteStudioRegenerateRequest = Body(...),
         db: CharactersRAGDB = Depends(get_chacha_db_for_user),
         rate_limiter: RateLimiter = Depends(get_rate_limiter_dep),
         current_user: User = Depends(get_request_user),
@@ -3373,7 +3393,8 @@ async def regenerate_note_studio_endpoint(
 
         studio_state = await NotesStudioService(db=db).regenerate_note_markdown(
             note_id=note_id,
-            current_markdown=regenerate_in.current_markdown if regenerate_in else None,
+            expected_version=regenerate_in.expected_version,
+            current_markdown=regenerate_in.current_markdown,
         )
         studio_state["note"] = _attach_keywords_inline(db, studio_state["note"])
         studio_state["note"] = _attach_folders_inline(db, studio_state["note"])

--- a/tldw_Server_API/app/api/v1/schemas/notes_studio.py
+++ b/tldw_Server_API/app/api/v1/schemas/notes_studio.py
@@ -5,13 +5,20 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 if TYPE_CHECKING:
     from .notes_schemas import NoteResponse
 
 NoteStudioTemplateType = Literal["lined", "grid", "cornell"]
 NoteStudioHandwritingMode = Literal["off", "accented"]
+
+NOTE_STUDIO_MAX_MARKDOWN_LENGTH = 5_000_000
+NOTE_STUDIO_MAX_PROVIDER_LENGTH = 100
+NOTE_STUDIO_MAX_MODEL_LENGTH = 200
+NOTE_STUDIO_MAX_SOURCE_NOTE_ID_LENGTH = 128
+NOTE_STUDIO_MAX_SECTION_IDS = 50
+NOTE_STUDIO_MAX_SECTION_ID_LENGTH = 128
 
 
 class NoteStudioDocumentBase(BaseModel):
@@ -76,8 +83,18 @@ class NoteStudioDocumentResponse(NoteStudioDocumentBase):
 
 
 class NoteStudioDeriveRequest(BaseModel):
-    source_note_id: str = Field(..., description="Source note identifier used for derivation.")
-    excerpt_text: str = Field(..., description="Selected source excerpt used for Studio generation.")
+    source_note_id: str = Field(
+        ...,
+        min_length=1,
+        max_length=NOTE_STUDIO_MAX_SOURCE_NOTE_ID_LENGTH,
+        description="Source note identifier used for derivation.",
+    )
+    excerpt_text: str = Field(
+        ...,
+        min_length=1,
+        max_length=NOTE_STUDIO_MAX_MARKDOWN_LENGTH,
+        description="Selected source excerpt used for Studio generation.",
+    )
     template_type: NoteStudioTemplateType = Field(
         "lined",
         description="Notebook template to use for the derived Studio note.",
@@ -86,13 +103,29 @@ class NoteStudioDeriveRequest(BaseModel):
         "accented",
         description="Handwriting accent mode for the derived Studio note.",
     )
-    provider: str | None = Field(default=None, description="Optional provider override for structured generation.")
-    model: str | None = Field(default=None, description="Optional model override for structured generation.")
+    provider: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=NOTE_STUDIO_MAX_PROVIDER_LENGTH,
+        description="Optional provider override for structured generation.",
+    )
+    model: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=NOTE_STUDIO_MAX_MODEL_LENGTH,
+        description="Optional model override for structured generation.",
+    )
 
 
 class NoteStudioRegenerateRequest(BaseModel):
+    expected_version: int = Field(
+        ...,
+        ge=1,
+        description="Current note version observed by the caller before regeneration.",
+    )
     current_markdown: str | None = Field(
         default=None,
+        max_length=NOTE_STUDIO_MAX_MARKDOWN_LENGTH,
         description="Optional current Markdown companion from the editor when regenerating a stale Studio note.",
     )
 
@@ -104,10 +137,36 @@ class NoteStudioDiagramRequest(BaseModel):
     )
     source_section_ids: list[str] = Field(
         default_factory=list,
+        max_length=NOTE_STUDIO_MAX_SECTION_IDS,
         description="Canonical Studio section identifiers used as diagram sources.",
     )
-    provider: str | None = Field(default=None, description="Optional provider override for diagram generation.")
-    model: str | None = Field(default=None, description="Optional model override for diagram generation.")
+    provider: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=NOTE_STUDIO_MAX_PROVIDER_LENGTH,
+        description="Optional provider override for diagram generation.",
+    )
+    model: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=NOTE_STUDIO_MAX_MODEL_LENGTH,
+        description="Optional model override for diagram generation.",
+    )
+
+    @field_validator("source_section_ids")
+    @classmethod
+    def validate_source_section_ids(cls, value: list[str]) -> list[str]:
+        normalized: list[str] = []
+        for section_id in value:
+            text = str(section_id).strip()
+            if not text:
+                raise ValueError("source_section_ids cannot contain empty section IDs.")
+            if len(text) > NOTE_STUDIO_MAX_SECTION_ID_LENGTH:
+                raise ValueError(
+                    f"source_section_ids entries must be {NOTE_STUDIO_MAX_SECTION_ID_LENGTH} characters or fewer."
+                )
+            normalized.append(text)
+        return normalized
 
 
 class NoteStudioStateResponse(BaseModel):

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -30113,6 +30113,7 @@ for _note_store_method in (
     "get_note_studio_document",
     "create_note_studio_document",
     "upsert_note_studio_document",
+    "update_note_studio_diagram_manifest",
     "list_notes",
     "list_deleted_notes",
     "get_notes_batch",

--- a/tldw_Server_API/app/core/DB_Management/chacha/note_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/note_store.py
@@ -505,28 +505,26 @@ class NoteStore:
             required=False,
         )
         now = self._db._get_current_utc_timestamp_iso()
-        where_clauses = ["note_id = ?"]
-        params: list[Any] = [diagram_manifest_json_str, now, normalized_note_id]
-
-        if expected_companion_content_hash is None:
-            where_clauses.append("companion_content_hash IS NULL")
-        else:
-            where_clauses.append("companion_content_hash = ?")
-            params.append(expected_companion_content_hash)
-
-        if expected_render_version is not None:
-            where_clauses.append("render_version = ?")
-            params.append(expected_render_version)
-
-        if expected_last_modified is not None:
-            where_clauses.append("last_modified = ?")
-            params.append(expected_last_modified)
 
         query = (
             "UPDATE note_studio_documents "
             "SET diagram_manifest_json = ?, last_modified = ? "
-            f"WHERE {' AND '.join(where_clauses)}"  # nosec B608
+            "WHERE note_id = ? "
+            "AND ((? IS NULL AND companion_content_hash IS NULL) OR companion_content_hash = ?) "
+            "AND (? IS NULL OR render_version = ?) "
+            "AND (? IS NULL OR last_modified = ?)"
         )
+        params: list[Any] = [
+            diagram_manifest_json_str,
+            now,
+            normalized_note_id,
+            expected_companion_content_hash,
+            expected_companion_content_hash,
+            expected_render_version,
+            expected_render_version,
+            expected_last_modified,
+            expected_last_modified,
+        ]
 
         def _execute(inner_conn: sqlite3.Connection | BackendConnectionWrapper) -> dict[str, Any]:
             prepared_query, prepared_params = self._db._prepare_backend_statement(query, tuple(params))

--- a/tldw_Server_API/app/core/DB_Management/chacha/note_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/note_store.py
@@ -485,6 +485,83 @@ class NoteStore:
             upsert=True,
         )
 
+    def update_note_studio_diagram_manifest(
+        self,
+        *,
+        note_id: str,
+        diagram_manifest_json: dict[str, Any] | None,
+        expected_companion_content_hash: str | None,
+        expected_render_version: int | None = None,
+        expected_last_modified: Any | None = None,
+        conn: sqlite3.Connection | BackendConnectionWrapper | None = None,
+    ) -> dict[str, Any]:
+        normalized_note_id = str(note_id).strip()
+        if not normalized_note_id:
+            raise InputError("note_id cannot be empty.")  # noqa: TRY003
+
+        diagram_manifest_json_str = self._serialize_note_studio_json_field(
+            diagram_manifest_json,
+            "diagram_manifest_json",
+            required=False,
+        )
+        now = self._db._get_current_utc_timestamp_iso()
+        where_clauses = ["note_id = ?"]
+        params: list[Any] = [diagram_manifest_json_str, now, normalized_note_id]
+
+        if expected_companion_content_hash is None:
+            where_clauses.append("companion_content_hash IS NULL")
+        else:
+            where_clauses.append("companion_content_hash = ?")
+            params.append(expected_companion_content_hash)
+
+        if expected_render_version is not None:
+            where_clauses.append("render_version = ?")
+            params.append(expected_render_version)
+
+        if expected_last_modified is not None:
+            where_clauses.append("last_modified = ?")
+            params.append(expected_last_modified)
+
+        query = (
+            "UPDATE note_studio_documents "
+            "SET diagram_manifest_json = ?, last_modified = ? "
+            f"WHERE {' AND '.join(where_clauses)}"  # nosec B608
+        )
+
+        def _execute(inner_conn: sqlite3.Connection | BackendConnectionWrapper) -> dict[str, Any]:
+            prepared_query, prepared_params = self._db._prepare_backend_statement(query, tuple(params))
+            cursor = inner_conn.execute(prepared_query, prepared_params or ())
+            if cursor.rowcount == 0:
+                current_document = self._fetch_note_studio_document_row(normalized_note_id, conn=inner_conn)
+                if not current_document:
+                    raise ConflictError(
+                        "Note studio document not found.",
+                        entity="note_studio_documents",
+                        entity_id=normalized_note_id,
+                    )  # noqa: TRY003
+                raise ConflictError(
+                    f"Note studio document for note ID '{normalized_note_id}' changed concurrently.",
+                    entity="note_studio_documents",
+                    entity_id=normalized_note_id,
+                )  # noqa: TRY003
+
+            updated_document = self._fetch_note_studio_document_row(normalized_note_id, conn=inner_conn)
+            if not updated_document:
+                raise CharactersRAGDBError(
+                    f"Failed to read note studio document for note ID '{normalized_note_id}'."
+                )  # noqa: TRY003
+            return updated_document
+
+        try:
+            if conn is None:
+                with self._db.transaction() as transaction_conn:
+                    return _execute(transaction_conn)
+            return _execute(conn)
+        except sqlite3.Error as e:
+            raise CharactersRAGDBError(f"SQLite error updating note studio diagram manifest: {e}") from e  # noqa: TRY003
+        except BackendDatabaseError as e:
+            raise CharactersRAGDBError(f"Backend error updating note studio diagram manifest: {e}") from e  # noqa: TRY003
+
     def list_notes(
         self,
         limit: int = 100,

--- a/tldw_Server_API/app/core/Notes/studio_service.py
+++ b/tldw_Server_API/app/core/Notes/studio_service.py
@@ -17,13 +17,20 @@ from tldw_Server_API.app.core.Notes.studio_markdown import (
     stable_content_hash,
     studio_payload_from_markdown,
 )
-from tldw_Server_API.app.core.Workflows.adapters.content import (
-    run_diagram_generate_adapter,
-    run_notes_studio_generate_adapter,
-)
-
 
 NoteStudioAdapter = Callable[[dict[str, Any], dict[str, Any]], Awaitable[dict[str, Any]]]
+
+
+async def _run_notes_studio_generate_adapter(request: dict[str, Any], context: dict[str, Any]) -> dict[str, Any]:
+    from tldw_Server_API.app.core.Workflows.adapters.content import run_notes_studio_generate_adapter
+
+    return await run_notes_studio_generate_adapter(request, context)
+
+
+async def _run_diagram_generate_adapter(request: dict[str, Any], context: dict[str, Any]) -> dict[str, Any]:
+    from tldw_Server_API.app.core.Workflows.adapters.content import run_diagram_generate_adapter
+
+    return await run_diagram_generate_adapter(request, context)
 
 
 @dataclass(slots=True)
@@ -31,8 +38,8 @@ class NotesStudioService:
     """Focused orchestration for Notes Studio state and sidecar persistence."""
 
     db: CharactersRAGDB
-    generation_adapter: NoteStudioAdapter = run_notes_studio_generate_adapter
-    diagram_adapter: NoteStudioAdapter = run_diagram_generate_adapter
+    generation_adapter: NoteStudioAdapter = _run_notes_studio_generate_adapter
+    diagram_adapter: NoteStudioAdapter = _run_diagram_generate_adapter
 
     async def derive_from_excerpt(
         self,
@@ -104,9 +111,18 @@ class NotesStudioService:
         self,
         *,
         note_id: str,
+        expected_version: int,
         current_markdown: str | None = None,
     ) -> dict[str, Any]:
         note = self._require_note(note_id)
+        current_version = int(note.get("version") or 0)
+        if current_version != expected_version:
+            raise ConflictError(
+                f"Note ID {note_id} regenerate failed: version mismatch "
+                f"(db has {current_version}, client expected {expected_version}).",
+                entity="notes",
+                entity_id=note_id,
+            )  # noqa: TRY003
         studio_document = self._require_studio_document(note_id)
         has_current_markdown_override = isinstance(current_markdown, str)
         markdown_source = current_markdown if has_current_markdown_override else str(note.get("content") or "")
@@ -135,7 +151,7 @@ class NotesStudioService:
             self.db.update_note(
                 note_id=note_id,
                 update_data={"title": rebuilt_title, "content": markdown},
-                expected_version=int(note.get("version", 1)),
+                expected_version=expected_version,
                 conn=conn,
             )
             updated_studio_document = self.db.upsert_note_studio_document(
@@ -170,6 +186,9 @@ class NotesStudioService:
         requested_section_ids = [str(section_id).strip() for section_id in (source_section_ids or []) if str(section_id).strip()]
         selected_sections = self._select_sections(payload=payload, requested_section_ids=requested_section_ids)
         diagram_context = self._build_diagram_context(selected_sections)
+        expected_companion_content_hash = studio_document.get("companion_content_hash")
+        expected_render_version = int(studio_document.get("render_version") or NOTE_STUDIO_RENDER_VERSION)
+        expected_last_modified = studio_document.get("last_modified")
 
         diagram_result = await self.diagram_adapter(
             {
@@ -197,17 +216,12 @@ class NotesStudioService:
             "format": str(diagram_result.get("format") or "mermaid"),
         }
 
-        updated_studio_document = self.db.upsert_note_studio_document(
+        updated_studio_document = self.db.update_note_studio_diagram_manifest(
             note_id=note_id,
-            payload_json=payload,
-            template_type=studio_document["template_type"],
-            handwriting_mode=studio_document["handwriting_mode"],
-            source_note_id=studio_document.get("source_note_id"),
-            excerpt_snapshot=studio_document.get("excerpt_snapshot"),
-            excerpt_hash=studio_document.get("excerpt_hash"),
             diagram_manifest_json=manifest,
-            companion_content_hash=studio_document.get("companion_content_hash"),
-            render_version=int(studio_document.get("render_version") or NOTE_STUDIO_RENDER_VERSION),
+            expected_companion_content_hash=expected_companion_content_hash,
+            expected_render_version=expected_render_version,
+            expected_last_modified=expected_last_modified,
         )
         return self._build_state(note_id=note_id, studio_document=updated_studio_document)
 
@@ -273,8 +287,12 @@ class NotesStudioService:
             return normalized_sections
 
         requested = set(requested_section_ids)
+        available = {str(section.get("id") or "") for section in normalized_sections}
+        missing = [section_id for section_id in requested_section_ids if section_id not in available]
+        if missing:
+            raise InputError(f"Unknown Studio section ID(s): {', '.join(missing)}")  # noqa: TRY003
         selected = [section for section in normalized_sections if str(section.get("id") or "") in requested]
-        return selected or normalized_sections
+        return selected
 
     @staticmethod
     def _build_diagram_context(selected_sections: list[dict[str, Any]]) -> dict[str, Any]:

--- a/tldw_Server_API/app/core/Workflows/adapters/knowledge/crud.py
+++ b/tldw_Server_API/app/core/Workflows/adapters/knowledge/crud.py
@@ -168,6 +168,7 @@ async def run_notes_adapter(config: dict[str, Any], context: dict[str, Any]) -> 
             return {"notes": [], "count": 0, "simulated": True}
         return {"error": f"unknown_action:{action}", "simulated": True}
 
+    service = None
     try:
         from tldw_Server_API.app.core.Notes.Notes_Library import NotesInteropService
 
@@ -254,6 +255,14 @@ async def run_notes_adapter(config: dict[str, Any], context: dict[str, Any]) -> 
     except _KNOWLEDGE_CRUD_NONCRITICAL_EXCEPTIONS:
         logger.exception("Notes adapter error")
         return {"error": "notes_error"}
+    finally:
+        if service is not None:
+            close_connections = getattr(service, "close_all_user_connections", None)
+            if callable(close_connections):
+                try:
+                    close_connections()
+                except _KNOWLEDGE_CRUD_NONCRITICAL_EXCEPTIONS as close_err:
+                    logger.warning("Notes adapter failed to close user DB connections: {}", type(close_err).__name__)
 
 
 @registry.register(

--- a/tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py
+++ b/tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py
@@ -365,6 +365,18 @@ def test_search_notes_rejects_excessive_keyword_tokens(client_with_notes_db: Tes
     assert "Too many keyword tokens" in response.json()["detail"]
 
 
+def test_search_notes_rejects_excessive_raw_keyword_tokens(client_with_notes_db: TestClient):
+    client = client_with_notes_db
+
+    response = client.get(
+        "/api/v1/notes/search/",
+        params=[("tokens", "topic") for _ in range(101)],
+    )
+
+    assert response.status_code == 400
+    assert "maximum raw tokens is 100" in response.json()["detail"]
+
+
 def test_search_notes_falls_back_to_integer_total_when_count_fails(
     client_with_notes_db: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py
+++ b/tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py
@@ -353,6 +353,18 @@ def test_search_notes_with_keyword_tokens_returns_pagination_total(client_with_n
     assert payload["pagination"]["next_offset"] == 2
 
 
+def test_search_notes_rejects_excessive_keyword_tokens(client_with_notes_db: TestClient):
+    client = client_with_notes_db
+
+    response = client.get(
+        "/api/v1/notes/search/",
+        params=[("tokens", f"topic-{index}") for index in range(21)],
+    )
+
+    assert response.status_code == 400
+    assert "Too many keyword tokens" in response.json()["detail"]
+
+
 def test_search_notes_falls_back_to_integer_total_when_count_fails(
     client_with_notes_db: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tldw_Server_API/tests/Notes_NEW/integration/test_notes_studio_api.py
+++ b/tldw_Server_API/tests/Notes_NEW/integration/test_notes_studio_api.py
@@ -15,6 +15,28 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGD
 pytestmark = pytest.mark.integration
 
 
+async def _test_generation_adapter(request: dict[str, object], _context: dict[str, object]) -> dict[str, object]:
+    excerpt = str(request.get("excerpt_text") or "").strip()
+    title = str(request.get("derived_title") or "Study Notes")
+    source_note_id = str(request.get("source_note_id") or "").strip()
+    template_type = str(request.get("template_type") or "lined")
+    cue_item = "Recall prompt: What is the key idea?" if template_type == "cornell" else "What is the key idea?"
+    return {
+        "payload": {
+            "meta": {"title": title, "source_note_id": source_note_id},
+            "sections": [
+                {"id": "cue-1", "kind": "cue", "title": "Key Questions", "items": [cue_item]},
+                {"id": "notes-1", "kind": "notes", "title": "Notes", "content": excerpt},
+                {"id": "summary-1", "kind": "summary", "title": "Summary", "content": excerpt},
+            ],
+        }
+    }
+
+
+async def _test_diagram_adapter(_request: dict[str, object], _context: dict[str, object]) -> dict[str, object]:
+    return {"diagram": "graph TD; A-->B", "format": "mermaid"}
+
+
 @pytest.fixture()
 def client_with_notes_studio_db(tmp_path, monkeypatch):
     db_path = tmp_path / "notes_studio_integration.db"
@@ -31,6 +53,17 @@ def client_with_notes_studio_db(tmp_path, monkeypatch):
 
     def override_db_dep():
         return db
+
+    service_cls = notes_endpoint.NotesStudioService
+
+    def _service_factory(*, db):
+        return service_cls(
+            db=db,
+            generation_adapter=_test_generation_adapter,
+            diagram_adapter=_test_diagram_adapter,
+        )
+
+    monkeypatch.setattr(notes_endpoint, "NotesStudioService", _service_factory)
 
     fastapi_app = FastAPI()
     fastapi_app.include_router(notes_endpoint.router, prefix="/api/v1/notes")
@@ -122,7 +155,10 @@ def test_notes_studio_derive_fetch_and_regenerate_flow(client_with_notes_studio_
     assert stale_response.json()["is_stale"] is True
     assert stale_response.json()["stale_reason"] == "companion_content_hash_mismatch"
 
-    regenerate_response = client.post(f"/api/v1/notes/{note_id}/studio/regenerate")
+    regenerate_response = client.post(
+        f"/api/v1/notes/{note_id}/studio/regenerate",
+        json={"expected_version": int(drift_response.json()["version"])},
+    )
     assert regenerate_response.status_code == 200, regenerate_response.text
     regenerated = regenerate_response.json()
     assert regenerated["is_stale"] is False
@@ -180,7 +216,8 @@ def test_notes_studio_regenerate_accepts_current_markdown_override(client_with_n
         },
     )
     assert derive_response.status_code == 201, derive_response.text
-    note_id = derive_response.json()["note"]["id"]
+    derived_note = derive_response.json()["note"]
+    note_id = derived_note["id"]
 
     override_markdown = (
         "# Biology Refined Study Notes\n\n"
@@ -194,7 +231,10 @@ def test_notes_studio_regenerate_accepts_current_markdown_override(client_with_n
 
     regenerate_response = client.post(
         f"/api/v1/notes/{note_id}/studio/regenerate",
-        json={"current_markdown": override_markdown},
+        json={
+            "expected_version": int(derived_note["version"]),
+            "current_markdown": override_markdown,
+        },
     )
     assert regenerate_response.status_code == 200, regenerate_response.text
     regenerated = regenerate_response.json()
@@ -229,11 +269,12 @@ def test_notes_studio_regenerate_treats_empty_current_markdown_as_an_explicit_ov
         },
     )
     assert derive_response.status_code == 201, derive_response.text
-    note_id = derive_response.json()["note"]["id"]
+    derived_note = derive_response.json()["note"]
+    note_id = derived_note["id"]
 
     regenerate_response = client.post(
         f"/api/v1/notes/{note_id}/studio/regenerate",
-        json={"current_markdown": ""},
+        json={"expected_version": int(derived_note["version"]), "current_markdown": ""},
     )
     assert regenerate_response.status_code == 200, regenerate_response.text
     regenerated = regenerate_response.json()
@@ -242,6 +283,69 @@ def test_notes_studio_regenerate_treats_empty_current_markdown_as_an_explicit_ov
     assert regenerated["note"]["title"] == "Biology Study Notes"
     assert regenerated["note"]["content"] == "# Biology Study Notes"
     assert regenerated["studio_document"]["payload_json"]["sections"] == []
+
+
+def test_notes_studio_regenerate_requires_expected_version(client_with_notes_studio_db: TestClient):
+    client = client_with_notes_studio_db
+    source_note_id = _create_source_note(
+        client,
+        title="Biology",
+        content="Cells use mitochondria to produce ATP.",
+    )
+
+    derive_response = client.post(
+        "/api/v1/notes/studio/derive",
+        json={
+            "source_note_id": source_note_id,
+            "excerpt_text": "Cells use mitochondria to produce ATP.",
+            "template_type": "cornell",
+            "handwriting_mode": "accented",
+        },
+    )
+    assert derive_response.status_code == 201, derive_response.text
+    note_id = derive_response.json()["note"]["id"]
+
+    response = client.post(f"/api/v1/notes/{note_id}/studio/regenerate")
+
+    assert response.status_code == 422
+
+
+def test_notes_studio_regenerate_rejects_stale_expected_version(client_with_notes_studio_db: TestClient):
+    client = client_with_notes_studio_db
+    source_note_id = _create_source_note(
+        client,
+        title="Biology",
+        content="Cells use mitochondria to produce ATP.",
+    )
+
+    derive_response = client.post(
+        "/api/v1/notes/studio/derive",
+        json={
+            "source_note_id": source_note_id,
+            "excerpt_text": "Cells use mitochondria to produce ATP.",
+            "template_type": "cornell",
+            "handwriting_mode": "accented",
+        },
+    )
+    assert derive_response.status_code == 201, derive_response.text
+    derived_note = derive_response.json()["note"]
+    note_id = derived_note["id"]
+
+    drift_response = client.patch(
+        f"/api/v1/notes/{note_id}",
+        json={"content": "# Edited elsewhere"},
+    )
+    assert drift_response.status_code == 200, drift_response.text
+
+    response = client.post(
+        f"/api/v1/notes/{note_id}/studio/regenerate",
+        json={
+            "expected_version": int(derived_note["version"]),
+            "current_markdown": "# Stale editor body",
+        },
+    )
+
+    assert response.status_code == 409
 
 
 def test_notes_studio_derive_rolls_back_note_when_sidecar_persistence_fails(
@@ -322,7 +426,10 @@ def test_notes_studio_regenerate_rolls_back_note_update_when_sidecar_upsert_fail
 
     monkeypatch.setattr(db, "upsert_note_studio_document", _raise_sidecar_failure)
 
-    regenerate_response = client.post(f"/api/v1/notes/{note_id}/studio/regenerate")
+    regenerate_response = client.post(
+        f"/api/v1/notes/{note_id}/studio/regenerate",
+        json={"expected_version": int(drift_response.json()["version"])},
+    )
     assert regenerate_response.status_code == 500
     assert regenerate_response.json()["detail"] == "A database error occurred while processing your request for note studio."
 
@@ -395,3 +502,27 @@ def test_notes_studio_rejects_invalid_excerpt_requests(
     )
 
     assert response.status_code == 400
+
+
+def test_notes_studio_derive_rejects_oversized_provider_override(
+    client_with_notes_studio_db: TestClient,
+):
+    client = client_with_notes_studio_db
+    source_note_id = _create_source_note(
+        client,
+        title="Source",
+        content="Useful content for provider validation.",
+    )
+
+    response = client.post(
+        "/api/v1/notes/studio/derive",
+        json={
+            "source_note_id": source_note_id,
+            "excerpt_text": "Useful content for provider validation.",
+            "template_type": "lined",
+            "handwriting_mode": "accented",
+            "provider": "p" * 101,
+        },
+    )
+
+    assert response.status_code == 422

--- a/tldw_Server_API/tests/Notes_NEW/unit/test_notes_studio_service.py
+++ b/tldw_Server_API/tests/Notes_NEW/unit/test_notes_studio_service.py
@@ -10,12 +10,54 @@ import pytest
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     CharactersRAGDB,
     CharactersRAGDBError,
+    ConflictError,
     InputError,
 )
 from tldw_Server_API.app.core.Notes.studio_service import NotesStudioService
 
 
 pytestmark = pytest.mark.unit
+
+
+async def _test_generation_adapter(request: dict[str, object], _context: dict[str, object]) -> dict[str, object]:
+    excerpt = str(request.get("excerpt_text") or "").strip()
+    title = str(request.get("derived_title") or "Study Notes")
+    source_note_id = str(request.get("source_note_id") or "").strip()
+    template_type = str(request.get("template_type") or "lined")
+    cue_item = "Recall prompt: What is the key idea?" if template_type == "cornell" else "What is the key idea?"
+    return {
+        "payload": {
+            "meta": {
+                "title": title,
+                "source_note_id": source_note_id,
+            },
+            "sections": [
+                {
+                    "id": "cue-1",
+                    "kind": "cue",
+                    "title": "Key Questions",
+                    "items": [cue_item],
+                },
+                {
+                    "id": "notes-1",
+                    "kind": "notes",
+                    "title": "Notes",
+                    "content": excerpt,
+                },
+                {
+                    "id": "summary-1",
+                    "kind": "summary",
+                    "title": "Summary",
+                    "content": excerpt,
+                },
+            ],
+        }
+    }
+
+
+def _service(db: CharactersRAGDB, **kwargs) -> NotesStudioService:
+    kwargs.setdefault("generation_adapter", _test_generation_adapter)
+    return NotesStudioService(db=db, **kwargs)
 
 
 @pytest.fixture()
@@ -54,7 +96,7 @@ def test_derive_creates_derived_note_and_sidecar(studio_db):
     )
     assert source_note_id is not None
 
-    service = NotesStudioService(db=db)
+    service = _service(db)
     excerpt = "The mitochondrion is the powerhouse of the cell."
 
     result = _derive_note(
@@ -142,7 +184,7 @@ def test_cornell_generation_includes_explicit_recall_prompt(studio_db):
     )
     assert source_note_id is not None
 
-    service = NotesStudioService(db=db)
+    service = _service(db)
     result = _derive_note(
         service,
         source_note_id=str(source_note_id),
@@ -169,7 +211,7 @@ def test_derive_rolls_back_note_when_sidecar_persistence_fails(studio_db, monkey
     )
     assert source_note_id is not None
 
-    service = NotesStudioService(db=db)
+    service = _service(db)
     original_note_ids = [note["id"] for note in db.list_notes()]
 
     def _raise_sidecar_failure(**_kwargs):
@@ -195,7 +237,7 @@ def test_get_state_detects_markdown_drift_and_regenerate_rebuilds_payload_from_c
     )
     assert source_note_id is not None
 
-    service = NotesStudioService(db=db)
+    service = _service(db)
     result = _derive_note(
         service,
         source_note_id=str(source_note_id),
@@ -229,7 +271,15 @@ def test_get_state_detects_markdown_drift_and_regenerate_rebuilds_payload_from_c
     assert stale_state["is_stale"] is True
     assert stale_state["stale_reason"] == "companion_content_hash_mismatch"
 
-    regenerated = asyncio.run(service.regenerate_note_markdown(note_id=note_id))
+    latest_note = db.get_note_by_id(note_id=note_id)
+    assert latest_note is not None
+
+    regenerated = asyncio.run(
+        service.regenerate_note_markdown(
+            note_id=note_id,
+            expected_version=int(latest_note["version"]),
+        )
+    )
     assert regenerated["is_stale"] is False
     assert regenerated["stale_reason"] is None
     assert regenerated["note"]["title"] == "Chemistry Refined Study Notes"
@@ -277,7 +327,7 @@ def test_regenerate_uses_current_markdown_override_without_persisting_drift_firs
     )
     assert source_note_id is not None
 
-    service = NotesStudioService(db=db)
+    service = _service(db)
     result = _derive_note(
         service,
         source_note_id=str(source_note_id),
@@ -298,6 +348,7 @@ def test_regenerate_uses_current_markdown_override_without_persisting_drift_firs
     regenerated = asyncio.run(
         service.regenerate_note_markdown(
             note_id=note_id,
+            expected_version=int(result["note"]["version"]),
             current_markdown=override_markdown,
         )
     )
@@ -320,7 +371,7 @@ def test_regenerate_treats_empty_current_markdown_as_an_explicit_override(studio
     )
     assert source_note_id is not None
 
-    service = NotesStudioService(db=db)
+    service = _service(db)
     result = _derive_note(
         service,
         source_note_id=str(source_note_id),
@@ -331,6 +382,7 @@ def test_regenerate_treats_empty_current_markdown_as_an_explicit_override(studio
     regenerated = asyncio.run(
         service.regenerate_note_markdown(
             note_id=note_id,
+            expected_version=int(result["note"]["version"]),
             current_markdown="",
         )
     )
@@ -349,7 +401,7 @@ def test_regenerate_rolls_back_note_update_when_sidecar_upsert_fails(studio_db, 
     )
     assert source_note_id is not None
 
-    service = NotesStudioService(db=db)
+    service = _service(db)
     result = _derive_note(
         service,
         source_note_id=str(source_note_id),
@@ -382,12 +434,51 @@ def test_regenerate_rolls_back_note_update_when_sidecar_upsert_fails(studio_db, 
     monkeypatch.setattr(db, "upsert_note_studio_document", _raise_sidecar_failure)
 
     with pytest.raises(CharactersRAGDBError, match="sidecar upsert failed"):
-        asyncio.run(service.regenerate_note_markdown(note_id=note_id))
+        latest_note = db.get_note_by_id(note_id=note_id)
+        assert latest_note is not None
+        asyncio.run(
+            service.regenerate_note_markdown(
+                note_id=note_id,
+                expected_version=int(latest_note["version"]),
+            )
+        )
 
     note_after_failure = db.get_note_by_id(note_id=note_id)
     assert note_after_failure is not None
     assert note_after_failure["title"] == "Astronomy Study Notes"
     assert note_after_failure["content"] == draft_markdown
+
+
+def test_regenerate_rejects_stale_expected_version(studio_db):
+    db = studio_db
+    source_note_id = db.add_note(
+        title="Biology",
+        content="Cells use mitochondria to produce ATP.",
+    )
+    assert source_note_id is not None
+
+    service = _service(db)
+    result = _derive_note(
+        service,
+        source_note_id=str(source_note_id),
+        excerpt_text="Cells use mitochondria to produce ATP.",
+    )
+    note_id = result["note"]["id"]
+
+    db.update_note(
+        note_id=note_id,
+        update_data={"content": "# Edited elsewhere"},
+        expected_version=int(result["note"]["version"]),
+    )
+
+    with pytest.raises(ConflictError, match="version mismatch"):
+        asyncio.run(
+            service.regenerate_note_markdown(
+                note_id=note_id,
+                expected_version=int(result["note"]["version"]),
+                current_markdown="# Stale editor body",
+            )
+        )
 
 
 def test_update_diagram_manifest_persists_notebook_diagram_metadata(studio_db):
@@ -398,7 +489,7 @@ def test_update_diagram_manifest_persists_notebook_diagram_metadata(studio_db):
     )
     assert source_note_id is not None
 
-    service = NotesStudioService(db=db)
+    service = _service(db)
     result = _derive_note(
         service,
         source_note_id=str(source_note_id),
@@ -424,6 +515,81 @@ def test_update_diagram_manifest_persists_notebook_diagram_metadata(studio_db):
     assert manifest["generation_status"] == "ready"
 
 
+def test_update_diagram_manifest_rejects_unknown_section_ids(studio_db):
+    db = studio_db
+    source_note_id = db.add_note(
+        title="History",
+        content="The printing press accelerated the spread of written knowledge.",
+    )
+    assert source_note_id is not None
+
+    service = _service(db)
+    result = _derive_note(
+        service,
+        source_note_id=str(source_note_id),
+        excerpt_text="The printing press accelerated the spread of written knowledge.",
+    )
+
+    with pytest.raises(InputError, match="Unknown Studio section"):
+        asyncio.run(
+            service.update_diagram_manifest(
+                note_id=result["note"]["id"],
+                diagram_type="flowchart",
+                source_section_ids=["missing-section"],
+            )
+        )
+
+
+def test_update_diagram_manifest_rejects_concurrent_sidecar_change(studio_db):
+    db = studio_db
+    source_note_id = db.add_note(
+        title="History",
+        content="The printing press accelerated the spread of written knowledge.",
+    )
+    assert source_note_id is not None
+
+    note_id_holder: dict[str, str] = {}
+
+    async def _diagram_adapter(_request: dict[str, object], _context: dict[str, object]) -> dict[str, object]:
+        note_id = note_id_holder["note_id"]
+        current_document = db.get_note_studio_document(note_id)
+        assert current_document is not None
+        db.upsert_note_studio_document(
+            note_id=note_id,
+            payload_json=current_document["payload_json"],
+            template_type=current_document["template_type"],
+            handwriting_mode=current_document["handwriting_mode"],
+            source_note_id=current_document.get("source_note_id"),
+            excerpt_snapshot=current_document.get("excerpt_snapshot"),
+            excerpt_hash=current_document.get("excerpt_hash"),
+            diagram_manifest_json={"status": "concurrent"},
+            companion_content_hash="sha256:concurrent",
+            render_version=int(current_document["render_version"]),
+        )
+        return {"diagram": "graph TD; A-->B", "format": "mermaid"}
+
+    service = _service(db, diagram_adapter=_diagram_adapter)
+    result = _derive_note(
+        service,
+        source_note_id=str(source_note_id),
+        excerpt_text="The printing press accelerated the spread of written knowledge.",
+    )
+    note_id_holder["note_id"] = result["note"]["id"]
+
+    with pytest.raises(ConflictError, match="changed concurrently"):
+        asyncio.run(
+            service.update_diagram_manifest(
+                note_id=result["note"]["id"],
+                diagram_type="flowchart",
+            )
+        )
+
+    persisted_document = db.get_note_studio_document(result["note"]["id"])
+    assert persisted_document is not None
+    assert persisted_document["companion_content_hash"] == "sha256:concurrent"
+    assert persisted_document["diagram_manifest_json"] == {"status": "concurrent"}
+
+
 @pytest.mark.parametrize(
     ("excerpt_text", "expected_message"),
     [
@@ -439,7 +605,7 @@ def test_derive_rejects_invalid_excerpt_requests(studio_db, excerpt_text, expect
     )
     assert source_note_id is not None
 
-    service = NotesStudioService(db=db)
+    service = _service(db)
 
     with pytest.raises(InputError, match=expected_message):
         _derive_note(

--- a/tldw_Server_API/tests/Workflows/adapters/test_knowledge_adapters.py
+++ b/tldw_Server_API/tests/Workflows/adapters/test_knowledge_adapters.py
@@ -1436,6 +1436,7 @@ async def test_notes_adapter_create_production_mode(monkeypatch):
     assert result.get("success") is True
     assert result.get("note") == mock_note
     mock_service.add_note.assert_called_once()
+    mock_service.close_all_user_connections.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Require `expected_version` for Notes Studio regenerate and reject stale editor writes.
- Validate diagram source section IDs and persist diagram manifests with a narrow compare-and-swap update.
- Bound Notes Studio/search inputs and close workflow-created Notes service connections.

## Verification
- `python -m pytest tldw_Server_API/tests/Notes_NEW/unit/test_notes_studio_service.py -q --timeout=900` -> 14 passed
- `python -m pytest tldw_Server_API/tests/Notes_NEW/integration/test_notes_studio_api.py -q --timeout=900` -> 11 passed
- `python -m pytest tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py::test_search_notes_rejects_excessive_keyword_tokens -q --timeout=900` -> 1 passed
- `python -m pytest tldw_Server_API/tests/Workflows/adapters/test_knowledge_adapters.py::test_notes_adapter_create_production_mode -q --timeout=900` -> 1 passed
- `python -m compileall -q <touched app files>` -> passed
- `python -m bandit -r <touched app paths> -f json -o /tmp/bandit_notes_module_review_hardening_9932.json` -> 0 results, 0 errors

## Change Summary
AI-authored PR. Per project policy, the human requester needs to replace this section with a human-written change summary explaining what changed and why before this PR is marked ready for review/merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Notes Studio to prevent stale regenerations, block diagram scope broadening, and avoid sidecar clobbers. Adds version checks, strict section validation, bounded inputs, narrow diagram updates, and closes workflow Notes service connections.

- **Bug Fixes**
  - Regenerate now requires `expected_version`; stale versions return 409. The request body is required.
  - Validate `source_section_ids`; unknown IDs return 400 with no fallback to all sections.
  - Update diagram manifests via compare-and-swap on `note_studio_documents` using expected companion hash/render version/last_modified to prevent concurrent overwrites.
  - Enforce Studio bounds (provider/model/source IDs, section ID count/length, markdown size) and keyword token limits (max 20 unique, 100 raw, 100 chars).
  - Close workflow-created `NotesInteropService` connections after operations.

- **Migration**
  - Clients must send `expected_version` in `POST /api/v1/notes/{note_id}/studio/regenerate` using the latest `note.version` from their most recent fetch.

<sup>Written for commit 509fe6155b51125eef51fa0a7995c7c1ed54e827. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

