### PR TITLE
Harden StudyPacks provenance validation

### DIFF
--- a/backlog/tasks/task-12009 - Harden-StudyPacks-review-findings.md
+++ b/backlog/tasks/task-12009 - Harden-StudyPacks-review-findings.md
@@ -4,7 +4,7 @@ title: Harden StudyPacks review findings
 status: Done
 assignee: []
 created_date: '2026-06-24 00:00'
-updated_date: '2026-06-24 04:33'
+updated_date: '2026-06-25 02:07'
 labels:
   - study-packs
   - review-hardening
@@ -39,7 +39,12 @@ Implemented validated fixes:
 - Generation validation now requires model `citation_text` to match bundle evidence, rejects embedded/trailing JSON, checks deck-name candidates with exact lookup, and no longer imports the Workflows adapter helper.
 - Regeneration source extraction preserves labels, locators, and persisted evidence as an excerpt hint when available.
 
+PR #2503 rebase/review follow-up:
+- Rebased `codex/studypacks-review-hardening` onto latest `origin/dev` (`e664332b682e9be4e1f89d05a262de155cebfa6e`).
+- Addressed Qodo review comments by documenting new helpers, removing broad exception swallowing from `extract_openai_content`, adding pytest unit markers, bounding regeneration excerpt hints with truncation metadata, returning a controlled 400 when total regenerate job payloads still exceed the Jobs cap, and caching deck-name fallback scans.
+
 Modified files:
+- `tldw_Server_API/app/api/v1/endpoints/flashcards.py`
 - `tldw_Server_API/app/core/StudyPacks/source_resolver.py`
 - `tldw_Server_API/app/core/StudyPacks/generation_service.py`
 - `tldw_Server_API/app/core/StudyPacks/jobs.py`
@@ -64,8 +69,8 @@ Modified files:
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Validated and fixed all confirmed StudyPacks review issues. Verification completed with:
-- `.venv/bin/python -m pytest tldw_Server_API/tests/StudyPacks -q` -> 71 passed, 162 warnings.
-- `.venv/bin/python -m bandit -r tldw_Server_API/app/core/StudyPacks -f json -o /tmp/bandit_study_packs_12009.json` -> no findings.
+- `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/StudyPacks -q` -> 74 passed, 168 warnings.
+- `/Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m bandit -r tldw_Server_API/app/core/StudyPacks tldw_Server_API/app/api/v1/endpoints/flashcards.py -f json -o /tmp/bandit_study_packs_12009_review_rebase.json` -> no findings.
 - `git diff --check` on touched StudyPacks files -> clean.
 
 No known blockers or skipped validations remain for this task.

--- a/backlog/tasks/task-12009 - Harden-StudyPacks-review-findings.md
+++ b/backlog/tasks/task-12009 - Harden-StudyPacks-review-findings.md
@@ -1,0 +1,72 @@
+---
+id: TASK-12009
+title: Harden StudyPacks review findings
+status: Done
+assignee: []
+created_date: '2026-06-24 00:00'
+updated_date: '2026-06-24 04:33'
+labels:
+  - study-packs
+  - review-hardening
+dependencies: []
+references:
+  - tldw_Server_API/app/core/StudyPacks
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and remediate validated StudyPacks review findings around provenance integrity, evidence bounds, regeneration locator preservation, JSON response strictness, deck-name allocation behavior, and import coupling discovered during validation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Validated findings have focused red-to-green regression coverage.
+- [x] #2 StudyPacks source evidence and citation provenance cannot be silently fabricated from caller/model text.
+- [x] #3 StudyPacks prompt/persistence evidence size is bounded.
+- [x] #4 Regeneration preserves source locator context.
+- [x] #5 JSON output parsing, deck-name allocation, and heavy import coupling are hardened where validated.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Manual Backlog task file fallback approved by the user after the Backlog MCP workflow was unavailable and repeated non-interactive `backlog task create` attempts hung without output.
+
+Implemented validated fixes:
+- Source resolver only accepts `excerpt_text` when it matches resolved note/media/message evidence and bounds evidence with `STUDY_PACK_MAX_EVIDENCE_CHARS_PER_SOURCE`, marking truncated locators.
+- Generation validation now requires model `citation_text` to match bundle evidence, rejects embedded/trailing JSON, checks deck-name candidates with exact lookup, and no longer imports the Workflows adapter helper.
+- Regeneration source extraction preserves labels, locators, and persisted evidence as an excerpt hint when available.
+
+Modified files:
+- `tldw_Server_API/app/core/StudyPacks/source_resolver.py`
+- `tldw_Server_API/app/core/StudyPacks/generation_service.py`
+- `tldw_Server_API/app/core/StudyPacks/jobs.py`
+- `tldw_Server_API/tests/StudyPacks/test_source_resolver.py`
+- `tldw_Server_API/tests/StudyPacks/test_generation_service.py`
+- `tldw_Server_API/tests/StudyPacks/test_study_pack_jobs.py`
+- `tldw_Server_API/tests/StudyPacks/test_generation_service_imports.py`
+- `tldw_Server_API/tests/StudyPacks/test_study_pack_endpoints_api.py`
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Validated and fixed all confirmed StudyPacks review issues. Verification completed with:
+- `.venv/bin/python -m pytest tldw_Server_API/tests/StudyPacks -q` -> 71 passed, 162 warnings.
+- `.venv/bin/python -m bandit -r tldw_Server_API/app/core/StudyPacks -f json -o /tmp/bandit_study_packs_12009.json` -> no findings.
+- `git diff --check` on touched StudyPacks files -> clean.
+
+No known blockers or skipped validations remain for this task.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/flashcards.py
+++ b/tldw_Server_API/app/api/v1/endpoints/flashcards.py
@@ -2137,19 +2137,26 @@ def regenerate_study_pack(
             "source_items": source_items,
         }
     )
-    job = jm.create_job(
-        domain=STUDY_PACKS_DOMAIN,
-        queue=study_pack_jobs_queue(),
-        job_type=STUDY_PACKS_JOB_TYPE,
-        payload=build_study_pack_job_payload(
-            request,
-            regenerate_from_pack_id=pack_id,
-            expected_version=int(pack["version"]) if pack.get("version") is not None else None,
-        ),
-        owner_user_id=str(current_user.id),
-        priority=5,
-        max_retries=2,
-    )
+    try:
+        job = jm.create_job(
+            domain=STUDY_PACKS_DOMAIN,
+            queue=study_pack_jobs_queue(),
+            job_type=STUDY_PACKS_JOB_TYPE,
+            payload=build_study_pack_job_payload(
+                request,
+                regenerate_from_pack_id=pack_id,
+                expected_version=int(pack["version"]) if pack.get("version") is not None else None,
+            ),
+            owner_user_id=str(current_user.id),
+            priority=5,
+            max_retries=2,
+        )
+    except ValueError as exc:
+        logger.warning("Study-pack regeneration payload rejected for pack {}: {}", pack_id, exc)
+        raise HTTPException(
+            status_code=400,
+            detail="Study pack regeneration payload is too large to enqueue.",
+        ) from exc
     return StudyPackJobAcceptedResponse(job=_serialize_study_pack_job(job))
 
 

--- a/tldw_Server_API/app/core/StudyPacks/generation_service.py
+++ b/tldw_Server_API/app/core/StudyPacks/generation_service.py
@@ -33,7 +33,6 @@ from tldw_Server_API.app.core.StudyPacks.types import (
     StudySourceBundle,
     StudySourceBundleItem,
 )
-from tldw_Server_API.app.core.Workflows.adapters._common import extract_openai_content
 
 try:
     from tldw_Server_API.app.core.Chat.chat_service import perform_chat_api_call_async
@@ -66,6 +65,38 @@ def _clean_text(value: Any) -> str:
     if value is None:
         return ""
     return str(value).strip()
+
+
+def _normalized_for_match(value: Any) -> str:
+    return " ".join(_clean_text(value).split())
+
+
+def extract_openai_content(response: Any) -> str | None:
+    """Extract generated text from the small OpenAI-style response surface used here."""
+
+    if isinstance(response, Mapping):
+        try:
+            choices = response.get("choices") or []
+            if choices and isinstance(choices[0], Mapping):
+                message = choices[0].get("message") or {}
+                if isinstance(message, Mapping):
+                    content = message.get("content")
+                    if isinstance(content, str):
+                        return content
+            text = response.get("content") or response.get("text")
+            if isinstance(text, str):
+                return text
+        except (AttributeError, IndexError, KeyError, TypeError, ValueError):
+            return None
+    if isinstance(response, str):
+        return response
+    return None
+
+
+def _citation_text_matches_evidence(citation_text: str, evidence_text: str) -> bool:
+    normalized_citation = _normalized_for_match(citation_text)
+    normalized_evidence = _normalized_for_match(evidence_text)
+    return bool(normalized_citation and normalized_citation in normalized_evidence)
 
 
 def _bundle_item_key(source_type: Any, source_id: Any) -> tuple[str, str]:
@@ -331,20 +362,32 @@ class StudyPackGenerationService:
 
     def _next_destination_deck_name(self, base_name: str) -> str:
         cleaned_base_name = _clean_text(base_name) or "Study Pack"
-        existing_names = {
-            _clean_text(deck.get("name"))
-            for deck in self.note_db.list_decks(limit=10_000, include_deleted=True, include_workspace_items=True)
-            if _clean_text(deck.get("name"))
-        }
-        if cleaned_base_name not in existing_names:
+        if not self._deck_name_exists(cleaned_base_name):
             return cleaned_base_name
 
         for suffix in range(2, _MAX_DECK_NAME_ATTEMPTS + 1):
             candidate_name = f"{cleaned_base_name} ({suffix})"
-            if candidate_name not in existing_names:
+            if not self._deck_name_exists(candidate_name):
                 return candidate_name
 
         raise CharactersRAGDBError(f"Could not allocate a unique deck name for '{cleaned_base_name}'")  # noqa: TRY003
+
+    def _deck_name_exists(self, deck_name: str) -> bool:
+        get_deck_by_name = getattr(self.note_db, "get_deck_by_name", None)
+        if callable(get_deck_by_name):
+            try:
+                return bool(get_deck_by_name(deck_name, include_deleted=True))
+            except TypeError:
+                return bool(get_deck_by_name(deck_name))
+
+        list_decks = getattr(self.note_db, "list_decks", None)
+        if not callable(list_decks):
+            return False
+        try:
+            decks = list_decks(limit=10_000, include_deleted=True, include_workspace_items=True)
+        except TypeError:
+            decks = list_decks()
+        return any(_clean_text(deck.get("name")) == deck_name for deck in decks if isinstance(deck, Mapping))
 
     async def _call_generation_model(self, *, system_prompt: str, user_prompt: str) -> str:
         response = await perform_chat_api_call_async(
@@ -516,6 +559,8 @@ class StudyPackGenerationService:
         citation_text = _clean_text(raw_citation.get("citation_text"))
         if not citation_text:
             raise StudyPackValidationError("Study-pack citations must include citation_text")
+        if not _citation_text_matches_evidence(citation_text, bundle_item.evidence_text):
+            raise StudyPackValidationError("Study-pack citation_text must match source evidence")
 
         locator = self._merge_citation_locator(bundle_item, raw_citation.get("locator"))
         return {
@@ -559,16 +604,6 @@ class StudyPackGenerationService:
             return json.loads(candidate_text)
         except json.JSONDecodeError as exc:
             direct_error = exc
-
-        decoder = json.JSONDecoder()
-        for index, char in enumerate(candidate_text):
-            if char not in "[{":
-                continue
-            try:
-                payload, _ = decoder.raw_decode(candidate_text[index:])
-                return payload
-            except json.JSONDecodeError:
-                continue
         raise StudyPackMalformedResponseError("Study-pack generation did not return valid JSON") from direct_error
 
 

--- a/tldw_Server_API/app/core/StudyPacks/generation_service.py
+++ b/tldw_Server_API/app/core/StudyPacks/generation_service.py
@@ -68,6 +68,8 @@ def _clean_text(value: Any) -> str:
 
 
 def _normalized_for_match(value: Any) -> str:
+    """Normalize whitespace before comparing model text to evidence."""
+
     return " ".join(_clean_text(value).split())
 
 
@@ -75,25 +77,26 @@ def extract_openai_content(response: Any) -> str | None:
     """Extract generated text from the small OpenAI-style response surface used here."""
 
     if isinstance(response, Mapping):
-        try:
-            choices = response.get("choices") or []
-            if choices and isinstance(choices[0], Mapping):
-                message = choices[0].get("message") or {}
+        choices = response.get("choices")
+        if isinstance(choices, Sequence) and not isinstance(choices, (str, bytes, bytearray)) and choices:
+            first_choice = choices[0]
+            if isinstance(first_choice, Mapping):
+                message = first_choice.get("message") or {}
                 if isinstance(message, Mapping):
                     content = message.get("content")
                     if isinstance(content, str):
                         return content
-            text = response.get("content") or response.get("text")
-            if isinstance(text, str):
-                return text
-        except (AttributeError, IndexError, KeyError, TypeError, ValueError):
-            return None
+        text = response.get("content") or response.get("text")
+        if isinstance(text, str):
+            return text
     if isinstance(response, str):
         return response
     return None
 
 
 def _citation_text_matches_evidence(citation_text: str, evidence_text: str) -> bool:
+    """Return whether a citation quote appears in the resolved evidence."""
+
     normalized_citation = _normalized_for_match(citation_text)
     normalized_evidence = _normalized_for_match(evidence_text)
     return bool(normalized_citation and normalized_citation in normalized_evidence)
@@ -362,17 +365,39 @@ class StudyPackGenerationService:
 
     def _next_destination_deck_name(self, base_name: str) -> str:
         cleaned_base_name = _clean_text(base_name) or "Study Pack"
-        if not self._deck_name_exists(cleaned_base_name):
+        existing_names = None if callable(getattr(self.note_db, "get_deck_by_name", None)) else self._existing_deck_names()
+        if not self._deck_name_exists(cleaned_base_name, existing_names=existing_names):
             return cleaned_base_name
 
         for suffix in range(2, _MAX_DECK_NAME_ATTEMPTS + 1):
             candidate_name = f"{cleaned_base_name} ({suffix})"
-            if not self._deck_name_exists(candidate_name):
+            if not self._deck_name_exists(candidate_name, existing_names=existing_names):
                 return candidate_name
 
         raise CharactersRAGDBError(f"Could not allocate a unique deck name for '{cleaned_base_name}'")  # noqa: TRY003
 
-    def _deck_name_exists(self, deck_name: str) -> bool:
+    def _existing_deck_names(self) -> set[str]:
+        """Fetch deck names once for stores without an exact name lookup API."""
+
+        list_decks = getattr(self.note_db, "list_decks", None)
+        if not callable(list_decks):
+            return set()
+        try:
+            decks = list_decks(limit=10_000, include_deleted=True, include_workspace_items=True)
+        except TypeError:
+            decks = list_decks()
+        return {
+            _clean_text(deck.get("name"))
+            for deck in decks
+            if isinstance(deck, Mapping) and _clean_text(deck.get("name"))
+        }
+
+    def _deck_name_exists(self, deck_name: str, *, existing_names: set[str] | None = None) -> bool:
+        """Return whether a deck name already exists, preferring exact DB lookup."""
+
+        if existing_names is not None:
+            return deck_name in existing_names
+
         get_deck_by_name = getattr(self.note_db, "get_deck_by_name", None)
         if callable(get_deck_by_name):
             try:
@@ -380,14 +405,7 @@ class StudyPackGenerationService:
             except TypeError:
                 return bool(get_deck_by_name(deck_name))
 
-        list_decks = getattr(self.note_db, "list_decks", None)
-        if not callable(list_decks):
-            return False
-        try:
-            decks = list_decks(limit=10_000, include_deleted=True, include_workspace_items=True)
-        except TypeError:
-            decks = list_decks()
-        return any(_clean_text(deck.get("name")) == deck_name for deck in decks if isinstance(deck, Mapping))
+        return deck_name in self._existing_deck_names()
 
     async def _call_generation_model(self, *, system_prompt: str, user_prompt: str) -> str:
         response = await perform_chat_api_call_async(

--- a/tldw_Server_API/app/core/StudyPacks/jobs.py
+++ b/tldw_Server_API/app/core/StudyPacks/jobs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from typing import Any
 
@@ -63,30 +64,61 @@ def build_study_pack_job_result(
     return result
 
 
-def extract_study_pack_source_items(source_bundle_json: Any) -> list[dict[str, str]]:
-    """Recover minimal source selections from a persisted study-pack bundle."""
+def _clean_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
 
-    if isinstance(source_bundle_json, dict):
-        items = source_bundle_json.get("items")
-    elif isinstance(source_bundle_json, list):
-        items = source_bundle_json
+
+def _compact_mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    return {
+        str(key): item
+        for key, item in value.items()
+        if item not in (None, "", [], {})
+    }
+
+
+def extract_study_pack_source_items(source_bundle_json: Any) -> list[dict[str, Any]]:
+    """Recover source selections from a persisted study-pack bundle."""
+
+    bundle_payload = source_bundle_json
+    if isinstance(bundle_payload, str):
+        try:
+            bundle_payload = json.loads(bundle_payload)
+        except json.JSONDecodeError:
+            bundle_payload = None
+
+    if isinstance(bundle_payload, dict):
+        items = bundle_payload.get("items")
+    elif isinstance(bundle_payload, list):
+        items = bundle_payload
     else:
         items = None
 
-    normalized: list[dict[str, str]] = []
+    normalized: list[dict[str, Any]] = []
     for item in items or []:
         if not isinstance(item, dict):
             continue
-        source_type = str(item.get("source_type") or "").strip()
-        source_id = str(item.get("source_id") or "").strip()
+        source_type = _clean_text(item.get("source_type"))
+        source_id = _clean_text(item.get("source_id"))
         if not source_type or not source_id:
             continue
-        normalized.append(
-            {
-                "source_type": source_type,
-                "source_id": source_id,
-            }
-        )
+        source_item: dict[str, Any] = {
+            "source_type": source_type,
+            "source_id": source_id,
+        }
+        label = _clean_text(item.get("label"))
+        if label:
+            source_item["label"] = label
+        locator = _compact_mapping(item.get("locator"))
+        if locator:
+            source_item["locator"] = locator
+        excerpt_text = _clean_text(item.get("excerpt_text")) or _clean_text(item.get("evidence_text"))
+        if excerpt_text:
+            source_item["excerpt_text"] = excerpt_text
+        normalized.append(source_item)
     return normalized
 
 

--- a/tldw_Server_API/app/core/StudyPacks/jobs.py
+++ b/tldw_Server_API/app/core/StudyPacks/jobs.py
@@ -6,10 +6,14 @@ import json
 import os
 from typing import Any
 
+from loguru import logger
+
 from tldw_Server_API.app.api.v1.schemas.study_packs import StudyPackCreateJobRequest
 
 STUDY_PACKS_DOMAIN = "study_packs"
 STUDY_PACKS_JOB_TYPE = "study_pack_generate"
+_DEFAULT_REGENERATION_EXCERPT_CHARS = 12_000
+_REGENERATION_EXCERPT_CHARS_ENV = "STUDY_PACK_MAX_EVIDENCE_CHARS_PER_SOURCE"
 
 
 def study_pack_jobs_queue() -> str:
@@ -65,12 +69,16 @@ def build_study_pack_job_result(
 
 
 def _clean_text(value: Any) -> str:
+    """Coerce optional values into stripped text."""
+
     if value is None:
         return ""
     return str(value).strip()
 
 
 def _compact_mapping(value: Any) -> dict[str, Any]:
+    """Return a locator mapping without empty fields."""
+
     if not isinstance(value, dict):
         return {}
     return {
@@ -78,6 +86,45 @@ def _compact_mapping(value: Any) -> dict[str, Any]:
         for key, item in value.items()
         if item not in (None, "", [], {})
     }
+
+
+def _max_regeneration_excerpt_chars() -> int:
+    """Return the maximum persisted evidence hint copied into regeneration jobs."""
+
+    configured_limit = _clean_text(os.getenv(_REGENERATION_EXCERPT_CHARS_ENV))
+    if not configured_limit:
+        return _DEFAULT_REGENERATION_EXCERPT_CHARS
+    try:
+        parsed_limit = int(configured_limit)
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid {} value {!r}; using default {}",
+            _REGENERATION_EXCERPT_CHARS_ENV,
+            configured_limit,
+            _DEFAULT_REGENERATION_EXCERPT_CHARS,
+        )
+        return _DEFAULT_REGENERATION_EXCERPT_CHARS
+    if parsed_limit <= 0:
+        logger.warning(
+            "Ignoring non-positive {} value {}; using default {}",
+            _REGENERATION_EXCERPT_CHARS_ENV,
+            parsed_limit,
+            _DEFAULT_REGENERATION_EXCERPT_CHARS,
+        )
+        return _DEFAULT_REGENERATION_EXCERPT_CHARS
+    return parsed_limit
+
+
+def _bound_regeneration_excerpt(excerpt_text: str, locator: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    """Bound regenerated excerpt hints and annotate locator metadata when truncated."""
+
+    max_chars = _max_regeneration_excerpt_chars()
+    if len(excerpt_text) <= max_chars:
+        return excerpt_text, locator
+    bounded_locator = dict(locator)
+    bounded_locator["excerpt_truncated"] = True
+    bounded_locator["excerpt_original_chars"] = len(excerpt_text)
+    return excerpt_text[:max_chars], bounded_locator
 
 
 def extract_study_pack_source_items(source_bundle_json: Any) -> list[dict[str, Any]]:
@@ -113,9 +160,11 @@ def extract_study_pack_source_items(source_bundle_json: Any) -> list[dict[str, A
         if label:
             source_item["label"] = label
         locator = _compact_mapping(item.get("locator"))
+        excerpt_text = _clean_text(item.get("excerpt_text")) or _clean_text(item.get("evidence_text"))
+        if excerpt_text:
+            excerpt_text, locator = _bound_regeneration_excerpt(excerpt_text, locator)
         if locator:
             source_item["locator"] = locator
-        excerpt_text = _clean_text(item.get("excerpt_text")) or _clean_text(item.get("evidence_text"))
         if excerpt_text:
             source_item["excerpt_text"] = excerpt_text
         normalized.append(source_item)

--- a/tldw_Server_API/app/core/StudyPacks/source_resolver.py
+++ b/tldw_Server_API/app/core/StudyPacks/source_resolver.py
@@ -73,6 +73,8 @@ def _parse_non_negative_float(value: Any, field_name: str) -> float:
 
 
 def _max_evidence_chars_per_source() -> int:
+    """Return the configured per-source evidence character limit."""
+
     configured_limit = _clean_text(os.getenv(_MAX_EVIDENCE_CHARS_ENV))
     if not configured_limit:
         return _DEFAULT_MAX_EVIDENCE_CHARS_PER_SOURCE
@@ -98,10 +100,14 @@ def _max_evidence_chars_per_source() -> int:
 
 
 def _normalized_for_match(value: Any) -> str:
+    """Normalize whitespace for source/excerpt containment checks."""
+
     return " ".join(_clean_text(value).split())
 
 
 def _candidate_contains_excerpt(candidate: str, excerpt_text: str) -> bool:
+    """Return whether an excerpt is present in canonical source evidence."""
+
     if excerpt_text in candidate:
         return True
     normalized_candidate = _normalized_for_match(candidate)
@@ -110,6 +116,8 @@ def _candidate_contains_excerpt(candidate: str, excerpt_text: str) -> bool:
 
 
 def _pick_evidence_text(selection: StudySourceSelection, *candidates: Any) -> str:
+    """Select evidence text, requiring caller excerpts to match a source candidate."""
+
     for candidate in candidates:
         text = _clean_text(candidate)
         if text:
@@ -123,6 +131,8 @@ def _pick_evidence_text(selection: StudySourceSelection, *candidates: Any) -> st
 
 
 def _bounded_evidence_text(evidence_text: str, locator: Mapping[str, Any]) -> tuple[str, dict[str, Any]]:
+    """Bound evidence text and annotate the locator when truncation occurs."""
+
     normalized_locator = dict(locator)
     max_chars = _max_evidence_chars_per_source()
     if len(evidence_text) <= max_chars:
@@ -137,6 +147,8 @@ def _prepare_evidence(
     locator: Mapping[str, Any],
     *candidates: Any,
 ) -> tuple[str, dict[str, Any]]:
+    """Resolve source-backed evidence and apply the configured evidence bound."""
+
     evidence_text = _pick_evidence_text(selection, *candidates)
     if not evidence_text:
         return "", dict(locator)

--- a/tldw_Server_API/app/core/StudyPacks/source_resolver.py
+++ b/tldw_Server_API/app/core/StudyPacks/source_resolver.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Mapping, Sequence
 from typing import Any
 
@@ -21,6 +22,8 @@ from .types import (
 )
 
 SUPPORTED_SOURCE_TYPES = frozenset({"note", "media", "message"})
+_DEFAULT_MAX_EVIDENCE_CHARS_PER_SOURCE = 12_000
+_MAX_EVIDENCE_CHARS_ENV = "STUDY_PACK_MAX_EVIDENCE_CHARS_PER_SOURCE"
 
 
 def _clean_text(value: Any) -> str:
@@ -69,14 +72,75 @@ def _parse_non_negative_float(value: Any, field_name: str) -> float:
     return parsed
 
 
+def _max_evidence_chars_per_source() -> int:
+    configured_limit = _clean_text(os.getenv(_MAX_EVIDENCE_CHARS_ENV))
+    if not configured_limit:
+        return _DEFAULT_MAX_EVIDENCE_CHARS_PER_SOURCE
+    try:
+        parsed_limit = int(configured_limit)
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid {} value {!r}; using default {}",
+            _MAX_EVIDENCE_CHARS_ENV,
+            configured_limit,
+            _DEFAULT_MAX_EVIDENCE_CHARS_PER_SOURCE,
+        )
+        return _DEFAULT_MAX_EVIDENCE_CHARS_PER_SOURCE
+    if parsed_limit <= 0:
+        logger.warning(
+            "Ignoring non-positive {} value {}; using default {}",
+            _MAX_EVIDENCE_CHARS_ENV,
+            parsed_limit,
+            _DEFAULT_MAX_EVIDENCE_CHARS_PER_SOURCE,
+        )
+        return _DEFAULT_MAX_EVIDENCE_CHARS_PER_SOURCE
+    return parsed_limit
+
+
+def _normalized_for_match(value: Any) -> str:
+    return " ".join(_clean_text(value).split())
+
+
+def _candidate_contains_excerpt(candidate: str, excerpt_text: str) -> bool:
+    if excerpt_text in candidate:
+        return True
+    normalized_candidate = _normalized_for_match(candidate)
+    normalized_excerpt = _normalized_for_match(excerpt_text)
+    return bool(normalized_excerpt and normalized_excerpt in normalized_candidate)
+
+
 def _pick_evidence_text(selection: StudySourceSelection, *candidates: Any) -> str:
-    if selection.excerpt_text:
-        return selection.excerpt_text
     for candidate in candidates:
         text = _clean_text(candidate)
         if text:
+            excerpt_text = _clean_text(selection.excerpt_text)
+            if excerpt_text:
+                if not _candidate_contains_excerpt(text, excerpt_text):
+                    raise ValueError("excerpt_text must match resolved source evidence")
+                return excerpt_text
             return text
     return ""
+
+
+def _bounded_evidence_text(evidence_text: str, locator: Mapping[str, Any]) -> tuple[str, dict[str, Any]]:
+    normalized_locator = dict(locator)
+    max_chars = _max_evidence_chars_per_source()
+    if len(evidence_text) <= max_chars:
+        return evidence_text, normalized_locator
+    normalized_locator["evidence_truncated"] = True
+    normalized_locator["evidence_original_chars"] = len(evidence_text)
+    return evidence_text[:max_chars], normalized_locator
+
+
+def _prepare_evidence(
+    selection: StudySourceSelection,
+    locator: Mapping[str, Any],
+    *candidates: Any,
+) -> tuple[str, dict[str, Any]]:
+    evidence_text = _pick_evidence_text(selection, *candidates)
+    if not evidence_text:
+        return "", dict(locator)
+    return _bounded_evidence_text(evidence_text, locator)
 
 
 class StudySourceResolver:
@@ -117,11 +181,11 @@ class StudySourceResolver:
             raise ValueError(f"Note '{selection.source_id}' not found")
 
         label = selection.label or _clean_text(note.get("title")) or f"Note {selection.source_id}"
-        evidence_text = _pick_evidence_text(selection, note.get("content"))
+        locator = {**selection.locator, "note_id": selection.source_id}
+        evidence_text, locator = _prepare_evidence(selection, locator, note.get("content"))
         if not evidence_text:
             raise ValueError(f"Note '{selection.source_id}' has no evidence text")
 
-        locator = {**selection.locator, "note_id": selection.source_id}
         return StudySourceBundleItem(
             source_type="note",
             source_id=selection.source_id,
@@ -146,15 +210,15 @@ class StudySourceResolver:
             )
 
         label = selection.label or _clean_text(message.get("sender")) or f"Message {message_id}"
-        evidence_text = _pick_evidence_text(selection, message.get("content"))
-        if not evidence_text:
-            raise ValueError(f"Message '{message_id}' has no evidence text")
-
         locator = {
             **selection.locator,
             "conversation_id": conversation_id,
             "message_id": message_id,
         }
+        evidence_text, locator = _prepare_evidence(selection, locator, message.get("content"))
+        if not evidence_text:
+            raise ValueError(f"Message '{message_id}' has no evidence text")
+
         return StudySourceBundleItem(
             source_type="message",
             source_id=message_id,
@@ -204,30 +268,34 @@ class StudySourceResolver:
             ]
             if evidence_parts:
                 chunk_id = _clean_text(chunks[0].get("uuid")) or str(chunk_index)
-                return StudySourceBundleItem(
-                    source_type="media",
-                    source_id=str(media_id),
-                    label=label,
-                    evidence_text=_pick_evidence_text(selection, "\n\n".join(evidence_parts)),
-                    locator={
+                chunk_locator = _bounded_evidence_text(
+                    _pick_evidence_text(selection, "\n\n".join(evidence_parts)),
+                    {
                         "media_id": media_id,
                         "chunk_id": chunk_id,
                         "chunk_index": chunk_index,
                     },
                 )
+                evidence_text, normalized_locator = chunk_locator
+                return StudySourceBundleItem(
+                    source_type="media",
+                    source_id=str(media_id),
+                    label=label,
+                    evidence_text=evidence_text,
+                    locator=normalized_locator,
+                )
 
         timestamp_value = locator.get("timestamp_seconds")
         transcript = _clean_text(get_latest_transcription(self.media_db, media_id))
-        evidence_text = _pick_evidence_text(selection, transcript)
-        if not evidence_text:
-            raise ValueError(f"Media {media_id} has no transcript evidence to resolve")
-
         normalized_locator: dict[str, Any] = {"media_id": media_id}
         if timestamp_value is not None:
             normalized_locator["timestamp_seconds"] = _parse_non_negative_float(
                 timestamp_value,
                 "timestamp_seconds",
             )
+        evidence_text, normalized_locator = _prepare_evidence(selection, normalized_locator, transcript)
+        if not evidence_text:
+            raise ValueError(f"Media {media_id} has no transcript evidence to resolve")
 
         return StudySourceBundleItem(
             source_type="media",

--- a/tldw_Server_API/tests/StudyPacks/test_generation_service.py
+++ b/tldw_Server_API/tests/StudyPacks/test_generation_service.py
@@ -10,7 +10,7 @@ from tldw_Server_API.app.api.v1.schemas.study_packs import StudyPackCreateJobReq
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, CharactersRAGDBError
 
 
-pytestmark = pytest.mark.asyncio
+pytestmark = [pytest.mark.asyncio, pytest.mark.unit]
 
 
 def _load_generation_modules():
@@ -290,6 +290,30 @@ def test_destination_deck_name_checks_exact_candidates_beyond_list_window(
     service.note_db = WindowedDeckDb()
 
     assert service._next_destination_deck_name("zzzz-existing") == "zzzz-existing (2)"  # nosec B101
+
+
+def test_destination_deck_name_fallback_lists_decks_once(
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    service, _ = _build_service(db, monkeypatch, [])
+
+    class ListOnlyDeckDb:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def list_decks(self, **_: Any) -> list[dict[str, str]]:
+            self.calls += 1
+            return [
+                {"name": "Fallback Pack"},
+                {"name": "Fallback Pack (2)"},
+            ]
+
+    deck_db = ListOnlyDeckDb()
+    service.note_db = deck_db
+
+    assert service._next_destination_deck_name("Fallback Pack") == "Fallback Pack (3)"  # nosec B101
+    assert deck_db.calls == 1  # nosec B101
 
 
 async def test_create_study_pack_from_request_uses_collision_safe_deck_suffixing(

--- a/tldw_Server_API/tests/StudyPacks/test_generation_service.py
+++ b/tldw_Server_API/tests/StudyPacks/test_generation_service.py
@@ -240,6 +240,58 @@ def test_validate_citation_payload_preserves_bundle_locator_over_conflicting_mod
     assert citation["locator"]["chunk_id"] == "chunk-99"  # nosec B101
 
 
+def test_validate_citation_payload_requires_citation_text_to_match_bundle_evidence(
+    db: CharactersRAGDB,
+    bundle: Any,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _, service_mod = _load_generation_modules()
+    service, _ = _build_service(db, monkeypatch, [])
+
+    with pytest.raises(service_mod.StudyPackValidationError, match="citation_text"):
+        service._validate_citation_payload(
+            {
+                "source_type": "note",
+                "source_id": "note-1",
+                "citation_text": "This unsupported citation is not in the note evidence.",
+            },
+            bundle_lookup={
+                ("note", "note-1"): bundle.items[0],
+            },
+        )
+
+
+def test_extract_json_payload_rejects_embedded_or_trailing_json(
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _, service_mod = _load_generation_modules()
+    service, _ = _build_service(db, monkeypatch, [])
+
+    with pytest.raises(service_mod.StudyPackMalformedResponseError, match="valid JSON"):
+        service._extract_json_payload('preface {"cards": []} trailing prose')
+
+
+def test_destination_deck_name_checks_exact_candidates_beyond_list_window(
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    service, _ = _build_service(db, monkeypatch, [])
+
+    class WindowedDeckDb:
+        def list_decks(self, **_: Any) -> list[dict[str, str]]:
+            return [{"name": f"aaa-{index:05d}"} for index in range(10_000)]
+
+        def get_deck_by_name(self, name: str, *, include_deleted: bool = False) -> dict[str, str] | None:
+            if name == "zzzz-existing":
+                return {"name": name}
+            return None
+
+    service.note_db = WindowedDeckDb()
+
+    assert service._next_destination_deck_name("zzzz-existing") == "zzzz-existing (2)"  # nosec B101
+
+
 async def test_create_study_pack_from_request_uses_collision_safe_deck_suffixing(
     db: CharactersRAGDB,
     bundle: Any,

--- a/tldw_Server_API/tests/StudyPacks/test_generation_service_imports.py
+++ b/tldw_Server_API/tests/StudyPacks/test_generation_service_imports.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
 
 def test_generation_service_does_not_import_workflows_adapter_common():
     source_path = (

--- a/tldw_Server_API/tests/StudyPacks/test_generation_service_imports.py
+++ b/tldw_Server_API/tests/StudyPacks/test_generation_service_imports.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def test_generation_service_does_not_import_workflows_adapter_common():
+    source_path = (
+        Path(__file__).resolve().parents[2]
+        / "app"
+        / "core"
+        / "StudyPacks"
+        / "generation_service.py"
+    )
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+
+    imported_modules = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+    assert "tldw_Server_API.app.core.Workflows.adapters._common" not in imported_modules  # nosec B101

--- a/tldw_Server_API/tests/StudyPacks/test_source_resolver.py
+++ b/tldw_Server_API/tests/StudyPacks/test_source_resolver.py
@@ -11,6 +11,9 @@ from tldw_Server_API.app.api.v1.schemas.study_packs import StudyPackSourceSelect
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 
 
+pytestmark = pytest.mark.unit
+
+
 def _load_study_modules():
     try:
         types_mod = import_module("tldw_Server_API.app.core.StudyPacks.types")

--- a/tldw_Server_API/tests/StudyPacks/test_source_resolver.py
+++ b/tldw_Server_API/tests/StudyPacks/test_source_resolver.py
@@ -411,7 +411,7 @@ def test_unsupported_or_incomplete_sources_fail_fast(
         )
 
 
-def test_excerpt_text_is_allowed_only_when_the_parent_source_still_exists():
+def test_excerpt_text_must_match_parent_source_text():
     db = MagicMock(spec=CharactersRAGDB)
     db.get_note_by_id.return_value = {
         "id": "note-2",
@@ -421,13 +421,41 @@ def test_excerpt_text_is_allowed_only_when_the_parent_source_still_exists():
     selection = _selection(
         source_type="note",
         source_id="note-2",
-        excerpt_text="Fast retransmit reacts before the timeout expires.",
+        excerpt_text="longer than the selected excerpt",
     )
 
     bundle = _resolver(db=db).resolve([selection])
 
-    assert bundle.items[0].evidence_text == "Fast retransmit reacts before the timeout expires."  # nosec B101
+    assert bundle.items[0].evidence_text == "longer than the selected excerpt"  # nosec B101
+
+    fabricated = _selection(
+        source_type="note",
+        source_id="note-2",
+        excerpt_text="Fast retransmit reacts before the timeout expires.",
+    )
+
+    with pytest.raises(ValueError, match="excerpt_text"):
+        _resolver(db=db).resolve([fabricated])
 
     db.get_note_by_id.return_value = None
     with pytest.raises(ValueError, match="Note 'note-2' not found"):
         _resolver(db=db).resolve([selection])
+
+
+def test_resolved_evidence_is_bounded_and_marks_truncated_sources(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("STUDY_PACK_MAX_EVIDENCE_CHARS_PER_SOURCE", "32")
+    db = MagicMock(spec=CharactersRAGDB)
+    db.get_note_by_id.return_value = {
+        "id": "note-long",
+        "title": "Long note",
+        "content": "abcdefghijklmnopqrstuvwxyz0123456789SOURCE-TAIL",
+    }
+
+    bundle = _resolver(db=db).resolve(
+        [_selection(source_type="note", source_id="note-long")]
+    )
+
+    item = bundle.items[0]
+    assert item.evidence_text == "abcdefghijklmnopqrstuvwxyz012345"  # nosec B101
+    assert item.locator["evidence_truncated"] is True  # nosec B101
+    assert item.locator["evidence_original_chars"] == 47  # nosec B101

--- a/tldw_Server_API/tests/StudyPacks/test_study_pack_endpoints_api.py
+++ b/tldw_Server_API/tests/StudyPacks/test_study_pack_endpoints_api.py
@@ -195,6 +195,37 @@ def test_regenerate_study_pack_job_uses_stored_source_bundle(
     ]
 
 
+def test_regenerate_study_pack_returns_400_when_job_payload_is_too_large(
+    client: TestClient,
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("JOBS_MAX_JSON_BYTES", "64")
+    deck_id = db.add_deck("Oversized Deck", workspace_id="ws-1")
+    pack_id = db.create_study_pack(
+        title="Oversized",
+        workspace_id="ws-1",
+        deck_id=deck_id,
+        source_bundle_json={
+            "items": [
+                {
+                    "source_type": "note",
+                    "source_id": "note-large",
+                    "label": "Large note",
+                    "locator": {"note_id": "note-large"},
+                    "evidence_text": "x" * 200,
+                }
+            ]
+        },
+        generation_options_json={"deck_mode": "new"},
+    )
+
+    response = client.post(f"/api/v1/flashcards/study-packs/{pack_id}/regenerate")
+
+    assert response.status_code == 400  # nosec B101
+    assert "too large" in response.json()["detail"]  # nosec B101
+
+
 def test_failed_study_pack_jobs_return_diagnostics_without_partial_pack(
     client: TestClient,
     jobs_db_path: Path,

--- a/tldw_Server_API/tests/StudyPacks/test_study_pack_endpoints_api.py
+++ b/tldw_Server_API/tests/StudyPacks/test_study_pack_endpoints_api.py
@@ -185,7 +185,14 @@ def test_regenerate_study_pack_job_uses_stored_source_bundle(
     assert int(job["payload"]["regenerate_from_pack_id"]) == pack_id  # nosec B101
     assert int(job["payload"]["expected_version"]) == 1  # nosec B101
     assert job["payload"]["title"] == "OSI Model"  # nosec B101
-    assert job["payload"]["source_items"] == [{"source_type": "note", "source_id": "note-1"}]  # nosec B101
+    assert job["payload"]["source_items"] == [  # nosec B101
+        {
+            "source_type": "note",
+            "source_id": "note-1",
+            "label": "Seed note",
+            "locator": {"note_id": "note-1"},
+        }
+    ]
 
 
 def test_failed_study_pack_jobs_return_diagnostics_without_partial_pack(

--- a/tldw_Server_API/tests/StudyPacks/test_study_pack_jobs.py
+++ b/tldw_Server_API/tests/StudyPacks/test_study_pack_jobs.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.StudyPacks.jobs import extract_study_pack_source_items
+
+
+def test_extract_study_pack_source_items_preserves_locator_label_and_evidence_hint():
+    source_items = extract_study_pack_source_items(
+        {
+            "items": [
+                {
+                    "source_type": "media",
+                    "source_id": "42",
+                    "label": "Lecture 42",
+                    "locator": {"chunk_index": 4, "timestamp_seconds": 61},
+                    "evidence_text": "The selected chunk explains slow start.",
+                }
+            ]
+        }
+    )
+
+    assert source_items == [  # nosec B101
+        {
+            "source_type": "media",
+            "source_id": "42",
+            "label": "Lecture 42",
+            "locator": {"chunk_index": 4, "timestamp_seconds": 61},
+            "excerpt_text": "The selected chunk explains slow start.",
+        }
+    ]

--- a/tldw_Server_API/tests/StudyPacks/test_study_pack_jobs.py
+++ b/tldw_Server_API/tests/StudyPacks/test_study_pack_jobs.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import pytest
+
 from tldw_Server_API.app.core.StudyPacks.jobs import extract_study_pack_source_items
+
+
+pytestmark = pytest.mark.unit
 
 
 def test_extract_study_pack_source_items_preserves_locator_label_and_evidence_hint():
@@ -25,5 +30,35 @@ def test_extract_study_pack_source_items_preserves_locator_label_and_evidence_hi
             "label": "Lecture 42",
             "locator": {"chunk_index": 4, "timestamp_seconds": 61},
             "excerpt_text": "The selected chunk explains slow start.",
+        }
+    ]
+
+
+def test_extract_study_pack_source_items_bounds_large_evidence_hints(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("STUDY_PACK_MAX_EVIDENCE_CHARS_PER_SOURCE", "12")
+
+    source_items = extract_study_pack_source_items(
+        {
+            "items": [
+                {
+                    "source_type": "note",
+                    "source_id": "note-large",
+                    "locator": {"note_id": "note-large"},
+                    "evidence_text": "abcdefghijklmnopqrstuvwxyz",
+                }
+            ]
+        }
+    )
+
+    assert source_items == [  # nosec B101
+        {
+            "source_type": "note",
+            "source_id": "note-large",
+            "locator": {
+                "note_id": "note-large",
+                "excerpt_truncated": True,
+                "excerpt_original_chars": 26,
+            },
+            "excerpt_text": "abcdefghijkl",
         }
     ]


### PR DESCRIPTION
## Summary
- Require StudyPacks excerpts and generated citation text to match resolved source evidence before generation/provenance persistence.
- Bound resolved evidence payloads, mark truncated locators, and preserve regeneration label/locator/evidence hints.
- Tighten generation response parsing, exact deck-name allocation, and remove the heavy Workflows helper import from StudyPacks generation.

## Test Plan
- /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest tldw_Server_API/tests/StudyPacks -q
- /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m bandit -r tldw_Server_API/app/core/StudyPacks -f json -o /tmp/bandit_study_packs_12009_worktree.json

## Change Summary Merge Gate
This PR was prepared by Codex. Project policy requires a human-authored Change summary explaining what changed and why before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens StudyPacks provenance and regeneration: excerpts and citations must match source text, evidence and regen hints are size-bounded, and oversized regenerate jobs return 400. Tightens JSON parsing, improves deck-name allocation with exact lookups and cached fallbacks, and removes the heavy `tldw_Server_API.app.core.Workflows.adapters._common` import.

- **Bug Fixes**
  - Enforce source-backed `excerpt_text` and `citation_text`; both must match resolved evidence.
  - Bound evidence and regeneration excerpt hints via `STUDY_PACK_MAX_EVIDENCE_CHARS_PER_SOURCE`; mark truncation in locators.
  - Reject embedded/trailing JSON in model output.
  - Preserve label/locator/excerpt on regeneration and accept stringified `source_bundle_json`.
  - Allocate deck names with exact lookup (`get_deck_by_name`) to avoid collisions beyond list windows.
  - Return 400 when regeneration job payload exceeds the Jobs size cap.

- **Refactors**
  - Inlined lightweight `extract_openai_content`; removed `tldw_Server_API.app.core.Workflows.adapters._common` dependency.
  - Cached deck-name fallback scans when falling back to `list_decks`.

<sup>Written for commit 6914632e572e8ce42bbcdb967188b4da42bc10b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

