### PR TITLE
Harden Watchlists core review findings

### DIFF
--- a/Docs/superpowers/plans/2026-06-23-watchlists-core-review-hardening.md
+++ b/Docs/superpowers/plans/2026-06-23-watchlists-core-review-hardening.md
@@ -1,0 +1,75 @@
+# Watchlists Core Review Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix validated Watchlists core review findings from TASK-10000 without broad module refactors.
+
+**Architecture:** Keep the changes at existing boundaries: filter safety stays in `Watchlists/filters.py`, tenant/status/cancellation behavior stays in pipeline and scheduler handler code, ownership checks stay in `Watchlists_DB.py`, and output enrichment scheduling reuses the existing `output_enrichment_handler.enrich_output` worker. Regression coverage is focused on the specific broken contracts.
+
+**Tech Stack:** FastAPI, pytest, SQLite-backed WatchlistsDatabase tests, existing `regex` dependency for bounded regular-expression execution.
+
+---
+
+## Stage 1: Regex Safety And Cancellation Contracts
+
+**Goal:** Prevent unsafe regex filters from blocking evaluation and stop treating task cancellation as recoverable noise.
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Watchlists/filters.py`
+- Modify: `tldw_Server_API/app/core/Watchlists/fetchers.py`
+- Modify: `tldw_Server_API/app/core/Watchlists/pipeline.py`
+- Test: `tldw_Server_API/tests/Watchlists/test_filters_matching.py`
+- Test: `tldw_Server_API/tests/Watchlists/test_watchlists_pipeline.py`
+
+**Success Criteria:** Unsafe or oversized regex filters do not match, normal regex filters still work, and `asyncio.CancelledError` is no longer in Watchlists recoverable exception tuples.
+
+**Tests:** `python -m pytest tldw_Server_API/tests/Watchlists/test_filters_matching.py tldw_Server_API/tests/Watchlists/test_watchlists_pipeline.py -q`
+
+**Status:** Complete
+
+## Stage 2: Tenant-Aware Pipeline And Scheduler Status
+
+**Goal:** Preserve tenant context from Scheduler payloads into URL egress policy checks and return the real pipeline status from scheduler handlers.
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Watchlists/pipeline.py`
+- Modify: `tldw_Server_API/app/core/Scheduler/handlers/watchlists.py`
+- Test: `tldw_Server_API/tests/Watchlists/test_watchlists_pipeline.py`
+- Test: `tldw_Server_API/tests/Watchlists/test_watchlists_scheduler_handler.py`
+
+**Success Criteria:** RSS and scrape-rule fetchers receive the explicit tenant ID, scheduler passes `tenant_id`, and cancelled pipeline results are reported as cancelled instead of succeeded.
+
+**Tests:** `python -m pytest tldw_Server_API/tests/Watchlists/test_watchlists_pipeline.py tldw_Server_API/tests/Watchlists/test_watchlists_scheduler_handler.py -q`
+
+**Status:** Complete
+
+## Stage 3: Source Association Ownership And Scope Failure Handling
+
+**Goal:** Enforce source ownership for tags, groups, seen-item helpers, and source deletion, and ensure malformed scopes cannot leave runs stuck.
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/Watchlists_DB.py`
+- Modify: `tldw_Server_API/app/core/Watchlists/pipeline.py`
+- Test: `tldw_Server_API/tests/Watchlists/test_watchlists_db_user_scope.py`
+- Test: `tldw_Server_API/tests/Watchlists/test_watchlists_pipeline.py`
+
+**Success Criteria:** Cross-user source association helpers raise or no-op without mutating owner rows, group assignment rejects foreign groups, malformed scopes are skipped safely, and unexpected pipeline failures update the run as failed.
+
+**Tests:** `python -m pytest tldw_Server_API/tests/Watchlists/test_watchlists_db_user_scope.py tldw_Server_API/tests/Watchlists/test_watchlists_pipeline.py -q`
+
+**Status:** Complete
+
+## Stage 4: Output Enrichment Scheduling And Verification
+
+**Goal:** Schedule the existing enrichment worker when output creation stores pending enrichment metadata.
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/watchlists.py`
+- Test: `tldw_Server_API/tests/Watchlists/test_watchlists_api.py`
+- Update: `backlog/tasks/task-10000 - Harden-Watchlists-core-review-findings.md`
+
+**Success Criteria:** Creating an output with briefing summary or topic grouping schedules `enrich_output` after artifact creation, existing output behavior remains unchanged, focused Watchlists tests pass, and Bandit reports no new findings on touched Python files.
+
+**Tests:** `python -m pytest tldw_Server_API/tests/Watchlists/test_watchlists_api.py -q`; `python -m bandit -r tldw_Server_API/app/core/Watchlists tldw_Server_API/app/core/Scheduler/handlers/watchlists.py tldw_Server_API/app/core/DB_Management/Watchlists_DB.py tldw_Server_API/app/api/v1/endpoints/watchlists.py -f json -o /tmp/bandit_watchlists_core_review_fixes.json`
+
+**Status:** Complete

--- a/backlog/tasks/task-10000 - Harden-Watchlists-core-review-findings.md
+++ b/backlog/tasks/task-10000 - Harden-Watchlists-core-review-findings.md
@@ -1,0 +1,61 @@
+---
+id: TASK-10000
+title: Harden Watchlists core review findings
+status: Done
+assignee: []
+created_date: 2026-06-23 21:55
+updated_date: 2026-06-25 00:02
+labels:
+- watchlists
+- core
+- security
+- review-fix
+dependencies: []
+references:
+- Docs/superpowers/plans/2026-06-23-watchlists-core-review-hardening.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix Watchlists core review findings around unsafe regex filters, tenant-aware egress policy checks, cancellation status handling, source ownership enforcement, malformed source scope cleanup, and output enrichment scheduling.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Regex filters reject or time-bound unsafe patterns without blocking job evaluation.
+- [x] #2 Watchlist jobs and scheduler payloads propagate tenant IDs to egress policy checks.
+- [x] #3 Cancelled runs are not swallowed and scheduler status reflects the pipeline result.
+- [x] #4 Source tags, groups, seen items, and deletes enforce source/user ownership in the core DB layer.
+- [x] #5 Malformed source scopes do not leave runs stuck in running status.
+- [x] #6 Output enrichment pending work is scheduled after output creation.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Review remediation complete for PR #2482. Branch rebased onto latest origin/dev and Watchlists diff remains scoped. Addressed Qodo comments by documenting B608 suppressions, adding regex timeout exception compatibility, moving enrichment scheduling into core Watchlists code, and routing enrichment through the durable Scheduler with idempotency plus fallback. Verification: focused changed tests passed (6 passed), broader Watchlists focused suite passed (96 passed, 1 skipped), py_compile passed with existing endpoint SyntaxWarnings only, git diff --check passed, Bandit touched app scope reported 0 findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+2026-06-24: Reopened to address PR #2482 review comments after rebasing onto latest origin/dev. Review items: justify new B608 suppressions, move enrichment scheduling out of endpoint, catch regex timeout variants, and route output enrichment through Scheduler with fallback only when unavailable.
+2026-06-24: PR #2482 review remediation completed. Rebased branch onto origin/dev, dropping unrelated Claims commits from the PR diff. Added documented B608 rationale comments, regex timeout variant handling, Scheduler-backed output enrichment submission with in-process fallback, and watchlists_enrich_output Scheduler task coverage.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -27,6 +27,7 @@ from typing import Any, Literal
 
 from fastapi import (
     APIRouter,
+    BackgroundTasks,
     Body,
     Depends,
     File,
@@ -90,6 +91,7 @@ from tldw_Server_API.app.core.Watchlists.fetchers import (
 from tldw_Server_API.app.core.Watchlists.filters import evaluate_filters as _evaluate_filters
 from tldw_Server_API.app.core.Watchlists.filters import normalize_filters as _normalize_job_filters
 from tldw_Server_API.app.core.Watchlists.opml import generate_opml, parse_opml
+from tldw_Server_API.app.core.Watchlists.output_enrichment_handler import schedule_output_enrichment
 from tldw_Server_API.app.core.Watchlists.pipeline import run_watchlist_job
 from tldw_Server_API.app.core.Watchlists.report_evidence import (
     build_legacy_live_only_readiness,
@@ -910,6 +912,10 @@ def _normalize_workflow_tenant_id(value: Any) -> str | None:
     if isinstance(value, (int, float)):
         return str(value)
     return None
+
+
+def _resolve_request_tenant_id(current_user: User) -> str:
+    return _normalize_workflow_tenant_id(getattr(current_user, "tenant_id", None)) or "default"
 
 
 async def _resolve_watchlist_workflow_tenant_id(*, current_user: User, resolved_user_id: int) -> str:
@@ -2199,6 +2205,7 @@ async def check_sources_now(
             run_result = await run_watchlist_job(
                 int(current_user.id),
                 manual_job_id,
+                tenant_id=_resolve_request_tenant_id(current_user),
                 source_ids_override=active_source_ids,
                 capture_companion_activity=True,
                 companion_route="/api/v1/watchlists/sources/check-now",
@@ -2539,6 +2546,7 @@ async def _build_source_preview_response(
     source_type: str,
     settings: dict[str, Any] | None,
     limit: int,
+    tenant_id: str = "default",
     etag: str | None = None,
     last_modified: str | None = None,
 ) -> PreviewResponse:
@@ -2557,7 +2565,7 @@ async def _build_source_preview_response(
                 normalized_url,
                 etag=etag,
                 last_modified=last_modified,
-                tenant_id="default",
+                tenant_id=tenant_id,
             )
             if isinstance(res, dict):
                 status = res.get("status")
@@ -2584,7 +2592,7 @@ async def _build_source_preview_response(
                 items = await fetch_site_items_with_rules(
                     base_url=str(scrape_rules.get("list_url") or normalized_url),
                     rules=scrape_rules,
-                    tenant_id="default",
+                    tenant_id=tenant_id,
                     fetch_diagnostics=fetch_events.append,
                 )
             except _WATCHLISTS_NONCRITICAL_EXCEPTIONS as exc:
@@ -2659,7 +2667,7 @@ async def _build_source_preview_response(
 async def test_source_draft(
     payload: SourceTestRequest = Body(...),
     limit: int = Query(20, ge=1, le=200),
-    _current_user: User = Depends(get_request_user),
+    current_user: User = Depends(get_request_user),
     _db=Depends(get_watchlists_db_for_user),
 ):
     return await _build_source_preview_response(
@@ -2668,6 +2676,7 @@ async def test_source_draft(
         source_type=str(payload.source_type),
         settings=payload.settings or {},
         limit=limit,
+        tenant_id=_resolve_request_tenant_id(current_user),
     )
 
 
@@ -2696,6 +2705,7 @@ async def test_source(
         source_type=str(getattr(src, "source_type", "")),
         settings=settings,
         limit=limit,
+        tenant_id=_resolve_request_tenant_id(current_user),
         etag=getattr(src, "etag", None),
         last_modified=getattr(src, "last_modified", None),
     )
@@ -4189,6 +4199,7 @@ async def trigger_run(
         result = await run_watchlist_job(
             int(current_user.id),
             job_id,
+            tenant_id=_resolve_request_tenant_id(current_user),
             capture_companion_activity=True,
             companion_route=f"/api/v1/watchlists/jobs/{job_id}/run",
         )
@@ -6313,6 +6324,7 @@ async def delete_output_preset(
 @router.post("/outputs", response_model=WatchlistOutput, summary="Generate an output from scraped items")
 async def create_output(
     payload: WatchlistOutputCreateRequest,
+    background_tasks: BackgroundTasks,
     current_user: User = Depends(get_request_user),
     db=Depends(get_watchlists_db_for_user),
     collections_db=Depends(get_collections_db_for_user),
@@ -7199,6 +7211,15 @@ async def create_output(
             chatbook_path=chatbook_path_update,
         )
         output = await _row_to_output(updated_row, user_id=user_id)
+
+    if needs_async_enrichment:
+        await schedule_output_enrichment(
+            output_id=int(output.id),
+            user_id=int(user_id),
+            grouping_config=payload.grouping,
+            summary_config=payload.briefing_summary,
+            fallback_submitter=background_tasks.add_task,
+        )
 
     return output
 

--- a/tldw_Server_API/app/core/DB_Management/Watchlists_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Watchlists_DB.py
@@ -1776,6 +1776,45 @@ class WatchlistsDatabase:
     # ------------------------
     # Sources
     # ------------------------
+    def _ensure_source_owner(self, source_id: int) -> int:
+        source_id = int(source_id)
+        self.get_source(source_id)
+        return source_id
+
+    def _validate_group_ids_for_user(self, group_ids: Iterable[int] | None) -> list[int]:
+        clean_ids: list[int] = []
+        seen: set[int] = set()
+        for gid in group_ids or []:
+            try:
+                val = int(gid)
+            except _WATCHLISTS_DB_NONCRITICAL_EXCEPTIONS:
+                continue
+            if val <= 0 or val in seen:
+                continue
+            seen.add(val)
+            clean_ids.append(val)
+        if not clean_ids:
+            return []
+
+        placeholders = ",".join(["?"] * len(clean_ids))
+        # B608 rationale: only placeholder tokens are generated; values are parameter-bound.
+        rows = self.backend.execute(
+            f"SELECT id FROM groups WHERE user_id = ? AND id IN ({placeholders})",  # nosec B608
+            tuple([self.user_id, *clean_ids]),
+        ).rows
+        found_ids: set[int] = set()
+        for row in rows:
+            raw_id = row.get("id")
+            if raw_id is None:
+                continue
+            try:
+                found_ids.add(int(raw_id))
+            except _WATCHLISTS_DB_NONCRITICAL_EXCEPTIONS:
+                continue
+        if found_ids != set(clean_ids):
+            raise ValueError("group_not_found")
+        return clean_ids
+
     def create_source(
         self,
         *,
@@ -1789,6 +1828,7 @@ class WatchlistsDatabase:
         watchlist_id: int | None = None,
     ) -> SourceRow:
         now = _utcnow_iso()
+        clean_group_ids = self._validate_group_ids_for_user(group_ids)
         # Try insert; if UNIQUE(user_id,url) violates, fetch existing id and proceed idempotently
         sid: int | None = None
         created_new = False
@@ -1828,8 +1868,8 @@ class WatchlistsDatabase:
                         "INSERT INTO source_tags (source_id, tag_id) SELECT ?, ? WHERE NOT EXISTS (SELECT 1 FROM source_tags WHERE source_id = ? AND tag_id = ?)",
                         (sid, tid, sid, tid),
                     )
-        if group_ids:
-            for gid in group_ids:
+        if clean_group_ids:
+            for gid in clean_group_ids:
                 try:
                     self.backend.execute(
                         "INSERT INTO source_groups (source_id, group_id) VALUES (?, ?) ON CONFLICT(source_id, group_id) DO NOTHING",
@@ -2022,6 +2062,7 @@ class WatchlistsDatabase:
         )
 
     def set_source_tags(self, source_id: int, tag_names: list[str]) -> list[str]:
+        source_id = self._ensure_source_owner(source_id)
         tag_ids = self.ensure_tag_ids(tag_names)
         self.backend.execute("DELETE FROM source_tags WHERE source_id = ?", (source_id,))
         for tid in tag_ids:
@@ -2042,17 +2083,8 @@ class WatchlistsDatabase:
         return [r.get("name") for r in rows if r.get("name")]
 
     def set_source_groups(self, source_id: int, group_ids: list[int]) -> list[int]:
-        clean_ids: list[int] = []
-        seen: set[int] = set()
-        for gid in group_ids or []:
-            try:
-                val = int(gid)
-            except _WATCHLISTS_DB_NONCRITICAL_EXCEPTIONS:
-                continue
-            if val in seen:
-                continue
-            seen.add(val)
-            clean_ids.append(val)
+        source_id = self._ensure_source_owner(source_id)
+        clean_ids = self._validate_group_ids_for_user(group_ids)
         self.backend.execute("DELETE FROM source_groups WHERE source_id = ?", (source_id,))
         for gid in clean_ids:
             try:
@@ -2069,6 +2101,7 @@ class WatchlistsDatabase:
 
     def get_source_group_ids(self, source_id: int) -> list[int]:
         """Return group IDs for a single source, ordered."""
+        source_id = self._ensure_source_owner(source_id)
         rows = self.backend.execute(
             "SELECT group_id FROM source_groups WHERE source_id = ? ORDER BY group_id",
             (source_id,),
@@ -2079,12 +2112,43 @@ class WatchlistsDatabase:
         """Return {source_id: [group_ids]} for multiple sources in one query."""
         if not source_ids:
             return {}
-        placeholders = ",".join(["?"] * len(source_ids))
-        rows = self.backend.execute(
-            f"SELECT source_id, group_id FROM source_groups WHERE source_id IN ({placeholders}) ORDER BY source_id, group_id",  # nosec B608
-            tuple(source_ids),
+        clean_source_ids: list[int] = []
+        seen: set[int] = set()
+        for sid in source_ids:
+            try:
+                source_id = int(sid)
+            except _WATCHLISTS_DB_NONCRITICAL_EXCEPTIONS:
+                continue
+            if source_id in seen:
+                continue
+            seen.add(source_id)
+            clean_source_ids.append(source_id)
+        if not clean_source_ids:
+            return {}
+        placeholders = ",".join(["?"] * len(clean_source_ids))
+        # B608 rationale: only placeholder tokens are generated; values are parameter-bound.
+        owned_rows = self.backend.execute(
+            f"SELECT id FROM sources WHERE user_id = ? AND id IN ({placeholders})",  # nosec B608
+            tuple([self.user_id, *clean_source_ids]),
         ).rows
-        result: dict[int, list[int]] = {sid: [] for sid in source_ids}
+        owned_ids: set[int] = set()
+        for row in owned_rows:
+            raw_id = row.get("id")
+            if raw_id is None:
+                continue
+            try:
+                owned_ids.add(int(raw_id))
+            except _WATCHLISTS_DB_NONCRITICAL_EXCEPTIONS:
+                continue
+        result: dict[int, list[int]] = {sid: [] for sid in clean_source_ids}
+        if not owned_ids:
+            return result
+        owned_placeholders = ",".join(["?"] * len(owned_ids))
+        # B608 rationale: only placeholder tokens for owned IDs are generated; values are parameter-bound.
+        rows = self.backend.execute(
+            f"SELECT source_id, group_id FROM source_groups WHERE source_id IN ({owned_placeholders}) ORDER BY source_id, group_id",  # nosec B608
+            tuple(sorted(owned_ids)),
+        ).rows
         for r in rows:
             sid = int(r.get("source_id"))
             gid = int(r.get("group_id"))
@@ -2093,6 +2157,10 @@ class WatchlistsDatabase:
         return result
 
     def delete_source(self, source_id: int) -> bool:
+        try:
+            source_id = self._ensure_source_owner(source_id)
+        except KeyError:
+            return False
         with self.transaction() as conn:
             self.backend.execute("DELETE FROM source_groups WHERE source_id = ?", (source_id,), connection=conn)
             self.backend.execute("DELETE FROM source_tags WHERE source_id = ?", (source_id,), connection=conn)
@@ -4530,6 +4598,7 @@ class WatchlistsDatabase:
     # RSS item-level dedup helpers
     # ------------------------
     def has_seen_item(self, source_id: int, item_key: str) -> bool:
+        source_id = self._ensure_source_owner(source_id)
         row = self.backend.execute(
             "SELECT 1 FROM source_seen_items WHERE source_id = ? AND item_key = ?",
             (source_id, item_key),
@@ -4545,6 +4614,7 @@ class WatchlistsDatabase:
         last_modified: str | None = None,
         seen_at: str | None = None,
     ) -> None:
+        source_id = self._ensure_source_owner(source_id)
         ts = seen_at or _utcnow_iso()
         # SQLite upsert pattern; backend handles SQL transparently in SQLite/Postgres where available
         try:
@@ -4577,6 +4647,7 @@ class WatchlistsDatabase:
                 )
 
     def list_seen_item_keys(self, source_id: int, *, limit: int | None = None) -> list[str]:
+        source_id = self._ensure_source_owner(source_id)
         sql = "SELECT item_key FROM source_seen_items WHERE source_id = ? ORDER BY last_seen_at DESC"
         params: tuple[Any, ...] = (source_id,)
         if isinstance(limit, int) and limit > 0:
@@ -4591,6 +4662,7 @@ class WatchlistsDatabase:
         return keys
 
     def get_seen_item_stats(self, source_id: int) -> dict[str, Any]:
+        source_id = self._ensure_source_owner(source_id)
         row = self.backend.execute(
             "SELECT COUNT(*) AS seen_count, MAX(last_seen_at) AS latest_seen_at "
             "FROM source_seen_items WHERE source_id = ?",
@@ -4610,6 +4682,7 @@ class WatchlistsDatabase:
         return {"seen_count": count_val, "latest_seen_at": latest_seen_at}
 
     def clear_seen_items(self, source_id: int) -> int:
+        source_id = self._ensure_source_owner(source_id)
         row = self.backend.execute(
             "SELECT COUNT(*) AS cnt FROM source_seen_items WHERE source_id = ?",
             (source_id,),

--- a/tldw_Server_API/app/core/Scheduler/handlers/watchlists.py
+++ b/tldw_Server_API/app/core/Scheduler/handlers/watchlists.py
@@ -1,7 +1,9 @@
 """
 Scheduler task handler for Watchlists runs.
 
-Task name: 'watchlist_run'
+Task names:
+- 'watchlist_run'
+- 'watchlists_enrich_output'
 Inputs expected in payload:
   payload = {
     'inputs': { 'watchlist_job_id': <int> },
@@ -20,6 +22,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from tldw_Server_API.app.core.Scheduler.base.registry import task
+from tldw_Server_API.app.core.Watchlists import output_enrichment_handler
 from tldw_Server_API.app.core.Watchlists.pipeline import run_watchlist_job
 
 
@@ -57,6 +60,42 @@ async def watchlist_run(payload: dict[str, Any]) -> dict[str, Any]:
     except Exception:
         raise ValueError("watchlist_run: user_id must be int-like") from None
 
+    tenant_id = payload.get("tenant_id")
+    if tenant_id is not None:
+        tenant_id = str(tenant_id)
+
     # Execute the real pipeline (handles run row creation, stats, and job history)
-    result = await run_watchlist_job(uid_int, int(job_id))
-    return {"run_id": result.get("run_id"), "status": "succeeded", "items_ingested": int(result.get("items_ingested", 0))}
+    result = await run_watchlist_job(uid_int, int(job_id), tenant_id=tenant_id)
+    status = str(result.get("status") or "succeeded")
+    return {"run_id": result.get("run_id"), "status": status, "items_ingested": int(result.get("items_ingested", 0))}
+
+
+@task(name="watchlists_enrich_output", max_retries=1, timeout=3600, queue="watchlists")
+async def watchlists_enrich_output(payload: dict[str, Any]) -> dict[str, Any]:
+    """Run deferred enrichment for a generated watchlist output."""
+    output_id = payload.get("output_id")
+    if output_id is None:
+        raise ValueError("watchlists_enrich_output: missing output_id")
+    user_id = payload.get("user_id")
+    if user_id is None:
+        raise ValueError("watchlists_enrich_output: missing user_id")
+    try:
+        output_id_int = int(output_id)
+        user_id_int = int(user_id)
+    except Exception:
+        raise ValueError("watchlists_enrich_output: output_id and user_id must be int-like") from None
+
+    grouping_config = payload.get("grouping_config")
+    if grouping_config is not None and not isinstance(grouping_config, dict):
+        raise ValueError("watchlists_enrich_output: grouping_config must be a dict when provided")
+    summary_config = payload.get("summary_config")
+    if summary_config is not None and not isinstance(summary_config, dict):
+        raise ValueError("watchlists_enrich_output: summary_config must be a dict when provided")
+
+    await output_enrichment_handler.enrich_output(
+        output_id=output_id_int,
+        user_id=user_id_int,
+        grouping_config=grouping_config,
+        summary_config=summary_config,
+    )
+    return {"output_id": output_id_int, "status": "completed"}

--- a/tldw_Server_API/app/core/Watchlists/fetchers.py
+++ b/tldw_Server_API/app/core/Watchlists/fetchers.py
@@ -39,7 +39,6 @@ from tldw_Server_API.app.core.Security.egress import is_url_allowed, is_url_allo
 from tldw_Server_API.app.core.testing import is_test_mode as _is_test_mode
 
 _WATCHLISTS_FETCHERS_NONCRITICAL_EXCEPTIONS = (
-    asyncio.CancelledError,
     asyncio.TimeoutError,
     AssertionError,
     AttributeError,

--- a/tldw_Server_API/app/core/Watchlists/filters.py
+++ b/tldw_Server_API/app/core/Watchlists/filters.py
@@ -5,6 +5,16 @@ from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+import regex as regex_engine
+
+
+_MAX_REGEX_PATTERN_LENGTH = 1000
+_REGEX_TIMEOUT_SECONDS = 0.05
+_REGEX_TIMEOUT_ERROR = getattr(regex_engine, "TimeoutError", TimeoutError)
+_NESTED_REGEX_QUANTIFIER_RE = re.compile(
+    r"\((?:[^()\\]|\\.)*(?:\*|\+|\{\d+(?:,\d*)?\})(?:[^()\\]|\\.)*\)\s*(?:\*|\+|\{\d+(?:,\d*)?\})"
+)
+
 
 def _to_list(val: Any) -> list[str]:
     if val is None:
@@ -108,8 +118,16 @@ def _match_author(value: dict[str, Any], candidate: dict[str, Any]) -> bool:
     return any(n in author for n in names)
 
 
-def _compile_regex(pattern: str, flags: str | None) -> re.Pattern[str] | None:
+def _looks_like_nested_quantifier(pattern: str) -> bool:
+    return bool(_NESTED_REGEX_QUANTIFIER_RE.search(pattern))
+
+
+def _compile_regex(pattern: str, flags: str | None) -> Any | None:
     if not pattern:
+        return None
+    if len(pattern) > _MAX_REGEX_PATTERN_LENGTH:
+        return None
+    if _looks_like_nested_quantifier(pattern):
         return None
     f = 0
     flag_text = flags if isinstance(flags, str) else None
@@ -118,15 +136,22 @@ def _compile_regex(pattern: str, flags: str | None) -> re.Pattern[str] | None:
     if isinstance(flag_text, str):
         flag_text = flag_text.lower()
         if "i" in flag_text:
-            f |= re.IGNORECASE
+            f |= regex_engine.IGNORECASE
         if "m" in flag_text:
-            f |= re.MULTILINE
+            f |= regex_engine.MULTILINE
         if "s" in flag_text:
-            f |= re.DOTALL
+            f |= regex_engine.DOTALL
     try:
-        return re.compile(pattern, f)
-    except (re.error, TypeError, ValueError):
+        return regex_engine.compile(pattern, f)
+    except (regex_engine.error, TypeError, ValueError):
         return None
+
+
+def _safe_regex_search(rx: Any, text: str) -> bool:
+    try:
+        return bool(rx.search(text, timeout=_REGEX_TIMEOUT_SECONDS))
+    except (_REGEX_TIMEOUT_ERROR, TimeoutError, regex_engine.error, TypeError, ValueError):
+        return False
 
 
 def _match_regex(value: dict[str, Any], candidate: dict[str, Any]) -> bool:
@@ -144,17 +169,17 @@ def _match_regex(value: dict[str, Any], candidate: dict[str, Any]) -> bool:
                 hay = str(candidate.get(name) or "")
             except (TypeError, ValueError):
                 continue
-            if rx.search(hay):
+            if _safe_regex_search(rx, hay):
                 return True
         return False
     field = value.get("field")
     if isinstance(field, str) and field:
         hay = str(candidate.get(field) or "")
-        return bool(rx.search(hay))
+        return _safe_regex_search(rx, hay)
     # Search across common fields
     for name in ("title", "summary", "content", "author"):
         hay = str(candidate.get(name) or "")
-        if rx.search(hay):
+        if _safe_regex_search(rx, hay):
             return True
     return False
 

--- a/tldw_Server_API/app/core/Watchlists/output_enrichment_handler.py
+++ b/tldw_Server_API/app/core/Watchlists/output_enrichment_handler.py
@@ -1,6 +1,6 @@
 """Async output enrichment handler for watchlist outputs.
 
-Runs as a background task to perform LLM-based enrichment:
+Runs as scheduler-backed background work to perform LLM-based enrichment:
 - Topic-based grouping (LLM classification)
 - Per-group summaries
 - Briefing-level summary
@@ -8,13 +8,171 @@ Runs as a background task to perform LLM-based enrichment:
 """
 from __future__ import annotations
 
+import asyncio
 import json
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
 if TYPE_CHECKING:
     from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
+
+
+@dataclass(frozen=True)
+class OutputEnrichmentScheduleResult:
+    """Result from attempting to schedule output enrichment."""
+
+    status: str
+    task_id: str | None = None
+    reason: str | None = None
+
+    @property
+    def submitted(self) -> bool:
+        return self.status == "submitted" and bool(self.task_id)
+
+
+def _dump_config(config: Any) -> dict[str, Any] | None:
+    if config is None:
+        return None
+    if isinstance(config, dict):
+        return dict(config)
+    model_dump = getattr(config, "model_dump", None)
+    if callable(model_dump):
+        try:
+            dumped = model_dump()
+        except (TypeError, ValueError):
+            return None
+        if isinstance(dumped, dict):
+            return dict(dumped)
+    return None
+
+
+def _build_enrichment_payload(
+    *,
+    output_id: int,
+    user_id: int,
+    grouping_config: Any | None,
+    summary_config: Any | None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "output_id": int(output_id),
+        "user_id": int(user_id),
+    }
+    grouping_payload = _dump_config(grouping_config)
+    summary_payload = _dump_config(summary_config)
+    if grouping_payload is not None:
+        payload["grouping_config"] = grouping_payload
+    if summary_payload is not None:
+        payload["summary_config"] = summary_payload
+    return payload
+
+
+def _schedule_enrichment_fallback(
+    *,
+    payload: dict[str, Any],
+    fallback_submitter: Callable[..., Any] | None,
+    reason: str,
+) -> OutputEnrichmentScheduleResult:
+    if fallback_submitter is None:
+        logger.warning(
+            "Output enrichment scheduler unavailable for output {} (reason={})",
+            payload["output_id"],
+            reason,
+        )
+        return OutputEnrichmentScheduleResult(status="queue_unavailable", reason=reason)
+    try:
+        fallback_submitter(enrich_output, **payload)
+    except Exception as exc:
+        logger.warning(
+            "Output enrichment fallback scheduling failed for output {} (error_type={})",
+            payload["output_id"],
+            type(exc).__name__,
+        )
+        return OutputEnrichmentScheduleResult(status="enqueue_failed", reason="fallback_submit_failed")
+    logger.warning(
+        "Output enrichment using in-process fallback for output {} (reason={})",
+        payload["output_id"],
+        reason,
+    )
+    return OutputEnrichmentScheduleResult(status="fallback_scheduled", reason=reason)
+
+
+async def schedule_output_enrichment(
+    *,
+    output_id: int,
+    user_id: int,
+    grouping_config: Any | None = None,
+    summary_config: Any | None = None,
+    scheduler: Any | None = None,
+    fallback_submitter: Callable[..., Any] | None = None,
+) -> OutputEnrichmentScheduleResult:
+    """Submit output enrichment to the durable Scheduler.
+
+    ``fallback_submitter`` is an optional compatibility path, normally
+    FastAPI's ``BackgroundTasks.add_task``. It is used only when Scheduler
+    resolution or submission fails.
+    """
+    payload = _build_enrichment_payload(
+        output_id=output_id,
+        user_id=user_id,
+        grouping_config=grouping_config,
+        summary_config=summary_config,
+    )
+    metadata = {
+        "source": "watchlists_output_enrichment",
+        "watchlist_output_id": payload["output_id"],
+        "user_id": str(payload["user_id"]),
+    }
+
+    try:
+        if scheduler is None:
+            from tldw_Server_API.app.core.Scheduler import get_global_scheduler
+
+            scheduler = await get_global_scheduler()
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "Output enrichment scheduler resolution failed for output {} (error_type={})",
+            payload["output_id"],
+            type(exc).__name__,
+        )
+        return _schedule_enrichment_fallback(
+            payload=payload,
+            fallback_submitter=fallback_submitter,
+            reason="scheduler_unavailable",
+        )
+
+    try:
+        task_id = await scheduler.submit(
+            "watchlists_enrich_output",
+            payload=payload,
+            queue_name="watchlists",
+            idempotency_key=f"watchlists-output-enrichment:{payload['user_id']}:{payload['output_id']}",
+            metadata=metadata,
+            max_retries=1,
+        )
+        logger.info(
+            "Output enrichment submitted for output {}, task_id={}",
+            payload["output_id"],
+            task_id,
+        )
+        return OutputEnrichmentScheduleResult(status="submitted", task_id=task_id)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "Output enrichment scheduler submit failed for output {} (error_type={})",
+            payload["output_id"],
+            type(exc).__name__,
+        )
+        return _schedule_enrichment_fallback(
+            payload=payload,
+            fallback_submitter=fallback_submitter,
+            reason="scheduler_submit_failed",
+        )
 
 
 async def enrich_output(

--- a/tldw_Server_API/app/core/Watchlists/pipeline.py
+++ b/tldw_Server_API/app/core/Watchlists/pipeline.py
@@ -70,7 +70,6 @@ except ImportError:  # pragma: no cover
     _bleach = None  # type: ignore[assignment]
 
 _WATCHLISTS_PIPELINE_NONCRITICAL_EXCEPTIONS = (
-    asyncio.CancelledError,
     asyncio.TimeoutError,
     AssertionError,
     AttributeError,
@@ -493,8 +492,9 @@ def _select_sources_for_scope(db: WatchlistsDatabase, scope: dict[str, Any]) -> 
     """
     selected: dict[int, SourceRow] = {}
     # Explicit IDs
-    for sid in map(int, scope.get("sources", []) or []):
+    for raw_sid in scope.get("sources", []) or []:
         try:
+            sid = int(raw_sid)
             r = db.get_source(sid)
             if int(r.active or 0) == 1:
                 selected[int(r.id)] = r
@@ -508,7 +508,14 @@ def _select_sources_for_scope(db: WatchlistsDatabase, scope: dict[str, Any]) -> 
             if int(r.active or 0) == 1:
                 selected[int(r.id)] = r
     # Groups
-    group_ids = scope.get("groups") or []
+    group_ids: list[int] = []
+    for raw_gid in scope.get("groups", []) or []:
+        try:
+            gid = int(raw_gid)
+        except _WATCHLISTS_PIPELINE_NONCRITICAL_EXCEPTIONS:
+            continue
+        if gid > 0:
+            group_ids.append(gid)
     if group_ids:
         try:
             rows = db.list_sources_by_group_ids(group_ids)
@@ -518,6 +525,19 @@ def _select_sources_for_scope(db: WatchlistsDatabase, scope: dict[str, Any]) -> 
         except _WATCHLISTS_PIPELINE_NONCRITICAL_EXCEPTIONS:
             pass
     return list(selected.values())
+
+
+def _resolve_watchlist_tenant_id(explicit_tenant_id: str | None) -> str:
+    if isinstance(explicit_tenant_id, str) and explicit_tenant_id.strip():
+        return explicit_tenant_id.strip()
+    try:
+        scope = get_scope()
+        org_id = getattr(scope, "effective_org_id", None) if scope else None
+        if org_id is not None:
+            return f"org_{int(org_id)}"
+    except _WATCHLISTS_PIPELINE_NONCRITICAL_EXCEPTIONS:
+        pass
+    return "default"
 
 
 async def _maybe_auto_generate_output(
@@ -662,6 +682,7 @@ async def run_watchlist_job(
     user_id: int,
     job_id: int,
     *,
+    tenant_id: str | None = None,
     source_ids_override: list[int] | None = None,
     capture_companion_activity: bool = False,
     companion_route: str | None = None,
@@ -675,6 +696,7 @@ async def run_watchlist_job(
     job = db.get_job(job_id)
     is_first_run = bool(not getattr(job, "last_run_at", None))
     run = db.create_run(job_id=job_id, status="running")
+    effective_tenant_id = _resolve_watchlist_tenant_id(tenant_id)
 
     job_output_prefs: dict[str, Any] = {}
     try:
@@ -983,7 +1005,7 @@ async def run_watchlist_job(
                                 etag=getattr(src, "etag", None),
                                 last_modified=getattr(src, "last_modified", None),
                                 timeout=8.0,
-                                tenant_id="default",
+                                tenant_id=effective_tenant_id,
                                 strategy=hist_strategy,
                                 max_pages=hist_max_pages,
                                 per_page_limit=hist_per_page,
@@ -997,7 +1019,7 @@ async def run_watchlist_job(
                                 etag=getattr(src, "etag", None),
                                 last_modified=getattr(src, "last_modified", None),
                                 timeout=8.0,
-                                tenant_id="default",
+                                tenant_id=effective_tenant_id,
                             )
                     status = int(res.get("status", 0) or 0)
                     if status == 304:
@@ -1357,7 +1379,7 @@ async def run_watchlist_job(
                             scraped_items = await fetch_site_items_with_rules(
                                 base_url=str(scrape_rules.get("list_url") or src.url),
                                 rules=scrape_rules,
-                                tenant_id="default",
+                                tenant_id=effective_tenant_id,
                             )
                         except _WATCHLISTS_PIPELINE_NONCRITICAL_EXCEPTIONS as exc:
                             logger.debug(f"Scrape rules fetch failed for source {getattr(src, 'id', '?')}: {exc}")
@@ -1820,5 +1842,23 @@ async def run_watchlist_job(
             logger.debug(f"post-run stats persistence failed for run {run.id}: {exc}")
 
         return {"run_id": run.id, **stats}
+    except asyncio.CancelledError:
+        with contextlib.suppress(_WATCHLISTS_PIPELINE_NONCRITICAL_EXCEPTIONS):
+            db.update_run(
+                run.id,
+                status="cancelled",
+                finished_at=_utcnow_iso(),
+                error_msg="cancelled",
+            )
+        raise
+    except Exception as exc:
+        with contextlib.suppress(_WATCHLISTS_PIPELINE_NONCRITICAL_EXCEPTIONS):
+            db.update_run(
+                run.id,
+                status="failed",
+                finished_at=_utcnow_iso(),
+                error_msg=_safe_source_error_text(exc) or type(exc).__name__,
+            )
+        raise
     finally:
         stack.close()

--- a/tldw_Server_API/tests/Watchlists/test_filters_matching.py
+++ b/tldw_Server_API/tests/Watchlists/test_filters_matching.py
@@ -2,7 +2,13 @@ import pytest
 
 pytestmark = pytest.mark.unit
 
-from tldw_Server_API.app.core.Watchlists.filters import normalize_filters, evaluate_filters
+from tldw_Server_API.app.core.Watchlists.filters import (
+    _REGEX_TIMEOUT_ERROR,
+    _compile_regex,
+    _safe_regex_search,
+    evaluate_filters,
+    normalize_filters,
+)
 
 
 def test_keyword_any_and_all():
@@ -44,6 +50,37 @@ def test_regex_flags_and_field():
 
     decision, _ = evaluate_filters(flt, {"title": "Regular", "author": "author: John Doe"})
     assert decision == "flag"
+
+
+def test_regex_nested_quantifier_pattern_is_rejected():
+    assert _compile_regex(r"(a+)+$", None) is None
+
+
+def test_regex_oversized_pattern_is_skipped():
+    pattern = "a" * 1001
+    flt = normalize_filters(
+        {
+            "filters": [
+                {
+                    "type": "regex",
+                    "action": "exclude",
+                    "value": {"pattern": pattern, "field": "title"},
+                }
+            ]
+        }
+    )
+
+    decision, _ = evaluate_filters(flt, {"title": pattern})
+
+    assert decision is None
+
+
+def test_safe_regex_search_handles_regex_timeout_variant():
+    class TimeoutRegex:
+        def search(self, text, timeout=None):
+            raise _REGEX_TIMEOUT_ERROR("timed out")
+
+    assert _safe_regex_search(TimeoutRegex(), "aaaaaaaa") is False
 
 
 def test_date_range_max_age_days():

--- a/tldw_Server_API/tests/Watchlists/test_output_enrichment_scheduler.py
+++ b/tldw_Server_API/tests/Watchlists/test_output_enrichment_scheduler.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.Watchlists import output_enrichment_handler
+
+
+pytestmark = pytest.mark.unit
+
+
+class RecordingScheduler:
+    def __init__(self, *, fail_submit: bool = False) -> None:
+        self.fail_submit = fail_submit
+        self.calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    async def submit(self, *args, **kwargs) -> str:
+        self.calls.append((args, kwargs))
+        if self.fail_submit:
+            raise RuntimeError("scheduler unavailable")
+        return "task_enrich_123"
+
+
+@pytest.mark.asyncio
+async def test_schedule_output_enrichment_submits_scheduler_task():
+    scheduler = RecordingScheduler()
+    grouping = SimpleNamespace(model_dump=lambda: {"group_by": "topic"})
+
+    result = await output_enrichment_handler.schedule_output_enrichment(
+        output_id=77,
+        user_id=555,
+        grouping_config=grouping,
+        summary_config={"enabled": True, "llm_provider": "mock"},
+        scheduler=scheduler,
+    )
+
+    assert result.status == "submitted"
+    assert result.task_id == "task_enrich_123"
+    assert result.submitted is True
+    assert len(scheduler.calls) == 1
+    args, kwargs = scheduler.calls[0]
+    assert args == ("watchlists_enrich_output",)
+    assert kwargs["queue_name"] == "watchlists"
+    assert kwargs["idempotency_key"] == "watchlists-output-enrichment:555:77"
+    assert kwargs["max_retries"] == 1
+    assert kwargs["metadata"] == {
+        "source": "watchlists_output_enrichment",
+        "watchlist_output_id": 77,
+        "user_id": "555",
+    }
+    assert kwargs["payload"] == {
+        "output_id": 77,
+        "user_id": 555,
+        "grouping_config": {"group_by": "topic"},
+        "summary_config": {"enabled": True, "llm_provider": "mock"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_schedule_output_enrichment_uses_fallback_when_scheduler_submit_fails():
+    scheduler = RecordingScheduler(fail_submit=True)
+    fallback_calls: list[tuple[Any, dict[str, Any]]] = []
+
+    def fallback_submitter(func, **kwargs):
+        fallback_calls.append((func, kwargs))
+
+    result = await output_enrichment_handler.schedule_output_enrichment(
+        output_id=88,
+        user_id=777,
+        summary_config={"enabled": True},
+        scheduler=scheduler,
+        fallback_submitter=fallback_submitter,
+    )
+
+    assert result.status == "fallback_scheduled"
+    assert result.reason == "scheduler_submit_failed"
+    assert result.submitted is False
+    assert fallback_calls == [
+        (
+            output_enrichment_handler.enrich_output,
+            {
+                "output_id": 88,
+                "user_id": 777,
+                "summary_config": {"enabled": True},
+            },
+        )
+    ]

--- a/tldw_Server_API/tests/Watchlists/test_watchlists_api.py
+++ b/tldw_Server_API/tests/Watchlists/test_watchlists_api.py
@@ -1366,6 +1366,70 @@ def test_output_deliveries_email_and_chatbook(client_with_user, monkeypatch, tmp
             assert stored_meta.get("origin") == "test"
 
 
+def test_output_creation_schedules_pending_enrichment(client_with_user, monkeypatch):
+    c = client_with_user
+    monkeypatch.setenv("TEST_MODE", "1")
+    scheduled: list[dict[str, object]] = []
+
+    async def fake_schedule_output_enrichment(**kwargs):
+        scheduled.append(kwargs)
+
+    endpoint_mod = import_module("tldw_Server_API.app.api.v1.endpoints.watchlists")
+
+    monkeypatch.setattr(endpoint_mod, "schedule_output_enrichment", fake_schedule_output_enrichment)
+
+    r = c.post(
+        "/api/v1/watchlists/sources",
+        json={
+            "name": "Enrichment Feed",
+            "url": "https://example.com/enrichment-feed.xml",
+            "source_type": "rss",
+            "tags": ["enrichment"],
+        },
+    )
+    assert r.status_code == 200, r.text
+    source_id = r.json()["id"]
+
+    r = c.post(
+        "/api/v1/watchlists/jobs",
+        json={
+            "name": "Enrichment Job",
+            "scope": {"sources": [source_id]},
+            "active": True,
+        },
+    )
+    assert r.status_code == 200, r.text
+    job_id = r.json()["id"]
+
+    r = c.post(f"/api/v1/watchlists/jobs/{job_id}/run")
+    assert r.status_code == 200, r.text
+    run_id = r.json()["id"]
+
+    r = c.post(
+        "/api/v1/watchlists/outputs",
+        json={
+            "run_id": run_id,
+            "title": "Enriched Digest",
+            "briefing_summary": {
+                "enabled": True,
+                "llm_provider": "mock",
+                "llm_model": "mock-model",
+            },
+        },
+    )
+
+    assert r.status_code == 200, r.text
+    output = r.json()
+    metadata = output.get("metadata") or {}
+    assert metadata["enrichment_status"] == "pending"
+    assert metadata["summary_status"] == "pending"
+    assert len(scheduled) == 1
+    assert scheduled[0]["output_id"] == output["id"]
+    assert scheduled[0]["user_id"] == 555
+    assert scheduled[0]["summary_config"].llm_provider == "mock"
+    assert callable(scheduled[0]["fallback_submitter"])
+
+
 def test_outputs_generate_audio_payload_triggers_workflow_and_updates_run_stats(client_with_user, monkeypatch):
 
     c = client_with_user

--- a/tldw_Server_API/tests/Watchlists/test_watchlists_db_user_scope.py
+++ b/tldw_Server_API/tests/Watchlists/test_watchlists_db_user_scope.py
@@ -128,6 +128,78 @@ def test_scraped_items_are_scoped_per_user_in_shared_backend(shared_watchlists_d
     assert int(owner_item_after.queued_for_briefing or 0) == 1
 
 
+def test_source_association_helpers_are_scoped_per_user_in_shared_backend(shared_watchlists_dbs):
+    user1_db, user2_db = shared_watchlists_dbs
+    owner_group = user1_db.create_group(name="owner-group", description="", parent_group_id=None)
+    source = user1_db.create_source(
+        name="owned-source",
+        url="https://example.com/owned-source.xml",
+        source_type="rss",
+        active=True,
+        settings_json=None,
+        tags=["news"],
+        group_ids=[int(owner_group.id)],
+    )
+    user1_db.mark_seen_item(int(source.id), "https://example.com/story-1")
+
+    with pytest.raises(KeyError):
+        user2_db.set_source_tags(int(source.id), ["evil"])
+    with pytest.raises(KeyError):
+        user2_db.set_source_groups(int(source.id), [])
+    with pytest.raises(KeyError):
+        user2_db.get_source_group_ids(int(source.id))
+    assert user2_db.get_source_group_ids_batch([int(source.id)]) == {int(source.id): []}
+
+    with pytest.raises(KeyError):
+        user2_db.has_seen_item(int(source.id), "https://example.com/story-1")
+    with pytest.raises(KeyError):
+        user2_db.mark_seen_item(int(source.id), "https://example.com/story-2")
+    with pytest.raises(KeyError):
+        user2_db.list_seen_item_keys(int(source.id))
+    with pytest.raises(KeyError):
+        user2_db.get_seen_item_stats(int(source.id))
+    with pytest.raises(KeyError):
+        user2_db.clear_seen_items(int(source.id))
+
+    assert user2_db.delete_source(int(source.id)) is False
+
+    owner_source = user1_db.get_source(int(source.id))
+    assert owner_source.tags == ["news"]
+    assert user1_db.get_source_group_ids(int(source.id)) == [int(owner_group.id)]
+    assert user1_db.has_seen_item(int(source.id), "https://example.com/story-1") is True
+    assert user1_db.list_seen_item_keys(int(source.id)) == ["https://example.com/story-1"]
+
+
+def test_source_group_assignment_rejects_foreign_groups(shared_watchlists_dbs):
+    user1_db, user2_db = shared_watchlists_dbs
+    foreign_group = user2_db.create_group(name="foreign-group", description="", parent_group_id=None)
+
+    with pytest.raises(ValueError, match="group_not_found"):
+        user1_db.create_source(
+            name="bad-source",
+            url="https://example.com/bad-source.xml",
+            source_type="rss",
+            active=True,
+            settings_json=None,
+            tags=[],
+            group_ids=[int(foreign_group.id)],
+        )
+
+    source = user1_db.create_source(
+        name="owner-source-no-group",
+        url="https://example.com/owner-source-no-group.xml",
+        source_type="rss",
+        active=True,
+        settings_json=None,
+        tags=[],
+        group_ids=[],
+    )
+    with pytest.raises(ValueError, match="group_not_found"):
+        user1_db.set_source_groups(int(source.id), [int(foreign_group.id)])
+
+    assert user1_db.get_source_group_ids(int(source.id)) == []
+
+
 def test_watchlist_clusters_are_scoped_per_user_in_shared_backend(shared_watchlists_dbs):
     user1_db, user2_db = shared_watchlists_dbs
     user1 = _seed_user_job_run_item(user1_db, label="u1-clusters")

--- a/tldw_Server_API/tests/Watchlists/test_watchlists_pipeline.py
+++ b/tldw_Server_API/tests/Watchlists/test_watchlists_pipeline.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import time
 from contextlib import contextmanager
@@ -6,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from tldw_Server_API.app.core.Watchlists import pipeline
+from tldw_Server_API.app.core.Watchlists import fetchers
 from tldw_Server_API.app.core.DB_Management.Watchlists_DB import WatchlistsDatabase
 from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
 from tldw_Server_API.app.core.DB_Management.Personalization_DB import PersonalizationDB
@@ -91,6 +93,159 @@ async def test_pipeline_happy_path_test_mode():
     assert run.status == "succeeded"
     stats = json.loads(run.stats_json or "{}") if run.stats_json else {}
     assert stats.get("items_found", 0) >= 3
+
+
+def test_watchlists_recoverable_exceptions_do_not_include_cancelled_error():
+    assert asyncio.CancelledError not in pipeline._WATCHLISTS_PIPELINE_NONCRITICAL_EXCEPTIONS
+    assert asyncio.CancelledError not in fetchers._WATCHLISTS_FETCHERS_NONCRITICAL_EXCEPTIONS
+
+
+@pytest.mark.asyncio
+async def test_run_watchlist_job_passes_tenant_id_to_rss_history_fetcher(monkeypatch):
+    user_id = 901
+    db = WatchlistsDatabase.for_user(user_id)
+    source = db.create_source(
+        name="Tenant Feed",
+        url="https://example.com/tenant-feed.xml",
+        source_type="rss",
+        active=True,
+        settings_json=json.dumps({"limit": 1}),
+        tags=[],
+        group_ids=[],
+    )
+    job = db.create_job(
+        name="Tenant Feed Job",
+        description=None,
+        scope_json=json.dumps({"sources": [int(source.id)]}),
+        schedule_expr=None,
+        schedule_timezone="UTC",
+        active=True,
+        max_concurrency=None,
+        per_host_delay_ms=None,
+        retry_policy_json=None,
+        output_prefs_json=None,
+    )
+    captured: dict[str, object] = {}
+    monkeypatch.setenv("TEST_MODE", "0")
+
+    async def fake_fetch_rss_feed_history(*args, tenant_id="default", **kwargs):
+        captured["tenant_id"] = tenant_id
+        return {"status": 304, "items": [], "etag": None, "last_modified": None}
+
+    monkeypatch.setattr(pipeline, "fetch_rss_feed_history", fake_fetch_rss_feed_history)
+
+    result = await run_watchlist_job(user_id, int(job.id), tenant_id="tenant-acme")
+
+    assert result["run_id"] > 0
+    assert captured["tenant_id"] == "tenant-acme"
+
+
+@pytest.mark.asyncio
+async def test_run_watchlist_job_passes_tenant_id_to_site_scrape_rules_fetcher(monkeypatch):
+    user_id = 902
+    db = WatchlistsDatabase.for_user(user_id)
+    source = db.create_source(
+        name="Tenant Site",
+        url="https://example.com/blog",
+        source_type="site",
+        active=True,
+        settings_json=json.dumps(
+            {
+                "scrape_rules": {
+                    "list_url": "https://example.com/blog",
+                    "limit": 1,
+                    "skip_article_fetch": True,
+                }
+            }
+        ),
+        tags=[],
+        group_ids=[],
+    )
+    job = db.create_job(
+        name="Tenant Site Job",
+        description=None,
+        scope_json=json.dumps({"sources": [int(source.id)]}),
+        schedule_expr=None,
+        schedule_timezone="UTC",
+        active=True,
+        max_concurrency=None,
+        per_host_delay_ms=None,
+        retry_policy_json=None,
+        output_prefs_json=None,
+    )
+    captured: dict[str, object] = {}
+    monkeypatch.setenv("TEST_MODE", "0")
+
+    async def fake_fetch_site_items_with_rules(*args, tenant_id="default", **kwargs):
+        captured["tenant_id"] = tenant_id
+        return [
+            {
+                "title": "Stub",
+                "url": "https://example.com/blog/stub",
+                "summary": "Stub summary",
+                "content": "Stub content",
+            }
+        ]
+
+    monkeypatch.setattr(pipeline, "fetch_site_items_with_rules", fake_fetch_site_items_with_rules)
+
+    result = await run_watchlist_job(user_id, int(job.id), tenant_id="tenant-site")
+
+    assert result["run_id"] > 0
+    assert captured["tenant_id"] == "tenant-site"
+
+
+@pytest.mark.asyncio
+async def test_run_watchlist_job_skips_malformed_source_scope_ids():
+    user_id = 903
+    db = WatchlistsDatabase.for_user(user_id)
+    job = db.create_job(
+        name="Malformed Scope Job",
+        description=None,
+        scope_json=json.dumps({"sources": ["not-an-int"]}),
+        schedule_expr=None,
+        schedule_timezone="UTC",
+        active=True,
+        max_concurrency=None,
+        per_host_delay_ms=None,
+        retry_policy_json=None,
+        output_prefs_json=None,
+    )
+
+    result = await run_watchlist_job(user_id, int(job.id))
+
+    assert result["items_found"] == 0
+    runs, _ = db.list_runs_for_job(int(job.id), limit=1, offset=0)
+    assert runs[0].status == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_run_watchlist_job_marks_run_failed_when_scope_resolution_raises(monkeypatch):
+    user_id = 904
+    db = WatchlistsDatabase.for_user(user_id)
+    job = db.create_job(
+        name="Scope Failure Job",
+        description=None,
+        scope_json=json.dumps({}),
+        schedule_expr=None,
+        schedule_timezone="UTC",
+        active=True,
+        max_concurrency=None,
+        per_host_delay_ms=None,
+        retry_policy_json=None,
+        output_prefs_json=None,
+    )
+
+    def fail_select_sources(*args, **kwargs):
+        raise RuntimeError("scope boom")
+
+    monkeypatch.setattr(pipeline, "_select_sources_for_scope", fail_select_sources)
+
+    with pytest.raises(RuntimeError, match="scope boom"):
+        await run_watchlist_job(user_id, int(job.id))
+
+    runs, _ = db.list_runs_for_job(int(job.id), limit=1, offset=0)
+    assert runs[0].status == "failed"
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Watchlists/test_watchlists_scheduler_handler.py
+++ b/tldw_Server_API/tests/Watchlists/test_watchlists_scheduler_handler.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.Scheduler.handlers import watchlists as watchlist_handler
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_watchlist_run_passes_tenant_id_and_preserves_pipeline_status(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_run_watchlist_job(user_id: int, job_id: int, **kwargs):
+        captured["user_id"] = user_id
+        captured["job_id"] = job_id
+        captured["tenant_id"] = kwargs.get("tenant_id")
+        return {"run_id": 42, "status": "cancelled", "items_ingested": 0}
+
+    monkeypatch.setattr(watchlist_handler, "run_watchlist_job", fake_run_watchlist_job)
+
+    result = await watchlist_handler.watchlist_run(
+        {
+            "inputs": {"watchlist_job_id": 7},
+            "user_id": "123",
+            "tenant_id": "tenant-acme",
+        }
+    )
+
+    assert captured == {"user_id": 123, "job_id": 7, "tenant_id": "tenant-acme"}
+    assert result == {"run_id": 42, "status": "cancelled", "items_ingested": 0}
+
+
+@pytest.mark.asyncio
+async def test_watchlists_enrich_output_calls_core_handler(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_enrich_output(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(watchlist_handler.output_enrichment_handler, "enrich_output", fake_enrich_output)
+
+    result = await watchlist_handler.watchlists_enrich_output(
+        {
+            "output_id": "77",
+            "user_id": "555",
+            "grouping_config": {"group_by": "topic"},
+            "summary_config": {"enabled": True, "llm_provider": "mock"},
+        }
+    )
+
+    assert result == {"output_id": 77, "status": "completed"}
+    assert captured == {
+        "output_id": 77,
+        "user_id": 555,
+        "grouping_config": {"group_by": "topic"},
+        "summary_config": {"enabled": True, "llm_provider": "mock"},
+    }


### PR DESCRIPTION
## Change summary

TODO: Human-authored Change summary required before this draft is marked ready. Explain what changed and why these implementation choices were made.

## Summary

- Adds bounded regex compilation and search in Watchlists filters to avoid runaway patterns.
- Preserves cancellation and failure status while carrying tenant scope through pipeline, scheduler, preview, and manual run fetch paths.
- Hardens Watchlists DB ownership checks for source groups and seen item helpers.
- Schedules output enrichment for outputs that require asynchronous enrichment.

## Test plan

- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && PYTHONPATH=$PWD python -m pytest tldw_Server_API/tests/Watchlists/test_filters_matching.py tldw_Server_API/tests/Watchlists/test_filter_evaluation_edge_cases.py tldw_Server_API/tests/Watchlists/test_watchlists_pipeline.py tldw_Server_API/tests/Watchlists/test_watchlists_pipeline_filters.py tldw_Server_API/tests/Watchlists/test_watchlists_scheduler_handler.py tldw_Server_API/tests/Watchlists/test_watchlists_db_user_scope.py tldw_Server_API/tests/Watchlists/test_watchlists_api.py -q`
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && PYTHONPATH=$PWD python -m bandit -r tldw_Server_API/app/core/Watchlists tldw_Server_API/app/core/Scheduler/handlers/watchlists.py tldw_Server_API/app/core/DB_Management/Watchlists_DB.py tldw_Server_API/app/api/v1/endpoints/watchlists.py -f json -o /tmp/bandit_watchlists_core_review_pr.json`
- `git diff --check`

## Notes

Draft PR because the required human-authored Change summary still needs to be filled in before merge readiness.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Watchlists with safe, time-bounded regex filters, real run status propagation, tenant-aware fetches, and strict DB ownership checks. Adds scheduler-backed output enrichment with idempotency and fallback; addresses TASK-10000.

- **Bug Fixes**
  - Make regex filters safe: use `regex` with timeouts, reject nested-quantifier and oversized patterns, and bound searches via a safe helper.
  - Preserve cancellations/failures: remove `asyncio.CancelledError` from recoverable sets, mark runs cancelled/failed, and return actual status from the scheduler.
  - Propagate `tenant_id` end-to-end: resolve from the request user, pass through preview, manual/scheduled runs, and into RSS history and site-rule fetchers.
  - Enforce ownership in DB: validate group IDs belong to the user; scope tags/groups/seen-item helpers and deletes to the owner; batch group lookups return only owned data.
  - Skip malformed scope IDs; unexpected scope failures mark the run failed.

- **New Features**
  - Schedule output enrichment via durable Scheduler task `watchlists_enrich_output` with idempotency; fall back to `BackgroundTasks` when Scheduler is unavailable.

<sup>Written for commit 1b5fcc357d8e4a59e28b1e6faa747794f5d70350. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

