### PR TITLE
Fix Usage quota accounting review findings

### DIFF
--- a/backlog/tasks/task-10000 - Fix-Usage-module-quota-and-accounting-review-findings.md
+++ b/backlog/tasks/task-10000 - Fix-Usage-module-quota-and-accounting-review-findings.md
@@ -1,0 +1,85 @@
+---
+id: TASK-10000
+title: Fix Usage module quota and accounting review findings
+status: Done
+assignee: []
+created_date: '2026-06-24 00:00'
+updated_date: '2026-06-24 00:00'
+labels:
+  - usage
+  - audio
+  - resource-governance
+  - code-review
+dependencies: []
+documentation: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the current-code review findings in `tldw_Server_API/app/core/Usage`: Resource Governor reservation idempotency, ResourceDailyLedger idempotency for repeated audio usage, atomic daily-minute consumption, best-effort LLM usage logging error boundaries, cancellation propagation, and pricing partial-match specificity.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Resource Governor stream/job reservations use unique operation IDs so concurrent limits are enforced.
+- [x] #2 Audio daily-minute ledger writes do not deduplicate distinct equal-size usage events.
+- [x] #3 Daily-minute quota check and consume is atomic for ledger-backed enforcement.
+- [x] #4 `log_llm_usage` preserves the documented best-effort/no-raise behavior for backend errors.
+- [x] #5 Quota helper catch-all behavior no longer swallows `asyncio.CancelledError`.
+- [x] #6 Pricing partial-match lookup prefers the most specific known model entry.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused failing regression tests for each reviewed behavior.
+2. Update Usage module implementations with minimal scoped fixes.
+3. Run targeted Usage/Resource Governance tests, source-scope Bandit, and diff checks.
+4. Update this Backlog task with verification results and final summary.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Manual Backlog task-file exception approved by the user because the Backlog CLI hung on task create/list/search in this repository during this session.
+
+Implemented fixes:
+- Added unique default audio-minute operation IDs while preserving explicit operation IDs for idempotent retries.
+- Added ledger-backed atomic daily-minute consumption and wired audio endpoints to use the single consume operation.
+- Changed Resource Governor stream/job reservation IDs to be unique per reservation.
+- Preserved cancellation propagation by excluding `asyncio.CancelledError` from quota noncritical exception handling.
+- Kept LLM usage logging best-effort for generic backend failures without logging sensitive exception text.
+- Removed raw per-user LLM metric labels and kept durable usage logs as the user-level source of truth.
+- Updated pricing fallback/placeholder handling and partial model lookup specificity.
+
+PR review follow-up:
+- Rebased `codex/usage-module-review-fixes-10000` onto latest `origin/dev` on 2026-06-24.
+- Moved endpoint legacy quota fallback decision logic into `app/core/Usage/audio_quota.py`, leaving endpoint helpers as shim resolution plus core delegation.
+- Updated unlimited-tier minute consumption so ledger unavailability cannot trigger bounded fail-open denial for users with `daily_minutes=None`.
+- Added regression coverage for unlimited-tier ledger unavailability and core-owned legacy fallback behavior.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed all reviewed Usage module issues and added regression coverage for quota accounting, Resource Governor concurrency, cancellation propagation, best-effort usage logging, metric label cardinality, and pricing specificity.
+
+Verification:
+- `python -m pytest tldw_Server_API/tests/Audio/test_audio_quota_rg_and_ledger.py::test_add_daily_minutes_writes_to_resource_daily_ledger tldw_Server_API/tests/Audio/test_audio_quota_rg_and_ledger.py::test_consume_daily_minutes_if_allowed_is_atomic_and_idempotent tldw_Server_API/tests/Audio/test_audio_quota_rg_and_ledger.py::test_can_start_stream_real_rg_enforces_limit_with_distinct_reservations tldw_Server_API/tests/Audio/test_audio_quota_rg_and_ledger.py::test_can_start_job_real_rg_enforces_limit_with_distinct_reservations tldw_Server_API/tests/Audio/test_audio_quota_unit.py::test_can_start_stream_propagates_cancellation tldw_Server_API/tests/Usage/test_usage_tracker_sqlite.py::test_log_llm_usage_repo_backend_error_is_best_effort tldw_Server_API/tests/Usage/test_pricing_catalog_overrides.py::test_pricing_partial_match_prefers_most_specific_model tldw_Server_API/tests/Usage/test_usage_review_fixes.py -q` passed.
+- `python -m pytest tldw_Server_API/tests/Audio/test_audio_quota_rg_and_ledger.py tldw_Server_API/tests/Audio/test_audio_quota_unit.py tldw_Server_API/tests/Usage/test_usage_review_fixes.py tldw_Server_API/tests/Usage/test_audio_rg_minutes_and_heartbeat.py tldw_Server_API/tests/Usage/test_usage_tracker_sqlite.py tldw_Server_API/tests/Usage/test_pricing_catalog.py tldw_Server_API/tests/Usage/test_pricing_catalog_overrides.py tldw_Server_API/tests/Usage/test_pricing_catalog_path.py -q` passed: 77 tests after PR review follow-up.
+- Post-logging tweak focused recheck passed: 2 tests.
+- Bandit scoped to touched production files passed with no findings.
+- Scoped `git diff --check` passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/audio/__init__.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/__init__.py
@@ -53,6 +53,7 @@ from tldw_Server_API.app.core.Usage.audio_quota import (
     can_start_job,
     can_start_stream,
     check_daily_minutes_allow,
+    consume_daily_minutes,
     finish_job,
     finish_stream,
     get_daily_minutes_used,

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio.py
@@ -235,6 +235,9 @@ from tldw_Server_API.app.core.Usage.audio_quota import (
     check_daily_minutes_allow as check_daily_minutes_allow,
 )
 from tldw_Server_API.app.core.Usage.audio_quota import (
+    consume_daily_minutes as consume_daily_minutes,
+)
+from tldw_Server_API.app.core.Usage.audio_quota import (
     finish_stream as finish_stream,
 )
 

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_streaming.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_streaming.py
@@ -48,11 +48,14 @@ from tldw_Server_API.app.core.Audio.streaming_exceptions import QuotaExceeded
 from tldw_Server_API.app.core.Audio.transcription_service import _map_openai_audio_model_to_whisper
 from tldw_Server_API.app.core.Audio.quota_helpers import EXPECTED_DB_EXC, EXPECTED_REDIS_EXC, _get_failopen_cap_minutes
 from tldw_Server_API.app.core.Usage.audio_quota import (
+    AudioQuotaStoreUnavailable,
     active_streams_count,
     add_daily_minutes,
     bytes_to_seconds,
     can_start_stream,
     check_daily_minutes_allow,
+    consume_daily_minutes,
+    consume_daily_minutes_with_legacy_fallback,
     finish_job,
     finish_stream,
     get_daily_minutes_used,
@@ -214,6 +217,7 @@ _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS = (
     *EXPECTED_DB_EXC,
     *EXPECTED_REDIS_EXC,
 )
+_AUDIO_QUOTA_DB_EXC = (*EXPECTED_DB_EXC, AudioQuotaStoreUnavailable)
 
 router = APIRouter(
     tags=["Audio"],
@@ -241,6 +245,7 @@ def _audio_shim_attr(name: str):
         "finish_stream": finish_stream,
         "check_daily_minutes_allow": check_daily_minutes_allow,
         "add_daily_minutes": add_daily_minutes,
+        "consume_daily_minutes": consume_daily_minutes,
         "bytes_to_seconds": bytes_to_seconds,
         "heartbeat_stream": heartbeat_stream,
         "active_streams_count": active_streams_count,
@@ -718,6 +723,17 @@ async def _check_daily_minutes_allow(user_id: int, minutes: float):
 
 async def _add_daily_minutes(user_id: int, minutes: float):
     return await _audio_shim_attr("add_daily_minutes")(user_id, minutes)
+
+
+async def _consume_daily_minutes(user_id: int, minutes: float, *, operation_id: str | None = None):
+    return await consume_daily_minutes_with_legacy_fallback(
+        user_id,
+        minutes,
+        operation_id=operation_id,
+        consume_fn=_audio_shim_attr("consume_daily_minutes"),
+        check_fn=_audio_shim_attr("check_daily_minutes_allow"),
+        add_fn=_audio_shim_attr("add_daily_minutes"),
+    )
 
 
 def _bytes_to_seconds(size_bytes: int, sample_rate: int) -> float:
@@ -1292,12 +1308,10 @@ async def websocket_transcribe(
                 _QuotaExceeded: If adding this chunk would exceed the user's daily minutes quota.
 
             Notes:
-                - Checks whether the user's remaining daily minutes allow this chunk; if allowed, increments the nonlocal
-                  `used_minutes` counter and records the minutes via `_add_daily_minutes`.
+                - Consumes this chunk from the user's daily minutes in one quota-store operation.
             """
             nonlocal used_minutes, failopen_remaining, remaining_minutes_snapshot
             minutes_chunk = float(seconds) / 60.0
-            deducted = False
             allow = False
             # Fast-path local check: if we have a remaining snapshot and this
             # chunk would exceed it, raise immediately without a DB round-trip.
@@ -1308,13 +1322,13 @@ async def websocket_transcribe(
             # chunk; on success, we treat the returned "remaining_after" value
             # as the new snapshot.
             try:
-                allow, remaining_after = await _check_daily_minutes_allow(user_id_for_usage, minutes_chunk)
+                allow, remaining_after = await _consume_daily_minutes(user_id_for_usage, minutes_chunk)
                 if allow and remaining_after is not None:
                     remaining_minutes_snapshot = float(remaining_after)
-            except EXPECTED_DB_EXC as e:
+            except _AUDIO_QUOTA_DB_EXC as e:
                 # Backing store failed; allow temporarily but deduct from bounded fail-open budget
                 logger.warning(
-                    f"_check_daily_minutes_allow failed during streaming; temporarily allowing (bounded fail-open). user_id={user_id_for_usage}, error={e}"
+                    f"consume_daily_minutes failed during streaming; temporarily allowing (bounded fail-open). user_id={user_id_for_usage}, error={e}"
                 )
                 allow = True
                 failopen_remaining -= minutes_chunk
@@ -1325,7 +1339,6 @@ async def websocket_transcribe(
                     increment_counter("audio_failopen_events_total", labels={"reason": "db_check"})
                 except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as m_err:
                     logger.debug(f"metrics increment failed (audio_failopen_db_check): error={m_err}")
-                deducted = True
                 if failopen_remaining <= 0:
                     try:
                         increment_counter("audio_failopen_cap_exhausted_total", labels={"reason": "db_check"})
@@ -1336,35 +1349,6 @@ async def websocket_transcribe(
                 # Raise structured signal to outer scope
                 raise _QuotaExceeded("daily_minutes")
             used_minutes += minutes_chunk
-            # Reduce the local snapshot so subsequent chunks can be checked
-            # without hitting the DB until it is exhausted or refreshed on
-            # the next successful check.
-            if remaining_minutes_snapshot is not None:
-                remaining_minutes_snapshot = max(0.0, remaining_minutes_snapshot - minutes_chunk)
-            try:
-                await _add_daily_minutes(user_id_for_usage, minutes_chunk)
-            except EXPECTED_DB_EXC as e:
-                # Could not record; continue streaming under bounded fail-open
-                logger.warning(
-                    f"Failed to record streaming minutes (bounded fail-open). user_id={user_id_for_usage}, error={e}"
-                )
-                if not deducted:
-                    failopen_remaining -= minutes_chunk
-                    try:
-                        increment_counter(
-                            "audio_failopen_minutes_total",
-                            value=float(minutes_chunk),
-                            labels={"reason": "db_record"},
-                        )
-                        increment_counter("audio_failopen_events_total", labels={"reason": "db_record"})
-                    except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as m_err:
-                        logger.debug(f"metrics increment failed (audio_failopen_db_record): error={m_err}")
-                    if failopen_remaining <= 0:
-                        try:
-                            increment_counter("audio_failopen_cap_exhausted_total", labels={"reason": "db_record"})
-                        except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as m_err:
-                            logger.debug(f"metrics increment failed (audio_failopen_cap_db_record): error={m_err}")
-                        raise _QuotaExceeded("daily_minutes") from None
             # Billing: accumulate fractional minutes; flush to cache when >= 1
             nonlocal _billing_minutes_accumulator
             if _ws_billing_org_id is not None:
@@ -1699,19 +1683,18 @@ async def websocket_audio_chat_stream(
         async def _on_audio_quota(seconds: float, _sr: int) -> None:
             nonlocal used_minutes, failopen_remaining, remaining_minutes_snapshot
             minutes_chunk = float(seconds) / 60.0
-            deducted = False
             allow = False
 
             if remaining_minutes_snapshot is not None and minutes_chunk > remaining_minutes_snapshot:
                 raise QuotaExceeded("daily_minutes")
 
             try:
-                allow, remaining_after = await _check_daily_minutes_allow(user_id_for_usage, minutes_chunk)
+                allow, remaining_after = await _consume_daily_minutes(user_id_for_usage, minutes_chunk)
                 if allow and remaining_after is not None:
                     remaining_minutes_snapshot = float(remaining_after)
-            except EXPECTED_DB_EXC as e:
+            except _AUDIO_QUOTA_DB_EXC as e:
                 logger.warning(
-                    f"_check_daily_minutes_allow failed during streaming; temporarily allowing "
+                    f"consume_daily_minutes failed during streaming; temporarily allowing "
                     f"(bounded fail-open). user_id={user_id_for_usage}, error={e}"
                 )
                 allow = True
@@ -1723,7 +1706,6 @@ async def websocket_audio_chat_stream(
                     increment_counter("audio_failopen_events_total", labels={"reason": "db_check"})
                 except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as m_err:  # noqa: BLE001
                     logger.debug(f"metrics increment failed (audio_chat_failopen_db_check): error={m_err}")
-                deducted = True
                 if failopen_remaining <= 0:
                     try:
                         increment_counter("audio_failopen_cap_exhausted_total", labels={"reason": "db_check"})
@@ -1737,33 +1719,6 @@ async def websocket_audio_chat_stream(
                 raise QuotaExceeded("daily_minutes") from None
 
             used_minutes += minutes_chunk
-            if remaining_minutes_snapshot is not None:
-                remaining_minutes_snapshot = max(0.0, remaining_minutes_snapshot - minutes_chunk)
-            try:
-                await _add_daily_minutes(user_id_for_usage, minutes_chunk)
-            except EXPECTED_DB_EXC as e:
-                logger.warning(
-                    f"Failed to record streaming minutes (bounded fail-open). user_id={user_id_for_usage}, error={e}"
-                )
-                if not deducted:
-                    failopen_remaining -= minutes_chunk
-                    try:
-                        increment_counter(
-                            "audio_failopen_minutes_total",
-                            value=float(minutes_chunk),
-                            labels={"reason": "db_record"},
-                        )
-                        increment_counter("audio_failopen_events_total", labels={"reason": "db_record"})
-                    except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as m_err:
-                        logger.debug(f"metrics increment failed (audio_chat_failopen_db_record): error={m_err}")
-                    if failopen_remaining <= 0:
-                        try:
-                            increment_counter("audio_failopen_cap_exhausted_total", labels={"reason": "db_record"})
-                        except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS as m_err:
-                            logger.debug(
-                                f"metrics increment failed (audio_chat_failopen_cap_db_record): error={m_err}"
-                            )
-                        raise QuotaExceeded("daily_minutes") from None
 
         async def _on_heartbeat() -> None:
             try:

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
@@ -58,9 +58,12 @@ from tldw_Server_API.app.core.Metrics.stt_metrics import (
 )
 from tldw_Server_API.app.core.testing import is_test_mode
 from tldw_Server_API.app.core.Usage.audio_quota import (
+    AudioQuotaStoreUnavailable,
     add_daily_minutes,
     can_start_job,
     check_daily_minutes_allow,
+    consume_daily_minutes,
+    consume_daily_minutes_with_legacy_fallback,
     finish_job,
     get_job_heartbeat_interval_seconds,
     get_limits_for_user,
@@ -76,6 +79,7 @@ router = APIRouter(
         429: {"description": "Rate limit exceeded"},
     },
 )
+_AUDIO_QUOTA_DB_EXC = (*EXPECTED_DB_EXC, AudioQuotaStoreUnavailable)
 
 _AUDIO_TRANSCRIPTIONS_NONCRITICAL_EXCEPTIONS = (
     AssertionError,
@@ -185,6 +189,7 @@ def _audio_shim_attr(name: str):
     defaults: dict[str, Any] = {
         "check_daily_minutes_allow": check_daily_minutes_allow,
         "add_daily_minutes": add_daily_minutes,
+        "consume_daily_minutes": consume_daily_minutes,
         "get_job_heartbeat_interval_seconds": get_job_heartbeat_interval_seconds,
         "heartbeat_jobs": heartbeat_jobs,
         "get_limits_for_user": get_limits_for_user,
@@ -262,6 +267,17 @@ async def _check_daily_minutes_allow(user_id: int, minutes: float):
 
 async def _add_daily_minutes(user_id: int, minutes: float):
     return await _audio_shim_attr("add_daily_minutes")(user_id, minutes)
+
+
+async def _consume_daily_minutes(user_id: int, minutes: float, *, operation_id: str | None = None):
+    return await consume_daily_minutes_with_legacy_fallback(
+        user_id,
+        minutes,
+        operation_id=operation_id,
+        consume_fn=_audio_shim_attr("consume_daily_minutes"),
+        check_fn=_audio_shim_attr("check_daily_minutes_allow"),
+        add_fn=_audio_shim_attr("add_daily_minutes"),
+    )
 
 
 def _stt_provider_envelope(stt_registry: Any, provider_name: str) -> Optional[dict[str, Any]]:
@@ -832,10 +848,14 @@ async def create_transcription(
 
         minutes_est = duration_seconds / 60.0
         try:
-            allow, remaining_after = await _check_daily_minutes_allow(current_user.id, minutes_est)
-        except EXPECTED_DB_EXC as e:
+            allow, remaining_after = await _consume_daily_minutes(
+                current_user.id,
+                minutes_est,
+                operation_id=f"audio-transcription:{rid}:daily-minutes",
+            )
+        except _AUDIO_QUOTA_DB_EXC as e:
             logger.exception(
-                'check_daily_minutes_allow failed; allowing by default: user_id={}, error={}; request_id={}',
+                'consume_daily_minutes failed; allowing by default: user_id={}, error={}; request_id={}',
                 current_user.id,
                 e,
                 rid,
@@ -1083,15 +1103,6 @@ async def create_transcription(
         else:
             redaction_outcome = "skipped"
 
-        try:
-            await _add_daily_minutes(current_user.id, minutes_est)
-        except EXPECTED_DB_EXC as e:
-            logger.exception(
-                'Failed to record daily minutes: user_id={}, error={}; request_id={}',
-                current_user.id,
-                e,
-                rid,
-            )
         # Billing: record actual transcription minutes to org-level enforcement
         if enforcement_enabled() and billing_org_id is not None and minutes_est > 0:
             _billed_minutes = max(1, int(math.ceil(minutes_est)))

--- a/tldw_Server_API/app/core/DB_Management/Resource_Daily_Ledger.py
+++ b/tldw_Server_API/app/core/DB_Management/Resource_Daily_Ledger.py
@@ -170,6 +170,133 @@ class ResourceDailyLedger:
             logger.error(f"ResourceDailyLedger.add failed: {e}")
             raise
 
+    async def consume_if_available(self, entry: LedgerEntry, daily_cap: int) -> tuple[bool, int]:
+        """
+        Add a ledger entry only when it fits within the daily cap.
+
+        Returns ``(allowed, remaining_after_units)``. Duplicate ``op_id`` values
+        are treated as already consumed and return the current remaining value.
+        """
+        if not self._initialized:
+            await self.initialize()
+
+        day = self._to_day_utc(entry.occurred_at)
+        cap = int(max(0, daily_cap))
+        units = int(max(0, entry.units))
+        is_pg = await self._using_postgres_backend()
+        try:
+            async with self.db_pool.transaction() as conn:
+                if is_pg:
+                    day_param: date = date.fromisoformat(day)
+                    lock_key = (
+                        f"{entry.entity_scope}:{entry.entity_value}:"
+                        f"{entry.category}:{day}"
+                    )
+                    await conn.execute("SELECT pg_advisory_xact_lock(hashtext($1))", lock_key)
+                    existing = await conn.fetchval(
+                        """
+                        SELECT 1 FROM resource_daily_ledger
+                        WHERE day_utc = $1 AND entity_scope = $2 AND entity_value = $3
+                          AND category = $4 AND op_id = $5
+                        LIMIT 1
+                        """,
+                        day_param,
+                        entry.entity_scope,
+                        entry.entity_value,
+                        entry.category,
+                        entry.op_id,
+                    )
+                    used = int(
+                        await conn.fetchval(
+                            """
+                            SELECT COALESCE(SUM(units), 0)
+                            FROM resource_daily_ledger
+                            WHERE day_utc = $1 AND entity_scope = $2 AND entity_value = $3 AND category = $4
+                            """,
+                            day_param,
+                            entry.entity_scope,
+                            entry.entity_value,
+                            entry.category,
+                        )
+                        or 0
+                    )
+                    if existing:
+                        return True, max(0, cap - used)
+                    remaining_before = max(0, cap - used)
+                    if units > remaining_before:
+                        return False, remaining_before
+                    await conn.execute(
+                        """
+                        INSERT INTO resource_daily_ledger
+                          (day_utc, entity_scope, entity_value, category, units, op_id, occurred_at, created_at)
+                        VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
+                        ON CONFLICT (day_utc, entity_scope, entity_value, category, op_id) DO NOTHING
+                        """,
+                        day_param,
+                        entry.entity_scope,
+                        entry.entity_value,
+                        entry.category,
+                        units,
+                        entry.op_id,
+                        entry.occurred_at,
+                    )
+                    return True, max(0, remaining_before - units)
+
+                existing_cursor = await conn.execute(
+                    """
+                    SELECT 1 FROM resource_daily_ledger
+                    WHERE day_utc = ? AND entity_scope = ? AND entity_value = ?
+                      AND category = ? AND op_id = ?
+                    LIMIT 1
+                    """,
+                    day,
+                    entry.entity_scope,
+                    entry.entity_value,
+                    entry.category,
+                    entry.op_id,
+                )
+                existing = await existing_cursor.fetchone()
+                used_cursor = await conn.execute(
+                    """
+                    SELECT COALESCE(SUM(units), 0)
+                    FROM resource_daily_ledger
+                    WHERE day_utc = ? AND entity_scope = ? AND entity_value = ? AND category = ?
+                    """,
+                    day,
+                    entry.entity_scope,
+                    entry.entity_value,
+                    entry.category,
+                )
+                used_row = await used_cursor.fetchone()
+                used = int((used_row[0] if used_row else 0) or 0)
+                if existing:
+                    return True, max(0, cap - used)
+                remaining_before = max(0, cap - used)
+                if units > remaining_before:
+                    return False, remaining_before
+                await conn.execute(
+                    """
+                    INSERT INTO resource_daily_ledger
+                      (day_utc, entity_scope, entity_value, category, units, op_id, occurred_at, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
+                    """,
+                    day,
+                    entry.entity_scope,
+                    entry.entity_value,
+                    entry.category,
+                    units,
+                    entry.op_id,
+                    entry.occurred_at.isoformat(),
+                )
+                return True, max(0, remaining_before - units)
+        except Exception as e:
+            logger.error(f"ResourceDailyLedger.consume_if_available failed: {e}")
+            raise
+
+    async def add_if_within_daily_cap(self, entry: LedgerEntry, daily_cap: int) -> tuple[bool, int]:
+        """Backward-compatible alias for atomic capped ledger consumption."""
+        return await self.consume_if_available(entry, daily_cap=daily_cap)
+
     async def total_for_day(self, entity_scope: str, entity_value: str, category: str, day_utc: str | None = None) -> int:
         if not self._initialized:
             await self.initialize()

--- a/tldw_Server_API/app/core/Usage/audio_quota.py
+++ b/tldw_Server_API/app/core/Usage/audio_quota.py
@@ -17,12 +17,15 @@ import asyncio
 import configparser
 import contextlib
 import os
+import uuid
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from functools import lru_cache
 
 from loguru import logger
 
 from tldw_Server_API.app.core.AuthNZ.database import DatabasePool, get_db_pool
+from tldw_Server_API.app.core.AuthNZ.exceptions import DatabaseError as AuthNZDatabaseError
 
 try:
     from tldw_Server_API.app.core.Metrics.metrics_manager import MetricDefinition, MetricType, get_metrics_registry
@@ -80,7 +83,6 @@ except ImportError:  # pragma: no cover
     LedgerEntry = None  # type: ignore
 
 _AUDIO_QUOTA_NONCRITICAL_EXCEPTIONS = (
-    asyncio.CancelledError,
     asyncio.TimeoutError,
     AssertionError,
     AttributeError,
@@ -99,6 +101,15 @@ _AUDIO_QUOTA_NONCRITICAL_EXCEPTIONS = (
     UnicodeDecodeError,
     configparser.Error,
 )
+
+
+_DailyMinutesConsumeFn = Callable[..., Awaitable[tuple[bool, float | None]]]
+_DailyMinutesCheckFn = Callable[[int, float], Awaitable[tuple[bool, float | None]]]
+_DailyMinutesAddFn = Callable[[int, float], Awaitable[None]]
+
+
+class AudioQuotaStoreUnavailable(AuthNZDatabaseError):
+    """Raised when canonical daily-minute quota storage is unavailable."""
 
 
 # Default tier limits (can be extended later via configuration or DB)
@@ -148,6 +159,8 @@ _rg_stream_handles: dict[int, list[str]] = {}
 _rg_job_handles: dict[int, list[str]] = {}
 _rg_job_handle_locks: dict[int, asyncio.Lock] = {}
 _rg_job_handle_locks_lock = asyncio.Lock()
+_audio_minutes_consume_locks: dict[int, asyncio.Lock] = {}
+_audio_minutes_consume_locks_lock = asyncio.Lock()
 _rg_audio_init_error: str | None = None
 _rg_audio_init_error_logged = False
 _rg_audio_fallback_logged = False
@@ -333,6 +346,17 @@ async def _cleanup_job_handle_lock(user_id: int) -> None:
         lock = _rg_job_handle_locks.get(uid)
         if lock and not lock.locked():
             _rg_job_handle_locks.pop(uid, None)
+
+
+async def _get_audio_minutes_consume_lock(user_id: int) -> asyncio.Lock:
+    """Return the per-user lock used by fallback minute consumption."""
+    uid = int(user_id)
+    async with _audio_minutes_consume_locks_lock:
+        lock = _audio_minutes_consume_locks.get(uid)
+        if lock is None:
+            lock = asyncio.Lock()
+            _audio_minutes_consume_locks[uid] = lock
+        return lock
 
 
 async def _cleanup_stream_handles(user_id: int) -> None:
@@ -610,11 +634,10 @@ async def _get_daily_ledger() -> ResourceDailyLedger | None:
     Lazily initialize the shared ResourceDailyLedger for audio minutes.
 
     When available, the ledger is the canonical source of truth for daily
-    minutes caps: callers write new usage via ``add_daily_minutes`` and read
-    remaining quota via ``_ledger_remaining_minutes``. The legacy
-    ``audio_usage_daily`` table is consulted only for a one-time backfill on
-    first use (per process) and as a fallback when the ledger cannot be
-    initialized.
+    minutes caps: callers write new usage via ``add_daily_minutes`` or
+    ``consume_daily_minutes`` and read remaining quota via
+    ``_ledger_remaining_minutes``. The legacy ``audio_usage_daily`` table is
+    consulted only for a one-time backfill on first use (per process).
     """
     global _daily_ledger
     # If the ledger implementation is not available, skip silently.
@@ -711,26 +734,55 @@ async def _backfill_audio_usage_daily_to_ledger(ledger: ResourceDailyLedger) -> 
         )
 
 
-async def add_daily_minutes(user_id: int, minutes: float) -> None:
-    if minutes <= 0:
-        return
-    day = datetime.now(timezone.utc).date().isoformat()
+def _audio_minutes_units(minutes: float) -> int:
+    return int(max(0, round(float(minutes) * 60.0)))
 
-    # Record against the shared ResourceDailyLedger; this is the canonical
-    # source of truth for audio daily minutes. Legacy audio_usage_daily
-    # counters are no longer written to and remain as compatibility state
-    # only for pre-upgrade rows.
-    units = int(max(0, round(float(minutes) * 60.0)))
+
+def _audio_minutes_op_id(user_id: int, day: str, units: int, operation_id: str | None = None) -> str:
+    if operation_id is not None:
+        op_id = str(operation_id).strip()
+        if op_id:
+            return op_id
+    return f"audio-minutes:{int(user_id)}:{day}:{int(units)}:{uuid.uuid4().hex}"
+
+
+async def _require_daily_ledger() -> ResourceDailyLedger:
+    ledger = await _get_daily_ledger()
+    if ledger is None or LedgerEntry is None:
+        raise AudioQuotaStoreUnavailable("audio quota daily ledger is unavailable")
+    return ledger
+
+
+def _build_audio_minutes_entry(user_id: int, units: int, operation_id: str | None = None) -> LedgerEntry:
+    day = datetime.now(timezone.utc).date().isoformat()
+    return LedgerEntry(  # type: ignore[call-arg, return-value]
+        entity_scope="user",
+        entity_value=str(int(user_id)),
+        category="minutes",
+        units=int(units),
+        op_id=_audio_minutes_op_id(user_id=int(user_id), day=day, units=int(units), operation_id=operation_id),
+        occurred_at=datetime.now(timezone.utc),
+    )
+
+
+async def add_daily_minutes(
+    user_id: int,
+    minutes: float,
+    *,
+    operation_id: str | None = None,
+    op_id: str | None = None,
+) -> None:
+    units = _audio_minutes_units(minutes)
+    if units <= 0:
+        return
+
     try:
         ledger = await _get_daily_ledger()
-        if ledger is not None and LedgerEntry is not None and units > 0:
-            entry = LedgerEntry(  # type: ignore[call-arg]
-                entity_scope="user",
-                entity_value=str(int(user_id)),
-                category="minutes",
+        if ledger is not None and LedgerEntry is not None:
+            entry = _build_audio_minutes_entry(
+                user_id=int(user_id),
                 units=units,
-                op_id=f"audio-minutes:{int(user_id)}:{day}:{units}",
-                occurred_at=datetime.now(timezone.utc),
+                operation_id=operation_id or op_id,
             )
             try:
                 await ledger.add(entry)
@@ -741,6 +793,115 @@ async def add_daily_minutes(user_id: int, minutes: float) -> None:
 
     # Legacy audio_usage_daily writes have been removed; usage is tracked
     # solely via ResourceDailyLedger for new events.
+
+
+async def consume_daily_minutes(
+    user_id: int,
+    minutes_requested: float,
+    *,
+    operation_id: str | None = None,
+    op_id: str | None = None,
+) -> tuple[bool, float | None]:
+    """
+    Atomically enforce and record audio daily-minute usage.
+
+    Returns ``(allowed, remaining_after)``. ``remaining_after`` is ``None`` for
+    unlimited tiers. If the canonical ledger is unavailable, raises
+    ``AudioQuotaStoreUnavailable`` so API layers can use bounded fail-open.
+    """
+    units = _audio_minutes_units(minutes_requested)
+    if units <= 0:
+        return await check_daily_minutes_allow(user_id, 0.0)
+
+    limits = await get_limits_for_user(user_id)
+    limit = limits.get("daily_minutes")
+
+    if limit is None:
+        await add_daily_minutes(user_id, minutes_requested, operation_id=operation_id or op_id)
+        return True, None
+
+    ledger = await _require_daily_ledger()
+    entry = _build_audio_minutes_entry(user_id=int(user_id), units=units, operation_id=operation_id or op_id)
+    cap_units = _audio_minutes_units(float(limit))
+    if cap_units <= 0:
+        _metrics_increment("audio_quota_violations_total", {"type": "daily_minutes"})
+        return False, 0.0
+
+    try:
+        consume_if_available = getattr(ledger, "consume_if_available", None)
+        if callable(consume_if_available):
+            allowed, remaining_units = await consume_if_available(entry, daily_cap=cap_units)
+            if not allowed:
+                _metrics_increment("audio_quota_violations_total", {"type": "daily_minutes"})
+            return bool(allowed), float(max(0, int(remaining_units))) / 60.0
+
+        # Compatibility fallback for tests/lightweight fakes. Real
+        # ResourceDailyLedger provides consume_if_available for DB-backed
+        # atomicity; this lock avoids same-process races when that API is not
+        # present.
+        consume_lock = await _get_audio_minutes_consume_lock(int(user_id))
+        async with consume_lock:
+            remaining_units = await ledger.remaining_for_day(
+                entity_scope="user",
+                entity_value=str(int(user_id)),
+                category="minutes",
+                daily_cap=cap_units,
+            )
+            if units > remaining_units:
+                _metrics_increment("audio_quota_violations_total", {"type": "daily_minutes"})
+                return False, float(max(0, int(remaining_units))) / 60.0
+            await ledger.add(entry)
+            return True, float(max(0, int(remaining_units) - units)) / 60.0
+    except _AUDIO_QUOTA_NONCRITICAL_EXCEPTIONS as exc:
+        logger.debug("Audio quotas consume failed")
+        raise AudioQuotaStoreUnavailable("audio quota daily ledger consume failed") from exc
+
+
+async def consume_daily_minutes_if_allowed(
+    user_id: int,
+    minutes: float,
+    *,
+    op_id: str | None = None,
+    operation_id: str | None = None,
+) -> tuple[bool, float | None]:
+    return await consume_daily_minutes(
+        user_id=user_id,
+        minutes_requested=minutes,
+        operation_id=operation_id or op_id,
+    )
+
+
+async def consume_daily_minutes_with_legacy_fallback(
+    user_id: int,
+    minutes: float,
+    *,
+    operation_id: str | None = None,
+    consume_fn: _DailyMinutesConsumeFn | None = None,
+    check_fn: _DailyMinutesCheckFn | None = None,
+    add_fn: _DailyMinutesAddFn | None = None,
+) -> tuple[bool, float | None]:
+    """
+    Consume daily minutes, preserving legacy check/add overrides for callers.
+
+    Endpoint modules historically expose quota helpers as monkeypatchable shim
+    points. This keeps the compatibility decision in core while allowing those
+    callers to supply their resolved helper functions.
+    """
+    resolved_consume = consume_fn or consume_daily_minutes
+    resolved_check = check_fn or check_daily_minutes_allow
+    resolved_add = add_fn or add_daily_minutes
+
+    legacy_quota_override = resolved_consume is consume_daily_minutes and (
+        resolved_check is not check_daily_minutes_allow
+        or resolved_add is not add_daily_minutes
+    )
+    if legacy_quota_override:
+        allowed, remaining_after = await resolved_check(user_id, minutes)
+        if allowed:
+            await resolved_add(user_id, minutes)
+        return allowed, remaining_after
+
+    return await resolved_consume(user_id, minutes, operation_id=operation_id)
 
 
 async def _ledger_remaining_minutes(user_id: int, daily_limit_minutes: float) -> float | None:
@@ -822,7 +983,7 @@ async def can_start_job(user_id: int) -> tuple[bool, str]:
                 categories={"jobs": {"units": 1}},  # type: ignore[call-arg]
                 tags={"policy_id": policy_id, "endpoint": "audio.jobs"},
             )
-            dec, handle_id = await gov.reserve(req, op_id=f"audio-job:{entity}")
+            dec, handle_id = await gov.reserve(req, op_id=f"audio-job:{entity}:{uuid.uuid4().hex}")
             if not dec.allowed or not handle_id:
                 _metrics_increment("audio_quota_violations_total", {"type": "concurrent_jobs"})
                 return False, "Concurrent job limit reached"
@@ -913,7 +1074,7 @@ async def can_start_stream(user_id: int) -> tuple[bool, str]:
                 categories={"streams": {"units": 1}},  # type: ignore[call-arg]
                 tags={"policy_id": policy_id, "endpoint": "audio.stream"},
             )
-            dec, handle_id = await gov.reserve(req, op_id=f"audio-stream:{entity}")
+            dec, handle_id = await gov.reserve(req, op_id=f"audio-stream:{entity}:{uuid.uuid4().hex}")
             if not dec.allowed or not handle_id:
                 _metrics_increment("audio_quota_violations_total", {"type": "concurrent_streams"})
                 return False, "Concurrent streams limit reached"
@@ -984,7 +1145,10 @@ async def check_daily_minutes_allow(user_id: int, minutes_requested: float) -> t
     if limit is None:
         return True, None
 
-    # Prefer the shared ResourceDailyLedger when available to enforce daily caps.
+    # Enforce new usage against the shared ResourceDailyLedger. Legacy
+    # audio_usage_daily rows are backfilled into the ledger during
+    # initialization and are not a safe fallback after new writes moved to the
+    # ledger-only path.
     ledger_remaining = await _ledger_remaining_minutes(user_id=int(user_id), daily_limit_minutes=float(limit))
     if ledger_remaining is not None:
         if minutes_requested > ledger_remaining:
@@ -992,13 +1156,7 @@ async def check_daily_minutes_allow(user_id: int, minutes_requested: float) -> t
             return False, max(0.0, ledger_remaining)
         return True, ledger_remaining - minutes_requested
 
-    # Fallback to legacy audio_usage_daily enforcement.
-    used = await get_daily_minutes_used(user_id)
-    remaining = float(limit) - float(used)
-    if minutes_requested > remaining:
-        _metrics_increment("audio_quota_violations_total", {"type": "daily_minutes"})
-        return False, max(0.0, remaining)
-    return True, remaining - minutes_requested
+    raise AudioQuotaStoreUnavailable("audio quota daily ledger is unavailable")
 
 
 def bytes_to_seconds(byte_count: int, sample_rate: int) -> float:

--- a/tldw_Server_API/app/core/Usage/pricing_catalog.py
+++ b/tldw_Server_API/app/core/Usage/pricing_catalog.py
@@ -41,6 +41,13 @@ def _rate_value(rates: dict, *keys: str, default: float | None = None) -> float 
     return default
 
 
+UNKNOWN_BILLABLE_RATE = {"prompt": 0.01, "completion": 0.03}
+
+
+def _unknown_billable_rate() -> dict[str, float]:
+    return dict(UNKNOWN_BILLABLE_RATE)
+
+
 # Baseline defaults (USD per 1K tokens). These are indicative and can be
 # refined over time. Kept conservative to avoid under-estimating.
 DEFAULT_PRICING: dict[str, dict[str, dict[str, float]]] = {
@@ -256,16 +263,20 @@ class PricingCatalog:
         if mdl in prov_map:
             return self._entry_rate_details(prov_map[mdl], estimated=False)
 
+        best_match: tuple[str, dict] | None = None
         for mk, rates in prov_map.items():
-            if mk in mdl or mdl in mk:
-                return self._entry_rate_details(rates, estimated=True)
+            if mdl and mk and (mk in mdl or mdl in mk):
+                if best_match is None or len(mk) > len(best_match[0]):
+                    best_match = (mk, rates)
+        if best_match is not None:
+            return self._entry_rate_details(best_match[1], estimated=True)
 
-        return {"prompt": 0.01, "completion": 0.03}, True
+        return _unknown_billable_rate(), True
 
     @staticmethod
     def _entry_rate_details(rates: dict, *, estimated: bool) -> tuple[dict[str, float], bool]:
         if isinstance(rates, dict) and rates.get("placeholder"):
-            return {"prompt": 0.0, "completion": 0.0}, True
+            return _unknown_billable_rate(), True
         if not isinstance(rates, dict):
             return {"prompt": 0.0, "completion": 0.0}, True
         details = {
@@ -342,23 +353,29 @@ def _lookup_model_across_providers(catalog: PricingCatalog, model: str) -> tuple
         if mdl in prov_map:
             r = prov_map[mdl]
             if isinstance(r, dict) and r.get("placeholder"):
-                return 0.0, 0.0, True
+                return UNKNOWN_BILLABLE_RATE["prompt"], UNKNOWN_BILLABLE_RATE["completion"], True
             return (
                 float(r.get("prompt", 0.0)),
                 float(r.get("completion", 0.0)),
                 bool(r.get("estimated", False)),
             )
 
-    # Second pass: partial match across all providers
+    # Second pass: partial match across all providers, preferring the most
+    # specific catalog key.
+    best_match: dict | None = None
+    best_key_length = -1
     for prov_name, prov_map in catalog._catalog.items():
         for mk, r in prov_map.items():
-            if mk in mdl or mdl in mk:
-                if isinstance(r, dict) and r.get("placeholder"):
-                    return 0.0, 0.0, True
-                return float(r.get("prompt", 0.0)), float(r.get("completion", 0.0)), True
+            if mdl and mk and (mk in mdl or mdl in mk) and len(mk) > best_key_length:
+                best_match = r
+                best_key_length = len(mk)
+    if best_match is not None:
+        if isinstance(best_match, dict) and best_match.get("placeholder"):
+            return UNKNOWN_BILLABLE_RATE["prompt"], UNKNOWN_BILLABLE_RATE["completion"], True
+        return float(best_match.get("prompt", 0.0)), float(best_match.get("completion", 0.0)), True
 
     # Fallback: same conservative default as PricingCatalog.get_rates
-    return 0.01, 0.03, True
+    return UNKNOWN_BILLABLE_RATE["prompt"], UNKNOWN_BILLABLE_RATE["completion"], True
 
 
 def list_provider_models(provider: str) -> list[str]:

--- a/tldw_Server_API/app/core/Usage/usage_tracker.py
+++ b/tldw_Server_API/app/core/Usage/usage_tracker.py
@@ -366,17 +366,8 @@ async def log_llm_usage(
                 float(t_cost),
                 labels={"provider": str(provider or "unknown"), "model": str(model or "unknown")},
             )
-            # Per-user and per-operation breakdowns
-            if user_id is not None:
-                increment_counter(
-                    "llm_cost_dollars_by_user",
-                    float(t_cost),
-                    labels={
-                        "provider": str(provider or "unknown"),
-                        "model": str(model or "unknown"),
-                        "user_id": str(user_id),
-                    },
-                )
+            # Per-operation breakdowns are low-cardinality enough for metrics;
+            # user-level usage remains available in the durable usage log.
             if operation:
                 increment_counter(
                     "llm_cost_dollars_by_operation",
@@ -393,17 +384,6 @@ async def log_llm_usage(
                     float(pt),
                     labels={"provider": str(provider or "unknown"), "model": str(model or "unknown"), "type": "prompt"},
                 )
-                if user_id is not None:
-                    increment_counter(
-                        "llm_tokens_used_total_by_user",
-                        float(pt),
-                        labels={
-                            "provider": str(provider or "unknown"),
-                            "model": str(model or "unknown"),
-                            "type": "prompt",
-                            "user_id": str(user_id),
-                        },
-                    )
                 if operation:
                     increment_counter(
                         "llm_tokens_used_total_by_operation",
@@ -421,17 +401,6 @@ async def log_llm_usage(
                     float(ct),
                     labels={"provider": str(provider or "unknown"), "model": str(model or "unknown"), "type": "completion"},
                 )
-                if user_id is not None:
-                    increment_counter(
-                        "llm_tokens_used_total_by_user",
-                        float(ct),
-                        labels={
-                            "provider": str(provider or "unknown"),
-                            "model": str(model or "unknown"),
-                            "type": "completion",
-                            "user_id": str(user_id),
-                        },
-                    )
                 if operation:
                     increment_counter(
                         "llm_tokens_used_total_by_operation",
@@ -443,9 +412,11 @@ async def log_llm_usage(
                             "operation": str(operation or ""),
                         },
                     )
-        except _USAGE_NONCRITICAL_EXCEPTIONS:
+        except asyncio.CancelledError:
+            raise
+        except Exception:
             # Metrics must never impact request flow
-            pass
+            logger.debug("LLM usage metrics update skipped/failed")
 
         db_pool: DatabasePool = await get_db_pool()
         repo = AuthnzUsageRepo(db_pool)
@@ -524,9 +495,13 @@ async def log_llm_usage(
                             occurred_at=datetime.now(timezone.utc),
                         )
                         await ledger.add(entry)
-        except _USAGE_NONCRITICAL_EXCEPTIONS:
+        except asyncio.CancelledError:
+            raise
+        except Exception:
             # Ledger writes must never affect request flow
-            pass
-    except _USAGE_NONCRITICAL_EXCEPTIONS:
+            logger.debug("LLM usage daily ledger write skipped/failed")
+    except asyncio.CancelledError:
+        raise
+    except Exception:
         # Never break request processing due to logging errors
         logger.debug("LLM usage logging skipped/failed")

--- a/tldw_Server_API/tests/Audio/test_audio_quota_rg_and_ledger.py
+++ b/tldw_Server_API/tests/Audio/test_audio_quota_rg_and_ledger.py
@@ -56,14 +56,62 @@ async def test_add_daily_minutes_writes_to_resource_daily_ledger(tmp_path, monke
         # Default tier is "free" with a nonzero daily_minutes cap; ledger is
         # the enforcement source of truth.
         await audio_quota.add_daily_minutes(user_id, 2.5)
+        await audio_quota.add_daily_minutes(user_id, 2.5)
 
         # ResourceDailyLedger lives in the same AuthNZ DB; query totals via DAL
         ledger = ResourceDailyLedger(db_pool=pool)
         await ledger.initialize()
         today = datetime.now(timezone.utc).date().strftime("%Y-%m-%d")
-        # Units are stored as whole seconds; 2.5 minutes ≈ 150 seconds
+        # Units are stored as whole seconds; two 2.5 minute events ≈ 300 seconds.
         total_units = await ledger.total_for_day("user", str(user_id), "minutes", day_utc=today)
-        assert 145 <= total_units <= 155, f"Expected ~150 seconds, got {total_units}"
+        assert 295 <= total_units <= 305, f"Expected ~300 seconds, got {total_units}"
+    finally:
+        await pool.close()
+
+
+@pytest.mark.asyncio
+async def test_consume_daily_minutes_if_allowed_is_atomic_and_idempotent(tmp_path, monkeypatch):
+    db_path = tmp_path / "users_audio_atomic_ledger.db"
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    from tldw_Server_API.app.core.AuthNZ.database import reset_db_pool, get_db_pool
+    from tldw_Server_API.app.core.DB_Management.Resource_Daily_Ledger import ResourceDailyLedger
+    from tldw_Server_API.app.core.Usage import audio_quota
+
+    audio_quota._daily_ledger = None  # type: ignore[attr-defined]
+    audio_quota._audio_minutes_legacy_backfill_done = False  # type: ignore[attr-defined]
+
+    async def _limits(_user_id: int):
+        return {
+            "daily_minutes": 2.0,
+            "concurrent_streams": 1,
+            "concurrent_jobs": 1,
+            "max_file_size_mb": 25,
+        }
+
+    monkeypatch.setattr(audio_quota, "get_limits_for_user", _limits)
+    await reset_db_pool()
+    pool = await get_db_pool()
+    try:
+        allowed_1, remaining_1 = await audio_quota.consume_daily_minutes_if_allowed(51, 1.0, op_id="evt-1")
+        allowed_2, remaining_2 = await audio_quota.consume_daily_minutes_if_allowed(51, 1.0, op_id="evt-2")
+        retry_allowed, retry_remaining = await audio_quota.consume_daily_minutes_if_allowed(51, 1.0, op_id="evt-2")
+        denied, remaining_3 = await audio_quota.consume_daily_minutes_if_allowed(51, 0.1, op_id="evt-3")
+
+        assert allowed_1 is True
+        assert remaining_1 == pytest.approx(1.0)
+        assert allowed_2 is True
+        assert remaining_2 == pytest.approx(0.0)
+        assert retry_allowed is True
+        assert retry_remaining == pytest.approx(0.0)
+        assert denied is False
+        assert remaining_3 == pytest.approx(0.0)
+
+        ledger = ResourceDailyLedger(db_pool=pool)
+        await ledger.initialize()
+        today = datetime.now(timezone.utc).date().strftime("%Y-%m-%d")
+        assert await ledger.total_for_day("user", "51", "minutes", day_utc=today) == 120
     finally:
         await pool.close()
 
@@ -131,6 +179,61 @@ async def test_can_start_stream_and_finish_stream_via_rg_integration(monkeypatch
     await audio_quota.finish_stream(user_id)
     active_after = await audio_quota.active_streams_count(user_id)
     assert active_after == 1
+
+
+@pytest.mark.asyncio
+async def test_can_start_stream_real_rg_enforces_limit_with_distinct_reservations(monkeypatch):
+    from tldw_Server_API.app.core.Resource_Governance import MemoryResourceGovernor
+    from tldw_Server_API.app.core.Usage import audio_quota
+
+    audio_quota._reset_in_process_counters_for_tests()
+    gov = MemoryResourceGovernor(
+        policies={
+            "audio.default": {
+                "streams": {"max_concurrent": 2, "ttl_sec": 30},
+                "scopes": ["user"],
+            }
+        }
+    )
+
+    async def _fake_get_audio_rg():
+        return gov
+
+    monkeypatch.setattr(audio_quota, "_get_audio_rg_governor", _fake_get_audio_rg)
+
+    assert await audio_quota.can_start_stream(211) == (True, "OK")
+    assert await audio_quota.can_start_stream(211) == (True, "OK")
+
+    allowed, reason = await audio_quota.can_start_stream(211)
+    assert allowed is False
+    assert "Concurrent streams" in reason
+
+
+@pytest.mark.asyncio
+async def test_can_start_job_real_rg_enforces_limit_with_distinct_reservations(monkeypatch):
+    from tldw_Server_API.app.core.Resource_Governance import MemoryResourceGovernor
+    from tldw_Server_API.app.core.Usage import audio_quota
+
+    audio_quota._reset_in_process_counters_for_tests()
+    gov = MemoryResourceGovernor(
+        policies={
+            "audio.default": {
+                "jobs": {"max_concurrent": 1, "ttl_sec": 30},
+                "scopes": ["user"],
+            }
+        }
+    )
+
+    async def _fake_get_audio_rg():
+        return gov
+
+    monkeypatch.setattr(audio_quota, "_get_audio_rg_governor", _fake_get_audio_rg)
+
+    assert await audio_quota.can_start_job(212) == (True, "OK")
+
+    allowed, reason = await audio_quota.can_start_job(212)
+    assert allowed is False
+    assert "Concurrent job" in reason
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Audio/test_audio_quota_unit.py
+++ b/tldw_Server_API/tests/Audio/test_audio_quota_unit.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 
@@ -297,6 +299,24 @@ async def test_can_start_stream_rg_reserve_failure_log_is_sanitized(monkeypatch)
     assert logger_stub.debugs == ["RG reserve failed for streams, failing open"]
     assert "rg streams reserve failed" not in str(logger_stub.debugs)
     assert "/private/rg.sock" not in str(logger_stub.debugs)
+
+
+@pytest.mark.asyncio
+async def test_can_start_stream_propagates_cancellation(monkeypatch):
+    from tldw_Server_API.app.core.Usage import audio_quota
+
+    class _CancellingGovernor:
+        async def reserve(self, req, op_id=None):  # noqa: ARG002
+            raise asyncio.CancelledError()
+
+    async def _fake_get_audio_rg_governor():
+        return _CancellingGovernor()
+
+    monkeypatch.setattr(audio_quota, "_get_audio_rg_governor", _fake_get_audio_rg_governor)
+    monkeypatch.setattr(audio_quota, "RGRequest", _SimpleRGRequest)
+
+    with pytest.raises(asyncio.CancelledError):
+        await audio_quota.can_start_stream(123)
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Usage/test_pricing_catalog_overrides.py
+++ b/tldw_Server_API/tests/Usage/test_pricing_catalog_overrides.py
@@ -69,6 +69,30 @@ def test_pricing_overrides_env_preserves_estimated_metadata(monkeypatch):
     assert "qwen-new-current" in catalog._catalog["qwen"]
 
 
+def test_pricing_partial_match_prefers_most_specific_model(monkeypatch):
+    monkeypatch.setenv(
+        "PRICING_OVERRIDES",
+        json.dumps(
+            {
+                "OpenAI": {
+                    "gpt-4": {"prompt": 0.030, "completion": 0.060},
+                    "gpt-4o-mini": {"prompt": 0.00015, "completion": 0.0006},
+                }
+            }
+        ),
+    )
+
+    from tldw_Server_API.app.core.Usage.pricing_catalog import PricingCatalog
+
+    catalog = PricingCatalog()
+
+    prompt_rate, completion_rate, estimated = catalog.get_rates("openai", "gpt-4o-mini-future")
+
+    assert prompt_rate == pytest.approx(0.00015)
+    assert completion_rate == pytest.approx(0.0006)
+    assert estimated is True
+
+
 def test_pricing_overrides_env_parse_warning_is_sanitized(monkeypatch):
     mod = importlib.import_module("tldw_Server_API.app.core.Usage.pricing_catalog")
     monkeypatch.setenv("PRICING_OVERRIDES", "{invalid")

--- a/tldw_Server_API/tests/Usage/test_usage_review_fixes.py
+++ b/tldw_Server_API/tests/Usage/test_usage_review_fixes.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_add_daily_minutes_counts_repeated_same_duration_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tldw_Server_API.app.core.Usage import audio_quota
+
+    entries = []
+
+    class FakeLedger:
+        async def add(self, entry):
+            entries.append(entry)
+            return True
+
+    async def fake_get_daily_ledger():
+        return FakeLedger()
+
+    monkeypatch.setattr(audio_quota, "_get_daily_ledger", fake_get_daily_ledger)
+
+    await audio_quota.add_daily_minutes(user_id=7, minutes=1.0)
+    await audio_quota.add_daily_minutes(user_id=7, minutes=1.0)
+
+    assert [entry.units for entry in entries] == [60, 60]
+    assert len({entry.op_id for entry in entries}) == 2
+
+
+@pytest.mark.asyncio
+async def test_add_daily_minutes_accepts_explicit_operation_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tldw_Server_API.app.core.Usage import audio_quota
+
+    entries = []
+
+    class FakeLedger:
+        async def add(self, entry):
+            entries.append(entry)
+            return True
+
+    async def fake_get_daily_ledger():
+        return FakeLedger()
+
+    monkeypatch.setattr(audio_quota, "_get_daily_ledger", fake_get_daily_ledger)
+
+    await audio_quota.add_daily_minutes(user_id=7, minutes=1.0, operation_id="audio-stream:abc:chunk-1")
+
+    assert entries[0].op_id == "audio-stream:abc:chunk-1"
+
+
+@pytest.mark.asyncio
+async def test_consume_daily_minutes_records_allowed_usage(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tldw_Server_API.app.core.Usage import audio_quota
+
+    entries = []
+
+    class FakeLedger:
+        async def remaining_for_day(self, *, entity_scope, entity_value, category, daily_cap):
+            assert entity_scope == "user"
+            assert entity_value == "42"
+            assert category == "minutes"
+            assert daily_cap == 600
+            return 300
+
+        async def add(self, entry):
+            entries.append(entry)
+            return True
+
+    async def fake_get_daily_ledger():
+        return FakeLedger()
+
+    async def fake_get_limits_for_user(user_id: int):
+        assert user_id == 42
+        return {"daily_minutes": 10.0}
+
+    monkeypatch.setattr(audio_quota, "_get_daily_ledger", fake_get_daily_ledger)
+    monkeypatch.setattr(audio_quota, "get_limits_for_user", fake_get_limits_for_user)
+
+    allowed, remaining = await audio_quota.consume_daily_minutes(
+        user_id=42,
+        minutes_requested=2.0,
+        operation_id="audio-file:req-1",
+    )
+
+    assert allowed is True
+    assert remaining == pytest.approx(3.0)
+    assert len(entries) == 1
+    assert entries[0].units == 120
+    assert entries[0].op_id == "audio-file:req-1"
+
+
+@pytest.mark.asyncio
+async def test_consume_daily_minutes_denies_without_recording(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tldw_Server_API.app.core.Usage import audio_quota
+
+    entries = []
+
+    class FakeLedger:
+        async def remaining_for_day(self, *, entity_scope, entity_value, category, daily_cap):
+            return 30
+
+        async def add(self, entry):
+            entries.append(entry)
+            return True
+
+    async def fake_get_daily_ledger():
+        return FakeLedger()
+
+    async def fake_get_limits_for_user(user_id: int):
+        return {"daily_minutes": 10.0}
+
+    monkeypatch.setattr(audio_quota, "_get_daily_ledger", fake_get_daily_ledger)
+    monkeypatch.setattr(audio_quota, "get_limits_for_user", fake_get_limits_for_user)
+
+    allowed, remaining = await audio_quota.consume_daily_minutes(
+        user_id=42,
+        minutes_requested=1.0,
+        operation_id="audio-file:req-denied",
+    )
+
+    assert allowed is False
+    assert remaining == pytest.approx(0.5)
+    assert entries == []
+
+
+@pytest.mark.asyncio
+async def test_consume_daily_minutes_surfaces_store_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tldw_Server_API.app.core.Usage import audio_quota
+
+    async def fake_get_daily_ledger():
+        return None
+
+    async def fake_get_limits_for_user(user_id: int):
+        return {"daily_minutes": 10.0}
+
+    monkeypatch.setattr(audio_quota, "_get_daily_ledger", fake_get_daily_ledger)
+    monkeypatch.setattr(audio_quota, "get_limits_for_user", fake_get_limits_for_user)
+
+    with pytest.raises(audio_quota.AudioQuotaStoreUnavailable):
+        await audio_quota.consume_daily_minutes(
+            user_id=42,
+            minutes_requested=1.0,
+            operation_id="audio-file:req-store-down",
+        )
+
+
+@pytest.mark.asyncio
+async def test_consume_daily_minutes_allows_unlimited_tier_when_store_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.Usage import audio_quota
+
+    async def fake_get_daily_ledger():
+        return None
+
+    async def fake_get_limits_for_user(user_id: int):
+        assert user_id == 42
+        return {"daily_minutes": None}
+
+    monkeypatch.setattr(audio_quota, "_get_daily_ledger", fake_get_daily_ledger)
+    monkeypatch.setattr(audio_quota, "get_limits_for_user", fake_get_limits_for_user)
+
+    allowed, remaining = await audio_quota.consume_daily_minutes(
+        user_id=42,
+        minutes_requested=10.0,
+        operation_id="audio-file:req-unlimited",
+    )
+
+    assert allowed is True
+    assert remaining is None
+
+
+@pytest.mark.asyncio
+async def test_consume_daily_minutes_legacy_fallback_lives_in_core() -> None:
+    from tldw_Server_API.app.core.Usage import audio_quota
+
+    calls = []
+
+    async def fake_check(user_id: int, minutes: float):
+        calls.append(("check", user_id, minutes))
+        return True, 4.0
+
+    async def fake_add(user_id: int, minutes: float):
+        calls.append(("add", user_id, minutes))
+
+    allowed, remaining = await audio_quota.consume_daily_minutes_with_legacy_fallback(
+        user_id=42,
+        minutes=1.0,
+        operation_id="audio-file:req-legacy",
+        consume_fn=audio_quota.consume_daily_minutes,
+        check_fn=fake_check,
+        add_fn=fake_add,
+    )
+
+    assert allowed is True
+    assert remaining == pytest.approx(4.0)
+    assert calls == [("check", 42, 1.0), ("add", 42, 1.0)]
+
+
+@pytest.mark.asyncio
+async def test_audio_quota_helpers_propagate_cancelled_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tldw_Server_API.app.core.Usage import audio_quota
+
+    async def cancelled_daily_ledger():
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(audio_quota, "_get_daily_ledger", cancelled_daily_ledger)
+
+    with pytest.raises(asyncio.CancelledError):
+        await audio_quota.add_daily_minutes(user_id=1, minutes=1.0)
+
+
+@pytest.mark.asyncio
+async def test_log_llm_usage_does_not_emit_per_user_metric_labels(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tldw_Server_API.app.core.Usage import usage_tracker
+
+    calls = []
+
+    def capture_counter(name, value=1, labels=None):
+        calls.append((name, dict(labels or {})))
+
+    async def fail_get_db_pool():
+        raise RuntimeError("stop before persistence")
+
+    monkeypatch.setattr(
+        usage_tracker,
+        "get_settings",
+        lambda: SimpleNamespace(LLM_USAGE_ENABLED=True, USAGE_LOG_DISABLE_META=True, PII_REDACT_LOGS=False),
+    )
+    monkeypatch.setattr(usage_tracker, "increment_counter", capture_counter)
+    monkeypatch.setattr(usage_tracker, "get_db_pool", fail_get_db_pool)
+
+    await usage_tracker.log_llm_usage(
+        user_id=123,
+        key_id=None,
+        endpoint="POST:/api/v1/chat/completions",
+        operation="chat",
+        provider="openai",
+        model="gpt-4o-mini",
+        status=200,
+        latency_ms=10,
+        prompt_tokens=5,
+        completion_tokens=2,
+        total_tokens=7,
+        request_id="req-metrics",
+    )
+
+    assert calls
+    assert not any(name.endswith("_by_user") for name, _labels in calls)
+    assert all("user_id" not in labels for _name, labels in calls)
+
+
+def test_placeholder_pricing_uses_conservative_estimate_for_billable_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PRICING_OVERRIDES", raising=False)
+
+    from tldw_Server_API.app.core.Usage.pricing_catalog import PricingCatalog
+
+    catalog = PricingCatalog()
+
+    prompt_rate, completion_rate, estimated = catalog.get_rates("qwen", "qwen-max")
+
+    assert prompt_rate > 0
+    assert completion_rate > 0
+    assert estimated is True
+
+
+def test_documented_free_pricing_can_remain_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PRICING_OVERRIDES", raising=False)
+
+    from tldw_Server_API.app.core.Usage.pricing_catalog import PricingCatalog
+
+    catalog = PricingCatalog()
+
+    prompt_rate, completion_rate, estimated = catalog.get_rates("zai", "glm-4.7-flash")
+
+    assert prompt_rate == 0.0
+    assert completion_rate == 0.0
+    assert estimated is False

--- a/tldw_Server_API/tests/Usage/test_usage_tracker_sqlite.py
+++ b/tldw_Server_API/tests/Usage/test_usage_tracker_sqlite.py
@@ -413,6 +413,49 @@ async def test_log_llm_usage_failure_log_is_sanitized(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_log_llm_usage_repo_backend_error_is_best_effort(monkeypatch):
+    from tldw_Server_API.app.core.Usage import usage_tracker as usage_tracker_module
+
+    class _FailingRepo:
+        def __init__(self, _pool):
+            pass
+
+        async def get_api_key_name(self, *, key_id: int):  # noqa: ARG002
+            return None
+
+        async def insert_llm_usage_log(self, **_kwargs):
+            raise Exception("postgres usage insert failed at /private/usage-db")
+
+    async def _fake_get_db_pool():
+        return object()
+
+    logger_stub = _LoggerStub()
+    monkeypatch.setattr(usage_tracker_module, "get_settings", _safe_usage_settings)
+    monkeypatch.setattr(usage_tracker_module, "get_db_pool", _fake_get_db_pool)
+    monkeypatch.setattr(usage_tracker_module, "AuthnzUsageRepo", _FailingRepo)
+    monkeypatch.setattr(usage_tracker_module, "logger", logger_stub)
+
+    await usage_tracker_module.log_llm_usage(
+        user_id=1,
+        key_id=None,
+        endpoint="POST:/api/v1/chat/completions",
+        operation="chat",
+        provider="test",
+        model="test-model",
+        status=200,
+        latency_ms=1,
+        prompt_tokens=1,
+        completion_tokens=1,
+        total_tokens=2,
+        request_id="raw-request-id",
+    )
+
+    assert logger_stub.debugs == ["LLM usage logging skipped/failed"]
+    assert "postgres usage insert failed" not in str(logger_stub.debugs)
+    assert "/private/usage-db" not in str(logger_stub.debugs)
+
+
+@pytest.mark.asyncio
 async def test_log_llm_usage_persists_router_enrichment(monkeypatch):
     monkeypatch.setenv("AUTH_MODE", "single_user")
     monkeypatch.setenv("SINGLE_USER_API_KEY", "ut-key-" + uuid.uuid4().hex)


### PR DESCRIPTION
## Change summary
AI-generated draft; human owner should review and replace or confirm this section before merge per repository policy.

- Fix audio quota accounting so same-duration events are counted separately, Resource Governor reservations use unique operation IDs, and daily minute consumption can be enforced atomically through ResourceDailyLedger.
- Wire audio streaming/transcription quota paths to the atomic consume helper while keeping bounded fail-open behavior for quota store failures.
- Harden Usage logging and pricing behavior by preserving cancellation, keeping LLM usage logging best-effort, removing raw per-user metric labels, and preferring specific model pricing matches with conservative placeholder rates.

## Test plan
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Audio/test_audio_quota_rg_and_ledger.py tldw_Server_API/tests/Audio/test_audio_quota_unit.py tldw_Server_API/tests/Usage/test_usage_review_fixes.py tldw_Server_API/tests/Usage/test_audio_rg_minutes_and_heartbeat.py tldw_Server_API/tests/Usage/test_usage_tracker_sqlite.py tldw_Server_API/tests/Usage/test_pricing_catalog.py tldw_Server_API/tests/Usage/test_pricing_catalog_overrides.py tldw_Server_API/tests/Usage/test_pricing_catalog_path.py -q`
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Usage tldw_Server_API/app/core/DB_Management/Resource_Daily_Ledger.py tldw_Server_API/app/api/v1/endpoints/audio/__init__.py tldw_Server_API/app/api/v1/endpoints/audio/audio.py tldw_Server_API/app/api/v1/endpoints/audio/audio_streaming.py tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py -f json -o /tmp/bandit_usage_review_fixes_worktree.json`
- `git diff --cached --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes audio quota accounting with atomic ledger-side daily-minute consumption and correct concurrency enforcement to prevent overuse. Streaming and transcription now consume minutes in one step, with bounded fail-open when the quota store is down.

- **Bug Fixes**
  - Added `consume_daily_minutes` using `ResourceDailyLedger.consume_if_available` for atomic enforcement; generates unique op IDs, counts equal-duration events separately, and supports idempotent retries.
  - Wired streaming/transcription to `consume_daily_minutes` via a core legacy-compatible fallback; unlimited tiers continue when the ledger is unavailable.
  - Resource Governor reservations for streams/jobs now use unique operation IDs per reservation.
  - Preserved cancellation propagation; kept LLM usage logging best-effort, removed per-user metric labels, and sanitized debug logs.
  - Pricing partial-match now picks the most specific model; placeholders use conservative default rates.

<sup>Written for commit 21a610f332f512075d22afe2133e608c118664d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

