### PR TITLE
Harden Slides module review findings

### DIFF
--- a/IMPLEMENTATION_PLAN_slides_review_fixes.md
+++ b/IMPLEMENTATION_PLAN_slides_review_fixes.md
@@ -1,0 +1,23 @@
+## Stage 1: Regression Coverage
+**Goal**: Capture the validated Slides review findings with focused tests.
+**Success Criteria**: Tests fail before production edits for script-safe export settings, markdown sanitization fallback, default asset caps, render limits, chunk fan-out limits, DB sync-log atomicity, malformed FTS handling, and schema init concurrency.
+**Tests**: Targeted `tldw_Server_API/tests/Slides` pytest cases.
+**Status**: Complete
+
+## Stage 2: Core Hardening
+**Goal**: Implement bounded and atomic behavior in the Slides core module.
+**Success Criteria**: Export settings are script-safe, bleach fallback remains active without CSS sanitizer support, asset/render/generation ceilings are enforced by default, DB sync logging is transactional, malformed FTS is handled, and schema init is locked.
+**Tests**: Focused Slides regression tests pass.
+**Status**: Complete
+
+## Stage 3: API Wiring
+**Goal**: Keep API callers aligned with the hardened core behavior.
+**Success Criteria**: API asset resolution passes explicit caps and malformed search queries map to controlled client errors.
+**Tests**: Existing Slides/API tests plus targeted DB/export/render coverage.
+**Status**: Complete
+
+## Stage 4: Verification
+**Goal**: Verify the touched scope and record results.
+**Success Criteria**: Targeted pytest run passes, Bandit reports no new findings for touched production files, and diff checks pass.
+**Tests**: `pytest` targeted Slides tests, Bandit touched scope, `git diff --check`.
+**Status**: Complete

--- a/backlog/tasks/task-12002 - Harden-Slides-module-review-findings.md
+++ b/backlog/tasks/task-12002 - Harden-Slides-module-review-findings.md
@@ -1,0 +1,50 @@
+---
+id: TASK-12002
+title: Harden Slides module review findings
+status: Done
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the current Slides module review findings under `tldw_Server_API/app/core/Slides`, including script-safe export settings, atomic sync logging, bounded generation chunking, default asset caps, render duration/count caps, markdown sanitization fallback, malformed FTS handling, and schema initialization locking.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Exported Reveal HTML does not embed raw script-closing settings JSON.
+- [x] #2 Presentation create/update mutations and sync logs are atomic.
+- [x] #3 Generation chunking, slide asset resolution, and video rendering enforce resource ceilings by default.
+- [x] #4 Markdown sanitization continues to use bleach when CSS sanitizer support is unavailable.
+- [x] #5 Malformed presentation search queries return controlled validation errors.
+- [x] #6 Slides schema initialization is safe under concurrent first use.
+- [x] #7 Focused Slides tests and Bandit pass for touched scope.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Plan: IMPLEMENTATION_PLAN_slides_review_fixes.md.
+
+RED verification: focused regression run failed before implementation because the new render limit constants did not exist, confirming the tests were exercising unfixed behavior.
+
+Implemented script-safe inline settings JSON for Reveal exports, independent bleach markdown sanitization when CSS sanitizer support is unavailable, default slide asset byte caps with post-read verification, explicit render slide/duration/total ceilings, generation source/chunk fan-out ceilings, transactional sync-log writes, malformed FTS query validation, schema initialization locking, API search error mapping, API asset cap propagation, and Reveal settings enum validation.
+
+GREEN verification: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides -q` passed with 171 passed and 369 warnings.
+
+Security verification: Bandit on touched production files wrote /tmp/bandit_slides_review_fixes.json and reported 0 results, 0 errors, and zero high/medium/low severity findings. `git diff --check` on touched files exited 0.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened the validated Slides review findings. Exports now serialize settings safely for inline scripts and keep bleach sanitization active without optional CSS sanitizer support. Asset resolution, slide generation chunking, and video rendering now enforce default resource ceilings. Presentation create/update sync logs are written in the same transaction as the mutation, malformed FTS searches return controlled validation errors, and schema initialization is serialized for concurrent first use. API export/search paths now pass the hardened caps and validation through to callers.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Bandit run for touched code when applicable or documented skip
+- [x] #4 Final summary added
+<!-- DOD:END -->

--- a/backlog/tasks/task-12002 - Harden-Slides-module-review-findings.md
+++ b/backlog/tasks/task-12002 - Harden-Slides-module-review-findings.md
@@ -35,12 +35,14 @@ GREEN verification: `source .venv/bin/activate && python -m pytest tldw_Server_A
 Security verification: Bandit on touched production files wrote /tmp/bandit_slides_review_fixes.json and reported 0 results, 0 errors, and zero high/medium/low severity findings. `git diff --check` on touched files exited 0.
 PR follow-up 2026-06-24: rebased branch onto origin/dev at 2618c4b70. Qodo review reported four actionable issues: broad/silent optional import catches, silent generator setting fallback, negative chunk size bypass, and overbroad FTS OperationalError mapping. Reopening task for review-comment remediation.
 PR follow-up completed 2026-06-24: addressed Qodo review comments after rebase onto origin/dev 2618c4b70. Fixed optional bleach/CSSSanitizer imports to only catch ImportError, made invalid generator integer settings visible via warnings while propagating unexpected settings backend failures, rejected non-positive chunk_size_tokens before LLM calls, and narrowed FTS OperationalError mapping so non-query database errors propagate. Added regression tests for each behavior and stabilized the Slides ordering property test health check.
+PR follow-up 2026-06-24: rebased again onto origin/dev e664332b68. New CodeRabbit comments report missing FTS no-such-column classification and unbounded thread joins in the schema lock regression test. Reopening task for remediation.
+Second PR follow-up completed 2026-06-24: addressed CodeRabbit comments after rebase onto origin/dev e664332b68. Added no-such-column FTS query classification for invalid fielded search terms and bounded the schema initialization thread joins with an alive-thread assertion.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Slides hardening PR rebased onto latest dev and review comments remediated. Verification: python -m pytest tldw_Server_API/tests/Slides -q -> 176 passed; python -m bandit -r touched Slides production files -f json -> 0 findings; git diff --check -> clean.
+Slides hardening PR rebased onto latest dev again and all known Qodo/CodeRabbit comments remediated. Verification: focused DB review tests -> 3 passed; python -m pytest tldw_Server_API/tests/Slides -q -> 177 passed; Bandit on touched Slides production files -> 0 findings; git diff --check -> clean.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12002 - Harden-Slides-module-review-findings.md
+++ b/backlog/tasks/task-12002 - Harden-Slides-module-review-findings.md
@@ -33,12 +33,14 @@ Implemented script-safe inline settings JSON for Reveal exports, independent ble
 GREEN verification: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides -q` passed with 171 passed and 369 warnings.
 
 Security verification: Bandit on touched production files wrote /tmp/bandit_slides_review_fixes.json and reported 0 results, 0 errors, and zero high/medium/low severity findings. `git diff --check` on touched files exited 0.
+PR follow-up 2026-06-24: rebased branch onto origin/dev at 2618c4b70. Qodo review reported four actionable issues: broad/silent optional import catches, silent generator setting fallback, negative chunk size bypass, and overbroad FTS OperationalError mapping. Reopening task for review-comment remediation.
+PR follow-up completed 2026-06-24: addressed Qodo review comments after rebase onto origin/dev 2618c4b70. Fixed optional bleach/CSSSanitizer imports to only catch ImportError, made invalid generator integer settings visible via warnings while propagating unexpected settings backend failures, rejected non-positive chunk_size_tokens before LLM calls, and narrowed FTS OperationalError mapping so non-query database errors propagate. Added regression tests for each behavior and stabilized the Slides ordering property test health check.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Hardened the validated Slides review findings. Exports now serialize settings safely for inline scripts and keep bleach sanitization active without optional CSS sanitizer support. Asset resolution, slide generation chunking, and video rendering now enforce default resource ceilings. Presentation create/update sync logs are written in the same transaction as the mutation, malformed FTS searches return controlled validation errors, and schema initialization is serialized for concurrent first use. API export/search paths now pass the hardened caps and validation through to callers.
+Slides hardening PR rebased onto latest dev and review comments remediated. Verification: python -m pytest tldw_Server_API/tests/Slides -q -> 176 passed; python -m bandit -r touched Slides production files -f json -> 0 findings; git diff --check -> clean.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/endpoints/slides.py
+++ b/tldw_Server_API/app/api/v1/endpoints/slides.py
@@ -71,7 +71,10 @@ from tldw_Server_API.app.core.Jobs.manager import JobManager
 from tldw_Server_API.app.core.Metrics.metrics_manager import get_metrics_registry
 from tldw_Server_API.app.core.RAG.rag_service.unified_pipeline import unified_rag_pipeline
 from tldw_Server_API.app.core.Slides.slides_db import ConflictError, InputError, SlidesDatabase, VisualStyleRow
-from tldw_Server_API.app.core.Slides.slides_assets import resolve_slide_asset
+from tldw_Server_API.app.core.Slides.slides_assets import (
+    MAX_RESOLVED_SLIDE_ASSET_BYTES,
+    resolve_slide_asset,
+)
 from tldw_Server_API.app.core.Slides.slides_export import (
     SlidesAssetsMissingError,
     SlidesExportError,
@@ -146,6 +149,12 @@ _SETTINGS_ALLOWLIST: dict[str, tuple[type, ...]] = {
     "loop": (bool,),
     "rtl": (bool,),
     "navigationMode": (str,),
+}
+
+_SETTINGS_STRING_ENUMS: dict[str, set[str]] = {
+    "transition": {"none", "fade", "slide", "convex", "concave", "zoom"},
+    "backgroundTransition": {"none", "fade", "slide", "convex", "concave", "zoom"},
+    "navigationMode": {"default", "linear", "grid"},
 }
 
 _ETAG_RE = re.compile(r'^(W/)?"v(?P<version>\d+)"$')
@@ -379,6 +388,9 @@ def _validate_settings(settings: dict[str, Any] | None) -> dict[str, Any] | None
         if value is None:
             continue
         if not isinstance(value, expected):
+            raise HTTPException(status_code=422, detail=f"invalid_settings: {key}")
+        allowed_values = _SETTINGS_STRING_ENUMS.get(key)
+        if allowed_values is not None and str(value).strip() not in allowed_values:
             raise HTTPException(status_code=422, detail=f"invalid_settings: {key}")
     return settings
 
@@ -1243,7 +1255,10 @@ async def search_presentations(
     include_deleted: bool = Query(False),
     db: SlidesDatabase = Depends(get_slides_db_for_user),
 ) -> PresentationSearchResponse:
-    rows, total = db.search_presentations(query=q, limit=limit, offset=offset, include_deleted=include_deleted)
+    try:
+        rows, total = db.search_presentations(query=q, limit=limit, offset=offset, include_deleted=include_deleted)
+    except InputError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     return PresentationSearchResponse(
         presentations=[_build_summary(row) for row in rows],
         total=total,
@@ -2302,6 +2317,7 @@ async def export_presentation(
             asset_ref,
             collections_db=collections_db,
             user_id=user_id,
+            max_bytes=MAX_RESOLVED_SLIDE_ASSET_BYTES,
         )
     try:
         metrics = get_metrics_registry()

--- a/tldw_Server_API/app/core/Slides/presentation_rendering.py
+++ b/tldw_Server_API/app/core/Slides/presentation_rendering.py
@@ -20,7 +20,11 @@ from PIL import Image, ImageDraw, ImageFont, ImageOps
 from loguru import logger
 
 from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
-from tldw_Server_API.app.core.Slides.slides_assets import SlidesAssetError, resolve_slide_asset
+from tldw_Server_API.app.core.Slides.slides_assets import (
+    MAX_RESOLVED_SLIDE_ASSET_BYTES,
+    SlidesAssetError,
+    resolve_slide_asset,
+)
 from tldw_Server_API.app.core.Slides.slides_db import SlidesDatabase
 
 _SUPPORTED_RENDER_FORMATS = {"mp4", "webm"}
@@ -33,6 +37,10 @@ _ACCENT_COLOR = "#38bdf8"
 _DEFAULT_FFMPEG_TIMEOUT_SECONDS = 120
 _DEFAULT_FFPROBE_TIMEOUT_SECONDS = 30
 _TRANSITION_DURATION_SECONDS = 0.75
+MAX_RENDER_SLIDES = 200
+MAX_RENDER_SLIDE_DURATION_SECONDS = 300.0
+MAX_RENDER_TOTAL_DURATION_SECONDS = 3600.0
+MAX_RENDER_AUDIO_ASSET_BYTES = 50 * 1024 * 1024
 _TRANSITION_FILTERS = {
     "cut": "cut",
     "fade": "fade",
@@ -238,6 +246,34 @@ def _duration_seconds_from_ms(value: Any) -> float | None:
     return float(value) / 1000.0
 
 
+def _validate_render_slides_before_ffmpeg(slides: list[dict[str, Any]]) -> None:
+    if len(slides) > MAX_RENDER_SLIDES:
+        raise PresentationRenderError("presentation_render_slides_too_many")
+    for slide in slides:
+        manual_duration_seconds = _duration_seconds_from_ms(
+            _slide_studio_metadata(slide).get("manual_duration_ms")
+        )
+        if (
+            manual_duration_seconds is not None
+            and manual_duration_seconds > MAX_RENDER_SLIDE_DURATION_SECONDS
+        ):
+            raise PresentationRenderError("presentation_render_duration_too_long")
+
+
+def _validate_resolved_render_duration(
+    *,
+    slide_duration_seconds: float,
+    total_duration_seconds: float | None = None,
+) -> None:
+    if slide_duration_seconds > MAX_RENDER_SLIDE_DURATION_SECONDS:
+        raise PresentationRenderError("presentation_render_duration_too_long")
+    if (
+        total_duration_seconds is not None
+        and total_duration_seconds > MAX_RENDER_TOTAL_DURATION_SECONDS
+    ):
+        raise PresentationRenderError("presentation_render_duration_too_long")
+
+
 def _probe_media_duration_seconds(media_path: Path) -> float | None:
     ffprobe_path = _resolve_ffprobe_path()
     if ffprobe_path is None or not media_path.exists():
@@ -343,7 +379,12 @@ def _materialize_slide_image(
     asset_ref = image.get("asset_ref")
     if isinstance(asset_ref, str) and asset_ref.strip():
         try:
-            resolved = resolve_slide_asset(asset_ref, collections_db=collections_db, user_id=user_id)
+            resolved = resolve_slide_asset(
+                asset_ref,
+                collections_db=collections_db,
+                user_id=user_id,
+                max_bytes=MAX_RESOLVED_SLIDE_ASSET_BYTES,
+            )
         except SlidesAssetError as exc:
             raise PresentationRenderError("presentation_render_asset_unavailable") from exc
         raw_bytes = _decode_data_b64(str(resolved.get("data_b64") or ""), error_code="presentation_render_asset_invalid")
@@ -382,7 +423,12 @@ def _materialize_slide_audio(
         return None
 
     try:
-        resolved = resolve_slide_asset(asset_ref, collections_db=collections_db, user_id=user_id)
+        resolved = resolve_slide_asset(
+            asset_ref,
+            collections_db=collections_db,
+            user_id=user_id,
+            max_bytes=MAX_RENDER_AUDIO_ASSET_BYTES,
+        )
     except SlidesAssetError as exc:
         raise PresentationRenderError("presentation_render_asset_unavailable") from exc
 
@@ -817,16 +863,6 @@ def render_presentation_video(
     if normalized_format not in _SUPPORTED_RENDER_FORMATS:
         raise PresentationRenderError("presentation_render_format_invalid")
 
-    output_root = Path(output_dir)
-    output_root.mkdir(parents=True, exist_ok=True)
-    storage_name = _build_storage_name(
-        presentation_id=presentation_id,
-        presentation_version=presentation_version,
-        output_format=normalized_format,
-    )
-    output_path = output_root / storage_name
-    ffmpeg_path = _resolve_ffmpeg_path()
-
     render_slides = slides or [
         {
             "order": 0,
@@ -837,6 +873,17 @@ def render_presentation_video(
             "metadata": {},
         }
     ]
+    _validate_render_slides_before_ffmpeg(render_slides)
+
+    output_root = Path(output_dir)
+    output_root.mkdir(parents=True, exist_ok=True)
+    storage_name = _build_storage_name(
+        presentation_id=presentation_id,
+        presentation_version=presentation_version,
+        output_format=normalized_format,
+    )
+    output_path = output_root / storage_name
+    ffmpeg_path = _resolve_ffmpeg_path()
 
     with tempfile.TemporaryDirectory(prefix="presentation-render-") as temp_dir_str:
         temp_dir = Path(temp_dir_str)
@@ -865,6 +912,7 @@ def render_presentation_video(
                     slide,
                     audio_duration_seconds=audio_duration_seconds,
                 )
+                _validate_resolved_render_duration(slide_duration_seconds=slide_duration_seconds)
                 prepared_slides.append(
                     _PreparedSlideRender(
                         slide=slide,
@@ -882,6 +930,10 @@ def render_presentation_video(
         has_visual_transitions = any(transition != "cut" for transition in boundary_transitions)
         total_expected_duration_seconds = sum(
             prepared.effective_duration_seconds for prepared in prepared_slides
+        )
+        _validate_resolved_render_duration(
+            slide_duration_seconds=0.0,
+            total_duration_seconds=total_expected_duration_seconds,
         )
 
         if not has_visual_transitions:

--- a/tldw_Server_API/app/core/Slides/slides_assets.py
+++ b/tldw_Server_API/app/core/Slides/slides_assets.py
@@ -74,7 +74,7 @@ def resolve_slide_asset(
     *,
     collections_db: Any | None = None,
     user_id: int | None = None,
-    max_bytes: int | None = None,
+    max_bytes: int | None = MAX_RESOLVED_SLIDE_ASSET_BYTES,
 ) -> dict[str, Any]:
     """Resolve a slide asset reference into file-backed bytes and metadata."""
 
@@ -106,6 +106,8 @@ def resolve_slide_asset(
         metadata=metadata,
     )
     raw_bytes = file_path.read_bytes()
+    if isinstance(max_bytes, int) and max_bytes > 0 and len(raw_bytes) > max_bytes:
+        raise SlidesAssetError("slide_asset_too_large")
     return {
         "asset_ref": asset_ref,
         "mime": mime,

--- a/tldw_Server_API/app/core/Slides/slides_db.py
+++ b/tldw_Server_API/app/core/Slides/slides_db.py
@@ -89,6 +89,7 @@ class VisualStyleRow:
 class SlidesDatabase:
     _SCHEMA_VERSION = 1
     _schema_init_paths: ClassVar[set[str]] = set()
+    _schema_init_lock: ClassVar[threading.Lock] = threading.Lock()
 
     def __init__(self, db_path: str | Path, client_id: str) -> None:
         if not client_id:
@@ -104,125 +105,130 @@ class SlidesDatabase:
         self._ensure_schema()
 
     def _ensure_schema(self) -> None:
-        if self._db_path_str in self._schema_init_paths:
+        cache_schema_path = self._db_path_str != ":memory:"
+        if cache_schema_path and self._db_path_str in self._schema_init_paths:
             return
-        conn = self.get_connection()
-        try:
-            conn.executescript(
-                """
-                CREATE TABLE IF NOT EXISTS schema_version (
-                    version INTEGER PRIMARY KEY NOT NULL
-                );
-                INSERT OR IGNORE INTO schema_version (version) VALUES (0);
+        with self._schema_init_lock:
+            if cache_schema_path and self._db_path_str in self._schema_init_paths:
+                return
+            conn = self.get_connection()
+            try:
+                conn.executescript(
+                    """
+                    CREATE TABLE IF NOT EXISTS schema_version (
+                        version INTEGER PRIMARY KEY NOT NULL
+                    );
+                    INSERT OR IGNORE INTO schema_version (version) VALUES (0);
 
-                CREATE TABLE IF NOT EXISTS presentations (
-                    id TEXT PRIMARY KEY,
-                    title TEXT NOT NULL,
-                    description TEXT,
-                    theme TEXT DEFAULT 'black',
-                    marp_theme TEXT,
-                    template_id TEXT,
-                    visual_style_id TEXT,
-                    visual_style_scope TEXT,
-                    visual_style_name TEXT,
-                    visual_style_version INTEGER,
-                    visual_style_snapshot TEXT,
-                    settings TEXT,
-                    studio_data TEXT,
-                    slides TEXT NOT NULL,
-                    slides_text TEXT NOT NULL,
-                    source_type TEXT,
-                    source_ref TEXT,
-                    source_query TEXT,
-                    custom_css TEXT,
-                    created_at DATETIME NOT NULL,
-                    last_modified DATETIME NOT NULL,
-                    deleted INTEGER DEFAULT 0,
-                    client_id TEXT NOT NULL,
-                    version INTEGER DEFAULT 1
-                );
+                    CREATE TABLE IF NOT EXISTS presentations (
+                        id TEXT PRIMARY KEY,
+                        title TEXT NOT NULL,
+                        description TEXT,
+                        theme TEXT DEFAULT 'black',
+                        marp_theme TEXT,
+                        template_id TEXT,
+                        visual_style_id TEXT,
+                        visual_style_scope TEXT,
+                        visual_style_name TEXT,
+                        visual_style_version INTEGER,
+                        visual_style_snapshot TEXT,
+                        settings TEXT,
+                        studio_data TEXT,
+                        slides TEXT NOT NULL,
+                        slides_text TEXT NOT NULL,
+                        source_type TEXT,
+                        source_ref TEXT,
+                        source_query TEXT,
+                        custom_css TEXT,
+                        created_at DATETIME NOT NULL,
+                        last_modified DATETIME NOT NULL,
+                        deleted INTEGER DEFAULT 0,
+                        client_id TEXT NOT NULL,
+                        version INTEGER DEFAULT 1
+                    );
 
-                CREATE INDEX IF NOT EXISTS idx_presentations_deleted ON presentations(deleted);
-                CREATE INDEX IF NOT EXISTS idx_presentations_created ON presentations(created_at);
+                    CREATE INDEX IF NOT EXISTS idx_presentations_deleted ON presentations(deleted);
+                    CREATE INDEX IF NOT EXISTS idx_presentations_created ON presentations(created_at);
 
-                CREATE TABLE IF NOT EXISTS presentations_versions (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    presentation_id TEXT NOT NULL,
-                    version INTEGER NOT NULL,
-                    payload_json TEXT NOT NULL,
-                    created_at DATETIME NOT NULL,
-                    client_id TEXT NOT NULL
-                );
+                    CREATE TABLE IF NOT EXISTS presentations_versions (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        presentation_id TEXT NOT NULL,
+                        version INTEGER NOT NULL,
+                        payload_json TEXT NOT NULL,
+                        created_at DATETIME NOT NULL,
+                        client_id TEXT NOT NULL
+                    );
 
-                CREATE UNIQUE INDEX IF NOT EXISTS idx_presentations_versions_unique
-                    ON presentations_versions(presentation_id, version);
-                CREATE INDEX IF NOT EXISTS idx_presentations_versions_pid
-                    ON presentations_versions(presentation_id);
-                CREATE INDEX IF NOT EXISTS idx_presentations_versions_created
-                    ON presentations_versions(created_at);
+                    CREATE UNIQUE INDEX IF NOT EXISTS idx_presentations_versions_unique
+                        ON presentations_versions(presentation_id, version);
+                    CREATE INDEX IF NOT EXISTS idx_presentations_versions_pid
+                        ON presentations_versions(presentation_id);
+                    CREATE INDEX IF NOT EXISTS idx_presentations_versions_created
+                        ON presentations_versions(created_at);
 
-                CREATE VIRTUAL TABLE IF NOT EXISTS presentations_fts USING fts5(
-                    title,
-                    slides_text,
-                    content=presentations,
-                    content_rowid=rowid
-                );
+                    CREATE VIRTUAL TABLE IF NOT EXISTS presentations_fts USING fts5(
+                        title,
+                        slides_text,
+                        content=presentations,
+                        content_rowid=rowid
+                    );
 
-                CREATE TRIGGER IF NOT EXISTS presentations_ai AFTER INSERT ON presentations BEGIN
-                  INSERT INTO presentations_fts(rowid, title, slides_text)
-                  VALUES (new.rowid, new.title, new.slides_text);
-                END;
+                    CREATE TRIGGER IF NOT EXISTS presentations_ai AFTER INSERT ON presentations BEGIN
+                      INSERT INTO presentations_fts(rowid, title, slides_text)
+                      VALUES (new.rowid, new.title, new.slides_text);
+                    END;
 
-                CREATE TRIGGER IF NOT EXISTS presentations_ad AFTER DELETE ON presentations BEGIN
-                  INSERT INTO presentations_fts(presentations_fts, rowid, title, slides_text)
-                  VALUES ('delete', old.rowid, old.title, old.slides_text);
-                END;
+                    CREATE TRIGGER IF NOT EXISTS presentations_ad AFTER DELETE ON presentations BEGIN
+                      INSERT INTO presentations_fts(presentations_fts, rowid, title, slides_text)
+                      VALUES ('delete', old.rowid, old.title, old.slides_text);
+                    END;
 
-                CREATE TRIGGER IF NOT EXISTS presentations_au AFTER UPDATE ON presentations BEGIN
-                  INSERT INTO presentations_fts(presentations_fts, rowid, title, slides_text)
-                  VALUES ('delete', old.rowid, old.title, old.slides_text);
-                  INSERT INTO presentations_fts(rowid, title, slides_text)
-                  VALUES (new.rowid, new.title, new.slides_text);
-                END;
+                    CREATE TRIGGER IF NOT EXISTS presentations_au AFTER UPDATE ON presentations BEGIN
+                      INSERT INTO presentations_fts(presentations_fts, rowid, title, slides_text)
+                      VALUES ('delete', old.rowid, old.title, old.slides_text);
+                      INSERT INTO presentations_fts(rowid, title, slides_text)
+                      VALUES (new.rowid, new.title, new.slides_text);
+                    END;
 
-                CREATE TABLE IF NOT EXISTS sync_log (
-                    change_id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    entity TEXT NOT NULL,
-                    entity_uuid TEXT NOT NULL,
-                    operation TEXT NOT NULL CHECK(operation IN ('create','update','delete','restore')),
-                    timestamp DATETIME NOT NULL,
-                    client_id TEXT NOT NULL,
-                    version INTEGER NOT NULL,
-                    payload TEXT
-                );
+                    CREATE TABLE IF NOT EXISTS sync_log (
+                        change_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        entity TEXT NOT NULL,
+                        entity_uuid TEXT NOT NULL,
+                        operation TEXT NOT NULL CHECK(operation IN ('create','update','delete','restore')),
+                        timestamp DATETIME NOT NULL,
+                        client_id TEXT NOT NULL,
+                        version INTEGER NOT NULL,
+                        payload TEXT
+                    );
 
-                CREATE INDEX IF NOT EXISTS idx_sync_log_ts ON sync_log(timestamp);
-                CREATE INDEX IF NOT EXISTS idx_sync_log_entity_uuid ON sync_log(entity_uuid);
-                CREATE INDEX IF NOT EXISTS idx_sync_log_client_id ON sync_log(client_id);
+                    CREATE INDEX IF NOT EXISTS idx_sync_log_ts ON sync_log(timestamp);
+                    CREATE INDEX IF NOT EXISTS idx_sync_log_entity_uuid ON sync_log(entity_uuid);
+                    CREATE INDEX IF NOT EXISTS idx_sync_log_client_id ON sync_log(client_id);
 
-                CREATE TABLE IF NOT EXISTS visual_styles (
-                    id TEXT PRIMARY KEY,
-                    name TEXT NOT NULL,
-                    scope TEXT NOT NULL,
-                    style_payload TEXT NOT NULL,
-                    created_at DATETIME NOT NULL,
-                    updated_at DATETIME NOT NULL
-                );
+                    CREATE TABLE IF NOT EXISTS visual_styles (
+                        id TEXT PRIMARY KEY,
+                        name TEXT NOT NULL,
+                        scope TEXT NOT NULL,
+                        style_payload TEXT NOT NULL,
+                        created_at DATETIME NOT NULL,
+                        updated_at DATETIME NOT NULL
+                    );
 
-                CREATE INDEX IF NOT EXISTS idx_visual_styles_scope ON visual_styles(scope);
-                CREATE INDEX IF NOT EXISTS idx_visual_styles_name ON visual_styles(name);
-                """
-            )
-            self._ensure_marp_theme_column(conn)
-            self._ensure_template_id_column(conn)
-            self._ensure_presentation_visual_style_columns(conn)
-            self._ensure_studio_data_column(conn)
-            self._ensure_visual_styles_table(conn)
-            conn.commit()
-            self._schema_init_paths.add(self._db_path_str)
-        except sqlite3.Error as exc:
-            conn.rollback()
-            raise SchemaError(f"Failed to initialize Slides DB schema: {exc}") from exc
+                    CREATE INDEX IF NOT EXISTS idx_visual_styles_scope ON visual_styles(scope);
+                    CREATE INDEX IF NOT EXISTS idx_visual_styles_name ON visual_styles(name);
+                    """
+                )
+                self._ensure_marp_theme_column(conn)
+                self._ensure_template_id_column(conn)
+                self._ensure_presentation_visual_style_columns(conn)
+                self._ensure_studio_data_column(conn)
+                self._ensure_visual_styles_table(conn)
+                conn.commit()
+                if cache_schema_path:
+                    self._schema_init_paths.add(self._db_path_str)
+            except sqlite3.Error as exc:
+                conn.rollback()
+                raise SchemaError(f"Failed to initialize Slides DB schema: {exc}") from exc
 
     def get_connection(self) -> sqlite3.Connection:
         conn = getattr(self._local, "connection", None)
@@ -255,6 +261,8 @@ class SlidesDatabase:
 
     def _insert_sync_log(
         self,
+        conn: sqlite3.Connection,
+        /,
         *,
         entity_uuid: str,
         operation: str,
@@ -262,22 +270,21 @@ class SlidesDatabase:
         payload: dict[str, Any] | None = None,
     ) -> None:
         payload_json = json.dumps(payload) if payload is not None else None
-        with self.transaction() as conn:
-            conn.execute(
-                """
-                INSERT INTO sync_log (entity, entity_uuid, operation, timestamp, client_id, version, payload)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    "presentations",
-                    entity_uuid,
-                    operation,
-                    self._utcnow_iso(),
-                    self.client_id,
-                    version,
-                    payload_json,
-                ),
+        conn.execute(
+            """
+            INSERT INTO sync_log (entity, entity_uuid, operation, timestamp, client_id, version, payload)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "presentations",
+                entity_uuid,
+                operation,
+                self._utcnow_iso(),
+                self.client_id,
+                version,
+                payload_json,
             )
+        )
 
     @staticmethod
     def _ensure_marp_theme_column(conn: sqlite3.Connection) -> None:
@@ -619,12 +626,13 @@ class SlidesDatabase:
                 )
                 row = self._fetch_presentation_by_id(conn, pres_id, include_deleted=True)
                 self._insert_version_snapshot(conn, row)
-            self._insert_sync_log(
-                entity_uuid=pres_id,
-                operation="create",
-                version=1,
-                payload={"title": title, "theme": theme},
-            )
+                self._insert_sync_log(
+                    conn,
+                    entity_uuid=pres_id,
+                    operation="create",
+                    version=1,
+                    payload={"title": title, "theme": theme},
+                )
             return row
         except sqlite3.IntegrityError as exc:
             if "UNIQUE" in str(exc).upper() or "PRIMARY" in str(exc).upper():
@@ -693,8 +701,11 @@ class SlidesDatabase:
         )
         count_sql = count_sql_template.format_map(locals())  # nosec B608
         conn = self.get_connection()
-        rows = conn.execute(sql, (query, limit, offset)).fetchall()
-        count_row = conn.execute(count_sql, (query,)).fetchone()
+        try:
+            rows = conn.execute(sql, (query, limit, offset)).fetchall()
+            count_row = conn.execute(count_sql, (query,)).fetchone()
+        except sqlite3.OperationalError as exc:
+            raise InputError("search query is invalid") from exc
         total = int(count_row["cnt"]) if count_row else 0
         return [PresentationRow(**dict(row)) for row in rows], total
 
@@ -754,12 +765,13 @@ class SlidesDatabase:
                 raise ConflictError("version_conflict", entity="presentations", identifier=presentation_id)
             row = self._fetch_presentation_by_id(conn, presentation_id, include_deleted=True)
             self._insert_version_snapshot(conn, row)
-        self._insert_sync_log(
-            entity_uuid=presentation_id,
-            operation=operation,
-            version=next_version,
-            payload={"fields": list(update_fields.keys())},
-        )
+            self._insert_sync_log(
+                conn,
+                entity_uuid=presentation_id,
+                operation=operation,
+                version=next_version,
+                payload={"fields": list(update_fields.keys())},
+            )
         return row
 
     def list_presentation_versions(

--- a/tldw_Server_API/app/core/Slides/slides_db.py
+++ b/tldw_Server_API/app/core/Slides/slides_db.py
@@ -356,6 +356,20 @@ class SlidesDatabase:
         return PresentationRow(**dict(row))
 
     @staticmethod
+    def _is_fts_query_error(exc: sqlite3.OperationalError) -> bool:
+        message = str(exc).lower()
+        return any(
+            marker in message
+            for marker in (
+                "fts5: syntax error",
+                "fts5 syntax error",
+                "malformed match",
+                "unterminated string",
+                "syntax error near",
+            )
+        )
+
+    @staticmethod
     def _build_version_payload(row: PresentationRow) -> dict[str, Any]:
         return {
             "id": row.id,
@@ -705,6 +719,8 @@ class SlidesDatabase:
             rows = conn.execute(sql, (query, limit, offset)).fetchall()
             count_row = conn.execute(count_sql, (query,)).fetchone()
         except sqlite3.OperationalError as exc:
+            if not self._is_fts_query_error(exc):
+                raise
             raise InputError("search query is invalid") from exc
         total = int(count_row["cnt"]) if count_row else 0
         return [PresentationRow(**dict(row)) for row in rows], total

--- a/tldw_Server_API/app/core/Slides/slides_db.py
+++ b/tldw_Server_API/app/core/Slides/slides_db.py
@@ -364,6 +364,7 @@ class SlidesDatabase:
                 "fts5: syntax error",
                 "fts5 syntax error",
                 "malformed match",
+                "no such column:",
                 "unterminated string",
                 "syntax error near",
             )

--- a/tldw_Server_API/app/core/Slides/slides_export.py
+++ b/tldw_Server_API/app/core/Slides/slides_export.py
@@ -19,12 +19,12 @@ from loguru import logger
 
 try:
     import bleach  # type: ignore
-except Exception:  # pragma: no cover - bleach is a declared dependency
+except ImportError:  # pragma: no cover - bleach is a declared dependency
     bleach = None
 
 try:
     from bleach.css_sanitizer import CSSSanitizer  # type: ignore
-except Exception:  # pragma: no cover - CSS sanitizer depends on optional tinycss2
+except ImportError:  # pragma: no cover - CSS sanitizer depends on optional tinycss2
     CSSSanitizer = None  # type: ignore
 
 try:

--- a/tldw_Server_API/app/core/Slides/slides_export.py
+++ b/tldw_Server_API/app/core/Slides/slides_export.py
@@ -19,9 +19,12 @@ from loguru import logger
 
 try:
     import bleach  # type: ignore
-    from bleach.css_sanitizer import CSSSanitizer  # type: ignore
 except Exception:  # pragma: no cover - bleach is a declared dependency
     bleach = None
+
+try:
+    from bleach.css_sanitizer import CSSSanitizer  # type: ignore
+except Exception:  # pragma: no cover - CSS sanitizer depends on optional tinycss2
     CSSSanitizer = None  # type: ignore
 
 try:
@@ -426,6 +429,17 @@ def _sanitize_markdown(markdown_text: str) -> str:
         protocols=_ALLOWED_PROTOCOLS,
         strip=True,
         strip_comments=True,
+    )
+
+
+def _json_for_inline_script(value: Any) -> str:
+    return (
+        json.dumps(value, ensure_ascii=True)
+        .replace("&", "\\u0026")
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("\u2028", "\\u2028")
+        .replace("\u2029", "\\u2029")
     )
 
 
@@ -926,7 +940,7 @@ def export_presentation_bundle(
 ) -> bytes:
     resolved_assets = _resolve_assets_dir(assets_dir)
     _validate_reveal_assets(resolved_assets, theme)
-    settings_json = json.dumps(settings or {}, ensure_ascii=True)
+    settings_json = _json_for_inline_script(settings or {})
     sanitized_css = _sanitize_custom_css(
         _compose_export_css(custom_css=custom_css, visual_style_snapshot=visual_style_snapshot)
     )
@@ -1030,7 +1044,7 @@ def export_presentation_pdf(
 
     resolved_assets = _resolve_assets_dir(assets_dir)
     _validate_reveal_assets(resolved_assets, theme)
-    settings_json = json.dumps(settings or {}, ensure_ascii=True)
+    settings_json = _json_for_inline_script(settings or {})
     sanitized_css = _sanitize_custom_css(
         _compose_export_css(custom_css=custom_css, visual_style_snapshot=visual_style_snapshot)
     )

--- a/tldw_Server_API/app/core/Slides/slides_generator.py
+++ b/tldw_Server_API/app/core/Slides/slides_generator.py
@@ -69,6 +69,18 @@ _SYSTEM_PROMPT = (
 )
 
 _SUMMARY_SYSTEM_PROMPT = "Summarize the following content for slide generation."
+DEFAULT_MAX_SOURCE_TOKENS = 50_000
+DEFAULT_MAX_SOURCE_CHARS = 200_000
+MAX_SOURCE_CHUNKS = 20
+MAX_CHUNK_SIZE_TOKENS = 4_000
+
+
+def _positive_int_setting(name: str, default: int) -> int:
+    try:
+        value = int(settings.get(name, default))
+    except Exception:
+        return default
+    return value if value > 0 else default
 
 
 def _normalize_provider(provider: str | None) -> str:
@@ -169,18 +181,28 @@ class SlidesGenerator:
         source_text = source_text.strip()
         actual_tokens = count_tokens(source_text)
         actual_chars = len(source_text)
+        effective_max_source_tokens = (
+            max_source_tokens
+            if max_source_tokens is not None
+            else _positive_int_setting("SLIDES_MAX_SOURCE_TOKENS", DEFAULT_MAX_SOURCE_TOKENS)
+        )
+        effective_max_source_chars = (
+            max_source_chars
+            if max_source_chars is not None
+            else _positive_int_setting("SLIDES_MAX_SOURCE_CHARS", DEFAULT_MAX_SOURCE_CHARS)
+        )
 
         limit_exceeded = False
-        if max_source_tokens is not None and actual_tokens > max_source_tokens:
+        if actual_tokens > effective_max_source_tokens:
             limit_exceeded = True
-        if max_source_chars is not None and actual_chars > max_source_chars:
+        if actual_chars > effective_max_source_chars:
             limit_exceeded = True
 
         if limit_exceeded and not enable_chunking:
             raise SlidesSourceTooLargeError(
                 "input_too_large",
-                max_source_tokens=max_source_tokens,
-                max_source_chars=max_source_chars,
+                max_source_tokens=effective_max_source_tokens,
+                max_source_chars=effective_max_source_chars,
                 actual_tokens=actual_tokens,
                 actual_chars=actual_chars,
             )
@@ -201,6 +223,8 @@ class SlidesGenerator:
                 temperature=temperature,
                 chunk_size_tokens=chunk_size_tokens,
                 summary_tokens=summary_tokens,
+                actual_tokens=actual_tokens,
+                actual_chars=actual_chars,
             )
 
         user_prompt = "Source material:\n" + prepared_text
@@ -279,9 +303,13 @@ class SlidesGenerator:
         temperature: float | None,
         chunk_size_tokens: int | None,
         summary_tokens: int | None,
+        actual_tokens: int | None = None,
+        actual_chars: int | None = None,
     ) -> str:
         """Reduce oversized source text into a prompt-sized summary before slide generation."""
         chunk_size = chunk_size_tokens or 1000
+        if chunk_size > MAX_CHUNK_SIZE_TOKENS:
+            raise SlidesGenerationInputError("chunk_size_too_large")
         mode = str(settings.get("TOKEN_ESTIMATOR_MODE") or "whitespace").lower()
         if mode == "char_approx":
             try:
@@ -295,6 +323,13 @@ class SlidesGenerator:
 
         if not chunks:
             return ""
+        max_chunks = _positive_int_setting("SLIDES_MAX_SOURCE_CHUNKS", MAX_SOURCE_CHUNKS)
+        if len(chunks) > max_chunks:
+            raise SlidesSourceTooLargeError(
+                "input_too_large",
+                actual_tokens=actual_tokens,
+                actual_chars=actual_chars,
+            )
 
         summary_target = summary_tokens or 200
         summaries: list[str] = []

--- a/tldw_Server_API/app/core/Slides/slides_generator.py
+++ b/tldw_Server_API/app/core/Slides/slides_generator.py
@@ -76,11 +76,16 @@ MAX_CHUNK_SIZE_TOKENS = 4_000
 
 
 def _positive_int_setting(name: str, default: int) -> int:
+    raw_value = settings.get(name, default)
     try:
-        value = int(settings.get(name, default))
-    except Exception:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        logger.warning("slides generation: invalid integer setting {}; using default {}", name, default)
         return default
-    return value if value > 0 else default
+    if value <= 0:
+        logger.warning("slides generation: non-positive integer setting {}; using default {}", name, default)
+        return default
+    return value
 
 
 def _normalize_provider(provider: str | None) -> str:
@@ -307,14 +312,27 @@ class SlidesGenerator:
         actual_chars: int | None = None,
     ) -> str:
         """Reduce oversized source text into a prompt-sized summary before slide generation."""
-        chunk_size = chunk_size_tokens or 1000
+        if chunk_size_tokens is None:
+            chunk_size = 1000
+        else:
+            try:
+                chunk_size = int(chunk_size_tokens)
+            except (TypeError, ValueError) as exc:
+                raise SlidesGenerationInputError("chunk_size_invalid") from exc
+        if chunk_size < 1:
+            raise SlidesGenerationInputError("chunk_size_invalid")
         if chunk_size > MAX_CHUNK_SIZE_TOKENS:
             raise SlidesGenerationInputError("chunk_size_too_large")
         mode = str(settings.get("TOKEN_ESTIMATOR_MODE") or "whitespace").lower()
         if mode == "char_approx":
             try:
                 chars_per_token = max(1, int(settings.get("TOKEN_CHAR_APPROX_DIVISOR", 4)))
-            except Exception:
+            except (TypeError, ValueError):
+                logger.warning(
+                    "slides generation: invalid integer setting {}; using default {}",
+                    "TOKEN_CHAR_APPROX_DIVISOR",
+                    4,
+                )
                 chars_per_token = 4
             size_chars = chunk_size * chars_per_token
             chunks = _chunk_by_chars(source_text, size_chars)

--- a/tldw_Server_API/tests/Slides/test_presentation_rendering.py
+++ b/tldw_Server_API/tests/Slides/test_presentation_rendering.py
@@ -7,6 +7,8 @@ import pytest
 from PIL import Image, ImageChops
 
 from tldw_Server_API.app.core.Slides.presentation_rendering import (
+    MAX_RENDER_SLIDES,
+    MAX_RENDER_SLIDE_DURATION_SECONDS,
     PresentationRenderError,
     _TRANSITION_DURATION_SECONDS,
     _build_transition_video_command,
@@ -451,6 +453,66 @@ def test_render_presentation_video_rejects_unsupported_format(tmp_path):
         )
 
     assert exc.value.code == "presentation_render_format_invalid"
+
+
+def test_render_presentation_video_rejects_excessive_slide_count_before_ffmpeg(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.presentation_rendering._resolve_ffmpeg_path",
+        lambda: (_ for _ in ()).throw(AssertionError("ffmpeg should not be resolved")),
+    )
+
+    with pytest.raises(PresentationRenderError) as exc:
+        render_presentation_video(
+            presentation_id="pres_too_many",
+            presentation_version=1,
+            title="Deck",
+            slides=[
+                {
+                    "order": index,
+                    "layout": "content",
+                    "title": f"Slide {index}",
+                    "content": "Body",
+                    "metadata": {},
+                }
+                for index in range(MAX_RENDER_SLIDES + 1)
+            ],
+            output_format="mp4",
+            output_dir=tmp_path,
+        )
+
+    assert exc.value.code == "presentation_render_slides_too_many"
+
+
+def test_render_presentation_video_rejects_excessive_manual_duration_before_ffmpeg(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.presentation_rendering._resolve_ffmpeg_path",
+        lambda: (_ for _ in ()).throw(AssertionError("ffmpeg should not be resolved")),
+    )
+
+    with pytest.raises(PresentationRenderError) as exc:
+        render_presentation_video(
+            presentation_id="pres_too_long",
+            presentation_version=1,
+            title="Deck",
+            slides=[
+                {
+                    "order": 0,
+                    "layout": "content",
+                    "title": "Slide",
+                    "content": "Body",
+                    "metadata": {
+                        "studio": {
+                            "timing_mode": "manual",
+                            "manual_duration_ms": int((MAX_RENDER_SLIDE_DURATION_SECONDS + 1) * 1000),
+                        }
+                    },
+                }
+            ],
+            output_format="mp4",
+            output_dir=tmp_path,
+        )
+
+    assert exc.value.code == "presentation_render_duration_too_long"
 
 
 def test_run_ffmpeg_command_logs_stderr_on_failure(tmp_path, monkeypatch):

--- a/tldw_Server_API/tests/Slides/test_slides_assets.py
+++ b/tldw_Server_API/tests/Slides/test_slides_assets.py
@@ -87,3 +87,34 @@ def test_resolve_slide_asset_rejects_oversized_files_before_read(tmp_path, monke
         )
 
     assert exc.value.code == "slide_asset_too_large"
+
+
+def test_resolve_slide_asset_enforces_default_size_limit_before_read(tmp_path, monkeypatch):
+    file_path = tmp_path / "cover.png"
+    file_path.write_bytes(b"x" * (MAX_RESOLVED_SLIDE_ASSET_BYTES + 1))
+
+    fake_db = SimpleNamespace(
+        get_output_artifact=lambda output_id: SimpleNamespace(
+            id=output_id,
+            format="png",
+            storage_path="cover.png",
+            metadata_json=None,
+            title="Cover",
+            type="generated_image",
+        ),
+        resolve_output_storage_path=lambda path_value: str(path_value),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.slides_assets._resolve_output_path_for_user",
+        lambda user_id, path_value: file_path,
+    )
+    monkeypatch.setattr(
+        Path,
+        "read_bytes",
+        lambda self: (_ for _ in ()).throw(AssertionError("read_bytes should not be called")),
+    )
+
+    with pytest.raises(SlidesAssetError) as exc:
+        resolve_slide_asset("output:123", collections_db=fake_db, user_id=1)
+
+    assert exc.value.code == "slide_asset_too_large"

--- a/tldw_Server_API/tests/Slides/test_slides_db.py
+++ b/tldw_Server_API/tests/Slides/test_slides_db.py
@@ -221,6 +221,31 @@ def test_slides_db_search_rejects_malformed_fts_query(tmp_path):
     db.close_connection()
 
 
+def test_slides_db_search_rejects_unknown_fts_column(tmp_path):
+    db_path = tmp_path / "Slides.db"
+    db = SlidesDatabase(db_path=db_path, client_id="tester")
+    db.create_presentation(
+        presentation_id=None,
+        title="Search Deck",
+        description=None,
+        theme="black",
+        marp_theme=None,
+        settings=None,
+        studio_data=None,
+        slides=_sample_slides(),
+        slides_text="alpha beta gamma",
+        source_type="manual",
+        source_ref=None,
+        source_query=None,
+        custom_css=None,
+    )
+
+    with pytest.raises(InputError):
+        db.search_presentations(query="unknown_column:alpha", limit=10, offset=0, include_deleted=False)
+
+    db.close_connection()
+
+
 def test_slides_db_search_does_not_map_non_fts_operational_errors(tmp_path, monkeypatch):
     db_path = tmp_path / "Slides.db"
     db = SlidesDatabase(db_path=db_path, client_id="tester")
@@ -322,8 +347,9 @@ def test_slides_db_schema_initialization_serializes_column_migrations(tmp_path, 
     for thread in threads:
         thread.start()
     for thread in threads:
-        thread.join()
+        thread.join(timeout=5)
 
+    assert all(not thread.is_alive() for thread in threads)
     assert errors == []
 
 

--- a/tldw_Server_API/tests/Slides/test_slides_db.py
+++ b/tldw_Server_API/tests/Slides/test_slides_db.py
@@ -1,8 +1,11 @@
 import json
+import sqlite3
+import threading
+import time
 
 import pytest
 
-from tldw_Server_API.app.core.Slides.slides_db import SlidesDatabase, ConflictError
+from tldw_Server_API.app.core.Slides.slides_db import SlidesDatabase, ConflictError, InputError
 
 
 def _sample_slides() -> str:
@@ -191,6 +194,121 @@ def test_slides_db_search(tmp_path):
     assert total == 1
     assert rows[0].title == "Search Deck"
     db.close_connection()
+
+
+def test_slides_db_search_rejects_malformed_fts_query(tmp_path):
+    db_path = tmp_path / "Slides.db"
+    db = SlidesDatabase(db_path=db_path, client_id="tester")
+    db.create_presentation(
+        presentation_id=None,
+        title="Search Deck",
+        description=None,
+        theme="black",
+        marp_theme=None,
+        settings=None,
+        studio_data=None,
+        slides=_sample_slides(),
+        slides_text="alpha beta gamma",
+        source_type="manual",
+        source_ref=None,
+        source_query=None,
+        custom_css=None,
+    )
+
+    with pytest.raises(InputError):
+        db.search_presentations(query='"unterminated', limit=10, offset=0, include_deleted=False)
+
+    db.close_connection()
+
+
+def test_create_presentation_rolls_back_when_sync_log_fails(tmp_path, monkeypatch):
+    db_path = tmp_path / "Slides.db"
+    db = SlidesDatabase(db_path=db_path, client_id="tester")
+
+    def _fail_sync_log(*args, **kwargs):
+        raise RuntimeError("sync log failed")
+
+    monkeypatch.setattr(SlidesDatabase, "_insert_sync_log", _fail_sync_log)
+
+    with pytest.raises(RuntimeError, match="sync log failed"):
+        db.create_presentation(
+            presentation_id="pres_sync_atomic",
+            title="Deck",
+            description=None,
+            theme="black",
+            marp_theme=None,
+            settings=None,
+            studio_data=None,
+            slides=_sample_slides(),
+            slides_text="Deck Intro A B",
+            source_type="manual",
+            source_ref=None,
+            source_query=None,
+            custom_css=None,
+        )
+
+    with pytest.raises(KeyError):
+        db.get_presentation_by_id("pres_sync_atomic", include_deleted=True)
+
+    db.close_connection()
+
+
+def test_slides_db_schema_initialization_serializes_column_migrations(tmp_path, monkeypatch):
+    db_path = tmp_path / "Slides.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE presentations (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                description TEXT,
+                theme TEXT DEFAULT 'black',
+                settings TEXT,
+                slides TEXT NOT NULL,
+                slides_text TEXT NOT NULL,
+                source_type TEXT,
+                source_ref TEXT,
+                source_query TEXT,
+                custom_css TEXT,
+                created_at DATETIME NOT NULL,
+                last_modified DATETIME NOT NULL,
+                deleted INTEGER DEFAULT 0,
+                client_id TEXT NOT NULL,
+                version INTEGER DEFAULT 1
+            )
+            """
+        )
+    SlidesDatabase._schema_init_paths.discard(str(db_path.resolve()))
+
+    def _slow_marp_theme_migration(conn):
+        columns = conn.execute("PRAGMA table_info(presentations)").fetchall()
+        if any(col["name"] == "marp_theme" for col in columns):
+            return
+        time.sleep(0.05)
+        conn.execute("ALTER TABLE presentations ADD COLUMN marp_theme TEXT")
+
+    monkeypatch.setattr(
+        SlidesDatabase,
+        "_ensure_marp_theme_column",
+        staticmethod(_slow_marp_theme_migration),
+    )
+
+    errors: list[BaseException] = []
+
+    def _open_database(client_id: str) -> None:
+        try:
+            db = SlidesDatabase(db_path=db_path, client_id=client_id)
+            db.close_connection()
+        except BaseException as exc:  # pragma: no cover - assertion reports details below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_open_database, args=(f"tester-{index}",)) for index in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
 
 
 def test_slides_db_soft_delete_restore(tmp_path):

--- a/tldw_Server_API/tests/Slides/test_slides_db.py
+++ b/tldw_Server_API/tests/Slides/test_slides_db.py
@@ -221,6 +221,22 @@ def test_slides_db_search_rejects_malformed_fts_query(tmp_path):
     db.close_connection()
 
 
+def test_slides_db_search_does_not_map_non_fts_operational_errors(tmp_path, monkeypatch):
+    db_path = tmp_path / "Slides.db"
+    db = SlidesDatabase(db_path=db_path, client_id="tester")
+
+    class LockedConnection:
+        def execute(self, *args, **kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(db, "get_connection", lambda: LockedConnection())
+
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        db.search_presentations(query="alpha", limit=10, offset=0, include_deleted=False)
+
+    db.close_connection()
+
+
 def test_create_presentation_rolls_back_when_sync_log_fails(tmp_path, monkeypatch):
     db_path = tmp_path / "Slides.db"
     db = SlidesDatabase(db_path=db_path, client_id="tester")

--- a/tldw_Server_API/tests/Slides/test_slides_export.py
+++ b/tldw_Server_API/tests/Slides/test_slides_export.py
@@ -1,3 +1,6 @@
+import builtins
+import importlib
+import importlib.util
 import io
 import zipfile
 
@@ -117,6 +120,29 @@ def test_sanitize_markdown_uses_bleach_without_css_sanitizer():
     assert "<ul>" in html
     assert "<li>one</li>" in html
     assert "&lt;ul" not in html
+
+
+def test_slides_export_reraises_unexpected_css_sanitizer_import_errors(monkeypatch):
+    import tldw_Server_API.app.core.Slides.slides_export as slides_export_module
+
+    original_import = builtins.__import__
+    spec = importlib.util.spec_from_file_location(
+        "tldw_Server_API.app.core.Slides._slides_export_import_probe",
+        slides_export_module.__file__,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    probe_module = importlib.util.module_from_spec(spec)
+
+    def _raise_for_css_sanitizer(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "bleach.css_sanitizer":
+            raise RuntimeError("unexpected import failure")
+        return original_import(name, globals, locals, fromlist, level)
+
+    with monkeypatch.context() as patch_context:
+        patch_context.setattr(builtins, "__import__", _raise_for_css_sanitizer)
+        with pytest.raises(RuntimeError, match="unexpected import failure"):
+            spec.loader.exec_module(probe_module)
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Slides/test_slides_export.py
+++ b/tldw_Server_API/tests/Slides/test_slides_export.py
@@ -7,6 +7,7 @@ from tldw_Server_API.app.core.Slides.slides_export import (
     SlidesAssetsMissingError,
     SlidesExportInputError,
     _normalize_pdf_options,
+    _sanitize_markdown,
     export_presentation_bundle,
     export_presentation_markdown,
 )
@@ -81,6 +82,41 @@ def test_export_bundle_includes_assets(tmp_path):
         assert "assets/custom.css" in index_html
         assert "data:image/png;base64," in index_html
         assert "alt=\"Logo\"" in index_html
+
+
+def test_export_bundle_escapes_settings_for_inline_script(tmp_path):
+    assets_dir = _build_assets(tmp_path)
+    bundle = export_presentation_bundle(
+        title="Deck",
+        slides=[
+            {
+                "order": 0,
+                "layout": "content",
+                "title": "Slide",
+                "content": "Hello",
+                "speaker_notes": None,
+                "metadata": {},
+            }
+        ],
+        theme="black",
+        settings={"transition": "</script><script>alert(1)</script>", "controls": True},
+        custom_css=None,
+        assets_dir=assets_dir,
+    )
+
+    with zipfile.ZipFile(io.BytesIO(bundle)) as zf:
+        index_html = zf.read("index.html").decode("utf-8")
+
+    assert "</script><script>alert(1)</script>" not in index_html
+    assert "\\u003c/script\\u003e\\u003cscript\\u003ealert(1)\\u003c/script\\u003e" in index_html
+
+
+def test_sanitize_markdown_uses_bleach_without_css_sanitizer():
+    html = _sanitize_markdown("- one")
+
+    assert "<ul>" in html
+    assert "<li>one</li>" in html
+    assert "&lt;ul" not in html
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Slides/test_slides_generator.py
+++ b/tldw_Server_API/tests/Slides/test_slides_generator.py
@@ -4,8 +4,10 @@ import pytest
 
 from tldw_Server_API.app.core.Slides.slides_generator import (
     SlidesGenerator,
+    SlidesGenerationInputError,
     SlidesGenerationOutputError,
     SlidesSourceTooLargeError,
+    _positive_int_setting,
 )
 
 
@@ -81,6 +83,96 @@ def test_generate_rejects_excessive_chunk_fanout(monkeypatch):
             chunk_size_tokens=3,
             summary_tokens=None,
         )
+
+
+def test_generate_rejects_non_positive_chunk_size_before_llm(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.slides_generator.is_test_mode",
+        lambda: False,
+    )
+
+    def _unexpected_llm_call(*args, **kwargs):
+        raise AssertionError("LLM should not be called for invalid chunk size")
+
+    generator = SlidesGenerator(llm_call=_unexpected_llm_call)
+
+    with pytest.raises(SlidesGenerationInputError, match="chunk_size_invalid"):
+        generator.generate_from_text(
+            source_text=" ".join(f"word{i}" for i in range(20)),
+            title_hint=None,
+            provider="openai",
+            model=None,
+            api_key=None,
+            temperature=None,
+            max_tokens=None,
+            max_source_tokens=None,
+            max_source_chars=None,
+            enable_chunking=True,
+            chunk_size_tokens=-1,
+            summary_tokens=None,
+        )
+
+
+def test_positive_int_setting_logs_invalid_config_and_reraises_unexpected_errors(monkeypatch):
+    import tldw_Server_API.app.core.Slides.slides_generator as slides_generator
+
+    logged: list[tuple[str, tuple[object, ...]]] = []
+    monkeypatch.setattr(
+        slides_generator,
+        "settings",
+        {"SLIDES_MAX_SOURCE_CHUNKS": "not-an-int"},
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.slides_generator.logger.warning",
+        lambda message, *args: logged.append((message, args)),
+    )
+
+    assert _positive_int_setting("SLIDES_MAX_SOURCE_CHUNKS", 20) == 20
+    assert logged
+    assert logged[0][1][0] == "SLIDES_MAX_SOURCE_CHUNKS"
+
+    class BrokenSettings:
+        def get(self, name, default=None):
+            raise RuntimeError("settings backend failed")
+
+    monkeypatch.setattr(slides_generator, "settings", BrokenSettings())
+
+    with pytest.raises(RuntimeError, match="settings backend failed"):
+        _positive_int_setting("SLIDES_MAX_SOURCE_CHUNKS", 20)
+
+
+def test_chunk_char_approx_logs_invalid_divisor_setting(monkeypatch):
+    import tldw_Server_API.app.core.Slides.slides_generator as slides_generator
+
+    logged: list[tuple[str, tuple[object, ...]]] = []
+    monkeypatch.setattr(
+        slides_generator,
+        "settings",
+        {
+            "TOKEN_ESTIMATOR_MODE": "char_approx",
+            "TOKEN_CHAR_APPROX_DIVISOR": "bad",
+            "SLIDES_MAX_SOURCE_CHUNKS": 10,
+        },
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.slides_generator.logger.warning",
+        lambda message, *args: logged.append((message, args)),
+    )
+    generator = SlidesGenerator(llm_call=_stub_llm_call)
+
+    summary = generator._chunk_and_summarize(
+        source_text="abcdef",
+        provider="openai",
+        model=None,
+        api_key=None,
+        temperature=None,
+        chunk_size_tokens=3,
+        summary_tokens=None,
+    )
+
+    assert summary == "Summary chunk"
+    assert logged
+    assert logged[0][1][0] == "TOKEN_CHAR_APPROX_DIVISOR"
 
 
 def test_generate_parses_json_response(monkeypatch):

--- a/tldw_Server_API/tests/Slides/test_slides_generator.py
+++ b/tldw_Server_API/tests/Slides/test_slides_generator.py
@@ -55,6 +55,34 @@ def test_generate_rejects_large_input_without_chunking():
         )
 
 
+def test_generate_rejects_excessive_chunk_fanout(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.slides_generator.is_test_mode",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.slides_generator.MAX_SOURCE_CHUNKS",
+        2,
+    )
+    generator = SlidesGenerator(llm_call=_stub_llm_call)
+
+    with pytest.raises(SlidesSourceTooLargeError):
+        generator.generate_from_text(
+            source_text=" ".join(f"word{i}" for i in range(9)),
+            title_hint=None,
+            provider="openai",
+            model=None,
+            api_key=None,
+            temperature=None,
+            max_tokens=None,
+            max_source_tokens=None,
+            max_source_chars=None,
+            enable_chunking=True,
+            chunk_size_tokens=3,
+            summary_tokens=None,
+        )
+
+
 def test_generate_parses_json_response(monkeypatch):
     monkeypatch.setattr(
         "tldw_Server_API.app.core.Slides.slides_generator.is_test_mode",

--- a/tldw_Server_API/tests/Slides/test_slides_ordering.py
+++ b/tldw_Server_API/tests/Slides/test_slides_ordering.py
@@ -1,9 +1,10 @@
-from hypothesis import given, strategies as st
+from hypothesis import HealthCheck, given, settings, strategies as st
 
 from tldw_Server_API.app.api.v1.endpoints.slides import _normalize_slides
 from tldw_Server_API.app.api.v1.schemas.slides_schemas import Slide, SlideLayout
 
 
+@settings(suppress_health_check=[HealthCheck.too_slow])
 @given(st.lists(st.integers(min_value=0, max_value=10), min_size=1, max_size=5, unique=True))
 def test_normalize_slides_orders_contiguous(orders):
     slides = [


### PR DESCRIPTION
## Summary
- Harden Slides exports with script-safe Reveal settings serialization and a bleach markdown sanitizer fallback that still works without optional CSS sanitizer support.
- Add default resource ceilings for slide asset resolution, generation chunk fan-out/source size, and presentation video render slide/duration limits.
- Make presentation sync-log writes transactional with create/update mutations, handle malformed FTS searches as validation errors, serialize schema initialization, and propagate hardened API validation/caps.

## Test Plan
- [x] `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides -q` (171 passed)
- [x] `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Slides/slides_export.py tldw_Server_API/app/core/Slides/slides_assets.py tldw_Server_API/app/core/Slides/presentation_rendering.py tldw_Server_API/app/core/Slides/slides_generator.py tldw_Server_API/app/core/Slides/slides_db.py tldw_Server_API/app/api/v1/endpoints/slides.py -f json -o /tmp/bandit_slides_review_fixes_worktree.json` (0 findings)
- [x] `git diff --check`

## Tracking
- Backlog: TASK-12002

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the Slides module to reduce XSS risk, enforce tighter resource limits, and improve DB/API reliability. Addresses TASK-12002.

- **New Features**
  - Add default ceilings for asset size (enforced before read), generation chunking/source size, and video rendering (slides per deck, per-slide/total duration, audio size).
  - Validate Reveal settings enums in the API and pass asset size caps to resolution calls.
  - Pre-FFmpeg checks reject excessive slide counts and manual durations.

- **Bug Fixes**
  - Escape settings JSON for inline scripts to prevent injection; keep `bleach` markdown sanitization working without `CSSSanitizer` and re-raise unexpected import failures.
  - Make presentation create/update and sync-log writes atomic; serialize schema initialization with a lock.
  - Map malformed FTS queries (including unknown fields) to 422 while letting non-query `OperationalError`s propagate; validate generator chunk size (reject non-positive/too-large) and cap chunk fan-out.

<sup>Written for commit a8e02dd8cd0beb6836caf3fc8cd1ef70da7ccbe2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

