### PR TITLE
Harden Research Workspace capability readiness

### DIFF
--- a/Docs/superpowers/plans/2026-06-23-research-workspace-capability-readiness-hardening.md
+++ b/Docs/superpowers/plans/2026-06-23-research-workspace-capability-readiness-hardening.md
@@ -1,0 +1,58 @@
+# Research Workspace Capability Readiness Hardening Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the Research_Workspace capability review findings without changing unrelated workspace behavior.
+
+**Architecture:** Keep the API endpoint thin and keep capability derivation in `tldw_Server_API/app/core/Research_Workspace/capabilities.py`. Replace endpoint-function health imports with core-owned, injectable health probes that run concurrently with bounded timeouts. Preserve the existing sanitized capability response shape while tightening typing and docs.
+
+**Tech Stack:** FastAPI-adjacent Python core code, Pydantic schemas, pytest/pytest-asyncio, Bandit.
+
+---
+
+## Stage 1: Regression Coverage
+**Goal**: Prove the review findings with focused tests before code changes.
+**Success Criteria**: Tests fail for real Slides DB unavailability, API endpoint collector imports, timeout/concurrency behavior, sync placeholder top-level status, schema key typing, and README function naming.
+**Tests**: `tldw_Server_API/tests/Research_Workspace/test_capability_derivation.py` and `tldw_Server_API/tests/Research_Workspace/test_capability_endpoint.py`.
+**Status**: Complete
+
+- [x] Add a collector test showing `try_get_slides_db_for_user` returning `None` makes `slides_generation` block.
+- [x] Add a collector test showing slow probes are bounded and independent probes run concurrently.
+- [x] Add a source-level assertion that core capability collection no longer imports API endpoint health functions.
+- [x] Add a derivation test showing implemented ready capabilities are not top-level degraded solely because `sync_share` is still unknown.
+- [x] Add a schema test showing capability response keys use the `ResearchWorkspaceCapabilityId` literal.
+- [x] Add a README check for the actual `collect_research_workspace_capabilities()` function name.
+
+## Stage 2: Core Collector Fixes
+**Goal**: Make capability collection reliable without depending on API endpoint functions.
+**Success Criteria**: Collectors are core-owned/injectable, probes have bounded timeouts, and synchronous Slides work does not block the event loop.
+**Tests**: Focused Research Workspace tests pass.
+**Status**: Complete
+
+- [x] Add a small `ResearchWorkspaceHealthCollectors` dataclass to carry collector callables.
+- [x] Run aggregate, RAG, LLM, Slides, and TTS probes with `asyncio.gather` and per-probe timeout handling.
+- [x] Move aggregate, RAG, and LLM checks to core-owned best-effort probes instead of importing endpoint callables.
+- [x] Run the Slides DB probe through `asyncio.to_thread`.
+- [x] Return sanitized `unknown` payloads on timeout or unexpected collector exceptions.
+
+## Stage 3: Capability Semantics And Contract Cleanup
+**Goal**: Fix fail-open and noisy-status behavior while preserving the frontend contract.
+**Success Criteria**: Broken Slides DB blocks Slides generation, `sync_share` remains advertised but does not make all-ready implemented capabilities top-level degraded, schema keys are typed, and README naming is accurate.
+**Tests**: Focused Research Workspace tests pass.
+**Status**: Complete
+
+- [x] Change real Slides DB lookup failure to `unavailable` so composed `slides_generation` blocks.
+- [x] Exclude the placeholder `sync_share` capability from overall status until a concrete sync collector exists.
+- [x] Tighten the Pydantic capabilities mapping to `dict[ResearchWorkspaceCapabilityId, ResearchWorkspaceCapability]`.
+- [x] Correct the README architecture note to use `collect_research_workspace_capabilities()`.
+
+## Stage 4: Verification And Backlog Closeout
+**Goal**: Verify the focused behavior and record task status.
+**Success Criteria**: Tests, Bandit, and diff checks complete with outcomes recorded in TASK-2423.
+**Tests**: `python -m pytest tldw_Server_API/tests/Research_Workspace -q`; Bandit on touched backend files.
+**Status**: Complete
+
+- [x] Run focused Research Workspace tests.
+- [x] Run Bandit on touched backend source.
+- [x] Run `git diff --check`.
+- [x] Update TASK-2423 implementation notes/final summary with verification results.

--- a/backlog/tasks/task-2423 - Harden-Research-Workspace-capability-readiness.md
+++ b/backlog/tasks/task-2423 - Harden-Research-Workspace-capability-readiness.md
@@ -1,0 +1,51 @@
+---
+id: TASK-2423
+title: Harden Research Workspace capability readiness
+status: Done
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the current Research_Workspace capability module review findings: fail closed for real Slides DB unavailability, decouple core health collection from API endpoint functions, bound/concurrently run health probes, stop placeholder sync/share from forcing degraded overall status, tighten capability response typing, and correct README function naming.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Plan: Docs/superpowers/plans/2026-06-23-research-workspace-capability-readiness-hardening.md
+
+Implemented review fixes:
+- Slides DB lookup returning None now reports unavailable, so slides_generation blocks instead of warning/failing open.
+- Core capability collection now uses injectable ResearchWorkspaceHealthCollectors and concurrent bounded probes instead of importing API endpoint health functions.
+- The sync_share placeholder remains in the response but no longer degrades the top-level status by itself.
+- Capability response mapping keys are typed as ResearchWorkspaceCapabilityId.
+- README function naming now matches collect_research_workspace_capabilities().
+
+Verification:
+- source .venv/bin/activate && python -m pytest --confcutdir=tldw_Server_API/tests/Research_Workspace tldw_Server_API/tests/Research_Workspace -q => 20 passed, 2 warnings in 95.67s.
+- source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Research_Workspace tldw_Server_API/app/api/v1/schemas/research_workspace_capabilities.py -f json -o /tmp/bandit_research_workspace_capability_readiness.json => 0 findings.
+- git diff --check => passed.
+
+Note: the official Backlog CLI hung in this environment and the fallback CLI did not support adding acceptance criteria after task creation, so the task acceptance criteria section remains empty.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened Research Workspace capability readiness by failing closed for unavailable Slides DB access, replacing endpoint health imports with injectable concurrent timeout-bounded core probes, preventing the sync/share placeholder from degrading otherwise-ready capabilities, tightening schema key typing, and correcting README naming. Focused Research Workspace tests, Bandit, and diff checks passed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2423 - Harden-Research-Workspace-capability-readiness.md
+++ b/backlog/tasks/task-2423 - Harden-Research-Workspace-capability-readiness.md
@@ -2,6 +2,7 @@
 id: TASK-2423
 title: Harden Research Workspace capability readiness
 status: Done
+updated_date: 2026-06-24 20:07
 ---
 
 ## Description
@@ -42,6 +43,8 @@ Follow-up verification:
 - AUTH_MODE=single_user SINGLE_USER_TEST_API_KEY=test-api-key-12345 SINGLE_USER_API_KEY=test-api-key-12345 python -m pytest --confcutdir=tldw_Server_API/tests/Research_Workspace tldw_Server_API/tests/Research_Workspace -q => 22 passed, 2 warnings in 14.38s.
 - python -m bandit -r tldw_Server_API/app/core/Research_Workspace tldw_Server_API/app/api/v1/schemas/research_workspace_capabilities.py -f json -o /tmp/bandit_research_workspace_capability_readiness_review_followup.json => 0 findings.
 - git diff --check => passed.
+2026-06-24 Qodo follow-up pass: rebased onto latest origin/dev, added helper docstrings, preserved subsystem reason_code values through dependency capability mapping, made slides probe timeouts fail closed as unavailable/blocking for slides generation, replaced untyped lambda test double, added pytest unit markers for Research Workspace tests, and added regressions for slides timeout handling plus unknown dependency reason-code preservation. Verification: Research Workspace focused pytest suite passed (24 passed, 2 warnings); Bandit on touched Research Workspace scope reported 0 findings; git diff --check passed.
+Final Qodo follow-up verification after reason-code sanitization: AUTH_MODE=single_user SINGLE_USER_TEST_API_KEY=test-api-key-12345 SINGLE_USER_API_KEY=test-api-key-12345 python -m pytest --confcutdir=tldw_Server_API/tests/Research_Workspace tldw_Server_API/tests/Research_Workspace -q => 25 passed, 2 warnings in 29.87s. Bandit touched scope => 0 findings. git diff --check => passed. Branch comparison against origin/dev before commit => 0 behind / 2 ahead.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2423 - Harden-Research-Workspace-capability-readiness.md
+++ b/backlog/tasks/task-2423 - Harden-Research-Workspace-capability-readiness.md
@@ -32,6 +32,16 @@ Verification:
 - git diff --check => passed.
 
 Note: the official Backlog CLI hung in this environment and the fallback CLI did not support adding acceptance criteria after task creation, so the task acceptance criteria section remains empty.
+PR review follow-up on 2026-06-24:
+- Added Loguru exception logging for unexpected Research Workspace health probe and collector failures while keeping response payloads sanitized.
+- Updated async collector invocation to recognize callable objects with async __call__ methods.
+- Moved get_chacha_health_snapshot() behind asyncio.to_thread to preserve event-loop responsiveness.
+- Added focused regression coverage for async callable collector instances and off-thread ChaCha health snapshot collection.
+
+Follow-up verification:
+- AUTH_MODE=single_user SINGLE_USER_TEST_API_KEY=test-api-key-12345 SINGLE_USER_API_KEY=test-api-key-12345 python -m pytest --confcutdir=tldw_Server_API/tests/Research_Workspace tldw_Server_API/tests/Research_Workspace -q => 22 passed, 2 warnings in 14.38s.
+- python -m bandit -r tldw_Server_API/app/core/Research_Workspace tldw_Server_API/app/api/v1/schemas/research_workspace_capabilities.py -f json -o /tmp/bandit_research_workspace_capability_readiness_review_followup.json => 0 findings.
+- git diff --check => passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/app/api/v1/schemas/research_workspace_capabilities.py
+++ b/tldw_Server_API/app/api/v1/schemas/research_workspace_capabilities.py
@@ -33,5 +33,5 @@ class ResearchWorkspaceCapabilitiesResponse(BaseModel):
 
     status: ResearchWorkspaceOverallStatus
     ttl_seconds: int = 30
-    capabilities: dict[str, ResearchWorkspaceCapability]
+    capabilities: dict[ResearchWorkspaceCapabilityId, ResearchWorkspaceCapability]
     timestamp: datetime

--- a/tldw_Server_API/app/core/Research_Workspace/README.md
+++ b/tldw_Server_API/app/core/Research_Workspace/README.md
@@ -35,7 +35,7 @@ Research_Workspace currently owns the capability-readiness contract for the Rese
 
 ### Core Flow
 
-- The endpoint calls `collect_research_workspace_health()`, then `build_research_workspace_capabilities()` maps subsystem health into capability modes and reason codes.
+- The endpoint calls `collect_research_workspace_capabilities()`, then `build_research_workspace_capabilities()` maps subsystem health into capability modes and reason codes.
 - Capability ids are composed from dependency health rather than direct feature execution. The response tells the WebUI whether to allow, warn, or block an action.
 - TTS readiness is derived from configured provider availability and should not initialize TTS providers during capability checks.
 

--- a/tldw_Server_API/app/core/Research_Workspace/capabilities.py
+++ b/tldw_Server_API/app/core/Research_Workspace/capabilities.py
@@ -8,6 +8,8 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any, Mapping
 
+from loguru import logger
+
 from tldw_Server_API.app.api.v1.schemas.research_workspace_capabilities import (
     ResearchWorkspaceCapabilitiesResponse,
     ResearchWorkspaceCapability,
@@ -317,6 +319,7 @@ async def _run_health_probe(
     except (asyncio.TimeoutError, TimeoutError):
         return {"status": "unknown", "reason_code": f"{probe_name}_health_timeout"}
     except Exception:
+        logger.exception("Unexpected error running Research Workspace health probe: {}", probe_name)
         return {"status": "unknown", "reason_code": f"{probe_name}_health_unknown"}
     return result if isinstance(result, Mapping) else {"status": "unknown"}
 
@@ -325,12 +328,18 @@ async def _invoke_health_collector(
     collector: Callable[..., Mapping[str, Any] | Awaitable[Mapping[str, Any]]],
     **kwargs: Any,
 ) -> Mapping[str, Any]:
-    if inspect.iscoroutinefunction(collector):
+    if _is_async_callable(collector):
         return await collector(**kwargs)
     result = await asyncio.to_thread(collector, **kwargs)
     if inspect.isawaitable(result):
         return await result
     return result
+
+
+def _is_async_callable(collector: Callable[..., Any]) -> bool:
+    return inspect.iscoroutinefunction(collector) or inspect.iscoroutinefunction(
+        getattr(collector, "__call__", None)
+    )
 
 
 async def _collect_aggregate_health() -> Mapping[str, Any]:
@@ -346,17 +355,19 @@ async def _collect_aggregate_health() -> Mapping[str, Any]:
         if checks["database"].get("status") != "healthy":
             overall = "degraded"
     except Exception:
+        logger.exception("Failed to collect Research Workspace database health")
         checks["database"] = {"status": "unhealthy", "reason_code": "database_health_unknown"}
         overall = "unhealthy"
 
     try:
         from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_health_snapshot
 
-        chacha_health = get_chacha_health_snapshot()
+        chacha_health = await asyncio.to_thread(get_chacha_health_snapshot)
         checks["chacha_notes"] = chacha_health if isinstance(chacha_health, Mapping) else {"status": "unknown"}
         if checks["chacha_notes"].get("status") not in {"healthy", "ok"} and overall == "ok":
             overall = "degraded"
     except Exception:
+        logger.exception("Failed to collect Research Workspace ChaCha notes health")
         checks["chacha_notes"] = {"status": "unhealthy", "reason_code": "chacha_health_unknown"}
         if overall == "ok":
             overall = "degraded"
@@ -381,6 +392,7 @@ async def _collect_rag_health() -> Mapping[str, Any]:
             return {"status": "unhealthy", "components": components}
         return {"status": "healthy", "components": components}
     except Exception:
+        logger.exception("Failed to collect Research Workspace RAG health")
         return {"status": "unknown", "reason_code": "rag_health_unknown"}
 
 
@@ -423,6 +435,7 @@ async def _collect_llm_health() -> Mapping[str, Any]:
 
         return health
     except Exception:
+        logger.exception("Failed to collect Research Workspace LLM health")
         return {"status": "unknown", "reason_code": "llm_health_unknown"}
 
 
@@ -444,6 +457,7 @@ def _collect_slides_health(*, user_id: int | str | None = None) -> Mapping[str, 
         )
         return {"status": "ok"}
     except Exception:
+        logger.exception("Failed to collect Research Workspace Slides health")
         return {"status": "unavailable", "reason_code": "slides_unavailable"}
 
 
@@ -467,4 +481,5 @@ async def _collect_tts_health() -> Mapping[str, Any]:
             },
         }
     except Exception:
+        logger.exception("Failed to collect Research Workspace TTS health")
         return {"status": "unknown", "reason_code": "tts_health_unknown"}

--- a/tldw_Server_API/app/core/Research_Workspace/capabilities.py
+++ b/tldw_Server_API/app/core/Research_Workspace/capabilities.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -41,6 +42,7 @@ _UNAVAILABLE_STATUSES = {
     "disabled",
     "not_ready",
 }
+_REASON_CODE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,95}$")
 
 
 HealthCollector = Callable[[], Mapping[str, Any] | Awaitable[Mapping[str, Any]]]
@@ -141,6 +143,7 @@ async def collect_research_workspace_capabilities(
             "slides",
             active_collectors.slides_health,
             timeout_seconds=probe_timeout_seconds,
+            timeout_status="unavailable",
             user_id=user_id,
         ),
         _run_health_probe(
@@ -213,13 +216,19 @@ def _dependency_capability(
     degraded_reason: str | None = None,
 ) -> ResearchWorkspaceCapability:
     status = _status(health)
+    reason_code = _reason_code(health)
     if status == "ready":
         return _cap("ready", "allow", [dependency])
     if status == "degraded":
-        return _cap("degraded", "warn", [dependency], degraded_reason or f"{dependency}_degraded")
+        return _cap("degraded", "warn", [dependency], reason_code or degraded_reason or f"{dependency}_degraded")
     if status == "unavailable":
-        return _cap("unavailable", "block", [dependency], unavailable_reason or f"{dependency}_unavailable")
-    return _cap("unknown", "warn", [dependency], f"{dependency}_unknown")
+        return _cap(
+            "unavailable",
+            "block",
+            [dependency],
+            reason_code or unavailable_reason or f"{dependency}_unavailable",
+        )
+    return _cap("unknown", "warn", [dependency], reason_code or f"{dependency}_unknown")
 
 
 def _compose_capability(
@@ -286,6 +295,17 @@ def _status(payload: Mapping[str, Any] | None) -> ResearchWorkspaceCapabilitySta
     return "unknown"
 
 
+def _reason_code(payload: Mapping[str, Any] | None) -> str | None:
+    """Return a sanitized reason code from a subsystem health payload."""
+    if not isinstance(payload, Mapping):
+        return None
+    value = payload.get("reason_code")
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized if _REASON_CODE_PATTERN.fullmatch(normalized) else None
+
+
 def _mapping_value(payload: Mapping[str, Any] | None, key: str) -> Mapping[str, Any] | None:
     if not isinstance(payload, Mapping):
         return None
@@ -294,6 +314,7 @@ def _mapping_value(payload: Mapping[str, Any] | None, key: str) -> Mapping[str, 
 
 
 def _default_health_collectors() -> ResearchWorkspaceHealthCollectors:
+    """Return the production health collectors used by the capabilities endpoint."""
     return ResearchWorkspaceHealthCollectors(
         aggregate_health=_collect_aggregate_health,
         rag_health=_collect_rag_health,
@@ -308,8 +329,10 @@ async def _run_health_probe(
     collector: Callable[..., Mapping[str, Any] | Awaitable[Mapping[str, Any]]],
     *,
     timeout_seconds: float,
+    timeout_status: ResearchWorkspaceCapabilityStatus = "unknown",
     **kwargs: Any,
 ) -> Mapping[str, Any]:
+    """Run one health collector with a bounded timeout and sanitized fallback payload."""
     timeout = max(0.001, float(timeout_seconds or _DEFAULT_PROBE_TIMEOUT_SECONDS))
     try:
         result = await asyncio.wait_for(
@@ -317,7 +340,7 @@ async def _run_health_probe(
             timeout=timeout,
         )
     except (asyncio.TimeoutError, TimeoutError):
-        return {"status": "unknown", "reason_code": f"{probe_name}_health_timeout"}
+        return {"status": timeout_status, "reason_code": f"{probe_name}_health_timeout"}
     except Exception:
         logger.exception("Unexpected error running Research Workspace health probe: {}", probe_name)
         return {"status": "unknown", "reason_code": f"{probe_name}_health_unknown"}
@@ -328,6 +351,7 @@ async def _invoke_health_collector(
     collector: Callable[..., Mapping[str, Any] | Awaitable[Mapping[str, Any]]],
     **kwargs: Any,
 ) -> Mapping[str, Any]:
+    """Invoke sync, async, and async-callable health collectors consistently."""
     if _is_async_callable(collector):
         return await collector(**kwargs)
     result = await asyncio.to_thread(collector, **kwargs)
@@ -337,6 +361,7 @@ async def _invoke_health_collector(
 
 
 def _is_async_callable(collector: Callable[..., Any]) -> bool:
+    """Return whether a callable or callable instance should run on the event loop."""
     return inspect.iscoroutinefunction(collector) or inspect.iscoroutinefunction(
         getattr(collector, "__call__", None)
     )

--- a/tldw_Server_API/app/core/Research_Workspace/capabilities.py
+++ b/tldw_Server_API/app/core/Research_Workspace/capabilities.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-import json
+import asyncio
+import inspect
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any, Mapping
@@ -22,6 +25,8 @@ RESEARCH_WORKSPACE_CAPABILITY_IDS = (
     "export_download",
     "sync_share",
 )
+_OVERALL_STATUS_EXCLUDED_CAPABILITY_IDS = {"sync_share"}
+_DEFAULT_PROBE_TIMEOUT_SECONDS = 2.0
 
 _READY_STATUSES = {"healthy", "ok", "ready", "available", "up", "operational"}
 _DEGRADED_STATUSES = {"degraded", "partial", "warning"}
@@ -34,6 +39,23 @@ _UNAVAILABLE_STATUSES = {
     "disabled",
     "not_ready",
 }
+
+
+HealthCollector = Callable[[], Mapping[str, Any] | Awaitable[Mapping[str, Any]]]
+SlidesHealthCollector = Callable[
+    ..., Mapping[str, Any] | Awaitable[Mapping[str, Any]]
+]
+
+
+@dataclass(frozen=True)
+class ResearchWorkspaceHealthCollectors:
+    """Health probe callables used by Research Workspace capability collection."""
+
+    aggregate_health: HealthCollector
+    rag_health: HealthCollector
+    llm_health: HealthCollector
+    slides_health: SlidesHealthCollector
+    tts_health: HealthCollector
 
 
 def build_research_workspace_capabilities(
@@ -92,13 +114,39 @@ def build_research_workspace_capabilities(
 async def collect_research_workspace_capabilities(
     *,
     user_id: int | str | None = None,
+    collectors: ResearchWorkspaceHealthCollectors | None = None,
+    probe_timeout_seconds: float = _DEFAULT_PROBE_TIMEOUT_SECONDS,
 ) -> ResearchWorkspaceCapabilitiesResponse:
     """Collect lightweight local health snapshots for the Research Workspace contract."""
-    aggregate = await _collect_aggregate_health()
-    rag = await _collect_rag_health()
-    llm = await _collect_llm_health()
-    slides = _collect_slides_health(user_id=user_id)
-    tts = await _collect_tts_health()
+    active_collectors = collectors or _default_health_collectors()
+    aggregate, rag, llm, slides, tts = await asyncio.gather(
+        _run_health_probe(
+            "aggregate",
+            active_collectors.aggregate_health,
+            timeout_seconds=probe_timeout_seconds,
+        ),
+        _run_health_probe(
+            "rag",
+            active_collectors.rag_health,
+            timeout_seconds=probe_timeout_seconds,
+        ),
+        _run_health_probe(
+            "llm",
+            active_collectors.llm_health,
+            timeout_seconds=probe_timeout_seconds,
+        ),
+        _run_health_probe(
+            "slides",
+            active_collectors.slides_health,
+            timeout_seconds=probe_timeout_seconds,
+            user_id=user_id,
+        ),
+        _run_health_probe(
+            "tts",
+            active_collectors.tts_health,
+            timeout_seconds=probe_timeout_seconds,
+        ),
+    )
 
     return build_research_workspace_capabilities(
         aggregate_health=aggregate,
@@ -196,7 +244,12 @@ def _overall_status(capabilities: Mapping[str, ResearchWorkspaceCapability]) -> 
     source = capabilities.get("source_browse")
     if source and source.mode == "block":
         return "unavailable"
-    if any(capability.mode in {"block", "warn"} for capability in capabilities.values()):
+    status_capabilities = [
+        capability
+        for capability_id, capability in capabilities.items()
+        if capability_id not in _OVERALL_STATUS_EXCLUDED_CAPABILITY_IDS
+    ]
+    if any(capability.mode in {"block", "warn"} for capability in status_capabilities):
         return "degraded"
     return "ready"
 
@@ -238,38 +291,137 @@ def _mapping_value(payload: Mapping[str, Any] | None, key: str) -> Mapping[str, 
     return value if isinstance(value, Mapping) else None
 
 
-async def _collect_aggregate_health() -> Mapping[str, Any]:
+def _default_health_collectors() -> ResearchWorkspaceHealthCollectors:
+    return ResearchWorkspaceHealthCollectors(
+        aggregate_health=_collect_aggregate_health,
+        rag_health=_collect_rag_health,
+        llm_health=_collect_llm_health,
+        slides_health=_collect_slides_health,
+        tts_health=_collect_tts_health,
+    )
+
+
+async def _run_health_probe(
+    probe_name: str,
+    collector: Callable[..., Mapping[str, Any] | Awaitable[Mapping[str, Any]]],
+    *,
+    timeout_seconds: float,
+    **kwargs: Any,
+) -> Mapping[str, Any]:
+    timeout = max(0.001, float(timeout_seconds or _DEFAULT_PROBE_TIMEOUT_SECONDS))
     try:
-        from starlette.responses import Response
-
-        from tldw_Server_API.app.api.v1.endpoints.health import api_health
-
-        result = await api_health()
-        if isinstance(result, Response):
-            body = getattr(result, "body", b"")
-            decoded = json.loads(body.decode("utf-8")) if isinstance(body, bytes) else json.loads(str(body))
-            return decoded if isinstance(decoded, Mapping) else {"status": "unknown"}
-        return result if isinstance(result, Mapping) else {"status": "unknown"}
+        result = await asyncio.wait_for(
+            _invoke_health_collector(collector, **kwargs),
+            timeout=timeout,
+        )
+    except (asyncio.TimeoutError, TimeoutError):
+        return {"status": "unknown", "reason_code": f"{probe_name}_health_timeout"}
     except Exception:
-        return {"status": "unknown", "reason_code": "aggregate_health_unknown"}
+        return {"status": "unknown", "reason_code": f"{probe_name}_health_unknown"}
+    return result if isinstance(result, Mapping) else {"status": "unknown"}
+
+
+async def _invoke_health_collector(
+    collector: Callable[..., Mapping[str, Any] | Awaitable[Mapping[str, Any]]],
+    **kwargs: Any,
+) -> Mapping[str, Any]:
+    if inspect.iscoroutinefunction(collector):
+        return await collector(**kwargs)
+    result = await asyncio.to_thread(collector, **kwargs)
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+async def _collect_aggregate_health() -> Mapping[str, Any]:
+    checks: dict[str, Mapping[str, Any]] = {}
+    overall = "ok"
+
+    try:
+        from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+
+        pool = await get_db_pool()
+        database_health = await pool.health_check()
+        checks["database"] = database_health if isinstance(database_health, Mapping) else {"status": "unknown"}
+        if checks["database"].get("status") != "healthy":
+            overall = "degraded"
+    except Exception:
+        checks["database"] = {"status": "unhealthy", "reason_code": "database_health_unknown"}
+        overall = "unhealthy"
+
+    try:
+        from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_health_snapshot
+
+        chacha_health = get_chacha_health_snapshot()
+        checks["chacha_notes"] = chacha_health if isinstance(chacha_health, Mapping) else {"status": "unknown"}
+        if checks["chacha_notes"].get("status") not in {"healthy", "ok"} and overall == "ok":
+            overall = "degraded"
+    except Exception:
+        checks["chacha_notes"] = {"status": "unhealthy", "reason_code": "chacha_health_unknown"}
+        if overall == "ok":
+            overall = "degraded"
+
+    return {"status": overall, "checks": checks}
 
 
 async def _collect_rag_health() -> Mapping[str, Any]:
     try:
-        from tldw_Server_API.app.api.v1.endpoints.rag_health import health_check
+        from tldw_Server_API.app.core.RAG.rag_service.resilience import get_coordinator
 
-        result = await health_check()
-        return result if isinstance(result, Mapping) else {"status": "unknown"}
+        coordinator = get_coordinator()
+        components: dict[str, Mapping[str, Any]] = {}
+        for name, breaker in getattr(coordinator, "circuit_breakers", {}).items():
+            stats = breaker.get_stats()
+            state = str(stats.get("state") or "unknown")
+            components[f"circuit_breaker_{name}"] = {
+                "status": "unhealthy" if state == "open" else "healthy",
+                "state": state,
+            }
+        if any(component.get("status") == "unhealthy" for component in components.values()):
+            return {"status": "unhealthy", "components": components}
+        return {"status": "healthy", "components": components}
     except Exception:
         return {"status": "unknown", "reason_code": "rag_health_unknown"}
 
 
 async def _collect_llm_health() -> Mapping[str, Any]:
     try:
-        from tldw_Server_API.app.api.v1.endpoints.llm_providers import llm_health
+        from tldw_Server_API.app.core.Chat.provider_manager import get_provider_manager
+        from tldw_Server_API.app.core.Chat.rate_limiter import get_rate_limiter
+        from tldw_Server_API.app.core.Chat.request_queue import get_request_queue
 
-        result = await llm_health()
-        return result if isinstance(result, Mapping) else {"status": "unknown"}
+        health: dict[str, Any] = {"status": "healthy", "components": {}}
+        provider_manager = get_provider_manager()
+        if provider_manager is None:
+            health["components"]["providers"] = {"initialized": False}
+            health["status"] = "degraded"
+        else:
+            report = provider_manager.get_health_report()
+            any_unhealthy = any(
+                provider.get("status") in {"unhealthy", "circuit_open"}
+                for provider in report.values()
+                if isinstance(provider, Mapping)
+            )
+            health["components"]["providers"] = {
+                "initialized": True,
+                "count": len(report),
+                "report": report,
+            }
+            if any_unhealthy:
+                health["status"] = "degraded"
+
+        request_queue = get_request_queue()
+        if request_queue is None:
+            health["components"]["queue"] = {"initialized": False}
+            health["status"] = "degraded"
+        else:
+            queue_status = request_queue.get_queue_status()
+            health["components"]["queue"] = {"initialized": True, **queue_status}
+
+        rate_limiter = get_rate_limiter()
+        health["components"]["rate_limiter"] = {"initialized": rate_limiter is not None}
+
+        return health
     except Exception:
         return {"status": "unknown", "reason_code": "llm_health_unknown"}
 
@@ -282,11 +434,17 @@ def _collect_slides_health(*, user_id: int | str | None = None) -> Mapping[str, 
 
         db = try_get_slides_db_for_user(current_user=SimpleNamespace(id=user_id))
         if db is None:
-            return {"status": "unknown", "reason_code": "slides_health_unknown"}
-        db.list_presentations(limit=1, offset=0, include_deleted=True, sort_column="created_at", sort_direction="DESC")
+            return {"status": "unavailable", "reason_code": "slides_unavailable"}
+        db.list_presentations(
+            limit=1,
+            offset=0,
+            include_deleted=True,
+            sort_column="created_at",
+            sort_direction="DESC",
+        )
         return {"status": "ok"}
     except Exception:
-        return {"status": "unknown", "reason_code": "slides_health_unknown"}
+        return {"status": "unavailable", "reason_code": "slides_unavailable"}
 
 
 async def _collect_tts_health() -> Mapping[str, Any]:

--- a/tldw_Server_API/tests/Research_Workspace/test_capability_derivation.py
+++ b/tldw_Server_API/tests/Research_Workspace/test_capability_derivation.py
@@ -1,13 +1,23 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
+import asyncio
+import sys
+import time
+from types import ModuleType, SimpleNamespace
+from typing import get_args
 
 import pytest
 
+from tldw_Server_API.app.api.v1.schemas.research_workspace_capabilities import (
+    ResearchWorkspaceCapabilitiesResponse,
+    ResearchWorkspaceCapabilityId,
+)
 from tldw_Server_API.app.core.Research_Workspace import capabilities
 from tldw_Server_API.app.core.Research_Workspace.capabilities import (
     RESEARCH_WORKSPACE_CAPABILITY_IDS,
+    ResearchWorkspaceHealthCollectors,
     build_research_workspace_capabilities,
+    collect_research_workspace_capabilities,
 )
 
 
@@ -50,7 +60,7 @@ def test_ready_dependencies_allow_core_research_workspace_actions():
     assert response.capabilities["export_download"].mode == "allow"
     assert response.capabilities["sync_share"].status == "unknown"
     assert response.capabilities["sync_share"].mode == "warn"
-    assert response.status == "degraded"
+    assert response.status == "ready"
     assert response.ttl_seconds == 30
 
 
@@ -192,6 +202,26 @@ def test_slides_and_tts_health_only_gate_their_artifact_types():
     assert response.capabilities["audio_summary"].mode == "block"
 
 
+def test_slides_db_lookup_failure_blocks_slides_generation(monkeypatch):
+    fake_slides_deps = ModuleType("tldw_Server_API.app.api.v1.API_Deps.Slides_DB_Deps")
+    fake_slides_deps.try_get_slides_db_for_user = lambda current_user: None
+    monkeypatch.setitem(
+        sys.modules,
+        "tldw_Server_API.app.api.v1.API_Deps.Slides_DB_Deps",
+        fake_slides_deps,
+    )
+
+    slides_health = capabilities._collect_slides_health(user_id=42)
+    response = build_research_workspace_capabilities(
+        **_health_inputs(slides_health=slides_health)
+    )
+
+    assert slides_health["status"] == "unavailable"
+    assert response.capabilities["slides_generation"].reason_code == "slides_unavailable"
+    assert response.capabilities["slides_generation"].mode == "block"
+    assert response.capabilities["artifact_text_generation"].mode == "allow"
+
+
 def test_capability_payload_does_not_leak_raw_errors_paths_or_secrets():
     response = build_research_workspace_capabilities(
         **_health_inputs(
@@ -230,6 +260,22 @@ def test_capability_payload_does_not_leak_raw_errors_paths_or_secrets():
     assert "api_key" not in dumped
 
 
+def test_capability_response_keys_are_typed_as_known_capability_ids():
+    annotation = ResearchWorkspaceCapabilitiesResponse.model_fields["capabilities"].annotation
+    key_type = get_args(annotation)[0]
+
+    assert get_args(key_type) == get_args(ResearchWorkspaceCapabilityId)
+
+
+def test_core_capability_collector_does_not_import_api_endpoint_health_functions():
+    source = capabilities.__loader__.get_source(capabilities.__name__)
+
+    assert source is not None
+    assert "app.api.v1.endpoints.health" not in source
+    assert "app.api.v1.endpoints.rag_health" not in source
+    assert "app.api.v1.endpoints.llm_providers" not in source
+
+
 @pytest.mark.asyncio
 async def test_tts_health_collection_uses_config_without_provider_initialization(monkeypatch):
     class FakeTtsConfigManager:
@@ -239,19 +285,71 @@ async def test_tts_health_collection_uses_config_without_provider_initialization
         def get_enabled_providers(self):
             return ["openai"]
 
-    async def forbidden_setup_health():
-        raise AssertionError("Research Workspace capability collection must not initialize TTS providers")
-
     monkeypatch.setattr(
         "tldw_Server_API.app.core.TTS.tts_config.get_tts_config_manager",
         lambda: FakeTtsConfigManager(),
-    )
-    monkeypatch.setattr(
-        "tldw_Server_API.app.api.v1.endpoints.audio.audio_health.collect_setup_tts_health",
-        forbidden_setup_health,
-        raising=False,
     )
 
     result = await capabilities._collect_tts_health()
 
     assert result == {"status": "healthy", "providers": {"available": 1, "total": 2}}
+
+
+@pytest.mark.asyncio
+async def test_capability_collection_runs_bounded_independent_probes_concurrently():
+    started: list[str] = []
+
+    async def slow_aggregate_health():
+        started.append("aggregate")
+        await asyncio.sleep(0.2)
+        return {
+            "status": "ok",
+            "checks": {
+                "database": {"status": "healthy"},
+                "chacha_notes": {"status": "healthy"},
+            },
+        }
+
+    async def ready_rag_health():
+        started.append("rag")
+        await asyncio.sleep(0.01)
+        return {"status": "healthy"}
+
+    async def ready_llm_health():
+        started.append("llm")
+        await asyncio.sleep(0.01)
+        return {
+            "status": "healthy",
+            "components": {"providers": {"initialized": True, "count": 1}},
+        }
+
+    def ready_slides_health(*, user_id: int | str | None = None):
+        started.append(f"slides:{user_id}")
+        time.sleep(0.01)
+        return {"status": "ok"}
+
+    async def ready_tts_health():
+        started.append("tts")
+        await asyncio.sleep(0.01)
+        return {"status": "healthy", "providers": {"available": 1}}
+
+    collectors = ResearchWorkspaceHealthCollectors(
+        aggregate_health=slow_aggregate_health,
+        rag_health=ready_rag_health,
+        llm_health=ready_llm_health,
+        slides_health=ready_slides_health,
+        tts_health=ready_tts_health,
+    )
+
+    started_at = time.perf_counter()
+    response = await collect_research_workspace_capabilities(
+        user_id=42,
+        collectors=collectors,
+        probe_timeout_seconds=0.05,
+    )
+    elapsed = time.perf_counter() - started_at
+
+    assert elapsed < 0.15
+    assert set(started) == {"aggregate", "rag", "llm", "slides:42", "tts"}
+    assert response.capabilities["source_browse"].status == "unknown"
+    assert response.capabilities["chat"].mode == "warn"

--- a/tldw_Server_API/tests/Research_Workspace/test_capability_derivation.py
+++ b/tldw_Server_API/tests/Research_Workspace/test_capability_derivation.py
@@ -20,6 +20,8 @@ from tldw_Server_API.app.core.Research_Workspace.capabilities import (
     collect_research_workspace_capabilities,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _health_inputs(**overrides):
     inputs = {
@@ -186,6 +188,30 @@ def test_rag_unavailable_blocks_chat_as_dependency_failure():
     assert response.capabilities["artifact_text_generation"].mode == "allow"
 
 
+def test_unknown_dependency_health_preserves_probe_reason_code():
+    response = build_research_workspace_capabilities(
+        **_health_inputs(
+            rag_health={"status": "unknown", "reason_code": "rag_health_timeout"}
+        )
+    )
+
+    assert response.capabilities["chat"].status == "unknown"
+    assert response.capabilities["chat"].mode == "warn"
+    assert response.capabilities["chat"].reason_code == "rag_health_timeout"
+    assert response.capabilities["artifact_text_generation"].mode == "allow"
+
+
+def test_dependency_health_rejects_unsafe_reason_code_values():
+    response = build_research_workspace_capabilities(
+        **_health_inputs(
+            rag_health={"status": "unknown", "reason_code": "/tmp/secret"}
+        )
+    )
+
+    assert response.capabilities["chat"].reason_code == "rag_unknown"
+    assert "/tmp/secret" not in response.model_dump_json()
+
+
 def test_slides_and_tts_health_only_gate_their_artifact_types():
     response = build_research_workspace_capabilities(
         **_health_inputs(
@@ -204,7 +230,12 @@ def test_slides_and_tts_health_only_gate_their_artifact_types():
 
 def test_slides_db_lookup_failure_blocks_slides_generation(monkeypatch):
     fake_slides_deps = ModuleType("tldw_Server_API.app.api.v1.API_Deps.Slides_DB_Deps")
-    fake_slides_deps.try_get_slides_db_for_user = lambda current_user: None
+
+    def fake_try_get_slides_db_for_user(current_user: object) -> None:
+        assert current_user is not None
+        return None
+
+    fake_slides_deps.try_get_slides_db_for_user = fake_try_get_slides_db_for_user
     monkeypatch.setitem(
         sys.modules,
         "tldw_Server_API.app.api.v1.API_Deps.Slides_DB_Deps",
@@ -353,6 +384,54 @@ async def test_capability_collection_runs_bounded_independent_probes_concurrentl
     assert set(started) == {"aggregate", "rag", "llm", "slides:42", "tts"}
     assert response.capabilities["source_browse"].status == "unknown"
     assert response.capabilities["chat"].mode == "warn"
+
+
+@pytest.mark.asyncio
+async def test_slides_probe_timeout_blocks_slides_generation():
+    async def ready_aggregate_health():
+        return {
+            "status": "ok",
+            "checks": {
+                "database": {"status": "healthy"},
+                "chacha_notes": {"status": "healthy"},
+            },
+        }
+
+    async def ready_rag_health():
+        return {"status": "healthy"}
+
+    async def ready_llm_health():
+        return {
+            "status": "healthy",
+            "components": {"providers": {"initialized": True, "count": 1}},
+        }
+
+    async def slow_slides_health(*, user_id: int | str | None = None):
+        assert user_id == 42
+        await asyncio.sleep(0.2)
+        return {"status": "ok"}
+
+    async def ready_tts_health():
+        return {"status": "healthy", "providers": {"available": 1}}
+
+    collectors = ResearchWorkspaceHealthCollectors(
+        aggregate_health=ready_aggregate_health,
+        rag_health=ready_rag_health,
+        llm_health=ready_llm_health,
+        slides_health=slow_slides_health,
+        tts_health=ready_tts_health,
+    )
+
+    response = await collect_research_workspace_capabilities(
+        user_id=42,
+        collectors=collectors,
+        probe_timeout_seconds=0.01,
+    )
+
+    assert response.capabilities["slides_generation"].status == "unavailable"
+    assert response.capabilities["slides_generation"].mode == "block"
+    assert response.capabilities["slides_generation"].reason_code == "slides_health_timeout"
+    assert response.capabilities["artifact_text_generation"].mode == "allow"
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Research_Workspace/test_capability_derivation.py
+++ b/tldw_Server_API/tests/Research_Workspace/test_capability_derivation.py
@@ -353,3 +353,62 @@ async def test_capability_collection_runs_bounded_independent_probes_concurrentl
     assert set(started) == {"aggregate", "rag", "llm", "slides:42", "tts"}
     assert response.capabilities["source_browse"].status == "unknown"
     assert response.capabilities["chat"].mode == "warn"
+
+
+@pytest.mark.asyncio
+async def test_async_callable_collector_instances_are_invoked_without_thread_pool(monkeypatch):
+    class AsyncCollector:
+        async def __call__(self, *, marker: str):
+            return {"status": "healthy", "marker": marker}
+
+    async def forbidden_to_thread(*args, **kwargs):
+        raise AssertionError("async callable instances must not be sent to a thread pool")
+
+    monkeypatch.setattr(capabilities.asyncio, "to_thread", forbidden_to_thread)
+
+    result = await capabilities._invoke_health_collector(AsyncCollector(), marker="probe")
+
+    assert result == {"status": "healthy", "marker": "probe"}
+
+
+@pytest.mark.asyncio
+async def test_aggregate_health_collects_chacha_snapshot_off_thread(monkeypatch):
+    called: list[str] = []
+
+    class FakePool:
+        async def health_check(self):
+            return {"status": "healthy"}
+
+    async def get_db_pool():
+        return FakePool()
+
+    def get_chacha_health_snapshot():
+        return {"status": "healthy"}
+
+    fake_auth_database = ModuleType("tldw_Server_API.app.core.AuthNZ.database")
+    fake_auth_database.get_db_pool = get_db_pool
+    fake_chacha_deps = ModuleType("tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps")
+    fake_chacha_deps.get_chacha_health_snapshot = get_chacha_health_snapshot
+
+    async def tracking_to_thread(func, *args, **kwargs):
+        called.append(func.__name__)
+        return func(*args, **kwargs)
+
+    monkeypatch.setitem(sys.modules, "tldw_Server_API.app.core.AuthNZ.database", fake_auth_database)
+    monkeypatch.setitem(
+        sys.modules,
+        "tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps",
+        fake_chacha_deps,
+    )
+    monkeypatch.setattr(capabilities.asyncio, "to_thread", tracking_to_thread)
+
+    result = await capabilities._collect_aggregate_health()
+
+    assert result == {
+        "status": "ok",
+        "checks": {
+            "database": {"status": "healthy"},
+            "chacha_notes": {"status": "healthy"},
+        },
+    }
+    assert called == ["get_chacha_health_snapshot"]

--- a/tldw_Server_API/tests/Research_Workspace/test_capability_endpoint.py
+++ b/tldw_Server_API/tests/Research_Workspace/test_capability_endpoint.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -88,3 +89,12 @@ def test_openapi_contains_research_workspace_capabilities_path():
 
     assert "/api/v1/research-workspace/capabilities" in schema["paths"]
     assert "/api/v1/research-studio/capabilities" not in schema["paths"]
+
+
+def test_research_workspace_readme_names_current_collector_function():
+    readme = Path("tldw_Server_API/app/core/Research_Workspace/README.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "collect_research_workspace_capabilities()" in readme
+    assert "collect_research_workspace_health()" not in readme

--- a/tldw_Server_API/tests/Research_Workspace/test_capability_endpoint.py
+++ b/tldw_Server_API/tests/Research_Workspace/test_capability_endpoint.py
@@ -10,6 +10,8 @@ from tldw_Server_API.app.api.v1.router_groups.content import API_V1_PREFIX, iter
 from tldw_Server_API.app.core.AuthNZ.permissions import MEDIA_READ
 from tldw_Server_API.app.core.Research_Workspace.capabilities import build_research_workspace_capabilities
 
+pytestmark = pytest.mark.unit
+
 
 def _closure_values(callable_obj: Any) -> list[Any]:
     closure = getattr(callable_obj, "__closure__", None) or ()


### PR DESCRIPTION
## Summary
- Fail closed when Slides DB readiness is unavailable so slide generation blocks instead of warning through a broken dependency.
- Replace endpoint health imports with injectable, timeout-bounded core probes that run concurrently.
- Tighten capability response key typing and fix the Research Workspace README collector name.

## Test Plan
- [x] AUTH_MODE=single_user SINGLE_USER_TEST_API_KEY=test-api-key-12345 SINGLE_USER_API_KEY=test-api-key-12345 python -m pytest --confcutdir=tldw_Server_API/tests/Research_Workspace tldw_Server_API/tests/Research_Workspace -q
- [x] python -m bandit -r tldw_Server_API/app/core/Research_Workspace tldw_Server_API/app/api/v1/schemas/research_workspace_capabilities.py -f json -o /tmp/bandit_research_workspace_capability_readiness_pr.json
- [x] git diff --check origin/dev...HEAD

## Merge Note
- Per repo policy, this AI-authored PR still needs a human-written Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Research Workspace capability readiness by moving to injectable, concurrent, timeout-bounded probes and failing closed for Slides DB unavailability and probe timeouts (TASK-2423). Adds structured exception logging, preserves sanitized probe reason_code values in capability mapping, and runs ChaCha health off-thread to keep the event loop responsive.

- **Bug Fixes**
  - Slides DB `None` and probe timeouts now mark Slides as unavailable, blocking `slides_generation`.
  - `sync_share` is excluded from overall status so otherwise-ready capabilities report ready.
  - Capability map keys are typed as `ResearchWorkspaceCapabilityId`.
  - Probe `reason_code` values are sanitized and preserved; unsafe values are dropped.

- **Refactors**
  - Introduced `ResearchWorkspaceHealthCollectors` and concurrent probes with per-probe timeouts; sanitized fallback payloads on errors/timeouts.
  - Replaced endpoint imports with core-owned health checks for aggregate, RAG (circuit breakers), LLM (provider manager/queue/rate limiter), Slides, and TTS.
  - Added support for async callable collector instances.

<sup>Written for commit 89f6fbcb5e35583d0f5e4ad04333baf9e9ac6769. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

