### PR TITLE
Harden Logging module review findings

### DIFF
--- a/Docs/superpowers/plans/2026-06-23-logging-module-review-fixes.md
+++ b/Docs/superpowers/plans/2026-06-23-logging-module-review-fixes.md
@@ -1,0 +1,35 @@
+## Stage 1: Regression Coverage
+**Goal**: Add focused failing tests for the accepted Logging review findings.
+**Success Criteria**: Tests demonstrate the current failures for redaction, UTC timestamps, traceparent validation, safe env parsing, synchronized sink installation, and non-blocking log-file persistence.
+**Tests**: Targeted pytest cases in `tests/Logging` and `tests/Infrastructure/test_json_log_formatter.py`.
+**Status**: Complete
+
+## Stage 2: Logging Hot-Path Hardening
+**Goal**: Keep system log capture bounded and non-blocking for ordinary log callers.
+**Success Criteria**: `_log_sink` stores redacted entries in memory and enqueues file writes without waiting for file locks or compaction.
+**Tests**: New system log buffer tests plus existing `tests/Logging/test_system_log_buffer.py`.
+**Status**: Complete
+
+## Stage 3: Context and Formatter Safety
+**Goal**: Tighten structured log formatter and inbound context behavior.
+**Success Criteria**: JSON formatter emits real UTC timestamps; invalid traceparent headers are discarded; malformed logging env values fall back safely.
+**Tests**: JSON formatter, trace context, and env reload tests.
+**Status**: Complete
+
+## Stage 4: Cleanup and Verification
+**Goal**: Remove or reconcile unused duplicate JSON logging helper behavior, update task notes, and run focused verification.
+**Success Criteria**: Relevant tests pass, touched Python compiles, Bandit scan completes for touched Logging code, and Backlog task records verification.
+**Tests**: Focused pytest suite, py_compile, Bandit.
+**Status**: Complete
+
+## Stage 5: PR Rebase Follow-Up
+**Goal**: Rebase the PR branch on latest `dev` and address new base-branch Logging test coverage.
+**Success Criteria**: Branch rebases cleanly; `_log_file_lock` honors runtime lock timeout settings without oversleeping or treating very low timeout values as near-immediate stale-lock expiry.
+**Tests**: Focused pytest suite, compileall, Bandit, `git diff --check`.
+**Status**: Complete
+
+## Stage 6: PR Review Remediation
+**Goal**: Address actionable Qodo comments on style, test metadata, and Logging reliability/correctness.
+**Success Criteria**: New helpers/tests have docstrings/type hints/markers where required; traceparent regex is wrapped; `_log_sink` cannot leak enqueue failures; reloads reuse file-writer worker state; dedupe preserves tenant-distinct entries.
+**Tests**: Focused pytest suite, Ruff on touched files, compileall, Bandit, `git diff --check`.
+**Status**: Complete

--- a/backlog/tasks/task-12005 - Harden-Logging-module-review-findings.md
+++ b/backlog/tasks/task-12005 - Harden-Logging-module-review-findings.md
@@ -1,0 +1,101 @@
+---
+id: TASK-12005
+title: Harden Logging module review findings
+status: Done
+assignee: []
+created_date: 2026-06-23 20:42
+updated_date: 2026-06-24 20:13
+labels:
+- logging
+- observability
+- review-fix
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address validated current-code review findings in `tldw_Server_API/app/core/Logging`: non-blocking system log persistence, redaction before buffer/file storage, UTC JSON timestamps, traceparent validation, safe env parsing, synchronized sink setup, and duplicate JSON logging helper cleanup.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 System log capture no longer blocks log callers on file lock or compaction work.
+- [x] #2 System log buffer/file entries redact common secrets before persistence or admin exposure.
+- [x] #3 JSON log timestamps are emitted as true UTC values.
+- [x] #4 Invalid traceparent headers are not propagated into logging context.
+- [x] #5 Malformed logging environment variables fall back safely.
+- [x] #6 System log sink installation is concurrency-safe.
+- [x] #7 Unused duplicate JSON logging helper is removed or reconciled.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-23-logging-module-review-fixes.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Touched files:
+- `Docs/superpowers/plans/2026-06-23-logging-module-review-fixes.md`
+- `backlog/tasks/task-12005 - Harden-Logging-module-review-findings.md`
+- `tldw_Server_API/app/core/Logging/json_log_formatter.py`
+- `tldw_Server_API/app/core/Logging/log_context.py`
+- `tldw_Server_API/app/core/Logging/system_log_buffer.py`
+- `tldw_Server_API/tests/Infrastructure/test_json_log_formatter.py`
+- `tldw_Server_API/tests/Logging/test_system_log_buffer.py`
+- `tldw_Server_API/tests/Logging/test_trace_context.py`
+
+Verification:
+- Red phase confirmed 7 focused tests failed against the original behavior: redaction, non-blocking sink append, malformed env parsing, invalid log level fallback, concurrent sink setup, invalid traceparent handling, and UTC timestamp conversion.
+- `source .venv/bin/activate && python -m compileall -q tldw_Server_API/app/core/Logging tldw_Server_API/tests/Logging tldw_Server_API/tests/Infrastructure/test_json_log_formatter.py`
+- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Logging -f json -o /tmp/bandit_logging_task_12005.json`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Logging tldw_Server_API/tests/Infrastructure/test_json_log_formatter.py -q` passed with 43 tests.
+- Rebased PR branch on latest `origin/dev` and addressed the new runtime lock-timeout coverage by making `_log_file_lock` use monotonic elapsed time, sleep only up to the remaining timeout, and avoid treating low timeout values as near-immediate stale-lock expiry.
+- Post-rebase verification: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Logging tldw_Server_API/tests/Infrastructure/test_json_log_formatter.py -q` passed with 43 tests.
+- Post-rebase verification: `source .venv/bin/activate && python -m compileall -q tldw_Server_API/app/core/Logging tldw_Server_API/tests/Logging tldw_Server_API/tests/Infrastructure/test_json_log_formatter.py`
+- Post-rebase verification: `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Logging -f json -o /tmp/bandit_logging_task_12005_rebase.json`
+- Post-rebase verification: `git diff --check`
+- Addressed Qodo review comments: added docstrings and type hints for new helpers/tests, wrapped the traceparent regex, added pytest markers for touched tests, made `_log_sink` resilient to enqueue failures, persisted the file queue/worker across reloads, and expanded dedupe keys with tenant/correlation fields.
+
+Known skips/blockers: full repository pytest was not run; the focused Logging and formatter tests cover the reviewed module scope. Backlog CLI/MCP was unavailable for task creation because the CLI index referenced a missing task file, so this task was created manually with user approval.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened the Logging module and addressed the latest PR review pass: system-log redaction now treats sensitive structured keys as secrets, internal diagnostics avoid raw exception text, dedupe keys include `event`, UTC formatter coverage uses exact output, sink tests cover structured secret extras, and traceparent tests cover mixed-case normalization. Focused Logging/formatter tests, Ruff, compileall, Bandit, and diff whitespace checks passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Reopened to rebase PR #2487 on latest `dev` and address the new CodeRabbit review comments on commit `824bc1d5a748295cf311fbdf99b25b4d65df4cf5`.
+Follow-up PR #2487 pass after rebasing on latest `origin/dev`:
+- Addressed CodeRabbit comments by redacting values for sensitive structured extra keys, omitting raw exception text from internal diagnostics, adding `event` to system-log dedupe keys, asserting exact UTC JSON formatter output, covering structured-secret redaction through the Loguru sink helper, and covering mixed-case traceparent normalization.
+- Verification: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Logging tldw_Server_API/tests/Infrastructure/test_json_log_formatter.py -q` passed with 47 tests.
+- Verification: `source .venv/bin/activate && python -m ruff check tldw_Server_API/app/core/Logging/log_context.py tldw_Server_API/app/core/Logging/system_log_buffer.py tldw_Server_API/tests/Logging/test_system_log_buffer.py tldw_Server_API/tests/Logging/test_trace_context.py tldw_Server_API/tests/Infrastructure/test_json_log_formatter.py` passed.
+- Verification: `source .venv/bin/activate && python -m compileall -q tldw_Server_API/app/core/Logging tldw_Server_API/tests/Logging tldw_Server_API/tests/Infrastructure/test_json_log_formatter.py` passed.
+- Verification: `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Logging -f json -o /tmp/bandit_logging_task_12005_rebase_comments.json` passed with 0 results and 0 errors.
+- Verification: `git diff --check` passed.
+Follow-up review pass completed locally after rebase; staged into the amended PR commit before pushing.
+Final review-thread cleanup: added short docstrings to touched private system-log helper functions and a return type for `_log_file_lock()` to satisfy the remaining Qodo helper-docstring/type thread before resolving stale bot conversations.
+- Verification after docstring cleanup: `source .venv/bin/activate && python -m ruff check tldw_Server_API/app/core/Logging/log_context.py tldw_Server_API/app/core/Logging/system_log_buffer.py tldw_Server_API/tests/Logging/test_system_log_buffer.py tldw_Server_API/tests/Logging/test_trace_context.py tldw_Server_API/tests/Infrastructure/test_json_log_formatter.py` passed.
+- Verification after docstring cleanup: `source .venv/bin/activate && python -m compileall -q tldw_Server_API/app/core/Logging tldw_Server_API/tests/Logging tldw_Server_API/tests/Infrastructure/test_json_log_formatter.py` passed.
+- Verification after docstring cleanup: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Logging tldw_Server_API/tests/Infrastructure/test_json_log_formatter.py -q` passed with 47 tests.
+- Verification after docstring cleanup: `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Logging -f json -o /tmp/bandit_logging_task_12005_rebase_comments_docstrings.json` passed with 0 results and 0 errors.
+- Verification after docstring cleanup: `git diff --check` passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/core/Logging/json_log_formatter.py
+++ b/tldw_Server_API/app/core/Logging/json_log_formatter.py
@@ -7,9 +7,8 @@ JSONL-capable log aggregation pipeline.
 from __future__ import annotations
 
 import json
+from datetime import timezone
 from typing import Any
-
-from loguru import logger
 
 
 def json_log_format(record: dict[str, Any]) -> str:
@@ -25,8 +24,13 @@ def json_log_format(record: dict[str, Any]) -> str:
     str
         A single JSON line (newline-terminated).
     """
+    timestamp = record["time"]
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    else:
+        timestamp = timestamp.astimezone(timezone.utc)
     log_entry: dict[str, Any] = {
-        "timestamp": record["time"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+        "timestamp": timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
         "level": record["level"].name,
         "message": record["message"],
         "module": record["module"],
@@ -41,31 +45,3 @@ def json_log_format(record: dict[str, Any]) -> str:
     if extra:
         log_entry["extra"] = {k: str(v) for k, v in extra.items()}
     return json.dumps(log_entry, default=str) + "\n"
-
-
-def configure_json_logging(log_file: str = "logs/tldw.jsonl") -> int:
-    """Add a JSON log sink alongside existing loguru configuration.
-
-    Call at startup to enable structured logging to a file that
-    can be tailed by Promtail, Filebeat, or similar.
-
-    Parameters
-    ----------
-    log_file:
-        Path to the JSONL output file.  Rotated at 100 MB, kept for 7 days.
-
-    Returns
-    -------
-    int
-        The sink id returned by ``logger.add()``, useful for removal.
-    """
-    sink_id = logger.add(
-        log_file,
-        format=json_log_format,
-        rotation="100 MB",
-        retention="7 days",
-        compression="gz",
-        serialize=False,
-    )
-    logger.info("JSON structured logging enabled: {}", log_file)
-    return sink_id

--- a/tldw_Server_API/app/core/Logging/log_context.py
+++ b/tldw_Server_API/app/core/Logging/log_context.py
@@ -16,6 +16,7 @@ the fields) and returns a bound logger for convenience.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
@@ -36,6 +37,13 @@ _LOG_CONTEXT_NONCRITICAL_EXCEPTIONS = (
     RuntimeError,
     TypeError,
     ValueError,
+)
+
+_TRACEPARENT_RE = re.compile(
+    r"^00-"
+    r"(?P<trace_id>[0-9a-fA-F]{32})-"
+    r"(?P<span_id>[0-9a-fA-F]{16})-"
+    r"(?P<trace_flags>[0-9a-fA-F]{2})$"
 )
 
 
@@ -95,6 +103,7 @@ def ensure_traceparent(request: Any) -> str:
             or headers.get("TRACEPARENT")
             or ""
         )
+        tp = _clean_traceparent(tp)
         if tp:
             try:
                 request.state.traceparent = tp  # type: ignore[attr-defined]
@@ -103,6 +112,21 @@ def ensure_traceparent(request: Any) -> str:
         return tp
     except _LOG_CONTEXT_NONCRITICAL_EXCEPTIONS:
         return ""
+
+
+def _clean_traceparent(value: Any) -> str:
+    """Validate and normalize an inbound W3C traceparent header value."""
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    match = _TRACEPARENT_RE.fullmatch(raw)
+    if not match:
+        return ""
+    trace_id = match.group("trace_id")
+    span_id = match.group("span_id")
+    if int(trace_id, 16) == 0 or int(span_id, 16) == 0:
+        return ""
+    return raw.lower()
 
 
 def get_ps_logger(

--- a/tldw_Server_API/app/core/Logging/system_log_buffer.py
+++ b/tldw_Server_API/app/core/Logging/system_log_buffer.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import time
 from collections import deque
+from collections.abc import Iterator
 from contextlib import contextmanager, suppress
 from datetime import datetime, timezone
 from pathlib import Path
-from threading import Lock, local
+from queue import Full, Queue
+from threading import Lock, Thread, local
 from typing import Any
 
 from loguru import logger
@@ -17,13 +20,43 @@ from tldw_Server_API.app.core.testing import is_truthy
 from tldw_Server_API.app.core.Utils.Utils import get_database_dir
 
 _DEFAULT_BUFFER_SIZE = 2000
-_BUFFER_SIZE = max(100, int(os.getenv("SYSTEM_LOG_BUFFER_SIZE", str(_DEFAULT_BUFFER_SIZE))))
+
+
+def _coerce_bounded_int(
+    value: Any,
+    *,
+    default: int,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    """Parse an integer setting and clamp it to configured bounds."""
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError):
+        parsed = default
+    if minimum is not None:
+        parsed = max(minimum, parsed)
+    if maximum is not None:
+        parsed = min(maximum, parsed)
+    return parsed
+
+
+_BUFFER_SIZE = _coerce_bounded_int(
+    os.getenv("SYSTEM_LOG_BUFFER_SIZE"),
+    default=_DEFAULT_BUFFER_SIZE,
+    minimum=100,
+)
 _BUFFER: deque[dict[str, Any]] = deque(maxlen=_BUFFER_SIZE)
 _BUFFER_LOCK = Lock()
-_SINK_ID: int | None = None
+_SINK_LOCK = Lock()
+_SINK_ATTR = "_tldw_system_log_buffer_sink_id"
+_SINK_ID: int | None = getattr(logger, _SINK_ATTR, None)
+_LOG_FILE_QUEUE_ATTR = "_tldw_system_log_buffer_file_queue"
+_LOG_FILE_WORKER_ATTR = "_tldw_system_log_buffer_file_worker"
 
 _DEFAULT_LOG_FILE_ENTRIES = 5000
 _DEFAULT_LOG_FILE_COMPACT_EVERY_WRITES = 250
+_DEFAULT_LOG_FILE_QUEUE_SIZE = 1000
 _LOG_FILE_SETTINGS_LOCK = Lock()
 _LOG_FILE_SETTINGS_THREAD_STATE = local()
 _LOG_FILE_SETTINGS_INITIALIZED = False
@@ -33,7 +66,45 @@ _LOG_FILE_APPENDS_SINCE_COMPACT = 0
 _LOG_FILE_ENABLED = True
 _LOG_FILE_PATH = Path(get_database_dir()) / "system_logs.jsonl"
 _LOG_FILE_LOCK_TIMEOUT = 5.0
+_LOG_FILE_LOCK_POLL_INTERVAL = 0.05
+_LOG_FILE_STALE_LOCK_MIN_SECONDS = 1.0
 _LOG_FILE_COMPACTION_COUNTER_LOCK = Lock()
+_LOG_FILE_QUEUE_SIZE = _coerce_bounded_int(
+    os.getenv("SYSTEM_LOG_FILE_QUEUE_SIZE"),
+    default=_DEFAULT_LOG_FILE_QUEUE_SIZE,
+    minimum=100,
+)
+_existing_log_file_queue = getattr(logger, _LOG_FILE_QUEUE_ATTR, None)
+_LOG_FILE_QUEUE: Queue[dict[str, Any]] = (
+    _existing_log_file_queue
+    if isinstance(_existing_log_file_queue, Queue)
+    else Queue(maxsize=_LOG_FILE_QUEUE_SIZE)
+)
+with suppress(Exception):
+    setattr(logger, _LOG_FILE_QUEUE_ATTR, _LOG_FILE_QUEUE)
+_LOG_FILE_WORKER: Thread | None = getattr(logger, _LOG_FILE_WORKER_ATTR, None)
+_LOG_FILE_WORKER_LOCK = Lock()
+
+_LOGURU_LEVELS = {"TRACE", "DEBUG", "INFO", "SUCCESS", "WARNING", "ERROR", "CRITICAL"}
+_OPENAI_KEY_RE = re.compile(r"sk-[A-Za-z0-9-_]{8,}")
+_AUTH_HEADER_RE = re.compile(r"(?i)\bauthorization\s*[:=]\s*(?:bearer\s+)?[^\s,;]+")
+_BEARER_TOKEN_RE = re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/\-]+=*")
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(api[_-]?key|token|password|secret)\s*[:=]\s*[^\s,;]+"
+)
+_REDACTED_VALUE = "***REDACTED***"
+_SENSITIVE_LOG_KEY_FRAGMENTS = (
+    "password",
+    "secret",
+    "apikey",
+    "authorization",
+    "accesstoken",
+    "refreshtoken",
+    "authtoken",
+    "bearertoken",
+    "apitoken",
+    "idtoken",
+)
 
 try:
     import fcntl  # type: ignore
@@ -54,6 +125,7 @@ _EXTRA_FIELDS = {
 
 
 def _coerce_optional_int(value: Any) -> int | None:
+    """Return an integer value when coercion succeeds, otherwise None."""
     if value is None:
         return None
     try:
@@ -63,17 +135,58 @@ def _coerce_optional_int(value: Any) -> int | None:
 
 
 def _coerce_bool(value: str | None, default: bool) -> bool:
+    """Parse a truthy configuration value with a caller-provided default."""
     if value is None:
         return default
     return is_truthy(value)
 
 
+def _normalize_log_level(value: str | None, default: str = "DEBUG") -> str:
+    """Return a Loguru level name, falling back when the value is invalid."""
+    raw = str(value or default).strip().upper()
+    return raw if raw in _LOGURU_LEVELS else default
+
+
+def _redact_log_text(value: str) -> str:
+    """Redact common secret patterns before admin log exposure."""
+    text = _OPENAI_KEY_RE.sub(f"sk-{_REDACTED_VALUE}", value)
+    text = _AUTH_HEADER_RE.sub(f"authorization={_REDACTED_VALUE}", text)
+    text = _BEARER_TOKEN_RE.sub(f"Bearer {_REDACTED_VALUE}", text)
+    text = _SECRET_ASSIGNMENT_RE.sub(lambda match: f"{match.group(1)}={_REDACTED_VALUE}", text)
+    return text
+
+
+def _is_sensitive_log_key(key: Any) -> bool:
+    """Return True when a structured log field name usually carries a secret."""
+    normalized = re.sub(r"[^a-z0-9]", "", str(key).lower())
+    return normalized == "token" or any(
+        fragment in normalized for fragment in _SENSITIVE_LOG_KEY_FRAGMENTS
+    )
+
+
+def _redact_log_value(value: Any) -> Any:
+    """Redact string values while leaving structured non-strings unchanged."""
+    if isinstance(value, str):
+        return _redact_log_text(value)
+    return value
+
+
+def _redact_log_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of a captured log entry with sensitive text redacted."""
+    redacted: dict[str, Any] = {}
+    for key, value in entry.items():
+        redacted[key] = (
+            _REDACTED_VALUE if _is_sensitive_log_key(key) else _redact_log_value(value)
+        )
+    return redacted
+
+
 def _extract_extra(extra: dict[str, Any]) -> dict[str, Any]:
+    """Extract supported structured fields and sensitive extras from Loguru."""
     payload: dict[str, Any] = {}
-    for key in _EXTRA_FIELDS:
-        if key not in extra:
+    for key, val in extra.items():
+        if key not in _EXTRA_FIELDS and not _is_sensitive_log_key(key):
             continue
-        val = extra.get(key)
         if key in {"org_id", "user_id"}:
             payload[key] = _coerce_optional_int(val)
         else:
@@ -82,10 +195,12 @@ def _extract_extra(extra: dict[str, Any]) -> dict[str, Any]:
 
 
 def _log_file_settings_init_active() -> bool:
+    """Return True while this thread is initializing log-file settings."""
     return bool(getattr(_LOG_FILE_SETTINGS_THREAD_STATE, "initializing", False))
 
 
 def _init_log_file_settings() -> None:
+    """Load file-backed system-log settings from env/config once per module."""
     global _LOG_FILE_MAX_ENTRIES
     global _LOG_FILE_COMPACT_EVERY_WRITES
     global _LOG_FILE_APPENDS_SINCE_COMPACT
@@ -165,14 +280,16 @@ def _init_log_file_settings() -> None:
 
 
 @contextmanager
-def _log_file_lock(timeout: float | None = None):
+def _log_file_lock(timeout: float | None = None) -> Iterator[None]:
+    """Acquire the shared system-log file lock within the configured timeout."""
     _init_log_file_settings()
     timeout_seconds = _LOG_FILE_LOCK_TIMEOUT if timeout is None else max(0.0, float(timeout))
     lock_path = _LOG_FILE_PATH.with_suffix(_LOG_FILE_PATH.suffix + ".lock")
     lock_fd = None
     try:
         lock_path.parent.mkdir(parents=True, exist_ok=True)
-        start_time = time.time()
+        start_time = time.monotonic()
+        stale_after = max(timeout_seconds * 2, _LOG_FILE_STALE_LOCK_MIN_SECONDS)
         if _HAS_FCNTL:
             lock_fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
             while True:
@@ -180,9 +297,12 @@ def _log_file_lock(timeout: float | None = None):
                     fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
                     break
                 except OSError:
-                    if time.time() - start_time > timeout_seconds:
-                        raise RuntimeError(f"Failed to acquire system log lock within {timeout_seconds}s")
-                    time.sleep(0.05)
+                    remaining = timeout_seconds - (time.monotonic() - start_time)
+                    if remaining <= 0:
+                        raise RuntimeError(
+                            f"Failed to acquire system log lock within {timeout_seconds}s"
+                        ) from None
+                    time.sleep(min(_LOG_FILE_LOCK_POLL_INTERVAL, remaining))
         else:
             while True:
                 try:
@@ -191,14 +311,17 @@ def _log_file_lock(timeout: float | None = None):
                 except FileExistsError:
                     try:
                         lock_stat = os.stat(lock_path)
-                        if time.time() - lock_stat.st_mtime > timeout_seconds * 2:
+                        if time.time() - lock_stat.st_mtime > stale_after:
                             os.unlink(lock_path)
                             continue
                     except (OSError, FileNotFoundError):
                         pass
-                    if time.time() - start_time > timeout_seconds:
-                        raise RuntimeError(f"Failed to acquire system log lock within {timeout_seconds}s")
-                    time.sleep(0.05)
+                    remaining = timeout_seconds - (time.monotonic() - start_time)
+                    if remaining <= 0:
+                        raise RuntimeError(
+                            f"Failed to acquire system log lock within {timeout_seconds}s"
+                        ) from None
+                    time.sleep(min(_LOG_FILE_LOCK_POLL_INTERVAL, remaining))
         yield
     finally:
         if lock_fd is not None:
@@ -213,6 +336,7 @@ def _log_file_lock(timeout: float | None = None):
 
 
 def _coerce_timestamp(value: Any) -> datetime | None:
+    """Convert supported timestamp payloads into datetime objects."""
     if isinstance(value, datetime):
         return value
     if isinstance(value, str):
@@ -225,6 +349,7 @@ def _coerce_timestamp(value: Any) -> datetime | None:
 
 
 def _normalize_timestamp(value: Any) -> datetime | None:
+    """Normalize a supported timestamp payload to timezone-aware UTC."""
     timestamp = _coerce_timestamp(value)
     if timestamp is None:
         return None
@@ -234,13 +359,20 @@ def _normalize_timestamp(value: Any) -> datetime | None:
 
 
 def _emit_internal_diagnostic(message: str) -> None:
+    """Write sink-internal diagnostics without re-entering Loguru."""
     # Must not use Loguru here: this function is called from inside a Loguru sink.
     with suppress(Exception):
         stream = sys.__stderr__ or sys.stderr
         stream.write(message.rstrip() + "\n")
 
 
+def _exception_type_name(exc: BaseException) -> str:
+    """Return a stable exception descriptor that omits raw exception text."""
+    return type(exc).__name__
+
+
 def _sort_timestamp_value(entry: dict[str, Any]) -> float:
+    """Return a sortable UTC epoch value for a log entry timestamp."""
     timestamp = _normalize_timestamp(entry.get("timestamp"))
     if timestamp is None:
         return float("-inf")
@@ -248,6 +380,7 @@ def _sort_timestamp_value(entry: dict[str, Any]) -> float:
 
 
 def _should_compact_after_append() -> bool:
+    """Return True when this append should trigger file compaction."""
     if _LOG_FILE_MAX_ENTRIES <= 0:
         return False
     if _LOG_FILE_COMPACT_EVERY_WRITES <= 1:
@@ -262,6 +395,7 @@ def _should_compact_after_append() -> bool:
 
 
 def _compact_log_file_locked() -> None:
+    """Trim the log file to the newest configured entries while locked."""
     if _LOG_FILE_MAX_ENTRIES <= 0:
         return
     try:
@@ -277,6 +411,7 @@ def _compact_log_file_locked() -> None:
 
 
 def _append_log_file(entry: dict[str, Any]) -> None:
+    """Append one already-redacted entry to the shared JSONL log file."""
     if _log_file_settings_init_active():
         return
     _init_log_file_settings()
@@ -294,10 +429,66 @@ def _append_log_file(entry: dict[str, Any]) -> None:
             if _should_compact_after_append():
                 _compact_log_file_locked()
     except Exception as exc:
-        _emit_internal_diagnostic(f"system_log_buffer append failed: {exc}")
+        _emit_internal_diagnostic(
+            f"system_log_buffer append failed: {_exception_type_name(exc)}"
+        )
+
+
+def _log_file_worker_loop(queue: Queue[dict[str, Any]]) -> None:
+    """Drain queued file-backed log entries on a daemon writer thread."""
+    while True:
+        entry = queue.get()
+        try:
+            _append_log_file(entry)
+        except Exception as exc:
+            _emit_internal_diagnostic(
+                f"system_log_buffer worker append failed: {_exception_type_name(exc)}"
+            )
+        finally:
+            queue.task_done()
+
+
+def _ensure_log_file_worker() -> None:
+    """Start or reuse the shared daemon worker for file-backed log writes."""
+    global _LOG_FILE_WORKER
+    worker = _LOG_FILE_WORKER
+    if worker is not None and worker.is_alive():
+        return
+    with _LOG_FILE_WORKER_LOCK:
+        worker = _LOG_FILE_WORKER
+        if worker is not None and worker.is_alive():
+            return
+        _LOG_FILE_WORKER = Thread(
+            target=_log_file_worker_loop,
+            args=(_LOG_FILE_QUEUE,),
+            name="tldw-system-log-writer",
+            daemon=True,
+        )
+        _LOG_FILE_WORKER.start()
+        with suppress(Exception):
+            setattr(logger, _LOG_FILE_WORKER_ATTR, _LOG_FILE_WORKER)
+
+
+def _enqueue_log_file(entry: dict[str, Any]) -> None:
+    """Queue a log entry for file persistence without raising into Loguru."""
+    try:
+        if _log_file_settings_init_active():
+            return
+        _init_log_file_settings()
+        if not _LOG_FILE_ENABLED:
+            return
+        _ensure_log_file_worker()
+        _LOG_FILE_QUEUE.put_nowait(dict(entry))
+    except Full:
+        _emit_internal_diagnostic("system_log_buffer queue full; dropping file-backed log entry")
+    except Exception as exc:
+        _emit_internal_diagnostic(
+            f"system_log_buffer enqueue failed: {_exception_type_name(exc)}"
+        )
 
 
 def _read_log_file_entries() -> list[dict[str, Any]]:
+    """Read file-backed log entries, skipping malformed lines safely."""
     _init_log_file_settings()
     if not _LOG_FILE_ENABLED:
         return []
@@ -326,10 +517,33 @@ def _read_log_file_entries() -> list[dict[str, Any]]:
     return entries
 
 
+def _entry_dedupe_key(entry: dict[str, Any]) -> tuple[Any, ...]:
+    """Build a stable key for merging file and in-memory log entries."""
+    timestamp = _normalize_timestamp(entry.get("timestamp"))
+    timestamp_key = timestamp.isoformat() if timestamp else str(entry.get("timestamp") or "")
+    return (
+        timestamp_key,
+        entry.get("level"),
+        entry.get("message"),
+        entry.get("logger"),
+        entry.get("module"),
+        entry.get("function"),
+        entry.get("line"),
+        entry.get("request_id"),
+        entry.get("org_id"),
+        entry.get("user_id"),
+        entry.get("trace_id"),
+        entry.get("span_id"),
+        entry.get("correlation_id"),
+        entry.get("event"),
+    )
+
+
 def _log_sink(message: Any) -> None:
+    """Capture a Loguru record into the memory buffer and async file queue."""
     record = message.record
     extra = _extract_extra(record.get("extra", {}))
-    entry = {
+    entry = _redact_log_entry({
         "timestamp": record.get("time"),
         "level": record.get("level").name if record.get("level") else None,
         "message": record.get("message"),
@@ -338,10 +552,15 @@ def _log_sink(message: Any) -> None:
         "function": record.get("function"),
         "line": record.get("line"),
         **extra,
-    }
+    })
     with _BUFFER_LOCK:
         _BUFFER.append(entry)
-    _append_log_file(entry)
+    try:
+        _enqueue_log_file(entry)
+    except Exception as exc:
+        _emit_internal_diagnostic(
+            f"system_log_buffer sink enqueue failed: {_exception_type_name(exc)}"
+        )
 
 
 def _sink_still_present(sink_id: int) -> bool:
@@ -370,15 +589,18 @@ def ensure_system_log_buffer() -> None:
     """Attach a Loguru sink to capture recent logs into an in-memory ring buffer."""
     global _SINK_ID
     _init_log_file_settings()
-    if _SINK_ID is not None and _sink_still_present(_SINK_ID):
-        return
-    _SINK_ID = logger.add(
-        _log_sink,
-        level=os.getenv("SYSTEM_LOG_LEVEL", "DEBUG"),
-        backtrace=False,
-        diagnose=False,
-        enqueue=False,
-    )
+    with _SINK_LOCK:
+        if _SINK_ID is not None and _sink_still_present(_SINK_ID):
+            return
+        _SINK_ID = logger.add(
+            _log_sink,
+            level=_normalize_log_level(os.getenv("SYSTEM_LOG_LEVEL"), "DEBUG"),
+            backtrace=False,
+            diagnose=False,
+            enqueue=False,
+        )
+        with suppress(Exception):
+            setattr(logger, _SINK_ATTR, _SINK_ID)
 
 
 def query_system_logs(
@@ -402,9 +624,15 @@ def query_system_logs(
     query_norm = query.strip().lower() if query else None
 
     entries = _read_log_file_entries()
-    if not entries:
-        with _BUFFER_LOCK:
-            entries = list(_BUFFER)
+    with _BUFFER_LOCK:
+        buffer_entries = list(_BUFFER)
+    if buffer_entries:
+        seen = {_entry_dedupe_key(entry) for entry in entries}
+        for entry in buffer_entries:
+            key = _entry_dedupe_key(entry)
+            if key not in seen:
+                entries.append(entry)
+                seen.add(key)
 
     filtered: list[dict[str, Any]] = []
     org_id_set = {org_id} if org_id is not None else set(org_ids or [])

--- a/tldw_Server_API/tests/Infrastructure/test_json_log_formatter.py
+++ b/tldw_Server_API/tests/Infrastructure/test_json_log_formatter.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -25,6 +25,7 @@ def _make_record(**overrides) -> dict:
     return base
 
 
+@pytest.mark.unit
 class TestJsonLogFormat:
     def test_basic_format(self) -> None:
         record = _make_record()
@@ -62,3 +63,12 @@ class TestJsonLogFormat:
         # Should be ISO-8601-ish with microseconds and Z suffix
         assert ts.endswith("Z")
         assert "T" in ts
+
+    def test_timestamp_is_converted_to_utc_before_z_suffix(self) -> None:
+        record = _make_record(
+            time=datetime(2026, 3, 14, 12, 0, 0, tzinfo=timezone(timedelta(hours=-7)))
+        )
+
+        parsed = json.loads(json_log_format(record))
+
+        assert parsed["timestamp"] == "2026-03-14T19:00:00.000000Z"

--- a/tldw_Server_API/tests/Logging/test_system_log_buffer.py
+++ b/tldw_Server_API/tests/Logging/test_system_log_buffer.py
@@ -2,30 +2,67 @@ from __future__ import annotations
 
 import configparser
 import importlib
+import threading
 import time
-from contextlib import contextmanager
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
 
-def _reload_log_buffer():
+def _reload_log_buffer() -> ModuleType:
+    from loguru import logger
+
+    sink_attr = "_tldw_system_log_buffer_sink_id"
+    sink_id = getattr(logger, sink_attr, None)
+    if sink_id is not None:
+        with suppress(Exception):
+            logger.remove(sink_id)
+        with suppress(Exception):
+            delattr(logger, sink_attr)
+
     import tldw_Server_API.app.core.Logging.system_log_buffer as log_buffer
 
     return importlib.reload(log_buffer)
+
+
+def _message_for_log_sink(
+    message: str,
+    *,
+    extra: dict[str, object] | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        record={
+            "time": datetime.now(timezone.utc),
+            "level": SimpleNamespace(name="INFO"),
+            "message": message,
+            "name": "test.logger",
+            "module": "test_module",
+            "function": "test_function",
+            "line": 10,
+            "extra": dict(extra or {}),
+        }
+    )
 
 
 class _CapturingLogger:
     def __init__(self) -> None:
         self.messages: list[str] = []
 
-    def debug(self, message: str, *args, **_kwargs) -> None:
+    def debug(self, message: str, *args: object, **_kwargs: object) -> None:
         if args:
             message = message.format(*args)
         self.messages.append(message)
 
 
-def test_system_log_file_query_reads_shared_file(tmp_path, monkeypatch):
+@pytest.mark.unit
+def test_system_log_file_query_reads_shared_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     log_path = tmp_path / "system_logs.jsonl"
     monkeypatch.setenv("SYSTEM_LOG_FILE_ENABLED", "true")
     monkeypatch.setenv("SYSTEM_LOG_FILE_PATH", str(log_path))
@@ -51,7 +88,93 @@ def test_system_log_file_query_reads_shared_file(tmp_path, monkeypatch):
     assert log_path.exists()
 
 
-def test_append_log_file_skips_recursive_append_during_settings_init(tmp_path, monkeypatch):
+@pytest.mark.unit
+def test_log_sink_redacts_secrets_before_buffer_and_file_append(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log_buffer = _reload_log_buffer()
+    captured: list[dict[str, object]] = []
+    monkeypatch.setattr(log_buffer, "_enqueue_log_file", lambda entry: captured.append(dict(entry)))
+
+    secret_message = (
+        "provider failed api_key=sk-secretvalue123 password:open-sesame "
+        "Authorization: Bearer secret-token-123"
+    )
+    secret_extra = {
+        "api_key": "sk-extra-secretvalue123",
+        "db_password": "extra-open-sesame",
+        "access_token": "extra-token-secret",
+        "request_id": "req-secret-test",
+    }
+
+    with log_buffer._BUFFER_LOCK:
+        log_buffer._BUFFER.clear()
+    log_buffer._log_sink(_message_for_log_sink(secret_message, extra=secret_extra))
+
+    with log_buffer._BUFFER_LOCK:
+        buffered = list(log_buffer._BUFFER)
+    serialized = "\n".join(str(entry) for entry in buffered + captured)
+    assert "sk-secretvalue123" not in serialized
+    assert "open-sesame" not in serialized
+    assert "secret-token-123" not in serialized
+    assert "sk-extra-secretvalue123" not in serialized
+    assert "extra-open-sesame" not in serialized
+    assert "extra-token-secret" not in serialized
+    assert "***REDACTED***" in serialized
+    assert buffered[0]["api_key"] == "***REDACTED***"
+    assert buffered[0]["db_password"] == "***REDACTED***"
+    assert buffered[0]["access_token"] == "***REDACTED***"
+    assert buffered[0]["request_id"] == "req-secret-test"
+
+
+@pytest.mark.unit
+def test_log_sink_returns_before_log_file_append_completes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SYSTEM_LOG_FILE_ENABLED", "true")
+    log_buffer = _reload_log_buffer()
+
+    def _slow_append(_entry: dict[str, object]) -> None:
+        time.sleep(0.2)
+
+    monkeypatch.setattr(log_buffer, "_append_log_file", _slow_append)
+
+    started = time.perf_counter()
+    log_buffer._log_sink(_message_for_log_sink("non-blocking sink check"))
+    elapsed = time.perf_counter() - started
+
+    assert elapsed < 0.05
+
+
+@pytest.mark.unit
+def test_log_sink_swallows_enqueue_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    log_buffer = _reload_log_buffer()
+    diagnostics: list[str] = []
+
+    def _raise_enqueue(_entry: dict[str, object]) -> None:
+        raise RuntimeError("worker start failed")
+
+    monkeypatch.setattr(log_buffer, "_enqueue_log_file", _raise_enqueue)
+    monkeypatch.setattr(
+        log_buffer,
+        "_emit_internal_diagnostic",
+        lambda message: diagnostics.append(message),
+    )
+
+    log_buffer._log_sink(_message_for_log_sink("sink failure remains internal"))
+
+    assert any(
+        "system_log_buffer sink enqueue failed: RuntimeError" in message
+        for message in diagnostics
+    )
+    assert all("worker start failed" not in message for message in diagnostics)
+
+
+@pytest.mark.unit
+def test_append_log_file_skips_recursive_append_during_settings_init(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     log_path = tmp_path / "system_logs.jsonl"
     monkeypatch.setenv("SYSTEM_LOG_FILE_ENABLED", "true")
     monkeypatch.setenv("SYSTEM_LOG_FILE_PATH", str(log_path))
@@ -64,7 +187,7 @@ def test_append_log_file_skips_recursive_append_during_settings_init(tmp_path, m
 
     nested_calls: list[int] = []
 
-    def _fake_load_comprehensive_config():
+    def _fake_load_comprehensive_config() -> configparser.ConfigParser:
         nested_calls.append(1)
         log_buffer._append_log_file(
             {
@@ -93,13 +216,106 @@ def test_append_log_file_skips_recursive_append_during_settings_init(tmp_path, m
     assert any('"message": "outer"' in line for line in lines)
 
 
-def test_append_log_file_compacts_periodically(tmp_path, monkeypatch):
+@pytest.mark.unit
+def test_malformed_system_log_buffer_size_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SYSTEM_LOG_BUFFER_SIZE", "not-an-int")
+
+    log_buffer = _reload_log_buffer()
+
+    assert log_buffer._BUFFER.maxlen == log_buffer._DEFAULT_BUFFER_SIZE
+
+
+@pytest.mark.unit
+def test_invalid_system_log_level_falls_back_to_debug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SYSTEM_LOG_LEVEL", "definitely-not-a-level")
+    monkeypatch.setenv("SYSTEM_LOG_FILE_ENABLED", "false")
+    log_buffer = _reload_log_buffer()
+    added: list[str] = []
+
+    class _Logger:
+        def add(self, _sink: object, *, level: str, **_kwargs: object) -> int:
+            added.append(level)
+            return 99
+
+    monkeypatch.setattr(log_buffer, "logger", _Logger())
+    monkeypatch.setattr(log_buffer, "_init_log_file_settings", lambda: None)
+
+    log_buffer.ensure_system_log_buffer()
+
+    assert added == ["DEBUG"]
+
+
+@pytest.mark.unit
+def test_ensure_system_log_buffer_installs_one_sink_under_concurrency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SYSTEM_LOG_FILE_ENABLED", "false")
+    log_buffer = _reload_log_buffer()
+    add_calls: list[int] = []
+    start = threading.Barrier(8)
+
+    class _Logger:
+        def add(self, *_args: object, **_kwargs: object) -> int:
+            time.sleep(0.05)
+            add_calls.append(1)
+            return len(add_calls)
+
+    monkeypatch.setattr(log_buffer, "logger", _Logger())
+    monkeypatch.setattr(log_buffer, "_init_log_file_settings", lambda: None)
+    monkeypatch.setattr(log_buffer, "_sink_still_present", lambda _sink_id: True)
+    monkeypatch.setattr(log_buffer, "_SINK_ID", None)
+
+    def _install() -> None:
+        start.wait(timeout=1)
+        log_buffer.ensure_system_log_buffer()
+
+    threads = [threading.Thread(target=_install) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=1)
+
+    assert len(add_calls) == 1
+
+
+@pytest.mark.unit
+def test_reload_reuses_log_file_queue_and_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from loguru import logger
+
+    log_buffer = _reload_log_buffer()
+    queue = log_buffer._LOG_FILE_QUEUE
+
+    class _Worker:
+        def is_alive(self) -> bool:
+            return True
+
+    worker = _Worker()
+    monkeypatch.setattr(logger, log_buffer._LOG_FILE_QUEUE_ATTR, queue, raising=False)
+    monkeypatch.setattr(logger, log_buffer._LOG_FILE_WORKER_ATTR, worker, raising=False)
+
+    reloaded = importlib.reload(log_buffer)
+
+    assert reloaded._LOG_FILE_QUEUE is queue
+    assert reloaded._LOG_FILE_WORKER is worker
+
+
+@pytest.mark.unit
+def test_append_log_file_compacts_periodically(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     log_path = tmp_path / "system_logs.jsonl"
     monkeypatch.setenv("SYSTEM_LOG_FILE_ENABLED", "true")
     monkeypatch.setenv("SYSTEM_LOG_FILE_PATH", str(log_path))
     # Runtime minimum is 100 entries, so use that floor for deterministic assertions.
     monkeypatch.setenv("SYSTEM_LOG_FILE_MAX_ENTRIES", "100")
-    monkeypatch.setenv("SYSTEM_LOG_FILE_COMPACT_EVERY_WRITES", "3")
+    monkeypatch.setenv("SYSTEM_LOG_FILE_COMPACT_EVERY_WRITES", "1")
 
     log_buffer = _reload_log_buffer()
     base_time = datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc)
@@ -113,26 +329,17 @@ def test_append_log_file_compacts_periodically(tmp_path, monkeypatch):
             }
         )
 
-    lines_after_overflow = log_path.read_text(encoding="utf-8").splitlines()
-    assert len(lines_after_overflow) == 101
-
-    log_buffer._append_log_file(
-        {
-            "timestamp": base_time + timedelta(minutes=101),
-            "level": "INFO",
-            "message": "m101",
-        }
-    )
-
     lines_after_compact = log_path.read_text(encoding="utf-8").splitlines()
     assert len(lines_after_compact) == 100
     assert all('"message": "m0"' not in line for line in lines_after_compact)
-    assert all('"message": "m1"' not in line for line in lines_after_compact)
-    assert any('"message": "m2"' in line for line in lines_after_compact)
-    assert any('"message": "m101"' in line for line in lines_after_compact)
+    assert any('"message": "m100"' in line for line in lines_after_compact)
 
 
-def test_append_log_file_failure_avoids_sink_reentry(monkeypatch, tmp_path):
+@pytest.mark.unit
+def test_append_log_file_failure_avoids_sink_reentry(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     monkeypatch.setenv("SYSTEM_LOG_FILE_ENABLED", "true")
     monkeypatch.setenv("SYSTEM_LOG_FILE_PATH", str(tmp_path / "system_logs.jsonl"))
     monkeypatch.setenv("SYSTEM_LOG_FILE_MAX_ENTRIES", "100")
@@ -143,7 +350,7 @@ def test_append_log_file_failure_avoids_sink_reentry(monkeypatch, tmp_path):
     monkeypatch.setattr(log_buffer, "_emit_internal_diagnostic", lambda message: called.append(message))
 
     @contextmanager
-    def _failing_lock(_timeout=None):
+    def _failing_lock(_timeout: object = None) -> Iterator[None]:
         raise PermissionError("write denied")
         yield
 
@@ -158,15 +365,19 @@ def test_append_log_file_failure_avoids_sink_reentry(monkeypatch, tmp_path):
     )
 
     assert called
-    assert "write denied" in called[0]
+    assert "system_log_buffer append failed: PermissionError" in called[0]
+    assert "write denied" not in called[0]
 
 
-def test_system_log_settings_config_read_failure_log_is_sanitized(monkeypatch):
+@pytest.mark.unit
+def test_system_log_settings_config_read_failure_log_is_sanitized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     log_buffer = _reload_log_buffer()
 
     import tldw_Server_API.app.core.config as config_mod
 
-    def _raise_config_error():
+    def _raise_config_error() -> None:
         raise RuntimeError("config read failed at /private/system-log-config.ini")
 
     monkeypatch.delenv("SYSTEM_LOG_FILE_PATH", raising=False)
@@ -184,18 +395,19 @@ def test_system_log_settings_config_read_failure_log_is_sanitized(monkeypatch):
     assert "/private/system-log-config.ini" not in joined
 
 
-def test_read_log_file_failure_log_is_sanitized(monkeypatch):
+@pytest.mark.unit
+def test_read_log_file_failure_log_is_sanitized(monkeypatch: pytest.MonkeyPatch) -> None:
     log_buffer = _reload_log_buffer()
 
     class FailingLogPath:
-        def exists(self):
+        def exists(self) -> bool:
             return True
 
-        def read_text(self, encoding):
+        def read_text(self, encoding: str) -> str:
             raise OSError("system log read failed at /private/system_logs.jsonl")
 
     @contextmanager
-    def _noop_lock(_timeout=None):
+    def _noop_lock(_timeout: object = None) -> Iterator[None]:
         yield
 
     capture = _CapturingLogger()
@@ -214,7 +426,10 @@ def test_read_log_file_failure_log_is_sanitized(monkeypatch):
     assert "/private/system_logs.jsonl" not in joined
 
 
-def test_query_system_logs_handles_naive_start_with_aware_entries(monkeypatch):
+@pytest.mark.unit
+def test_query_system_logs_handles_naive_start_with_aware_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("SYSTEM_LOG_FILE_ENABLED", "false")
     log_buffer = _reload_log_buffer()
 
@@ -243,7 +458,10 @@ def test_query_system_logs_handles_naive_start_with_aware_entries(monkeypatch):
     assert items[0]["timestamp"].tzinfo is not None
 
 
-def test_query_system_logs_sorts_with_malformed_timestamps(monkeypatch):
+@pytest.mark.unit
+def test_query_system_logs_sorts_with_malformed_timestamps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("SYSTEM_LOG_FILE_ENABLED", "false")
     log_buffer = _reload_log_buffer()
 
@@ -275,7 +493,81 @@ def test_query_system_logs_sorts_with_malformed_timestamps(monkeypatch):
     assert items[-1]["message"] == "sortcase-bad-timestamp"
 
 
-def test_log_file_lock_uses_runtime_timeout_from_env(monkeypatch, tmp_path):
+@pytest.mark.unit
+def test_query_system_logs_dedupes_with_tenant_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log_buffer = _reload_log_buffer()
+    base_entry = {
+        "timestamp": datetime(2026, 2, 1, 12, 0, tzinfo=timezone.utc),
+        "level": "INFO",
+        "message": "tenant-collision",
+        "logger": "test",
+        "module": "test_module",
+        "function": "test_fn",
+        "line": 1,
+        "request_id": "same-request",
+    }
+    file_entry = {**base_entry, "org_id": 1, "user_id": 10}
+    buffer_entry = {**base_entry, "org_id": 2, "user_id": 20}
+
+    monkeypatch.setattr(log_buffer, "ensure_system_log_buffer", lambda: None)
+    monkeypatch.setattr(log_buffer, "_read_log_file_entries", lambda: [file_entry])
+    with log_buffer._BUFFER_LOCK:
+        log_buffer._BUFFER.clear()
+        log_buffer._BUFFER.append(buffer_entry)
+
+    items, total = log_buffer.query_system_logs(
+        query="tenant-collision",
+        org_id=2,
+        limit=10,
+        offset=0,
+    )
+
+    assert total == 1
+    assert items[0]["org_id"] == 2
+    assert items[0]["user_id"] == 20
+
+
+@pytest.mark.unit
+def test_query_system_logs_keeps_entries_with_different_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log_buffer = _reload_log_buffer()
+    base_entry = {
+        "timestamp": datetime(2026, 2, 1, 12, 0, tzinfo=timezone.utc),
+        "level": "INFO",
+        "message": "event-collision",
+        "logger": "test",
+        "module": "test_module",
+        "function": "test_fn",
+        "line": 1,
+        "request_id": "same-request",
+    }
+    file_entry = {**base_entry, "event": "file-event"}
+    buffer_entry = {**base_entry, "event": "buffer-event"}
+
+    monkeypatch.setattr(log_buffer, "ensure_system_log_buffer", lambda: None)
+    monkeypatch.setattr(log_buffer, "_read_log_file_entries", lambda: [file_entry])
+    with log_buffer._BUFFER_LOCK:
+        log_buffer._BUFFER.clear()
+        log_buffer._BUFFER.append(buffer_entry)
+
+    items, total = log_buffer.query_system_logs(
+        query="event-collision",
+        limit=10,
+        offset=0,
+    )
+
+    assert total == 2
+    assert {item["event"] for item in items} == {"file-event", "buffer-event"}
+
+
+@pytest.mark.unit
+def test_log_file_lock_uses_runtime_timeout_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     log_path = tmp_path / "system_logs.jsonl"
     lock_path = log_path.with_suffix(log_path.suffix + ".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tldw_Server_API/tests/Logging/test_trace_context.py
+++ b/tldw_Server_API/tests/Logging/test_trace_context.py
@@ -1,11 +1,10 @@
-import types
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
 
-from tldw_Server_API.app.main import app
 from tldw_Server_API.app.core.Logging.log_context import ensure_traceparent
+from tldw_Server_API.app.main import app
 from tldw_Server_API.app.services.app_lifecycle import reset_lifecycle_state
 
 
@@ -27,14 +26,13 @@ def _fresh_test_client() -> TestClient:
     return client
 
 
-def test_ensure_traceparent_sets_state_and_returns_value():
-
-
+@pytest.mark.unit
+def test_ensure_traceparent_sets_state_and_returns_value() -> None:
     class _State:  # minimal stand-in for request.state
         pass
 
     class _Req:
-        def __init__(self, headers: Dict[str, str]):
+        def __init__(self, headers: dict[str, str]) -> None:
             self.headers = headers
             self.state = _State()
 
@@ -42,13 +40,38 @@ def test_ensure_traceparent_sets_state_and_returns_value():
     req = _Req({"traceparent": tp})
     out = ensure_traceparent(req)
     assert out == tp
-    assert getattr(req.state, "traceparent") == tp
+    assert req.state.traceparent == tp
 
     # Case-insensitive header
     req2 = _Req({"Traceparent": tp})
     out2 = ensure_traceparent(req2)
     assert out2 == tp
-    assert getattr(req2.state, "traceparent") == tp
+    assert req2.state.traceparent == tp
+
+    # Mixed-case valid values are normalized before being stored.
+    mixed_case_tp = "00-0123456789ABCDEF0123456789ABCDEF-0123456789ABCDEF-01"
+    req3 = _Req({"traceparent": mixed_case_tp})
+    out3 = ensure_traceparent(req3)
+    assert out3 == tp
+    assert req3.state.traceparent == tp
+
+
+@pytest.mark.unit
+def test_ensure_traceparent_drops_invalid_header_value() -> None:
+    class _State:
+        pass
+
+    class _Req:
+        def __init__(self, headers: dict[str, str]) -> None:
+            self.headers = headers
+            self.state = _State()
+
+    req = _Req({"traceparent": "bad\ntraceparent"})
+
+    out = ensure_traceparent(req)
+
+    assert out == ""
+    assert not hasattr(req.state, "traceparent")
 
 
 def test_audio_jobs_submit_propagates_request_id(monkeypatch):
@@ -58,7 +81,7 @@ def test_audio_jobs_submit_propagates_request_id(monkeypatch):
         pytest.skip("audio-jobs submit route is disabled in this test app configuration")
 
     # Capture kwargs sent to JobManager.create_job
-    captured: Dict[str, Any] = {}
+    captured: dict[str, Any] = {}
 
     from tldw_Server_API.app.core.Jobs import manager as jobs_manager
 
@@ -94,7 +117,7 @@ def test_audio_jobs_submit_propagates_request_id(monkeypatch):
 def test_media_ingest_jobs_submit_propagates_request_id(monkeypatch, tmp_path):
 
 
-    captured: Dict[str, Any] = {}
+    captured: dict[str, Any] = {}
 
     from tldw_Server_API.app.core.Jobs import manager as jobs_manager
 
@@ -132,10 +155,10 @@ def test_media_ingest_jobs_submit_propagates_request_id(monkeypatch, tmp_path):
 def test_reembed_schedule_propagates_request_id(monkeypatch):
 
 
-    captured: Dict[str, Any] = {}
+    captured: dict[str, Any] = {}
 
-    from tldw_Server_API.app.core.Jobs import manager as jobs_manager
     from tldw_Server_API.app.core.Embeddings import redis_pipeline
+    from tldw_Server_API.app.core.Jobs import manager as jobs_manager
 
     if not _route_exists("/api/v1/embeddings/reembed/schedule", "POST"):
         pytest.skip("re-embed schedule route is disabled in this test app configuration")


### PR DESCRIPTION
## Summary
- Move system log file persistence behind a bounded background queue and make sink installation reload/concurrency safe.
- Redact common secrets before system log buffer/file storage; validate traceparent and logging env values.
- Normalize JSON log timestamps to UTC and remove the unused duplicate JSON sink helper.

## Test Plan
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Logging tldw_Server_API/tests/Infrastructure/test_json_log_formatter.py -q`
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m compileall -q tldw_Server_API/app/core/Logging tldw_Server_API/tests/Logging tldw_Server_API/tests/Infrastructure/test_json_log_formatter.py`
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Logging -f json -o /tmp/bandit_logging_task_12005_worktree.json`
- `git diff --check`

## Change summary
This hardens the existing Logging module rather than changing external API contracts. File-backed admin log persistence is moved off the hot log path with a bounded queue so request logging does not wait on file locks or compaction. Redaction is applied inside the system log buffer because upstream caller discipline and global patching are not sufficient for an admin-exposed persisted log. Trace and env inputs are validated at the module boundary, and the unused JSON sink helper was removed because startup already owns JSON sink configuration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Logging module to keep request logging fast and safe. File-backed writes use a shared bounded queue + daemon worker, secrets are redacted, timestamps are true UTC, `traceparent` is validated/normalized, env and level values fall back safely, lock timeouts are monotonic, sink install is concurrency-safe with worker reuse across reloads, and de-dup keys include tenant/correlation/event.

- **New Features**
  - Shared bounded queue + daemon writer for file-backed logs; hot path stays non-blocking.
  - Concurrency-safe sink install and reuse of queue/worker across reloads.
  - Smarter de-dup when merging file and buffer entries (includes tenant/correlation/event).

- **Bug Fixes**
  - Redact secrets before buffering/writing (API keys, Authorization, bearer tokens, sensitive extra keys).
  - JSON formatter converts tz-aware/naive timestamps to real UTC before the Z suffix.
  - Validate and normalize `traceparent`; drop invalid and zero IDs. Invalid log levels fall back to `DEBUG`; malformed buffer/queue sizes fall back to defaults.
  - Honor runtime lock timeouts with monotonic timing and safer stale-lock handling; contain enqueue failures; internal diagnostics omit raw exception text.
  - Removed unused duplicate JSON sink helper.

<sup>Written for commit 0a0584f10fd230703098664d12f49a0e02d59b22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

