### PR TITLE
Fix Notes_Tasks review findings

### DIFF
--- a/backlog/tasks/task-2422 - Fix-Notes_Tasks-review-findings.md
+++ b/backlog/tasks/task-2422 - Fix-Notes_Tasks-review-findings.md
@@ -4,7 +4,7 @@ title: Fix Notes_Tasks review findings
 status: Done
 assignee: []
 created_date: '2026-06-23 14:44'
-updated_date: '2026-06-23 15:05'
+updated_date: '2026-06-24 12:36'
 labels:
   - notes
   - tasks
@@ -44,6 +44,17 @@ Verification:
 - `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Notes_Tasks tldw_Server_API/app/core/DB_Management/chacha/task_store.py -f json -o /tmp/bandit_notes_tasks_review_fixes.json` -> 0 findings.
 
 Known skips/blockers: none.
+
+PR review follow-up:
+- Added docstrings for the task metadata-token helper functions.
+- Marked the service test module as unit tests.
+- Broadened stale discovery to handle parser-valid tab and multi-space checkbox syntax.
+
+Rebase/review verification:
+- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Notes_Tasks/unit -q` -> 55 passed.
+- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py -q` -> 60 passed.
+- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Notes_NEW/integration/test_notes_tasks_api.py tldw_Server_API/tests/Notes_NEW/integration/test_notes_tasks_reconciliation_api.py -q` -> 37 passed.
+- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Notes_Tasks tldw_Server_API/app/core/DB_Management/chacha/task_store.py -f json -o /tmp/bandit_notes_tasks_review_rebase.json` -> 0 findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2422 - Fix-Notes_Tasks-review-findings.md
+++ b/backlog/tasks/task-2422 - Fix-Notes_Tasks-review-findings.md
@@ -1,0 +1,57 @@
+---
+id: TASK-2422
+title: Fix Notes_Tasks review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 14:44'
+updated_date: '2026-06-23 15:05'
+labels:
+  - notes
+  - tasks
+  - review
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address current-code review findings in the Notes_Tasks module: prevent task text from being silently reinterpreted as metadata, stop current warning-state notes from being reprocessed as stale forever, and align stale checklist discovery with the parser-supported unordered checkbox bullets.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Literal task text containing allowlisted metadata token syntax is rejected or escaped so reconciliation cannot silently remove it.
+- [x] #2 Current warning-state notes are not treated as stale candidates until their note version changes, while warning state remains visible to callers.
+- [x] #3 Stale checklist discovery recognizes every unordered checkbox bullet syntax accepted by the parser.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Use TDD. Add focused regression coverage before production changes, then verify with Notes_Tasks unit tests, Notes task API integration tests, task-store tests covering stale discovery, and Bandit on touched backend scope.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the Notes_Tasks review findings by rejecting parseable metadata-token syntax in literal task text, returning current warning reconciliation state without reprocessing, and aligning stale checklist discovery with the parser-supported `-`, `*`, and `+` checkbox bullets. Added regression coverage in the Notes task service tests and ChaCha task-store tests.
+
+Verification:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Notes_Tasks/unit -q` -> 55 passed.
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py -q` -> 60 passed.
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Notes_NEW/integration/test_notes_tasks_api.py tldw_Server_API/tests/Notes_NEW/integration/test_notes_tasks_reconciliation_api.py -q` -> 37 passed.
+- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Notes_Tasks tldw_Server_API/app/core/DB_Management/chacha/task_store.py -f json -o /tmp/bandit_notes_tasks_review_fixes.json` -> 0 findings.
+
+Known skips/blockers: none.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
@@ -28,9 +28,8 @@ class TaskStore:
 
     _TASK_JSON_FIELDS = ("metadata_json",)
     _EVENT_JSON_FIELDS = ("old_value_json", "new_value_json")
-    _CHECKLIST_DISCOVERY_PATTERNS = tuple(
-        f"%{bullet} [{marker}]%" for bullet in ("-", "*", "+") for marker in (" ", "x", "X")
-    )
+    _CHECKLIST_DISCOVERY_MARKER_PATTERNS = ("%[ ]%", "%[x]%", "%[X]%")
+    _CHECKLIST_DISCOVERY_BULLET_PATTERNS = ("%-%", "%*%", "%+%")
     _TASK_STATUSES = {"open", "done"}
     _PROJECTION_STATUSES = {"live", "unlinked", "deleted", "ambiguous"}
     _MIN_LIMIT = 1
@@ -1473,10 +1472,9 @@ class TaskStore:
                     n.content LIKE ?
                  OR n.content LIKE ?
                  OR n.content LIKE ?
-                 OR n.content LIKE ?
-                 OR n.content LIKE ?
-                 OR n.content LIKE ?
-                 OR n.content LIKE ?
+               )
+               AND (
+                    n.content LIKE ?
                  OR n.content LIKE ?
                  OR n.content LIKE ?
                )
@@ -1489,7 +1487,8 @@ class TaskStore:
             """,
             (
                 self._deleted_value(False),
-                *self._CHECKLIST_DISCOVERY_PATTERNS,
+                *self._CHECKLIST_DISCOVERY_MARKER_PATTERNS,
+                *self._CHECKLIST_DISCOVERY_BULLET_PATTERNS,
                 self._clamp_limit(limit),
             ),
         )
@@ -1499,7 +1498,8 @@ class TaskStore:
         """Count checklist-bearing notes whose task reconciliation is stale or missing."""
         params: list[Any] = [
             self._deleted_value(False),
-            *self._CHECKLIST_DISCOVERY_PATTERNS,
+            *self._CHECKLIST_DISCOVERY_MARKER_PATTERNS,
+            *self._CHECKLIST_DISCOVERY_BULLET_PATTERNS,
         ]
         sql_query = """
             SELECT COUNT(*) AS stale_count
@@ -1510,10 +1510,9 @@ class TaskStore:
                     n.content LIKE ?
                  OR n.content LIKE ?
                  OR n.content LIKE ?
-                 OR n.content LIKE ?
-                 OR n.content LIKE ?
-                 OR n.content LIKE ?
-                 OR n.content LIKE ?
+               )
+               AND (
+                    n.content LIKE ?
                  OR n.content LIKE ?
                  OR n.content LIKE ?
                )

--- a/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/task_store.py
@@ -28,6 +28,9 @@ class TaskStore:
 
     _TASK_JSON_FIELDS = ("metadata_json",)
     _EVENT_JSON_FIELDS = ("old_value_json", "new_value_json")
+    _CHECKLIST_DISCOVERY_PATTERNS = tuple(
+        f"%{bullet} [{marker}]%" for bullet in ("-", "*", "+") for marker in (" ", "x", "X")
+    )
     _TASK_STATUSES = {"open", "done"}
     _PROJECTION_STATUSES = {"live", "unlinked", "deleted", "ambiguous"}
     _MIN_LIMIT = 1
@@ -1470,21 +1473,23 @@ class TaskStore:
                     n.content LIKE ?
                  OR n.content LIKE ?
                  OR n.content LIKE ?
+                 OR n.content LIKE ?
+                 OR n.content LIKE ?
+                 OR n.content LIKE ?
+                 OR n.content LIKE ?
+                 OR n.content LIKE ?
+                 OR n.content LIKE ?
                )
                AND (
                     r.note_id IS NULL
                  OR r.note_version < n.version
-                 OR r.status != ?
                )
              ORDER BY n.last_modified DESC, n.id ASC
              LIMIT ?
             """,
             (
                 self._deleted_value(False),
-                "%- [ ]%",
-                "%- [x]%",
-                "%- [X]%",
-                "clean",
+                *self._CHECKLIST_DISCOVERY_PATTERNS,
                 self._clamp_limit(limit),
             ),
         )
@@ -1494,10 +1499,7 @@ class TaskStore:
         """Count checklist-bearing notes whose task reconciliation is stale or missing."""
         params: list[Any] = [
             self._deleted_value(False),
-            "%- [ ]%",
-            "%- [x]%",
-            "%- [X]%",
-            "clean",
+            *self._CHECKLIST_DISCOVERY_PATTERNS,
         ]
         sql_query = """
             SELECT COUNT(*) AS stale_count
@@ -1508,11 +1510,16 @@ class TaskStore:
                     n.content LIKE ?
                  OR n.content LIKE ?
                  OR n.content LIKE ?
+                 OR n.content LIKE ?
+                 OR n.content LIKE ?
+                 OR n.content LIKE ?
+                 OR n.content LIKE ?
+                 OR n.content LIKE ?
+                 OR n.content LIKE ?
                )
                AND (
                     r.note_id IS NULL
                  OR r.note_version < n.version
-                 OR r.status != ?
                )
         """
         if note_id is not None:

--- a/tldw_Server_API/app/core/Notes_Tasks/service.py
+++ b/tldw_Server_API/app/core/Notes_Tasks/service.py
@@ -27,6 +27,8 @@ _TASK_STATUSES = {"open", "done"}
 
 
 def _task_text_contains_parseable_metadata_token(text: str) -> bool:
+    """Return True when literal task text contains metadata syntax the parser would consume."""
+
     for match in _TASK_TEXT_METADATA_TOKEN_RE.finditer(text):
         if _is_parseable_task_text_metadata_token(name=match.group("name"), value=match.group("value")):
             return True
@@ -34,6 +36,8 @@ def _task_text_contains_parseable_metadata_token(text: str) -> bool:
 
 
 def _is_parseable_task_text_metadata_token(*, name: str, value: str) -> bool:
+    """Validate one allowlisted task metadata token using the markdown parser's value rules."""
+
     normalized_name = name.casefold()
     normalized_value = value.strip()
     if normalized_name == "due":

--- a/tldw_Server_API/app/core/Notes_Tasks/service.py
+++ b/tldw_Server_API/app/core/Notes_Tasks/service.py
@@ -22,7 +22,33 @@ _CHECKLIST_RE = re.compile(
 )
 _METADATA_TOKEN_ORDER = ("due_date", "priority", "estimate")
 _METADATA_TOKEN_NAMES = {"due_date": "due", "priority": "priority", "estimate": "estimate"}
+_TASK_TEXT_METADATA_TOKEN_RE = re.compile(r"@(?P<name>due|priority|estimate)\((?P<value>[^)]*)\)", re.IGNORECASE)
 _TASK_STATUSES = {"open", "done"}
+
+
+def _task_text_contains_parseable_metadata_token(text: str) -> bool:
+    for match in _TASK_TEXT_METADATA_TOKEN_RE.finditer(text):
+        if _is_parseable_task_text_metadata_token(name=match.group("name"), value=match.group("value")):
+            return True
+    return False
+
+
+def _is_parseable_task_text_metadata_token(*, name: str, value: str) -> bool:
+    normalized_name = name.casefold()
+    normalized_value = value.strip()
+    if normalized_name == "due":
+        if re.fullmatch(r"\d{4}-\d{2}-\d{2}", normalized_value) is None:
+            return False
+        try:
+            date.fromisoformat(normalized_value)
+        except ValueError:
+            return False
+        return True
+    if normalized_name == "priority":
+        return normalized_value.casefold() in {"high", "medium", "low"}
+    if normalized_name == "estimate":
+        return re.fullmatch(r"\d+[mhd]", normalized_value.casefold()) is not None
+    return False
 
 
 @dataclass(frozen=True)
@@ -122,8 +148,15 @@ class NotesTaskService:
     ) -> ReconciliationResult | None:
         note = self._require_note(db, note_id)
         state = db.get_reconciliation_state(note_id)
-        if state is not None and int(state["note_version"]) == int(note["version"]) and state["status"] == "clean":
-            return None
+        if state is not None and int(state["note_version"]) == int(note["version"]):
+            if state["status"] == "clean":
+                return None
+            return ReconciliationResult(
+                note_id=note_id,
+                note_version=int(state["note_version"]),
+                parsed_count=int(state.get("item_count") or 0),
+                warning_count=int(state.get("warning_count") or 0),
+            )
         return self.reconcile_note(
             db=db,
             note_id=note_id,
@@ -498,6 +531,11 @@ class NotesTaskService:
             raise InputError("Task text must be 2000 characters or fewer.")
         if "\n" in text or "\r" in text:
             raise InputError("Task text cannot contain newline characters.")
+        if _task_text_contains_parseable_metadata_token(text):
+            raise InputError(
+                "Task text cannot include parseable metadata tokens; "
+                "pass due_date, priority, or estimate metadata separately."
+            )
 
     @staticmethod
     def _validate_task_status(status: str) -> None:

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
@@ -1509,14 +1509,22 @@ def test_candidate_notes_for_task_discovery_excludes_currently_reconciled_notes(
     assert plain_note_id not in {row["id"] for row in candidates}  # nosec B101
 
 
-def test_candidate_notes_for_task_discovery_matches_parser_checkbox_bullets(db: CharactersRAGDB) -> None:
+def test_candidate_notes_for_task_discovery_matches_parser_checkbox_bullets_and_spacing(db: CharactersRAGDB) -> None:
     dash_note_id = _create_note(db, content="- [ ] Dash task\n")
     star_note_id = _create_note(db, content="* [x] Star task\n")
     plus_note_id = _create_note(db, content="+ [X] Plus task\n")
+    tab_note_id = _create_note(db, content="-\t[ ] Tab task\n")
+    spaced_note_id = _create_note(db, content="*   [x] Spaced task\n")
 
     candidates = db.candidate_notes_for_task_discovery(limit=10)
 
-    assert {row["id"] for row in candidates} == {dash_note_id, star_note_id, plus_note_id}  # nosec B101
+    assert {row["id"] for row in candidates} == {  # nosec B101
+        dash_note_id,
+        star_note_id,
+        plus_note_id,
+        tab_note_id,
+        spaced_note_id,
+    }
 
 
 def test_candidate_notes_for_task_discovery_excludes_current_warning_state_until_note_changes(

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py
@@ -1507,3 +1507,37 @@ def test_candidate_notes_for_task_discovery_excludes_currently_reconciled_notes(
 
     assert db.candidate_notes_for_task_discovery(limit=10) == []  # nosec B101
     assert plain_note_id not in {row["id"] for row in candidates}  # nosec B101
+
+
+def test_candidate_notes_for_task_discovery_matches_parser_checkbox_bullets(db: CharactersRAGDB) -> None:
+    dash_note_id = _create_note(db, content="- [ ] Dash task\n")
+    star_note_id = _create_note(db, content="* [x] Star task\n")
+    plus_note_id = _create_note(db, content="+ [X] Plus task\n")
+
+    candidates = db.candidate_notes_for_task_discovery(limit=10)
+
+    assert {row["id"] for row in candidates} == {dash_note_id, star_note_id, plus_note_id}  # nosec B101
+
+
+def test_candidate_notes_for_task_discovery_excludes_current_warning_state_until_note_changes(
+    db: CharactersRAGDB,
+) -> None:
+    note_id = _create_note(db, content="- [ ] Review @due(not-a-date)\n")
+    db.set_reconciliation_state(
+        note_id=note_id,
+        note_version=1,
+        status="warnings",
+        item_count=1,
+        warning_count=1,
+    )
+
+    assert db.candidate_notes_for_task_discovery(limit=10) == []  # nosec B101
+    assert db.count_candidate_notes_for_task_discovery(note_id=note_id) == 0  # nosec B101
+
+    db.update_note(
+        note_id=note_id,
+        update_data={"content": "- [ ] Review @due(not-a-date)\n- [ ] Follow up\n"},
+        expected_version=1,
+    )
+
+    assert db.count_candidate_notes_for_task_discovery(note_id=note_id) == 1  # nosec B101

--- a/tldw_Server_API/tests/Notes_Tasks/unit/test_service.py
+++ b/tldw_Server_API/tests/Notes_Tasks/unit/test_service.py
@@ -53,6 +53,55 @@ def test_create_task_for_note_rejects_invalid_status_without_rewriting_note(db: 
     assert db.list_tasks(note_id=str(note["id"])) == []
 
 
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Call @priority(high) customer",
+        "Ship @due(2026-06-30)",
+        "Plan @estimate(2h)",
+    ],
+)
+def test_task_text_rejects_parseable_metadata_tokens(text: str) -> None:
+    with pytest.raises(InputError, match="metadata tokens"):
+        NotesTaskService._validate_task_text(text)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Call @foo(bar) customer",
+        "Call @due(not-a-date) customer",
+        "Call @priority(urgent) customer",
+        "Call @estimate(two-hours) customer",
+    ],
+)
+def test_task_text_allows_unknown_or_malformed_metadata_like_plain_text(text: str) -> None:
+    NotesTaskService._validate_task_text(text)
+
+
+def test_ensure_note_reconciled_preserves_current_warning_state_without_reprocessing(
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = NotesTaskService()
+    note = _add_note(db, title="Tasks", content="- [ ] Review @due(not-a-date)\n")
+    first = service.reconcile_note_current(db=db, note_id=str(note["id"]), actor=_actor())
+    assert first.warning_count == 1
+
+    monkeypatch.setattr(
+        service._reconciler,
+        "reconcile_note",
+        lambda **_: pytest.fail("current warning state should not be reconciled again"),
+    )
+
+    cached = service.ensure_note_reconciled(db=db, note_id=str(note["id"]), actor=_actor())
+
+    assert cached is not None
+    assert cached.note_id == str(note["id"])
+    assert cached.note_version == int(note["version"])
+    assert cached.warning_count == 1
+
+
 def test_reconcile_stale_notes_reports_actual_remaining_count(db: CharactersRAGDB) -> None:
     service = NotesTaskService()
     for index in range(3):

--- a/tldw_Server_API/tests/Notes_Tasks/unit/test_service.py
+++ b/tldw_Server_API/tests/Notes_Tasks/unit/test_service.py
@@ -12,6 +12,9 @@ from tldw_Server_API.app.core.Notes_Tasks.models import TaskActor
 from tldw_Server_API.app.core.Notes_Tasks.service import NotesTaskService
 
 
+pytestmark = pytest.mark.unit
+
+
 @pytest.fixture()
 def db(tmp_path: Path) -> CharactersRAGDB:
     database = CharactersRAGDB(str(tmp_path / "notes_task_service.db"), client_id="notes_task_service_test")


### PR DESCRIPTION
## Summary
- Reject parseable task metadata token syntax in literal task text so reconciliation cannot silently strip it.
- Preserve current warning reconciliation state without repeatedly treating those notes as stale.
- Align stale checklist discovery with parser-supported `-`, `*`, and `+` checkbox bullets, including tab and multi-space whitespace before the checkbox marker.

## Review Follow-up
- Added docstrings for the new task metadata-token helper functions.
- Marked the service test module as unit tests; the task-store test module already had module-level unit marking.
- Rebased on latest `origin/dev` and force-pushed with lease.
- Replied to all three Qodo inline review threads.

## Verification
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Notes_Tasks/unit -q` -> 55 passed.
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_chacha_task_store.py -q` -> 60 passed.
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Notes_NEW/integration/test_notes_tasks_api.py tldw_Server_API/tests/Notes_NEW/integration/test_notes_tasks_reconciliation_api.py -q` -> 37 passed.
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Notes_Tasks tldw_Server_API/app/core/DB_Management/chacha/task_store.py -f json -o /tmp/bandit_notes_tasks_review_rebase.json` -> 0 findings.

## Change Summary
AI-generated PR merge gate: human requester still needs to provide the final Change summary explaining what changed and why these implementation choices were made.