### PR TITLE
Harden Sharing module review findings

### DIFF
--- a/IMPLEMENTATION_PLAN_sharing_review_fixes_12001.md
+++ b/IMPLEMENTATION_PLAN_sharing_review_fixes_12001.md
@@ -1,0 +1,36 @@
+# Sharing Review Fixes Implementation Plan
+
+## Stage 1: Token Creation And Redemption
+
+**Goal**: Enforce resource ownership for share-token creation and make public imports consume token uses atomically.
+**Success Criteria**: Workspace tokens call the workspace ownership guard, chatbook ownership is checked before token creation, public import cannot exceed `max_uses`, and password-protected imports have a usable verification path.
+**Tests**: Focused Sharing endpoint tests for workspace/chatbook ownership rejection, max-use claiming, and password inline verification/import.
+**Status**: Complete
+
+## Stage 2: Workspace Deletion Cleanup
+
+**Goal**: Wire the Sharing cleanup hook into workspace deletion.
+**Success Criteria**: Deleting a workspace invokes `on_workspace_deleted` after the local workspace delete succeeds and revokes active workspace shares/tokens.
+**Tests**: Workspace endpoint test covering hook invocation and existing hook tests.
+**Status**: Complete
+
+## Stage 3: Clone Data Integrity
+
+**Goal**: Preserve media chunks during clone and report successful copy counts.
+**Success Criteria**: Cloned media receives source unvectorized chunks when available, skipped/failed sources/notes/artifacts are not counted as copied, and partial clone behavior is explicit.
+**Tests**: Clone service tests for chunk copy and accurate counts on failures.
+**Status**: Complete
+
+## Stage 4: Audit Failure Behavior
+
+**Goal**: Prevent post-mutation audit failures from returning misleading failed user operations.
+**Success Criteria**: Endpoint mutations that already completed do not return 500 solely because audit logging failed; failures remain logged without leaking sensitive details.
+**Tests**: Sharing endpoint test that simulates audit failure after share creation.
+**Status**: Complete
+
+## Stage 5: Verification And Task Closeout
+
+**Goal**: Verify focused behavior and record task evidence.
+**Success Criteria**: Focused pytest suite passes, compile check passes, Bandit touched-scope scan is recorded, and Backlog task acceptance criteria/DoD/final summary are updated.
+**Tests**: `python -m pytest` on touched Sharing/workspace tests, `python -m compileall`, and `python -m bandit` on touched code.
+**Status**: Complete

--- a/backlog/tasks/task-12001 - Harden-Sharing-module-review-findings.md
+++ b/backlog/tasks/task-12001 - Harden-Sharing-module-review-findings.md
@@ -1,0 +1,134 @@
+---
+id: TASK-12001
+title: Harden Sharing module review findings
+status: Done
+assignee: []
+created_date: 2026-06-24 00:00
+updated_date: 2026-06-25 02:20
+labels:
+- sharing
+- security
+- review-fix
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address validated review findings in the Sharing module and its API wiring: resource ownership for token creation, atomic token use claiming, password-protected import flow, workspace deletion cleanup, clone chunk preservation and copy counts, and audit failure behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Workspace and chatbook share tokens require owner validation before creation.
+- [x] #2 Public token imports consume `max_uses` atomically and cannot exceed configured limits.
+- [x] #3 Password-protected non-prototype imports have a usable verified path.
+- [x] #4 Workspace deletion revokes active workspace shares and tokens through the Sharing cleanup hook.
+- [x] #5 Workspace clone preserves media chunks or records reprocessing status, and reports successful copy counts.
+- [x] #6 Sharing mutation endpoints handle audit-write failures without returning misleading partial failures.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused failing tests for token ownership, import claiming/password verification, deletion cleanup, clone chunks/counts, and audit failure behavior.
+2. Patch Sharing endpoint/service code with minimal behavior changes that match existing patterns.
+3. Run focused Sharing tests, compile checks for touched Python files, Bandit on touched scope, and diff hygiene.
+4. Update this task with verification results and final summary.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Task created manually because Backlog MCP was unavailable and the installed Backlog CLI hung on search/list/create operations in this workspace. User approved the temporary manual fallback.
+
+RED verification before implementation:
+- `.venv/bin/python -m pytest tldw_Server_API/tests/Sharing/test_sharing_endpoints.py::TestWorkspaceSharing::test_share_workspace_succeeds_when_audit_write_fails tldw_Server_API/tests/Sharing/test_sharing_endpoints.py::TestShareTokens::test_create_workspace_token_requires_owned_workspace tldw_Server_API/tests/Sharing/test_sharing_endpoints.py::TestShareTokens::test_create_chatbook_token_requires_owned_chatbook tldw_Server_API/tests/Sharing/test_sharing_endpoints.py::TestPublicEndpoints::test_public_import_accepts_password_for_protected_token tldw_Server_API/tests/Sharing/test_sharing_endpoints.py::TestPublicEndpoints::test_public_import_uses_atomic_claim_for_use_limit tldw_Server_API/tests/Sharing/test_clone_service.py::test_copy_media_deep_copies_unvectorized_chunks tldw_Server_API/tests/Sharing/test_clone_service.py::test_clone_skipped_source_log_is_sanitized_when_media_copy_fails tldw_Server_API/tests/Sharing/test_clone_service.py::test_clone_source_failure_log_is_sanitized tldw_Server_API/tests/Sharing/test_clone_service.py::test_clone_note_failure_log_is_sanitized tldw_Server_API/tests/Sharing/test_clone_service.py::test_clone_artifact_failure_log_is_sanitized tldw_Server_API/tests/Sharing/test_clone_service.py::test_clone_skips_source_when_media_copy_fails tldw_Server_API/tests/Workspaces/test_workspaces_api.py::test_delete_workspace_invokes_sharing_cleanup_hook -q` failed with 12 expected failures.
+
+Implementation:
+- Added best-effort Sharing audit logging so successful mutations are not reported as failed solely due to audit persistence errors.
+- Added ownership checks before workspace/chatbook token creation and preserved prototype ownership checks.
+- Updated public import to verify password-protected non-prototype links inline and consume `max_uses` through atomic `claim_token_use`.
+- Wired workspace deletion to `on_workspace_deleted` after the local delete succeeds.
+- Updated clone logic to pass source unvectorized chunks into target media creation and report attempted/copied/failed counts separately.
+
+Verification:
+- `.venv/bin/python -m compileall -q tldw_Server_API/app/api/v1/endpoints/sharing.py tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/core/Sharing` passed.
+- Focused regression pytest command passed: 12 passed.
+- `.venv/bin/python -m pytest tldw_Server_API/tests/Sharing tldw_Server_API/tests/Workspaces/test_workspaces_api.py::test_delete_workspace_invokes_sharing_cleanup_hook -q` passed: 152 passed, 360 warnings.
+- `.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sharing tldw_Server_API/app/api/v1/endpoints/sharing.py tldw_Server_API/app/api/v1/endpoints/workspaces.py -f json -o /tmp/bandit_sharing_review_fixes.json` passed. Report totals: 0 results, 0 high/medium/low severity findings.
+
+PR #2495 review follow-up:
+- Rebasing on latest `origin/dev` completed cleanly.
+- Moved chatbook file ownership checks and sync ChatbookService job lookup into a threadpool-backed helper before returning from the async request path.
+- Added `PublicImportRequest` with optional `password` so unprotected public imports accept `{}` request bodies while protected imports still require a password.
+- Fixed `workspace_deletion_hook.on_workspace_deleted` to await `get_db_pool()` before constructing `SharedWorkspaceRepo`.
+- Added contextual workspace cleanup failure logging with `workspace_id` and `owner_user_id`.
+- Added regressions for empty JSON public import, awaited cleanup hook revocation flow, and contextual cleanup logging.
+
+Review follow-up verification:
+- `.venv/bin/python -m compileall -q tldw_Server_API/app/api/v1/endpoints/sharing.py tldw_Server_API/app/api/v1/schemas/sharing_schemas.py tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/core/Sharing` passed.
+- Targeted review-fix pytest command passed: 6 passed.
+- `.venv/bin/python -m pytest tldw_Server_API/tests/Sharing tldw_Server_API/tests/Workspaces/test_workspaces_api.py::test_delete_workspace_invokes_sharing_cleanup_hook tldw_Server_API/tests/Workspaces/test_workspaces_api.py::test_delete_workspace_cleanup_failure_log_includes_context -q` passed: 155 passed, 363 warnings.
+- `.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sharing tldw_Server_API/app/api/v1/endpoints/sharing.py tldw_Server_API/app/api/v1/endpoints/workspaces.py tldw_Server_API/app/api/v1/schemas/sharing_schemas.py -f json -o /tmp/bandit_sharing_review_fixes_comments.json` passed. Report totals: 0 results, 0 high/medium/low severity findings.
+
+Modified files:
+- `tldw_Server_API/app/api/v1/endpoints/sharing.py`
+- `tldw_Server_API/app/api/v1/endpoints/workspaces.py`
+- `tldw_Server_API/app/api/v1/schemas/sharing_schemas.py`
+- `tldw_Server_API/app/core/Sharing/clone_service.py`
+- `tldw_Server_API/app/core/Sharing/workspace_deletion_hook.py`
+- `tldw_Server_API/tests/Sharing/test_sharing_endpoints.py`
+- `tldw_Server_API/tests/Sharing/test_clone_service.py`
+- `tldw_Server_API/tests/Sharing/test_workspace_deletion_hook.py`
+- `tldw_Server_API/tests/Workspaces/test_workspaces_api.py`
+- `IMPLEMENTATION_PLAN_sharing_review_fixes_12001.md`
+- `backlog/tasks/task-12001 - Harden-Sharing-module-review-findings.md`
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened Sharing token creation/import paths, workspace deletion cleanup, clone fidelity/count reporting, and audit failure behavior. Regression tests, compile check, and Bandit touched-scope scan all passed; no skipped blockers remain.
+Second PR review pass rebased onto latest dev and addressed all new CodeRabbit comments: plan markdown formatting, chatbook storage user id ownership checks, production cleanup-hook log context, and sparse chunk clone preservation. Focused and broader regression tests, compile check, diff check, and Bandit all passed; markdownlint-cli2 was unavailable locally.
+Final push state is rebased on the latest fetched `origin/dev` and verified after that rebase: compile passed, 172 targeted/broad regression tests passed, and Bandit reported 0 findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Second PR review follow-up:
+- Latest `origin/dev` advanced by 71 commits; rebased `codex/sharing-review-fixes-12001` cleanly on top of it.
+- New CodeRabbit actionable comments to address: implementation plan markdownlint formatting, chatbook ownership storage user id, workspace deletion hook contextual production failure logging, and sparse unvectorized chunk copying.
+Second PR review follow-up implementation:
+- Added H1 and blank-line spacing to `IMPLEMENTATION_PLAN_sharing_review_fixes_12001.md` for markdownlint MD041/MD022.
+- Updated chatbook ownership verification to resolve the storage user id once and use `user.id_int` when available for the ChaCha DB lookup and threadpool-backed ownership scan.
+- Moved contextual cleanup failure logging into `workspace_deletion_hook.on_workspace_deleted`, so the production swallowed-error path includes `workspace_id` and `owner_user_id` without exception details.
+- Added `get_unvectorized_max_chunk_index` to the Media DB read API/runtime surface and used it in `CloneService` so sparse active chunk indexes are included during clone.
+- Added regressions covering numeric-string chatbook owner ids, contextual hook failure logging, sparse chunk clone range selection, and the new Media DB max-index helper.
+
+Second follow-up verification:
+- RED run before implementation failed the three new behavior regressions as expected.
+- `.venv/bin/python -m pytest ...` focused DB/Sharing set passed: 18 passed, 58 warnings.
+- `.venv/bin/python -m pytest tldw_Server_API/tests/Sharing tldw_Server_API/tests/Workspaces/test_workspaces_api.py::test_delete_workspace_invokes_sharing_cleanup_hook tldw_Server_API/tests/Workspaces/test_workspaces_api.py::test_delete_workspace_cleanup_failure_log_includes_context -q` passed: 157 passed, 367 warnings.
+- `.venv/bin/python -m compileall -q ...` for touched Python modules passed.
+- `.venv/bin/python -m bandit -r ... -f json -o /tmp/bandit_sharing_review_fixes_second_followup.json` passed with 0 findings.
+- `git diff --check` passed.
+- `markdownlint-cli2 IMPLEMENTATION_PLAN_sharing_review_fixes_12001.md` could not be run locally because `markdownlint-cli2` is not installed in the worktree environment.
+Final post-rebase verification before push:
+- Fetched latest `origin/dev`, rebased again after dev advanced by 5 commits, and confirmed branch state `0 1` against `origin/dev`.
+- `.venv/bin/python -m compileall -q ...` for touched Python modules passed after final rebase.
+- `.venv/bin/python -m pytest tldw_Server_API/tests/Sharing ... tldw_Server_API/tests/MediaDB2/test_unvectorized_chunk_count.py -q` passed after final rebase: 172 passed, 408 warnings.
+- `.venv/bin/python -m bandit -r ... -f json -o /tmp/bandit_sharing_review_fixes_second_followup_final.json` passed after final rebase with 0 findings.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/sharing.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sharing.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, Response, status
 from loguru import logger
+from starlette.concurrency import run_in_threadpool
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user, rbac_rate_limit
 from tldw_Server_API.app.api.v1.utils.pagination import build_offset_pagination_meta
@@ -30,6 +31,7 @@ from ..schemas.sharing_schemas import (
     CreateTokenRequest,
     PrototypeLinkExchangeRequest,
     PrototypeLinkExchangeResponse,
+    PublicImportRequest,
     PublicSharePreview,
     ResourceType,
     SharedChatRequest,
@@ -120,6 +122,23 @@ def _get_audit_service():
     if _cached_audit_service is None:
         _cached_audit_service = ShareAuditService()
     return _cached_audit_service
+
+
+def _safe_exception_type(exc: BaseException) -> str:
+    exc_type = exc.__class__.__name__
+    if exc_type and all(char.isalnum() or char == "_" for char in exc_type):
+        return exc_type
+    return "Exception"
+
+
+async def _audit_log_best_effort(audit: Any, event_type: str, **kwargs: Any) -> None:
+    try:
+        await audit.log(event_type, **kwargs)
+    except Exception as exc:
+        logger.warning(
+            f"Sharing audit log failed; event_type={event_type}; "
+            f"exception_type={_safe_exception_type(exc)}"
+        )
 
 
 async def shutdown_sharing_audit_service() -> None:
@@ -307,6 +326,95 @@ async def _verify_workspace_ownership(workspace_id: str, user: User) -> None:
         ) from exc
 
 
+def _chatbook_ownership_exists_sync(
+    *,
+    normalized_id: str,
+    user_id: Any,
+    user_id_int: int | None,
+    db: Any | None,
+) -> bool:
+    """Run sync chatbook ownership checks away from the event loop."""
+    from pathlib import Path
+
+    from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+
+    if db is not None:
+        try:
+            from tldw_Server_API.app.core.Chatbooks.chatbook_models import ExportStatus
+            from tldw_Server_API.app.core.Chatbooks.chatbook_service import ChatbookService
+
+            service = ChatbookService(user_id, db, user_id_int=user_id_int)
+            export_job = service.get_export_job(normalized_id)
+            if export_job and str(export_job.user_id) == str(user_id):
+                job_status = getattr(export_job.status, "value", export_job.status)
+                if job_status == ExportStatus.COMPLETED.value and export_job.output_path:
+                    output_path = Path(export_job.output_path).resolve()
+                    export_dir = Path(service.export_dir).resolve()
+                    try:
+                        output_path.relative_to(export_dir)
+                    except ValueError:
+                        return False
+                    if output_path.is_file():
+                        return True
+        except Exception:
+            logger.debug("Chatbook export job ownership check skipped")
+
+    candidate_names = {Path(normalized_id).name}
+    if not normalized_id.endswith(".chatbook"):
+        candidate_names.add(f"{Path(normalized_id).name}.chatbook")
+
+    for root in (
+        DatabasePaths.get_user_chatbooks_exports_dir(user_id),
+        DatabasePaths.get_user_chatbooks_imports_dir(user_id),
+    ):
+        root_path = root.resolve()
+        for name in candidate_names:
+            candidate = (root_path / name).resolve()
+            try:
+                candidate.relative_to(root_path)
+            except ValueError:
+                continue
+            if candidate.is_file():
+                return True
+
+    return False
+
+
+async def _verify_chatbook_ownership(chatbook_id: str, user: User) -> None:
+    """Verify a chatbook token target resolves to a file owned by this user."""
+    normalized_id = str(chatbook_id or "").strip()
+    if not normalized_id:
+        raise HTTPException(status_code=404, detail="Resource not found")
+
+    user_id_int = user.id_int if hasattr(user, "id_int") else None
+    storage_user_id = user_id_int if user_id_int is not None else user.id
+    try:
+        db_lookup_user_id = int(storage_user_id)
+    except (TypeError, ValueError):
+        db_lookup_user_id = None
+
+    db = None
+    if db_lookup_user_id is not None:
+        try:
+            from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user_id
+
+            db = await get_chacha_db_for_user_id(db_lookup_user_id)
+        except Exception:
+            logger.debug("Chatbook export job ownership check skipped")
+
+    owned = await run_in_threadpool(
+        _chatbook_ownership_exists_sync,
+        normalized_id=normalized_id,
+        user_id=storage_user_id,
+        user_id_int=user_id_int,
+        db=db,
+    )
+    if owned:
+        return
+
+    raise HTTPException(status_code=404, detail="Resource not found")
+
+
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Workspace Sharing CRUD
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -351,7 +459,8 @@ async def share_workspace(
             detail="An internal error occurred while creating the share.",
         ) from exc
 
-    await audit.log(
+    await _audit_log_best_effort(
+        audit,
         "share.created",
         resource_type="workspace",
         resource_id=workspace_id,
@@ -409,7 +518,8 @@ async def update_share(
     if not updated:
         raise HTTPException(status_code=404, detail="Share not found")
 
-    await audit.log(
+    await _audit_log_best_effort(
+        audit,
         "share.updated",
         resource_type="workspace",
         resource_id=existing["workspace_id"],
@@ -442,7 +552,8 @@ async def revoke_share(
 
     await repo.revoke_share(share_id)
 
-    await audit.log(
+    await _audit_log_best_effort(
+        audit,
         "share.revoked",
         resource_type="workspace",
         resource_id=existing["workspace_id"],
@@ -586,7 +697,8 @@ async def clone_shared_workspace(
 
     job_id = str(_uuid.uuid4())
 
-    await audit.log(
+    await _audit_log_best_effort(
+        audit,
         "share.cloned",
         resource_type="workspace",
         resource_id=share["workspace_id"],
@@ -787,7 +899,8 @@ async def chat_with_shared_workspace(
                 chacha_db=owner_chacha,
             )
 
-        await audit.log(
+        await _audit_log_best_effort(
+            audit,
             "share.chat",
             resource_type="workspace",
             resource_id=share["workspace_id"],
@@ -826,7 +939,11 @@ async def create_token(
 ):
     svc = await _maybe_await(_get_token_service())
     audit = _get_audit_service()
-    if body.resource_type == ResourceType.PROTOTYPE_WORKSPACE:
+    if body.resource_type == ResourceType.WORKSPACE:
+        await _verify_workspace_ownership(body.resource_id, user)
+    elif body.resource_type == ResourceType.CHATBOOK:
+        await _verify_chatbook_ownership(body.resource_id, user)
+    elif body.resource_type == ResourceType.PROTOTYPE_WORKSPACE:
         await _get_owned_prototype_workspace(
             prototype_workspace_id=body.resource_id,
             owner_user_id=user.id,
@@ -843,7 +960,8 @@ async def create_token(
         expires_at=body.expires_at,
     )
 
-    await audit.log(
+    await _audit_log_best_effort(
+        audit,
         "token.created",
         resource_type=body.resource_type.value,
         resource_id=body.resource_id,
@@ -891,7 +1009,8 @@ async def revoke_token(
     svc = await _maybe_await(_get_token_service())
     await svc.revoke_token(token_id)
 
-    await audit.log(
+    await _audit_log_best_effort(
+        audit,
         "token.revoked",
         resource_type=token["resource_type"],
         resource_id=token["resource_id"],
@@ -955,7 +1074,8 @@ async def public_verify_password(
 
     ok = await svc.verify_password(validated, body.password)
     event = "token.password_verified" if ok else "token.password_failed"
-    await audit.log(
+    await _audit_log_best_effort(
+        audit,
         event,
         resource_type=validated["resource_type"],
         resource_id=validated["resource_id"],
@@ -1026,7 +1146,8 @@ async def public_prototype_session_exchange(
     if validated.get("is_password_protected"):
         if body.password:
             password_ok = await svc.verify_password(validated, body.password)
-            await audit.log(
+            await _audit_log_best_effort(
+                audit,
                 "token.password_verified" if password_ok else "token.password_failed",
                 resource_type=validated["resource_type"],
                 resource_id=validated["resource_id"],
@@ -1119,7 +1240,8 @@ async def public_prototype_session_exchange(
         await svc.release_token_use(validated["id"])
         claim_released = True
     try:
-        await audit.log(
+        await _audit_log_best_effort(
+            audit,
             "token.prototype_session_exchanged",
             resource_type=validated["resource_type"],
             resource_id=validated["resource_id"],
@@ -1165,13 +1287,14 @@ async def public_prototype_session_exchange(
 async def public_import(
     token: str,
     request: Request,
+    body: PublicImportRequest | None = None,
     user: User = Depends(get_request_user),
 ):
     svc = await _maybe_await(_get_token_service())
     audit = _get_audit_service()
 
-    validated = await svc.validate_token(token)
-    if not validated:
+    validated = await svc.validate_token(token, allow_exhausted=True)
+    if not validated or validated.get("is_use_exhausted"):
         raise HTTPException(status_code=404, detail="Resource not found")
 
     if validated.get("resource_type") == ResourceType.PROTOTYPE_WORKSPACE.value:
@@ -1180,17 +1303,35 @@ async def public_import(
             detail="Prototype workspace links must be exchanged via /prototype-session",
         )
 
-    # [CRITICAL FIX #4] Block import on password-protected tokens without verification
     if validated.get("is_password_protected"):
+        if body is None or not body.password:
+            raise HTTPException(
+                status_code=403,
+                detail="Password verification required.",
+            )
+        ok = await svc.verify_password(validated, body.password)
+        await _audit_log_best_effort(
+            audit,
+            "token.password_verified" if ok else "token.password_failed",
+            resource_type=validated["resource_type"],
+            resource_id=validated["resource_id"],
+            owner_user_id=validated["owner_user_id"],
+            token_id=validated["id"],
+            ip_address=_client_ip(request),
+            user_agent=request.headers.get("user-agent"),
+        )
+        if not ok:
+            raise HTTPException(status_code=403, detail="Invalid password")
+
+    claimed = await svc.claim_token_use(validated["id"])
+    if not claimed:
         raise HTTPException(
-            status_code=403,
-            detail="Password verification required. Call /verify first.",
+            status_code=404,
+            detail="Resource not found",
         )
 
-    # Increment use count
-    await svc.use_token(validated["id"])
-
-    await audit.log(
+    await _audit_log_best_effort(
+        audit,
         "token.used",
         resource_type=validated["resource_type"],
         resource_id=validated["resource_id"],

--- a/tldw_Server_API/app/api/v1/endpoints/workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspaces.py
@@ -77,6 +77,7 @@ from tldw_Server_API.app.core.DB_Management.media_db.errors import DatabaseError
 from tldw_Server_API.app.core.Jobs.manager import JobManager
 from tldw_Server_API.app.core.Sandbox.store import get_store as get_sandbox_store
 from tldw_Server_API.app.core.Sandbox.workspace_volumes import SandboxWorkspaceVolumeService
+from tldw_Server_API.app.core.Sharing.workspace_deletion_hook import on_workspace_deleted
 from tldw_Server_API.app.core.Workspaces.file_inventory_ignore import build_inventory_ignore_policy
 from tldw_Server_API.app.core.Workspaces.file_inventory_jobs import (
     WorkspaceFileInventoryEnqueueError,
@@ -1188,6 +1189,15 @@ async def delete_workspace(
         db.delete_workspace(workspace_id, ws["version"])
     except (ConflictError, InputError, CharactersRAGDBError) as exc:
         raise map_db_error_to_http(exc, default_detail="Failed to delete workspace") from exc
+    try:
+        await on_workspace_deleted(workspace_id, current_user.id)
+    except Exception:
+        logger.warning(
+            "Workspace sharing cleanup hook failed after workspace deletion; "
+            "workspace_id={} owner_user_id={}",
+            workspace_id,
+            current_user.id,
+        )
 
 
 # ── Memberships ─────────────────────────────────────────────────

--- a/tldw_Server_API/app/api/v1/schemas/sharing_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sharing_schemas.py
@@ -133,6 +133,10 @@ class VerifyPasswordRequest(BaseModel):
     password: str = Field(..., min_length=1)
 
 
+class PublicImportRequest(BaseModel):
+    password: str | None = Field(None, min_length=1, max_length=128)
+
+
 class VerifyPasswordResponse(BaseModel):
     verified: bool
     session_token: str | None = None

--- a/tldw_Server_API/app/core/DB_Management/media_db/api.py
+++ b/tldw_Server_API/app/core/DB_Management/media_db/api.py
@@ -615,6 +615,40 @@ def get_unvectorized_chunk_count(
     return reader.get_unvectorized_chunk_count(media_id)
 
 
+def get_unvectorized_max_chunk_index(
+    db: MediaDbLike | MediaDbReadLike,
+    media_id: int,
+) -> int | None:
+    """Return the highest active unvectorized chunk index for a media item."""
+    db_instance = unwrap_media_database_like(db)
+    if is_media_database_like(db_instance):
+        try:
+            media_id_int = int(media_id)
+        except (TypeError, ValueError):
+            return None
+
+        try:
+            cursor = db_instance.execute_query(
+                "SELECT MAX(chunk_index) AS max_chunk_index FROM UnvectorizedMediaChunks "
+                "WHERE media_id = ? AND deleted = 0",
+                (media_id_int,),
+            )
+            row = cursor.fetchone()
+            if not row:
+                return None
+            value = row.get("max_chunk_index") if isinstance(row, dict) else row[0]
+            return int(value) if value is not None else None
+        except Exception as exc:
+            _raise_read_error("get_unvectorized_max_chunk_index", exc)
+
+    reader = _require_read_method(
+        db,
+        "get_unvectorized_max_chunk_index",
+        error_message="db must expose the Media DB read contract.",
+    )
+    return reader.get_unvectorized_max_chunk_index(media_id)
+
+
 def get_unvectorized_anchor_index_for_offset(
     db: MediaDbLike | MediaDbReadLike,
     media_id: int,
@@ -1123,6 +1157,7 @@ __all__ = [
     "get_unvectorized_chunk_count",
     "get_unvectorized_chunk_index_by_uuid",
     "get_unvectorized_chunks_in_range",
+    "get_unvectorized_max_chunk_index",
     "get_paginated_files",
     "get_paginated_trash_files",
     "list_chunking_templates",

--- a/tldw_Server_API/app/core/DB_Management/media_db/media_database_impl.py
+++ b/tldw_Server_API/app/core/DB_Management/media_db/media_database_impl.py
@@ -494,6 +494,7 @@ from tldw_Server_API.app.core.DB_Management.media_db.runtime.unvectorized_chunk_
     get_unvectorized_chunk_count,
     get_unvectorized_chunk_index_by_uuid,
     get_unvectorized_chunks_in_range,
+    get_unvectorized_max_chunk_index,
 )
 
 class MediaDatabase:
@@ -1795,6 +1796,7 @@ MediaDatabase.get_unvectorized_chunk_by_index = get_unvectorized_chunk_by_index
 MediaDatabase.get_unvectorized_chunk_count = get_unvectorized_chunk_count
 MediaDatabase.get_unvectorized_chunk_index_by_uuid = get_unvectorized_chunk_index_by_uuid
 MediaDatabase.get_unvectorized_chunks_in_range = get_unvectorized_chunks_in_range
+MediaDatabase.get_unvectorized_max_chunk_index = get_unvectorized_max_chunk_index
 MediaDatabase._postgres_migrate_to_v5 = run_postgres_migrate_to_v5
 MediaDatabase._postgres_migrate_to_v6 = run_postgres_migrate_to_v6
 MediaDatabase._postgres_migrate_to_v7 = run_postgres_migrate_to_v7

--- a/tldw_Server_API/app/core/DB_Management/media_db/runtime/unvectorized_chunk_reads.py
+++ b/tldw_Server_API/app/core/DB_Management/media_db/runtime/unvectorized_chunk_reads.py
@@ -11,6 +11,10 @@ def get_unvectorized_chunk_count(self, media_id: int) -> int | None:
     return media_db_api.get_unvectorized_chunk_count(self, media_id)
 
 
+def get_unvectorized_max_chunk_index(self, media_id: int) -> int | None:
+    return media_db_api.get_unvectorized_max_chunk_index(self, media_id)
+
+
 def get_unvectorized_anchor_index_for_offset(self, media_id: int, approx_offset: int) -> int | None:
     return media_db_api.get_unvectorized_anchor_index_for_offset(self, media_id, approx_offset)
 
@@ -43,4 +47,5 @@ __all__ = [
     "get_unvectorized_chunk_count",
     "get_unvectorized_chunk_index_by_uuid",
     "get_unvectorized_chunks_in_range",
+    "get_unvectorized_max_chunk_index",
 ]

--- a/tldw_Server_API/app/core/Sharing/clone_service.py
+++ b/tldw_Server_API/app/core/Sharing/clone_service.py
@@ -9,6 +9,9 @@ from loguru import logger
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.media_db.api import (
     get_media_transcripts,
+    get_unvectorized_chunk_count,
+    get_unvectorized_chunks_in_range,
+    get_unvectorized_max_chunk_index,
 )
 from tldw_Server_API.app.core.DB_Management.media_db.legacy_transcripts import (
     upsert_transcript,
@@ -88,6 +91,8 @@ class CloneService:
         # 3. Copy sources
         sources = self._src_chacha.list_workspace_sources(workspace_id)
         total_sources = len(sources)
+        sources_copied = 0
+        sources_failed = 0
         media_id_map: dict[str, str] = {}  # old_media_id -> new_media_id
 
         for i, source in enumerate(sources):
@@ -95,10 +100,11 @@ class CloneService:
             if old_media_id:
                 new_media_id = self._copy_media_item(old_media_id)
                 if new_media_id:
-                    media_id_map[old_media_id] = new_media_id
+                    media_id_map[str(old_media_id)] = new_media_id
                 else:
                     # Media copy failed — skip this source to avoid dangling references
                     logger.warning("Skipping workspace source because media copy failed")
+                    sources_failed += 1
                     if total_sources > 0:
                         _progress("copying_sources", 0.1 + 0.5 * ((i + 1) / total_sources))
                     continue
@@ -106,14 +112,16 @@ class CloneService:
             # Add source to new workspace (use mapped ID, or None for non-media sources)
             source_data = {
                 "id": str(uuid.uuid4()),
-                "media_id": media_id_map.get(old_media_id) if old_media_id else None,
+                "media_id": media_id_map.get(str(old_media_id)) if old_media_id else None,
                 "source_type": source.get("source_type", "media"),
                 "title": source.get("title", ""),
                 "url": source.get("url"),
             }
             try:
                 self._tgt_chacha.add_workspace_source(new_ws_id, source_data)
+                sources_copied += 1
             except Exception as exc:
+                sources_failed += 1
                 logger.warning(
                     f"Failed to copy workspace source; exception_type={_safe_exception_type(exc)}"
                 )
@@ -123,6 +131,8 @@ class CloneService:
 
         # 4. Copy notes
         notes = self._src_chacha.list_workspace_notes(workspace_id)
+        notes_copied = 0
+        notes_failed = 0
         for note in notes:
             note_data = {
                 "title": note.get("title", ""),
@@ -130,7 +140,9 @@ class CloneService:
             }
             try:
                 self._tgt_chacha.add_workspace_note(new_ws_id, note_data)
+                notes_copied += 1
             except Exception as exc:
+                notes_failed += 1
                 logger.warning(
                     f"Failed to copy workspace note; exception_type={_safe_exception_type(exc)}"
                 )
@@ -138,6 +150,8 @@ class CloneService:
 
         # 5. Copy artifacts
         artifacts = self._src_chacha.list_workspace_artifacts(workspace_id)
+        artifacts_copied = 0
+        artifacts_failed = 0
         for artifact in artifacts:
             artifact_data = {
                 "id": str(uuid.uuid4()),
@@ -147,7 +161,9 @@ class CloneService:
             }
             try:
                 self._tgt_chacha.add_workspace_artifact(new_ws_id, artifact_data)
+                artifacts_copied += 1
             except Exception as exc:
+                artifacts_failed += 1
                 logger.warning(
                     f"Failed to copy workspace artifact; exception_type={_safe_exception_type(exc)}"
                 )
@@ -163,11 +179,60 @@ class CloneService:
         return {
             "workspace_id": new_ws_id,
             "name": ws_data["name"],
-            "sources_copied": total_sources,
-            "notes_copied": len(notes),
-            "artifacts_copied": len(artifacts),
+            "sources_copied": sources_copied,
+            "sources_attempted": total_sources,
+            "sources_failed": sources_failed,
+            "notes_copied": notes_copied,
+            "notes_attempted": len(notes),
+            "notes_failed": notes_failed,
+            "artifacts_copied": artifacts_copied,
+            "artifacts_attempted": len(artifacts),
+            "artifacts_failed": artifacts_failed,
             "media_id_map": media_id_map,
         }
+
+    def _copy_unvectorized_chunks(self, source_media_id: int) -> list[dict[str, Any]] | None:
+        """Load chunks from the source media DB in the target insert format."""
+        try:
+            chunk_count = get_unvectorized_chunk_count(self._src_media, source_media_id)
+            if chunk_count is None:
+                return None
+            if chunk_count <= 0:
+                return []
+            max_chunk_index = get_unvectorized_max_chunk_index(self._src_media, source_media_id)
+            if max_chunk_index is None:
+                return []
+
+            rows = get_unvectorized_chunks_in_range(
+                self._src_media,
+                source_media_id,
+                0,
+                max_chunk_index,
+            )
+        except Exception as exc:
+            logger.warning(
+                f"Failed to load media chunks during clone; exception_type={_safe_exception_type(exc)}"
+            )
+            return None
+
+        chunks: list[dict[str, Any]] = []
+        for row in rows:
+            text = row.get("chunk_text")
+            if text is None:
+                continue
+            metadata = {}
+            source_chunk_uuid = row.get("uuid")
+            if source_chunk_uuid:
+                metadata["source_chunk_uuid"] = str(source_chunk_uuid)
+            chunk = {
+                "text": text,
+                "start_char": row.get("start_char"),
+                "end_char": row.get("end_char"),
+                "chunk_type": row.get("chunk_type"),
+                "metadata": metadata,
+            }
+            chunks.append(chunk)
+        return chunks
 
     def _copy_media_item(self, media_id: str) -> str | None:
         """Copy a single media item (with chunks and transcripts) from source to target Media DB."""
@@ -184,9 +249,9 @@ class CloneService:
             else:
                 keywords = list(raw_kw) if raw_kw else []
 
+            chunks = self._copy_unvectorized_chunks(source_media_id)
+
             # Insert media into target; capture actual DB-generated ID
-            # Note: chunks are not separately readable; they'll be re-generated
-            # from content during re-ingestion if needed.
             result = self._tgt_media.add_media_with_keywords(
                 url=media.get("url", ""),
                 title=media.get("title", "Untitled"),
@@ -198,6 +263,7 @@ class CloneService:
                 author=media.get("author", "Unknown"),
                 ingestion_date=media.get("ingestion_date", ""),
                 overwrite=False,
+                chunks=chunks,
             )
             # result is (media_id: int|None, media_uuid: str|None, status_message: str)
             new_media_id = result[0]

--- a/tldw_Server_API/app/core/Sharing/workspace_deletion_hook.py
+++ b/tldw_Server_API/app/core/Sharing/workspace_deletion_hook.py
@@ -24,7 +24,7 @@ async def on_workspace_deleted(workspace_id: str, owner_user_id: int) -> None:
         from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
         from tldw_Server_API.app.core.AuthNZ.repos.shared_workspace_repo import SharedWorkspaceRepo
 
-        pool = get_db_pool()
+        pool = await get_db_pool()
         repo = SharedWorkspaceRepo(db_pool=pool)
 
         # Revoke all workspace shares
@@ -46,4 +46,8 @@ async def on_workspace_deleted(workspace_id: str, owner_user_id: int) -> None:
             metadata={"trigger": "workspace_deletion"},
         )
     except Exception:
-        logger.warning(f"workspace_deletion_hook failed for {workspace_id}")
+        logger.warning(
+            "workspace_deletion_hook failed; workspace_id={} owner_user_id={}",
+            workspace_id,
+            owner_user_id,
+        )

--- a/tldw_Server_API/tests/DB_Management/test_media_db_api_error_contracts.py
+++ b/tldw_Server_API/tests/DB_Management/test_media_db_api_error_contracts.py
@@ -95,6 +95,10 @@ class _RowlessLegacyDb(_BrokenLegacyDb):
             "get_unvectorized_chunks_in_range",
             lambda db: media_db_api.get_unvectorized_chunks_in_range(db, 1, 0, 1),
         ),
+        (
+            "get_unvectorized_max_chunk_index",
+            lambda db: media_db_api.get_unvectorized_max_chunk_index(db, 1),
+        ),
         ("lookup_section_for_offset", lambda db: media_db_api.lookup_section_for_offset(db, 1, 10)),
         ("lookup_section_by_heading", lambda db: media_db_api.lookup_section_by_heading(db, 1, "intro")),
     ],

--- a/tldw_Server_API/tests/DB_Management/test_media_db_api_imports.py
+++ b/tldw_Server_API/tests/DB_Management/test_media_db_api_imports.py
@@ -278,6 +278,7 @@ def test_media_db_api_exposes_read_contract_functions() -> None:
     assert callable(getattr(media_db_api, "get_unvectorized_chunk_index_by_uuid", None))
     assert callable(getattr(media_db_api, "get_unvectorized_chunk_by_index", None))
     assert callable(getattr(media_db_api, "get_unvectorized_chunks_in_range", None))
+    assert callable(getattr(media_db_api, "get_unvectorized_max_chunk_index", None))
     assert callable(getattr(media_db_api, "search_media", None))
     assert callable(getattr(media_db_api, "list_document_versions", None))
     assert callable(getattr(media_db_api, "soft_delete_document_version", None))
@@ -295,6 +296,16 @@ def test_media_db_api_get_unvectorized_chunk_count_accepts_lightweight_read_doub
     result = media_db_api.get_unvectorized_chunk_count(StubReader(), 9)
 
     assert result == 10
+
+
+def test_media_db_api_get_unvectorized_max_chunk_index_accepts_lightweight_read_double() -> None:
+    class StubReader:
+        def get_unvectorized_max_chunk_index(self, media_id: int):
+            return media_id + 3
+
+    result = media_db_api.get_unvectorized_max_chunk_index(StubReader(), 9)
+
+    assert result == 12
 
 
 def test_media_db_api_has_unvectorized_chunks_accepts_lightweight_read_double() -> None:

--- a/tldw_Server_API/tests/MediaDB2/test_unvectorized_chunk_count.py
+++ b/tldw_Server_API/tests/MediaDB2/test_unvectorized_chunk_count.py
@@ -9,6 +9,7 @@ pytestmark = pytest.mark.unit
 def test_get_unvectorized_chunk_count_invalid_media_id_returns_none(memory_db_factory) -> None:
     db = memory_db_factory("chunk_count_invalid")
     assert db.get_unvectorized_chunk_count("not-an-int") is None
+    assert db.get_unvectorized_max_chunk_index("not-an-int") is None
 
 
 def test_get_unvectorized_chunk_count_returns_zero_for_media_without_chunks(memory_db_factory) -> None:
@@ -22,6 +23,7 @@ def test_get_unvectorized_chunk_count_returns_zero_for_media_without_chunks(memo
     )
     assert media_id is not None
     assert db.get_unvectorized_chunk_count(media_id) == 0
+    assert db.get_unvectorized_max_chunk_index(media_id) is None
 
 
 def test_get_unvectorized_chunk_count_returns_active_chunk_rows(memory_db_factory) -> None:
@@ -40,3 +42,35 @@ def test_get_unvectorized_chunk_count_returns_active_chunk_rows(memory_db_factor
     )
     assert media_id is not None
     assert db.get_unvectorized_chunk_count(media_id) == 2
+    assert db.get_unvectorized_max_chunk_index(media_id) == 1
+
+
+def test_get_unvectorized_max_chunk_index_returns_sparse_highest_active_index(
+    memory_db_factory,
+) -> None:
+    db = memory_db_factory("chunk_max_sparse")
+    chunks = [
+        {"text": "chunk zero", "start_char": 0, "end_char": 9, "chunk_type": "text"},
+        {"text": "chunk one", "start_char": 10, "end_char": 19, "chunk_type": "text"},
+        {"text": "chunk two", "start_char": 20, "end_char": 29, "chunk_type": "text"},
+    ]
+    media_id, _uuid, _msg = db.add_media_with_keywords(
+        url="https://example.com/sparse-chunks",
+        title="Sparse chunks",
+        media_type="document",
+        content="chunk zero chunk one chunk two",
+        overwrite=True,
+        chunks=chunks,
+    )
+    assert media_id is not None
+
+    db.execute_query(
+        "UPDATE UnvectorizedMediaChunks "
+        "SET deleted = 1, version = version + 1, client_id = ? "
+        "WHERE media_id = ? AND chunk_index = ?",
+        ("chunk_max_sparse", media_id, 1),
+        commit=True,
+    )
+
+    assert db.get_unvectorized_chunk_count(media_id) == 2
+    assert db.get_unvectorized_max_chunk_index(media_id) == 2

--- a/tldw_Server_API/tests/Sharing/test_clone_service.py
+++ b/tldw_Server_API/tests/Sharing/test_clone_service.py
@@ -152,6 +152,147 @@ def test_copy_media_passes_keywords_as_list():
     assert set(keywords_val) == {"alpha", "beta", "gamma"}
 
 
+def test_copy_media_deep_copies_unvectorized_chunks():
+    media_row = {
+        "url": "",
+        "title": "T",
+        "type": "text",
+        "content": "first second",
+        "keywords": "",
+        "prompt": "",
+        "transcription_model": "",
+        "author": "",
+        "ingestion_date": "",
+    }
+    svc, _, _, _, tgt_media = _make_service(
+        src_media_items=media_row,
+        add_result=(1, "u1", "ok"),
+    )
+    source_chunks = [
+        {
+            "chunk_text": "first",
+            "start_char": 0,
+            "end_char": 5,
+            "chunk_type": "text",
+            "uuid": "src-chunk-1",
+        },
+        {
+            "chunk_text": "second",
+            "start_char": 6,
+            "end_char": 12,
+            "chunk_type": "text",
+            "uuid": "src-chunk-2",
+        },
+    ]
+
+    with (
+        patch(
+            "tldw_Server_API.app.core.Sharing.clone_service.get_unvectorized_chunk_count",
+            return_value=2,
+            create=True,
+        ),
+        patch(
+            "tldw_Server_API.app.core.Sharing.clone_service.get_unvectorized_max_chunk_index",
+            return_value=1,
+            create=True,
+        ),
+        patch(
+            "tldw_Server_API.app.core.Sharing.clone_service.get_unvectorized_chunks_in_range",
+            return_value=source_chunks,
+            create=True,
+        ),
+        patch(
+            "tldw_Server_API.app.core.Sharing.clone_service.get_media_transcripts",
+            return_value=[],
+        ),
+    ):
+        new_id = svc._copy_media_item("10")
+
+    assert new_id == "1"
+    call_kwargs = tgt_media.add_media_with_keywords.call_args.kwargs
+    assert call_kwargs["chunks"] == [
+        {
+            "text": "first",
+            "start_char": 0,
+            "end_char": 5,
+            "chunk_type": "text",
+            "metadata": {"source_chunk_uuid": "src-chunk-1"},
+        },
+        {
+            "text": "second",
+            "start_char": 6,
+            "end_char": 12,
+            "chunk_type": "text",
+            "metadata": {"source_chunk_uuid": "src-chunk-2"},
+        },
+    ]
+
+
+def test_copy_media_uses_max_chunk_index_for_sparse_unvectorized_chunks():
+    media_row = {
+        "url": "",
+        "title": "T",
+        "type": "text",
+        "content": "first third",
+        "keywords": "",
+        "prompt": "",
+        "transcription_model": "",
+        "author": "",
+        "ingestion_date": "",
+    }
+    svc, _, _, _, tgt_media = _make_service(
+        src_media_items=media_row,
+        add_result=(1, "u1", "ok"),
+    )
+    source_chunks = [
+        {
+            "chunk_text": "first",
+            "start_char": 0,
+            "end_char": 5,
+            "chunk_type": "text",
+            "uuid": "src-chunk-1",
+        },
+        {
+            "chunk_text": "third",
+            "start_char": 12,
+            "end_char": 17,
+            "chunk_type": "text",
+            "uuid": "src-chunk-3",
+        },
+    ]
+    max_index = MagicMock(return_value=2)
+    range_reader = MagicMock(return_value=source_chunks)
+
+    with (
+        patch(
+            "tldw_Server_API.app.core.Sharing.clone_service.get_unvectorized_chunk_count",
+            return_value=2,
+            create=True,
+        ),
+        patch(
+            "tldw_Server_API.app.core.Sharing.clone_service.get_unvectorized_max_chunk_index",
+            max_index,
+            create=True,
+        ),
+        patch(
+            "tldw_Server_API.app.core.Sharing.clone_service.get_unvectorized_chunks_in_range",
+            range_reader,
+            create=True,
+        ),
+        patch(
+            "tldw_Server_API.app.core.Sharing.clone_service.get_media_transcripts",
+            return_value=[],
+        ),
+    ):
+        new_id = svc._copy_media_item("10")
+
+    assert new_id == "1"
+    max_index.assert_called_once_with(svc._src_media, 10)
+    range_reader.assert_called_once_with(svc._src_media, 10, 0, 2)
+    call_kwargs = tgt_media.add_media_with_keywords.call_args.kwargs
+    assert [chunk["text"] for chunk in call_kwargs["chunks"]] == ["first", "third"]
+
+
 def test_copy_media_deep_copies_transcripts():
     media_row = {
         "url": "",
@@ -277,7 +418,9 @@ def test_clone_skipped_source_log_is_sanitized_when_media_copy_fails():
         result = svc.clone_workspace("ws-1")
 
     logged_text = _logged_text(fake_logger)
-    assert result["sources_copied"] == 1
+    assert result["sources_attempted"] == 1
+    assert result["sources_copied"] == 0
+    assert result["sources_failed"] == 1
     assert result["media_id_map"] == {}
     tgt_chacha.add_workspace_source.assert_not_called()
     assert "Skipping workspace source because media copy failed" in logged_text
@@ -303,7 +446,9 @@ def test_clone_source_failure_log_is_sanitized():
         result = svc.clone_workspace("ws-1")
 
     logged_text = _logged_text(fake_logger)
-    assert result["sources_copied"] == 1
+    assert result["sources_attempted"] == 1
+    assert result["sources_copied"] == 0
+    assert result["sources_failed"] == 1
     assert "Failed to copy workspace source; exception_type=RuntimeError" in logged_text
     _assert_sensitive_markers_absent(logged_text)
 
@@ -320,7 +465,9 @@ def test_clone_note_failure_log_is_sanitized():
         result = svc.clone_workspace("ws-1")
 
     logged_text = _logged_text(fake_logger)
-    assert result["notes_copied"] == 1
+    assert result["notes_attempted"] == 1
+    assert result["notes_copied"] == 0
+    assert result["notes_failed"] == 1
     assert "Failed to copy workspace note; exception_type=ValueError" in logged_text
     _assert_sensitive_markers_absent(logged_text)
 
@@ -337,7 +484,9 @@ def test_clone_artifact_failure_log_is_sanitized():
         result = svc.clone_workspace("ws-1")
 
     logged_text = _logged_text(fake_logger)
-    assert result["artifacts_copied"] == 1
+    assert result["artifacts_attempted"] == 1
+    assert result["artifacts_copied"] == 0
+    assert result["artifacts_failed"] == 1
     assert "Failed to copy workspace artifact; exception_type=PermissionError" in logged_text
     _assert_sensitive_markers_absent(logged_text)
 
@@ -525,7 +674,9 @@ def test_clone_skips_source_when_media_copy_fails():
     ):
         result = svc.clone_workspace("ws-1")
 
-    assert result["sources_copied"] == 1
+    assert result["sources_attempted"] == 1
+    assert result["sources_copied"] == 0
+    assert result["sources_failed"] == 1
     # add_workspace_source should NOT have been called since the media copy failed
     tgt_chacha.add_workspace_source.assert_not_called()
 

--- a/tldw_Server_API/tests/Sharing/test_sharing_endpoints.py
+++ b/tldw_Server_API/tests/Sharing/test_sharing_endpoints.py
@@ -137,6 +137,48 @@ async def test_shared_with_me_workspace_name_preload_log_is_sanitized(
 
 
 @pytest.mark.asyncio
+async def test_verify_chatbook_ownership_uses_storage_user_id_for_numeric_users(monkeypatch):
+    from tldw_Server_API.app.api.v1.API_Deps import ChaCha_Notes_DB_Deps as chacha_deps
+    from tldw_Server_API.app.api.v1.endpoints import sharing
+
+    fake_db = object()
+    captured: dict[str, object] = {}
+
+    async def _get_chacha_db_for_user_id(user_id: int):
+        captured["db_user_id"] = user_id
+        return fake_db
+
+    def _owned_sync(
+        *,
+        normalized_id: str,
+        user_id: int | str,
+        user_id_int: int | None,
+        db: object | None,
+    ) -> bool:
+        captured["normalized_id"] = normalized_id
+        captured["helper_user_id"] = user_id
+        captured["helper_user_id_int"] = user_id_int
+        captured["helper_db"] = db
+        return True
+
+    monkeypatch.setattr(chacha_deps, "get_chacha_db_for_user_id", _get_chacha_db_for_user_id)
+    monkeypatch.setattr(sharing, "_chatbook_ownership_exists_sync", _owned_sync)
+
+    await sharing._verify_chatbook_ownership(
+        "export-123",
+        SimpleNamespace(id="1", id_int=1),
+    )
+
+    assert captured == {
+        "db_user_id": 1,
+        "normalized_id": "export-123",
+        "helper_user_id": 1,
+        "helper_user_id_int": 1,
+        "helper_db": fake_db,
+    }
+
+
+@pytest.mark.asyncio
 async def test_shared_with_me_workspace_name_resolution_log_is_sanitized(
     repo,
     test_user,
@@ -407,6 +449,32 @@ class TestWorkspaceSharing:
         assert data["workspace_id"] == "ws-1"
         assert data["access_level"] == "view_chat"
 
+    def test_share_workspace_succeeds_when_audit_write_fails(
+        self,
+        client,
+        mock_repo,
+        monkeypatch,
+    ):
+        class _FailingAuditService:
+            async def log(self, *args, **kwargs):
+                raise RuntimeError("audit backend unavailable")
+
+        monkeypatch.setattr(
+            sharing_endpoints,
+            "_get_audit_service",
+            lambda: _FailingAuditService(),
+        )
+
+        resp = client.post("/api/v1/sharing/workspaces/ws-audit/share", json={
+            "share_scope_type": "team",
+            "share_scope_id": 10,
+            "access_level": "view_chat",
+            "allow_clone": True,
+        })
+
+        assert resp.status_code == 200
+        assert resp.json()["workspace_id"] == "ws-audit"
+
     def test_share_workspace_duplicate(self, client, mock_repo):
         client.post("/api/v1/sharing/workspaces/ws-dup/share", json={
             "share_scope_type": "team",
@@ -610,6 +678,57 @@ class TestShareTokens:
         assert "raw_token" in data
         assert data["resource_type"] == "workspace"
 
+    def test_create_workspace_token_requires_owned_workspace(
+        self,
+        client,
+        mock_repo,
+        monkeypatch,
+    ):
+        calls: list[tuple[str, int]] = []
+
+        async def _record_workspace_ownership(workspace_id: str, user: User):
+            calls.append((workspace_id, user.id))
+
+        monkeypatch.setattr(
+            sharing_endpoints,
+            "_verify_workspace_ownership",
+            _record_workspace_ownership,
+        )
+
+        resp = client.post("/api/v1/sharing/tokens", json={
+            "resource_type": "workspace",
+            "resource_id": "ws-owned",
+        })
+
+        assert resp.status_code == 200
+        assert calls == [("ws-owned", 1)]
+
+    def test_create_chatbook_token_requires_owned_chatbook(
+        self,
+        client,
+        mock_repo,
+        monkeypatch,
+    ):
+        calls: list[tuple[str, int]] = []
+
+        async def _record_chatbook_ownership(chatbook_id: str, user: User):
+            calls.append((chatbook_id, user.id))
+
+        monkeypatch.setattr(
+            sharing_endpoints,
+            "_verify_chatbook_ownership",
+            _record_chatbook_ownership,
+            raising=False,
+        )
+
+        resp = client.post("/api/v1/sharing/tokens", json={
+            "resource_type": "chatbook",
+            "resource_id": "chatbook-1",
+        })
+
+        assert resp.status_code == 200
+        assert calls == [("chatbook-1", 1)]
+
     def test_create_prototype_workspace_token(self, client, mock_repo):
         resp = client.post("/api/v1/sharing/tokens", json={
             "resource_type": "prototype_workspace",
@@ -730,6 +849,16 @@ class TestPublicEndpoints:
         assert resp.status_code == 200
         assert resp.json()["resource_id"] == "ws-1"
 
+    def test_public_import_accepts_empty_json_for_unprotected_token(self, client, mock_repo):
+        create = client.post("/api/v1/sharing/tokens", json={
+            "resource_type": "workspace",
+            "resource_id": "ws-empty-json",
+        })
+        raw_token = create.json()["raw_token"]
+        resp = client.post(f"/api/v1/sharing/public/{raw_token}/import", json={})
+        assert resp.status_code == 200
+        assert resp.json()["resource_id"] == "ws-empty-json"
+
     def test_public_import_blocked_when_password_protected(self, client, mock_repo):
         """Password-protected tokens cannot be imported without verification."""
         create = client.post("/api/v1/sharing/tokens", json={
@@ -741,6 +870,42 @@ class TestPublicEndpoints:
         resp = client.post(f"/api/v1/sharing/public/{raw_token}/import")
         assert resp.status_code == 403
         assert "Password verification required" in resp.json()["detail"]
+
+    def test_public_import_accepts_password_for_protected_token(self, client, mock_repo):
+        create = client.post("/api/v1/sharing/tokens", json={
+            "resource_type": "workspace",
+            "resource_id": "ws-pw-ok",
+            "password": "secret123",
+        })
+        raw_token = create.json()["raw_token"]
+        resp = client.post(
+            f"/api/v1/sharing/public/{raw_token}/import",
+            json={"password": "secret123"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["resource_id"] == "ws-pw-ok"
+
+    def test_public_import_uses_atomic_claim_for_use_limit(
+        self,
+        client,
+        mock_repo,
+        monkeypatch,
+    ):
+        create = client.post("/api/v1/sharing/tokens", json={
+            "resource_type": "workspace",
+            "resource_id": "ws-limit",
+            "max_uses": 1,
+        })
+        raw_token = create.json()["raw_token"]
+
+        async def _claim_lost_race(token_id: int) -> bool:
+            return False
+
+        monkeypatch.setattr(mock_repo, "claim_token_use", _claim_lost_race)
+
+        resp = client.post(f"/api/v1/sharing/public/{raw_token}/import")
+
+        assert resp.status_code == 404
 
     def test_public_import_rejects_prototype_workspace_token(self, client, mock_repo):
         create = client.post("/api/v1/sharing/tokens", json={

--- a/tldw_Server_API/tests/Sharing/test_workspace_deletion_hook.py
+++ b/tldw_Server_API/tests/Sharing/test_workspace_deletion_hook.py
@@ -1,7 +1,7 @@
 """Tests for workspace deletion hook."""
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -55,6 +55,58 @@ async def test_on_workspace_deleted_hook_swallows_errors():
 
 
 @pytest.mark.asyncio
+async def test_on_workspace_deleted_hook_awaits_pool_and_revokes_resources():
+    from tldw_Server_API.app.core.Sharing import workspace_deletion_hook
+
+    calls: list[tuple[str, str, int]] = []
+
+    class _FakeRepo:
+        async def revoke_shares_for_workspace(self, workspace_id: str, owner_user_id: int):
+            calls.append(("shares", workspace_id, owner_user_id))
+
+        async def revoke_tokens_for_resource(
+            self,
+            resource_type: str,
+            resource_id: str,
+            owner_user_id: int,
+        ):
+            calls.append((f"tokens:{resource_type}", resource_id, owner_user_id))
+
+    class _FakeAudit:
+        def __init__(self, repo):
+            self.repo = repo
+
+        async def log(self, *args, **kwargs):
+            calls.append(("audit", kwargs["resource_id"], kwargs["owner_user_id"]))
+
+    fake_pool = object()
+    get_pool = AsyncMock(return_value=fake_pool)
+    fake_repo = _FakeRepo()
+    repo_factory = MagicMock(return_value=fake_repo)
+
+    with (
+        patch("tldw_Server_API.app.core.AuthNZ.database.get_db_pool", get_pool),
+        patch(
+            "tldw_Server_API.app.core.AuthNZ.repos.shared_workspace_repo.SharedWorkspaceRepo",
+            repo_factory,
+        ),
+        patch(
+            "tldw_Server_API.app.core.Sharing.share_audit_service.ShareAuditService",
+            _FakeAudit,
+        ),
+    ):
+        await workspace_deletion_hook.on_workspace_deleted("ws-del", 1)
+
+    get_pool.assert_awaited_once_with()
+    repo_factory.assert_called_once_with(db_pool=fake_pool)
+    assert calls == [
+        ("shares", "ws-del", 1),
+        ("tokens:workspace", "ws-del", 1),
+        ("audit", "ws-del", 1),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_on_workspace_deleted_hook_failure_log_is_sanitized():
     """Fail-open hook logs should not expose backend exception details."""
     from tldw_Server_API.app.core.Sharing import workspace_deletion_hook
@@ -82,6 +134,10 @@ async def test_on_workspace_deleted_hook_failure_log_is_sanitized():
         for part in call.args
     )
     assert "workspace_deletion_hook failed" in logged_text
+    assert "workspace_id" in logged_text
+    assert "ws-missing" in logged_text
+    assert "owner_user_id" in logged_text
+    assert "999" in logged_text
     assert "sqlite://" not in logged_text
     assert "/tmp/private/users.db" not in logged_text
     assert "supersecret" not in logged_text

--- a/tldw_Server_API/tests/Workspaces/test_workspaces_api.py
+++ b/tldw_Server_API/tests/Workspaces/test_workspaces_api.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi import FastAPI
@@ -369,6 +370,79 @@ def test_workspace_api_accepts_and_returns_study_materials_policy(workspace_fast
         workspace_fastapi_app.dependency_overrides.pop(get_chacha_db_for_user, None)
         workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_READ_RATE_LIMIT, None)
         workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_WRITE_RATE_LIMIT, None)
+
+
+@pytest.mark.integration
+def test_delete_workspace_invokes_sharing_cleanup_hook(
+    workspace_fastapi_app,
+    db,
+    monkeypatch,
+):
+    async def _allow_rate_limit() -> None:
+        return None
+
+    cleanup_calls: list[tuple[str, int]] = []
+
+    async def _record_cleanup(workspace_id: str, owner_user_id: int) -> None:
+        cleanup_calls.append((workspace_id, owner_user_id))
+
+    db.upsert_workspace("ws-delete-hook", "Delete Hook")
+    workspace_fastapi_app.dependency_overrides[get_request_user] = lambda: SimpleNamespace(id=1)
+    workspace_fastapi_app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    workspace_fastapi_app.dependency_overrides[WORKSPACES_DELETE_RATE_LIMIT] = _allow_rate_limit
+    monkeypatch.setattr(
+        workspaces_endpoint,
+        "on_workspace_deleted",
+        _record_cleanup,
+        raising=False,
+    )
+    try:
+        with TestClient(workspace_fastapi_app, raise_server_exceptions=False) as client:
+            response = client.delete("/api/v1/workspaces/ws-delete-hook")
+    finally:
+        workspace_fastapi_app.dependency_overrides.pop(get_request_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(get_chacha_db_for_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_DELETE_RATE_LIMIT, None)
+
+    assert response.status_code == 204, response.text
+    assert cleanup_calls == [("ws-delete-hook", 1)]
+
+
+@pytest.mark.integration
+def test_delete_workspace_cleanup_failure_log_includes_context(
+    workspace_fastapi_app,
+    db,
+    monkeypatch,
+):
+    async def _allow_rate_limit() -> None:
+        return None
+
+    async def _fail_cleanup(workspace_id: str, owner_user_id: int) -> None:
+        raise RuntimeError("cleanup backend unavailable")
+
+    fake_logger = MagicMock()
+    db.upsert_workspace("ws-delete-log", "Delete Log")
+    workspace_fastapi_app.dependency_overrides[get_request_user] = lambda: SimpleNamespace(id=1)
+    workspace_fastapi_app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    workspace_fastapi_app.dependency_overrides[WORKSPACES_DELETE_RATE_LIMIT] = _allow_rate_limit
+    monkeypatch.setattr(workspaces_endpoint, "on_workspace_deleted", _fail_cleanup)
+    monkeypatch.setattr(workspaces_endpoint, "logger", fake_logger)
+    try:
+        with TestClient(workspace_fastapi_app, raise_server_exceptions=False) as client:
+            response = client.delete("/api/v1/workspaces/ws-delete-log")
+    finally:
+        workspace_fastapi_app.dependency_overrides.pop(get_request_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(get_chacha_db_for_user, None)
+        workspace_fastapi_app.dependency_overrides.pop(WORKSPACES_DELETE_RATE_LIMIT, None)
+
+    assert response.status_code == 204, response.text
+    fake_logger.warning.assert_called_once()
+    assert fake_logger.warning.call_args.args == (
+        "Workspace sharing cleanup hook failed after workspace deletion; "
+        "workspace_id={} owner_user_id={}",
+        "ws-delete-log",
+        1,
+    )
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Summary: Harden Sharing token creation/import paths, workspace deletion cleanup, clone chunk/count behavior, audit failure handling, and review follow-ups. Latest review follow-up: rebased on latest dev and addressed CodeRabbit comments by formatting the implementation plan for markdownlint, using the resolved storage user id for chatbook ownership checks, moving contextual workspace cleanup failure logging into the hook, and copying sparse unvectorized chunks through a Media DB max-index helper. Verification: after final rebase onto origin/dev, compileall passed, combined Sharing/workspace/DB regression set passed (172 tests), Bandit touched-scope scan reported 0 findings, and git diff --check passed. Note: markdownlint-cli2 is not installed locally, so exact markdownlint execution could not be run; the plan file was updated to the requested H1/blank-line structure. Change summary note: this PR was prepared by Codex; the project merge gate still requires a human-authored Change summary explaining what changed and why before merge.