### PR TITLE
Harden legacy WebSearch review findings

### DIFF
--- a/IMPLEMENTATION_PLAN_legacy_websearch_review_fixes.md
+++ b/IMPLEMENTATION_PLAN_legacy_websearch_review_fixes.md
@@ -1,0 +1,23 @@
+## Stage 1: Regression Coverage
+**Goal**: Pin the accepted legacy WebSearch review findings with focused tests.
+**Success Criteria**: New tests fail against the current implementation for secret logging, all-provider failure propagation, non-interactive review behavior, bounded evidence payloads, and runtime validation.
+**Tests**: Focused WebSearch unit tests under `tldw_Server_API/tests/WebSearch/unit/`.
+**Status**: Complete
+
+## Stage 2: Legacy WebSearch Hardening
+**Goal**: Patch `Web_Search.py` without changing the live `Web_Scraping` endpoint path.
+**Success Criteria**: Provider logs redact API keys, all-provider failures surface as structured errors, user review does not call `input()`, evidence omits full article text by default, and DuckDuckGo uses explicit runtime validation.
+**Tests**: New focused WebSearch unit tests plus existing legacy sanitizer tests.
+**Status**: Complete
+
+## Stage 3: Documentation Cleanup
+**Goal**: Make `core/WebSearch/README.md` accurately describe this folder as legacy/non-routable.
+**Success Criteria**: README no longer advertises provider support as the active endpoint implementation.
+**Tests**: Review/diff check.
+**Status**: Complete
+
+## Stage 4: Verification and Task Finalization
+**Goal**: Verify the touched scope and record results in Backlog.
+**Success Criteria**: Focused pytest, compile check, Bandit, and `git diff --check` complete; Backlog task records verification and final summary.
+**Tests**: Focused pytest command, compileall, Bandit on touched app scope, diff check.
+**Status**: Complete

--- a/backlog/tasks/task-12000 - Fix-legacy-WebSearch-module-review-findings.md
+++ b/backlog/tasks/task-12000 - Fix-legacy-WebSearch-module-review-findings.md
@@ -1,0 +1,70 @@
+---
+id: TASK-12000
+title: Fix legacy WebSearch module review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 11:20'
+updated_date: '2026-06-23 15:10'
+labels:
+  - websearch
+  - legacy
+  - review-fix
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address validated review findings in `tldw_Server_API/app/core/WebSearch/Web_Search.py`, which is a legacy/parallel WebSearch implementation. Scope is secret-safe logging, non-interactive server behavior, provider failure propagation, bounded evidence payloads, stale docs cleanup, provider stub clarity, and runtime validation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Google WebSearch logging does not include provider API keys.
+- [x] #2 Legacy `generate_and_search` returns a structured `processing_error` when every provider call fails.
+- [x] #3 Legacy `user_review` cannot block server execution on `input()`.
+- [x] #4 Legacy aggregate evidence does not return full scraped article content by default.
+- [x] #5 Legacy provider stubs are explicitly non-production or removed from advertised support.
+- [x] #6 Focused tests, compile check, and Bandit touched-scope verification are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused failing regression tests for the accepted review findings.
+2. Patch legacy `Web_Search.py` with minimal behavior changes.
+3. Refresh `core/WebSearch/README.md` to mark the module as legacy/non-routable.
+4. Run focused tests, compile check, Bandit, and diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Task created manually because Backlog MCP was unavailable and the Backlog CLI hung on search/list/create operations in this workspace. User approved the temporary manual fallback. The task was moved to TASK-12000 after unrelated untracked task files appeared with overlapping TASK-10000 IDs.
+
+Red verification before production changes:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/WebSearch/unit/test_legacy_websearch_sanitizers.py -q` reported 10 failed and 4 passed for the new regressions.
+
+Final verification:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/WebSearch/unit/test_legacy_websearch_sanitizers.py tldw_Server_API/tests/WebSearch/unit/test_deprecated_session_shims_removed.py tldw_Server_API/tests/Web_Scraping/test_phase3_3_sanitizers.py -q` passed with 42 passed and 97 warnings.
+- `source .venv/bin/activate && python -m compileall -q tldw_Server_API/app/core/WebSearch tldw_Server_API/tests/WebSearch/unit/test_legacy_websearch_sanitizers.py` passed.
+- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/WebSearch -f json -o /tmp/bandit_legacy_websearch_review_fixes.json` exited 0; JSON reported `results: 0`, `errors: []`.
+- `git diff --check -- <touched files>` passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened the legacy `core/WebSearch` module by redacting sensitive Google request parameters in logs, surfacing all-provider failures as structured `processing_error` responses with warnings, replacing terminal-based `user_review` with a server-side fail-fast error, removing raw `original_content` from aggregate evidence payloads, making legacy provider stubs explicit, replacing DuckDuckGo `assert` validation with `ValueError`, and switching random delay jitter to `secrets.SystemRandom` so Bandit reports no findings. Updated the README to mark this package as legacy/non-routable and added focused regression tests.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12000 - Fix-legacy-WebSearch-module-review-findings.md
+++ b/backlog/tasks/task-12000 - Fix-legacy-WebSearch-module-review-findings.md
@@ -4,7 +4,7 @@ title: Fix legacy WebSearch module review findings
 status: Done
 assignee: []
 created_date: '2026-06-23 11:20'
-updated_date: '2026-06-23 15:10'
+updated_date: '2026-06-23 21:26'
 labels:
   - websearch
   - legacy
@@ -51,6 +51,9 @@ Final verification:
 - `source .venv/bin/activate && python -m compileall -q tldw_Server_API/app/core/WebSearch tldw_Server_API/tests/WebSearch/unit/test_legacy_websearch_sanitizers.py` passed.
 - `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/WebSearch -f json -o /tmp/bandit_legacy_websearch_review_fixes.json` exited 0; JSON reported `results: 0`, `errors: []`.
 - `git diff --check -- <touched files>` passed.
+
+Pull request:
+- https://github.com/rmusser01/tldw_server/pull/2492
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12000 - Fix-legacy-WebSearch-module-review-findings.md
+++ b/backlog/tasks/task-12000 - Fix-legacy-WebSearch-module-review-findings.md
@@ -3,12 +3,12 @@ id: TASK-12000
 title: Fix legacy WebSearch module review findings
 status: Done
 assignee: []
-created_date: '2026-06-23 11:20'
-updated_date: '2026-06-23 21:26'
+created_date: 2026-06-23 11:20
+updated_date: 2026-06-24 19:48
 labels:
-  - websearch
-  - legacy
-  - review-fix
+- websearch
+- legacy
+- review-fix
 dependencies: []
 priority: medium
 ---
@@ -60,6 +60,7 @@ Pull request:
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Hardened the legacy `core/WebSearch` module by redacting sensitive Google request parameters in logs, surfacing all-provider failures as structured `processing_error` responses with warnings, replacing terminal-based `user_review` with a server-side fail-fast error, removing raw `original_content` from aggregate evidence payloads, making legacy provider stubs explicit, replacing DuckDuckGo `assert` validation with `ValueError`, and switching random delay jitter to `secrets.SystemRandom` so Bandit reports no findings. Updated the README to mark this package as legacy/non-routable and added focused regression tests.
+Follow-up PR review pass rebased the branch onto latest `dev`, addressed all actionable review threads, and reran focused tests, compile, Bandit, and diff checks successfully.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
@@ -71,3 +72,16 @@ Hardened the legacy `core/WebSearch` module by redacting sensitive Google reques
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+2026-06-24 follow-up: Reopened to rebase PR #2492 on latest `dev` and address review comments/check failures before re-finalizing.
+2026-06-24 follow-up results: Rebased PR #2492 onto latest `dev` and addressed the four actionable review comments: direct `logger.info` for the touched Google parameter log line, docstrings on new helper functions, removal of the extra `pytest.mark.asyncio` marker while retaining the module-level `unit` marker, and bounded `relevant_results` response/debug-log projection that omits `original_content` by default with an explicit `include_original_content` opt-in.
+
+Follow-up verification:
+- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/WebSearch/unit/test_legacy_websearch_sanitizers.py tldw_Server_API/tests/WebSearch/unit/test_deprecated_session_shims_removed.py tldw_Server_API/tests/Web_Scraping/test_phase3_3_sanitizers.py -q` passed with 44 passed and 96 warnings.
+- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m compileall -q tldw_Server_API/app/core/WebSearch tldw_Server_API/tests/WebSearch/unit/test_legacy_websearch_sanitizers.py` passed.
+- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/WebSearch -f json -o /tmp/bandit_legacy_websearch_review_fixes_rebased.json` exited 0; JSON reported `results: 0`, `errors: 0`.
+- `git diff --check` passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/core/WebSearch/README.md
+++ b/tldw_Server_API/app/core/WebSearch/README.md
@@ -1,17 +1,28 @@
 # WebSearch
 
-## 1. Descriptive of Current Feature Set
+## 1. Legacy Status
 
-- Purpose: Unified web search and aggregation across multiple providers with optional LLM-powered subquery generation, relevance scoring, and final-answer synthesis.
-- Providers: Google CSE, DuckDuckGo, Brave (AI/web), Kagi, Searx, Tavily. Bing is present in legacy code but not exposed as a supported engine in the public schema.
+This package is a legacy/parallel WebSearch implementation kept for compatibility
+tests and consolidation history. The production API endpoint currently delegates
+to `tldw_Server_API/app/core/Web_Scraping/WebSearch_APIs.py`, not to
+`Web_Search.py`.
+
+Do not add new providers or endpoint behavior here. New work should target the
+live `Web_Scraping.WebSearch_APIs` path unless a migration plan explicitly
+switches production callers to this package.
+
+## 2. Descriptive of Current Feature Set
+
+- Purpose: Legacy web search and aggregation helpers with optional LLM-powered subquery generation, relevance scoring, and final-answer synthesis.
+- Providers: Google CSE, DuckDuckGo, Brave (AI/web), Kagi, and Bing have partial legacy adapters. Searx, Serper, Tavily parser integration, Baidu, and Yandex are explicit non-production stubs in this package.
 - Pipeline (optional stages):
   - Subquery generation via LLM to broaden coverage.
   - Provider search, normalization, and result shaping.
   - Optional user review/selection step.
   - Relevance evaluation via LLM and article scraping for evidence.
   - Aggregation into a concise final answer with citations and a confidence estimate.
-- Cancellation-aware: Aggregate stage observes client disconnect and aborts in-flight work.
-- Security and egress: Outbound requests respect centralized egress/SSRF policy; provider calls use browser-like headers.
+- Cancellation-aware: Relevance evaluation accepts a cancellation event, but this package is not wired to the production endpoint.
+- Security and egress: Network calls route through the centralized HTTP client; live endpoint egress behavior is owned by `Web_Scraping.WebSearch_APIs`.
 - Inputs/Outputs:
   - Request model: `tldw_Server_API/app/api/v1/schemas/websearch_schemas.py:14` (engine, query, options, aggregation flags)
   - Raw response: `tldw_Server_API/app/api/v1/schemas/websearch_schemas.py:62`
@@ -22,7 +33,7 @@
 Notes
 - The API endpoint today delegates to the Web_Scraping implementation for providers and orchestration. This module hosts the parallel pipeline (and helpers) as part of an ongoing consolidation effort.
 
-## 2. Technical Details of Features
+## 3. Technical Details of Features
 
 - Architecture & Flow
   - Phase 1 (Generate + Search): `generate_and_search` builds sub-queries (optional), executes provider calls, and normalizes results.
@@ -59,12 +70,13 @@ Notes
   - Provider adapters return structured dicts with `processing_error` when normalization fails; endpoint traps exceptions and returns 500 with error detail.
   - Aggregate stage guards against malformed LLM outputs; returns a safe fallback when summarization is unavailable.
 
-## 3. Developer-Related/Relevant Information for Contributors
+## 4. Developer-Related/Relevant Information for Contributors
 
 - Folder Structure
   - This module (`core/WebSearch`) contains the parallel pipeline and helpers. The API endpoint currently delegates to `core/Web_Scraping/WebSearch_APIs.py`, which also holds provider adapters, UA profiles, and the article scraper.
 - Adding/Updating a Provider
-  - Implement `search_web_<provider>` and a matching `parse_<provider>_results` that appends standardized items into `web_search_results_dict`.
+  - Prefer implementing providers in `core/Web_Scraping/WebSearch_APIs.py`, the live endpoint path.
+  - Only implement `search_web_<provider>` and matching `parse_<provider>_results` here if a migration plan explicitly revives this package.
   - Enforce egress policy at the start of any network call using `evaluate_url_policy`.
   - Use `_websearch_browser_headers` for realistic headers where appropriate.
   - Update supported engines if the provider becomes publicly exposed: `tldw_Server_API/app/api/v1/schemas/websearch_schemas.py:9`–`tldw_Server_API/app/api/v1/schemas/websearch_schemas.py:19`.

--- a/tldw_Server_API/app/core/WebSearch/Web_Search.py
+++ b/tldw_Server_API/app/core/WebSearch/Web_Search.py
@@ -4,8 +4,8 @@
 # Imports
 import asyncio
 import json
-import random
 import re
+import secrets
 import time
 from html import unescape
 from typing import Any, Optional, TypedDict
@@ -62,10 +62,46 @@ _WEBSEARCH_RUNTIME_EXCEPTIONS = (
     ValueError,
 )
 
+_SENSITIVE_LOG_FIELD_NAMES = {
+    "api_key",
+    "apikey",
+    "authorization",
+    "key",
+    "password",
+    "secret",
+    "token",
+}
+_DELAY_RANDOM = secrets.SystemRandom()
+
 
 def _set_processing_error(output_dict: dict[str, Any], message: str) -> None:
     output_dict["processing_error"] = message
     logging.error(message)
+
+
+def _redact_sensitive_mapping(mapping: dict[str, Any]) -> dict[str, Any]:
+    redacted: dict[str, Any] = {}
+    for key, value in mapping.items():
+        normalized_key = key.lower().replace("-", "_")
+        if normalized_key in _SENSITIVE_LOG_FIELD_NAMES or any(
+            token in normalized_key for token in ("api_key", "token", "secret")
+        ):
+            redacted[key] = "[REDACTED]"
+        else:
+            redacted[key] = value
+    return redacted
+
+
+def _legacy_provider_not_implemented(provider: str) -> dict[str, Any]:
+    message = f"Legacy WebSearch provider '{provider}' is not implemented"
+    return {
+        "search_engine": provider,
+        "results": [],
+        "total_results_found": 0,
+        "search_time": 0.0,
+        "error": None,
+        "processing_error": message,
+    }
 
 
 def _websearch_browser_headers(
@@ -259,6 +295,7 @@ def generate_and_search(question: str, search_params: dict) -> dict:
     web_search_results_dict["search_query"] = question
 
     # 3. Perform searches and accumulate all raw results
+    provider_warnings: list[dict[str, Any]] = []
     for q in all_queries:
         logging.info(f"Performing web search for query: {q}")
         raw_results = perform_websearch(
@@ -285,6 +322,16 @@ def generate_and_search(question: str, search_params: dict) -> dict:
         # Check for errors or invalid data
         if not isinstance(raw_results, dict) or raw_results.get("processing_error"):
             logging.error(f"Error or invalid data returned for query '{q}': {raw_results}")
+            message = (
+                raw_results.get("processing_error")
+                if isinstance(raw_results, dict)
+                else "Invalid web search result"
+            )
+            provider_warnings.append({
+                "phase": "provider",
+                "query": q,
+                "message": message,
+            })
             continue
 
         logging.info(f"Search results found for query '{q}': {len(raw_results.get('results', []))}")
@@ -294,6 +341,11 @@ def generate_and_search(question: str, search_params: dict) -> dict:
         web_search_results_dict["total_results_found"] += raw_results.get("total_results_found", 0)
         web_search_results_dict["search_time"] += raw_results.get("search_time", 0.0)
         logging.info(f"Total results found so far: {len(web_search_results_dict['results'])}")
+
+    if provider_warnings:
+        web_search_results_dict["warnings"] = provider_warnings
+        if not web_search_results_dict["results"]:
+            web_search_results_dict["processing_error"] = provider_warnings[0]["message"]
 
     return {
         "web_search_results_dict": web_search_results_dict,
@@ -325,8 +377,7 @@ async def analyze_and_aggregate(
     # 5. Allow user to review and select relevant results (if enabled)
     logging.info("Reviewing and selecting relevant results")
     if search_params.get("user_review", False):
-        logging.info("User review enabled")
-        relevant_results = review_and_select_results({"results": list(relevant_results.values())})
+        raise ValueError("Interactive user_review is not supported in server-side WebSearch")
 
     # 6. Summarize/aggregate final answer
     final_answer = aggregate_results(
@@ -522,7 +573,7 @@ async def search_result_relevance(
 
         try:
             # Add delay to avoid rate limiting
-            sleep_time = random.uniform(0.2, 0.6)
+            sleep_time = _DELAY_RANDOM.uniform(0.2, 0.6)
             await asyncio.sleep(sleep_time)
 
             if cancel_event and cancel_event.is_set():
@@ -613,18 +664,7 @@ def review_and_select_results(web_search_results_dict: dict) -> dict:
     Returns:
         Dict: A dictionary containing only the user-selected relevant results.
     """
-    relevant_results = {}
-    print("Review the search results and select the relevant ones:")
-    for idx, result in enumerate(web_search_results_dict["results"]):
-        print(f"\nResult {idx + 1}:")
-        print(f"Title: {result['title']}")
-        print(f"URL: {result['url']}")
-        print(f"Content: {result['content'][:200]}...")  # Show a preview of the content
-        user_input = input("Is this result relevant? (y/n): ").strip().lower()
-        if user_input == 'y':
-            relevant_results[str(idx)] = result
-
-    return relevant_results
+    raise ValueError("Interactive user_review is not supported in server-side WebSearch")
 
 
 ######################### Result Aggregation & Combination #########################
@@ -744,7 +784,6 @@ def aggregate_results(
         evidence_payload.append({
             "id": rid,
             "content": res.get("content"),
-            "original_content": res.get("original_content"),
             "reasoning": res.get("reasoning"),
             "chunk_index": chunk_assignments.get(rid),
         })
@@ -971,7 +1010,7 @@ def perform_websearch(search_engine, search_query, content_country, search_lang,
         search_engines_cfg = loaded_config_data.get('search_engines', {})
 
         if search_engine.lower() == "baidu":
-            raise NotImplementedError("Baidu search is not implemented")
+            return _legacy_provider_not_implemented("baidu")
 
         elif search_engine.lower() == "bing":
             # Prepare the arguments for search_web_bing
@@ -1070,19 +1109,26 @@ def perform_websearch(search_engine, search_query, content_country, search_lang,
             web_search_results = search_web_kagi(query=search_query, limit=result_count)
 
         elif search_engine.lower() == "serper":
-            raise NotImplementedError("Serper search is not implemented")
+            return _legacy_provider_not_implemented("serper")
 
         elif search_engine.lower() == "tavily":
-            raise NotImplementedError("Tavily search is not implemented")
+            return _legacy_provider_not_implemented("tavily")
 
         elif search_engine.lower() == "searx":
-            raise NotImplementedError("Searx search is not implemented")
+            return _legacy_provider_not_implemented("searx")
 
         elif search_engine.lower() == "yandex":
-            raise NotImplementedError("Yandex search is not implemented")
+            return _legacy_provider_not_implemented("yandex")
 
         else:
-            return f"Error: Invalid Search Engine Name {search_engine}"
+            return {
+                "search_engine": search_engine,
+                "results": [],
+                "total_results_found": 0,
+                "search_time": 0.0,
+                "error": None,
+                "processing_error": f"Error: Invalid Search Engine Name {search_engine}",
+            }
 
         web_search_results_dict = process_web_search_results(web_search_results, search_engine)
         return web_search_results_dict
@@ -1171,7 +1217,7 @@ def process_web_search_results(search_results: dict, search_engine: str) -> dict
     try:
         # Parse results based on the search engine
         if search_engine.lower() == "baidu":
-            pass  # Placeholder for Baidu-specific parsing
+            _set_processing_error(web_search_results_dict, "Legacy WebSearch provider 'baidu' is not implemented")
         elif search_engine.lower() == "bing":
             parse_bing_results(search_results, web_search_results_dict)
         elif search_engine.lower() == "brave":
@@ -1226,11 +1272,11 @@ def parse_html_search_results_generic(soup):
 # https://cloud.baidu.com/doc/APIGUIDE/s/Xk1myz05f
 # https://oxylabs.io/blog/how-to-scrape-baidu-search-results
 def search_web_baidu(arg1, arg2, arg3):
-    pass
+    raise NotImplementedError("Legacy WebSearch provider 'baidu' is not implemented")
 
 
 def search_parse_baidu_results():
-    pass
+    raise NotImplementedError("Legacy WebSearch provider 'baidu' is not implemented")
 
 
 ######################### Bing Search #########################
@@ -1497,7 +1543,8 @@ def search_web_duckduckgo(
         timelimit: str | None = None,
         max_results: int | None = None,
 ) -> list[dict[str, str]]:
-    assert keywords, "keywords is mandatory"
+    if not keywords:
+        raise ValueError("keywords is mandatory")
 
     payload = {
         "q": keywords,
@@ -1763,7 +1810,7 @@ def search_web_google(
         if sort_results_by:
             params["sort"] = sort_results_by
 
-        logging.info(f"Prepared parameters for Google Search: {params}")
+        logging.info(f"Prepared parameters for Google Search: {_redact_sensitive_mapping(params)}")
 
         # Make the API call
         response = fetch(method="GET", url=search_url, params=params)
@@ -2013,7 +2060,7 @@ def search_web_searx(search_query, language='auto', time_range='', safesearch=0,
         headers = _websearch_browser_headers(accept_lang="en-US,en;q=0.5")
 
         # Add a random delay to mimic human behavior
-        delay = random.uniform(2, 5)  # Random delay between 2 and 5 seconds
+        delay = _DELAY_RANDOM.uniform(2, 5)  # Random delay between 2 and 5 seconds
         time.sleep(delay)
 
         response = fetch(method="GET", url=search_url, headers=headers)
@@ -2052,7 +2099,7 @@ def search_web_searx(search_query, language='auto', time_range='', safesearch=0,
 
 
 def parse_searx_results(searx_search_results, web_search_results_dict):
-    pass
+    _set_processing_error(web_search_results_dict, "Legacy WebSearch provider 'searx' is not implemented")
 
 
 
@@ -2061,13 +2108,13 @@ def parse_searx_results(searx_search_results, web_search_results_dict):
 #
 # https://github.com/YassKhazzan/openperplex_backend_os/blob/main/sources_searcher.py
 def search_web_serper():
-    pass
+    raise NotImplementedError("Legacy WebSearch provider 'serper' is not implemented")
 
 
 
 
 def parse_serper_results(serper_search_results, web_search_results_dict):
-    pass
+    _set_processing_error(web_search_results_dict, "Legacy WebSearch provider 'serper' is not implemented")
 
 
 ######################### Tavily Search #########################
@@ -2107,7 +2154,7 @@ def search_web_tavily(search_query, result_count=10, site_whitelist=None, site_b
 
 
 def parse_tavily_results(tavily_search_results, web_search_results_dict):
-    pass
+    _set_processing_error(web_search_results_dict, "Legacy WebSearch provider 'tavily' is not implemented")
 
 
 
@@ -2119,13 +2166,13 @@ def parse_tavily_results(tavily_search_results, web_search_results_dict):
 # https://yandex.cloud/en/docs/search-api/concepts/response
 # https://github.com/yandex-cloud/cloudapi/blob/master/yandex/cloud/searchapi/v2/search_query.proto
 def search_web_yandex():
-    pass
+    raise NotImplementedError("Legacy WebSearch provider 'yandex' is not implemented")
 
 
 
 
 def parse_yandex_results(yandex_search_results, web_search_results_dict):
-    pass
+    _set_processing_error(web_search_results_dict, "Legacy WebSearch provider 'yandex' is not implemented")
 
 #
 # End of Web_Search.py

--- a/tldw_Server_API/app/core/WebSearch/Web_Search.py
+++ b/tldw_Server_API/app/core/WebSearch/Web_Search.py
@@ -13,6 +13,7 @@ from urllib.parse import unquote, urlencode, urlparse
 
 #
 # 3rd-Party Imports
+from loguru import logger
 from lxml.etree import _Element
 from lxml.html import document_fromstring
 
@@ -80,6 +81,7 @@ def _set_processing_error(output_dict: dict[str, Any], message: str) -> None:
 
 
 def _redact_sensitive_mapping(mapping: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of a mapping with known secret-bearing fields redacted."""
     redacted: dict[str, Any] = {}
     for key, value in mapping.items():
         normalized_key = key.lower().replace("-", "_")
@@ -93,6 +95,7 @@ def _redact_sensitive_mapping(mapping: dict[str, Any]) -> dict[str, Any]:
 
 
 def _legacy_provider_not_implemented(provider: str) -> dict[str, Any]:
+    """Build a structured legacy-provider response for unsupported adapters."""
     message = f"Legacy WebSearch provider '{provider}' is not implemented"
     return {
         "search_engine": provider,
@@ -102,6 +105,24 @@ def _legacy_provider_not_implemented(provider: str) -> dict[str, Any]:
         "error": None,
         "processing_error": message,
     }
+
+
+def _sanitize_relevant_results_for_response(
+        relevant_results: dict[str, dict[str, Any]],
+        *,
+        include_original_content: bool = False,
+) -> dict[str, dict[str, Any]]:
+    """Project relevance results into a bounded response payload."""
+    sanitized_results: dict[str, dict[str, Any]] = {}
+    for result_id, result in relevant_results.items():
+        sanitized_result = dict(result)
+        original_content = sanitized_result.pop("original_content", None)
+        if include_original_content and original_content is not None:
+            sanitized_result["original_content"] = original_content
+        elif original_content is not None:
+            sanitized_result["original_content_chars"] = len(str(original_content))
+        sanitized_results[result_id] = sanitized_result
+    return sanitized_results
 
 
 def _websearch_browser_headers(
@@ -372,7 +393,7 @@ async def analyze_and_aggregate(
         cancel_event=cancel_event,
     )
     logging.debug("Relevant results returned by search_result_relevance:")
-    logging.debug(json.dumps(relevant_results, indent=2))
+    logging.debug(json.dumps(_sanitize_relevant_results_for_response(relevant_results), indent=2))
 
     # 5. Allow user to review and select relevant results (if enabled)
     logging.info("Reviewing and selecting relevant results")
@@ -390,11 +411,16 @@ async def analyze_and_aggregate(
     if not isinstance(final_answer.get("text"), str):
         raise ValueError("Aggregation produced an invalid final_answer payload")
 
+    response_relevant_results = _sanitize_relevant_results_for_response(
+        relevant_results,
+        include_original_content=bool(search_params.get("include_original_content", False)),
+    )
+
     # 7. Return the final data
     logging.info("Returning final websearch results")
     return {
         "final_answer": final_answer,
-        "relevant_results": relevant_results,
+        "relevant_results": response_relevant_results,
         "web_search_results_dict": web_search_results_dict
     }
 
@@ -1810,7 +1836,7 @@ def search_web_google(
         if sort_results_by:
             params["sort"] = sort_results_by
 
-        logging.info(f"Prepared parameters for Google Search: {_redact_sensitive_mapping(params)}")
+        logger.info(f"Prepared parameters for Google Search: {_redact_sensitive_mapping(params)}")
 
         # Make the API call
         response = fetch(method="GET", url=search_url, params=params)

--- a/tldw_Server_API/tests/WebSearch/unit/test_legacy_websearch_sanitizers.py
+++ b/tldw_Server_API/tests/WebSearch/unit/test_legacy_websearch_sanitizers.py
@@ -97,7 +97,7 @@ def test_search_web_google_redacts_api_key_from_legacy_logs(monkeypatch):
         def warning(self, message, *args, **kwargs):
             messages.append(str(message))
 
-    monkeypatch.setattr(web_search, "logging", DummyLogger())
+    monkeypatch.setattr(web_search, "logger", DummyLogger())
     monkeypatch.setattr(web_search, "fetch", lambda **_kwargs: DummyResponse())
     monkeypatch.setattr(
         web_search,
@@ -151,7 +151,6 @@ def test_generate_and_search_marks_all_legacy_provider_failures(monkeypatch):
     ]
 
 
-@pytest.mark.asyncio
 async def test_legacy_user_review_fails_fast_without_input(monkeypatch):
     async def fake_relevance(*_args, **_kwargs):
         return {"0": {"content": "summary", "reasoning": "matches"}}
@@ -168,6 +167,61 @@ async def test_legacy_user_review_fails_fast_without_input(monkeypatch):
             {"main_goal": "query", "sub_questions": []},
             {"user_review": True, "relevance_analysis_llm": "fake", "final_answer_llm": None},
         )
+
+
+async def test_analyze_and_aggregate_omits_raw_original_content_from_response(monkeypatch):
+    raw_content = "raw scraped article text" * 100
+
+    async def fake_relevance(*_args, **_kwargs):
+        return {
+            "0": {
+                "content": "summary",
+                "original_content": raw_content,
+                "reasoning": "matches",
+            }
+        }
+
+    monkeypatch.setattr(web_search, "search_result_relevance", fake_relevance)
+
+    result = await web_search.analyze_and_aggregate(
+        {"results": [{"id": "0", "url": "https://example.com", "content": "snippet"}]},
+        {"main_goal": "query", "sub_questions": []},
+        {"user_review": False, "relevance_analysis_llm": "fake", "final_answer_llm": None},
+    )
+
+    relevant_result = result["relevant_results"]["0"]
+    assert "original_content" not in relevant_result
+    assert relevant_result["original_content_chars"] == len(raw_content)
+    assert result["final_answer"]["evidence"][0]["content"] == "summary"
+    assert "original_content" not in result["final_answer"]["evidence"][0]
+
+
+async def test_analyze_and_aggregate_can_opt_into_raw_original_content(monkeypatch):
+    raw_content = "raw scraped article text"
+
+    async def fake_relevance(*_args, **_kwargs):
+        return {
+            "0": {
+                "content": "summary",
+                "original_content": raw_content,
+                "reasoning": "matches",
+            }
+        }
+
+    monkeypatch.setattr(web_search, "search_result_relevance", fake_relevance)
+
+    result = await web_search.analyze_and_aggregate(
+        {"results": [{"id": "0", "url": "https://example.com", "content": "snippet"}]},
+        {"main_goal": "query", "sub_questions": []},
+        {
+            "user_review": False,
+            "relevance_analysis_llm": "fake",
+            "final_answer_llm": None,
+            "include_original_content": True,
+        },
+    )
+
+    assert result["relevant_results"]["0"]["original_content"] == raw_content
 
 
 def test_legacy_aggregate_evidence_omits_raw_original_content():

--- a/tldw_Server_API/tests/WebSearch/unit/test_legacy_websearch_sanitizers.py
+++ b/tldw_Server_API/tests/WebSearch/unit/test_legacy_websearch_sanitizers.py
@@ -46,7 +46,7 @@ def test_search_web_searx_sanitizes_legacy_fetch_errors(monkeypatch):
     def fail_fetch(**_kwargs):
         raise RuntimeError("legacy searx token at /private/searx.key")
 
-    monkeypatch.setattr(web_search.random, "uniform", lambda *_args: 0)
+    monkeypatch.setattr(web_search._DELAY_RANDOM, "uniform", lambda *_args: 0)
     monkeypatch.setattr(web_search.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(web_search, "fetch", fail_fetch)
 
@@ -74,3 +74,136 @@ def test_search_web_tavily_sanitizes_legacy_fetch_errors(monkeypatch):
     assert result == "There was an error searching for content."
     assert "legacy tavily token" not in result
     assert "/private/tavily.key" not in result
+
+
+def test_search_web_google_redacts_api_key_from_legacy_logs(monkeypatch):
+    secret_key = "secret-google-key"
+    messages: list[str] = []
+
+    class DummyResponse:
+        def json(self):
+            return {"items": []}
+
+    class DummyLogger:
+        def info(self, message, *args, **kwargs):
+            messages.append(str(message))
+
+        def error(self, message, *args, **kwargs):
+            messages.append(str(message))
+
+        def debug(self, message, *args, **kwargs):
+            messages.append(str(message))
+
+        def warning(self, message, *args, **kwargs):
+            messages.append(str(message))
+
+    monkeypatch.setattr(web_search, "logging", DummyLogger())
+    monkeypatch.setattr(web_search, "fetch", lambda **_kwargs: DummyResponse())
+    monkeypatch.setattr(
+        web_search,
+        "loaded_config_data",
+        {
+            "search_engines": {
+                "google_search_api_url": "https://customsearch.googleapis.com/customsearch/v1",
+                "google_simp_trad_chinese": "1",
+                "limit_google_search_to_country": False,
+                "google_search_country": "countryUS",
+                "google_search_engine_id": "engine-id",
+                "google_search_api_key": secret_key,
+                "google_safe_search": "off",
+            }
+        },
+    )
+
+    web_search.search_web_google("query")
+
+    logged_text = "\n".join(messages)
+    assert secret_key not in logged_text
+    assert "'key': '[REDACTED]'" in logged_text
+
+
+def test_generate_and_search_marks_all_legacy_provider_failures(monkeypatch):
+    def fail_provider(**_kwargs):
+        return {"processing_error": "Error performing web search", "results": []}
+
+    monkeypatch.setattr(web_search, "perform_websearch", fail_provider)
+
+    result = web_search.generate_and_search(
+        "query",
+        {
+            "engine": "google",
+            "content_country": "US",
+            "search_lang": "en",
+            "output_lang": "en",
+            "result_count": 1,
+        },
+    )
+
+    web_results = result["web_search_results_dict"]
+    assert web_results["results"] == []
+    assert web_results["processing_error"] == "Error performing web search"
+    assert web_results["warnings"] == [
+        {
+            "phase": "provider",
+            "query": "query",
+            "message": "Error performing web search",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_legacy_user_review_fails_fast_without_input(monkeypatch):
+    async def fake_relevance(*_args, **_kwargs):
+        return {"0": {"content": "summary", "reasoning": "matches"}}
+
+    monkeypatch.setattr(web_search, "search_result_relevance", fake_relevance)
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("input() should not be called")),
+    )
+
+    with pytest.raises(ValueError, match="Interactive user_review is not supported"):
+        await web_search.analyze_and_aggregate(
+            {"results": [{"id": "0", "url": "https://example.com", "content": "snippet"}]},
+            {"main_goal": "query", "sub_questions": []},
+            {"user_review": True, "relevance_analysis_llm": "fake", "final_answer_llm": None},
+        )
+
+
+def test_legacy_aggregate_evidence_omits_raw_original_content():
+    result = web_search.aggregate_results(
+        relevant_results={
+            "0": {
+                "content": "summary",
+                "original_content": "raw scraped article text" * 100,
+                "reasoning": "matches",
+            }
+        },
+        question="query",
+        sub_questions=[],
+        api_endpoint=None,
+    )
+
+    evidence = result["evidence"][0]
+    assert "original_content" not in evidence
+    assert evidence["content"] == "summary"
+
+
+@pytest.mark.parametrize("engine", ["baidu", "serper", "tavily", "searx", "yandex"])
+def test_legacy_perform_websearch_reports_unimplemented_provider(engine):
+    result = web_search.perform_websearch(
+        search_engine=engine,
+        search_query="query",
+        content_country="US",
+        search_lang="en",
+        output_lang="en",
+        result_count=1,
+    )
+
+    assert result["processing_error"] == f"Legacy WebSearch provider '{engine}' is not implemented"
+    assert result["results"] == []
+
+
+def test_search_web_duckduckgo_rejects_empty_keywords_with_value_error():
+    with pytest.raises(ValueError, match="keywords is mandatory"):
+        web_search.search_web_duckduckgo("")


### PR DESCRIPTION
## Summary
- Hardened the legacy core/WebSearch module against the review findings: sensitive log redaction, non-blocking server behavior, explicit unsupported legacy providers, and safer result evidence handling.
- Updated legacy-module documentation and added focused unit coverage.
- Added the implementation plan and Backlog task record for the review unit.

## Verification
- `python -m pytest tldw_Server_API/tests/WebSearch/unit/test_legacy_websearch_sanitizers.py tldw_Server_API/tests/WebSearch/unit/test_deprecated_session_shims_removed.py tldw_Server_API/tests/Web_Scraping/test_phase3_3_sanitizers.py -q` -> 42 passed
- `python -m compileall -q tldw_Server_API/app/core/WebSearch tldw_Server_API/tests/WebSearch/unit/test_legacy_websearch_sanitizers.py` -> passed
- `python -m bandit -r tldw_Server_API/app/core/WebSearch -f json -o /tmp/bandit_legacy_websearch_review_fixes_worktree.json` -> 0 findings, 0 errors
- `git diff --cached --check` -> passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the legacy `tldw_Server_API/app/core/WebSearch` module to keep the server non-blocking and secrets-safe. Marks the module as legacy, adds focused tests, an implementation plan, and a Backlog task; no changes to the production `Web_Scraping` endpoint.

- **Bug Fixes**
  - Redacts API keys and tokens in Google request logs.
  - Aggregates provider warnings and sets `processing_error` when all providers fail.
  - Disables interactive `user_review` by raising a clear `ValueError`.
  - Bounds `relevant_results` in responses and logs; omits `original_content` by default with `include_original_content` opt-in.
  - Removes `original_content` from final-answer evidence.
  - Returns structured `processing_error` for unsupported legacy providers (`baidu`, `serper`, `tavily`, `searx`, `yandex`) and invalid engines.
  - Replaces DuckDuckGo `assert` with `ValueError` for empty keywords.
  - Uses `secrets.SystemRandom` for delay jitter to avoid insecure randomness.

<sup>Written for commit 35e1b936ec8d624ae57bb0f4a3ea3b45c2716bf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

