### PR TITLE
fix(third-party): harden provider adapters

### DIFF
--- a/backlog/tasks/task-11000 - Harden-Third-Party-provider-review-findings.md
+++ b/backlog/tasks/task-11000 - Harden-Third-Party-provider-review-findings.md
@@ -2,6 +2,7 @@
 id: TASK-11000
 title: Harden Third_Party provider review findings
 status: Done
+updated_date: 2026-06-24 20:18
 ---
 
 ## Description
@@ -33,12 +34,28 @@ Verification:
 Finalization update:
 - Bandit report path aligned to /tmp/bandit_third_party_review_11000.json (0 findings).
 - No known skips or blockers.
+Review follow-up in progress:
+- Rebase PR branch onto latest dev.
+- Verify Qodo inline comments against current code.
+- Address accepted review items with focused regression coverage and verification.
+Review follow-up complete:
+- Rebasing: PR branch rebased onto latest origin/dev on 2026-06-24.
+- Centralized ThirdPartyHTTPStatusError in app/core/exceptions.py and updated adapters to import it from the shared module.
+- Closed successful fetch responses in viXra lookup/search paths and Scopus DOI lookup.
+- Added type annotations to the newly added tests/helpers and regression coverage for successful Scopus/viXra response closure.
+
+Follow-up verification:
+- python -m compileall -q tldw_Server_API/app/core/Third_Party tldw_Server_API/app/core/exceptions.py touched tests (clean)
+- git diff --check (clean)
+- python -m pytest focused Third_Party/Research suites -q (120 passed)
+- python -m bandit -r tldw_Server_API/app/core/exceptions.py tldw_Server_API/app/core/Third_Party -f json -o /tmp/bandit_third_party_review_11000_followup.json (0 findings)
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Fixed the accepted Third_Party review findings: BioRxiv filtered pagination now advances based on upstream batch size, PMC OA PDF downloads use bounded temp-file streaming plus PMCID/PDF validation, selected JSON adapters surface HTTP status failures, arXiv/CitEc metadata URLs use HTTPS, and viXra search applies requested pagination before enrichment. Added focused regression coverage and ran security verification.
+Review follow-up rebased the PR onto latest dev, moved the Third_Party HTTP status exception into core exceptions, closed successful Scopus/viXra responses, annotated the added tests/helpers, and added closure regression coverage. Focused tests, compile check, whitespace check, and Bandit all passed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-11000 - Harden-Third-Party-provider-review-findings.md
+++ b/backlog/tasks/task-11000 - Harden-Third-Party-provider-review-findings.md
@@ -1,0 +1,52 @@
+---
+id: TASK-11000
+title: Harden Third_Party provider review findings
+status: Done
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix current Third_Party module review findings: BioRxiv filtered pagination, PMC OA bounded PDF download, provider HTTP status handling, plain HTTP metadata URLs where supported, and viXra pagination semantics.
+
+Reference: tldw_Server_API/app/core/Third_Party
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 BioRxiv filtered searches continue across full upstream batches and have regression coverage.
+- [x] #2 PMC OA PDF downloads use bounded streaming validation instead of unbounded response.content.
+- [x] #3 Provider adapters distinguish non-404 HTTP failures from successful empty records where practical.
+- [x] #4 Plain HTTP scholarly metadata URLs are upgraded to HTTPS where provider support exists.
+- [x] #5 viXra search pagination behavior is corrected or honestly represented with tests.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Verification:
+- python -m pytest tldw_Server_API/tests/Research/test_biorxiv_sanitizers.py tldw_Server_API/tests/Research/test_pmc_oa_sanitizers.py tldw_Server_API/tests/Research/test_vixra_sanitizers.py tldw_Server_API/tests/Research/test_arxiv_sanitizers.py tldw_Server_API/tests/Research/test_repec_sanitizers.py tldw_Server_API/tests/http_client/test_third_party_adapters_http.py -q (67 passed)
+- python -m pytest tldw_Server_API/tests/Research/test_semantic_scholar_sanitizers.py tldw_Server_API/tests/Research/test_ieee_sanitizers.py tldw_Server_API/tests/Research/test_springer_sanitizers.py tldw_Server_API/tests/Research/test_scopus_sanitizers.py tldw_Server_API/tests/Research/test_paper_search_endpoints.py tldw_Server_API/tests/Research/test_error_mapping_endpoints.py -q (52 passed)
+- python -m bandit -r touched Third_Party files -f json -o /tmp/bandit_third_party_review_11000.json (0 findings)
+- git diff --check on touched scope (clean)
+- python -m compileall -q tldw_Server_API/app/core/Third_Party (clean)
+Finalization update:
+- Bandit report path aligned to /tmp/bandit_third_party_review_11000.json (0 findings).
+- No known skips or blockers.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the accepted Third_Party review findings: BioRxiv filtered pagination now advances based on upstream batch size, PMC OA PDF downloads use bounded temp-file streaming plus PMCID/PDF validation, selected JSON adapters surface HTTP status failures, arXiv/CitEc metadata URLs use HTTPS, and viXra search applies requested pagination before enrichment. Added focused regression coverage and ran security verification.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Third_Party/Arxiv.py
+++ b/tldw_Server_API/app/core/Third_Party/Arxiv.py
@@ -33,7 +33,7 @@ ARXIV_DEFAULT_PAGE_SIZE = 10
 
 
 def fetch_arxiv_pdf_url(paper_id: str) -> Optional[str]:
-    base_url = f"http://export.arxiv.org/api/query?id_list={paper_id}"
+    base_url = f"https://export.arxiv.org/api/query?id_list={paper_id}"
     try:
         r = fetch(method="GET", url=base_url, timeout=10)
         if r.status_code >= 400:
@@ -83,7 +83,7 @@ def search_arxiv_custom_api(query: Optional[str], author: Optional[str], year: O
 
 
 def fetch_arxiv_xml(paper_id: str) -> Optional[str]:
-    base_url = "http://export.arxiv.org/api/query?id_list="
+    base_url = "https://export.arxiv.org/api/query?id_list="
     try:
         r = fetch(method="GET", url=base_url + paper_id, timeout=10)
         if r.status_code >= 400:
@@ -165,7 +165,7 @@ def parse_arxiv_feed(xml_content: bytes) -> list[dict[str, Any]]:
 
 def build_query_url(query: Optional[str], author: Optional[str], year: Optional[str], start: int,
                     max_results: int = ARXIV_DEFAULT_PAGE_SIZE) -> str:
-    base_url = "http://export.arxiv.org/api/query?"  # HTTP, not HTTPS for export.arxiv.org
+    base_url = "https://export.arxiv.org/api/query?"
     search_terms = []
 
     if query:

--- a/tldw_Server_API/app/core/Third_Party/BioRxiv.py
+++ b/tldw_Server_API/app/core/Third_Party/BioRxiv.py
@@ -189,7 +189,7 @@ def search_biorxiv(
                 return f"/details/{server_norm}/{interval}/{cursor}"
             return f"/details/{server_norm}/{f}/{t}/{cursor}"
 
-        def _fetch(cursor: int) -> tuple[list[dict[str, Any]], int]:
+        def _fetch(cursor: int) -> tuple[list[dict[str, Any]], int, int]:
             # Rely on /details; apply keyword/category filters client-side; pass category as query param too when possible
             path = _details_path(cursor)
             url = f"{BIO_RXIV_API_BASE}{path}"
@@ -219,10 +219,11 @@ def search_biorxiv(
                         pass
 
             collection = data.get("collection") or []
+            raw_count = len(collection)
             normed = [_normalize_item(item) for item in collection]
             # Be a good citizen: tiny delay to avoid hammering
             time.sleep(0.2)
-            return normed, total
+            return normed, total, raw_count
 
         # Gather enough batches to satisfy post-filter slicing
         collected: list[dict[str, Any]] = []
@@ -231,7 +232,7 @@ def search_biorxiv(
         batches = 0
         total = 0
         while batches < max_batches and len(collected) < (within_batch_offset + limit):
-            batch_items, total_val = _fetch(cursor)
+            batch_items, total_val, raw_count = _fetch(cursor)
             if total == 0:
                 total = total_val
             # Apply client-side filters (ensure results reflect requested filters even if server ignores params)
@@ -249,11 +250,11 @@ def search_biorxiv(
                 batch_items = [it for it in batch_items if (item := (it.get("category") or "").lower()) == cl or item.replace(" ", "_") == cl]
 
             collected.extend(batch_items)
-            if len(batch_items) < BATCH:
-                # End reached (returned fewer than BATCH entries)
+            batches += 1
+            if raw_count < BATCH:
+                # End reached (upstream returned fewer than BATCH entries)
                 break
             cursor += BATCH
-            batches += 1
 
         # Now slice according to within-batch offset and limit
         page_items = collected[within_batch_offset:within_batch_offset + limit]
@@ -328,7 +329,7 @@ def search_biorxiv_pubs(
                 return f"/pubs/{server_norm}/{interval}/{cursor}"
             return f"/pubs/{server_norm}/{f}/{t}/{cursor}"
 
-        def _fetch(cursor: int) -> tuple[list[dict[str, Any]], int]:
+        def _fetch(cursor: int) -> tuple[list[dict[str, Any]], int, int]:
             url = f"{BIO_RXIV_API_BASE}{_interval_path(cursor)}"
             data = _get_json(url, timeout=15)
             cnt = 0
@@ -338,9 +339,10 @@ def search_biorxiv_pubs(
                     cnt = int(msgs[0].get("count") or 0)
                 except (TypeError, ValueError):
                     cnt = 0
-            coll = [_normalize_published_item(it) for it in (data.get("collection") or [])]
+            raw_collection = data.get("collection") or []
+            coll = [_normalize_published_item(it) for it in raw_collection]
             time.sleep(0.2)
-            return coll, cnt
+            return coll, cnt, len(raw_collection)
 
         collected: list[dict[str, Any]] = []
         cursor = first_cursor
@@ -348,17 +350,17 @@ def search_biorxiv_pubs(
         max_batches = 5
         total_count = 0
         while batches < max_batches and len(collected) < (within_batch_offset + limit):
-            items, cnt = _fetch(cursor)
+            items, cnt, raw_count = _fetch(cursor)
             if total_count == 0:
                 total_count = cnt
             if q and q.strip():
                 ql = q.strip().lower()
                 items = [it for it in items if (it.get("preprint_title") or "").lower().find(ql) >= 0 or (it.get("preprint_abstract") or "").lower().find(ql) >= 0 or (it.get("preprint_authors") or "").lower().find(ql) >= 0]
             collected.extend(items)
-            if len(items) < BATCH:
+            batches += 1
+            if raw_count < BATCH:
                 break
             cursor += BATCH
-            batches += 1
 
         page_items = collected[within_batch_offset:within_batch_offset + limit]
         return page_items, (len(collected) if q else total_count), None

--- a/tldw_Server_API/app/core/Third_Party/Elsevier_Scopus.py
+++ b/tldw_Server_API/app/core/Third_Party/Elsevier_Scopus.py
@@ -9,11 +9,9 @@ import contextlib
 import os
 from typing import Any
 
+from tldw_Server_API.app.core.exceptions import ThirdPartyHTTPStatusError
 from tldw_Server_API.app.core.http_client import fetch
-from tldw_Server_API.app.core.Third_Party._http_helpers import (
-    ThirdPartyHTTPStatusError,
-    fetch_json_checked,
-)
+from tldw_Server_API.app.core.Third_Party._http_helpers import fetch_json_checked
 
 
 def fetch_json(**kwargs: Any) -> Any:
@@ -129,20 +127,20 @@ def get_scopus_by_doi(doi: str) -> tuple[dict | None, str | None]:
             "view": "STANDARD",
         }
         r = fetch(method="GET", url=BASE_URL, headers=_headers(), params=params, timeout=20)
-        if r.status_code == 404:
+        try:
+            if r.status_code == 404:
+                return None, None
+            if r.status_code >= 400:
+                return None, f"Scopus API HTTP Error: {r.status_code}"
+            data = r.json() or {}
+            sr = data.get("search-results") or {}
+            entries = sr.get("entry") or []
+            if not entries:
+                return None, None
+            return _normalize_entry(entries[0]), None
+        finally:
             with contextlib.suppress(Exception):
                 r.close()
-            return None, None
-        if r.status_code >= 400:
-            with contextlib.suppress(Exception):
-                r.close()
-            return None, f"Scopus API HTTP Error: {r.status_code}"
-        data = r.json() or {}
-        sr = data.get("search-results") or {}
-        entries = sr.get("entry") or []
-        if not entries:
-            return None, None
-        return _normalize_entry(entries[0]), None
     except TimeoutError:
         return None, "Scopus request timed out."
     except Exception:

--- a/tldw_Server_API/app/core/Third_Party/Elsevier_Scopus.py
+++ b/tldw_Server_API/app/core/Third_Party/Elsevier_Scopus.py
@@ -9,7 +9,15 @@ import contextlib
 import os
 from typing import Any
 
-from tldw_Server_API.app.core.http_client import fetch, fetch_json
+from tldw_Server_API.app.core.http_client import fetch
+from tldw_Server_API.app.core.Third_Party._http_helpers import (
+    ThirdPartyHTTPStatusError,
+    fetch_json_checked,
+)
+
+
+def fetch_json(**kwargs: Any) -> Any:
+    return fetch_json_checked(**kwargs)
 
 
 def _missing_key_error() -> str:
@@ -101,6 +109,8 @@ def search_scopus(
         entries = sr.get("entry") or []
         items = [_normalize_entry(e) for e in entries]
         return items, total, None
+    except ThirdPartyHTTPStatusError as exc:
+        return None, 0, f"Scopus API HTTP Error: {exc.status_code}"
     except TimeoutError:
         return None, 0, "Scopus request timed out."
     except Exception:
@@ -123,6 +133,10 @@ def get_scopus_by_doi(doi: str) -> tuple[dict | None, str | None]:
             with contextlib.suppress(Exception):
                 r.close()
             return None, None
+        if r.status_code >= 400:
+            with contextlib.suppress(Exception):
+                r.close()
+            return None, f"Scopus API HTTP Error: {r.status_code}"
         data = r.json() or {}
         sr = data.get("search-results") or {}
         entries = sr.get("entry") or []

--- a/tldw_Server_API/app/core/Third_Party/IEEE_Xplore.py
+++ b/tldw_Server_API/app/core/Third_Party/IEEE_Xplore.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 import os
 from typing import Any
 
+from tldw_Server_API.app.core.exceptions import ThirdPartyHTTPStatusError
 from tldw_Server_API.app.core.Third_Party._http_helpers import (
-    ThirdPartyHTTPStatusError,
     fetch_json_checked,
 )
 

--- a/tldw_Server_API/app/core/Third_Party/IEEE_Xplore.py
+++ b/tldw_Server_API/app/core/Third_Party/IEEE_Xplore.py
@@ -8,7 +8,14 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from tldw_Server_API.app.core.http_client import fetch_json
+from tldw_Server_API.app.core.Third_Party._http_helpers import (
+    ThirdPartyHTTPStatusError,
+    fetch_json_checked,
+)
+
+
+def fetch_json(**kwargs: Any) -> Any:
+    return fetch_json_checked(**kwargs)
 
 
 def _missing_key_error() -> str:
@@ -102,6 +109,8 @@ def search_ieee(
         articles = data.get("articles") or []
         items = [_normalize_article(it) for it in articles]
         return items, total, None
+    except ThirdPartyHTTPStatusError as exc:
+        return None, 0, f"IEEE Xplore API HTTP Error: {exc.status_code}"
     except TimeoutError:
         return None, 0, "IEEE Xplore request timed out."
     except Exception:
@@ -125,6 +134,10 @@ def get_ieee_by_doi(doi: str) -> tuple[dict | None, str | None]:
         if not articles:
             return None, None
         return _normalize_article(articles[0]), None
+    except ThirdPartyHTTPStatusError as exc:
+        if exc.status_code == 404:
+            return None, None
+        return None, f"IEEE Xplore API HTTP Error: {exc.status_code}"
     except TimeoutError:
         return None, "IEEE Xplore request timed out."
     except Exception:
@@ -148,6 +161,10 @@ def get_ieee_by_id(article_number: str) -> tuple[dict | None, str | None]:
         if not articles:
             return None, None
         return _normalize_article(articles[0]), None
+    except ThirdPartyHTTPStatusError as exc:
+        if exc.status_code == 404:
+            return None, None
+        return None, f"IEEE Xplore API HTTP Error: {exc.status_code}"
     except TimeoutError:
         return None, "IEEE Xplore request timed out."
     except Exception:

--- a/tldw_Server_API/app/core/Third_Party/PMC_OA.py
+++ b/tldw_Server_API/app/core/Third_Party/PMC_OA.py
@@ -9,12 +9,18 @@ exposes a simple PDF download helper for PMC articles.
 from __future__ import annotations
 
 import contextlib
+import re
+import tempfile
+from pathlib import Path
 from typing import Any
 from defusedxml import ElementTree as DET
 
-from tldw_Server_API.app.core.http_client import fetch
+from tldw_Server_API.app.core.exceptions import DownloadError
+from tldw_Server_API.app.core.http_client import download, fetch
 
 BASE_URL = "https://www.ncbi.nlm.nih.gov/pmc/utils/oa/oa.fcgi"
+PMC_PDF_MAX_BYTES = 50 * 1024 * 1024
+_PMCID_RE = re.compile(r"^(?:PMC)?(?P<num>\d+)$", re.IGNORECASE)
 
 
 def _get_xml(params: dict[str, Any]) -> Any:
@@ -119,20 +125,36 @@ def download_pmc_pdf(pmcid: str) -> tuple[bytes | None, str | None, str | None]:
     Returns (content_bytes, filename, error_message)
     """
     try:
-        pmcid_num = str(pmcid).strip().lstrip("PMC")
-        if not pmcid_num:
+        pmcid_text = str(pmcid or "").strip()
+        if not pmcid_text:
             return None, None, "PMCID cannot be empty"
+        match = _PMCID_RE.fullmatch(pmcid_text)
+        if match is None:
+            return None, None, "Invalid PMCID."
+        pmcid_num = match.group("num")
         url = f"https://pmc.ncbi.nlm.nih.gov/PMC{pmcid_num}/pdf"
-        r = fetch(method="GET", url=url, timeout=30)
-        if r.status_code >= 400:
-            return None, None, f"PMC PDF HTTP error: {r.status_code}"
-        # Best-effort filename from headers; default to PMC{pmcid}.pdf
         filename = f"PMC{pmcid_num}.pdf"
-        cd = r.headers.get("Content-Disposition")
-        if cd and "filename=" in cd:
-            filename = cd.split("filename=")[-1].strip('"')
-        return r.content, filename, None
+        with tempfile.TemporaryDirectory(prefix="pmc_oa_pdf_") as tmp_dir:
+            dest = Path(tmp_dir) / filename
+            downloaded_path = download(
+                url=url,
+                dest=dest,
+                timeout=30,
+                max_bytes_total=PMC_PDF_MAX_BYTES,
+                require_content_type="application/pdf",
+            )
+            content = downloaded_path.read_bytes()
+        if not content.startswith(b"%PDF"):
+            return None, None, "PMC PDF download did not return a valid PDF."
+        return content, filename, None
     except TimeoutError:
         return None, None, "PMC PDF download timed out."
+    except DownloadError as exc:
+        match = re.search(r"status\s+(\d{3})", str(exc), re.IGNORECASE)
+        if match:
+            return None, None, f"PMC PDF HTTP Error: {match.group(1)}"
+        if "Disk quota exceeded" in str(exc):
+            return None, None, "PMC PDF download exceeded size limit."
+        return None, None, "PMC PDF download failed."
     except Exception:
         return None, None, "PMC PDF download failed."

--- a/tldw_Server_API/app/core/Third_Party/RePEc.py
+++ b/tldw_Server_API/app/core/Third_Party/RePEc.py
@@ -115,7 +115,7 @@ def get_ref_by_handle(handle: str) -> tuple[dict[str, Any] | None, str | None]:
 
 # ---------------- CitEc API: citations for a RePEc handle ----------------
 
-_CITEC_BASE = "http://citec.repec.org/api"
+_CITEC_BASE = "https://citec.repec.org/api"
 
 
 def get_citations_plain(handle: str) -> tuple[dict[str, Any] | None, str | None]:

--- a/tldw_Server_API/app/core/Third_Party/Semantic_Scholar.py
+++ b/tldw_Server_API/app/core/Third_Party/Semantic_Scholar.py
@@ -6,8 +6,8 @@ Adapter for the Semantic Scholar API using the centralized HTTP client.
 
 from typing import Any, Optional
 
+from tldw_Server_API.app.core.exceptions import ThirdPartyHTTPStatusError
 from tldw_Server_API.app.core.Third_Party._http_helpers import (
-    ThirdPartyHTTPStatusError,
     fetch_json_checked,
 )
 

--- a/tldw_Server_API/app/core/Third_Party/Semantic_Scholar.py
+++ b/tldw_Server_API/app/core/Third_Party/Semantic_Scholar.py
@@ -6,7 +6,14 @@ Adapter for the Semantic Scholar API using the centralized HTTP client.
 
 from typing import Any, Optional
 
-from tldw_Server_API.app.core.http_client import fetch_json
+from tldw_Server_API.app.core.Third_Party._http_helpers import (
+    ThirdPartyHTTPStatusError,
+    fetch_json_checked,
+)
+
+
+def fetch_json(**kwargs: Any) -> Any:
+    return fetch_json_checked(**kwargs)
 
 FIELDS_OF_STUDY_CHOICES = [
     "Computer Science", "Medicine", "Chemistry", "Biology", "Materials Science",
@@ -80,6 +87,8 @@ def search_papers_semantic_scholar(
         # Optional pacing if needed; retries/backoff handled centrally
         # time.sleep(0.2)
         return data, None
+    except ThirdPartyHTTPStatusError as exc:
+        return None, f"Semantic Scholar API HTTP Error: {exc.status_code}"
     except Exception:
         return None, "Semantic Scholar search failed."
 
@@ -97,6 +106,10 @@ def get_paper_details_semantic_scholar(
         data = fetch_json(method="GET", url=url, params=params, timeout=10)
         # time.sleep(0.2)
         return data, None
+    except ThirdPartyHTTPStatusError as exc:
+        if exc.status_code == 404:
+            return None, None
+        return None, f"Semantic Scholar API HTTP Error: {exc.status_code}"
     except Exception:
         return None, "Semantic Scholar paper details lookup failed."
 

--- a/tldw_Server_API/app/core/Third_Party/Springer_Nature.py
+++ b/tldw_Server_API/app/core/Third_Party/Springer_Nature.py
@@ -7,7 +7,14 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from tldw_Server_API.app.core.http_client import fetch_json
+from tldw_Server_API.app.core.Third_Party._http_helpers import (
+    ThirdPartyHTTPStatusError,
+    fetch_json_checked,
+)
+
+
+def fetch_json(**kwargs: Any) -> Any:
+    return fetch_json_checked(**kwargs)
 
 
 def _missing_key_error() -> str:
@@ -99,6 +106,8 @@ def search_springer(
         records = data.get("records") or []
         items = [_normalize_record(rec) for rec in records]
         return items, total, None
+    except ThirdPartyHTTPStatusError as exc:
+        return None, 0, f"Springer API HTTP Error: {exc.status_code}"
     except TimeoutError:
         return None, 0, "Springer request timed out."
     except Exception:
@@ -121,6 +130,10 @@ def get_springer_by_doi(doi: str) -> tuple[dict | None, str | None]:
         if not records:
             return None, None
         return _normalize_record(records[0]), None
+    except ThirdPartyHTTPStatusError as exc:
+        if exc.status_code == 404:
+            return None, None
+        return None, f"Springer API HTTP Error: {exc.status_code}"
     except TimeoutError:
         return None, "Springer request timed out."
     except Exception:

--- a/tldw_Server_API/app/core/Third_Party/Springer_Nature.py
+++ b/tldw_Server_API/app/core/Third_Party/Springer_Nature.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 import os
 from typing import Any
 
+from tldw_Server_API.app.core.exceptions import ThirdPartyHTTPStatusError
 from tldw_Server_API.app.core.Third_Party._http_helpers import (
-    ThirdPartyHTTPStatusError,
     fetch_json_checked,
 )
 

--- a/tldw_Server_API/app/core/Third_Party/Vixra.py
+++ b/tldw_Server_API/app/core/Third_Party/Vixra.py
@@ -15,6 +15,7 @@ extracted unless trivially available; PDF ingest path uses the resolved pdf_url.
 """
 from __future__ import annotations
 
+import contextlib
 import re
 from typing import Any
 from urllib.parse import quote as urlquote
@@ -39,26 +40,35 @@ def _try_pdf(url: str) -> str | None:
     try:
         # Prefer a tiny GET with Range to preflight content-type without fetching the body
         r = fetch(method="GET", url=url, timeout=15, allow_redirects=True, headers={"Range": "bytes=0-0"})
-        if getattr(r, "status_code", 0) == 200 or getattr(r, "status_code", 0) == 206:
-            ct = (r.headers.get("content-type") or "").lower()
-            if "pdf" in ct or url.lower().endswith(".pdf"):
-                return url
-        return None
+        try:
+            if getattr(r, "status_code", 0) == 200 or getattr(r, "status_code", 0) == 206:
+                ct = (r.headers.get("content-type") or "").lower()
+                if "pdf" in ct or url.lower().endswith(".pdf"):
+                    return url
+            return None
+        finally:
+            with contextlib.suppress(Exception):
+                r.close()
     except _VIXRA_NONCRITICAL_EXCEPTIONS:
         return None
+
 
 def _extract_pdf_from_abs(abs_url: str) -> str | None:
     try:
         r = fetch(method="GET", url=abs_url, timeout=20)
-        if r.status_code >= 400:
+        try:
+            if r.status_code >= 400:
+                return None
+            text = r.text or ""
+            m = re.search(r"href=\"(/pdf/[A-Za-z0-9\./v_-]+?\.pdf)\"", text, re.IGNORECASE)
+            if m:
+                href = m.group(1)
+                if href.startswith("/"):
+                    return f"https://vixra.org{href}"
             return None
-        text = r.text or ""
-        m = re.search(r"href=\"(/pdf/[A-Za-z0-9\./v_-]+?\.pdf)\"", text, re.IGNORECASE)
-        if m:
-            href = m.group(1)
-            if href.startswith("/"):
-                return f"https://vixra.org{href}"
-        return None
+        finally:
+            with contextlib.suppress(Exception):
+                r.close()
     except _VIXRA_NONCRITICAL_EXCEPTIONS:
         return None
 
@@ -83,8 +93,12 @@ def get_vixra_by_id(vid: str) -> tuple[dict[str, Any] | None, str | None]:
         html = None
         try:
             r_abs = fetch(method="GET", url=abs_url, timeout=20)
-            if r_abs.status_code == 200:
-                html = r_abs.text or None
+            try:
+                if r_abs.status_code == 200:
+                    html = r_abs.text or None
+            finally:
+                with contextlib.suppress(Exception):
+                    r_abs.close()
         except _VIXRA_NONCRITICAL_EXCEPTIONS:
             html = None
 
@@ -135,9 +149,13 @@ def search(term: str, page: int = 1, results_per_page: int = 10) -> tuple[list[d
         for url in candidates:
             try:
                 r = fetch(method="GET", url=url, timeout=20)
-                if r.status_code == 200 and r.text:
-                    html = r.text
-                    break
+                try:
+                    if r.status_code == 200 and r.text:
+                        html = r.text
+                        break
+                finally:
+                    with contextlib.suppress(Exception):
+                        r.close()
             except _VIXRA_NONCRITICAL_EXCEPTIONS:
                 continue
         if not html:
@@ -173,8 +191,12 @@ def search(term: str, page: int = 1, results_per_page: int = 10) -> tuple[list[d
             pub_date = None
             try:
                 r_abs = fetch(method="GET", url=abs_url, timeout=12)
-                if r_abs.status_code == 200 and r_abs.text:
-                    better_title, authors, pub_date = _parse_abs_details(r_abs.text)
+                try:
+                    if r_abs.status_code == 200 and r_abs.text:
+                        better_title, authors, pub_date = _parse_abs_details(r_abs.text)
+                finally:
+                    with contextlib.suppress(Exception):
+                        r_abs.close()
             except _VIXRA_NONCRITICAL_EXCEPTIONS:
                 pass
             item = {

--- a/tldw_Server_API/app/core/Third_Party/Vixra.py
+++ b/tldw_Server_API/app/core/Third_Party/Vixra.py
@@ -143,9 +143,14 @@ def search(term: str, page: int = 1, results_per_page: int = 10) -> tuple[list[d
         if not html:
             return [], 0, "viXra search failed to fetch results"
 
-        # Parse /abs/ links with titles
-        # Look for anchors like <a href="/abs/1901.0001">Title...</a>
-        items: list[dict[str, Any]] = []
+        safe_page = max(1, int(page or 1))
+        safe_page_size = max(1, int(results_per_page or 10))
+        start_index = (safe_page - 1) * safe_page_size
+        end_index = start_index + safe_page_size
+
+        # Parse /abs/ links with titles before slicing, so pagination applies
+        # to the result set rather than to enriched first-page items.
+        candidates: list[tuple[str, str]] = []
         seen: set[str] = set()
         for m in re.finditer(r"<a[^>]+href=\"(/abs/[A-Za-z0-9\.v/_-]+)\"[^>]*>(.*?)</a>", html, re.IGNORECASE | re.DOTALL):
             href = m.group(1)
@@ -157,6 +162,10 @@ def search(term: str, page: int = 1, results_per_page: int = 10) -> tuple[list[d
             if not vid or vid in seen:
                 continue
             seen.add(vid)
+            candidates.append((vid, title))
+
+        items: list[dict[str, Any]] = []
+        for vid, title in candidates[start_index:end_index]:
             # Enrich from abstract page for authors (and better title if available)
             abs_url = f"https://vixra.org/abs/{vid}"
             authors = None
@@ -181,9 +190,7 @@ def search(term: str, page: int = 1, results_per_page: int = 10) -> tuple[list[d
                 "provider": "vixra",
             }
             items.append(item)
-            if len(items) >= results_per_page:
-                break
-        total = len(items)
+        total = len(candidates)
         return items, total, None
     except TimeoutError:
         return None, 0, "viXra search request timed out."

--- a/tldw_Server_API/app/core/Third_Party/_http_helpers.py
+++ b/tldw_Server_API/app/core/Third_Party/_http_helpers.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_Server_API.app.core.exceptions import JSONDecodeError
+from tldw_Server_API.app.core.http_client import fetch
+
+
+class ThirdPartyHTTPStatusError(RuntimeError):
+    def __init__(self, status_code: int, reason: str | None = None) -> None:
+        self.status_code = int(status_code)
+        self.reason = reason or ""
+        message = f"HTTP Error: {self.status_code}"
+        if self.reason:
+            message = f"{message} - {self.reason}"
+        super().__init__(message)
+
+
+def fetch_json_checked(
+    *,
+    method: str,
+    url: str,
+    require_json_ct: bool = True,
+    max_bytes: int | None = None,
+    **kwargs: Any,
+) -> Any:
+    response = fetch(method=method, url=url, **kwargs)
+    try:
+        if response.status_code >= 400:
+            raise ThirdPartyHTTPStatusError(
+                response.status_code,
+                getattr(response, "reason_phrase", "") or None,
+            )
+        content_type = (response.headers.get("content-type") or "").lower()
+        if require_json_ct and "application/json" not in content_type:
+            raise JSONDecodeError("Response is not application/json")
+        if max_bytes is not None and len(response.content) > max_bytes:
+            raise JSONDecodeError("JSON response exceeds configured byte limit")
+        return response.json()
+    finally:
+        response.close()

--- a/tldw_Server_API/app/core/Third_Party/_http_helpers.py
+++ b/tldw_Server_API/app/core/Third_Party/_http_helpers.py
@@ -2,18 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from tldw_Server_API.app.core.exceptions import JSONDecodeError
+from tldw_Server_API.app.core.exceptions import JSONDecodeError, ThirdPartyHTTPStatusError
 from tldw_Server_API.app.core.http_client import fetch
-
-
-class ThirdPartyHTTPStatusError(RuntimeError):
-    def __init__(self, status_code: int, reason: str | None = None) -> None:
-        self.status_code = int(status_code)
-        self.reason = reason or ""
-        message = f"HTTP Error: {self.status_code}"
-        if self.reason:
-            message = f"{message} - {self.reason}"
-        super().__init__(message)
 
 
 def fetch_json_checked(

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -35,6 +35,18 @@ class JSONDecodeError(Exception):
     """Raised when a response expected to be JSON cannot be decoded or is invalid."""
 
 
+class ThirdPartyHTTPStatusError(RuntimeError):
+    """Raised when a Third_Party provider returns an HTTP error status."""
+
+    def __init__(self, status_code: int, reason: str | None = None) -> None:
+        self.status_code = int(status_code)
+        self.reason = reason or ""
+        message = f"HTTP Error: {self.status_code}"
+        if self.reason:
+            message = f"{message} - {self.reason}"
+        super().__init__(message)
+
+
 class TokenizerUnavailable(Exception):
     """Raised when tokenizer support is unavailable."""
 

--- a/tldw_Server_API/tests/Research/test_arxiv_sanitizers.py
+++ b/tldw_Server_API/tests/Research/test_arxiv_sanitizers.py
@@ -129,3 +129,29 @@ def test_get_arxiv_by_id_sanitizes_fetch_failures(monkeypatch):
     assert "arxiv by-id token" not in error
     assert "/private/arxiv-by-id.xml" not in error
     assert "paper-id-from-/private/request" not in error
+
+
+def test_arxiv_query_builder_uses_https_export_endpoint():
+    url = arxiv.build_query_url("retrieval", author=None, year=None, start=0, max_results=1)
+
+    assert url.startswith("https://export.arxiv.org/api/query?")
+
+
+def test_fetch_arxiv_xml_uses_https_export_endpoint(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        status_code = 200
+        text = "<feed />"
+
+    def fake_fetch(**kwargs):
+        captured["url"] = kwargs["url"]
+        return FakeResponse()
+
+    monkeypatch.setattr(arxiv, "fetch", fake_fetch)
+    monkeypatch.setattr(arxiv.time, "sleep", lambda _seconds: None)
+
+    xml = arxiv.fetch_arxiv_xml("2401.00001")
+
+    assert xml == "<feed />"
+    assert captured["url"] == "https://export.arxiv.org/api/query?id_list=2401.00001"

--- a/tldw_Server_API/tests/Research/test_arxiv_sanitizers.py
+++ b/tldw_Server_API/tests/Research/test_arxiv_sanitizers.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from tldw_Server_API.app.core.Third_Party import Arxiv as arxiv
@@ -6,8 +8,11 @@ from tldw_Server_API.app.core.Third_Party import Arxiv as arxiv
 pytestmark = pytest.mark.unit
 
 
-def test_fetch_arxiv_pdf_url_sanitizes_fetch_logs(monkeypatch, capsys):
-    def fail_fetch(**_kwargs):
+def test_fetch_arxiv_pdf_url_sanitizes_fetch_logs(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fail_fetch(**_kwargs: Any) -> None:
         raise RuntimeError("arxiv pdf token at /private/arxiv-pdf.key")
 
     monkeypatch.setattr(arxiv, "fetch", fail_fetch)
@@ -22,8 +27,8 @@ def test_fetch_arxiv_pdf_url_sanitizes_fetch_logs(monkeypatch, capsys):
     assert "paper-id-from-/private/request" not in output
 
 
-def test_search_arxiv_custom_api_sanitizes_fetch_failures(monkeypatch):
-    def fail_fetch(**_kwargs):
+def test_search_arxiv_custom_api_sanitizes_fetch_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_fetch(**_kwargs: Any) -> None:
         raise RuntimeError("arxiv search token at /private/arxiv-search.key")
 
     monkeypatch.setattr(arxiv, "fetch", fail_fetch)
@@ -43,8 +48,8 @@ def test_search_arxiv_custom_api_sanitizes_fetch_failures(monkeypatch):
     assert "/private/arxiv-search.key" not in error
 
 
-def test_search_arxiv_custom_api_preserves_timeout_classification(monkeypatch):
-    def fail_fetch(**_kwargs):
+def test_search_arxiv_custom_api_preserves_timeout_classification(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_fetch(**_kwargs: Any) -> None:
         raise TimeoutError("timed out at /private/arxiv-timeout.key")
 
     monkeypatch.setattr(arxiv, "fetch", fail_fetch)
@@ -64,8 +69,11 @@ def test_search_arxiv_custom_api_preserves_timeout_classification(monkeypatch):
     assert "/private/arxiv-timeout.key" not in error
 
 
-def test_fetch_arxiv_xml_sanitizes_fetch_logs(monkeypatch, capsys):
-    def fail_fetch(**_kwargs):
+def test_fetch_arxiv_xml_sanitizes_fetch_logs(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fail_fetch(**_kwargs: Any) -> None:
         raise RuntimeError("arxiv xml token at /private/arxiv.xml")
 
     monkeypatch.setattr(arxiv, "fetch", fail_fetch)
@@ -80,12 +88,15 @@ def test_fetch_arxiv_xml_sanitizes_fetch_logs(monkeypatch, capsys):
     assert "paper-id-from-/private/request" not in output
 
 
-def test_parse_arxiv_feed_sanitizes_parser_fallback_warning(monkeypatch, capsys):
+def test_parse_arxiv_feed_sanitizes_parser_fallback_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     class EmptySoup:
-        def find_all(self, _name):
+        def find_all(self, _name: str) -> list[Any]:
             return []
 
-    def fake_soup(_xml_content, parser):
+    def fake_soup(_xml_content: bytes, parser: str) -> EmptySoup:
         if parser == "lxml-xml":
             raise arxiv.FeatureNotFound("lxml load failed at /private/lxml-plugin.so")
         return EmptySoup()
@@ -101,8 +112,8 @@ def test_parse_arxiv_feed_sanitizes_parser_fallback_warning(monkeypatch, capsys)
     assert "/private/lxml-plugin.so" not in output
 
 
-def test_get_arxiv_by_id_sanitizes_parse_failures(monkeypatch):
-    def fail_parse(_xml_content):
+def test_get_arxiv_by_id_sanitizes_parse_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_parse(_xml_content: str) -> None:
         raise ValueError("arxiv parse path at /private/arxiv-feed.xml")
 
     monkeypatch.setattr(arxiv, "fetch_arxiv_xml", lambda _paper_id: "<feed />")
@@ -116,8 +127,8 @@ def test_get_arxiv_by_id_sanitizes_parse_failures(monkeypatch):
     assert "/private/arxiv-feed.xml" not in error
 
 
-def test_get_arxiv_by_id_sanitizes_fetch_failures(monkeypatch):
-    def fail_fetch_xml(_paper_id):
+def test_get_arxiv_by_id_sanitizes_fetch_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_fetch_xml(_paper_id: str) -> None:
         raise RuntimeError("arxiv by-id token at /private/arxiv-by-id.xml")
 
     monkeypatch.setattr(arxiv, "fetch_arxiv_xml", fail_fetch_xml)
@@ -131,20 +142,20 @@ def test_get_arxiv_by_id_sanitizes_fetch_failures(monkeypatch):
     assert "paper-id-from-/private/request" not in error
 
 
-def test_arxiv_query_builder_uses_https_export_endpoint():
+def test_arxiv_query_builder_uses_https_export_endpoint() -> None:
     url = arxiv.build_query_url("retrieval", author=None, year=None, start=0, max_results=1)
 
     assert url.startswith("https://export.arxiv.org/api/query?")
 
 
-def test_fetch_arxiv_xml_uses_https_export_endpoint(monkeypatch):
-    captured = {}
+def test_fetch_arxiv_xml_uses_https_export_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, str] = {}
 
     class FakeResponse:
         status_code = 200
         text = "<feed />"
 
-    def fake_fetch(**kwargs):
+    def fake_fetch(**kwargs: Any) -> FakeResponse:
         captured["url"] = kwargs["url"]
         return FakeResponse()
 

--- a/tldw_Server_API/tests/Research/test_biorxiv_sanitizers.py
+++ b/tldw_Server_API/tests/Research/test_biorxiv_sanitizers.py
@@ -150,3 +150,93 @@ def test_biorxiv_provider_paths_preserve_timeout_classification(
     assert error == expected_timeout
     for term in sensitive_terms:
         assert term not in error
+
+
+def test_search_biorxiv_filtered_query_continues_after_empty_filtered_batch(monkeypatch):
+    cursors: list[int] = []
+
+    def fake_get_json(url, params=None, timeout=15):
+        del params, timeout
+        cursor = int(url.rstrip("/").split("/")[-1])
+        cursors.append(cursor)
+        if cursor == 0:
+            collection = [
+                {
+                    "doi": f"10.1101/nonmatch.{i}",
+                    "title": f"Unrelated preprint {i}",
+                    "authors": "No Match",
+                    "abstract": "irrelevant",
+                    "server": "biorxiv",
+                    "version": 1,
+                }
+                for i in range(100)
+            ]
+            return {"messages": [{"count": "100", "total": "101"}], "collection": collection}
+        if cursor == 100:
+            return {
+                "messages": [{"count": "1", "total": "101"}],
+                "collection": [
+                    {
+                        "doi": "10.1101/target",
+                        "title": "Target kinase discovery",
+                        "authors": "Match Author",
+                        "abstract": "relevant",
+                        "server": "biorxiv",
+                        "version": 1,
+                    }
+                ],
+            }
+        return {"messages": [{"count": "0", "total": "101"}], "collection": []}
+
+    monkeypatch.setattr(biorxiv, "_get_json", fake_get_json)
+    monkeypatch.setattr(biorxiv.time, "sleep", lambda _seconds: None)
+
+    items, total, error = biorxiv.search_biorxiv("target kinase", limit=1)
+
+    assert error is None
+    assert [item["doi"] for item in items or []] == ["10.1101/target"]
+    assert total == 1
+    assert cursors == [0, 100]
+
+
+def test_search_biorxiv_pubs_filtered_query_continues_after_empty_filtered_batch(monkeypatch):
+    cursors: list[int] = []
+
+    def fake_get_json(url, timeout=15, params=None):
+        del timeout, params
+        cursor = int(url.rstrip("/").split("/")[-1])
+        cursors.append(cursor)
+        if cursor == 0:
+            collection = [
+                {
+                    "biorxiv_doi": f"10.1101/pub-nonmatch.{i}",
+                    "preprint_title": f"Unrelated publication {i}",
+                    "preprint_authors": "No Match",
+                    "preprint_abstract": "irrelevant",
+                }
+                for i in range(100)
+            ]
+            return {"messages": [{"count": "100"}], "collection": collection}
+        if cursor == 100:
+            return {
+                "messages": [{"count": "1"}],
+                "collection": [
+                    {
+                        "biorxiv_doi": "10.1101/pub-target",
+                        "preprint_title": "Target clinical publication",
+                        "preprint_authors": "Match Author",
+                        "preprint_abstract": "relevant",
+                    }
+                ],
+            }
+        return {"messages": [{"count": "0"}], "collection": []}
+
+    monkeypatch.setattr(biorxiv, "_get_json", fake_get_json)
+    monkeypatch.setattr(biorxiv.time, "sleep", lambda _seconds: None)
+
+    items, total, error = biorxiv.search_biorxiv_pubs(q="target clinical", limit=1)
+
+    assert error is None
+    assert [item["biorxiv_doi"] for item in items or []] == ["10.1101/pub-target"]
+    assert total == 1
+    assert cursors == [0, 100]

--- a/tldw_Server_API/tests/Research/test_biorxiv_sanitizers.py
+++ b/tldw_Server_API/tests/Research/test_biorxiv_sanitizers.py
@@ -1,3 +1,6 @@
+from collections.abc import Callable
+from typing import Any
+
 import pytest
 
 from tldw_Server_API.app.core.Third_Party import BioRxiv as biorxiv
@@ -105,15 +108,15 @@ _BIORXIV_ERROR_CASES = (
     _BIORXIV_ERROR_CASES,
 )
 def test_biorxiv_provider_paths_sanitize_fetch_failures(
-    monkeypatch,
-    patch_attr,
-    call_provider,
-    error_index,
-    expected_error,
-    _expected_timeout,
-    sensitive_terms,
-):
-    def fail_fetch(*_args, **_kwargs):
+    monkeypatch: pytest.MonkeyPatch,
+    patch_attr: str,
+    call_provider: Callable[[], tuple[Any, ...]],
+    error_index: int,
+    expected_error: str,
+    _expected_timeout: str,
+    sensitive_terms: tuple[str, ...],
+) -> None:
+    def fail_fetch(*_args: Any, **_kwargs: Any) -> None:
         raise RuntimeError(f"{sensitive_terms[0]} at {sensitive_terms[1]}")
 
     monkeypatch.setattr(biorxiv, patch_attr, fail_fetch)
@@ -131,15 +134,15 @@ def test_biorxiv_provider_paths_sanitize_fetch_failures(
     _BIORXIV_ERROR_CASES,
 )
 def test_biorxiv_provider_paths_preserve_timeout_classification(
-    monkeypatch,
-    patch_attr,
-    call_provider,
-    error_index,
-    _expected_error,
-    expected_timeout,
-    sensitive_terms,
-):
-    def fail_fetch(*_args, **_kwargs):
+    monkeypatch: pytest.MonkeyPatch,
+    patch_attr: str,
+    call_provider: Callable[[], tuple[Any, ...]],
+    error_index: int,
+    _expected_error: str,
+    expected_timeout: str,
+    sensitive_terms: tuple[str, ...],
+) -> None:
+    def fail_fetch(*_args: Any, **_kwargs: Any) -> None:
         raise TimeoutError(f"timed out for {sensitive_terms[0]} at {sensitive_terms[1]}")
 
     monkeypatch.setattr(biorxiv, patch_attr, fail_fetch)
@@ -152,10 +155,12 @@ def test_biorxiv_provider_paths_preserve_timeout_classification(
         assert term not in error
 
 
-def test_search_biorxiv_filtered_query_continues_after_empty_filtered_batch(monkeypatch):
+def test_search_biorxiv_filtered_query_continues_after_empty_filtered_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     cursors: list[int] = []
 
-    def fake_get_json(url, params=None, timeout=15):
+    def fake_get_json(url: str, params: dict[str, Any] | None = None, timeout: int = 15) -> dict[str, Any]:
         del params, timeout
         cursor = int(url.rstrip("/").split("/")[-1])
         cursors.append(cursor)
@@ -199,10 +204,12 @@ def test_search_biorxiv_filtered_query_continues_after_empty_filtered_batch(monk
     assert cursors == [0, 100]
 
 
-def test_search_biorxiv_pubs_filtered_query_continues_after_empty_filtered_batch(monkeypatch):
+def test_search_biorxiv_pubs_filtered_query_continues_after_empty_filtered_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     cursors: list[int] = []
 
-    def fake_get_json(url, timeout=15, params=None):
+    def fake_get_json(url: str, timeout: int = 15, params: dict[str, Any] | None = None) -> dict[str, Any]:
         del timeout, params
         cursor = int(url.rstrip("/").split("/")[-1])
         cursors.append(cursor)

--- a/tldw_Server_API/tests/Research/test_pmc_oa_sanitizers.py
+++ b/tldw_Server_API/tests/Research/test_pmc_oa_sanitizers.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+from typing import Any
+
 import pytest
 
 from tldw_Server_API.app.core.Third_Party import PMC_OA as pmc_oa
@@ -6,8 +9,8 @@ from tldw_Server_API.app.core.Third_Party import PMC_OA as pmc_oa
 pytestmark = pytest.mark.unit
 
 
-def test_pmc_oa_identify_sanitizes_xml_failures(monkeypatch):
-    def fail_get_xml(_params):
+def test_pmc_oa_identify_sanitizes_xml_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_get_xml(_params: dict[str, Any]) -> None:
         raise RuntimeError("pmc oa token at /private/pmc-oa.key")
 
     monkeypatch.setattr(pmc_oa, "_get_xml", fail_get_xml)
@@ -20,8 +23,8 @@ def test_pmc_oa_identify_sanitizes_xml_failures(monkeypatch):
     assert "/private/pmc-oa.key" not in error
 
 
-def test_pmc_oa_identify_preserves_timeout_classification(monkeypatch):
-    def fail_get_xml(_params):
+def test_pmc_oa_identify_preserves_timeout_classification(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_get_xml(_params: dict[str, Any]) -> None:
         raise TimeoutError("timed out at /private/pmc-oa-timeout.key")
 
     monkeypatch.setattr(pmc_oa, "_get_xml", fail_get_xml)
@@ -34,8 +37,8 @@ def test_pmc_oa_identify_preserves_timeout_classification(monkeypatch):
     assert "/private/pmc-oa-timeout.key" not in error
 
 
-def test_pmc_oa_query_sanitizes_xml_failures(monkeypatch):
-    def fail_get_xml(_params):
+def test_pmc_oa_query_sanitizes_xml_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_get_xml(_params: dict[str, Any]) -> None:
         raise RuntimeError("pmc oa query token at /private/pmc-oa-query.key")
 
     monkeypatch.setattr(pmc_oa, "_get_xml", fail_get_xml)
@@ -50,8 +53,8 @@ def test_pmc_oa_query_sanitizes_xml_failures(monkeypatch):
     assert "PMC123456" not in error
 
 
-def test_pmc_oa_query_preserves_timeout_classification(monkeypatch):
-    def fail_get_xml(_params):
+def test_pmc_oa_query_preserves_timeout_classification(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_get_xml(_params: dict[str, Any]) -> None:
         raise TimeoutError("timed out at /private/pmc-oa-query-timeout.key")
 
     monkeypatch.setattr(pmc_oa, "_get_xml", fail_get_xml)
@@ -65,8 +68,8 @@ def test_pmc_oa_query_preserves_timeout_classification(monkeypatch):
     assert "/private/pmc-oa-query-timeout.key" not in error
 
 
-def test_download_pmc_pdf_sanitizes_download_failures(monkeypatch):
-    def fail_download(**_kwargs):
+def test_download_pmc_pdf_sanitizes_download_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_download(**_kwargs: Any) -> None:
         raise RuntimeError("pmc pdf token at /private/pmc-pdf.key")
 
     monkeypatch.setattr(pmc_oa, "download", fail_download)
@@ -81,8 +84,8 @@ def test_download_pmc_pdf_sanitizes_download_failures(monkeypatch):
     assert "PMC123456" not in error
 
 
-def test_download_pmc_pdf_preserves_timeout_classification(monkeypatch):
-    def fail_download(**_kwargs):
+def test_download_pmc_pdf_preserves_timeout_classification(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_download(**_kwargs: Any) -> None:
         raise TimeoutError("timed out at /private/pmc-pdf-timeout.key")
 
     monkeypatch.setattr(pmc_oa, "download", fail_download)
@@ -96,8 +99,8 @@ def test_download_pmc_pdf_preserves_timeout_classification(monkeypatch):
     assert "/private/pmc-pdf-timeout.key" not in error
 
 
-def test_download_pmc_pdf_rejects_invalid_pmcid_without_fetch(monkeypatch):
-    def fail_fetch(**_kwargs):
+def test_download_pmc_pdf_rejects_invalid_pmcid_without_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_fetch(**_kwargs: Any) -> None:
         raise AssertionError("fetch should not be called for an invalid PMCID")
 
     monkeypatch.setattr(pmc_oa, "fetch", fail_fetch)
@@ -109,10 +112,13 @@ def test_download_pmc_pdf_rejects_invalid_pmcid_without_fetch(monkeypatch):
     assert error == "Invalid PMCID."
 
 
-def test_download_pmc_pdf_uses_bounded_download_and_validates_pdf(monkeypatch, tmp_path):
-    calls = {}
+def test_download_pmc_pdf_uses_bounded_download_and_validates_pdf(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: dict[str, Any] = {}
 
-    def fake_download(**kwargs):
+    def fake_download(**kwargs: Any) -> Path:
         calls.update(kwargs)
         dest = tmp_path / "pmc.pdf"
         dest.write_bytes(b"%PDF-1.7\nbody")
@@ -131,8 +137,12 @@ def test_download_pmc_pdf_uses_bounded_download_and_validates_pdf(monkeypatch, t
     assert calls["dest"].name == "PMC123456.pdf"
 
 
-def test_download_pmc_pdf_rejects_non_pdf_download(monkeypatch, tmp_path):
-    def fake_download(**kwargs):
+def test_download_pmc_pdf_rejects_non_pdf_download(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def fake_download(**kwargs: Any) -> Path:
+        del kwargs
         dest = tmp_path / "not-pdf.pdf"
         dest.write_bytes(b"<html>not found</html>")
         return dest

--- a/tldw_Server_API/tests/Research/test_pmc_oa_sanitizers.py
+++ b/tldw_Server_API/tests/Research/test_pmc_oa_sanitizers.py
@@ -65,11 +65,11 @@ def test_pmc_oa_query_preserves_timeout_classification(monkeypatch):
     assert "/private/pmc-oa-query-timeout.key" not in error
 
 
-def test_download_pmc_pdf_sanitizes_fetch_failures(monkeypatch):
-    def fail_fetch(**_kwargs):
+def test_download_pmc_pdf_sanitizes_download_failures(monkeypatch):
+    def fail_download(**_kwargs):
         raise RuntimeError("pmc pdf token at /private/pmc-pdf.key")
 
-    monkeypatch.setattr(pmc_oa, "fetch", fail_fetch)
+    monkeypatch.setattr(pmc_oa, "download", fail_download)
 
     content, filename, error = pmc_oa.download_pmc_pdf("PMC123456")
 
@@ -82,10 +82,10 @@ def test_download_pmc_pdf_sanitizes_fetch_failures(monkeypatch):
 
 
 def test_download_pmc_pdf_preserves_timeout_classification(monkeypatch):
-    def fail_fetch(**_kwargs):
+    def fail_download(**_kwargs):
         raise TimeoutError("timed out at /private/pmc-pdf-timeout.key")
 
-    monkeypatch.setattr(pmc_oa, "fetch", fail_fetch)
+    monkeypatch.setattr(pmc_oa, "download", fail_download)
 
     content, filename, error = pmc_oa.download_pmc_pdf("PMC123456")
 
@@ -94,3 +94,53 @@ def test_download_pmc_pdf_preserves_timeout_classification(monkeypatch):
     assert error == "PMC PDF download timed out."
     assert "timed out at" not in error
     assert "/private/pmc-pdf-timeout.key" not in error
+
+
+def test_download_pmc_pdf_rejects_invalid_pmcid_without_fetch(monkeypatch):
+    def fail_fetch(**_kwargs):
+        raise AssertionError("fetch should not be called for an invalid PMCID")
+
+    monkeypatch.setattr(pmc_oa, "fetch", fail_fetch)
+
+    content, filename, error = pmc_oa.download_pmc_pdf("PMCX123")
+
+    assert content is None
+    assert filename is None
+    assert error == "Invalid PMCID."
+
+
+def test_download_pmc_pdf_uses_bounded_download_and_validates_pdf(monkeypatch, tmp_path):
+    calls = {}
+
+    def fake_download(**kwargs):
+        calls.update(kwargs)
+        dest = tmp_path / "pmc.pdf"
+        dest.write_bytes(b"%PDF-1.7\nbody")
+        return dest
+
+    monkeypatch.setattr(pmc_oa, "download", fake_download)
+
+    content, filename, error = pmc_oa.download_pmc_pdf("pmc123456")
+
+    assert error is None
+    assert filename == "PMC123456.pdf"
+    assert content == b"%PDF-1.7\nbody"
+    assert calls["url"] == "https://pmc.ncbi.nlm.nih.gov/PMC123456/pdf"
+    assert calls["max_bytes_total"] == pmc_oa.PMC_PDF_MAX_BYTES
+    assert calls["require_content_type"] == "application/pdf"
+    assert calls["dest"].name == "PMC123456.pdf"
+
+
+def test_download_pmc_pdf_rejects_non_pdf_download(monkeypatch, tmp_path):
+    def fake_download(**kwargs):
+        dest = tmp_path / "not-pdf.pdf"
+        dest.write_bytes(b"<html>not found</html>")
+        return dest
+
+    monkeypatch.setattr(pmc_oa, "download", fake_download)
+
+    content, filename, error = pmc_oa.download_pmc_pdf("PMC123456")
+
+    assert content is None
+    assert filename is None
+    assert error == "PMC PDF download did not return a valid PDF."

--- a/tldw_Server_API/tests/Research/test_repec_sanitizers.py
+++ b/tldw_Server_API/tests/Research/test_repec_sanitizers.py
@@ -92,3 +92,27 @@ def test_get_citations_amf_raw_preserves_timeout_classification(monkeypatch):
     assert error == "CitEc request timed out."
     assert "timed out at" not in error
     assert "/private/citec-amf-timeout.key" not in error
+
+
+def test_citec_base_uses_https():
+    assert repec._CITEC_BASE.startswith("https://")
+
+
+def test_get_citations_plain_uses_https_citec_url(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        status_code = 200
+        text = "<citationData id=\"RePEc:abc:def:123\"><citedBy>1</citedBy><cites>2</cites></citationData>"
+
+    def fake_fetch(**kwargs):
+        captured["url"] = kwargs["url"]
+        return FakeResponse()
+
+    monkeypatch.setattr(repec, "fetch", fake_fetch)
+
+    item, error = repec.get_citations_plain("RePEc:abc:def:123")
+
+    assert error is None
+    assert item is not None
+    assert captured["url"] == "https://citec.repec.org/api/plain/RePEc:abc:def:123"

--- a/tldw_Server_API/tests/Research/test_repec_sanitizers.py
+++ b/tldw_Server_API/tests/Research/test_repec_sanitizers.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from tldw_Server_API.app.core.Third_Party import RePEc as repec
@@ -6,10 +8,10 @@ from tldw_Server_API.app.core.Third_Party import RePEc as repec
 pytestmark = pytest.mark.unit
 
 
-def test_get_ref_by_handle_sanitizes_fetch_failures(monkeypatch):
+def test_get_ref_by_handle_sanitizes_fetch_failures(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("REPEC_API_CODE", "test-code")
 
-    def fail_fetch(**_kwargs):
+    def fail_fetch(**_kwargs: Any) -> None:
         raise RuntimeError("repec token at /private/repec.key")
 
     monkeypatch.setattr(repec, "fetch", fail_fetch)
@@ -22,10 +24,10 @@ def test_get_ref_by_handle_sanitizes_fetch_failures(monkeypatch):
     assert "/private/repec.key" not in error
 
 
-def test_get_ref_by_handle_preserves_timeout_classification(monkeypatch):
+def test_get_ref_by_handle_preserves_timeout_classification(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("REPEC_API_CODE", "test-code")
 
-    def fail_fetch(**_kwargs):
+    def fail_fetch(**_kwargs: Any) -> None:
         raise TimeoutError("timed out at /private/repec-timeout.key")
 
     monkeypatch.setattr(repec, "fetch", fail_fetch)
@@ -38,8 +40,8 @@ def test_get_ref_by_handle_preserves_timeout_classification(monkeypatch):
     assert "/private/repec-timeout.key" not in error
 
 
-def test_get_citations_plain_sanitizes_fetch_failures(monkeypatch):
-    def fail_fetch(**_kwargs):
+def test_get_citations_plain_sanitizes_fetch_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_fetch(**_kwargs: Any) -> None:
         raise RuntimeError("citec token at /private/citec.key")
 
     monkeypatch.setattr(repec, "fetch", fail_fetch)
@@ -52,8 +54,8 @@ def test_get_citations_plain_sanitizes_fetch_failures(monkeypatch):
     assert "/private/citec.key" not in error
 
 
-def test_get_citations_plain_preserves_timeout_classification(monkeypatch):
-    def fail_fetch(**_kwargs):
+def test_get_citations_plain_preserves_timeout_classification(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_fetch(**_kwargs: Any) -> None:
         raise TimeoutError("timed out at /private/citec-timeout.key")
 
     monkeypatch.setattr(repec, "fetch", fail_fetch)
@@ -66,8 +68,8 @@ def test_get_citations_plain_preserves_timeout_classification(monkeypatch):
     assert "/private/citec-timeout.key" not in error
 
 
-def test_get_citations_amf_raw_sanitizes_fetch_failures(monkeypatch):
-    def fail_fetch(**_kwargs):
+def test_get_citations_amf_raw_sanitizes_fetch_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_fetch(**_kwargs: Any) -> None:
         raise RuntimeError("citec amf token at /private/citec-amf.key")
 
     monkeypatch.setattr(repec, "fetch", fail_fetch)
@@ -80,8 +82,8 @@ def test_get_citations_amf_raw_sanitizes_fetch_failures(monkeypatch):
     assert "/private/citec-amf.key" not in error
 
 
-def test_get_citations_amf_raw_preserves_timeout_classification(monkeypatch):
-    def fail_fetch(**_kwargs):
+def test_get_citations_amf_raw_preserves_timeout_classification(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_fetch(**_kwargs: Any) -> None:
         raise TimeoutError("timed out at /private/citec-amf-timeout.key")
 
     monkeypatch.setattr(repec, "fetch", fail_fetch)
@@ -94,18 +96,18 @@ def test_get_citations_amf_raw_preserves_timeout_classification(monkeypatch):
     assert "/private/citec-amf-timeout.key" not in error
 
 
-def test_citec_base_uses_https():
+def test_citec_base_uses_https() -> None:
     assert repec._CITEC_BASE.startswith("https://")
 
 
-def test_get_citations_plain_uses_https_citec_url(monkeypatch):
-    captured = {}
+def test_get_citations_plain_uses_https_citec_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, str] = {}
 
     class FakeResponse:
         status_code = 200
         text = "<citationData id=\"RePEc:abc:def:123\"><citedBy>1</citedBy><cites>2</cites></citationData>"
 
-    def fake_fetch(**kwargs):
+    def fake_fetch(**kwargs: Any) -> FakeResponse:
         captured["url"] = kwargs["url"]
         return FakeResponse()
 

--- a/tldw_Server_API/tests/Research/test_scopus_sanitizers.py
+++ b/tldw_Server_API/tests/Research/test_scopus_sanitizers.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from tldw_Server_API.app.core.Third_Party import Elsevier_Scopus as scopus
@@ -6,10 +8,10 @@ from tldw_Server_API.app.core.Third_Party import Elsevier_Scopus as scopus
 pytestmark = pytest.mark.unit
 
 
-def test_search_scopus_sanitizes_fetch_failures(monkeypatch):
+def test_search_scopus_sanitizes_fetch_failures(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ELSEVIER_API_KEY", "test-key")
 
-    def fail_fetch_json(**_kwargs):
+    def fail_fetch_json(**_kwargs: Any) -> None:
         raise RuntimeError("scopus token at /private/scopus.key")
 
     monkeypatch.setattr(scopus, "fetch_json", fail_fetch_json)
@@ -23,10 +25,10 @@ def test_search_scopus_sanitizes_fetch_failures(monkeypatch):
     assert "/private/scopus.key" not in error
 
 
-def test_search_scopus_preserves_timeout_classification(monkeypatch):
+def test_search_scopus_preserves_timeout_classification(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ELSEVIER_API_KEY", "test-key")
 
-    def fail_fetch_json(**_kwargs):
+    def fail_fetch_json(**_kwargs: Any) -> None:
         raise TimeoutError("timed out at /private/scopus-timeout.key")
 
     monkeypatch.setattr(scopus, "fetch_json", fail_fetch_json)
@@ -40,10 +42,10 @@ def test_search_scopus_preserves_timeout_classification(monkeypatch):
     assert "/private/scopus-timeout.key" not in error
 
 
-def test_get_scopus_by_doi_sanitizes_fetch_failures(monkeypatch):
+def test_get_scopus_by_doi_sanitizes_fetch_failures(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ELSEVIER_API_KEY", "test-key")
 
-    def fail_fetch(**_kwargs):
+    def fail_fetch(**_kwargs: Any) -> None:
         raise RuntimeError("scopus doi token at /private/scopus-doi.key")
 
     monkeypatch.setattr(scopus, "fetch", fail_fetch)
@@ -56,10 +58,10 @@ def test_get_scopus_by_doi_sanitizes_fetch_failures(monkeypatch):
     assert "/private/scopus-doi.key" not in error
 
 
-def test_get_scopus_by_doi_preserves_timeout_classification(monkeypatch):
+def test_get_scopus_by_doi_preserves_timeout_classification(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ELSEVIER_API_KEY", "test-key")
 
-    def fail_fetch(**_kwargs):
+    def fail_fetch(**_kwargs: Any) -> None:
         raise TimeoutError("timed out at /private/scopus-doi-timeout.key")
 
     monkeypatch.setattr(scopus, "fetch", fail_fetch)
@@ -70,3 +72,41 @@ def test_get_scopus_by_doi_preserves_timeout_classification(monkeypatch):
     assert error == "Scopus request timed out."
     assert "timed out at" not in error
     assert "/private/scopus-doi-timeout.key" not in error
+
+
+def test_get_scopus_by_doi_closes_successful_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ELSEVIER_API_KEY", "test-key")
+
+    class FakeResponse:
+        status_code = 200
+        closed = False
+
+        def json(self) -> dict[str, Any]:
+            return {
+                "search-results": {
+                    "entry": [
+                        {
+                            "eid": "2-s2.0-123",
+                            "dc:title": "Title",
+                            "prism:doi": "10.123/ok",
+                        }
+                    ]
+                }
+            }
+
+        def close(self) -> None:
+            self.closed = True
+
+    response = FakeResponse()
+
+    def fake_fetch(**_kwargs: Any) -> FakeResponse:
+        return response
+
+    monkeypatch.setattr(scopus, "fetch", fake_fetch)
+
+    item, error = scopus.get_scopus_by_doi("10.123/ok")
+
+    assert error is None
+    assert item is not None
+    assert item["doi"] == "10.123/ok"
+    assert response.closed

--- a/tldw_Server_API/tests/Research/test_vixra_sanitizers.py
+++ b/tldw_Server_API/tests/Research/test_vixra_sanitizers.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from tldw_Server_API.app.core.Third_Party import Vixra as vixra
@@ -6,8 +8,8 @@ from tldw_Server_API.app.core.Third_Party import Vixra as vixra
 pytestmark = pytest.mark.unit
 
 
-def test_get_vixra_by_id_sanitizes_resolution_failures(monkeypatch):
-    def fail_try_pdf(_url):
+def test_get_vixra_by_id_sanitizes_resolution_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_try_pdf(_url: str) -> None:
         raise RuntimeError("vixra token at /private/vixra.key")
 
     monkeypatch.setattr(vixra, "_try_pdf", fail_try_pdf)
@@ -20,8 +22,8 @@ def test_get_vixra_by_id_sanitizes_resolution_failures(monkeypatch):
     assert "/private/vixra.key" not in error
 
 
-def test_get_vixra_by_id_preserves_timeout_classification(monkeypatch):
-    def fail_try_pdf(_url):
+def test_get_vixra_by_id_preserves_timeout_classification(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_try_pdf(_url: str) -> None:
         raise TimeoutError("timed out at /private/vixra-timeout.key")
 
     monkeypatch.setattr(vixra, "_try_pdf", fail_try_pdf)
@@ -34,8 +36,8 @@ def test_get_vixra_by_id_preserves_timeout_classification(monkeypatch):
     assert "/private/vixra-timeout.key" not in error
 
 
-def test_search_sanitizes_setup_failures(monkeypatch):
-    def fail_quote(_value):
+def test_search_sanitizes_setup_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_quote(_value: str) -> None:
         raise RuntimeError("vixra search token at /private/vixra-search.key")
 
     monkeypatch.setattr(vixra, "urlquote", fail_quote)
@@ -49,8 +51,8 @@ def test_search_sanitizes_setup_failures(monkeypatch):
     assert "/private/vixra-search.key" not in error
 
 
-def test_search_preserves_timeout_classification(monkeypatch):
-    def fail_quote(_value):
+def test_search_preserves_timeout_classification(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_quote(_value: str) -> None:
         raise TimeoutError("timed out at /private/vixra-search-timeout.key")
 
     monkeypatch.setattr(vixra, "urlquote", fail_quote)
@@ -64,31 +66,41 @@ def test_search_preserves_timeout_classification(monkeypatch):
     assert "/private/vixra-search-timeout.key" not in error
 
 
-def test_search_applies_page_before_enriching_results(monkeypatch):
+def test_search_applies_page_before_enriching_results(monkeypatch: pytest.MonkeyPatch) -> None:
     search_html = """
         <a href="/abs/1001.0001">First result</a>
         <a href="/abs/1001.0002">Second result</a>
         <a href="/abs/1001.0003">Third result</a>
     """
     abs_requests: list[str] = []
+    responses: list["FakeResponse"] = []
 
     class FakeResponse:
-        def __init__(self, text):
+        def __init__(self, text: str) -> None:
             self.status_code = 200
             self.text = text
+            self.headers: dict[str, str] = {}
+            self.closed = False
 
-    def fake_fetch(**kwargs):
+        def close(self) -> None:
+            self.closed = True
+
+    def fake_fetch(**kwargs: Any) -> FakeResponse:
         url = kwargs["url"]
         if "/find/" in url or "?search=" in url or "?find=" in url:
-            return FakeResponse(search_html)
+            response = FakeResponse(search_html)
+            responses.append(response)
+            return response
         if "/abs/" in url:
             abs_requests.append(url)
             vid = url.rsplit("/", 1)[-1]
-            return FakeResponse(
+            response = FakeResponse(
                 f'<meta name="citation_title" content="Better {vid}">'
                 f'<meta name="citation_author" content="Author {vid}">'
                 '<meta name="citation_date" content="2024-01-01">'
             )
+            responses.append(response)
+            return response
         raise AssertionError(f"unexpected URL: {url}")
 
     monkeypatch.setattr(vixra, "fetch", fake_fetch)
@@ -100,3 +112,5 @@ def test_search_applies_page_before_enriching_results(monkeypatch):
     assert [item["id"] for item in items or []] == ["1001.0002"]
     assert [item["title"] for item in items or []] == ["Better 1001.0002"]
     assert abs_requests == ["https://vixra.org/abs/1001.0002"]
+    assert responses
+    assert all(response.closed for response in responses)

--- a/tldw_Server_API/tests/Research/test_vixra_sanitizers.py
+++ b/tldw_Server_API/tests/Research/test_vixra_sanitizers.py
@@ -62,3 +62,41 @@ def test_search_preserves_timeout_classification(monkeypatch):
     assert error == "viXra search request timed out."
     assert "timed out at" not in error
     assert "/private/vixra-search-timeout.key" not in error
+
+
+def test_search_applies_page_before_enriching_results(monkeypatch):
+    search_html = """
+        <a href="/abs/1001.0001">First result</a>
+        <a href="/abs/1001.0002">Second result</a>
+        <a href="/abs/1001.0003">Third result</a>
+    """
+    abs_requests: list[str] = []
+
+    class FakeResponse:
+        def __init__(self, text):
+            self.status_code = 200
+            self.text = text
+
+    def fake_fetch(**kwargs):
+        url = kwargs["url"]
+        if "/find/" in url or "?search=" in url or "?find=" in url:
+            return FakeResponse(search_html)
+        if "/abs/" in url:
+            abs_requests.append(url)
+            vid = url.rsplit("/", 1)[-1]
+            return FakeResponse(
+                f'<meta name="citation_title" content="Better {vid}">'
+                f'<meta name="citation_author" content="Author {vid}">'
+                '<meta name="citation_date" content="2024-01-01">'
+            )
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(vixra, "fetch", fake_fetch)
+
+    items, total, error = vixra.search("quantum", page=2, results_per_page=1)
+
+    assert error is None
+    assert total == 3
+    assert [item["id"] for item in items or []] == ["1001.0002"]
+    assert [item["title"] for item in items or []] == ["Better 1001.0002"]
+    assert abs_requests == ["https://vixra.org/abs/1001.0002"]

--- a/tldw_Server_API/tests/http_client/test_third_party_adapters_http.py
+++ b/tldw_Server_API/tests/http_client/test_third_party_adapters_http.py
@@ -1,7 +1,9 @@
+from collections.abc import Callable
 import os
 from typing import Any
 
 import httpx
+import pytest
 
 import tldw_Server_API.app.core.http_client as http_client
 from tldw_Server_API.app.core.Third_Party import HAL as hal
@@ -18,11 +20,11 @@ from tldw_Server_API.app.core.Third_Party import Semantic_Scholar as semantic_sc
 from tldw_Server_API.app.core.Third_Party import Springer_Nature as springer
 
 
-def _mock_transport(handler):
+def _mock_transport(handler: Callable[[httpx.Request], httpx.Response]) -> httpx.MockTransport:
     return httpx.MockTransport(handler)
 
 
-def test_hal_raw_media_types(monkeypatch):
+def test_hal_raw_media_types(monkeypatch: pytest.MonkeyPatch) -> None:
     # Allow HAL host in egress policy
     monkeypatch.setenv("EGRESS_ALLOWLIST", "api.archives-ouvertes.fr")
 
@@ -57,7 +59,7 @@ def test_hal_raw_media_types(monkeypatch):
     assert media_type == "application/json"
 
 
-def test_crossref_get_by_doi_404_and_success(monkeypatch):
+def test_crossref_get_by_doi_404_and_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("EGRESS_ALLOWLIST", "api.crossref.org")
     def handler(request: httpx.Request) -> httpx.Response:
         # Works lookup path
@@ -93,7 +95,7 @@ def test_crossref_get_by_doi_404_and_success(monkeypatch):
     assert item["doi"] == "10.123/ok"
 
 
-def test_openalex_get_by_doi_404_and_success(monkeypatch):
+def test_openalex_get_by_doi_404_and_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("EGRESS_ALLOWLIST", "api.openalex.org")
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -125,7 +127,7 @@ def test_openalex_get_by_doi_404_and_success(monkeypatch):
     assert item["doi"] == "10.321/ok"
 
 
-def test_scopus_get_by_doi_404_and_success(monkeypatch):
+def test_scopus_get_by_doi_404_and_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("EGRESS_ALLOWLIST", "api.elsevier.com")
     os.environ["ELSEVIER_API_KEY"] = "test_key"
 
@@ -165,7 +167,7 @@ def test_scopus_get_by_doi_404_and_success(monkeypatch):
     assert item["doi"] == "10.123/ok"
 
 
-def test_eartharxiv_get_by_doi_404_and_success(monkeypatch):
+def test_eartharxiv_get_by_doi_404_and_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("EGRESS_ALLOWLIST", "api.osf.io")
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -207,7 +209,7 @@ def test_eartharxiv_get_by_doi_404_and_success(monkeypatch):
     assert item["doi"] == "10.321/ok"
 
 
-def test_ieee_get_by_doi_404_and_success(monkeypatch):
+def test_ieee_get_by_doi_404_and_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("EGRESS_ALLOWLIST", "ieeexploreapi.ieee.org")
     os.environ["IEEE_API_KEY"] = "abc"
 
@@ -234,7 +236,7 @@ def test_ieee_get_by_doi_404_and_success(monkeypatch):
     assert item["doi"] == "10.1111/ok"
 
 
-def test_osf_get_by_doi_404_and_success(monkeypatch):
+def test_osf_get_by_doi_404_and_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("EGRESS_ALLOWLIST", "api.osf.io")
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -268,7 +270,7 @@ def test_osf_get_by_doi_404_and_success(monkeypatch):
     assert err is None and item is not None and item["doi"] == "10.333/also-ok"
 
 
-def test_biorxiv_get_by_doi_404_and_success(monkeypatch):
+def test_biorxiv_get_by_doi_404_and_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("EGRESS_ALLOWLIST", "api.biorxiv.org")
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -293,7 +295,7 @@ def test_biorxiv_get_by_doi_404_and_success(monkeypatch):
     assert err is None and item is not None and item["doi"] == "10.987/ok"
 
 
-def test_iacr_fetch_conference_and_raw(monkeypatch):
+def test_iacr_fetch_conference_and_raw(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("EGRESS_ALLOWLIST", "www.iacr.org")
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -317,7 +319,7 @@ def test_iacr_fetch_conference_and_raw(monkeypatch):
     assert err2 is None and media_type.startswith("application/json") and content
 
 
-def test_figshare_search_and_oai_raw(monkeypatch):
+def test_figshare_search_and_oai_raw(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("EGRESS_ALLOWLIST", "api.figshare.com")
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -352,7 +354,7 @@ def test_figshare_search_and_oai_raw(monkeypatch):
     assert err2 is None and content == b"<oai/>" and media_type == "application/xml"
 
 
-def test_semantic_scholar_search_surfaces_http_error_status(monkeypatch):
+def test_semantic_scholar_search_surfaces_http_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("EGRESS_ALLOWLIST", "api.semanticscholar.org")
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -371,7 +373,7 @@ def test_semantic_scholar_search_surfaces_http_error_status(monkeypatch):
     assert "HTTP Error: 429" in err
 
 
-def test_ieee_search_surfaces_http_error_status(monkeypatch):
+def test_ieee_search_surfaces_http_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("EGRESS_ALLOWLIST", "ieeexploreapi.ieee.org")
     monkeypatch.setenv("IEEE_API_KEY", "bad-key")
 
@@ -392,7 +394,7 @@ def test_ieee_search_surfaces_http_error_status(monkeypatch):
     assert "HTTP Error: 401" in err
 
 
-def test_springer_search_surfaces_http_error_status(monkeypatch):
+def test_springer_search_surfaces_http_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("EGRESS_ALLOWLIST", "api.springernature.com")
     monkeypatch.setenv("SPRINGER_NATURE_API_KEY", "bad-key")
 
@@ -413,7 +415,7 @@ def test_springer_search_surfaces_http_error_status(monkeypatch):
     assert "HTTP Error: 500" in err
 
 
-def test_scopus_lookup_surfaces_non_404_http_error_status(monkeypatch):
+def test_scopus_lookup_surfaces_non_404_http_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("EGRESS_ALLOWLIST", "api.elsevier.com")
     monkeypatch.setenv("ELSEVIER_API_KEY", "bad-key")
 

--- a/tldw_Server_API/tests/http_client/test_third_party_adapters_http.py
+++ b/tldw_Server_API/tests/http_client/test_third_party_adapters_http.py
@@ -14,6 +14,8 @@ from tldw_Server_API.app.core.Third_Party import OSF as osf
 from tldw_Server_API.app.core.Third_Party import BioRxiv as biorxiv
 from tldw_Server_API.app.core.Third_Party import IACR as iacr
 from tldw_Server_API.app.core.Third_Party import Figshare as figshare
+from tldw_Server_API.app.core.Third_Party import Semantic_Scholar as semantic_scholar
+from tldw_Server_API.app.core.Third_Party import Springer_Nature as springer
 
 
 def _mock_transport(handler):
@@ -348,3 +350,84 @@ def test_figshare_search_and_oai_raw(monkeypatch):
     assert err is None and items and total >= 1
     content, media_type, err2 = figshare.oai_raw({"verb": "Identify"})
     assert err2 is None and content == b"<oai/>" and media_type == "application/xml"
+
+
+def test_semantic_scholar_search_surfaces_http_error_status(monkeypatch):
+    monkeypatch.setenv("EGRESS_ALLOWLIST", "api.semanticscholar.org")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.host == "api.semanticscholar.org"
+        return httpx.Response(429, json={"message": "Too Many Requests"}, request=request)
+
+    def fake_create_client(*args: Any, **kwargs: Any) -> httpx.Client:
+        return httpx.Client(transport=_mock_transport(handler))
+
+    monkeypatch.setattr(http_client, "create_client", fake_create_client)
+
+    data, err = semantic_scholar.search_papers_semantic_scholar("retrieval")
+
+    assert data is None
+    assert err is not None
+    assert "HTTP Error: 429" in err
+
+
+def test_ieee_search_surfaces_http_error_status(monkeypatch):
+    monkeypatch.setenv("EGRESS_ALLOWLIST", "ieeexploreapi.ieee.org")
+    monkeypatch.setenv("IEEE_API_KEY", "bad-key")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.host == "ieeexploreapi.ieee.org"
+        return httpx.Response(401, json={"message": "invalid key"}, request=request)
+
+    def fake_create_client(*args: Any, **kwargs: Any) -> httpx.Client:
+        return httpx.Client(transport=_mock_transport(handler))
+
+    monkeypatch.setattr(http_client, "create_client", fake_create_client)
+
+    items, total, err = ieee.search_ieee("retrieval", 0, 10)
+
+    assert items is None
+    assert total == 0
+    assert err is not None
+    assert "HTTP Error: 401" in err
+
+
+def test_springer_search_surfaces_http_error_status(monkeypatch):
+    monkeypatch.setenv("EGRESS_ALLOWLIST", "api.springernature.com")
+    monkeypatch.setenv("SPRINGER_NATURE_API_KEY", "bad-key")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.host == "api.springernature.com"
+        return httpx.Response(500, json={"error": "server error"}, request=request)
+
+    def fake_create_client(*args: Any, **kwargs: Any) -> httpx.Client:
+        return httpx.Client(transport=_mock_transport(handler))
+
+    monkeypatch.setattr(http_client, "create_client", fake_create_client)
+
+    items, total, err = springer.search_springer("retrieval", 0, 10)
+
+    assert items is None
+    assert total == 0
+    assert err is not None
+    assert "HTTP Error: 500" in err
+
+
+def test_scopus_lookup_surfaces_non_404_http_error_status(monkeypatch):
+    monkeypatch.setenv("EGRESS_ALLOWLIST", "api.elsevier.com")
+    monkeypatch.setenv("ELSEVIER_API_KEY", "bad-key")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.host == "api.elsevier.com"
+        return httpx.Response(500, json={"service-error": "unavailable"}, request=request)
+
+    def fake_create_client(*args: Any, **kwargs: Any) -> httpx.Client:
+        return httpx.Client(transport=_mock_transport(handler))
+
+    monkeypatch.setattr(http_client, "create_client", fake_create_client)
+
+    item, err = scopus.get_scopus_by_doi("10.500/error")
+
+    assert item is None
+    assert err is not None
+    assert "HTTP Error: 500" in err


### PR DESCRIPTION
## Summary
- Harden Third_Party provider adapters for BioRxiv filtered pagination, PMC OA PDF download bounds, JSON HTTP status handling, HTTPS metadata URLs, and viXra pagination.
- Add a small status-aware Third_Party JSON helper used by selected adapters.
- Add focused regression coverage and record the work in Backlog TASK-11000.

## Test Plan
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Research/test_biorxiv_sanitizers.py tldw_Server_API/tests/Research/test_pmc_oa_sanitizers.py tldw_Server_API/tests/Research/test_vixra_sanitizers.py tldw_Server_API/tests/Research/test_arxiv_sanitizers.py tldw_Server_API/tests/Research/test_repec_sanitizers.py tldw_Server_API/tests/http_client/test_third_party_adapters_http.py tldw_Server_API/tests/Research/test_semantic_scholar_sanitizers.py tldw_Server_API/tests/Research/test_ieee_sanitizers.py tldw_Server_API/tests/Research/test_springer_sanitizers.py tldw_Server_API/tests/Research/test_scopus_sanitizers.py tldw_Server_API/tests/Research/test_paper_search_endpoints.py tldw_Server_API/tests/Research/test_error_mapping_endpoints.py -q` (119 passed)
- `python -m bandit -r <touched Third_Party files> -f json -o /tmp/bandit_third_party_review_pr_11000_post_rebase.json` (0 findings)
- `git diff --check HEAD`
- `python -m compileall -q tldw_Server_API/app/core/Third_Party`

## Change summary
Draft PR note: this PR is materially AI-authored. Per repository policy, a human requester must replace this section with a human-written change summary explaining what changed and why before merge readiness.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened third-party provider adapters to fix BioRxiv/viXra pagination, enforce bounded PMC OA PDF downloads, surface HTTP errors, and upgrade arXiv/CitEc to HTTPS. Aligns with `TASK-11000` and centralizes status-aware JSON handling across Scopus, IEEE, Springer, and Semantic Scholar.

- **Bug Fixes**
  - BioRxiv: continue across upstream batches when filtered pages are empty; apply filters client-side.
  - PMC OA: bounded temp-file downloads via `download` with `PMC_PDF_MAX_BYTES`, require `application/pdf`, validate `%PDF`; stricter PMCID check; clearer errors.
  - arXiv and CitEc: switch API/export endpoints to HTTPS.
  - viXra: apply pagination before enrichment; total reflects full candidate set; close HTTP responses.
  - Scopus/IEEE/Springer/Semantic Scholar: status-aware JSON handling surfaces HTTP error messages; 404 treated as not-found; close Scopus responses.

- **Refactors**
  - Added `fetch_json_checked` and centralized `ThirdPartyHTTPStatusError` for consistent, status-aware JSON handling across adapters.

<sup>Written for commit 5cf3d925252be8b16273ad3a95e737f877a0c37c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

