### PR TITLE
Fix Utils module review findings

### DIFF
--- a/IMPLEMENTATION_PLAN_utils_review_fixes_9941.md
+++ b/IMPLEMENTATION_PLAN_utils_review_fixes_9941.md
@@ -1,0 +1,36 @@
+# Implementation Plan: Utils Module Review Findings
+
+## Stage 1: Image Validation Hardening
+
+**Goal**: Ensure image data URI helpers accept only valid raster image payloads and enforce original pixel bounds before resizing.
+**Success Criteria**: Small image validation rejects non-image bytes; MIME mismatches are rejected; chunked processing rejects images above the configured original pixel cap before resize.
+**Tests**: Focused tests in `tldw_Server_API/tests/Utils/test_image_validation.py` and `tldw_Server_API/tests/Utils/test_chunked_image_processor.py`.
+**Status**: Complete
+
+## Stage 2: CPU Batcher Correctness
+
+**Goal**: Prevent `CPUBoundBatcher` from leaving futures pending when operations arrive while a prior batch is draining.
+**Success Criteria**: Concurrent/staggered additions all complete without timeout and no pending work is stranded.
+**Tests**: Focused async test in `tldw_Server_API/tests/Utils/test_cpu_bound_handler.py`.
+**Status**: Complete
+
+## Stage 3: Safe Metadata Index Reliability
+
+**Goal**: Fail metadata updates when identifier index writes fail unexpectedly, while preserving compatibility for known missing-table migrations.
+**Success Criteria**: Missing identifier table remains non-fatal; unexpected database/index failures propagate to the caller transaction.
+**Tests**: Unit tests in `tldw_Server_API/tests/MediaDB2/test_safe_metadata_utils.py`.
+**Status**: Complete
+
+## Stage 4: Sensitive Logging and Legacy Cleanup
+
+**Goal**: Remove raw sensitive payload logging, avoid unauthenticated ffmpeg executable download behavior, and delete placeholder/no-op legacy code.
+**Success Criteria**: Segment extraction and rejected external image URL logging avoid raw payloads; ffmpeg helper no longer downloads executable archives without verification; `get_user_database_path` and the no-op temp path line are removed.
+**Tests**: Focused tests in `tldw_Server_API/tests/Utils/test_utils_general.py` and existing Utils tests.
+**Status**: Complete
+
+## Stage 5: Verification and Task Finalization
+
+**Goal**: Run focused tests and security checks, update Backlog task, and report remaining risk.
+**Success Criteria**: Targeted pytest checks pass; touched Python files compile; Bandit reports no new findings for touched Utils scope; Backlog task records touched files and verification.
+**Tests**: `python -m pytest` for touched Utils/MediaDB2 tests, `python -m py_compile` or compileall for touched modules, and Bandit on touched source files.
+**Status**: Complete

--- a/backlog/tasks/task-9941 - Fix-Utils-module-review-findings.md
+++ b/backlog/tasks/task-9941 - Fix-Utils-module-review-findings.md
@@ -1,0 +1,84 @@
+---
+id: TASK-9941
+title: Fix Utils module review findings
+status: Done
+assignee: []
+created_date: '2026-06-24'
+updated_date: '2026-06-24'
+labels:
+  - review
+  - utils
+  - security
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address validated current-code review findings in `tldw_Server_API/app/core/Utils`: image payload validation, chunked image pixel caps, CPU batcher pending futures, safe-metadata index failure handling, sensitive logging, ffmpeg download behavior, placeholder cleanup, and no-op cleanup.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Small chat image data URIs verify actual image bytes and MIME before acceptance.
+- [x] #2 Chunked image processing enforces original pixel limits before resize.
+- [x] #3 CPU batcher cannot leave queued futures pending.
+- [x] #4 Safe metadata identifier index failures do not silently corrupt search state.
+- [x] #5 Sensitive transcript or rejected URL payloads are not logged raw.
+- [x] #6 ffmpeg helper avoids unauthenticated executable download or verifies integrity.
+- [x] #7 Placeholder/no-op legacy Utils code is removed.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing regression tests for image byte validation, original pixel cap enforcement, CPU batch draining, safe-metadata index failures, and logging cleanup.
+2. Patch Utils modules with minimal behavior changes while preserving public APIs where active callers exist.
+3. Remove or tighten unused placeholder/no-op legacy code.
+4. Run targeted pytest, compile checks, Bandit on touched Utils scope, and update this task with results.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Manual Backlog task-file creation approved by user because the official Backlog CLI hung on search/list/create and the bundled Python clone is documented as unsafe for live mutations.
+
+Implemented fixes:
+- Verified image data URI bytes with Pillow, strict base64 decoding, and declared/detected MIME matching; corrupt image parser errors now reject cleanly.
+- Enforced chunked-image original pixel limits before resize.
+- Rescheduled CPU batcher work that arrives while a batch is draining.
+- Re-raised unexpected safe-metadata identifier-index failures while preserving missing-table compatibility.
+- Removed raw segment/rejected URL payload logging.
+- Disabled unauthenticated ffmpeg binary auto-download and hardened the CUDA probe to resolve `nvidia-smi` before subprocess execution.
+- Removed `get_user_database_path` placeholder and the no-op temp-path assignment in `download_file`.
+
+Touched-file verification:
+- `python -m pytest tldw_Server_API/tests/Utils/test_utils_general.py tldw_Server_API/tests/Utils/test_image_validation.py tldw_Server_API/tests/Utils/test_chunked_image_processor.py tldw_Server_API/tests/Utils/test_cpu_bound_handler.py tldw_Server_API/tests/MediaDB2/test_safe_metadata_utils.py -q` -> 70 passed.
+- `python -m pytest tldw_Server_API/tests/Chat_NEW/unit/test_request_size_and_image_limits.py tldw_Server_API/tests/Chat/integration/test_chat_fixes_integration.py tldw_Server_API/tests/Chat/unit/test_chat_endpoint_helpers.py -q` -> 24 passed.
+- `python -m py_compile` over touched Utils modules -> passed.
+- `git diff --check` over touched files -> passed.
+- `python -m bandit` over exact touched Utils files -> passed with zero findings. Folder-wide Utils Bandit still reports two pre-existing low-severity findings in untouched `torch_import_guard.py`.
+
+PR review follow-up:
+- Rebased PR #2483 on latest `origin/dev`.
+- Addressed review findings for `# nosec` rationale, CPU batch task bookkeeping, markdown plan heading/spacing, credential-bearing URL logging, metadata compatibility filtering, and raw segment error logging.
+- Added focused regressions for CPU batch task reference retention, URL userinfo redaction, unsupported metadata errors, and segment error-path redaction.
+- Added focused docstrings for changed Utils helpers after the PR pre-merge docstring coverage warning; local AST scan over changed production files reports 100% coverage.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed all reviewed Utils findings and added focused regression coverage for image validation, chunked image sizing, CPU batch draining, safe metadata failure propagation, sensitive logging, ffmpeg download behavior, and legacy cleanup. Verification passed for targeted Utils/related chat tests, compile checks, diff whitespace checks, and Bandit over the edited Utils files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Utils/System_Checks_Lib.py
+++ b/tldw_Server_API/app/core/Utils/System_Checks_Lib.py
@@ -22,8 +22,10 @@
 import os
 import platform
 import shutil
-import subprocess
-import zipfile
+# TASK-9941 Bandit B404 rationale: subprocess is limited to the local
+# nvidia-smi availability probe; callers cannot supply commands and shell=True
+# is not used.
+import subprocess  # nosec B404
 
 from tldw_Server_API.app.core.Utils.Utils import logging
 
@@ -37,6 +39,7 @@ processing_choice: str = "cpu"
 #
 
 def platform_check():
+    """Detect the host operating system and record whether supported checks can run."""
     global userOS
     if platform.system() == "Linux":
         logging.info("Linux OS detected; running Linux-appropriate checks")
@@ -53,14 +56,24 @@ def platform_check():
 
 # Check for NVIDIA GPU and CUDA availability
 def cuda_check():
+    """Probe for NVIDIA CUDA support using a resolved local nvidia-smi executable."""
     global processing_choice
     if "CUDA_VISIBLE_DEVICES" in os.environ:
         logging.info(f"CUDA_VISIBLE_DEVICES is set: {os.environ['CUDA_VISIBLE_DEVICES']}")
     else:
         logging.info("CUDA_VISIBLE_DEVICES not set.")
+
+    nvidia_smi = shutil.which("nvidia-smi")
+    if not nvidia_smi:
+        logging.warning("CUDA is not installed or configured correctly.")
+        processing_choice = "cpu"
+        return False
+
     try:
         # Run nvidia-smi to capture its output
-        nvidia_smi_output = subprocess.check_output(["nvidia-smi"], text=True)
+        # TASK-9941 Bandit B603 rationale: nvidia_smi comes from shutil.which("nvidia-smi"),
+        # is executed as a fixed argv list, and shell=True is not used.
+        nvidia_smi_output = subprocess.check_output([nvidia_smi], text=True)  # nosec B603
 
         # Look for CUDA version in the output
         if "CUDA Version" in nvidia_smi_output:
@@ -75,7 +88,7 @@ def cuda_check():
             processing_choice = "cpu"
             return False
 
-    except subprocess.CalledProcessError as e:
+    except (subprocess.CalledProcessError, OSError) as e:
         logging.error(f"Failed to run 'nvidia-smi': {str(e)}")
         processing_choice = "cpu"
         return False
@@ -87,6 +100,7 @@ def cuda_check():
 
 # Ask user if they would like to use either their GPU or their CPU for transcription
 def decide_cpugpu():
+    """Prompt for CPU/GPU processing preference, defaulting to the current choice when non-interactive."""
     global processing_choice
     try:
         processing_input = input("Would you like to use your GPU or CPU for transcription? (1/cuda)GPU/(2/cpu)CPU): ")
@@ -112,6 +126,7 @@ def decide_cpugpu():
 
 # check for existence of ffmpeg
 def check_ffmpeg():
+    """Return whether ffmpeg is available from PATH or the local Bin fallback."""
     if shutil.which("ffmpeg"):
         logging.debug("ffmpeg found installed on the local system, in the local PATH, or in the './Bin' folder")
         return True #fix 'Asserion error: none is not true' in Tests\Summarization\test_summarize.py
@@ -149,58 +164,9 @@ def check_ffmpeg():
 
 # Download ffmpeg
 def download_ffmpeg():
-    FFMPEG_DOWNLOAD_URL = "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip"
-    try:
-        user_choice = input("Do you want to download ffmpeg? (y/N): ")
-    except EOFError:
-        logging.debug("No interactive input available; skipping ffmpeg download prompt")
-        return False
-    if user_choice.lower() not in ['y', 'yes', '1']:  # Simplified input check
-        logging.info("ffmpeg will not be downloaded.")
-        return False
-
-    logging.info("Downloading ffmpeg...")
-    try:
-        zip_path = "ffmpeg-release-essentials.zip"
-        # Use centralized downloader with retries + egress enforcement
-        download(url=FFMPEG_DOWNLOAD_URL, dest=zip_path)
-
-        logging.info("Extracting ffmpeg.exe...")
-        with zipfile.ZipFile(zip_path, 'r') as zip_ref:
-            ffmpeg_path = None
-            for file_info in zip_ref.infolist():
-                if file_info.filename.endswith("ffmpeg.exe"):
-                    ffmpeg_path = file_info.filename
-                    break
-            if ffmpeg_path is None:
-                # Raise a FileNotFoundError if ffmpeg.exe is not found in the zip.
-                raise FileNotFoundError("ffmpeg.exe not found in the zip file.")
-            bin_folder = os.path.join(".", "Bin")
-            if not os.path.exists(bin_folder):
-                os.makedirs(bin_folder)
-
-            zip_ref.extract(ffmpeg_path, path=bin_folder)
-
-            src_path = os.path.join(bin_folder, ffmpeg_path)
-            dst_path = os.path.join(bin_folder, "ffmpeg.exe")
-            shutil.move(src_path, dst_path)  # Move to the correct location (./Bin/ffmpeg.exe).
-
-        os.remove(zip_path)  # Clean up: Delete the downloaded zip file.
-        logging.info("ffmpeg.exe has been successfully downloaded and extracted to the './Bin' folder.")
-        return True # returns if the process was succesful
-
-    # Handle potential errors during the download and extraction process.
-    except DownloadError as e:
-        logging.error(f"Error downloading ffmpeg: {e}")
-        return False
-    except (FileNotFoundError, zipfile.BadZipFile, OSError) as e:
-        logging.error(f"Error extracting or moving ffmpeg: {e}")
-        return False
-    except Exception as e:
-        logging.error(f"An unexpected error occurred: {e}")
-        return False
-
-#
-#
-#######################################################################################################################
-from tldw_Server_API.app.core.http_client import DownloadError, download
+    """Refuse automatic executable download and direct users to trusted installation channels."""
+    logging.warning(
+        "Automatic ffmpeg executable download is disabled. Install ffmpeg manually "
+        "or through a trusted package manager."
+    )
+    return False

--- a/tldw_Server_API/app/core/Utils/Utils.py
+++ b/tldw_Server_API/app/core/Utils/Utils.py
@@ -63,10 +63,20 @@ from tldw_Server_API.app.core.http_client import RetryPolicy, download, fetch
 logging = logger
 
 def extract_text_from_segments(segments, include_timestamps=True):
-    logger.trace(f"Segments received: {segments}")
+    """Extract transcript text from nested segment structures without logging raw content."""
+    def _describe_segment_shape(data):
+        """Summarize segment container shape for redacted diagnostic logs."""
+        if isinstance(data, list):
+            return f"list length={len(data)}"
+        if isinstance(data, dict):
+            return f"dict keys={len(data)}"
+        return type(data).__name__
+
+    logger.trace(f"Segments received: type={type(segments).__name__}, shape={_describe_segment_shape(segments)}")
     logger.trace(f"Type of segments: {type(segments)}")
 
     def _format_seconds_value(value):
+        """Format numeric timestamp values without unnecessary trailing zeros."""
         try:
             number = float(value)
         except (TypeError, ValueError):
@@ -76,6 +86,7 @@ def extract_text_from_segments(segments, include_timestamps=True):
         return f"{number:.2f}".rstrip("0").rstrip(".")
 
     def extract_text_recursive(data):
+        """Walk nested segment data and collect transcript text entries."""
         results = []
         if isinstance(data, dict):
             if 'Text' in data and isinstance(data['Text'], str):
@@ -100,7 +111,10 @@ def extract_text_from_segments(segments, include_timestamps=True):
     if pieces:
         return '\n'.join(pieces)
 
-    logging.error(f"Unable to extract text from segments: {segments}")
+    logger.error(
+        f"Unable to extract text from segments: type={type(segments).__name__}, "
+        f"shape={_describe_segment_shape(segments)}"
+    )
     return "Error: Unable to extract transcription"
 
 #
@@ -191,6 +205,7 @@ def get_project_relative_path(relative_path: str | os.PathLike[AnyStr]) -> str:
     return path
 
 def get_chromadb_path():
+    """Return the project-local ChromaDB storage path."""
     path = os.path.join(get_project_root(), 'Databases', 'chroma_db')
     logging.trace(f"ChromaDB path: {path}")
     return path
@@ -229,6 +244,7 @@ openai_tts_voices = ["alloy", "echo", "fable", "onyx", "nova", "shimmer"]
 
 
 def format_api_name(api):
+    """Return a display name for a configured API provider key."""
     name_mapping = {
         "openai": "OpenAI",
         "anthropic": "Anthropic",
@@ -264,6 +280,7 @@ def format_api_name(api):
 # logging.basicConfig(filename='debug-runtime.log', encoding='utf-8', level=logging.DEBUG)
 
 def format_metadata_as_text(metadata):
+    """Format media metadata mappings into a human-readable multi-line summary."""
     if not metadata:
         return "No metadata available"
 
@@ -312,6 +329,7 @@ def format_metadata_as_text(metadata):
 
 
 def convert_to_seconds(time_str):
+    """Convert seconds or HH:MM:SS-like duration values to whole seconds."""
     if not time_str:
         return 0
 
@@ -320,6 +338,7 @@ def convert_to_seconds(time_str):
         return 0
 
     def _as_int(value: float) -> int:
+        """Round a non-negative duration component to an integer second."""
         if value < 0:
             raise ValueError("Time values must be non-negative")
         quantized = Decimal(str(value)).quantize(Decimal("1"), rounding=ROUND_HALF_UP)
@@ -380,6 +399,7 @@ def truncate_content(content: str | None, max_length: int = 200) -> str | None:
 #
 # File-saving Function Definitions
 def save_to_file(video_urls, filename):
+    """Write a list of video URLs to a newline-delimited text file."""
     with open(filename, 'w') as file:
         file.write('\n'.join(video_urls))
     logging.info(f"Video URLs saved to {filename}")
@@ -457,7 +477,7 @@ def smart_download(url: str, tmp_dir: Path) -> Path:
 
 
 def download_file(url, dest_path, expected_checksum=None, max_retries=3, delay=5):
-    dest_path + '.tmp'
+    """Download a URL to disk with retries, resume support, and optional checksum validation."""
     dest_dir = os.path.dirname(dest_path)
     if dest_dir:
         os.makedirs(dest_dir, exist_ok=True)
@@ -497,6 +517,7 @@ def download_file_if_missing(url: str, local_path: str) -> None:
         raise
 
 def create_download_directory(title):
+    """Create and return a sanitized Results subdirectory for downloaded media."""
     base_dir = "Results"
     # Remove characters that are illegal in Windows filenames and normalize
     safe_title = normalize_title(title, preserve_spaces=False)
@@ -511,6 +532,7 @@ def create_download_directory(title):
 
 
 def safe_read_file(file_path):
+    """Read a text file using detected or fallback encodings, returning an error string on failure."""
     encodings = ['utf-8', 'utf-16', 'ascii', 'latin-1', 'iso-8859-1', 'cp1252', 'utf-8-sig']
 
     logging.info(f"Attempting to read file: {file_path}")
@@ -577,6 +599,7 @@ def generate_unique_filename(base_path, base_filename):
 
 
 def generate_unique_identifier(file_path):
+    """Build a local identifier from file timestamp, content hash, and filename."""
     filename = os.path.basename(file_path)
     timestamp = int(time.time())
 
@@ -600,6 +623,7 @@ def generate_unique_identifier(file_path):
 
 # Helper function to validate URL format
 def is_valid_url(url: str) -> bool:
+    """Return whether a string matches the accepted URL pattern."""
     regex = re.compile(
         r'^(?:http|ftp)s?://'  # http:// or https://
         r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|'  # domain...
@@ -612,6 +636,7 @@ def is_valid_url(url: str) -> bool:
 
 
 def verify_checksum(file_path, expected_checksum):
+    """Return whether a file's SHA-256 digest matches the expected checksum."""
     sha256_hash = hashlib.sha256()
     with open(file_path, 'rb') as f:
         for byte_block in iter(lambda: f.read(4096), b''):
@@ -620,6 +645,7 @@ def verify_checksum(file_path, expected_checksum):
 
 
 def normalize_title(title, preserve_spaces=False):
+    """Normalize a title into a filesystem-safe ASCII name."""
     # Normalize the string to 'NFKD' form and encode to 'ascii' ignoring non-ascii characters
     title = unicodedata.normalize('NFKD', title).encode('ascii', 'ignore').decode('ascii')
 
@@ -642,6 +668,7 @@ def normalize_title(title, preserve_spaces=False):
 
 
 def clean_youtube_url(url):
+    """Remove playlist query parameters from a YouTube URL."""
     parsed_url = urlparse(url)
     query_params = parse_qs(parsed_url.query)
     if 'list' in query_params:
@@ -696,6 +723,7 @@ def sanitize_filename(filename, *, max_total_length: int | None = None, extensio
 
 
 def format_transcription(content):
+    """Convert escaped transcript newlines into simple HTML line breaks."""
     # Replace '\n' with actual line breaks
     content = content.replace('\\n', '\n')
     # Split the content by newlines first
@@ -735,6 +763,7 @@ def sanitize_user_input(message):
     return message
 
 def format_file_path(file_path, fallback_path=None):
+    """Return an existing file path, falling back to an alternate path when available."""
     if file_path and os.path.exists(file_path):
         logging.debug(f"File exists: {file_path}")
         return file_path
@@ -795,6 +824,7 @@ def get_db_config():
 temp_files = []
 
 def save_temp_file(file):
+    """Persist an uploaded file-like object to a unique path in the system temp directory."""
     global temp_files
     temp_dir = tempfile.gettempdir()
 
@@ -821,6 +851,7 @@ def save_temp_file(file):
     return temp_path
 
 def cleanup_temp_files():
+    """Delete temporary files recorded by save_temp_file."""
     global temp_files
     for file_path in temp_files:
         if os.path.exists(file_path):
@@ -832,6 +863,7 @@ def cleanup_temp_files():
     temp_files.clear()
 
 def generate_unique_id():
+    """Return a unique uploaded-file identifier."""
     return f"uploaded_file_{uuid.uuid4()}"
 
 class FileProcessor:
@@ -927,6 +959,7 @@ class ZipValidator:
 
     @staticmethod
     def _is_malicious_zip_path(filename: str) -> bool:
+        """Return whether a zip entry path attempts absolute or parent traversal."""
         normalized = filename.replace("\\", "/")
         if normalized.startswith("/") or normalized.startswith("//"):
             return True
@@ -988,6 +1021,7 @@ class ZipValidator:
             return False, f"Error processing zip file: {str(e)}", []
 
 def format_text_with_line_breaks(text):
+    """Insert HTML line breaks after sentence-ending punctuation."""
     # Split the text into sentences and add line breaks
     sentences = text.replace('. ', '.<br>').replace('? ', '?<br>').replace('! ', '!<br>')
     return sentences
@@ -1063,15 +1097,13 @@ def extract_media_id_from_result_string(result_msg: str | None) -> str | None:
         return None
 
 def is_valid_date(date_string): # Placeholder
+    """Return whether a string is a YYYY-MM-DD date."""
     try:
         datetime.strptime(date_string, '%Y-%m-%d')
         return True
     except ValueError:
         return False
 
-
-def get_user_database_path():
-    return None
 
 #
 # End of Utils.py

--- a/tldw_Server_API/app/core/Utils/chunked_image_processor.py
+++ b/tldw_Server_API/app/core/Utils/chunked_image_processor.py
@@ -55,12 +55,22 @@ async def process_image_chunked(
     try:
         # Load image with PIL for processing
         image = Image.open(io.BytesIO(image_data))
+        original_width, original_height = image.width, image.height
+        original_pixels = original_width * original_height
+
+        # Check pixel count before any resize so decompression work is bounded by
+        # the original payload, not the thumbnail result.
+        if original_pixels > MAX_IMAGE_PIXELS:
+            raise ValueError(f"Image too large: {original_pixels} pixels")
 
         # Validate image dimensions
         if image.width > MAX_IMAGE_DIMENSION or image.height > MAX_IMAGE_DIMENSION:
             # Resize if too large
             image.thumbnail((MAX_IMAGE_DIMENSION, MAX_IMAGE_DIMENSION), Image.Resampling.LANCZOS)
-            logger.info(f"Resized large image from {image.width}x{image.height}")
+            logger.info(
+                f"Resized large image from {original_width}x{original_height} "
+                f"to {image.width}x{image.height}"
+            )
 
         # Check pixel count
         if image.width * image.height > MAX_IMAGE_PIXELS:
@@ -321,6 +331,7 @@ class StreamingImageProcessor:
         semaphore = asyncio.Semaphore(max_concurrent)
 
         async def process_with_limit(url):
+            """Process one image URL while respecting the shared concurrency limit."""
             async with semaphore:
                 return await self.process_image_url(url, max_size_bytes)
 

--- a/tldw_Server_API/app/core/Utils/cpu_bound_handler.py
+++ b/tldw_Server_API/app/core/Utils/cpu_bound_handler.py
@@ -45,12 +45,14 @@ CPU_THREAD_POOL: Optional[ThreadPoolExecutor] = None
 
 
 def _create_cpu_thread_pool() -> ThreadPoolExecutor:
+    """Create and register the shared CPU thread pool."""
     pool = ThreadPoolExecutor(max_workers=8, thread_name_prefix="cpu_worker")
     register_executor("cpu_thread_pool", pool)
     return pool
 
 
 def get_cpu_thread_pool() -> ThreadPoolExecutor:
+    """Return a reusable thread pool for CPU-bound fallback execution."""
     global CPU_THREAD_POOL
     if CPU_THREAD_POOL is None or getattr(CPU_THREAD_POOL, "_shutdown", False):
         CPU_THREAD_POOL = _create_cpu_thread_pool()
@@ -58,10 +60,12 @@ def get_cpu_thread_pool() -> ThreadPoolExecutor:
 
 
 def _env_flag_true(name: str) -> bool:
+    """Return whether an environment flag is enabled."""
     return env_flag_enabled(name)
 
 
 def _get_worker_count(default: int = 4) -> int:
+    """Read the configured CPU process-pool worker count."""
     try:
         return int(os.getenv("TLDR_CPU_PROCPOOL_WORKERS", default))
     except Exception:
@@ -69,6 +73,7 @@ def _get_worker_count(default: int = 4) -> int:
 
 
 def _process_pool_disabled() -> bool:
+    """Return whether CPU process-pool creation should be skipped."""
     # Disable if explicit flag set or generic TESTING=true
     return _env_flag_true("TLDR_DISABLE_CPU_PROCPOOL") or _env_flag_true("TESTING")
 
@@ -221,6 +226,7 @@ async def process_large_json_async(data: Any) -> str:
         JSON string
     """
     def _json_dump(payload: Any) -> str:
+        """Serialize JSON compactly while preserving unicode characters."""
         return json.dumps(payload, ensure_ascii=False, separators=(',', ':'))
 
     # For small payloads, process inline
@@ -332,7 +338,6 @@ class CPUBoundBatcher:
                 finally:
                     self._batch_task = None
             await self._process_batch(delay=False)
-            self._batch_task = None
 
         return await future
 
@@ -357,14 +362,23 @@ class CPUBoundBatcher:
             )
             tasks.append((task, future))
 
-        # Wait for all to complete
-        for task, future in tasks:
-            try:
-                result = await task
-                future.set_result(result)
-            except Exception as e:
-                future.set_exception(e)
-        self._batch_task = None
+        try:
+            # Wait for all to complete
+            for task, future in tasks:
+                try:
+                    result = await task
+                    if not future.done():
+                        future.set_result(result)
+                except Exception as e:
+                    if not future.done():
+                        future.set_exception(e)
+        finally:
+            current_task = asyncio.current_task()
+            if self._batch_task is current_task or (self._batch_task is not None and self._batch_task.done()):
+                self._batch_task = None
+            if self.pending_operations and (self._batch_task is None or self._batch_task.done()):
+                delay_next = len(self.pending_operations) < self.batch_size
+                self._batch_task = asyncio.create_task(self._process_batch(delay=delay_next))
 
 
 # Global batcher instance

--- a/tldw_Server_API/app/core/Utils/image_validation.py
+++ b/tldw_Server_API/app/core/Utils/image_validation.py
@@ -7,6 +7,7 @@ import io
 import os
 import re
 from typing import Optional
+from urllib.parse import urlparse
 
 from loguru import logger
 from PIL import Image
@@ -19,6 +20,7 @@ _IMAGE_VALIDATION_NONCRITICAL_EXCEPTIONS = (
     TypeError,
     ValueError,
 )
+_IMAGE_INTEGRITY_EXCEPTIONS = _IMAGE_VALIDATION_NONCRITICAL_EXCEPTIONS + (SyntaxError,)
 
 #######################################################################################################################
 #
@@ -176,8 +178,9 @@ def safe_decode_base64_image(base64_data: str, mime_type: str) -> Optional[bytes
         Decoded bytes if valid, None otherwise
     """
     try:
+        normalized_mime = str(mime_type or "").lower().strip()
         # Final validation of MIME type
-        if not validate_mime_type(mime_type):
+        if not validate_mime_type(normalized_mime):
             logger.warning(f"Invalid MIME type for decoding: {mime_type}")
             return None
 
@@ -188,6 +191,22 @@ def safe_decode_base64_image(base64_data: str, mime_type: str) -> Optional[bytes
         max_bytes = get_max_base64_bytes()
         if len(decoded_data) > max_bytes:
             logger.warning(f"Decoded image too large: {len(decoded_data)} > {max_bytes}")
+            return None
+
+        try:
+            with Image.open(io.BytesIO(decoded_data)) as img:
+                detected_mime = Image.MIME.get(img.format or "")
+                img.verify()
+        except _IMAGE_INTEGRITY_EXCEPTIONS as exc:
+            logger.warning("Decoded image failed integrity validation: {}", exc)
+            return None
+
+        if detected_mime and detected_mime.lower() != normalized_mime:
+            logger.warning(
+                "Decoded image MIME mismatch: expected {}, detected {}",
+                normalized_mime,
+                detected_mime.lower(),
+            )
             return None
 
         # TODO: Add optional virus/malware scanning here
@@ -229,7 +248,18 @@ def validate_image_url(url: str) -> tuple[bool, Optional[str], Optional[bytes]]:
         return True, mime_type, decoded_bytes
     else:
         # For now, we don't support external URLs for security reasons
-        logger.warning(f"External image URLs not supported: {url[:100]}")
+        try:
+            parsed = urlparse(str(url or ""))
+            host = parsed.hostname or "unknown"
+            if parsed.port is not None:
+                host = f"{host}:{parsed.port}"
+            logger.warning(
+                "External image URLs not supported: scheme={}, host={}",
+                parsed.scheme or "unknown",
+                host,
+            )
+        except (TypeError, ValueError, AttributeError):
+            logger.warning("External image URLs not supported: unparsable URL")
         return False, None, None
 
 
@@ -251,7 +281,7 @@ def validate_uploaded_image_bytes(
             width, height = img.size
             detected_mime = Image.MIME.get(img.format or "")
             img.verify()
-    except _IMAGE_VALIDATION_NONCRITICAL_EXCEPTIONS as exc:
+    except _IMAGE_INTEGRITY_EXCEPTIONS as exc:
         logger.warning("Uploaded image failed integrity validation: {}", exc)
         return False, "Uploaded image failed integrity validation", None, None
 

--- a/tldw_Server_API/app/core/Utils/metadata_utils.py
+++ b/tldw_Server_API/app/core/Utils/metadata_utils.py
@@ -9,6 +9,7 @@ _ARXIV_RE = re.compile(r"^[a-z\-]+(\/\d{7})$|^(\d{4}\.\d{4,5})(v\d+)?$", re.IGNO
 
 
 def _norm_str(v: Any) -> Optional[str]:
+    """Normalize optional metadata values to non-empty strings."""
     if v is None:
         return None
     s = str(v).strip()
@@ -146,6 +147,17 @@ def update_version_safe_metadata_in_transaction(
             connection=connection,
         )
 
+    def _identifier_index_failure_is_compatible(exc: Exception) -> bool:
+        """Return whether an identifier index error matches legacy-compatible failures."""
+        message = str(exc or "").lower()
+        compatible_markers = (
+            "no such table",
+            "does not exist",
+            "undefined table",
+            "unsupported upsert",
+        )
+        return any(marker in message for marker in compatible_markers)
+
     # Maintain identifier index using backend-specific upsert.
     # Accept both canonical and legacy key variants for robustness.
     try:
@@ -179,6 +191,8 @@ def update_version_safe_metadata_in_transaction(
         )
     except (sqlite3.OperationalError, DatabaseError) as exc:
         # Missing identifier table or unsupported upsert is not fatal.
+        if not _identifier_index_failure_is_compatible(exc):
+            raise
         logger.debug(
             'Identifier index update skipped (missing table/unsupported upsert) for dv_id={}: {}',
             dv_id,
@@ -191,3 +205,4 @@ def update_version_safe_metadata_in_transaction(
             exc,
             exc_info=True,
         )
+        raise

--- a/tldw_Server_API/tests/Chat/integration/test_chat_fixes_integration.py
+++ b/tldw_Server_API/tests/Chat/integration/test_chat_fixes_integration.py
@@ -111,11 +111,11 @@ class TestMultiImagePersistence:
             conv_id = chat_db.add_conversation({"character_id": 1, "title": "Multi Image Conversation"})
             img_data_uri_1 = (
                 "data:image/png;base64,"
-                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII="
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg=="
             )
             img_data_uri_2 = (
                 "data:image/png;base64,"
-                "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAFUlEQVR42mNgYGD4z8DAwMgABBgAFSgC/7IvmV0AAAAASUVORK5CYII="
+                "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAFUlEQVR4nGNkaPj/n4GBgYEJRIAwACUZAoKPUI0GAAAAAElFTkSuQmCC"
             )
             message_obj = {
                 "role": "user",

--- a/tldw_Server_API/tests/MediaDB2/test_safe_metadata_utils.py
+++ b/tldw_Server_API/tests/MediaDB2/test_safe_metadata_utils.py
@@ -1,6 +1,21 @@
 import pytest
 
 
+class _FakeMetadataDB:
+    def __init__(self, index_error=None):
+        from tldw_Server_API.app.core.DB_Management.backends.base import BackendType
+
+        self.backend_type = BackendType.SQLITE
+        self.index_error = index_error
+        self.queries = []
+
+    def execute_query(self, query, params, connection=None):
+        self.queries.append((query, params, connection))
+        if "DocumentVersionIdentifiers" in query and self.index_error is not None:
+            raise self.index_error
+        return None
+
+
 def test_normalize_safe_metadata_doi_valid():
 
 
@@ -44,3 +59,53 @@ def test_normalize_safe_metadata_arxiv_pass_through():
 
     sm = normalize_safe_metadata({"arXiv": "1706.03762v2"})
     assert sm.get("arxiv_id") == "1706.03762v2"
+
+
+def test_update_version_safe_metadata_propagates_unexpected_identifier_index_failure():
+    from tldw_Server_API.app.core.DB_Management.media_db.errors import DatabaseError
+    from tldw_Server_API.app.core.Utils.metadata_utils import update_version_safe_metadata_in_transaction
+
+    db = _FakeMetadataDB(index_error=DatabaseError("constraint failed"))
+
+    with pytest.raises(DatabaseError, match="constraint failed"):
+        update_version_safe_metadata_in_transaction(
+            db=db,
+            dv_id=12,
+            safe_metadata_json='{"doi":"10.1000/example"}',
+            merged_metadata={"doi": "10.1000/example"},
+            connection=object(),
+        )
+
+
+def test_update_version_safe_metadata_propagates_unrelated_unsupported_identifier_failure():
+    from tldw_Server_API.app.core.DB_Management.media_db.errors import DatabaseError
+    from tldw_Server_API.app.core.Utils.metadata_utils import update_version_safe_metadata_in_transaction
+
+    db = _FakeMetadataDB(index_error=DatabaseError("unsupported column type"))
+
+    with pytest.raises(DatabaseError, match="unsupported column type"):
+        update_version_safe_metadata_in_transaction(
+            db=db,
+            dv_id=12,
+            safe_metadata_json='{"doi":"10.1000/example"}',
+            merged_metadata={"doi": "10.1000/example"},
+            connection=object(),
+        )
+
+
+def test_update_version_safe_metadata_skips_missing_identifier_table_for_legacy_schema():
+    import sqlite3
+
+    from tldw_Server_API.app.core.Utils.metadata_utils import update_version_safe_metadata_in_transaction
+
+    db = _FakeMetadataDB(index_error=sqlite3.OperationalError("no such table: DocumentVersionIdentifiers"))
+
+    update_version_safe_metadata_in_transaction(
+        db=db,
+        dv_id=12,
+        safe_metadata_json='{"doi":"10.1000/example"}',
+        merged_metadata={"doi": "10.1000/example"},
+        connection=object(),
+    )
+
+    assert len(db.queries) == 2

--- a/tldw_Server_API/tests/Utils/test_chunked_image_processor.py
+++ b/tldw_Server_API/tests/Utils/test_chunked_image_processor.py
@@ -73,3 +73,21 @@ async def test_streaming_image_processor_rejects_invalid_image_payload():
     assert image_data is None
     assert mime_type == "image/png"
     assert "Invalid image format" in error
+
+
+@pytest.mark.asyncio
+async def test_process_image_chunked_rejects_original_pixel_count_before_resize(monkeypatch):
+    class OversizedImage:
+        width = cip.MAX_IMAGE_DIMENSION + 1
+        height = cip.MAX_IMAGE_DIMENSION + 1
+        mode = "RGB"
+
+        def thumbnail(self, *_args, **_kwargs):
+            raise AssertionError("thumbnail should not run before pixel limit validation")
+
+    monkeypatch.setattr(cip, "PIL_AVAILABLE", True)
+    monkeypatch.setattr(cip.Image, "open", lambda _payload: OversizedImage())
+
+    with pytest.raises(ValueError, match="Image too large"):
+        async for _chunk in cip.process_image_chunked(b"fake", "image/png"):
+            pass

--- a/tldw_Server_API/tests/Utils/test_cpu_bound_handler.py
+++ b/tldw_Server_API/tests/Utils/test_cpu_bound_handler.py
@@ -2,7 +2,9 @@ import base64
 
 import pytest
 
+from tldw_Server_API.app.core.Utils import cpu_bound_handler as cbh
 from tldw_Server_API.app.core.Utils.cpu_bound_handler import (
+    CPUBoundBatcher,
     _process_pool_disabled,
     decode_large_base64_async,
     json_encode_heavy,
@@ -45,3 +47,79 @@ def test_process_pool_disabled_accepts_testing_y(monkeypatch):
     monkeypatch.delenv("TLDR_DISABLE_CPU_PROCPOOL", raising=False)
     monkeypatch.setenv("TESTING", "y")
     assert _process_pool_disabled() is True
+
+
+@pytest.mark.asyncio
+async def test_cpu_bound_batcher_reschedules_operations_added_while_batch_is_draining(monkeypatch):
+    started = cbh.asyncio.Event()
+    release = cbh.asyncio.Event()
+
+    async def fake_run_cpu_bound_thread(func, *args, **kwargs):
+        if args and args[0] == "first":
+            started.set()
+            await release.wait()
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(cbh, "run_cpu_bound_thread", fake_run_cpu_bound_thread)
+
+    batcher = CPUBoundBatcher(batch_size=10, timeout=0.01)
+
+    def identity(value: str) -> str:
+        return value
+
+    first = cbh.asyncio.create_task(batcher.add_operation(identity, "first"))
+    await cbh.asyncio.wait_for(started.wait(), timeout=0.5)
+
+    second = cbh.asyncio.create_task(batcher.add_operation(identity, "second"))
+    await cbh.asyncio.sleep(0)
+    release.set()
+
+    results = await cbh.asyncio.wait_for(cbh.asyncio.gather(first, second), timeout=0.5)
+
+    assert results == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_cpu_bound_batcher_keeps_rescheduled_task_reference_after_full_batch(monkeypatch):
+    started = cbh.asyncio.Event()
+    release = cbh.asyncio.Event()
+
+    async def fake_run_cpu_bound_thread(func, *args, **kwargs):
+        if args and args[0] == "first":
+            started.set()
+            await release.wait()
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(cbh, "run_cpu_bound_thread", fake_run_cpu_bound_thread)
+
+    batcher = CPUBoundBatcher(batch_size=2, timeout=60)
+
+    def identity(value: str) -> str:
+        return value
+
+    first = cbh.asyncio.create_task(batcher.add_operation(identity, "first"))
+    await cbh.asyncio.sleep(0)
+    second = cbh.asyncio.create_task(batcher.add_operation(identity, "second"))
+    await cbh.asyncio.wait_for(started.wait(), timeout=0.5)
+    third = cbh.asyncio.create_task(batcher.add_operation(identity, "third"))
+    await cbh.asyncio.sleep(0)
+
+    release.set()
+    await cbh.asyncio.wait_for(cbh.asyncio.gather(first, second), timeout=0.5)
+
+    try:
+        assert not third.done()
+        assert batcher._batch_task is not None
+        assert not batcher._batch_task.done()
+    finally:
+        if batcher._batch_task is not None and not batcher._batch_task.done():
+            batcher._batch_task.cancel()
+            try:
+                await batcher._batch_task
+            except cbh.asyncio.CancelledError:
+                pass
+            batcher._batch_task = None
+        if not third.done():
+            await batcher._process_batch(delay=False)
+
+    assert await cbh.asyncio.wait_for(third, timeout=0.5) == "third"

--- a/tldw_Server_API/tests/Utils/test_image_validation.py
+++ b/tldw_Server_API/tests/Utils/test_image_validation.py
@@ -16,6 +16,9 @@ from tldw_Server_API.app.core.Utils.image_validation import (
     MAX_BASE64_STRING_LENGTH,
 )
 
+PNG_BASE64_1X1 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+BROKEN_PNG_BASE64_1X1 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII="
+
 
 class TestValidateMimeType:
     """Test MIME type validation."""
@@ -81,13 +84,12 @@ class TestValidateDataUri:
     def test_valid_png_data_uri(self):
         """Test validation of valid PNG data URI."""
         # Small valid PNG base64
-        png_base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
-        data_uri = f"data:image/png;base64,{png_base64}"
+        data_uri = f"data:image/png;base64,{PNG_BASE64_1X1}"
 
         is_valid, mime_type, base64_data = validate_data_uri(data_uri)
         assert is_valid is True
         assert mime_type == "image/png"
-        assert base64_data == png_base64
+        assert base64_data == PNG_BASE64_1X1
 
     def test_valid_jpeg_data_uri(self):
         """Test validation of valid JPEG data URI."""
@@ -152,12 +154,31 @@ class TestSafeDecodeBase64Image:
     """Test safe base64 image decoding."""
 
     def test_valid_base64_decode(self):
-        """Test successful decoding of valid base64."""
-        test_data = b"Hello, World!"
-        base64_data = base64.b64encode(test_data).decode('utf-8')
+        """Test successful decoding of valid image base64."""
+        test_data = base64.b64decode(PNG_BASE64_1X1)
+
+        decoded = safe_decode_base64_image(PNG_BASE64_1X1, "image/png")
+        assert decoded == test_data
+
+    def test_rejects_non_image_payload_for_allowed_mime_type(self):
+        """Valid base64 bytes must still be a parseable image."""
+        base64_data = base64.b64encode(b"Hello, World!").decode('utf-8')
 
         decoded = safe_decode_base64_image(base64_data, "image/png")
-        assert decoded == test_data
+
+        assert decoded is None
+
+    def test_rejects_broken_image_payload_without_raising(self):
+        """Corrupt image bytes should fail validation instead of escaping parser errors."""
+        decoded = safe_decode_base64_image(BROKEN_PNG_BASE64_1X1, "image/png")
+
+        assert decoded is None
+
+    def test_rejects_image_payload_that_does_not_match_declared_mime_type(self):
+        """Declared MIME type must match the decoded image format."""
+        decoded = safe_decode_base64_image(PNG_BASE64_1X1, "image/jpeg")
+
+        assert decoded is None
 
     def test_invalid_mime_type_decode(self):
         """Test that invalid MIME type prevents decoding."""
@@ -187,12 +208,10 @@ class TestSafeDecodeBase64Image:
             mock_logger.warning.assert_called()
 
     def test_valid_size_data(self):
-        """Test acceptance of data within size limits."""
-        # Create data just under the limit
-        valid_data = b"A" * (MAX_BASE64_BYTES - 100)
-        base64_data = base64.b64encode(valid_data).decode('utf-8')
+        """Test acceptance of valid image data within size limits."""
+        valid_data = base64.b64decode(PNG_BASE64_1X1)
 
-        decoded = safe_decode_base64_image(base64_data, "image/png")
+        decoded = safe_decode_base64_image(PNG_BASE64_1X1, "image/png")
         assert decoded == valid_data
 
     def test_base64_with_validation_flag(self):
@@ -210,9 +229,8 @@ class TestValidateImageUrl:
 
     def test_valid_data_uri(self):
         """Test validation of valid data URI."""
-        test_data = b"Test image data"
-        base64_data = base64.b64encode(test_data).decode('utf-8')
-        data_uri = f"data:image/png;base64,{base64_data}"
+        test_data = base64.b64decode(PNG_BASE64_1X1)
+        data_uri = f"data:image/png;base64,{PNG_BASE64_1X1}"
 
         is_valid, mime_type, decoded_bytes = validate_image_url(data_uri)
         assert is_valid is True
@@ -249,6 +267,42 @@ class TestValidateImageUrl:
             assert mime_type is None
             assert decoded_bytes is None
             mock_logger.warning.assert_called()
+
+    def test_external_url_logs_without_sensitive_query_values(self):
+        """Rejected external URLs should not leak query strings into logs."""
+        url = "https://example.com/image.png?token=secret-value"
+
+        with patch('tldw_Server_API.app.core.Utils.image_validation.logger') as mock_logger:
+            is_valid, mime_type, decoded_bytes = validate_image_url(url)
+
+        assert is_valid is False
+        assert mime_type is None
+        assert decoded_bytes is None
+        logged = " ".join(
+            " ".join(str(arg) for arg in call.args)
+            for call in mock_logger.warning.call_args_list
+        )
+        assert "secret-value" not in logged
+        assert "token=" not in logged
+
+    def test_external_url_logs_without_userinfo_credentials(self):
+        """Rejected external URLs should not leak username/password userinfo."""
+        url = "https://user:secret-pass@example.com:8443/image.png"
+
+        with patch('tldw_Server_API.app.core.Utils.image_validation.logger') as mock_logger:
+            is_valid, mime_type, decoded_bytes = validate_image_url(url)
+
+        assert is_valid is False
+        assert mime_type is None
+        assert decoded_bytes is None
+        logged = " ".join(
+            " ".join(str(arg) for arg in call.args)
+            for call in mock_logger.warning.call_args_list
+        )
+        assert "user" not in logged
+        assert "secret-pass" not in logged
+        assert "@" not in logged
+        assert "example.com:8443" in logged
 
     def test_file_url_not_supported(self):
         """Test that file URLs are not supported."""
@@ -316,10 +370,8 @@ class TestIntegration:
 
     def test_full_validation_workflow_success(self):
         """Test successful validation of a complete data URI."""
-        # Create a small valid "image"
-        image_data = b"fake image content"
-        base64_data = base64.b64encode(image_data).decode('utf-8')
-        data_uri = f"data:image/png;base64,{base64_data}"
+        image_data = base64.b64decode(PNG_BASE64_1X1)
+        data_uri = f"data:image/png;base64,{PNG_BASE64_1X1}"
 
         # Full validation workflow
         is_valid, mime_type, decoded = validate_image_url(data_uri)

--- a/tldw_Server_API/tests/Utils/test_utils_general.py
+++ b/tldw_Server_API/tests/Utils/test_utils_general.py
@@ -88,6 +88,52 @@ def test_extract_text_from_segments_rounds_timestamps_to_hundredths():
     assert result == "0.84s - 1.1s | What?"
 
 
+def test_extract_text_from_segments_trace_logs_shape_not_raw_text(monkeypatch):
+    trace_messages = []
+
+    class Recorder:
+        def trace(self, message):
+            trace_messages.append(str(message))
+
+        def error(self, *_args, **_kwargs):
+            pass
+
+    monkeypatch.setattr(Utils, "logger", Recorder())
+
+    result = Utils.extract_text_from_segments(
+        [{"Time_Start": 0, "Time_End": 1, "Text": "private transcript"}],
+        include_timestamps=False,
+    )
+
+    assert result == "private transcript"
+    assert trace_messages
+    assert all("private transcript" not in message for message in trace_messages)
+
+
+def test_extract_text_from_segments_error_logs_shape_not_raw_text(monkeypatch):
+    error_messages = []
+
+    class Recorder:
+        def trace(self, *_args, **_kwargs):
+            pass
+
+        def error(self, message):
+            error_messages.append(str(message))
+
+    recorder = Recorder()
+    monkeypatch.setattr(Utils, "logger", recorder)
+    monkeypatch.setattr(Utils, "logging", recorder)
+
+    result = Utils.extract_text_from_segments(
+        [{"Caption": "private transcript"}],
+        include_timestamps=False,
+    )
+
+    assert result == "Error: Unable to extract transcription"
+    assert error_messages
+    assert all("private transcript" not in message for message in error_messages)
+
+
 def test_save_temp_file_normalizes_and_preserves_content(monkeypatch):
     class DummyUpload:
         def __init__(self, name, data):
@@ -205,7 +251,7 @@ def test_check_ffmpeg_handles_unknown_os(monkeypatch):
     assert result is False
 
 
-def test_cuda_check_uses_direct_subprocess_invocation(monkeypatch):
+def test_cuda_check_uses_resolved_direct_subprocess_invocation(monkeypatch):
     System_Checks_Lib.processing_choice = "cpu"
     recorded = {}
 
@@ -214,14 +260,37 @@ def test_cuda_check_uses_direct_subprocess_invocation(monkeypatch):
         recorded["kwargs"] = kwargs
         return "GPU info line\nCUDA Version: 12.4\n"
 
+    monkeypatch.setattr(
+        System_Checks_Lib.shutil,
+        "which",
+        lambda name: "/usr/bin/nvidia-smi" if name == "nvidia-smi" else None,
+    )
     monkeypatch.setattr(System_Checks_Lib.subprocess, "check_output", _fake_check_output)
 
     result = System_Checks_Lib.cuda_check()
 
     assert result is True
     assert System_Checks_Lib.processing_choice == "cuda"
-    assert recorded["cmd"] == ["nvidia-smi"]
+    assert recorded["cmd"] == ["/usr/bin/nvidia-smi"]
     assert "shell" not in recorded["kwargs"]
+
+
+def test_download_ffmpeg_does_not_download_unverified_binary(monkeypatch):
+    calls = []
+
+    def fake_download(**_kwargs):
+        calls.append("download")
+        raise AssertionError("download should not be called")
+
+    monkeypatch.setattr(System_Checks_Lib, "input", lambda *_args, **_kwargs: "y", raising=False)
+    monkeypatch.setattr(System_Checks_Lib, "download", fake_download, raising=False)
+
+    assert System_Checks_Lib.download_ffmpeg() is False
+    assert calls == []
+
+
+def test_utils_no_user_database_path_placeholder():
+    assert not hasattr(Utils, "get_user_database_path")
 
 
 def _raise_eof(*_args, **_kwargs):


### PR DESCRIPTION
## Summary
- Harden Utils image validation, pixel limits, CPU batch draining, metadata failure handling, and sensitive logging.
- Disable unauthenticated ffmpeg binary download and harden the nvidia-smi probe.
- Add focused regression tests plus Backlog task and implementation plan records.

## Verification
- 70 passed: Utils/MediaDB focused tests from the clean worktree.
- 24 passed: related chat image tests from the clean worktree.
- py_compile passed for touched Utils modules.
- git diff --check passed for touched tracked files.
- Bandit passed with zero findings on exact touched Utils files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Utils for real-image validation, pre-resize pixel caps, reliable CPU batching, safer logs, and stricter CUDA/ffmpeg checks. Reduces security risk and prevents stalled work; aligns with task 9941.

- **Bug Fixes**
  - Image validation: verify raster bytes with Pillow, require strict MIME match, reject corrupt payloads (incl. parser `SyntaxError`); sanitize external URL logs to scheme/host only; keep strict limits in data URIs and uploads.
  - Chunked images: enforce original pixel caps before any resize in `chunked_image_processor`; log resize from→to.
  - CPU batching: prevent stranded futures, reschedule ops that arrive while a batch drains, keep batch task reference until pending work finishes; avoid double-setting futures.
  - Metadata indexing: propagate unexpected identifier-index failures; keep missing-table/unsupported-upsert non‑fatal with explicit compatibility check.
  - Safer logs: avoid raw segment text in traces/errors; log types/shapes instead.
  - System checks: resolve `nvidia-smi` via `shutil.which`, run without shell, handle missing binary and `OSError` cleanly.
  - Added focused regression tests across image validation, batching, metadata, logging, and system checks.

- **Migration**
  - `download_ffmpeg()` no longer downloads binaries; install `ffmpeg` via a trusted package manager.
  - Removed `get_user_database_path`; update any external callers if used.

<sup>Written for commit 28140835831351ebed80739dec512a2e900009b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

