### PR TITLE
Harden Templating renderer

### DIFF
--- a/Docs/Published/User_Guides/WebUI_Extension/Chatbook_Tools_Getting_Started.md
+++ b/Docs/Published/User_Guides/WebUI_Extension/Chatbook_Tools_Getting_Started.md
@@ -51,7 +51,6 @@ Optional defaults in config.txt:
 ```ini
 [Chat-Templating]
 allow_random = false
-allow_external_calls = false
 max_output_chars = 2000
 render_timeout_ms = 250
 default_timezone = UTC

--- a/Docs/User_Guides/WebUI_Extension/Chatbook_Tools_Getting_Started.md
+++ b/Docs/User_Guides/WebUI_Extension/Chatbook_Tools_Getting_Started.md
@@ -51,7 +51,6 @@ Optional defaults in config.txt:
 ```ini
 [Chat-Templating]
 allow_random = false
-allow_external_calls = false
 max_output_chars = 2000
 render_timeout_ms = 250
 default_timezone = UTC

--- a/IMPLEMENTATION_PLAN_templating_renderer_hardening_10007.md
+++ b/IMPLEMENTATION_PLAN_templating_renderer_hardening_10007.md
@@ -1,0 +1,29 @@
+## Stage 1: Regression Tests
+**Goal**: Capture the reviewed renderer failure modes before production changes.
+**Success Criteria**: Focused tests fail for uncaught runtime errors, expensive expressions, callable extra exposure, timezone default behavior, and unused API surface.
+**Tests**: `python -m pytest tldw_Server_API/tests/Chat_NEW/unit/test_template_renderer.py -q`
+**Status**: Complete
+
+## Stage 2: Renderer Hardening
+**Goal**: Enforce expression constraints, fail safely on runtime errors, and make context exposure explicit.
+**Success Criteria**: Renderer returns original text for unsafe/runtime failures and only approved helper calls are callable.
+**Tests**: Focused template renderer tests pass.
+**Status**: Complete
+
+## Stage 3: API Cleanup And Documentation
+**Goal**: Remove unused options/classes and update docs/tests to match the smaller surface.
+**Success Criteria**: No references remain to removed API surface; README describes the hardened behavior accurately.
+**Tests**: Reference search plus focused tests.
+**Status**: Complete
+
+## Stage 4: Verification
+**Goal**: Prove the touched scope works and does not add security findings.
+**Success Criteria**: Focused tests, Bandit on touched production code, and diff checks pass or have documented blockers.
+**Tests**: `python -m pytest ...`, `python -m bandit ...`, `git diff --check`.
+**Status**: Complete
+
+## Stage 5: PR Review Remediation
+**Goal**: Address PR review comments after rebasing onto the latest `dev`.
+**Success Criteria**: Review comments are reflected in code/tests without weakening the renderer hardening.
+**Tests**: Focused pytest slice, Bandit on touched core files, and diff checks.
+**Status**: Complete

--- a/backlog/tasks/task-10007 - Harden-Templating-renderer-review-findings.md
+++ b/backlog/tasks/task-10007 - Harden-Templating-renderer-review-findings.md
@@ -1,0 +1,80 @@
+---
+id: TASK-10007
+title: Harden Templating renderer review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 20:57'
+updated_date: '2026-06-23 21:50'
+labels:
+  - templating
+  - security
+  - review-fix
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix validated review findings in `tldw_Server_API/app/core/Templating`: harden resource limits, preserve fail-safe renderer behavior for runtime errors, prevent arbitrary callable exposure through template context extras, make timezone defaults effective, and remove unused API surface.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Renderer returns the original template instead of raising for arithmetic and oversized range runtime failures
+- [x] #2 Renderer rejects expensive constructs before allocating large outputs
+- [x] #3 Templates cannot call arbitrary methods from `ctx.extra`; only approved helpers/facades remain callable
+- [x] #4 `TemplateEnv.timezone` drives default date helpers
+- [x] #5 Unused external-call option and unused render error class are removed
+- [x] #6 Focused tests, Bandit, and diff checks are recorded
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+- Add failing regression tests for runtime arithmetic failures, oversized range failures, expensive string multiplication, callable object exposure, timezone defaults, and removed API surface.
+- Implement renderer validation and sandbox changes in `template_renderer.py`.
+- Update consumers/tests for the removed `allow_external_calls` and `TemplateRenderError` API surface.
+- Run focused templating/chat dictionary/chatbook tests, Bandit on the renderer, and whitespace diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added regression tests for renderer runtime arithmetic/range failures, expensive string multiplication, arbitrary method-call blocking, timezone defaults, and removed API surface.
+- Added template AST call/operator guardrails in the renderer and dictionary validator.
+- Added an explicit safe-callable sandbox and marked only renderer helpers, seeded random helpers, `user()`, and the regex match facade as callable from templates.
+- Removed the no-op external-call option and unused render error class.
+- Updated runtime/user docs to remove the stale external-call option and describe the stricter safe-call behavior.
+- Added narrow Bandit suppressions for existing non-cryptographic random selection/helper paths.
+- Addressed PR review comments by adding module/sandbox docstrings, marking touched unit tests, typing new test helper methods, narrowing arithmetic fallback handling to render-time only, and avoiding per-call safe-method set allocation.
+<!-- SECTION:NOTES:END -->
+
+## Verification
+
+<!-- SECTION:VERIFICATION:BEGIN -->
+- Red step confirmed: renderer tests initially failed for uncaught `ZeroDivisionError`, uncaught oversized `range` `OverflowError`, string multiplication rendering, arbitrary `ctx.extra` method calls, timezone default behavior, and stale API surface.
+- Red step confirmed: dictionary validator tests initially failed to flag string multiplication and arbitrary method calls.
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chat_NEW/unit/test_template_renderer.py tldw_Server_API/tests/Chat_NEW/unit/test_chat_dictionary_templates.py tldw_Server_API/tests/Chat_NEW/unit/test_dictionary_validator.py tldw_Server_API/tests/Chatbooks/test_chatbooks_template_mode_and_dict_strict.py -q` - 39 passed, 91 warnings.
+- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Templating/template_renderer.py tldw_Server_API/app/core/Chat/chat_dictionary.py tldw_Server_API/app/core/Chat/validate_dictionary.py -f json -o /tmp/bandit_templating_renderer_10007.json` - 0 results, 0 errors.
+- `git diff --check -- tldw_Server_API/app/core/Templating/template_renderer.py tldw_Server_API/app/core/Chat/chat_dictionary.py tldw_Server_API/app/core/Chat/validate_dictionary.py tldw_Server_API/app/core/Templating/README.md Docs/User_Guides/WebUI_Extension/Chatbook_Tools_Getting_Started.md Docs/Published/User_Guides/WebUI_Extension/Chatbook_Tools_Getting_Started.md tldw_Server_API/tests/Chat_NEW/unit/test_template_renderer.py tldw_Server_API/tests/Chat_NEW/unit/test_dictionary_validator.py` - passed.
+- `rg -n "[ \t]+$" IMPLEMENTATION_PLAN_templating_renderer_hardening_10007.md "backlog/tasks/task-10007 - Harden-Templating-renderer-review-findings.md"` - no matches.
+- PR comment pass: `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Chat_NEW/unit/test_template_renderer.py tldw_Server_API/tests/Chat_NEW/unit/test_chat_dictionary_templates.py tldw_Server_API/tests/Chat_NEW/unit/test_dictionary_validator.py tldw_Server_API/tests/Chatbooks/test_chatbooks_template_mode_and_dict_strict.py -q` - 39 passed, 90 warnings.
+- PR comment pass: `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Templating/template_renderer.py tldw_Server_API/app/core/Chat/chat_dictionary.py tldw_Server_API/app/core/Chat/validate_dictionary.py -f json -o /tmp/bandit_templating_renderer_10007_final.json` - 0 results, 0 errors.
+<!-- SECTION:VERIFICATION:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened the Templating renderer by failing safely for runtime arithmetic/range errors, rejecting expensive operators and unapproved calls during validation, restricting callable access to explicit safe helpers/facades, applying `TemplateEnv.timezone` to default date helpers, and removing unused external-call/error-class API surface. Aligned dictionary validation and docs with the renderer behavior and verified the focused chat/chatbook template slice plus Bandit.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Chat/chat_dictionary.py
+++ b/tldw_Server_API/app/core/Chat/chat_dictionary.py
@@ -94,6 +94,7 @@ class _SafeMatch:
     """
 
     __slots__ = ("_m",)
+    _tldw_template_safe_methods = frozenset({"group", "groups", "groupdict", "start", "end"})
 
     def __init__(self, match: re.Match):
         self._m = match

--- a/tldw_Server_API/app/core/Chat/validate_dictionary.py
+++ b/tldw_Server_API/app/core/Chat/validate_dictionary.py
@@ -153,6 +153,8 @@ _DISALLOWED_NODE_TYPES = {
     nodes.Extends,
     nodes.With,
     nodes.ScopedEvalContextModifier,
+    nodes.Mul,
+    nodes.Pow,
 }
 
 # Functions available in templates (Stage 1)
@@ -173,6 +175,10 @@ _ALLOWED_FUNCS = {
     "matched_text",
     "env",
     "user",
+}
+
+_ALLOWED_METHOD_CALLS_BY_ROOT = {
+    "match": frozenset({"end", "group", "groupdict", "groups", "start"}),
 }
 
 
@@ -196,6 +202,15 @@ def _template_ast_checks(text: str) -> tuple[list[dict[str, Any]], list[dict[str
             "message": str(e),
         })
         return errs, warns
+
+    def _root_name(n: nodes.Node) -> str | None:
+        if isinstance(n, nodes.Name):
+            return n.name
+        if isinstance(n, nodes.Getattr):
+            return _root_name(n.node)
+        if isinstance(n, nodes.Getitem):
+            return _root_name(n.node)
+        return None
 
     def _walk(n: nodes.Node) -> None:
         if isinstance(n, tuple(_DISALLOWED_NODE_TYPES)):
@@ -222,6 +237,21 @@ def _template_ast_checks(text: str) -> tuple[list[dict[str, Any]], list[dict[str
                             "field": "replacement",
                             "message": f"Unknown function: {func_name}",
                         })
+            elif isinstance(target, nodes.Getattr):
+                root = _root_name(target.node)
+                allowed_methods = _ALLOWED_METHOD_CALLS_BY_ROOT.get(str(root or ""))
+                if allowed_methods is None or target.attr not in allowed_methods:
+                    errs.append({
+                        "code": "template_forbidden_construct",
+                        "field": "replacement",
+                        "message": f"Forbidden method call: {target.attr}",
+                    })
+            else:
+                errs.append({
+                    "code": "template_forbidden_construct",
+                    "field": "replacement",
+                    "message": f"Forbidden callable: {type(target).__name__}",
+                })
         for child in n.iter_child_nodes():
             _walk(child)
 

--- a/tldw_Server_API/app/core/Templating/README.md
+++ b/tldw_Server_API/app/core/Templating/README.md
@@ -1,10 +1,10 @@
 # Templating
 
-Templating provides the sandboxed Jinja rendering helper used by chat dictionaries, chatbooks, and prompt-adjacent flows. It builds a constrained environment from configuration, validates expression-only rendering where requested, exposes safe date/random helpers, truncates oversized output, and records render timeout metrics after rendering completes.
+Templating provides the sandboxed Jinja rendering helper used by chat dictionaries, chatbooks, and prompt-adjacent flows. It builds a constrained environment from configuration, validates expression-only rendering where requested, exposes safe date/random helpers, rejects unsafe calls and expensive expressions, truncates oversized output, and records render timeout metrics after rendering completes.
 
 ## Start Here
 
-- `template_renderer.py` is the only implementation file and contains the renderer, environment options, context objects, and error types.
+- `template_renderer.py` is the only implementation file and contains the renderer, environment options, and context objects.
 - There is no dedicated REST endpoint for this package; it is consumed by chat and chatbook code.
 - Related tests: `tests/Chat_NEW/unit/test_template_renderer.py`.
 
@@ -12,7 +12,7 @@ Templating provides the sandboxed Jinja rendering helper used by chat dictionari
 
 - Build a sandboxed Jinja environment with controlled globals and filters.
 - Render templates with `TemplateContext`, `TemplateOptions`, and environment-derived defaults.
-- Log render timeout metrics after completion, truncate oversized output, and apply cache and expression-only constraints.
+- Log render timeout metrics after completion, truncate oversized output, and apply cache, call-safety, and expression-only constraints.
 - Provide deterministic and bounded date/random helper behavior.
 - Fall back to the original input text on parse, validation, or render failures.
 
@@ -29,9 +29,9 @@ Templating provides the sandboxed Jinja rendering helper used by chat dictionari
 
 ## Extension Points
 
-- For a new safe helper or filter, add it in `template_renderer.py` and cover sandbox behavior in `tests/Chat_NEW/unit/test_template_renderer.py`.
+- For a new safe helper or filter, add it in `template_renderer.py`, mark it as template-safe, and cover sandbox behavior in `tests/Chat_NEW/unit/test_template_renderer.py`.
 - For new configuration options, extend `TemplateOptions`, `options_from_env`, and tests for default/override behavior.
-- For a new consumer, pass an explicit `TemplateContext` instead of exposing raw application objects to templates.
+- For a new consumer, pass an explicit `TemplateContext` with JSON-like values or an approved facade instead of exposing raw application objects to templates.
 
 ## Testing
 
@@ -41,4 +41,4 @@ Templating provides the sandboxed Jinja rendering helper used by chat dictionari
 
 - The renderer is intentionally sandboxed; avoid adding helpers that can reach the filesystem, network, process environment, or arbitrary Python objects.
 - Expression-only mode is a validation path, not just a style preference, and callers may depend on it to reject block templates.
-- Output limits are enforced by truncation; timeout settings currently produce logs/metrics rather than interrupting an in-progress render.
+- Output limits are enforced by truncation after render, while known expensive expressions are rejected before render; timeout settings currently produce logs/metrics rather than interrupting an in-progress render.

--- a/tldw_Server_API/app/core/Templating/template_renderer.py
+++ b/tldw_Server_API/app/core/Templating/template_renderer.py
@@ -1,13 +1,16 @@
+"""Sandboxed Jinja template rendering for chat dictionary substitutions."""
+
 from __future__ import annotations
 
+import contextlib
 import os
 import re
-import time
 import threading
+import time
 from collections import OrderedDict
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 from typing import Any
 
 from jinja2 import StrictUndefined, TemplateError, nodes
@@ -15,6 +18,7 @@ from jinja2.sandbox import SandboxedEnvironment
 from loguru import logger
 
 from tldw_Server_API.app.core.Metrics import increment_counter, observe_histogram
+from tldw_Server_API.app.core.config import load_comprehensive_config
 from tldw_Server_API.app.core.testing import is_truthy
 
 try:  # Python 3.9+
@@ -65,19 +69,15 @@ class TemplateContext:
 @dataclass
 class TemplateOptions:
     allow_random: bool = False
-    allow_external_calls: bool = False
     max_output_chars: int = 2000
     timeout_ms: int = 250
     random_seed: int | None = None
     cache_max_entries: int = 256
 
 
-import contextlib
-
-from tldw_Server_API.app.core.config import load_comprehensive_config
-
-
 def options_from_env() -> TemplateOptions:
+    """Build renderer options from environment variables and config.txt fallbacks."""
+
     def _truthy(name: str, default: bool = False) -> bool:
         val = os.getenv(name)
         if val is None:
@@ -127,7 +127,6 @@ def options_from_env() -> TemplateOptions:
 
     return TemplateOptions(
         allow_random=_truthy("CHAT_DICT_TEMPLATES_ALLOW_RANDOM", _cfg_bool("Chat-Templating", "allow_random", False)),
-        allow_external_calls=_truthy("TEMPLATES_ALLOW_EXTERNAL_CALLS", _cfg_bool("Chat-Templating", "allow_external_calls", False)),
         max_output_chars=_int("MAX_TEMPLATE_OUTPUT_CHARS", _cfg_int("Chat-Templating", "max_output_chars", 2000)),
         timeout_ms=_int("TEMPLATE_RENDER_TIMEOUT_MS", _cfg_int("Chat-Templating", "render_timeout_ms", 250)),
         random_seed=seed,
@@ -140,10 +139,37 @@ def options_from_env() -> TemplateOptions:
 # -----------------------------
 
 
+_TEMPLATE_SAFE_CALLABLE_ATTR = "_tldw_template_safe_callable"
+_TEMPLATE_SAFE_METHODS_ATTR = "_tldw_template_safe_methods"
+
+
+def _mark_template_safe_callable(fn: Any) -> Any:
+    """Mark an internal helper callable as safe for the template sandbox."""
+    setattr(fn, _TEMPLATE_SAFE_CALLABLE_ATTR, True)
+    return fn
+
+
+class _TemplateSandboxedEnvironment(SandboxedEnvironment):
+    """Jinja sandbox that only permits explicitly marked helper callables."""
+
+    def is_safe_callable(self, obj: Any) -> bool:
+        """Return whether the sandbox may invoke ``obj`` from a template."""
+        if bool(getattr(obj, _TEMPLATE_SAFE_CALLABLE_ATTR, False)):
+            return True
+
+        bound_self = getattr(obj, "__self__", None)
+        method_name = getattr(obj, "__name__", None)
+        allowed_methods = getattr(bound_self, _TEMPLATE_SAFE_METHODS_ATTR, ())
+        if not isinstance(method_name, str) or not isinstance(allowed_methods, frozenset):
+            return False
+        return method_name in allowed_methods
+
+
 def _build_env() -> SandboxedEnvironment:
-    env = SandboxedEnvironment(autoescape=False, undefined=StrictUndefined)
+    env = _TemplateSandboxedEnvironment(autoescape=False, undefined=StrictUndefined)
 
     # Add minimal custom filter: slugify
+    @_mark_template_safe_callable
     def _slugify(s: Any) -> str:
         t = str(s or "")
         t = t.strip().lower()
@@ -181,8 +207,9 @@ def _fn_now(fmt: str = "%Y-%m-%d", tz: str | None = None) -> str:
     return datetime.now(tz=tzinfo).strftime(fmt)
 
 
-def _fn_today(fmt: str = "%Y-%m-%d") -> str:
-    return date.today().strftime(fmt)
+def _fn_today(fmt: str = "%Y-%m-%d", tz: str | None = None) -> str:
+    tzinfo = _tzinfo(tz)
+    return datetime.now(tz=tzinfo).date().strftime(fmt)
 
 
 def _fn_iso_now(tz: str | None = None) -> str:
@@ -200,10 +227,13 @@ def _sanitize_user(user_raw: Mapping[str, Any] | None) -> dict[str, Any]:
 
 
 class _RandomFacade:
+    _tldw_template_safe_methods = frozenset({"randint", "choice"})
+
     def __init__(self, seed: int | None = None):
         import random as _random  # local import to avoid global state surprises
 
-        self._random = _random.Random()
+        # Template random helpers are non-cryptographic and seedable for tests.
+        self._random = _random.Random()  # nosec B311
         if seed is not None:
             with contextlib.suppress(_TEMPLATE_NONCRITICAL_EXCEPTIONS):
                 self._random.seed(seed)
@@ -240,15 +270,35 @@ _DISALLOWED_NODE_TYPES = {
     nodes.Extends,
     nodes.With,
     nodes.ScopedEvalContextModifier,
+    nodes.Mul,
+    nodes.Pow,
+}
+
+_ALLOWED_CALL_NAMES = {
+    "choice",
+    "iso_now",
+    "lower",
+    "now",
+    "now_tz",
+    "randint",
+    "title",
+    "today",
+    "upper",
+    "user",
+}
+
+_ALLOWED_METHOD_CALLS_BY_ROOT = {
+    "match": frozenset({"end", "group", "groupdict", "groups", "start"}),
 }
 
 _COMPILED_TEMPLATE_CACHE: OrderedDict[str, Any] = OrderedDict()
 _COMPILED_TEMPLATE_CACHE_LOCK = threading.Lock()
+_MAX_CACHED_TEMPLATE_SOURCE_CHARS = 8192
 
 
 def _get_compiled_template(template_src: str, max_entries: int) -> Any:
     """Return a compiled template using a bounded LRU cache keyed by source text."""
-    if max_entries <= 0:
+    if max_entries <= 0 or len(template_src) > _MAX_CACHED_TEMPLATE_SOURCE_CHARS:
         return _ENV.from_string(template_src)
 
     with _COMPILED_TEMPLATE_CACHE_LOCK:
@@ -273,15 +323,37 @@ def _clear_template_cache() -> None:
 
 
 def _validate_expression_only(template_src: str) -> None:
+    """Reject unsupported Jinja constructs before compiling the template."""
     # Block statements/tags are intentionally unsupported for this feature.
     if "{%" in template_src:
         raise ValueError("Forbidden construct in template: BlockTag")
 
     ast = _ENV.parse(template_src)
 
+    def _root_name(n: nodes.Node) -> str | None:
+        if isinstance(n, nodes.Name):
+            return n.name
+        if isinstance(n, nodes.Getattr):
+            return _root_name(n.node)
+        if isinstance(n, nodes.Getitem):
+            return _root_name(n.node)
+        return None
+
     def _walk(n: nodes.Node) -> None:
         if isinstance(n, tuple(_DISALLOWED_NODE_TYPES)):
             raise ValueError(f"Forbidden construct in template: {type(n).__name__}")
+        if isinstance(n, nodes.Call):
+            target = n.node
+            if isinstance(target, nodes.Name):
+                if target.name not in _ALLOWED_CALL_NAMES:
+                    raise ValueError(f"Forbidden callable in template: {target.name}")
+            elif isinstance(target, nodes.Getattr):
+                root = _root_name(target.node)
+                allowed_methods = _ALLOWED_METHOD_CALLS_BY_ROOT.get(str(root or ""))
+                if allowed_methods is None or target.attr not in allowed_methods:
+                    raise ValueError(f"Forbidden method call in template: {target.attr}")
+            else:
+                raise ValueError(f"Forbidden callable in template: {type(target).__name__}")
         for child in n.iter_child_nodes():
             _walk(child)
 
@@ -291,10 +363,6 @@ def _validate_expression_only(template_src: str) -> None:
 # -----------------------------
 # Render Entry Point
 # -----------------------------
-
-
-class TemplateRenderError(Exception):
-    pass
 
 
 def render(text: str, ctx: TemplateContext, options: TemplateOptions | None = None) -> str:
@@ -325,15 +393,45 @@ def render(text: str, ctx: TemplateContext, options: TemplateOptions | None = No
 
     # Build helper functions and variables exposed to the template
     # Functions are provided via the render context so they can be gated per-call.
+    default_tz = str(ctx.env.timezone or "UTC")
+
+    @_mark_template_safe_callable
+    def _now(fmt: str = "%Y-%m-%d", tz: str | None = None) -> str:
+        return _fn_now(fmt=fmt, tz=tz or default_tz)
+
+    @_mark_template_safe_callable
+    def _today(fmt: str = "%Y-%m-%d", tz: str | None = None) -> str:
+        return _fn_today(fmt=fmt, tz=tz or default_tz)
+
+    @_mark_template_safe_callable
+    def _iso_now(tz: str | None = None) -> str:
+        return _fn_iso_now(tz=tz or default_tz)
+
+    @_mark_template_safe_callable
+    def _now_tz(fmt: str = "%Y-%m-%d", tz: str = "UTC") -> str:
+        return _fn_now(fmt=fmt, tz=tz)
+
+    @_mark_template_safe_callable
+    def _upper(s: Any) -> str:
+        return str(s).upper()
+
+    @_mark_template_safe_callable
+    def _lower(s: Any) -> str:
+        return str(s).lower()
+
+    @_mark_template_safe_callable
+    def _title(s: Any) -> str:
+        return str(s).title()
+
     helpers: dict[str, Any] = {
-        "now": _fn_now,
-        "today": _fn_today,
-        "iso_now": _fn_iso_now,
-        "now_tz": lambda fmt="%Y-%m-%d", tz="UTC": _fn_now(fmt=fmt, tz=tz),
+        "now": _now,
+        "today": _today,
+        "iso_now": _iso_now,
+        "now_tz": _now_tz,
         # Built-in string helpers also exist as Jinja filters, but provide callables too
-        "upper": lambda s: str(s).upper(),
-        "lower": lambda s: str(s).lower(),
-        "title": lambda s: str(s).title(),
+        "upper": _upper,
+        "lower": _lower,
+        "title": _title,
     }
 
     # Random helpers gated
@@ -346,7 +444,12 @@ def render(text: str, ctx: TemplateContext, options: TemplateOptions | None = No
 
     # Optional user() callable returns a sanitized view
     safe_user = _sanitize_user(ctx.user)
-    helpers["user"] = (lambda _u=safe_user: lambda: dict(_u))()
+
+    @_mark_template_safe_callable
+    def _user() -> dict[str, Any]:
+        return dict(safe_user)
+
+    helpers["user"] = _user
 
     # Collect variables for rendering
     render_vars: dict[str, Any] = {}
@@ -367,6 +470,14 @@ def render(text: str, ctx: TemplateContext, options: TemplateOptions | None = No
     try:
         tmpl = _get_compiled_template(text, int(opts.cache_max_entries))
         output = tmpl.render(render_vars)
+    except ArithmeticError as e:
+        logger.debug(f"template_render_arithmetic_failure: {e}")
+        with contextlib.suppress(_TEMPLATE_NONCRITICAL_EXCEPTIONS):
+            increment_counter(
+                "template_render_failure_total",
+                labels={"source": metrics_source, "reason": "arithmetic"},
+            )
+        return text
     except _TEMPLATE_NONCRITICAL_EXCEPTIONS as e:
         logger.debug(f"template_render_failure: {e}")
         with contextlib.suppress(_TEMPLATE_NONCRITICAL_EXCEPTIONS):

--- a/tldw_Server_API/tests/Chat_NEW/unit/test_dictionary_validator.py
+++ b/tldw_Server_API/tests/Chat_NEW/unit/test_dictionary_validator.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 import tldw_Server_API.app.core.Chat.validate_dictionary as validate_module
 from tldw_Server_API.app.core.Chat.validate_dictionary import validate_dictionary
+
+pytestmark = pytest.mark.unit
 
 
 def _mk(payload_entries):
@@ -39,6 +43,22 @@ def test_template_forbidden_construct():
 
 
     payload = _mk([{"type": "literal", "pattern": "hello", "replacement": "{% for x in y %}hi{% endfor %}"}])
+    res = validate_dictionary(payload)
+    assert any(e.get("code") == "template_forbidden_construct" for e in res.errors)
+
+
+def test_template_expensive_operator_forbidden():
+
+
+    payload = _mk([{"type": "literal", "pattern": "hello", "replacement": "{{ 'x' * 100 }}"}])
+    res = validate_dictionary(payload)
+    assert any(e.get("code") == "template_forbidden_construct" for e in res.errors)
+
+
+def test_template_arbitrary_method_call_forbidden():
+
+
+    payload = _mk([{"type": "literal", "pattern": "hello", "replacement": "{{ obj.public_method() }}"}])
     res = validate_dictionary(payload)
     assert any(e.get("code") == "template_forbidden_construct" for e in res.errors)
 

--- a/tldw_Server_API/tests/Chat_NEW/unit/test_template_renderer.py
+++ b/tldw_Server_API/tests/Chat_NEW/unit/test_template_renderer.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
-
 import os
+from dataclasses import fields
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
 
 from tldw_Server_API.app.core.Templating.template_renderer import (
     TemplateContext,
@@ -12,6 +15,9 @@ from tldw_Server_API.app.core.Templating.template_renderer import (
     _ENV,
     render,
 )
+import tldw_Server_API.app.core.Templating.template_renderer as template_renderer
+
+pytestmark = pytest.mark.unit
 
 
 def test_basic_now_renders_year():
@@ -82,7 +88,7 @@ def test_compiled_template_cache_reuses_compiled_template(monkeypatch):
     calls = {"n": 0}
     original_from_string = _ENV.from_string
 
-    def counting_from_string(src):
+    def counting_from_string(src: str) -> Any:
         calls["n"] += 1
         return original_from_string(src)
 
@@ -98,3 +104,74 @@ def test_compiled_template_cache_reuses_compiled_template(monkeypatch):
     assert out1 == "ok"
     assert out2 == "ok"
     assert calls["n"] == 1
+
+
+def test_runtime_arithmetic_errors_fallback_to_original():
+    ctx = TemplateContext()
+    tpl = "{{ 1 / 0 }}"
+
+    out = render(tpl, ctx, TemplateOptions())
+
+    assert out == tpl
+
+
+def test_oversized_range_errors_fallback_to_original():
+    ctx = TemplateContext()
+    tpl = "{{ range(1000000)|list|length }}"
+
+    out = render(tpl, ctx, TemplateOptions())
+
+    assert out == tpl
+
+
+def test_expensive_string_multiplication_is_rejected_before_rendering():
+    ctx = TemplateContext()
+    tpl = "{{ 'x' * 100 }}"
+
+    out = render(tpl, ctx, TemplateOptions(max_output_chars=20))
+
+    assert out == tpl
+
+
+def test_extra_objects_cannot_call_public_methods():
+    class Probe:
+        def __init__(self) -> None:
+            self.hit = False
+
+        def public_method(self) -> str:
+            self.hit = True
+            return "CALLED"
+
+    probe = Probe()
+    tpl = "{{ obj.public_method() }}"
+
+    out = render(tpl, TemplateContext(extra={"obj": probe}), TemplateOptions())
+
+    assert out == tpl
+    assert probe.hit is False
+
+
+def test_default_now_uses_context_timezone(monkeypatch):
+    real_datetime = datetime
+
+    class FrozenDateTime:
+        @classmethod
+        def now(cls, tz: Any = None) -> datetime:
+            value = real_datetime(2026, 1, 1, 0, 30, tzinfo=timezone.utc)
+            if tz is not None:
+                return value.astimezone(tz)
+            return value
+
+    monkeypatch.setattr(template_renderer, "datetime", FrozenDateTime)
+    ctx = TemplateContext(env=TemplateEnv(timezone="America/Los_Angeles"))
+
+    out = render("{{ now('%Y-%m-%d') }}", ctx, TemplateOptions())
+
+    assert out == "2025-12-31"
+
+
+def test_unused_renderer_api_surface_is_removed():
+    option_names = {field.name for field in fields(TemplateOptions)}
+
+    assert "allow_external_calls" not in option_names
+    assert not hasattr(template_renderer, "TemplateRenderError")


### PR DESCRIPTION
Summary: Hardened the Templating renderer sandbox by disallowing unsafe calls and expensive operators, honoring TemplateEnv timezone for default time values, and avoiding cache retention for large template sources. Updated dictionary validation, docs, tests, and Backlog.md tracking. Tests: python -m pytest tldw_Server_API/tests/Chat_NEW/unit/test_template_renderer.py tldw_Server_API/tests/Chat_NEW/unit/test_chat_dictionary_templates.py tldw_Server_API/tests/Chat_NEW/unit/test_dictionary_validator.py tldw_Server_API/tests/Chatbooks/test_chatbooks_template_mode_and_dict_strict.py -q (39 passed); python -m bandit -r touched core files -f json (0 findings); git diff --check HEAD~1 HEAD. Merge gate: human-authored Change summary still required before merge per project policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the templating renderer to block unsafe calls and expensive operators, honor `TemplateEnv.timezone` in default date helpers, and skip caching very large templates. It now falls back to the original text on runtime errors (e.g., division by zero or oversized `range`) and removes the unused external-call option and error class.

- **New Features**
  - Callable allow-list: `now`, `today`, `iso_now`, `now_tz`, `upper`, `lower`, `title`, `user`, plus `randint`/`choice` when enabled; method calls allowed only on safe facades (e.g., `match.group`/`groups`/`groupdict`/`start`/`end`).
  - Validator guardrails: reject `*` and `**` operators and flag forbidden call targets and methods.
  - Timezone defaults: `now`/`today`/`iso_now` use `TemplateEnv.timezone` by default; `today` accepts `tz`.
  - Caching and safety: bypass LRU cache for sources > 8 KiB; arithmetic/runtime failures return the original template text.

- **Migration**
  - Remove `allow_external_calls` from `TemplateOptions`, config `[Chat-Templating]`, and any `TEMPLATES_ALLOW_EXTERNAL_CALLS` env usage.
  - Stop importing `TemplateRenderError`; failures now return the original template instead of raising.
  - Templates can no longer call arbitrary methods via `ctx.extra`; only approved helpers/facades are callable.

<sup>Written for commit 5fb057083b174a0811f410365d58a109a0eb4b32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

