### PR TITLE
Harden WebClipper review findings

### DIFF
--- a/IMPLEMENTATION_PLAN_webclipper_review_hardening_10006.md
+++ b/IMPLEMENTATION_PLAN_webclipper_review_hardening_10006.md
@@ -1,0 +1,17 @@
+## Stage 1: Regression Coverage
+**Goal**: Add focused failing tests for the reviewed WebClipper defects.
+**Success Criteria**: Tests cover existing-note collision rejection, active attachment rejection, backend-safe lookup behavior, and payload bounds.
+**Tests**: Focused `test_web_clipper_service.py` and schema/API coverage where appropriate.
+**Status**: Complete
+
+## Stage 2: Service and Schema Hardening
+**Goal**: Implement the minimal changes needed to satisfy the regression tests.
+**Success Criteria**: WebClipper rejects unsafe note claims and unsafe attachments, enforces bounded payloads, and avoids SQLite-only deleted predicates.
+**Tests**: Focused WebClipper unit/API tests pass.
+**Status**: Complete
+
+## Stage 3: Verification and Closeout
+**Goal**: Verify the touched scope and update tracking.
+**Success Criteria**: Focused tests pass, Bandit reports no new touched-scope findings, diff hygiene passes, and TASK-10006 records outcomes.
+**Tests**: `python -m pytest` on focused WebClipper tests; `python -m bandit` on touched WebClipper/schema files; `git diff --check`.
+**Status**: Complete

--- a/backlog/tasks/task-10006 - Harden-WebClipper-core-review-findings.md
+++ b/backlog/tasks/task-10006 - Harden-WebClipper-core-review-findings.md
@@ -1,0 +1,83 @@
+---
+id: TASK-10006
+title: Harden WebClipper core review findings
+status: Done
+assignee: []
+created_date: '2026-06-23'
+updated_date: '2026-06-23'
+labels:
+  - web-clipper
+  - security
+  - backend
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the current-code WebClipper core review findings: prevent client `clip_id` collisions from claiming existing notes, harden clipper-created attachment safety, make core note lookups backend-safe, add practical request payload bounds, and reduce the most direct API/core coupling where it can be done without broad refactoring.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Existing non-clip notes cannot be overwritten through WebClipper `clip_id` collisions.
+- [x] #2 Clipper attachments cannot persist active HTML/SVG content that is later served inline.
+- [x] #3 WebClipper note and workspace-note lookups use backend-safe deleted predicates.
+- [x] #4 Clipper request payloads have practical body, metadata, keyword, and attachment bounds.
+- [x] #5 Focused WebClipper tests and Bandit on touched Python scope are run, or blockers are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Plan file: `IMPLEMENTATION_PLAN_webclipper_review_hardening_10006.md`
+
+Initial scope:
+1. Add failing regression tests for the review findings.
+2. Update WebClipper schema and service helpers for note-claim, attachment, payload, and backend-safety behavior.
+3. Run focused tests, Bandit, and diff hygiene; record results here.
+
+Backlog MCP was unavailable in this session and `backlog task create` hung without output twice, so this task file was created manually after user approval.
+
+Implemented:
+- Moved WebClipper schema definitions into `tldw_Server_API.app.core.WebClipper.schemas` and kept the API schema module as a compatibility re-export.
+- Added schema bounds for clip IDs, titles, URLs, body fields, keywords, attachment counts/content, capture metadata JSON, and enrichment payloads.
+- Rejected client saves that try to claim an existing note without an existing WebClipper sidecar.
+- Removed active HTML/SVG attachment support and blocked `.htm`, `.html`, and `.svg` clipper attachment filenames.
+- Replaced SQLite-only WebClipper note/workspace-note deleted predicates with backend-native deleted values.
+
+Verification:
+- RED: focused new WebClipper regression selection failed with 7 failures before implementation.
+- GREEN: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Notes_NEW/unit/test_web_clipper_service.py tldw_Server_API/tests/Notes_NEW/unit/test_web_clipper_endpoint_error_mapping.py tldw_Server_API/tests/Notes_NEW/integration/test_web_clipper_api.py tldw_Server_API/tests/ChaChaNotesDB/test_web_clipper_db.py -q` -> 56 passed, 125 warnings.
+- Black: `python -m black --check` on touched Python files -> 4 files unchanged.
+- Bandit: `/tmp/bandit_webclipper_10006.json` -> 0 results, 0 errors, 0 skipped.
+- Diff hygiene: `git diff --check` on touched scope -> passed.
+- Clean worktree PR verification on `codex/webclipper-review-hardening-10006`: focused WebClipper suite -> 56 passed, 124 warnings; Black -> 4 files unchanged; Bandit `/tmp/bandit_webclipper_10006_worktree.json` -> 0 results, 0 errors, 0 skipped; `git diff --check` and `git diff --cached --check` passed.
+- PR review follow-up:
+  - Rebased the branch onto latest `origin/dev`.
+  - Moved clipper sidecar lookup into the `save_clip()` transaction before collision decisions.
+  - Enforced the capture metadata JSON bound after service-level metadata merge.
+  - Removed manual SQL preparation from `_fetch_note_row()` so backend-aware transaction wrappers prepare once.
+  - Replaced the private-helper test with public `save_clip()` regression coverage for stale pre-transaction sidecar state and merged metadata bounds.
+  - Focused service unit run after the follow-up: `python -m pytest tldw_Server_API/tests/Notes_NEW/unit/test_web_clipper_service.py -q` -> 25 passed, 57 warnings.
+  - Final post-format focused WebClipper suite: `python -m pytest tldw_Server_API/tests/Notes_NEW/unit/test_web_clipper_service.py tldw_Server_API/tests/Notes_NEW/unit/test_web_clipper_endpoint_error_mapping.py tldw_Server_API/tests/Notes_NEW/integration/test_web_clipper_api.py tldw_Server_API/tests/ChaChaNotesDB/test_web_clipper_db.py -q` -> 57 passed, 123 warnings.
+  - Final Black check on touched Python files -> 4 files unchanged.
+  - Final Bandit report `/tmp/bandit_webclipper_2496_final.json` -> 0 results, 0 errors, 0 skipped.
+  - Final diff hygiene: `git diff --check` and `git diff --check origin/dev...HEAD` passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened WebClipper save/enrichment contracts against the reviewed collision, attachment, backend portability, payload-boundary, and core/API coupling findings. Focused WebClipper service/API/DB verification passed, Bandit reported zero findings on touched source, and diff hygiene passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/schemas/web_clipper_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/web_clipper_schemas.py
@@ -1,201 +1,35 @@
-"""Schemas for the browser extension web clipper."""
+"""API aliases for browser extension web clipper schemas."""
 
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Any, Literal
+from tldw_Server_API.app.core.WebClipper.schemas import (
+    WebClipperAttachmentRecord,
+    WebClipperDestination,
+    WebClipperEnrichmentPayload,
+    WebClipperEnrichmentResponse,
+    WebClipperEnrichmentStatus,
+    WebClipperEnrichmentType,
+    WebClipperOutcomeState,
+    WebClipperSaveRequest,
+    WebClipperSaveResponse,
+    WebClipperSaveResult,
+    WebClipperSavedNote,
+    WebClipperStatusResponse,
+    WebClipperWorkspacePlacement,
+)
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
-
-WebClipperDestination = Literal["note", "workspace", "both"]
-WebClipperOutcomeState = Literal["saved", "saved_with_warnings", "partially_saved", "failed"]
-WebClipperEnrichmentStatus = Literal["pending", "running", "complete", "failed"]
-WebClipperEnrichmentType = Literal["ocr", "vlm"]
-
-
-class WebClipperSaveRequest(BaseModel):
-    """Typed save request for a browser clip."""
-
-    class NotePayload(BaseModel):
-        title: str | None = Field(default=None, min_length=1, description="Optional user-edited note title.")
-        comment: str | None = Field(default=None, description="Optional user comment for the saved note.")
-        folder_id: int | None = Field(default=None, ge=1, description="Optional note folder destination.")
-        keywords: list[str] = Field(default_factory=list, description="Optional filing keywords for the note.")
-
-        model_config = ConfigDict(extra="forbid")
-
-    class WorkspacePayload(BaseModel):
-        workspace_id: str = Field(..., min_length=1, description="Workspace destination identifier.")
-
-        model_config = ConfigDict(extra="forbid")
-
-    class ContentPayload(BaseModel):
-        visible_body: str | None = Field(default=None, description="Primary visible clip body for the saved note.")
-        full_extract: str | None = Field(default=None, description="Full extracted page/article text.")
-        selected_text: str | None = Field(default=None, description="Explicit user-selected text, when available.")
-
-        model_config = ConfigDict(extra="forbid")
-
-    class AttachmentPayload(BaseModel):
-        slot: str = Field(..., min_length=1, description="Deterministic attachment slot name.")
-        file_name: str | None = Field(default=None, min_length=1, description="Original file name supplied by the client.")
-        media_type: str = Field(..., min_length=1, description="Attachment media type.")
-        text_content: str | None = Field(default=None, description="UTF-8 text content for small text attachments.")
-        content_base64: str | None = Field(default=None, description="Base64-encoded attachment bytes.")
-        source_url: str | None = Field(default=None, description="Optional source URL for the captured asset.")
-
-        model_config = ConfigDict(extra="forbid")
-
-    class EnhancementOptions(BaseModel):
-        run_ocr: bool = Field(default=False, description="Whether OCR should run after save.")
-        run_vlm: bool = Field(default=False, description="Whether VLM analysis should run after save.")
-
-        model_config = ConfigDict(extra="forbid")
-
-    clip_id: str = Field(..., min_length=1, description="Client idempotency key for the clip save.")
-    clip_type: str = Field(..., min_length=1, description="Clip type chosen by the user.")
-    source_url: str = Field(..., min_length=1, description="Source URL for the clip.")
-    source_title: str = Field(..., min_length=1, description="Source page title.")
-    destination_mode: WebClipperDestination = Field(default="note", description="Visible destination choice.")
-    note: NotePayload = Field(default_factory=NotePayload, description="Note filing and visible-body options.")
-    workspace: WorkspacePayload | None = Field(
-        default=None,
-        description="Workspace placement target when destination_mode includes a workspace.",
-    )
-    content: ContentPayload = Field(default_factory=ContentPayload, description="Structured extracted content payload.")
-    attachments: list[AttachmentPayload] = Field(
-        default_factory=list,
-        description="Structured attachment inputs for deterministic slot persistence.",
-    )
-    enhancements: EnhancementOptions = Field(
-        default_factory=EnhancementOptions,
-        description="Requested OCR/VLM follow-up actions.",
-    )
-    capture_metadata: dict[str, Any] = Field(
-        default_factory=dict,
-        description="Structured capture metadata and fallback information.",
-    )
-    source_note_version: int | None = Field(
-        default=None,
-        ge=1,
-        description="Optional source note version for idempotent follow-up stages.",
-    )
-
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
-
-    @model_validator(mode="after")
-    def validate_workspace_destination(self) -> "WebClipperSaveRequest":
-        if self.destination_mode in {"workspace", "both"} and self.workspace is None:
-            raise ValueError("workspace is required when destination_mode targets a workspace.")
-        return self
-
-
-class WebClipperEnrichmentPayload(BaseModel):
-    """Structured payload for OCR/VLM follow-up work."""
-
-    clip_id: str = Field(..., min_length=1)
-    enrichment_type: WebClipperEnrichmentType = Field(..., description="OCR or VLM enrichment kind.")
-    status: WebClipperEnrichmentStatus = Field(default="pending")
-    inline_summary: str | None = Field(default=None, description="Concise inline summary for the note body.")
-    structured_payload: dict[str, Any] = Field(default_factory=dict, description="Full structured enrichment payload.")
-    source_note_version: int = Field(
-        ...,
-        ge=1,
-        description="Source note version used when the enrichment was produced.",
-    )
-    error: str | None = Field(default=None, description="Optional failure reason.")
-
-    model_config = ConfigDict(extra="forbid")
-
-
-class WebClipperSavedNote(BaseModel):
-    """Canonical note information returned from clipper flows."""
-
-    id: str = Field(..., min_length=1)
-    title: str = Field(..., min_length=1)
-    version: int = Field(..., ge=1)
-
-    model_config = ConfigDict(extra="forbid")
-
-
-class WebClipperWorkspacePlacement(BaseModel):
-    """Read-only workspace placement summary for a canonical clip note."""
-
-    workspace_id: str = Field(..., min_length=1)
-    workspace_note_id: int = Field(..., ge=1)
-    source_note_id: str = Field(..., min_length=1)
-    source_note_version: int | None = Field(default=None, ge=1)
-
-    model_config = ConfigDict(extra="forbid")
-
-
-class WebClipperAttachmentRecord(BaseModel):
-    """Persisted attachment metadata returned by the clipper service."""
-
-    slot: str = Field(..., min_length=1)
-    file_name: str = Field(..., min_length=1)
-    original_file_name: str = Field(..., min_length=1)
-    content_type: str | None = Field(default=None)
-    size_bytes: int = Field(..., ge=0)
-    uploaded_at: datetime
-    url: str = Field(..., min_length=1)
-
-    model_config = ConfigDict(extra="forbid")
-
-
-class WebClipperSaveResponse(BaseModel):
-    """Detailed outcome payload for a clip save."""
-
-    clip_id: str = Field(..., min_length=1)
-    status: WebClipperOutcomeState = Field(..., description="High-level save outcome state.")
-    note: WebClipperSavedNote | None = None
-    workspace_placement: WebClipperWorkspacePlacement | None = None
-    attachments: list[WebClipperAttachmentRecord] = Field(default_factory=list)
-    warnings: list[str] = Field(default_factory=list)
-    note_id: str = Field(..., min_length=1, description="Backward-compatible canonical note identifier.")
-    workspace_placement_saved: bool = Field(default=False)
-    workspace_placement_count: int = Field(default=0, ge=0)
-
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
-
-
-class WebClipperSaveResult(BaseModel):
-    """Backward-compatible minimal outcome payload for earlier Task 1 tests."""
-
-    clip_id: str = Field(..., min_length=1)
-    note_id: str = Field(..., min_length=1)
-    status: WebClipperOutcomeState = Field(..., description="High-level save outcome state.")
-    workspace_placement_saved: bool = Field(default=False)
-    workspace_placement_count: int = Field(default=0, ge=0)
-    warnings: list[str] = Field(default_factory=list)
-
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
-
-
-class WebClipperStatusResponse(BaseModel):
-    """Current canonical state for a saved clip."""
-
-    clip_id: str = Field(..., min_length=1)
-    status: WebClipperOutcomeState = Field(...)
-    note: WebClipperSavedNote
-    workspace_placements: list[WebClipperWorkspacePlacement] = Field(default_factory=list)
-    attachments: list[WebClipperAttachmentRecord] = Field(default_factory=list)
-    analysis: dict[str, Any] = Field(default_factory=dict)
-    content_budget: dict[str, Any] = Field(default_factory=dict)
-
-    model_config = ConfigDict(extra="forbid")
-
-
-class WebClipperEnrichmentResponse(BaseModel):
-    """Result of storing an OCR/VLM enrichment payload."""
-
-    clip_id: str = Field(..., min_length=1)
-    enrichment_type: WebClipperEnrichmentType
-    status: WebClipperEnrichmentStatus
-    source_note_version: int = Field(..., ge=1)
-    inline_applied: bool = Field(default=False)
-    inline_summary: str | None = Field(default=None)
-    conflict_reason: str | None = Field(default=None)
-    warnings: list[str] = Field(default_factory=list)
-
-    model_config = ConfigDict(extra="forbid")
+__all__ = [
+    "WebClipperAttachmentRecord",
+    "WebClipperDestination",
+    "WebClipperEnrichmentPayload",
+    "WebClipperEnrichmentResponse",
+    "WebClipperEnrichmentStatus",
+    "WebClipperEnrichmentType",
+    "WebClipperOutcomeState",
+    "WebClipperSaveRequest",
+    "WebClipperSaveResponse",
+    "WebClipperSaveResult",
+    "WebClipperSavedNote",
+    "WebClipperStatusResponse",
+    "WebClipperWorkspacePlacement",
+]

--- a/tldw_Server_API/app/core/WebClipper/schemas.py
+++ b/tldw_Server_API/app/core/WebClipper/schemas.py
@@ -1,0 +1,312 @@
+"""Core schemas for the browser extension web clipper."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+WebClipperDestination = Literal["note", "workspace", "both"]
+WebClipperOutcomeState = Literal["saved", "saved_with_warnings", "partially_saved", "failed"]
+WebClipperEnrichmentStatus = Literal["pending", "running", "complete", "failed"]
+WebClipperEnrichmentType = Literal["ocr", "vlm"]
+
+_MAX_CLIP_ID_CHARS = 256
+_MAX_CLIP_TYPE_CHARS = 64
+_MAX_SOURCE_URL_CHARS = 4096
+_MAX_TITLE_CHARS = 512
+_MAX_COMMENT_CHARS = 20_000
+_MAX_KEYWORDS = 64
+_MAX_KEYWORD_CHARS = 128
+_MAX_BODY_CHARS = 1_000_000
+_MAX_ATTACHMENTS = 16
+_MAX_ATTACHMENT_SLOT_CHARS = 128
+_MAX_ATTACHMENT_FILENAME_CHARS = 180
+_MAX_ATTACHMENT_MEDIA_TYPE_CHARS = 127
+_MAX_ATTACHMENT_TEXT_CHARS = 1_000_000
+_MAX_ATTACHMENT_BASE64_CHARS = 35_000_000
+MAX_CAPTURE_METADATA_JSON_CHARS = 65_536
+_MAX_ENRICHMENT_INLINE_SUMMARY_CHARS = 20_000
+_MAX_STRUCTURED_PAYLOAD_JSON_CHARS = 262_144
+
+
+def _json_size_chars(value: Any) -> int:
+    try:
+        return len(json.dumps(value, ensure_ascii=False))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Value must be JSON serializable.") from exc
+
+
+def validate_capture_metadata_json_size(value: dict[str, Any]) -> dict[str, Any]:
+    """Return capture metadata after enforcing the canonical JSON size limit."""
+    if _json_size_chars(value) > MAX_CAPTURE_METADATA_JSON_CHARS:
+        raise ValueError(f"capture_metadata JSON must be {MAX_CAPTURE_METADATA_JSON_CHARS} characters or fewer.")
+    return value
+
+
+class WebClipperSaveRequest(BaseModel):
+    """Typed save request for a browser clip."""
+
+    class NotePayload(BaseModel):
+        title: str | None = Field(
+            default=None,
+            min_length=1,
+            max_length=_MAX_TITLE_CHARS,
+            description="Optional user-edited note title.",
+        )
+        comment: str | None = Field(
+            default=None,
+            max_length=_MAX_COMMENT_CHARS,
+            description="Optional user comment for the saved note.",
+        )
+        folder_id: int | None = Field(default=None, ge=1, description="Optional note folder destination.")
+        keywords: list[str] = Field(
+            default_factory=list,
+            max_length=_MAX_KEYWORDS,
+            description="Optional filing keywords for the note.",
+        )
+
+        model_config = ConfigDict(extra="forbid")
+
+        @field_validator("keywords")
+        @classmethod
+        def validate_keyword_lengths(cls, value: list[str]) -> list[str]:
+            for keyword in value:
+                if len(str(keyword or "").strip()) > _MAX_KEYWORD_CHARS:
+                    raise ValueError(f"Keywords must be {_MAX_KEYWORD_CHARS} characters or fewer.")
+            return value
+
+    class WorkspacePayload(BaseModel):
+        workspace_id: str = Field(..., min_length=1, max_length=128, description="Workspace destination identifier.")
+
+        model_config = ConfigDict(extra="forbid")
+
+    class ContentPayload(BaseModel):
+        visible_body: str | None = Field(
+            default=None,
+            max_length=_MAX_BODY_CHARS,
+            description="Primary visible clip body for the saved note.",
+        )
+        full_extract: str | None = Field(
+            default=None,
+            max_length=_MAX_BODY_CHARS,
+            description="Full extracted page/article text.",
+        )
+        selected_text: str | None = Field(
+            default=None,
+            max_length=_MAX_BODY_CHARS,
+            description="Explicit user-selected text, when available.",
+        )
+
+        model_config = ConfigDict(extra="forbid")
+
+    class AttachmentPayload(BaseModel):
+        slot: str = Field(
+            ..., min_length=1, max_length=_MAX_ATTACHMENT_SLOT_CHARS, description="Deterministic attachment slot name."
+        )
+        file_name: str | None = Field(
+            default=None,
+            min_length=1,
+            max_length=_MAX_ATTACHMENT_FILENAME_CHARS,
+            description="Original file name supplied by the client.",
+        )
+        media_type: str = Field(
+            ...,
+            min_length=1,
+            max_length=_MAX_ATTACHMENT_MEDIA_TYPE_CHARS,
+            description="Attachment media type.",
+        )
+        text_content: str | None = Field(
+            default=None,
+            max_length=_MAX_ATTACHMENT_TEXT_CHARS,
+            description="UTF-8 text content for small text attachments.",
+        )
+        content_base64: str | None = Field(
+            default=None,
+            max_length=_MAX_ATTACHMENT_BASE64_CHARS,
+            description="Base64-encoded attachment bytes.",
+        )
+        source_url: str | None = Field(
+            default=None, max_length=_MAX_SOURCE_URL_CHARS, description="Optional source URL for the captured asset."
+        )
+
+        model_config = ConfigDict(extra="forbid")
+
+    class EnhancementOptions(BaseModel):
+        run_ocr: bool = Field(default=False, description="Whether OCR should run after save.")
+        run_vlm: bool = Field(default=False, description="Whether VLM analysis should run after save.")
+
+        model_config = ConfigDict(extra="forbid")
+
+    clip_id: str = Field(
+        ..., min_length=1, max_length=_MAX_CLIP_ID_CHARS, description="Client idempotency key for the clip save."
+    )
+    clip_type: str = Field(
+        ..., min_length=1, max_length=_MAX_CLIP_TYPE_CHARS, description="Clip type chosen by the user."
+    )
+    source_url: str = Field(..., min_length=1, max_length=_MAX_SOURCE_URL_CHARS, description="Source URL for the clip.")
+    source_title: str = Field(..., min_length=1, max_length=_MAX_TITLE_CHARS, description="Source page title.")
+    destination_mode: WebClipperDestination = Field(default="note", description="Visible destination choice.")
+    note: NotePayload = Field(default_factory=NotePayload, description="Note filing and visible-body options.")
+    workspace: WorkspacePayload | None = Field(
+        default=None,
+        description="Workspace placement target when destination_mode includes a workspace.",
+    )
+    content: ContentPayload = Field(default_factory=ContentPayload, description="Structured extracted content payload.")
+    attachments: list[AttachmentPayload] = Field(
+        default_factory=list,
+        max_length=_MAX_ATTACHMENTS,
+        description="Structured attachment inputs for deterministic slot persistence.",
+    )
+    enhancements: EnhancementOptions = Field(
+        default_factory=EnhancementOptions,
+        description="Requested OCR/VLM follow-up actions.",
+    )
+    capture_metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Structured capture metadata and fallback information.",
+    )
+    source_note_version: int | None = Field(
+        default=None,
+        ge=1,
+        description="Optional source note version for idempotent follow-up stages.",
+    )
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    @field_validator("capture_metadata")
+    @classmethod
+    def validate_capture_metadata_size(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return validate_capture_metadata_json_size(value)
+
+    @model_validator(mode="after")
+    def validate_workspace_destination(self) -> "WebClipperSaveRequest":
+        if self.destination_mode in {"workspace", "both"} and self.workspace is None:
+            raise ValueError("workspace is required when destination_mode targets a workspace.")
+        return self
+
+
+class WebClipperEnrichmentPayload(BaseModel):
+    """Structured payload for OCR/VLM follow-up work."""
+
+    clip_id: str = Field(..., min_length=1, max_length=_MAX_CLIP_ID_CHARS)
+    enrichment_type: WebClipperEnrichmentType = Field(..., description="OCR or VLM enrichment kind.")
+    status: WebClipperEnrichmentStatus = Field(default="pending")
+    inline_summary: str | None = Field(
+        default=None,
+        max_length=_MAX_ENRICHMENT_INLINE_SUMMARY_CHARS,
+        description="Concise inline summary for the note body.",
+    )
+    structured_payload: dict[str, Any] = Field(default_factory=dict, description="Full structured enrichment payload.")
+    source_note_version: int = Field(
+        ...,
+        ge=1,
+        description="Source note version used when the enrichment was produced.",
+    )
+    error: str | None = Field(default=None, max_length=4096, description="Optional failure reason.")
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("structured_payload")
+    @classmethod
+    def validate_structured_payload_size(cls, value: dict[str, Any]) -> dict[str, Any]:
+        if _json_size_chars(value) > _MAX_STRUCTURED_PAYLOAD_JSON_CHARS:
+            raise ValueError(
+                f"structured_payload JSON must be {_MAX_STRUCTURED_PAYLOAD_JSON_CHARS} characters or fewer."
+            )
+        return value
+
+
+class WebClipperSavedNote(BaseModel):
+    """Canonical note information returned from clipper flows."""
+
+    id: str = Field(..., min_length=1)
+    title: str = Field(..., min_length=1)
+    version: int = Field(..., ge=1)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class WebClipperWorkspacePlacement(BaseModel):
+    """Read-only workspace placement summary for a canonical clip note."""
+
+    workspace_id: str = Field(..., min_length=1)
+    workspace_note_id: int = Field(..., ge=1)
+    source_note_id: str = Field(..., min_length=1)
+    source_note_version: int | None = Field(default=None, ge=1)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class WebClipperAttachmentRecord(BaseModel):
+    """Persisted attachment metadata returned by the clipper service."""
+
+    slot: str = Field(..., min_length=1)
+    file_name: str = Field(..., min_length=1)
+    original_file_name: str = Field(..., min_length=1)
+    content_type: str | None = Field(default=None)
+    size_bytes: int = Field(..., ge=0)
+    uploaded_at: datetime
+    url: str = Field(..., min_length=1)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class WebClipperSaveResponse(BaseModel):
+    """Detailed outcome payload for a clip save."""
+
+    clip_id: str = Field(..., min_length=1)
+    status: WebClipperOutcomeState = Field(..., description="High-level save outcome state.")
+    note: WebClipperSavedNote | None = None
+    workspace_placement: WebClipperWorkspacePlacement | None = None
+    attachments: list[WebClipperAttachmentRecord] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    note_id: str = Field(..., min_length=1, description="Backward-compatible canonical note identifier.")
+    workspace_placement_saved: bool = Field(default=False)
+    workspace_placement_count: int = Field(default=0, ge=0)
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class WebClipperSaveResult(BaseModel):
+    """Backward-compatible minimal outcome payload for earlier Task 1 tests."""
+
+    clip_id: str = Field(..., min_length=1)
+    note_id: str = Field(..., min_length=1)
+    status: WebClipperOutcomeState = Field(..., description="High-level save outcome state.")
+    workspace_placement_saved: bool = Field(default=False)
+    workspace_placement_count: int = Field(default=0, ge=0)
+    warnings: list[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class WebClipperStatusResponse(BaseModel):
+    """Current canonical state for a saved clip."""
+
+    clip_id: str = Field(..., min_length=1)
+    status: WebClipperOutcomeState = Field(...)
+    note: WebClipperSavedNote
+    workspace_placements: list[WebClipperWorkspacePlacement] = Field(default_factory=list)
+    attachments: list[WebClipperAttachmentRecord] = Field(default_factory=list)
+    analysis: dict[str, Any] = Field(default_factory=dict)
+    content_budget: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class WebClipperEnrichmentResponse(BaseModel):
+    """Result of storing an OCR/VLM enrichment payload."""
+
+    clip_id: str = Field(..., min_length=1)
+    enrichment_type: WebClipperEnrichmentType
+    status: WebClipperEnrichmentStatus
+    source_note_version: int = Field(..., ge=1)
+    inline_applied: bool = Field(default=False)
+    inline_summary: str | None = Field(default=None)
+    conflict_reason: str | None = Field(default=None)
+    warnings: list[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid")

--- a/tldw_Server_API/app/core/WebClipper/service.py
+++ b/tldw_Server_API/app/core/WebClipper/service.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
-from tldw_Server_API.app.api.v1.schemas.web_clipper_schemas import (
+from tldw_Server_API.app.core.WebClipper.schemas import (
     WebClipperAttachmentRecord,
     WebClipperEnrichmentPayload,
     WebClipperEnrichmentResponse,
@@ -22,8 +22,10 @@ from tldw_Server_API.app.api.v1.schemas.web_clipper_schemas import (
     WebClipperSavedNote,
     WebClipperStatusResponse,
     WebClipperWorkspacePlacement,
+    validate_capture_metadata_json_size,
 )
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    BackendType,
     CharactersRAGDB,
     CharactersRAGDBError,
     ConflictError,
@@ -45,25 +47,30 @@ _MAX_OCR_INLINE = 1_500
 _MAX_VLM_INLINE = 1_000
 _MAX_MACHINE_INLINE = 2_500
 _MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024
-_ALLOWED_ATTACHMENT_MEDIA_TYPES: frozenset[str] = frozenset({
-    "image/png",
-    "image/jpeg",
-    "image/gif",
-    "image/webp",
-    "image/svg+xml",
-    "text/plain",
-    "text/html",
-    "text/markdown",
-    "text/csv",
-    "application/pdf",
-    "application/json",
-})
+_ALLOWED_ATTACHMENT_MEDIA_TYPES: frozenset[str] = frozenset(
+    {
+        "image/png",
+        "image/jpeg",
+        "image/gif",
+        "image/webp",
+        "text/plain",
+        "text/markdown",
+        "text/csv",
+        "application/pdf",
+        "application/json",
+    }
+)
+_BLOCKED_ATTACHMENT_SUFFIXES: frozenset[str] = frozenset({".htm", ".html", ".svg"})
 _FULL_EXTRACT_SPILLOVER_THRESHOLD = 20_000
 _TRUNCATION_MARKER = "Truncated. Full extract preserved in clip metadata."
 _ENRICHMENT_SECTION_START = "<!-- web-clipper-enrichment:start -->"
 _ENRICHMENT_SECTION_END = "<!-- web-clipper-enrichment:end -->"
 _WEB_CLIPPER_SOURCE_PREFIX = "web-clipper"
 WorkspaceSourceJobEnqueuer = Callable[[str, dict[str, Any]], None]
+
+
+class _ClipIdCollisionError(ConflictError):
+    """Raised when a WebClipper request attempts to claim a non-clipper note."""
 
 
 @dataclass(slots=True)
@@ -79,8 +86,6 @@ class WebClipperService:
     def save_clip(self, request: WebClipperSaveRequest) -> WebClipperSaveResponse:
         """Create or update the canonical note and optional workspace placement."""
         warnings: list[str] = []
-        existing_document = self.db.get_note_clipper_document_by_clip_id(request.clip_id)
-        capture_metadata = self._merge_capture_metadata(existing_document, request)
         analysis_state = self._current_analysis_state(request.clip_id)
         self._record_requested_enhancements(analysis_state, request)
 
@@ -90,15 +95,27 @@ class WebClipperService:
             fallback_full_extract=request.content.full_extract,
         )
         note_title = self._resolve_note_title(request)
-        note_content = self._render_note_content(
-            request=request,
-            visible_body=visible_body,
-            analysis=analysis_state,
-            capture_metadata=capture_metadata,
-        )
         try:
             with self.db.transaction() as conn:
                 existing_note = self._fetch_note_row(request.clip_id, conn=conn)
+                existing_document = self.db._fetch_note_clipper_document_row(
+                    column="clip_id",
+                    value=request.clip_id,
+                    conn=conn,
+                )
+                capture_metadata = self._merge_capture_metadata(existing_document, request)
+                note_content = self._render_note_content(
+                    request=request,
+                    visible_body=visible_body,
+                    analysis=analysis_state,
+                    capture_metadata=capture_metadata,
+                )
+                if existing_note is not None and existing_document is None:
+                    raise _ClipIdCollisionError(
+                        "A non-clipper note already exists with this clip_id.",
+                        entity="notes",
+                        entity_id=request.clip_id,
+                    )
                 if existing_note is None:
                     note_id = self.db.add_note(
                         title=note_title,
@@ -140,6 +157,8 @@ class WebClipperService:
                     source_note_version=int(persisted_note["version"]),
                     conn=conn,
                 )
+        except _ClipIdCollisionError:
+            raise
         except (CharactersRAGDBError, ConflictError) as exc:
             return WebClipperSaveResponse(
                 clip_id=request.clip_id,
@@ -233,8 +252,7 @@ class WebClipperService:
         clip_document = self._require_clip_document(clip_id)
         note = self._require_note(clip_id)
         placements = [
-            self._placement_response_from_row(row)
-            for row in self.db.list_note_clipper_workspace_placements(clip_id)
+            self._placement_response_from_row(row) for row in self.db.list_note_clipper_workspace_placements(clip_id)
         ]
         attachments = self._list_attachments(note_id=clip_id)
         analysis = self._normalize_json_dict(clip_document.get("analysis_json"))
@@ -368,10 +386,15 @@ class WebClipperService:
         existing_document: dict[str, Any] | None,
         request: WebClipperSaveRequest,
     ) -> dict[str, Any]:
-        merged = self._normalize_json_dict(existing_document.get("capture_metadata_json") if existing_document else None)
+        merged = self._normalize_json_dict(
+            existing_document.get("capture_metadata_json") if existing_document else None
+        )
         merged.update(request.capture_metadata)
         merged.setdefault("captured_at", datetime.now(timezone.utc).isoformat())
-        return merged
+        try:
+            return validate_capture_metadata_json_size(merged)
+        except ValueError as exc:
+            raise InputError(str(exc)) from exc  # noqa: TRY003
 
     def _current_analysis_state(self, clip_id: str) -> dict[str, Any]:
         current_document = self.db.get_note_clipper_document_by_clip_id(clip_id)
@@ -503,7 +526,7 @@ class WebClipperService:
             None,
         )
         if source_index is not None:
-            body_parts = parts[source_index + 1:]
+            body_parts = parts[source_index + 1 :]
             if body_parts:
                 return "\n\n".join(body_parts).strip()
             return ""
@@ -538,6 +561,9 @@ class WebClipperService:
             capture_metadata=capture_metadata,
         )
 
+    def _active_deleted_value(self) -> bool | int:
+        return False if self.db.backend_type == BackendType.POSTGRESQL else 0
+
     def _extract_comment_from_note(self, note: dict[str, Any]) -> str | None:
         content = self._strip_machine_section(str(note.get("content") or ""))
         blocks = [block.strip() for block in content.split("\n\n") if block.strip()]
@@ -560,10 +586,7 @@ class WebClipperService:
             normalized_keywords.append(text)
 
         existing_keywords = self.db.get_keywords_for_note(note_id)
-        existing_ids_by_text = {
-            str(row["keyword"]): int(row["id"])
-            for row in existing_keywords
-        }
+        existing_ids_by_text = {str(row["keyword"]): int(row["id"]) for row in existing_keywords}
         desired_keyword_ids: set[int] = set()
 
         for text in normalized_keywords:
@@ -598,7 +621,7 @@ class WebClipperService:
     def _sync_note_folder(self, note_id: str, folder_id: int | None, warnings: list[str]) -> None:
         if folder_id is None:
             return
-        deleted_value = False if self.db.backend_type.name == "POSTGRESQL" else 0
+        deleted_value = self._active_deleted_value()
         with self.db.transaction() as conn:
             folder_row = conn.execute(
                 "SELECT id FROM note_folders WHERE id = ? AND deleted = ?",
@@ -655,6 +678,9 @@ class WebClipperService:
             raise InputError("Invalid attachment path.") from exc  # noqa: TRY003
 
         resolved_media_type = attachment.media_type or mimetypes.guess_type(safe_file_name)[0]
+        if any(suffix.lower() in _BLOCKED_ATTACHMENT_SUFFIXES for suffix in Path(safe_file_name).suffixes):
+            raise InputError("Attachment file type is not allowed.")  # noqa: TRY003
+        resolved_media_type = str(resolved_media_type or "").split(";", maxsplit=1)[0].strip().lower() or None
         if resolved_media_type is None or resolved_media_type not in _ALLOWED_ATTACHMENT_MEDIA_TYPES:
             raise InputError(  # noqa: TRY003
                 f"Attachment media type '{resolved_media_type}' is not allowed. "
@@ -690,7 +716,9 @@ class WebClipperService:
                 encoding="utf-8",
             )
         except OSError as exc:
-            raise CharactersRAGDBError(f"Attachment persistence failed for slot '{attachment.slot}'.") from exc  # noqa: TRY003
+            raise CharactersRAGDBError(
+                f"Attachment persistence failed for slot '{attachment.slot}'."
+            ) from exc  # noqa: TRY003
         return self._attachment_response(note_id=note_id, file_path=target_path)
 
     def _ensure_workspace_placement(
@@ -864,8 +892,8 @@ class WebClipperService:
         keywords: list[str],
     ) -> None:
         workspace_note = self.db.execute_query(
-            "SELECT * FROM workspace_notes WHERE workspace_id = ? AND id = ? AND deleted = 0",
-            (workspace_id, workspace_note_id),
+            "SELECT * FROM workspace_notes WHERE workspace_id = ? AND id = ? AND deleted = ?",
+            (workspace_id, workspace_note_id, self._active_deleted_value()),
         ).fetchone()
         if workspace_note is None:
             raise ConflictError(
@@ -929,11 +957,16 @@ class WebClipperService:
     def _require_clip_document(self, clip_id: str) -> dict[str, Any]:
         document = self.db.get_note_clipper_document_by_clip_id(clip_id)
         if document is None:
-            raise ConflictError("Clip document not found.", entity="note_clipper_documents", entity_id=clip_id)  # noqa: TRY003
+            raise ConflictError(
+                "Clip document not found.", entity="note_clipper_documents", entity_id=clip_id
+            )  # noqa: TRY003
         return document
 
     def _fetch_note_row(self, note_id: str, *, conn: Any) -> dict[str, Any] | None:
-        row = conn.execute("SELECT * FROM notes WHERE id = ? AND deleted = 0", (note_id,)).fetchone()
+        row = conn.execute(
+            "SELECT * FROM notes WHERE id = ? AND deleted = ?",
+            (note_id, self._active_deleted_value()),
+        ).fetchone()
         return dict(row) if row else None
 
     def _truncate_inline_summary(self, enrichment_type: str, inline_summary: str | None) -> str | None:
@@ -949,7 +982,7 @@ class WebClipperService:
         if start == -1 or end == -1 or end < start:
             return content.strip()
         prefix = content[:start].rstrip()
-        suffix = content[end + len(_ENRICHMENT_SECTION_END):].strip()
+        suffix = content[end + len(_ENRICHMENT_SECTION_END) :].strip()
         if prefix and suffix:
             return f"{prefix}\n\n{suffix}".strip()
         return (prefix or suffix).strip()
@@ -995,7 +1028,9 @@ class WebClipperService:
         suffix = "".join(Path(basename).suffixes)
         if not suffix:
             suffix = mimetypes.guess_extension(mimetypes.guess_type(basename)[0] or "") or ".bin"
-        safe_slot = sanitize_filename(str(slot or ""), max_total_length=max(1, 180 - len(suffix))).replace(" ", "_").strip("._")
+        safe_slot = (
+            sanitize_filename(str(slot or ""), max_total_length=max(1, 180 - len(suffix))).replace(" ", "_").strip("._")
+        )
         if not safe_slot:
             safe_slot = "attachment"
         return f"{safe_slot}{suffix.lower()}"

--- a/tldw_Server_API/tests/Notes_NEW/unit/test_web_clipper_service.py
+++ b/tldw_Server_API/tests/Notes_NEW/unit/test_web_clipper_service.py
@@ -15,12 +15,14 @@ from tldw_Server_API.app.api.v1.schemas.web_clipper_schemas import (
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     CharactersRAGDB,
     CharactersRAGDBError,
+    ConflictError,
+    InputError,
 )
 from tldw_Server_API.app.core.DB_Management.media_db import api as media_db_api
 from tldw_Server_API.app.core.DB_Management.media_db.native_class import MediaDatabase
 from tldw_Server_API.app.core.WebClipper import service as web_clipper_service_module
+from tldw_Server_API.app.core.WebClipper.schemas import MAX_CAPTURE_METADATA_JSON_CHARS
 from tldw_Server_API.app.core.WebClipper.service import WebClipperService
-
 
 pytestmark = pytest.mark.unit
 
@@ -84,6 +86,51 @@ def _save_request(
     )
 
 
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda payload: payload.update(
+            {
+                "content": {
+                    "visible_body": "x" * 1_000_001,
+                    "full_extract": None,
+                    "selected_text": None,
+                }
+            }
+        ),
+        lambda payload: payload.update(
+            {
+                "note": {
+                    "title": "Example Story",
+                    "comment": None,
+                    "keywords": ["k" * 129],
+                }
+            }
+        ),
+        lambda payload: payload.update(
+            {
+                "attachments": [
+                    {
+                        "slot": f"slot-{index}",
+                        "file_name": f"slot-{index}.txt",
+                        "media_type": "text/plain",
+                        "text_content": "payload",
+                    }
+                    for index in range(17)
+                ]
+            }
+        ),
+        lambda payload: payload.update({"capture_metadata": {"oversized": "x" * 65_537}}),
+    ],
+)
+def test_web_clipper_request_rejects_unbounded_payloads(mutation):
+    payload = _save_request(destination_mode="note", clip_id="clip-bounds").model_dump()
+    mutation(payload)
+
+    with pytest.raises(ValueError):
+        WebClipperSaveRequest.model_validate(payload)
+
+
 def test_save_clip_creates_canonical_note_and_sidecar(clipper_db):
     service = WebClipperService(db=clipper_db, user_id=1)
 
@@ -106,6 +153,49 @@ def test_save_clip_creates_canonical_note_and_sidecar(clipper_db):
     assert clip_doc["note_id"] == "clip-123"
 
 
+def test_save_clip_rejects_existing_non_clipper_note_id(clipper_db):
+    service = WebClipperService(db=clipper_db, user_id=1)
+    clipper_db.add_note(
+        title="Existing user note",
+        content="This note must not be claimed by a clipper request.",
+        note_id="existing-note",
+    )
+
+    request = _save_request(destination_mode="note", clip_id="existing-note")
+
+    with pytest.raises(ConflictError):
+        service.save_clip(request)
+
+    note = clipper_db.get_note_by_id("existing-note")
+    assert note is not None
+    assert note["title"] == "Existing user note"
+    assert note["content"] == "This note must not be claimed by a clipper request."
+    assert clipper_db.get_note_clipper_document_by_clip_id("existing-note") is None
+
+
+def test_save_clip_rechecks_clipper_document_inside_transaction(clipper_db, monkeypatch: pytest.MonkeyPatch):
+    clipper_db.add_note(title="Existing Clip", content="Previous body", note_id="clip-race")
+    clipper_db.upsert_note_clipper_document(
+        clip_id="clip-race",
+        note_id="clip-race",
+        clip_type="article",
+        source_url="https://example.com/story",
+        source_title="Example Story",
+        capture_metadata={"captured_at": "2026-01-01T00:00:00+00:00"},
+        enrichments={},
+        content_budget={},
+        source_note_version=1,
+    )
+    monkeypatch.setattr(clipper_db, "get_note_clipper_document_by_clip_id", lambda _clip_id: None)
+    service = WebClipperService(db=clipper_db, user_id=1)
+
+    result = service.save_clip(_save_request(clip_id="clip-race", destination_mode="note"))
+
+    assert result.status == "saved"
+    assert result.note is not None
+    assert result.note.id == "clip-race"
+
+
 def test_save_clip_retry_reuses_note_workspace_and_attachment(clipper_db):
     service = WebClipperService(db=clipper_db, user_id=1)
     request = _save_request(include_attachment=True)
@@ -121,6 +211,54 @@ def test_save_clip_retry_reuses_note_workspace_and_attachment(clipper_db):
     assert len(status.workspace_placements) == 1
     assert len(status.attachments) == 1
     assert status.attachments[0].slot == "page-screenshot"
+
+
+def test_save_clip_rejects_active_html_and_svg_attachments(clipper_db):
+    service = WebClipperService(db=clipper_db, user_id=1)
+    request = _save_request(destination_mode="note", clip_id="clip-active-attachments")
+    request.attachments = [
+        WebClipperSaveRequest.AttachmentPayload(
+            slot="html-capture",
+            file_name="html-capture.html",
+            media_type="text/html",
+            text_content="<script>window.pwned = true</script>",
+        ),
+        WebClipperSaveRequest.AttachmentPayload(
+            slot="svg-capture",
+            file_name="svg-capture.svg",
+            media_type="image/svg+xml",
+            text_content="<svg><script>window.pwned = true</script></svg>",
+        ),
+    ]
+
+    result = service.save_clip(request)
+    status = service.get_clip_status("clip-active-attachments")
+
+    assert result.status == "saved_with_warnings"
+    assert result.attachments == []
+    assert status.attachments == []
+    assert len(result.warnings) == 2
+    assert all("not allowed" in warning for warning in result.warnings)
+
+
+def test_save_clip_rejects_oversized_merged_capture_metadata(clipper_db):
+    existing_metadata = {"stored": "x" * (MAX_CAPTURE_METADATA_JSON_CHARS - len(json.dumps({"stored": ""})) - 64)}
+    clipper_db.add_note(title="Existing Clip", content="Previous body", note_id="clip-metadata")
+    clipper_db.upsert_note_clipper_document(
+        clip_id="clip-metadata",
+        note_id="clip-metadata",
+        clip_type="article",
+        source_url="https://example.com/story",
+        source_title="Example Story",
+        capture_metadata=existing_metadata,
+        enrichments={},
+        content_budget={},
+        source_note_version=1,
+    )
+    service = WebClipperService(db=clipper_db, user_id=1)
+
+    with pytest.raises(InputError, match="capture_metadata JSON"):
+        service.save_clip(_save_request(clip_id="clip-metadata", destination_mode="note"))
 
 
 def test_save_clip_creates_media_backed_workspace_source(clipper_db, media_db):
@@ -190,7 +328,9 @@ def test_save_clip_retry_reuses_workspace_source_and_still_attempts_job_enqueue(
     assert calls[0][1]["media_id"] == calls[1][1]["media_id"] == sources[0]["media_id"]
 
 
-def test_save_clip_returns_partially_saved_when_workspace_creation_fails_after_note(clipper_db, monkeypatch: pytest.MonkeyPatch):
+def test_save_clip_returns_partially_saved_when_workspace_creation_fails_after_note(
+    clipper_db, monkeypatch: pytest.MonkeyPatch
+):
     service = WebClipperService(db=clipper_db, user_id=1)
 
     def _boom(*_args, **_kwargs):


### PR DESCRIPTION
## Summary
- Move WebClipper request models into core and keep the API schema module as a compatibility re-export.
- Add practical request bounds for clip payloads, metadata, keywords, and attachments.
- Reject unsafe note-ID claims, active HTML/SVG clip attachments, and SQLite-only deleted predicates.
- Add focused regression coverage and task tracking for TASK-10006.

## Change summary
Maintainer note: this PR was prepared by Codex. Per project policy, a human maintainer should replace this section with their own change summary before merge.

## Tests
- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Notes_NEW/unit/test_web_clipper_service.py tldw_Server_API/tests/Notes_NEW/unit/test_web_clipper_endpoint_error_mapping.py tldw_Server_API/tests/Notes_NEW/integration/test_web_clipper_api.py tldw_Server_API/tests/ChaChaNotesDB/test_web_clipper_db.py -q` -> 56 passed, 124 warnings
- `python -m black --check` on touched Python files -> 4 files unchanged
- `python -m bandit -r tldw_Server_API/app/core/WebClipper tldw_Server_API/app/api/v1/schemas/web_clipper_schemas.py -f json -o /tmp/bandit_webclipper_10006_rebased.json` -> 0 results, 0 errors, 0 skipped
- `git diff --check origin/dev...HEAD` -> passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened WebClipper saves and enrichments by enforcing payload bounds, blocking active HTML/SVG attachments and filenames, and preventing `clip_id` collisions with non-clip notes. Uses backend‑native deleted checks and moves schemas to core with a compatible API re-export. Addresses TASK-10006.

- **Bug Fixes**
  - Block claiming existing non-clip notes via `clip_id` collision (conflict).
  - Disallow HTML/SVG attachments and `.htm`, `.html`, `.svg` file names; skip with warnings.
  - Enforce limits on titles, bodies, keywords, attachments, base64 sizes, and JSON; validate `capture_metadata` after merge.
  - Use backend-native `deleted` values in notes and `workspace_notes` queries; check sidecar inside the transaction to avoid races.

- **Refactors**
  - Move WebClipper schemas to `tldw_Server_API.app.core.WebClipper.schemas`; keep `tldw_Server_API/app/api/v1/schemas/web_clipper_schemas.py` as a compatibility re-export.

<sup>Written for commit a4d8ba5e12f0f713d7742d8a31774e15c280ac1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

