### PR TITLE
Harden TTS review findings

### DIFF
--- a/IMPLEMENTATION_PLAN_tts_review_fixes.md
+++ b/IMPLEMENTATION_PLAN_tts_review_fixes.md
@@ -34,3 +34,10 @@
 **Success Criteria**: Focused tests pass, Bandit reports no new actionable findings in touched production code, and task notes/final summary are updated.
 **Tests**: `python -m pytest ...`, `python -m bandit -r ...`, `git diff --check`.
 **Status**: Complete
+
+## Stage 6: PR Review Thread Closeout
+
+**Goal**: Address the remaining PR #2484 review-thread state after rebasing on latest `dev`.
+**Success Criteria**: Changed-span docstring coverage is above the bot threshold, unresolved functional comments are verified against current code, and review threads are resolved after push.
+**Tests**: Changed-span docstring coverage script, Ruff, `py_compile`, focused TTS pytest batches, Bandit touched production scope, `git diff --check`.
+**Status**: Complete

--- a/IMPLEMENTATION_PLAN_tts_review_fixes.md
+++ b/IMPLEMENTATION_PLAN_tts_review_fixes.md
@@ -1,0 +1,29 @@
+## Stage 1: Regression Coverage
+**Goal**: Add focused tests for the reviewed TTS defects before production changes.
+**Success Criteria**: Tests fail against the current behavior for config redaction/env mapping, VibeVoice generation config propagation, conversion failure surfacing, subprocess timeout handling, and realtime websocket egress validation.
+**Tests**: Targeted pytest runs for the new/updated TTS test files.
+**Status**: Complete
+
+## Stage 2: VibeVoice State and Async Boundaries
+**Goal**: Forward VibeVoice generation configuration in non-streaming mode, serialize shared model state, and move blocking local generation calls off the event loop.
+**Success Criteria**: VibeVoice uses request generation config consistently, model reload/generation paths cannot concurrently mutate shared model state, and local blocking generation entry points run through thread offload.
+**Tests**: VibeVoice adapter unit tests and compile checks for touched adapters.
+**Status**: Complete
+
+## Stage 3: Audio Conversion Hardening
+**Goal**: Bound ffmpeg/ffprobe subprocess calls and surface voice-reference conversion failures.
+**Success Criteria**: Audio converter subprocesses return timeout failures instead of waiting indefinitely, and strict voice-reference conversion raises instead of silently returning original bytes.
+**Tests**: Audio converter and audio utility regression tests.
+**Status**: Complete
+
+## Stage 4: Security Policy and Config Redaction
+**Goal**: Enforce central egress policy for realtime websocket backend URLs and redact TTS provider secrets by default.
+**Success Criteria**: Websocket realtime adapters reject URLs denied by egress policy, `TTSConfig.to_dict()`/YAML export redact API keys unless explicitly requested, and stale non-TTS env mappings are removed.
+**Tests**: Realtime adapter and TTS config regression tests.
+**Status**: Complete
+
+## Stage 5: Verification and Task Closeout
+**Goal**: Run focused tests plus Bandit on touched production TTS scope and record outcomes in TASK-10001.
+**Success Criteria**: Focused tests pass, Bandit reports no new actionable findings in touched production code, and task notes/final summary are updated.
+**Tests**: `python -m pytest ...`, `python -m bandit -r ...`, `git diff --check`.
+**Status**: Complete

--- a/IMPLEMENTATION_PLAN_tts_review_fixes.md
+++ b/IMPLEMENTATION_PLAN_tts_review_fixes.md
@@ -1,28 +1,35 @@
+# TTS Review Fixes Rollout Plan
+
 ## Stage 1: Regression Coverage
+
 **Goal**: Add focused tests for the reviewed TTS defects before production changes.
 **Success Criteria**: Tests fail against the current behavior for config redaction/env mapping, VibeVoice generation config propagation, conversion failure surfacing, subprocess timeout handling, and realtime websocket egress validation.
 **Tests**: Targeted pytest runs for the new/updated TTS test files.
 **Status**: Complete
 
 ## Stage 2: VibeVoice State and Async Boundaries
+
 **Goal**: Forward VibeVoice generation configuration in non-streaming mode, serialize shared model state, and move blocking local generation calls off the event loop.
 **Success Criteria**: VibeVoice uses request generation config consistently, model reload/generation paths cannot concurrently mutate shared model state, and local blocking generation entry points run through thread offload.
 **Tests**: VibeVoice adapter unit tests and compile checks for touched adapters.
 **Status**: Complete
 
 ## Stage 3: Audio Conversion Hardening
+
 **Goal**: Bound ffmpeg/ffprobe subprocess calls and surface voice-reference conversion failures.
 **Success Criteria**: Audio converter subprocesses return timeout failures instead of waiting indefinitely, and strict voice-reference conversion raises instead of silently returning original bytes.
 **Tests**: Audio converter and audio utility regression tests.
 **Status**: Complete
 
 ## Stage 4: Security Policy and Config Redaction
+
 **Goal**: Enforce central egress policy for realtime websocket backend URLs and redact TTS provider secrets by default.
 **Success Criteria**: Websocket realtime adapters reject URLs denied by egress policy, `TTSConfig.to_dict()`/YAML export redact API keys unless explicitly requested, and stale non-TTS env mappings are removed.
 **Tests**: Realtime adapter and TTS config regression tests.
 **Status**: Complete
 
 ## Stage 5: Verification and Task Closeout
+
 **Goal**: Run focused tests plus Bandit on touched production TTS scope and record outcomes in TASK-10001.
 **Success Criteria**: Focused tests pass, Bandit reports no new actionable findings in touched production code, and task notes/final summary are updated.
 **Tests**: `python -m pytest ...`, `python -m bandit -r ...`, `git diff --check`.

--- a/backlog/tasks/task-10001 - Fix-TTS-module-review-findings.md
+++ b/backlog/tasks/task-10001 - Fix-TTS-module-review-findings.md
@@ -1,0 +1,66 @@
+---
+id: TASK-10001
+title: Fix TTS module review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 21:55'
+updated_date: '2026-06-23 22:09'
+labels:
+  - tts
+  - security
+  - review
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the current-code review findings in tldw_Server_API/app/core/TTS: VibeVoice non-stream config propagation, VibeVoice shared model-state races, blocking local TTS generation in async paths, ffmpeg subprocess timeouts, voice-reference conversion failures, realtime websocket egress policy enforcement, TTS config secret redaction, and stale Anthropic env mapping.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 VibeVoice non-stream generation forwards request generation config and guards shared model state.
+- [x] #2 Local blocking generation calls are offloaded from the event loop.
+- [x] #3 Audio conversion subprocesses are bounded by timeouts.
+- [x] #4 Voice-reference conversion errors surface instead of silently using raw bytes.
+- [x] #5 Realtime websocket TTS URLs pass central egress policy checks before connecting.
+- [x] #6 TTS config export redacts provider API keys by default and removes non-TTS Anthropic key mapping.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Stage 1: Add focused regression coverage for reviewed TTS defects.
+Stage 2: Repair VibeVoice config propagation, model-state locking, and async offload boundaries.
+Stage 3: Bound audio converter subprocesses and surface voice-reference conversion failures.
+Stage 4: Enforce realtime websocket egress policy and redact TTS config secrets by default.
+Stage 5: Run focused tests, Bandit on touched TTS scope, and record verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Touched production files: tldw_Server_API/app/core/TTS/utils.py, tts_config.py, audio_utils.py, audio_converter.py, adapters/vibevoice_adapter.py, adapters/vibevoice_realtime_adapter.py, adapters/chatterbox_adapter.py, adapters/dia_adapter.py, adapters/higgs_adapter.py, adapters/kokoro_adapter.py. Added/updated focused tests under tldw_Server_API/tests/TTS and tldw_Server_API/tests/TTS_NEW.
+
+Verification passed: focused 10-test regression set; nearby 43-test TTS utility/config/VibeVoice suite; 77-test Chatterbox/Higgs/Kokoro mock/flow suite; py_compile on touched production TTS files; git diff --check on touched scope; Bandit touched production TTS scope wrote /tmp/bandit_tts_review_fixes.json with errors=[] and results_count=0. No separate user-facing docs were needed for these internal hardening fixes.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the TTS review findings: VibeVoice now forwards non-stream generation config and serializes model variant reload/generation state; local blocking generation calls in Chatterbox, Dia, Higgs, VibeVoice, and Kokoro stream iteration now run through thread offload helpers; ffmpeg/ffprobe calls in audio_converter are timeout-bounded; voice-reference conversion opts into strict failures; VibeVoice realtime websocket sessions enforce central egress policy before connecting; TTS config export redacts provider API keys by default and ignores ANTHROPIC_API_KEY; touched-scope Bandit warnings were cleaned up.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+- [x] #7 Focused regression tests cover the repaired review findings.
+- [x] #8 Bandit runs on touched TTS production scope.
+<!-- DOD:END -->

--- a/backlog/tasks/task-10001 - Fix-TTS-module-review-findings.md
+++ b/backlog/tasks/task-10001 - Fix-TTS-module-review-findings.md
@@ -3,12 +3,12 @@ id: TASK-10001
 title: Fix TTS module review findings
 status: Done
 assignee: []
-created_date: '2026-06-23 21:55'
-updated_date: '2026-06-23 22:09'
+created_date: 2026-06-23 21:55
+updated_date: 2026-06-25 02:19
 labels:
-  - tts
-  - security
-  - review
+- tts
+- security
+- review
 dependencies: []
 priority: high
 ---
@@ -20,6 +20,7 @@ Address the current-code review findings in tldw_Server_API/app/core/TTS: VibeVo
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
+
 <!-- AC:BEGIN -->
 - [x] #1 VibeVoice non-stream generation forwards request generation config and guards shared model state.
 - [x] #2 Local blocking generation calls are offloaded from the event loop.
@@ -44,16 +45,19 @@ Stage 5: Run focused tests, Bandit on touched TTS scope, and record verification
 <!-- SECTION:NOTES:BEGIN -->
 Touched production files: tldw_Server_API/app/core/TTS/utils.py, tts_config.py, audio_utils.py, audio_converter.py, adapters/vibevoice_adapter.py, adapters/vibevoice_realtime_adapter.py, adapters/chatterbox_adapter.py, adapters/dia_adapter.py, adapters/higgs_adapter.py, adapters/kokoro_adapter.py. Added/updated focused tests under tldw_Server_API/tests/TTS and tldw_Server_API/tests/TTS_NEW.
 
-Verification passed: focused 10-test regression set; nearby 43-test TTS utility/config/VibeVoice suite; 77-test Chatterbox/Higgs/Kokoro mock/flow suite; py_compile on touched production TTS files; git diff --check on touched scope; Bandit touched production TTS scope wrote /tmp/bandit_tts_review_fixes.json with errors=[] and results_count=0. No separate user-facing docs were needed for these internal hardening fixes.
+PR #2484 follow-up rebased the branch onto latest dev and addressed Qodo/CodeRabbit review comments: VibeVoice model hints are canonicalized case-insensitively, Q8 variant reloads recompute quantization, VibeVoice streaming releases the model-state lock before yielding chunks, realtime websocket policy errors use sanitized origins and pin resolved IPs through an aiohttp resolver, audio converter long-running operations accept timeout overrides, canonical TTS config saves refuse redacted secrets unless include_secrets=True, new helpers/tests have docstrings/type cleanup, and markdown plan formatting was corrected.
+
+Fresh verification passed after the review follow-up: Ruff touched Python scope; 26-test focused review suite; 51-test TTS config/audio/VibeVoice suite; 77-test Chatterbox/Higgs/Kokoro suite; py_compile on touched production and test Python files; git diff --check; Bandit touched production TTS scope wrote /tmp/bandit_tts_review_fixes_rebased.json with errors=[] and results_count=0.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixed the TTS review findings: VibeVoice now forwards non-stream generation config and serializes model variant reload/generation state; local blocking generation calls in Chatterbox, Dia, Higgs, VibeVoice, and Kokoro stream iteration now run through thread offload helpers; ffmpeg/ffprobe calls in audio_converter are timeout-bounded; voice-reference conversion opts into strict failures; VibeVoice realtime websocket sessions enforce central egress policy before connecting; TTS config export redacts provider API keys by default and ignores ANTHROPIC_API_KEY; touched-scope Bandit warnings were cleaned up.
+Fixed the original TTS review findings and the PR #2484 follow-up comments. The follow-up hardens VibeVoice variant switching and stream lock scope, pins realtime websocket DNS results after egress validation, prevents sensitive websocket URL details and canonical TTS config secrets from being leaked or overwritten, exposes timeout overrides for long-running audio converter operations, and strengthens regression tests so the fixes are covered by behavior checks rather than source-string checks.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
+
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded

--- a/backlog/tasks/task-10001 - Fix-TTS-module-review-findings.md
+++ b/backlog/tasks/task-10001 - Fix-TTS-module-review-findings.md
@@ -4,13 +4,31 @@ title: Fix TTS module review findings
 status: Done
 assignee: []
 created_date: 2026-06-23 21:55
-updated_date: 2026-06-25 02:19
+updated_date: 2026-06-25 02:52
 labels:
 - tts
 - security
 - review
 dependencies: []
 priority: high
+modified_files:
+- IMPLEMENTATION_PLAN_tts_review_fixes.md
+- tldw_Server_API/app/core/TTS/adapters/chatterbox_adapter.py
+- tldw_Server_API/app/core/TTS/adapters/dia_adapter.py
+- tldw_Server_API/app/core/TTS/adapters/higgs_adapter.py
+- tldw_Server_API/app/core/TTS/adapters/kokoro_adapter.py
+- tldw_Server_API/app/core/TTS/adapters/vibevoice_adapter.py
+- tldw_Server_API/app/core/TTS/adapters/vibevoice_realtime_adapter.py
+- tldw_Server_API/app/core/TTS/audio_converter.py
+- tldw_Server_API/app/core/TTS/audio_utils.py
+- tldw_Server_API/app/core/TTS/tts_config.py
+- tldw_Server_API/app/core/TTS/utils.py
+- tldw_Server_API/tests/TTS/test_vibevoice_adapter_unit.py
+- tldw_Server_API/tests/TTS/unit/test_audio_converter_time_stretch.py
+- tldw_Server_API/tests/TTS/unit/test_local_adapter_async_offload.py
+- tldw_Server_API/tests/TTS/unit/test_tts_config_security.py
+- tldw_Server_API/tests/TTS/unit/test_vibevoice_realtime_adapter_security.py
+- tldw_Server_API/tests/TTS_NEW/unit/test_tts_audio_utils.py
 ---
 
 ## Description
@@ -53,7 +71,7 @@ Fresh verification passed after the review follow-up: Ruff touched Python scope;
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixed the original TTS review findings and the PR #2484 follow-up comments. The follow-up hardens VibeVoice variant switching and stream lock scope, pins realtime websocket DNS results after egress validation, prevents sensitive websocket URL details and canonical TTS config secrets from being leaked or overwritten, exposes timeout overrides for long-running audio converter operations, and strengthens regression tests so the fixes are covered by behavior checks rather than source-string checks.
+Fixed the original TTS review findings and the PR #2484 follow-up comments. The follow-up hardens VibeVoice variant switching and stream lock scope, pins realtime websocket DNS results after egress validation, prevents sensitive websocket URL details and canonical TTS config secrets from being leaked or overwritten, exposes timeout overrides for long-running audio converter operations, documents changed helpers/tests to satisfy the PR docstring coverage gate, and strengthens regression tests so the fixes are covered by behavior checks rather than source-string checks.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -68,3 +86,10 @@ Fixed the original TTS review findings and the PR #2484 follow-up comments. The 
 - [x] #7 Focused regression tests cover the repaired review findings.
 - [x] #8 Bandit runs on touched TTS production scope.
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Reopened for PR #2484 final comment pass: address remaining unresolved review threads and CodeRabbit docstring coverage warning on the current pushed branch.
+Final PR #2484 comment pass: added docstrings to changed TTS helper/test definitions flagged by the bot coverage warning, confirmed changed-span docstring coverage at 104/104 (100.0%), reran Ruff, py_compile, git diff --check, focused TTS pytest batches (51 passed and 77 passed), and Bandit touched production TTS scope with errors=[] and results_count=0 in /tmp/bandit_tts_review_fixes_docstrings.json.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/core/TTS/adapters/chatterbox_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/chatterbox_adapter.py
@@ -30,7 +30,7 @@ from loguru import logger
 from ..tts_exceptions import (
     TTSModelLoadError,
 )
-from ..utils import parse_bool
+from ..utils import parse_bool, run_tts_blocking_call
 from ..chatterbox_catalog import (
     CHATTERBOX_LANGUAGE_CODES,
     ChatterboxModelFamily,
@@ -1073,18 +1073,20 @@ class ChatterboxAdapter(TTSAdapter):
             self._prepare_bf16_runtime(model)
 
             # Generate full waveform tensor (1, N)
-            with self._bf16_autocast_context():
-                if family is ChatterboxModelFamily.MULTILINGUAL:
-                    audio_tensor = model.generate(
+            def _generate_audio_tensor():
+                with self._bf16_autocast_context():
+                    if family is ChatterboxModelFamily.MULTILINGUAL:
+                        return model.generate(
+                            self.preprocess_text(request.text),
+                            language_id=language_id,
+                            **filtered_kwargs,
+                        )
+                    return model.generate(
                         self.preprocess_text(request.text),
-                        language_id=language_id,
                         **filtered_kwargs,
                     )
-                else:
-                    audio_tensor = model.generate(
-                        self.preprocess_text(request.text),
-                        **filtered_kwargs,
-                    )
+
+            audio_tensor = await run_tts_blocking_call(_generate_audio_tensor)
             # Stream using shared waveform streamer
             from tldw_Server_API.app.core.TTS.waveform_streamer import stream_encoded_waveform
             async for chunk in stream_encoded_waveform(
@@ -1176,7 +1178,8 @@ class ChatterboxAdapter(TTSAdapter):
         """Generate a VC waveform and stream encoded audio bytes."""
         model = await self._get_vc_model()
         self.sample_rate = int(getattr(model, "sr", 24000))
-        audio_tensor = model.generate(
+        audio_tensor = await run_tts_blocking_call(
+            model.generate,
             audio=source_audio_path,
             target_voice_path=target_voice_path,
         )

--- a/tldw_Server_API/app/core/TTS/adapters/chatterbox_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/chatterbox_adapter.py
@@ -27,15 +27,15 @@ import numpy as np
 # Third-party Imports
 from loguru import logger
 
-from ..tts_exceptions import (
-    TTSModelLoadError,
-)
-from ..utils import parse_bool, run_tts_blocking_call
 from ..chatterbox_catalog import (
     CHATTERBOX_LANGUAGE_CODES,
     ChatterboxModelFamily,
     resolve_chatterbox_model_family,
 )
+from ..tts_exceptions import (
+    TTSModelLoadError,
+)
+from ..utils import parse_bool, run_tts_blocking_call
 
 # Local Imports
 from .base import AudioFormat, ProviderStatus, TTSAdapter, TTSCapabilities, TTSRequest, TTSResponse, VoiceInfo
@@ -878,7 +878,7 @@ class ChatterboxAdapter(TTSAdapter):
         if callable(to_device):
             with contextlib.suppress(*_CHATTERBOX_RUNTIME_EXCEPTIONS):
                 conditionals = to_device(self.device)
-        setattr(model, "conds", conditionals)
+        model.conds = conditionals
 
     async def _prepare_cached_conditionals(
         self,
@@ -1020,9 +1020,9 @@ class ChatterboxAdapter(TTSAdapter):
 
         if converted is not None:
             with contextlib.suppress(*_CHATTERBOX_RUNTIME_EXCEPTIONS):
-                setattr(model, "t3", converted)
+                model.t3 = converted
         with contextlib.suppress(*_CHATTERBOX_RUNTIME_EXCEPTIONS):
-            setattr(model, "_tldw_bf16_prepared", True)
+            model._tldw_bf16_prepared = True
 
     def _bf16_autocast_context(self):
         """Return a torch autocast context for BF16 generation, or a no-op context."""
@@ -1074,6 +1074,7 @@ class ChatterboxAdapter(TTSAdapter):
 
             # Generate full waveform tensor (1, N)
             def _generate_audio_tensor():
+                """Generate a Chatterbox waveform tensor for the selected model family."""
                 with self._bf16_autocast_context():
                     if family is ChatterboxModelFamily.MULTILINGUAL:
                         return model.generate(

--- a/tldw_Server_API/app/core/TTS/adapters/dia_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/dia_adapter.py
@@ -25,7 +25,7 @@ from ..tts_exceptions import (
 )
 from ..tts_resource_manager import get_resource_manager
 from ..tts_validation import validate_tts_request
-from ..utils import parse_bool
+from ..utils import parse_bool, run_tts_blocking_call
 
 #
 # Local Imports
@@ -431,8 +431,11 @@ class DiaAdapter(TTSAdapter):
                     "Dia generation requires torch, which is unavailable",
                     provider=self.provider_name,
                 )
-            with torch_mod.no_grad():
-                outputs = self.model.generate(**inputs, **gen_kwargs)
+            def _generate_outputs():
+                with torch_mod.no_grad():
+                    return self.model.generate(**inputs, **gen_kwargs)
+
+            outputs = await run_tts_blocking_call(_generate_outputs)
 
             # Decode to audio waveform
             audio_array = self._decode_dia_output(outputs[0])

--- a/tldw_Server_API/app/core/TTS/adapters/dia_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/dia_adapter.py
@@ -432,6 +432,7 @@ class DiaAdapter(TTSAdapter):
                     provider=self.provider_name,
                 )
             def _generate_outputs():
+                """Run Dia model generation without blocking the event loop."""
                 with torch_mod.no_grad():
                     return self.model.generate(**inputs, **gen_kwargs)
 

--- a/tldw_Server_API/app/core/TTS/adapters/higgs_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/higgs_adapter.py
@@ -25,7 +25,7 @@ from ..tts_exceptions import (
 )
 from ..tts_resource_manager import get_resource_manager
 from ..tts_validation import validate_tts_request
-from ..utils import parse_bool
+from ..utils import parse_bool, run_tts_blocking_call
 
 #
 # Local Imports
@@ -437,7 +437,10 @@ class HiggsAdapter(TTSAdapter):
             if extras.get("min_new_tokens") is not None:
                 with contextlib.suppress(Exception):
                     gen_kwargs["min_new_tokens"] = int(extras.get("min_new_tokens"))
-            output: HiggsAudioResponse = self.serve_engine.generate(**gen_kwargs)
+            output: HiggsAudioResponse = await run_tts_blocking_call(
+                self.serve_engine.generate,
+                **gen_kwargs,
+            )
 
             # Convert numpy audio to tensor and back to numpy for processing
             audio_array = output.audio

--- a/tldw_Server_API/app/core/TTS/adapters/kokoro_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/kokoro_adapter.py
@@ -38,7 +38,7 @@ from ..tts_resource_manager import get_resource_manager as _get_resource_manager
 from ...testing import env_flag_enabled, is_explicit_pytest_runtime, is_test_mode
 from ...Utils.torch_import_guard import safe_import_torch
 from ..tts_validation import validate_tts_request
-from ..utils import parse_bool
+from ..utils import parse_bool, run_tts_blocking_next
 
 #
 # Local Imports
@@ -554,9 +554,10 @@ class KokoroAdapter(TTSAdapter):
                         import time as _time
                         start_t = _time.time()
                         tokens = _np.array(self_k.tokenizer.tokenize(phonemes), dtype=_np.int64)
-                        assert len(tokens) <= MAX_PHONEME_LENGTH, (
-                            f"Context length is {MAX_PHONEME_LENGTH}, but leave room for the pad token 0 at the start & end"
-                        )
+                        if len(tokens) > MAX_PHONEME_LENGTH:
+                            raise ValueError(
+                                f"Context length is {MAX_PHONEME_LENGTH}, but leave room for the pad token 0 at the start & end"
+                            )
 
                         voice_vec = voice[len(tokens)]
                         tokens = [[0, *tokens, 0]]
@@ -908,11 +909,14 @@ class KokoroAdapter(TTSAdapter):
                 if hasattr(base_iter, "__aiter__") or inspect.isasyncgen(base_iter):
                     stream_iter = base_iter
                 else:
-                    def _sync_source():
-                        yield from base_iter
+                    sync_iterator = iter(base_iter)
+                    sentinel = object()
 
                     async def _async_wrap():
-                        for item in _sync_source():
+                        while True:
+                            item = await run_tts_blocking_next(sync_iterator, sentinel)
+                            if item is sentinel:
+                                break
                             yield item
                     stream_iter = _async_wrap()
             else:
@@ -953,12 +957,16 @@ class KokoroAdapter(TTSAdapter):
                         )
                 pipeline = self.kokoro_pt_pipelines[key]
 
-                # Define a sync generator wrapper to async iterate
-                def _sync_iter():
-                    yield from pipeline(text, voice=voice_path, speed=request.speed, model=self.kokoro_pt_model)
+                sync_iterator = iter(
+                    pipeline(text, voice=voice_path, speed=request.speed, model=self.kokoro_pt_model)
+                )
+                sentinel = object()
 
                 async def _async_iter():
-                    for result in _sync_iter():
+                    while True:
+                        result = await run_tts_blocking_next(sync_iterator, sentinel)
+                        if result is sentinel:
+                            break
                         yield result
 
                 stream_iter = _async_iter()

--- a/tldw_Server_API/app/core/TTS/adapters/kokoro_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/kokoro_adapter.py
@@ -20,6 +20,8 @@ from typing import Any, Optional
 import numpy as np
 from loguru import logger
 
+from ...testing import env_flag_enabled, is_explicit_pytest_runtime, is_test_mode
+from ...Utils.torch_import_guard import safe_import_torch
 from ..phoneme_overrides import (
     PhonemeOverrideEntry,
     apply_overrides_to_text,
@@ -35,8 +37,6 @@ from ..tts_exceptions import (
     TTSProviderNotConfiguredError,
 )
 from ..tts_resource_manager import get_resource_manager as _get_resource_manager
-from ...testing import env_flag_enabled, is_explicit_pytest_runtime, is_test_mode
-from ...Utils.torch_import_guard import safe_import_torch
 from ..tts_validation import validate_tts_request
 from ..utils import parse_bool, run_tts_blocking_next
 
@@ -542,6 +542,7 @@ class KokoroAdapter(TTSAdapter):
 
                 if callable(orig_create_audio) and not getattr(_konnx.Kokoro, "_tldw_speed_patch", False):
                     def _patched_create_audio(self_k, phonemes, voice, speed):
+                        """Create Kokoro ONNX audio while passing speed with a compatible dtype."""
                         from kokoro_onnx.config import MAX_PHONEME_LENGTH, SAMPLE_RATE  # type: ignore
                         from kokoro_onnx.log import log as _log  # type: ignore
 
@@ -913,6 +914,7 @@ class KokoroAdapter(TTSAdapter):
                     sentinel = object()
 
                     async def _async_wrap():
+                        """Adapt Kokoro ONNX's synchronous stream iterator for async streaming."""
                         while True:
                             item = await run_tts_blocking_next(sync_iterator, sentinel)
                             if item is sentinel:
@@ -963,6 +965,7 @@ class KokoroAdapter(TTSAdapter):
                 sentinel = object()
 
                 async def _async_iter():
+                    """Adapt Kokoro PyTorch's synchronous stream iterator for async streaming."""
                     while True:
                         result = await run_tts_blocking_next(sync_iterator, sentinel)
                         if result is sentinel:

--- a/tldw_Server_API/app/core/TTS/adapters/vibevoice_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/vibevoice_adapter.py
@@ -152,6 +152,14 @@ class VibeVoiceAdapter(TTSAdapter):
     # Voice presets loaded from files
     VOICE_PRESETS = {}
 
+    @classmethod
+    def _canonical_variant(cls, variant: Any) -> Optional[str]:
+        """Return the canonical model variant key for a case-insensitive hint."""
+        if not isinstance(variant, str):
+            return None
+        variant_lookup = {name.lower(): name for name in cls.MODEL_VARIANTS}
+        return variant_lookup.get(variant.strip().lower())
+
     def __init__(self, config: Optional[dict[str, Any]] = None):
         super().__init__(config)
 
@@ -203,16 +211,7 @@ class VibeVoiceAdapter(TTSAdapter):
         self.batch_size = self.config.get("vibevoice_batch_size", 1)
 
         # Memory optimization settings (4-bit quantization is effectively CUDA-only)
-        requested_quant = parse_bool(self.config.get("vibevoice_use_quantization", False), default=False)
-        self.use_quantization = requested_quant and self.device == "cuda"
-        # If using the pre-quantized 7B-Q8 variant (or Q8 repo), avoid stacking 4-bit quantization
-        try:
-            if self.variant.upper() == "7B-Q8" or "vibevoice-large-q8" in str(self.model_path).lower():
-                if self.use_quantization:
-                    logger.info("VibeVoice: Disabling additional 4-bit quantization for 7B-Q8 model")
-                self.use_quantization = False
-        except _VIBEVOICE_NONCRITICAL_EXCEPTIONS:
-            pass
+        self.use_quantization = self._compute_use_quantization_for_variant(self.variant, self.model_path)
         self.auto_cleanup = self.config.get("vibevoice_auto_cleanup", True)
         # Auto-download behavior: config override > env overrides > default False
         cfg_auto = self.config.get("vibevoice_auto_download")
@@ -781,9 +780,10 @@ class VibeVoiceAdapter(TTSAdapter):
 
         # Check if a different model variant was requested
         requested_model = getattr(request, "model", None) or request.extra_params.get("model")
-        if requested_model and requested_model in self.MODEL_VARIANTS and requested_model != self.variant:
-            await self._ensure_model_variant(requested_model)
-        effective_variant = requested_model if requested_model in self.MODEL_VARIANTS else self.variant
+        requested_variant = self._canonical_variant(requested_model)
+        if requested_variant and requested_variant != self.variant:
+            await self._ensure_model_variant(requested_variant)
+        effective_variant = requested_variant or self.variant
 
         # Extract generation parameters
         cfg_scale = request.cfg_scale or request.extra_params.get("cfg_scale", self.default_cfg_scale)
@@ -1056,32 +1056,31 @@ class VibeVoiceAdapter(TTSAdapter):
                 self._check_cancellation()
                 outputs = await run_tts_blocking_call(_generate_outputs)
 
-                # Get the generated audio
-                if outputs.speech_outputs and outputs.speech_outputs[0] is not None:
-                    audio_array = outputs.speech_outputs[0].cpu().numpy()
-
-                    # Stream the audio in chunks with configurable size
-                    chunk_size = int(self.sample_rate * self.stream_chunk_size)
-                    for i in range(0, len(audio_array), chunk_size):
-                        # Check for cancellation during streaming
-                        self._check_cancellation()
-
-                        chunk = audio_array[i:i + chunk_size]
-
-                        if len(chunk) > 0:
-                            # Normalize to int16
-                            normalized_chunk = normalizer.normalize(chunk, target_dtype=np.int16)
-
-                            # Encode to target format
-                            encoded_bytes = writer.write_chunk(normalized_chunk)
-                            if encoded_bytes:
-                                yield encoded_bytes
-                else:
+                if not outputs.speech_outputs or outputs.speech_outputs[0] is None:
                     logger.error("No audio output generated from VibeVoice")
                     raise TTSGenerationError(
                         "Failed to generate audio",
                         provider=self.provider_name
                     )
+                audio_array = outputs.speech_outputs[0].cpu().numpy()
+
+            # Stream the materialized audio outside the model-state lock so slow
+            # clients do not block later generations or model variant reloads.
+            chunk_size = int(self.sample_rate * self.stream_chunk_size)
+            for i in range(0, len(audio_array), chunk_size):
+                # Check for cancellation during streaming
+                self._check_cancellation()
+
+                chunk = audio_array[i:i + chunk_size]
+
+                if len(chunk) > 0:
+                    # Normalize to int16
+                    normalized_chunk = normalizer.normalize(chunk, target_dtype=np.int16)
+
+                    # Encode to target format
+                    encoded_bytes = writer.write_chunk(normalized_chunk)
+                    if encoded_bytes:
+                        yield encoded_bytes
 
             # Finalize stream
             final_bytes = writer.write_chunk(finalize=True)
@@ -1317,6 +1316,23 @@ class VibeVoiceAdapter(TTSAdapter):
             logger.error(f"Failed to generate synthetic voice: {e}")
             return None
 
+    def _compute_use_quantization_for_variant(self, variant: str, model_path: Any) -> bool:
+        """Return whether extra 4-bit quantization should be applied for a variant."""
+        requested_quant = parse_bool(self.config.get("vibevoice_use_quantization", False), default=False)
+        use_quantization = requested_quant and self.device == "cuda"
+        try:
+            is_prequantized = (
+                variant.upper() == "7B-Q8"
+                or "vibevoice-large-q8" in str(model_path).lower()
+            )
+            if is_prequantized:
+                if use_quantization:
+                    logger.info("VibeVoice: Disabling additional 4-bit quantization for 7B-Q8 model")
+                return False
+        except _VIBEVOICE_NONCRITICAL_EXCEPTIONS:
+            return use_quantization
+        return use_quantization
+
     async def _reload_model_for_variant(self, variant: str):
         """Reload the model with a different variant (1.5B or 7B)"""
         if variant not in self.MODEL_VARIANTS:
@@ -1331,6 +1347,7 @@ class VibeVoiceAdapter(TTSAdapter):
         self.model_path = variant_config["path"]
         self.context_length = variant_config["context"]
         self.frame_rate = variant_config["frame_rate"]
+        self.use_quantization = self._compute_use_quantization_for_variant(variant, self.model_path)
 
         # Reinitialize with new variant
         logger.info(f"Reloading VibeVoice with variant: {variant}")

--- a/tldw_Server_API/app/core/TTS/adapters/vibevoice_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/vibevoice_adapter.py
@@ -30,7 +30,7 @@ from ..tts_exceptions import (
 )
 from ..tts_resource_manager import get_resource_manager
 from ..tts_validation import validate_tts_request
-from ..utils import parse_bool
+from ..utils import parse_bool, run_tts_blocking_call
 
 #
 # Local Imports
@@ -255,6 +255,7 @@ class VibeVoiceAdapter(TTSAdapter):
         # Cancellation support
         self._generation_cancelled = False
         self._current_generation_task = None
+        self._model_state_lock = asyncio.Lock()
 
         # Memory tracking
         self._memory_stats = {
@@ -781,10 +782,8 @@ class VibeVoiceAdapter(TTSAdapter):
         # Check if a different model variant was requested
         requested_model = getattr(request, "model", None) or request.extra_params.get("model")
         if requested_model and requested_model in self.MODEL_VARIANTS and requested_model != self.variant:
-            logger.info(f"Switching VibeVoice model from {self.variant} to {requested_model}")
-            self.variant = requested_model
-            # Reload model with new variant
-            await self._reload_model_for_variant(requested_model)
+            await self._ensure_model_variant(requested_model)
+        effective_variant = requested_model if requested_model in self.MODEL_VARIANTS else self.variant
 
         # Extract generation parameters
         cfg_scale = request.cfg_scale or request.extra_params.get("cfg_scale", self.default_cfg_scale)
@@ -872,6 +871,7 @@ class VibeVoiceAdapter(TTSAdapter):
                 "speaker_mapping": speaker_mapping,
                 "voice_references": voice_references,
                 "speakers_to_voices": request.extra_params.get("speakers_to_voices") if hasattr(request, 'extra_params') else None,
+                "model_variant": effective_variant,
             }
 
             if request.stream:
@@ -946,11 +946,7 @@ class VibeVoiceAdapter(TTSAdapter):
         gen_config: Optional[dict[str, Any]] = None
     ) -> AsyncGenerator[bytes, None]:
         """Stream audio from VibeVoice model"""
-        if not self.model or not self.processor:
-            raise TTSModelNotFoundError(
-                "VibeVoice model not initialized",
-                provider=self.provider_name
-            )
+        gen_config = gen_config if isinstance(gen_config, dict) else {}
 
         # Import StreamingAudioWriter
         from tldw_Server_API.app.core.TTS.streaming_audio_writer import AudioNormalizer, StreamingAudioWriter
@@ -963,89 +959,102 @@ class VibeVoiceAdapter(TTSAdapter):
         )
 
         try:
-            # Prepare input with speaker settings
-            input_data = self._prepare_vibevoice_input(request, voice, speaker_id)
+            async with self._model_state_lock:
+                expected_variant = gen_config.get("model_variant")
+                if expected_variant and expected_variant != self.variant:
+                    await self._reload_model_for_variant(str(expected_variant))
 
-            # Prepare input data for generation
-            # VibeVoice uses voice samples directly, not embeddings
+                if not self.model or not self.processor:
+                    raise TTSModelNotFoundError(
+                        "VibeVoice model not initialized",
+                        provider=self.provider_name
+                    )
 
-            # Merge default mapping from config with request-provided mapping
-            merged_mapping = None
-            if isinstance(self.default_speakers_to_voices, dict):
-                merged_mapping = dict(self.default_speakers_to_voices)
-            req_mapping = gen_config.get("speakers_to_voices") if isinstance(gen_config, dict) else None
-            if isinstance(req_mapping, dict):
-                merged_mapping = {**(merged_mapping or {}), **req_mapping}
+                # Prepare input with speaker settings
+                input_data = self._prepare_vibevoice_input(request, voice, speaker_id)
 
-            # Prepare voice samples list ordered by speaker index expected by VibeVoice
-            voice_samples = self._build_voice_samples(
-                input_data["text"],
-                voice_reference_path,
-                voice,
-                merged_mapping,
-            )
+                # Prepare input data for generation
+                # VibeVoice uses voice samples directly, not embeddings
 
-            # Prepare inputs for the model
-            inputs = self.processor(
-                text=[input_data["text"]],  # Wrap in list for batch
-                voice_samples=[voice_samples] if voice_samples else None,
-                padding=True,
-                return_tensors="pt",
-                return_attention_mask=True
-            )
-            torch_mod = _get_torch(allow_import=True)
-            if torch_mod is None:
-                raise TTSProviderNotConfiguredError(
-                    "VibeVoice generation requires torch, which is unavailable",
-                    provider=self.provider_name,
+                # Merge default mapping from config with request-provided mapping
+                merged_mapping = None
+                if isinstance(self.default_speakers_to_voices, dict):
+                    merged_mapping = dict(self.default_speakers_to_voices)
+                req_mapping = gen_config.get("speakers_to_voices")
+                if isinstance(req_mapping, dict):
+                    merged_mapping = {**(merged_mapping or {}), **req_mapping}
+
+                # Prepare voice samples list ordered by speaker index expected by VibeVoice
+                voice_samples = self._build_voice_samples(
+                    input_data["text"],
+                    voice_reference_path,
+                    voice,
+                    merged_mapping,
                 )
 
-            # Move tensors to device
-            for k, v in inputs.items():
-                if torch_mod.is_tensor(v):
-                    inputs[k] = v.to(self.device)
+                # Prepare inputs for the model
+                inputs = self.processor(
+                    text=[input_data["text"]],  # Wrap in list for batch
+                    voice_samples=[voice_samples] if voice_samples else None,
+                    padding=True,
+                    return_tensors="pt",
+                    return_attention_mask=True
+                )
+                torch_mod = _get_torch(allow_import=True)
+                if torch_mod is None:
+                    raise TTSProviderNotConfiguredError(
+                        "VibeVoice generation requires torch, which is unavailable",
+                        provider=self.provider_name,
+                    )
 
-            # Prepare generation config from gen_config parameter
-            cfg_scale = gen_config.get("cfg_scale", self.default_cfg_scale)
-            temperature = gen_config.get("temperature", self.default_temperature)
-            top_p = gen_config.get("top_p", self.default_top_p)
-            top_k = gen_config.get("top_k", self.default_top_k)
-            seed = gen_config.get("seed")
+                # Move tensors to device
+                for k, v in inputs.items():
+                    if torch_mod.is_tensor(v):
+                        inputs[k] = v.to(self.device)
 
-            # Set seed for reproducibility
-            if seed is not None:
-                torch_mod.manual_seed(seed)
-                if self.device == "cuda" and _torch_cuda_available(allow_import=False):
-                    torch_mod.cuda.manual_seed(seed)
+                # Prepare generation config from gen_config parameter
+                cfg_scale = gen_config.get("cfg_scale", self.default_cfg_scale)
+                temperature = gen_config.get("temperature", self.default_temperature)
+                top_p = gen_config.get("top_p", self.default_top_p)
+                top_k = gen_config.get("top_k", self.default_top_k)
+                seed = gen_config.get("seed")
 
-            # Create generation config
-            generation_config = {
-                'do_sample': temperature > 0.0,
-                'temperature': temperature if temperature > 0.0 else 1.0,
-                'top_p': top_p,
-            }
+                # Set seed for reproducibility
+                if seed is not None:
+                    torch_mod.manual_seed(seed)
+                    if self.device == "cuda" and _torch_cuda_available(allow_import=False):
+                        torch_mod.cuda.manual_seed(seed)
 
-            # Add top_k if specified
-            if top_k > 0:
-                generation_config['top_k'] = top_k
+                # Create generation config
+                generation_config = {
+                    'do_sample': temperature > 0.0,
+                    'temperature': temperature if temperature > 0.0 else 1.0,
+                    'top_p': top_p,
+                }
 
-            # Generate with VibeVoice model
-            with torch_mod.no_grad():
-                # Check for cancellation before generation
+                # Add top_k if specified
+                if top_k > 0:
+                    generation_config['top_k'] = top_k
+
+                def _generate_outputs():
+                    with torch_mod.no_grad():
+                        self._check_cancellation()
+                        return self.model.generate(
+                            **inputs,
+                            # Bound generation to prevent runaway
+                            max_new_tokens=self.context_length,
+                            cfg_scale=cfg_scale,
+                            tokenizer=self.processor.tokenizer,
+                            generation_config=generation_config,
+                            is_prefill=bool(voice_samples),
+                            refresh_negative=True,
+                            show_progress_bar=False,
+                            verbose=False
+                        )
+
+                # Generate with VibeVoice model
                 self._check_cancellation()
-
-                outputs = self.model.generate(
-                    **inputs,
-                    # Bound generation to prevent runaway
-                    max_new_tokens=self.context_length,
-                    cfg_scale=cfg_scale,
-                    tokenizer=self.processor.tokenizer,
-                    generation_config=generation_config,
-                    is_prefill=bool(voice_samples),
-                    refresh_negative=True,
-                    show_progress_bar=False,
-                    verbose=False
-                )
+                outputs = await run_tts_blocking_call(_generate_outputs)
 
                 # Get the generated audio
                 if outputs.speech_outputs and outputs.speech_outputs[0] is not None:
@@ -1111,7 +1120,7 @@ class VibeVoiceAdapter(TTSAdapter):
     ) -> bytes:
         """Generate complete audio from VibeVoice"""
         all_audio = b""
-        async for chunk in self._stream_audio_vibevoice(request, voice, speaker_id, voice_reference_path):
+        async for chunk in self._stream_audio_vibevoice(request, voice, speaker_id, voice_reference_path, gen_config):
             all_audio += chunk
         return all_audio
 
@@ -1317,6 +1326,7 @@ class VibeVoiceAdapter(TTSAdapter):
         await self._cleanup_resources()
 
         # Update configuration for new variant
+        self.variant = variant
         variant_config = self.MODEL_VARIANTS[variant]
         self.model_path = variant_config["path"]
         self.context_length = variant_config["context"]
@@ -1325,6 +1335,16 @@ class VibeVoiceAdapter(TTSAdapter):
         # Reinitialize with new variant
         logger.info(f"Reloading VibeVoice with variant: {variant}")
         await self.initialize()
+
+    async def _ensure_model_variant(self, variant: str) -> None:
+        """Serialize model variant changes for registry-reused adapters."""
+        if variant not in self.MODEL_VARIANTS:
+            raise ValueError(f"Invalid variant: {variant}. Must be one of {list(self.MODEL_VARIANTS.keys())}")
+        async with self._model_state_lock:
+            if variant == self.variant:
+                return
+            logger.info(f"Switching VibeVoice model from {self.variant} to {variant}")
+            await self._reload_model_for_variant(variant)
 
     def _get_best_attention_implementation(self) -> str:
         """Get the best available attention implementation based on hardware and config."""

--- a/tldw_Server_API/app/core/TTS/adapters/vibevoice_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/vibevoice_adapter.py
@@ -161,6 +161,7 @@ class VibeVoiceAdapter(TTSAdapter):
         return variant_lookup.get(variant.strip().lower())
 
     def __init__(self, config: Optional[dict[str, Any]] = None):
+        """Initialize VibeVoice model state, generation defaults, and voice discovery."""
         super().__init__(config)
 
         # Model variant selection (1.5B or 7B)
@@ -1037,6 +1038,7 @@ class VibeVoiceAdapter(TTSAdapter):
                     generation_config['top_k'] = top_k
 
                 def _generate_outputs():
+                    """Run VibeVoice generation with cancellation and bounded token output."""
                     with torch_mod.no_grad():
                         self._check_cancellation()
                         return self.model.generate(

--- a/tldw_Server_API/app/core/TTS/adapters/vibevoice_realtime_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/vibevoice_realtime_adapter.py
@@ -7,11 +7,13 @@ import contextlib
 import json
 import os
 from typing import Any, Optional
+from urllib.parse import urlparse, urlunparse
 
 #
 # Third-party Imports
 from loguru import logger
 
+from ...Security.egress import evaluate_url_policy
 from ..realtime_session import RealtimeSessionConfig, RealtimeTTSSession
 from ..tts_exceptions import (
     TTSProviderInitializationError,
@@ -36,6 +38,38 @@ from .base import (
 #######################################################################################################################
 #
 # VibeVoice Realtime Adapter (Skeleton)
+
+
+def _websocket_url_to_policy_url(ws_url: str) -> str:
+    try:
+        parsed = urlparse(ws_url)
+    except (TypeError, ValueError) as exc:
+        raise TTSProviderInitializationError(
+            "Invalid VibeVoice Realtime websocket URL",
+            provider=VibeVoiceRealtimeAdapter.PROVIDER_KEY,
+            details={"error": str(exc)},
+        ) from exc
+
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in {"ws", "wss"}:
+        raise TTSProviderInitializationError(
+            "VibeVoice Realtime websocket URL must use ws:// or wss://",
+            provider=VibeVoiceRealtimeAdapter.PROVIDER_KEY,
+            details={"scheme": scheme or None},
+        )
+    policy_scheme = "https" if scheme == "wss" else "http"
+    return urlunparse(parsed._replace(scheme=policy_scheme))
+
+
+def _validate_websocket_egress(ws_url: str) -> None:
+    policy_url = _websocket_url_to_policy_url(ws_url)
+    result = evaluate_url_policy(policy_url)
+    if not result.allowed:
+        raise TTSProviderInitializationError(
+            f"VibeVoice Realtime websocket URL denied by egress policy: {result.reason}",
+            provider=VibeVoiceRealtimeAdapter.PROVIDER_KEY,
+            details={"reason": result.reason, "url": policy_url},
+        )
 
 
 class VibeVoiceRealtimeAdapter(TTSAdapter):
@@ -212,6 +246,8 @@ class _VibeVoiceRealtimeWebSocketSession(RealtimeTTSSession):
         return self._error
 
     async def start(self) -> None:
+        _validate_websocket_egress(self._ws_url)
+
         try:
             import aiohttp
         except Exception as exc:
@@ -286,7 +322,9 @@ class _VibeVoiceRealtimeWebSocketSession(RealtimeTTSSession):
                 elif msg.type == aiohttp.WSMsgType.TEXT:
                     try:
                         data = json.loads(msg.data)
-                    except Exception:
+                    except (json.JSONDecodeError, TypeError, ValueError):
+                        data = None
+                    if not isinstance(data, dict):
                         continue
                     msg_type = str(data.get("type") or "").lower()
                     if msg_type == "error":

--- a/tldw_Server_API/app/core/TTS/adapters/vibevoice_realtime_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/vibevoice_realtime_adapter.py
@@ -55,6 +55,7 @@ class _PinnedWebSocketResolver:
     """Aiohttp-compatible resolver that pins a validated host to known IPs."""
 
     def __init__(self, hostname: str, resolved_ips: tuple[str, ...]) -> None:
+        """Store the validated hostname and IP addresses for websocket pinning."""
         self._hostname = hostname.strip().rstrip(".").lower()
         self._resolved_ips = resolved_ips
 
@@ -296,6 +297,8 @@ class VibeVoiceRealtimeAdapter(TTSAdapter):
 
 
 class _VibeVoiceRealtimeWebSocketSession(RealtimeTTSSession):
+    """Manage a validated websocket-backed VibeVoice realtime TTS session."""
+
     def __init__(
         self,
         *,
@@ -317,9 +320,11 @@ class _VibeVoiceRealtimeWebSocketSession(RealtimeTTSSession):
 
     @property
     def error(self) -> Optional[Exception]:
+        """Return the terminal backend or transport error, if one occurred."""
         return self._error
 
     async def start(self) -> None:
+        """Validate outbound websocket policy and open the realtime backend session."""
         validation = await asyncio.to_thread(_validate_websocket_egress, self._ws_url)
 
         try:
@@ -392,6 +397,7 @@ class _VibeVoiceRealtimeWebSocketSession(RealtimeTTSSession):
         await self._ws.send_json(payload)
 
     async def _recv_loop(self) -> None:
+        """Forward backend audio frames into the consumer queue until the session ends."""
         try:
             if not self._ws:
                 return

--- a/tldw_Server_API/app/core/TTS/adapters/vibevoice_realtime_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/vibevoice_realtime_adapter.py
@@ -6,6 +6,8 @@ import asyncio
 import contextlib
 import json
 import os
+import socket
+from dataclasses import dataclass
 from typing import Any, Optional
 from urllib.parse import urlparse, urlunparse
 
@@ -40,7 +42,50 @@ from .base import (
 # VibeVoice Realtime Adapter (Skeleton)
 
 
+@dataclass(frozen=True)
+class _WebSocketEgressValidation:
+    """Validated websocket origin and DNS pins from the egress policy check."""
+
+    policy_url: str
+    hostname: str
+    resolved_ips: tuple[str, ...]
+
+
+class _PinnedWebSocketResolver:
+    """Aiohttp-compatible resolver that pins a validated host to known IPs."""
+
+    def __init__(self, hostname: str, resolved_ips: tuple[str, ...]) -> None:
+        self._hostname = hostname.strip().rstrip(".").lower()
+        self._resolved_ips = resolved_ips
+
+    async def resolve(
+        self,
+        host: str,
+        port: int = 0,
+        family: int = socket.AF_INET,
+    ) -> list[dict[str, Any]]:
+        """Resolve the validated websocket hostname to the pinned IP set."""
+        if host.strip().rstrip(".").lower() != self._hostname:
+            return []
+        return [
+            {
+                "hostname": host,
+                "host": ip,
+                "port": port,
+                "family": socket.AF_INET6 if ":" in ip else socket.AF_INET,
+                "proto": 0,
+                "flags": socket.AI_NUMERICHOST,
+            }
+            for ip in self._resolved_ips
+        ]
+
+    async def close(self) -> None:
+        """Release resolver resources."""
+        return None
+
+
 def _websocket_url_to_policy_url(ws_url: str) -> str:
+    """Convert a websocket URL to a redacted HTTP(S) origin for egress checks."""
     try:
         parsed = urlparse(ws_url)
     except (TypeError, ValueError) as exc:
@@ -51,17 +96,34 @@ def _websocket_url_to_policy_url(ws_url: str) -> str:
         ) from exc
 
     scheme = (parsed.scheme or "").lower()
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise TTSProviderInitializationError(
+            "Invalid VibeVoice Realtime websocket URL port",
+            provider=VibeVoiceRealtimeAdapter.PROVIDER_KEY,
+            details={"error": str(exc)},
+        ) from exc
     if scheme not in {"ws", "wss"}:
         raise TTSProviderInitializationError(
             "VibeVoice Realtime websocket URL must use ws:// or wss://",
             provider=VibeVoiceRealtimeAdapter.PROVIDER_KEY,
             details={"scheme": scheme or None},
         )
+    hostname = parsed.hostname
+    if not hostname:
+        raise TTSProviderInitializationError(
+            "VibeVoice Realtime websocket URL must include a hostname",
+            provider=VibeVoiceRealtimeAdapter.PROVIDER_KEY,
+        )
     policy_scheme = "https" if scheme == "wss" else "http"
-    return urlunparse(parsed._replace(scheme=policy_scheme))
+    safe_host = f"[{hostname}]" if ":" in hostname and not hostname.startswith("[") else hostname
+    safe_netloc = f"{safe_host}:{port}" if port is not None else safe_host
+    return urlunparse((policy_scheme, safe_netloc, "", "", "", ""))
 
 
-def _validate_websocket_egress(ws_url: str) -> None:
+def _validate_websocket_egress(ws_url: str) -> _WebSocketEgressValidation:
+    """Validate websocket egress and return resolved IPs for DNS pinning."""
     policy_url = _websocket_url_to_policy_url(ws_url)
     result = evaluate_url_policy(policy_url)
     if not result.allowed:
@@ -70,6 +132,18 @@ def _validate_websocket_egress(ws_url: str) -> None:
             provider=VibeVoiceRealtimeAdapter.PROVIDER_KEY,
             details={"reason": result.reason, "url": policy_url},
         )
+    parsed = urlparse(policy_url)
+    hostname = parsed.hostname or ""
+    resolved_ips = tuple(
+        str(ip).strip()
+        for ip in (getattr(result, "resolved_ips", ()) or ())
+        if str(ip).strip()
+    )
+    return _WebSocketEgressValidation(
+        policy_url=policy_url,
+        hostname=hostname,
+        resolved_ips=resolved_ips,
+    )
 
 
 class VibeVoiceRealtimeAdapter(TTSAdapter):
@@ -246,7 +320,7 @@ class _VibeVoiceRealtimeWebSocketSession(RealtimeTTSSession):
         return self._error
 
     async def start(self) -> None:
-        _validate_websocket_egress(self._ws_url)
+        validation = await asyncio.to_thread(_validate_websocket_egress, self._ws_url)
 
         try:
             import aiohttp
@@ -257,7 +331,14 @@ class _VibeVoiceRealtimeWebSocketSession(RealtimeTTSSession):
                 details={"error": str(exc)},
             ) from exc
 
-        self._session = aiohttp.ClientSession()
+        connector = None
+        if validation.resolved_ips:
+            connector = aiohttp.TCPConnector(
+                resolver=_PinnedWebSocketResolver(validation.hostname, validation.resolved_ips),
+                use_dns_cache=False,
+            )
+
+        self._session = aiohttp.ClientSession(connector=connector)
         self._ws = await self._session.ws_connect(
             self._ws_url,
             headers=self._ws_headers,

--- a/tldw_Server_API/app/core/TTS/audio_converter.py
+++ b/tldw_Server_API/app/core/TTS/audio_converter.py
@@ -50,6 +50,8 @@ class AudioConversionError(TTSError):
 class AudioConverter:
     """Audio conversion and processing utilities"""
 
+    DEFAULT_SUBPROCESS_TIMEOUT_SECONDS = 60.0
+
     # Common audio formats and their codecs
     AUDIO_CODECS = {
         'wav': 'pcm_s16le',
@@ -69,6 +71,40 @@ class AudioConverter:
                 path_str = str(path).replace("'", "'\\''")
                 tmp.write(f"file '{path_str}'\n".encode())
         return tmp.name
+
+    @staticmethod
+    def _coerce_timeout(timeout_seconds: Any = None) -> float:
+        try:
+            timeout = float(timeout_seconds)
+        except (TypeError, ValueError):
+            timeout = AudioConverter.DEFAULT_SUBPROCESS_TIMEOUT_SECONDS
+        if timeout <= 0:
+            return AudioConverter.DEFAULT_SUBPROCESS_TIMEOUT_SECONDS
+        return timeout
+
+    @staticmethod
+    async def _run_subprocess(
+        cmd: list[str],
+        *,
+        timeout_seconds: Any = None,
+    ) -> tuple[int, bytes, bytes]:
+        timeout = AudioConverter._coerce_timeout(timeout_seconds)
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout)
+        except asyncio.TimeoutError:
+            with contextlib.suppress(ProcessLookupError):
+                process.kill()
+            cleanup_timeout = min(1.0, timeout)
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await asyncio.wait_for(process.communicate(), timeout=cleanup_timeout)
+            message = f"Subprocess timed out after {timeout:.1f}s: {cmd[0]}".encode()
+            return -1, b"", message
+        return int(process.returncode or 0), stdout, stderr
 
     @staticmethod
     async def concat_audio_files(
@@ -98,13 +134,11 @@ class AudioConverter:
                 cmd.extend(['-b:a', str(kwargs['bitrate'])])
             cmd.extend(['-c:a', codec, str(output_path)])
 
-            process = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
+            returncode, _stdout, stderr = await AudioConverter._run_subprocess(
+                cmd,
+                timeout_seconds=kwargs.get("timeout_seconds"),
             )
-            stdout, stderr = await process.communicate()
-            if process.returncode != 0:
+            if returncode != 0:
                 logger.error(f"Concat failed: {stderr.decode()}")
                 return False
             logger.info(f"Concatenated {len(input_paths)} files into {output_path.name}")
@@ -148,13 +182,10 @@ class AudioConverter:
                 '-c:a', 'aac',
                 str(output_path),
             ]
-            process = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
+            returncode, _stdout, stderr = await AudioConverter._run_subprocess(
+                cmd,
             )
-            stdout, stderr = await process.communicate()
-            if process.returncode != 0:
+            if returncode != 0:
                 logger.error(f"M4B packaging failed: {stderr.decode()}")
                 return False
             logger.info(f"Packaged M4B with {len(input_paths)} chapters: {output_path.name}")
@@ -246,15 +277,9 @@ class AudioConverter:
             ]
 
             # Run conversion
-            process = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
-            )
+            returncode, _stdout, stderr = await AudioConverter._run_subprocess(cmd)
 
-            stdout, stderr = await process.communicate()
-
-            if process.returncode != 0:
+            if returncode != 0:
                 logger.error(f"FFmpeg conversion failed: {stderr.decode()}")
                 return False
 
@@ -313,15 +338,12 @@ class AudioConverter:
             cmd.extend(['-c:a', codec, str(output_path)])
 
             # Run conversion
-            process = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
+            returncode, _stdout, stderr = await AudioConverter._run_subprocess(
+                cmd,
+                timeout_seconds=kwargs.get("timeout_seconds"),
             )
 
-            stdout, stderr = await process.communicate()
-
-            if process.returncode != 0:
+            if returncode != 0:
                 logger.error(f"Format conversion failed: {stderr.decode()}")
                 return False
 
@@ -385,15 +407,9 @@ class AudioConverter:
                 str(file_path)
             ]
 
-            process = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
-            )
+            returncode, stdout, stderr = await AudioConverter._run_subprocess(cmd)
 
-            stdout, stderr = await process.communicate()
-
-            if process.returncode == 0 and stdout:
+            if returncode == 0 and stdout:
                 return float(stdout.decode().strip())
             else:
                 logger.error(f"Could not get duration: {stderr.decode()}")
@@ -436,15 +452,9 @@ class AudioConverter:
                 str(file_path)
             ]
 
-            process = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
-            )
+            returncode, stdout, _stderr = await AudioConverter._run_subprocess(cmd)
 
-            stdout, stderr = await process.communicate()
-
-            if process.returncode == 0 and stdout:
+            if returncode == 0 and stdout:
                 import json
                 data = json.loads(stdout.decode())
                 if data.get('streams'):
@@ -487,13 +497,7 @@ class AudioConverter:
                 '-f', 'null', '-'
             ]
 
-            process = await asyncio.create_subprocess_exec(
-                *cmd_analyze,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
-            )
-
-            stdout, stderr = await process.communicate()
+            _returncode, _stdout, stderr = await AudioConverter._run_subprocess(cmd_analyze)
 
             # Parse loudness info from stderr (ffmpeg outputs to stderr)
             import json
@@ -514,15 +518,9 @@ class AudioConverter:
                 str(output_path)
             ]
 
-            process = await asyncio.create_subprocess_exec(
-                *cmd_normalize,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
-            )
+            returncode, _stdout, stderr = await AudioConverter._run_subprocess(cmd_normalize)
 
-            stdout, stderr = await process.communicate()
-
-            if process.returncode != 0:
+            if returncode != 0:
                 logger.error(f"Normalization failed: {stderr.decode()}")
                 return False
 
@@ -584,13 +582,8 @@ class AudioConverter:
                 '-filter:a', filter_spec,
                 str(output_path)
             ]
-            process = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
-            )
-            stdout, stderr = await process.communicate()
-            if process.returncode != 0:
+            returncode, _stdout, stderr = await AudioConverter._run_subprocess(cmd)
+            if returncode != 0:
                 logger.error(f"Time-stretch failed: {stderr.decode()}")
                 return False
             logger.info(f"Time-stretch applied (ratio: {speed_ratio})")
@@ -629,15 +622,9 @@ class AudioConverter:
                 str(output_path)
             ]
 
-            process = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
-            )
+            returncode, _stdout, stderr = await AudioConverter._run_subprocess(cmd)
 
-            stdout, stderr = await process.communicate()
-
-            if process.returncode != 0:
+            if returncode != 0:
                 logger.error(f"Silence trimming failed: {stderr.decode()}")
                 return False
 
@@ -679,15 +666,9 @@ class AudioConverter:
                 str(output_path)
             ]
 
-            process = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
-            )
+            returncode, _stdout, stderr = await AudioConverter._run_subprocess(cmd)
 
-            stdout, stderr = await process.communicate()
-
-            if process.returncode != 0:
+            if returncode != 0:
                 logger.error(f"Segment extraction failed: {stderr.decode()}")
                 return False
 
@@ -725,15 +706,9 @@ class AudioConverter:
                 str(output_path)
             ]
 
-            process = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
-            )
+            returncode, _stdout, stderr = await AudioConverter._run_subprocess(cmd)
 
-            stdout, stderr = await process.communicate()
-
-            if process.returncode != 0:
+            if returncode != 0:
                 logger.error(f"Resampling failed: {stderr.decode()}")
                 return False
 

--- a/tldw_Server_API/app/core/TTS/audio_converter.py
+++ b/tldw_Server_API/app/core/TTS/audio_converter.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import os
 import shutil
+
 # Fixed ffmpeg/ffprobe probes resolve executables and do not use shell.
 import subprocess  # nosec B404
 import tempfile
@@ -74,6 +75,7 @@ class AudioConverter:
 
     @staticmethod
     def _coerce_timeout(timeout_seconds: Any = None) -> float:
+        """Return a positive subprocess timeout, falling back to the default."""
         try:
             timeout = float(timeout_seconds)
         except (TypeError, ValueError):
@@ -88,6 +90,7 @@ class AudioConverter:
         *,
         timeout_seconds: Any = None,
     ) -> tuple[int, bytes, bytes]:
+        """Run an audio subprocess with bounded execution and cleanup on timeout."""
         timeout = AudioConverter._coerce_timeout(timeout_seconds)
         process = await asyncio.create_subprocess_exec(
             *cmd,
@@ -154,6 +157,7 @@ class AudioConverter:
         chapter_titles: list[str],
         *,
         metadata: Optional[dict[str, str]] = None,
+        timeout_seconds: Any = None,
     ) -> bool:
         if not input_paths:
             logger.error("No input files provided for M4B packaging")
@@ -184,6 +188,7 @@ class AudioConverter:
             ]
             returncode, _stdout, stderr = await AudioConverter._run_subprocess(
                 cmd,
+                timeout_seconds=timeout_seconds,
             )
             if returncode != 0:
                 logger.error(f"M4B packaging failed: {stderr.decode()}")
@@ -236,7 +241,9 @@ class AudioConverter:
         output_path: Path,
         sample_rate: int = 22050,
         channels: int = 1,
-        bit_depth: int = 16
+        bit_depth: int = 16,
+        *,
+        timeout_seconds: Any = None,
     ) -> bool:
         """
         Convert audio file to WAV format with specified parameters.
@@ -247,6 +254,7 @@ class AudioConverter:
             sample_rate: Target sample rate in Hz
             channels: Number of audio channels (1=mono, 2=stereo)
             bit_depth: Bit depth (16 or 24)
+            timeout_seconds: Optional subprocess timeout override
 
         Returns:
             True if conversion successful, False otherwise
@@ -277,7 +285,10 @@ class AudioConverter:
             ]
 
             # Run conversion
-            returncode, _stdout, stderr = await AudioConverter._run_subprocess(cmd)
+            returncode, _stdout, stderr = await AudioConverter._run_subprocess(
+                cmd,
+                timeout_seconds=timeout_seconds,
+            )
 
             if returncode != 0:
                 logger.error(f"FFmpeg conversion failed: {stderr.decode()}")
@@ -474,7 +485,9 @@ class AudioConverter:
     async def normalize_audio(
         input_path: Path,
         output_path: Path,
-        target_level: float = -23.0
+        target_level: float = -23.0,
+        *,
+        timeout_seconds: Any = None,
     ) -> bool:
         """
         Normalize audio loudness using EBU R128 standard.
@@ -483,6 +496,7 @@ class AudioConverter:
             input_path: Path to input audio
             output_path: Path for normalized output
             target_level: Target loudness in LUFS (default -23)
+            timeout_seconds: Optional subprocess timeout override
 
         Returns:
             True if successful
@@ -497,7 +511,10 @@ class AudioConverter:
                 '-f', 'null', '-'
             ]
 
-            _returncode, _stdout, stderr = await AudioConverter._run_subprocess(cmd_analyze)
+            _returncode, _stdout, stderr = await AudioConverter._run_subprocess(
+                cmd_analyze,
+                timeout_seconds=timeout_seconds,
+            )
 
             # Parse loudness info from stderr (ffmpeg outputs to stderr)
             import json
@@ -518,7 +535,10 @@ class AudioConverter:
                 str(output_path)
             ]
 
-            returncode, _stdout, stderr = await AudioConverter._run_subprocess(cmd_normalize)
+            returncode, _stdout, stderr = await AudioConverter._run_subprocess(
+                cmd_normalize,
+                timeout_seconds=timeout_seconds,
+            )
 
             if returncode != 0:
                 logger.error(f"Normalization failed: {stderr.decode()}")
@@ -551,6 +571,8 @@ class AudioConverter:
         input_path: Path,
         output_path: Path,
         speed_ratio: float,
+        *,
+        timeout_seconds: Any = None,
     ) -> bool:
         """
         Time-stretch audio using ffmpeg atempo filter.
@@ -559,6 +581,7 @@ class AudioConverter:
             input_path: Path to input audio
             output_path: Path for stretched output
             speed_ratio: Playback speed ratio (e.g., 1.05 to speed up)
+            timeout_seconds: Optional subprocess timeout override
 
         Returns:
             True if successful
@@ -582,7 +605,10 @@ class AudioConverter:
                 '-filter:a', filter_spec,
                 str(output_path)
             ]
-            returncode, _stdout, stderr = await AudioConverter._run_subprocess(cmd)
+            returncode, _stdout, stderr = await AudioConverter._run_subprocess(
+                cmd,
+                timeout_seconds=timeout_seconds,
+            )
             if returncode != 0:
                 logger.error(f"Time-stretch failed: {stderr.decode()}")
                 return False
@@ -597,7 +623,9 @@ class AudioConverter:
         input_path: Path,
         output_path: Path,
         threshold: float = -40.0,
-        duration: float = 0.5
+        duration: float = 0.5,
+        *,
+        timeout_seconds: Any = None,
     ) -> bool:
         """
         Trim silence from beginning and end of audio.
@@ -607,6 +635,7 @@ class AudioConverter:
             output_path: Path for trimmed output
             threshold: Silence threshold in dB
             duration: Minimum silence duration to trim (seconds)
+            timeout_seconds: Optional subprocess timeout override
 
         Returns:
             True if successful
@@ -622,7 +651,10 @@ class AudioConverter:
                 str(output_path)
             ]
 
-            returncode, _stdout, stderr = await AudioConverter._run_subprocess(cmd)
+            returncode, _stdout, stderr = await AudioConverter._run_subprocess(
+                cmd,
+                timeout_seconds=timeout_seconds,
+            )
 
             if returncode != 0:
                 logger.error(f"Silence trimming failed: {stderr.decode()}")
@@ -640,7 +672,9 @@ class AudioConverter:
         input_path: Path,
         output_path: Path,
         start_time: float,
-        duration: float
+        duration: float,
+        *,
+        timeout_seconds: Any = None,
     ) -> bool:
         """
         Extract a segment from audio file.
@@ -650,6 +684,7 @@ class AudioConverter:
             output_path: Path for segment output
             start_time: Start time in seconds
             duration: Segment duration in seconds
+            timeout_seconds: Optional subprocess timeout override
 
         Returns:
             True if successful
@@ -666,7 +701,10 @@ class AudioConverter:
                 str(output_path)
             ]
 
-            returncode, _stdout, stderr = await AudioConverter._run_subprocess(cmd)
+            returncode, _stdout, stderr = await AudioConverter._run_subprocess(
+                cmd,
+                timeout_seconds=timeout_seconds,
+            )
 
             if returncode != 0:
                 logger.error(f"Segment extraction failed: {stderr.decode()}")
@@ -683,7 +721,9 @@ class AudioConverter:
     async def resample_audio(
         input_path: Path,
         output_path: Path,
-        target_sample_rate: int
+        target_sample_rate: int,
+        *,
+        timeout_seconds: Any = None,
     ) -> bool:
         """
         Resample audio to target sample rate.
@@ -692,6 +732,7 @@ class AudioConverter:
             input_path: Path to input audio
             output_path: Path for resampled output
             target_sample_rate: Target sample rate in Hz
+            timeout_seconds: Optional subprocess timeout override
 
         Returns:
             True if successful
@@ -706,7 +747,10 @@ class AudioConverter:
                 str(output_path)
             ]
 
-            returncode, _stdout, stderr = await AudioConverter._run_subprocess(cmd)
+            returncode, _stdout, stderr = await AudioConverter._run_subprocess(
+                cmd,
+                timeout_seconds=timeout_seconds,
+            )
 
             if returncode != 0:
                 logger.error(f"Resampling failed: {stderr.decode()}")

--- a/tldw_Server_API/app/core/TTS/audio_converter.py
+++ b/tldw_Server_API/app/core/TTS/audio_converter.py
@@ -116,6 +116,7 @@ class AudioConverter:
         target_format: str,
         **kwargs,
     ) -> bool:
+        """Concatenate audio files into the requested target format using ffmpeg."""
         if not input_paths:
             logger.error("No input files provided for concatenation")
             return False
@@ -159,6 +160,7 @@ class AudioConverter:
         metadata: Optional[dict[str, str]] = None,
         timeout_seconds: Any = None,
     ) -> bool:
+        """Package concatenated audio files into an M4B with chapter metadata."""
         if not input_paths:
             logger.error("No input files provided for M4B packaging")
             return False

--- a/tldw_Server_API/app/core/TTS/audio_utils.py
+++ b/tldw_Server_API/app/core/TTS/audio_utils.py
@@ -232,7 +232,8 @@ class AudioProcessor:
         audio_bytes: bytes,
         target_format: str = 'wav',
         target_sample_rate: Optional[int] = None,
-        provider: Optional[str] = None
+        provider: Optional[str] = None,
+        strict: bool = False,
     ) -> bytes:
         """
         Convert audio to target format and sample rate.
@@ -242,12 +243,15 @@ class AudioProcessor:
             target_format: Target format (wav, mp3, flac)
             target_sample_rate: Target sample rate (Hz)
             provider: Provider name for specific requirements
+            strict: Raise when conversion fails instead of returning original bytes
 
         Returns:
             Converted audio bytes
         """
         if not self.ffmpeg_available and not self.librosa_available:
             logger.warning("No audio conversion libraries available")
+            if strict:
+                raise RuntimeError("Audio conversion failed: no conversion libraries available")
             return audio_bytes
 
         # Get provider requirements if specified
@@ -345,6 +349,8 @@ class AudioProcessor:
 
         except _AUDIO_PROCESS_EXCEPTIONS as e:
             logger.error(f"Audio conversion failed ({type(e).__name__})")
+            if strict:
+                raise RuntimeError("Audio conversion failed") from e
             return audio_bytes  # Return original if conversion fails
 
     async def convert_audio_async(
@@ -352,7 +358,8 @@ class AudioProcessor:
         audio_bytes: bytes,
         target_format: str = 'wav',
         target_sample_rate: Optional[int] = None,
-        provider: Optional[str] = None
+        provider: Optional[str] = None,
+        strict: bool = False,
     ) -> bytes:
         """
         Async-friendly wrapper around convert_audio.
@@ -369,6 +376,7 @@ class AudioProcessor:
                 target_format=target_format,
                 target_sample_rate=target_sample_rate,
                 provider=provider,
+                strict=strict,
             ),
         )
 
@@ -475,7 +483,8 @@ def process_voice_reference(
             audio_bytes = processor.convert_audio(
                 audio_bytes,
                 target_format='wav',
-                provider=provider
+                provider=provider,
+                strict=True,
             )
             logger.info(f"Voice reference converted for {provider}")
 
@@ -524,6 +533,7 @@ async def process_voice_reference_async(
                 audio_bytes,
                 target_format='wav',
                 provider=provider,
+                strict=True,
             )
             logger.info(f"Voice reference converted for {provider}")
 

--- a/tldw_Server_API/app/core/TTS/tts_config.py
+++ b/tldw_Server_API/app/core/TTS/tts_config.py
@@ -36,6 +36,9 @@ from .utils import parse_bool
 #
 # TTS Configuration Schema
 
+# Redaction marker only; not a credential.
+REDACTED_SECRET = "********"  # nosec B105
+
 class ProviderConfig(BaseModel):
     """Configuration for a single TTS provider"""
     enabled: bool = False
@@ -408,7 +411,6 @@ class TTSConfigManager:
         api_key_env_vars = {
             'OPENAI_API_KEY': ('openai', 'api_key'),
             'ELEVENLABS_API_KEY': ('elevenlabs', 'api_key'),
-            'ANTHROPIC_API_KEY': ('anthropic', 'api_key'),
         }
 
         for env_var, (provider, field) in api_key_env_vars.items():
@@ -476,18 +478,34 @@ class TTSConfigManager:
         enabled = self.get_enabled_providers()
         return [p for p in config.provider_priority if p in enabled]
 
-    def to_dict(self) -> dict[str, Any]:
+    @staticmethod
+    def _redact_provider_secrets(config_dict: dict[str, Any]) -> dict[str, Any]:
+        providers = config_dict.get("providers")
+        if not isinstance(providers, dict):
+            return config_dict
+
+        for provider_config in providers.values():
+            if not isinstance(provider_config, dict):
+                continue
+            if provider_config.get("api_key"):
+                provider_config["api_key"] = REDACTED_SECRET
+        return config_dict
+
+    def to_dict(self, *, include_secrets: bool = False) -> dict[str, Any]:
         """Convert configuration to dictionary"""
         cfg = self.get_config()
-        return model_dump_compat(cfg)
+        config_dict = model_dump_compat(cfg)
+        if not include_secrets:
+            config_dict = self._redact_provider_secrets(config_dict)
+        return config_dict
 
-    def save_yaml(self, path: Optional[Path] = None):
+    def save_yaml(self, path: Optional[Path] = None, *, include_secrets: bool = False):
         """Save current configuration to YAML file"""
         path = path or self.yaml_path
         if not path:
             raise ValueError("No YAML path specified")
 
-        config_dict = self.to_dict()
+        config_dict = self.to_dict(include_secrets=include_secrets)
 
         # Convert ProviderConfig objects to dicts
         if 'providers' in config_dict:

--- a/tldw_Server_API/app/core/TTS/tts_config.py
+++ b/tldw_Server_API/app/core/TTS/tts_config.py
@@ -480,6 +480,7 @@ class TTSConfigManager:
 
     @staticmethod
     def _redact_provider_secrets(config_dict: dict[str, Any]) -> dict[str, Any]:
+        """Replace provider API keys in a serialized config dictionary."""
         providers = config_dict.get("providers")
         if not isinstance(providers, dict):
             return config_dict
@@ -491,6 +492,17 @@ class TTSConfigManager:
                 provider_config["api_key"] = REDACTED_SECRET
         return config_dict
 
+    def _has_provider_secrets(self) -> bool:
+        """Return whether the loaded config contains provider API keys."""
+        config_dict = model_dump_compat(self.get_config())
+        providers = config_dict.get("providers")
+        if not isinstance(providers, dict):
+            return False
+        return any(
+            isinstance(provider_config, dict) and bool(provider_config.get("api_key"))
+            for provider_config in providers.values()
+        )
+
     def to_dict(self, *, include_secrets: bool = False) -> dict[str, Any]:
         """Convert configuration to dictionary"""
         cfg = self.get_config()
@@ -499,11 +511,24 @@ class TTSConfigManager:
             config_dict = self._redact_provider_secrets(config_dict)
         return config_dict
 
-    def save_yaml(self, path: Optional[Path] = None, *, include_secrets: bool = False):
+    def save_yaml(self, path: Optional[Path] = None, *, include_secrets: bool = False) -> None:
         """Save current configuration to YAML file"""
         path = path or self.yaml_path
         if not path:
             raise ValueError("No YAML path specified")
+
+        target_path = Path(path).expanduser()
+        configured_path = Path(self.yaml_path).expanduser() if self.yaml_path else None
+        if (
+            not include_secrets
+            and configured_path is not None
+            and target_path == configured_path
+            and self._has_provider_secrets()
+        ):
+            raise ValueError(
+                "Refusing to overwrite TTS config with redacted provider secrets; "
+                "pass include_secrets=True for persisted saves or choose an export path."
+            )
 
         config_dict = self.to_dict(include_secrets=include_secrets)
 
@@ -514,10 +539,10 @@ class TTSConfigManager:
                     cfg = config_dict['providers'][provider_name]
                     config_dict['providers'][provider_name] = model_dump_compat(cfg)
 
-        with open(path, 'w') as f:
+        with open(target_path, 'w') as f:
             yaml.dump(config_dict, f, default_flow_style=False, sort_keys=False)
 
-        logger.info(f"Saved TTS configuration to {path}")
+        logger.info(f"Saved TTS configuration to {target_path}")
 
 
 # Singleton instance

--- a/tldw_Server_API/app/core/TTS/utils.py
+++ b/tldw_Server_API/app/core/TTS/utils.py
@@ -8,6 +8,7 @@ Currently includes:
 """
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import hmac
 import json
@@ -16,6 +17,7 @@ import os
 import platform
 import re
 import unicodedata
+from collections.abc import Callable, Iterator
 from typing import Any
 
 from tldw_Server_API.app.core.testing import is_truthy
@@ -59,6 +61,22 @@ def parse_bool(value: Any, default: bool | None = False) -> bool:
         return bool(default) if default is not None else False
     # Fallback for other types
     return bool(value) if default is None else bool(default)
+
+
+async def run_tts_blocking_call(func: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Any:
+    """Run a synchronous local TTS runtime call without blocking the event loop."""
+    return await asyncio.to_thread(func, *args, **kwargs)
+
+
+async def run_tts_blocking_next(iterator: Iterator[Any], sentinel: Any) -> Any:
+    """Fetch the next item from a synchronous iterator without blocking the event loop."""
+    def _next_item() -> Any:
+        try:
+            return next(iterator)
+        except StopIteration:
+            return sentinel
+
+    return await asyncio.to_thread(_next_item)
 
 
 def estimate_max_new_tokens(

--- a/tldw_Server_API/app/core/TTS/utils.py
+++ b/tldw_Server_API/app/core/TTS/utils.py
@@ -71,6 +71,7 @@ async def run_tts_blocking_call(func: Callable[..., Any], /, *args: Any, **kwarg
 async def run_tts_blocking_next(iterator: Iterator[Any], sentinel: Any) -> Any:
     """Fetch the next item from a synchronous iterator without blocking the event loop."""
     def _next_item() -> Any:
+        """Return the next iterator item or the sentinel when exhausted."""
         try:
             return next(iterator)
         except StopIteration:

--- a/tldw_Server_API/tests/TTS/test_vibevoice_adapter_unit.py
+++ b/tldw_Server_API/tests/TTS/test_vibevoice_adapter_unit.py
@@ -1,9 +1,11 @@
+"""Unit tests for VibeVoice adapter request and model-state behavior."""
+
 import asyncio
-import os
+
 import pytest
 
-from tldw_Server_API.app.core.TTS.adapters.vibevoice_adapter import VibeVoiceAdapter
 from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
+from tldw_Server_API.app.core.TTS.adapters.vibevoice_adapter import VibeVoiceAdapter
 
 
 @pytest.mark.unit
@@ -150,3 +152,66 @@ async def test_generate_complete_forwards_generation_config(monkeypatch):
     assert audio == b"chunk"
     assert seen["gen_config"] is generation_config
     assert seen["voice_reference_path"] == "/tmp/reference.wav"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_generate_canonicalizes_lowercase_requested_variant(monkeypatch):
+    adapter = VibeVoiceAdapter({})
+    adapter.available_voices = {"speaker_1": "/voices/speaker.wav"}
+    seen: dict[str, object] = {}
+
+    async def fake_ensure_initialized():
+        return True
+
+    async def fake_ensure_model_variant(variant):
+        seen["variant"] = variant
+        adapter.variant = variant
+
+    def fake_stream(_request, _voice, _speaker_id, _voice_reference_path=None, gen_config=None):
+        seen["gen_config"] = gen_config
+
+        async def _chunks():
+            yield b"chunk"
+
+        return _chunks()
+
+    monkeypatch.setattr(adapter, "ensure_initialized", fake_ensure_initialized)
+    monkeypatch.setattr(adapter, "_ensure_model_variant", fake_ensure_model_variant)
+    monkeypatch.setattr(adapter, "_stream_audio_vibevoice", fake_stream)
+    monkeypatch.setattr(adapter, "cleanup_after_generation", fake_ensure_initialized)
+
+    request = TTSRequest(
+        text="Speaker 1: hello",
+        voice="speaker_1",
+        model="7B",
+        format=AudioFormat.WAV,
+        stream=True,
+    )
+
+    response = await adapter.generate(request)
+
+    assert response.audio_stream is not None
+    assert seen["variant"] == "7B"
+    assert seen["gen_config"]["model_variant"] == "7B"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_reload_model_for_q8_variant_recomputes_quantization(monkeypatch):
+    adapter = VibeVoiceAdapter({"vibevoice_device": "cuda", "vibevoice_use_quantization": True})
+    adapter.use_quantization = True
+
+    async def fake_cleanup_resources():
+        return None
+
+    async def fake_initialize():
+        return True
+
+    monkeypatch.setattr(adapter, "_cleanup_resources", fake_cleanup_resources)
+    monkeypatch.setattr(adapter, "initialize", fake_initialize)
+
+    await adapter._reload_model_for_variant("7B-Q8")
+
+    assert adapter.variant == "7B-Q8"
+    assert adapter.use_quantization is False

--- a/tldw_Server_API/tests/TTS/test_vibevoice_adapter_unit.py
+++ b/tldw_Server_API/tests/TTS/test_vibevoice_adapter_unit.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from tldw_Server_API.app.core.TTS.adapters.vibevoice_adapter import VibeVoiceAdapter
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
 
 
 @pytest.mark.unit
@@ -105,3 +106,47 @@ def test_request_overrides_default_for_same_speaker():
     )
 
     assert res == ["/override/one.wav"]
+
+
+@pytest.mark.unit
+def test_vibevoice_adapter_initializes_model_state_lock():
+    adapter = VibeVoiceAdapter({})
+
+    assert isinstance(adapter._model_state_lock, asyncio.Lock)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_generate_complete_forwards_generation_config(monkeypatch):
+    adapter = VibeVoiceAdapter({})
+    request = TTSRequest(text="Speaker 1: hello", voice="speaker_1", format=AudioFormat.WAV)
+    generation_config = {"cfg_scale": 1.7, "speakers_to_voices": {"1": "alice"}}
+    seen: dict[str, object] = {}
+
+    async def fake_stream(
+        request_arg,
+        voice_arg,
+        speaker_id_arg,
+        voice_reference_path=None,
+        gen_config=None,
+    ):
+        seen["request"] = request_arg
+        seen["voice"] = voice_arg
+        seen["speaker_id"] = speaker_id_arg
+        seen["voice_reference_path"] = voice_reference_path
+        seen["gen_config"] = gen_config
+        yield b"chunk"
+
+    monkeypatch.setattr(adapter, "_stream_audio_vibevoice", fake_stream)
+
+    audio = await adapter._generate_complete_vibevoice(
+        request,
+        "speaker_1",
+        1,
+        "/tmp/reference.wav",
+        generation_config,
+    )
+
+    assert audio == b"chunk"
+    assert seen["gen_config"] is generation_config
+    assert seen["voice_reference_path"] == "/tmp/reference.wav"

--- a/tldw_Server_API/tests/TTS/test_vibevoice_adapter_unit.py
+++ b/tldw_Server_API/tests/TTS/test_vibevoice_adapter_unit.py
@@ -112,6 +112,7 @@ def test_request_overrides_default_for_same_speaker():
 
 @pytest.mark.unit
 def test_vibevoice_adapter_initializes_model_state_lock():
+    """Verify VibeVoice creates an async lock for model state changes."""
     adapter = VibeVoiceAdapter({})
 
     assert isinstance(adapter._model_state_lock, asyncio.Lock)
@@ -120,6 +121,7 @@ def test_vibevoice_adapter_initializes_model_state_lock():
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_generate_complete_forwards_generation_config(monkeypatch):
+    """Verify non-streaming generation forwards per-request generation config."""
     adapter = VibeVoiceAdapter({})
     request = TTSRequest(text="Speaker 1: hello", voice="speaker_1", format=AudioFormat.WAV)
     generation_config = {"cfg_scale": 1.7, "speakers_to_voices": {"1": "alice"}}
@@ -132,6 +134,7 @@ async def test_generate_complete_forwards_generation_config(monkeypatch):
         voice_reference_path=None,
         gen_config=None,
     ):
+        """Capture arguments passed into the streaming implementation."""
         seen["request"] = request_arg
         seen["voice"] = voice_arg
         seen["speaker_id"] = speaker_id_arg
@@ -157,21 +160,26 @@ async def test_generate_complete_forwards_generation_config(monkeypatch):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_generate_canonicalizes_lowercase_requested_variant(monkeypatch):
+    """Verify lowercase variant requests are mapped to canonical model names."""
     adapter = VibeVoiceAdapter({})
     adapter.available_voices = {"speaker_1": "/voices/speaker.wav"}
     seen: dict[str, object] = {}
 
     async def fake_ensure_initialized():
+        """Pretend the adapter is initialized for generation."""
         return True
 
     async def fake_ensure_model_variant(variant):
+        """Capture the canonical variant selected by generation."""
         seen["variant"] = variant
         adapter.variant = variant
 
     def fake_stream(_request, _voice, _speaker_id, _voice_reference_path=None, gen_config=None):
+        """Return a tiny async stream while recording generation config."""
         seen["gen_config"] = gen_config
 
         async def _chunks():
+            """Yield a single audio chunk for the fake stream."""
             yield b"chunk"
 
         return _chunks()
@@ -199,13 +207,16 @@ async def test_generate_canonicalizes_lowercase_requested_variant(monkeypatch):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_reload_model_for_q8_variant_recomputes_quantization(monkeypatch):
+    """Verify Q8 variant reload disables external quantization flags."""
     adapter = VibeVoiceAdapter({"vibevoice_device": "cuda", "vibevoice_use_quantization": True})
     adapter.use_quantization = True
 
     async def fake_cleanup_resources():
+        """Pretend cleanup completed before reinitialization."""
         return None
 
     async def fake_initialize():
+        """Pretend model initialization completed after reload."""
         return True
 
     monkeypatch.setattr(adapter, "_cleanup_resources", fake_cleanup_resources)

--- a/tldw_Server_API/tests/TTS/unit/test_audio_converter_time_stretch.py
+++ b/tldw_Server_API/tests/TTS/unit/test_audio_converter_time_stretch.py
@@ -1,3 +1,5 @@
+"""Regression tests for AudioConverter time stretch and subprocess timeouts."""
+
 import pytest
 
 from tldw_Server_API.app.core.TTS import audio_converter as ac_mod
@@ -79,6 +81,70 @@ async def test_convert_format_kills_subprocess_on_timeout(monkeypatch, tmp_path)
 
     assert ok is False
     assert process.killed is True
+
+
+@pytest.mark.asyncio
+async def test_long_running_converter_methods_forward_timeout_override(monkeypatch, tmp_path):
+    calls: list[float] = []
+
+    async def fake_run_subprocess(_cmd, *, timeout_seconds=None):
+        calls.append(timeout_seconds)
+        return 0, b"", b'{"input_i": -23.0}'
+
+    async def fake_duration(_path):
+        return 1.0
+
+    monkeypatch.setattr(ac_mod.AudioConverter, "_run_subprocess", staticmethod(fake_run_subprocess))
+    monkeypatch.setattr(ac_mod.AudioConverter, "get_duration", staticmethod(fake_duration))
+
+    in_path = tmp_path / "in.wav"
+    in_path.write_bytes(b"audio")
+    second_path = tmp_path / "second.wav"
+    second_path.write_bytes(b"audio")
+    timeout_seconds = 123.0
+
+    assert await ac_mod.AudioConverter.convert_to_wav(
+        in_path,
+        tmp_path / "converted.wav",
+        timeout_seconds=timeout_seconds,
+    )
+    assert await ac_mod.AudioConverter.package_m4b_with_chapters(
+        [in_path, second_path],
+        tmp_path / "book.m4b",
+        ["One", "Two"],
+        timeout_seconds=timeout_seconds,
+    )
+    assert await ac_mod.AudioConverter.normalize_audio(
+        in_path,
+        tmp_path / "normalized.wav",
+        timeout_seconds=timeout_seconds,
+    )
+    assert await ac_mod.AudioConverter.time_stretch(
+        in_path,
+        tmp_path / "stretched.wav",
+        1.25,
+        timeout_seconds=timeout_seconds,
+    )
+    assert await ac_mod.AudioConverter.trim_silence(
+        in_path,
+        tmp_path / "trimmed.wav",
+        timeout_seconds=timeout_seconds,
+    )
+    assert await ac_mod.AudioConverter.extract_segment(
+        in_path,
+        tmp_path / "segment.wav",
+        0,
+        1,
+        timeout_seconds=timeout_seconds,
+    )
+    assert await ac_mod.AudioConverter.resample_audio(
+        in_path,
+        tmp_path / "resampled.wav",
+        16000,
+        timeout_seconds=timeout_seconds,
+    )
+
+    assert calls == [timeout_seconds] * 8
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/TTS/unit/test_audio_converter_time_stretch.py
+++ b/tldw_Server_API/tests/TTS/unit/test_audio_converter_time_stretch.py
@@ -42,6 +42,46 @@ async def test_time_stretch_builds_ffmpeg_command(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_convert_format_kills_subprocess_on_timeout(monkeypatch, tmp_path):
+    class HangingProcess:
+        def __init__(self):
+            self.returncode = None
+            self.killed = False
+
+        async def communicate(self):
+            await ac_mod.asyncio.sleep(5)
+            return b"", b""
+
+        def kill(self):
+            self.killed = True
+            self.returncode = -9
+
+    process = HangingProcess()
+
+    async def fake_exec(*_cmd, **_kwargs):
+        return process
+
+    monkeypatch.setattr(ac_mod.asyncio, "create_subprocess_exec", fake_exec)
+
+    in_path = tmp_path / "in.wav"
+    in_path.write_bytes(b"audio")
+    out_path = tmp_path / "out.mp3"
+
+    ok = await ac_mod.asyncio.wait_for(
+        ac_mod.AudioConverter.convert_format(
+            in_path,
+            out_path,
+            "mp3",
+            timeout_seconds=0.01,
+        ),
+        timeout=0.2,
+    )
+
+    assert ok is False
+    assert process.killed is True
+
+
+@pytest.mark.asyncio
 async def test_time_stretch_rejects_non_positive_ratio(tmp_path):
     in_path = tmp_path / "in.wav"
     in_path.write_bytes(b"audio")

--- a/tldw_Server_API/tests/TTS/unit/test_audio_converter_time_stretch.py
+++ b/tldw_Server_API/tests/TTS/unit/test_audio_converter_time_stretch.py
@@ -45,22 +45,29 @@ async def test_time_stretch_builds_ffmpeg_command(monkeypatch, tmp_path):
 
 @pytest.mark.asyncio
 async def test_convert_format_kills_subprocess_on_timeout(monkeypatch, tmp_path):
+    """Verify timed-out format conversion kills the child process."""
     class HangingProcess:
+        """Fake subprocess that never completes unless killed."""
+
         def __init__(self):
+            """Initialize fake process state."""
             self.returncode = None
             self.killed = False
 
         async def communicate(self):
+            """Simulate a subprocess communicate call that hangs."""
             await ac_mod.asyncio.sleep(5)
             return b"", b""
 
         def kill(self):
+            """Record that timeout cleanup killed the subprocess."""
             self.killed = True
             self.returncode = -9
 
     process = HangingProcess()
 
     async def fake_exec(*_cmd, **_kwargs):
+        """Return the hanging process instead of launching ffmpeg."""
         return process
 
     monkeypatch.setattr(ac_mod.asyncio, "create_subprocess_exec", fake_exec)
@@ -85,13 +92,16 @@ async def test_convert_format_kills_subprocess_on_timeout(monkeypatch, tmp_path)
 
 @pytest.mark.asyncio
 async def test_long_running_converter_methods_forward_timeout_override(monkeypatch, tmp_path):
+    """Verify long-running converter helpers pass through timeout overrides."""
     calls: list[float] = []
 
     async def fake_run_subprocess(_cmd, *, timeout_seconds=None):
+        """Record each timeout passed to the subprocess wrapper."""
         calls.append(timeout_seconds)
         return 0, b"", b'{"input_i": -23.0}'
 
     async def fake_duration(_path):
+        """Return a stable duration for chapter metadata generation."""
         return 1.0
 
     monkeypatch.setattr(ac_mod.AudioConverter, "_run_subprocess", staticmethod(fake_run_subprocess))

--- a/tldw_Server_API/tests/TTS/unit/test_local_adapter_async_offload.py
+++ b/tldw_Server_API/tests/TTS/unit/test_local_adapter_async_offload.py
@@ -1,0 +1,29 @@
+import inspect
+
+import pytest
+
+from tldw_Server_API.app.core.TTS.adapters import (
+    chatterbox_adapter,
+    dia_adapter,
+    higgs_adapter,
+    kokoro_adapter,
+    vibevoice_adapter,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_blocking_local_generation_paths_use_thread_offload_helper():
+    checked_sources = [
+        inspect.getsource(chatterbox_adapter.ChatterboxAdapter._stream_audio_chatterbox),
+        inspect.getsource(chatterbox_adapter.ChatterboxAdapter._stream_voice_conversion_chatterbox),
+        inspect.getsource(dia_adapter.DiaAdapter._stream_audio_dia),
+        inspect.getsource(higgs_adapter.HiggsAdapter._stream_audio_higgs),
+        inspect.getsource(vibevoice_adapter.VibeVoiceAdapter._stream_audio_vibevoice),
+    ]
+
+    for source in checked_sources:
+        assert "run_tts_blocking_call" in source
+
+    kokoro_source = inspect.getsource(kokoro_adapter.KokoroAdapter._stream_audio_kokoro)
+    assert "run_tts_blocking_next" in kokoro_source

--- a/tldw_Server_API/tests/TTS/unit/test_local_adapter_async_offload.py
+++ b/tldw_Server_API/tests/TTS/unit/test_local_adapter_async_offload.py
@@ -29,6 +29,7 @@ def _code_object_references_name(func, name: str) -> bool:
 
 
 def test_blocking_local_generation_paths_use_thread_offload_helper():
+    """Verify local generation paths reference shared async offload helpers."""
     assert chatterbox_adapter.run_tts_blocking_call is tts_utils.run_tts_blocking_call
     assert dia_adapter.run_tts_blocking_call is tts_utils.run_tts_blocking_call
     assert higgs_adapter.run_tts_blocking_call is tts_utils.run_tts_blocking_call

--- a/tldw_Server_API/tests/TTS/unit/test_local_adapter_async_offload.py
+++ b/tldw_Server_API/tests/TTS/unit/test_local_adapter_async_offload.py
@@ -1,7 +1,8 @@
-import inspect
+"""Regression tests for offloading blocking local TTS adapter calls."""
 
 import pytest
 
+from tldw_Server_API.app.core.TTS import utils as tts_utils
 from tldw_Server_API.app.core.TTS.adapters import (
     chatterbox_adapter,
     dia_adapter,
@@ -13,17 +14,36 @@ from tldw_Server_API.app.core.TTS.adapters import (
 pytestmark = pytest.mark.unit
 
 
+def _code_object_references_name(func, name: str) -> bool:
+    """Return whether a function or nested function references a global name."""
+    pending = [func.__code__]
+    while pending:
+        code = pending.pop()
+        if name in code.co_names:
+            return True
+        pending.extend(
+            const for const in code.co_consts
+            if hasattr(const, "co_names") and hasattr(const, "co_consts")
+        )
+    return False
+
+
 def test_blocking_local_generation_paths_use_thread_offload_helper():
-    checked_sources = [
-        inspect.getsource(chatterbox_adapter.ChatterboxAdapter._stream_audio_chatterbox),
-        inspect.getsource(chatterbox_adapter.ChatterboxAdapter._stream_voice_conversion_chatterbox),
-        inspect.getsource(dia_adapter.DiaAdapter._stream_audio_dia),
-        inspect.getsource(higgs_adapter.HiggsAdapter._stream_audio_higgs),
-        inspect.getsource(vibevoice_adapter.VibeVoiceAdapter._stream_audio_vibevoice),
-    ]
+    assert chatterbox_adapter.run_tts_blocking_call is tts_utils.run_tts_blocking_call
+    assert dia_adapter.run_tts_blocking_call is tts_utils.run_tts_blocking_call
+    assert higgs_adapter.run_tts_blocking_call is tts_utils.run_tts_blocking_call
+    assert vibevoice_adapter.run_tts_blocking_call is tts_utils.run_tts_blocking_call
+    assert kokoro_adapter.run_tts_blocking_next is tts_utils.run_tts_blocking_next
 
-    for source in checked_sources:
-        assert "run_tts_blocking_call" in source
-
-    kokoro_source = inspect.getsource(kokoro_adapter.KokoroAdapter._stream_audio_kokoro)
-    assert "run_tts_blocking_next" in kokoro_source
+    assert _code_object_references_name(
+        chatterbox_adapter.ChatterboxAdapter._stream_audio_chatterbox,
+        "run_tts_blocking_call",
+    )
+    assert _code_object_references_name(
+        chatterbox_adapter.ChatterboxAdapter._stream_voice_conversion_chatterbox,
+        "run_tts_blocking_call",
+    )
+    assert _code_object_references_name(dia_adapter.DiaAdapter._stream_audio_dia, "run_tts_blocking_call")
+    assert _code_object_references_name(higgs_adapter.HiggsAdapter._stream_audio_higgs, "run_tts_blocking_call")
+    assert _code_object_references_name(vibevoice_adapter.VibeVoiceAdapter._stream_audio_vibevoice, "run_tts_blocking_call")
+    assert _code_object_references_name(kokoro_adapter.KokoroAdapter._stream_audio_kokoro, "run_tts_blocking_next")

--- a/tldw_Server_API/tests/TTS/unit/test_tts_config_security.py
+++ b/tldw_Server_API/tests/TTS/unit/test_tts_config_security.py
@@ -1,5 +1,7 @@
-import yaml
+"""Security regression tests for TTS config serialization."""
+
 import pytest
+import yaml
 
 from tldw_Server_API.app.core.TTS.tts_config import ProviderConfig, TTSConfig, TTSConfigManager
 
@@ -50,6 +52,36 @@ def test_save_yaml_redacts_provider_api_keys_by_default(tmp_path):
     data = yaml.safe_load(path.read_text())
     assert data["providers"]["openai"]["api_key"] == "********"
     assert "sk-secret-openai" not in path.read_text()
+
+
+def test_save_yaml_refuses_redacted_canonical_config(tmp_path):
+    manager = _manager_with_config(
+        TTSConfig(
+            providers={
+                "openai": ProviderConfig(enabled=True, api_key="sk-secret-openai"),
+            }
+        )
+    )
+    manager.yaml_path = tmp_path / "tts.yaml"
+
+    with pytest.raises(ValueError, match="redacted provider secrets"):
+        manager.save_yaml()
+
+
+def test_save_yaml_can_persist_canonical_config_with_explicit_secrets(tmp_path):
+    manager = _manager_with_config(
+        TTSConfig(
+            providers={
+                "openai": ProviderConfig(enabled=True, api_key="sk-secret-openai"),
+            }
+        )
+    )
+    manager.yaml_path = tmp_path / "tts.yaml"
+
+    manager.save_yaml(include_secrets=True)
+
+    data = yaml.safe_load(manager.yaml_path.read_text())
+    assert data["providers"]["openai"]["api_key"] == "sk-secret-openai"
 
 
 def test_env_overrides_ignore_non_tts_anthropic_api_key(monkeypatch):

--- a/tldw_Server_API/tests/TTS/unit/test_tts_config_security.py
+++ b/tldw_Server_API/tests/TTS/unit/test_tts_config_security.py
@@ -9,6 +9,7 @@ pytestmark = pytest.mark.unit
 
 
 def _manager_with_config(config: TTSConfig) -> TTSConfigManager:
+    """Build a TTSConfigManager around an in-memory config for tests."""
     manager = TTSConfigManager.__new__(TTSConfigManager)
     manager.yaml_path = None
     manager.config_txt_path = None
@@ -19,6 +20,7 @@ def _manager_with_config(config: TTSConfig) -> TTSConfigManager:
 
 
 def test_to_dict_redacts_provider_api_keys_by_default():
+    """Verify serialized TTS config redacts provider API keys by default."""
     manager = _manager_with_config(
         TTSConfig(
             providers={
@@ -38,6 +40,7 @@ def test_to_dict_redacts_provider_api_keys_by_default():
 
 
 def test_save_yaml_redacts_provider_api_keys_by_default(tmp_path):
+    """Verify ad hoc YAML export redacts provider API keys by default."""
     manager = _manager_with_config(
         TTSConfig(
             providers={
@@ -55,6 +58,7 @@ def test_save_yaml_redacts_provider_api_keys_by_default(tmp_path):
 
 
 def test_save_yaml_refuses_redacted_canonical_config(tmp_path):
+    """Verify canonical config saves cannot accidentally persist redacted secrets."""
     manager = _manager_with_config(
         TTSConfig(
             providers={
@@ -69,6 +73,7 @@ def test_save_yaml_refuses_redacted_canonical_config(tmp_path):
 
 
 def test_save_yaml_can_persist_canonical_config_with_explicit_secrets(tmp_path):
+    """Verify canonical config saves can include secrets only when explicit."""
     manager = _manager_with_config(
         TTSConfig(
             providers={
@@ -85,6 +90,7 @@ def test_save_yaml_can_persist_canonical_config_with_explicit_secrets(tmp_path):
 
 
 def test_env_overrides_ignore_non_tts_anthropic_api_key(monkeypatch):
+    """Verify generic Anthropic API keys are ignored by TTS env overrides."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-secret")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)

--- a/tldw_Server_API/tests/TTS/unit/test_tts_config_security.py
+++ b/tldw_Server_API/tests/TTS/unit/test_tts_config_security.py
@@ -1,0 +1,63 @@
+import yaml
+import pytest
+
+from tldw_Server_API.app.core.TTS.tts_config import ProviderConfig, TTSConfig, TTSConfigManager
+
+pytestmark = pytest.mark.unit
+
+
+def _manager_with_config(config: TTSConfig) -> TTSConfigManager:
+    manager = TTSConfigManager.__new__(TTSConfigManager)
+    manager.yaml_path = None
+    manager.config_txt_path = None
+    manager._config = config
+    manager._env_overrides = {}
+    manager._sources = {}
+    return manager
+
+
+def test_to_dict_redacts_provider_api_keys_by_default():
+    manager = _manager_with_config(
+        TTSConfig(
+            providers={
+                "openai": ProviderConfig(enabled=True, api_key="sk-secret-openai"),
+                "elevenlabs": ProviderConfig(enabled=True, api_key="xi-secret"),
+            }
+        )
+    )
+
+    redacted = manager.to_dict()
+    with_secrets = manager.to_dict(include_secrets=True)
+
+    assert redacted["providers"]["openai"]["api_key"] == "********"
+    assert redacted["providers"]["elevenlabs"]["api_key"] == "********"
+    assert "sk-secret-openai" not in repr(redacted)
+    assert with_secrets["providers"]["openai"]["api_key"] == "sk-secret-openai"
+
+
+def test_save_yaml_redacts_provider_api_keys_by_default(tmp_path):
+    manager = _manager_with_config(
+        TTSConfig(
+            providers={
+                "openai": ProviderConfig(enabled=True, api_key="sk-secret-openai"),
+            }
+        )
+    )
+    path = tmp_path / "tts.yaml"
+
+    manager.save_yaml(path)
+
+    data = yaml.safe_load(path.read_text())
+    assert data["providers"]["openai"]["api_key"] == "********"
+    assert "sk-secret-openai" not in path.read_text()
+
+
+def test_env_overrides_ignore_non_tts_anthropic_api_key(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-secret")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+    manager = TTSConfigManager.__new__(TTSConfigManager)
+
+    env_config = manager._load_env_overrides()
+
+    assert "anthropic" not in env_config.get("providers", {})

--- a/tldw_Server_API/tests/TTS/unit/test_vibevoice_realtime_adapter_security.py
+++ b/tldw_Server_API/tests/TTS/unit/test_vibevoice_realtime_adapter_security.py
@@ -1,0 +1,38 @@
+import pytest
+
+from tldw_Server_API.app.core.Security.egress import URLPolicyResult
+from tldw_Server_API.app.core.TTS.adapters import vibevoice_realtime_adapter as rt_module
+from tldw_Server_API.app.core.TTS.adapters.vibevoice_realtime_adapter import (
+    _VibeVoiceRealtimeWebSocketSession,
+)
+from tldw_Server_API.app.core.TTS.realtime_session import RealtimeSessionConfig
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSProviderInitializationError
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_realtime_websocket_session_rejects_egress_denied_url(monkeypatch):
+    calls: list[str] = []
+
+    def fake_evaluate_url_policy(url: str, **_kwargs):
+        calls.append(url)
+        return URLPolicyResult(False, "blocked by test policy")
+
+    monkeypatch.setattr(rt_module, "evaluate_url_policy", fake_evaluate_url_policy, raising=False)
+
+    session = _VibeVoiceRealtimeWebSocketSession(
+        ws_url="ws://blocked.example.test/socket",
+        ws_headers=None,
+        ws_timeout=1.0,
+        config=RealtimeSessionConfig(
+            model="vibevoice-realtime-0.5b",
+            voice="alloy",
+            response_format="pcm",
+        ),
+    )
+
+    with pytest.raises(TTSProviderInitializationError, match="blocked by test policy"):
+        await session.start()
+
+    assert calls == ["http://blocked.example.test/socket"]

--- a/tldw_Server_API/tests/TTS/unit/test_vibevoice_realtime_adapter_security.py
+++ b/tldw_Server_API/tests/TTS/unit/test_vibevoice_realtime_adapter_security.py
@@ -15,9 +15,11 @@ pytestmark = pytest.mark.unit
 
 @pytest.mark.asyncio
 async def test_realtime_websocket_session_rejects_egress_denied_url(monkeypatch):
+    """Verify realtime websocket startup rejects URLs denied by egress policy."""
     calls: list[str] = []
 
     def fake_evaluate_url_policy(url: str, **_kwargs):
+        """Return a denied policy result while recording the normalized URL."""
         calls.append(url)
         return URLPolicyResult(False, "blocked by test policy")
 
@@ -42,7 +44,9 @@ async def test_realtime_websocket_session_rejects_egress_denied_url(monkeypatch)
 
 @pytest.mark.asyncio
 async def test_realtime_websocket_egress_denial_redacts_sensitive_url(monkeypatch):
+    """Verify egress denial details do not expose websocket credentials."""
     def fake_evaluate_url_policy(url: str, **_kwargs):
+        """Assert policy evaluation receives the sanitized origin URL."""
         assert url == "https://example.test"
         return URLPolicyResult(False, "blocked by test policy")
 
@@ -69,9 +73,11 @@ async def test_realtime_websocket_egress_denial_redacts_sensitive_url(monkeypatc
 
 
 def test_validate_websocket_egress_returns_resolved_ips_for_pinning(monkeypatch):
+    """Verify websocket egress validation returns resolved IPs for pinning."""
     calls: list[str] = []
 
     def fake_evaluate_url_policy(url: str, **_kwargs):
+        """Return an allowed policy result with a resolved public IP."""
         calls.append(url)
         return URLPolicyResult(True, None, ("93.184.216.34",))
 
@@ -87,6 +93,7 @@ def test_validate_websocket_egress_returns_resolved_ips_for_pinning(monkeypatch)
 
 @pytest.mark.asyncio
 async def test_pinned_websocket_resolver_uses_validated_ips():
+    """Verify the pinned resolver only resolves the validated hostname."""
     resolver = rt_module._PinnedWebSocketResolver("public.example.test", ("93.184.216.34",))
 
     resolved = await resolver.resolve("public.example.test", 443)

--- a/tldw_Server_API/tests/TTS/unit/test_vibevoice_realtime_adapter_security.py
+++ b/tldw_Server_API/tests/TTS/unit/test_vibevoice_realtime_adapter_security.py
@@ -1,3 +1,5 @@
+"""Security tests for VibeVoice realtime websocket egress handling."""
+
 import pytest
 
 from tldw_Server_API.app.core.Security.egress import URLPolicyResult
@@ -35,4 +37,69 @@ async def test_realtime_websocket_session_rejects_egress_denied_url(monkeypatch)
     with pytest.raises(TTSProviderInitializationError, match="blocked by test policy"):
         await session.start()
 
-    assert calls == ["http://blocked.example.test/socket"]
+    assert calls == ["http://blocked.example.test"]
+
+
+@pytest.mark.asyncio
+async def test_realtime_websocket_egress_denial_redacts_sensitive_url(monkeypatch):
+    def fake_evaluate_url_policy(url: str, **_kwargs):
+        assert url == "https://example.test"
+        return URLPolicyResult(False, "blocked by test policy")
+
+    monkeypatch.setattr(rt_module, "evaluate_url_policy", fake_evaluate_url_policy, raising=False)
+
+    session = _VibeVoiceRealtimeWebSocketSession(
+        ws_url="wss://user:secret-token@example.test/socket?api_key=leaked#frag",
+        ws_headers=None,
+        ws_timeout=1.0,
+        config=RealtimeSessionConfig(
+            model="vibevoice-realtime-0.5b",
+            voice="alloy",
+            response_format="pcm",
+        ),
+    )
+
+    with pytest.raises(TTSProviderInitializationError) as exc_info:
+        await session.start()
+
+    details = exc_info.value.details
+    assert details["url"] == "https://example.test"
+    assert "secret-token" not in repr(details)
+    assert "api_key" not in repr(details)
+
+
+def test_validate_websocket_egress_returns_resolved_ips_for_pinning(monkeypatch):
+    calls: list[str] = []
+
+    def fake_evaluate_url_policy(url: str, **_kwargs):
+        calls.append(url)
+        return URLPolicyResult(True, None, ("93.184.216.34",))
+
+    monkeypatch.setattr(rt_module, "evaluate_url_policy", fake_evaluate_url_policy, raising=False)
+
+    validation = rt_module._validate_websocket_egress("wss://public.example.test/socket")
+
+    assert calls == ["https://public.example.test"]
+    assert validation.policy_url == "https://public.example.test"
+    assert validation.hostname == "public.example.test"
+    assert validation.resolved_ips == ("93.184.216.34",)
+
+
+@pytest.mark.asyncio
+async def test_pinned_websocket_resolver_uses_validated_ips():
+    resolver = rt_module._PinnedWebSocketResolver("public.example.test", ("93.184.216.34",))
+
+    resolved = await resolver.resolve("public.example.test", 443)
+    mismatch = await resolver.resolve("other.example.test", 443)
+
+    assert resolved == [
+        {
+            "hostname": "public.example.test",
+            "host": "93.184.216.34",
+            "port": 443,
+            "family": rt_module.socket.AF_INET,
+            "proto": 0,
+            "flags": rt_module.socket.AI_NUMERICHOST,
+        }
+    ]
+    assert mismatch == []

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_audio_utils.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_audio_utils.py
@@ -100,6 +100,52 @@ def test_convert_audio_fallback_log_sanitizes_exception_text(monkeypatch):
     assert all(secret_detail not in message for message in logged_messages)
 
 
+def test_convert_audio_strict_failure_raises_without_returning_original(monkeypatch):
+    processor = audio_utils.AudioProcessor.__new__(audio_utils.AudioProcessor)
+    processor.ffmpeg_available = False
+    processor.librosa_available = True
+    audio_bytes = b"original audio"
+
+    def fail_load(*args, **kwargs):
+        raise RuntimeError("decode failed")
+
+    fake_librosa = types.SimpleNamespace(load=fail_load)
+    fake_soundfile = types.SimpleNamespace(write=lambda *args, **kwargs: None)
+    monkeypatch.setitem(sys.modules, "librosa", fake_librosa)
+    monkeypatch.setitem(sys.modules, "soundfile", fake_soundfile)
+
+    with pytest.raises(RuntimeError, match="Audio conversion failed"):
+        processor.convert_audio(audio_bytes, strict=True)
+
+
+def test_process_voice_reference_uses_strict_conversion(monkeypatch):
+    seen: dict[str, object] = {}
+
+    class FailingConversionProcessor:
+        PROVIDER_REQUIREMENTS = {"higgs": {"sample_rate": 24000}}
+
+        def decode_base64_audio(self, _base64_audio):
+            return b"raw-reference"
+
+        def convert_audio(self, audio_bytes, **kwargs):
+            seen["audio_bytes"] = audio_bytes
+            seen["strict"] = kwargs.get("strict")
+            raise RuntimeError("conversion failed")
+
+    monkeypatch.setattr(audio_utils, "AudioProcessor", FailingConversionProcessor)
+
+    processed, error = audio_utils.process_voice_reference(
+        "cmF3LXJlZmVyZW5jZQ==",
+        "higgs",
+        validate=False,
+        convert=True,
+    )
+
+    assert processed is None
+    assert "conversion failed" in error
+    assert seen == {"audio_bytes": b"raw-reference", "strict": True}
+
+
 def test_check_ffmpeg_fallback_log_sanitizes_exception_text(monkeypatch):
     processor = audio_utils.AudioProcessor.__new__(audio_utils.AudioProcessor)
     processor.ffmpeg_path = None

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_audio_utils.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_audio_utils.py
@@ -101,12 +101,14 @@ def test_convert_audio_fallback_log_sanitizes_exception_text(monkeypatch):
 
 
 def test_convert_audio_strict_failure_raises_without_returning_original(monkeypatch):
+    """Verify strict conversion failure raises instead of returning source bytes."""
     processor = audio_utils.AudioProcessor.__new__(audio_utils.AudioProcessor)
     processor.ffmpeg_available = False
     processor.librosa_available = True
     audio_bytes = b"original audio"
 
     def fail_load(*args, **kwargs):
+        """Raise from the fallback decoder to simulate conversion failure."""
         raise RuntimeError("decode failed")
 
     fake_librosa = types.SimpleNamespace(load=fail_load)
@@ -119,15 +121,20 @@ def test_convert_audio_strict_failure_raises_without_returning_original(monkeypa
 
 
 def test_process_voice_reference_uses_strict_conversion(monkeypatch):
+    """Verify voice-reference conversion requests strict failure behavior."""
     seen: dict[str, object] = {}
 
     class FailingConversionProcessor:
+        """AudioProcessor stub that records strict conversion options."""
+
         PROVIDER_REQUIREMENTS = {"higgs": {"sample_rate": 24000}}
 
         def decode_base64_audio(self, _base64_audio):
+            """Return decoded reference bytes for the conversion path."""
             return b"raw-reference"
 
         def convert_audio(self, audio_bytes, **kwargs):
+            """Record conversion arguments and simulate a conversion failure."""
             seen["audio_bytes"] = audio_bytes
             seen["strict"] = kwargs.get("strict")
             raise RuntimeError("conversion failed")


### PR DESCRIPTION
## Summary
- Harden VibeVoice generation config handling and serialize model variant reload/generation state.
- Offload blocking local TTS generation paths and bound ffmpeg/ffprobe subprocess execution.
- Enforce realtime websocket egress policy and redact TTS provider secrets by default.

## Verification
- `python -m pytest tldw_Server_API/tests/TTS/test_vibevoice_adapter_unit.py tldw_Server_API/tests/TTS/unit/test_tts_config_security.py tldw_Server_API/tests/TTS/unit/test_vibevoice_realtime_adapter_security.py tldw_Server_API/tests/TTS/unit/test_local_adapter_async_offload.py tldw_Server_API/tests/TTS_NEW/unit/test_tts_audio_utils.py tldw_Server_API/tests/TTS/unit/test_audio_converter_time_stretch.py tldw_Server_API/tests/TTS/unit/test_audio_converter_sanitizer.py tldw_Server_API/tests/TTS/unit/test_audio_converter_m4b.py -q` -> 43 passed.
- `python -m pytest tldw_Server_API/tests/TTS/adapters/test_chatterbox_adapter_mock.py tldw_Server_API/tests/TTS/adapters/test_higgs_adapter_mock.py tldw_Server_API/tests/TTS/test_phoneme_overrides.py -q` -> 77 passed.
- `python -m py_compile ...` on touched production TTS files passed.
- `git diff --check` passed.
- `python -m bandit -r ... -f json -o /tmp/bandit_tts_review_fixes_clean_worktree.json` -> errors=[], results_count=0.

## Notes
- Backlog: TASK-10001.
- AI-generated PR merge policy still requires a human-written Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the TTS module to prevent model-state races, unblock async paths, and tighten security across adapters and audio utilities. Fulfills TASK-10001 by forwarding VibeVoice generation config, bounding `ffmpeg`/`ffprobe` calls (with per-call timeouts), enforcing realtime egress policy with DNS pinning, and redacting provider secrets by default.

- **Bug Fixes**
  - VibeVoice: forward per-request generation config to streaming/complete; canonicalize model variant hints; serialize reload/generation with an async lock and release it before streaming; recompute quantization for `7B-Q8`; offload blocking `model.generate` via `run_tts_blocking_call`.
  - Async: offload local blocking generation in `chatterbox`, `dia`, and `higgs` via `run_tts_blocking_call`; convert Kokoro sync iterators with `run_tts_blocking_next`; raise `ValueError` for long Kokoro phoneme inputs.
  - Audio: add subprocess timeouts with kill-on-timeout and per-call overrides; bound `get_duration`/`get_audio_info`; make voice-reference conversion strict (raise on failure).

- **Security**
  - Realtime: enforce websocket egress policy for `ws://`/`wss://` URLs, sanitize policy URLs, and pin DNS to validated IPs via a custom resolver.
  - Config: redact provider `api_key` in `TTSConfig.to_dict()` and YAML by default (opt-in `include_secrets`); refuse overwriting the canonical YAML with redacted secrets unless `include_secrets=True`; remove non-TTS `ANTHROPIC_API_KEY` env mapping.

<sup>Written for commit 1087d72fe6c4a05ec6eff3b8a15e29790a0923df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

