### PR TITLE
Fix Usage module quota accounting review findings

### DIFF
--- a/Docs/superpowers/plans/2026-06-23-usage-module-review-fixes.md
+++ b/Docs/superpowers/plans/2026-06-23-usage-module-review-fixes.md
@@ -1,0 +1,66 @@
+# Usage Module Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix validated review findings in `tldw_Server_API/app/core/Usage` without changing unrelated Usage behavior.
+
+**Architecture:** Keep existing module boundaries for this pass, but add small helpers where they reduce risk: explicit audio minute operation ids, a single daily-minute consume helper, safe pricing fallback behavior, and bounded metrics labels. Preserve legacy endpoint compatibility with wrappers around the new consume API.
+
+**Tech Stack:** FastAPI service code, async Python, AuthNZ `DatabasePool`, `ResourceDailyLedger`, pytest, Bandit.
+
+---
+
+## Stage 1: Audio Minute Ledger Correctness
+**Goal**: Make repeated same-duration audio minute events count separately.
+**Success Criteria**: Two calls with the same user/day/minute value produce two ledger entries unless the same explicit operation id is reused.
+**Tests**: `tests/Usage/test_usage_review_fixes.py::test_add_daily_minutes_counts_repeated_same_duration_events`.
+**Status**: Complete
+
+- [x] Write the failing duplicate-duration ledger test.
+- [x] Run the test and confirm it fails because only one event is counted.
+- [x] Add an explicit operation-id path to `add_daily_minutes`, generating a unique id by default.
+- [x] Run the focused test and confirm it passes.
+
+## Stage 2: Daily Minute Consume Semantics
+**Goal**: Replace separate check/add endpoint usage with a single consume helper and safe fallback behavior.
+**Success Criteria**: Callers can consume daily minutes through one helper; ledger unavailability surfaces a quota-store failure instead of silently reading stale legacy usage.
+**Tests**: Add tests for `consume_daily_minutes`, denial without mutation, ledger unavailable failure, and endpoint wrappers using the new helper.
+**Status**: Complete
+
+- [x] Write failing tests for `consume_daily_minutes` success, denial, and ledger-unavailable failure.
+- [x] Run those tests and confirm expected failures.
+- [x] Implement `consume_daily_minutes` and route wrappers/callers through it.
+- [x] Run Usage and touched Audio endpoint tests.
+
+## Stage 3: Cancellation And Metrics Hardening
+**Goal**: Stop swallowing `asyncio.CancelledError` and remove per-user Prometheus labels.
+**Success Criteria**: Cancellation propagates from audio quota helpers; LLM usage metrics no longer emit `*_by_user` metrics or `user_id` labels.
+**Tests**: Add cancellation and metrics-regression tests.
+**Status**: Complete
+
+- [x] Write failing tests for cancellation propagation and no per-user metric labels.
+- [x] Run tests and confirm failures.
+- [x] Remove `CancelledError` from noncritical exception handling and delete per-user metric emission.
+- [x] Run focused tests.
+
+## Stage 4: Pricing Budget Safety
+**Goal**: Prevent placeholder billable models from recording zero USD budget usage.
+**Success Criteria**: Placeholder pricing entries resolve to a conservative estimated fallback instead of zero unless explicitly marked free.
+**Tests**: Add pricing tests for Qwen placeholder behavior and true free placeholders.
+**Status**: Complete
+
+- [x] Write failing pricing tests.
+- [x] Run tests and confirm failures.
+- [x] Update pricing entry handling with conservative placeholder fallback while preserving documented free non-placeholder entries.
+- [x] Run pricing and usage tracker tests.
+
+## Stage 5: Documentation And Verification
+**Goal**: Update docs and verify touched scope.
+**Success Criteria**: README reflects current AuthNZ/RG/ledger behavior; focused tests and Bandit results are recorded in TASK-12004.
+**Tests**: Existing focused test commands plus Bandit.
+**Status**: Complete
+
+- [x] Update `tldw_Server_API/app/core/Usage/README.md`.
+- [x] Run focused pytest for `tests/Usage` and relevant Audio tests.
+- [x] Run Bandit on touched Usage files.
+- [x] Update TASK-12004 with notes, checked acceptance criteria, and final summary.

--- a/backlog/tasks/task-12004 - Fix-Usage-module-review-findings.md
+++ b/backlog/tasks/task-12004 - Fix-Usage-module-review-findings.md
@@ -1,0 +1,128 @@
+---
+id: TASK-12004
+title: Fix Usage module review findings
+status: Done
+assignee: []
+created_date: 2026-06-23 20:27
+updated_date: 2026-06-25 02:16
+labels:
+- usage
+- quota
+- budget
+- review-fix
+dependencies: []
+priority: high
+modified_files:
+- Docs/superpowers/plans/2026-06-23-usage-module-review-fixes.md
+- tldw_Server_API/app/api/v1/endpoints/audio/__init__.py
+- tldw_Server_API/app/api/v1/endpoints/audio/audio.py
+- tldw_Server_API/app/api/v1/endpoints/audio/audio_streaming.py
+- tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
+- tldw_Server_API/app/core/DB_Management/Resource_Daily_Ledger.py
+- tldw_Server_API/app/core/Usage/README.md
+- tldw_Server_API/app/core/Usage/audio_quota.py
+- tldw_Server_API/app/core/Usage/pricing_catalog.py
+- tldw_Server_API/app/core/Usage/usage_tracker.py
+- tldw_Server_API/app/core/exceptions.py
+- tldw_Server_API/tests/Usage/test_usage_review_fixes.py
+- tldw_Server_API/tests/Usage/test_usage_tracker_sqlite.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address validated current-code review findings in `tldw_Server_API/app/core/Usage`: audio minute ledger correctness, ledger-unavailable quota behavior, single-operation daily-minute consumption, cancellation propagation, USD budget safety for placeholder pricing, metrics cardinality, and Usage module README accuracy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Repeated same-duration audio minute events are counted separately in ResourceDailyLedger.
+- [x] #2 Ledger-unavailable audio minute quota paths preserve enforcement semantics or surface quota-store failure for bounded fail-open handling.
+- [x] #3 Daily audio minute check/consume has a single operation that prevents stale separate check/add endpoint usage.
+- [x] #4 Placeholder or unknown billable model prices cannot silently produce zero USD budget usage.
+- [x] #5 Audio quota helpers do not swallow asyncio.CancelledError.
+- [x] #6 Usage metrics avoid per-user high-cardinality labels.
+- [x] #7 Usage README reflects current ledger/RG/AuthNZ behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-23-usage-module-review-fixes.md
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added focused regression tests in `tldw_Server_API/tests/Usage/test_usage_review_fixes.py`.
+- Added unique/default audio minute operation ids and explicit operation-id support for idempotent callers.
+- Added `ResourceDailyLedger.consume_if_available()` and `audio_quota.consume_daily_minutes()` for store-backed daily-minute enforcement plus recording.
+- Updated audio transcription and streaming call sites to use consume semantics while retaining legacy test-shim compatibility.
+- Removed per-user Prometheus LLM metrics; durable AuthNZ usage logs remain the per-user source of truth.
+- Changed placeholder pricing to use conservative billable fallback rates while preserving documented free non-placeholder zero rates.
+- Updated `tldw_Server_API/app/core/Usage/README.md` for ledger/RG/AuthNZ behavior and documented the `audio_quota.py` boundary to discourage adding more unrelated responsibilities before a dedicated extraction.
+<!-- SECTION:NOTES:END -->
+
+## Modified Files
+
+<!-- SECTION:MODIFIED_FILES:BEGIN -->
+- `Docs/superpowers/plans/2026-06-23-usage-module-review-fixes.md`
+- `tldw_Server_API/app/api/v1/endpoints/audio/__init__.py`
+- `tldw_Server_API/app/api/v1/endpoints/audio/audio.py`
+- `tldw_Server_API/app/api/v1/endpoints/audio/audio_streaming.py`
+- `tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py`
+- `tldw_Server_API/app/core/DB_Management/Resource_Daily_Ledger.py`
+- `tldw_Server_API/app/core/Usage/README.md`
+- `tldw_Server_API/app/core/Usage/audio_quota.py`
+- `tldw_Server_API/app/core/Usage/pricing_catalog.py`
+- `tldw_Server_API/app/core/Usage/usage_tracker.py`
+- `tldw_Server_API/tests/Usage/test_usage_review_fixes.py`
+<!-- SECTION:MODIFIED_FILES:END -->
+
+## Verification
+
+<!-- SECTION:VERIFICATION:BEGIN -->
+- Red test confirmation: `source .venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Usage/test_usage_review_fixes.py` initially failed 8 tests as expected.
+- Focused Usage suite: `source .venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Usage` -> 57 passed, 1 skipped.
+- Relevant Audio endpoint/quota suite: `source .venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Audio/test_audio_transcriptions_hotwords.py tldw_Server_API/tests/Audio/test_audio_transcriptions_adapter_path.py tldw_Server_API/tests/Audio/test_audio_transcription_language_normalization.py tldw_Server_API/tests/Audio/test_audio_transcriptions_timed_segments.py tldw_Server_API/tests/Audio/test_audio_transcription_retention_and_redaction.py tldw_Server_API/tests/Audio/test_ws_audio_chat_stream.py tldw_Server_API/tests/Audio/test_audio_router_import_resilience.py tldw_Server_API/tests/Audio/test_audio_streaming_truthiness_flags.py tldw_Server_API/tests/Audio/test_audio_quota_rg_and_ledger.py tldw_Server_API/tests/Audio/test_audio_quota_unit.py` -> 117 passed.
+- Syntax: `source .venv/bin/activate && python -m compileall -q ...` on touched Python paths -> passed.
+- Bandit: `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Usage tldw_Server_API/app/core/DB_Management/Resource_Daily_Ledger.py tldw_Server_API/app/api/v1/endpoints/audio/audio_streaming.py tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py tldw_Server_API/app/api/v1/endpoints/audio/audio.py tldw_Server_API/app/api/v1/endpoints/audio/__init__.py -f json -o /tmp/bandit_usage_12004.json` -> 0 findings, `results: []`.
+<!-- SECTION:VERIFICATION:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the Usage review findings by making audio minute usage ledger entries unique by default, adding a store-backed consume operation for daily-minute enforcement, surfacing ledger-unavailable failures to bounded fail-open paths, preserving cancellation propagation, removing per-user Prometheus LLM labels, pricing billable placeholders conservatively, and refreshing Usage documentation.
+PR #2491 follow-up rebased the branch onto latest `origin/dev` and resolved all actionable review comments while preserving the existing PII-safe logging boundary.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Reopened for PR #2491 review follow-up on 2026-06-24: address Qodo review comments, rebase onto latest dev, rerun focused verification, and push updated branch.
+PR #2491 follow-up addressed Qodo review items: centralized endpoint quota compatibility logic in core Usage, moved AudioQuotaStoreUnavailable to core exceptions, added missing type hints/docstrings, made zero-minute consumption a no-op when quota storage is unavailable, pruned fallback consume locks, and logged safe exception types for best-effort metrics/ledger failures without leaking raw exception messages.
+
+Follow-up verification on 2026-06-24:
+- `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest -q tldw_Server_API/tests/Usage/test_usage_review_fixes.py` -> 11 passed.
+- `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest -q tldw_Server_API/tests/Usage` -> 57 passed, 1 skipped.
+- Relevant Audio suite with known base-failing `test_audio_chat_ws_records_metrics` deselected -> 112 passed, 1 deselected.
+- Compile check on touched Python files -> passed.
+- Bandit touched app scope -> 0 findings in `/tmp/bandit_usage_12004_pr_followup.json`.
+2026-06-25: Rebasing PR #2491 onto latest origin/dev exposed overlap with previously merged Usage quota changes. Resolving conflicts by keeping latest dev context while retaining the review-driven fixes for atomic quota consumption, compatibility shims, logging, docs, and tests.
+Rebase verification on 2026-06-25 after resolving latest `origin/dev` conflicts:
+- Focused review regression: `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest -q tldw_Server_API/tests/Usage/test_usage_review_fixes.py` -> 11 passed.
+- Full Usage suite: `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest -q tldw_Server_API/tests/Usage` -> 59 passed, 1 skipped.
+- Relevant Audio endpoint/quota suite with known base-failing `test_audio_chat_ws_records_metrics` deselected -> 116 passed, 1 deselected.
+- Compile check on touched Python files -> passed.
+- Bandit touched app scope -> 0 findings in `/tmp/bandit_usage_12004_rebase_latest.json`.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_streaming.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_streaming.py
@@ -47,15 +47,15 @@ from tldw_Server_API.app.core.Audio.error_payloads import _maybe_debug_details
 from tldw_Server_API.app.core.Audio.streaming_exceptions import QuotaExceeded
 from tldw_Server_API.app.core.Audio.transcription_service import _map_openai_audio_model_to_whisper
 from tldw_Server_API.app.core.Audio.quota_helpers import EXPECTED_DB_EXC, EXPECTED_REDIS_EXC, _get_failopen_cap_minutes
+from tldw_Server_API.app.core.exceptions import AudioQuotaStoreUnavailable
 from tldw_Server_API.app.core.Usage.audio_quota import (
-    AudioQuotaStoreUnavailable,
     active_streams_count,
     add_daily_minutes,
     bytes_to_seconds,
     can_start_stream,
     check_daily_minutes_allow,
     consume_daily_minutes,
-    consume_daily_minutes_with_legacy_fallback,
+    consume_daily_minutes_with_compat,
     finish_job,
     finish_stream,
     get_daily_minutes_used,
@@ -725,14 +725,17 @@ async def _add_daily_minutes(user_id: int, minutes: float):
     return await _audio_shim_attr("add_daily_minutes")(user_id, minutes)
 
 
-async def _consume_daily_minutes(user_id: int, minutes: float, *, operation_id: str | None = None):
-    return await consume_daily_minutes_with_legacy_fallback(
-        user_id,
-        minutes,
+async def _consume_daily_minutes(
+    user_id: int,
+    minutes: float,
+    *,
+    operation_id: str | None = None,
+) -> tuple[bool, float | None]:
+    return await consume_daily_minutes_with_compat(
+        user_id=user_id,
+        minutes=minutes,
         operation_id=operation_id,
-        consume_fn=_audio_shim_attr("consume_daily_minutes"),
-        check_fn=_audio_shim_attr("check_daily_minutes_allow"),
-        add_fn=_audio_shim_attr("add_daily_minutes"),
+        quota_helper_resolver=_audio_shim_attr,
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
@@ -41,6 +41,7 @@ from tldw_Server_API.app.core.Audio.error_payloads import _http_error_detail
 from tldw_Server_API.app.core.Audio.quota_helpers import EXPECTED_DB_EXC
 from tldw_Server_API.app.core.Audio.transcription_service import _map_openai_audio_model_to_whisper
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.exceptions import AudioQuotaStoreUnavailable
 from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.stt_policy import (
     apply_transcript_text_policy,
     build_audio_retention_decision,
@@ -58,12 +59,11 @@ from tldw_Server_API.app.core.Metrics.stt_metrics import (
 )
 from tldw_Server_API.app.core.testing import is_test_mode
 from tldw_Server_API.app.core.Usage.audio_quota import (
-    AudioQuotaStoreUnavailable,
     add_daily_minutes,
     can_start_job,
     check_daily_minutes_allow,
     consume_daily_minutes,
-    consume_daily_minutes_with_legacy_fallback,
+    consume_daily_minutes_with_compat,
     finish_job,
     get_job_heartbeat_interval_seconds,
     get_limits_for_user,
@@ -269,14 +269,17 @@ async def _add_daily_minutes(user_id: int, minutes: float):
     return await _audio_shim_attr("add_daily_minutes")(user_id, minutes)
 
 
-async def _consume_daily_minutes(user_id: int, minutes: float, *, operation_id: str | None = None):
-    return await consume_daily_minutes_with_legacy_fallback(
-        user_id,
-        minutes,
+async def _consume_daily_minutes(
+    user_id: int,
+    minutes: float,
+    *,
+    operation_id: str | None = None,
+) -> tuple[bool, float | None]:
+    return await consume_daily_minutes_with_compat(
+        user_id=user_id,
+        minutes=minutes,
         operation_id=operation_id,
-        consume_fn=_audio_shim_attr("consume_daily_minutes"),
-        check_fn=_audio_shim_attr("check_daily_minutes_allow"),
-        add_fn=_audio_shim_attr("add_daily_minutes"),
+        quota_helper_resolver=_audio_shim_attr,
     )
 
 

--- a/tldw_Server_API/app/core/Usage/README.md
+++ b/tldw_Server_API/app/core/Usage/README.md
@@ -19,43 +19,61 @@ observability, and user-facing usage summaries.
 - Normalize usage payloads from provider-specific response shapes.
 - Track per-user and per-resource usage in middleware and quota helpers.
 - Provide pricing lookup and override behavior for cost estimates.
-- Support audio-minute quota TTL caches and Resource Governance heartbeat
-  integration.
+- Enforce audio daily-minute quotas through the shared ResourceDailyLedger,
+  with Resource Governance heartbeat integration for concurrent audio work.
 
 ## Module Map
 
-- `usage_tracker.py` provides the SQLite-backed usage tracker and aggregation
+- `usage_tracker.py` normalizes and persists LLM usage into the AuthNZ usage
+  tables, emits low-cardinality operational metrics, and exposes aggregation
   helpers used by middleware and reports.
-- `audio_quota.py` implements audio-minute quota cache checks and updates.
+- `audio_quota.py` implements audio limits. Daily minutes use
+  ResourceDailyLedger as the canonical store; stream/job concurrency is routed
+  through Resource Governance when enabled.
 - `llm_usage_normalizer.py` converts provider response usage into a common
   shape.
 - `pricing_catalog.py` loads model/provider pricing defaults and overrides.
 
 ## How It Connects
 
-- Billing enforcement reads usage context when deciding plan limits.
-- User profile and audio flows use audio quota helpers for per-user limits.
-- Logging and Metrics consume usage events for operational visibility.
+- Billing and virtual-key enforcement read durable usage logs when deciding
+  token and USD budget limits.
+- Audio flows call `consume_daily_minutes` to enforce and record daily-minute
+  usage in one store-backed operation.
+- Metrics receive provider/model/operation counters; user-level breakdowns stay
+  in durable logs to avoid high-cardinality Prometheus labels.
 
 ## Extension Points
 
 - Add resource-specific counters in `usage_tracker.py` only after defining the
   consumer and aggregation semantics.
 - Add provider pricing in `pricing_catalog.py` with tests for override and path
-  loading behavior.
+  loading behavior. Use non-placeholder zero rates only for documented free
+  models; placeholder rates fall back to conservative billable estimates.
+- Keep new audio quota behavior separated by concern. `audio_quota.py` still
+  owns daily-minute, Resource Governance concurrency, and legacy compatibility
+  paths; larger additions should first extract minute ledger or concurrency
+  helpers behind the existing public functions.
 
 ## Testing
 
 - Tracker and middleware behavior: `tests/Usage/test_usage_tracker_sqlite.py`,
   `tests/Usage/test_usage_middleware.py`, and `tests/Usage/test_usage_aggregator.py`.
-- Audio quota behavior: `tests/Usage/test_audio_quota_ttl_cache.py` and
-  `tests/Usage/test_audio_rg_minutes_and_heartbeat.py`.
+- Audio quota behavior: `tests/Usage/test_audio_quota_ttl_cache.py`,
+  `tests/Usage/test_audio_rg_minutes_and_heartbeat.py`,
+  `tests/Audio/test_audio_quota_rg_and_ledger.py`, and
+  `tests/Usage/test_usage_review_fixes.py`.
 - Pricing and normalization: `tests/Usage/test_pricing_catalog.py`,
   `tests/Usage/test_pricing_catalog_overrides.py`, and
   `tests/Usage/test_llm_usage_normalizer.py`.
 
 ## Gotchas
 
-- Avoid high-cardinality metric labels for user/provider/model combinations.
+- Avoid high-cardinality metric labels. Provider/model/operation dimensions are
+  acceptable for operational counters; per-user usage belongs in AuthNZ usage
+  logs and query APIs.
 - Provider usage fields vary widely; normalize defensively and preserve unknowns
   only when a downstream consumer needs them.
+- Do not fall back to legacy `audio_usage_daily` for new daily-minute
+  enforcement. It is only backfilled into ResourceDailyLedger for upgrade
+  compatibility.

--- a/tldw_Server_API/app/core/Usage/audio_quota.py
+++ b/tldw_Server_API/app/core/Usage/audio_quota.py
@@ -21,11 +21,12 @@ import uuid
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from functools import lru_cache
+from typing import Any
 
 from loguru import logger
 
 from tldw_Server_API.app.core.AuthNZ.database import DatabasePool, get_db_pool
-from tldw_Server_API.app.core.AuthNZ.exceptions import DatabaseError as AuthNZDatabaseError
+from tldw_Server_API.app.core.exceptions import AudioQuotaStoreUnavailable
 
 try:
     from tldw_Server_API.app.core.Metrics.metrics_manager import MetricDefinition, MetricType, get_metrics_registry
@@ -101,15 +102,6 @@ _AUDIO_QUOTA_NONCRITICAL_EXCEPTIONS = (
     UnicodeDecodeError,
     configparser.Error,
 )
-
-
-_DailyMinutesConsumeFn = Callable[..., Awaitable[tuple[bool, float | None]]]
-_DailyMinutesCheckFn = Callable[[int, float], Awaitable[tuple[bool, float | None]]]
-_DailyMinutesAddFn = Callable[[int, float], Awaitable[None]]
-
-
-class AudioQuotaStoreUnavailable(AuthNZDatabaseError):
-    """Raised when canonical daily-minute quota storage is unavailable."""
 
 
 # Default tier limits (can be extended later via configuration or DB)
@@ -357,6 +349,15 @@ async def _get_audio_minutes_consume_lock(user_id: int) -> asyncio.Lock:
             lock = asyncio.Lock()
             _audio_minutes_consume_locks[uid] = lock
         return lock
+
+
+async def _cleanup_audio_minutes_consume_lock(user_id: int, expected_lock: asyncio.Lock) -> None:
+    """Remove an idle fallback minute-consume lock from the per-user lock map."""
+    uid = int(user_id)
+    async with _audio_minutes_consume_locks_lock:
+        lock = _audio_minutes_consume_locks.get(uid)
+        if lock is expected_lock and not lock.locked():
+            _audio_minutes_consume_locks.pop(uid, None)
 
 
 async def _cleanup_stream_handles(user_id: int) -> None:
@@ -735,10 +736,12 @@ async def _backfill_audio_usage_daily_to_ledger(ledger: ResourceDailyLedger) -> 
 
 
 def _audio_minutes_units(minutes: float) -> int:
+    """Convert fractional minutes into the integer second units used by the ledger."""
     return int(max(0, round(float(minutes) * 60.0)))
 
 
 def _audio_minutes_op_id(user_id: int, day: str, units: int, operation_id: str | None = None) -> str:
+    """Return a stable caller operation id or generate a unique audio-minute id."""
     if operation_id is not None:
         op_id = str(operation_id).strip()
         if op_id:
@@ -747,6 +750,7 @@ def _audio_minutes_op_id(user_id: int, day: str, units: int, operation_id: str |
 
 
 async def _require_daily_ledger() -> ResourceDailyLedger:
+    """Return the canonical daily ledger or raise when quota storage is unavailable."""
     ledger = await _get_daily_ledger()
     if ledger is None or LedgerEntry is None:
         raise AudioQuotaStoreUnavailable("audio quota daily ledger is unavailable")
@@ -754,6 +758,7 @@ async def _require_daily_ledger() -> ResourceDailyLedger:
 
 
 def _build_audio_minutes_entry(user_id: int, units: int, operation_id: str | None = None) -> LedgerEntry:
+    """Build a daily-ledger entry for audio minute consumption."""
     day = datetime.now(timezone.utc).date().isoformat()
     return LedgerEntry(  # type: ignore[call-arg, return-value]
         entity_scope="user",
@@ -806,22 +811,34 @@ async def consume_daily_minutes(
     Atomically enforce and record audio daily-minute usage.
 
     Returns ``(allowed, remaining_after)``. ``remaining_after`` is ``None`` for
-    unlimited tiers. If the canonical ledger is unavailable, raises
+    unlimited tiers or a no-op request whose remaining quota cannot be computed.
+    If the canonical ledger is unavailable for a positive consume, raises
     ``AudioQuotaStoreUnavailable`` so API layers can use bounded fail-open.
     """
     units = _audio_minutes_units(minutes_requested)
     if units <= 0:
-        return await check_daily_minutes_allow(user_id, 0.0)
+        limits = await get_limits_for_user(user_id)
+        limit = limits.get("daily_minutes")
+        if limit is None:
+            return True, None
+        remaining = await _ledger_remaining_minutes(user_id=int(user_id), daily_limit_minutes=float(limit))
+        if remaining is None:
+            return True, None
+        return True, remaining
 
     limits = await get_limits_for_user(user_id)
     limit = limits.get("daily_minutes")
-
-    if limit is None:
-        await add_daily_minutes(user_id, minutes_requested, operation_id=operation_id or op_id)
-        return True, None
-
     ledger = await _require_daily_ledger()
     entry = _build_audio_minutes_entry(user_id=int(user_id), units=units, operation_id=operation_id or op_id)
+
+    if limit is None:
+        try:
+            await ledger.add(entry)
+            return True, None
+        except _AUDIO_QUOTA_NONCRITICAL_EXCEPTIONS as exc:
+            logger.debug("Audio quotas unlimited daily-minute add failed")
+            raise AudioQuotaStoreUnavailable("audio quota daily ledger add failed") from exc
+
     cap_units = _audio_minutes_units(float(limit))
     if cap_units <= 0:
         _metrics_increment("audio_quota_violations_total", {"type": "daily_minutes"})
@@ -840,21 +857,87 @@ async def consume_daily_minutes(
         # atomicity; this lock avoids same-process races when that API is not
         # present.
         consume_lock = await _get_audio_minutes_consume_lock(int(user_id))
-        async with consume_lock:
-            remaining_units = await ledger.remaining_for_day(
-                entity_scope="user",
-                entity_value=str(int(user_id)),
-                category="minutes",
-                daily_cap=cap_units,
-            )
-            if units > remaining_units:
-                _metrics_increment("audio_quota_violations_total", {"type": "daily_minutes"})
-                return False, float(max(0, int(remaining_units))) / 60.0
-            await ledger.add(entry)
-            return True, float(max(0, int(remaining_units) - units)) / 60.0
+        try:
+            async with consume_lock:
+                remaining_units = await ledger.remaining_for_day(
+                    entity_scope="user",
+                    entity_value=str(int(user_id)),
+                    category="minutes",
+                    daily_cap=cap_units,
+                )
+                if units > remaining_units:
+                    _metrics_increment("audio_quota_violations_total", {"type": "daily_minutes"})
+                    return False, float(max(0, int(remaining_units))) / 60.0
+                await ledger.add(entry)
+                return True, float(max(0, int(remaining_units) - units)) / 60.0
+        finally:
+            await _cleanup_audio_minutes_consume_lock(int(user_id), consume_lock)
     except _AUDIO_QUOTA_NONCRITICAL_EXCEPTIONS as exc:
         logger.debug("Audio quotas consume failed")
         raise AudioQuotaStoreUnavailable("audio quota daily ledger consume failed") from exc
+
+
+AudioQuotaCheckFn = Callable[[int, float], Awaitable[tuple[bool, float | None]]]
+AudioQuotaAddFn = Callable[[int, float], Awaitable[Any]]
+AudioQuotaConsumeFn = Callable[..., Awaitable[tuple[bool, float | None]]]
+AudioQuotaHelperResolver = Callable[[str], Any]
+
+
+def _resolve_audio_quota_helper(
+    resolver: AudioQuotaHelperResolver | None,
+    name: str,
+    default: Any,
+    *,
+    optional: bool = False,
+) -> Any:
+    """Resolve an endpoint shim helper while preserving core defaults."""
+    if resolver is None:
+        return default
+    try:
+        return resolver(name)
+    except (AttributeError, KeyError, NameError):
+        if optional:
+            return None
+        return default
+
+
+async def consume_daily_minutes_with_compat(
+    user_id: int,
+    minutes: float,
+    *,
+    operation_id: str | None = None,
+    quota_helper_resolver: AudioQuotaHelperResolver | None = None,
+) -> tuple[bool, float | None]:
+    """Consume daily minutes while honoring legacy endpoint quota shims."""
+    check_fn: AudioQuotaCheckFn = _resolve_audio_quota_helper(
+        quota_helper_resolver,
+        "check_daily_minutes_allow",
+        check_daily_minutes_allow,
+    )
+    add_fn: AudioQuotaAddFn = _resolve_audio_quota_helper(
+        quota_helper_resolver,
+        "add_daily_minutes",
+        add_daily_minutes,
+    )
+    consume_fn: AudioQuotaConsumeFn | None = _resolve_audio_quota_helper(
+        quota_helper_resolver,
+        "consume_daily_minutes",
+        consume_daily_minutes,
+        optional=True,
+    )
+    legacy_quota_override = (
+        consume_fn is None
+        or (
+            consume_fn is consume_daily_minutes
+            and (check_fn is not check_daily_minutes_allow or add_fn is not add_daily_minutes)
+        )
+    )
+    if legacy_quota_override:
+        allowed, remaining_after = await check_fn(user_id, minutes)
+        if allowed:
+            await add_fn(user_id, minutes)
+        return allowed, remaining_after
+    return await consume_fn(user_id, minutes, operation_id=operation_id)
 
 
 async def consume_daily_minutes_if_allowed(
@@ -864,44 +947,12 @@ async def consume_daily_minutes_if_allowed(
     op_id: str | None = None,
     operation_id: str | None = None,
 ) -> tuple[bool, float | None]:
+    """Backward-compatible alias for atomic daily-minute consumption."""
     return await consume_daily_minutes(
         user_id=user_id,
         minutes_requested=minutes,
         operation_id=operation_id or op_id,
     )
-
-
-async def consume_daily_minutes_with_legacy_fallback(
-    user_id: int,
-    minutes: float,
-    *,
-    operation_id: str | None = None,
-    consume_fn: _DailyMinutesConsumeFn | None = None,
-    check_fn: _DailyMinutesCheckFn | None = None,
-    add_fn: _DailyMinutesAddFn | None = None,
-) -> tuple[bool, float | None]:
-    """
-    Consume daily minutes, preserving legacy check/add overrides for callers.
-
-    Endpoint modules historically expose quota helpers as monkeypatchable shim
-    points. This keeps the compatibility decision in core while allowing those
-    callers to supply their resolved helper functions.
-    """
-    resolved_consume = consume_fn or consume_daily_minutes
-    resolved_check = check_fn or check_daily_minutes_allow
-    resolved_add = add_fn or add_daily_minutes
-
-    legacy_quota_override = resolved_consume is consume_daily_minutes and (
-        resolved_check is not check_daily_minutes_allow
-        or resolved_add is not add_daily_minutes
-    )
-    if legacy_quota_override:
-        allowed, remaining_after = await resolved_check(user_id, minutes)
-        if allowed:
-            await resolved_add(user_id, minutes)
-        return allowed, remaining_after
-
-    return await resolved_consume(user_id, minutes, operation_id=operation_id)
 
 
 async def _ledger_remaining_minutes(user_id: int, daily_limit_minutes: float) -> float | None:

--- a/tldw_Server_API/app/core/Usage/pricing_catalog.py
+++ b/tldw_Server_API/app/core/Usage/pricing_catalog.py
@@ -45,6 +45,7 @@ UNKNOWN_BILLABLE_RATE = {"prompt": 0.01, "completion": 0.03}
 
 
 def _unknown_billable_rate() -> dict[str, float]:
+    """Return a fresh copy of the conservative unknown billable rate sentinel."""
     return dict(UNKNOWN_BILLABLE_RATE)
 
 

--- a/tldw_Server_API/app/core/Usage/usage_tracker.py
+++ b/tldw_Server_API/app/core/Usage/usage_tracker.py
@@ -51,6 +51,11 @@ _tokens_daily_ledger_lock = asyncio.Lock()
 _tokens_legacy_backfill_done: set[str] = set()
 
 
+def _safe_exception_type(exc: BaseException) -> str:
+    """Return a log-safe exception type label without exception details."""
+    return type(exc).__name__
+
+
 async def _get_tokens_daily_ledger() -> ResourceDailyLedger | None:
     global _tokens_daily_ledger
     if ResourceDailyLedger is None or LedgerEntry is None:
@@ -414,9 +419,9 @@ async def log_llm_usage(
                     )
         except asyncio.CancelledError:
             raise
-        except Exception:
+        except Exception as exc:
             # Metrics must never impact request flow
-            logger.debug("LLM usage metrics update skipped/failed")
+            logger.debug(f"LLM usage metrics update skipped/failed; exception_type={_safe_exception_type(exc)}")
 
         db_pool: DatabasePool = await get_db_pool()
         repo = AuthnzUsageRepo(db_pool)
@@ -424,7 +429,8 @@ async def log_llm_usage(
         try:
             if not effective_token_name and key_id is not None:
                 effective_token_name = await repo.get_api_key_name(key_id=int(key_id))
-        except Exception:
+        except Exception as exc:
+            logger.debug(f"LLM usage API key name lookup skipped/failed; exception_type={_safe_exception_type(exc)}")
             effective_token_name = token_name
         await repo.insert_llm_usage_log(
             user_id=user_id,
@@ -497,11 +503,11 @@ async def log_llm_usage(
                         await ledger.add(entry)
         except asyncio.CancelledError:
             raise
-        except Exception:
+        except Exception as exc:
             # Ledger writes must never affect request flow
-            logger.debug("LLM usage daily ledger write skipped/failed")
+            logger.debug(f"LLM usage daily ledger write skipped/failed; exception_type={_safe_exception_type(exc)}")
     except asyncio.CancelledError:
         raise
-    except Exception:
+    except Exception as exc:
         # Never break request processing due to logging errors
-        logger.debug("LLM usage logging skipped/failed")
+        logger.debug(f"LLM usage logging skipped/failed; exception_type={_safe_exception_type(exc)}")

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from loguru import logger
 
+from .AuthNZ.exceptions import DatabaseError as AuthNZDatabaseError
 from .exception_types import PromptCatalogError  # noqa: F401 - re-exported for compatibility.
 
 if hasattr(status, "HTTP_422_UNPROCESSABLE_CONTENT"):
@@ -25,6 +26,10 @@ class EgressPolicyError(Exception):
 
 class NetworkError(Exception):
     """Raised for network transport errors (connect/read timeouts, DNS, TLS, etc.)."""
+
+
+class AudioQuotaStoreUnavailable(AuthNZDatabaseError):
+    """Raised when canonical audio daily-minute quota storage is unavailable."""
 
 
 class RetryExhaustedError(Exception):

--- a/tldw_Server_API/tests/Usage/test_usage_review_fixes.py
+++ b/tldw_Server_API/tests/Usage/test_usage_review_fixes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -13,14 +14,14 @@ pytestmark = pytest.mark.unit
 async def test_add_daily_minutes_counts_repeated_same_duration_events(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.core.Usage import audio_quota
 
-    entries = []
+    entries: list[Any] = []
 
     class FakeLedger:
-        async def add(self, entry):
+        async def add(self, entry: Any) -> bool:
             entries.append(entry)
             return True
 
-    async def fake_get_daily_ledger():
+    async def fake_get_daily_ledger() -> FakeLedger:
         return FakeLedger()
 
     monkeypatch.setattr(audio_quota, "_get_daily_ledger", fake_get_daily_ledger)
@@ -36,14 +37,14 @@ async def test_add_daily_minutes_counts_repeated_same_duration_events(monkeypatc
 async def test_add_daily_minutes_accepts_explicit_operation_id(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.core.Usage import audio_quota
 
-    entries = []
+    entries: list[Any] = []
 
     class FakeLedger:
-        async def add(self, entry):
+        async def add(self, entry: Any) -> bool:
             entries.append(entry)
             return True
 
-    async def fake_get_daily_ledger():
+    async def fake_get_daily_ledger() -> FakeLedger:
         return FakeLedger()
 
     monkeypatch.setattr(audio_quota, "_get_daily_ledger", fake_get_daily_ledger)
@@ -57,24 +58,31 @@ async def test_add_daily_minutes_accepts_explicit_operation_id(monkeypatch: pyte
 async def test_consume_daily_minutes_records_allowed_usage(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.core.Usage import audio_quota
 
-    entries = []
+    entries: list[Any] = []
 
     class FakeLedger:
-        async def remaining_for_day(self, *, entity_scope, entity_value, category, daily_cap):
+        async def remaining_for_day(
+            self,
+            *,
+            entity_scope: str,
+            entity_value: str,
+            category: str,
+            daily_cap: int,
+        ) -> int:
             assert entity_scope == "user"
             assert entity_value == "42"
             assert category == "minutes"
             assert daily_cap == 600
             return 300
 
-        async def add(self, entry):
+        async def add(self, entry: Any) -> bool:
             entries.append(entry)
             return True
 
-    async def fake_get_daily_ledger():
+    async def fake_get_daily_ledger() -> FakeLedger:
         return FakeLedger()
 
-    async def fake_get_limits_for_user(user_id: int):
+    async def fake_get_limits_for_user(user_id: int) -> dict[str, float]:
         assert user_id == 42
         return {"daily_minutes": 10.0}
 
@@ -98,20 +106,27 @@ async def test_consume_daily_minutes_records_allowed_usage(monkeypatch: pytest.M
 async def test_consume_daily_minutes_denies_without_recording(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.core.Usage import audio_quota
 
-    entries = []
+    entries: list[Any] = []
 
     class FakeLedger:
-        async def remaining_for_day(self, *, entity_scope, entity_value, category, daily_cap):
+        async def remaining_for_day(
+            self,
+            *,
+            entity_scope: str,
+            entity_value: str,
+            category: str,
+            daily_cap: int,
+        ) -> int:
             return 30
 
-        async def add(self, entry):
+        async def add(self, entry: Any) -> bool:
             entries.append(entry)
             return True
 
-    async def fake_get_daily_ledger():
+    async def fake_get_daily_ledger() -> FakeLedger:
         return FakeLedger()
 
-    async def fake_get_limits_for_user(user_id: int):
+    async def fake_get_limits_for_user(user_id: int) -> dict[str, float]:
         return {"daily_minutes": 10.0}
 
     monkeypatch.setattr(audio_quota, "_get_daily_ledger", fake_get_daily_ledger)
@@ -132,10 +147,10 @@ async def test_consume_daily_minutes_denies_without_recording(monkeypatch: pytes
 async def test_consume_daily_minutes_surfaces_store_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.core.Usage import audio_quota
 
-    async def fake_get_daily_ledger():
+    async def fake_get_daily_ledger() -> None:
         return None
 
-    async def fake_get_limits_for_user(user_id: int):
+    async def fake_get_limits_for_user(user_id: int) -> dict[str, float]:
         return {"daily_minutes": 10.0}
 
     monkeypatch.setattr(audio_quota, "_get_daily_ledger", fake_get_daily_ledger)
@@ -150,25 +165,22 @@ async def test_consume_daily_minutes_surfaces_store_unavailable(monkeypatch: pyt
 
 
 @pytest.mark.asyncio
-async def test_consume_daily_minutes_allows_unlimited_tier_when_store_unavailable(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_consume_daily_minutes_zero_minutes_allows_without_ledger(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.core.Usage import audio_quota
 
-    async def fake_get_daily_ledger():
+    async def fake_get_daily_ledger() -> None:
         return None
 
-    async def fake_get_limits_for_user(user_id: int):
-        assert user_id == 42
-        return {"daily_minutes": None}
+    async def fake_get_limits_for_user(user_id: int) -> dict[str, float]:
+        return {"daily_minutes": 10.0}
 
     monkeypatch.setattr(audio_quota, "_get_daily_ledger", fake_get_daily_ledger)
     monkeypatch.setattr(audio_quota, "get_limits_for_user", fake_get_limits_for_user)
 
     allowed, remaining = await audio_quota.consume_daily_minutes(
         user_id=42,
-        minutes_requested=10.0,
-        operation_id="audio-file:req-unlimited",
+        minutes_requested=0.0,
+        operation_id="audio-file:req-empty",
     )
 
     assert allowed is True
@@ -176,37 +188,55 @@ async def test_consume_daily_minutes_allows_unlimited_tier_when_store_unavailabl
 
 
 @pytest.mark.asyncio
-async def test_consume_daily_minutes_legacy_fallback_lives_in_core() -> None:
+async def test_consume_daily_minutes_fallback_cleans_user_lock(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.core.Usage import audio_quota
 
-    calls = []
+    entries: list[Any] = []
 
-    async def fake_check(user_id: int, minutes: float):
-        calls.append(("check", user_id, minutes))
-        return True, 4.0
+    class FakeLedger:
+        async def remaining_for_day(
+            self,
+            *,
+            entity_scope: str,
+            entity_value: str,
+            category: str,
+            daily_cap: int,
+        ) -> int:
+            return 600
 
-    async def fake_add(user_id: int, minutes: float):
-        calls.append(("add", user_id, minutes))
+        async def add(self, entry: Any) -> bool:
+            entries.append(entry)
+            return True
 
-    allowed, remaining = await audio_quota.consume_daily_minutes_with_legacy_fallback(
+    async def fake_get_daily_ledger() -> FakeLedger:
+        return FakeLedger()
+
+    async def fake_get_limits_for_user(user_id: int) -> dict[str, float]:
+        return {"daily_minutes": 10.0}
+
+    async with audio_quota._audio_minutes_consume_locks_lock:
+        audio_quota._audio_minutes_consume_locks.clear()
+
+    monkeypatch.setattr(audio_quota, "_get_daily_ledger", fake_get_daily_ledger)
+    monkeypatch.setattr(audio_quota, "get_limits_for_user", fake_get_limits_for_user)
+
+    allowed, remaining = await audio_quota.consume_daily_minutes(
         user_id=42,
-        minutes=1.0,
-        operation_id="audio-file:req-legacy",
-        consume_fn=audio_quota.consume_daily_minutes,
-        check_fn=fake_check,
-        add_fn=fake_add,
+        minutes_requested=1.0,
+        operation_id="audio-file:req-lock-cleanup",
     )
 
     assert allowed is True
-    assert remaining == pytest.approx(4.0)
-    assert calls == [("check", 42, 1.0), ("add", 42, 1.0)]
+    assert remaining == pytest.approx(9.0)
+    assert len(entries) == 1
+    assert 42 not in audio_quota._audio_minutes_consume_locks
 
 
 @pytest.mark.asyncio
 async def test_audio_quota_helpers_propagate_cancelled_error(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.core.Usage import audio_quota
 
-    async def cancelled_daily_ledger():
+    async def cancelled_daily_ledger() -> None:
         raise asyncio.CancelledError()
 
     monkeypatch.setattr(audio_quota, "_get_daily_ledger", cancelled_daily_ledger)
@@ -219,12 +249,12 @@ async def test_audio_quota_helpers_propagate_cancelled_error(monkeypatch: pytest
 async def test_log_llm_usage_does_not_emit_per_user_metric_labels(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.core.Usage import usage_tracker
 
-    calls = []
+    calls: list[tuple[str, dict[str, str]]] = []
 
-    def capture_counter(name, value=1, labels=None):
+    def capture_counter(name: str, value: float = 1, labels: dict[str, str] | None = None) -> None:
         calls.append((name, dict(labels or {})))
 
-    async def fail_get_db_pool():
+    async def fail_get_db_pool() -> None:
         raise RuntimeError("stop before persistence")
 
     monkeypatch.setattr(

--- a/tldw_Server_API/tests/Usage/test_usage_tracker_sqlite.py
+++ b/tldw_Server_API/tests/Usage/test_usage_tracker_sqlite.py
@@ -406,7 +406,7 @@ async def test_log_llm_usage_failure_log_is_sanitized(monkeypatch):
         request_id="raw-request-id",
     )
 
-    assert logger_stub.debugs == ["LLM usage logging skipped/failed"]
+    assert logger_stub.debugs == ["LLM usage logging skipped/failed; exception_type=RuntimeError"]
     assert "usage DB failed" not in str(logger_stub.debugs)
     assert "/private/llm-usage.db" not in str(logger_stub.debugs)
     assert "raw-request-id" not in str(logger_stub.debugs)
@@ -450,7 +450,7 @@ async def test_log_llm_usage_repo_backend_error_is_best_effort(monkeypatch):
         request_id="raw-request-id",
     )
 
-    assert logger_stub.debugs == ["LLM usage logging skipped/failed"]
+    assert logger_stub.debugs == ["LLM usage logging skipped/failed; exception_type=Exception"]
     assert "postgres usage insert failed" not in str(logger_stub.debugs)
     assert "/private/usage-db" not in str(logger_stub.debugs)
 


### PR DESCRIPTION
## Change Summary

AI-generated draft. Human requester must replace this section before merge with a human-written explanation of what changed and why these implementation choices were made.

## Summary

- Rebased PR branch onto latest `origin/dev` and kept the branch to one unique commit.
- Centralized endpoint daily-minute compatibility logic in `audio_quota.consume_daily_minutes_with_compat`.
- Moved `AudioQuotaStoreUnavailable` into `core/exceptions.py` and imported it from there at endpoint call sites.
- Added requested type hints/docstrings and regression coverage for zero-minute no-op consumption plus fallback lock cleanup.
- Logged safe exception types for best-effort Usage metrics/ledger failures without exposing raw exception messages.

## Test Plan

- PASS: `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest -q tldw_Server_API/tests/Usage/test_usage_review_fixes.py` -> 11 passed.
- PASS: `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest -q tldw_Server_API/tests/Usage` -> 57 passed, 1 skipped.
- PASS: Relevant Audio quota/transcription/streaming suite with known base-failing `test_audio_chat_ws_records_metrics` deselected -> 112 passed, 1 deselected.
- PASS: compile check on touched Python files with `python -m compileall -q ...`.
- PASS: Bandit on touched application scope -> 0 findings in `/tmp/bandit_usage_12004_pr_followup.json`.
