### PR TITLE
fix: harden Research core review findings

### DIFF
--- a/Docs/superpowers/plans/2026-06-23-research-core-review-hardening-plan.md
+++ b/Docs/superpowers/plans/2026-06-23-research-core-review-hardening-plan.md
@@ -1,0 +1,170 @@
+# Research Core Review Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Verify and fix validated Research core review findings from TASK-9922.
+**Status:** Complete.
+
+**Architecture:** Keep fixes inside the existing Research service, worker, artifact store, and phase handlers. Use owner-scoped service helpers, per-user worker path resolution, immutable artifact file paths, cooperative phase cancellation, and budget checks at provider-call boundaries.
+
+**Tech Stack:** Python, FastAPI service layer, SQLite-backed `ResearchSessionsDB`, pytest, Bandit.
+
+---
+
+### Task 1: Owner Scoping and Checkpoint Replay Guards
+
+**Status:** Complete.
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Research/service.py`
+- Test: `tldw_Server_API/tests/Research/test_research_core_hardening.py`
+
+- [x] **Step 1: Write failing tests**
+
+Add tests showing that a shared `ResearchService(research_db_path=...)` rejects cross-owner `get_session`, `get_artifact`, `pause_run`, `resume_run`, `cancel_run`, `build_package`, and `approve_checkpoint`, and that stale or already-approved checkpoints cannot be replayed.
+
+- [x] **Step 2: Verify red**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Research/test_research_core_hardening.py -q
+```
+
+Expected: the new owner-scope and stale-checkpoint tests fail against the current code.
+
+- [x] **Step 3: Implement minimal fix**
+
+Add an internal `_get_owned_session(db, owner_user_id, session_id)` helper in `ResearchService` and use it from public methods. Add `_validate_checkpoint_approval_state(...)` to require owner match, pending checkpoint, latest checkpoint, `waiting_human` status, and the expected phase for each checkpoint type before patching or enqueueing.
+
+- [x] **Step 4: Verify green**
+
+Run the same pytest command and confirm the new tests pass.
+
+### Task 2: Worker Per-User Store Resolution
+
+**Status:** Complete.
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Research/jobs_worker.py`
+- Modify: `tldw_Server_API/app/core/Research/jobs.py`
+- Test: `tldw_Server_API/tests/Research/test_research_core_hardening.py`
+
+- [x] **Step 1: Write failing tests**
+
+Add tests showing `run_research_jobs_worker` handler path resolution uses `job["owner_user_id"]` to derive `DatabasePaths.get_research_sessions_db_path(owner)` and `DatabasePaths.get_user_outputs_dir(owner)` when explicit worker override paths are not supplied.
+
+- [x] **Step 2: Verify red**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Research/test_research_core_hardening.py -q
+```
+
+Expected: the worker resolution test fails against the current fixed shared-path behavior.
+
+- [x] **Step 3: Implement minimal fix**
+
+Allow `run_research_jobs_worker` to pass explicit paths only when supplied by arguments or environment. Otherwise resolve per-job paths from `owner_user_id`; if owner is absent, raise a deterministic `ValueError`.
+
+- [x] **Step 4: Verify green**
+
+Run the same pytest command and confirm the new test passes.
+
+### Task 3: Immutable Artifact Versions
+
+**Status:** Complete.
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Research/artifact_store.py`
+- Modify if needed: `tldw_Server_API/app/core/DB_Management/ResearchSessionsDB.py`
+- Test: `tldw_Server_API/tests/Research/test_research_core_hardening.py`
+
+- [x] **Step 1: Write failing tests**
+
+Add a test that writes two versions of the same artifact and asserts each DB row points to a different existing file whose content matches the row checksum and original payload.
+
+- [x] **Step 2: Verify red**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Research/test_research_core_hardening.py -q
+```
+
+Expected: the test fails because both rows currently point at one overwritten path.
+
+- [x] **Step 3: Implement minimal fix**
+
+Compute `next_version` before writing and write to a filename containing `.v<version>` before the extension, using a temporary file and `replace()` for atomic publication.
+
+- [x] **Step 4: Verify green**
+
+Run the same pytest command and confirm the new test passes.
+
+### Task 4: Cooperative Cancellation and Budget Limits
+
+**Status:** Complete.
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Research/jobs.py`
+- Modify: `tldw_Server_API/app/core/Research/limits.py`
+- Test: `tldw_Server_API/tests/Research/test_research_core_hardening.py`
+
+- [x] **Step 1: Write failing tests**
+
+Add tests showing collection stops before the second focus-area provider call when the first call marks `cancel_requested`, and collection raises a structured limit error when configured `max_searches` is exhausted.
+
+- [x] **Step 2: Verify red**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Research/test_research_core_hardening.py -q
+```
+
+Expected: cancellation and limit tests fail against the current phase handler.
+
+- [x] **Step 3: Implement minimal fix**
+
+Add `_halt_for_control_between_steps(...)`, load `ResearchLimits` from `session.limits_json`, check runtime and search budgets before provider calls, and return/cancel promptly between focus areas.
+
+- [x] **Step 4: Verify green**
+
+Run the same pytest command and confirm the new tests pass.
+
+### Task 5: Final Verification and Task Update
+
+**Status:** Complete.
+
+**Files:**
+- Modify: `backlog/tasks/task-9922 - Harden-Research-core-review-findings.md`
+
+- [x] **Step 1: Run focused tests**
+
+```bash
+./.venv/bin/python -m pytest -p no:unraisableexception tldw_Server_API/tests/Research/test_research_core_hardening.py -q
+```
+
+- [x] **Step 2: Run focused compatibility tests**
+
+```bash
+./.venv/bin/python -m pytest -p no:unraisableexception tldw_Server_API/tests/Research/test_research_artifact_store.py::test_write_json_artifact_records_manifest tldw_Server_API/tests/Research/test_research_jobs_service.py::test_approve_plan_review_enqueues_collecting_job tldw_Server_API/tests/Research/test_research_jobs_service.py::test_approve_sources_review_enqueues_synthesizing_job_and_writes_review_artifact tldw_Server_API/tests/Research/test_research_jobs_service.py::test_approve_sources_review_with_recollect_enqueues_collecting_job tldw_Server_API/tests/Research/test_research_jobs_service.py::test_approve_outline_review_enqueues_packaging_job tldw_Server_API/tests/Research/test_research_jobs_service.py::test_approve_outline_review_patch_enqueues_resynthesis_with_locked_outline tldw_Server_API/tests/Research/test_research_jobs_service.py::test_get_session_bundle_and_allowlisted_artifacts tldw_Server_API/tests/Research/test_research_jobs_service.py::test_pause_run_marks_active_executable_session_pause_requested tldw_Server_API/tests/Research/test_research_jobs_service.py::test_resume_run_reenqueues_executable_phase_and_restores_checkpoint_wait tldw_Server_API/tests/Research/test_research_jobs_service.py::test_cancel_run_requests_active_work_and_terminalizes_idle_sessions -q
+```
+
+- [x] **Step 3: Run Bandit on touched production scope**
+
+```bash
+./.venv/bin/python -m bandit -r tldw_Server_API/app/core/Research/service.py tldw_Server_API/app/core/Research/artifact_store.py tldw_Server_API/app/core/Research/jobs.py tldw_Server_API/app/core/Research/jobs_worker.py -f json -o /tmp/bandit_research_core_hardening.json
+```
+
+- [x] **Step 4: Run diff hygiene**
+
+```bash
+git diff --check -- tldw_Server_API/app/core/Research/service.py tldw_Server_API/app/core/Research/artifact_store.py tldw_Server_API/app/core/Research/jobs.py tldw_Server_API/app/core/Research/jobs_worker.py tldw_Server_API/tests/Research/test_research_core_hardening.py Docs/superpowers/plans/2026-06-23-research-core-review-hardening-plan.md "backlog/tasks/task-9922 - Harden-Research-core-review-findings.md"
+```
+
+- [x] **Step 5: Update Backlog task**
+
+Record validated findings, changed files, test results, Bandit result, known skips, and final summary in TASK-9922.

--- a/backlog/tasks/task-9922 - Harden-Research-core-review-findings.md
+++ b/backlog/tasks/task-9922 - Harden-Research-core-review-findings.md
@@ -1,0 +1,57 @@
+---
+id: TASK-9922
+title: Harden Research core review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 18:28'
+updated_date: '2026-06-23 18:58'
+labels:
+  - research
+  - security
+  - hardening
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and address validated current-state review findings in tldw_Server_API/app/core/Research: worker per-user store routing, owner scoping, checkpoint replay guards, artifact version durability, cancellation responsiveness, and limits enforcement.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Validated findings are either fixed with focused tests or documented as not applicable after verification.
+- [x] #2 Research service APIs enforce owner scoping for session reads, artifacts, control actions, checkpoint approval, and package builds.
+- [x] #3 Research Jobs worker can process API-created per-user sessions without shared-path mismatch.
+- [x] #4 Artifact version storage preserves historical versions and avoids version race regressions.
+- [x] #5 Pause/cancel and configured research limits are enforced during long-running phases.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Plan file: Docs/superpowers/plans/2026-06-23-research-core-review-hardening-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verification pass confirmed all six review findings were present in current code before fixes. Implemented owner-scoped service reads/actions, checkpoint replay guards, per-user Jobs worker path resolution, unique immutable artifact storage files with latest aliases, cooperative cancellation checks, and collection budget enforcement. Added focused regression coverage in tldw_Server_API/tests/Research/test_research_core_hardening.py. PR review follow-up: async Research job handlers now offload artifact writes through asyncio.to_thread to avoid blocking the event loop. Verification: hardening pytest 10 passed; compatibility pytest slice 10 passed; py_compile passed; git diff --check passed; Bandit JSON reported errors=0 and results=0. Known skip/workaround: default pytest cleanup with the unraisableexception plugin hung during earlier red runs, so focused verification used -p no:unraisableexception.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Validated and fixed all six Research core review findings plus PR review feedback. Owner checks now gate session reads, artifacts, control actions, checkpoint approval, and package builds; checkpoint approvals require the current pending checkpoint in the expected waiting phase; Jobs worker paths resolve per owner from job payloads; artifact rows point at unique immutable files while preserving latest-name aliases; long collection/synthesis work checks cancellation; collection enforces configured search, fetched-doc, and runtime budgets; async job handlers offload artifact writes instead of blocking the event loop. Verification passed: 10 focused hardening tests, 10 compatibility tests, py_compile, git diff --check, and Bandit errors=0 results=0.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Research/artifact_store.py
+++ b/tldw_Server_API/app/core/Research/artifact_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -31,6 +32,22 @@ class ResearchArtifactStore:
         artifact_dir = self.base_dir / "research" / session_id
         artifact_dir.mkdir(parents=True, exist_ok=True)
         return artifact_dir / safe_name
+
+    def _versioned_artifact_path(self, session_id: str, artifact_name: str, artifact_version: int) -> Path:
+        path = self._artifact_path(session_id, artifact_name)
+        unique_suffix = uuid.uuid4().hex
+        suffix = "".join(path.suffixes)
+        if suffix:
+            stem = path.name[: -len(suffix)]
+            return path.with_name(f"{stem}.v{artifact_version}.{unique_suffix}{suffix}")
+        return path.with_name(f"{path.name}.v{artifact_version}.{unique_suffix}")
+
+    @staticmethod
+    def _write_bytes_atomically(path: Path, encoded: bytes) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+        tmp_path.write_bytes(encoded)
+        tmp_path.replace(path)
 
     def _next_version(self, session_id: str, artifact_name: str) -> int:
         existing = [
@@ -78,14 +95,16 @@ class ResearchArtifactStore:
         job_id: str | None,
     ) -> ResearchArtifactRow:
         owner_user_id = str(owner_user_id)
-        path = self._artifact_path(session_id, artifact_name)
+        safe_name = self._artifact_path(session_id, artifact_name).name
+        next_version = self._next_version(session_id, safe_name)
+        path = self._versioned_artifact_path(session_id, safe_name, next_version)
         encoded = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
-        path.write_bytes(encoded)
-        next_version = self._next_version(session_id, path.name)
+        self._write_bytes_atomically(path, encoded)
+        self._write_bytes_atomically(self._artifact_path(session_id, safe_name), encoded)
         artifact, _ = self.db.record_artifact_with_event(
             owner_user_id=owner_user_id,
             session_id=session_id,
-            artifact_name=path.name,
+            artifact_name=safe_name,
             artifact_version=next_version,
             storage_path=str(path),
             content_type="application/json",
@@ -95,7 +114,7 @@ class ResearchArtifactStore:
             job_id=job_id,
             event_type="artifact",
             event_payload=self._artifact_event_payload(
-                artifact_name=path.name,
+                artifact_name=safe_name,
                 artifact_version=next_version,
                 content_type="application/json",
                 phase=phase,
@@ -115,17 +134,19 @@ class ResearchArtifactStore:
         job_id: str | None,
     ) -> ResearchArtifactRow:
         owner_user_id = str(owner_user_id)
-        path = self._artifact_path(session_id, artifact_name)
+        safe_name = self._artifact_path(session_id, artifact_name).name
+        next_version = self._next_version(session_id, safe_name)
+        path = self._versioned_artifact_path(session_id, safe_name, next_version)
         encoded = "".join(
             f"{json.dumps(record, sort_keys=True)}\n"
             for record in records
         ).encode("utf-8")
-        path.write_bytes(encoded)
-        next_version = self._next_version(session_id, path.name)
+        self._write_bytes_atomically(path, encoded)
+        self._write_bytes_atomically(self._artifact_path(session_id, safe_name), encoded)
         artifact, _ = self.db.record_artifact_with_event(
             owner_user_id=owner_user_id,
             session_id=session_id,
-            artifact_name=path.name,
+            artifact_name=safe_name,
             artifact_version=next_version,
             storage_path=str(path),
             content_type="application/x-ndjson",
@@ -135,7 +156,7 @@ class ResearchArtifactStore:
             job_id=job_id,
             event_type="artifact",
             event_payload=self._artifact_event_payload(
-                artifact_name=path.name,
+                artifact_name=safe_name,
                 artifact_version=next_version,
                 content_type="application/x-ndjson",
                 phase=phase,
@@ -156,14 +177,16 @@ class ResearchArtifactStore:
         content_type: str = "text/plain",
     ) -> ResearchArtifactRow:
         owner_user_id = str(owner_user_id)
-        path = self._artifact_path(session_id, artifact_name)
+        safe_name = self._artifact_path(session_id, artifact_name).name
+        next_version = self._next_version(session_id, safe_name)
+        path = self._versioned_artifact_path(session_id, safe_name, next_version)
         encoded = content.encode("utf-8")
-        path.write_bytes(encoded)
-        next_version = self._next_version(session_id, path.name)
+        self._write_bytes_atomically(path, encoded)
+        self._write_bytes_atomically(self._artifact_path(session_id, safe_name), encoded)
         artifact, _ = self.db.record_artifact_with_event(
             owner_user_id=owner_user_id,
             session_id=session_id,
-            artifact_name=path.name,
+            artifact_name=safe_name,
             artifact_version=next_version,
             storage_path=str(path),
             content_type=content_type,
@@ -173,7 +196,7 @@ class ResearchArtifactStore:
             job_id=job_id,
             event_type="artifact",
             event_payload=self._artifact_event_payload(
-                artifact_name=path.name,
+                artifact_name=safe_name,
                 artifact_version=next_version,
                 content_type=content_type,
                 phase=phase,

--- a/tldw_Server_API/app/core/Research/jobs.py
+++ b/tldw_Server_API/app/core/Research/jobs.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
 from dataclasses import asdict
 from datetime import UTC, datetime
 from pathlib import Path
@@ -12,6 +14,7 @@ from tldw_Server_API.app.core.Research.artifact_store import ResearchArtifactSto
 from tldw_Server_API.app.core.Research.broker import ResearchBroker
 from tldw_Server_API.app.core.Research.chat_handoff import deliver_research_chat_handoff
 from tldw_Server_API.app.core.Research.exporter import build_final_package
+from tldw_Server_API.app.core.Research.limits import ResearchLimits, ensure_limit_available
 from tldw_Server_API.app.core.Research.models import (
     ResearchEvidenceNote,
     ResearchPlan,
@@ -84,6 +87,46 @@ def _checkpoint_event_payload(*, checkpoint: Any, phase: str | None) -> dict[str
     }
 
 
+def _limits_from_session(session: Any) -> ResearchLimits | None:
+    payload = session.limits_json if isinstance(getattr(session, "limits_json", None), dict) else {}
+    required = ("max_searches", "max_fetched_docs", "max_runtime_seconds")
+    if not any(key in payload for key in required):
+        return None
+    try:
+        unlimited = 2_147_483_647
+        return ResearchLimits(
+            max_searches=int(payload["max_searches"]) if "max_searches" in payload else unlimited,
+            max_fetched_docs=int(payload["max_fetched_docs"]) if "max_fetched_docs" in payload else unlimited,
+            max_runtime_seconds=int(payload["max_runtime_seconds"]) if "max_runtime_seconds" in payload else unlimited,
+        )
+    except (TypeError, ValueError):
+        raise ValueError("research_limit_invalid") from None
+
+
+def _enforce_limit_available(limits: ResearchLimits | None, usage: dict[str, int], key: str) -> None:
+    if limits is None:
+        return
+    error = ensure_limit_available(limits, usage, key)
+    if error is not None:
+        raise ValueError(f"{error.code}:{error.limit_key}")
+
+
+def _update_runtime_usage(*, usage: dict[str, int], started_at: float) -> None:
+    usage["runtime_seconds"] = int(max(0, time.monotonic() - started_at))
+
+
+async def _write_json_artifact(artifact_store: ResearchArtifactStore, **kwargs: Any) -> Any:
+    return await asyncio.to_thread(artifact_store.write_json, **kwargs)
+
+
+async def _write_jsonl_artifact(artifact_store: ResearchArtifactStore, **kwargs: Any) -> Any:
+    return await asyncio.to_thread(artifact_store.write_jsonl, **kwargs)
+
+
+async def _write_text_artifact(artifact_store: ResearchArtifactStore, **kwargs: Any) -> Any:
+    return await asyncio.to_thread(artifact_store.write_text, **kwargs)
+
+
 def enqueue_research_phase_job(
     *,
     jm: Any,
@@ -100,6 +143,7 @@ def enqueue_research_phase_job(
         "session_id": session_id,
         "phase": phase,
         "checkpoint_id": checkpoint_id,
+        "owner_user_id": str(owner_user_id),
         "policy_version": int(policy_version),
     }
     if isinstance(payload_overrides, dict):
@@ -206,7 +250,8 @@ async def _handle_planning_phase(
         follow_up_background=follow_up_background,
     )
 
-    artifact_store.write_json(
+    await _write_json_artifact(
+        artifact_store,
         owner_user_id=session.owner_user_id,
         session_id=session.id,
         artifact_name="plan.json",
@@ -214,7 +259,8 @@ async def _handle_planning_phase(
         phase=session.phase,
         job_id=job_id,
     )
-    artifact_store.write_json(
+    await _write_json_artifact(
+        artifact_store,
         owner_user_id=session.owner_user_id,
         session_id=session.id,
         artifact_name="provider_config.json",
@@ -277,6 +323,9 @@ async def _handle_collecting_phase(
     pinned_source_ids = set(approved_sources.get("pinned_source_ids", []))
     recollect = approved_sources.get("recollect", {}) if isinstance(approved_sources.get("recollect"), dict) else {}
     recollect_enabled = bool(recollect.get("enabled"))
+    limits = _limits_from_session(session)
+    usage = {"searches": 0, "fetched_docs": 0, "runtime_seconds": 0}
+    started_at = time.monotonic()
 
     sources_by_fingerprint: dict[str, dict[str, Any]] = {}
     evidence_notes: list[dict[str, Any]] = []
@@ -313,6 +362,13 @@ async def _handle_collecting_phase(
                 evidence_notes.append(dict(note))
 
     for focus_area in plan.focus_areas:
+        halted = _halt_for_control_before_phase(db=db, session_id=session.id)
+        if halted is not None:
+            return halted
+        _update_runtime_usage(usage=usage, started_at=started_at)
+        _enforce_limit_available(limits, usage, "runtime_seconds")
+        _enforce_limit_available(limits, usage, "searches")
+        _enforce_limit_available(limits, usage, "fetched_docs")
         result = await broker.collect_focus_area(
             session_id=session.id,
             owner_user_id=session.owner_user_id,
@@ -324,6 +380,12 @@ async def _handle_collecting_phase(
                 "recollect": dict(recollect),
             },
         )
+        usage["searches"] += 1
+        usage["fetched_docs"] += len(result.sources)
+        _update_runtime_usage(usage=usage, started_at=started_at)
+        _enforce_limit_available(limits, usage, "runtime_seconds")
+        if limits is not None and usage["fetched_docs"] > limits.max_fetched_docs:
+            raise ValueError("research_limit_exceeded:fetched_docs")
         for source in result.sources:
             serialized = asdict(source)
             if serialized["source_id"] in dropped_source_ids:
@@ -363,6 +425,9 @@ async def _handle_collecting_phase(
             if gap not in gap_set:
                 gap_set.add(gap)
                 remaining_gaps.append(gap)
+        halted = _halt_for_control_before_phase(db=db, session_id=session.id)
+        if halted is not None:
+            return halted
 
     source_registry = list(sources_by_fingerprint.values())
     attempted_lane_total = sum(lane_attempts.values())
@@ -385,7 +450,8 @@ async def _handle_collecting_phase(
         "review_directives": approved_sources if approved_sources else None,
     }
 
-    artifact_store.write_json(
+    await _write_json_artifact(
+        artifact_store,
         owner_user_id=session.owner_user_id,
         session_id=session.id,
         artifact_name="source_registry.json",
@@ -395,7 +461,8 @@ async def _handle_collecting_phase(
         phase="collecting",
         job_id=job_id,
     )
-    artifact_store.write_jsonl(
+    await _write_jsonl_artifact(
+        artifact_store,
         owner_user_id=session.owner_user_id,
         session_id=session.id,
         artifact_name="evidence_notes.jsonl",
@@ -403,7 +470,8 @@ async def _handle_collecting_phase(
         phase="collecting",
         job_id=job_id,
     )
-    artifact_store.write_json(
+    await _write_json_artifact(
+        artifact_store,
         owner_user_id=session.owner_user_id,
         session_id=session.id,
         artifact_name="collection_summary.json",
@@ -609,6 +677,9 @@ async def _handle_synthesizing_phase(
         outline_seed=outline_seed if approved_outline_locked else None,
         approved_outline_locked=approved_outline_locked,
     )
+    halted = _halt_for_control_before_phase(db=db, session_id=session.id)
+    if halted is not None:
+        return halted
 
     outline_payload = {
         "query": plan.query,
@@ -619,7 +690,8 @@ async def _handle_synthesizing_phase(
         "claims": [asdict(claim) for claim in result.claims],
     }
 
-    artifact_store.write_json(
+    await _write_json_artifact(
+        artifact_store,
         owner_user_id=session.owner_user_id,
         session_id=session.id,
         artifact_name="outline_v1.json",
@@ -627,7 +699,8 @@ async def _handle_synthesizing_phase(
         phase="synthesizing",
         job_id=job_id,
     )
-    artifact_store.write_json(
+    await _write_json_artifact(
+        artifact_store,
         owner_user_id=session.owner_user_id,
         session_id=session.id,
         artifact_name="claims.json",
@@ -635,7 +708,8 @@ async def _handle_synthesizing_phase(
         phase="synthesizing",
         job_id=job_id,
     )
-    artifact_store.write_text(
+    await _write_text_artifact(
+        artifact_store,
         owner_user_id=session.owner_user_id,
         session_id=session.id,
         artifact_name="report_v1.md",
@@ -644,7 +718,8 @@ async def _handle_synthesizing_phase(
         job_id=job_id,
         content_type="text/markdown",
     )
-    artifact_store.write_json(
+    await _write_json_artifact(
+        artifact_store,
         owner_user_id=session.owner_user_id,
         session_id=session.id,
         artifact_name="synthesis_summary.json",
@@ -652,7 +727,8 @@ async def _handle_synthesizing_phase(
         phase="synthesizing",
         job_id=job_id,
     )
-    artifact_store.write_json(
+    await _write_json_artifact(
+        artifact_store,
         owner_user_id=session.owner_user_id,
         session_id=session.id,
         artifact_name="verification_summary.json",
@@ -660,7 +736,8 @@ async def _handle_synthesizing_phase(
         phase="synthesizing",
         job_id=job_id,
     )
-    artifact_store.write_json(
+    await _write_json_artifact(
+        artifact_store,
         owner_user_id=session.owner_user_id,
         session_id=session.id,
         artifact_name="unsupported_claims.json",
@@ -668,7 +745,8 @@ async def _handle_synthesizing_phase(
         phase="synthesizing",
         job_id=job_id,
     )
-    artifact_store.write_json(
+    await _write_json_artifact(
+        artifact_store,
         owner_user_id=session.owner_user_id,
         session_id=session.id,
         artifact_name="contradictions.json",
@@ -676,7 +754,8 @@ async def _handle_synthesizing_phase(
         phase="synthesizing",
         job_id=job_id,
     )
-    artifact_store.write_json(
+    await _write_json_artifact(
+        artifact_store,
         owner_user_id=session.owner_user_id,
         session_id=session.id,
         artifact_name="source_trust.json",
@@ -770,7 +849,8 @@ async def _handle_packaging_phase(
         source_trust=list(source_trust_payload.get("sources", [])),
     )
 
-    artifact_store.write_json(
+    await _write_json_artifact(
+        artifact_store,
         owner_user_id=session.owner_user_id,
         session_id=session.id,
         artifact_name="bundle.json",

--- a/tldw_Server_API/app/core/Research/jobs_worker.py
+++ b/tldw_Server_API/app/core/Research/jobs_worker.py
@@ -12,6 +12,7 @@ from loguru import logger
 from tldw_Server_API.app.core.Jobs.worker_sdk import WorkerConfig, WorkerSDK
 from tldw_Server_API.app.core.Jobs.worker_utils import coerce_int as _coerce_int
 from tldw_Server_API.app.core.Jobs.worker_utils import jobs_manager_from_env as _jobs_manager
+from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 
 from .jobs import RESEARCH_DOMAIN, RESEARCH_QUEUE, handle_research_phase_job
 
@@ -45,19 +46,34 @@ async def run_research_jobs_worker(
 
         _stop_watcher_task = asyncio.create_task(_watch_stop())
 
-    resolved_research_db_path = Path(research_db_path or os.getenv("RESEARCH_SESSIONS_DB_PATH") or "Databases/ResearchSessions.db")
-    resolved_outputs_dir = Path(outputs_dir or os.getenv("RESEARCH_OUTPUTS_DIR") or "Databases/outputs")
+    research_db_path_override = research_db_path or os.getenv("RESEARCH_SESSIONS_DB_PATH")
+    outputs_dir_override = outputs_dir or os.getenv("RESEARCH_OUTPUTS_DIR")
+    resolved_research_db_path = Path(research_db_path_override) if research_db_path_override else None
+    resolved_outputs_dir = Path(outputs_dir_override) if outputs_dir_override else None
+
+    def _paths_for_job(job: dict[str, object]) -> tuple[Path, Path]:
+        payload = job.get("payload") if isinstance(job.get("payload"), dict) else {}
+        owner_user_id = str(job.get("owner_user_id") or payload.get("owner_user_id") or "").strip()
+        if (resolved_research_db_path is None or resolved_outputs_dir is None) and not owner_user_id:
+            raise ValueError("missing research owner_user_id")
+        research_path = resolved_research_db_path or DatabasePaths.get_research_sessions_db_path(owner_user_id)
+        output_path = resolved_outputs_dir or DatabasePaths.get_user_outputs_dir(owner_user_id)
+        return research_path, output_path
+
+    async def _cancel_check(job: dict[str, object]) -> bool:
+        return bool(job.get("cancel_requested_at") or job.get("cancelled_at"))
 
     async def _handler(job: dict[str, object]) -> dict[str, object]:
+        research_path, output_path = _paths_for_job(job)
         return await handle_research_phase_job(
             job,
-            research_db_path=resolved_research_db_path,
-            outputs_dir=resolved_outputs_dir,
+            research_db_path=research_path,
+            outputs_dir=output_path,
         )
 
     logger.info("Research Jobs worker starting: queue={} worker_id={}", RESEARCH_QUEUE, worker_id)
     try:
-        await sdk.run(handler=_handler)
+        await sdk.run(handler=_handler, cancel_check=_cancel_check)
     finally:
         if _stop_watcher_task is not None and not _stop_watcher_task.done():
             _stop_watcher_task.cancel()

--- a/tldw_Server_API/app/core/Research/service.py
+++ b/tldw_Server_API/app/core/Research/service.py
@@ -41,6 +41,11 @@ _CHECKPOINT_PHASES = {
 }
 _TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
 _CHECKPOINT_BLOCKED_CONTROL_STATES = {"paused", "pause_requested", "cancel_requested", "cancelled"}
+_CHECKPOINT_EXPECTED_PHASES = {
+    "plan_review": "awaiting_plan_review",
+    "sources_review": "awaiting_source_review",
+    "outline_review": "awaiting_outline_review",
+}
 
 
 class ResearchService:
@@ -91,6 +96,18 @@ class ResearchService:
         if self._job_manager is not None:
             return self._job_manager
         return jobs_manager_from_env()
+
+    @staticmethod
+    def _get_owned_session(
+        *,
+        db: ResearchSessionsDB,
+        owner_user_id: str,
+        session_id: str,
+    ) -> ResearchSessionRow:
+        session = db.get_session(session_id)
+        if session is None or session.owner_user_id != str(owner_user_id):
+            raise KeyError(session_id)
+        return session
 
     @staticmethod
     def _normalized_event_payload_json(payload: dict[str, Any]) -> str:
@@ -227,6 +244,24 @@ class ResearchService:
         if checkpoint_type == "outline_review":
             return "approved_outline.json"
         raise ValueError(f"unsupported checkpoint type: {checkpoint_type}")
+
+    @staticmethod
+    def _validate_checkpoint_approval_state(
+        *,
+        session: ResearchSessionRow,
+        checkpoint: ResearchCheckpointRow,
+    ) -> None:
+        expected_phase = _CHECKPOINT_EXPECTED_PHASES.get(checkpoint.checkpoint_type)
+        if expected_phase is None:
+            raise ValueError(f"unsupported checkpoint type: {checkpoint.checkpoint_type}")
+        if session.status != "waiting_human":
+            raise ValueError("checkpoint_approval_not_allowed")
+        if session.phase != expected_phase:
+            raise ValueError("checkpoint_approval_not_allowed")
+        if session.latest_checkpoint_id != checkpoint.id:
+            raise ValueError("checkpoint_approval_not_allowed")
+        if checkpoint.status != "pending":
+            raise ValueError("checkpoint_approval_not_allowed")
 
     @staticmethod
     def _checkpoint_event_payload(
@@ -372,15 +407,14 @@ class ResearchService:
     ) -> ResearchSessionRow:
         """Resolve a review checkpoint and advance the session to the next phase."""
         db = self._db_for_user(owner_user_id)
-        session = db.get_session(session_id)
-        if session is None:
-            raise KeyError(session_id)
+        session = self._get_owned_session(db=db, owner_user_id=owner_user_id, session_id=session_id)
         if session.control_state in _CHECKPOINT_BLOCKED_CONTROL_STATES:
             raise ValueError("checkpoint_approval_not_allowed")
 
         checkpoint = db.get_checkpoint(checkpoint_id)
         if checkpoint is None or checkpoint.session_id != session_id:
             raise KeyError(checkpoint_id)
+        self._validate_checkpoint_approval_state(session=session, checkpoint=checkpoint)
 
         patch_result = apply_checkpoint_patch(
             checkpoint_type=checkpoint.checkpoint_type,
@@ -475,9 +509,7 @@ class ResearchService:
     ) -> dict[str, Any]:
         """Build and persist the final deep research package."""
         db = self._db_for_user(owner_user_id)
-        session = db.get_session(session_id)
-        if session is None:
-            raise KeyError(session_id)
+        self._get_owned_session(db=db, owner_user_id=owner_user_id, session_id=session_id)
 
         package = build_final_package(
             brief=brief,
@@ -527,9 +559,7 @@ class ResearchService:
         session_id: str,
     ) -> ResearchRunSnapshotResponse:
         db = self._db_for_user(owner_user_id)
-        session = db.get_session(session_id)
-        if session is None:
-            raise KeyError(session_id)
+        session = self._get_owned_session(db=db, owner_user_id=owner_user_id, session_id=session_id)
 
         checkpoint_summary: ResearchCheckpointSummary | None = None
         if session.latest_checkpoint_id:
@@ -587,9 +617,7 @@ class ResearchService:
 
     def get_session(self, *, owner_user_id: str, session_id: str) -> ResearchSessionRow:
         db = self._db_for_user(owner_user_id)
-        session = db.get_session(session_id)
-        if session is None:
-            raise KeyError(session_id)
+        session = self._get_owned_session(db=db, owner_user_id=owner_user_id, session_id=session_id)
         handoff = db.get_chat_handoff(session_id)
         chat_id = None
         if handoff is not None:
@@ -652,9 +680,7 @@ class ResearchService:
 
     def pause_run(self, *, owner_user_id: str, session_id: str) -> ResearchSessionRow:
         db = self._db_for_user(owner_user_id)
-        session = db.get_session(session_id)
-        if session is None:
-            raise KeyError(session_id)
+        session = self._get_owned_session(db=db, owner_user_id=owner_user_id, session_id=session_id)
         if self._is_terminal(session):
             raise ValueError("pause_not_allowed")
         if session.control_state in {"paused", "pause_requested"}:
@@ -699,9 +725,7 @@ class ResearchService:
 
     def resume_run(self, *, owner_user_id: str, session_id: str) -> ResearchSessionRow:
         db = self._db_for_user(owner_user_id)
-        session = db.get_session(session_id)
-        if session is None:
-            raise KeyError(session_id)
+        session = self._get_owned_session(db=db, owner_user_id=owner_user_id, session_id=session_id)
         if session.control_state != "paused":
             raise ValueError("resume_not_allowed")
         if self._is_terminal(session):
@@ -781,9 +805,7 @@ class ResearchService:
 
     def cancel_run(self, *, owner_user_id: str, session_id: str) -> ResearchSessionRow:
         db = self._db_for_user(owner_user_id)
-        session = db.get_session(session_id)
-        if session is None:
-            raise KeyError(session_id)
+        session = self._get_owned_session(db=db, owner_user_id=owner_user_id, session_id=session_id)
         if self._is_terminal(session):
             raise ValueError("cancel_not_allowed")
         if session.control_state == "cancel_requested":
@@ -851,6 +873,7 @@ class ResearchService:
             raise ValueError("artifact_not_allowed")
 
         db = self._db_for_user(owner_user_id)
+        self._get_owned_session(db=db, owner_user_id=owner_user_id, session_id=session_id)
         artifact_row = self._get_latest_artifact_row(db=db, session_id=session_id, artifact_name=artifact_name)
         if artifact_row is None:
             raise KeyError(artifact_name)

--- a/tldw_Server_API/tests/Research/test_research_core_hardening.py
+++ b/tldw_Server_API/tests/Research/test_research_core_hardening.py
@@ -1,0 +1,576 @@
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+class _RecordingJobs:
+    def __init__(self):
+        self.created_jobs: list[dict[str, object]] = []
+        self.cancelled_jobs: list[tuple[int, str | None]] = []
+
+    def create_job(self, **kwargs):
+        job_id = len(self.created_jobs) + 100
+        job = {"id": job_id, "uuid": f"job-{job_id}", "status": "queued", **kwargs}
+        self.created_jobs.append(job)
+        return job
+
+    def cancel_job(self, job_id: int, *, reason: str | None = None):
+        self.cancelled_jobs.append((job_id, reason))
+        return True
+
+
+def _service_bundle(tmp_path):
+    from tldw_Server_API.app.core.DB_Management.ResearchSessionsDB import ResearchSessionsDB
+    from tldw_Server_API.app.core.Research.artifact_store import ResearchArtifactStore
+    from tldw_Server_API.app.core.Research.service import ResearchService
+
+    db_path = tmp_path / "research.db"
+    outputs_dir = tmp_path / "outputs"
+    jobs = _RecordingJobs()
+    service = ResearchService(
+        research_db_path=db_path,
+        outputs_dir=outputs_dir,
+        job_manager=jobs,
+    )
+    db = ResearchSessionsDB(db_path)
+    store = ResearchArtifactStore(base_dir=outputs_dir, db=db)
+    return service, db, store, jobs
+
+
+def _create_session(db, *, owner_user_id: str = "1", phase: str = "drafting_plan", status: str = "queued", limits=None):
+    return db.create_session(
+        owner_user_id=owner_user_id,
+        query=f"Research query for owner {owner_user_id}",
+        source_policy="balanced",
+        autonomy_mode="checkpointed",
+        limits_json=limits or {},
+        phase=phase,
+        status=status,
+    )
+
+
+def _write_bundle_artifact(store, session):
+    store.write_json(
+        owner_user_id=session.owner_user_id,
+        session_id=session.id,
+        artifact_name="bundle.json",
+        payload={"question": session.query, "claims": []},
+        phase="completed",
+        job_id=None,
+    )
+
+
+def test_service_rejects_foreign_owner_for_reads_artifacts_and_controls(tmp_path):
+    service, db, store, _jobs = _service_bundle(tmp_path)
+
+    readable = _create_session(db, phase="completed", status="completed")
+    _write_bundle_artifact(store, readable)
+    active = _create_session(db, phase="collecting", status="queued")
+    db.attach_active_job(active.id, "41")
+    paused = _create_session(db, phase="synthesizing", status="queued")
+    db.update_control_state(paused.id, control_state="paused")
+
+    with pytest.raises(KeyError):
+        service.get_session(owner_user_id="2", session_id=readable.id)
+    with pytest.raises(KeyError):
+        service.get_stream_snapshot(owner_user_id="2", session_id=readable.id)
+    with pytest.raises(KeyError):
+        service.get_artifact(owner_user_id="2", session_id=readable.id, artifact_name="bundle.json")
+    with pytest.raises(KeyError):
+        service.get_bundle(owner_user_id="2", session_id=readable.id)
+    with pytest.raises(KeyError):
+        service.pause_run(owner_user_id="2", session_id=active.id)
+    with pytest.raises(KeyError):
+        service.resume_run(owner_user_id="2", session_id=paused.id)
+    with pytest.raises(KeyError):
+        service.cancel_run(owner_user_id="2", session_id=active.id)
+    with pytest.raises(KeyError):
+        service.build_package(
+            owner_user_id="2",
+            session_id=readable.id,
+            brief={"query": readable.query},
+            outline={},
+            report_markdown="# Report",
+            claims=[],
+            source_inventory=[],
+        )
+
+
+def test_service_rejects_foreign_owner_checkpoint_approval(tmp_path):
+    service, db, _store, jobs = _service_bundle(tmp_path)
+    session = _create_session(db, phase="awaiting_plan_review", status="waiting_human")
+    checkpoint = db.create_checkpoint(
+        session_id=session.id,
+        checkpoint_type="plan_review",
+        proposed_payload={
+            "query": session.query,
+            "focus_areas": ["background"],
+            "source_policy": session.source_policy,
+            "autonomy_mode": session.autonomy_mode,
+            "stop_criteria": {"min_cited_sections": 1},
+        },
+    )
+
+    with pytest.raises(KeyError):
+        service.approve_checkpoint(
+            owner_user_id="2",
+            session_id=session.id,
+            checkpoint_id=checkpoint.id,
+        )
+
+    assert jobs.created_jobs == []
+
+
+def test_checkpoint_approval_rejects_resolved_stale_and_wrong_phase_checkpoints(tmp_path):
+    service, db, _store, jobs = _service_bundle(tmp_path)
+    session = _create_session(db, phase="awaiting_plan_review", status="waiting_human")
+    approved = db.create_checkpoint(
+        session_id=session.id,
+        checkpoint_type="plan_review",
+        proposed_payload={
+            "query": session.query,
+            "focus_areas": ["background"],
+            "source_policy": session.source_policy,
+            "autonomy_mode": session.autonomy_mode,
+            "stop_criteria": {"min_cited_sections": 1},
+        },
+    )
+    service.approve_checkpoint(owner_user_id="1", session_id=session.id, checkpoint_id=approved.id)
+
+    with pytest.raises(ValueError, match="checkpoint"):
+        service.approve_checkpoint(owner_user_id="1", session_id=session.id, checkpoint_id=approved.id)
+
+    wrong_phase = _create_session(db, phase="awaiting_source_review", status="waiting_human")
+    wrong_phase_checkpoint = db.create_checkpoint(
+        session_id=wrong_phase.id,
+        checkpoint_type="plan_review",
+        proposed_payload={
+            "query": wrong_phase.query,
+            "focus_areas": ["background"],
+            "source_policy": wrong_phase.source_policy,
+            "autonomy_mode": wrong_phase.autonomy_mode,
+            "stop_criteria": {"min_cited_sections": 1},
+        },
+    )
+    with pytest.raises(ValueError, match="checkpoint"):
+        service.approve_checkpoint(
+            owner_user_id="1",
+            session_id=wrong_phase.id,
+            checkpoint_id=wrong_phase_checkpoint.id,
+        )
+
+    stale_session = _create_session(db, phase="awaiting_plan_review", status="waiting_human")
+    stale_checkpoint = db.create_checkpoint(
+        session_id=stale_session.id,
+        checkpoint_type="plan_review",
+        proposed_payload={
+            "query": stale_session.query,
+            "focus_areas": ["old"],
+            "source_policy": stale_session.source_policy,
+            "autonomy_mode": stale_session.autonomy_mode,
+            "stop_criteria": {"min_cited_sections": 1},
+        },
+    )
+    db.create_checkpoint(
+        session_id=stale_session.id,
+        checkpoint_type="plan_review",
+        proposed_payload={
+            "query": stale_session.query,
+            "focus_areas": ["new"],
+            "source_policy": stale_session.source_policy,
+            "autonomy_mode": stale_session.autonomy_mode,
+            "stop_criteria": {"min_cited_sections": 1},
+        },
+    )
+    with pytest.raises(ValueError, match="checkpoint"):
+        service.approve_checkpoint(
+            owner_user_id="1",
+            session_id=stale_session.id,
+            checkpoint_id=stale_checkpoint.id,
+        )
+
+    assert len(jobs.created_jobs) == 1
+
+
+def test_artifact_versions_use_distinct_immutable_files(tmp_path):
+    from tldw_Server_API.app.core.DB_Management.ResearchSessionsDB import ResearchSessionsDB
+    from tldw_Server_API.app.core.Research.artifact_store import ResearchArtifactStore
+
+    db = ResearchSessionsDB(tmp_path / "research.db")
+    session = _create_session(db)
+    store = ResearchArtifactStore(base_dir=tmp_path / "outputs", db=db)
+
+    first = store.write_json(
+        owner_user_id="1",
+        session_id=session.id,
+        artifact_name="plan.json",
+        payload={"focus_areas": ["old"]},
+        phase="drafting_plan",
+        job_id=None,
+    )
+    second = store.write_json(
+        owner_user_id="1",
+        session_id=session.id,
+        artifact_name="plan.json",
+        payload={"focus_areas": ["new"]},
+        phase="drafting_plan",
+        job_id=None,
+    )
+
+    assert first.storage_path != second.storage_path
+    for artifact, expected in ((first, {"focus_areas": ["old"]}), (second, {"focus_areas": ["new"]})):
+        content = Path(artifact.storage_path).read_bytes()
+        assert json.loads(content.decode("utf-8")) == expected
+        assert hashlib.sha256(content).hexdigest() == artifact.checksum
+
+
+def test_artifact_storage_paths_do_not_collide_when_version_allocator_repeats(tmp_path, monkeypatch):
+    from tldw_Server_API.app.core.DB_Management.ResearchSessionsDB import ResearchSessionsDB
+    from tldw_Server_API.app.core.Research.artifact_store import ResearchArtifactStore
+
+    db = ResearchSessionsDB(tmp_path / "research.db")
+    session = _create_session(db)
+    store = ResearchArtifactStore(base_dir=tmp_path / "outputs", db=db)
+    monkeypatch.setattr(store, "_next_version", lambda session_id, artifact_name: 1)
+
+    first = store.write_json(
+        owner_user_id="1",
+        session_id=session.id,
+        artifact_name="plan.json",
+        payload={"focus_areas": ["first"]},
+        phase="drafting_plan",
+        job_id=None,
+    )
+    second = store.write_json(
+        owner_user_id="1",
+        session_id=session.id,
+        artifact_name="plan.json",
+        payload={"focus_areas": ["second"]},
+        phase="drafting_plan",
+        job_id=None,
+    )
+
+    assert first.artifact_version == second.artifact_version == 1
+    assert first.storage_path != second.storage_path
+    assert json.loads(Path(first.storage_path).read_text(encoding="utf-8")) == {"focus_areas": ["first"]}
+    assert json.loads(Path(second.storage_path).read_text(encoding="utf-8")) == {"focus_areas": ["second"]}
+
+
+@pytest.mark.asyncio
+async def test_planning_phase_offloads_artifact_writes_from_event_loop(monkeypatch, tmp_path):
+    from tldw_Server_API.app.core.DB_Management.ResearchSessionsDB import ResearchSessionsDB
+    from tldw_Server_API.app.core.Research import jobs
+    from tldw_Server_API.app.core.Research.jobs import handle_research_phase_job
+
+    db_path = tmp_path / "research.db"
+    db = ResearchSessionsDB(db_path)
+    session = _create_session(db, phase="drafting_plan", status="queued")
+    offloaded: list[str] = []
+
+    async def fake_to_thread(func, /, *args, **kwargs):
+        offloaded.append(func.__name__)
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(jobs.asyncio, "to_thread", fake_to_thread)
+
+    result = await handle_research_phase_job(
+        {"id": 5, "payload": {"session_id": session.id, "phase": "drafting_plan"}},
+        research_db_path=db_path,
+        outputs_dir=tmp_path / "outputs",
+    )
+
+    assert result["phase"] == "awaiting_plan_review"
+    assert offloaded == ["write_json", "write_json"]
+
+
+@pytest.mark.asyncio
+async def test_research_worker_resolves_per_user_paths_when_no_override(monkeypatch, tmp_path):
+    from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+    from tldw_Server_API.app.core.config import settings
+    from tldw_Server_API.app.core.Research import jobs_worker
+
+    previous_user_db_base = settings.get("USER_DB_BASE_DIR")
+    settings.USER_DB_BASE_DIR = str(tmp_path / "user_dbs")
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(tmp_path / "user_dbs"))
+    monkeypatch.delenv("RESEARCH_SESSIONS_DB_PATH", raising=False)
+    monkeypatch.delenv("RESEARCH_OUTPUTS_DIR", raising=False)
+    captured: dict[str, Path] = {}
+
+    class FakeSDK:
+        def __init__(self, jm, cfg):
+            self.jm = jm
+            self.cfg = cfg
+
+        async def run(self, *, handler, **kwargs):
+            await handler(
+                {
+                    "id": 1,
+                    "owner_user_id": "7",
+                    "payload": {"session_id": "rs_1", "phase": "drafting_plan"},
+                }
+            )
+
+        def stop(self):
+            return None
+
+    async def fake_handle(job, *, research_db_path, outputs_dir):
+        captured["research_db_path"] = Path(research_db_path)
+        captured["outputs_dir"] = Path(outputs_dir)
+        return {"ok": True}
+
+    monkeypatch.setattr(jobs_worker, "WorkerSDK", FakeSDK)
+    monkeypatch.setattr(jobs_worker, "_jobs_manager", lambda: object())
+    monkeypatch.setattr(jobs_worker, "handle_research_phase_job", fake_handle)
+
+    expected_research_db_path = DatabasePaths.get_research_sessions_db_path("7")
+    expected_outputs_dir = DatabasePaths.get_user_outputs_dir("7")
+    try:
+        await jobs_worker.run_research_jobs_worker()
+    finally:
+        if previous_user_db_base is not None:
+            settings.USER_DB_BASE_DIR = previous_user_db_base
+        else:
+            try:
+                del settings.USER_DB_BASE_DIR
+            except AttributeError:
+                pass
+
+    assert captured["research_db_path"] == expected_research_db_path
+    assert captured["outputs_dir"] == expected_outputs_dir
+
+
+@pytest.mark.asyncio
+async def test_collecting_phase_stops_between_focus_areas_when_cancel_requested(tmp_path):
+    from tldw_Server_API.app.core.DB_Management.ResearchSessionsDB import ResearchSessionsDB
+    from tldw_Server_API.app.core.Research.artifact_store import ResearchArtifactStore
+    from tldw_Server_API.app.core.Research.jobs import handle_research_phase_job
+    from tldw_Server_API.app.core.Research.models import (
+        ResearchCollectionResult,
+        ResearchEvidenceNote,
+        ResearchSourceRecord,
+    )
+
+    db_path = tmp_path / "research.db"
+    db = ResearchSessionsDB(db_path)
+    session = _create_session(db, phase="collecting", status="queued")
+    store = ResearchArtifactStore(base_dir=tmp_path / "outputs", db=db)
+    store.write_json(
+        owner_user_id="1",
+        session_id=session.id,
+        artifact_name="plan.json",
+        payload={
+            "query": session.query,
+            "focus_areas": ["first", "second"],
+            "source_policy": session.source_policy,
+            "autonomy_mode": session.autonomy_mode,
+            "stop_criteria": {"min_cited_sections": 1},
+        },
+        phase="drafting_plan",
+        job_id=None,
+    )
+
+    class CancelAfterFirstBroker:
+        def __init__(self):
+            self.calls: list[str] = []
+
+        async def collect_focus_area(self, **kwargs):
+            focus_area = str(kwargs["focus_area"])
+            self.calls.append(focus_area)
+            db.update_control_state(session.id, control_state="cancel_requested")
+            return ResearchCollectionResult(
+                sources=[
+                    ResearchSourceRecord(
+                        source_id=f"src_{focus_area}",
+                        focus_area=focus_area,
+                        source_type="local_document",
+                        provider="local_corpus",
+                        title=f"Source {focus_area}",
+                        url=None,
+                        snippet="Evidence",
+                        published_at=None,
+                        retrieved_at="2026-03-07T00:00:00+00:00",
+                        fingerprint=f"fp_{focus_area}",
+                        trust_tier="internal",
+                        metadata={},
+                    )
+                ],
+                evidence_notes=[
+                    ResearchEvidenceNote(
+                        note_id=f"note_{focus_area}",
+                        source_id=f"src_{focus_area}",
+                        focus_area=focus_area,
+                        kind="supporting",
+                        text="Evidence",
+                        citation_locator=None,
+                        confidence=0.8,
+                        metadata={},
+                    )
+                ],
+                collection_metrics={
+                    "lane_counts": {"local": 1, "academic": 0, "web": 0},
+                    "lane_attempts": {"local": 1, "academic": 0, "web": 0},
+                    "deduped_sources": 0,
+                },
+                remaining_gaps=[],
+            )
+
+    broker = CancelAfterFirstBroker()
+
+    result = await handle_research_phase_job(
+        {"id": 5, "payload": {"session_id": session.id, "phase": "collecting"}},
+        research_db_path=db_path,
+        outputs_dir=tmp_path / "outputs",
+        broker=broker,
+    )
+
+    assert broker.calls == ["first"]
+    assert result["phase"] == "collecting"
+    assert db.get_session(session.id).status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_collecting_phase_enforces_search_limit_before_provider_call(tmp_path):
+    from tldw_Server_API.app.core.DB_Management.ResearchSessionsDB import ResearchSessionsDB
+    from tldw_Server_API.app.core.Research.artifact_store import ResearchArtifactStore
+    from tldw_Server_API.app.core.Research.jobs import handle_research_phase_job
+
+    db_path = tmp_path / "research.db"
+    db = ResearchSessionsDB(db_path)
+    session = _create_session(
+        db,
+        phase="collecting",
+        status="queued",
+        limits={"max_searches": 0, "max_fetched_docs": 10, "max_runtime_seconds": 300},
+    )
+    store = ResearchArtifactStore(base_dir=tmp_path / "outputs", db=db)
+    store.write_json(
+        owner_user_id="1",
+        session_id=session.id,
+        artifact_name="plan.json",
+        payload={
+            "query": session.query,
+            "focus_areas": ["first"],
+            "source_policy": session.source_policy,
+            "autonomy_mode": session.autonomy_mode,
+            "stop_criteria": {"min_cited_sections": 1},
+        },
+        phase="drafting_plan",
+        job_id=None,
+    )
+
+    class Broker:
+        def __init__(self):
+            self.calls = 0
+
+        async def collect_focus_area(self, **kwargs):
+            self.calls += 1
+            raise AssertionError("provider should not be called after budget exhaustion")
+
+    broker = Broker()
+
+    with pytest.raises(ValueError, match="research_limit_exceeded"):
+        await handle_research_phase_job(
+            {"id": 5, "payload": {"session_id": session.id, "phase": "collecting"}},
+            research_db_path=db_path,
+            outputs_dir=tmp_path / "outputs",
+            broker=broker,
+        )
+
+    assert broker.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_collecting_phase_enforces_fetched_doc_limit_before_next_provider_call(tmp_path):
+    from tldw_Server_API.app.core.DB_Management.ResearchSessionsDB import ResearchSessionsDB
+    from tldw_Server_API.app.core.Research.artifact_store import ResearchArtifactStore
+    from tldw_Server_API.app.core.Research.jobs import handle_research_phase_job
+    from tldw_Server_API.app.core.Research.models import (
+        ResearchCollectionResult,
+        ResearchEvidenceNote,
+        ResearchSourceRecord,
+    )
+
+    db_path = tmp_path / "research.db"
+    db = ResearchSessionsDB(db_path)
+    session = _create_session(
+        db,
+        phase="collecting",
+        status="queued",
+        limits={"max_searches": 10, "max_fetched_docs": 1, "max_runtime_seconds": 300},
+    )
+    store = ResearchArtifactStore(base_dir=tmp_path / "outputs", db=db)
+    store.write_json(
+        owner_user_id="1",
+        session_id=session.id,
+        artifact_name="plan.json",
+        payload={
+            "query": session.query,
+            "focus_areas": ["first", "second"],
+            "source_policy": session.source_policy,
+            "autonomy_mode": session.autonomy_mode,
+            "stop_criteria": {"min_cited_sections": 1},
+        },
+        phase="drafting_plan",
+        job_id=None,
+    )
+
+    class Broker:
+        def __init__(self):
+            self.calls: list[str] = []
+
+        async def collect_focus_area(self, **kwargs):
+            focus_area = str(kwargs["focus_area"])
+            self.calls.append(focus_area)
+            return ResearchCollectionResult(
+                sources=[
+                    ResearchSourceRecord(
+                        source_id=f"src_{focus_area}",
+                        focus_area=focus_area,
+                        source_type="local_document",
+                        provider="local_corpus",
+                        title=f"Source {focus_area}",
+                        url=None,
+                        snippet="Evidence",
+                        published_at=None,
+                        retrieved_at="2026-03-07T00:00:00+00:00",
+                        fingerprint=f"fp_{focus_area}",
+                        trust_tier="internal",
+                        metadata={},
+                    )
+                ],
+                evidence_notes=[
+                    ResearchEvidenceNote(
+                        note_id=f"note_{focus_area}",
+                        source_id=f"src_{focus_area}",
+                        focus_area=focus_area,
+                        kind="supporting",
+                        text="Evidence",
+                        citation_locator=None,
+                        confidence=0.8,
+                        metadata={},
+                    )
+                ],
+                collection_metrics={
+                    "lane_counts": {"local": 1, "academic": 0, "web": 0},
+                    "lane_attempts": {"local": 1, "academic": 0, "web": 0},
+                    "deduped_sources": 0,
+                },
+                remaining_gaps=[],
+            )
+
+    broker = Broker()
+
+    with pytest.raises(ValueError, match="research_limit_exceeded:fetched_docs"):
+        await handle_research_phase_job(
+            {"id": 5, "payload": {"session_id": session.id, "phase": "collecting"}},
+            research_db_path=db_path,
+            outputs_dir=tmp_path / "outputs",
+            broker=broker,
+        )
+
+    assert broker.calls == ["first"]


### PR DESCRIPTION
## Summary
- Enforce owner-scoped Research session access for reads, artifacts, control actions, package builds, and checkpoint approval.
- Add checkpoint replay guards, per-user Jobs worker path resolution, immutable artifact version files, and cooperative cancellation/limit enforcement.
- Offload Research job artifact writes from async handlers via `asyncio.to_thread(...)` to avoid blocking the event loop.
- Add focused regression coverage for the validated Research core review findings and PR review feedback; record TASK-9922.

## Test Plan
- [x] `python -m pytest -p no:unraisableexception tldw_Server_API/tests/Research/test_research_core_hardening.py -q` (`10 passed`)
- [x] `python -m pytest -p no:unraisableexception tldw_Server_API/tests/Research/test_research_artifact_store.py::test_write_json_artifact_records_manifest tldw_Server_API/tests/Research/test_research_jobs_service.py::test_approve_plan_review_enqueues_collecting_job tldw_Server_API/tests/Research/test_research_jobs_service.py::test_approve_sources_review_enqueues_synthesizing_job_and_writes_review_artifact tldw_Server_API/tests/Research/test_research_jobs_service.py::test_approve_sources_review_with_recollect_enqueues_collecting_job tldw_Server_API/tests/Research/test_research_jobs_service.py::test_approve_outline_review_enqueues_packaging_job tldw_Server_API/tests/Research/test_research_jobs_service.py::test_approve_outline_review_patch_enqueues_resynthesis_with_locked_outline tldw_Server_API/tests/Research/test_research_jobs_service.py::test_get_session_bundle_and_allowlisted_artifacts tldw_Server_API/tests/Research/test_research_jobs_service.py::test_pause_run_marks_active_executable_session_pause_requested tldw_Server_API/tests/Research/test_research_jobs_service.py::test_resume_run_reenqueues_executable_phase_and_restores_checkpoint_wait tldw_Server_API/tests/Research/test_research_jobs_service.py::test_cancel_run_requests_active_work_and_terminalizes_idle_sessions -q` (`10 passed`)
- [x] `python -m py_compile tldw_Server_API/app/core/Research/service.py tldw_Server_API/app/core/Research/artifact_store.py tldw_Server_API/app/core/Research/jobs.py tldw_Server_API/app/core/Research/jobs_worker.py tldw_Server_API/tests/Research/test_research_core_hardening.py`
- [x] `git diff --check`
- [x] `python -m bandit -r tldw_Server_API/app/core/Research/service.py tldw_Server_API/app/core/Research/artifact_store.py tldw_Server_API/app/core/Research/jobs.py tldw_Server_API/app/core/Research/jobs_worker.py -f json -o /tmp/bandit_research_core_hardening_rebase.json` (`errors=0`, `results=0`)

## Change Summary
PR created by Codex. Before merge readiness, the human requester must replace this section with a human-written Change summary explaining what changed and why these implementation choices were made.
