### PR TITLE
Harden Setup module review findings

### DIFF
--- a/Docs/superpowers/plans/2026-06-23-setup-module-review-hardening.md
+++ b/Docs/superpowers/plans/2026-06-23-setup-module-review-hardening.md
@@ -1,0 +1,97 @@
+# Setup Module Review Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden the current `tldw_Server_API/app/core/Setup` module against the validated review findings without broad setup refactoring.
+
+**Architecture:** Keep each fix on the existing setup boundaries: install-plan validation stays in `install_schema.py`, preview-plan construction stays in `readiness_service.py`, config writes stay in `setup_manager.py`, and persistence/install hardening stays inside the Setup stores and install manager. Add focused regression tests beside the existing setup tests and preserve existing API payload shapes except for the new explicit custom-embedding acknowledgement field.
+
+**Tech Stack:** Python, FastAPI setup core, Pydantic v2 models, pytest, Bandit.
+
+---
+
+### Stage 1: Regression Tests
+
+**Goal:** Reproduce each validated review finding with focused tests before production changes.
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Setup/test_install_manager_dependencies.py`
+- Modify: `tldw_Server_API/tests/Setup/test_setup_manager_masking.py`
+- Modify: `tldw_Server_API/tests/Setup/test_audio_readiness_store.py`
+- Modify: `tldw_Server_API/tests/Setup/test_setup_readiness_preview.py`
+
+**Success Criteria:** New focused tests fail for the current vulnerable behavior and fail for the expected reason.
+
+**Tests:**
+- `python -m pytest tldw_Server_API/tests/Setup/test_install_manager_dependencies.py tldw_Server_API/tests/Setup/test_setup_manager_masking.py tldw_Server_API/tests/Setup/test_audio_readiness_store.py tldw_Server_API/tests/Setup/test_setup_readiness_preview.py -q`
+
+**Status:** Complete
+
+### Stage 2: Installer Execution Hardening
+
+**Goal:** Prevent installer logs from exposing index credentials, bound subprocess execution, and block unpinned VCS requirements by default.
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Setup/install_manager.py`
+- Test: `tldw_Server_API/tests/Setup/test_install_manager_dependencies.py`
+
+**Success Criteria:** Installer command logging and errors are redacted, subprocess execution uses a configurable timeout, and unpinned VCS dependencies are skipped unless explicitly allowed.
+
+**Tests:**
+- `python -m pytest tldw_Server_API/tests/Setup/test_install_manager_dependencies.py -q`
+
+**Status:** Complete
+
+### Stage 3: Persistence Hardening
+
+**Goal:** Make setup config, setup readiness, audio readiness, and install status persistence resistant to truncation and lost updates.
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Setup/setup_manager.py`
+- Modify: `tldw_Server_API/app/core/Setup/readiness_store.py`
+- Modify: `tldw_Server_API/app/core/Setup/audio_readiness_store.py`
+- Modify: `tldw_Server_API/app/core/Setup/install_manager.py`
+- Test: `tldw_Server_API/tests/Setup/test_setup_manager_masking.py`
+- Test: `tldw_Server_API/tests/Setup/test_audio_readiness_store.py`
+- Test: `tldw_Server_API/tests/Setup/test_setup_readiness_store.py`
+
+**Success Criteria:** Atomic replace failures preserve existing files and concurrent in-process updates preserve independent fields; file lock scopes cover load/merge/save writes where the store owns the persistence path.
+
+**Tests:**
+- `python -m pytest tldw_Server_API/tests/Setup/test_setup_manager_masking.py tldw_Server_API/tests/Setup/test_audio_readiness_store.py tldw_Server_API/tests/Setup/test_setup_readiness_store.py -q`
+
+**Status:** Complete
+
+### Stage 4: Custom Embedding Trust Boundary
+
+**Goal:** Require explicit custom embedding trust acknowledgement in the install plan schema, not only the preview path.
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Setup/install_schema.py`
+- Modify: `tldw_Server_API/app/core/Setup/readiness_service.py`
+- Test: `tldw_Server_API/tests/Setup/test_install_manager_dependencies.py`
+- Test: `tldw_Server_API/tests/Setup/test_setup_readiness_preview.py`
+
+**Success Criteria:** Direct install plans containing `embeddings.custom` without acknowledgement are rejected, acknowledged preview plans include the acknowledgement marker, and ordinary curated Hugging Face/ONNX install plans remain accepted.
+
+**Tests:**
+- `python -m pytest tldw_Server_API/tests/Setup/test_install_manager_dependencies.py tldw_Server_API/tests/Setup/test_setup_readiness_preview.py -q`
+
+**Status:** Complete
+
+### Stage 5: Verification and Closeout
+
+**Goal:** Run focused setup verification, security scanning, and record final task evidence.
+
+**Files:**
+- Modify: `backlog/tasks/task-12010 - Harden-Setup-module-review-findings.md`
+- Modify: `Docs/superpowers/plans/2026-06-23-setup-module-review-hardening.md`
+
+**Success Criteria:** Focused tests pass, Bandit runs on touched Setup production files, diff whitespace check passes, and Backlog records verification results and any skips.
+
+**Tests:**
+- `python -m pytest tldw_Server_API/tests/Setup/test_install_manager_dependencies.py tldw_Server_API/tests/Setup/test_setup_manager_masking.py tldw_Server_API/tests/Setup/test_audio_readiness_store.py tldw_Server_API/tests/Setup/test_setup_readiness_store.py tldw_Server_API/tests/Setup/test_setup_readiness_preview.py -q`
+- `python -m bandit -r tldw_Server_API/app/core/Setup/install_manager.py tldw_Server_API/app/core/Setup/install_schema.py tldw_Server_API/app/core/Setup/setup_manager.py tldw_Server_API/app/core/Setup/readiness_service.py tldw_Server_API/app/core/Setup/readiness_store.py tldw_Server_API/app/core/Setup/audio_readiness_store.py -f json -o /tmp/bandit_setup_module_review_hardening.json`
+- `git diff --check`
+
+**Status:** Complete

--- a/backlog/tasks/task-12010 - Harden-Setup-module-review-findings.md
+++ b/backlog/tasks/task-12010 - Harden-Setup-module-review-findings.md
@@ -1,0 +1,73 @@
+---
+id: TASK-12010
+title: Harden Setup module review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 21:16'
+updated_date: '2026-06-23 21:39'
+labels:
+  - setup
+  - security
+  - review
+dependencies: []
+references:
+  - tldw_Server_API/app/core/Setup
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the validated Setup module review findings: redact installer command secrets, make setup config/readiness/status persistence atomic and locked where needed, require explicit custom embedding trust acknowledgement at the install schema boundary, bound installer subprocesses, and prevent automatic unpinned VCS dependency installs.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Targeted regression tests reproduce the validated setup review findings before production changes.
+- [x] #2 Installer subprocess logging redacts credentials and subprocess execution is timeout bounded.
+- [x] #3 Setup config, readiness, audio readiness, and install status persistence avoid truncation/lost-update hazards.
+- [x] #4 Custom Hugging Face embedding trust requires an explicit acknowledgement at the install plan boundary.
+- [x] #5 Unpinned VCS dependency installs are blocked unless explicitly overridden.
+- [x] #6 Focused setup tests, Bandit on touched setup code, and diff checks are recorded before completion.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Manual task record created because the Backlog MCP resources were unavailable and the official Backlog CLI hung on search/list/create in this checkout. The user approved a manual Backlog task-file exception before repository edits.
+
+Plan: Docs/superpowers/plans/2026-06-23-setup-module-review-hardening.md
+
+Implemented:
+- Added secret-aware redaction and bounded subprocess output handling for setup installer commands.
+- Added a configurable setup subprocess timeout via `TLDW_SETUP_SUBPROCESS_TIMEOUT_SECONDS`.
+- Blocked unpinned VCS requirements by default, with `TLDW_SETUP_ALLOW_UNPINNED_VCS=1` as the explicit override.
+- Added atomic writes and same-directory lock files for setup config, setup readiness, audio readiness, and installer status persistence.
+- Added `trusted_custom_model_acknowledged` to the embeddings install plan and enforced it for direct custom embedding installs.
+- Added focused regression coverage for the reviewed failure modes.
+
+Verification:
+- `python -m compileall -q ...Setup production files...` passed.
+- `python -m pytest ...focused new regression nodeids... -q --timeout=180` passed: 8 passed.
+- `python -m pytest tldw_Server_API/tests/Setup/test_install_manager_dependencies.py tldw_Server_API/tests/Setup/test_setup_manager_masking.py tldw_Server_API/tests/Setup/test_audio_readiness_store.py tldw_Server_API/tests/Setup/test_setup_readiness_store.py tldw_Server_API/tests/Setup/test_setup_readiness_preview.py -q --timeout=180` passed: 52 passed.
+- `python -m pytest tldw_Server_API/tests/Setup/test_setup_readiness_api.py tldw_Server_API/tests/Setup/test_setup_audio_installer_lifecycle_api.py tldw_Server_API/tests/Setup/test_audio_bundle_provisioning.py -q --timeout=180` passed: 47 passed.
+- Bandit on touched Setup production files completed with 0 findings in `/tmp/bandit_setup_module_review_hardening.json`.
+- Task-scoped `git diff --check -- ...touched files...` passed.
+- Repo-wide `git diff --check` was not clean because of an unrelated pre-existing whitespace issue in `tldw_Server_API/tests/FileArtifacts/test_file_artifacts_service_exports.py:317`.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed.
+- [x] #2 Tests or verification recorded.
+- [x] #3 Documentation updated when relevant.
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip.
+- [x] #5 Final summary added.
+- [x] #6 Known skips or blockers documented.
+<!-- DOD:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened the Setup module against the approved review findings. Installer subprocesses now redact secrets, use bounded output capture and timeouts, and block unpinned VCS installs by default. Setup config/readiness/status persistence now uses atomic writes and lock files to avoid truncation and lost updates. Custom embedding installs now require an explicit trust acknowledgement at the install-plan boundary. Focused Setup tests and Bandit passed; the only diff-check caveat is an unrelated whitespace issue outside the touched Setup scope.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-12010 - Harden-Setup-module-review-findings.md
+++ b/backlog/tasks/task-12010 - Harden-Setup-module-review-findings.md
@@ -4,7 +4,7 @@ title: Harden Setup module review findings
 status: Done
 assignee: []
 created_date: '2026-06-23 21:16'
-updated_date: '2026-06-23 21:39'
+updated_date: '2026-06-24 13:02'
 labels:
   - setup
   - security
@@ -57,6 +57,12 @@ Verification:
 - Bandit on touched Setup production files completed with 0 findings in `/tmp/bandit_setup_module_review_hardening.json`.
 - Task-scoped `git diff --check -- ...touched files...` passed.
 - Repo-wide `git diff --check` was not clean because of an unrelated pre-existing whitespace issue in `tldw_Server_API/tests/FileArtifacts/test_file_artifacts_service_exports.py:317`.
+
+Review follow-up on 2026-06-24:
+- Rebased PR branch `codex/setup-review-hardening` onto latest `origin/dev`.
+- Addressed Qodo comments by adding setup-specific exception types, replacing setup subprocess and lock timeout generic exceptions, making subprocess output readback non-UTF-8 tolerant, and broadening pinned VCS revision extraction beyond `.git@`.
+- Added regression tests for non-UTF-8 subprocess output, custom subprocess errors, VCS pins without `.git`, SSH VCS pins with userinfo, and setup readiness lock timeout exceptions.
+- Verification after review follow-up: compileall passed; focused review nodeids passed: 7 passed; focused Setup suite passed: 58 passed; broader Setup API/audio suite passed: 47 passed; Bandit report `/tmp/bandit_setup_module_review_rebase.json` had 0 findings; `git diff --check` passed.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12010 - Harden-Setup-module-review-findings.md
+++ b/backlog/tasks/task-12010 - Harden-Setup-module-review-findings.md
@@ -12,6 +12,7 @@ labels:
 dependencies: []
 references:
   - tldw_Server_API/app/core/Setup
+  - https://github.com/rmusser01/tldw_server/pull/2499
 priority: high
 ---
 
@@ -37,6 +38,8 @@ Fix the validated Setup module review findings: redact installer command secrets
 Manual task record created because the Backlog MCP resources were unavailable and the official Backlog CLI hung on search/list/create in this checkout. The user approved a manual Backlog task-file exception before repository edits.
 
 Plan: Docs/superpowers/plans/2026-06-23-setup-module-review-hardening.md
+
+Pull request: https://github.com/rmusser01/tldw_server/pull/2499
 
 Implemented:
 - Added secret-aware redaction and bounded subprocess output handling for setup installer commands.

--- a/tldw_Server_API/app/core/Setup/audio_readiness_store.py
+++ b/tldw_Server_API/app/core/Setup/audio_readiness_store.py
@@ -22,6 +22,7 @@ from tldw_Server_API.app.core.Setup.audio_bundle_catalog import (
     build_audio_selection_key,
     get_audio_bundle_catalog,
 )
+from tldw_Server_API.app.core.exceptions import SetupLockTimeoutError
 
 CONFIG_ROOT = setup_manager.CONFIG_RELATIVE_PATH.parent
 READINESS_FILENAME = "setup_audio_readiness.json"
@@ -180,7 +181,7 @@ def _readiness_file_lock(path: Path | None):
                     lock_path.unlink()
                     continue
             if time.monotonic() >= deadline:
-                raise TimeoutError("Timed out waiting for audio readiness lock")
+                raise SetupLockTimeoutError("Timed out waiting for audio readiness lock")
             time.sleep(0.05)
     try:
         yield

--- a/tldw_Server_API/app/core/Setup/audio_readiness_store.py
+++ b/tldw_Server_API/app/core/Setup/audio_readiness_store.py
@@ -6,6 +6,8 @@ import contextlib
 import json
 import os
 import tempfile
+import threading
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
@@ -24,6 +26,8 @@ from tldw_Server_API.app.core.Setup.audio_bundle_catalog import (
 CONFIG_ROOT = setup_manager.CONFIG_RELATIVE_PATH.parent
 READINESS_FILENAME = "setup_audio_readiness.json"
 _STORE: AudioReadinessStore | None = None
+_READINESS_LOCK_TIMEOUT_SECONDS = 10.0
+_READINESS_LOCK_STALE_SECONDS = 300.0
 
 
 def _utc_now() -> str:
@@ -156,11 +160,44 @@ def _resolve_readiness_file() -> Path | None:
     return None
 
 
+@contextlib.contextmanager
+def _readiness_file_lock(path: Path | None):
+    if path is None:
+        yield
+        return
+
+    lock_path = path.with_name(f"{path.name}.lock")
+    deadline = time.monotonic() + _READINESS_LOCK_TIMEOUT_SECONDS
+    fd: int | None = None
+    while fd is None:
+        try:
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            os.write(fd, str(os.getpid()).encode("ascii", errors="ignore"))
+        except FileExistsError:
+            with contextlib.suppress(FileNotFoundError):
+                if time.time() - lock_path.stat().st_mtime > _READINESS_LOCK_STALE_SECONDS:
+                    lock_path.unlink()
+                    continue
+            if time.monotonic() >= deadline:
+                raise TimeoutError("Timed out waiting for audio readiness lock")
+            time.sleep(0.05)
+    try:
+        yield
+    finally:
+        if fd is not None:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+        with contextlib.suppress(FileNotFoundError):
+            lock_path.unlink()
+
+
 class AudioReadinessStore:
     """Read and write the setup audio readiness snapshot."""
 
     def __init__(self, path: Path | None = None) -> None:
         self.path = path
+        self._lock = threading.RLock()
 
     def load(self) -> dict[str, Any]:
         default_record = AudioReadinessRecord()
@@ -175,6 +212,11 @@ class AudioReadinessStore:
             return default_record.model_dump()
 
     def save(self, readiness: dict[str, Any]) -> dict[str, Any]:
+        with self._lock:
+            with _readiness_file_lock(self.path):
+                return self._save_locked(readiness)
+
+    def _save_locked(self, readiness: dict[str, Any]) -> dict[str, Any]:
         payload = dict(readiness)
         payload["updated_at"] = _utc_now()
         record = AudioReadinessRecord.model_validate(payload)
@@ -207,9 +249,11 @@ class AudioReadinessStore:
         return data
 
     def update(self, **fields: Any) -> dict[str, Any]:
-        current = self.load()
-        current.update(fields)
-        return self.save(current)
+        with self._lock:
+            with _readiness_file_lock(self.path):
+                current = self.load()
+                current.update(fields)
+                return self._save_locked(current)
 
     def reset(self) -> dict[str, Any]:
         return self.save(AudioReadinessRecord().model_dump())

--- a/tldw_Server_API/app/core/Setup/install_manager.py
+++ b/tldw_Server_API/app/core/Setup/install_manager.py
@@ -9,6 +9,7 @@ import importlib.util
 import inspect
 import json
 import os
+import re
 import shutil
 import subprocess  # nosec B404 - setup provisioning intentionally invokes vetted command lists without a shell
 import sys
@@ -42,6 +43,12 @@ from tldw_Server_API.app.core.Utils.pydantic_compat import model_dump_compat
 
 CONFIG_ROOT = setup_manager.CONFIG_RELATIVE_PATH.parent
 STATUS_FILENAME = 'setup_install_status.json'
+DEFAULT_SUBPROCESS_TIMEOUT_SECONDS = 900.0
+SUBPROCESS_OUTPUT_SNIPPET_CHARS = 16_384
+_REDACTED = "[redacted]"
+_SECRET_OPTION_NAMES = {"--index-url", "--extra-index-url"}
+_MOVING_VCS_REFS = {"", "head", "main", "master", "develop", "development", "dev", "trunk"}
+_VCS_COMMIT_RE = re.compile(r"^[0-9a-f]{40}([0-9a-f]{24})?$", re.IGNORECASE)
 
 
 _LATEST_STATUS_DATA: dict[str, Any] | None = None
@@ -83,6 +90,32 @@ def _resolve_status_file() -> Path | None:
 
     logger.warning('No writable location found for setup install status; running without persistence.')
     return None
+
+
+def _write_json_file_atomically(path: Path, data: dict[str, Any]) -> None:
+    """Write JSON through a same-directory temp file and atomic replace."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            'w',
+            encoding='utf-8',
+            dir=path.parent,
+            prefix=f'{path.name}.',
+            suffix='.tmp',
+            delete=False,
+        ) as handle:
+            json.dump(data, handle, indent=2)
+            handle.flush()
+            os.fsync(handle.fileno())
+            tmp_path = handle.name
+        os.replace(tmp_path, path)
+    except Exception:
+        if tmp_path:
+            with contextlib.suppress(FileNotFoundError):
+                Path(tmp_path).unlink()
+        raise
 
 
 def _install_dependencies(plan: InstallPlan, status: InstallationStatus, errors: list[str]) -> None:
@@ -194,6 +227,12 @@ def _ensure_requirement(requirement: PipRequirement) -> None:
         _INSTALLED_DEPENDENCIES.add(package_name)
         return
 
+    if _is_unpinned_vcs_requirement(package_name) and not _allow_unpinned_vcs_requirements():
+        raise PipInstallBlockedError(
+            f'Unpinned VCS dependency installs are disabled by default: {package_name}. '
+            'Pin the requirement to an immutable commit or set TLDW_SETUP_ALLOW_UNPINNED_VCS=1.'
+        )
+
     if not _pip_allowed():
         raise PipInstallBlockedError('Package installs disabled via TLDW_SETUP_SKIP_PIP')
 
@@ -263,6 +302,35 @@ def _select_package(requirement: PipRequirement) -> str | None:
         elif requirement.cpu_package:
             package = requirement.cpu_package
     return package
+
+
+def _allow_unpinned_vcs_requirements() -> bool:
+    flag = os.getenv('TLDW_SETUP_ALLOW_UNPINNED_VCS')
+    return bool(flag and flag.strip().lower() in {'1', 'true', 'yes', 'y', 'on'})
+
+
+def _is_vcs_requirement(package: str) -> bool:
+    return package.strip().lower().startswith(('git+', 'hg+', 'svn+', 'bzr+'))
+
+
+def _vcs_requirement_revision(package: str) -> str | None:
+    spec = package.strip().split('#', 1)[0]
+    marker = '.git@'
+    if marker not in spec:
+        return None
+    revision = spec.rsplit(marker, 1)[1].strip()
+    return revision or None
+
+
+def _is_unpinned_vcs_requirement(package: str) -> bool:
+    if not _is_vcs_requirement(package):
+        return False
+    revision = _vcs_requirement_revision(package)
+    if revision is None:
+        return True
+    if revision.lower() in _MOVING_VCS_REFS:
+        return True
+    return _VCS_COMMIT_RE.fullmatch(revision) is None
 
 
 def _cuda_available() -> bool:
@@ -439,7 +507,7 @@ class InstallationStatus:
             return
 
         try:
-            self.path.write_text(json.dumps(self.data, indent=2), encoding='utf-8')
+            _write_json_file_atomically(self.path, self.data)
         except Exception:  # noqa: BLE001
             if not self._persist_failed:
                 logger.warning(
@@ -498,7 +566,7 @@ def _persist_install_status_snapshot(data: dict[str, Any]) -> None:
     path = _resolve_status_file()
     if path:
         try:
-            path.write_text(json.dumps(data, indent=2), encoding='utf-8')
+            _write_json_file_atomically(path, data)
         except Exception:  # noqa: BLE001
             logger.warning('Failed to persist qualified setup install status to {}', path, exc_info=True)
     _record_latest_status(data)
@@ -1527,18 +1595,90 @@ def _snapshot_repo(repo_id: str) -> None:
         raise
 
 
-def _run_subprocess(command: list[str]) -> None:
-    logger.info('Running command: {}', ' '.join(command))
-    result = subprocess.run(  # nosec B603 - command argv is assembled from trusted setup requirement mappings
-        command,
-        check=False,
-        capture_output=True,
-        text=True,
+def _redact_secret_text(value: str) -> str:
+    redacted = re.sub(r'(?i)([a-z][a-z0-9+.-]*://)[^/\s@]+@', rf'\1{_REDACTED}@', value)
+    return re.sub(
+        r'(?i)([?&][^=\s&]*(?:token|key|secret|password|credential|auth)[^=\s&]*=)[^&\s]+',
+        rf'\1{_REDACTED}',
+        redacted,
     )
+
+
+def _redact_command(command: list[str]) -> list[str]:
+    redacted: list[str] = []
+    redact_next = False
+    for part in command:
+        if redact_next:
+            redacted.append(_redact_secret_text(part))
+            redact_next = False
+            continue
+        option, separator, value = part.partition('=')
+        if part in _SECRET_OPTION_NAMES:
+            redacted.append(part)
+            redact_next = True
+        elif separator and option in _SECRET_OPTION_NAMES:
+            redacted.append(f'{option}={_redact_secret_text(value)}')
+        else:
+            redacted.append(_redact_secret_text(part))
+    return redacted
+
+
+def _subprocess_timeout_seconds() -> float | None:
+    raw = os.getenv('TLDW_SETUP_SUBPROCESS_TIMEOUT_SECONDS')
+    if raw is None or not raw.strip():
+        return DEFAULT_SUBPROCESS_TIMEOUT_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning('Invalid TLDW_SETUP_SUBPROCESS_TIMEOUT_SECONDS value; using default.')
+        return DEFAULT_SUBPROCESS_TIMEOUT_SECONDS
+    if value <= 0:
+        return None
+    return value
+
+
+def _format_timeout(seconds: float | None) -> str:
+    if seconds is None:
+        return 'configured'
+    if float(seconds).is_integer():
+        return str(int(seconds))
+    return str(seconds)
+
+
+def _read_bounded_output(handle: Any) -> str:
+    handle.seek(0)
+    output = handle.read(SUBPROCESS_OUTPUT_SNIPPET_CHARS + 1)
+    if len(output) > SUBPROCESS_OUTPUT_SNIPPET_CHARS:
+        output = output[:SUBPROCESS_OUTPUT_SNIPPET_CHARS] + '\n[output truncated]'
+    return _redact_secret_text(output)
+
+
+def _run_subprocess(command: list[str], *, timeout_seconds: float | None = None) -> None:
+    timeout = _subprocess_timeout_seconds() if timeout_seconds is None else timeout_seconds
+    logger.info('Running command: {}', ' '.join(_redact_command(command)))
+    try:
+        with tempfile.TemporaryFile('w+', encoding='utf-8') as stdout_handle, tempfile.TemporaryFile(
+            'w+',
+            encoding='utf-8',
+        ) as stderr_handle:
+            result = subprocess.run(  # nosec B603 - command argv is assembled from trusted setup requirement mappings
+                command,
+                check=False,
+                stdout=stdout_handle,
+                stderr=stderr_handle,
+                text=True,
+                timeout=timeout,
+            )
+            stderr_output = _read_bounded_output(stderr_handle)
+            stdout_output = _read_bounded_output(stdout_handle)
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f'Command timed out after {_format_timeout(timeout)} seconds') from exc
     if result.returncode != 0:
-        raise RuntimeError(result.stderr.strip() or f'Command failed with exit code {result.returncode}')
-    if result.stdout:
-        logger.debug(result.stdout)
+        raise RuntimeError(stderr_output.strip() or f'Command failed with exit code {result.returncode}')
+    if stdout_output:
+        logger.debug(stdout_output)
+
+
 @dataclass(frozen=True)
 class PipRequirement:
     package: str

--- a/tldw_Server_API/app/core/Setup/install_manager.py
+++ b/tldw_Server_API/app/core/Setup/install_manager.py
@@ -39,6 +39,7 @@ from tldw_Server_API.app.core.Setup.audio_bundle_catalog import (
     get_audio_bundle_catalog,
 )
 from tldw_Server_API.app.core.Setup.install_schema import DEFAULT_WHISPER_MODELS, InstallPlan
+from tldw_Server_API.app.core.exceptions import SetupSubprocessError
 from tldw_Server_API.app.core.Utils.pydantic_compat import model_dump_compat
 
 CONFIG_ROOT = setup_manager.CONFIG_RELATIVE_PATH.parent
@@ -315,10 +316,10 @@ def _is_vcs_requirement(package: str) -> bool:
 
 def _vcs_requirement_revision(package: str) -> str | None:
     spec = package.strip().split('#', 1)[0]
-    marker = '.git@'
-    if marker not in spec:
+    revision_marker = spec.rfind('@')
+    if revision_marker <= spec.rfind('/'):
         return None
-    revision = spec.rsplit(marker, 1)[1].strip()
+    revision = spec[revision_marker + 1:].strip()
     return revision or None
 
 
@@ -1648,33 +1649,37 @@ def _format_timeout(seconds: float | None) -> str:
 def _read_bounded_output(handle: Any) -> str:
     handle.seek(0)
     output = handle.read(SUBPROCESS_OUTPUT_SNIPPET_CHARS + 1)
+    truncated = len(output) > SUBPROCESS_OUTPUT_SNIPPET_CHARS
     if len(output) > SUBPROCESS_OUTPUT_SNIPPET_CHARS:
-        output = output[:SUBPROCESS_OUTPUT_SNIPPET_CHARS] + '\n[output truncated]'
-    return _redact_secret_text(output)
+        output = output[:SUBPROCESS_OUTPUT_SNIPPET_CHARS]
+    if isinstance(output, bytes):
+        text = output.decode('utf-8', errors='replace')
+    else:
+        text = str(output)
+    if truncated:
+        text += '\n[output truncated]'
+    return _redact_secret_text(text)
 
 
 def _run_subprocess(command: list[str], *, timeout_seconds: float | None = None) -> None:
     timeout = _subprocess_timeout_seconds() if timeout_seconds is None else timeout_seconds
     logger.info('Running command: {}', ' '.join(_redact_command(command)))
     try:
-        with tempfile.TemporaryFile('w+', encoding='utf-8') as stdout_handle, tempfile.TemporaryFile(
-            'w+',
-            encoding='utf-8',
-        ) as stderr_handle:
+        with tempfile.TemporaryFile('w+b') as stdout_handle, tempfile.TemporaryFile('w+b') as stderr_handle:
             result = subprocess.run(  # nosec B603 - command argv is assembled from trusted setup requirement mappings
                 command,
                 check=False,
                 stdout=stdout_handle,
                 stderr=stderr_handle,
-                text=True,
+                text=False,
                 timeout=timeout,
             )
             stderr_output = _read_bounded_output(stderr_handle)
             stdout_output = _read_bounded_output(stdout_handle)
     except subprocess.TimeoutExpired as exc:
-        raise RuntimeError(f'Command timed out after {_format_timeout(timeout)} seconds') from exc
+        raise SetupSubprocessError(f'Command timed out after {_format_timeout(timeout)} seconds') from exc
     if result.returncode != 0:
-        raise RuntimeError(stderr_output.strip() or f'Command failed with exit code {result.returncode}')
+        raise SetupSubprocessError(stderr_output.strip() or f'Command failed with exit code {result.returncode}')
     if stdout_output:
         logger.debug(stdout_output)
 

--- a/tldw_Server_API/app/core/Setup/install_schema.py
+++ b/tldw_Server_API/app/core/Setup/install_schema.py
@@ -64,6 +64,10 @@ class EmbeddingsInstall(BaseModel):
     huggingface: list[str] = Field(default_factory=list)
     custom: list[str] = Field(default_factory=list)
     onnx: list[str] = Field(default_factory=list)
+    trusted_custom_model_acknowledged: bool = Field(
+        default=False,
+        exclude_if=lambda value: value is False,
+    )
 
     @model_validator(mode='before')
     @classmethod
@@ -75,6 +79,15 @@ class EmbeddingsInstall(BaseModel):
             entries = normalised.get(key) or []
             normalised[key] = [item.strip() for item in entries if item and item.strip()]
         return normalised
+
+    @model_validator(mode='after')
+    def _validate_custom_trust_acknowledgement(self) -> EmbeddingsInstall:
+        self.huggingface = list(dict.fromkeys(self.huggingface))
+        self.custom = list(dict.fromkeys(self.custom))
+        self.onnx = list(dict.fromkeys(self.onnx))
+        if self.custom and not self.trusted_custom_model_acknowledged:
+            raise ValueError("custom embedding trust acknowledgement is required")
+        return self
 
 
 class InstallPlan(BaseModel):

--- a/tldw_Server_API/app/core/Setup/readiness_service.py
+++ b/tldw_Server_API/app/core/Setup/readiness_service.py
@@ -110,6 +110,8 @@ def _merge_install_plan(target: dict[str, Any], source: InstallPlan) -> None:
     for key in ("huggingface", "custom", "onnx"):
         for model in source_embeddings.get(key, []):
             _append_unique(target["embeddings"][key], model)
+    if source_embeddings.get("trusted_custom_model_acknowledged"):
+        target["embeddings"]["trusted_custom_model_acknowledged"] = True
 
 
 def _model_dump(model: Any) -> dict[str, Any]:
@@ -264,6 +266,8 @@ def _preview_embeddings_lane(
     if provider == "huggingface":
         target = "custom" if _truthy(lane.get("trusted_custom_model")) else "huggingface"
         _append_unique(install_plan["embeddings"][target], model)
+        if target == "custom":
+            install_plan["embeddings"]["trusted_custom_model_acknowledged"] = True
     elif provider == "onnx":
         _append_unique(install_plan["embeddings"]["onnx"], model)
 

--- a/tldw_Server_API/app/core/Setup/readiness_store.py
+++ b/tldw_Server_API/app/core/Setup/readiness_store.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from tldw_Server_API.app.core.Setup import setup_manager
 from tldw_Server_API.app.core.Setup.readiness_models import LANE_IDS, LANE_STATUSES, OVERLAY_IDS
+from tldw_Server_API.app.core.exceptions import SetupLockTimeoutError
 
 CONFIG_ROOT = setup_manager.CONFIG_RELATIVE_PATH.parent
 READINESS_FILENAME = "setup_readiness.json"
@@ -135,7 +136,7 @@ def _readiness_file_lock(path: Path | None):
                     lock_path.unlink()
                     continue
             if time.monotonic() >= deadline:
-                raise TimeoutError("Timed out waiting for setup readiness lock")
+                raise SetupLockTimeoutError("Timed out waiting for setup readiness lock")
             time.sleep(0.05)
     try:
         yield

--- a/tldw_Server_API/app/core/Setup/readiness_store.py
+++ b/tldw_Server_API/app/core/Setup/readiness_store.py
@@ -7,6 +7,7 @@ import json
 import os
 import tempfile
 import threading
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
@@ -20,6 +21,8 @@ from tldw_Server_API.app.core.Setup.readiness_models import LANE_IDS, LANE_STATU
 CONFIG_ROOT = setup_manager.CONFIG_RELATIVE_PATH.parent
 READINESS_FILENAME = "setup_readiness.json"
 _STORE: SetupReadinessStore | None = None
+_READINESS_LOCK_TIMEOUT_SECONDS = 10.0
+_READINESS_LOCK_STALE_SECONDS = 300.0
 
 
 def _utc_now() -> str:
@@ -112,6 +115,38 @@ def _resolve_readiness_file() -> Path | None:
     return None
 
 
+@contextlib.contextmanager
+def _readiness_file_lock(path: Path | None):
+    if path is None:
+        yield
+        return
+
+    lock_path = path.with_name(f"{path.name}.lock")
+    deadline = time.monotonic() + _READINESS_LOCK_TIMEOUT_SECONDS
+    fd: int | None = None
+    while fd is None:
+        try:
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            os.write(fd, str(os.getpid()).encode("ascii", errors="ignore"))
+        except FileExistsError:
+            with contextlib.suppress(FileNotFoundError):
+                if time.time() - lock_path.stat().st_mtime > _READINESS_LOCK_STALE_SECONDS:
+                    lock_path.unlink()
+                    continue
+            if time.monotonic() >= deadline:
+                raise TimeoutError("Timed out waiting for setup readiness lock")
+            time.sleep(0.05)
+    try:
+        yield
+    finally:
+        if fd is not None:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+        with contextlib.suppress(FileNotFoundError):
+            lock_path.unlink()
+
+
 class SetupReadinessStore:
     """Read and write the first-run setup readiness snapshot."""
 
@@ -133,42 +168,47 @@ class SetupReadinessStore:
 
     def save(self, readiness: dict[str, Any]) -> dict[str, Any]:
         with self._lock:
-            payload = dict(readiness)
-            payload["updated_at"] = _utc_now()
-            record = SetupReadinessRecord.model_validate(payload)
-            data = record.model_dump()
+            with _readiness_file_lock(self.path):
+                return self._save_locked(readiness)
 
-            if not self.path:
-                return data
+    def _save_locked(self, readiness: dict[str, Any]) -> dict[str, Any]:
+        payload = dict(readiness)
+        payload["updated_at"] = _utc_now()
+        record = SetupReadinessRecord.model_validate(payload)
+        data = record.model_dump()
 
-            self.path.parent.mkdir(parents=True, exist_ok=True)
-            tmp_path: str | None = None
-            try:
-                with tempfile.NamedTemporaryFile(
-                    "w",
-                    encoding="utf-8",
-                    dir=self.path.parent,
-                    prefix=f"{self.path.name}.",
-                    suffix=".tmp",
-                    delete=False,
-                ) as handle:
-                    json.dump(data, handle, indent=2)
-                    handle.flush()
-                    os.fsync(handle.fileno())
-                    tmp_path = handle.name
-                os.replace(tmp_path, self.path)
-            except Exception:
-                if tmp_path:
-                    with contextlib.suppress(FileNotFoundError):
-                        Path(tmp_path).unlink()
-                raise
+        if not self.path:
             return data
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                dir=self.path.parent,
+                prefix=f"{self.path.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as handle:
+                json.dump(data, handle, indent=2)
+                handle.flush()
+                os.fsync(handle.fileno())
+                tmp_path = handle.name
+            os.replace(tmp_path, self.path)
+        except Exception:
+            if tmp_path:
+                with contextlib.suppress(FileNotFoundError):
+                    Path(tmp_path).unlink()
+            raise
+        return data
 
     def update(self, **fields: Any) -> dict[str, Any]:
         with self._lock:
-            current = self.load()
-            current.update(fields)
-            return self.save(current)
+            with _readiness_file_lock(self.path):
+                current = self.load()
+                current.update(fields)
+                return self._save_locked(current)
 
     def reset(self) -> dict[str, Any]:
         return self.save(SetupReadinessRecord().model_dump())

--- a/tldw_Server_API/app/core/Setup/setup_manager.py
+++ b/tldw_Server_API/app/core/Setup/setup_manager.py
@@ -22,6 +22,7 @@ from typing import Any, Callable
 from loguru import logger
 
 from tldw_Server_API.app.core.config_paths import resolve_config_file, resolve_config_root
+from tldw_Server_API.app.core.exceptions import SetupLockTimeoutError
 from tldw_Server_API.app.core.testing import env_flag_enabled
 from tldw_Server_API.app.core.Utils.Utils import get_project_root
 
@@ -641,7 +642,7 @@ def _config_file_lock(config_path: Path):
                     lock_path.unlink()
                     continue
             if time.monotonic() >= deadline:
-                raise TimeoutError(f"Timed out waiting for setup config lock: {lock_path}")
+                raise SetupLockTimeoutError(f"Timed out waiting for setup config lock: {lock_path}")
             time.sleep(0.05)
     try:
         yield

--- a/tldw_Server_API/app/core/Setup/setup_manager.py
+++ b/tldw_Server_API/app/core/Setup/setup_manager.py
@@ -7,9 +7,12 @@ file handling logic across routers or UI layers.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import re
 import shutil
+import tempfile
+import time
 from configparser import ConfigParser
 from datetime import datetime
 from difflib import SequenceMatcher
@@ -63,6 +66,8 @@ _OPTIONAL_EMPTY_VALUE_FIELDS = {
 _provider_catalog_update_fields: set[tuple[str, str]] | None = None
 
 _remote_access_hook: Callable[[bool], None] | None = None
+_CONFIG_LOCK_TIMEOUT_SECONDS = 10.0
+_CONFIG_LOCK_STALE_SECONDS = 300.0
 
 
 def register_remote_access_hook(callback: Callable[[bool], None]) -> None:
@@ -576,43 +581,106 @@ def update_config(updates: dict[str, dict[str, Any]], *, create_backup: bool = T
     if not updates:
         raise ValueError("No updates provided for configuration")
 
-    parser = _load_config_parser()
     config_path = get_config_file_path()
+    remote_access_value: bool | None = None
 
-    # Validate sections/keys and types against existing config
-    _validate_updates(parser, updates)
+    with _config_file_lock(config_path):
+        parser = _load_config_parser()
 
-    # Stage updates into the in-memory parser so that downstream hooks can read booleans
-    for section, items in updates.items():
-        if not parser.has_section(section):
-            parser.add_section(section)
-        for key, value in items.items():
-            parser.set(section, key, _coerce_to_string(value))
+        # Validate sections/keys and types against existing config
+        _validate_updates(parser, updates)
 
-    backup_path = None
-    if create_backup:
-        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
-        backup_path = config_path.with_suffix(config_path.suffix + f".pre-setup-{timestamp}.bak")
-        shutil.copy2(config_path, backup_path)
-        logger.info(f"Created backup of config.txt at {backup_path}")
+        # Stage updates into the in-memory parser so that downstream hooks can read booleans
+        for section, items in updates.items():
+            if not parser.has_section(section):
+                parser.add_section(section)
+            for key, value in items.items():
+                parser.set(section, key, _coerce_to_string(value))
 
-    # Write changes back while preserving comments and unrelated formatting
-    _write_config_preserving_comments(config_path, updates)
+        backup_path = None
+        if create_backup:
+            timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+            backup_path = config_path.with_suffix(config_path.suffix + f".pre-setup-{timestamp}.bak")
+            shutil.copy2(config_path, backup_path)
+            logger.info(f"Created backup of config.txt at {backup_path}")
+
+        # Write changes back while preserving comments and unrelated formatting
+        _write_config_preserving_comments(config_path, updates)
+
+        if (
+            _remote_access_hook
+            and SETUP_SECTION in updates
+            and REMOTE_ACCESS_FIELD in updates[SETUP_SECTION]
+        ):
+            remote_access_value = parser.getboolean(SETUP_SECTION, REMOTE_ACCESS_FIELD, fallback=False)
 
     logger.info("Configuration file updated via setup manager (comments preserved)")
 
-    if (
-        _remote_access_hook
-        and SETUP_SECTION in updates
-        and REMOTE_ACCESS_FIELD in updates[SETUP_SECTION]
-    ):
+    if remote_access_value is not None:
         try:
-            new_value = parser.getboolean(SETUP_SECTION, REMOTE_ACCESS_FIELD, fallback=False)
-            _remote_access_hook(new_value)
+            _remote_access_hook(remote_access_value)
         except Exception:  # noqa: BLE001
             logger.exception("Failed to propagate remote setup access change")
 
     return backup_path
+
+
+@contextlib.contextmanager
+def _config_file_lock(config_path: Path):
+    lock_path = config_path.with_name(f"{config_path.name}.lock")
+    deadline = time.monotonic() + _CONFIG_LOCK_TIMEOUT_SECONDS
+    fd: int | None = None
+    while fd is None:
+        try:
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            os.write(fd, str(os.getpid()).encode("ascii", errors="ignore"))
+        except FileExistsError:
+            with contextlib.suppress(FileNotFoundError):
+                if time.time() - lock_path.stat().st_mtime > _CONFIG_LOCK_STALE_SECONDS:
+                    lock_path.unlink()
+                    continue
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Timed out waiting for setup config lock: {lock_path}")
+            time.sleep(0.05)
+    try:
+        yield
+    finally:
+        if fd is not None:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+        with contextlib.suppress(FileNotFoundError):
+            lock_path.unlink()
+
+
+def _write_text_atomically(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path: str | None = None
+    existing_mode: int | None = None
+    with contextlib.suppress(FileNotFoundError):
+        existing_mode = path.stat().st_mode
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            newline="",
+            dir=path.parent,
+            prefix=f"{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+            tmp_path = handle.name
+        if existing_mode is not None:
+            os.chmod(tmp_path, existing_mode & 0o7777)
+        os.replace(tmp_path, path)
+    except Exception:
+        if tmp_path:
+            with contextlib.suppress(FileNotFoundError):
+                Path(tmp_path).unlink()
+        raise
 
 
 def _write_config_preserving_comments(config_path: Path, updates: dict[str, dict[str, Any]]) -> None:
@@ -707,8 +775,7 @@ def _write_config_preserving_comments(config_path: Path, updates: dict[str, dict
             for key, value in items.items():
                 out_lines.append(f"{key} = {value}{default_line_ending}")
 
-    with config_path.open("w", encoding="utf-8", newline="") as handle:
-        handle.write("".join(out_lines))
+    _write_text_atomically(config_path, "".join(out_lines))
 
 
 def _validate_updates(parser: ConfigParser, updates: dict[str, dict[str, Any]]) -> None:

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -130,6 +130,18 @@ class ValidationError(BadRequestError):
     """Raised when validation of input parameters fails."""
 
 
+class SetupError(RuntimeError):
+    """Base class for first-run setup and installer failures."""
+
+
+class SetupSubprocessError(SetupError):
+    """Raised when a setup-managed subprocess fails or times out."""
+
+
+class SetupLockTimeoutError(SetupError):
+    """Raised when setup state persistence cannot acquire its lock."""
+
+
 class InvalidGovernanceCandidateError(ValueError):
     """Raised when a policy source returns a malformed governance candidate."""
 

--- a/tldw_Server_API/tests/Setup/test_audio_readiness_store.py
+++ b/tldw_Server_API/tests/Setup/test_audio_readiness_store.py
@@ -1,5 +1,7 @@
 import pytest
 import sys
+import threading
+import time
 
 from tldw_Server_API.app.core.Setup import install_manager
 from tldw_Server_API.app.core.Setup import audio_readiness_store
@@ -166,6 +168,42 @@ def test_audio_readiness_save_keeps_existing_file_when_atomic_replace_fails(tmp_
 
     assert readiness_path.read_text(encoding="utf-8") == initial_contents
     assert list(tmp_path.glob("audio_readiness.json.*.tmp")) == []
+
+
+def test_audio_readiness_update_preserves_concurrent_fields(tmp_path, monkeypatch):
+    readiness_path = tmp_path / "audio_readiness.json"
+    store = AudioReadinessStore(readiness_path)
+    first_load_started = threading.Event()
+    original_load = store.load
+    load_calls = 0
+
+    def slow_first_load():
+        nonlocal load_calls
+        load_calls += 1
+        data = original_load()
+        if load_calls == 1:
+            first_load_started.set()
+            time.sleep(0.05)
+        return data
+
+    monkeypatch.setattr(store, "load", slow_first_load)
+
+    first = threading.Thread(target=lambda: store.update(selected_bundle_id="cpu_local"))
+    second = threading.Thread(
+        target=lambda: store.update(imported_packs=[{"pack_path": "audio_packs/custom.json"}])
+    )
+
+    first.start()
+    assert first_load_started.wait(timeout=1)
+    second.start()
+    first.join(timeout=1)
+    second.join(timeout=1)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    readiness = store.load()
+    assert readiness["selected_bundle_id"] == "cpu_local"
+    assert readiness["imported_packs"] == [{"pack_path": "audio_packs/custom.json"}]
 
 
 def test_resolve_readiness_file_candidate_failure_log_is_sanitized(tmp_path, monkeypatch):

--- a/tldw_Server_API/tests/Setup/test_install_manager_dependencies.py
+++ b/tldw_Server_API/tests/Setup/test_install_manager_dependencies.py
@@ -10,6 +10,7 @@ import pytest
 
 from tldw_Server_API.app.core.Setup import install_manager
 from tldw_Server_API.app.core.Setup.install_schema import InstallPlan, TTSInstall
+from tldw_Server_API.app.core.exceptions import SetupSubprocessError
 
 
 class _CapturingLogger:
@@ -143,9 +144,9 @@ def test_run_subprocess_redacts_pip_index_credentials(monkeypatch):
 
     def fake_run(command, check=False, capture_output=True, text=True, timeout=None, **kwargs):  # noqa: ARG001
         if kwargs.get("stdout") is not None:
-            kwargs["stdout"].write("")
+            kwargs["stdout"].write(b"")
         if kwargs.get("stderr") is not None:
-            kwargs["stderr"].write("")
+            kwargs["stderr"].write(b"")
         return types.SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(install_manager.subprocess, "run", fake_run)
@@ -180,7 +181,7 @@ def test_run_subprocess_uses_timeout_and_redacts_timeout_errors(monkeypatch):
 
     monkeypatch.setattr(install_manager.subprocess, "run", fake_run)
 
-    with pytest.raises(RuntimeError, match="timed out after 7"):
+    with pytest.raises(SetupSubprocessError, match="timed out after 7"):
         install_manager._run_subprocess(
             [
                 install_manager.sys.executable,
@@ -197,6 +198,40 @@ def test_run_subprocess_uses_timeout_and_redacts_timeout_errors(monkeypatch):
     joined = _joined_records(logger)
     assert "secret-token" not in joined
     assert "user:secret-token" not in joined
+
+
+def test_run_subprocess_decodes_non_utf8_output_safely(monkeypatch):
+    logger = _CapturingLogger()
+    monkeypatch.setattr(install_manager, "logger", logger)
+
+    def fake_run(command, check=False, capture_output=True, text=True, timeout=None, **kwargs):  # noqa: ARG001
+        kwargs["stdout"].write(b"ok: \xff https://user:secret-token@example.test/simple")
+        kwargs["stderr"].write(b"")
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(install_manager.subprocess, "run", fake_run)
+
+    install_manager._run_subprocess(["demo-command"])
+
+    joined = _joined_records(logger)
+    assert "secret-token" not in joined
+    assert "[redacted]" in joined
+
+
+def test_run_subprocess_raises_custom_error_for_nonzero_exit(monkeypatch):
+    def fake_run(command, check=False, capture_output=True, text=True, timeout=None, **kwargs):  # noqa: ARG001
+        kwargs["stdout"].write(b"")
+        kwargs["stderr"].write(b"\xff failed https://user:secret-token@example.test/simple")
+        return types.SimpleNamespace(returncode=2, stdout="", stderr="")
+
+    monkeypatch.setattr(install_manager.subprocess, "run", fake_run)
+
+    with pytest.raises(SetupSubprocessError) as exc_info:
+        install_manager._run_subprocess(["demo-command"])
+
+    message = str(exc_info.value)
+    assert "secret-token" not in message
+    assert "[redacted]" in message
 
 
 def test_install_plan_rejects_custom_embeddings_without_trust_acknowledgement():
@@ -249,6 +284,41 @@ def test_unpinned_vcs_requirement_is_blocked_by_default(monkeypatch):
         )
 
     assert executed == []
+
+
+def test_vcs_requirement_revision_accepts_commit_after_repo_without_dot_git():
+    commit = "a" * 40
+
+    assert install_manager._is_unpinned_vcs_requirement(
+        f"git+https://github.com/org/repo@{commit}#egg=repo"
+    ) is False
+
+
+def test_vcs_requirement_revision_accepts_ssh_userinfo_and_dot_git_commit():
+    commit = "b" * 40
+
+    assert install_manager._is_unpinned_vcs_requirement(
+        f"git+ssh://git@github.com/org/repo.git@{commit}#egg=repo"
+    ) is False
+
+
+def test_pinned_vcs_requirement_without_dot_git_is_not_blocked(monkeypatch):
+    commit = "c" * 40
+    requirement = f"git+https://github.com/org/repo@{commit}#egg=repo"
+    executed: list[list[str]] = []
+    monkeypatch.delenv("TLDW_SETUP_ALLOW_UNPINNED_VCS", raising=False)
+    monkeypatch.setattr(install_manager, "_pip_allowed", lambda: True)
+    monkeypatch.setattr(
+        install_manager.subprocess,
+        "run",
+        lambda *_args, **_kwargs: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(install_manager, "_run_subprocess", lambda cmd: executed.append(cmd))
+
+    install_manager._ensure_requirement(install_manager.PipRequirement(package=requirement))
+
+    assert executed
+    assert executed[0][-1] == requirement
 
 
 def test_install_plan_accepts_kitten_tts():

--- a/tldw_Server_API/tests/Setup/test_install_manager_dependencies.py
+++ b/tldw_Server_API/tests/Setup/test_install_manager_dependencies.py
@@ -16,6 +16,9 @@ class _CapturingLogger:
     def __init__(self):
         self.records = []
 
+    def info(self, message, *args, **kwargs):
+        self.records.append(("info", message, args, dict(kwargs)))
+
     def debug(self, message, *args, **kwargs):
         self.records.append(("debug", message, args, dict(kwargs)))
 
@@ -132,6 +135,120 @@ def test_dependencies_trigger_pip_install(monkeypatch):
         pip_cmd = commands[0]
         assert pip_cmd[:4] == [install_manager.sys.executable, '-m', 'pip', 'install']
         assert any('faster-whisper' in part for part in pip_cmd)
+
+
+def test_run_subprocess_redacts_pip_index_credentials(monkeypatch):
+    logger = _CapturingLogger()
+    monkeypatch.setattr(install_manager, "logger", logger)
+
+    def fake_run(command, check=False, capture_output=True, text=True, timeout=None, **kwargs):  # noqa: ARG001
+        if kwargs.get("stdout") is not None:
+            kwargs["stdout"].write("")
+        if kwargs.get("stderr") is not None:
+            kwargs["stderr"].write("")
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(install_manager.subprocess, "run", fake_run)
+
+    install_manager._run_subprocess(
+        [
+            install_manager.sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--index-url",
+            "https://user:secret-token@example.test/simple",
+            "demo-package",
+        ]
+    )
+
+    joined = _joined_records(logger)
+    assert "secret-token" not in joined
+    assert "user:secret-token" not in joined
+    assert "[redacted]" in joined
+
+
+def test_run_subprocess_uses_timeout_and_redacts_timeout_errors(monkeypatch):
+    logger = _CapturingLogger()
+    observed_timeouts: list[float | None] = []
+    monkeypatch.setattr(install_manager, "logger", logger)
+    monkeypatch.setenv("TLDW_SETUP_SUBPROCESS_TIMEOUT_SECONDS", "7")
+
+    def fake_run(command, check=False, capture_output=True, text=True, timeout=None, **_kwargs):  # noqa: ARG001
+        observed_timeouts.append(timeout)
+        raise install_manager.subprocess.TimeoutExpired(cmd=command, timeout=timeout)
+
+    monkeypatch.setattr(install_manager.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="timed out after 7"):
+        install_manager._run_subprocess(
+            [
+                install_manager.sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--index-url",
+                "https://user:secret-token@example.test/simple",
+                "demo-package",
+            ]
+        )
+
+    assert observed_timeouts == [7.0]
+    joined = _joined_records(logger)
+    assert "secret-token" not in joined
+    assert "user:secret-token" not in joined
+
+
+def test_install_plan_rejects_custom_embeddings_without_trust_acknowledgement():
+    with pytest.raises(ValueError, match="trust acknowledgement"):
+        InstallPlan.model_validate(
+            {
+                "stt": [],
+                "tts": [],
+                "embeddings": {"huggingface": [], "custom": ["custom/requires-trust"], "onnx": []},
+            }
+        )
+
+
+def test_install_plan_accepts_custom_embeddings_with_trust_acknowledgement():
+    plan = InstallPlan.model_validate(
+        {
+            "stt": [],
+            "tts": [],
+            "embeddings": {
+                "huggingface": [],
+                "custom": ["custom/allowed-with-ack"],
+                "onnx": [],
+                "trusted_custom_model_acknowledged": True,
+            },
+        }
+    )
+
+    assert plan.embeddings.custom == ["custom/allowed-with-ack"]
+    assert plan.embeddings.trusted_custom_model_acknowledged is True
+
+
+def test_unpinned_vcs_requirement_is_blocked_by_default(monkeypatch):
+    monkeypatch.delenv("TLDW_SETUP_ALLOW_UNPINNED_VCS", raising=False)
+    monkeypatch.setattr(install_manager, "_pip_allowed", lambda: True)
+    monkeypatch.setattr(importlib.util, "find_spec", lambda _name: None)
+    monkeypatch.setattr(
+        install_manager.subprocess,
+        "run",
+        lambda *_args, **_kwargs: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    executed: list[list[str]] = []
+    monkeypatch.setattr(install_manager, "_run_subprocess", lambda cmd: executed.append(cmd))
+
+    with pytest.raises(install_manager.PipInstallBlockedError, match="Unpinned VCS"):
+        install_manager._ensure_requirement(
+            install_manager.PipRequirement(
+                package="git+https://github.com/example/unpinned.git",
+                import_name="example_unpinned",
+            )
+        )
+
+    assert executed == []
 
 
 def test_install_plan_accepts_kitten_tts():

--- a/tldw_Server_API/tests/Setup/test_setup_manager_masking.py
+++ b/tldw_Server_API/tests/Setup/test_setup_manager_masking.py
@@ -1,3 +1,6 @@
+import pytest
+
+from tldw_Server_API.app.core.Setup import setup_manager
 from tldw_Server_API.app.core.Setup.setup_manager import get_config_snapshot, SENSITIVE_KEY_MARKERS
 
 
@@ -25,3 +28,25 @@ def test_secret_values_are_masked_in_config_snapshot():
         assert entry.get("value") == ""
         # is_set helps clients know if a masked secret exists (optional but desirable)
         assert "is_set" in entry
+
+
+def test_update_config_preserves_existing_config_when_atomic_replace_fails(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.txt"
+    original = (
+        "[Setup]\n"
+        "enable_first_time_setup = true\n"
+        "setup_completed = false\n"
+        "allow_remote_setup_access = false\n"
+    )
+    config_path.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(setup_manager, "get_config_file_path", lambda: config_path)
+
+    def _raise_replace(_src, _dst):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(setup_manager.os, "replace", _raise_replace)
+
+    with pytest.raises(OSError, match="replace failed"):
+        setup_manager.update_config({"Setup": {"setup_completed": True}}, create_backup=False)
+
+    assert config_path.read_text(encoding="utf-8") == original

--- a/tldw_Server_API/tests/Setup/test_setup_readiness_preview.py
+++ b/tldw_Server_API/tests/Setup/test_setup_readiness_preview.py
@@ -186,6 +186,7 @@ def test_acknowledged_trusted_custom_hf_enters_custom_install_plan():
 
     assert preview["lanes"]["embeddings_rag"]["status"] == "previewed"
     assert "custom/allowed-with-ack" in preview["install_plan"]["embeddings"]["custom"]
+    assert preview["install_plan"]["embeddings"]["trusted_custom_model_acknowledged"] is True
 
 
 def test_local_chat_preview_only_emits_existing_config_keys():

--- a/tldw_Server_API/tests/Setup/test_setup_readiness_store.py
+++ b/tldw_Server_API/tests/Setup/test_setup_readiness_store.py
@@ -7,6 +7,7 @@ import pytest
 
 from tldw_Server_API.app.core.Setup import readiness_store
 from tldw_Server_API.app.core.Setup.readiness_store import SetupReadinessStore
+from tldw_Server_API.app.core.exceptions import SetupLockTimeoutError
 
 
 def test_readiness_store_defaults_to_not_started(tmp_path):
@@ -101,3 +102,14 @@ def test_readiness_store_update_preserves_concurrent_fields(tmp_path, monkeypatc
     readiness = store.load()
     assert readiness["selected_profile_id"] == "local_performance"
     assert readiness["operation_id"] == "op-1"
+
+
+def test_readiness_store_lock_timeout_uses_setup_exception(tmp_path, monkeypatch):
+    readiness_path = tmp_path / "setup_readiness.json"
+    readiness_path.with_name("setup_readiness.json.lock").write_text("locked", encoding="utf-8")
+    monkeypatch.setattr(readiness_store, "_READINESS_LOCK_TIMEOUT_SECONDS", 0.0)
+    monkeypatch.setattr(readiness_store, "_READINESS_LOCK_STALE_SECONDS", 300.0)
+
+    with pytest.raises(SetupLockTimeoutError, match="setup readiness lock"):
+        with readiness_store._readiness_file_lock(readiness_path):
+            pytest.fail("lock should not be acquired")


### PR DESCRIPTION
## Summary
- Harden Setup installer execution by redacting command secrets, bounding subprocess output/timeouts, using setup-specific exceptions, and blocking unpinned VCS installs by default.
- Make Setup config/readiness/audio readiness/install status persistence atomic and lock-protected where it owns the persistence path.
- Require explicit custom embedding trust acknowledgement at the install-plan boundary and add regression tests for the reviewed findings and follow-up comments.

## Review Follow-Up
- Rebased `codex/setup-review-hardening` onto latest `origin/dev`; final reviewed head: `e08cc67ae`.
- Addressed Qodo comments:
  - Replaced generic subprocess/lock timeout exceptions with setup-specific exception types from `tldw_Server_API.app.core.exceptions`.
  - Made setup subprocess output capture tolerant of non-UTF-8 bytes while preserving redaction.
  - Broadened VCS revision parsing to support pinned `@<commit>` requirements without a `.git` suffix and SSH userinfo forms.

## Verification
- `python -m compileall -q tldw_Server_API/app/core/exceptions.py tldw_Server_API/app/core/Setup/install_manager.py tldw_Server_API/app/core/Setup/install_schema.py tldw_Server_API/app/core/Setup/setup_manager.py tldw_Server_API/app/core/Setup/readiness_service.py tldw_Server_API/app/core/Setup/readiness_store.py tldw_Server_API/app/core/Setup/audio_readiness_store.py`
- `python -m pytest tldw_Server_API/tests/Setup/test_install_manager_dependencies.py::test_run_subprocess_uses_timeout_and_redacts_timeout_errors tldw_Server_API/tests/Setup/test_install_manager_dependencies.py::test_run_subprocess_decodes_non_utf8_output_safely tldw_Server_API/tests/Setup/test_install_manager_dependencies.py::test_run_subprocess_raises_custom_error_for_nonzero_exit tldw_Server_API/tests/Setup/test_install_manager_dependencies.py::test_vcs_requirement_revision_accepts_commit_after_repo_without_dot_git tldw_Server_API/tests/Setup/test_install_manager_dependencies.py::test_vcs_requirement_revision_accepts_ssh_userinfo_and_dot_git_commit tldw_Server_API/tests/Setup/test_install_manager_dependencies.py::test_pinned_vcs_requirement_without_dot_git_is_not_blocked tldw_Server_API/tests/Setup/test_setup_readiness_store.py::test_readiness_store_lock_timeout_uses_setup_exception -q --timeout=180` (7 passed)
- `python -m pytest tldw_Server_API/tests/Setup/test_install_manager_dependencies.py tldw_Server_API/tests/Setup/test_setup_manager_masking.py tldw_Server_API/tests/Setup/test_audio_readiness_store.py tldw_Server_API/tests/Setup/test_setup_readiness_store.py tldw_Server_API/tests/Setup/test_setup_readiness_preview.py -q --timeout=180` (58 passed)
- `python -m pytest tldw_Server_API/tests/Setup/test_setup_readiness_api.py tldw_Server_API/tests/Setup/test_setup_audio_installer_lifecycle_api.py tldw_Server_API/tests/Setup/test_audio_bundle_provisioning.py -q --timeout=180` (47 passed)
- `python -m bandit -r tldw_Server_API/app/core/exceptions.py tldw_Server_API/app/core/Setup/install_manager.py tldw_Server_API/app/core/Setup/install_schema.py tldw_Server_API/app/core/Setup/setup_manager.py tldw_Server_API/app/core/Setup/readiness_service.py tldw_Server_API/app/core/Setup/readiness_store.py tldw_Server_API/app/core/Setup/audio_readiness_store.py -f json -o /tmp/bandit_setup_module_review_rebase_latest_dev.json` (0 results, 0 errors)
- `git diff --check`

## Change Summary
AI draft: a human owner must review or replace this section before merge to satisfy the repository's AI-generated PR change-summary policy.
