### PR TITLE
Fix Telegram pairing code scope handling

### DIFF
--- a/IMPLEMENTATION_PLAN_telegram_core_review_fixes.md
+++ b/IMPLEMENTATION_PLAN_telegram_core_review_fixes.md
@@ -1,0 +1,23 @@
+## Stage 1: Regression Tests
+**Goal**: Capture the reviewed Telegram core risks before production edits.
+**Success Criteria**: Tests fail for cross-scope pairing-code consumption, plaintext code storage, and unsafe session mapper inputs.
+**Tests**: Targeted Telegram runtime/session mapper pytest tests.
+**Status**: Complete
+
+## Stage 2: Runtime Repository Fixes
+**Goal**: Scope-bind pairing-code consumption and hash newly stored pairing codes.
+**Success Criteria**: Pairing codes are consumed atomically by scope and no new raw code is persisted.
+**Tests**: Runtime repo tests pass for SQLite path and endpoint link flow uses scoped consumption.
+**Status**: Complete
+
+## Stage 3: Session Mapper Hardening
+**Goal**: Make session/conversation identity derivation canonical and reject unsafe component values.
+**Success Criteria**: Public helpers accept scalar IDs, reject non-scalars, and preserve existing stable outputs for current supported Telegram IDs where required.
+**Tests**: Session mapper tests cover accepted scalars, rejected containers/objects, and delimiter-safe UUID derivation.
+**Status**: Complete
+
+## Stage 4: Verification
+**Goal**: Verify targeted behavior and security checks for touched code.
+**Success Criteria**: Targeted tests and Bandit complete with no new findings in touched scope.
+**Tests**: `python -m pytest ...` and `python -m bandit ...`.
+**Status**: Complete

--- a/backlog/tasks/task-12007 - Fix-Telegram-core-review-findings.md
+++ b/backlog/tasks/task-12007 - Fix-Telegram-core-review-findings.md
@@ -1,0 +1,77 @@
+---
+id: TASK-12007
+title: Fix Telegram core review findings
+status: Done
+assignee: []
+created_date: '2026-06-24 00:00'
+updated_date: '2026-06-24 05:10'
+labels:
+  - telegram
+  - security
+  - authnz
+dependencies: []
+references:
+  - IMPLEMENTATION_PLAN_telegram_core_review_fixes.md
+  - https://github.com/rmusser01/tldw_server/pull/2498
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address validated review findings in Telegram core/runtime code: scope-bind pairing-code consumption, avoid plaintext pairing-code storage for new codes, and canonicalize Telegram session mapper inputs.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Pairing codes can only be consumed in the scope where they were created.
+- [x] #2 New pairing codes are stored hashed rather than as plaintext bearer credentials.
+- [x] #3 Telegram session IDs are derived from canonical, scalar-safe inputs and reject unsafe values.
+- [x] #4 Regression tests cover scope mismatch, hash-only storage, and canonical input validation.
+- [x] #5 Targeted tests and Bandit pass for touched scope.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Backlog MCP tools were not exposed in this session. The Backlog CLI was available, but `search`, `list`, `view`, and `task create` hung repeatedly, including with browser-opening disabled. The user approved direct task-file creation as the temporary fallback.
+
+Implemented:
+- Scoped Telegram pairing-code consumption by passing `scope_type` and `scope_id` through the webhook link path and enforcing those values inside the runtime repository.
+- Stored newly created Telegram pairing codes as HMAC-SHA256 digests using the shared AuthNZ HMAC key derivation, while preserving the existing raw one-time code return for the admin link-start response.
+- Kept legacy plaintext pairing-code consumption as a scoped fallback for active rows created before this fix.
+- Hardened Telegram session mapper inputs to reject non-scalar IDs and derive persona/character UUIDs from canonical JSON component boundaries.
+
+Verification:
+- `python -m pytest tldw_Server_API/tests/AuthNZ/unit/test_telegram_runtime_repo.py tldw_Server_API/tests/Telegram/test_telegram_session_mapper.py tldw_Server_API/tests/Telegram/test_telegram_linking_and_policy.py::test_link_command_consumes_pairing_code_with_current_scope -q` passed: 13 passed, 57 warnings.
+- `DATABASE_URL=sqlite:////tmp/tldw_tg_endpoint_task12007.db python -m pytest tldw_Server_API/tests/Telegram/test_telegram_linking_and_policy.py -q` passed: 7 passed, 324 warnings.
+- `python -m bandit tldw_Server_API/app/core/Telegram/session_mapper.py tldw_Server_API/app/core/AuthNZ/repos/telegram_runtime_repo.py tldw_Server_API/app/api/v1/endpoints/telegram_support.py -f json -o /tmp/bandit_telegram_core_review.json` passed: no findings.
+- PR: https://github.com/rmusser01/tldw_server/pull/2498
+
+PR review/rebase follow-up:
+- Replayed the PR changes onto latest `origin/dev` (`ab4ebc51ed0c958f3cfc12b3b7a3bf387aa4dd2a`) after sandbox restrictions blocked in-place `git rebase` metadata writes.
+- Checked issue comments, review comments, formal reviews, and review threads on PR #2498. There were no inline/formal actionable review comments. Bot comments were status/summary only; Qodo suggested a future dedicated pairing-code hash column/migration as a follow-up, but did not flag it as a required fix for this PR.
+- Addressed Qodo PR review comments after rebase by adding helper docstrings, caching Telegram pairing-code HMAC key derivation, adding pytest unit markers/return types to new tests, and splitting the link-command scope regression into separate wrong-scope and correct-scope tests.
+- Re-verified after review fixes:
+  - `python -m pytest tldw_Server_API/tests/AuthNZ/unit/test_telegram_runtime_repo.py tldw_Server_API/tests/Telegram/test_telegram_session_mapper.py tldw_Server_API/tests/Telegram/test_telegram_linking_and_policy.py::test_link_command_rejects_pairing_code_for_wrong_scope tldw_Server_API/tests/Telegram/test_telegram_linking_and_policy.py::test_link_command_links_pairing_code_for_current_scope -q` passed: 14 passed, 58 warnings.
+  - `DATABASE_URL=sqlite:////tmp/tldw_tg_endpoint_task12007_reviewfix.db python -m pytest tldw_Server_API/tests/Telegram/test_telegram_linking_and_policy.py -q` passed: 8 passed, 324 warnings.
+  - `python -m bandit tldw_Server_API/app/core/Telegram/session_mapper.py tldw_Server_API/app/core/AuthNZ/repos/telegram_runtime_repo.py tldw_Server_API/app/api/v1/endpoints/telegram_support.py -f json -o /tmp/bandit_telegram_core_review_reviewfix.json` passed: no findings.
+
+Local verification caveat:
+- Full `tldw_Server_API/tests/Telegram/test_telegram_linking_and_policy.py` failed against the default workspace SQLite AuthNZ database before policy assertions in the admin bot seeding helper because the existing `org_provider_secrets` table lacks the `created_by` column (`sqlite3.OperationalError: table org_provider_secrets has no column named created_by`). The same suite passed against a fresh temporary AuthNZ database, so this is local schema drift rather than a Telegram runtime/session regression.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the Telegram review findings by scope-binding pairing code redemption, hashing newly stored pairing codes, and hardening Telegram session identity derivation against non-scalar inputs and delimiter collisions. Added focused regression coverage for repository storage/consumption, session mapper validation, and webhook link-command scope propagation. Targeted tests, the Telegram endpoint policy suite against a fresh temporary AuthNZ database, and Bandit passed for the touched scope; the default workspace AuthNZ SQLite database still has local schema drift noted above.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
@@ -841,7 +841,11 @@ async def _handle_telegram_link_command(
     if pairing_code is None:
         return _telegram_webhook_error(status.HTTP_400_BAD_REQUEST, "pairing_code_required")
 
-    consumed_pairing = await runtime_repo.consume_pairing_code(pairing_code)
+    consumed_pairing = await runtime_repo.consume_pairing_code(
+        pairing_code,
+        scope_type=scope.scope_type,
+        scope_id=scope.scope_id,
+    )
     if consumed_pairing is None:
         return _telegram_webhook_error(status.HTTP_403_FORBIDDEN, "invalid_pairing_code")
 

--- a/tldw_Server_API/app/core/AuthNZ/repos/telegram_runtime_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/telegram_runtime_repo.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from functools import lru_cache
 from typing import Any
 
 from loguru import logger
 
 from tldw_Server_API.app.core.AuthNZ.database import DatabasePool, get_db_pool
+from tldw_Server_API.app.core.AuthNZ.crypto_utils import derive_hmac_key
 
 
 def _normalize_scope_type(scope_type: str) -> str:
@@ -19,6 +23,27 @@ def _normalize_scope_type(scope_type: str) -> str:
 def _normalize_optional_text(value: Any) -> str | None:
     text = str(value or "").strip()
     return text or None
+
+
+def _normalize_pairing_code(value: Any) -> str:
+    """Normalize a user-entered Telegram pairing code for lookup or storage."""
+    code = str(value or "").strip().upper()
+    if not code:
+        raise ValueError("pairing_code is required")
+    return code
+
+
+@lru_cache(maxsize=1)
+def _telegram_pairing_hmac_key() -> bytes:
+    """Return cached HMAC key material for Telegram pairing-code digests."""
+    return derive_hmac_key()
+
+
+def _hash_pairing_code(pairing_code: str) -> str:
+    """Build a domain-separated HMAC digest for a normalized pairing code."""
+    message = f"telegram_pairing_code:{pairing_code}".encode("utf-8")
+    digest = hmac.new(_telegram_pairing_hmac_key(), message, hashlib.sha256).hexdigest()
+    return f"hmac_sha256:{digest}"
 
 
 @dataclass
@@ -252,7 +277,8 @@ class TelegramRuntimeRepo:
         now: datetime | None = None,
     ) -> dict[str, Any]:
         created_at = now or datetime.now(timezone.utc)
-        code = str(pairing_code or "").strip().upper()
+        code = _normalize_pairing_code(pairing_code)
+        code_hash = _hash_pairing_code(code)
         scope_type_value = _normalize_scope_type(scope_type)
         if getattr(self.db_pool, "pool", None) is not None:
             row = await self.db_pool.fetchone(
@@ -262,14 +288,16 @@ class TelegramRuntimeRepo:
                 ) VALUES ($1, $2, $3, $4, $5, $6, NULL)
                 RETURNING id, pairing_code, scope_type, scope_id, auth_user_id, created_at, expires_at, consumed_at
                 """,
-                code,
+                code_hash,
                 scope_type_value,
                 int(scope_id),
                 int(auth_user_id),
                 self._normalize_datetime_for_postgres(created_at),
                 self._normalize_datetime_for_postgres(expires_at),
             )
-            return self._row_to_dict(row)
+            out = self._row_to_dict(row)
+            out["pairing_code"] = code
+            return out
 
         await self.db_pool.execute(
             """
@@ -278,46 +306,78 @@ class TelegramRuntimeRepo:
             ) VALUES (?, ?, ?, ?, ?, ?, NULL)
             """,
             (
-                code,
+                code_hash,
                 scope_type_value,
                 int(scope_id),
                 int(auth_user_id),
                 created_at.isoformat(),
                 expires_at.isoformat(),
             ),
-        )
+            )
         row = await self.db_pool.fetchone(
             """
             SELECT id, pairing_code, scope_type, scope_id, auth_user_id, created_at, expires_at, consumed_at
             FROM telegram_pairing_codes
             WHERE pairing_code = ?
             """,
-            (code,),
+            (code_hash,),
         )
-        return self._row_to_dict(row)
+        out = self._row_to_dict(row)
+        out["pairing_code"] = code
+        return out
 
     async def consume_pairing_code(
         self,
         pairing_code: str,
         *,
+        scope_type: str,
+        scope_id: int,
         now: datetime | None = None,
     ) -> dict[str, Any] | None:
         current = now or datetime.now(timezone.utc)
-        code = str(pairing_code or "").strip().upper()
+        code = _normalize_pairing_code(pairing_code)
+        code_hash = _hash_pairing_code(code)
+        scope_type_value = _normalize_scope_type(scope_type)
+        scope_id_value = int(scope_id)
         if getattr(self.db_pool, "pool", None) is not None:
             row = await self.db_pool.fetchone(
                 """
                 UPDATE telegram_pairing_codes
                 SET consumed_at = $2
                 WHERE pairing_code = $1
+                  AND scope_type = $3
+                  AND scope_id = $4
                   AND consumed_at IS NULL
                   AND expires_at > $2
                 RETURNING id, pairing_code, scope_type, scope_id, auth_user_id, created_at, expires_at, consumed_at
                 """,
-                code,
+                code_hash,
                 self._normalize_datetime_for_postgres(current),
+                scope_type_value,
+                scope_id_value,
             )
-            return self._row_to_dict(row) if row else None
+            if row is None:
+                row = await self.db_pool.fetchone(
+                    """
+                    UPDATE telegram_pairing_codes
+                    SET consumed_at = $2
+                    WHERE pairing_code = $1
+                      AND scope_type = $3
+                      AND scope_id = $4
+                      AND consumed_at IS NULL
+                      AND expires_at > $2
+                    RETURNING id, pairing_code, scope_type, scope_id, auth_user_id, created_at, expires_at, consumed_at
+                    """,
+                    code,
+                    self._normalize_datetime_for_postgres(current),
+                    scope_type_value,
+                    scope_id_value,
+                )
+            if row is None:
+                return None
+            out = self._row_to_dict(row)
+            out["pairing_code"] = code
+            return out
 
         async with self.db_pool.transaction() as conn:
             await conn.execute(
@@ -325,29 +385,72 @@ class TelegramRuntimeRepo:
                 UPDATE telegram_pairing_codes
                 SET consumed_at = ?
                 WHERE pairing_code = ?
+                  AND scope_type = ?
+                  AND scope_id = ?
                   AND consumed_at IS NULL
                   AND datetime(expires_at) > datetime(?)
                 """,
                 (
                     current.isoformat(),
-                    code,
+                    code_hash,
+                    scope_type_value,
+                    scope_id_value,
                     current.isoformat(),
                 ),
             )
             changes_row = await conn.execute("SELECT changes() AS changed")
             changed = await changes_row.fetchone()
             if int(self._row_to_dict(changed).get("changed") or 0) <= 0:
-                return None
+                await conn.execute(
+                    """
+                    UPDATE telegram_pairing_codes
+                    SET consumed_at = ?
+                    WHERE pairing_code = ?
+                      AND scope_type = ?
+                      AND scope_id = ?
+                      AND consumed_at IS NULL
+                      AND datetime(expires_at) > datetime(?)
+                    """,
+                    (
+                        current.isoformat(),
+                        code,
+                        scope_type_value,
+                        scope_id_value,
+                        current.isoformat(),
+                    ),
+                )
+                changes_row = await conn.execute("SELECT changes() AS changed")
+                changed = await changes_row.fetchone()
+                if int(self._row_to_dict(changed).get("changed") or 0) <= 0:
+                    return None
             row_cursor = await conn.execute(
                 """
                 SELECT id, pairing_code, scope_type, scope_id, auth_user_id, created_at, expires_at, consumed_at
                 FROM telegram_pairing_codes
                 WHERE pairing_code = ?
+                  AND scope_type = ?
+                  AND scope_id = ?
                 """,
-                (code,),
+                (code_hash, scope_type_value, scope_id_value),
             )
             row = await row_cursor.fetchone()
-            return self._row_to_dict(row) if row else None
+            if row is None:
+                row_cursor = await conn.execute(
+                    """
+                    SELECT id, pairing_code, scope_type, scope_id, auth_user_id, created_at, expires_at, consumed_at
+                    FROM telegram_pairing_codes
+                    WHERE pairing_code = ?
+                      AND scope_type = ?
+                      AND scope_id = ?
+                    """,
+                    (code, scope_type_value, scope_id_value),
+                )
+                row = await row_cursor.fetchone()
+            if row is None:
+                return None
+            out = self._row_to_dict(row)
+            out["pairing_code"] = code
+            return out
 
     async def upsert_actor_link(
         self,

--- a/tldw_Server_API/app/core/Telegram/session_mapper.py
+++ b/tldw_Server_API/app/core/Telegram/session_mapper.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import uuid
 from typing import Any
 
@@ -9,8 +10,8 @@ _CHARACTER_CONVERSATION_NAMESPACE = uuid.UUID("8f6d6df3-0b13-5c67-a1f4-5c62fa2d4
 
 
 def _coerce_nonempty_string(value: Any) -> str:
-    if value is None:
-        raise ValueError("value must be a non-empty string")
+    if not isinstance(value, (str, int)) or isinstance(value, bool):
+        raise ValueError("value must be a non-empty scalar string or integer")
     text = str(value).strip()
     if not text:
         raise ValueError("value must be a non-empty string")
@@ -20,6 +21,11 @@ def _coerce_nonempty_string(value: Any) -> str:
 def _coerce_nonempty_id(value: Any, *, field_name: str) -> str:
     text = _coerce_nonempty_string(value)
     return text if text else field_name
+
+
+def _canonical_uuid_name(*components: str) -> str:
+    """Serialize UUID name components with unambiguous boundaries."""
+    return json.dumps(list(components), ensure_ascii=False, separators=(",", ":"))
 
 
 def build_telegram_session_key(
@@ -51,10 +57,20 @@ def derive_telegram_assistant_conversation_id(session_key: str) -> str:
 def derive_telegram_persona_session_id(session_key: str, *, persona_id: Any) -> str:
     key = _coerce_nonempty_string(session_key)
     persona = _coerce_nonempty_id(persona_id, field_name="persona")
-    return str(uuid.uuid5(_PERSONA_SESSION_NAMESPACE, f"{key}:persona:{persona}"))
+    return str(
+        uuid.uuid5(
+            _PERSONA_SESSION_NAMESPACE,
+            _canonical_uuid_name(key, "persona", persona),
+        )
+    )
 
 
 def derive_telegram_character_conversation_id(session_key: str, *, character_id: Any) -> str:
     key = _coerce_nonempty_string(session_key)
     character = _coerce_nonempty_id(character_id, field_name="character")
-    return str(uuid.uuid5(_CHARACTER_CONVERSATION_NAMESPACE, f"{key}:character:{character}"))
+    return str(
+        uuid.uuid5(
+            _CHARACTER_CONVERSATION_NAMESPACE,
+            _canonical_uuid_name(key, "character", character),
+        )
+    )

--- a/tldw_Server_API/tests/AuthNZ/unit/test_telegram_runtime_repo.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_telegram_runtime_repo.py
@@ -67,8 +67,37 @@ async def test_telegram_runtime_repo_persists_receipts_pairing_codes_and_links(t
     )
     assert pairing["pairing_code"] == "ABCD1234"
 
-    consumed_pairing = await repo.consume_pairing_code("abcd1234", now=now + timedelta(minutes=1))
-    missing_pairing = await repo.consume_pairing_code("ABCD1234", now=now + timedelta(minutes=1))
+    stored_pairing = await pool.fetchone(
+        """
+        SELECT pairing_code
+        FROM telegram_pairing_codes
+        WHERE id = ?
+        """,
+        (pairing["id"],),
+    )
+    assert stored_pairing is not None
+    assert stored_pairing["pairing_code"] != "ABCD1234"
+    assert str(stored_pairing["pairing_code"]).startswith("hmac_sha256:")
+
+    wrong_scope_pairing = await repo.consume_pairing_code(
+        "abcd1234",
+        scope_type="team",
+        scope_id=23,
+        now=now + timedelta(minutes=1),
+    )
+    consumed_pairing = await repo.consume_pairing_code(
+        "abcd1234",
+        scope_type="team",
+        scope_id=22,
+        now=now + timedelta(minutes=1),
+    )
+    missing_pairing = await repo.consume_pairing_code(
+        "ABCD1234",
+        scope_type="team",
+        scope_id=22,
+        now=now + timedelta(minutes=1),
+    )
+    assert wrong_scope_pairing is None
     assert consumed_pairing is not None
     assert consumed_pairing["auth_user_id"] == 901
     assert missing_pairing is None

--- a/tldw_Server_API/tests/Telegram/test_telegram_linking_and_policy.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_linking_and_policy.py
@@ -7,6 +7,9 @@ from fastapi import Request
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
 from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
+    TelegramCommand,
+    TelegramScope,
+    _handle_telegram_link_command,
     _reset_telegram_link_state_for_tests,
     _reset_telegram_webhook_state_for_tests,
 )
@@ -98,6 +101,99 @@ def _seed_telegram_bot(
         },
     )
     assert response.status_code == 200, response.text
+
+
+class _ScopeAwareRuntimeRepo:
+    def __init__(self) -> None:
+        self.consume_calls: list[tuple[str, str, int]] = []
+        self.link_calls: list[dict[str, object]] = []
+
+    async def consume_pairing_code(
+        self,
+        pairing_code: str,
+        *,
+        scope_type: str,
+        scope_id: int,
+    ) -> dict[str, int] | None:
+        self.consume_calls.append((pairing_code, scope_type, scope_id))
+        if scope_type == "team" and scope_id == 22:
+            return {"auth_user_id": 303}
+        return None
+
+    async def upsert_actor_link(
+        self,
+        *,
+        scope_type: str,
+        scope_id: int,
+        telegram_user_id: int,
+        auth_user_id: int,
+        telegram_username: str | None,
+    ) -> dict[str, object]:
+        link = {
+            "scope_type": scope_type,
+            "scope_id": scope_id,
+            "telegram_user_id": telegram_user_id,
+            "auth_user_id": auth_user_id,
+            "telegram_username": telegram_username,
+        }
+        self.link_calls.append(link)
+        return link
+
+
+@pytest.mark.unit
+async def test_link_command_rejects_pairing_code_for_wrong_scope() -> None:
+    runtime_repo = _ScopeAwareRuntimeRepo()
+    payload = {
+        "message": {
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 99, "username": "candidate"},
+            "text": "/link ABCD1234",
+        }
+    }
+    command = TelegramCommand(action="link", input="ABCD1234")
+
+    wrong_scope = await _handle_telegram_link_command(
+        scope=TelegramScope(scope_type="team", scope_id=23),
+        payload=payload,
+        command=command,
+        runtime_repo=runtime_repo,
+    )
+
+    assert wrong_scope.status_code == 403
+    assert runtime_repo.consume_calls == [("ABCD1234", "team", 23)]
+    assert runtime_repo.link_calls == []
+
+
+@pytest.mark.unit
+async def test_link_command_links_pairing_code_for_current_scope() -> None:
+    runtime_repo = _ScopeAwareRuntimeRepo()
+    payload = {
+        "message": {
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 99, "username": "candidate"},
+            "text": "/link ABCD1234",
+        }
+    }
+    command = TelegramCommand(action="link", input="ABCD1234")
+
+    correct_scope = await _handle_telegram_link_command(
+        scope=TelegramScope(scope_type="team", scope_id=22),
+        payload=payload,
+        command=command,
+        runtime_repo=runtime_repo,
+    )
+
+    assert correct_scope.status_code == 200
+    assert runtime_repo.consume_calls[-1] == ("ABCD1234", "team", 22)
+    assert runtime_repo.link_calls == [
+        {
+            "scope_type": "team",
+            "scope_id": 22,
+            "telegram_user_id": 99,
+            "auth_user_id": 303,
+            "telegram_username": "candidate",
+        }
+    ]
 
 
 def test_start_link_creates_pairing_code(client, auth_headers, principal_override):

--- a/tldw_Server_API/tests/Telegram/test_telegram_session_mapper.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_session_mapper.py
@@ -56,6 +56,16 @@ def test_build_telegram_session_key_rejects_missing_group_chat_id():
         )
 
 
+@pytest.mark.unit
+def test_build_telegram_session_key_rejects_non_scalar_components() -> None:
+    with pytest.raises(ValueError):
+        build_telegram_session_key(
+            tenant_id={"scope": "tenant-a"},
+            chat_type="private",
+            telegram_user_id=200,
+        )
+
+
 def test_assistant_conversation_id_is_stable_for_same_session_key():
     key = build_telegram_session_key(
         tenant_id="tenant-a",
@@ -85,6 +95,30 @@ def test_persona_session_ids_differ_for_different_persona_ids():
     assert first != second
     assert uuid.UUID(first)
     assert uuid.UUID(second)
+
+
+@pytest.mark.unit
+def test_persona_session_id_uses_canonical_component_boundaries() -> None:
+    first = derive_telegram_persona_session_id("tenant:dm:user:persona:alpha", persona_id="beta")
+    second = derive_telegram_persona_session_id("tenant:dm:user", persona_id="alpha:persona:beta")
+
+    assert first != second
+
+
+@pytest.mark.unit
+def test_persona_and_character_ids_reject_non_scalar_identifiers() -> None:
+    key = build_telegram_session_key(
+        tenant_id="tenant-a",
+        chat_type="private",
+        telegram_chat_id=999,
+        telegram_user_id=200,
+    )
+
+    with pytest.raises(ValueError):
+        derive_telegram_persona_session_id(key, persona_id={"id": "persona-a"})
+
+    with pytest.raises(ValueError):
+        derive_telegram_character_conversation_id(key, character_id=["character-a"])
 
 
 def test_character_conversation_ids_differ_for_different_character_ids():


### PR DESCRIPTION
## Summary
- Scope-bind Telegram pairing code redemption and hash new codes at rest.
- Harden Telegram session mapper IDs against non-scalar input and delimiter collisions.
- Add Backlog task/plan records plus regression coverage for the review findings.

## Test Plan
- [x] /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ/unit/test_telegram_runtime_repo.py tldw_Server_API/tests/Telegram/test_telegram_session_mapper.py tldw_Server_API/tests/Telegram/test_telegram_linking_and_policy.py::test_link_command_consumes_pairing_code_with_current_scope -q
- [x] DATABASE_URL=sqlite:////tmp/tldw_tg_endpoint_task12007_pr_wt.db /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/Telegram/test_telegram_linking_and_policy.py -q
- [x] /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m bandit tldw_Server_API/app/core/Telegram/session_mapper.py tldw_Server_API/app/core/AuthNZ/repos/telegram_runtime_repo.py tldw_Server_API/app/api/v1/endpoints/telegram_support.py -f json -o /tmp/bandit_telegram_core_review_pr_wt.json
- [x] git diff --check

## Notes
- The default workspace AuthNZ SQLite database has local schema drift around org_provider_secrets.created_by; the endpoint suite passed against a fresh temporary AuthNZ DB.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope-bind Telegram pairing code redemption and hash new codes at rest to block cross-scope linking and plaintext secrets. Harden Telegram session ID derivation (scalar-only inputs, canonical JSON boundaries) and wire scope through the webhook.

- Bug Fixes
  - Require scope-matched pairing code consumption; pass `scope_type`/`scope_id` from webhook; wrong scope returns 403.
  - Store new pairing codes as HMAC-SHA256 (domain-separated) with a cached key; return raw on create; keep scoped fallback for legacy plaintext codes.
  - Validate session mapper to accept only scalar IDs; derive UUIDs from canonical JSON component lists to avoid delimiter collisions.
  - Added focused regression tests; Bandit clean; recorded implementation plan and backlog task.

<sup>Written for commit 54c90dfa0acb1f581baa7b3cabc13b6a5349939a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

