### PR TITLE
Harden Monitoring review findings

### DIFF
--- a/IMPLEMENTATION_PLAN_monitoring_review_hardening.md
+++ b/IMPLEMENTATION_PLAN_monitoring_review_hardening.md
@@ -1,0 +1,63 @@
+# Monitoring Review Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for behavior changes and superpowers:verification-before-completion before finalizing. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Verify and fix validated Monitoring module review findings from TASK-2417.
+
+**Architecture:** Keep changes scoped to Monitoring services, their immediate API schemas/endpoints, and Guardian/Topic monitoring DB helpers where atomic behavior is required. Prefer existing project patterns: FastAPI dependency authorization, DB_Management wrappers, Loguru sanitized logging, and focused pytest coverage.
+
+**Tech Stack:** FastAPI, Pydantic, SQLite DB wrappers, pytest, Bandit.
+
+---
+
+## Stage 1: Validate Findings
+**Goal:** Re-check each review finding against current code and decide whether it remains valid.
+**Success Criteria:** Each finding is classified as valid or not applicable with concrete code evidence.
+**Tests:** Read-only inspection only.
+**Status:** Complete
+
+- [x] Confirm notification settings routes are protected only by `SYSTEM_LOGS` and can change/read local notification paths.
+- [x] Confirm SMTP STARTTLS failure is suppressed before login/send.
+- [x] Confirm notification dispatch and digest buffering are unbounded.
+- [x] Confirm self-monitoring partner approval uses the current user's Guardian DB and cannot resolve the owner's rule in per-user DB mode.
+- [x] Confirm dedupe/escalation check-then-act behavior and decide a minimal atomicity fix.
+- [x] Confirm topic regex compilation uses local heuristics instead of the shared regex safety validator.
+- [x] Confirm notification module docs still describe webhook/email as simulated future behavior.
+
+## Stage 2: Red Tests
+**Goal:** Add failing regression tests for every validated behavior change.
+**Success Criteria:** Focused tests fail for the expected reason before production code changes.
+**Tests:** Focused pytest invocations for new/updated tests.
+**Status:** Complete
+
+- [x] Add endpoint tests for requiring stronger permission on notification settings updates/test sends while preserving read access.
+- [x] Add notification-service tests for path bounding, STARTTLS fail-closed, queue/digest caps, and docs-relevant behavior.
+- [x] Add self-monitoring endpoint/service test proving partner approval resolves the owner's DB rather than the approver's DB.
+- [x] Add TopicMonitoringDB/service tests for atomic duplicate suppression and shared regex safety.
+
+## Stage 3: Implement Fixes
+**Goal:** Make the minimal production changes needed to satisfy the red tests.
+**Success Criteria:** Focused tests from Stage 2 pass without broad refactors.
+**Tests:** Same focused pytest commands as Stage 2.
+**Status:** Complete
+
+- [x] Split notification mutation authorization from log-read authorization.
+- [x] Restrict notification sink paths to project-owned allowed roots and make recent-notification tail use the validated path.
+- [x] Fail SMTP sends when `smtp_starttls` is enabled and STARTTLS cannot be established.
+- [x] Replace per-notification daemon threads with a bounded queue/worker and cap digest buffers.
+- [x] Resolve partner approval against the owner rule's Guardian DB and keep partner authorization explicit.
+- [x] Add atomic TopicMonitoringDB duplicate insert support and use it from topic evaluation.
+- [x] Reuse shared regex safety validation in topic monitoring compilation.
+- [x] Refresh stale Monitoring module comments.
+
+## Stage 4: Verification
+**Goal:** Run focused and security verification for touched scope.
+**Success Criteria:** Tests and Bandit complete with no new failures/findings in touched production files.
+**Tests:** Focused Monitoring/Guardian pytest files, `git diff --check`, and Bandit on touched production paths.
+**Status:** Complete
+
+- [x] Run focused tests for Monitoring notification/API/topic changes.
+- [x] Run focused tests for Guardian self-monitoring partner approval changes.
+- [x] Run `git diff --check`.
+- [x] Run Bandit on touched production files.
+- [x] Update TASK-2417 with verification results and final summary.

--- a/backlog/tasks/task-2417 - Harden-Monitoring-module-review-findings.md
+++ b/backlog/tasks/task-2417 - Harden-Monitoring-module-review-findings.md
@@ -1,0 +1,66 @@
+---
+id: TASK-2417
+title: Harden Monitoring module review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 18:20'
+updated_date: '2026-06-24 04:21'
+labels:
+  - monitoring
+  - security
+  - review-fix
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and fix validated Monitoring module review findings. Scope: notification permission/path safety, SMTP TLS failure behavior, bounded delivery and digest buffering, self-monitoring partner approval in per-user DB mode, dedupe/escalation atomicity, shared regex safety, and stale Monitoring docs.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Validated review findings are fixed or explicitly documented as not applicable
+- [x] #2 Focused regression tests cover each behavior change
+- [x] #3 Touched Monitoring/API/DB tests pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+IMPLEMENTATION_PLAN_monitoring_review_hardening.md
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Verification
+
+<!-- SECTION:VERIFICATION:BEGIN -->
+- `source .venv/bin/activate && python -m py_compile ...` for touched app/test files: passed.
+- `source .venv/bin/activate && python -m pytest --confcutdir=tldw_Server_API/tests/Monitoring -q tldw_Server_API/tests/Monitoring/test_notification_service.py tldw_Server_API/tests/Monitoring/test_monitoring_notifications_settings.py tldw_Server_API/tests/Monitoring/test_topic_monitoring.py`: 46 passed.
+- `source .venv/bin/activate && python -m pytest --confcutdir=tldw_Server_API/tests/AuthNZ_Unit -q tldw_Server_API/tests/AuthNZ_Unit/test_monitoring_permissions_claims.py`: 9 passed.
+- `source .venv/bin/activate && python -m pytest --confcutdir=tldw_Server_API/tests/Guardian -q tldw_Server_API/tests/Guardian/test_self_monitoring.py tldw_Server_API/tests/Guardian/test_self_monitoring_endpoints.py`: 89 passed.
+- `git diff --check`: passed.
+- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Monitoring tldw_Server_API/app/api/v1/endpoints/monitoring.py tldw_Server_API/app/api/v1/endpoints/self_monitoring.py tldw_Server_API/app/api/v1/schemas/guardian_schemas.py tldw_Server_API/app/core/DB_Management/TopicMonitoring_DB.py tldw_Server_API/app/core/DB_Management/Guardian_DB.py -f json -o /tmp/bandit_monitoring_2417.json`: passed, 0 results.
+- Repeated the focused verification after moving the fixes to worktree branch `codex/monitoring-review-hardening-2417`; endpoint/permission tests now set `SINGLE_USER_TEST_API_KEY` explicitly so router startup does not depend on ambient shell state.
+- Worktree Bandit output `/tmp/bandit_monitoring_2417_worktree.json`: 0 results, 0 errors.
+- Draft PR created against `dev`: https://github.com/rmusser01/tldw_server/pull/2479
+- PR review follow-up: rebased onto latest `origin/dev`, documented the `B608` suppression rationale, moved partner approval owner DB selection into core helpers, added non-creating existing Guardian DB resolution for owner lookups, and made Topic Monitoring regex length behavior explicitly follow the shared `MAX_REGEX_LENGTH`.
+- Review-fix verification: `py_compile` for touched app/test files passed; focused pytest batches passed (`Monitoring`: 47, `AuthNZ`: 9, `Guardian`: 90); `git diff --check` passed; `/tmp/bandit_monitoring_2417_reviewfix.json` reported 0 results and 0 errors.
+- Note: plain pytest without `--confcutdir` was blocked before these tests by the repository-wide autouse fixture importing `character_chat_sessions` -> Research/RAG/NLTK/sklearn/pandas. Focused verification used `--confcutdir` to avoid that unrelated heavy fixture path.
+<!-- SECTION:VERIFICATION:END -->
+
+## Final Summary
+
+<!-- SECTION:SUMMARY:BEGIN -->
+Fixed all validated Monitoring review findings: notification mutation endpoints now require `system.configure`, notification file sinks are restricted to trusted roots, SMTP STARTTLS failures fail closed, webhook/email delivery uses a bounded worker queue, digest buffers are capped, partner approval can resolve the owner's Guardian DB, Topic Monitoring duplicate insert is atomic, self-monitoring escalation updates are DB-atomic, topic regex compilation uses the shared safety validator, and stale notification module comments were refreshed.
+<!-- SECTION:SUMMARY:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/monitoring.py
+++ b/tldw_Server_API/app/api/v1/endpoints/monitoring.py
@@ -33,7 +33,7 @@ from tldw_Server_API.app.api.v1.schemas.monitoring_schemas import (
     WatchlistUpsertResponse,
 )
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
-from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_LOGS
+from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_CONFIGURE, SYSTEM_LOGS
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.repos.admin_monitoring_repo import (
     AuthnzAdminMonitoringRepo,
@@ -524,6 +524,7 @@ async def get_notifications_settings() -> NotificationSettings:
     response_model=NotificationSettings,
     tags=["monitoring"],
     summary="Update notification settings (runtime only)",
+    dependencies=[Depends(RequirePermission(SYSTEM_CONFIGURE))],
 )
 async def update_notifications_settings(
     payload: NotificationSettingsUpdate,
@@ -539,6 +540,11 @@ async def update_notifications_settings(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Notification file path must be non-empty",
             )
+        if not svc.is_file_path_allowed(str(file_val)):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Notification file path is outside allowed directories",
+            )
     updated = svc.update_settings(**data)
     return NotificationSettings(**updated)
 
@@ -548,6 +554,7 @@ async def update_notifications_settings(
     response_model=NotificationTestResponse,
     tags=["monitoring"],
     summary="Send a test notification (critical by default)",
+    dependencies=[Depends(RequirePermission(SYSTEM_CONFIGURE))],
 )
 async def send_test_notification(payload: NotificationTestRequest) -> NotificationTestResponse:
     """Send a synthetic test notification using the current settings."""

--- a/tldw_Server_API/app/api/v1/endpoints/self_monitoring.py
+++ b/tldw_Server_API/app/api/v1/endpoints/self_monitoring.py
@@ -25,7 +25,9 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
-from tldw_Server_API.app.api.v1.API_Deps.guardian_deps import get_guardian_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.guardian_deps import (
+    get_guardian_db_for_user,
+)
 from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.guardian_schemas import (
     CrisisResource,
@@ -49,8 +51,10 @@ from tldw_Server_API.app.core.DB_Management.Guardian_DB import GuardianDB
 from tldw_Server_API.app.core.Monitoring.self_monitoring_service import (
     CRISIS_DISCLAIMER,
     CRISIS_RESOURCES,
+    SelfMonitoringOwnerDbResolutionError,
     SelfMonitoringService,
     get_self_monitoring_service,
+    resolve_partner_approval_guardian_db,
 )
 
 router = APIRouter()
@@ -235,7 +239,11 @@ def approve_deactivation(
     db: GuardianDB = Depends(get_guardian_db_for_user),
 ):
     """Approve deactivation of a rule (partner_approval bypass mode)."""
-    svc = _get_service(db)
+    try:
+        owner_db = resolve_partner_approval_guardian_db(db, body.owner_user_id)
+    except SelfMonitoringOwnerDbResolutionError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    svc = _get_service(owner_db)
     result = svc.approve_deactivation(rule_id, _user_id(user), body.token)
     if not result.get("ok"):
         raise HTTPException(status_code=400, detail=result.get("error", "Failed"))

--- a/tldw_Server_API/app/api/v1/schemas/guardian_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/guardian_schemas.py
@@ -378,6 +378,10 @@ class DeactivationConfirmRequest(BaseModel):
 
 class DeactivationApproveRequest(BaseModel):
     token: str = Field(..., description="Confirmation token from deactivation request")
+    owner_user_id: str | None = Field(
+        default=None,
+        description="Owner user ID for resolving the rule's Guardian DB in per-user DB mode",
+    )
 
 
 class DetailResponse(BaseModel):

--- a/tldw_Server_API/app/core/DB_Management/Guardian_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Guardian_DB.py
@@ -2060,6 +2060,157 @@ class GuardianDB:
             finally:
                 conn.close()
 
+    def update_escalation_for_trigger(
+        self,
+        rule: SelfMonitoringRule,
+        user_id: str,
+        session_id: str | None,
+    ) -> dict[str, Any]:
+        """Atomically update escalation counters for one rule trigger."""
+        info: dict[str, Any] = {"escalated": False, "effective_action": rule.action}
+        if rule.escalation_session_threshold <= 0 and rule.escalation_window_threshold <= 0:
+            return info
+
+        now = datetime.now(timezone.utc)
+        now_iso = now.isoformat()
+
+        with self._lock:
+            conn = self._connect()
+            try:
+                begin_immediate_if_needed(conn)
+                row = conn.execute(
+                    "SELECT * FROM escalation_state WHERE rule_id = ? AND user_id = ?",
+                    (rule.id, str(user_id)),
+                ).fetchone()
+
+                if row:
+                    if session_id and row["session_id"] != session_id:
+                        session_count = 1
+                    else:
+                        session_count = int(row["session_trigger_count"] or 0) + 1
+                else:
+                    session_count = 1
+
+                if rule.escalation_window_days > 0 and rule.escalation_window_threshold > 0:
+                    since = (now - timedelta(days=rule.escalation_window_days)).isoformat()
+                    count_row = conn.execute(
+                        "SELECT COUNT(*) AS cnt FROM self_monitoring_alerts "
+                        "WHERE user_id = ? AND rule_id = ? AND created_at >= ?",
+                        (str(user_id), rule.id, since),
+                    ).fetchone()
+                    window_count = int(count_row["cnt"] if count_row else 0) + 1
+                elif row:
+                    window_count = int(row["window_trigger_count"] or 0) + 1
+                else:
+                    window_count = 1
+
+                if row and row["cooldown_until"]:
+                    try:
+                        cooldown_dt = datetime.fromisoformat(row["cooldown_until"])
+                        if now >= cooldown_dt:
+                            self._upsert_escalation_state_with_connection(
+                                conn,
+                                rule_id=rule.id,
+                                user_id=user_id,
+                                session_id=session_id,
+                                session_trigger_count=session_count,
+                                window_trigger_count=window_count,
+                                current_escalated_action=None,
+                                escalated_at=None,
+                                cooldown_until=None,
+                                updated_at=now_iso,
+                            )
+                            conn.commit()
+                            return info
+                    except (ValueError, TypeError):
+                        pass
+
+                escalated = False
+                escalated_action = None
+
+                if (
+                    rule.escalation_session_threshold > 0
+                    and session_count >= rule.escalation_session_threshold
+                    and rule.escalation_session_action
+                ):
+                    escalated = True
+                    escalated_action = rule.escalation_session_action
+
+                if (
+                    rule.escalation_window_threshold > 0
+                    and window_count >= rule.escalation_window_threshold
+                    and rule.escalation_window_action
+                ):
+                    escalated = True
+                    escalated_action = rule.escalation_window_action
+
+                cooldown_until_iso = None
+                if escalated and rule.cooldown_minutes > 0:
+                    cooldown_until_iso = (now + timedelta(minutes=rule.cooldown_minutes)).isoformat()
+
+                self._upsert_escalation_state_with_connection(
+                    conn,
+                    rule_id=rule.id,
+                    user_id=user_id,
+                    session_id=session_id,
+                    session_trigger_count=session_count,
+                    window_trigger_count=window_count,
+                    current_escalated_action=escalated_action if escalated else None,
+                    escalated_at=now_iso if escalated else None,
+                    cooldown_until=cooldown_until_iso,
+                    updated_at=now_iso,
+                )
+                conn.commit()
+
+                if escalated and escalated_action:
+                    info["escalated"] = True
+                    info["effective_action"] = escalated_action
+                    info["session_trigger_count"] = session_count
+                    info["window_trigger_count"] = window_count
+                    info["escalated_action"] = escalated_action
+                return info
+            except Exception:
+                conn.rollback()
+                raise
+            finally:
+                conn.close()
+
+    @staticmethod
+    def _upsert_escalation_state_with_connection(
+        conn: sqlite3.Connection,
+        *,
+        rule_id: str,
+        user_id: str,
+        session_id: str | None,
+        session_trigger_count: int,
+        window_trigger_count: int,
+        current_escalated_action: str | None,
+        escalated_at: str | None,
+        cooldown_until: str | None,
+        updated_at: str,
+    ) -> None:
+        conn.execute(
+            """INSERT INTO escalation_state
+            (rule_id, user_id, session_id, session_trigger_count,
+             window_trigger_count, current_escalated_action,
+             escalated_at, cooldown_until, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(rule_id, user_id) DO UPDATE SET
+                session_id = excluded.session_id,
+                session_trigger_count = excluded.session_trigger_count,
+                window_trigger_count = excluded.window_trigger_count,
+                current_escalated_action = excluded.current_escalated_action,
+                escalated_at = excluded.escalated_at,
+                cooldown_until = excluded.cooldown_until,
+                updated_at = excluded.updated_at""",
+            (
+                rule_id, str(user_id), session_id,
+                session_trigger_count, window_trigger_count,
+                current_escalated_action, escalated_at,
+                cooldown_until, updated_at,
+            ),
+        )
+
     def reset_escalation_state(self, rule_id: str, user_id: str) -> bool:
         with self._lock:
             conn = self._connect()

--- a/tldw_Server_API/app/core/DB_Management/TopicMonitoring_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/TopicMonitoring_DB.py
@@ -552,43 +552,143 @@ class TopicMonitoringDB:
         with self._lock:
             conn = self._connect()
             try:
-                created_at = alert.created_at or _utcnow_iso()
-                metadata_json = None
-                if alert.metadata is not None:
-                    try:
-                        metadata_json = json.dumps(alert.metadata, ensure_ascii=False)
-                    except Exception:
-                        metadata_json = None
-                cur = conn.execute(
-                    """
-                    INSERT INTO topic_alerts (
-                        created_at, user_id, scope_type, scope_id, source, watchlist_id,
-                        rule_id, rule_category, rule_severity, pattern, source_id, chunk_id, chunk_seq,
-                        text_snippet, metadata, is_read, read_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        created_at,
-                        alert.user_id,
-                        alert.scope_type,
-                        alert.scope_id,
-                        alert.source,
-                        alert.watchlist_id,
-                        alert.rule_id,
-                        alert.rule_category,
-                        alert.rule_severity,
-                        alert.pattern,
-                        alert.source_id,
-                        alert.chunk_id,
-                        alert.chunk_seq,
-                        alert.text_snippet,
-                        metadata_json,
-                        int(alert.is_read or 0),
-                        alert.read_at,
-                    ),
-                )
+                cur = self._insert_alert_with_connection(conn, alert)
                 conn.commit()
                 return int(cur.lastrowid)
+            finally:
+                conn.close()
+
+    @staticmethod
+    def _alert_metadata_json(alert: TopicAlert) -> str | None:
+        if alert.metadata is None:
+            return None
+        try:
+            return json.dumps(alert.metadata, ensure_ascii=False)
+        except Exception:
+            return None
+
+    def _insert_alert_with_connection(
+        self,
+        conn: sqlite3.Connection,
+        alert: TopicAlert,
+    ) -> sqlite3.Cursor:
+        created_at = alert.created_at or _utcnow_iso()
+        return conn.execute(
+            """
+            INSERT INTO topic_alerts (
+                created_at, user_id, scope_type, scope_id, source, watchlist_id,
+                rule_id, rule_category, rule_severity, pattern, source_id, chunk_id, chunk_seq,
+                text_snippet, metadata, is_read, read_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                created_at,
+                alert.user_id,
+                alert.scope_type,
+                alert.scope_id,
+                alert.source,
+                alert.watchlist_id,
+                alert.rule_id,
+                alert.rule_category,
+                alert.rule_severity,
+                alert.pattern,
+                alert.source_id,
+                alert.chunk_id,
+                alert.chunk_seq,
+                alert.text_snippet,
+                self._alert_metadata_json(alert),
+                int(alert.is_read or 0),
+                alert.read_at,
+            ),
+        )
+
+    @staticmethod
+    def _duplicate_where_clause(
+        user_id: str | None,
+        watchlist_id: str,
+        source: str,
+        threshold: str,
+        *,
+        pattern: str | None = None,
+        rule_id: str | None = None,
+        source_id: str | None = None,
+    ) -> tuple[str, list[Any]]:
+        clauses = ["watchlist_id = ?", "source = ?", "created_at >= ?"]
+        params: list[Any] = [str(watchlist_id), str(source), threshold]
+        if user_id is None:
+            clauses.append("user_id IS NULL")
+        else:
+            clauses.append("user_id = ?")
+            params.append(str(user_id))
+        if rule_id:
+            clauses.append("rule_id = ?")
+            params.append(str(rule_id))
+        elif pattern:
+            clauses.append("pattern = ?")
+            params.append(str(pattern))
+        if source_id:
+            clauses.append("source_id = ?")
+            params.append(str(source_id))
+        return " AND ".join(clauses), params
+
+    def _recent_duplicate_exists_with_connection(
+        self,
+        conn: sqlite3.Connection,
+        user_id: str | None,
+        watchlist_id: str,
+        source: str,
+        threshold: str,
+        *,
+        pattern: str | None = None,
+        rule_id: str | None = None,
+        source_id: str | None = None,
+    ) -> bool:
+        where, params = self._duplicate_where_clause(
+            user_id,
+            watchlist_id,
+            source,
+            threshold,
+            pattern=pattern,
+            rule_id=rule_id,
+            source_id=source_id,
+        )
+        # TASK-2417: WHERE is built from fixed fragments only; values stay parameterized.
+        cur = conn.execute(
+            f"SELECT 1 FROM topic_alerts WHERE {where} LIMIT 1",  # nosec B608
+            params,
+        )
+        return cur.fetchone() is not None
+
+    def insert_alert_if_not_duplicate(
+        self,
+        alert: TopicAlert,
+        *,
+        window_seconds: int = 300,
+    ) -> int | None:
+        """Insert alert only when no duplicate exists in the dedupe window."""
+        threshold = (datetime.now(timezone.utc) - timedelta(seconds=window_seconds)).isoformat()
+        with self._lock:
+            conn = self._connect()
+            try:
+                begin_immediate_if_needed(conn)
+                if self._recent_duplicate_exists_with_connection(
+                    conn,
+                    user_id=alert.user_id,
+                    watchlist_id=alert.watchlist_id,
+                    source=alert.source,
+                    threshold=threshold,
+                    rule_id=alert.rule_id,
+                    pattern=alert.pattern,
+                    source_id=alert.source_id,
+                ):
+                    conn.commit()
+                    return None
+                cur = self._insert_alert_with_connection(conn, alert)
+                conn.commit()
+                return int(cur.lastrowid)
+            except Exception:
+                conn.rollback()
+                raise
             finally:
                 conn.close()
 
@@ -609,29 +709,16 @@ class TopicMonitoringDB:
         with self._lock:
             conn = self._connect()
             try:
-                clauses = ["watchlist_id = ?", "source = ?", "created_at >= ?"]
-                params: list[Any] = [str(watchlist_id), str(source), threshold]
-                if user_id is None:
-                    clauses.append("user_id IS NULL")
-                else:
-                    clauses.append("user_id = ?")
-                    params.append(str(user_id))
-                if rule_id:
-                    clauses.append("rule_id = ?")
-                    params.append(str(rule_id))
-                elif pattern:
-                    clauses.append("pattern = ?")
-                    params.append(str(pattern))
-                if source_id:
-                    clauses.append("source_id = ?")
-                    params.append(str(source_id))
-                where = " AND ".join(clauses)
-                cur = conn.execute(
-                    f"SELECT 1 FROM topic_alerts WHERE {where} LIMIT 1",  # nosec B608
-                    params,
+                return self._recent_duplicate_exists_with_connection(
+                    conn,
+                    user_id,
+                    watchlist_id,
+                    source,
+                    threshold,
+                    pattern=pattern,
+                    rule_id=rule_id,
+                    source_id=source_id,
                 )
-                row = cur.fetchone()
-                return bool(row)
             finally:
                 conn.close()
 

--- a/tldw_Server_API/app/core/DB_Management/db_path_utils.py
+++ b/tldw_Server_API/app/core/DB_Management/db_path_utils.py
@@ -531,6 +531,28 @@ class DatabasePaths:
         return user_dir
 
     @staticmethod
+    def resolve_user_base_directory(
+        user_id: Optional[UserId],
+        *,
+        base_dir_override: Optional[Union[str, Path]] = None,
+        allow_legacy_alias: bool = False,
+    ) -> Path:
+        """Resolve a user's database directory without creating it."""
+        if base_dir_override is not None:
+            base_path = _normalize_user_db_base_dir(Path(base_dir_override))
+        else:
+            base_path = DatabasePaths.resolve_user_db_base_dir(
+                allow_legacy_alias=allow_legacy_alias
+            )
+        safe_user_id = _resolve_user_id_for_storage(user_id)
+        user_dir = (base_path / safe_user_id).resolve()
+        try:
+            user_dir.relative_to(base_path)
+        except ValueError as exc:
+            raise ValueError(f"Computed user directory escapes base path: {user_dir!r}") from exc
+        return user_dir
+
+    @staticmethod
     def get_media_db_path(user_id: Optional[UserId]) -> Path:
         """Get the path to the user's media database."""
         user_dir = DatabasePaths.get_user_base_directory(user_id)
@@ -641,6 +663,12 @@ class DatabasePaths:
     def get_guardian_db_path(user_id: Optional[UserId]) -> Path:
         """Get the path to the user's Guardian/self-monitoring database."""
         user_dir = DatabasePaths.get_user_base_directory(user_id)
+        return user_dir / DatabasePaths.GUARDIAN_DB_NAME
+
+    @staticmethod
+    def resolve_guardian_db_path(user_id: Optional[UserId]) -> Path:
+        """Resolve the user's Guardian DB path without creating directories."""
+        user_dir = DatabasePaths.resolve_user_base_directory(user_id)
         return user_dir / DatabasePaths.GUARDIAN_DB_NAME
 
     @staticmethod

--- a/tldw_Server_API/app/core/DB_Management/guardian_db_resolver.py
+++ b/tldw_Server_API/app/core/DB_Management/guardian_db_resolver.py
@@ -46,3 +46,12 @@ def resolve_guardian_db_for_user_id(user_id: object) -> GuardianDB:
     storage_user_id = coerce_guardian_storage_user_id(user_id)
     db_path = DatabasePaths.get_guardian_db_path(storage_user_id)
     return GuardianDB(str(db_path))
+
+
+def resolve_existing_guardian_db_for_user_id(user_id: object) -> GuardianDB:
+    """Return an existing GuardianDB for ``user_id`` without creating storage."""
+    storage_user_id = coerce_guardian_storage_user_id(user_id)
+    db_path = DatabasePaths.resolve_guardian_db_path(storage_user_id)
+    if not db_path.parent.is_dir() or not db_path.is_file():
+        raise FileNotFoundError("Guardian DB does not exist")
+    return GuardianDB(str(db_path))

--- a/tldw_Server_API/app/core/Monitoring/notification_service.py
+++ b/tldw_Server_API/app/core/Monitoring/notification_service.py
@@ -1,29 +1,35 @@
 from __future__ import annotations
 
 """
-Notification scaffolding for Topic Monitoring.
+Notification delivery for Topic Monitoring.
 
-Goals (Phase 1):
-- Provide a minimal, local-first notification hook for high-severity alerts.
-- Avoid external dependencies; log to JSONL file and simulate webhook/email via configuration flags.
+Goals:
+- Provide a local-first notification hook for high-severity alerts.
+- Log to a bounded JSONL sink and optionally deliver webhook/email notifications.
 
 Configuration (env or config dict under 'monitoring.notifications'):
 - MONITORING_NOTIFY_ENABLED: 'true'|'false' (default: false)
 - MONITORING_NOTIFY_MIN_SEVERITY: 'info'|'warning'|'critical' (default: 'critical')
 - MONITORING_NOTIFY_FILE: path for JSONL sink (default: 'Databases/monitoring_notifications.log')
-- MONITORING_NOTIFY_WEBHOOK_URL: URL (future use; not sent in offline mode)
-- MONITORING_NOTIFY_EMAIL_TO: comma-separated emails (future use; not sent in Phase 1)
+- MONITORING_NOTIFY_ALLOWED_DIRS: additional absolute directories allowed for file sinks
+- MONITORING_NOTIFY_WEBHOOK_URL: optional webhook URL for async delivery
+- MONITORING_NOTIFY_EMAIL_TO: comma-separated emails for async SMTP delivery
+- MONITORING_NOTIFY_MAX_QUEUE: maximum pending webhook/email deliveries (default: 1000)
+- MONITORING_NOTIFY_MAX_DIGEST_ITEMS_PER_RECIPIENT: per-recipient digest cap (default: 1000)
 - MONITORING_NOTIFY_DIGEST_MODE: 'immediate'|'hourly'|'daily' (default: 'immediate').
   'hourly'/'daily' buffer generic/guardian notifications until callers invoke
   flush_digest(), which emits one compiled monitoring_digest payload per recipient.
 
-This scaffolding records intent locally so operators can forward to their systems.
+The JSONL file is restricted to trusted notification directories so the recent
+notifications endpoint cannot be pointed at arbitrary host files.
 """
 
 import contextlib
 import json
 import os
+import queue
 import smtplib
+import tempfile
 import threading
 from datetime import datetime, timezone
 from email.mime.text import MIMEText
@@ -35,7 +41,7 @@ from tenacity import RetryError, retry, stop_after_attempt, wait_exponential
 
 from tldw_Server_API.app.core.config import load_and_log_configs
 from tldw_Server_API.app.core.DB_Management.TopicMonitoring_DB import TopicAlert
-from tldw_Server_API.app.core.testing import is_truthy
+from tldw_Server_API.app.core.testing import is_explicit_pytest_runtime, is_test_mode, is_truthy
 
 _SEVERITY_ORDER = {"info": 0, "warning": 1, "critical": 2}
 
@@ -66,54 +72,138 @@ class NotificationService:
         self.enabled = is_truthy(os.getenv("MONITORING_NOTIFY_ENABLED", str((ncfg or {}).get("enabled", False))))
         self.min_severity = str(os.getenv("MONITORING_NOTIFY_MIN_SEVERITY", (ncfg or {}).get("min_severity", "critical"))).strip().lower()
         raw_file = os.getenv("MONITORING_NOTIFY_FILE", (ncfg or {}).get("file", "Databases/monitoring_notifications.log"))
-        self.file_path = self._resolve_file_path(raw_file)
+        try:
+            self.file_path = self._resolve_file_path(raw_file)
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            logger.warning("Invalid MONITORING_NOTIFY_FILE; using default ({})", _safe_exception_label(exc))
+            self.file_path = str(self._default_file_path())
         self.webhook_url = os.getenv("MONITORING_NOTIFY_WEBHOOK_URL", (ncfg or {}).get("webhook_url", ""))
         self.email_to = os.getenv("MONITORING_NOTIFY_EMAIL_TO", (ncfg or {}).get("email_to", ""))
         # SMTP configuration (optional)
         self.smtp_host = os.getenv("MONITORING_NOTIFY_SMTP_HOST", (ncfg or {}).get("smtp_host", ""))
         raw_smtp_port = os.getenv("MONITORING_NOTIFY_SMTP_PORT", (ncfg or {}).get("smtp_port", "587"))
-        self.smtp_port = self._coerce_int(raw_smtp_port, 587)
+        self.smtp_port = self._coerce_int(raw_smtp_port, 587, "MONITORING_NOTIFY_SMTP_PORT")
         self.smtp_starttls = is_truthy(os.getenv("MONITORING_NOTIFY_SMTP_STARTTLS", (ncfg or {}).get("smtp_starttls", "true")))
         self.smtp_user = os.getenv("MONITORING_NOTIFY_SMTP_USER", (ncfg or {}).get("smtp_user", ""))
         self.smtp_password = os.getenv("MONITORING_NOTIFY_SMTP_PASSWORD", (ncfg or {}).get("smtp_password", ""))
         self.email_from = os.getenv("MONITORING_NOTIFY_EMAIL_FROM", (ncfg or {}).get("email_from", self.smtp_user or ""))
+        self.max_delivery_queue_size = max(
+            1,
+            self._coerce_int(
+                os.getenv(
+                    "MONITORING_NOTIFY_MAX_QUEUE",
+                    (ncfg or {}).get("max_queue_size", 1000),
+                ),
+                1000,
+                "MONITORING_NOTIFY_MAX_QUEUE",
+            ),
+        )
+        self.max_digest_items_per_recipient = max(
+            1,
+            self._coerce_int(
+                os.getenv(
+                    "MONITORING_NOTIFY_MAX_DIGEST_ITEMS_PER_RECIPIENT",
+                    (ncfg or {}).get("max_digest_items_per_recipient", 1000),
+                ),
+                1000,
+                "MONITORING_NOTIFY_MAX_DIGEST_ITEMS_PER_RECIPIENT",
+            ),
+        )
         self.digest_mode = os.getenv(
             "MONITORING_NOTIFY_DIGEST_MODE",
             (ncfg or {}).get("digest_mode", "immediate"),
         ).strip().lower()
         self._lock = threading.RLock()
         self._pending_digests: dict[str, list[dict[str, Any]]] = {}
+        self._delivery_queue: queue.Queue[tuple[str, Any]] = queue.Queue(maxsize=self.max_delivery_queue_size)
+        self._delivery_worker_started = False
+        self._delivery_worker_lock = threading.RLock()
         with contextlib.suppress(OSError):
             Path(self.file_path).parent.mkdir(parents=True, exist_ok=True)
 
     @staticmethod
-    def _coerce_int(value: Any, default: int) -> int:
+    def _coerce_int(value: Any, default: int, label: str = "integer") -> int:
         if value is None or value == "":
             return default
         try:
             return int(value)
         except (TypeError, ValueError):
-            logger.warning(f"Invalid MONITORING_NOTIFY_SMTP_PORT={value!r}; using {default}")
+            logger.warning("Invalid {}={!r}; using {}", label, value, default)
             return default
 
     @staticmethod
-    def _resolve_file_path(raw_file: str) -> str:
+    def _project_root() -> Path:
+        try:
+            from tldw_Server_API.app.core.Utils.Utils import get_project_root as _gpr
+            return Path(_gpr()).resolve()
+        except (AttributeError, ImportError, OSError, RuntimeError, TypeError, ValueError):
+            root = _find_project_root(Path(__file__).resolve())
+            if root is None:
+                root = Path(__file__).resolve().parent
+            return root.resolve()
+
+    @classmethod
+    def _default_file_path(cls) -> Path:
+        return (cls._project_root() / "Databases" / "monitoring_notifications.log").resolve(strict=False)
+
+    @staticmethod
+    def _parse_allowed_dirs(raw_dirs: str | None) -> list[Path]:
+        if not raw_dirs:
+            return []
+        parts: list[str] = []
+        for chunk in str(raw_dirs).split(os.pathsep):
+            parts.extend(piece.strip() for piece in chunk.split(","))
+        allowed: list[Path] = []
+        for part in parts:
+            if not part:
+                continue
+            with contextlib.suppress(OSError, RuntimeError, TypeError, ValueError):
+                candidate = Path(part).expanduser().resolve(strict=False)
+                if candidate.is_absolute():
+                    allowed.append(candidate)
+        return allowed
+
+    @classmethod
+    def _allowed_file_roots(cls) -> list[Path]:
+        root = cls._project_root()
+        allowed = [
+            (root / "Databases").resolve(strict=False),
+            (root / "logs").resolve(strict=False),
+        ]
+        allowed.extend(cls._parse_allowed_dirs(os.getenv("MONITORING_NOTIFY_ALLOWED_DIRS")))
+        if is_test_mode() or is_explicit_pytest_runtime():
+            with contextlib.suppress(OSError, RuntimeError, TypeError, ValueError):
+                allowed.append(Path(tempfile.gettempdir()).resolve(strict=False))
+        return allowed
+
+    @staticmethod
+    def _path_is_within(path: Path, root: Path) -> bool:
+        with contextlib.suppress(ValueError):
+            path.relative_to(root)
+            return True
+        return False
+
+    @classmethod
+    def _resolve_file_path(cls, raw_file: str) -> str:
+        if raw_file is None or not str(raw_file).strip():
+            raise ValueError("Notification file path must be non-empty")
         try:
             fp = Path(str(raw_file))
             if not fp.is_absolute():
-                try:
-                    from tldw_Server_API.app.core.Utils.Utils import get_project_root as _gpr
-                    root = Path(_gpr()).resolve()
-                    fp = root / fp
-                except (AttributeError, ImportError, OSError, RuntimeError, TypeError, ValueError):
-                    root = _find_project_root(Path(__file__).resolve())
-                    if root is None:
-                        root = Path(__file__).resolve().parent
-                    fp = root / fp
-            return str(fp)
+                fp = cls._project_root() / fp
+            resolved = fp.expanduser().resolve(strict=False)
         except (OSError, RuntimeError, TypeError, ValueError):
-            fallback_root = _find_project_root(Path(__file__).resolve()) or Path(__file__).resolve().parent
-            return str(fallback_root / str(raw_file))
+            raise
+        if not any(cls._path_is_within(resolved, root) for root in cls._allowed_file_roots()):
+            raise ValueError("Notification file path is outside allowed directories")
+        return str(resolved)
+
+    def is_file_path_allowed(self, raw_file: str) -> bool:
+        try:
+            self._resolve_file_path(raw_file)
+            return True
+        except (OSError, RuntimeError, TypeError, ValueError):
+            return False
 
     @staticmethod
     def _parse_email_recipients(raw: str | None) -> list[str]:
@@ -230,20 +320,50 @@ class NotificationService:
         except (OSError, RuntimeError, TypeError, ValueError) as e:
             file_written = False
             logger.warning("Notification file sink failed ({})", _safe_exception_label(e))
-        # Best-effort asynchronous sends (non-blocking)
-        try:
-            if self.webhook_url:
-                threading.Thread(target=self._send_webhook_safe, args=(payload,), daemon=True).start()
-        except (OSError, RuntimeError) as e:
-            logger.debug("Webhook thread start failed ({})", _safe_exception_label(e))
+        # Best-effort asynchronous sends through a bounded worker queue.
+        if self.webhook_url:
+            self._enqueue_delivery("webhook", payload)
         try:
             # Email optional and only if SMTP configured and recipients provided
             recipients = self._parse_email_recipients(self.email_to)
             if recipients and self.smtp_host and self.email_from:
-                threading.Thread(target=self._send_email_safe, args=(alert,), daemon=True).start()
+                self._enqueue_delivery("email", alert)
         except (OSError, RuntimeError) as e:
-            logger.debug("Email thread start failed ({})", _safe_exception_label(e))
+            logger.debug("Email delivery enqueue failed ({})", _safe_exception_label(e))
         return "logged" if file_written else "failed"
+
+    def _start_delivery_worker(self) -> None:
+        with self._delivery_worker_lock:
+            if self._delivery_worker_started:
+                return
+            threading.Thread(target=self._delivery_worker, daemon=True).start()
+            self._delivery_worker_started = True
+
+    def _enqueue_delivery(self, kind: str, item: Any) -> bool:
+        try:
+            self._start_delivery_worker()
+            self._delivery_queue.put_nowait((kind, item))
+            return True
+        except queue.Full:
+            logger.warning("Notification delivery queue full; dropped {} delivery", kind)
+        except (OSError, RuntimeError, TypeError, ValueError) as e:
+            logger.debug("{} delivery enqueue failed ({})", kind.capitalize(), _safe_exception_label(e))
+        return False
+
+    def _delivery_worker(self) -> None:
+        while True:
+            kind, item = self._delivery_queue.get()
+            try:
+                if kind == "webhook":
+                    self._send_webhook_safe(item)
+                elif kind == "email":
+                    self._send_email_safe(item)
+                else:
+                    logger.debug("Unknown notification delivery kind {}", kind)
+            except Exception as exc:  # defensive: safe senders should not raise
+                logger.info("Notification delivery failed ({})", _safe_exception_label(exc))
+            finally:
+                self._delivery_queue.task_done()
 
     @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=8), reraise=False)
     def _send_webhook(self, payload: dict[str, Any]) -> None:
@@ -261,7 +381,7 @@ class NotificationService:
         except (OSError, RuntimeError, TypeError, ValueError) as e:
             logger.info("Webhook notify failed ({})", _safe_exception_label(e))
 
-    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=8), reraise=False)
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=8), reraise=True)
     def _send_email(self, alert: TopicAlert) -> None:
         recipients = self._parse_email_recipients(self.email_to)
         if not (self.smtp_host and self.email_from and recipients):
@@ -283,8 +403,10 @@ class NotificationService:
 
         with smtplib.SMTP(self.smtp_host, self.smtp_port, timeout=10) as server:
             if self.smtp_starttls:
-                with contextlib.suppress(OSError, RuntimeError, smtplib.SMTPException):
+                try:
                     server.starttls()
+                except (OSError, RuntimeError, smtplib.SMTPException) as exc:
+                    raise RuntimeError("SMTP STARTTLS failed") from exc
             if self.smtp_user:
                 server.login(self.smtp_user, self.smtp_password or "")
             server.sendmail(self.email_from, recipients, msg.as_string())
@@ -307,11 +429,8 @@ class NotificationService:
         except (OSError, RuntimeError, TypeError, ValueError) as e:
             file_written = False
             logger.warning("Notification file sink failed ({})", _safe_exception_label(e))
-        try:
-            if self.webhook_url:
-                threading.Thread(target=self._send_webhook_safe, args=(payload,), daemon=True).start()
-        except (OSError, RuntimeError) as e:
-            logger.debug("Webhook thread start failed ({})", _safe_exception_label(e))
+        if self.webhook_url:
+            self._enqueue_delivery("webhook", payload)
         return "logged" if file_written else "failed"
 
     @staticmethod
@@ -329,9 +448,22 @@ class NotificationService:
         if self.digest_mode in ("hourly", "daily"):
             recipient = self._digest_recipient_key(payload.get("user_id", "_default"))
             with self._lock:
-                self._pending_digests.setdefault(recipient, []).append(dict(payload))
+                self._store_digest_items_locked(recipient, [dict(payload)])
             return "batched"
         return self.notify_generic(payload)
+
+    def _store_digest_items_locked(
+        self,
+        recipient_key: str,
+        items: list[dict[str, Any]],
+        *,
+        prepend: bool = False,
+    ) -> None:
+        existing = self._pending_digests.get(recipient_key, [])
+        combined = list(items) + existing if prepend else existing + list(items)
+        if len(combined) > self.max_digest_items_per_recipient:
+            combined = combined[-self.max_digest_items_per_recipient :]
+        self._pending_digests[recipient_key] = combined
 
     @staticmethod
     def _digest_severity(items: list[dict[str, Any]]) -> str:
@@ -403,9 +535,7 @@ class NotificationService:
             with self._lock:
                 for recipient_key, items in failed.items():
                     if items:
-                        self._pending_digests[recipient_key] = (
-                            items + self._pending_digests.get(recipient_key, [])
-                        )
+                        self._store_digest_items_locked(recipient_key, items, prepend=True)
 
         return processed_count
 

--- a/tldw_Server_API/app/core/Monitoring/self_monitoring_service.py
+++ b/tldw_Server_API/app/core/Monitoring/self_monitoring_service.py
@@ -35,6 +35,9 @@ from tldw_Server_API.app.core.DB_Management.Guardian_DB import (
     GuardianDB,
     SelfMonitoringRule,
 )
+from tldw_Server_API.app.core.DB_Management.guardian_db_resolver import (
+    resolve_existing_guardian_db_for_user_id,
+)
 from tldw_Server_API.app.core.Moderation.governance_utils import (
     chat_type_matches,
     is_schedule_active,
@@ -49,6 +52,23 @@ _SELFMON_NONCRITICAL_EXCEPTIONS = (
     AttributeError,
     re.error,
 )
+
+
+class SelfMonitoringOwnerDbResolutionError(ValueError):
+    """Raised when a partner approval owner DB cannot be resolved safely."""
+
+
+def resolve_partner_approval_guardian_db(
+    current_db: GuardianDB,
+    owner_user_id: object | None,
+) -> GuardianDB:
+    """Select the Guardian DB for partner approval without creating owner storage."""
+    if owner_user_id is None or str(owner_user_id).strip() == "":
+        return current_db
+    try:
+        return resolve_existing_guardian_db_for_user_id(owner_user_id)
+    except (FileNotFoundError, OSError, RuntimeError, TypeError, ValueError) as exc:
+        raise SelfMonitoringOwnerDbResolutionError("Owner Guardian DB not found") from exc
 
 
 # ── Crisis Resources ──────────────────────────────────────────
@@ -385,97 +405,7 @@ class SelfMonitoringService:
             return info
 
         try:
-            state = self._db.get_escalation_state(rule.id, user_id)
-            now = datetime.now(timezone.utc)
-            now_iso = now.isoformat()
-            session_count = 0
-
-            if state:
-                # Reset session counter if session changed
-                if session_id and state.session_id != session_id:
-                    session_count = 1
-                else:
-                    session_count = (state.session_trigger_count or 0) + 1
-            else:
-                session_count = 1
-
-            # Rolling-window count: query actual alerts within the window
-            # instead of monotonically incrementing a counter.
-            # +1 because the current trigger's alert hasn't been recorded yet.
-            if rule.escalation_window_days > 0 and rule.escalation_window_threshold > 0:
-                window_count = self._db.count_alerts_in_window(
-                    user_id, rule.id, rule.escalation_window_days,
-                ) + 1  # include the current (not-yet-persisted) trigger
-            elif state:
-                window_count = (state.window_trigger_count or 0) + 1
-            else:
-                window_count = 1
-
-            # Check cooldown-based auto de-escalation: if a previous
-            # escalation has a cooldown_until in the past, clear it.
-            if state and state.cooldown_until:
-                try:
-                    cooldown_dt = datetime.fromisoformat(state.cooldown_until)
-                    if now >= cooldown_dt:
-                        # Cooldown expired — reset escalation state
-                        self._db.upsert_escalation_state(
-                            rule_id=rule.id,
-                            user_id=user_id,
-                            session_id=session_id,
-                            session_trigger_count=session_count,
-                            window_trigger_count=window_count,
-                            current_escalated_action=None,
-                            escalated_at=None,
-                            cooldown_until=None,
-                        )
-                        return info
-                except (ValueError, TypeError):
-                    pass  # malformed cooldown_until — ignore
-
-            escalated = False
-            escalated_action = None
-
-            # Session-level escalation
-            if (
-                rule.escalation_session_threshold > 0
-                and session_count >= rule.escalation_session_threshold
-                and rule.escalation_session_action
-            ):
-                escalated = True
-                escalated_action = rule.escalation_session_action
-
-            # Window-level escalation (cross-session)
-            if (
-                rule.escalation_window_threshold > 0
-                and window_count >= rule.escalation_window_threshold
-                and rule.escalation_window_action
-            ):
-                escalated = True
-                escalated_action = rule.escalation_window_action
-
-            # Compute cooldown_until when escalation triggers
-            cooldown_until_iso = None
-            if escalated and rule.cooldown_minutes > 0:
-                cooldown_until_iso = (now + timedelta(minutes=rule.cooldown_minutes)).isoformat()
-
-            self._db.upsert_escalation_state(
-                rule_id=rule.id,
-                user_id=user_id,
-                session_id=session_id,
-                session_trigger_count=session_count,
-                window_trigger_count=window_count,
-                current_escalated_action=escalated_action if escalated else None,
-                escalated_at=now_iso if escalated else None,
-                cooldown_until=cooldown_until_iso,
-            )
-
-            if escalated and escalated_action:
-                info["escalated"] = True
-                info["effective_action"] = escalated_action
-                info["session_trigger_count"] = session_count
-                info["window_trigger_count"] = window_count
-                info["escalated_action"] = escalated_action
-
+            return self._db.update_escalation_for_trigger(rule, user_id, session_id)
         except _SELFMON_NONCRITICAL_EXCEPTIONS:
             logger.debug("Escalation check failed")
 

--- a/tldw_Server_API/app/core/Monitoring/topic_monitoring_service.py
+++ b/tldw_Server_API/app/core/Monitoring/topic_monitoring_service.py
@@ -28,6 +28,7 @@ from typing import Any
 
 from loguru import logger
 
+from tldw_Server_API.app.core.Character_Chat.regex_safety import validate_regex_safety
 from tldw_Server_API.app.api.v1.schemas.monitoring_schemas import Watchlist, WatchlistRule
 from tldw_Server_API.app.core.config import load_and_log_configs
 from tldw_Server_API.app.core.DB_Management.TopicMonitoring_DB import (
@@ -409,7 +410,11 @@ class TopicMonitoringService:
     def _is_regex_dangerous(expr: str) -> bool:
         if not expr:
             return True
-        if len(expr) > 2000:
+        try:
+            is_safe, _reason = validate_regex_safety(expr)
+            if not is_safe:
+                return True
+        except (OSError, RuntimeError, TypeError, ValueError, re.error):
             return True
         # Nested quantifiers heuristic
         try:
@@ -776,15 +781,6 @@ class TopicMonitoringService:
                         )
                         continue
                 else:
-                    if self._db.recent_duplicate_exists(
-                        user_id=alert_user_id,
-                        watchlist_id=str(wid),
-                        source=str(source),
-                        rule_id=str(cr.rule_id),
-                        pattern=str(cr.pattern_text),
-                        window_seconds=self._dedup_window_seconds,
-                    ):
-                        continue
                     dedupe_meta = {}
                 snippet = self._snippet_around(text, match_span[0], match_span[1], max_len=200)
                 # Scope reflects the matched watchlist's scope
@@ -818,7 +814,15 @@ class TopicMonitoringService:
                     text_snippet=snippet,
                     metadata=combined_meta or None,
                 )
-                self._db.insert_alert(alert)
+                if streaming_mode:
+                    self._db.insert_alert(alert)
+                else:
+                    alert_id = self._db.insert_alert_if_not_duplicate(
+                        alert,
+                        window_seconds=self._dedup_window_seconds,
+                    )
+                    if alert_id is None:
+                        continue
                 # Notify if configured and severity threshold met
                 try:
                     notifier = get_notification_service()

--- a/tldw_Server_API/tests/AuthNZ_Unit/test_monitoring_permissions_claims.py
+++ b/tldw_Server_API/tests/AuthNZ_Unit/test_monitoring_permissions_claims.py
@@ -8,8 +8,17 @@ from starlette.requests import Request
 from tldw_Server_API.app.api.v1.API_Deps import auth_deps
 from tldw_Server_API.app.api.v1.endpoints import admin as admin_mod
 from tldw_Server_API.app.api.v1.endpoints import monitoring as monitoring_mod
-from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_LOGS
+from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_CONFIGURE, SYSTEM_LOGS
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+
+@pytest.fixture(autouse=True)
+def _single_user_test_key(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SINGLE_USER_TEST_API_KEY", "monitoring-test-key")
+    reset_settings()
+    yield
+    reset_settings()
 
 
 def _build_app_with_overrides(
@@ -42,6 +51,34 @@ def _build_app_with_overrides(
         return _FakeMonitoringService()
 
     monitoring_mod.get_topic_monitoring_service = _fake_get_topic_monitoring_service  # type: ignore[assignment]
+
+    class _FakeNotificationService:
+        def get_settings(self) -> dict:
+            return {
+                "enabled": False,
+                "min_severity": "critical",
+                "file": "Databases/monitoring_notifications.log",
+                "webhook_url": "",
+                "email_to": "",
+                "smtp_host": "",
+                "smtp_port": 587,
+                "smtp_starttls": True,
+                "smtp_user": "",
+                "email_from": "",
+            }
+
+        def update_settings(self, **kwargs) -> dict:
+            settings = self.get_settings()
+            settings.update(kwargs)
+            return settings
+
+        def is_file_path_allowed(self, _path: str) -> bool:
+            return True
+
+        def notify(self, _alert) -> str:
+            return "logged"
+
+    monitoring_mod.get_notification_service = lambda: _FakeNotificationService()  # type: ignore[assignment]
 
     return app
 
@@ -156,6 +193,65 @@ async def test_monitoring_notification_settings_403_when_missing_system_logs_per
     assert resp.status_code == 403
     detail = resp.json().get("detail", "")
     assert SYSTEM_LOGS in detail
+
+
+@pytest.mark.asyncio
+async def test_monitoring_notification_settings_update_403_for_system_logs_only():
+    principal = _make_principal(
+        is_admin=False,
+        roles=["user"],
+        permissions=[SYSTEM_LOGS],
+    )
+    app = _build_app_with_overrides(principal=principal)
+
+    with TestClient(app) as client:
+        resp = client.put(
+            "/api/v1/monitoring/notifications/settings",
+            json={"enabled": True},
+        )
+
+    assert resp.status_code == 403
+    detail = resp.json().get("detail", "")
+    assert SYSTEM_CONFIGURE in detail
+
+
+@pytest.mark.asyncio
+async def test_monitoring_notification_settings_update_200_with_system_configure():
+    principal = _make_principal(
+        is_admin=False,
+        roles=["user"],
+        permissions=[SYSTEM_LOGS, SYSTEM_CONFIGURE],
+    )
+    app = _build_app_with_overrides(principal=principal)
+
+    with TestClient(app) as client:
+        resp = client.put(
+            "/api/v1/monitoring/notifications/settings",
+            json={"enabled": True},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json().get("enabled") is True
+
+
+@pytest.mark.asyncio
+async def test_monitoring_notification_test_403_for_system_logs_only():
+    principal = _make_principal(
+        is_admin=False,
+        roles=["user"],
+        permissions=[SYSTEM_LOGS],
+    )
+    app = _build_app_with_overrides(principal=principal)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/monitoring/notifications/test",
+            json={"message": "probe", "severity": "critical"},
+        )
+
+    assert resp.status_code == 403
+    detail = resp.json().get("detail", "")
+    assert SYSTEM_CONFIGURE in detail
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Guardian/test_self_monitoring.py
+++ b/tldw_Server_API/tests/Guardian/test_self_monitoring.py
@@ -300,7 +300,7 @@ class TestEscalation:
         def fail_escalation_state(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
             raise RuntimeError("escalation backend failed at /private/escalation.db")
 
-        monkeypatch.setattr(db, "get_escalation_state", fail_escalation_state)
+        monkeypatch.setattr(db, "update_escalation_for_trigger", fail_escalation_state)
 
         messages: list[str] = []
         sink_id = selfmon_module.logger.add(lambda message: messages.append(str(message)), level="DEBUG")
@@ -313,6 +313,56 @@ class TestEscalation:
         joined = "\n".join(messages)
         assert "Escalation check failed" in joined
         assert "escalation.db" not in joined
+
+    def test_escalation_uses_atomic_db_helper(self, monkeypatch, db, svc):
+        rule = _create_rule(
+            db,
+            patterns=["trigger"],
+            action="notify",
+            escalation_session_threshold=1,
+            escalation_session_action="block",
+        )
+        calls: list[tuple[str, str, str | None]] = []
+
+        def _fake_update(rule_arg, user_id, session_id):
+            calls.append((rule_arg.id, user_id, session_id))
+            return {
+                "escalated": True,
+                "effective_action": "block",
+                "session_trigger_count": 1,
+                "window_trigger_count": 1,
+                "escalated_action": "block",
+            }
+
+        monkeypatch.setattr(db, "update_escalation_for_trigger", _fake_update, raising=False)
+
+        result = svc._check_escalation(rule, "user1", "session1")
+
+        assert calls == [(rule.id, "user1", "session1")]
+        assert result["escalated"] is True
+        assert result["effective_action"] == "block"
+
+    def test_update_escalation_for_trigger_updates_state_atomically(self, db):
+        rule = _create_rule(
+            db,
+            patterns=["trigger"],
+            action="notify",
+            escalation_session_threshold=2,
+            escalation_session_action="block",
+            cooldown_minutes=0,
+        )
+
+        first = db.update_escalation_for_trigger(rule, "user1", "session1")
+        second = db.update_escalation_for_trigger(rule, "user1", "session1")
+
+        assert first == {"escalated": False, "effective_action": "notify"}
+        assert second["escalated"] is True
+        assert second["effective_action"] == "block"
+        assert second["session_trigger_count"] == 2
+        state = db.get_escalation_state(rule.id, "user1")
+        assert state is not None
+        assert state.session_trigger_count == 2
+        assert state.current_escalated_action == "block"
 
     def test_window_escalation(self, db, svc):
         _create_rule(

--- a/tldw_Server_API/tests/Guardian/test_self_monitoring_endpoints.py
+++ b/tldw_Server_API/tests/Guardian/test_self_monitoring_endpoints.py
@@ -1,0 +1,86 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.endpoints import self_monitoring as selfmon_endpoint
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+from tldw_Server_API.app.core.config import settings as app_settings
+from tldw_Server_API.app.core.DB_Management.Guardian_DB import GuardianDB
+from tldw_Server_API.app.core.Monitoring import self_monitoring_service as selfmon_service
+from tldw_Server_API.app.core.Monitoring.self_monitoring_service import SelfMonitoringService
+
+
+def _user(user_id: str) -> User:
+    return User(id=user_id, username=user_id, roles=["user"], permissions=[])
+
+
+def test_partner_approval_endpoint_can_target_owner_guardian_db(tmp_path, monkeypatch):
+    owner_db = GuardianDB(str(tmp_path / "owner.db"))
+    partner_db = GuardianDB(str(tmp_path / "partner.db"))
+    rule = owner_db.create_self_monitoring_rule(
+        user_id="owner1",
+        name="Owner Rule",
+        patterns=["word"],
+        notification_frequency="every_message",
+        bypass_protection="partner_approval",
+        bypass_partner_user_id="partner1",
+        cooldown_minutes=99999,
+    )
+    request_result = SelfMonitoringService(owner_db).request_deactivation(rule.id, "owner1")
+    token = request_result["confirmation_token"]
+
+    app = FastAPI()
+    app.include_router(selfmon_endpoint.router, prefix="/api/v1/self-monitoring")
+
+    async def _current_partner():
+        return _user("partner1")
+
+    app.dependency_overrides[selfmon_endpoint.get_request_user] = _current_partner
+    app.dependency_overrides[selfmon_endpoint.get_guardian_db_for_user] = lambda: partner_db
+
+    def _existing_db_for_user_id(user_id):
+        if str(user_id) == "owner1":
+            return owner_db
+        return partner_db
+
+    monkeypatch.setattr(
+        selfmon_service,
+        "resolve_existing_guardian_db_for_user_id",
+        _existing_db_for_user_id,
+    )
+
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/api/v1/self-monitoring/rules/{rule.id}/approve-deactivation",
+            json={"token": token, "owner_user_id": "owner1"},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "disabled"
+    assert owner_db.get_self_monitoring_rule(rule.id).enabled is False
+    assert partner_db.get_self_monitoring_rule(rule.id) is None
+
+
+def test_partner_approval_missing_owner_db_does_not_create_storage(tmp_path, monkeypatch):
+    user_db_base = tmp_path / "user_databases"
+    partner_db = GuardianDB(str(tmp_path / "partner.db"))
+
+    app = FastAPI()
+    app.include_router(selfmon_endpoint.router, prefix="/api/v1/self-monitoring")
+
+    async def _current_partner():
+        return _user("partner1")
+
+    app.dependency_overrides[selfmon_endpoint.get_request_user] = _current_partner
+    app.dependency_overrides[selfmon_endpoint.get_guardian_db_for_user] = lambda: partner_db
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(user_db_base))
+    monkeypatch.setitem(app_settings, "USER_DB_BASE_DIR", str(user_db_base))
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/self-monitoring/rules/missing-rule/approve-deactivation",
+            json={"token": "bad-token", "owner_user_id": "123456"},
+        )
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Owner Guardian DB not found"
+    assert not user_db_base.exists()

--- a/tldw_Server_API/tests/Monitoring/test_monitoring_notifications_settings.py
+++ b/tldw_Server_API/tests/Monitoring/test_monitoring_notifications_settings.py
@@ -6,9 +6,18 @@ from starlette.requests import Request
 from tldw_Server_API.app.api.v1.API_Deps import auth_deps
 from tldw_Server_API.app.api.v1.endpoints import monitoring as monitoring_mod
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
 
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _single_user_test_key(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SINGLE_USER_TEST_API_KEY", "monitoring-test-key")
+    reset_settings()
+    yield
+    reset_settings()
 
 
 def _make_admin_principal() -> AuthPrincipal:
@@ -58,6 +67,9 @@ def _build_app_with_overrides(monkeypatch: pytest.MonkeyPatch):
             self.updated = True
             return self.get_settings()
 
+        def is_file_path_allowed(self, _path: str) -> bool:
+            return True
+
     fake_service = _FakeNotificationService()
     monkeypatch.setattr(monitoring_mod, "get_notification_service", lambda: fake_service)
     return app, fake_service
@@ -72,4 +84,20 @@ def test_notification_settings_rejects_empty_file(monkeypatch: pytest.MonkeyPatc
     assert resp.status_code == 400
     detail = resp.json().get("detail", "")
     assert "file" in detail
+    assert fake_service.updated is False
+
+
+def test_notification_settings_rejects_disallowed_file_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    app, fake_service = _build_app_with_overrides(monkeypatch)
+    fake_service.is_file_path_allowed = lambda _path: False  # type: ignore[method-assign]
+
+    with TestClient(app) as client:
+        resp = client.put(
+            "/api/v1/monitoring/notifications/settings",
+            json={"file": "/etc/passwd"},
+        )
+
+    assert resp.status_code == 400
+    detail = resp.json().get("detail", "")
+    assert "Notification file path" in detail
     assert fake_service.updated is False

--- a/tldw_Server_API/tests/Monitoring/test_notification_service.py
+++ b/tldw_Server_API/tests/Monitoring/test_notification_service.py
@@ -3,6 +3,7 @@ import json
 import builtins
 from pathlib import Path
 
+import pytest
 from tenacity import Future, RetryError
 
 import tldw_Server_API.app.core.Monitoring.notification_service as notification_service
@@ -137,6 +138,58 @@ def test_notification_splits_email_recipients(monkeypatch):
     assert sent["from"] == "sender@example.com"
 
 
+def test_notification_send_email_fails_closed_when_starttls_fails(monkeypatch):
+    monkeypatch.setenv("MONITORING_NOTIFY_SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("MONITORING_NOTIFY_EMAIL_TO", "a@example.com")
+    monkeypatch.setenv("MONITORING_NOTIFY_EMAIL_FROM", "sender@example.com")
+    monkeypatch.setenv("MONITORING_NOTIFY_SMTP_STARTTLS", "true")
+
+    sent: dict[str, object] = {}
+
+    class _FakeSMTP:
+        def __init__(self, host, port, timeout=None):
+            sent["host"] = host
+            sent["port"] = port
+            sent["timeout"] = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def starttls(self):
+            sent["starttls"] = True
+            raise notification_service.smtplib.SMTPException("tls unavailable")
+
+        def login(self, user, password):
+            sent["login"] = (user, password)
+
+        def sendmail(self, from_addr, to_addrs, msg):
+            sent["sendmail"] = True
+
+    monkeypatch.setattr(notification_service.smtplib, "SMTP", _FakeSMTP)
+
+    svc = NotificationService()
+    alert = TopicAlert(
+        user_id="u",
+        scope_type="user",
+        scope_id="u",
+        source="chat.input",
+        watchlist_id="w",
+        rule_category="adult",
+        rule_severity="critical",
+        pattern="nsfw",
+        text_snippet="...nsfw...",
+    )
+
+    with pytest.raises(RuntimeError, match="SMTP STARTTLS failed"):
+        svc._send_email(alert)
+
+    assert sent["starttls"] is True
+    assert "sendmail" not in sent
+
+
 def test_notification_update_settings_normalizes_relative_file(tmp_path, monkeypatch):
 
 
@@ -152,6 +205,62 @@ def test_notification_update_settings_normalizes_relative_file(tmp_path, monkeyp
     assert svc.file_path == str(expected)
     assert updated["file"] == str(expected)
     assert expected.parent.exists()
+
+
+def test_notify_generic_uses_single_delivery_worker(monkeypatch, tmp_path):
+    svc = NotificationService()
+    svc.enabled = True
+    svc.min_severity = "info"
+    svc.file_path = str(tmp_path / "notifications.jsonl")
+    svc.webhook_url = "https://example.com/hook"
+
+    created_threads: list[object] = []
+
+    class _FakeThread:
+        def __init__(self, *, target=None, args=(), daemon=None):  # noqa: ANN001, ANN002
+            _ = (args, daemon)
+            created_threads.append(target)
+
+        def start(self) -> None:
+            return None
+
+    monkeypatch.setattr(notification_service.threading, "Thread", _FakeThread)
+
+    for _ in range(5):
+        assert svc.notify_generic(
+            {"type": "guardian_alert", "severity": "warning", "user_id": "u1"}
+        ) == "logged"
+
+    assert len(created_threads) == 1
+
+
+def test_digest_buffer_is_capped_per_recipient(monkeypatch):
+    monkeypatch.setenv("MONITORING_NOTIFY_MAX_DIGEST_ITEMS_PER_RECIPIENT", "2")
+    svc = NotificationService()
+    svc.enabled = True
+    svc.min_severity = "info"
+    svc.digest_mode = "hourly"
+    delivered: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        svc,
+        "notify_generic",
+        lambda payload: delivered.append(payload) or "logged",
+    )
+
+    for idx in range(3):
+        assert svc.notify_or_batch(
+            {
+                "type": "guardian_alert",
+                "severity": "info",
+                "user_id": "u1",
+                "idx": idx,
+            }
+        ) == "batched"
+
+    assert svc.get_pending_digest_count("u1") == 2
+    assert svc.flush_digest("u1") == 2
+    assert [item["idx"] for item in delivered[0]["items"]] == [1, 2]
 
 
 def test_notification_update_settings_file_failure_log_is_sanitized(tmp_path, monkeypatch):
@@ -386,10 +495,13 @@ def test_notify_generic_only_schedules_webhook_path(monkeypatch, tmp_path):
     result = svc.notify_generic({"type": "guardian_alert", "severity": "warning", "user_id": "u1"})
 
     assert result == "logged"
-    assert svc._send_webhook_safe in targets
-    assert svc._send_email_safe not in targets
+    assert targets == [svc._delivery_worker]
+    queued = list(svc._delivery_queue.queue)
+    assert len(queued) == 1
+    assert queued[0][0] == "webhook"
 
-def test_notify_generic_webhook_thread_failure_log_is_sanitized(monkeypatch, tmp_path):
+
+def test_notify_generic_webhook_enqueue_failure_log_is_sanitized(monkeypatch, tmp_path):
     svc = NotificationService()
     svc.enabled = True
     svc.min_severity = "info"
@@ -411,12 +523,12 @@ def test_notify_generic_webhook_thread_failure_log_is_sanitized(monkeypatch, tmp
         notification_service.logger.remove(sink_id)
 
     assert result == "logged"
-    assert any("Webhook thread start failed" in message for message in messages)
+    assert any("Webhook delivery enqueue failed" in message for message in messages)
     assert secret_thread_detail not in "\n".join(messages)
     assert "private-webhook-dispatch" not in "\n".join(messages)
 
 
-def test_notify_webhook_thread_failure_log_is_sanitized(monkeypatch, tmp_path):
+def test_notify_webhook_enqueue_failure_log_is_sanitized(monkeypatch, tmp_path):
     svc = NotificationService()
     svc.enabled = True
     svc.min_severity = "info"
@@ -450,13 +562,13 @@ def test_notify_webhook_thread_failure_log_is_sanitized(monkeypatch, tmp_path):
         notification_service.logger.remove(sink_id)
 
     assert result == "logged"
-    assert any("Webhook thread start failed" in message for message in messages)
+    assert any("Webhook delivery enqueue failed" in message for message in messages)
     joined = "\n".join(messages)
     assert secret_thread_detail not in joined
     assert "private-topic-webhook-dispatch" not in joined
 
 
-def test_notify_email_thread_failure_log_is_sanitized(monkeypatch, tmp_path):
+def test_notify_email_enqueue_failure_log_is_sanitized(monkeypatch, tmp_path):
     svc = NotificationService()
     svc.enabled = True
     svc.min_severity = "info"
@@ -492,7 +604,7 @@ def test_notify_email_thread_failure_log_is_sanitized(monkeypatch, tmp_path):
         notification_service.logger.remove(sink_id)
 
     assert result == "logged"
-    assert any("Email thread start failed" in message for message in messages)
+    assert any("Email delivery enqueue failed" in message for message in messages)
     joined = "\n".join(messages)
     assert secret_thread_detail not in joined
     assert "private-topic-email-dispatch" not in joined

--- a/tldw_Server_API/tests/Monitoring/test_topic_monitoring.py
+++ b/tldw_Server_API/tests/Monitoring/test_topic_monitoring.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 from loguru import logger
 
+from tldw_Server_API.app.core.Character_Chat.constants import MAX_REGEX_LENGTH
 from tldw_Server_API.app.core.Monitoring.topic_monitoring_service import (
     TopicMonitoringService,
     get_topic_monitoring_service,
@@ -91,6 +92,44 @@ def test_topic_monitoring_regex_pattern_with_flags(tmp_path, monkeypatch):
     db = TopicMonitoringDB(db_path=str(db_file))
     items = db.list_alerts(user_id="u1")
     assert any((it.get("pattern") or "") == "badword" for it in items)
+
+
+def test_topic_monitoring_regex_uses_shared_safety_validator(tmp_path, monkeypatch):
+    import tldw_Server_API.app.core.Monitoring.topic_monitoring_service as tms
+
+    db_file = tmp_path / "alerts.db"
+    monkeypatch.setenv("MONITORING_ALERTS_DB", str(db_file))
+    monkeypatch.setenv("MONITORING_ENABLED", "true")
+    wl_file = tmp_path / "watchlists.json"
+    wl_file.write_text(json.dumps({"watchlists": []}), encoding="utf-8")
+    monkeypatch.setenv("MONITORING_WATCHLISTS_FILE", str(wl_file))
+    monkeypatch.setattr(tms, "validate_regex_safety", lambda _pattern: (False, "blocked"), raising=False)
+
+    _reset_topic_monitoring_service()
+    svc = get_topic_monitoring_service()
+    svc.reload()
+
+    wl = Watchlist(
+        name="Unsafe Regex WL",
+        description="Validator should reject",
+        enabled=True,
+        scope_type="user",
+        scope_id="u1",
+        rules=[WatchlistRule(pattern="/badword/i", category="custom", severity="warning")],
+    )
+    svc.upsert_watchlist(wl)
+
+    count = svc.evaluate_and_alert(user_id="u1", text="BADWORD here", source="chat.input")
+
+    assert count == 0
+    db = TopicMonitoringDB(db_path=str(db_file))
+    assert db.list_alerts(user_id="u1") == []
+
+
+def test_topic_monitoring_regex_uses_shared_length_limit():
+    expr = "a" * (MAX_REGEX_LENGTH + 1)
+
+    assert TopicMonitoringService._is_regex_dangerous(expr) is True
 
 
 def test_topic_monitoring_skips_empty_pattern(tmp_path, monkeypatch):
@@ -392,6 +431,31 @@ def test_list_alerts_without_user_id_returns_all(tmp_path: Path) -> None:
     user_items = db.list_alerts(user_id="u1")
     assert len(user_items) == 1
     assert user_items[0].get("user_id") == "u1"
+
+
+def test_insert_alert_if_not_duplicate_keeps_check_and_insert_atomic(tmp_path: Path) -> None:
+    db = TopicMonitoringDB(db_path=str(tmp_path / "alerts.db"))
+    alert = TopicAlert(
+        user_id="u1",
+        scope_type="user",
+        scope_id="u1",
+        source="chat.input",
+        watchlist_id="w1",
+        rule_id="r1",
+        rule_category="test",
+        rule_severity="warning",
+        pattern="needle",
+        text_snippet="needle",
+    )
+
+    first_id = db.insert_alert_if_not_duplicate(alert, window_seconds=300)
+    second_id = db.insert_alert_if_not_duplicate(alert, window_seconds=300)
+
+    assert isinstance(first_id, int)
+    assert second_id is None
+    items = db.list_alerts(user_id="u1")
+    assert len(items) == 1
+    assert items[0]["id"] == first_id
 
 
 def test_topic_monitoring_reload_updates_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Harden Monitoring notification permissions, file sink validation, SMTP STARTTLS failure handling, bounded delivery queues, and digest buffers.
- Move duplicate alert insertion and self-monitoring escalation updates into atomic DB helpers, and resolve partner approval against the owner DB.
- Reuse shared regex safety validation and add focused regression coverage plus TASK-2417 tracking.

## Verification
- python -m py_compile for touched app/test files
- python -m pytest --confcutdir=tldw_Server_API/tests/Monitoring -q tldw_Server_API/tests/Monitoring/test_notification_service.py tldw_Server_API/tests/Monitoring/test_monitoring_notifications_settings.py tldw_Server_API/tests/Monitoring/test_topic_monitoring.py
- python -m pytest --confcutdir=tldw_Server_API/tests/AuthNZ_Unit -q tldw_Server_API/tests/AuthNZ_Unit/test_monitoring_permissions_claims.py
- python -m pytest --confcutdir=tldw_Server_API/tests/Guardian -q tldw_Server_API/tests/Guardian/test_self_monitoring.py tldw_Server_API/tests/Guardian/test_self_monitoring_endpoints.py
- git diff --check
- python -m bandit -r touched Monitoring/API/DB paths -f json -o /tmp/bandit_monitoring_2417_rebased.json: 0 results, 0 errors

## Change summary
Human-authored change summary required before this PR is merge-ready.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Monitoring module to address review findings in TASK-2417, improving safety, correctness, and robustness of notifications and self-monitoring. Tightened permissions, enforced safe notification file sinks and fail-closed SMTP TLS, bounded delivery/digest buffers, and made dedupe/escalation updates atomic.

- **Bug Fixes**
  - Notification mutations/test sends now require `SYSTEM_CONFIGURE`; reads remain gated by `SYSTEM_LOGS`.
  - Rejects notification file paths outside allowed roots; settings API validates paths.
  - SMTP `STARTTLS` failures now fail closed before login/send.
  - Replaced per-notification threads with a bounded delivery queue; capped digest items per recipient.
  - Added atomic `insert_alert_if_not_duplicate` to prevent duplicate alerts; streaming mode unchanged.
  - Partner approval resolves the owner’s Guardian DB without creating storage; endpoint accepts `owner_user_id`.
  - Topic regex compilation uses the shared safety validator and `MAX_REGEX_LENGTH`; unsafe patterns are blocked.

- **Refactors**
  - Moved self-monitoring escalation updates into an atomic DB helper (`update_escalation_for_trigger`).
  - Extracted reusable DB helpers for alert insertion/duplicate checks and non-creating Guardian DB resolution.
  - Refreshed notification service docs/comments for current behavior.

<sup>Written for commit fabc03d3178558c3d9b124baaa68173ed7183233. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

