### PR TITLE
Harden Sync review findings

### DIFF
--- a/IMPLEMENTATION_PLAN_sync_module_review_fixes_12012.md
+++ b/IMPLEMENTATION_PLAN_sync_module_review_fixes_12012.md
@@ -1,0 +1,23 @@
+## Stage 1: Regression Coverage
+**Goal**: Add focused tests for each validated Sync review finding before changing implementation code.
+**Success Criteria**: Tests fail for the reviewed defects, not for setup or syntax issues.
+**Tests**: Targeted Sync v2 service/domain adapter tests and MediaDB2 legacy sync client tests.
+**Status**: Complete
+
+## Stage 2: Sync V2 Hardening
+**Goal**: Fix blob chunk idempotency, payload size accounting, and tombstone adapter handling with minimal changes.
+**Success Criteria**: Conflicting duplicate chunks cannot overwrite staged data, inline envelope payloads are size-limited, and tombstone envelopes follow delete conflict semantics.
+**Tests**: New and existing `tldw_Server_API/tests/Sync` targeted tests.
+**Status**: Complete
+
+## Stage 3: Legacy Sync Client Fixes
+**Goal**: Restore media FTS update support and prevent outbound sync from stalling behind other clients' log rows.
+**Success Criteria**: Media title/content updates refresh FTS without crashing, and skipped non-local sync rows advance the local sent marker.
+**Tests**: New and existing `tldw_Server_API/tests/MediaDB2/test_sync_client.py` targeted tests.
+**Status**: Complete
+
+## Stage 4: Verification And Task Finalization
+**Goal**: Run focused tests and Bandit on touched Sync code, then update Backlog task records.
+**Success Criteria**: Targeted tests pass, Bandit results are recorded, and `TASK-12012` has touched files plus final notes.
+**Tests**: Targeted pytest commands and Bandit on the touched Sync scope.
+**Status**: Complete

--- a/backlog/tasks/task-12012 - Harden-Sync-module-review-findings.md
+++ b/backlog/tasks/task-12012 - Harden-Sync-module-review-findings.md
@@ -1,0 +1,102 @@
+---
+id: TASK-12012
+title: Harden Sync module review findings
+status: Done
+created_date: 2026-06-24 04:26
+labels:
+- sync
+- code-review
+- bugfix
+priority: high
+references:
+- tldw_Server_API/app/core/Sync
+- Review findings from current thread
+modified_files:
+- IMPLEMENTATION_PLAN_sync_module_review_fixes_12012.md
+- tldw_Server_API/app/core/DB_Management/Sync_DB.py
+- tldw_Server_API/app/core/DB_Management/media_db/media_database_impl.py
+- tldw_Server_API/app/core/DB_Management/media_db/runtime/fts_ops.py
+- tldw_Server_API/app/core/Sync/Sync_Client.py
+- tldw_Server_API/app/core/Sync/v2/blob_store.py
+- tldw_Server_API/app/core/Sync/v2/domain_adapters/chat.py
+- tldw_Server_API/app/core/Sync/v2/domain_adapters/notes.py
+- tldw_Server_API/app/core/Sync/v2/domain_adapters/workspaces.py
+- tldw_Server_API/app/core/Sync/v2/service.py
+- tldw_Server_API/app/core/Sync/v2/store.py
+- tldw_Server_API/tests/MediaDB2/test_sync_client.py
+- tldw_Server_API/tests/Sync/test_sync_v2_blob_store.py
+- tldw_Server_API/tests/Sync/test_sync_v2_domain_adapters.py
+- tldw_Server_API/tests/Sync/test_sync_v2_service.py
+updated_date: 2026-06-25 02:10
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix validated current-code review findings in `tldw_Server_API/app/core/Sync`: blob chunk idempotency, Sync v2 payload size enforcement, legacy media FTS lookup, tombstone adapter handling, and legacy outbound sync marker advancement.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Duplicate blob chunks with conflicting content are rejected before staged chunk data can be overwritten.
+- [x] #2 Sync v2 envelope payload data contributes to the configured payload size limit.
+- [x] #3 Legacy media updates that affect title/content do not crash when refreshing FTS data.
+- [x] #4 Workspace, note, and chat adapters treat Sync v2 tombstone operations as deletes for conflict detection.
+- [x] #5 Legacy outbound sync advances past log rows from other clients instead of retrying the same skipped rows forever.
+- [x] #6 Focused regression tests cover each fixed behavior.
+- [x] #7 Targeted tests and Bandit run on the touched scope.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add regression tests that capture the reviewed failures and verify they fail against current code.
+2. Patch Sync v2 blob upload handling, payload size accounting, domain adapter tombstone predicates, and legacy sync client behavior with minimal changes.
+3. Re-run the focused tests and Bandit, then update this task with touched files and verification results.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Created `IMPLEMENTATION_PLAN_sync_module_review_fixes_12012.md` with staged regression, implementation, verification, and finalization steps.
+Implemented the Sync review fixes and verified them.
+
+Red checks observed before implementation:
+- Focused regression run failed for duplicate blob chunk overwrite, tombstone operation-only handling, other-client outbound cursor advancement, and missing legacy Media FTS helper.
+- Adjusted payload regression then failed because a divergent `envelope.payload` was accepted despite exceeding the configured limit.
+
+Green verification:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Sync/test_sync_v2_service.py::test_push_rejects_divergent_legacy_payload_over_actual_serialized_size_limit tldw_Server_API/tests/Sync/test_sync_v2_service.py::test_blob_upload_conflicting_duplicate_chunk_does_not_overwrite_existing_chunk tldw_Server_API/tests/Sync/test_sync_v2_domain_adapters.py::test_domain_adapters_conflict_tombstone_operation_without_deleted_flag tldw_Server_API/tests/MediaDB2/test_sync_client.py::TestClientSyncEnginePush::test_push_advances_past_other_clients_changes_without_network_call tldw_Server_API/tests/MediaDB2/test_sync_client.py::TestClientSyncEnginePullApply::test_pull_and_apply_media_title_update_refreshes_fts -q` -> 7 passed.
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Sync/test_sync_v2_service.py tldw_Server_API/tests/Sync/test_sync_v2_domain_adapters.py tldw_Server_API/tests/MediaDB2/test_sync_client.py -q` -> 168 passed.
+- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Sync tldw_Server_API/app/core/DB_Management/Sync_DB.py -f json -o /tmp/bandit_sync_review_fixes_12012.json` -> 0 findings.
+Reopened after PR review comments on #2502. Follow-up fixes: add annotations to new regression tests, move legacy Media FTS lookup behind DB_Management, document blob hash helper, and make staged blob chunk publication no-overwrite under concurrent writers.
+PR review follow-up implemented and verified.
+
+Follow-up changes:
+- Added type annotations to the new regression tests flagged in review.
+- Moved the legacy Media FTS title/content lookup into `media_db.runtime.fts_ops` and bound it on `MediaDatabase`.
+- Added a docstring for `_sha256_file`.
+- Reworked staged blob chunk writes to publish via a unique temp file plus no-overwrite `os.link`, verifying any pre-existing target before accepting idempotency.
+- Added a focused blob-store race regression proving a losing concurrent writer cannot overwrite an already published chunk.
+
+Follow-up verification:
+- Focused regressions: `python -m pytest tldw_Server_API/tests/Sync/test_sync_v2_blob_store.py::test_local_blob_store_does_not_overwrite_chunk_after_publish_race tldw_Server_API/tests/Sync/test_sync_v2_service.py::test_push_rejects_divergent_legacy_payload_over_actual_serialized_size_limit tldw_Server_API/tests/Sync/test_sync_v2_service.py::test_blob_upload_conflicting_duplicate_chunk_does_not_overwrite_existing_chunk tldw_Server_API/tests/Sync/test_sync_v2_domain_adapters.py::test_domain_adapters_conflict_tombstone_operation_without_deleted_flag tldw_Server_API/tests/MediaDB2/test_sync_client.py::TestClientSyncEnginePush::test_push_advances_past_other_clients_changes_without_network_call tldw_Server_API/tests/MediaDB2/test_sync_client.py::TestClientSyncEnginePullApply::test_pull_and_apply_media_title_update_refreshes_fts -q` -> 8 passed.
+- Broader touched tests: `python -m pytest tldw_Server_API/tests/Sync/test_sync_v2_blob_store.py tldw_Server_API/tests/Sync/test_sync_v2_service.py tldw_Server_API/tests/Sync/test_sync_v2_domain_adapters.py tldw_Server_API/tests/MediaDB2/test_sync_client.py -q` -> 174 passed.
+- Bandit touched app scope: `python -m bandit -r tldw_Server_API/app/core/Sync tldw_Server_API/app/core/DB_Management/Sync_DB.py tldw_Server_API/app/core/DB_Management/media_db/runtime/fts_ops.py tldw_Server_API/app/core/DB_Management/media_db/media_database_impl.py -f json -o /tmp/bandit_sync_review_fixes_12012_pr_comments.json` -> 0 findings.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened the Sync module review findings by preventing conflicting duplicate blob chunks from overwriting staged data, explicitly accounting for divergent inline envelope payload bytes, using `tombstone` as the Sync v2 delete operation in domain adapters, restoring legacy Media FTS lookup for title/content updates, and advancing legacy outbound sync past log rows created by other local clients. Added focused regression tests for the fixed behaviors and verified the touched test files plus Bandit on the touched Sync scope.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/DB_Management/Sync_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Sync_DB.py
@@ -4363,6 +4363,39 @@ class SyncDatabase:
                 connection=conn,
             )
 
+    def get_blob_chunk(
+        self,
+        upload_id: str,
+        chunk_index: int,
+        *,
+        dataset_id: str | None = None,
+    ) -> SyncBlobChunk | None:
+        """Return a recorded blob chunk for duplicate-upload preflight checks."""
+
+        if dataset_id is None:
+            row = _first(
+                self.execute(
+                    """
+                    SELECT * FROM sync_blob_chunks
+                     WHERE upload_id = ? AND chunk_index = ?
+                    """,
+                    (upload_id, chunk_index),
+                )
+            )
+        else:
+            row = _first(
+                self.execute(
+                    """
+                    SELECT * FROM sync_blob_chunks
+                     WHERE upload_id = ? AND dataset_id = ? AND chunk_index = ?
+                    """,
+                    (upload_id, dataset_id, chunk_index),
+                )
+            )
+        if row is None:
+            return None
+        return _blob_chunk_from_row(row)
+
     def record_blob_chunk(self, chunk: SyncBlobChunkCreate) -> SyncBlobChunk:
         """Record one uploaded blob chunk idempotently."""
 

--- a/tldw_Server_API/app/core/DB_Management/media_db/media_database_impl.py
+++ b/tldw_Server_API/app/core/DB_Management/media_db/media_database_impl.py
@@ -64,6 +64,7 @@ from tldw_Server_API.app.core.DB_Management.media_db.runtime.fts_ops import (
     _delete_fts_media,
     _update_fts_keyword,
     _update_fts_media,
+    sync_get_media_fts_values,
     sync_refresh_fts_for_entity,
 )
 from tldw_Server_API.app.core.DB_Management.media_db.runtime.chunk_fts_ops import (
@@ -2075,6 +2076,7 @@ MediaDatabase._update_fts_media = _update_fts_media
 MediaDatabase._delete_fts_media = _delete_fts_media
 MediaDatabase._update_fts_keyword = _update_fts_keyword
 MediaDatabase._delete_fts_keyword = _delete_fts_keyword
+MediaDatabase.sync_get_media_fts_values = sync_get_media_fts_values
 MediaDatabase.sync_refresh_fts_for_entity = sync_refresh_fts_for_entity
 MediaDatabase.ensure_chunk_fts = ensure_chunk_fts
 MediaDatabase.maybe_rebuild_chunk_fts_if_empty = maybe_rebuild_chunk_fts_if_empty

--- a/tldw_Server_API/app/core/DB_Management/media_db/runtime/fts_ops.py
+++ b/tldw_Server_API/app/core/DB_Management/media_db/runtime/fts_ops.py
@@ -335,10 +335,32 @@ def sync_refresh_fts_for_entity(
         return
 
 
+def sync_get_media_fts_values(
+    self: Any,
+    conn,
+    *,
+    entity_uuid: str,
+) -> dict[str, str]:
+    """Return current Media values needed for legacy sync FTS refreshes."""
+
+    row = self._fetchone_with_connection(
+        conn,
+        "SELECT title, content FROM Media WHERE uuid = ?",
+        (entity_uuid,),
+    )
+    if row is None:
+        return {}
+    return {
+        "title": str(row.get("title") or ""),
+        "content": str(row.get("content") or ""),
+    }
+
+
 __all__ = [
     "_delete_fts_keyword",
     "_delete_fts_media",
     "_update_fts_keyword",
     "_update_fts_media",
+    "sync_get_media_fts_values",
     "sync_refresh_fts_for_entity",
 ]

--- a/tldw_Server_API/app/core/Sync/Sync_Client.py
+++ b/tldw_Server_API/app/core/Sync/Sync_Client.py
@@ -324,6 +324,14 @@ class ClientSyncEngine:
         client_changes = [c for c in (local_changes or []) if c.get('client_id') == self.client_id]
 
         if not client_changes:
+            skipped_max_id = _max_change_id(local_changes or [])
+            if skipped_max_id > self.last_local_log_id_sent:
+                self.last_local_log_id_sent = skipped_max_id
+                self._save_sync_state()
+                logger.info(
+                    f"Advanced last_local_log_id_sent to {skipped_max_id} "
+                    "after skipping outbound changes from other clients."
+                )
             logger.info("No local changes to push.")
             return
 
@@ -1013,6 +1021,14 @@ class ClientSyncEngine:
         except ValueError as e:
             logger.error(f"Error getting columns for table {table_name}: {e}")
             return None
+
+    def _get_current_media_for_fts(self, cursor: sqlite3.Cursor, uuid: str) -> dict[str, str]:
+        """Return current Media title/content values used to refresh FTS rows."""
+
+        try:
+            return self.db.sync_get_media_fts_values(cursor.connection, entity_uuid=uuid)
+        except DatabaseError as exc:
+            raise DatabaseError(f"Could not fetch Media FTS values for {uuid}") from exc
 
 
 # --- Example Usage ---

--- a/tldw_Server_API/app/core/Sync/v2/blob_store.py
+++ b/tldw_Server_API/app/core/Sync/v2/blob_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import shutil
 import tempfile
 from collections.abc import Iterator
@@ -43,9 +44,19 @@ class LocalSyncBlobStore:
         storage_key = f"_uploads/{upload_segment}/{chunk_index}.part"
         target = self.resolve_storage_key(storage_key)
         target.parent.mkdir(parents=True, exist_ok=True)
-        temp_path = target.with_suffix(target.suffix + ".tmp")
-        temp_path.write_bytes(payload)
-        temp_path.replace(target)
+        temp_path = _chunk_temp_path(target, chunk_index=chunk_index)
+        try:
+            temp_path.write_bytes(payload)
+            os.link(temp_path, target)
+        except FileExistsError:
+            if _sha256_file(target) != expected_hash:
+                raise SyncBlobStoreError(
+                    "Sync blob chunk storage key already contains different content"
+                )
+        except OSError as exc:
+            raise SyncBlobStoreError("Sync blob chunk write failed") from exc
+        finally:
+            _discard_temp_path(temp_path)
         return storage_key
 
     def commit_upload(
@@ -158,6 +169,16 @@ def _sha256(payload: bytes) -> str:
     return "sha256:" + hashlib.sha256(payload).hexdigest()
 
 
+def _sha256_file(path: Path) -> str:
+    """Return the SHA-256 digest for a file without loading it all into memory."""
+
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(STREAM_CHUNK_SIZE):
+            hasher.update(chunk)
+    return "sha256:" + hasher.hexdigest()
+
+
 def _hash_digest(value: str) -> str:
     prefix = "sha256:"
     if not value.startswith(prefix) or len(value) != len(prefix) + 64:
@@ -190,6 +211,18 @@ def _commit_temp_path(final_path: Path, *, digest: str, upload_segment: str) -> 
         delete=False,
         dir=final_path.parent,
         prefix=f"{digest}.{upload_segment}.",
+        suffix=".tmp",
+    )
+    temp_path = Path(temp_file.name)
+    temp_file.close()
+    return temp_path
+
+
+def _chunk_temp_path(target: Path, *, chunk_index: int) -> Path:
+    temp_file = tempfile.NamedTemporaryFile(
+        delete=False,
+        dir=target.parent,
+        prefix=f"{chunk_index}.",
         suffix=".tmp",
     )
     temp_path = Path(temp_file.name)

--- a/tldw_Server_API/app/core/Sync/v2/domain_adapters/chat.py
+++ b/tldw_Server_API/app/core/Sync/v2/domain_adapters/chat.py
@@ -72,7 +72,7 @@ def _manual_delete_conflict(envelope: SyncEnvelopeCreate) -> AdapterConflict:
 
 
 def _is_delete(envelope: SyncEnvelope | SyncEnvelopeCreate) -> bool:
-    return envelope.operation == "delete" or bool(
+    return envelope.operation == "tombstone" or bool(
         envelope.payload_clear.get("deleted")
         or envelope.payload_clear.get("soft_deleted")
         or envelope.payload_clear.get("tombstone")

--- a/tldw_Server_API/app/core/Sync/v2/domain_adapters/notes.py
+++ b/tldw_Server_API/app/core/Sync/v2/domain_adapters/notes.py
@@ -84,7 +84,7 @@ def _manual_delete_conflict(envelope: SyncEnvelopeCreate) -> AdapterConflict:
 
 
 def _is_delete(envelope: SyncEnvelope | SyncEnvelopeCreate) -> bool:
-    return envelope.operation == "delete" or bool(
+    return envelope.operation == "tombstone" or bool(
         envelope.payload_clear.get("deleted")
         or envelope.payload_clear.get("soft_deleted")
         or envelope.payload_clear.get("tombstone")

--- a/tldw_Server_API/app/core/Sync/v2/domain_adapters/workspaces.py
+++ b/tldw_Server_API/app/core/Sync/v2/domain_adapters/workspaces.py
@@ -100,7 +100,7 @@ def _manual_delete_conflict(envelope: SyncEnvelopeCreate) -> AdapterConflict:
 
 
 def _is_delete(envelope: SyncEnvelope | SyncEnvelopeCreate) -> bool:
-    return envelope.operation == "delete" or bool(
+    return envelope.operation == "tombstone" or bool(
         envelope.payload_clear.get("deleted")
         or envelope.payload_clear.get("soft_deleted")
         or envelope.payload_clear.get("tombstone")

--- a/tldw_Server_API/app/core/Sync/v2/service.py
+++ b/tldw_Server_API/app/core/Sync/v2/service.py
@@ -2197,11 +2197,29 @@ class SyncV2Service:
         self._validate_sha256_hash(chunk_hash, field_name="chunk_hash")
         if len(chunk_payload) > self.settings.max_chunk_bytes:
             raise SyncStoreError("Sync blob chunk exceeds the server size limit")
+        if chunk_index < 0 or chunk_index >= session.chunk_count:
+            raise SyncStoreError("Sync blob chunk index is outside the upload session")
         if offset_bytes < 0:
             raise SyncStoreError("Sync blob chunk offset is invalid")
+        expected_offset = session.chunk_size * chunk_index
+        if offset_bytes != expected_offset:
+            raise SyncStoreError("Sync blob chunk offset does not match the upload session")
         expected_size = min(session.chunk_size, max(session.size_bytes - offset_bytes, 0))
         if len(chunk_payload) != expected_size:
             raise SyncStoreError("Sync blob chunk size does not match the upload session")
+        existing_chunk = self.store.get_blob_chunk(
+            upload_id,
+            chunk_index,
+            dataset_id=dataset_id,
+        )
+        if existing_chunk is not None and (
+            existing_chunk.offset_bytes != offset_bytes
+            or existing_chunk.size_bytes != len(chunk_payload)
+            or existing_chunk.chunk_hash != chunk_hash
+        ):
+            raise SyncIdempotencyConflictError(
+                "Sync blob chunk was reused with different content"
+            )
         try:
             storage_key = blob_store.write_upload_chunk(
                 upload_id=upload_id,
@@ -3473,7 +3491,12 @@ class SyncV2Service:
         actual_size = 0
         if envelope.payload_ciphertext is not None:
             actual_size += len(envelope.payload_ciphertext.encode("utf-8"))
-        actual_size += _compact_json_size(envelope.payload_clear)
+        payload_size = _compact_json_size(envelope.payload)
+        payload_clear_size = _compact_json_size(envelope.payload_clear)
+        if envelope.payload and envelope.payload_clear and envelope.payload != envelope.payload_clear:
+            actual_size += payload_size + payload_clear_size
+        else:
+            actual_size += max(payload_size, payload_clear_size)
         actual_size += _compact_json_size(envelope.routing_metadata)
         actual_size += _compact_json_size(envelope.dependencies)
         return actual_size > max_bytes

--- a/tldw_Server_API/app/core/Sync/v2/store.py
+++ b/tldw_Server_API/app/core/Sync/v2/store.py
@@ -440,6 +440,19 @@ class SyncV2Store:
     def record_blob_chunk(self, chunk: SyncBlobChunkCreate) -> SyncBlobChunk:
         return self.db.record_blob_chunk(chunk)
 
+    def get_blob_chunk(
+        self,
+        upload_id: str,
+        chunk_index: int,
+        *,
+        dataset_id: str | None = None,
+    ) -> SyncBlobChunk | None:
+        return self.db.get_blob_chunk(
+            upload_id,
+            chunk_index,
+            dataset_id=dataset_id,
+        )
+
     def complete_blob_upload(self, blob: SyncBlobObjectCreate) -> SyncBlobObject:
         return self.db.complete_blob_upload(blob)
 

--- a/tldw_Server_API/tests/MediaDB2/test_sync_client.py
+++ b/tldw_Server_API/tests/MediaDB2/test_sync_client.py
@@ -5,6 +5,7 @@
 import json
 import os
 from datetime import datetime, timedelta
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -332,6 +333,38 @@ class TestClientSyncEnginePush:
         assert sync_engine.last_local_log_id_sent == only_change_id
 
 
+    @patch('tldw_Server_API.app.core.Sync.Sync_Client.fetch')
+    def test_push_advances_past_other_clients_changes_without_network_call(
+        self,
+        mock_post: MagicMock,
+        sync_engine: ClientSyncEngine,
+        client_db: Any,
+    ) -> None:
+        """Rows from other local DB clients should not pin the outbound cursor forever."""
+        client_db.execute_query(
+            (
+                "INSERT INTO sync_log (entity, entity_uuid, operation, timestamp, client_id, version, payload) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)"
+            ),
+            (
+                "Keywords",
+                "keyword-from-other-client",
+                "create",
+                "2023-10-27T11:05:00Z",
+                "other-client",
+                1,
+                '{"uuid":"keyword-from-other-client","keyword":"other client row"}',
+            ),
+            commit=True,
+        )
+        only_change_id = client_db.get_sync_log_entries(since_change_id=0)[0]["change_id"]
+
+        sync_engine._push_local_changes()
+
+        mock_post.assert_not_called()
+        assert sync_engine.last_local_log_id_sent == only_change_id
+
+
 class TestClientSyncEnginePullApply:
 
     @patch('tldw_Server_API.app.core.Sync.Sync_Client.fetch')
@@ -638,6 +671,56 @@ class TestClientSyncEnginePullApply:
         ).fetchone()
         assert row["cnt"] == 0
         assert sync_engine.last_server_log_id_processed == 121
+
+    @patch('tldw_Server_API.app.core.Sync.Sync_Client.fetch')
+    def test_pull_and_apply_media_title_update_refreshes_fts(
+        self,
+        mock_get: MagicMock,
+        sync_engine: ClientSyncEngine,
+        client_db: Any,
+    ) -> None:
+        """Media title/content updates should preserve current FTS values for omitted fields."""
+        media_id, media_uuid, _ = client_db.add_media_with_keywords(
+            title="sync original media",
+            media_type="article",
+            content="media content alpha",
+            keywords=[],
+        )
+        assert media_id is not None
+
+        server_change = create_mock_log_entry(
+            change_id=122,
+            entity="Media",
+            uuid=media_uuid,
+            op="update",
+            client="other_client",
+            version=2,
+            payload_dict={"uuid": media_uuid, "title": "sync updated media"},
+            ts="2023-10-28T12:32:00Z",
+        )
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"changes": [server_change], "latest_change_id": 122}
+        mock_get.return_value = mock_response
+
+        sync_engine.last_server_log_id_processed = 121
+        sync_engine._pull_and_apply_remote_changes()
+
+        media_row = client_db.execute_query(
+            "SELECT title, content, version, last_modified FROM Media WHERE uuid = ?",
+            (media_uuid,),
+        ).fetchone()
+        fts_row = client_db.execute_query(
+            "SELECT title, content FROM media_fts WHERE rowid = ?",
+            (media_id,),
+        ).fetchone()
+        assert media_row["title"] == "sync updated media"
+        assert media_row["content"] == "media content alpha"
+        assert media_row["version"] == 2
+        assert media_row["last_modified"] == "2023-10-28T12:32:00Z"
+        assert fts_row["title"] == "sync updated media"
+        assert fts_row["content"] == "media content alpha"
+        assert sync_engine.last_server_log_id_processed == 122
 
     @patch('tldw_Server_API.app.core.Sync.Sync_Client.fetch')
     def test_apply_idempotency(self, mock_get, sync_engine, client_db):

--- a/tldw_Server_API/tests/Sync/test_sync_v2_blob_store.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_blob_store.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import shutil
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -121,6 +123,41 @@ def test_local_blob_store_uses_unique_commit_temp_paths_for_same_payload_hash(
     assert first_key == second_key
     assert len(commit_write_paths) == 2
     assert len(set(commit_write_paths)) == 2
+
+
+def test_local_blob_store_does_not_overwrite_chunk_after_publish_race(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalSyncBlobStore(tmp_path / "sync_blobs")
+    existing_payload = b"winner"
+    losing_payload = b"losing"
+    upload_id = "upload-1"
+    storage_key = store.write_upload_chunk(
+        upload_id=upload_id,
+        chunk_index=0,
+        payload=existing_payload,
+        expected_hash=_sha256(existing_payload),
+    )
+    target = store.resolve_storage_key(storage_key)
+    original_link = os.link
+
+    def publish_race(src: Any, dst: Any, *args: Any, **kwargs: Any) -> None:
+        if Path(dst) == target:
+            raise FileExistsError
+        original_link(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(os, "link", publish_race)
+
+    with pytest.raises(SyncBlobStoreError, match="different content"):
+        store.write_upload_chunk(
+            upload_id=upload_id,
+            chunk_index=0,
+            payload=losing_payload,
+            expected_hash=_sha256(losing_payload),
+        )
+
+    assert target.read_bytes() == existing_payload
 
 
 def test_local_blob_store_commit_cleanup_failure_is_nonfatal(

--- a/tldw_Server_API/tests/Sync/test_sync_v2_domain_adapters.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_domain_adapters.py
@@ -450,7 +450,7 @@ def test_notes_adapter_accepts_linear_delete_after_upsert():
     )
     incoming = _envelope(
         client_envelope_id="note-delete",
-        operation="delete",
+        operation="tombstone",
         payload_clear={"entity_kind": "note", "deleted": True},
         payload_hash="sha256:delete",
         base_version="note-v1",
@@ -476,12 +476,43 @@ def test_notes_adapter_conflicts_delete_vs_update():
     )
     incoming = _envelope(
         client_envelope_id="note-delete",
-        operation="delete",
+        operation="tombstone",
         payload_clear={"entity_kind": "note", "deleted": True},
         payload_hash="sha256:delete",
     )
 
     outcome = NotesDomainAdapter().evaluate_envelope(
+        incoming,
+        dataset=_dataset(),
+        context=_context(prior),
+    )
+
+    assert isinstance(outcome, AdapterConflict)
+    assert outcome.conflict_type == "delete_update_conflict"
+
+
+@pytest.mark.parametrize("domain", ["notes", "chat", "workspaces"])
+def test_domain_adapters_conflict_tombstone_operation_without_deleted_flag(domain: str) -> None:
+    prior = _stored(
+        _envelope(
+            client_envelope_id=f"{domain}-update",
+            domain=domain,
+            payload_clear=_domain_payload(domain),
+            payload_hash=f"sha256:{domain}-update",
+            entity_version=f"{domain}-v2",
+        )
+    )
+    incoming = _envelope(
+        client_envelope_id=f"{domain}-tombstone",
+        domain=domain,
+        operation="tombstone",
+        payload_clear=_domain_payload(domain),
+        payload_hash=f"sha256:{domain}-tombstone",
+        base_version=f"{domain}-v1",
+        entity_version=f"{domain}-v3",
+    )
+
+    outcome = _adapter_for_domain(domain).evaluate_envelope(
         incoming,
         dataset=_dataset(),
         context=_context(prior),

--- a/tldw_Server_API/tests/Sync/test_sync_v2_service.py
+++ b/tldw_Server_API/tests/Sync/test_sync_v2_service.py
@@ -1778,6 +1778,38 @@ def test_push_rejects_clear_payloads_over_actual_serialized_size_limit(
     ]
 
 
+def test_push_rejects_divergent_legacy_payload_over_actual_serialized_size_limit(
+    sync_store: SyncV2Store,
+    registry: SyncAdapterRegistry,
+) -> None:
+    service = SyncV2Service(
+        store=sync_store,
+        adapters=registry,
+        clock=_clock,
+        settings=SyncV2Settings(max_envelope_payload_bytes=40),
+    )
+    _register_devices(service, "user-1", "device-1")
+    service.enroll_dataset(user_id="user-1", dataset_id="dataset-1", domains=["notes.note"])
+    envelope = _envelope(
+        client_envelope_id="legacy-payload-too-large",
+        payload_ciphertext=None,
+        payload_clear={},
+        routing_metadata={},
+        payload_size_bytes=1,
+    )
+    object.__setattr__(envelope, "payload", {"body": "x" * 80})
+
+    result = service.push(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        device_id="device-1",
+        envelopes=[envelope],
+    )
+
+    assert result.accepted == []
+    assert [item.error_code for item in result.rejected] == ["payload_too_large"]
+
+
 def test_conflict_push_retry_reuses_existing_unresolved_conflict(
     sync_store: SyncV2Store,
 ):
@@ -4571,6 +4603,76 @@ def test_blob_upload_completion_returns_committed_blob_when_cleanup_fails(
     )
 
     assert blob.status == "available"
+    assert blob_store.read_blob(blob.storage_key) == payload
+
+
+def test_blob_upload_conflicting_duplicate_chunk_does_not_overwrite_existing_chunk(
+    sync_store: SyncV2Store,
+    registry: SyncAdapterRegistry,
+    tmp_path: Path,
+) -> None:
+    blob_store = LocalSyncBlobStore(tmp_path / "sync_blobs")
+    service = SyncV2Service(
+        store=sync_store,
+        adapters=registry,
+        clock=_clock,
+        id_factory=lambda prefix: f"{prefix}-generated",
+        blob_store=blob_store,
+        settings=SyncV2Settings(
+            supports_attachments=True,
+            max_blob_bytes=64,
+            max_chunk_bytes=16,
+            server_trusted_encryption=_ready_encryption(),
+        ),
+    )
+    _register_devices(service, "user-1", "device-1")
+    service.enroll_dataset(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        domains=["notes.note", "attachment.ref"],
+    )
+    payload = b"original"
+    conflicting_payload = b"rewritte"
+    session = service.create_blob_upload_session(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        device_id="device-1",
+        domain="notes.note",
+        entity_id="note-1",
+        attachment_id="attachment-1",
+        content_type="application/octet-stream",
+        size_bytes=len(payload),
+        payload_hash=_sha256(payload),
+        chunk_size=len(payload),
+        chunk_count=1,
+    )
+    service.upload_blob_chunk(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        upload_id=session.upload_id,
+        chunk_index=0,
+        offset_bytes=0,
+        chunk_payload=payload,
+        chunk_hash=_sha256(payload),
+    )
+
+    with pytest.raises(SyncIdempotencyConflictError, match="different content"):
+        service.upload_blob_chunk(
+            user_id="user-1",
+            dataset_id="dataset-1",
+            upload_id=session.upload_id,
+            chunk_index=0,
+            offset_bytes=0,
+            chunk_payload=conflicting_payload,
+            chunk_hash=_sha256(conflicting_payload),
+        )
+
+    blob = service.complete_blob_upload(
+        user_id="user-1",
+        dataset_id="dataset-1",
+        upload_id=session.upload_id,
+    )
+
     assert blob_store.read_blob(blob.storage_key) == payload
 
 


### PR DESCRIPTION
## Summary
- Harden Sync v2 blob chunk idempotency so conflicting duplicate chunks cannot overwrite staged data.
- Enforce payload size accounting for divergent inline envelope payloads and align domain adapters on tombstone operations.
- Fix legacy Sync client Media FTS refresh and outbound cursor advancement for other-client rows.

## Verification
- `PYTHONPATH=$PWD python -m pytest tldw_Server_API/tests/Sync/test_sync_v2_service.py tldw_Server_API/tests/Sync/test_sync_v2_domain_adapters.py tldw_Server_API/tests/MediaDB2/test_sync_client.py -q` -> 168 passed
- `PYTHONPATH=$PWD python -m bandit -r tldw_Server_API/app/core/Sync tldw_Server_API/app/core/DB_Management/Sync_DB.py -f json -o /tmp/bandit_sync_review_fixes_12012_worktree.json` -> 0 findings

## Backlog
- TASK-12012

## Change summary
This PR is AI-authored and is intentionally draft. Before merge, the human requester must replace this section with a human-written Change summary explaining what changed and why these implementation choices were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Sync v2 to block duplicate blob chunks from overwriting staged data, enforce correct payload size checks, and fix legacy client sync behavior. Adds race-safe, no-overwrite chunk publishing and improved validations. Addresses TASK-12012.

- **Bug Fixes**
  - Reject conflicting duplicate blob chunks with DB preflight and on-disk hash check; validate index, offset, size, and hash; publish chunks via no-overwrite link to avoid races.
  - Enforce `max_envelope_payload_bytes` by counting both `payload` and `payload_clear` when they differ.
  - Treat `tombstone` as a delete in `notes`, `chat`, and `workspaces` adapters for correct conflict detection.
  - Legacy client: advance `last_local_log_id_sent` past other-client rows; restore Media FTS refresh using current title/content on partial updates.
  - Added focused tests, including a blob-store publish race regression.

<sup>Written for commit 285338008683e1efadda65612fd917238f0c7ad5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

