### PR TITLE
Harden Security module review findings

### DIFF
--- a/Docs/Code_Documentation/Jobs_Module.md
+++ b/Docs/Code_Documentation/Jobs_Module.md
@@ -490,7 +490,7 @@ jm.fail_job(job["id"], error="boom", retryable=True, worker_id=worker_id, lease_
 ### Encryption & Rotation
 
 - Enabling encryption
-  - Set `WORKFLOWS_ARTIFACT_ENC_KEY` to a base64-encoded AES key (16/24/32 bytes)
+  - Set `WORKFLOWS_ARTIFACT_ENC_KEY` to a strict base64-encoded 32-byte AES-256 key
   - Enable globally with `JOBS_ENCRYPT=true` or per-domain with `JOBS_ENCRYPT_<DOMAIN>=true`
   - When enabled, `payload`/`result` are stored as envelopes: `{ "_encrypted": {"_enc":"aesgcm:v1", ... } }`
 - Reading with dual keys (rotation window)

--- a/Docs/Design/Workflows.md
+++ b/Docs/Design/Workflows.md
@@ -247,7 +247,7 @@ In single-user mode, the fixed user is exposed with admin-like claims for compat
 
 - PII/Secrets:
   - Log redaction for `log` step: `WORKFLOWS_REDACT_LOGS=true|false` (default true) applies PII redaction to messages before emitting to logs.
-  - Field-level encryption for artifact metadata: enable with `WORKFLOWS_ARTIFACT_ENCRYPTION=true` and provide `WORKFLOWS_ARTIFACT_ENC_KEY` (base64 16/24/32 bytes for AES-GCM). Encrypted metadata is transparently decrypted on read when the key is present; otherwise a placeholder is returned.
+  - Field-level encryption for artifact metadata: enable with `WORKFLOWS_ARTIFACT_ENCRYPTION=true` and provide `WORKFLOWS_ARTIFACT_ENC_KEY` (strict base64-encoded 32-byte AES-256 key). Encrypted metadata is transparently decrypted on read when the key is present; otherwise a placeholder is returned.
   - Scoped secrets injection: run requests accept `secrets` (map of strings). These are injected into the execution context as `context.secrets` and never persisted. Secrets are cleared from memory when the run reaches a terminal state.
 
 ### Webhooks: Delivery History, Replay, and Replay Protection

--- a/Docs/Published/Code_Documentation/Jobs_Module.md
+++ b/Docs/Published/Code_Documentation/Jobs_Module.md
@@ -473,7 +473,7 @@ jm.fail_job(job["id"], error="boom", retryable=True, worker_id=worker_id, lease_
 ### Encryption & Rotation
 
 - Enabling encryption
-  - Set `WORKFLOWS_ARTIFACT_ENC_KEY` to a base64-encoded AES key (16/24/32 bytes)
+  - Set `WORKFLOWS_ARTIFACT_ENC_KEY` to a strict base64-encoded 32-byte AES-256 key
   - Enable globally with `JOBS_ENCRYPT=true` or per-domain with `JOBS_ENCRYPT_<DOMAIN>=true`
   - When enabled, `payload`/`result` are stored as envelopes: `{ "_encrypted": {"_enc":"aesgcm:v1", ... } }`
 - Reading with dual keys (rotation window)

--- a/backlog/tasks/task-12008 - Harden-Security-module-review-findings.md
+++ b/backlog/tasks/task-12008 - Harden-Security-module-review-findings.md
@@ -1,0 +1,87 @@
+---
+id: TASK-12008
+title: Harden Security module review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 21:17'
+updated_date: '2026-06-24 19:07'
+labels:
+  - security
+  - hardening
+  - review-fix
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the current-code Security module review findings: DNS rebinding/check-then-use hardening, trusted-proxy setup client-IP parsing, strict AES key validation, explicit auth/webhook secret configuration, setup CSP nonce/dead-code cleanup, and DNS timeout race cleanup.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Egress policy detects private/reserved DNS drift when pinned resolution is reused.
+- [x] #2 Setup access guard resolves proxied client IPs without trusting spoofed leftmost X-Forwarded-For.
+- [x] #3 Crypto helpers fail closed on invalid configured AES keys instead of deriving keys silently.
+- [x] #4 Secret manager has explicit strong configs for JWT and webhook helper secrets.
+- [x] #5 Setup CSP removes ineffective nonce-injection behavior or wires it correctly, with tests updated.
+- [x] #6 Focused Security tests and Bandit touched-scope scan pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+- Add failing regression tests for each reviewed behavior.
+- Implement minimal Security module changes to satisfy the tests.
+- Update central HTTP egress validation to use the safer pinned-resolution policy.
+- Run focused tests and Bandit on touched production files.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Manual Backlog task creation was approved because Backlog MCP resources were unavailable and `backlog search`, `backlog task list`, and `backlog task create` hung in this workspace.
+- Added pinned DNS drift detection to egress policy and updated the central HTTP client to reuse cached resolutions as pins for later policy checks.
+- Replaced process-global DNS timeout mutation with a bounded daemon-thread resolver wrapper.
+- Updated trusted-proxy setup guard parsing to walk `X-Forwarded-For` from the proxy side and return the first untrusted client IP.
+- Made AES-GCM JSON helper key loading strict for configured and explicit keys.
+- Added explicit strong secret manager configs for JWT and webhook master secrets.
+- Removed ineffective setup CSP nonce generation/injection state and updated tests/docs around the intentionally relaxed setup CSP.
+- Moved the finished work to a clean worktree from `origin/dev` on branch `codex/security-module-review-fixes-12008`.
+- Rebasing follow-up: addressed Qodo review comments by adding test classification markers/import cleanup, moving async egress validation off the event loop, replacing per-call DNS resolver threads with a bounded executor, logging invalid AES key configuration without leaking key material, aligning docs/tests to strict 32-byte AES-256 keys, skipping malformed trusted-proxy XFF entries, and reading JWT secrets from `[AuthNZ]`.
+<!-- SECTION:NOTES:END -->
+
+## Verification
+
+<!-- SECTION:VERIFICATION:BEGIN -->
+- `env SINGLE_USER_API_KEY=0123456789abcdef0123456789abcdef python -m pytest --confcutdir=tldw_Server_API/tests/Security tldw_Server_API/tests/Security -q` -> 66 passed.
+- `python -m pytest --confcutdir=tldw_Server_API/tests/http_client tldw_Server_API/tests/http_client/test_http_client.py tldw_Server_API/tests/http_client/test_http_client_truthiness_flags.py -q` -> 24 passed.
+- `python -m bandit -r ...touched production files... -f json -o /tmp/bandit_security_12008_worktree.json` -> 0 errors, 0 findings.
+- `git diff --check` -> passed.
+- Follow-up after rebase on latest `origin/dev`:
+  - `env SINGLE_USER_API_KEY=0123456789abcdef0123456789abcdef /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest --confcutdir=tldw_Server_API/tests/Security tldw_Server_API/tests/Security -q` -> 69 passed, 7 warnings.
+  - `env SINGLE_USER_API_KEY=0123456789abcdef0123456789abcdef /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest --confcutdir=tldw_Server_API/tests/http_client tldw_Server_API/tests/http_client/test_http_client.py tldw_Server_API/tests/http_client/test_http_client_truthiness_flags.py -q` -> 25 passed, 2 warnings.
+  - `env SINGLE_USER_API_KEY=0123456789abcdef0123456789abcdef /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/External_Sources/test_reference_manager_storage.py::test_oauth_state_metadata_is_encrypted_at_rest_when_crypto_enabled -q` -> 1 passed, 9 warnings.
+  - `env SINGLE_USER_API_KEY=0123456789abcdef0123456789abcdef /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Security/egress.py tldw_Server_API/app/core/Security/crypto.py tldw_Server_API/app/core/Security/secret_manager.py tldw_Server_API/app/core/Security/setup_access_guard.py tldw_Server_API/app/core/http_client.py -f json -o /tmp/bandit_security_12008_followup.json` -> 0 errors, 0 findings.
+  - `git diff --check` -> passed.
+  - `rg -n "WORKFLOWS_ARTIFACT_ENC_KEY.*16/24/32|base64 16/24/32|reference-manager-test-key|config_section=\"Auth\"" Docs tldw_Server_API/tests tldw_Server_API/app/core/Security -g '*.md' -g '*.py'` -> no matches.
+<!-- SECTION:VERIFICATION:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened the current Security module review findings across egress, setup proxy access control, crypto key validation, secret configuration, and setup CSP cleanup. Regression coverage was added for the reviewed behaviors, focused Security/HTTP client tests pass, and touched production files have a clean Bandit scan.
+
+Follow-up review comments were addressed after rebasing on the latest `dev`: async HTTP egress validation now leaves the event loop, egress DNS resolution uses a bounded executor, invalid AES env keys emit explicit non-secret error logs, AES docs/tests require strict base64 32-byte keys, malformed trusted-proxy XFF entries are skipped instead of falling back to the proxy peer, JWT secret config lookup uses `[AuthNZ]`, and new/modified tests carry unit markers with corrected imports.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Security/README.md
+++ b/tldw_Server_API/app/core/Security/README.md
@@ -28,15 +28,15 @@ untrusted URLs or sensitive configuration.
 
 - Reject unsafe outbound URLs before network calls.
 - Set security headers, CSP variants, HSTS behavior, and request IDs.
-- Guard remote Setup UI access and setup-specific CSP nonces.
+- Guard remote Setup UI access and setup-specific CSP policy.
 - Load and validate secrets without hard-coded defaults or log leakage.
 - Provide safe pickle and encrypted JSON helpers for callers that must handle
   serialized or sensitive blobs.
 
 ## Module Map
 
-- `egress.py` evaluates URL allow/deny/private-IP/port policies and tenant
-  webhook rules.
+- `egress.py` evaluates URL allow/deny/private-IP/port policies, DNS drift
+  checks for reused resolutions, and tenant webhook rules.
 - `url_validation.py` exposes endpoint-friendly safe-URL assertions.
 - `middleware.py` adds response hardening headers.
 - `request_id_middleware.py` sanitizes or creates `X-Request-ID`.
@@ -62,10 +62,13 @@ untrusted URLs or sensitive configuration.
 - Outbound callers should validate URLs through `egress.py` or
   `url_validation.py` before constructing network clients. The policy layer
   resolves global environment settings, workflow context, tenant webhook
-  allowances, private-address rejection, and port restrictions.
+  allowances, private-address rejection, port restrictions, and pinned DNS
+  resolution checks when a caller reuses an earlier egress decision.
 - Secret consumers use `secret_manager.py` for source precedence and validation;
   Jobs and related persistence use `crypto.py` for encrypted JSON blobs when
-  they need to store sensitive structured metadata.
+  they need to store sensitive structured metadata. AES-GCM helper keys must be
+  strict base64 encodings of 32-byte keys; invalid configured keys disable the
+  helper instead of being converted into derived key material.
 
 ### Security And Operations
 
@@ -73,7 +76,8 @@ untrusted URLs or sensitive configuration.
   create local allowlists that bypass private-IP, scheme, or port checks.
 - Setup UI rules are path-sensitive: changes to setup access or CSP behavior
   must preserve the distinction between `/setup`, `/docs`, and normal API
-  routes.
+  routes. Setup CSP is intentionally relaxed enough for the setup UI bundle and
+  does not rewrite response bodies to inject nonces.
 - Request IDs are sanitized on ingress and propagated through logs; do not let
   caller-provided IDs become log injection or unbounded cardinality sources.
 

--- a/tldw_Server_API/app/core/Security/crypto.py
+++ b/tldw_Server_API/app/core/Security/crypto.py
@@ -11,10 +11,11 @@ Env:
 
 import base64
 import binascii
-import hashlib
 import json
 import os
 from typing import Any
+
+from loguru import logger
 
 try:
     from Cryptodome.Cipher import AES
@@ -33,40 +34,28 @@ _JSON_CRYPTO_DECRYPT_EXCEPTIONS = (
 _JSON_CRYPTO_WITH_B64_EXCEPTIONS = _B64_DECODE_EXCEPTIONS + _JSON_CRYPTO_DECRYPT_EXCEPTIONS
 
 
-def _get_key_from_env() -> bytes | None:
-    key_b64 = os.getenv("WORKFLOWS_ARTIFACT_ENC_KEY", "").strip()
+def _get_key_from_env_var(env_name: str) -> bytes | None:
+    key_b64 = os.getenv(env_name, "").strip()
     if not key_b64:
         return None
-    # Try strict base64 decode first
-    raw: bytes | None
     try:
-        raw = base64.b64decode(key_b64)
+        raw = base64.b64decode(key_b64, validate=True)
     except _B64_DECODE_EXCEPTIONS:
-        raw = None
-    # If base64 failed, derive from the literal string
-    if raw is None or len(raw) == 0:
-        # Treat provided env var as passphrase; derive a 32-byte key deterministically
-        return hashlib.sha256(key_b64.encode("utf-8")).digest()
-    # Accept standard AES key sizes directly; otherwise derive via SHA-256
-    if len(raw) in (16, 24, 32):
-        return raw
-    return hashlib.sha256(raw).digest()
+        logger.error(f"{env_name} is set but invalid; expected strict base64 encoding of a 32-byte AES-256 key")
+        return None
+    if len(raw) != 32:
+        logger.error(f"{env_name} is set but invalid; expected strict base64 encoding of a 32-byte AES-256 key")
+        return None
+    return raw
+
+
+def _get_key_from_env() -> bytes | None:
+    return _get_key_from_env_var("WORKFLOWS_ARTIFACT_ENC_KEY")
 
 
 def _get_secondary_key_from_env() -> bytes | None:
     """Optional fallback key for dual-read stage during key rotation."""
-    key_b64 = os.getenv("JOBS_CRYPTO_SECONDARY_KEY", "").strip()
-    if not key_b64:
-        return None
-    try:
-        raw = base64.b64decode(key_b64)
-    except _B64_DECODE_EXCEPTIONS:
-        raw = None
-    if raw is None or len(raw) == 0:
-        return hashlib.sha256(key_b64.encode("utf-8")).digest()
-    if len(raw) in (16, 24, 32):
-        return raw
-    return hashlib.sha256(raw).digest()
+    return _get_key_from_env_var("JOBS_CRYPTO_SECONDARY_KEY")
 
 
 def encrypt_json_blob(data: dict[str, Any]) -> dict[str, Any] | None:
@@ -122,16 +111,10 @@ def decrypt_json_blob(envelope: dict[str, Any]) -> dict[str, Any] | None:
 
 def _decode_key_b64(key_b64: str) -> bytes | None:
     try:
-        raw = base64.b64decode(key_b64)
+        raw = base64.b64decode(key_b64, validate=True)
     except _B64_DECODE_EXCEPTIONS:
-        raw = None
-    if raw is None or len(raw) == 0:
-        # Derive from literal if not valid base64
-        return hashlib.sha256(key_b64.encode("utf-8")).digest()
-    if len(raw) in (16, 24, 32):
-        return raw
-    # For non-standard lengths, derive a 32-byte AES key deterministically
-    return hashlib.sha256(raw).digest()
+        return None
+    return raw if len(raw) == 32 else None
 
 
 def encrypt_json_blob_with_key(data: dict[str, Any], key_b64: str) -> dict[str, Any] | None:

--- a/tldw_Server_API/app/core/Security/egress.py
+++ b/tldw_Server_API/app/core/Security/egress.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import contextlib
 import ipaddress
 import os
 import socket
+from concurrent import futures
 from collections.abc import Sequence
 from dataclasses import dataclass
 from urllib.parse import urlparse
@@ -23,6 +23,11 @@ PROFILENAME = "WORKFLOWS_EGRESS_PROFILE"  # strict | permissive | custom
 # Webhook-specific per-tenant allow/deny controls
 WEBHOOK_ALLOWLIST_ENV = "WORKFLOWS_WEBHOOK_ALLOWLIST"
 WEBHOOK_DENYLIST_ENV = "WORKFLOWS_WEBHOOK_DENYLIST"
+DNS_RESOLVER_MAX_WORKERS = 4
+_DNS_RESOLVER_EXECUTOR = futures.ThreadPoolExecutor(
+    max_workers=DNS_RESOLVER_MAX_WORKERS,
+    thread_name_prefix="tldw-egress-dns",
+)
 
 
 PRIVATE_RANGES = [
@@ -99,6 +104,21 @@ def _host_matches_allowlist(host: str, allowlist: Sequence[str]) -> bool:
     return False
 
 
+def _getaddrinfo_with_timeout(host: str, timeout_s: float = 2.0) -> list[tuple]:
+    future = _DNS_RESOLVER_EXECUTOR.submit(
+        socket.getaddrinfo,
+        host,
+        None,
+        family=socket.AF_UNSPEC,  # both IPv4 and IPv6
+        type=socket.SOCK_STREAM,
+    )
+    try:
+        return list(future.result(timeout=timeout_s))
+    except (futures.TimeoutError, OSError, ValueError):
+        future.cancel()
+        return []
+
+
 def _resolve_host_ips(host: str) -> list[str]:
     """Resolve the host to all A/AAAA addresses with a short timeout.
 
@@ -106,26 +126,9 @@ def _resolve_host_ips(host: str) -> list[str]:
     in an empty list which callers must treat as unsafe.
     """
     try:
-        prev_timeout = None
-        try:
-            prev_timeout = socket.getdefaulttimeout()
-            # Short timeout to avoid long blocks during DNS resolution
-            socket.setdefaulttimeout(2.0)
-        except (OSError, TypeError, ValueError):
-            prev_timeout = None
-
-        try:
-            infos = socket.getaddrinfo(
-                host,
-                None,
-                family=socket.AF_UNSPEC,  # both IPv4 and IPv6
-                type=socket.SOCK_STREAM,
-            )
-        except (OSError, ValueError):
+        infos = _getaddrinfo_with_timeout(host)
+        if not infos:
             return []
-        finally:
-            with contextlib.suppress(OSError, TypeError, ValueError):
-                socket.setdefaulttimeout(prev_timeout)
 
         addrs: list[str] = []
         for _family, _stype, _proto, _canon, sockaddr in infos:
@@ -164,6 +167,12 @@ def _normalize_resolved_ips(ips: Sequence[str] | None) -> tuple[str, ...]:
     return tuple(out)
 
 
+def _same_resolved_ip_set(left: Sequence[str], right: Sequence[str]) -> bool:
+    return {str(ip).strip() for ip in left if str(ip).strip()} == {
+        str(ip).strip() for ip in right if str(ip).strip()
+    }
+
+
 def _resolve_and_check_private(host: str) -> tuple[bool, list[str]]:
     ips: list[str] = []
     # If the host is already an IP address, check directly
@@ -196,6 +205,7 @@ def evaluate_url_policy(
     denylist: Sequence[str] | None = None,
     block_private_override: bool | None = None,
     resolved_ips_override: Sequence[str] | None = None,
+    pinned_resolved_ips: Sequence[str] | None = None,
 ) -> URLPolicyResult:
     """Evaluate whether a URL passes the egress policy."""
     try:
@@ -292,8 +302,14 @@ def evaluate_url_policy(
                 if not resolved_ips:
                     return URLPolicyResult(False, "Host could not be resolved")
                 return URLPolicyResult(False, "URL resolves to a private or reserved address", resolved_ips)
+        pinned_ips = _normalize_resolved_ips(pinned_resolved_ips)
+        if pinned_ips and not _same_resolved_ip_set(resolved_ips, pinned_ips):
+            return URLPolicyResult(False, "DNS resolution changed since policy check", resolved_ips)
     else:
         resolved_ips = _normalize_resolved_ips(resolved_ips_override)
+        pinned_ips = _normalize_resolved_ips(pinned_resolved_ips)
+        if pinned_ips and resolved_ips and not _same_resolved_ip_set(resolved_ips, pinned_ips):
+            return URLPolicyResult(False, "DNS resolution changed since policy check", resolved_ips)
 
     return URLPolicyResult(True, None, resolved_ips)
 

--- a/tldw_Server_API/app/core/Security/secret_manager.py
+++ b/tldw_Server_API/app/core/Security/secret_manager.py
@@ -188,6 +188,30 @@ class SecretManager:
                 required=False,
                 min_length=20,
                 description="Groq API key for evaluations"
+            ),
+
+            "jwt_secret_key": SecretConfig(
+                name="jwt_secret_key",
+                secret_type=SecretType.JWT_SECRET,
+                env_var="JWT_SECRET_KEY",
+                config_section="AuthNZ",
+                config_key="jwt_secret_key",
+                required=False,
+                min_length=32,
+                rotation_days=365,
+                description="JWT signing secret for multi-user authentication mode"
+            ),
+
+            "webhook_master_secret": SecretConfig(
+                name="webhook_master_secret",
+                secret_type=SecretType.WEBHOOK_SECRET,
+                env_var="WEBHOOK_MASTER_SECRET",
+                config_section="Security",
+                config_key="webhook_master_secret",
+                required=False,
+                min_length=32,
+                rotation_days=365,
+                description="Master secret for webhook signing"
             )
         }
 

--- a/tldw_Server_API/app/core/Security/setup_access_guard.py
+++ b/tldw_Server_API/app/core/Security/setup_access_guard.py
@@ -29,7 +29,6 @@ def _env_true(name: str) -> bool:
     return is_truthy(raw)
 
 
-
 def _get_peer_ip(request: Request) -> str | None:
     try:
         return request.client.host if request.client else None
@@ -104,33 +103,47 @@ class SetupAccessGuardMiddleware(BaseHTTPMiddleware):
     def _resolve_client_ip(self, request: Request, trusted_proxies: list[ipaddress._BaseNetwork]) -> str | None:
         """Resolve client IP using X-Forwarded-For only when the peer is a trusted proxy.
 
-        - If remote peer is in trusted_proxies and XFF present, use the first (leftmost) XFF IP.
+        - If remote peer is in trusted_proxies and XFF present, walk the chain
+          from right to left and return the first untrusted IP.
         - Else, use the socket peer.
-        - X-Real-IP is considered only when peer is trusted and header is present.
+        - X-Real-IP is considered only when peer is trusted, XFF is absent, and
+          the header is valid.
         """
         peer = _get_peer_ip(request)
         try:
             peer_ip_obj = ipaddress.ip_address(peer) if peer else None
         except ValueError:
             peer_ip_obj = None
+
         def _is_trusted(ip: ipaddress._BaseAddress | None) -> bool:
             return bool(ip and any(ip in net for net in trusted_proxies))
 
         if _is_trusted(peer_ip_obj):
-            # Prefer X-Real-IP if present and valid; else leftmost XFF element
+            fwd = request.headers.get("x-forwarded-for") or request.headers.get("X-Forwarded-For")
+            if fwd:
+                parsed_chain: list[ipaddress._BaseAddress] = []
+                malformed_entries = False
+                for raw_part in fwd.split(","):
+                    part = raw_part.strip()
+                    if not part:
+                        continue
+                    try:
+                        parsed_chain.append(ipaddress.ip_address(part))
+                    except ValueError:
+                        malformed_entries = True
+                        continue
+                if malformed_entries:
+                    logger.warning("Malformed X-Forwarded-For entry ignored for trusted Setup proxy")
+                for ip_obj in reversed(parsed_chain):
+                    if not _is_trusted(ip_obj):
+                        return str(ip_obj)
+                if parsed_chain:
+                    return str(parsed_chain[0])
             xr = request.headers.get("x-real-ip") or request.headers.get("X-Real-IP")
             if xr:
                 try:
                     ipaddress.ip_address(xr.strip())
                     return xr.strip()
-                except ValueError:
-                    pass
-            fwd = request.headers.get("x-forwarded-for") or request.headers.get("X-Forwarded-For")
-            if fwd:
-                try:
-                    leftmost = fwd.split(",")[0].strip()
-                    ipaddress.ip_address(leftmost)
-                    return leftmost
                 except ValueError:
                     pass
         return peer

--- a/tldw_Server_API/app/core/Security/setup_csp.py
+++ b/tldw_Server_API/app/core/Security/setup_csp.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import base64
-import contextlib
 import os
-import re
 from typing import Callable
 
 from loguru import logger
@@ -13,37 +10,8 @@ from starlette.responses import Response
 
 from tldw_Server_API.app.core.testing import is_truthy
 
-_SCRIPT_TAG_RE = re.compile(rb"<script(\s[^>]*)?>", re.IGNORECASE)
 
-
-def _gen_nonce() -> str:
-    # 128-bit random, URL-safe base64 without padding
-    raw = os.urandom(16)
-    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
-
-
-def _inject_nonce_into_html(html: bytes, nonce: str) -> bytes:
-    # Insert nonce attribute into every <script ...> tag
-    nonce_attr = f' nonce="{nonce}"'.encode()
-
-    def _repl(match: re.Match[bytes]) -> bytes:
-        tag = match.group(0)
-        # If nonce already present, leave as-is
-        if b" nonce=" in tag:
-            return tag
-        # Insert just before closing '>' of the opening tag
-        if tag.endswith(b">"):
-            return tag[:-1] + nonce_attr + b">"
-        return tag + nonce_attr
-
-    try:
-        return _SCRIPT_TAG_RE.sub(_repl, html)
-    except Exception:
-        logger.debug("Nonce injection regex failed")
-        return html
-
-
-def _build_setup_csp(nonce: str, *, allow_inline_scripts: bool, allow_eval: bool) -> str:
+def _build_setup_csp(*, allow_inline_scripts: bool, allow_eval: bool) -> str:
     """Build CSP for Setup UI.
 
     - /setup keeps inline scripts allowed since the setup flow relies on helpers.
@@ -82,11 +50,6 @@ class SetupCSPMiddleware(BaseHTTPMiddleware):
         if not path.startswith("/setup"):
             return await call_next(request)
 
-        # Generate a nonce to future-proof policy customization; store on state
-        nonce = _gen_nonce()
-        with contextlib.suppress(Exception):
-            request.state.csp_nonce = nonce
-
         response = await call_next(request)
         try:
             allow_inline_scripts = True
@@ -101,7 +64,7 @@ class SetupCSPMiddleware(BaseHTTPMiddleware):
                 allow_eval = True
             response.headers.setdefault(
                 "Content-Security-Policy",
-                _build_setup_csp(nonce, allow_inline_scripts=allow_inline_scripts, allow_eval=allow_eval),
+                _build_setup_csp(allow_inline_scripts=allow_inline_scripts, allow_eval=allow_eval),
             )
         except Exception:
             # Best-effort header set; return original response

--- a/tldw_Server_API/app/core/http_client.py
+++ b/tldw_Server_API/app/core/http_client.py
@@ -1022,7 +1022,7 @@ def _validate_egress_or_raise(
         res = evaluate_url_policy(
             url,
             block_private_override=block_override,
-            resolved_ips_override=pinned_ips,
+            pinned_resolved_ips=pinned_ips,
         )
     else:
         res = evaluate_url_policy(url, block_private_override=block_override)
@@ -1043,6 +1043,14 @@ def _validate_egress_or_raise(
                 "http_client_egress_denials_total", 1, labels={"reason": (reason or "denied")}
             )
         raise EgressPolicyError(reason)
+
+
+async def _avalidate_egress_or_raise(
+    url: str,
+    *,
+    dns_pin_cache: dict[str, tuple[str, ...]] | None = None,
+) -> None:
+    await asyncio.to_thread(_validate_egress_or_raise, url, dns_pin_cache=dns_pin_cache)
 
 
 def _is_url_allowed(url: str) -> bool:
@@ -2115,7 +2123,7 @@ async def _afetch_httpx(
     retry = retry or RetryPolicy()
     _validate_retry_files_seekable(files, retry)
     dns_pin_cache: dict[str, tuple[str, ...]] = {}
-    _validate_egress_or_raise(url, dns_pin_cache=dns_pin_cache)
+    await _avalidate_egress_or_raise(url, dns_pin_cache=dns_pin_cache)
     _validate_proxies_or_raise(proxies)
 
     attempts = max(1, retry.attempts)
@@ -2214,7 +2222,7 @@ async def _afetch_httpx(
 
                 # Manual redirect handling inside each attempt
                 while True:
-                    _validate_egress_or_raise(cur_url, dns_pin_cache=dns_pin_cache)
+                    await _avalidate_egress_or_raise(cur_url, dns_pin_cache=dns_pin_cache)
                     resp, reason = await _do_once(ac, cur_url)
                     if resp is None:
                         # Special HEAD fallbacks: disable HTTP/2, then GET with Range 0-0
@@ -2439,7 +2447,7 @@ async def _afetch_aiohttp(
     retry = retry or RetryPolicy()
     _validate_retry_files_seekable(files, retry)
     dns_pin_cache: dict[str, tuple[str, ...]] = {}
-    _validate_egress_or_raise(url, dns_pin_cache=dns_pin_cache)
+    await _avalidate_egress_or_raise(url, dns_pin_cache=dns_pin_cache)
     _validate_proxies_or_raise(proxies)
 
     attempts = max(1, retry.attempts)
@@ -2515,7 +2523,7 @@ async def _afetch_aiohttp(
             redirects = 0
 
             while True:
-                _validate_egress_or_raise(cur_url, dns_pin_cache=dns_pin_cache)
+                await _avalidate_egress_or_raise(cur_url, dns_pin_cache=dns_pin_cache)
                 resp, reason = await _do_once(session, cur_url)
                 if resp is None:
                     if method_upper == "HEAD" and not _head_get_range_tried:
@@ -2737,7 +2745,7 @@ async def apost(
     """
     if httpx is None:  # pragma: no cover
         raise RuntimeError("httpx is not available")  # noqa: TRY003
-    _validate_egress_or_raise(url)
+    await _avalidate_egress_or_raise(url)
     _validate_proxies_or_raise(proxies)
 
     need_close = False
@@ -3431,7 +3439,7 @@ async def _astream_bytes_httpx(
         raise RuntimeError("httpx is not available")  # noqa: TRY003
     retry = retry or RetryPolicy()
     _validate_retry_files_seekable(files, retry)
-    _validate_egress_or_raise(url)
+    await _avalidate_egress_or_raise(url)
     _validate_proxies_or_raise(proxies)
 
     need_close = False
@@ -3636,7 +3644,7 @@ async def _astream_bytes_aiohttp(
         raise RuntimeError("aiohttp is not available")  # noqa: TRY003
     retry = retry or RetryPolicy()
     _validate_retry_files_seekable(files, retry)
-    _validate_egress_or_raise(url)
+    await _avalidate_egress_or_raise(url)
     _validate_proxies_or_raise(proxies)
 
     session = client or _get_aiohttp_session()
@@ -3875,7 +3883,7 @@ async def _astream_sse_httpx(
         hdrs.update(headers)
     retry = retry or RetryPolicy()
     dns_pin_cache: dict[str, tuple[str, ...]] = {}
-    _validate_egress_or_raise(url, dns_pin_cache=dns_pin_cache)
+    await _avalidate_egress_or_raise(url, dns_pin_cache=dns_pin_cache)
     _validate_proxies_or_raise(proxies)
 
     need_close = False
@@ -3894,7 +3902,7 @@ async def _astream_sse_httpx(
         for attempt in range(1, attempts + 1):
             # manual redirect handling before starting to read body
             while True:
-                _validate_egress_or_raise(cur_url, dns_pin_cache=dns_pin_cache)
+                await _avalidate_egress_or_raise(cur_url, dns_pin_cache=dns_pin_cache)
                 try:
                     # Optional cert pinning
                     try:
@@ -4012,7 +4020,7 @@ async def _astream_sse_aiohttp(
         hdrs.update(headers)
     retry = retry or RetryPolicy()
     dns_pin_cache: dict[str, tuple[str, ...]] = {}
-    _validate_egress_or_raise(url, dns_pin_cache=dns_pin_cache)
+    await _avalidate_egress_or_raise(url, dns_pin_cache=dns_pin_cache)
     _validate_proxies_or_raise(proxies)
 
     session = client or _get_aiohttp_session()
@@ -4024,7 +4032,7 @@ async def _astream_sse_aiohttp(
 
     for attempt in range(1, attempts + 1):
         while True:
-            _validate_egress_or_raise(cur_url, dns_pin_cache=dns_pin_cache)
+            await _avalidate_egress_or_raise(cur_url, dns_pin_cache=dns_pin_cache)
             try:
                 # Optional cert pinning
                 try:

--- a/tldw_Server_API/tests/External_Sources/test_reference_manager_storage.py
+++ b/tldw_Server_API/tests/External_Sources/test_reference_manager_storage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 from pathlib import Path
 
 import aiosqlite
@@ -148,7 +149,7 @@ async def test_oauth_state_metadata_is_encrypted_at_rest_when_crypto_enabled(
     sqlite_db: aiosqlite.Connection,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("WORKFLOWS_ARTIFACT_ENC_KEY", "reference-manager-test-key")
+    monkeypatch.setenv("WORKFLOWS_ARTIFACT_ENC_KEY", base64.b64encode(b"r" * 32).decode("ascii"))
 
     await svc.create_oauth_state(
         sqlite_db,

--- a/tldw_Server_API/tests/Security/test_crypto.py
+++ b/tldw_Server_API/tests/Security/test_crypto.py
@@ -5,6 +5,17 @@ import pytest
 from tldw_Server_API.app.core.Security import crypto
 
 
+pytestmark = pytest.mark.unit
+
+
+class _CapturingLogger:
+    def __init__(self):
+        self.records = []
+
+    def error(self, message, *args, **kwargs):
+        self.records.append(("error", message, args, dict(kwargs)))
+
+
 @pytest.mark.skipif(not crypto._HAS_CRYPTO, reason="Crypto backend not available")
 def test_decrypt_json_blob_invalid_base64_returns_none(monkeypatch):
     key = base64.b64encode(b"a" * 32).decode("ascii")
@@ -18,3 +29,21 @@ def test_decrypt_json_blob_with_key_invalid_base64_returns_none():
     key = base64.b64encode(b"b" * 32).decode("ascii")
     envelope = {"_enc": "aesgcm:v1", "nonce": "abc", "ct": "abc", "tag": "abc"}
     assert crypto.decrypt_json_blob_with_key(envelope, key) is None
+
+
+@pytest.mark.skipif(not crypto._HAS_CRYPTO, reason="Crypto backend not available")
+def test_encrypt_json_blob_rejects_invalid_env_key(monkeypatch):
+    logger = _CapturingLogger()
+    monkeypatch.setattr(crypto, "logger", logger)
+    monkeypatch.setenv("WORKFLOWS_ARTIFACT_ENC_KEY", "not-a-valid-base64-key")
+
+    assert crypto.encrypt_json_blob({"secret": "value"}) is None
+    assert logger.records
+    assert "WORKFLOWS_ARTIFACT_ENC_KEY is set but invalid" in logger.records[0][1]
+
+
+@pytest.mark.skipif(not crypto._HAS_CRYPTO, reason="Crypto backend not available")
+def test_encrypt_json_blob_with_key_rejects_wrong_length_key():
+    short_key = base64.b64encode(b"short").decode("ascii")
+
+    assert crypto.encrypt_json_blob_with_key({"secret": "value"}, short_key) is None

--- a/tldw_Server_API/tests/Security/test_egress.py
+++ b/tldw_Server_API/tests/Security/test_egress.py
@@ -1,10 +1,13 @@
 import os
 
 import pytest
+from fastapi import HTTPException
 
 from tldw_Server_API.app.core.Security import egress
 from tldw_Server_API.app.core.Security.url_validation import assert_url_safe
-from fastapi import HTTPException
+
+
+pytestmark = pytest.mark.unit
 
 
 def _always_public(host: str):
@@ -71,3 +74,59 @@ class TestEgressPolicy:
         res = egress.evaluate_url_policy("https://example.com/resource")
         assert res.allowed is True
         assert res.resolved_ips == ("93.184.216.34",)
+
+    def test_pinned_resolution_rejects_dns_drift(self, monkeypatch):
+        monkeypatch.setenv("WORKFLOWS_EGRESS_PROFILE", "permissive")
+        monkeypatch.setenv("WORKFLOWS_EGRESS_BLOCK_PRIVATE", "true")
+        monkeypatch.delenv("WORKFLOWS_EGRESS_ALLOWLIST", raising=False)
+        monkeypatch.delenv("WORKFLOWS_EGRESS_DENYLIST", raising=False)
+        monkeypatch.delenv("EGRESS_ALLOWLIST", raising=False)
+        monkeypatch.delenv("EGRESS_DENYLIST", raising=False)
+        monkeypatch.setattr(egress, "_resolve_and_check_private", lambda _host: (True, ["93.184.216.35"]))
+
+        res = egress.evaluate_url_policy(
+            "https://example.com/resource",
+            pinned_resolved_ips=["93.184.216.34"],
+        )
+
+        assert res.allowed is False
+        assert "changed" in (res.reason or "").lower()
+
+    def test_resolve_host_ips_does_not_mutate_global_socket_timeout(self, monkeypatch):
+        calls: list[object] = []
+
+        monkeypatch.setattr(egress.socket, "setdefaulttimeout", lambda value: calls.append(value))
+        monkeypatch.setattr(
+            egress.socket,
+            "getaddrinfo",
+            lambda *_args, **_kwargs: [
+                (egress.socket.AF_INET, egress.socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443)),
+            ],
+        )
+
+        assert egress._resolve_host_ips("example.com") == ["93.184.216.34"]
+        assert calls == []
+
+    def test_getaddrinfo_uses_bounded_executor(self, monkeypatch):
+        seen: dict[str, object] = {}
+        expected = [
+            (egress.socket.AF_INET, egress.socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443)),
+        ]
+
+        class _FakeFuture:
+            def result(self, timeout):
+                seen["timeout"] = timeout
+                return expected
+
+        class _FakeExecutor:
+            _max_workers = 2
+
+            def submit(self, func, *args, **kwargs):
+                seen["submitted"] = (func, args, kwargs)
+                return _FakeFuture()
+
+        monkeypatch.setattr(egress, "_DNS_RESOLVER_EXECUTOR", _FakeExecutor())
+
+        assert egress._getaddrinfo_with_timeout("example.com", timeout_s=0.25) == expected
+        assert seen["timeout"] == 0.25
+        assert seen["submitted"]

--- a/tldw_Server_API/tests/Security/test_secret_manager.py
+++ b/tldw_Server_API/tests/Security/test_secret_manager.py
@@ -1,6 +1,11 @@
 import configparser
 
+import pytest
+
 from tldw_Server_API.app.core.Security import secret_manager as sm
+
+
+pytestmark = pytest.mark.unit
 
 
 class _CapturingLogger:
@@ -113,3 +118,37 @@ def test_secret_health_check_outer_failure_is_sanitized(monkeypatch):
     assert "Health check failed" in health["issues"]
     assert all("secret config iteration failed" not in issue for issue in health["issues"])
     assert all("/private/secrets.db" not in issue for issue in health["issues"])
+
+
+def test_auth_helper_secret_configs_are_strong(monkeypatch):
+    monkeypatch.setattr(sm, "load_comprehensive_config", _empty_config)
+    manager = sm.SecretManager(validate_on_startup=False)
+
+    jwt_config = manager._secret_configs["jwt_secret_key"]
+    webhook_config = manager._secret_configs["webhook_master_secret"]
+
+    assert jwt_config.secret_type is sm.SecretType.JWT_SECRET
+    assert jwt_config.min_length >= 32
+    assert webhook_config.secret_type is sm.SecretType.WEBHOOK_SECRET
+    assert webhook_config.min_length >= 32
+
+
+def test_jwt_secret_helper_reads_authnz_config_section(monkeypatch):
+    config = configparser.ConfigParser()
+    config.add_section("AuthNZ")
+    config.set("AuthNZ", "jwt_secret_key", "a" * 32)
+
+    monkeypatch.setattr(sm, "load_comprehensive_config", lambda: config)
+    monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+    manager = sm.SecretManager(validate_on_startup=False)
+
+    assert manager.get_secret("jwt_secret_key", required=True) == "a" * 32
+
+
+def test_jwt_secret_helper_rejects_short_secret(monkeypatch):
+    monkeypatch.setattr(sm, "load_comprehensive_config", _empty_config)
+    monkeypatch.setenv("JWT_SECRET_KEY", "short-but-custom")
+    manager = sm.SecretManager(validate_on_startup=False)
+
+    with pytest.raises(sm.SecretValidationError):
+        manager.get_secret("jwt_secret_key", required=True)

--- a/tldw_Server_API/tests/Security/test_setup_access_guard.py
+++ b/tldw_Server_API/tests/Security/test_setup_access_guard.py
@@ -1,8 +1,15 @@
+import ipaddress
+from types import SimpleNamespace
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+import pytest
 
 import tldw_Server_API.app.core.Security.setup_access_guard as guard
 from tldw_Server_API.app.core.Security.setup_access_guard import SetupAccessGuardMiddleware
+
+
+pytestmark = pytest.mark.unit
 
 
 def _make_app() -> FastAPI:
@@ -50,3 +57,37 @@ def test_setup_blocks_remote_when_toggle_off(monkeypatch):
     client = TestClient(_make_app())
     resp = client.get("/setup/ping")
     assert resp.status_code == 403
+
+
+def test_trusted_proxy_ignores_spoofed_leftmost_x_forwarded_for():
+    middleware = SetupAccessGuardMiddleware(_make_app())
+    request = SimpleNamespace(
+        client=SimpleNamespace(host="10.0.0.10"),
+        headers={
+            "x-forwarded-for": "127.0.0.1, 198.51.100.20, 10.0.0.10",
+        },
+    )
+
+    client_ip = middleware._resolve_client_ip(
+        request,
+        [ipaddress.ip_network("10.0.0.0/24")],
+    )
+
+    assert client_ip == "198.51.100.20"
+
+
+def test_trusted_proxy_skips_malformed_x_forwarded_for_entries():
+    middleware = SetupAccessGuardMiddleware(_make_app())
+    request = SimpleNamespace(
+        client=SimpleNamespace(host="10.0.0.10"),
+        headers={
+            "x-forwarded-for": "not-an-ip, 198.51.100.20, 10.0.0.10",
+        },
+    )
+
+    client_ip = middleware._resolve_client_ip(
+        request,
+        [ipaddress.ip_network("10.0.0.0/24")],
+    )
+
+    assert client_ip == "198.51.100.20"

--- a/tldw_Server_API/tests/Security/test_setup_csp_eval_policy.py
+++ b/tldw_Server_API/tests/Security/test_setup_csp_eval_policy.py
@@ -1,9 +1,12 @@
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.core.Security import setup_csp as setup_csp_module
 from tldw_Server_API.app.core.Security.setup_csp import SetupCSPMiddleware
+
+
+pytestmark = pytest.mark.unit
 
 
 class _CapturingLogger:
@@ -18,15 +21,6 @@ def _joined_records(logger: _CapturingLogger) -> str:
     return "\n".join(f"{level} {message} {args!r} {kwargs!r}" for level, message, args, kwargs in logger.records)
 
 
-def _capture_setup_csp_logs():
-    messages: list[str] = []
-    sink_id = setup_csp_module.logger.add(
-        lambda message: messages.append(str(message)),
-        level="DEBUG",
-    )
-    return messages, sink_id
-
-
 def _make_app() -> FastAPI:
     app = FastAPI()
     app.add_middleware(SetupCSPMiddleware)
@@ -34,6 +28,17 @@ def _make_app() -> FastAPI:
     @app.get("/setup/ping")
     async def setup_ping():
         return {"ok": True}
+
+    return app
+
+
+def _make_state_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(SetupCSPMiddleware)
+
+    @app.get("/setup/state")
+    async def setup_state(request: Request):
+        return {"has_csp_nonce": hasattr(request.state, "csp_nonce")}
 
     return app
 
@@ -72,26 +77,6 @@ def test_setup_csp_no_eval_env_falsy_enables_eval(monkeypatch, falsy):
     assert "'unsafe-eval'" in script_src
 
 
-def test_nonce_injection_regex_failure_log_is_sanitized(monkeypatch):
-    class FailingScriptTagRegex:
-        def sub(self, _repl, _html):
-            raise RuntimeError("nonce regex failed at /private/setup-csp.html")
-
-    monkeypatch.setattr(setup_csp_module, "_SCRIPT_TAG_RE", FailingScriptTagRegex())
-    messages, sink_id = _capture_setup_csp_logs()
-
-    try:
-        html = setup_csp_module._inject_nonce_into_html(b"<script></script>", "nonce")
-    finally:
-        setup_csp_module.logger.remove(sink_id)
-
-    joined = "\n".join(messages)
-    assert html == b"<script></script>"
-    assert "Nonce injection regex failed" in joined
-    assert "nonce regex failed" not in joined
-    assert "/private/setup-csp.html" not in joined
-
-
 def test_setup_csp_header_failure_log_is_sanitized(monkeypatch):
     logger = _CapturingLogger()
 
@@ -112,6 +97,13 @@ def test_setup_csp_header_failure_log_is_sanitized(monkeypatch):
     assert "CSP header failed" not in joined
     assert "/private/setup-csp.html" not in joined
     assert "exc_info" not in joined
+
+
+def test_setup_csp_does_not_set_unused_nonce_state():
+    response = TestClient(_make_state_app()).get("/setup/state")
+
+    assert response.status_code == 200
+    assert response.json() == {"has_csp_nonce": False}
 
 
 def test_setup_csp_default_allows_eval(monkeypatch):

--- a/tldw_Server_API/tests/http_client/test_http_client.py
+++ b/tldw_Server_API/tests/http_client/test_http_client.py
@@ -356,11 +356,11 @@ async def test_afetch_pins_dns_resolution_for_subsequent_egress_checks(monkeypat
     from tldw_Server_API.app.core.http_client import afetch, create_async_client
     from tldw_Server_API.app.core.Security import egress as egress_mod
 
-    observed_overrides: list[object] = []
+    observed_pins: list[object] = []
 
-    def _fake_policy(url: str, *, block_private_override=None, resolved_ips_override=None):  # noqa: ARG001
-        observed_overrides.append(resolved_ips_override)
-        if resolved_ips_override is None:
+    def _fake_policy(url: str, *, block_private_override=None, resolved_ips_override=None, pinned_resolved_ips=None):  # noqa: ARG001
+        observed_pins.append(pinned_resolved_ips)
+        if pinned_resolved_ips is None:
             return types.SimpleNamespace(
                 allowed=True,
                 reason=None,
@@ -369,7 +369,7 @@ async def test_afetch_pins_dns_resolution_for_subsequent_egress_checks(monkeypat
         return types.SimpleNamespace(
             allowed=True,
             reason=None,
-            resolved_ips=tuple(resolved_ips_override),
+            resolved_ips=tuple(pinned_resolved_ips),
         )
 
     monkeypatch.setattr(egress_mod, "evaluate_url_policy", _fake_policy)
@@ -384,11 +384,38 @@ async def test_afetch_pins_dns_resolution_for_subsequent_egress_checks(monkeypat
     try:
         resp = await afetch(method="GET", url="http://93.184.216.34/start", client=client, allow_redirects=True)
         assert resp.status_code == 200
-        assert observed_overrides
-        assert observed_overrides[0] is None
-        assert all(v == ("93.184.216.34",) for v in observed_overrides[1:])
+        assert observed_pins
+        assert observed_pins[0] is None
+        assert all(v == ("93.184.216.34",) for v in observed_pins[1:])
     finally:
         await client.aclose()
+
+
+@requires_httpx
+@pytest.mark.asyncio
+async def test_apost_runs_egress_validation_off_event_loop(monkeypatch):
+    import types
+
+    import tldw_Server_API.app.core.http_client as hc
+
+    calls: list[object] = []
+
+    async def _fake_to_thread(func, *args, **kwargs):
+        calls.append((func, args, kwargs))
+        return func(*args, **kwargs)
+
+    class _DummyClient:
+        async def post(self, *args, **kwargs):  # noqa: ARG002
+            return types.SimpleNamespace(status_code=200)
+
+    monkeypatch.setattr(hc.asyncio, "to_thread", _fake_to_thread)
+    monkeypatch.setattr(hc, "_validate_egress_or_raise", lambda *args, **kwargs: None)
+
+    response = await hc.apost(url="https://example.com/api", client=_DummyClient())
+
+    assert response.status_code == 200
+    assert calls
+    assert calls[0][0] is hc._validate_egress_or_raise
 
 
 @requires_httpx

--- a/tldw_Server_API/tests/http_client/test_http_client_truthiness_flags.py
+++ b/tldw_Server_API/tests/http_client/test_http_client_truthiness_flags.py
@@ -92,9 +92,9 @@ def test_validate_egress_reuses_dns_pin_cache_for_same_host(monkeypatch):
 
     calls: list[object] = []
 
-    def _fake_policy(url: str, *, block_private_override=None, resolved_ips_override=None):
-        calls.append(resolved_ips_override)
-        if resolved_ips_override is None:
+    def _fake_policy(url: str, *, block_private_override=None, resolved_ips_override=None, pinned_resolved_ips=None):
+        calls.append(pinned_resolved_ips)
+        if pinned_resolved_ips is None:
             return types.SimpleNamespace(
                 allowed=True,
                 reason=None,
@@ -103,7 +103,7 @@ def test_validate_egress_reuses_dns_pin_cache_for_same_host(monkeypatch):
         return types.SimpleNamespace(
             allowed=True,
             reason=None,
-            resolved_ips=tuple(resolved_ips_override),
+            resolved_ips=tuple(pinned_resolved_ips),
         )
 
     monkeypatch.setattr(egress_mod, "evaluate_url_policy", _fake_policy)


### PR DESCRIPTION
## Summary
- Harden Security egress policy with DNS drift checks for reused resolutions and remove process-global DNS timeout mutation.
- Fix Setup trusted-proxy client IP resolution, strict AES-GCM key validation, and explicit JWT/webhook secret configs.
- Remove ineffective Setup CSP nonce rewrite behavior while documenting the relaxed Setup CSP policy.

## Test Plan
- env SINGLE_USER_API_KEY=0123456789abcdef0123456789abcdef python -m pytest --confcutdir=tldw_Server_API/tests/Security tldw_Server_API/tests/Security -q
- python -m pytest --confcutdir=tldw_Server_API/tests/http_client tldw_Server_API/tests/http_client/test_http_client.py tldw_Server_API/tests/http_client/test_http_client_truthiness_flags.py -q
- python -m bandit -r tldw_Server_API/app/core/Security/egress.py tldw_Server_API/app/core/Security/setup_access_guard.py tldw_Server_API/app/core/Security/crypto.py tldw_Server_API/app/core/Security/secret_manager.py tldw_Server_API/app/core/Security/setup_csp.py tldw_Server_API/app/core/http_client.py -f json -o /tmp/bandit_security_12008_worktree.json
- git diff --check

## Change Summary
Human-authored rationale required before merge per project policy. This PR is opened as a draft until that is added.

## Notes
- DNS hardening here is policy-level drift detection for reused egress resolutions, not transport-level socket pinning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the Security module to tighten SSRF defenses, secret validation, and setup behavior. Adds DNS pin reuse with drift detection, enforces strict AES-256 keys, fixes trusted-proxy parsing, and removes unused Setup CSP nonce/state while moving egress checks off the event loop.

- **New Features**
  - Add pinned DNS drift detection to egress policy and reuse pins in central `http_client`.
  - Add explicit secret configs for JWT and webhook signing with strong minimum lengths.

- **Bug Fixes**
  - Fix trusted-proxy client IP resolution by walking X-Forwarded-For from right to left and ignoring spoofed or malformed entries.
  - Make AES-GCM helpers require strict base64-encoded 32-byte keys; remove derivation from invalid inputs and fail closed.
  - Replace process-global DNS timeout mutation with a bounded thread-based resolver.
  - Run egress validation and DNS pin checks off the event loop in `http_client`.
  - Remove ineffective Setup CSP nonce rewriting and stop setting unused request state; keep Setup CSP intentionally relaxed for setup UI.

<sup>Written for commit 0c56abb69fb928b01de8de9bd358eace6b8cb533. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

