### PR TITLE
Harden Notifications delivery boundaries

### DIFF
--- a/IMPLEMENTATION_PLAN_notifications_review_hardening_10004.md
+++ b/IMPLEMENTATION_PLAN_notifications_review_hardening_10004.md
@@ -1,0 +1,23 @@
+## Stage 1: Regression Coverage
+**Goal**: Add focused tests for the validated Notifications review findings.
+**Success Criteria**: Tests fail against current code for unbounded email delivery, unsafe failure details, and email helper timeout/delegation behavior.
+**Tests**: `tldw_Server_API/tests/Notifications/test_notifications_service.py`, `tldw_Server_API/tests/Notifications/test_email_delivery.py`
+**Status**: Complete
+
+## Stage 2: Service Boundary Hardening
+**Goal**: Bound and sanitize `NotificationsService` email delivery inputs and failure outputs.
+**Success Criteria**: Recipient fanout, attachments, filenames, and error details are constrained before delivery.
+**Tests**: Focused Notifications service tests.
+**Status**: Complete
+
+## Stage 3: Email Helper Consolidation
+**Goal**: Remove the duplicate raw SMTP sending path from `email_delivery.py` while preserving the public helper.
+**Success Criteria**: `send_notification_email()` delegates to AuthNZ email service and SMTP config exposes an explicit timeout for compatibility checks.
+**Tests**: Focused email delivery tests.
+**Status**: Complete
+
+## Stage 4: Documentation and Verification
+**Goal**: Align README scope and record verification.
+**Success Criteria**: README describes actual core package ownership; targeted tests and Bandit pass or blockers are documented.
+**Tests**: Notifications tests and Bandit on touched production files.
+**Status**: Complete

--- a/backlog/tasks/task-10004 - Harden-Notifications-module-review-findings.md
+++ b/backlog/tasks/task-10004 - Harden-Notifications-module-review-findings.md
@@ -1,0 +1,103 @@
+---
+id: TASK-10004
+title: Harden Notifications module review findings
+status: Done
+assignee: []
+created_date: 2026-06-23 21:44
+updated_date: 2026-06-24 20:11
+labels:
+- notifications
+- security
+- review-fix
+dependencies: []
+priority: high
+modified_files:
+- IMPLEMENTATION_PLAN_notifications_review_hardening_10004.md
+- backlog/tasks/task-10004 - Harden-Notifications-module-review-findings.md
+- tldw_Server_API/app/api/v1/endpoints/watchlists.py
+- tldw_Server_API/app/core/Notifications/README.md
+- tldw_Server_API/app/core/Notifications/email_delivery.py
+- tldw_Server_API/app/core/Notifications/service.py
+- tldw_Server_API/tests/Notifications/test_email_delivery.py
+- tldw_Server_API/tests/Notifications/test_notifications_service.py
+- tldw_Server_API/tests/Watchlists/test_delivery_integrations.py
+- tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and fix validated Notifications module review findings. Scope: bounded email fanout and attachments, redacted delivery failure reporting, duplicate SMTP helper cleanup/delegation, explicit SMTP timeout handling, and README scope accuracy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Validated review findings are fixed or explicitly documented as not applicable
+- [x] #2 Focused regression tests cover each behavior change
+- [x] #3 Touched Notifications tests pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+- Add failing regression tests for recipient fanout limits, attachment limits, and redacted failure results.
+- Add failing regression tests for email_delivery delegation/config timeout behavior.
+- Implement the smallest compatible fixes in the Notifications module.
+- Update the Notifications README to match actual core package ownership.
+- Run focused tests plus Bandit on touched production files and record results.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added service-level recipient normalization, dedupe, validation, and fanout limits before email delivery.
+- Added attachment count, filename, and total byte checks before delivery.
+- Changed email result details and failure logs to use masked recipients and exception type only; raw exception strings, subjects, and full recipient addresses are no longer returned by `NotificationsService`.
+- Addressed PR review feedback after rebasing on `origin/dev`: email delivery failures now use bound Loguru context plus a redacted traceback-bearing exception object.
+- Rebased again on the latest `origin/dev` on 2026-06-24 (`3a3ed8042`); the final base movements did not touch Notifications/Watchlists paths, so focused tests and static checks were re-run on that base.
+- Added explicit attachment `content` presence/type validation before delivery to keep malformed attachments from reaching AuthNZ SMTP delivery.
+- Added a shared Watchlists email attachment filename builder and routed both create-output and retry-delivery paths through it so `/`, `\`, control characters, and overlong titles do not produce invalid notification attachments.
+- Lazily initialize the AuthNZ email service so non-email notification flows do not require email/AuthNZ configuration at service construction time.
+- Preserved the public `send_notification_email()` helper while removing its duplicate raw SMTP sender path; it now delegates to AuthNZ `EmailService`.
+- Kept the legacy SMTP config compatibility helper and added explicit positive `SMTP_TIMEOUT` parsing.
+- Updated the core Notifications README to describe actual package ownership and safe delivery boundaries.
+<!-- SECTION:NOTES:END -->
+
+## Verification
+
+<!-- SECTION:VERIFICATION:BEGIN -->
+- Red step confirmed: focused Notifications tests initially failed for too many recipients, oversized attachments, raw failure details, missing SMTP timeout config, and raw SMTP helper behavior.
+- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest --confcutdir=tldw_Server_API/tests/Notifications tldw_Server_API/tests/Notifications/test_notifications_service.py tldw_Server_API/tests/Notifications/test_email_delivery.py -q` - 12 passed.
+- `SINGLE_USER_TEST_API_KEY=test-key-for-notifications-pr /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest --confcutdir=tldw_Server_API/tests/Notifications tldw_Server_API/tests/Notifications/test_notifications_service.py tldw_Server_API/tests/Notifications/test_email_delivery.py tldw_Server_API/tests/Watchlists/test_delivery_integrations.py tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py -q` - 30 passed.
+- `SINGLE_USER_TEST_API_KEY=test-key-for-notifications-pr /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest --confcutdir=tldw_Server_API/tests/Notifications tldw_Server_API/tests/Notifications/test_companion_reflection_notifications.py tldw_Server_API/tests/Notifications/test_reminder_jobs_worker.py tldw_Server_API/tests/Notifications/test_notifications_sse.py tldw_Server_API/tests/Notifications/test_jobs_notifications_service.py tldw_Server_API/tests/Notifications/test_email_delivery.py tldw_Server_API/tests/Notifications/test_reminders_service.py tldw_Server_API/tests/Notifications/test_scheduled_task_automation_db.py tldw_Server_API/tests/Notifications/test_bridge_opt_out.py tldw_Server_API/tests/Notifications/test_reminders_api.py tldw_Server_API/tests/Notifications/test_reminders_scheduler.py tldw_Server_API/tests/Notifications/test_scheduled_task_automation_service.py tldw_Server_API/tests/Notifications/test_notifications_service.py tldw_Server_API/tests/Notifications/test_notifications_api.py tldw_Server_API/tests/Notifications/test_reminders_schemas.py tldw_Server_API/tests/Notifications/test_notifications_service_lifecycle.py tldw_Server_API/tests/Notifications/test_notifications_prune_service.py tldw_Server_API/tests/Notifications/test_companion_reminders_activity_bridge.py -q` - 125 passed.
+- `SINGLE_USER_TEST_API_KEY=test-key-for-notifications-pr /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py tldw_Server_API/tests/Notifications/test_scheduled_tasks_control_plane.py -q` - 46 passed.
+- `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m ruff check tldw_Server_API/app/core/Notifications/service.py tldw_Server_API/app/core/Notifications/email_delivery.py tldw_Server_API/tests/Notifications/test_notifications_service.py tldw_Server_API/tests/Notifications/test_email_delivery.py` - passed.
+- `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m py_compile tldw_Server_API/app/core/Notifications/service.py tldw_Server_API/app/core/Notifications/email_delivery.py tldw_Server_API/app/api/v1/endpoints/watchlists.py` - compiled; Watchlists emitted two pre-existing `return` in `finally` syntax warnings outside this change.
+- `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Notifications/service.py tldw_Server_API/app/core/Notifications/email_delivery.py tldw_Server_API/app/api/v1/endpoints/watchlists.py -f json -o /tmp/bandit_notifications_pr2493_rebase_20260624_3a3ed8042.json` - 0 findings, 0 errors.
+- `git diff --check` - passed.
+- A full `ruff check` over the large Watchlists endpoint still reports pre-existing import-order/SIM114/B009 findings unrelated to this PR; the scoped Notifications lint check passed.
+- Running all `tldw_Server_API/tests/Notifications` under `--confcutdir=tldw_Server_API/tests/Notifications` produced fixture errors in scheduled-task API/control-plane tests because that boundary hides the shared `client_user_only` fixture. Those two files passed when run without the conftest boundary.
+<!-- SECTION:VERIFICATION:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened the Notifications core package by bounding email fanout and attachments, redacting delivery failure details, consolidating legacy notification email delivery through AuthNZ, and correcting package documentation. Rebased on latest `origin/dev` and addressed all current PR review comments, including structured redacted traceback logging, attachment content schema validation, Watchlists attachment filename sanitization, `memoryview.nbytes` attachment sizing, and ASCII control-character filename rejection. Added focused regression tests for the validated review findings and verified the broader Notifications suite using the appropriate fixture setup for scheduled-task API/control-plane tests.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+2026-06-24 13:00: Addressed two additional CodeRabbit review comments after the latest rebase check: `_attachment_content_size_bytes()` now uses `memoryview.nbytes` so non-byte memoryviews are measured by bytes, and attachment filename validation now rejects all ASCII control characters including NUL, unit separator, and DEL. Added focused regression coverage for both cases. Fresh verification before amend: focused Notifications/Watchlists delivery slice passed with 34 tests, broader non-scheduled Notifications slice passed with 129 tests, scoped Ruff passed, `py_compile` passed with the same pre-existing Watchlists `return`-in-`finally` warnings, `git diff --check` passed, and Bandit report `/tmp/bandit_notifications_pr2493_coderabbit_final.json` produced 0 findings.
+2026-06-24 13:06 final verification after rebasing onto `origin/dev` at `7ab6ae8c4`: focused delivery slice passed (`34 passed, 86 warnings`), broader non-scheduled Notifications slice passed (`129 passed, 661 warnings`), scheduled API/control-plane slice passed (`46 passed, 1534 warnings`), scoped Ruff passed, `py_compile` passed with the same pre-existing Watchlists `return`-in-`finally` warnings, `git diff --check` passed, and Bandit report `/tmp/bandit_notifications_pr2493_rebased_final.json` produced 0 findings. The branch is 0 behind and 1 ahead of `origin/dev` after rebase.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -302,6 +302,8 @@ WATCHLISTS_DELETE_RESTORE_WINDOW_SECONDS = max(
 _TEMPLATE_NAME_RE = re.compile(r"^[A-Za-z0-9_\-]+$")
 _WATCHLIST_MIN_SCHEDULE_INTERVAL_MINUTES = max(1, int(os.getenv("WATCHLIST_MIN_SCHEDULE_INTERVAL_MINUTES", "5") or 5))
 _EMAIL_RECIPIENT_PATTERN = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+_EMAIL_ATTACHMENT_FILENAME_MAX_LENGTH = 255
+_EMAIL_ATTACHMENT_UNSAFE_FILENAME_RE = re.compile(r'[<>:"/\\|?*\x00-\x1f]+')
 
 _WATCHLISTS_UX_BASELINE = {
     "uc1_f1_first_source_setup_percent": 92.96,
@@ -1274,6 +1276,25 @@ def _build_report_snapshot_filename(output_title: str, ts: str) -> str:
     filename = _build_output_filename(output_title, "evidence", ts, "md")
     stem = filename.rsplit(".", 1)[0]
     return f"{stem}.json"
+
+
+def _build_watchlist_email_attachment_filename(
+    title: str | None,
+    output_id: int | None,
+    ext: str,
+) -> str:
+    safe_ext = re.sub(r"[^A-Za-z0-9]+", "", str(ext or "md").lower()) or "md"
+    fallback = f"watchlist-output-{output_id or 'unknown'}"
+    safe_base = _EMAIL_ATTACHMENT_UNSAFE_FILENAME_RE.sub(
+        "_",
+        str(title or fallback),
+    ).strip(" ._")
+    if not safe_base:
+        safe_base = fallback
+
+    max_base_length = max(1, _EMAIL_ATTACHMENT_FILENAME_MAX_LENGTH - len(safe_ext) - 1)
+    safe_base = safe_base[:max_base_length].rstrip(" ._") or fallback[:max_base_length]
+    return f"{safe_base}.{safe_ext}"
 
 
 async def _write_report_snapshot_for_user(user_id: int, filename: str, snapshot: dict[str, Any]) -> None:
@@ -5246,10 +5267,9 @@ async def retry_run_delivery(
         attachments = None
         if email_cfg.get("attach_file", True) and output.content:
             ext = "html" if output_format == "html" else "md"
-            safe_base = title.replace("/", "_")
             attachments = [
                 {
-                    "filename": f"{safe_base}.{ext}",
+                    "filename": _build_watchlist_email_attachment_filename(title, output.id, ext),
                     "content": (output.content or "").encode("utf-8"),
                 }
             ]
@@ -7136,10 +7156,9 @@ async def create_output(
             attachments = None
             if email_cfg.get("attach_file", True) and output.content:
                 ext = "html" if (output.format or output_format) == "html" else "md"
-                safe_base = (title or f"watchlist-output-{output.id}").replace("/", "_")
                 attachments = [
                     {
-                        "filename": f"{safe_base}.{ext}",
+                        "filename": _build_watchlist_email_attachment_filename(title, output.id, ext),
                         "content": (output.content or "").encode("utf-8"),
                     }
                 ]

--- a/tldw_Server_API/app/core/Notifications/README.md
+++ b/tldw_Server_API/app/core/Notifications/README.md
@@ -1,10 +1,9 @@
 # Notifications
 
-The Notifications module delivers user-facing events and generated outputs
-through email, Chatbook persistence, notification APIs, SSE streams, reminder
-bridges, and Jobs-backed notification workers. The small core package contains
-delivery services; endpoint and scheduler packages provide the broader control
-plane.
+The Notifications core package contains delivery helpers for user-facing
+events and generated outputs. It handles bounded email delivery through AuthNZ
+and Chatbook persistence. Endpoint, scheduler, reminder, SSE, and Jobs worker
+packages own the broader notification control plane.
 
 ## Start Here
 
@@ -17,11 +16,11 @@ plane.
 
 ## Responsibilities
 
-- Send email through the AuthNZ email service and report per-recipient status.
+- Send bounded email through the AuthNZ email service and report masked
+  per-recipient status.
 - Store generated content as Chatbook documents when requested by Watchlists or
   other workflows.
-- Support notification API/service flows for lifecycle, pruning, SSE, reminders,
-  and companion/reflection bridges.
+- Provide formatting helpers for notification email content.
 - Keep delivery failures structured rather than raising raw provider exceptions
   into callers.
 
@@ -29,20 +28,21 @@ plane.
 
 - `service.py` defines `NotificationsService` and `NotificationResult` for email
   and Chatbook delivery.
-- `email_delivery.py` contains email delivery helper logic used by notification
-  tests and services.
+- `email_delivery.py` contains email formatting and a compatibility
+  `send_notification_email()` helper that delegates to AuthNZ email delivery.
 
 ## How It Connects
 
 - Watchlists uses Notifications to deliver report outputs by email or Chatbook.
-- Reminders enqueue notification work through scheduler and worker services.
+- Reminders enqueue notification work through scheduler and worker services
+  outside this core package.
 - AuthNZ owns email provider configuration and message sending.
 - Chat document generation and ChaChaNotes DB persistence are used for Chatbook
   delivery.
 
 ## Extension Points
 
-- Add a new delivery channel by adding a focused method returning
+- Add a new core delivery channel by adding a focused method returning
   `NotificationResult`, then wire it from endpoint/service code.
 - Keep channel-specific provider credentials outside this module; use the owning
   integration or AuthNZ provider.
@@ -60,7 +60,9 @@ plane.
 
 ## Gotchas
 
-- Email delivery is often partially successful. Preserve per-recipient details
-  when aggregating status.
+- Email delivery is often partially successful. Preserve masked per-recipient
+  details when aggregating status.
+- Keep fanout and attachment limits at this service boundary so new callers
+  inherit safe defaults.
 - Chatbook delivery writes to the per-user ChaChaNotes DB; use temp DB fixtures
   in tests.

--- a/tldw_Server_API/app/core/Notifications/email_delivery.py
+++ b/tldw_Server_API/app/core/Notifications/email_delivery.py
@@ -1,10 +1,11 @@
 """
 Email Notification Delivery
 
-Sends notification emails via SMTP. Configured through environment variables:
+Formats notification emails and delegates delivery to the AuthNZ email service.
+The legacy SMTP config helper still recognizes:
 - SMTP_HOST, SMTP_PORT, SMTP_USERNAME, SMTP_PASSWORD
 - EMAIL_FROM (sender email)
-- SMTP_USE_TLS (default: true)
+- SMTP_USE_TLS (default: true), SMTP_TIMEOUT (default: 10)
 
 Usage:
     from tldw_Server_API.app.core.Notifications.email_delivery import send_notification_email
@@ -19,17 +20,13 @@ Usage:
 
 from __future__ import annotations
 
-import asyncio
 import html
 import os
-import smtplib
-import ssl
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
 from urllib.parse import urlparse, urlunparse
-from uuid import uuid4
 
 from loguru import logger
+
+from tldw_Server_API.app.core.AuthNZ.email_service import get_email_service
 
 
 def _read_env_text(*names: str, default: str = "") -> str:
@@ -42,7 +39,7 @@ def _read_env_text(*names: str, default: str = "") -> str:
     return default
 
 
-def _get_smtp_config() -> dict[str, str | int | bool] | None:
+def _get_smtp_config() -> dict[str, str | int | bool | float] | None:
     """Read SMTP config from environment. Returns None if not configured."""
     host = os.environ.get("SMTP_HOST", "").strip()
     if not host:
@@ -60,6 +57,16 @@ def _get_smtp_config() -> dict[str, str | int | bool] | None:
         )
         return None
 
+    raw_timeout = os.environ.get("SMTP_TIMEOUT", "10").strip()
+    try:
+        timeout = float(raw_timeout)
+    except ValueError:
+        logger.warning("SMTP_TIMEOUT is invalid; email delivery disabled")
+        return None
+    if timeout <= 0:
+        logger.warning("SMTP_TIMEOUT must be positive; email delivery disabled")
+        return None
+
     return {
         "host": host,
         "port": port,
@@ -72,11 +79,12 @@ def _get_smtp_config() -> dict[str, str | int | bool] | None:
         ),
         "use_tls": os.environ.get("SMTP_USE_TLS", "true").lower()
         in ("true", "1", "yes"),
+        "timeout": timeout,
     }
 
 
 def is_email_delivery_configured() -> bool:
-    """Check if SMTP is configured for email delivery."""
+    """Check if legacy SMTP environment settings are configured."""
     return _get_smtp_config() is not None
 
 
@@ -88,12 +96,13 @@ def _mask_email_address(address: str) -> str:
     return f"{prefix}***@{domain}"
 
 
-def _redact_log_text(value: object, *sensitive_values: str) -> str:
-    redacted = str(value)
-    for sensitive_value in sensitive_values:
-        if sensitive_value:
-            redacted = redacted.replace(sensitive_value, "[redacted]")
-    return redacted
+def _plain_text_to_html(body_text: str) -> str:
+    escaped = html.escape(body_text)
+    return f"<pre>{escaped}</pre>"
+
+
+def _redacted_exception_for_log(exc: BaseException) -> RuntimeError:
+    return RuntimeError(f"{type(exc).__name__}: redacted").with_traceback(exc.__traceback__)
 
 
 async def send_notification_email(
@@ -102,62 +111,24 @@ async def send_notification_email(
     body_text: str,
     body_html: str | None = None,
 ) -> bool:
-    """Send a notification email via SMTP.
+    """Send a notification email through the AuthNZ email service.
 
     Returns True on success, False on failure (logged, not raised).
     """
-    return await asyncio.to_thread(
-        _send_notification_email_sync,
-        to,
-        subject,
-        body_text,
-        body_html,
-    )
-
-
-def _send_notification_email_sync(
-    to: str,
-    subject: str,
-    body_text: str,
-    body_html: str | None = None,
-) -> bool:
-    config = _get_smtp_config()
-    if not config:
-        logger.debug("Email delivery not configured (SMTP_HOST not set)")
-        return False
-
-    msg = MIMEMultipart("alternative")
-    msg["Subject"] = subject
-    msg["From"] = str(config["from_address"])
-    msg["To"] = to
-
-    msg.attach(MIMEText(body_text, "plain"))
-    if body_html:
-        msg.attach(MIMEText(body_html, "html"))
-
-    notification_id = uuid4().hex[:12]
-    masked_to = _mask_email_address(to)
     try:
-        with smtplib.SMTP(str(config["host"]), int(config["port"])) as server:
-            if config["use_tls"]:
-                context = ssl.create_default_context()
-                server.starttls(context=context)
-            if config["user"] and config["password"]:
-                server.login(str(config["user"]), str(config["password"]))
-            server.sendmail(str(config["from_address"]), to, msg.as_string())
-
-        logger.info(
-            "Notification email sent (id={}, recipient={})",
-            notification_id,
-            masked_to,
+        return await get_email_service().send_email(
+            to_email=to,
+            subject=subject,
+            html_body=body_html or _plain_text_to_html(body_text),
+            text_body=body_text,
         )
-        return True
     except Exception as exc:
-        logger.error(
-            "Failed to send notification email (id={}, recipient={}): {}",
-            notification_id,
-            masked_to,
-            _redact_log_text(exc, to, subject),
+        logger.bind(
+            operation="notifications.send_notification_email",
+            recipient=_mask_email_address(to),
+            exception_type=type(exc).__name__,
+        ).opt(exception=_redacted_exception_for_log(exc)).error(
+            "Failed to send notification email"
         )
         return False
 

--- a/tldw_Server_API/app/core/Notifications/service.py
+++ b/tldw_Server_API/app/core/Notifications/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -10,12 +11,114 @@ from tldw_Server_API.app.core.Chat.document_generator import DocumentGeneratorSe
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 
+_EMAIL_RECIPIENT_PATTERN = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+MAX_EMAIL_RECIPIENTS = 50
+MAX_EMAIL_ATTACHMENTS = 5
+MAX_EMAIL_ATTACHMENT_BYTES = 10 * 1024 * 1024
+MAX_EMAIL_ATTACHMENT_FILENAME_LENGTH = 255
+
 
 @dataclass
 class NotificationResult:
     channel: str
     status: str
     details: dict[str, Any] = field(default_factory=dict)
+
+
+def _mask_email_address(address: str) -> str:
+    local, separator, domain = address.partition("@")
+    if not separator or not domain:
+        return "[invalid-recipient]"
+    prefix = local[:1] if local else "*"
+    return f"{prefix}***@{domain}"
+
+
+def _normalize_email_recipients(recipients: list[str] | None) -> tuple[list[str], int]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    invalid_count = 0
+    for raw_recipient in recipients or []:
+        if not isinstance(raw_recipient, str):
+            invalid_count += 1
+            continue
+        recipient = raw_recipient.strip()
+        if not recipient:
+            continue
+        if (
+            len(recipient) > 254
+            or "\r" in recipient
+            or "\n" in recipient
+            or not _EMAIL_RECIPIENT_PATTERN.fullmatch(recipient.lower())
+        ):
+            invalid_count += 1
+            continue
+        dedupe_key = recipient.lower()
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        normalized.append(recipient)
+    return normalized, invalid_count
+
+
+def _redacted_exception_for_log(exc: BaseException) -> RuntimeError:
+    return RuntimeError(f"{type(exc).__name__}: redacted").with_traceback(exc.__traceback__)
+
+
+def _attachment_content_size_bytes(content: bytes | bytearray | memoryview | str) -> int:
+    if isinstance(content, memoryview):
+        return content.nbytes
+    if isinstance(content, (bytes, bytearray)):
+        return len(content)
+    return len(content.encode("utf-8"))
+
+
+def _validate_email_attachments(
+    attachments: list[dict[str, Any]] | None,
+) -> dict[str, Any] | None:
+    if not attachments:
+        return None
+    if len(attachments) > MAX_EMAIL_ATTACHMENTS:
+        return {
+            "reason": "too_many_attachments",
+            "attachment_count": len(attachments),
+            "max_attachments": MAX_EMAIL_ATTACHMENTS,
+        }
+
+    total_bytes = 0
+    for attachment in attachments:
+        if not isinstance(attachment, dict):
+            return {
+                "reason": "invalid_attachment",
+                "attachment_count": len(attachments),
+            }
+        filename = str(attachment.get("filename") or "").strip()
+        if (
+            not filename
+            or len(filename) > MAX_EMAIL_ATTACHMENT_FILENAME_LENGTH
+            or "/" in filename
+            or "\\" in filename
+            or any(ord(char) < 32 or ord(char) == 127 for char in filename)
+        ):
+            return {
+                "reason": "invalid_attachment_filename",
+                "attachment_count": len(attachments),
+            }
+        if "content" not in attachment or not isinstance(
+            attachment["content"],
+            (bytes, bytearray, memoryview, str),
+        ):
+            return {
+                "reason": "invalid_attachment_content",
+                "attachment_count": len(attachments),
+            }
+        total_bytes += _attachment_content_size_bytes(attachment["content"])
+        if total_bytes > MAX_EMAIL_ATTACHMENT_BYTES:
+            return {
+                "reason": "attachment_limit_exceeded",
+                "attachment_count": len(attachments),
+                "max_attachment_bytes": MAX_EMAIL_ATTACHMENT_BYTES,
+            }
+    return None
 
 
 class NotificationsService:
@@ -26,8 +129,13 @@ class NotificationsService:
     def __init__(self, *, user_id: int, user_email: str | None = None) -> None:
         self.user_id = int(user_id)
         self.user_email = user_email
-        self._email_service = get_email_service()
+        self._email_service: Any | None = None
         self._doc_service: DocumentGeneratorService | None = None
+
+    def _ensure_email_service(self) -> Any:
+        if self._email_service is None:
+            self._email_service = get_email_service()
+        return self._email_service
 
     def _ensure_doc_service(self) -> DocumentGeneratorService:
         if self._doc_service is None:
@@ -46,30 +154,72 @@ class NotificationsService:
         attachments: list[dict[str, Any]] | None = None,
         fallback_to_user_email: bool = True,
     ) -> NotificationResult:
-        recips = [r.strip() for r in (recipients or []) if r and r.strip()]
+        recips, invalid_count = _normalize_email_recipients(recipients)
         if not recips and fallback_to_user_email and self.user_email:
-            recips = [self.user_email]
+            recips, fallback_invalid_count = _normalize_email_recipients([self.user_email])
+            invalid_count += fallback_invalid_count
+        if invalid_count:
+            return NotificationResult(
+                channel="email",
+                status="failed",
+                details={
+                    "reason": "invalid_recipients",
+                    "invalid_recipient_count": invalid_count,
+                },
+            )
+        if len(recips) > MAX_EMAIL_RECIPIENTS:
+            return NotificationResult(
+                channel="email",
+                status="failed",
+                details={
+                    "reason": "too_many_recipients",
+                    "recipient_count": len(recips),
+                    "max_recipients": MAX_EMAIL_RECIPIENTS,
+                },
+            )
         if not recips:
             return NotificationResult(
                 channel="email",
                 status="skipped",
                 details={"reason": "no_recipients"},
             )
+        attachment_error = _validate_email_attachments(attachments)
+        if attachment_error is not None:
+            return NotificationResult(
+                channel="email",
+                status="failed",
+                details=attachment_error,
+            )
 
         deliveries: list[dict[str, Any]] = []
+        email_service = self._ensure_email_service()
         for addr in recips:
+            masked_addr = _mask_email_address(addr)
             try:
-                ok = await self._email_service.send_email(
+                ok = await email_service.send_email(
                     to_email=addr,
                     subject=subject,
                     html_body=html_body,
                     text_body=text_body,
                     attachments=attachments,
                 )
-                deliveries.append({"recipient": addr, "status": "sent" if ok else "failed"})
+                deliveries.append({"recipient": masked_addr, "status": "sent" if ok else "failed"})
             except Exception as exc:
-                logger.error(f"Email delivery to {addr} failed: {exc}")
-                deliveries.append({"recipient": addr, "status": "error", "error": str(exc)})
+                logger.bind(
+                    operation="notifications.deliver_email",
+                    user_id=self.user_id,
+                    recipient=masked_addr,
+                    exception_type=type(exc).__name__,
+                ).opt(exception=_redacted_exception_for_log(exc)).error(
+                    "Email delivery failed"
+                )
+                deliveries.append(
+                    {
+                        "recipient": masked_addr,
+                        "status": "error",
+                        "error_type": type(exc).__name__,
+                    }
+                )
 
         if all(entry["status"] == "sent" for entry in deliveries):
             status = "sent"
@@ -80,7 +230,7 @@ class NotificationsService:
         return NotificationResult(
             channel="email",
             status=status,
-            details={"deliveries": deliveries, "subject": subject},
+            details={"deliveries": deliveries, "recipient_count": len(recips)},
         )
 
     def deliver_chatbook(

--- a/tldw_Server_API/tests/Notifications/test_email_delivery.py
+++ b/tldw_Server_API/tests/Notifications/test_email_delivery.py
@@ -1,5 +1,4 @@
 import pytest
-from loguru import logger
 
 from tldw_Server_API.app.core.Notifications import email_delivery
 
@@ -14,8 +13,27 @@ def _clear_smtp_env(monkeypatch):
         "SMTP_FROM_ADDRESS",
         "EMAIL_FROM",
         "SMTP_USE_TLS",
+        "SMTP_TIMEOUT",
     ):
         monkeypatch.delenv(name, raising=False)
+
+
+class _FakeLogger:
+    def __init__(self):
+        self.bound_calls = []
+        self.opt_calls = []
+        self.error_calls = []
+
+    def bind(self, **kwargs):
+        self.bound_calls.append(kwargs)
+        return self
+
+    def opt(self, **kwargs):
+        self.opt_calls.append(kwargs)
+        return self
+
+    def error(self, message, *args, **kwargs):
+        self.error_calls.append((message, args, kwargs))
 
 
 def test_invalid_smtp_port_is_treated_as_unconfigured(monkeypatch):
@@ -41,6 +59,18 @@ def test_smtp_config_uses_canonical_email_service_env_names(monkeypatch):
     assert config["from_address"] == "alerts@example.test"
 
 
+def test_smtp_config_includes_explicit_timeout(monkeypatch):
+    _clear_smtp_env(monkeypatch)
+    monkeypatch.setenv("SMTP_HOST", "smtp.example.test")
+    monkeypatch.setenv("SMTP_PORT", "2525")
+    monkeypatch.setenv("SMTP_TIMEOUT", "7.5")
+
+    config = email_delivery._get_smtp_config()
+
+    assert config is not None
+    assert config["timeout"] == 7.5
+
+
 def test_format_notification_email_escapes_html_and_drops_unsafe_links():
     _subject, body_text, body_html = email_delivery.format_notification_email(
         kind="watchlist",
@@ -59,101 +89,63 @@ def test_format_notification_email_escapes_html_and_drops_unsafe_links():
 
 
 @pytest.mark.asyncio
-async def test_send_notification_email_uses_safe_logs_and_canonical_sender(
+async def test_send_notification_email_delegates_to_authnz_email_service(
     monkeypatch,
 ):
     _clear_smtp_env(monkeypatch)
-    monkeypatch.setenv("SMTP_HOST", "smtp.example.test")
-    monkeypatch.setenv("SMTP_PORT", "2525")
-    monkeypatch.setenv("SMTP_USERNAME", "smtp-user")
-    monkeypatch.setenv("SMTP_PASSWORD", "smtp-password")
-    monkeypatch.setenv("EMAIL_FROM", "alerts@example.test")
 
-    smtp_calls = []
+    calls = []
 
-    class FakeSMTP:
-        def __init__(self, host, port):
-            smtp_calls.append(("connect", host, port))
+    class FakeEmailService:
+        async def send_email(self, **kwargs):
+            calls.append(kwargs)
+            return True
 
-        def __enter__(self):
-            return self
+    monkeypatch.setattr(email_delivery, "get_email_service", lambda: FakeEmailService(), raising=False)
 
-        def __exit__(self, exc_type, exc, tb):
-            return False
-
-        def starttls(self, context):
-            smtp_calls.append(("starttls", context is not None))
-
-        def login(self, user, password):
-            smtp_calls.append(("login", user, password))
-
-        def sendmail(self, from_address, to_address, payload):
-            smtp_calls.append(("sendmail", from_address, to_address, payload))
-
-    monkeypatch.setattr(email_delivery.smtplib, "SMTP", FakeSMTP)
-
-    logs = []
-    sink_id = logger.add(lambda message: logs.append(str(message)), format="{message}")
-    try:
-        result = await email_delivery.send_notification_email(
-            to="person@example.test",
-            subject="Sensitive subject",
-            body_text="plain body",
-            body_html="<p>html body</p>",
-        )
-    finally:
-        logger.remove(sink_id)
+    result = await email_delivery.send_notification_email(
+        to="person@example.test",
+        subject="Sensitive subject",
+        body_text="plain body",
+        body_html="<p>html body</p>",
+    )
 
     assert result is True
-    assert ("login", "smtp-user", "smtp-password") in smtp_calls
-    assert any(call[:3] == ("sendmail", "alerts@example.test", "person@example.test") for call in smtp_calls)
-    rendered_logs = "\n".join(logs)
-    assert "person@example.test" not in rendered_logs
-    assert "Sensitive subject" not in rendered_logs
-    assert "p***@example.test" in rendered_logs
+    assert calls == [
+        {
+            "to_email": "person@example.test",
+            "subject": "Sensitive subject",
+            "html_body": "<p>html body</p>",
+            "text_body": "plain body",
+        }
+    ]
 
 
 @pytest.mark.asyncio
-async def test_send_notification_email_redacts_failure_logs(monkeypatch):
+async def test_send_notification_email_returns_false_when_authnz_delivery_fails(monkeypatch):
     _clear_smtp_env(monkeypatch)
-    monkeypatch.setenv("SMTP_HOST", "smtp.example.test")
-    monkeypatch.setenv("SMTP_PORT", "2525")
-    monkeypatch.setenv("EMAIL_FROM", "alerts@example.test")
+    fake_logger = _FakeLogger()
 
-    class FailingSMTP:
-        def __init__(self, host, port):
-            pass
+    class FailingEmailService:
+        async def send_email(self, **kwargs):  # noqa: ARG002
+            raise RuntimeError("failed person@example.test while sending Sensitive subject")
 
-        def __enter__(self):
-            return self
+    monkeypatch.setattr(email_delivery, "get_email_service", lambda: FailingEmailService(), raising=False)
+    monkeypatch.setattr(email_delivery, "logger", fake_logger)
 
-        def __exit__(self, exc_type, exc, tb):
-            return False
-
-        def starttls(self, context):
-            pass
-
-        def sendmail(self, from_address, to_address, payload):
-            raise RuntimeError(
-                "failed person@example.test while sending Sensitive subject"
-            )
-
-    monkeypatch.setattr(email_delivery.smtplib, "SMTP", FailingSMTP)
-
-    logs = []
-    sink_id = logger.add(lambda message: logs.append(str(message)), format="{message}")
-    try:
-        result = await email_delivery.send_notification_email(
-            to="person@example.test",
-            subject="Sensitive subject",
-            body_text="plain body",
-        )
-    finally:
-        logger.remove(sink_id)
+    result = await email_delivery.send_notification_email(
+        to="person@example.test",
+        subject="Sensitive subject",
+        body_text="plain body",
+    )
 
     assert result is False
-    rendered_logs = "\n".join(logs)
-    assert "person@example.test" not in rendered_logs
-    assert "Sensitive subject" not in rendered_logs
-    assert "p***@example.test" in rendered_logs
-    assert "[redacted]" in rendered_logs
+    assert fake_logger.bound_calls[0] == {
+        "operation": "notifications.send_notification_email",
+        "recipient": "p***@example.test",
+        "exception_type": "RuntimeError",
+    }
+    redacted_exception = fake_logger.opt_calls[0]["exception"]
+    assert redacted_exception.__traceback__ is not None
+    assert "person@example.test" not in str(redacted_exception)
+    assert "Sensitive subject" not in str(redacted_exception)

--- a/tldw_Server_API/tests/Notifications/test_notifications_service.py
+++ b/tldw_Server_API/tests/Notifications/test_notifications_service.py
@@ -1,5 +1,8 @@
+from array import array
+
 import pytest
 
+from tldw_Server_API.app.core.Notifications import service as notifications_service
 from tldw_Server_API.app.core.Notifications.service import NotificationsService
 
 
@@ -18,6 +21,29 @@ class _FakeEmailService:
             }
         )
         return True
+
+
+class _FailingEmailService:
+    async def send_email(self, *, to_email, subject, html_body, text_body, attachments=None):  # noqa: ARG002
+        raise RuntimeError(f"failed to send to {to_email} with subject {subject}")
+
+
+class _FakeLogger:
+    def __init__(self):
+        self.bound_calls = []
+        self.opt_calls = []
+        self.error_calls = []
+
+    def bind(self, **kwargs):
+        self.bound_calls.append(kwargs)
+        return self
+
+    def opt(self, **kwargs):
+        self.opt_calls.append(kwargs)
+        return self
+
+    def error(self, message, *args, **kwargs):
+        self.error_calls.append((message, args, kwargs))
 
 
 class _FakeDocService:
@@ -97,6 +123,177 @@ async def test_notifications_email_skips_without_recipient(monkeypatch):
     assert result.status == "skipped"
     assert result.details["reason"] == "no_recipients"
     assert not fake_email.calls
+
+
+@pytest.mark.asyncio
+async def test_notifications_email_rejects_too_many_recipients(monkeypatch):
+    fake_email = _FakeEmailService()
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Notifications.service.get_email_service",
+        lambda: fake_email,
+    )
+    monkeypatch.setattr(notifications_service, "MAX_EMAIL_RECIPIENTS", 2, raising=False)
+
+    svc = NotificationsService(user_id=1, user_email=None)
+    result = await svc.deliver_email(
+        subject="Bulk",
+        html_body="<p>Bulk</p>",
+        text_body="Bulk",
+        recipients=["a@example.com", "b@example.com", "c@example.com"],
+    )
+
+    assert result.status == "failed"
+    assert result.details["reason"] == "too_many_recipients"
+    assert result.details["recipient_count"] == 3
+    assert fake_email.calls == []
+
+
+@pytest.mark.asyncio
+async def test_notifications_email_rejects_oversized_attachments(monkeypatch):
+    fake_email = _FakeEmailService()
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Notifications.service.get_email_service",
+        lambda: fake_email,
+    )
+    monkeypatch.setattr(notifications_service, "MAX_EMAIL_ATTACHMENT_BYTES", 4, raising=False)
+
+    svc = NotificationsService(user_id=1, user_email="user@example.com")
+    result = await svc.deliver_email(
+        subject="Large",
+        html_body="<p>Large</p>",
+        text_body="Large",
+        recipients=None,
+        attachments=[{"filename": "large.txt", "content": b"12345"}],
+    )
+
+    assert result.status == "failed"
+    assert result.details["reason"] == "attachment_limit_exceeded"
+    assert result.details["attachment_count"] == 1
+    assert fake_email.calls == []
+
+
+@pytest.mark.asyncio
+async def test_notifications_email_sizes_memoryview_attachments_by_bytes(monkeypatch):
+    fake_email = _FakeEmailService()
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Notifications.service.get_email_service",
+        lambda: fake_email,
+    )
+    monkeypatch.setattr(notifications_service, "MAX_EMAIL_ATTACHMENT_BYTES", 3, raising=False)
+
+    svc = NotificationsService(user_id=1, user_email="user@example.com")
+    result = await svc.deliver_email(
+        subject="Wide memoryview",
+        html_body="<p>Large</p>",
+        text_body="Large",
+        recipients=None,
+        attachments=[
+            {
+                "filename": "wide.bin",
+                "content": memoryview(array("H", [1, 2])),
+            }
+        ],
+    )
+
+    assert result.status == "failed"
+    assert result.details["reason"] == "attachment_limit_exceeded"
+    assert fake_email.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("filename", ["null-\x00.txt", "unit-\x1f.txt", "delete-\x7f.txt"])
+async def test_notifications_email_rejects_control_char_attachment_filenames(
+    monkeypatch,
+    filename,
+):
+    fake_email = _FakeEmailService()
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Notifications.service.get_email_service",
+        lambda: fake_email,
+    )
+
+    svc = NotificationsService(user_id=1, user_email="user@example.com")
+    result = await svc.deliver_email(
+        subject="Bad filename",
+        html_body="<p>Bad</p>",
+        text_body="Bad",
+        recipients=None,
+        attachments=[{"filename": filename, "content": b"ok"}],
+    )
+
+    assert result.status == "failed"
+    assert result.details["reason"] == "invalid_attachment_filename"
+    assert fake_email.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "attachment",
+    [
+        {"filename": "missing-content.txt"},
+        {"filename": "bad-content.txt", "content": object()},
+    ],
+)
+async def test_notifications_email_rejects_invalid_attachment_content(monkeypatch, attachment):
+    fake_email = _FakeEmailService()
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Notifications.service.get_email_service",
+        lambda: fake_email,
+    )
+
+    svc = NotificationsService(user_id=1, user_email="user@example.com")
+    result = await svc.deliver_email(
+        subject="Invalid attachment",
+        html_body="<p>Invalid</p>",
+        text_body="Invalid",
+        recipients=None,
+        attachments=[attachment],
+    )
+
+    assert result.status == "failed"
+    assert result.details["reason"] == "invalid_attachment_content"
+    assert result.details["attachment_count"] == 1
+    assert fake_email.calls == []
+
+
+@pytest.mark.asyncio
+async def test_notifications_email_redacts_failure_details(monkeypatch):
+    fake_logger = _FakeLogger()
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Notifications.service.get_email_service",
+        lambda: _FailingEmailService(),
+    )
+    monkeypatch.setattr(notifications_service, "logger", fake_logger)
+
+    svc = NotificationsService(user_id=1, user_email=None)
+    result = await svc.deliver_email(
+        subject="Sensitive Subject",
+        html_body="<p>fail</p>",
+        text_body="fail",
+        recipients=["person@example.com"],
+    )
+
+    rendered_details = repr(result.details)
+    assert result.status == "failed"
+    assert "person@example.com" not in rendered_details
+    assert "Sensitive Subject" not in rendered_details
+    assert "RuntimeError" in rendered_details
+    assert "p***@example.com" in rendered_details
+    assert fake_logger.bound_calls[0] == {
+        "operation": "notifications.deliver_email",
+        "user_id": 1,
+        "recipient": "p***@example.com",
+        "exception_type": "RuntimeError",
+    }
+    redacted_exception = fake_logger.opt_calls[0]["exception"]
+    assert redacted_exception.__traceback__ is not None
+    assert "person@example.com" not in str(redacted_exception)
+    assert "Sensitive Subject" not in str(redacted_exception)
 
 
 def test_notifications_chatbook_delivery(monkeypatch):

--- a/tldw_Server_API/tests/Watchlists/test_delivery_integrations.py
+++ b/tldw_Server_API/tests/Watchlists/test_delivery_integrations.py
@@ -38,6 +38,23 @@ def client_with_user(monkeypatch, tmp_path):
     app.dependency_overrides.clear()
 
 
+def test_watchlist_email_attachment_filename_sanitizes_separators_and_length():
+    from tldw_Server_API.app.api.v1.endpoints import watchlists
+
+    title = "Daily / Digest \\ Briefing " + ("x" * 300)
+    filename = watchlists._build_watchlist_email_attachment_filename(title, 55, "md")
+
+    assert filename.endswith(".md")
+    assert "/" not in filename
+    assert "\\" not in filename
+    assert "\r" not in filename
+    assert "\n" not in filename
+    assert len(filename) <= 255
+
+    fallback_filename = watchlists._build_watchlist_email_attachment_filename("/\\", 55, "md")
+    assert fallback_filename == "watchlist-output-55.md"
+
+
 def test_output_deliveries_email_and_chatbook(client_with_user: TestClient):
     c = client_with_user
 

--- a/tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py
+++ b/tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py
@@ -270,6 +270,7 @@ async def test_retry_run_audio_does_not_mutate_state_when_queue_submit_fails(mon
 async def test_retry_run_delivery_redelivers_latest_output_and_updates_metadata(monkeypatch):
     from tldw_Server_API.app.api.v1.endpoints.watchlists import retry_run_delivery
 
+    unsafe_title = "Daily / Digest \\ Briefing " + ("x" * 300)
     run = SimpleNamespace(id=10, job_id=7, stats_json="{}", error_msg=None)
     db = MagicMock()
     db.get_run.return_value = run
@@ -293,13 +294,13 @@ async def test_retry_run_delivery_redelivers_latest_output_and_updates_metadata(
         id=55,
         run_id=10,
         job_id=7,
-        title="Daily Digest",
+        title=unsafe_title,
         format="md",
         metadata_json=json.dumps(
             {
                 "origin": "watchlists",
                 "delivery_plan": {
-                    "email": {"enabled": True, "recipients": ["digest@example.com"], "attach_file": False}
+                    "email": {"enabled": True, "recipients": ["digest@example.com"], "attach_file": True}
                 },
             }
         ),
@@ -339,7 +340,7 @@ async def test_retry_run_delivery_redelivers_latest_output_and_updates_metadata(
     row_to_output = AsyncMock(
         return_value=SimpleNamespace(
             id=55,
-            title="Daily Digest",
+            title=unsafe_title,
             format="md",
             content="# Digest",
             metadata=json.loads(output_row.metadata_json),
@@ -347,6 +348,7 @@ async def test_retry_run_delivery_redelivers_latest_output_and_updates_metadata(
         )
     )
     monkeypatch.setattr("tldw_Server_API.app.api.v1.endpoints.watchlists._row_to_output", row_to_output)
+    email_kwargs: list[dict[str, Any]] = []
 
     class FakeNotificationsService:
         def __init__(self, *, user_id: int, user_email: str | None = None) -> None:
@@ -354,6 +356,7 @@ async def test_retry_run_delivery_redelivers_latest_output_and_updates_metadata(
             self.user_email = user_email
 
         async def deliver_email(self, **kwargs):
+            email_kwargs.append(kwargs)
             return SimpleNamespace(
                 channel="email",
                 status="sent",
@@ -399,6 +402,11 @@ async def test_retry_run_delivery_redelivers_latest_output_and_updates_metadata(
     assert metadata_update["delivery_retry_results"][0]["channel"] == "email"
     assert "provider" not in metadata_update["delivery_retry_results"][0]
     assert "subject" not in metadata_update["delivery_retry_results"][0]
+    attachment_filename = email_kwargs[0]["attachments"][0]["filename"]
+    assert attachment_filename.endswith(".md")
+    assert "/" not in attachment_filename
+    assert "\\" not in attachment_filename
+    assert len(attachment_filename) <= 255
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Change Summary (AI Draft)

This PR hardens the Notifications delivery boundary after review of `tldw_Server_API/app/core/Notifications/`.

- Bounds email recipient fanout, deduplicates recipients, and masks recipient details in delivery failures.
- Adds attachment count, filename, content-type, and byte-size validation before AuthNZ email delivery.
- Consolidates legacy notification email sending through AuthNZ `EmailService` and keeps `SMTP_TIMEOUT` parsing explicit.
- Adds structured redacted traceback logging for delivery failures without returning raw exception strings to callers.
- Sanitizes Watchlists email attachment filenames across initial output delivery and retry paths.
- Addresses the latest CodeRabbit comments by measuring `memoryview` attachments with `nbytes` and rejecting all ASCII control characters in attachment filenames.
- Updates Notifications README scope notes and records Backlog task TASK-10004.

Human merge note: project policy requires the human requester to provide or approve the final human-written Change summary before merge.

## Rebase Status

- Base branch: `dev`
- Latest fetched base: `7ab6ae8c4208af9a25e1ad53b0d8ed511aaa0f8f`
- Pushed head: `be05f9992242c76e5816d4bab212533fc1e10f09`
- Branch state at push: 0 behind, 1 ahead of `origin/dev`

## Review Comments Addressed

- Redacted traceback logging now uses bound Loguru context and a sanitized exception object.
- Imports were normalized in the touched test file.
- Attachment dictionaries now require supported `content` values before delivery.
- Watchlists attachment filenames now use a shared sanitizer.
- `memoryview` attachment sizes are counted with `nbytes` rather than element count.
- Attachment filenames now reject all ASCII control characters, including NUL, unit separator, and DEL.

## Verification

- `SINGLE_USER_TEST_API_KEY=test-key-for-notifications-pr /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest --confcutdir=tldw_Server_API/tests/Notifications tldw_Server_API/tests/Notifications/test_notifications_service.py tldw_Server_API/tests/Notifications/test_email_delivery.py tldw_Server_API/tests/Watchlists/test_delivery_integrations.py tldw_Server_API/tests/Watchlists/test_watchlists_operator_recovery.py -q` - 34 passed, 86 warnings.
- `SINGLE_USER_TEST_API_KEY=test-key-for-notifications-pr /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest --confcutdir=tldw_Server_API/tests/Notifications ...non-scheduled Notifications slice... -q` - 129 passed, 661 warnings.
- `SINGLE_USER_TEST_API_KEY=test-key-for-notifications-pr /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Notifications/test_scheduled_task_automation_api.py tldw_Server_API/tests/Notifications/test_scheduled_tasks_control_plane.py -q` - 46 passed, 1534 warnings.
- `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m ruff check tldw_Server_API/app/core/Notifications/service.py tldw_Server_API/app/core/Notifications/email_delivery.py tldw_Server_API/tests/Notifications/test_notifications_service.py tldw_Server_API/tests/Notifications/test_email_delivery.py` - passed.
- `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m py_compile tldw_Server_API/app/core/Notifications/service.py tldw_Server_API/app/core/Notifications/email_delivery.py tldw_Server_API/app/api/v1/endpoints/watchlists.py` - passed with the same pre-existing Watchlists `return`-in-`finally` warnings.
- `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Notifications/service.py tldw_Server_API/app/core/Notifications/email_delivery.py tldw_Server_API/app/api/v1/endpoints/watchlists.py -f json -o /tmp/bandit_notifications_pr2493_rebased_final.json` - 0 findings.
- `git diff --check` - passed.
