### PR TITLE
Harden StudySuggestions review findings

### DIFF
--- a/IMPLEMENTATION_PLAN_study_suggestions_review_fixes_9940.md
+++ b/IMPLEMENTATION_PLAN_study_suggestions_review_fixes_9940.md
@@ -1,0 +1,39 @@
+## Stage 1: Collision-Safe Action Fingerprints
+**Goal**: Replace delimiter-joined selection fingerprints with bounded, structured fingerprints that cannot collide on topic delimiters.
+**Success Criteria**: Distinct delimiter-containing topic selections produce distinct fingerprints; pending target IDs remain usable.
+**Tests**: Add focused action fingerprint tests in `tldw_Server_API/tests/StudySuggestions/test_study_suggestions_jobs_worker.py`.
+**Status**: Complete
+
+## Stage 2: Recency-Aware Anchor Status
+**Goal**: Make anchor status prefer the newest relevant state instead of letting stale failed jobs mask newer ready snapshots.
+**Success Criteria**: A newer active snapshot reports `ready` even when an older failed refresh job exists; newer pending/failed jobs still surface.
+**Tests**: Add status regression coverage in `tldw_Server_API/tests/StudySuggestions/test_study_suggestions_jobs_worker.py`.
+**Status**: Complete
+
+## Stage 3: Real Live Evidence Availability
+**Goal**: Hydrate snapshot evidence against backing note DB targets instead of treating frozen source IDs as available by definition.
+**Success Criteria**: Deleted/missing flashcard deck and quiz targets report unavailable while existing targets remain available.
+**Tests**: Add endpoint/core evidence coverage in `tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py`.
+**Status**: Complete
+
+## Stage 4: Finalization Failure Cleanup
+**Goal**: Prevent generated follow-up artifacts from being silently orphaned when generation-link finalization fails.
+**Success Criteria**: Failed finalization releases the pending reservation and cleans up generated flashcard decks.
+**Tests**: Add action endpoint regression coverage in `tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py`.
+**Status**: Complete
+
+## Stage 5: Verification And Closeout
+**Goal**: Run focused tests, touched-scope Bandit, and update task tracking.
+**Success Criteria**: Relevant tests pass; Bandit reports no new findings for touched backend files; Backlog task records verification.
+**Tests**: `python -m pytest` focused StudySuggestions tests, `python -m bandit` on touched backend scope.
+**Status**: Complete
+
+## Verification
+**Tests**:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/StudySuggestions/test_study_suggestions_jobs_worker.py -q --tb=short`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py -q --tb=short`
+
+**Security**:
+- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/StudySuggestions tldw_Server_API/app/api/v1/endpoints/study_suggestions.py tldw_Server_API/tests/StudySuggestions/test_study_suggestions_jobs_worker.py tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py -f json -o /tmp/bandit_study_suggestions_9940.json`
+
+**Result**: StudySuggestions worker/API suites passed; Bandit reported zero findings.

--- a/backlog/tasks/task-9940 - Harden-StudySuggestions-review-findings.md
+++ b/backlog/tasks/task-9940 - Harden-StudySuggestions-review-findings.md
@@ -1,0 +1,52 @@
+---
+id: TASK-9940
+title: Harden StudySuggestions review findings
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-23 22:05'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix validated current-code review findings in `tldw_Server_API/app/core/StudySuggestions` and its API boundary: collision-resistant fingerprints, recency-aware anchor status, real source availability evidence, and cleanup for failed action finalization.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Collision-safe bounded StudySuggestions selection fingerprints implemented
+- [x] #2 Anchor status ignores stale failed/pending jobs when a newer active snapshot exists
+- [x] #3 Snapshot live evidence checks backing quiz/flashcard source availability
+- [x] #4 Generated follow-up quiz/deck targets are cleaned up if link finalization fails
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Plan file: IMPLEMENTATION_PLAN_study_suggestions_review_fixes_9940.md
+Initial scope: fix collision-safe fingerprints, recency-aware status, live evidence availability, and finalization cleanup with failing-first tests.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Implemented hashed v2 fingerprints with legacy lookup candidates, recency-aware anchor status, DB-backed source availability for live evidence, and generated-target cleanup on finalization failure.
+Verification: StudySuggestions worker/API test files pass; Bandit touched-scope report has zero findings at /tmp/bandit_study_suggestions_9940.json.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed all four validated StudySuggestions review findings. Added regression coverage for fingerprint delimiter collisions, stale job status masking newer snapshots, deleted evidence sources, and failed follow-up finalization cleanup. Verification passed for the StudySuggestions worker/API test files and Bandit returned zero findings on the touched scope.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-9940 - Harden-StudySuggestions-review-findings.md
+++ b/backlog/tasks/task-9940 - Harden-StudySuggestions-review-findings.md
@@ -4,7 +4,7 @@ title: Harden StudySuggestions review findings
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-23 22:05'
+updated_date: 2026-06-24 04:51
 labels: []
 dependencies: []
 ---
@@ -38,7 +38,7 @@ Verification: StudySuggestions worker/API test files pass; Bandit touched-scope 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixed all four validated StudySuggestions review findings. Added regression coverage for fingerprint delimiter collisions, stale job status masking newer snapshots, deleted evidence sources, and failed follow-up finalization cleanup. Verification passed for the StudySuggestions worker/API test files and Bandit returned zero findings on the touched scope.
+Fixed all original StudySuggestions review findings plus PR #2490 review follow-up comments. Added core-owned generated-target cleanup, observable best-effort cleanup/release failure logging, helper docstrings, and live-evidence DB failure degradation with regression coverage. Final verification passed for 43 affected StudySuggestions tests, Ruff touched-file checks, Bandit touched backend scope with zero findings, and whitespace checks.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -50,3 +50,10 @@ Fixed all four validated StudySuggestions review findings. Added regression cove
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+PR #2490 review follow-up after rebasing onto latest `origin/dev`: address Qodo comments about moving generated-target cleanup into core StudySuggestions actions, documenting helper functions, logging best-effort cleanup/release failures, and degrading live evidence source lookup DB failures to unavailable instead of returning 500.
+Review follow-up completed: moved generated target cleanup into `app/core/StudySuggestions/actions.py`, replaced silent endpoint cleanup suppression with warning logs carrying operation identifiers, added docstrings to the reviewed snapshot helpers, and made live-evidence DB lookup failures return unavailable evidence. Verification: focused red tests failed before the fix; final `python -m pytest tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py tldw_Server_API/tests/StudySuggestions/test_study_suggestions_jobs_worker.py -q --tb=short` passed 43 tests. Ruff touched-file check passed. Bandit touched backend scope reported zero findings in `/tmp/bandit_study_suggestions_9940_reviewfix_worktree.json`. `git diff --check` passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/study_suggestions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/study_suggestions.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import threading
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -30,6 +30,7 @@ from tldw_Server_API.app.core.StudySuggestions.actions import (
     build_flashcard_generation_payload,
     build_follow_up_flashcard_deck_name,
     build_follow_up_flashcard_source_text,
+    build_legacy_selection_fingerprint,
     build_selection_fingerprint,
     canonicalize_follow_up_action,
     finalize_generation_link,
@@ -194,7 +195,7 @@ def _build_selection_fingerprint_variants(
     action_kind: str,
     generator_version: str | None,
     normalization_version: str,
-) -> tuple[str, str | None]:
+) -> tuple[str, tuple[str, ...]]:
     """Build current and legacy-compatible selection fingerprints for one action."""
 
     selection_fingerprint = build_selection_fingerprint(
@@ -206,19 +207,44 @@ def _build_selection_fingerprint_variants(
         generator_version=generator_version,
         normalization_version=normalization_version,
     )
-    legacy_selection_fingerprint = build_selection_fingerprint(
-        snapshot_id=snapshot_id,
-        target_service=target_service,
-        target_type=target_type,
-        selected_topics=selected_topics,
-        action_kind=action_kind,
-        generator_version=generator_version,
-        normalization_version=normalization_version,
-        include_normalization_version=False,
+    legacy_candidates = (
+        build_selection_fingerprint(
+            snapshot_id=snapshot_id,
+            target_service=target_service,
+            target_type=target_type,
+            selected_topics=selected_topics,
+            action_kind=action_kind,
+            generator_version=generator_version,
+            normalization_version=normalization_version,
+            include_normalization_version=False,
+        ),
+        build_legacy_selection_fingerprint(
+            snapshot_id=snapshot_id,
+            target_service=target_service,
+            target_type=target_type,
+            selected_topics=selected_topics,
+            action_kind=action_kind,
+            generator_version=generator_version,
+            normalization_version=normalization_version,
+        ),
+        build_legacy_selection_fingerprint(
+            snapshot_id=snapshot_id,
+            target_service=target_service,
+            target_type=target_type,
+            selected_topics=selected_topics,
+            action_kind=action_kind,
+            generator_version=generator_version,
+            normalization_version=normalization_version,
+            include_normalization_version=False,
+        ),
     )
-    return selection_fingerprint, (
-        legacy_selection_fingerprint if legacy_selection_fingerprint != selection_fingerprint else None
-    )
+    seen = {selection_fingerprint}
+    legacy_fingerprints: list[str] = []
+    for fingerprint in legacy_candidates:
+        if fingerprint and fingerprint not in seen:
+            seen.add(fingerprint)
+            legacy_fingerprints.append(fingerprint)
+    return selection_fingerprint, tuple(legacy_fingerprints)
 
 
 def _list_generation_link_candidates(
@@ -228,13 +254,20 @@ def _list_generation_link_candidates(
     target_service: str,
     target_type: str,
     selection_fingerprint: str,
-    legacy_selection_fingerprint: str | None,
+    legacy_selection_fingerprint: str | Iterable[str] | None,
 ) -> list[tuple[dict[str, Any], str]]:
     """Return matching generation links for current and legacy fingerprints."""
 
     candidates: list[tuple[dict[str, Any], str]] = []
     seen_fingerprints: set[str] = set()
-    for fingerprint in (selection_fingerprint, legacy_selection_fingerprint):
+    legacy_fingerprints: Iterable[str]
+    if legacy_selection_fingerprint is None:
+        legacy_fingerprints = ()
+    elif isinstance(legacy_selection_fingerprint, str):
+        legacy_fingerprints = (legacy_selection_fingerprint,)
+    else:
+        legacy_fingerprints = legacy_selection_fingerprint
+    for fingerprint in (selection_fingerprint, *legacy_fingerprints):
         if not fingerprint or fingerprint in seen_fingerprints:
             continue
         seen_fingerprints.add(fingerprint)
@@ -787,6 +820,33 @@ def _finalize_action(
         )
 
 
+def _cleanup_generated_action_target(
+    db: CharactersRAGDB,
+    *,
+    generated: dict[str, str] | None,
+) -> None:
+    """Best-effort cleanup when a target was generated but its link could not be finalized."""
+
+    if not generated:
+        return
+    target_service = str(generated.get("target_service") or "").strip().lower()
+    target_type = str(generated.get("target_type") or "").strip().lower()
+    target_id = str(generated.get("target_id") or "").strip()
+    if not target_id:
+        return
+
+    try:
+        target_int = int(target_id)
+    except (TypeError, ValueError):
+        return
+
+    if target_service == "flashcards" and target_type == "deck":
+        soft_delete_deck(db, deck_id=target_int)
+        return
+    if target_service == "quiz" and target_type == "quiz":
+        db.delete_quiz(target_int)
+
+
 class _EarlyReturn(Exception):
     """Internal signal to return an existing-link response from the sync prepare phase."""
 
@@ -818,6 +878,7 @@ async def trigger_suggestion_action(
     action_payload = payload.model_dump(mode="json")
     action_payload.update(action_contract)
     action_payload["selected_topics"] = selected_topics
+    generated: dict[str, str] | None = None
     try:
         generated = await _dispatch_follow_up_action(
             note_db=db,
@@ -846,6 +907,8 @@ async def trigger_suggestion_action(
                     target_type=action_contract["target_type"],
                     selection_fingerprint=selection_fingerprint,
                 )
+        with contextlib.suppress(Exception):
+            await asyncio.to_thread(_cleanup_generated_action_target, db, generated=generated)
         raise
     except Exception:
         if pending_reservation_created:
@@ -858,6 +921,8 @@ async def trigger_suggestion_action(
                     target_type=action_contract["target_type"],
                     selection_fingerprint=selection_fingerprint,
                 )
+        with contextlib.suppress(Exception):
+            await asyncio.to_thread(_cleanup_generated_action_target, db, generated=generated)
         raise
     return SuggestionActionResponse.model_validate(
         {

--- a/tldw_Server_API/app/api/v1/endpoints/study_suggestions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/study_suggestions.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import threading
 from collections.abc import Iterable, Iterator
 from pathlib import Path
@@ -12,9 +11,9 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, status
 from loguru import logger
 
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_auth_principal, get_request_user
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, get_request_user, User
 from tldw_Server_API.app.api.v1.schemas.study_suggestions import (
     SuggestionActionRequest,
     SuggestionActionResponse,
@@ -26,6 +25,7 @@ from tldw_Server_API.app.api.v1.schemas.study_suggestions import (
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, ConflictError
 from tldw_Server_API.app.core.Jobs.manager import JobManager
+from tldw_Server_API.app.core.StudySuggestions import snapshot_service
 from tldw_Server_API.app.core.StudySuggestions.actions import (
     build_flashcard_generation_payload,
     build_follow_up_flashcard_deck_name,
@@ -33,6 +33,7 @@ from tldw_Server_API.app.core.StudySuggestions.actions import (
     build_legacy_selection_fingerprint,
     build_selection_fingerprint,
     canonicalize_follow_up_action,
+    cleanup_generated_action_target,
     finalize_generation_link,
     find_generation_link_by_fingerprint,
     is_pending_generation_target_id,
@@ -46,7 +47,6 @@ from tldw_Server_API.app.core.StudySuggestions.actions import (
     resolve_selected_topic_semantic_keys,
     soft_delete_deck,
 )
-from tldw_Server_API.app.core.StudySuggestions import snapshot_service
 from tldw_Server_API.app.core.StudySuggestions.jobs import (
     STUDY_SUGGESTIONS_DOMAIN,
     STUDY_SUGGESTIONS_REFRESH_JOB_TYPE,
@@ -55,7 +55,6 @@ from tldw_Server_API.app.core.StudySuggestions.jobs import (
 )
 from tldw_Server_API.app.core.Workflows.adapters.content import run_flashcard_generate_adapter
 from tldw_Server_API.app.services.quiz_generator import generate_quiz_from_sources
-
 
 router = APIRouter(prefix="/study-suggestions", tags=["study-suggestions"])
 
@@ -380,9 +379,17 @@ def _persist_flashcard_deck(
     try:
         note_db.add_flashcards_bulk(flashcard_payloads)
     except Exception:
-        with contextlib.suppress(Exception):
+        try:
             soft_delete_deck(note_db, deck_id=int(deck_id))
-        logger.warning("Flashcard follow-up generation cleanup deleted deck after insert failure")
+        except Exception as cleanup_exc:
+            logger.warning(
+                "Flashcard follow-up generation cleanup failed deck_id={} snapshot_id={} error_type={}",
+                deck_id,
+                snapshot_row["id"],
+                type(cleanup_exc).__name__,
+            )
+        else:
+            logger.warning("Flashcard follow-up generation cleanup deleted deck after insert failure")
         raise
     return str(deck_id)
 
@@ -708,7 +715,7 @@ def _prepare_action(
                 selection_fingerprint=selection_fingerprint,
             )
             pending_reservation_created = True
-        except Exception:
+        except Exception as reservation_exc:
             existing_candidates = _list_generation_link_candidates(
                 db,
                 snapshot_id=snapshot_id,
@@ -735,7 +742,10 @@ def _prepare_action(
                 None,
             )
             if pending_existing:
-                raise HTTPException(status_code=409, detail="Study suggestion action already in progress")
+                raise HTTPException(
+                    status_code=409,
+                    detail="Study suggestion action already in progress",
+                ) from reservation_exc
             if live_existing and not payload.force_regenerate:
                 existing_link, _matched_existing_fingerprint = live_existing
                 raise _EarlyReturn(
@@ -749,7 +759,7 @@ def _prepare_action(
                             "target_id": str(existing_link["target_id"]),
                         }
                     )
-                )
+                ) from reservation_exc
             raise
 
     retired_selection_fingerprint = (
@@ -820,31 +830,88 @@ def _finalize_action(
         )
 
 
-def _cleanup_generated_action_target(
+async def _release_generation_link_reservation_best_effort(
+    db: CharactersRAGDB,
+    *,
+    snapshot_id: int,
+    target_service: str,
+    target_type: str,
+    selection_fingerprint: str,
+) -> None:
+    """Release an action reservation without hiding release failures from logs."""
+
+    try:
+        await asyncio.to_thread(
+            release_generation_link_reservation,
+            db,
+            snapshot_id=snapshot_id,
+            target_service=target_service,
+            target_type=target_type,
+            selection_fingerprint=selection_fingerprint,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to release study suggestion generation reservation "
+            "snapshot_id={} target={}/{} selection_fingerprint={} error_type={}",
+            snapshot_id,
+            target_service,
+            target_type,
+            selection_fingerprint,
+            type(exc).__name__,
+        )
+
+
+async def _cleanup_generated_action_target_best_effort(
     db: CharactersRAGDB,
     *,
     generated: dict[str, str] | None,
+    snapshot_id: int,
+    selection_fingerprint: str,
 ) -> None:
-    """Best-effort cleanup when a target was generated but its link could not be finalized."""
+    """Clean up an unlinked generated target without replacing the original action failure."""
 
     if not generated:
         return
-    target_service = str(generated.get("target_service") or "").strip().lower()
-    target_type = str(generated.get("target_type") or "").strip().lower()
-    target_id = str(generated.get("target_id") or "").strip()
-    if not target_id:
-        return
-
     try:
-        target_int = int(target_id)
-    except (TypeError, ValueError):
-        return
+        await asyncio.to_thread(cleanup_generated_action_target, db, generated=generated)
+    except Exception as exc:
+        logger.warning(
+            "Failed to cleanup generated study suggestion target "
+            "snapshot_id={} target={}/{} target_id={} selection_fingerprint={} error_type={}",
+            snapshot_id,
+            generated.get("target_service"),
+            generated.get("target_type"),
+            generated.get("target_id"),
+            selection_fingerprint,
+            type(exc).__name__,
+        )
 
-    if target_service == "flashcards" and target_type == "deck":
-        soft_delete_deck(db, deck_id=target_int)
-        return
-    if target_service == "quiz" and target_type == "quiz":
-        db.delete_quiz(target_int)
+
+async def _cleanup_failed_action_best_effort(
+    db: CharactersRAGDB,
+    *,
+    generated: dict[str, str] | None,
+    snapshot_id: int,
+    action_contract: dict[str, str],
+    selection_fingerprint: str,
+    pending_reservation_created: bool,
+) -> None:
+    """Best-effort reservation and generated-target cleanup for failed follow-up actions."""
+
+    if pending_reservation_created:
+        await _release_generation_link_reservation_best_effort(
+            db,
+            snapshot_id=snapshot_id,
+            target_service=action_contract["target_service"],
+            target_type=action_contract["target_type"],
+            selection_fingerprint=selection_fingerprint,
+        )
+    await _cleanup_generated_action_target_best_effort(
+        db,
+        generated=generated,
+        snapshot_id=snapshot_id,
+        selection_fingerprint=selection_fingerprint,
+    )
 
 
 class _EarlyReturn(Exception):
@@ -897,32 +964,24 @@ async def trigger_suggestion_action(
             retired_selection_fingerprint=retired_selection_fingerprint,
         )
     except HTTPException:
-        if pending_reservation_created:
-            with contextlib.suppress(Exception):
-                await asyncio.to_thread(
-                    release_generation_link_reservation,
-                    db,
-                    snapshot_id=snapshot_id,
-                    target_service=action_contract["target_service"],
-                    target_type=action_contract["target_type"],
-                    selection_fingerprint=selection_fingerprint,
-                )
-        with contextlib.suppress(Exception):
-            await asyncio.to_thread(_cleanup_generated_action_target, db, generated=generated)
+        await _cleanup_failed_action_best_effort(
+            db,
+            generated=generated,
+            snapshot_id=snapshot_id,
+            action_contract=action_contract,
+            selection_fingerprint=selection_fingerprint,
+            pending_reservation_created=pending_reservation_created,
+        )
         raise
     except Exception:
-        if pending_reservation_created:
-            with contextlib.suppress(Exception):
-                await asyncio.to_thread(
-                    release_generation_link_reservation,
-                    db,
-                    snapshot_id=snapshot_id,
-                    target_service=action_contract["target_service"],
-                    target_type=action_contract["target_type"],
-                    selection_fingerprint=selection_fingerprint,
-                )
-        with contextlib.suppress(Exception):
-            await asyncio.to_thread(_cleanup_generated_action_target, db, generated=generated)
+        await _cleanup_failed_action_best_effort(
+            db,
+            generated=generated,
+            snapshot_id=snapshot_id,
+            action_contract=action_contract,
+            selection_fingerprint=selection_fingerprint,
+            pending_reservation_created=pending_reservation_created,
+        )
         raise
     return SuggestionActionResponse.model_validate(
         {

--- a/tldw_Server_API/app/core/StudySuggestions/actions.py
+++ b/tldw_Server_API/app/core/StudySuggestions/actions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from collections.abc import Iterable, Mapping
 from typing import Any
@@ -11,6 +12,7 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGD
 
 DEFAULT_GENERATOR_VERSION = "v1"
 LEGACY_NORMALIZATION_VERSION = "legacy"
+SELECTION_FINGERPRINT_VERSION = "study-suggestions:v2"
 PENDING_GENERATION_TARGET_PREFIX = "pending:"
 FOLLOW_UP_ACTION_CONTRACTS = {
     "follow_up_quiz": {
@@ -109,7 +111,40 @@ def build_selection_fingerprint(
     normalization_version: str | None = None,
     include_normalization_version: bool = True,
 ) -> str:
-    """Build a stable, human-readable fingerprint for one follow-up action selection."""
+    """Build a stable, bounded fingerprint for one follow-up action selection."""
+
+    normalized_topics = normalize_selected_topics(selected_topics)
+    resolved_generator_version = _normalize_text(generator_version or DEFAULT_GENERATOR_VERSION) or DEFAULT_GENERATOR_VERSION
+    resolved_normalization_version = _resolve_normalization_version_values(
+        [normalization_version] if normalization_version is not None else []
+    )
+    payload = {
+        "action_kind": _normalize_text(action_kind),
+        "generator_version": resolved_generator_version,
+        "selected_topics": normalized_topics,
+        "snapshot_id": int(snapshot_id),
+        "target_service": _normalize_text(target_service),
+        "target_type": _normalize_text(target_type),
+    }
+    if include_normalization_version:
+        payload["normalization_version"] = resolved_normalization_version
+    canonical_payload = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical_payload.encode("utf-8")).hexdigest()
+    return f"{SELECTION_FINGERPRINT_VERSION}:{digest}"
+
+
+def build_legacy_selection_fingerprint(
+    *,
+    snapshot_id: int,
+    target_service: str,
+    target_type: str,
+    selected_topics: Iterable[object],
+    action_kind: str,
+    generator_version: str | None = None,
+    normalization_version: str | None = None,
+    include_normalization_version: bool = True,
+) -> str:
+    """Build the pre-v2 readable fingerprint format for compatibility lookups."""
 
     normalized_topics = normalize_selected_topics(selected_topics)
     resolved_generator_version = _normalize_text(generator_version or DEFAULT_GENERATOR_VERSION) or DEFAULT_GENERATOR_VERSION
@@ -570,9 +605,11 @@ __all__ = [
     "FOLLOW_UP_ACTION_CONTRACTS",
     "LEGACY_NORMALIZATION_VERSION",
     "PENDING_GENERATION_TARGET_PREFIX",
+    "SELECTION_FINGERPRINT_VERSION",
     "build_flashcard_generation_payload",
     "build_follow_up_flashcard_deck_name",
     "build_follow_up_flashcard_source_text",
+    "build_legacy_selection_fingerprint",
     "build_pending_generation_target_id",
     "build_selection_fingerprint",
     "canonicalize_follow_up_action",

--- a/tldw_Server_API/app/core/StudySuggestions/actions.py
+++ b/tldw_Server_API/app/core/StudySuggestions/actions.py
@@ -9,7 +9,6 @@ from typing import Any
 
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, ConflictError
 
-
 DEFAULT_GENERATOR_VERSION = "v1"
 LEGACY_NORMALIZATION_VERSION = "legacy"
 SELECTION_FINGERPRINT_VERSION = "study-suggestions:v2"
@@ -600,6 +599,33 @@ def soft_delete_deck(note_db: CharactersRAGDB, *, deck_id: int) -> None:
     note_db.soft_delete_deck_by_id(int(deck_id))
 
 
+def cleanup_generated_action_target(
+    note_db: CharactersRAGDB,
+    *,
+    generated: Mapping[str, object] | None,
+) -> None:
+    """Delete or soft-delete a generated follow-up target that could not be linked."""
+
+    if not generated:
+        return
+    target_service = _normalize_text(generated.get("target_service"))
+    target_type = _normalize_text(generated.get("target_type"))
+    target_id = str(generated.get("target_id") or "").strip()
+    if not target_id:
+        return
+
+    try:
+        target_int = int(target_id)
+    except (TypeError, ValueError):
+        return
+
+    if target_service == "flashcards" and target_type == "deck":
+        soft_delete_deck(note_db, deck_id=target_int)
+        return
+    if target_service == "quiz" and target_type == "quiz":
+        note_db.delete_quiz(target_int)
+
+
 __all__ = [
     "DEFAULT_GENERATOR_VERSION",
     "FOLLOW_UP_ACTION_CONTRACTS",
@@ -613,6 +639,7 @@ __all__ = [
     "build_pending_generation_target_id",
     "build_selection_fingerprint",
     "canonicalize_follow_up_action",
+    "cleanup_generated_action_target",
     "finalize_generation_link",
     "find_generation_link_by_fingerprint",
     "is_pending_generation_target_id",

--- a/tldw_Server_API/app/core/StudySuggestions/snapshot_service.py
+++ b/tldw_Server_API/app/core/StudySuggestions/snapshot_service.py
@@ -274,6 +274,40 @@ def _parse_job_created_at(value: Any) -> datetime | None:
     return None
 
 
+def _snapshot_created_at(snapshot_row: Mapping[str, Any] | None) -> datetime | None:
+    if not snapshot_row:
+        return None
+    return _parse_job_created_at(snapshot_row.get("created_at"))
+
+
+def _job_activity_at(job: Mapping[str, Any]) -> datetime | None:
+    for field_name in ("completed_at", "cancelled_at", "updated_at", "acquired_at", "started_at", "created_at"):
+        parsed = _parse_job_created_at(job.get(field_name))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _job_is_newer_than_snapshot(
+    job: Mapping[str, Any] | None,
+    snapshot_row: Mapping[str, Any] | None,
+) -> bool:
+    if not job:
+        return False
+    if not snapshot_row:
+        return True
+    payload = job.get("payload") or {}
+    if isinstance(payload, Mapping):
+        with contextlib.suppress(TypeError, ValueError):
+            if int(payload.get("snapshot_id")) == int(snapshot_row["id"]):
+                return True
+    job_created_at = _job_activity_at(job)
+    snapshot_created_at = _snapshot_created_at(snapshot_row)
+    if job_created_at is None or snapshot_created_at is None:
+        return False
+    return job_created_at > snapshot_created_at
+
+
 def _find_matching_job(
     *,
     job_manager: JobManager,
@@ -323,6 +357,8 @@ def get_anchor_status(
     """Resolve the current suggestion status for a concrete anchor."""
 
     anchor_id = int(anchor_id)
+    snapshots = note_db.list_suggestion_snapshots_for_anchor(anchor_type, anchor_id)
+    active_snapshot = next((row for row in snapshots if str(row.get("status") or "").strip().lower() == "active"), None)
     pending_job = _find_matching_job(
         job_manager=job_manager,
         anchor_type=anchor_type,
@@ -330,7 +366,7 @@ def get_anchor_status(
         statuses=("processing", "queued"),
         owner_user_id=owner_user_id,
     )
-    if pending_job:
+    if pending_job and _job_is_newer_than_snapshot(pending_job, active_snapshot):
         return {
             "anchor_type": anchor_type,
             "anchor_id": anchor_id,
@@ -346,7 +382,7 @@ def get_anchor_status(
         statuses=("failed",),
         owner_user_id=owner_user_id,
     )
-    if failed_job:
+    if failed_job and _job_is_newer_than_snapshot(failed_job, active_snapshot):
         return {
             "anchor_type": anchor_type,
             "anchor_id": anchor_id,
@@ -355,8 +391,6 @@ def get_anchor_status(
             "snapshot_id": None,
         }
 
-    snapshots = note_db.list_suggestion_snapshots_for_anchor(anchor_type, anchor_id)
-    active_snapshot = next((row for row in snapshots if str(row.get("status") or "").strip().lower() == "active"), None)
     if active_snapshot:
         return {
             "anchor_type": anchor_type,
@@ -366,6 +400,24 @@ def get_anchor_status(
             "snapshot_id": int(active_snapshot["id"]),
         }
 
+    if pending_job:
+        return {
+            "anchor_type": anchor_type,
+            "anchor_id": anchor_id,
+            "status": "pending",
+            "job_id": int(pending_job["id"]),
+            "snapshot_id": None,
+        }
+
+    if failed_job:
+        return {
+            "anchor_type": anchor_type,
+            "anchor_id": anchor_id,
+            "status": "failed",
+            "job_id": int(failed_job["id"]),
+            "snapshot_id": None,
+        }
+
     return {
         "anchor_type": anchor_type,
         "anchor_id": anchor_id,
@@ -373,6 +425,47 @@ def get_anchor_status(
         "job_id": None,
         "snapshot_id": None,
     }
+
+
+def _source_available_from_note_db(
+    note_db: CharactersRAGDB,
+    *,
+    source_type: str | None,
+    source_id: str | None,
+) -> bool:
+    if not source_type or not source_id:
+        return False
+    normalized_source_type = source_type.strip().lower()
+    normalized_source_id = source_id.strip()
+    if not normalized_source_id:
+        return False
+
+    if normalized_source_type == "flashcard_deck":
+        with contextlib.suppress(TypeError, ValueError):
+            deck = note_db.get_deck(int(normalized_source_id))
+            return bool(deck) and not bool(deck.get("deleted"))
+        return False
+    if normalized_source_type == "flashcard_card":
+        card = note_db.get_flashcard(normalized_source_id)
+        if not card:
+            return False
+        deck_id = card.get("deck_id")
+        if deck_id is None:
+            return True
+        with contextlib.suppress(TypeError, ValueError):
+            deck = note_db.get_deck(int(deck_id))
+            return bool(deck) and not bool(deck.get("deleted"))
+        return False
+    if normalized_source_type == "quiz":
+        with contextlib.suppress(TypeError, ValueError):
+            return note_db.get_quiz(int(normalized_source_id)) is not None
+        return False
+    if normalized_source_type == "quiz_attempt":
+        with contextlib.suppress(TypeError, ValueError):
+            return note_db.get_attempt(int(normalized_source_id)) is not None
+        return False
+
+    return True
 
 
 def load_live_evidence_for_snapshot(
@@ -396,13 +489,20 @@ def load_live_evidence_for_snapshot(
         topic_id = _safe_text(topic.get("id")) or f"topic-{index}"
         source_type = _safe_text(topic.get("source_type"))
         source_id = _safe_text(topic.get("source_id"))
+        source_available = _source_available_from_note_db(
+            note_db,
+            source_type=source_type,
+            source_id=source_id,
+        )
         item: dict[str, Any] = {
-            "source_available": bool(source_type and source_id),
+            "source_available": source_available,
         }
         if source_type:
             item["source_type"] = source_type
         if source_id:
             item["source_id"] = source_id
+        if not source_available:
+            item["reason"] = "unavailable"
         live_evidence[topic_id] = item
     return live_evidence
 

--- a/tldw_Server_API/app/core/StudySuggestions/snapshot_service.py
+++ b/tldw_Server_API/app/core/StudySuggestions/snapshot_service.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
-from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, ConflictError
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, CharactersRAGDBError, ConflictError
 from tldw_Server_API.app.core.Jobs.manager import JobManager
 
 from .flashcard_adapter import build_flashcard_suggestion_context, extract_flashcard_suggestion_evidence
@@ -275,12 +275,16 @@ def _parse_job_created_at(value: Any) -> datetime | None:
 
 
 def _snapshot_created_at(snapshot_row: Mapping[str, Any] | None) -> datetime | None:
+    """Return the snapshot creation timestamp normalized to an aware UTC datetime."""
+
     if not snapshot_row:
         return None
     return _parse_job_created_at(snapshot_row.get("created_at"))
 
 
 def _job_activity_at(job: Mapping[str, Any]) -> datetime | None:
+    """Return the newest available timestamp that represents observable job activity."""
+
     for field_name in ("completed_at", "cancelled_at", "updated_at", "acquired_at", "started_at", "created_at"):
         parsed = _parse_job_created_at(job.get(field_name))
         if parsed is not None:
@@ -292,6 +296,8 @@ def _job_is_newer_than_snapshot(
     job: Mapping[str, Any] | None,
     snapshot_row: Mapping[str, Any] | None,
 ) -> bool:
+    """Return whether a job status should supersede the current active snapshot."""
+
     if not job:
         return False
     if not snapshot_row:
@@ -433,6 +439,8 @@ def _source_available_from_note_db(
     source_type: str | None,
     source_id: str | None,
 ) -> bool:
+    """Return whether a frozen evidence source still resolves in the note database."""
+
     if not source_type or not source_id:
         return False
     normalized_source_type = source_type.strip().lower()
@@ -440,29 +448,32 @@ def _source_available_from_note_db(
     if not normalized_source_id:
         return False
 
-    if normalized_source_type == "flashcard_deck":
-        with contextlib.suppress(TypeError, ValueError):
-            deck = note_db.get_deck(int(normalized_source_id))
-            return bool(deck) and not bool(deck.get("deleted"))
-        return False
-    if normalized_source_type == "flashcard_card":
-        card = note_db.get_flashcard(normalized_source_id)
-        if not card:
+    try:
+        if normalized_source_type == "flashcard_deck":
+            with contextlib.suppress(TypeError, ValueError):
+                deck = note_db.get_deck(int(normalized_source_id))
+                return bool(deck) and not bool(deck.get("deleted"))
             return False
-        deck_id = card.get("deck_id")
-        if deck_id is None:
-            return True
-        with contextlib.suppress(TypeError, ValueError):
-            deck = note_db.get_deck(int(deck_id))
-            return bool(deck) and not bool(deck.get("deleted"))
-        return False
-    if normalized_source_type == "quiz":
-        with contextlib.suppress(TypeError, ValueError):
-            return note_db.get_quiz(int(normalized_source_id)) is not None
-        return False
-    if normalized_source_type == "quiz_attempt":
-        with contextlib.suppress(TypeError, ValueError):
-            return note_db.get_attempt(int(normalized_source_id)) is not None
+        if normalized_source_type == "flashcard_card":
+            card = note_db.get_flashcard(normalized_source_id)
+            if not card:
+                return False
+            deck_id = card.get("deck_id")
+            if deck_id is None:
+                return True
+            with contextlib.suppress(TypeError, ValueError):
+                deck = note_db.get_deck(int(deck_id))
+                return bool(deck) and not bool(deck.get("deleted"))
+            return False
+        if normalized_source_type == "quiz":
+            with contextlib.suppress(TypeError, ValueError):
+                return note_db.get_quiz(int(normalized_source_id)) is not None
+            return False
+        if normalized_source_type == "quiz_attempt":
+            with contextlib.suppress(TypeError, ValueError):
+                return note_db.get_attempt(int(normalized_source_id)) is not None
+            return False
+    except CharactersRAGDBError:
         return False
 
     return True

--- a/tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py
+++ b/tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py
@@ -8,14 +8,13 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
-from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, CharactersRAGDBError
 from tldw_Server_API.app.core.Jobs.manager import JobManager
-
 
 pytestmark = pytest.mark.integration
 
@@ -365,6 +364,46 @@ def test_snapshot_live_evidence_marks_deleted_deck_source_unavailable(
         },
     )
     db.soft_delete_deck_by_id(deck_id)
+
+    response = client.get(f"/api/v1/study-suggestions/snapshots/{snapshot_id}")
+
+    assert response.status_code == 200  # nosec B101
+    evidence = response.json()["live_evidence"]["topic-1"]
+    assert evidence["source_type"] == "flashcard_deck"  # nosec B101
+    assert evidence["source_id"] == str(deck_id)  # nosec B101
+    assert evidence["source_available"] is False  # nosec B101
+    assert evidence["reason"] == "unavailable"  # nosec B101
+
+
+def test_snapshot_live_evidence_db_failure_marks_source_unavailable(
+    client: TestClient,
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    deck_id = db.add_deck("Evidence Lookup Failure Deck", "desc")
+    snapshot_id = db.create_suggestion_snapshot(
+        service="flashcards",
+        activity_type="flashcard_review_session",
+        anchor_type="flashcard_review_session",
+        anchor_id=203,
+        suggestion_type="study_suggestions",
+        payload_json={
+            "topics": [
+                {
+                    "id": "topic-1",
+                    "display_label": "Renal basics",
+                    "source_type": "flashcard_deck",
+                    "source_id": str(deck_id),
+                    "selected": True,
+                }
+            ],
+        },
+    )
+
+    def fail_get_deck(deck_id_arg: int):
+        raise CharactersRAGDBError(f"deck lookup failed for {deck_id_arg}")
+
+    monkeypatch.setattr(db, "get_deck", fail_get_deck)
 
     response = client.get(f"/api/v1/study-suggestions/snapshots/{snapshot_id}")
 
@@ -939,6 +978,60 @@ def test_flashcard_follow_up_finalization_failure_soft_deletes_generated_deck(
     ]
     assert len(generated_decks) == 1  # nosec B101
     assert bool(generated_decks[0]["deleted"]) is True  # nosec B101
+
+
+def test_action_failure_logs_cleanup_and_reservation_release_failures(
+    client: TestClient,
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    endpoints_mod, _quizzes_mod, _flashcards_mod, _snapshot_service_mod, _jobs_mod, _actions_mod = _load_modules()
+    logger = _LoggerStub()
+    monkeypatch.setattr(endpoints_mod, "logger", logger)
+    attempt_id = _create_quiz_attempt(db)
+    snapshot_id = db.create_suggestion_snapshot(
+        service="quiz",
+        activity_type="quiz_attempt",
+        anchor_type="quiz_attempt",
+        anchor_id=attempt_id,
+        suggestion_type="study_suggestions",
+        payload_json={"topics": [{"id": "topic-1", "display_label": "Renal Basics", "selected": True}]},
+    )
+
+    async def fake_generate_flashcards(payload, context):
+        return {"flashcards": [{"front": "What filters blood?", "back": "Kidney."}]}
+
+    def fail_finalize_generation_link(*args, **kwargs):
+        raise RuntimeError("link finalization failed")
+
+    def fail_release_generation_link_reservation(*args, **kwargs):
+        raise RuntimeError("reservation release failed")
+
+    def fail_cleanup_generated_action_target(*args, **kwargs):
+        raise RuntimeError("cleanup failed")
+
+    monkeypatch.setattr(endpoints_mod, "run_flashcard_generate_adapter", fake_generate_flashcards)
+    monkeypatch.setattr(endpoints_mod, "finalize_generation_link", fail_finalize_generation_link)
+    monkeypatch.setattr(endpoints_mod, "release_generation_link_reservation", fail_release_generation_link_reservation)
+    monkeypatch.setattr(endpoints_mod, "cleanup_generated_action_target", fail_cleanup_generated_action_target)
+
+    with pytest.raises(RuntimeError, match="link finalization failed"):
+        client.post(
+            f"/api/v1/study-suggestions/snapshots/{snapshot_id}/actions",
+            json={
+                "target_service": "flashcards",
+                "target_type": "deck",
+                "action_kind": "follow_up_flashcards",
+                "selected_topic_ids": ["topic-1"],
+                "generator_version": "v1",
+                "force_regenerate": False,
+            },
+        )
+
+    warning_text = "\n".join(logger.warnings)
+    assert "Failed to release study suggestion generation reservation" in warning_text  # nosec B101
+    assert "Failed to cleanup generated study suggestion target" in warning_text  # nosec B101
+    assert f"snapshot_id={snapshot_id}" in warning_text  # nosec B101
 
 
 def test_flashcard_session_snapshot_can_generate_follow_up_quiz(

--- a/tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py
+++ b/tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py
@@ -341,6 +341,41 @@ def test_live_evidence_permission_failures_degrade_to_source_unavailable(
     assert body["live_evidence"]["reason"] == "unavailable"  # nosec B101
 
 
+def test_snapshot_live_evidence_marks_deleted_deck_source_unavailable(
+    client: TestClient,
+    db: CharactersRAGDB,
+):
+    deck_id = db.add_deck("Deleted Evidence Deck", "desc")
+    snapshot_id = db.create_suggestion_snapshot(
+        service="flashcards",
+        activity_type="flashcard_review_session",
+        anchor_type="flashcard_review_session",
+        anchor_id=202,
+        suggestion_type="study_suggestions",
+        payload_json={
+            "topics": [
+                {
+                    "id": "topic-1",
+                    "display_label": "Renal basics",
+                    "source_type": "flashcard_deck",
+                    "source_id": str(deck_id),
+                    "selected": True,
+                }
+            ],
+        },
+    )
+    db.soft_delete_deck_by_id(deck_id)
+
+    response = client.get(f"/api/v1/study-suggestions/snapshots/{snapshot_id}")
+
+    assert response.status_code == 200  # nosec B101
+    evidence = response.json()["live_evidence"]["topic-1"]
+    assert evidence["source_type"] == "flashcard_deck"  # nosec B101
+    assert evidence["source_id"] == str(deck_id)  # nosec B101
+    assert evidence["source_available"] is False  # nosec B101
+    assert evidence["reason"] == "unavailable"  # nosec B101
+
+
 def test_submit_attempt_enqueues_study_suggestions_refresh_job(
     client: TestClient,
     db: CharactersRAGDB,
@@ -857,6 +892,53 @@ def test_flashcard_follow_up_force_regenerate_creates_real_deck_and_link(
         selection_fingerprint=fingerprint,
     )
     assert linked is not None  # nosec B101
+
+
+def test_flashcard_follow_up_finalization_failure_soft_deletes_generated_deck(
+    client: TestClient,
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    endpoints_mod, _quizzes_mod, _flashcards_mod, _snapshot_service_mod, _jobs_mod, _actions_mod = _load_modules()
+    attempt_id = _create_quiz_attempt(db)
+    snapshot_id = db.create_suggestion_snapshot(
+        service="quiz",
+        activity_type="quiz_attempt",
+        anchor_type="quiz_attempt",
+        anchor_id=attempt_id,
+        suggestion_type="study_suggestions",
+        payload_json={"topics": [{"id": "topic-1", "display_label": "Renal Basics", "selected": True}]},
+    )
+
+    async def fake_generate_flashcards(payload, context):
+        return {"flashcards": [{"front": "What filters blood?", "back": "Kidney."}]}
+
+    def fail_finalize_generation_link(*args, **kwargs):
+        raise RuntimeError("link finalization failed")
+
+    monkeypatch.setattr(endpoints_mod, "run_flashcard_generate_adapter", fake_generate_flashcards)
+    monkeypatch.setattr(endpoints_mod, "finalize_generation_link", fail_finalize_generation_link)
+
+    with pytest.raises(RuntimeError, match="link finalization failed"):
+        client.post(
+            f"/api/v1/study-suggestions/snapshots/{snapshot_id}/actions",
+            json={
+                "target_service": "flashcards",
+                "target_type": "deck",
+                "action_kind": "follow_up_flashcards",
+                "selected_topic_ids": ["topic-1"],
+                "generator_version": "v1",
+                "force_regenerate": False,
+            },
+        )
+
+    generated_decks = [
+        deck
+        for deck in db.list_decks(include_deleted=True)
+        if str(deck.get("name") or "").startswith(f"Study Suggestions {snapshot_id}")
+    ]
+    assert len(generated_decks) == 1  # nosec B101
+    assert bool(generated_decks[0]["deleted"]) is True  # nosec B101
 
 
 def test_flashcard_session_snapshot_can_generate_follow_up_quiz(

--- a/tldw_Server_API/tests/StudySuggestions/test_study_suggestions_jobs_worker.py
+++ b/tldw_Server_API/tests/StudySuggestions/test_study_suggestions_jobs_worker.py
@@ -190,6 +190,54 @@ async def test_failed_jobs_surface_failed_without_mutating_prior_snapshots(
     assert snapshots[0]["payload_json"]["topics"][0]["display_label"] == "Original topic"  # nosec B101
 
 
+async def test_anchor_status_prefers_newer_ready_snapshot_over_older_failed_job(
+    db: CharactersRAGDB,
+    jobs_db_path: Path,
+):
+    _actions_mod, snapshot_service_mod, jobs_mod, _worker_mod = _load_modules()
+    jm = JobManager(db_path=jobs_db_path)
+    failed_job = jm.create_job(
+        domain=jobs_mod.STUDY_SUGGESTIONS_DOMAIN,
+        queue=jobs_mod.study_suggestions_jobs_queue(),
+        job_type=jobs_mod.STUDY_SUGGESTIONS_REFRESH_JOB_TYPE,
+        payload=jobs_mod.build_study_suggestions_job_payload(
+            job_type=jobs_mod.STUDY_SUGGESTIONS_REFRESH_JOB_TYPE,
+            anchor_type="quiz_attempt",
+            anchor_id=101,
+        ),
+        owner_user_id="1",
+        priority=5,
+        max_retries=1,
+    )
+    acquired = jm.acquire_next_job(
+        domain=jobs_mod.STUDY_SUGGESTIONS_DOMAIN,
+        queue=jobs_mod.study_suggestions_jobs_queue(),
+        lease_seconds=30,
+        worker_id="study-suggestions-worker-test",
+    )
+    assert acquired is not None  # nosec B101
+    assert int(acquired["id"]) == int(failed_job["id"])  # nosec B101
+    jm.fail_job(
+        int(acquired["id"]),
+        error="refresh failed",
+        retryable=False,
+        worker_id=str(acquired["worker_id"]),
+        lease_id=str(acquired["lease_id"]),
+    )
+    ready_snapshot_id = _create_snapshot(db, anchor_id=101)
+
+    status = snapshot_service_mod.get_anchor_status(
+        note_db=db,
+        job_manager=jm,
+        anchor_type="quiz_attempt",
+        anchor_id=101,
+        owner_user_id="1",
+    )
+
+    assert status["status"] == "ready"  # nosec B101
+    assert status["snapshot_id"] == ready_snapshot_id  # nosec B101
+
+
 async def test_anchor_status_pages_past_first_hundred_failed_jobs_for_matching_anchor(
     db: CharactersRAGDB,
     jobs_db_path: Path,
@@ -334,13 +382,36 @@ async def test_selection_fingerprint_includes_snapshot_target_topics_action_gene
         normalization_version="norm-v2",
     )
 
-    assert "snapshot_id=17" in fingerprint  # nosec B101
-    assert "target_service=quiz" in fingerprint  # nosec B101
-    assert "target_type=quiz" in fingerprint  # nosec B101
-    assert "topics=acid base,renal basics" in fingerprint  # nosec B101
-    assert "action_kind=follow_up_quiz" in fingerprint  # nosec B101
-    assert "generator_version=v2" in fingerprint  # nosec B101
-    assert "normalization_version=norm-v2" in fingerprint  # nosec B101
+    assert fingerprint.startswith("study-suggestions:v2:")  # nosec B101
+    assert "acid base" not in fingerprint  # nosec B101
+    assert "renal basics" not in fingerprint  # nosec B101
+
+
+async def test_selection_fingerprint_distinguishes_topic_delimiter_collisions():
+    actions_mod, _snapshot_service_mod, _jobs_mod, _worker_mod = _load_modules()
+
+    first = actions_mod.build_selection_fingerprint(
+        snapshot_id=17,
+        target_service="quiz",
+        target_type="quiz",
+        selected_topics=["a,b", "c"],
+        action_kind="follow_up_quiz",
+        generator_version="v2",
+        normalization_version="norm-v2",
+    )
+    second = actions_mod.build_selection_fingerprint(
+        snapshot_id=17,
+        target_service="quiz",
+        target_type="quiz",
+        selected_topics=["a", "b,c"],
+        action_kind="follow_up_quiz",
+        generator_version="v2",
+        normalization_version="norm-v2",
+    )
+
+    assert first != second  # nosec B101
+    assert len(first) <= 96  # nosec B101
+    assert len(second) <= 96  # nosec B101
 
 
 async def test_resolve_selected_topic_labels_defaults_to_snapshot_selected_topics():


### PR DESCRIPTION
## Summary
- Replace delimiter-joined StudySuggestions selection fingerprints with bounded v2 hashes while keeping legacy lookup candidates.
- Make anchor status and snapshot live evidence use current DB state instead of stale job/source assumptions.
- Clean up generated follow-up quiz/deck artifacts when generation-link finalization fails, with regression coverage.

## Test Plan
- [x] source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/StudySuggestions/test_study_suggestions_jobs_worker.py -q --tb=short
- [x] source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py -q --tb=short
- [x] source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/StudySuggestions tldw_Server_API/app/api/v1/endpoints/study_suggestions.py tldw_Server_API/tests/StudySuggestions/test_study_suggestions_jobs_worker.py tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py -f json -o /tmp/bandit_study_suggestions_9940_worktree.json

Change summary: This PR hardens StudySuggestions follow-up generation and snapshot status behavior based on the reviewed current module code. The fingerprint format is switched to structured hashing to avoid delimiter collisions and oversized pending IDs, while the endpoint still searches old readable and no-normalization fingerprints so existing links continue to dedupe. Status and evidence now favor current durable state over stale jobs or frozen source IDs, and failed finalization cleans up generated artifacts so retries do not leave orphaned decks or quizzes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened StudySuggestions with bounded, collision-safe v2 fingerprints, recency-aware anchor status, and robust cleanup with best‑effort logging. Live evidence now uses real DB lookups and marks sources unavailable (including on DB failures). Addresses TASK-9940 while preserving legacy fingerprint lookups.

- **Bug Fixes**
  - Switched to versioned SHA‑256 v2 selection fingerprints; endpoint searches multiple legacy formats to preserve dedupe.
  - Anchor status prefers the newest state; older failed/pending jobs no longer mask a newer active snapshot.
  - Live evidence is resolved from the notes DB; deleted/missing or lookup-error sources return unavailable with a reason.
  - On finalization failure, generated decks/quizzes are cleaned up and reservations released; cleanup/release failures are logged without masking the original error.

<sup>Written for commit 39d91afb43c84bd01c52b9c597117238686ff16a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

