### PR TITLE
Handle invalid PGVector metadata order keys

### DIFF
--- a/backlog/tasks/task-12007 - Address-PR-2506-vector-order-validation-review-comments.md
+++ b/backlog/tasks/task-12007 - Address-PR-2506-vector-order-validation-review-comments.md
@@ -1,0 +1,46 @@
+---
+id: TASK-12007
+title: Address PR 2506 vector order validation review comments
+status: Done
+labels:
+- review
+- vector-stores
+- pgvector
+modified_files:
+- tldw_Server_API/tests/RAG_NEW/unit/test_vector_store_list_vectors.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address PR 2506 review comments about test helper imports, docstrings, and type hints for vector listing metadata order validation coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 _FakeAdapterInvalidMetadataOrder imports InvalidMetadataOrderKeyError directly from core.exceptions.
+- [x] #2 New fake adapter and regression tests include docstrings and explicit type annotations.
+- [x] #3 Focused tests and Bandit verification are rerun before pushing.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Updated PR 2506 review follow-up tests to use the direct InvalidMetadataOrderKeyError import, add docstrings and type annotations for _FakeAdapterInvalidMetadataOrder and the new regression tests, and annotate only the newly added pytest assertions for Bandit B101. Verification: /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/RAG_NEW/unit/test_vector_store_list_vectors.py tldw_Server_API/tests/VectorStores/unit -q -> 29 passed, 5 warnings. git diff --check -> exit 0. Bandit on tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py -> exit 0, 0 findings. Bandit on the touched test file still exits 1 for the existing low-severity B101 pytest assert baseline, with 60 total B101 results and no findings on the newly added test lines.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py
+++ b/tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import pathlib
+import re
 import time
 import uuid
 from typing import Any
@@ -64,6 +65,7 @@ from tldw_Server_API.app.core.Embeddings.vector_store_meta_db import (
 from tldw_Server_API.app.core.Embeddings.vector_store_meta_db import (
     rename_store as meta_rename_store,
 )
+from tldw_Server_API.app.core.exceptions import InvalidMetadataOrderKeyError
 from tldw_Server_API.app.core.RAG.rag_service.vector_stores.base import (
     VectorStoreAdapter,
     VectorStoreConfig,
@@ -78,6 +80,7 @@ from tldw_Server_API.app.core.Utils.pydantic_compat import model_dump_compat
 
 RBAC_VECTOR_ADMIN = rbac_rate_limit("vector.admin")
 _ADMIN_CLAIM_PERMISSIONS = frozenset({"*", "system.configure"})
+_METADATA_ORDER_KEY_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
 
 _VECTORSTORE_NONCRITICAL_EXCEPTIONS = (
     asyncio.CancelledError,
@@ -1178,6 +1181,19 @@ async def list_vectors(
             raise HTTPException(status_code=400, detail={"error":"invalid_filter","message":str(e)}) from e
     if order_by and (order_by != 'id' and not order_by.startswith('metadata.')):
         raise HTTPException(status_code=400, detail={"error":"invalid_order_by","message":"order_by must be 'id' or 'metadata.<key>'"})
+    if order_by and order_by.startswith('metadata.'):
+        metadata_order_key = order_by.split('.', 1)[1]
+        if not _METADATA_ORDER_KEY_RE.fullmatch(metadata_order_key):
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "invalid_order_by",
+                    "message": (
+                        "metadata order key must be 1-128 characters of letters, "
+                        "numbers, underscore, or hyphen"
+                    ),
+                },
+            )
     # Prefer adapter-provided pagination helper when available (PG, future stores)
     list_fn = getattr(adapter, 'list_vectors_paginated', None)
     if callable(list_fn):
@@ -1193,6 +1209,11 @@ async def list_vectors(
                     metadata=row.get('metadata') or {},
                     content=row.get('content') or "",
                 ))
+        except InvalidMetadataOrderKeyError as e:
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "invalid_order_by", "message": str(e)},
+            ) from e
         except _VECTORSTORE_NONCRITICAL_EXCEPTIONS:
             logger.warning("Adapter list_vectors_paginated failed; falling back to Chroma path")
     if not items and total == 0:

--- a/tldw_Server_API/tests/RAG_NEW/unit/test_vector_store_list_vectors.py
+++ b/tldw_Server_API/tests/RAG_NEW/unit/test_vector_store_list_vectors.py
@@ -1,7 +1,10 @@
 import json as _json
+from typing import Any
+
 import pytest
 from fastapi.testclient import TestClient
 
+from tldw_Server_API.app.core.exceptions import InvalidMetadataOrderKeyError
 from tldw_Server_API.app.main import app
 
 
@@ -127,17 +130,26 @@ class _FakeAdapterPaginated:
 
 
 class _FakeAdapterInvalidMetadataOrder:
-    def __init__(self):
+    """Adapter double that raises PGVector metadata order validation errors."""
+
+    def __init__(self) -> None:
         self._initialized = True
 
-    async def initialize(self):  # pragma: no cover
+    async def initialize(self) -> None:  # pragma: no cover
+        """Mirror the vector adapter initialization contract."""
         self._initialized = True
 
-    async def list_vectors_paginated(self, store_id: str, limit: int, offset: int, filter=None, order_by=None, order_dir=None):  # noqa: ANN001
-        from tldw_Server_API.app.core.RAG.rag_service.vector_stores import pgvector_adapter as pg_mod
-
-        exc_type = getattr(pg_mod, "InvalidMetadataOrderKeyError", ValueError)
-        raise exc_type("metadata.score;drop")
+    async def list_vectors_paginated(
+        self,
+        store_id: str,
+        limit: int,
+        offset: int,
+        filter: dict[str, Any] | None = None,
+        order_by: str | None = None,
+        order_dir: str | None = None,
+    ) -> dict[str, Any]:
+        """Raise the adapter validation error that PGVector emits for unsafe ordering."""
+        raise InvalidMetadataOrderKeyError("metadata.score;drop")
 
 
 @pytest.mark.unit
@@ -246,10 +258,15 @@ def test_list_vectors_invalid_order_by_returns_400(monkeypatch, disable_heavy_st
 
 
 @pytest.mark.unit
-def test_list_vectors_invalid_metadata_order_key_returns_400(monkeypatch, disable_heavy_startup, admin_user):
+def test_list_vectors_invalid_metadata_order_key_returns_400(
+    monkeypatch: pytest.MonkeyPatch,
+    disable_heavy_startup: Any,
+    admin_user: Any,
+) -> None:
+    """Reject unsafe metadata order keys before the adapter receives the request."""
     from tldw_Server_API.app.api.v1.endpoints import vector_stores_openai as vs_mod
 
-    async def _fake_get_adapter_for_user(user, dim):  # noqa: ANN001
+    async def _fake_get_adapter_for_user(user: Any, dim: int) -> _FakeAdapter:
         return _FakeAdapter()
 
     monkeypatch.setattr(vs_mod, "_get_adapter_for_user", _fake_get_adapter_for_user, raising=True)
@@ -259,15 +276,20 @@ def test_list_vectors_invalid_metadata_order_key_returns_400(monkeypatch, disabl
         "/api/v1/vector_stores/store-xyz/vectors",
         params={"order_by": "metadata.score;drop", "order_dir": "asc"},
     )
-    assert r.status_code == 400
-    assert "invalid_order_by" in r.text
+    assert r.status_code == 400  # nosec B101
+    assert "invalid_order_by" in r.text  # nosec B101
 
 
 @pytest.mark.unit
-def test_list_vectors_adapter_invalid_metadata_order_key_returns_400(monkeypatch, disable_heavy_startup, admin_user):
+def test_list_vectors_adapter_invalid_metadata_order_key_returns_400(
+    monkeypatch: pytest.MonkeyPatch,
+    disable_heavy_startup: Any,
+    admin_user: Any,
+) -> None:
+    """Map adapter-raised metadata order validation errors to HTTP 400."""
     from tldw_Server_API.app.api.v1.endpoints import vector_stores_openai as vs_mod
 
-    async def _fake_get_adapter_for_user(user, dim):  # noqa: ANN001
+    async def _fake_get_adapter_for_user(user: Any, dim: int) -> _FakeAdapterInvalidMetadataOrder:
         return _FakeAdapterInvalidMetadataOrder()
 
     monkeypatch.setattr(vs_mod, "_get_adapter_for_user", _fake_get_adapter_for_user, raising=True)
@@ -277,8 +299,8 @@ def test_list_vectors_adapter_invalid_metadata_order_key_returns_400(monkeypatch
         "/api/v1/vector_stores/store-xyz/vectors",
         params={"order_by": "metadata.score", "order_dir": "asc"},
     )
-    assert r.status_code == 400
-    assert "invalid_order_by" in r.text
+    assert r.status_code == 400  # nosec B101
+    assert "invalid_order_by" in r.text  # nosec B101
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/RAG_NEW/unit/test_vector_store_list_vectors.py
+++ b/tldw_Server_API/tests/RAG_NEW/unit/test_vector_store_list_vectors.py
@@ -126,6 +126,20 @@ class _FakeAdapterPaginated:
         return {"items": items, "total": self._total}
 
 
+class _FakeAdapterInvalidMetadataOrder:
+    def __init__(self):
+        self._initialized = True
+
+    async def initialize(self):  # pragma: no cover
+        self._initialized = True
+
+    async def list_vectors_paginated(self, store_id: str, limit: int, offset: int, filter=None, order_by=None, order_dir=None):  # noqa: ANN001
+        from tldw_Server_API.app.core.RAG.rag_service.vector_stores import pgvector_adapter as pg_mod
+
+        exc_type = getattr(pg_mod, "InvalidMetadataOrderKeyError", ValueError)
+        raise exc_type("metadata.score;drop")
+
+
 @pytest.mark.unit
 def test_list_vectors_pagination_next_offset_chroma_fallback(monkeypatch, disable_heavy_startup, admin_user):
      # Fake adapter without list_vectors_paginated triggers Chroma fallback path
@@ -226,6 +240,42 @@ def test_list_vectors_invalid_order_by_returns_400(monkeypatch, disable_heavy_st
     r = client.get(
         "/api/v1/vector_stores/store-xyz/vectors",
         params={"order_by": "name", "order_dir": "asc"},
+    )
+    assert r.status_code == 400
+    assert "invalid_order_by" in r.text
+
+
+@pytest.mark.unit
+def test_list_vectors_invalid_metadata_order_key_returns_400(monkeypatch, disable_heavy_startup, admin_user):
+    from tldw_Server_API.app.api.v1.endpoints import vector_stores_openai as vs_mod
+
+    async def _fake_get_adapter_for_user(user, dim):  # noqa: ANN001
+        return _FakeAdapter()
+
+    monkeypatch.setattr(vs_mod, "_get_adapter_for_user", _fake_get_adapter_for_user, raising=True)
+
+    client = TestClient(app)
+    r = client.get(
+        "/api/v1/vector_stores/store-xyz/vectors",
+        params={"order_by": "metadata.score;drop", "order_dir": "asc"},
+    )
+    assert r.status_code == 400
+    assert "invalid_order_by" in r.text
+
+
+@pytest.mark.unit
+def test_list_vectors_adapter_invalid_metadata_order_key_returns_400(monkeypatch, disable_heavy_startup, admin_user):
+    from tldw_Server_API.app.api.v1.endpoints import vector_stores_openai as vs_mod
+
+    async def _fake_get_adapter_for_user(user, dim):  # noqa: ANN001
+        return _FakeAdapterInvalidMetadataOrder()
+
+    monkeypatch.setattr(vs_mod, "_get_adapter_for_user", _fake_get_adapter_for_user, raising=True)
+
+    client = TestClient(app)
+    r = client.get(
+        "/api/v1/vector_stores/store-xyz/vectors",
+        params={"order_by": "metadata.score", "order_dir": "asc"},
     )
     assert r.status_code == 400
     assert "invalid_order_by" in r.text


### PR DESCRIPTION
## Summary
- Add API-boundary validation for `order_by=metadata.<key>` using the same metadata key shape accepted by the PGVector adapter.
- Catch `InvalidMetadataOrderKeyError` before the broad vector-store fallback handler so invalid PGVector order keys return `400 invalid_order_by` instead of falling into the Chroma fallback path.
- Add regression coverage for invalid metadata order keys at the API boundary and adapter-raised validation errors.

## Test Plan
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/VectorStores/unit tldw_Server_API/tests/RAG_NEW/unit/test_vector_store_list_vectors.py -q` -> 29 passed, 5 warnings
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py -f json -o /tmp/bandit_pgvector_metadata_order_pr.json` -> exit 0, results []
- `git diff --check --cached` -> exit 0

## Merge Note
- Per repo policy, a human-authored Change summary is required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate metadata order keys in vector listing and return clear 400 errors for invalid `order_by=metadata.<key>`, preventing unsafe input and Chroma fallback.

- **Bug Fixes**
  - Enforce `metadata.<key>` to match `^[A-Za-z0-9_-]{1,128}$`; otherwise return `400 invalid_order_by`.
  - Map `InvalidMetadataOrderKeyError` from the PGVector adapter to `400 invalid_order_by`; added regression tests for API-boundary and adapter paths.

- **Refactors**
  - Test cleanup: direct `InvalidMetadataOrderKeyError` import, docstrings, and explicit type hints.

<sup>Written for commit 2828554bf0146a8ce2544618adf55d4c5ae6b79f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

