### PR TITLE
fix: harden Reminders review findings

### DIFF
--- a/backlog/tasks/task-2421 - Harden-Reminders-module-review-findings.md
+++ b/backlog/tasks/task-2421 - Harden-Reminders-module-review-findings.md
@@ -1,0 +1,40 @@
+---
+id: TASK-2421
+title: Harden Reminders module review findings
+status: Done
+updated_date: 2026-06-24 04:56
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the Reminders module review findings: skip disabled queued reminders, replace stale snooze tasks, honor reminder notification preferences, avoid unbounded snoozed-list scans, trust explicit snooze task links, and clean up unused RemindersService CRUD wrappers.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented Reminders review fixes: disabled queued reminder jobs now skip without creating notifications, reminder notification preferences suppress due notifications, one-time completion patching is shared for success/skips, repeat snoozes delete the prior active snooze task before linking the new task, explicit snooze_task_id links are trusted even after reminder title/body edits, current-format snoozed listing uses direct snooze_task_id lookup before legacy fallback, and unused RemindersService CRUD pass-throughs were removed. Added an index and CollectionsDatabase helpers for direct snooze lookup. Also narrowed the global character-chat test reset fixture so unrelated notification tests no longer import the Research/RAG/sklearn stack during setup.
+Moved fixes into worktree .worktrees/reminders-review-hardening-2421 on branch codex/reminders-review-hardening-2421 for PR preparation against dev. New-worktree verification: direct script exercised disabled task skip, reminder preference suppression, resnooze replacement, explicit snooze link matching after task edits, and direct snoozed listing; git diff --check passed; py_compile passed for touched Python files; Bandit on Reminders plus Collections_DB.py reported 0 findings/errors. The pytest focused suite was attempted in the new worktree but interrupted after hanging in pytest cleanup; the same 19-test notification/reminder suite passed before the move in the original tree.
+PR review follow-up on 2026-06-23: rebased branch codex/reminders-review-hardening-2421 onto latest origin/dev and dropped an unrelated Claims_Extraction commit that had leaked into the PR. Addressed Qodo review comments by adding docstrings to new DB/helper functions, adding type hints and docstrings to new reminder tests, treating jobs for deleted queued snooze tasks as skipped task_missing runs instead of worker failures, and narrowing current-format snoozed notification lookup to notification-linked active task IDs before legacy fallback. Verification after review follow-up: py_compile passed for touched Python files; focused review-specific pytest selection passed 6 tests; affected notification test files passed 12 tests; git diff --check passed; Bandit on touched production Reminders/Collections code reported 0 findings/errors. A wider Bandit run including pytest files produced expected LOW B101 assert findings and pre-existing LOW B106 literals in tests/conftest.py, with no production-code findings.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR branch codex/reminders-review-hardening-2421 onto latest origin/dev, removed the unrelated Claims_Extraction commit from the PR, and addressed all actionable Qodo review comments. Current fixes include missing docstrings/type hints, deleted queued snooze tasks being marked skipped instead of failed, and direct snoozed notification lookup limited to notification-linked active tasks before legacy fallback. Verification passed: py_compile on touched Python files, focused review-specific pytest selection (6 passed), affected notification test files (12 passed), git diff --check, and Bandit production-code scan (0 findings/errors).
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/DB_Management/Collections_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Collections_DB.py
@@ -946,6 +946,7 @@ class CollectionsDatabase:
                 delivered_at TEXT
             );
             CREATE INDEX IF NOT EXISTS idx_user_notifications_user_created ON user_notifications(user_id, created_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_user_notifications_user_snooze ON user_notifications(user_id, snooze_task_id, created_at DESC);
             CREATE INDEX IF NOT EXISTS idx_user_notifications_user_unread ON user_notifications(user_id, read_at);
             CREATE UNIQUE INDEX IF NOT EXISTS ux_user_notifications_user_dedupe ON user_notifications(user_id, dedupe_key) WHERE dedupe_key IS NOT NULL;
 
@@ -1198,6 +1199,7 @@ class CollectionsDatabase:
                 delivered_at TEXT
             );
             CREATE INDEX IF NOT EXISTS idx_user_notifications_user_created ON user_notifications(user_id, created_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_user_notifications_user_snooze ON user_notifications(user_id, snooze_task_id, created_at DESC);
             CREATE INDEX IF NOT EXISTS idx_user_notifications_user_unread ON user_notifications(user_id, read_at);
             CREATE UNIQUE INDEX IF NOT EXISTS ux_user_notifications_user_dedupe ON user_notifications(user_id, dedupe_key);
 
@@ -5557,6 +5559,63 @@ class CollectionsDatabase:
             (
                 "SELECT * FROM user_notifications "
                 "WHERE user_id = ? AND dismissed_at IS NOT NULL "
+                "ORDER BY created_at DESC LIMIT ? OFFSET ?"
+            ),
+            (self.user_id, limit, offset),
+        ).rows
+        return [self._notification_row_from_db(row) for row in rows]
+
+    def list_user_notifications_by_snooze_task_ids(
+        self,
+        task_ids: Iterable[str],
+    ) -> list[UserNotificationRow]:
+        """Return dismissed notifications linked to the supplied snooze task IDs."""
+        normalized_ids = sorted({str(task_id).strip() for task_id in task_ids if str(task_id).strip()})
+        if not normalized_ids:
+            return []
+
+        all_rows: list[dict[str, Any]] = []
+        chunk_size = 500
+        for start in range(0, len(normalized_ids), chunk_size):
+            chunk = normalized_ids[start : start + chunk_size]
+            placeholders = ",".join(["?"] * len(chunk))
+            rows = self.backend.execute(
+                (
+                    "SELECT * FROM user_notifications "
+                    f"WHERE user_id = ? AND dismissed_at IS NOT NULL AND snooze_task_id IN ({placeholders}) "  # nosec B608
+                    "ORDER BY created_at DESC"
+                ),
+                (self.user_id, *chunk),
+            ).rows
+            all_rows.extend(rows)
+
+        all_rows.sort(key=lambda row: (str(row.get("created_at") or ""), int(row.get("id") or 0)), reverse=True)
+        return [self._notification_row_from_db(row) for row in all_rows]
+
+    def list_user_notification_snooze_task_ids(self) -> list[str]:
+        """Return distinct non-empty snooze task IDs referenced by dismissed notifications."""
+        rows = self.backend.execute(
+            (
+                "SELECT DISTINCT snooze_task_id FROM user_notifications "
+                "WHERE user_id = ? AND dismissed_at IS NOT NULL "
+                "AND snooze_task_id IS NOT NULL AND snooze_task_id != '' "
+                "ORDER BY snooze_task_id"
+            ),
+            (self.user_id,),
+        ).rows
+        return [str(row.get("snooze_task_id") or "") for row in rows if row.get("snooze_task_id")]
+
+    def list_user_legacy_snooze_candidate_notifications(
+        self,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[UserNotificationRow]:
+        """Return dismissed legacy notifications that predate explicit snooze links."""
+        rows = self.backend.execute(
+            (
+                "SELECT * FROM user_notifications "
+                "WHERE user_id = ? AND dismissed_at IS NOT NULL AND snooze_task_id IS NULL "
                 "ORDER BY created_at DESC LIMIT ? OFFSET ?"
             ),
             (self.user_id, limit, offset),

--- a/tldw_Server_API/app/core/Reminders/reminder_jobs.py
+++ b/tldw_Server_API/app/core/Reminders/reminder_jobs.py
@@ -36,6 +36,18 @@ def _resolve_user_id(job: dict[str, Any], payload: dict[str, Any]) -> int:
     return int(owner)
 
 
+def _task_run_completion_patch(task: Any, *, now_iso: str, last_status: str) -> dict[str, Any]:
+    """Build the task state patch shared by completed and skipped runs."""
+    patch: dict[str, Any] = {
+        "last_run_at": now_iso,
+        "last_status": last_status,
+    }
+    if task.schedule_kind == "one_time":
+        patch["enabled"] = False
+        patch["next_run_at"] = None
+    return patch
+
+
 async def handle_reminder_job(
     job: dict[str, Any],
     *,
@@ -51,7 +63,6 @@ async def handle_reminder_job(
     now_iso = datetime.now(timezone.utc).isoformat()
 
     cdb = collections_db or CollectionsDatabase.for_user(user_id=user_id)
-    task = cdb.get_reminder_task(task_id)
     run = cdb.create_reminder_task_run(
         task_id=task_id,
         scheduled_for=payload.get("scheduled_for"),
@@ -65,6 +76,67 @@ async def handle_reminder_job(
 
     if run.status == "succeeded":
         return {"status": "succeeded", "task_id": task_id, "run_id": run.id, "deduped": True}
+    if run.status == "skipped":
+        return {"status": "skipped", "task_id": task_id, "run_id": run.id, "deduped": True}
+
+    try:
+        task = cdb.get_reminder_task(task_id)
+    except KeyError:
+        completed_at = datetime.now(timezone.utc).isoformat()
+        cdb.update_reminder_task_run_status(
+            run_id=run.id,
+            status="skipped",
+            error="task_missing",
+            completed_at=completed_at,
+        )
+        logger.info("Reminder job skipped for missing task: task_id={} run_id={}", task_id, run.id)
+        return {
+            "status": "skipped",
+            "reason": "task_missing",
+            "task_id": task_id,
+            "run_id": run.id,
+        }
+
+    if not task.enabled:
+        completed_at = datetime.now(timezone.utc).isoformat()
+        cdb.update_reminder_task_run_status(
+            run_id=run.id,
+            status="skipped",
+            error="task_disabled",
+            completed_at=completed_at,
+        )
+        cdb.update_reminder_task(
+            task_id,
+            _task_run_completion_patch(task, now_iso=now_iso, last_status="skipped"),
+        )
+        logger.info("Reminder job skipped for disabled task: task_id={} run_id={}", task_id, run.id)
+        return {
+            "status": "skipped",
+            "reason": "task_disabled",
+            "task_id": task_id,
+            "run_id": run.id,
+        }
+
+    prefs = cdb.get_notification_preferences()
+    if not prefs.reminder_enabled:
+        completed_at = datetime.now(timezone.utc).isoformat()
+        cdb.update_reminder_task_run_status(
+            run_id=run.id,
+            status="skipped",
+            error="reminder_notifications_disabled",
+            completed_at=completed_at,
+        )
+        cdb.update_reminder_task(
+            task_id,
+            _task_run_completion_patch(task, now_iso=now_iso, last_status="skipped"),
+        )
+        logger.info("Reminder job skipped by notification preferences: task_id={} run_id={}", task_id, run.id)
+        return {
+            "status": "skipped",
+            "reason": "reminder_notifications_disabled",
+            "task_id": task_id,
+            "run_id": run.id,
+        }
 
     notification = cdb.create_user_notification(
         kind="reminder_due",
@@ -88,14 +160,10 @@ async def handle_reminder_job(
         error=None,
         completed_at=datetime.now(timezone.utc).isoformat(),
     )
-    patch: dict[str, Any] = {
-        "last_run_at": now_iso,
-        "last_status": "succeeded",
-    }
-    if task.schedule_kind == "one_time":
-        patch["enabled"] = False
-        patch["next_run_at"] = None
-    cdb.update_reminder_task(task_id, patch)
+    cdb.update_reminder_task(
+        task_id,
+        _task_run_completion_patch(task, now_iso=now_iso, last_status="succeeded"),
+    )
     logger.info("Reminder job handled successfully: task_id={} run_id={}", task_id, run.id)
     return {
         "status": "succeeded",

--- a/tldw_Server_API/app/core/Reminders/reminders_service.py
+++ b/tldw_Server_API/app/core/Reminders/reminders_service.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any
 
 from tldw_Server_API.app.core.DB_Management.Collections_DB import (
     CollectionsDatabase,
@@ -41,9 +40,7 @@ def _notification_snooze_signature(notification: UserNotificationRow) -> tuple[s
 def _task_snooze_signature(task: ReminderTaskRow) -> tuple[str, str, str, str, str] | None:
     title = str(task.title or "")
     if (
-        task.schedule_kind != "one_time"
-        or not task.enabled
-        or not task.run_at
+        not _is_active_one_time_task(task)
         or not title.startswith(SNOOZE_TASK_TITLE_PREFIX)
     ):
         return None
@@ -54,6 +51,11 @@ def _task_snooze_signature(task: ReminderTaskRow) -> tuple[str, str, str, str, s
         str(task.link_id or ""),
         str(task.link_url or ""),
     )
+
+
+def _is_active_one_time_task(task: ReminderTaskRow) -> bool:
+    """Return whether a task is an enabled one-time reminder with a fire time."""
+    return task.schedule_kind == "one_time" and bool(task.enabled) and bool(task.run_at)
 
 
 def _parse_iso_datetime(value: str | None) -> datetime | None:
@@ -127,7 +129,7 @@ def _match_legacy_notification_snoozes(
 
 
 class RemindersService:
-    """Domain service for user reminder task lifecycle operations."""
+    """Domain service for notification snooze reminder behavior."""
 
     def __init__(
         self,
@@ -138,27 +140,11 @@ class RemindersService:
         self.user_id = int(user_id)
         self.collections = collections_db or CollectionsDatabase.for_user(self.user_id)
 
-    def create_task(self, **kwargs: Any) -> ReminderTaskRow:
-        task_id = self.collections.create_reminder_task(**kwargs)
-        return self.collections.get_reminder_task(task_id)
-
-    def list_tasks(self, *, include_disabled: bool = True) -> list[ReminderTaskRow]:
-        return self.collections.list_reminder_tasks(include_disabled=include_disabled)
-
-    def get_task(self, task_id: str) -> ReminderTaskRow:
-        return self.collections.get_reminder_task(task_id)
-
-    def update_task(self, task_id: str, patch: dict[str, Any]) -> ReminderTaskRow:
-        return self.collections.update_reminder_task(task_id, patch)
-
-    def delete_task(self, task_id: str) -> bool:
-        return self.collections.delete_reminder_task(task_id)
-
     def _list_active_snooze_tasks(self) -> dict[str, ReminderTaskRow]:
         return {
             task.id: task
             for task in self.collections.list_reminder_tasks(include_disabled=False)
-            if _task_snooze_signature(task) is not None
+            if _is_active_one_time_task(task)
         }
 
     def _match_notification_snoozes(
@@ -177,7 +163,7 @@ class RemindersService:
             if notification.snooze_task_id is not None:
                 if notification.snooze_task_id:
                     task = active_tasks.get(notification.snooze_task_id)
-                    if task is not None and _task_snooze_signature(task) == _notification_snooze_signature(notification):
+                    if task is not None and _is_active_one_time_task(task):
                         matches[notification.id] = NotificationSnoozeMatch(
                             task_ids=(task.id,),
                             run_at=task.run_at,
@@ -218,13 +204,42 @@ class RemindersService:
         if not active_tasks:
             return [], {}, 0
 
-        rows: list[UserNotificationRow] = []
-        matches_for_rows: dict[int, NotificationSnoozeMatch] = {}
-        total = 0
+        matched_rows: dict[int, UserNotificationRow] = {}
+        all_matches: dict[int, NotificationSnoozeMatch] = {}
+
+        linked_task_ids = set(self.collections.list_user_notification_snooze_task_ids()).intersection(active_tasks)
+        linked_rows = self.collections.list_user_notifications_by_snooze_task_ids(linked_task_ids)
+        linked_matches = self._match_notification_snoozes(
+            notifications=linked_rows,
+            active_tasks=active_tasks,
+        )
+        for row in linked_rows:
+            match = linked_matches.get(row.id)
+            if match is None:
+                continue
+            matched_rows[row.id] = row
+            all_matches[row.id] = match
+
+        legacy_active_tasks = {
+            task_id: task
+            for task_id, task in active_tasks.items()
+            if task_id not in linked_task_ids and _task_snooze_signature(task) is not None
+        }
+        if not legacy_active_tasks:
+            sorted_rows = sorted(
+                matched_rows.values(),
+                key=lambda row: (str(row.created_at or ""), row.id),
+                reverse=True,
+            )
+            total = len(sorted_rows)
+            rows = sorted_rows[bounded_offset : bounded_offset + bounded_limit]
+            matches_for_rows = {row.id: all_matches[row.id] for row in rows if row.id in all_matches}
+            return rows, matches_for_rows, total
+
         scan_offset = 0
 
         while True:
-            dismissed_rows = self.collections.list_user_dismissed_notifications(
+            dismissed_rows = self.collections.list_user_legacy_snooze_candidate_notifications(
                 limit=batch_size,
                 offset=scan_offset,
             )
@@ -233,21 +248,27 @@ class RemindersService:
 
             dismissed_matches = self._match_notification_snoozes(
                 notifications=dismissed_rows,
-                active_tasks=active_tasks,
+                active_tasks=legacy_active_tasks,
             )
             for row in dismissed_rows:
                 match = dismissed_matches.get(row.id)
                 if match is None:
                     continue
-                if total >= bounded_offset and len(rows) < bounded_limit:
-                    rows.append(row)
-                    matches_for_rows[row.id] = match
-                total += 1
+                matched_rows.setdefault(row.id, row)
+                all_matches.setdefault(row.id, match)
 
             scan_offset += len(dismissed_rows)
             if len(dismissed_rows) < batch_size:
                 break
 
+        sorted_rows = sorted(
+            matched_rows.values(),
+            key=lambda row: (str(row.created_at or ""), row.id),
+            reverse=True,
+        )
+        total = len(sorted_rows)
+        rows = sorted_rows[bounded_offset : bounded_offset + bounded_limit]
+        matches_for_rows = {row.id: all_matches[row.id] for row in rows if row.id in all_matches}
         return rows, matches_for_rows, total
 
     def cancel_notification_snooze(self, *, notification_id: int) -> list[str]:
@@ -271,6 +292,11 @@ class RemindersService:
             )
 
         source = self.collections.get_user_notification(notification_id)
+        previous_match = self.list_notification_snoozes(notifications=[source]).get(source.id)
+        if previous_match is not None:
+            for previous_task_id in previous_match.task_ids:
+                self.collections.delete_reminder_task(previous_task_id)
+
         run_at = (datetime.now(timezone.utc) + timedelta(minutes=minutes)).isoformat()
         task_id = self.collections.create_reminder_task(
             title=_build_snooze_task_title(source.title),

--- a/tldw_Server_API/tests/Notifications/test_reminder_jobs_worker.py
+++ b/tldw_Server_API/tests/Notifications/test_reminder_jobs_worker.py
@@ -98,3 +98,97 @@ async def test_reminder_job_deduplicates_by_run_slot(reminder_job_env):
     assert second["status"] == "succeeded"
     rows = cdb.list_user_notifications(limit=10, offset=0)
     assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_reminder_job_skips_disabled_task_without_notification(reminder_job_env: None) -> None:
+    """Disabled queued reminder tasks are marked skipped without notifications."""
+    user_id = 902
+    cdb, task_id, run_slot = _seed_one_time_task(user_id=user_id)
+    cdb.update_reminder_task(task_id, {"enabled": False})
+    fake_job = {
+        "id": 125,
+        "owner_user_id": str(user_id),
+        "payload": {
+            "task_id": task_id,
+            "user_id": user_id,
+            "scheduled_for": run_slot,
+        },
+    }
+
+    result = await handle_reminder_job(fake_job)
+
+    assert result == {
+        "status": "skipped",
+        "reason": "task_disabled",
+        "task_id": task_id,
+        "run_id": result["run_id"],
+    }
+    assert cdb.list_user_notifications(limit=10, offset=0) == []
+    run = cdb.get_reminder_task_run_by_slot(task_id=task_id, run_slot_key=run_slot)
+    assert run.status == "skipped"
+    assert run.error == "task_disabled"
+    assert cdb.get_reminder_task(task_id).last_status == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_reminder_job_honors_disabled_reminder_notifications(reminder_job_env: None) -> None:
+    """Disabled reminder notification preferences suppress due notifications."""
+    user_id = 903
+    cdb, task_id, run_slot = _seed_one_time_task(user_id=user_id)
+    cdb.update_notification_preferences(reminder_enabled=False)
+    fake_job = {
+        "id": 126,
+        "owner_user_id": str(user_id),
+        "payload": {
+            "task_id": task_id,
+            "user_id": user_id,
+            "scheduled_for": run_slot,
+        },
+    }
+
+    result = await handle_reminder_job(fake_job)
+
+    assert result == {
+        "status": "skipped",
+        "reason": "reminder_notifications_disabled",
+        "task_id": task_id,
+        "run_id": result["run_id"],
+    }
+    assert cdb.list_user_notifications(limit=10, offset=0) == []
+    run = cdb.get_reminder_task_run_by_slot(task_id=task_id, run_slot_key=run_slot)
+    assert run.status == "skipped"
+    assert run.error == "reminder_notifications_disabled"
+    refreshed_task = cdb.get_reminder_task(task_id)
+    assert refreshed_task.enabled is False
+    assert refreshed_task.last_status == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_reminder_job_skips_missing_task_without_worker_failure(reminder_job_env: None) -> None:
+    """Deleted queued snooze tasks are recorded as skipped instead of failed."""
+    user_id = 904
+    cdb, task_id, run_slot = _seed_one_time_task(user_id=user_id)
+    assert cdb.delete_reminder_task(task_id) is True
+    fake_job = {
+        "id": 127,
+        "owner_user_id": str(user_id),
+        "payload": {
+            "task_id": task_id,
+            "user_id": user_id,
+            "scheduled_for": run_slot,
+        },
+    }
+
+    result = await handle_reminder_job(fake_job)
+
+    assert result == {
+        "status": "skipped",
+        "reason": "task_missing",
+        "task_id": task_id,
+        "run_id": result["run_id"],
+    }
+    assert cdb.list_user_notifications(limit=10, offset=0) == []
+    run = cdb.get_reminder_task_run_by_slot(task_id=task_id, run_slot_key=run_slot)
+    assert run.status == "skipped"
+    assert run.error == "task_missing"

--- a/tldw_Server_API/tests/Notifications/test_reminders_service.py
+++ b/tldw_Server_API/tests/Notifications/test_reminders_service.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime, timezone
+from typing import NoReturn
 
 import pytest
 
-from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
+from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase, UserNotificationRow
 from tldw_Server_API.app.core.Reminders.reminders_service import RemindersService
 from tldw_Server_API.app.core.config import settings
 
@@ -68,3 +70,90 @@ def test_snooze_notification_rejects_invalid_minutes(reminders_service, minutes:
 def test_snooze_notification_raises_for_missing_notification(reminders_service):
     with pytest.raises(KeyError):
         reminders_service.snooze_notification(notification_id=999999, minutes=10)
+
+
+def test_snooze_notification_replaces_existing_active_snooze(reminders_service: RemindersService) -> None:
+    """Re-snoozing replaces the previous active snooze task."""
+    notification_id = _seed_notification()
+
+    first = reminders_service.snooze_notification(notification_id=notification_id, minutes=15)
+    second = reminders_service.snooze_notification(notification_id=notification_id, minutes=45)
+
+    assert second.id != first.id
+    with pytest.raises(KeyError):
+        reminders_service.collections.get_reminder_task(first.id)
+    assert reminders_service.collections.get_user_notification(notification_id).snooze_task_id == second.id
+    active_tasks = reminders_service.collections.list_reminder_tasks(include_disabled=False)
+    assert [task.id for task in active_tasks] == [second.id]
+
+
+def test_explicit_snooze_link_survives_task_title_body_edits(reminders_service: RemindersService) -> None:
+    """Explicit snooze links survive user edits to reminder title/body."""
+    notification_id = _seed_notification()
+    task = reminders_service.snooze_notification(notification_id=notification_id, minutes=30)
+    reminders_service.collections.update_reminder_task(
+        task.id,
+        {
+            "title": "User edited reminder title",
+            "body": "User edited reminder body",
+        },
+    )
+
+    notification = reminders_service.collections.get_user_notification(notification_id)
+    matches = reminders_service.list_notification_snoozes(notifications=[notification])
+
+    assert matches[notification_id].task_ids == (task.id,)
+    assert matches[notification_id].run_at == task.run_at
+    assert reminders_service.cancel_notification_snooze(notification_id=notification_id) == [task.id]
+    with pytest.raises(KeyError):
+        reminders_service.collections.get_reminder_task(task.id)
+
+
+def test_list_snoozed_notifications_uses_direct_snooze_links(
+    reminders_service: RemindersService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Current-format snoozes use direct links without scanning legacy rows."""
+    notification_id = _seed_notification()
+    task = reminders_service.snooze_notification(notification_id=notification_id, minutes=30)
+    unrelated_task_id = reminders_service.collections.create_reminder_task(
+        title="Unrelated one-time reminder",
+        body="Do not query this as a snooze",
+        schedule_kind="one_time",
+        run_at=task.run_at,
+        cron=None,
+        timezone="UTC",
+        enabled=True,
+    )
+    reminders_service.collections.update_reminder_task(unrelated_task_id, {"next_run_at": task.run_at})
+    queried_task_ids: set[str] = set()
+    original_direct_lookup = reminders_service.collections.list_user_notifications_by_snooze_task_ids
+
+    def _capture_direct_lookup(task_ids: Iterable[str]) -> list[UserNotificationRow]:
+        """Capture direct lookup IDs while preserving DB behavior."""
+        task_id_list = list(task_ids)
+        queried_task_ids.update(task_id_list)
+        return original_direct_lookup(task_id_list)
+
+    def _unexpected_legacy_scan(*_args: object, **_kwargs: object) -> NoReturn:
+        """Fail if the current-format snooze path falls back to legacy scanning."""
+        raise AssertionError("legacy dismissed notification scan should not be required")
+
+    monkeypatch.setattr(
+        reminders_service.collections,
+        "list_user_notifications_by_snooze_task_ids",
+        _capture_direct_lookup,
+    )
+    monkeypatch.setattr(
+        reminders_service.collections,
+        "list_user_legacy_snooze_candidate_notifications",
+        _unexpected_legacy_scan,
+    )
+
+    rows, matches, total = reminders_service.list_snoozed_notifications(limit=10, offset=0)
+
+    assert total == 1
+    assert [row.id for row in rows] == [notification_id]
+    assert matches[notification_id].task_ids == (task.id,)
+    assert matches[notification_id].run_at == task.run_at
+    assert queried_task_ids == {task.id}

--- a/tldw_Server_API/tests/conftest.py
+++ b/tldw_Server_API/tests/conftest.py
@@ -10,6 +10,7 @@ pytest_plugins = ["tldw_Server_API.tests._plugins.http_client_patch_guard"]
 from collections.abc import Callable
 import os
 from pathlib import Path
+import sys
 try:
     # Ensure tests see provider keys from the canonical location
     # Load once at collection time, without overriding explicit env
@@ -397,19 +398,20 @@ def _restore_user_db_env_and_chacha_cache():
 @pytest.fixture(autouse=True)
 def _reset_character_chat_complete_windows():
     """Ensure legacy /complete throttle cache is rebound per test loop."""
-    try:
-        from tldw_Server_API.app.api.v1.endpoints import character_chat_sessions as _chat_sessions
-
-        _chat_sessions.reset_complete_windows()
-    except Exception:
-        _ = None
+    module_name = "tldw_Server_API.app.api.v1.endpoints.character_chat_sessions"
+    _chat_sessions = sys.modules.get(module_name)
+    if _chat_sessions is not None:
+        try:
+            _chat_sessions.reset_complete_windows()
+        except Exception:
+            _ = None
     yield
-    try:
-        from tldw_Server_API.app.api.v1.endpoints import character_chat_sessions as _chat_sessions
-
-        _chat_sessions.reset_complete_windows()
-    except Exception:
-        _ = None
+    _chat_sessions = sys.modules.get(module_name)
+    if _chat_sessions is not None:
+        try:
+            _chat_sessions.reset_complete_windows()
+        except Exception:
+            _ = None
 
 
 def _log_lingering_threads():


### PR DESCRIPTION
## Summary
- Skip disabled queued reminder jobs and reminder-notification preference suppressions without creating due notifications.
- Replace stale active snooze tasks on re-snooze and trust explicit snooze task links after task edits.
- Add direct snooze lookup helpers/indexes and regression coverage, plus a narrow notification-test fixture cleanup.

## Verification
- Direct Reminders scenario verification passed in the PR worktree.
- `py_compile` passed for touched Python files.
- `git diff --check` passed.
- Bandit on `tldw_Server_API/app/core/Reminders` plus `Collections_DB.py` reported 0 findings/errors.
- The focused pytest notification/reminder suite passed before the move; in the new worktree pytest was attempted but interrupted after hanging in pytest cleanup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Reminders by skipping disabled or missing tasks, honoring reminder notification prefs, and making snoozes reliable and fast via direct links and stale-task replacement. Implements TASK-2421.

- **Bug Fixes**
  - Skip disabled reminder jobs, jobs when reminder notifications are off, and jobs for missing tasks; mark runs as "skipped" and disable one-time tasks without creating notifications (`reminder_jobs.py`).
  - Replace the existing active snooze task on re-snooze; trust explicit `snooze_task_id` even after title/body edits (`reminders_service.py`).
  - Use a new index and direct lookup for snoozed notifications; limit to notification-linked active task IDs and fall back to a small legacy scan only if needed (`Collections_DB.py`, `reminders_service.py`).
  - Add a shared one-time completion patch and remove unused RemindersService CRUD pass-throughs for consistency and cleanup (`reminder_jobs.py`, `reminders_service.py`).
  - Narrow a global test fixture to avoid importing heavy modules during unrelated tests (`tests/conftest.py`).

<sup>Written for commit c77ba74b53ac58f1bcd463c840b6a43a5c1deadf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

