### PR TITLE
Harden LLM_Calls review findings

### DIFF
--- a/backlog/tasks/task-2425 - Harden-LLM_Calls-review-findings.md
+++ b/backlog/tasks/task-2425 - Harden-LLM_Calls-review-findings.md
@@ -1,0 +1,63 @@
+---
+id: TASK-2425
+title: Harden LLM_Calls review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 14:41'
+updated_date: '2026-06-23 14:58'
+labels:
+  - security
+  - llm
+dependencies: []
+references: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and address validated findings from the current-code review of `tldw_Server_API/app/core/LLM_Calls`. Scope includes safe upstream 400 logging, sync-to-async streaming lifecycle and backpressure, MLX load race handling, Hugging Face GGUF destination validation, and documenting the summarization path-read finding as not currently active after verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Validated findings are backed by focused failing tests before production edits.
+- [x] #2 Upstream 400 logging avoids writing prompt, message, request body, or secret values to logs by default.
+- [x] #3 Sync-to-async streaming bridge applies bounded backpressure and closes sync iterators on cancellation.
+- [x] #4 MLX load failure from an older overlapping load cannot restore over a newer successful load.
+- [x] #5 Hugging Face GGUF downloads reject path traversal or path-component filenames.
+- [x] #6 Targeted tests and Bandit pass for touched scope.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Backlog MCP tools were unavailable and the Backlog CLI failed on stale internal task filename references. The user approved manual task creation as the fallback. Verification result before edits: the summarization arbitrary file-read finding is not active through `analyze()` because the file-reading helper is shadowed by a later `extract_text_from_input()` definition, and the remaining file-reading metadata helper has no callers.
+
+RED verification: focused regression tests failed before implementation for raw upstream 400-body logging, missing bounded stream bridge API, stale MLX session restore after an older failed load, and missing Hugging Face GGUF filename validation.
+
+Implemented safe upstream HTTP error metadata logging, bounded/cancellable `wrap_sync_stream`, OpenAI/Anthropic/Cohere async-stream delegation to the shared bridge, an MLX load generation guard, and GGUF filename validation before destination path construction.
+
+GREEN verification: focused four-test regression run passed with 4 passed and 18 warnings. Broader targeted suite passed with 62 passed and 134 warnings:
+`tldw_Server_API/tests/LLM_Calls/test_llm_streaming_and_security.py`,
+`tldw_Server_API/tests/LLM_Calls/test_mlx_provider.py`,
+`tldw_Server_API/tests/LLM_Calls/test_llm_providers.py::TestHuggingFaceAPI`, and
+`tldw_Server_API/tests/LLM_Adapters/unit/test_adapter_stream_error_normalization.py`.
+
+Bandit verification on touched production files exited 0 with zero findings. `git diff --check` on touched files exited 0.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened the validated `LLM_Calls` review findings. Provider 400 logging now records safe metadata instead of raw request/error bodies, sync-to-async streaming has bounded backpressure and cancellation cleanup, duplicated adapter stream bridges delegate to the shared helper, overlapping MLX load failures cannot restore stale sessions over newer successful loads, and Hugging Face GGUF download filenames are constrained to local `.gguf` filenames without path components.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2425 - Harden-LLM_Calls-review-findings.md
+++ b/backlog/tasks/task-2425 - Harden-LLM_Calls-review-findings.md
@@ -3,13 +3,20 @@ id: TASK-2425
 title: Harden LLM_Calls review findings
 status: Done
 assignee: []
-created_date: '2026-06-23 14:41'
-updated_date: '2026-06-23 14:58'
+created_date: 2026-06-23 14:41
+updated_date: 2026-06-24 04:13
 labels:
-  - security
-  - llm
+- security
+- llm
 dependencies: []
 references: []
+modified_files:
+- tldw_Server_API/app/core/LLM_Calls/streaming.py
+- tldw_Server_API/app/core/LLM_Calls/providers/mlx_provider.py
+- tldw_Server_API/tests/LLM_Calls/test_llm_streaming_and_security.py
+- tldw_Server_API/tests/LLM_Calls/test_llm_providers.py
+- tldw_Server_API/tests/LLM_Calls/test_mlx_provider.py
+- backlog/tasks/task-2425 - Harden-LLM_Calls-review-findings.md
 ---
 
 ## Description
@@ -49,7 +56,7 @@ Bandit verification on touched production files exited 0 with zero findings. `gi
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Hardened the validated `LLM_Calls` review findings. Provider 400 logging now records safe metadata instead of raw request/error bodies, sync-to-async streaming has bounded backpressure and cancellation cleanup, duplicated adapter stream bridges delegate to the shared helper, overlapping MLX load failures cannot restore stale sessions over newer successful loads, and Hugging Face GGUF download filenames are constrained to local `.gguf` filenames without path components.
+Rebased the PR branch onto latest `origin/dev` and addressed the validated PR review comments. The sync-to-async streaming bridge no longer consumes default-executor workers for chunk delivery and now logs iterator close failures at debug level. Superseded MLX loads now emit a distinct `superseded` metric status instead of being counted as successful applied loads. GGUF filename coverage was split into focused invalid and valid scenarios, with new regression tests for stream delivery and MLX metrics.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -61,3 +68,10 @@ Hardened the validated `LLM_Calls` review findings. Provider 400 logging now rec
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Reopened after fresh PR review comments on 2026-06-24. Validated four actionable items: log sync iterator close failures instead of swallowing them, remove default-executor dependency from `wrap_sync_stream`, split GGUF filename tests into focused scenarios, and avoid reporting superseded MLX loads as successful applied loads.
+Addressed fresh PR review comments after rebasing onto latest `origin/dev`. RED focused tests failed before production changes for default-executor stream delivery, swallowed close errors, and superseded MLX success metrics. Implemented async-queue stream delivery with `asyncio.run_coroutine_threadsafe`, debug logging for iterator close failures, superseded MLX load metric status, and split GGUF filename validation tests. GREEN verification: focused review-comment tests passed with 7 passed and 27 warnings; broader targeted suite passed with 68 passed and 149 warnings. Bandit on touched LLM_Calls production files exited 0 with zero findings. `git diff --check` exited 0.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/core/LLM_Calls/error_utils.py
+++ b/tldw_Server_API/app/core/LLM_Calls/error_utils.py
@@ -106,6 +106,35 @@ def _redact_sensitive_text(text: str) -> str:
     return text
 
 
+def _safe_http_error_metadata(body_json: Any = None, body_text: str | None = None) -> dict[str, Any]:
+    """Build log-safe metadata for upstream error payloads without body content."""
+    metadata: dict[str, Any] = {}
+    if isinstance(body_json, dict):
+        metadata["body_shape"] = "object"
+        err_obj = body_json.get("error")
+        if isinstance(err_obj, dict):
+            for key in ("type", "code", "param", "status"):
+                value = err_obj.get(key)
+                if isinstance(value, (str, int, float, bool)):
+                    metadata[f"error_{key}"] = _redact_sensitive_text(str(value))[:160]
+            message = err_obj.get("message")
+            if isinstance(message, str):
+                metadata["error_message_chars"] = len(message)
+        elif isinstance(err_obj, str):
+            metadata["error_chars"] = len(err_obj)
+        for key in ("type", "code", "param", "status"):
+            value = body_json.get(key)
+            if isinstance(value, (str, int, float, bool)) and f"error_{key}" not in metadata:
+                metadata[f"error_{key}"] = _redact_sensitive_text(str(value))[:160]
+        metadata["top_level_key_count"] = len(body_json)
+    elif body_json is not None:
+        metadata["body_shape"] = type(body_json).__name__
+    elif body_text:
+        metadata["body_shape"] = "raw_text"
+        metadata["raw_body_chars"] = len(body_text)
+    return metadata
+
+
 def log_http_400_body(provider: str, exc: Exception, parsed_body: Any = None, max_chars: int = 2000) -> None:
     try:
         status = get_http_status_from_exception(exc)
@@ -134,12 +163,16 @@ def log_http_400_body(provider: str, exc: Exception, parsed_body: Any = None, ma
             body_text = get_http_error_text(exc)
         except _ERROR_UTILS_NONCRITICAL_EXCEPTIONS:
             body_text = None
-    if not body_text:
+    if body_json is None and not body_text:
         return
-    body_text = _redact_sensitive_text(str(body_text))
-    if max_chars is not None and len(body_text) > max_chars:
-        body_text = body_text[:max_chars] + "...(truncated)"
-    logger.warning(f"{provider or 'unknown'}: upstream 400 response body: {body_text}")
+    metadata = _safe_http_error_metadata(body_json, str(body_text) if body_text else None)
+    try:
+        metadata_text = json.dumps(metadata, ensure_ascii=True, sort_keys=True)
+    except _ERROR_UTILS_NONCRITICAL_EXCEPTIONS:
+        metadata_text = "{}"
+    if max_chars is not None and len(metadata_text) > max_chars:
+        metadata_text = metadata_text[:max_chars] + "...(truncated)"
+    logger.warning(f"{provider or 'unknown'}: upstream 400 response metadata: {metadata_text}")
 
 
 def raise_chat_error_from_http(
@@ -173,9 +206,12 @@ def raise_chat_error_from_http(
                 message = parsed_body.get("message") or ""
         if not message:
             message = get_http_error_text(exc)
-        safe_text = _redact_sensitive_text(str(message))
-        if safe_text:
-            logger.error(f"{provider or 'unknown'} HTTP error response (status {status_code}): {repr(safe_text)[:500]}")
+        metadata = _safe_http_error_metadata(parsed_body, str(message) if message else None)
+        try:
+            metadata_text = json.dumps(metadata, ensure_ascii=True, sort_keys=True)
+        except _ERROR_UTILS_NONCRITICAL_EXCEPTIONS:
+            metadata_text = "{}"
+        logger.error(f"{provider or 'unknown'} HTTP error response (status {status_code}) metadata: {metadata_text}")
     else:
         logger.error(f"{provider or 'unknown'} HTTP error with no response payload: {exc}")
         message = get_http_error_text(exc)

--- a/tldw_Server_API/app/core/LLM_Calls/huggingface_api.py
+++ b/tldw_Server_API/app/core/LLM_Calls/huggingface_api.py
@@ -47,6 +47,20 @@ _HF_API_NONCRITICAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
 ) + _HF_HTTP_EXCEPTIONS
 
 
+def _validate_gguf_model_filename(model_file: str) -> str:
+    filename = str(model_file or "").strip()
+    if (
+        not filename
+        or "/" in filename
+        or "\\" in filename
+        or "\x00" in filename
+        or Path(filename).name != filename
+        or not filename.lower().endswith(".gguf")
+    ):
+        raise ValueError("model_file must be a GGUF filename without path components")
+    return filename
+
+
 async def _async_retry_sleep(delay: float, attempt: int) -> None:
     if delay > 0:
         await asyncio.sleep(delay * (attempt + 1))
@@ -520,7 +534,11 @@ async def download_gguf_model(
     """
     api = HuggingFaceAPI()
 
-    destination = destination_dir / model_file
+    model_file = _validate_gguf_model_filename(model_file)
+    destination_root = Path(destination_dir).resolve()
+    destination = (destination_root / model_file).resolve()
+    if destination.parent != destination_root:
+        raise ValueError("model_file destination must remain inside destination_dir")
 
     last_pct = {"v": -10.0}
 

--- a/tldw_Server_API/app/core/LLM_Calls/providers/anthropic_adapter.py
+++ b/tldw_Server_API/app/core/LLM_Calls/providers/anthropic_adapter.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-import threading
 from collections.abc import AsyncIterator, Iterable
 from typing import Any
 
@@ -20,6 +19,7 @@ from tldw_Server_API.app.core.LLM_Calls.sse import (
     sse_data,
     sse_done,
 )
+from tldw_Server_API.app.core.LLM_Calls.streaming import wrap_sync_stream
 from tldw_Server_API.app.core.testing import is_truthy
 
 from .base import ChatProvider
@@ -563,41 +563,8 @@ class AnthropicAdapter(ChatProvider):
         return await asyncio.to_thread(self.chat, request, timeout=timeout)
 
     async def astream(self, request: dict[str, Any], *, timeout: float | None = None) -> AsyncIterator[str]:
-        gen = self.stream(request, timeout=timeout)
-        loop = asyncio.get_running_loop()
-        queue: asyncio.Queue[Any] = asyncio.Queue()
-        sentinel = object()
-        stop_event = threading.Event()
-
-        def _worker() -> None:
-            try:
-                for item in gen:
-                    if stop_event.is_set():
-                        break
-                    loop.call_soon_threadsafe(queue.put_nowait, item)
-            except Exception as exc:
-                loop.call_soon_threadsafe(queue.put_nowait, exc)
-            finally:
-                try:
-                    if hasattr(gen, "close"):
-                        gen.close()
-                except _ANTHROPIC_NONCRITICAL_EXCEPTIONS:
-                    pass
-                loop.call_soon_threadsafe(queue.put_nowait, sentinel)
-
-        thread = threading.Thread(target=_worker, daemon=True)
-        thread.start()
-
-        try:
-            while True:
-                item = await queue.get()
-                if item is sentinel:
-                    break
-                if isinstance(item, Exception):
-                    raise item
-                yield item
-        finally:
-            stop_event.set()
+        async for item in wrap_sync_stream(self.stream(request, timeout=timeout)):
+            yield item
 
     def normalize_error(self, exc: Exception):  # type: ignore[override]
         from tldw_Server_API.app.core.LLM_Calls.error_utils import (

--- a/tldw_Server_API/app/core/LLM_Calls/providers/cohere_adapter.py
+++ b/tldw_Server_API/app/core/LLM_Calls/providers/cohere_adapter.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
-import threading
 import time
 from collections.abc import AsyncIterator, Iterable
 from typing import Any
@@ -38,6 +37,7 @@ from tldw_Server_API.app.core.LLM_Calls.sse import (
     sse_data,
     sse_done,
 )
+from tldw_Server_API.app.core.LLM_Calls.streaming import wrap_sync_stream
 from tldw_Server_API.app.core.Utils.Utils import logging
 
 from .base import ChatProvider
@@ -488,38 +488,5 @@ class CohereAdapter(ChatProvider):
         return await asyncio.to_thread(self.chat, request, timeout=timeout)
 
     async def astream(self, request: dict[str, Any], *, timeout: float | None = None) -> AsyncIterator[str]:
-        gen = self.stream(request, timeout=timeout)
-        loop = asyncio.get_running_loop()
-        queue: asyncio.Queue[Any] = asyncio.Queue()
-        sentinel = object()
-        stop_event = threading.Event()
-
-        def _worker() -> None:
-            try:
-                for item in gen:
-                    if stop_event.is_set():
-                        break
-                    loop.call_soon_threadsafe(queue.put_nowait, item)
-            except Exception as exc:
-                loop.call_soon_threadsafe(queue.put_nowait, exc)
-            finally:
-                try:
-                    if hasattr(gen, "close"):
-                        gen.close()
-                except Exception as stream_close_error:
-                    logger.debug("Cohere streaming generator close failed", exc_info=stream_close_error)
-                loop.call_soon_threadsafe(queue.put_nowait, sentinel)
-
-        thread = threading.Thread(target=_worker, daemon=True)
-        thread.start()
-
-        try:
-            while True:
-                item = await queue.get()
-                if item is sentinel:
-                    break
-                if isinstance(item, Exception):
-                    raise item
-                yield item
-        finally:
-            stop_event.set()
+        async for item in wrap_sync_stream(self.stream(request, timeout=timeout)):
+            yield item

--- a/tldw_Server_API/app/core/LLM_Calls/providers/mlx_provider.py
+++ b/tldw_Server_API/app/core/LLM_Calls/providers/mlx_provider.py
@@ -138,6 +138,7 @@ class MLXSessionRegistry:
         self._session: MLXSession | None = None
         self._inflight: int = 0
         self._metrics_registered = False
+        self._load_generation: int = 0
 
     def _set_concurrency(self, max_concurrent: int) -> None:
         max_concurrent = max(1, int(max_concurrent))
@@ -216,8 +217,11 @@ class MLXSessionRegistry:
                     settings[k] = v
 
         prev_session: MLXSession | None = None
+        load_generation: int
         with self._lock:
             prev_session = self._session
+            self._load_generation += 1
+            load_generation = self._load_generation
 
         mlx_mod = self._import_mlx()
         load_fn = getattr(mlx_mod, "load", None)
@@ -264,8 +268,9 @@ class MLXSessionRegistry:
                     raise
 
             with self._lock:
-                self._session = session
-                self._set_concurrency(settings.get("max_concurrent", 1))
+                if load_generation == self._load_generation:
+                    self._session = session
+                    self._set_concurrency(settings.get("max_concurrent", 1))
             try:
                 duration = time.time() - start
                 observe_histogram(
@@ -283,7 +288,8 @@ class MLXSessionRegistry:
         except Exception as exc:
             # Restore prior session on failure
             with self._lock:
-                self._session = prev_session
+                if load_generation == self._load_generation:
+                    self._session = prev_session
             try:
                 duration = time.time() - start
                 observe_histogram(

--- a/tldw_Server_API/app/core/LLM_Calls/providers/mlx_provider.py
+++ b/tldw_Server_API/app/core/LLM_Calls/providers/mlx_provider.py
@@ -267,10 +267,12 @@ class MLXSessionRegistry:
                     # On warmup failure, keep previous model and surface error
                     raise
 
+            applied = False
             with self._lock:
                 if load_generation == self._load_generation:
                     self._session = session
                     self._set_concurrency(settings.get("max_concurrent", 1))
+                    applied = True
             try:
                 duration = time.time() - start
                 observe_histogram(
@@ -278,10 +280,12 @@ class MLXSessionRegistry:
                     duration,
                     labels={"model": model_path},
                 )
-                increment_counter("mlx_load_total", labels={"model": model_path, "status": "success"})
-                set_gauge("mlx_active_sessions", 1.0)
-                set_gauge("mlx_requests_inflight", float(self._inflight))
-                set_gauge("mlx_queue_depth", 0.0)
+                status = "success" if applied else "superseded"
+                increment_counter("mlx_load_total", labels={"model": model_path, "status": status})
+                if applied:
+                    set_gauge("mlx_active_sessions", 1.0)
+                    set_gauge("mlx_requests_inflight", float(self._inflight))
+                    set_gauge("mlx_queue_depth", 0.0)
             except _MLX_NONCRITICAL_EXCEPTIONS:
                 pass
             return self.status()

--- a/tldw_Server_API/app/core/LLM_Calls/providers/openai_adapter.py
+++ b/tldw_Server_API/app/core/LLM_Calls/providers/openai_adapter.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import threading
 from collections.abc import AsyncIterator, Iterable
 from typing import Any
 
@@ -27,6 +26,7 @@ from tldw_Server_API.app.core.LLM_Calls.sse import (
     normalize_provider_line,
     sse_done,
 )
+from tldw_Server_API.app.core.LLM_Calls.streaming import wrap_sync_stream
 
 from .base import ChatProvider
 
@@ -336,41 +336,8 @@ class OpenAIAdapter(ChatProvider):
         return await asyncio.to_thread(self.chat, request, timeout=timeout)
 
     async def astream(self, request: dict[str, Any], *, timeout: float | None = None) -> AsyncIterator[str]:
-        gen = self.stream(request, timeout=timeout)
-        loop = asyncio.get_running_loop()
-        queue: asyncio.Queue[Any] = asyncio.Queue()
-        sentinel = object()
-        stop_event = threading.Event()
-
-        def _worker() -> None:
-            try:
-                for item in gen:
-                    if stop_event.is_set():
-                        break
-                    loop.call_soon_threadsafe(queue.put_nowait, item)
-            except Exception as exc:
-                loop.call_soon_threadsafe(queue.put_nowait, exc)
-            finally:
-                try:
-                    if hasattr(gen, "close"):
-                        gen.close()
-                except _OPENAI_ADAPTER_NONCRITICAL_EXCEPTIONS:
-                    pass
-                loop.call_soon_threadsafe(queue.put_nowait, sentinel)
-
-        thread = threading.Thread(target=_worker, daemon=True)
-        thread.start()
-
-        try:
-            while True:
-                item = await queue.get()
-                if item is sentinel:
-                    break
-                if isinstance(item, Exception):
-                    raise item
-                yield item
-        finally:
-            stop_event.set()
+        async for item in wrap_sync_stream(self.stream(request, timeout=timeout)):
+            yield item
 
     def normalize_error(self, exc: Exception):  # type: ignore[override]
         from tldw_Server_API.app.core.LLM_Calls.error_utils import (

--- a/tldw_Server_API/app/core/LLM_Calls/streaming.py
+++ b/tldw_Server_API/app/core/LLM_Calls/streaming.py
@@ -8,11 +8,13 @@ final sentinel using sse_done()/finalize_stream to avoid duplicates.
 """
 
 import asyncio
+import concurrent.futures
 import os
-import queue as thread_queue
 import threading
 from collections.abc import AsyncIterator, Iterable, Iterator
 from typing import Any, Callable, Optional
+
+from loguru import logger
 
 from tldw_Server_API.app.core.http_client import RetryPolicy, astream_sse
 from tldw_Server_API.app.core.LLM_Calls.error_utils import is_chunked_encoding_error
@@ -116,7 +118,8 @@ async def wrap_sync_stream(
 ) -> AsyncIterator[str]:
     """Bridge a sync generator into an async iterator without blocking the event loop."""
     max_queue_size = max(1, int(max_queue_size or _DEFAULT_SYNC_STREAM_QUEUE_SIZE))
-    queue: thread_queue.Queue[Any] = thread_queue.Queue(maxsize=max_queue_size)
+    loop = asyncio.get_running_loop()
+    queue: asyncio.Queue[Any] = asyncio.Queue(maxsize=max_queue_size)
     sentinel = object()
     stop_event = threading.Event()
     close_lock = threading.Lock()
@@ -133,28 +136,37 @@ async def wrap_sync_stream(
             if callable(close_fn):
                 close_fn()
         except Exception as close_error:
-            _ = close_error
+            logger.debug("Sync stream iterator close failed during cleanup: {}", close_error)
 
     def _put_item(item: Any) -> bool:
-        while not stop_event.is_set():
+        if stop_event.is_set():
+            return False
+        try:
+            put_future = asyncio.run_coroutine_threadsafe(queue.put(item), loop)
+        except RuntimeError as queue_error:
+            if not stop_event.is_set():
+                logger.debug("Sync stream queue put failed before scheduling: {}", queue_error)
+            return False
+
+        while True:
+            if stop_event.is_set():
+                put_future.cancel()
+                return False
             try:
-                queue.put(item, timeout=_SYNC_STREAM_QUEUE_TIMEOUT_SECONDS)
+                put_future.result(timeout=_SYNC_STREAM_QUEUE_TIMEOUT_SECONDS)
                 return True
-            except thread_queue.Full:
+            except concurrent.futures.TimeoutError:
                 continue
+            except concurrent.futures.CancelledError:
+                return False
+            except Exception as put_error:
+                if not stop_event.is_set():
+                    logger.debug("Sync stream queue put failed: {}", put_error)
+                return False
         return False
 
     def _put_sentinel() -> None:
-        while True:
-            try:
-                queue.put(sentinel, timeout=_SYNC_STREAM_QUEUE_TIMEOUT_SECONDS)
-                return
-            except thread_queue.Full:
-                if stop_event.is_set():
-                    try:
-                        queue.get_nowait()
-                    except thread_queue.Empty:
-                        pass
+        _put_item(sentinel)
 
     def _worker() -> None:
         try:
@@ -172,22 +184,9 @@ async def wrap_sync_stream(
     thread = threading.Thread(target=_worker, daemon=True)
     thread.start()
 
-    def _get_next_item() -> Any:
-        while True:
-            if stop_event.is_set():
-                try:
-                    return queue.get_nowait()
-                except thread_queue.Empty:
-                    return sentinel
-            try:
-                return queue.get(timeout=_SYNC_STREAM_QUEUE_TIMEOUT_SECONDS)
-            except thread_queue.Empty:
-                if not thread.is_alive():
-                    return sentinel
-
     try:
         while True:
-            item = await asyncio.to_thread(_get_next_item)
+            item = await queue.get()
             if item is sentinel:
                 break
             if isinstance(item, Exception):

--- a/tldw_Server_API/app/core/LLM_Calls/streaming.py
+++ b/tldw_Server_API/app/core/LLM_Calls/streaming.py
@@ -9,6 +9,7 @@ final sentinel using sse_done()/finalize_stream to avoid duplicates.
 
 import asyncio
 import os
+import queue as thread_queue
 import threading
 from collections.abc import AsyncIterator, Iterable, Iterator
 from typing import Any, Callable, Optional
@@ -17,6 +18,10 @@ from tldw_Server_API.app.core.http_client import RetryPolicy, astream_sse
 from tldw_Server_API.app.core.LLM_Calls.error_utils import is_chunked_encoding_error
 
 from .sse import is_done_line, normalize_provider_line, sse_data
+
+
+_DEFAULT_SYNC_STREAM_QUEUE_SIZE = 16
+_SYNC_STREAM_QUEUE_TIMEOUT_SECONDS = 0.05
 
 
 def iter_sse_lines_requests(
@@ -104,36 +109,85 @@ async def aiter_sse_lines_httpx(
         yield sse_data({"error": {"message": f"Stream iteration error: {str(e_stream)}", "type": f"{provider}_stream_error"}})
 
 
-async def wrap_sync_stream(sync_iter: Iterable[str]) -> AsyncIterator[str]:
+async def wrap_sync_stream(
+    sync_iter: Iterable[str],
+    *,
+    max_queue_size: int = _DEFAULT_SYNC_STREAM_QUEUE_SIZE,
+) -> AsyncIterator[str]:
     """Bridge a sync generator into an async iterator without blocking the event loop."""
-    loop = asyncio.get_running_loop()
-    queue: asyncio.Queue[Any] = asyncio.Queue()
+    max_queue_size = max(1, int(max_queue_size or _DEFAULT_SYNC_STREAM_QUEUE_SIZE))
+    queue: thread_queue.Queue[Any] = thread_queue.Queue(maxsize=max_queue_size)
     sentinel = object()
     stop_event = threading.Event()
+    close_lock = threading.Lock()
+    closed = False
+
+    def _close_sync_iter() -> None:
+        nonlocal closed
+        with close_lock:
+            if closed:
+                return
+            closed = True
+        try:
+            close_fn = getattr(sync_iter, "close", None)
+            if callable(close_fn):
+                close_fn()
+        except Exception as close_error:
+            _ = close_error
+
+    def _put_item(item: Any) -> bool:
+        while not stop_event.is_set():
+            try:
+                queue.put(item, timeout=_SYNC_STREAM_QUEUE_TIMEOUT_SECONDS)
+                return True
+            except thread_queue.Full:
+                continue
+        return False
+
+    def _put_sentinel() -> None:
+        while True:
+            try:
+                queue.put(sentinel, timeout=_SYNC_STREAM_QUEUE_TIMEOUT_SECONDS)
+                return
+            except thread_queue.Full:
+                if stop_event.is_set():
+                    try:
+                        queue.get_nowait()
+                    except thread_queue.Empty:
+                        pass
 
     def _worker() -> None:
         try:
             for item in sync_iter:
                 if stop_event.is_set():
                     break
-                loop.call_soon_threadsafe(queue.put_nowait, item)
+                if not _put_item(item):
+                    break
         except Exception as exc:
-            loop.call_soon_threadsafe(queue.put_nowait, exc)
+            _put_item(exc)
         finally:
-            try:
-                close_fn = getattr(sync_iter, "close", None)
-                if callable(close_fn):
-                    close_fn()
-            except Exception as close_error:
-                _ = close_error  # best-effort sync iterator close before final sentinel
-            loop.call_soon_threadsafe(queue.put_nowait, sentinel)
+            _close_sync_iter()
+            _put_sentinel()
 
     thread = threading.Thread(target=_worker, daemon=True)
     thread.start()
 
+    def _get_next_item() -> Any:
+        while True:
+            if stop_event.is_set():
+                try:
+                    return queue.get_nowait()
+                except thread_queue.Empty:
+                    return sentinel
+            try:
+                return queue.get(timeout=_SYNC_STREAM_QUEUE_TIMEOUT_SECONDS)
+            except thread_queue.Empty:
+                if not thread.is_alive():
+                    return sentinel
+
     try:
         while True:
-            item = await queue.get()
+            item = await asyncio.to_thread(_get_next_item)
             if item is sentinel:
                 break
             if isinstance(item, Exception):
@@ -141,6 +195,7 @@ async def wrap_sync_stream(sync_iter: Iterable[str]) -> AsyncIterator[str]:
             yield item
     finally:
         stop_event.set()
+        _close_sync_iter()
 
 
 async def aiter_normalized_sse(

--- a/tldw_Server_API/tests/LLM_Calls/test_llm_providers.py
+++ b/tldw_Server_API/tests/LLM_Calls/test_llm_providers.py
@@ -766,6 +766,29 @@ class TestHuggingFaceAPI:
             assert progress_calls[-1] == (1000, 1000)
 
     @pytest.mark.asyncio
+    async def test_download_gguf_model_rejects_path_component_filename(self, monkeypatch, tmp_path):
+        calls = []
+
+        async def fake_download_file(self, **kwargs):
+            calls.append(kwargs)
+            return True
+
+        monkeypatch.setattr(HuggingFaceAPI, "download_file", fake_download_file)
+
+        with pytest.raises(ValueError):
+            await download_gguf_model("TheBloke/Test-GGUF", "../evil.gguf", tmp_path)
+        with pytest.raises(ValueError):
+            await download_gguf_model("TheBloke/Test-GGUF", "nested/model.gguf", tmp_path)
+        with pytest.raises(ValueError):
+            await download_gguf_model("TheBloke/Test-GGUF", "model.bin", tmp_path)
+
+        assert calls == []
+
+        assert await download_gguf_model("TheBloke/Test-GGUF", "model.Q4_K_M.gguf", tmp_path)
+        assert calls[0]["filename"] == "model.Q4_K_M.gguf"
+        assert calls[0]["destination"] == tmp_path / "model.Q4_K_M.gguf"
+
+    @pytest.mark.asyncio
     async def test_find_best_gguf_model(self):
         """Test finding best GGUF model utility."""
         mock_models = [

--- a/tldw_Server_API/tests/LLM_Calls/test_llm_providers.py
+++ b/tldw_Server_API/tests/LLM_Calls/test_llm_providers.py
@@ -766,7 +766,15 @@ class TestHuggingFaceAPI:
             assert progress_calls[-1] == (1000, 1000)
 
     @pytest.mark.asyncio
-    async def test_download_gguf_model_rejects_path_component_filename(self, monkeypatch, tmp_path):
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "../evil.gguf",
+            "nested/model.gguf",
+            "model.bin",
+        ],
+    )
+    async def test_download_gguf_model_rejects_invalid_filename(self, monkeypatch, tmp_path, filename):
         calls = []
 
         async def fake_download_file(self, **kwargs):
@@ -776,13 +784,19 @@ class TestHuggingFaceAPI:
         monkeypatch.setattr(HuggingFaceAPI, "download_file", fake_download_file)
 
         with pytest.raises(ValueError):
-            await download_gguf_model("TheBloke/Test-GGUF", "../evil.gguf", tmp_path)
-        with pytest.raises(ValueError):
-            await download_gguf_model("TheBloke/Test-GGUF", "nested/model.gguf", tmp_path)
-        with pytest.raises(ValueError):
-            await download_gguf_model("TheBloke/Test-GGUF", "model.bin", tmp_path)
+            await download_gguf_model("TheBloke/Test-GGUF", filename, tmp_path)
 
         assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_download_gguf_model_accepts_simple_gguf_filename(self, monkeypatch, tmp_path):
+        calls = []
+
+        async def fake_download_file(self, **kwargs):
+            calls.append(kwargs)
+            return True
+
+        monkeypatch.setattr(HuggingFaceAPI, "download_file", fake_download_file)
 
         assert await download_gguf_model("TheBloke/Test-GGUF", "model.Q4_K_M.gguf", tmp_path)
         assert calls[0]["filename"] == "model.Q4_K_M.gguf"

--- a/tldw_Server_API/tests/LLM_Calls/test_llm_streaming_and_security.py
+++ b/tldw_Server_API/tests/LLM_Calls/test_llm_streaming_and_security.py
@@ -1,4 +1,7 @@
+import asyncio
 import json
+
+import pytest
 
 
 def test_google_stream_emits_done_once(monkeypatch):
@@ -119,3 +122,90 @@ def test_huggingface_headers_are_masked(monkeypatch):
     assert "HuggingFace headers:" in joined
     assert secret not in joined
     assert "***" in joined
+
+
+def test_http_400_logging_omits_prompt_and_request_body(monkeypatch):
+    from tldw_Server_API.app.core.Chat.Chat_Deps import ChatBadRequestError
+    from tldw_Server_API.app.core.LLM_Calls import error_utils
+
+    secret_prompt = "SECRET_PROMPT_CONTENT"
+    secret_key = "sk-secret-should-not-log"
+    body = {
+        "error": {
+            "message": f"Invalid request for prompt {secret_prompt}",
+            "type": "invalid_request_error",
+            "code": "bad_request",
+        },
+        "messages": [{"role": "user", "content": secret_prompt}],
+        "api_key": secret_key,
+    }
+
+    class _Resp:
+        status_code = 400
+        text = json.dumps(body)
+
+        def json(self):
+            return body
+
+    class _Exc(Exception):
+        response = _Resp()
+
+    warnings = []
+    errors = []
+
+    class _Logger:
+        def warning(self, msg):
+            warnings.append(str(msg))
+
+        def error(self, msg):
+            errors.append(str(msg))
+
+    monkeypatch.setattr(error_utils, "logger", _Logger())
+
+    exc = _Exc("upstream 400")
+    error_utils.log_http_400_body("openai", exc)
+    with pytest.raises(ChatBadRequestError):
+        error_utils.raise_chat_error_from_http("openai", exc)
+
+    rendered_logs = "\n".join(warnings + errors)
+    assert secret_prompt not in rendered_logs
+    assert secret_key not in rendered_logs
+    assert "messages" not in rendered_logs
+    assert "invalid_request_error" in rendered_logs
+
+
+@pytest.mark.asyncio
+async def test_wrap_sync_stream_applies_backpressure_and_closes_on_cancel():
+    from tldw_Server_API.app.core.LLM_Calls.streaming import wrap_sync_stream
+
+    class _FastIterator:
+        def __init__(self):
+            self.yielded = 0
+            self.closed = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self.closed:
+                raise StopIteration
+            self.yielded += 1
+            return f"chunk-{self.yielded}"
+
+        def close(self):
+            self.closed = True
+
+    source = _FastIterator()
+    stream = wrap_sync_stream(source, max_queue_size=1)
+
+    assert await stream.__anext__() == "chunk-1"
+    await asyncio.sleep(0.1)
+
+    assert source.yielded <= 3
+    await stream.aclose()
+    await asyncio.sleep(0.1)
+
+    yielded_after_close = source.yielded
+    assert source.closed is True
+    await asyncio.sleep(0.1)
+    assert source.yielded == yielded_after_close

--- a/tldw_Server_API/tests/LLM_Calls/test_llm_streaming_and_security.py
+++ b/tldw_Server_API/tests/LLM_Calls/test_llm_streaming_and_security.py
@@ -209,3 +209,54 @@ async def test_wrap_sync_stream_applies_backpressure_and_closes_on_cancel():
     assert source.closed is True
     await asyncio.sleep(0.1)
     assert source.yielded == yielded_after_close
+
+
+@pytest.mark.asyncio
+async def test_wrap_sync_stream_does_not_use_default_executor_for_delivery(monkeypatch):
+    from tldw_Server_API.app.core.LLM_Calls import streaming
+
+    async def fail_to_thread(*args, **kwargs):
+        raise AssertionError("wrap_sync_stream should not use the default executor for chunk delivery")
+
+    monkeypatch.setattr(streaming.asyncio, "to_thread", fail_to_thread)
+
+    chunks = []
+    async for chunk in streaming.wrap_sync_stream(iter(["chunk-1", "chunk-2"]), max_queue_size=1):
+        chunks.append(chunk)
+
+    assert chunks == ["chunk-1", "chunk-2"]
+
+
+@pytest.mark.asyncio
+async def test_wrap_sync_stream_logs_close_errors(monkeypatch):
+    from tldw_Server_API.app.core.LLM_Calls import streaming
+
+    class _ClosingIterator:
+        def __init__(self):
+            self._done = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self._done:
+                raise StopIteration
+            self._done = True
+            return "chunk"
+
+        def close(self):
+            raise RuntimeError("close failed")
+
+    debug_messages = []
+
+    def fake_debug(message, *args, **kwargs):
+        debug_messages.append(str(message).format(*args))
+
+    monkeypatch.setattr(streaming.logger, "debug", fake_debug)
+
+    chunks = []
+    async for chunk in streaming.wrap_sync_stream(_ClosingIterator()):
+        chunks.append(chunk)
+
+    assert chunks == ["chunk"]
+    assert any("close failed" in message for message in debug_messages)

--- a/tldw_Server_API/tests/LLM_Calls/test_mlx_provider.py
+++ b/tldw_Server_API/tests/LLM_Calls/test_mlx_provider.py
@@ -156,6 +156,56 @@ def test_failed_older_load_does_not_restore_over_newer_success(monkeypatch):
     assert reg.status()["model"] == "new"
 
 
+def test_superseded_older_load_records_superseded_metric(monkeypatch):
+    started = threading.Event()
+    release_slow_load = threading.Event()
+
+    class FakeTokenizer:
+        pass
+
+    def load(model_path, **kwargs):
+        if model_path == "slow-old":
+            started.set()
+            assert release_slow_load.wait(timeout=2)
+        return (f"model:{model_path}", FakeTokenizer())
+
+    fake = types.SimpleNamespace(
+        load=load,
+        generate=lambda *args, **kwargs: "ok",
+        generate_stream=lambda *args, **kwargs: iter(["ok"]),
+        embed=lambda *args, **kwargs: [1.0],
+    )
+    monkeypatch.setattr(mp.MLXSessionRegistry, "_import_mlx", lambda self: fake)
+
+    metric_statuses = []
+
+    def capture_counter(name, labels=None):
+        if name == "mlx_load_total":
+            metric_statuses.append((labels or {}).copy())
+
+    monkeypatch.setattr(mp, "increment_counter", capture_counter)
+    monkeypatch.setattr(mp, "observe_histogram", lambda *args, **kwargs: None)
+    monkeypatch.setattr(mp, "set_gauge", lambda *args, **kwargs: None)
+
+    reg = mp.MLXSessionRegistry()
+    load_overrides = {"max_concurrent": 1, "warmup": False, "compile": False}
+
+    def load_slow_success():
+        reg.load(model_path="slow-old", overrides=load_overrides)
+
+    worker = threading.Thread(target=load_slow_success)
+    worker.start()
+    assert started.wait(timeout=2)
+
+    reg.load(model_path="new", overrides=load_overrides)
+    release_slow_load.set()
+    worker.join(timeout=2)
+
+    assert reg.status()["model"] == "new"
+    assert {"model": "slow-old", "status": "superseded"} in metric_statuses
+    assert {"model": "slow-old", "status": "success"} not in metric_statuses
+
+
 def test_embeddings_response_uses_active_session_model(monkeypatch):
     _patch_mlx(monkeypatch)
     reg = mp.get_mlx_registry()

--- a/tldw_Server_API/tests/LLM_Calls/test_mlx_provider.py
+++ b/tldw_Server_API/tests/LLM_Calls/test_mlx_provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 import types
 
 import pytest
@@ -107,6 +108,52 @@ def test_load_reports_unapplied_runtime_overrides(monkeypatch):
     unapplied = status.get("config", {}).get("unapplied_runtime_overrides", {})
     assert unapplied.get("quantization") == "4bit"
     assert unapplied.get("max_kv_cache_size") == 4096
+
+
+def test_failed_older_load_does_not_restore_over_newer_success(monkeypatch):
+    started = threading.Event()
+    release_failure = threading.Event()
+
+    class FakeTokenizer:
+        pass
+
+    def load(model_path, **kwargs):
+        if model_path == "slow-fail":
+            started.set()
+            assert release_failure.wait(timeout=2)
+            raise RuntimeError("load failed")
+        return (f"model:{model_path}", FakeTokenizer())
+
+    fake = types.SimpleNamespace(
+        load=load,
+        generate=lambda *args, **kwargs: "ok",
+        generate_stream=lambda *args, **kwargs: iter(["ok"]),
+        embed=lambda *args, **kwargs: [1.0],
+    )
+    monkeypatch.setattr(mp.MLXSessionRegistry, "_import_mlx", lambda self: fake)
+
+    reg = mp.MLXSessionRegistry()
+    load_overrides = {"max_concurrent": 1, "warmup": False, "compile": False}
+    reg.load(model_path="old", overrides=load_overrides)
+
+    errors = []
+
+    def load_slow_failure():
+        try:
+            reg.load(model_path="slow-fail", overrides=load_overrides)
+        except Exception as exc:
+            errors.append(exc)
+
+    worker = threading.Thread(target=load_slow_failure)
+    worker.start()
+    assert started.wait(timeout=2)
+
+    reg.load(model_path="new", overrides=load_overrides)
+    release_failure.set()
+    worker.join(timeout=2)
+
+    assert errors
+    assert reg.status()["model"] == "new"
 
 
 def test_embeddings_response_uses_active_session_model(monkeypatch):


### PR DESCRIPTION
## Change summary

TODO: Human requester must write this section before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.

## Summary
- Replace raw upstream 400-body logging with safe metadata logging for LLM provider errors.
- Add bounded/cancellable sync-to-async stream bridging and route OpenAI, Anthropic, and Cohere async stream paths through it.
- Add MLX load race protection and Hugging Face GGUF filename validation, with regression coverage.

## Verification
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/LLM_Calls/test_llm_streaming_and_security.py tldw_Server_API/tests/LLM_Calls/test_mlx_provider.py tldw_Server_API/tests/LLM_Calls/test_llm_providers.py::TestHuggingFaceAPI tldw_Server_API/tests/LLM_Adapters/unit/test_adapter_stream_error_normalization.py -q`
  - Result: 62 passed, 137 warnings
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/LLM_Calls/error_utils.py tldw_Server_API/app/core/LLM_Calls/streaming.py tldw_Server_API/app/core/LLM_Calls/huggingface_api.py tldw_Server_API/app/core/LLM_Calls/providers/mlx_provider.py tldw_Server_API/app/core/LLM_Calls/providers/openai_adapter.py tldw_Server_API/app/core/LLM_Calls/providers/anthropic_adapter.py tldw_Server_API/app/core/LLM_Calls/providers/cohere_adapter.py -f json -o /tmp/bandit_llm_calls_2425_worktree.json`
  - Result: 0 findings
- `git diff --check`
  - Result: clean

## Notes
- The originally reviewed summarization arbitrary file-read finding was not validated: `analyze()` uses the later plain-text-preserving `extract_text_from_input()`, and the remaining file-reading metadata helper has no callers.
- Backlog CLI was blocked by stale task filename references, so `TASK-2425` was created manually after user approval.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened LLM_Calls for TASK-2425: upstream 400s now log safe metadata only, async streaming is centralized with backpressure and cancellation, MLX load races are prevented with clearer metrics, and GGUF filenames are validated to block traversal.

- **Bug Fixes**
  - Log only safe metadata for upstream 400s; no prompts, bodies, or secrets; updated error normalization logs.
  - Route OpenAI, Anthropic, and Cohere `astream` through bounded, cancellable `wrap_sync_stream`; avoids default executor and logs iterator close failures.
  - Guard MLX loads with a generation counter so older loads can’t overwrite newer; emit a "superseded" status instead of counting them as success.
  - Validate GGUF filenames; require a `.gguf` basename and keep the destination inside `destination_dir`.

<sup>Written for commit 3c37085411ec774ad68d4394125311f6ff8da3e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

