### PR TITLE
Harden Sandbox review findings

### DIFF
--- a/Docs/superpowers/plans/2026-06-23-sandbox-review-hardening.md
+++ b/Docs/superpowers/plans/2026-06-23-sandbox-review-hardening.md
@@ -1,0 +1,67 @@
+# Sandbox Review Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Verify the Sandbox review findings and fix every finding that reproduces against current code.
+
+**Architecture:** Keep fixes local to the affected Sandbox components. Add narrow regression tests before production changes, favoring existing test files and helper patterns.
+
+**Tech Stack:** Python, pytest, FastAPI-side Sandbox core, Docker/Lima/Firecracker runner helpers.
+
+---
+
+## Stage 1: Validate Findings
+
+**Goal**: Confirm each review item against current code and existing tests.
+**Success Criteria**: Each finding is marked valid or rejected with code-based rationale.
+**Tests**: Read and run focused pytest targets before edits where existing tests already cover behavior.
+**Status**: Complete
+
+- [x] Check snapshot restore behavior for symlink workspace roots.
+- [x] Check Docker hardening fallback behavior.
+- [x] Check Docker allowlist egress failure handling.
+- [x] Check Docker command logging for env leakage.
+- [x] Check artifact storage symlink handling.
+- [x] Check Lima status handling for non-zero commands.
+- [x] Check Lima and Firecracker env-file quoting.
+- [x] Check service runtime dispatch duplication and decide whether it is behavior-affecting.
+
+## Stage 2: Add Regression Tests
+
+**Goal**: Reproduce validated security/correctness findings with focused tests.
+**Success Criteria**: New tests fail for the expected reason before production changes.
+**Tests**: Targeted pytest invocations for each added test file/test case.
+**Status**: Complete
+
+- [x] Add a snapshot restore test that fails when the workspace root is a symlink.
+- [x] Add Docker runner tests for security-option fallback and env redaction.
+- [x] Add Docker egress setup tests that fail when rule application fails.
+- [x] Add artifact store/path tests for symlink escape prevention.
+- [x] Add Lima runner test proving non-zero commands still write status.
+- [x] Add Lima/Firecracker env-file tests for shell-safe quoting and key validation.
+
+## Stage 3: Implement Fixes
+
+**Goal**: Patch the minimal production code needed to pass the regression tests.
+**Success Criteria**: Targeted tests pass without weakening existing Sandbox behavior.
+**Tests**: Same targeted pytest invocations from Stage 2.
+**Status**: Complete
+
+- [x] Reject symlink workspace roots before snapshot restore backup/clear.
+- [x] Fail closed when configured Docker security options cannot be applied.
+- [x] Fail closed when Docker allowlist egress rules cannot be installed.
+- [x] Redact Docker env values from logs.
+- [x] Guard artifact storage reads/writes against symlink escapes.
+- [x] Ensure Lima entry scripts always write run status for non-zero commands.
+- [x] Shell-quote Lima/Firecracker env values and reject invalid env keys.
+
+## Stage 4: Verification and Task Finalization
+
+**Goal**: Verify focused tests, Bandit touched scope, and task metadata.
+**Success Criteria**: Test output and Bandit results are recorded in TASK-2420.
+**Tests**: Focused pytest targets plus `python -m bandit -r` on touched Sandbox paths.
+**Status**: Complete
+
+- [x] Run focused Sandbox regression tests.
+- [x] Run Bandit on touched Sandbox code.
+- [x] Update TASK-9929 with validated/rejected findings, test results, and final summary.

--- a/backlog/tasks/task-9929 - Harden-Sandbox-module-review-findings.md
+++ b/backlog/tasks/task-9929 - Harden-Sandbox-module-review-findings.md
@@ -3,16 +3,17 @@ id: TASK-9929
 title: Harden Sandbox module review findings
 status: Done
 assignee: []
-created_date: '2026-06-23 11:27'
-updated_date: '2026-06-23 11:51'
+created_date: 2026-06-23 11:27
+updated_date: 2026-06-25 02:06
 labels:
-  - sandbox
-  - security
-  - review
+- sandbox
+- security
+- review
 dependencies: []
 references:
-  - tldw_Server_API/app/core/Sandbox
-  - Docs/superpowers/plans/2026-06-23-sandbox-review-hardening.md
+- tldw_Server_API/app/core/Sandbox
+- Docs/superpowers/plans/2026-06-23-sandbox-review-hardening.md
+- https://github.com/rmusser01/tldw_server/pull/2509
 priority: high
 ---
 
@@ -64,3 +65,9 @@ Verification:
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Hardened Sandbox snapshot restore, Docker runner, artifact storage, and Lima/Firecracker guest script/env handling for the validated review findings. Added focused regression coverage for each reproduced defect and documented the non-behavior runtime-dispatch concern as deferred refactor work. Focused Sandbox tests, compileall, and diff check passed; Bandit has no errors and only the existing low-severity subprocess baseline remains in the touched Sandbox scope.
 <!-- SECTION:FINAL_SUMMARY:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+PR opened: https://github.com/rmusser01/tldw_server/pull/2509
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-9929 - Harden-Sandbox-module-review-findings.md
+++ b/backlog/tasks/task-9929 - Harden-Sandbox-module-review-findings.md
@@ -4,7 +4,7 @@ title: Harden Sandbox module review findings
 status: Done
 assignee: []
 created_date: 2026-06-23 11:27
-updated_date: 2026-06-25 02:06
+updated_date: 2026-06-26 06:30
 labels:
 - sandbox
 - security
@@ -70,4 +70,5 @@ Hardened Sandbox snapshot restore, Docker runner, artifact storage, and Lima/Fir
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 PR opened: https://github.com/rmusser01/tldw_server/pull/2509
+Rebased PR branch on latest origin/dev and addressed PR review feedback: Docker create failure messages now redact env values, Docker env redaction preserves --env names without inline values, Firecracker env files export variables to child commands, artifact writes use fd-relative openat-style traversal to close parent symlink race windows, artifact listing resolves root once, new artifact test module has docstrings, modified monkeypatch fixtures are typed, and Docker readiness-gate nosec is narrowed to explicit Bandit IDs. Verification after fixes: focused Sandbox suite 38 passed/1 skipped; compileall passed; git diff --check passed; Ruff passed on touched production files; Bandit JSON errors=0, high=0, medium=0, docker readiness findings=[] with existing low-severity subprocess baseline remaining.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-9929 - Harden-Sandbox-module-review-findings.md
+++ b/backlog/tasks/task-9929 - Harden-Sandbox-module-review-findings.md
@@ -4,7 +4,7 @@ title: Harden Sandbox module review findings
 status: Done
 assignee: []
 created_date: 2026-06-23 11:27
-updated_date: 2026-06-26 06:30
+updated_date: 2026-06-26 06:41
 labels:
 - sandbox
 - security
@@ -66,9 +66,10 @@ Verification:
 Hardened Sandbox snapshot restore, Docker runner, artifact storage, and Lima/Firecracker guest script/env handling for the validated review findings. Added focused regression coverage for each reproduced defect and documented the non-behavior runtime-dispatch concern as deferred refactor work. Focused Sandbox tests, compileall, and diff check passed; Bandit has no errors and only the existing low-severity subprocess baseline remains in the touched Sandbox scope.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
-## Implementation Notes
+## PR Reference
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 PR opened: https://github.com/rmusser01/tldw_server/pull/2509
 Rebased PR branch on latest origin/dev and addressed PR review feedback: Docker create failure messages now redact env values, Docker env redaction preserves --env names without inline values, Firecracker env files export variables to child commands, artifact writes use fd-relative openat-style traversal to close parent symlink race windows, artifact listing resolves root once, new artifact test module has docstrings, modified monkeypatch fixtures are typed, and Docker readiness-gate nosec is narrowed to explicit Bandit IDs. Verification after fixes: focused Sandbox suite 38 passed/1 skipped; compileall passed; git diff --check passed; Ruff passed on touched production files; Bandit JSON errors=0, high=0, medium=0, docker readiness findings=[] with existing low-severity subprocess baseline remaining.
+Second PR review pass addressed newly surfaced CodeRabbit threads: renamed duplicate Backlog heading, cleaned partial fallback egress rules before raising, rejected symlinked artifact and snapshot ancestors, reset Docker ENTRYPOINT for granular allowlist runs, removed raw RunSpec env values from Docker debug logging, and added child-env propagation coverage for Lima plus existing Firecracker coverage. Verification after second pass: focused Sandbox suite 43 passed/1 skipped; compileall passed; git diff --check passed; Ruff passed on touched production files; Bandit JSON errors=0, high=0, medium=0, docker readiness findings=[] with existing low-severity subprocess baseline remaining.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-9929 - Harden-Sandbox-module-review-findings.md
+++ b/backlog/tasks/task-9929 - Harden-Sandbox-module-review-findings.md
@@ -1,0 +1,66 @@
+---
+id: TASK-9929
+title: Harden Sandbox module review findings
+status: Done
+assignee: []
+created_date: '2026-06-23 11:27'
+updated_date: '2026-06-23 11:51'
+labels:
+  - sandbox
+  - security
+  - review
+dependencies: []
+references:
+  - tldw_Server_API/app/core/Sandbox
+  - Docs/superpowers/plans/2026-06-23-sandbox-review-hardening.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify and address validated findings from the current Sandbox module review. Scope is limited to `tldw_Server_API/app/core/Sandbox` and focused regression tests unless a validated fix requires a narrow adjacent test utility update.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Validated findings are reproduced with targeted tests before production changes.
+- [x] #2 Confirmed findings are fixed in the Sandbox module.
+- [x] #3 Non-applicable findings are documented with rationale.
+- [x] #4 Focused tests and Bandit on touched scope are run before completion.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Plan: Docs/superpowers/plans/2026-06-23-sandbox-review-hardening.md
+
+Backlog CLI allocator reused an occupied TASK-2420 in this checkout because several current task files are untracked and not reflected in the allocator state. A manual TASK-2424 Sandbox record then collided with another untracked TASK-2424, so the Sandbox record was renumbered to TASK-9929.
+
+Validated and fixed: snapshot restore symlink workspace root, Docker security-option fallback, Docker granular egress fail-open, Docker env-value log exposure, artifact storage symlink escapes, Lima/Firecracker non-zero status capture, and Lima/Firecracker shell env-file quoting/key validation.
+
+Not treated as an actionable defect in this slice: SandboxService runtime dispatch duplication. It is a maintainability smell, but no behavior/security failure was reproduced; broad runtime-dispatch refactoring is deferred to a separate design/refactor task.
+
+Verification:
+- Focused red run before fixes: 11 new regression tests failed for the expected reviewed behaviors.
+- Focused green run: `python -m pytest -q --confcutdir=tldw_Server_API/tests/sandbox tldw_Server_API/tests/sandbox/test_snapshot_manager_restore_security.py tldw_Server_API/tests/sandbox/test_docker_runner_hardening_defaults.py tldw_Server_API/tests/sandbox/test_docker_egress_enforcement.py tldw_Server_API/tests/sandbox/test_orchestrator_artifact_security.py tldw_Server_API/tests/sandbox/test_cross_runtime_cleanup_contracts.py` -> 34 passed, 1 skipped.
+- Compile: `python -m compileall -q` on touched Sandbox production files -> passed.
+- Diff check: `git diff --check` on touched files -> passed.
+- Bandit: touched Sandbox production scope wrote `/tmp/bandit_sandbox_review_hardening.json`, errors=0, results=95. The new Docker readiness-gate subprocess finding was suppressed with a scoped `# nosec`; remaining results are the existing low-severity Sandbox subprocess baseline.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed.
+- [x] #2 Tests or verification recorded.
+- [x] #3 Documentation updated when relevant.
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip.
+- [x] #5 Final summary added.
+- [x] #6 Known skips or blockers documented.
+<!-- DOD:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened Sandbox snapshot restore, Docker runner, artifact storage, and Lima/Firecracker guest script/env handling for the validated review findings. Added focused regression coverage for each reproduced defect and documented the non-behavior runtime-dispatch concern as deferred refactor work. Focused Sandbox tests, compileall, and diff check passed; Bandit has no errors and only the existing low-severity subprocess baseline remains in the touched Sandbox scope.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/core/Sandbox/network_policy.py
+++ b/tldw_Server_API/app/core/Sandbox/network_policy.py
@@ -285,6 +285,14 @@ def apply_egress_rules_atomic(container_ip: str, targets: Sequence[str], label: 
         logger.debug("network policy: iptables DROP rule failed for {}: {}", container_ip, e)
         failures.append(f"DROP raised {e}")
     if failures:
+        try:
+            delete_rules_by_label(label)
+        except _SANDBOX_NET_POLICY_NONCRITICAL_EXCEPTIONS as cleanup_exc:
+            logger.debug(
+                "network policy: failed to clean partial egress rules label={} error={}",
+                label,
+                cleanup_exc,
+            )
         raise RuntimeError(f"iptables egress rule application failed: {'; '.join(failures)}")
     return rule_specs
 

--- a/tldw_Server_API/app/core/Sandbox/network_policy.py
+++ b/tldw_Server_API/app/core/Sandbox/network_policy.py
@@ -251,27 +251,40 @@ def apply_egress_rules_atomic(container_ip: str, targets: Sequence[str], label: 
             logger.debug("iptables-restore failed; falling back to iterative iptables invocations")
     except _SANDBOX_NET_POLICY_NONCRITICAL_EXCEPTIONS as e:
         logger.debug(f"iptables-restore invocation failed: {e}")
-    # Fallback path: iterative `iptables` calls
+    # Fallback path: iterative `iptables` calls. This path must still fail
+    # closed; reporting rules as installed when iptables returned non-zero
+    # leaves allowlist containers with unrestricted egress.
+    failures: list[str] = []
     for tgt in targets:
         dspec = tgt if "/" in tgt else f"{tgt}/32"
         try:
-            subprocess.run([
+            proc = subprocess.run([
                 "iptables", "-I", "DOCKER-USER", "1",
                 "-s", container_ip, "-d", dspec, "-j", "ACCEPT",
                 "-m", "comment", "--comment", label,
             ], check=False)
-            rule_specs.append(f"DOCKER-USER -s {container_ip} -d {dspec} -j ACCEPT -m comment --comment {label}")
+            if proc.returncode == 0:
+                rule_specs.append(f"DOCKER-USER -s {container_ip} -d {dspec} -j ACCEPT -m comment --comment {label}")
+            else:
+                failures.append(f"ACCEPT {dspec} returned {proc.returncode}")
         except _SANDBOX_NET_POLICY_NONCRITICAL_EXCEPTIONS as e:
             logger.debug("network policy: iptables ACCEPT rule failed for {} -> {}: {}", container_ip, dspec, e)
+            failures.append(f"ACCEPT {dspec} raised {e}")
     try:
-        subprocess.run([
+        proc = subprocess.run([
             "iptables", "-A", "DOCKER-USER",
             "-s", container_ip, "-j", "DROP",
             "-m", "comment", "--comment", label,
         ], check=False)
-        rule_specs.append(f"DOCKER-USER -s {container_ip} -j DROP -m comment --comment {label}")
+        if proc.returncode == 0:
+            rule_specs.append(f"DOCKER-USER -s {container_ip} -j DROP -m comment --comment {label}")
+        else:
+            failures.append(f"DROP returned {proc.returncode}")
     except _SANDBOX_NET_POLICY_NONCRITICAL_EXCEPTIONS as e:
         logger.debug("network policy: iptables DROP rule failed for {}: {}", container_ip, e)
+        failures.append(f"DROP raised {e}")
+    if failures:
+        raise RuntimeError(f"iptables egress rule application failed: {'; '.join(failures)}")
     return rule_specs
 
 

--- a/tldw_Server_API/app/core/Sandbox/network_policy.py
+++ b/tldw_Server_API/app/core/Sandbox/network_policy.py
@@ -8,6 +8,7 @@ from collections.abc import Iterable, Sequence
 from typing import Callable
 
 from loguru import logger
+
 from tldw_Server_API.app.core.testing import is_truthy
 
 _SANDBOX_NET_POLICY_NONCRITICAL_EXCEPTIONS = (

--- a/tldw_Server_API/app/core/Sandbox/orchestrator.py
+++ b/tldw_Server_API/app/core/Sandbox/orchestrator.py
@@ -1194,6 +1194,54 @@ class SandboxOrchestrator:
                 parts.append(comp)
         return "/".join(parts)
 
+    def _resolve_artifact_file(self, art_dir: Path, rel: str) -> Path | None:
+        try:
+            if art_dir.is_symlink():
+                return None
+            root = art_dir.resolve()
+            full = art_dir / rel
+            if full.is_symlink():
+                return None
+            resolved = full.resolve(strict=True)
+            if resolved != root and root not in resolved.parents:
+                return None
+            if not resolved.is_file():
+                return None
+            return resolved
+        except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+            return None
+
+    def _prepare_artifact_write_path(self, art_dir: Path, rel: str) -> Path | None:
+        try:
+            if art_dir.is_symlink():
+                return None
+            root = art_dir.resolve()
+            parts = list(Path(rel).parts)
+            if not parts:
+                return None
+            current = art_dir
+            for part in parts[:-1]:
+                current = current / part
+                if current.is_symlink():
+                    return None
+                if current.exists():
+                    if not current.is_dir():
+                        return None
+                    resolved_current = current.resolve()
+                    if resolved_current != root and root not in resolved_current.parents:
+                        return None
+                    continue
+                current.mkdir(mode=_OWNER_ONLY_DIR_MODE, exist_ok=False)
+            full = current / parts[-1]
+            if full.is_symlink():
+                return None
+            parent_resolved = full.parent.resolve()
+            if parent_resolved != root and root not in parent_resolved.parents:
+                return None
+            return full
+        except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+            return None
+
     def store_artifacts(self, run_id: str, items: dict[str, bytes]) -> None:
         # Enforce caps and persist to filesystem under run's artifacts directory
         owner = None
@@ -1236,10 +1284,15 @@ class SandboxOrchestrator:
         persisted: dict[str, bytes] = {}
         for path, data in selected.items():
             rel = self._safe_rel(path)
-            full = art_dir / rel
             try:
-                full.parent.mkdir(parents=True, exist_ok=True)
-                with open(full, "wb") as f:
+                full = self._prepare_artifact_write_path(art_dir, rel)
+                if full is None:
+                    raise ValueError("artifact_path_rejected")
+                flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+                if hasattr(os, "O_NOFOLLOW"):
+                    flags |= os.O_NOFOLLOW
+                fd = os.open(str(full), flags, 0o600)
+                with os.fdopen(fd, "wb") as f:
                     f.write(data)
             except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS as e:
                 logger.debug(f"Failed to persist artifact {rel}: {e}")
@@ -1265,13 +1318,30 @@ class SandboxOrchestrator:
             owner = None
         art_dir = self._artifact_dir((owner or "unknown"), run_id)
         result: dict[str, int] = {}
-        if art_dir.exists():
-            for root, _dirs, files in os.walk(art_dir):
+        if art_dir.exists() and not art_dir.is_symlink():
+            for root, dirs, files in os.walk(art_dir):
+                root_path = Path(root)
+                safe_dirs: list[str] = []
+                for dirname in dirs:
+                    dir_path = root_path / dirname
+                    try:
+                        if dir_path.is_symlink():
+                            continue
+                        resolved_dir = dir_path.resolve()
+                        resolved_root = art_dir.resolve()
+                        if resolved_dir == resolved_root or resolved_root in resolved_dir.parents:
+                            safe_dirs.append(dirname)
+                    except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+                        continue
+                dirs[:] = safe_dirs
                 for fn in files:
                     full = Path(root) / fn
                     rel = str(full.relative_to(art_dir)).replace(os.sep, "/")
                     try:
-                        result[rel] = full.stat().st_size
+                        safe_file = self._resolve_artifact_file(art_dir, rel)
+                        if safe_file is None:
+                            continue
+                        result[rel] = safe_file.stat().st_size
                     except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
                         result[rel] = 0
             if result:
@@ -1290,9 +1360,9 @@ class SandboxOrchestrator:
         art_dir = self._artifact_dir((owner or "unknown"), run_id)
         if path:
             rel = self._safe_rel(path)
-            full = art_dir / rel
+            full = self._resolve_artifact_file(art_dir, rel)
             try:
-                if full.exists():
+                if full is not None:
                     with open(full, "rb") as f:
                         return f.read()
             except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
@@ -1310,13 +1380,7 @@ class SandboxOrchestrator:
             owner = None
         art_dir = self._artifact_dir((owner or "unknown"), run_id)
         rel = self._safe_rel(path)
-        full = art_dir / rel
-        try:
-            if full.exists() and full.is_file():
-                return full
-        except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
-            return None
-        return None
+        return self._resolve_artifact_file(art_dir, rel)
 
     # -----------------
     # Workspaces

--- a/tldw_Server_API/app/core/Sandbox/orchestrator.py
+++ b/tldw_Server_API/app/core/Sandbox/orchestrator.py
@@ -42,6 +42,7 @@ _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS = (
     UnicodeDecodeError,
     json.JSONDecodeError,
 )
+_ARTIFACT_OPENAT_SUPPORTED = os.open in os.supports_dir_fd and os.mkdir in os.supports_dir_fd
 
 _OWNER_ONLY_DIR_MODE = stat.S_IRWXU
 
@@ -1242,6 +1243,56 @@ class SandboxOrchestrator:
         except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
             return None
 
+    def _open_artifact_file_for_write(self, art_dir: Path, rel: str) -> int | None:
+        parts = list(Path(rel).parts)
+        if not parts or any(part in ("", ".", "..") for part in parts):
+            return None
+        if not _ARTIFACT_OPENAT_SUPPORTED:
+            return self._open_artifact_file_for_write_by_path(art_dir, rel)
+
+        nofollow = getattr(os, "O_NOFOLLOW", 0)
+        directory = getattr(os, "O_DIRECTORY", 0)
+        dir_flags = os.O_RDONLY | directory | nofollow
+        current_fd: int | None = None
+        try:
+            if art_dir.is_symlink():
+                return None
+            art_dir.mkdir(mode=_OWNER_ONLY_DIR_MODE, parents=True, exist_ok=True)
+            current_fd = os.open(str(art_dir), dir_flags)
+            if not stat.S_ISDIR(os.fstat(current_fd).st_mode):
+                return None
+            for part in parts[:-1]:
+                try:
+                    os.mkdir(part, _OWNER_ONLY_DIR_MODE, dir_fd=current_fd)
+                except FileExistsError:
+                    pass
+                next_fd = os.open(part, dir_flags, dir_fd=current_fd)
+                if not stat.S_ISDIR(os.fstat(next_fd).st_mode):
+                    os.close(next_fd)
+                    return None
+                os.close(current_fd)
+                current_fd = next_fd
+            flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | nofollow
+            return os.open(parts[-1], flags, 0o600, dir_fd=current_fd)
+        except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+            return None
+        finally:
+            if current_fd is not None:
+                with contextlib.suppress(_SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS):
+                    os.close(current_fd)
+
+    def _open_artifact_file_for_write_by_path(self, art_dir: Path, rel: str) -> int | None:
+        full = self._prepare_artifact_write_path(art_dir, rel)
+        if full is None:
+            return None
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            return os.open(str(full), flags, 0o600)
+        except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+            return None
+
     def store_artifacts(self, run_id: str, items: dict[str, bytes]) -> None:
         # Enforce caps and persist to filesystem under run's artifacts directory
         owner = None
@@ -1285,13 +1336,9 @@ class SandboxOrchestrator:
         for path, data in selected.items():
             rel = self._safe_rel(path)
             try:
-                full = self._prepare_artifact_write_path(art_dir, rel)
-                if full is None:
+                fd = self._open_artifact_file_for_write(art_dir, rel)
+                if fd is None:
                     raise ValueError("artifact_path_rejected")
-                flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-                if hasattr(os, "O_NOFOLLOW"):
-                    flags |= os.O_NOFOLLOW
-                fd = os.open(str(full), flags, 0o600)
                 with os.fdopen(fd, "wb") as f:
                     f.write(data)
             except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS as e:
@@ -1319,6 +1366,10 @@ class SandboxOrchestrator:
         art_dir = self._artifact_dir((owner or "unknown"), run_id)
         result: dict[str, int] = {}
         if art_dir.exists() and not art_dir.is_symlink():
+            try:
+                resolved_root = art_dir.resolve()
+            except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+                return result
             for root, dirs, files in os.walk(art_dir):
                 root_path = Path(root)
                 safe_dirs: list[str] = []
@@ -1328,7 +1379,6 @@ class SandboxOrchestrator:
                         if dir_path.is_symlink():
                             continue
                         resolved_dir = dir_path.resolve()
-                        resolved_root = art_dir.resolve()
                         if resolved_dir == resolved_root or resolved_root in resolved_dir.parents:
                             safe_dirs.append(dirname)
                     except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:

--- a/tldw_Server_API/app/core/Sandbox/orchestrator.py
+++ b/tldw_Server_API/app/core/Sandbox/orchestrator.py
@@ -1197,7 +1197,7 @@ class SandboxOrchestrator:
 
     def _resolve_artifact_file(self, art_dir: Path, rel: str) -> Path | None:
         try:
-            if art_dir.is_symlink():
+            if self._artifact_path_has_symlink_ancestor(art_dir):
                 return None
             root = art_dir.resolve()
             full = art_dir / rel
@@ -1212,9 +1212,25 @@ class SandboxOrchestrator:
         except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
             return None
 
+    def _artifact_path_has_symlink_ancestor(self, art_dir: Path) -> bool:
+        try:
+            root = self._artifact_root().absolute()
+            candidate = art_dir.absolute()
+            relative = candidate.relative_to(root)
+            current = root
+            if current.is_symlink():
+                return True
+            for part in relative.parts:
+                current = current / part
+                if current.is_symlink():
+                    return True
+            return False
+        except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+            return True
+
     def _prepare_artifact_write_path(self, art_dir: Path, rel: str) -> Path | None:
         try:
-            if art_dir.is_symlink():
+            if self._artifact_path_has_symlink_ancestor(art_dir):
                 return None
             root = art_dir.resolve()
             parts = list(Path(rel).parts)
@@ -1246,6 +1262,8 @@ class SandboxOrchestrator:
     def _open_artifact_file_for_write(self, art_dir: Path, rel: str) -> int | None:
         parts = list(Path(rel).parts)
         if not parts or any(part in ("", ".", "..") for part in parts):
+            return None
+        if self._artifact_path_has_symlink_ancestor(art_dir):
             return None
         if not _ARTIFACT_OPENAT_SUPPORTED:
             return self._open_artifact_file_for_write_by_path(art_dir, rel)
@@ -1365,7 +1383,7 @@ class SandboxOrchestrator:
             owner = None
         art_dir = self._artifact_dir((owner or "unknown"), run_id)
         result: dict[str, int] = {}
-        if art_dir.exists() and not art_dir.is_symlink():
+        if art_dir.exists() and not self._artifact_path_has_symlink_ancestor(art_dir):
             try:
                 resolved_root = art_dir.resolve()
             except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:

--- a/tldw_Server_API/app/core/Sandbox/runners/docker_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/docker_runner.py
@@ -73,15 +73,31 @@ class DockerRunner:
         idx = 0
         while idx < len(cmd):
             token = cmd[idx]
+            if token.startswith("--env="):
+                assignment = token.split("=", 1)[1]
+                redacted.append(f"--env={DockerRunner._redact_env_assignment(assignment)}")
+                idx += 1
+                continue
             redacted.append(token)
             if token in {"-e", "--env"} and idx + 1 < len(cmd):
                 assignment = str(cmd[idx + 1])
-                key = assignment.split("=", 1)[0].strip() or "<env>"
-                redacted.append(f"{key}=<redacted>")
+                redacted.append(DockerRunner._redact_env_assignment(assignment))
                 idx += 2
                 continue
             idx += 1
         return redacted
+
+    @staticmethod
+    def _redact_env_assignment(assignment: str) -> str:
+        if "=" not in assignment:
+            return assignment
+        key = assignment.split("=", 1)[0].strip() or "<env>"
+        return f"{key}=<redacted>"
+
+    @staticmethod
+    def _format_docker_failure(action: str, exc: subprocess.CalledProcessError, cmd: list[str]) -> str:
+        redacted_cmd = " ".join(DockerRunner._redact_docker_command([str(part) for part in cmd]))
+        return f"{action} failed (exit {exc.returncode}; cmd: {redacted_cmd})"
 
     @staticmethod
     def _docker_version() -> str | None:
@@ -618,9 +634,10 @@ class DockerRunner:
             _cleanup_staged_inputs()
             self._cleanup_egress_resources(egress_net_name, egress_label, cleanup_rules=False)
             self._clear_run_tracking(run_id)
+            failure = self._format_docker_failure("docker create", e, cmd)
             if security_opts:
-                raise RuntimeError(f"docker create failed with configured security options: {e}") from e
-            raise RuntimeError(f"docker create failed: {e}") from e
+                raise RuntimeError(f"{failure} with configured security options") from e
+            raise RuntimeError(failure) from e
 
         # Register container for cancellation
         try:
@@ -718,8 +735,8 @@ class DockerRunner:
                 logger.debug(f"egress allowlist: iptables apply failed: {e}")
                 _abort_egress_setup(f"egress allowlist setup failed: {e}", e)
             try:
-                # argv-only Docker control call; cid is returned by docker create.
-                subprocess.check_call(  # nosec
+                # argv-only Docker exec; cid is from docker create, command is constant.
+                subprocess.check_call(  # nosec B603 B607
                     ["docker", "exec", cid, "sh", "-lc", "touch /tmp/tldw-egress-ready"],
                     timeout=3,
                 )

--- a/tldw_Server_API/app/core/Sandbox/runners/docker_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/docker_runner.py
@@ -232,7 +232,15 @@ class DockerRunner:
             return False
 
     def start_run(self, run_id: str, spec: RunSpec, session_workspace: str | None = None) -> RunStatus:
-        logger.debug(f"DockerRunner.start_run called with spec: {spec}")
+        env_keys = sorted(str(key) for key in (spec.env or {}))
+        logger.debug(
+            "DockerRunner.start_run called runtime={} image={!r} command_len={} env_keys={} network_policy={!r}",
+            spec.runtime,
+            spec.base_image,
+            len(spec.command or []),
+            env_keys,
+            spec.network_policy,
+        )
         # Fake mode for tests/CI without Docker
         if self._truthy(os.getenv("TLDW_SANDBOX_DOCKER_FAKE_EXEC")):
             now = datetime.utcnow()
@@ -567,6 +575,8 @@ class DockerRunner:
             cmd += ["-p", f"{host_ip}:{host_port}:{container_port}"]
         if needs_ssh_caps:
             cmd += ["--cap-add", "SYS_CHROOT", "--cap-add", "SETUID", "--cap-add", "SETGID"]
+        if net_policy == "allowlist" and enforced and granular:
+            cmd += ["--entrypoint", ""]
 
         image = spec.base_image or "python:3.11-slim"
         cmd.append(image)

--- a/tldw_Server_API/app/core/Sandbox/runners/docker_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/docker_runner.py
@@ -68,6 +68,22 @@ class DockerRunner:
         return is_truthy(v)
 
     @staticmethod
+    def _redact_docker_command(cmd: list[str]) -> list[str]:
+        redacted: list[str] = []
+        idx = 0
+        while idx < len(cmd):
+            token = cmd[idx]
+            redacted.append(token)
+            if token in {"-e", "--env"} and idx + 1 < len(cmd):
+                assignment = str(cmd[idx + 1])
+                key = assignment.split("=", 1)[0].strip() or "<env>"
+                redacted.append(f"{key}=<redacted>")
+                idx += 2
+                continue
+            idx += 1
+        return redacted
+
+    @staticmethod
     def _docker_version() -> str | None:
         try:
             out = subprocess.check_output(["docker", "version", "--format", "{{.Server.Version}}"], text=True, timeout=2).strip()
@@ -544,17 +560,20 @@ class DockerRunner:
         # Run in shell to ensure environment and path; safely quote user command
         import shlex
         user_cmd = " ".join(shlex.quote(x) for x in list(spec.command))
-        # In granular enforcement mode, add a short delay to allow host iptables to be applied
-        delay_prefix = "sleep 1 && " if (net_policy == "allowlist" and enforced and granular) else ""
+        egress_gate_prefix = (
+            "while [ ! -f /tmp/tldw-egress-ready ]; do sleep 0.05; done && "
+            if (net_policy == "allowlist" and enforced and granular)
+            else ""
+        )
         staged_input_prefix = (
             "cp -R /tldw-staged-workspace/. /workspace/ && "
             if staged_input_dir
             else ""
         )
-        shell_str = f"mkdir -p /workspace && {staged_input_prefix}{delay_prefix}exec {user_cmd}"
+        shell_str = f"mkdir -p /workspace && {staged_input_prefix}{egress_gate_prefix}exec {user_cmd}"
         cmd += ["sh", "-lc", shell_str]
 
-        logger.info(f"Starting docker run: {' '.join(cmd)}")
+        logger.info(f"Starting docker run: {' '.join(self._redact_docker_command(cmd))}")
         started = datetime.utcnow()
         hub = get_hub()
         max_log = None
@@ -596,22 +615,12 @@ class DockerRunner:
                 resource_usage=usage,
             )
         except subprocess.CalledProcessError as e:
-            # If security opts were provided, retry without them for portability (e.g., profile not loaded)
+            _cleanup_staged_inputs()
+            self._cleanup_egress_resources(egress_net_name, egress_label, cleanup_rules=False)
+            self._clear_run_tracking(run_id)
             if security_opts:
-                try:
-                    logger.warning(f"docker create failed with security options; retrying without them: {e}")
-                    cmd_wo_sec = [c for c in cmd if c not in security_opts]
-                    cid = subprocess.check_output(cmd_wo_sec, text=True).strip()
-                except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e2:
-                    _cleanup_staged_inputs()
-                    self._cleanup_egress_resources(egress_net_name, egress_label, cleanup_rules=False)
-                    self._clear_run_tracking(run_id)
-                    raise RuntimeError(f"docker create failed (without security opts): {e2}") from e2
-            else:
-                _cleanup_staged_inputs()
-                self._cleanup_egress_resources(egress_net_name, egress_label, cleanup_rules=False)
-                self._clear_run_tracking(run_id)
-                raise RuntimeError(f"docker create failed: {e}") from e
+                raise RuntimeError(f"docker create failed with configured security options: {e}") from e
+            raise RuntimeError(f"docker create failed: {e}") from e
 
         # Register container for cancellation
         try:
@@ -666,6 +675,16 @@ class DockerRunner:
             self._clear_run_tracking(run_id)
             raise RuntimeError(f"docker start failed: {e}") from e
 
+        def _abort_egress_setup(message: str, exc: BaseException | None = None) -> None:
+            _cleanup_staged_inputs()
+            with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):
+                subprocess.check_call(["docker", "rm", "-f", cid])
+            self._cleanup_tracked_egress_resources(run_id, cleanup_rules=True)
+            self._clear_run_tracking(run_id)
+            if exc is not None:
+                raise RuntimeError(message) from exc
+            raise RuntimeError(message)
+
         # If granular egress allowlist is enabled, inspect container IP and apply host iptables rules
         container_ip: str | None = None
         if net_policy == "allowlist" and enforced and granular:
@@ -682,6 +701,9 @@ class DockerRunner:
                             break
             except _DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS as e:
                 logger.debug(f"egress allowlist: docker inspect for IP failed: {e}")
+                _abort_egress_setup(f"egress allowlist setup failed: docker inspect failed: {e}", e)
+            if not container_ip:
+                _abort_egress_setup("egress allowlist setup failed: no container IP found")
             # Resolve allowlist with wildcard/suffix support and apply atomically
             try:
                 raw = os.getenv("SANDBOX_EGRESS_ALLOWLIST") or getattr(app_settings, "SANDBOX_EGRESS_ALLOWLIST", "")
@@ -689,12 +711,21 @@ class DockerRunner:
                 raw = ""
             allow_targets: list[str] = expand_allowlist_to_targets(raw)
             try:
-                if container_ip:
-                    apply_egress_rules_atomic(container_ip, allow_targets, egress_label)
-                else:
-                    logger.debug("egress allowlist: no container IP found; skipping iptables application")
+                rules = apply_egress_rules_atomic(container_ip, allow_targets, egress_label)
+                if not rules:
+                    _abort_egress_setup("egress allowlist setup failed: no rules were installed")
             except _DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS as e:
                 logger.debug(f"egress allowlist: iptables apply failed: {e}")
+                _abort_egress_setup(f"egress allowlist setup failed: {e}", e)
+            try:
+                # argv-only Docker control call; cid is returned by docker create.
+                subprocess.check_call(  # nosec
+                    ["docker", "exec", cid, "sh", "-lc", "touch /tmp/tldw-egress-ready"],
+                    timeout=3,
+                )
+            except _DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS as e:
+                logger.debug(f"egress allowlist: readiness gate release failed: {e}")
+                _abort_egress_setup(f"egress allowlist setup failed: readiness gate release failed: {e}", e)
 
         # Publish start event
         with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):

--- a/tldw_Server_API/app/core/Sandbox/runners/firecracker_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/firecracker_runner.py
@@ -4,6 +4,7 @@ import contextlib
 import hashlib
 import json
 import os
+import re
 import shutil
 import socket
 import stat
@@ -35,6 +36,7 @@ _FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS = (
 )
 
 _OWNER_EXEC_ONLY_FILE_MODE = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
+_ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def _truthy(v: str | None) -> bool:
@@ -167,8 +169,10 @@ fi
 start_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 start_ms=$(date +%s%3N 2>/dev/null || date +%s)
 # Run command, capture stdout/stderr
+set +e
 /bin/sh -lc "{user_cmd}" > {log_path} 2>&1
 exit_code=$?
+set -e
 end_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 end_ms=$(date +%s%3N 2>/dev/null || date +%s)
 duration_ms=$((end_ms - start_ms))
@@ -184,15 +188,17 @@ exit $exit_code
 
 
 def _write_env_file(workspace: str, env: dict[str, str]) -> None:
+    import shlex
+
     if not env:
         return
     lines = []
     for k, v in env.items():
         key = str(k).strip()
-        if not key:
+        if not _ENV_KEY_RE.fullmatch(key):
             continue
         val = str(v).replace("\n", " ")
-        lines.append(f"{key}={val}")
+        lines.append(f"{key}={shlex.quote(val)}")
     if lines:
         Path(workspace, ".env").write_text("\n".join(lines) + "\n", encoding="utf-8")
 

--- a/tldw_Server_API/app/core/Sandbox/runners/firecracker_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/firecracker_runner.py
@@ -198,7 +198,7 @@ def _write_env_file(workspace: str, env: dict[str, str]) -> None:
         if not _ENV_KEY_RE.fullmatch(key):
             continue
         val = str(v).replace("\n", " ")
-        lines.append(f"{key}={shlex.quote(val)}")
+        lines.append(f"export {key}={shlex.quote(val)}")
     if lines:
         Path(workspace, ".env").write_text("\n".join(lines) + "\n", encoding="utf-8")
 

--- a/tldw_Server_API/app/core/Sandbox/runners/lima_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/lima_runner.py
@@ -4,6 +4,7 @@ import contextlib
 import hashlib
 import json
 import os
+import re
 import shutil
 import stat
 import subprocess
@@ -43,6 +44,7 @@ _LIMA_RUNNER_NONCRITICAL_EXCEPTIONS = (
 )
 
 _OWNER_EXEC_ONLY_FILE_MODE = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
+_ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def _truthy(v: str | None) -> bool:
@@ -618,8 +620,10 @@ fi
 start_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 start_ms=$(date +%s%3N 2>/dev/null || date +%s)
 # Run command, capture stdout/stderr
+set +e
 /bin/sh -lc "{user_cmd}" > {log_path} 2>&1
 exit_code=$?
+set -e
 end_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 end_ms=$(date +%s%3N 2>/dev/null || date +%s)
 duration_ms=$((end_ms - start_ms))
@@ -636,15 +640,17 @@ exit $exit_code
     @staticmethod
     def _write_env_file(workspace: str, env: dict[str, str]) -> None:
         """Write environment variables to a file for sourcing in the VM."""
+        import shlex
+
         if not env:
             return
         lines = []
         for k, v in env.items():
             key = str(k).strip()
-            if not key:
+            if not _ENV_KEY_RE.fullmatch(key):
                 continue
             val = str(v).replace("\n", " ")
-            lines.append(f"export {key}='{val}'")
+            lines.append(f"export {key}={shlex.quote(val)}")
         if lines:
             Path(workspace, ".env").write_text("\n".join(lines) + "\n", encoding="utf-8")
 

--- a/tldw_Server_API/app/core/Sandbox/snapshots.py
+++ b/tldw_Server_API/app/core/Sandbox/snapshots.py
@@ -234,6 +234,12 @@ class SnapshotManager:
             raise ValueError("Invalid workspace path")
 
         workspace_root = Path(workspace_path)
+        if workspace_root.is_symlink():
+            raise ValueError("Refusing symlink workspace root")
+        if workspace_root.exists():
+            if not workspace_root.is_dir():
+                raise ValueError(f"Invalid workspace path: {workspace_path}")
+            self._validate_workspace_tree_for_copy(workspace_root)
         backup_path = workspace_root.parent / f".restore_backup_{uuid.uuid4().hex}"
 
         # Take a backup first so failed restore can roll back atomically.

--- a/tldw_Server_API/app/core/Sandbox/snapshots.py
+++ b/tldw_Server_API/app/core/Sandbox/snapshots.py
@@ -68,6 +68,12 @@ class SnapshotManager:
         """Get the full path for a specific snapshot archive."""
         return self._snapshot_dir(session_id) / f"{snapshot_id}.tar.gz"
 
+    @staticmethod
+    def _has_symlink_ancestor(path: Path) -> bool:
+        """Return True when any existing parent component is a symlink."""
+        absolute = Path(os.path.abspath(path))
+        return any(parent.is_symlink() for parent in reversed(absolute.parents))
+
     def _metadata_path(self, session_id: str, snapshot_id: str) -> Path:
         """Get the path for a snapshot's metadata file."""
         return self._snapshot_dir(session_id) / f"{snapshot_id}.meta.json"
@@ -236,6 +242,8 @@ class SnapshotManager:
         workspace_root = Path(workspace_path)
         if workspace_root.is_symlink():
             raise ValueError("Refusing symlink workspace root")
+        if self._has_symlink_ancestor(workspace_root):
+            raise ValueError("Refusing symlink workspace ancestor")
         if workspace_root.exists():
             if not workspace_root.is_dir():
                 raise ValueError(f"Invalid workspace path: {workspace_path}")

--- a/tldw_Server_API/tests/sandbox/test_cross_runtime_cleanup_contracts.py
+++ b/tldw_Server_API/tests/sandbox/test_cross_runtime_cleanup_contracts.py
@@ -127,6 +127,16 @@ def test_firecracker_entry_script_exports_env_to_user_command(tmp_path: Path) ->
     assert "SAFE_VALUE=visible-in-child" in (tmp_path / "run.log").read_text(encoding="utf-8")
 
 
+def test_lima_entry_script_exports_env_to_user_command(tmp_path: Path) -> None:
+    LimaRunner._write_env_file(str(tmp_path), {"SAFE_VALUE": "visible-in-child"})
+    LimaRunner._write_entry_script(str(tmp_path), ["/usr/bin/env"])
+
+    result = _run_entry_script_with_local_workspace(tmp_path)
+
+    assert result.returncode == 0
+    assert "SAFE_VALUE=visible-in-child" in (tmp_path / "run.log").read_text(encoding="utf-8")
+
+
 def test_lima_real_run_cleans_run_dir_when_setup_fails_after_workspace_create(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tldw_Server_API/tests/sandbox/test_cross_runtime_cleanup_contracts.py
+++ b/tldw_Server_API/tests/sandbox/test_cross_runtime_cleanup_contracts.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -20,6 +22,99 @@ def _spec(runtime: RuntimeType, *, network_policy: str | None = "deny_all") -> R
         network_policy=network_policy,
         timeout_sec=5,
     )
+
+
+def _run_entry_script_with_local_workspace(workspace: Path) -> subprocess.CompletedProcess[str]:
+    entry = workspace / "entry.sh"
+    local_entry = workspace / "entry.local.sh"
+    script = entry.read_text(encoding="utf-8").replace("/workspace", str(workspace))
+    script = script.replace("date +%s%3N 2>/dev/null || date +%s", "date +%s")
+    local_entry.write_text(script, encoding="utf-8")
+    local_entry.chmod(0o700)
+    return subprocess.run(
+        ["/bin/sh", str(local_entry)],
+        cwd=str(workspace),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _source_env_file(workspace: Path) -> str:
+    probe = workspace / "source-env.sh"
+    probe.write_text(
+        "#!/bin/sh\n"
+        "set -e\n"
+        ". ./.env\n"
+        "printf '%s' \"$SAFE_VALUE\" > sourced-value.txt\n",
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        ["/bin/sh", str(probe)],
+        cwd=str(workspace),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"env file failed to source: stdout={result.stdout!r} stderr={result.stderr!r}")
+    return (workspace / "sourced-value.txt").read_text(encoding="utf-8")
+
+
+def test_lima_entry_script_writes_status_for_nonzero_user_command(tmp_path: Path) -> None:
+    LimaRunner._write_entry_script(str(tmp_path), ["false"])
+
+    result = _run_entry_script_with_local_workspace(tmp_path)
+
+    assert result.returncode == 1
+    status = json.loads((tmp_path / ".sandbox_status.json").read_text(encoding="utf-8"))
+    assert status["exit_code"] == 1
+    assert status["reason"] == "exit"
+
+
+def test_firecracker_entry_script_writes_status_for_nonzero_user_command(tmp_path: Path) -> None:
+    firecracker_module._write_entry_script(str(tmp_path), ["false"])
+
+    result = _run_entry_script_with_local_workspace(tmp_path)
+
+    assert result.returncode == 1
+    status = json.loads((tmp_path / ".sandbox_status.json").read_text(encoding="utf-8"))
+    assert status["exit_code"] == 1
+    assert status["reason"] == "exit"
+
+
+def test_lima_env_file_quotes_values_and_rejects_invalid_keys(tmp_path: Path) -> None:
+    marker = tmp_path / "env-injection-created"
+    raw_value = f"ok'; touch {marker}; echo '"
+    LimaRunner._write_env_file(
+        str(tmp_path),
+        {
+            "SAFE_VALUE": raw_value,
+            "BAD-NAME": "bad",
+        },
+    )
+
+    env_text = (tmp_path / ".env").read_text(encoding="utf-8")
+    assert "BAD-NAME" not in env_text
+    assert _source_env_file(tmp_path) == raw_value
+    assert not marker.exists()
+
+
+def test_firecracker_env_file_quotes_values_and_rejects_invalid_keys(tmp_path: Path) -> None:
+    marker = tmp_path / "env-injection-created"
+    raw_value = f"ok'; touch {marker}; echo '"
+    firecracker_module._write_env_file(
+        str(tmp_path),
+        {
+            "SAFE_VALUE": raw_value,
+            "BAD-NAME": "bad",
+        },
+    )
+
+    env_text = (tmp_path / ".env").read_text(encoding="utf-8")
+    assert "BAD-NAME" not in env_text
+    assert _source_env_file(tmp_path) == raw_value
+    assert not marker.exists()
 
 
 def test_lima_real_run_cleans_run_dir_when_setup_fails_after_workspace_create(

--- a/tldw_Server_API/tests/sandbox/test_cross_runtime_cleanup_contracts.py
+++ b/tldw_Server_API/tests/sandbox/test_cross_runtime_cleanup_contracts.py
@@ -117,6 +117,16 @@ def test_firecracker_env_file_quotes_values_and_rejects_invalid_keys(tmp_path: P
     assert not marker.exists()
 
 
+def test_firecracker_entry_script_exports_env_to_user_command(tmp_path: Path) -> None:
+    firecracker_module._write_env_file(str(tmp_path), {"SAFE_VALUE": "visible-in-child"})
+    firecracker_module._write_entry_script(str(tmp_path), ["/usr/bin/env"])
+
+    result = _run_entry_script_with_local_workspace(tmp_path)
+
+    assert result.returncode == 0
+    assert "SAFE_VALUE=visible-in-child" in (tmp_path / "run.log").read_text(encoding="utf-8")
+
+
 def test_lima_real_run_cleans_run_dir_when_setup_fails_after_workspace_create(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tldw_Server_API/tests/sandbox/test_docker_egress_enforcement.py
+++ b/tldw_Server_API/tests/sandbox/test_docker_egress_enforcement.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import json
 import os
 import shutil
+import subprocess
+from types import SimpleNamespace
 from typing import Any, Dict, List
 
 import pytest
 
+import tldw_Server_API.app.core.Sandbox.network_policy as network_policy_module
+import tldw_Server_API.app.core.Sandbox.runners.docker_runner as docker_module
 from tldw_Server_API.app.core.Sandbox.runners.docker_runner import DockerRunner
 from tldw_Server_API.app.core.Sandbox.models import RunSpec, RuntimeType
 
@@ -94,6 +99,93 @@ def test_docker_runner_creates_dedicated_network_when_granular_enabled(monkeypat
     idx = create.index("--network")
     net_name = create[idx + 1]
     assert net_name.startswith("tldw_sbx_")
+
+
+@pytest.mark.unit
+def test_apply_egress_rules_atomic_raises_when_fallback_rules_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def _failing_run(args: list[str], **kwargs: object) -> SimpleNamespace:
+        del kwargs
+        calls.append(list(args))
+        return SimpleNamespace(returncode=1)
+
+    monkeypatch.setattr(network_policy_module.subprocess, "run", _failing_run)
+
+    with pytest.raises(RuntimeError, match="iptables"):
+        network_policy_module.apply_egress_rules_atomic(
+            "172.18.0.2",
+            ["1.1.1.1/32"],
+            "tldw-run-egress-fail",
+        )
+
+    assert any(call[:1] == ["iptables-restore"] for call in calls)
+    assert any(call[:1] == ["iptables"] and "-j" in call and "DROP" in call for call in calls)
+
+
+@pytest.mark.unit
+def test_docker_runner_fails_closed_when_granular_egress_rules_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TLDW_SANDBOX_DOCKER_AVAILABLE", "1")
+    monkeypatch.delenv("TLDW_SANDBOX_DOCKER_FAKE_EXEC", raising=False)
+    monkeypatch.setenv("SANDBOX_EGRESS_ENFORCEMENT", "true")
+    monkeypatch.setenv("SANDBOX_EGRESS_GRANULAR_ENFORCEMENT", "true")
+    monkeypatch.setenv("SANDBOX_EGRESS_ALLOWLIST", "1.1.1.1")
+    check_calls: list[list[str]] = []
+    net_name = "tldw_sbx_runegressfai"
+
+    def _fake_run(args: list[str], **kwargs: object) -> SimpleNamespace:
+        del kwargs
+        check_calls.append(list(args))
+        return SimpleNamespace(returncode=0)
+
+    def _fake_check_output(cmd, text: bool = False, timeout: int | None = None) -> str:
+        del text, timeout
+        cmd_list = list(cmd)
+        if cmd_list[:3] == ["docker", "version", "--format"]:
+            return "24.0.0"
+        if cmd_list[:2] == ["docker", "create"]:
+            return "cid-egress-fail\n"
+        if cmd_list[:2] == ["docker", "inspect"]:
+            return json.dumps({net_name: {"IPAddress": "172.18.0.2"}})
+        raise AssertionError(f"Unexpected check_output call: {cmd_list!r}")
+
+    def _fake_check_call(cmd, timeout: int | None = None) -> int:
+        del timeout
+        cmd_list = list(cmd)
+        check_calls.append(cmd_list)
+        if cmd_list[:2] == ["docker", "start"]:
+            return 0
+        if cmd_list[:3] == ["docker", "rm", "-f"]:
+            return 0
+        raise AssertionError(f"Unexpected check_call call: {cmd_list!r}")
+
+    def _fail_apply(container_ip: str, allow_targets: list[str], label: str) -> list[str]:
+        del container_ip, allow_targets, label
+        raise RuntimeError("iptables unavailable")
+
+    class _LogsReached(Exception):
+        pass
+
+    monkeypatch.setattr(docker_module.subprocess, "run", _fake_run)
+    monkeypatch.setattr(docker_module.subprocess, "check_output", _fake_check_output)
+    monkeypatch.setattr(docker_module.subprocess, "check_call", _fake_check_call)
+    monkeypatch.setattr(docker_module.subprocess, "Popen", lambda *args, **kwargs: (_ for _ in ()).throw(_LogsReached()))
+    monkeypatch.setattr(docker_module, "apply_egress_rules_atomic", _fail_apply)
+    monkeypatch.setattr(DockerRunner, "_docker_version", staticmethod(lambda: "24.0.0"))
+
+    spec = RunSpec(
+        session_id=None,
+        runtime=RuntimeType.docker,
+        base_image="python:3.11-slim",
+        command=["python", "-c", "print('ok')"],
+        timeout_sec=5,
+        network_policy="allowlist",
+    )
+
+    with pytest.raises(RuntimeError, match="egress allowlist"):
+        DockerRunner().start_run(run_id="runegressfail", spec=spec)
+
+    assert ["docker", "rm", "-f", "cid-egress-fail"] in check_calls
 
 
 @pytest.mark.integration

--- a/tldw_Server_API/tests/sandbox/test_docker_egress_enforcement.py
+++ b/tldw_Server_API/tests/sandbox/test_docker_egress_enforcement.py
@@ -17,7 +17,9 @@ from tldw_Server_API.app.core.Sandbox.models import RunSpec, RuntimeType
 
 @pytest.mark.unit
 @pytest.mark.sandbox_real_docker
-def test_docker_runner_uses_network_none_when_allowlist_enforced_non_granular(monkeypatch):
+def test_docker_runner_uses_network_none_when_allowlist_enforced_non_granular(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
      # Make docker appear available and ensure execution path is taken
     monkeypatch.setenv("TLDW_SANDBOX_DOCKER_AVAILABLE", "1")
     # Build a spec with allowlist policy
@@ -61,7 +63,7 @@ def test_docker_runner_uses_network_none_when_allowlist_enforced_non_granular(mo
 
 @pytest.mark.unit
 @pytest.mark.sandbox_real_docker
-def test_docker_runner_creates_dedicated_network_when_granular_enabled(monkeypatch):
+def test_docker_runner_creates_dedicated_network_when_granular_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("TLDW_SANDBOX_DOCKER_AVAILABLE", "1")
     spec = RunSpec(
         session_id=None,
@@ -189,7 +191,7 @@ def test_docker_runner_fails_closed_when_granular_egress_rules_fail(monkeypatch:
 
 
 @pytest.mark.integration
-def test_apply_iptables_rules_on_supported_hosts(monkeypatch):
+def test_apply_iptables_rules_on_supported_hosts(monkeypatch: pytest.MonkeyPatch) -> None:
      # Only run when explicitly allowed
     if os.getenv("SANDBOX_TEST_ALLOW_IPTABLES_MUTATION") not in {"1", "true", "on", "yes"}:
         pytest.skip("iptables mutation not enabled")

--- a/tldw_Server_API/tests/sandbox/test_docker_egress_enforcement.py
+++ b/tldw_Server_API/tests/sandbox/test_docker_egress_enforcement.py
@@ -101,6 +101,9 @@ def test_docker_runner_creates_dedicated_network_when_granular_enabled(monkeypat
     idx = create.index("--network")
     net_name = create[idx + 1]
     assert net_name.startswith("tldw_sbx_")
+    assert "--entrypoint" in create
+    entrypoint_idx = create.index("--entrypoint")
+    assert create[entrypoint_idx + 1] == ""
 
 
 @pytest.mark.unit
@@ -123,6 +126,36 @@ def test_apply_egress_rules_atomic_raises_when_fallback_rules_fail(monkeypatch: 
 
     assert any(call[:1] == ["iptables-restore"] for call in calls)
     assert any(call[:1] == ["iptables"] and "-j" in call and "DROP" in call for call in calls)
+
+
+@pytest.mark.unit
+def test_apply_egress_rules_atomic_cleans_partial_fallback_rules(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+    cleaned_labels: list[str] = []
+
+    def _partially_failing_run(args: list[str], **kwargs: object) -> SimpleNamespace:
+        del kwargs
+        calls.append(list(args))
+        if args[:1] == ["iptables-restore"]:
+            return SimpleNamespace(returncode=1)
+        if "-j" in args and args[args.index("-j") + 1] == "ACCEPT":
+            return SimpleNamespace(returncode=0)
+        if "-j" in args and args[args.index("-j") + 1] == "DROP":
+            return SimpleNamespace(returncode=1)
+        raise AssertionError(f"unexpected iptables call: {args!r}")
+
+    monkeypatch.setattr(network_policy_module.subprocess, "run", _partially_failing_run)
+    monkeypatch.setattr(network_policy_module, "delete_rules_by_label", lambda label: cleaned_labels.append(label))
+
+    with pytest.raises(RuntimeError, match="iptables"):
+        network_policy_module.apply_egress_rules_atomic(
+            "172.18.0.2",
+            ["1.1.1.1/32"],
+            "tldw-run-partial",
+        )
+
+    assert cleaned_labels == ["tldw-run-partial"]
+    assert any(call[:1] == ["iptables"] and "-j" in call and "ACCEPT" in call for call in calls)
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/sandbox/test_docker_runner_hardening_defaults.py
+++ b/tldw_Server_API/tests/sandbox/test_docker_runner_hardening_defaults.py
@@ -37,7 +37,7 @@ class _FakeLogger:
         self.debug_messages.append(message)
 
 
-def _capture_docker_create_command(monkeypatch, spec: RunSpec) -> list[str]:
+def _capture_docker_create_command(monkeypatch: pytest.MonkeyPatch, spec: RunSpec) -> list[str]:
     """Return the docker create command without starting a real container."""
     monkeypatch.setenv("TLDW_SANDBOX_DOCKER_AVAILABLE", "1")
     monkeypatch.delenv("TLDW_SANDBOX_DOCKER_FAKE_EXEC", raising=False)
@@ -63,7 +63,9 @@ def _capture_docker_create_command(monkeypatch, spec: RunSpec) -> list[str]:
 
 
 @pytest.mark.unit
-def test_docker_runner_fails_closed_when_configured_security_opt_is_rejected(monkeypatch) -> None:
+def test_docker_runner_fails_closed_when_configured_security_opt_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Configured seccomp/AppArmor hardening should not be silently removed."""
     monkeypatch.setenv("TLDW_SANDBOX_DOCKER_AVAILABLE", "1")
     monkeypatch.delenv("TLDW_SANDBOX_DOCKER_FAKE_EXEC", raising=False)
@@ -102,7 +104,7 @@ def test_docker_runner_fails_closed_when_configured_security_opt_is_rejected(mon
 
 
 @pytest.mark.unit
-def test_docker_runner_redacts_env_values_from_logged_create_command(monkeypatch) -> None:
+def test_docker_runner_redacts_env_values_from_logged_create_command(monkeypatch: pytest.MonkeyPatch) -> None:
     """Docker command logging should not expose user-provided environment values."""
     fake_logger = _FakeLogger()
     monkeypatch.setattr(docker_module, "logger", fake_logger)
@@ -123,6 +125,63 @@ def test_docker_runner_redacts_env_values_from_logged_create_command(monkeypatch
     logged = "\n".join(fake_logger.info_messages)
     assert "secret-token-value" not in logged
     assert "API_TOKEN=<redacted>" in logged
+
+
+@pytest.mark.unit
+def test_docker_runner_redacts_env_values_from_create_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Docker create failures should not leak env values through exception strings."""
+    monkeypatch.setenv("TLDW_SANDBOX_DOCKER_AVAILABLE", "1")
+    monkeypatch.delenv("TLDW_SANDBOX_DOCKER_FAKE_EXEC", raising=False)
+    create_attempts: list[list[str]] = []
+
+    def _fake_check_output(cmd, text: bool = False, timeout: int | None = None) -> str:
+        del text, timeout
+        cmd_list = list(cmd)
+        if cmd_list[:3] == ["docker", "version", "--format"]:
+            return "24.0.0"
+        if cmd_list[:2] == ["docker", "create"]:
+            create_attempts.append(cmd_list)
+            raise subprocess.CalledProcessError(125, cmd_list)
+        raise AssertionError(f"Unexpected check_output call: {cmd_list!r}")
+
+    monkeypatch.setattr("subprocess.check_output", _fake_check_output)
+    spec = RunSpec(
+        session_id=None,
+        runtime=RuntimeType.docker,
+        base_image="python:3.11-slim",
+        command=["python", "-c", "print('ok')"],
+        timeout_sec=5,
+        network_policy="deny_all",
+        run_as_root=False,
+        read_only_root=True,
+        env={"API_TOKEN": "secret-token-value"},
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        DockerRunner().start_run(run_id="rid-create-failure-redaction", spec=spec)
+
+    message = str(exc_info.value)
+    assert create_attempts
+    assert "secret-token-value" not in message
+    assert "API_TOKEN=<redacted>" in message
+
+
+@pytest.mark.unit
+def test_redact_docker_command_preserves_env_flag_without_assignment() -> None:
+    """Docker --env can name a host env var without an inline value."""
+    redacted = DockerRunner._redact_docker_command(
+        ["docker", "create", "-e", "PYTEST_ADDOPTS", "--env", "API_TOKEN=secret", "image"]
+    )
+
+    assert redacted == [
+        "docker",
+        "create",
+        "-e",
+        "PYTEST_ADDOPTS",
+        "--env",
+        "API_TOKEN=<redacted>",
+        "image",
+    ]
 
 
 def _staged_mount_source(create_cmd: list[str]) -> str:
@@ -165,7 +224,7 @@ def _capture_staged_input_dir(monkeypatch, spec: RunSpec, session_workspace: str
 
 
 @pytest.mark.unit
-def test_docker_runner_defaults_to_non_root_uid_gid_and_read_only_rootfs(monkeypatch) -> None:
+def test_docker_runner_defaults_to_non_root_uid_gid_and_read_only_rootfs(monkeypatch: pytest.MonkeyPatch) -> None:
     """Default hardened Docker runs should use non-root uid/gid and read-only rootfs."""
     monkeypatch.delenv("SANDBOX_DOCKER_DEFAULT_UID", raising=False)
     monkeypatch.delenv("SANDBOX_DOCKER_DEFAULT_GID", raising=False)
@@ -190,7 +249,7 @@ def test_docker_runner_defaults_to_non_root_uid_gid_and_read_only_rootfs(monkeyp
 
 
 @pytest.mark.unit
-def test_docker_runner_bind_mounts_staged_workspace_for_inline_files(monkeypatch) -> None:
+def test_docker_runner_bind_mounts_staged_workspace_for_inline_files(monkeypatch: pytest.MonkeyPatch) -> None:
     """Inline files should be staged via read-only mount while /workspace stays tmpfs."""
     monkeypatch.delenv("SANDBOX_DOCKER_BIND_WORKSPACE", raising=False)
     spec = RunSpec(
@@ -262,7 +321,7 @@ def test_docker_runner_skips_symlinked_session_workspace_inputs(monkeypatch, tmp
 
 
 @pytest.mark.unit
-def test_docker_runner_normalizes_staged_input_modes(monkeypatch) -> None:
+def test_docker_runner_normalizes_staged_input_modes(monkeypatch: pytest.MonkeyPatch) -> None:
     """Inline staged files and parent directories should stay readable under restrictive umask."""
     spec = RunSpec(
         session_id=None,
@@ -294,7 +353,7 @@ def test_docker_runner_normalizes_staged_input_modes(monkeypatch) -> None:
 
 
 @pytest.mark.unit
-def test_docker_runner_uses_configured_non_root_uid_gid(monkeypatch) -> None:
+def test_docker_runner_uses_configured_non_root_uid_gid(monkeypatch: pytest.MonkeyPatch) -> None:
     """Configured Docker uid/gid should override hardened non-root defaults."""
     monkeypatch.setenv("SANDBOX_DOCKER_DEFAULT_UID", "2001")
     monkeypatch.setenv("SANDBOX_DOCKER_DEFAULT_GID", "3002")
@@ -317,7 +376,7 @@ def test_docker_runner_uses_configured_non_root_uid_gid(monkeypatch) -> None:
 
 
 @pytest.mark.unit
-def test_docker_runner_adds_ssh_caps_for_acp_internal_ssh_port(monkeypatch) -> None:
+def test_docker_runner_adds_ssh_caps_for_acp_internal_ssh_port(monkeypatch: pytest.MonkeyPatch) -> None:
     """ACP internal SSH mappings should receive the minimal OpenSSH capability set."""
     spec = RunSpec(
         session_id=None,

--- a/tldw_Server_API/tests/sandbox/test_docker_runner_hardening_defaults.py
+++ b/tldw_Server_API/tests/sandbox/test_docker_runner_hardening_defaults.py
@@ -128,6 +128,29 @@ def test_docker_runner_redacts_env_values_from_logged_create_command(monkeypatch
 
 
 @pytest.mark.unit
+def test_docker_runner_redacts_env_values_from_start_debug_log(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The early RunSpec debug log should not print env values."""
+    fake_logger = _FakeLogger()
+    monkeypatch.setattr(docker_module, "logger", fake_logger)
+    spec = RunSpec(
+        session_id=None,
+        runtime=RuntimeType.docker,
+        base_image="python:3.11-slim",
+        command=["python", "-c", "print('ok')"],
+        timeout_sec=5,
+        network_policy="deny_all",
+        run_as_root=False,
+        read_only_root=True,
+        env={"API_TOKEN": "secret-token-value"},
+    )
+
+    _capture_docker_create_command(monkeypatch, spec)
+
+    logged = "\n".join(fake_logger.debug_messages)
+    assert "secret-token-value" not in logged
+
+
+@pytest.mark.unit
 def test_docker_runner_redacts_env_values_from_create_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     """Docker create failures should not leak env values through exception strings."""
     monkeypatch.setenv("TLDW_SANDBOX_DOCKER_AVAILABLE", "1")

--- a/tldw_Server_API/tests/sandbox/test_docker_runner_hardening_defaults.py
+++ b/tldw_Server_API/tests/sandbox/test_docker_runner_hardening_defaults.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import os
 import stat
+import subprocess
 from pathlib import Path
 
 import pytest
 
+import tldw_Server_API.app.core.Sandbox.runners.docker_runner as docker_module
 from tldw_Server_API.app.core.Sandbox.models import RunSpec, RuntimeType
 from tldw_Server_API.app.core.Sandbox.runners.docker_runner import DockerRunner
 
@@ -14,6 +16,25 @@ class _StopAfterCreate(Exception):
     """Sentinel used to stop DockerRunner after docker create is assembled."""
 
     pass
+
+
+class _FakeLogger:
+    def __init__(self) -> None:
+        self.info_messages: list[str] = []
+        self.warning_messages: list[str] = []
+        self.debug_messages: list[str] = []
+
+    def info(self, message: str, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+        self.info_messages.append(message)
+
+    def warning(self, message: str, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+        self.warning_messages.append(message)
+
+    def debug(self, message: str, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+        self.debug_messages.append(message)
 
 
 def _capture_docker_create_command(monkeypatch, spec: RunSpec) -> list[str]:
@@ -39,6 +60,69 @@ def _capture_docker_create_command(monkeypatch, spec: RunSpec) -> list[str]:
     if not create_cmd:
         pytest.fail(f"docker create command not captured: {recorded_cmds!r}")
     return create_cmd
+
+
+@pytest.mark.unit
+def test_docker_runner_fails_closed_when_configured_security_opt_is_rejected(monkeypatch) -> None:
+    """Configured seccomp/AppArmor hardening should not be silently removed."""
+    monkeypatch.setenv("TLDW_SANDBOX_DOCKER_AVAILABLE", "1")
+    monkeypatch.delenv("TLDW_SANDBOX_DOCKER_FAKE_EXEC", raising=False)
+    monkeypatch.setenv("SANDBOX_DOCKER_SECCOMP", "/tmp/tldw-test-seccomp.json")
+    create_attempts: list[list[str]] = []
+
+    def _fake_check_output(cmd, text: bool = False, timeout: int | None = None) -> str:
+        del text, timeout
+        cmd_list = list(cmd)
+        if cmd_list[:3] == ["docker", "version", "--format"]:
+            return "24.0.0"
+        if cmd_list[:2] == ["docker", "create"]:
+            create_attempts.append(cmd_list)
+            if len(create_attempts) == 1:
+                raise subprocess.CalledProcessError(125, cmd_list)
+            raise AssertionError("docker create retried without required security options")
+        raise AssertionError(f"Unexpected check_output call: {cmd_list!r}")
+
+    monkeypatch.setattr("subprocess.check_output", _fake_check_output)
+    spec = RunSpec(
+        session_id=None,
+        runtime=RuntimeType.docker,
+        base_image="python:3.11-slim",
+        command=["python", "-c", "print('ok')"],
+        timeout_sec=5,
+        network_policy="deny_all",
+        run_as_root=False,
+        read_only_root=True,
+    )
+
+    with pytest.raises(RuntimeError, match="docker create failed"):
+        DockerRunner().start_run(run_id="rid-seccomp-fail", spec=spec)
+
+    assert len(create_attempts) == 1
+    assert "seccomp=/tmp/tldw-test-seccomp.json" in create_attempts[0]
+
+
+@pytest.mark.unit
+def test_docker_runner_redacts_env_values_from_logged_create_command(monkeypatch) -> None:
+    """Docker command logging should not expose user-provided environment values."""
+    fake_logger = _FakeLogger()
+    monkeypatch.setattr(docker_module, "logger", fake_logger)
+    spec = RunSpec(
+        session_id=None,
+        runtime=RuntimeType.docker,
+        base_image="python:3.11-slim",
+        command=["python", "-c", "print('ok')"],
+        timeout_sec=5,
+        network_policy="deny_all",
+        run_as_root=False,
+        read_only_root=True,
+        env={"API_TOKEN": "secret-token-value"},
+    )
+
+    _capture_docker_create_command(monkeypatch, spec)
+
+    logged = "\n".join(fake_logger.info_messages)
+    assert "secret-token-value" not in logged
+    assert "API_TOKEN=<redacted>" in logged
 
 
 def _staged_mount_source(create_cmd: list[str]) -> str:

--- a/tldw_Server_API/tests/sandbox/test_orchestrator_artifact_security.py
+++ b/tldw_Server_API/tests/sandbox/test_orchestrator_artifact_security.py
@@ -84,6 +84,28 @@ def test_store_artifacts_rejects_symlink_artifact_root(monkeypatch: pytest.Monke
 
 
 @pytest.mark.unit
+def test_store_artifacts_rejects_symlink_run_ancestor(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A symlinked run ancestor must not become the trusted artifact root."""
+    orch = _orchestrator_with_artifact_root(monkeypatch, tmp_path)
+    run_id = "run-artifact-ancestor-link"
+    art_dir = orch._artifact_dir("artifact-user", run_id)
+    art_dir.parent.parent.mkdir(parents=True, exist_ok=True)
+    outside_run = tmp_path / "outside-run-ancestor"
+    outside_run.mkdir()
+    symlink_run = art_dir.parent
+    try:
+        os.symlink(str(outside_run), str(symlink_run))
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    orch.store_artifacts(run_id, {"leaked.txt": b"secret"})
+
+    assert not (outside_run / "artifacts" / "leaked.txt").exists()
+    assert orch.get_artifact(run_id, "leaked.txt") is None
+    assert orch.get_artifact_path(run_id, "leaked.txt") is None
+
+
+@pytest.mark.unit
 def test_get_artifact_path_rejects_symlink_file_escape(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Artifact reads and path resolution must reject symlinked files."""
     orch = _orchestrator_with_artifact_root(monkeypatch, tmp_path)

--- a/tldw_Server_API/tests/sandbox/test_orchestrator_artifact_security.py
+++ b/tldw_Server_API/tests/sandbox/test_orchestrator_artifact_security.py
@@ -1,32 +1,42 @@
+"""Regression tests for Sandbox artifact path confinement."""
+
 from __future__ import annotations
 
+import contextlib
 import os
 from pathlib import Path
 
 import pytest
 
+import tldw_Server_API.app.core.Sandbox.orchestrator as orchestrator_module
 from tldw_Server_API.app.core.Sandbox.orchestrator import SandboxOrchestrator
 
 
 class _FakeArtifactStore:
+    """Minimal artifact accounting store for orchestrator artifact tests."""
+
     def __init__(self, owner: str = "artifact-user") -> None:
         self.owner = owner
         self.adjustments: list[int] = []
 
     def get_run_owner(self, run_id: str) -> str:
+        """Return the configured fake owner for any run."""
         del run_id
         return self.owner
 
     def try_reserve_user_artifact_bytes(self, owner: str, size: int, cap_user: int) -> bool:
+        """Accept every artifact reservation in tests."""
         del owner, size, cap_user
         return True
 
     def increment_user_artifact_bytes(self, owner: str, delta: int) -> None:
+        """Record artifact-byte adjustments made during rollback."""
         del owner
         self.adjustments.append(delta)
 
 
 def _orchestrator_with_artifact_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> SandboxOrchestrator:
+    """Return an orchestrator using a temp artifact root and fake store."""
     monkeypatch.setenv("SANDBOX_SHARED_ARTIFACTS_DIR", str(tmp_path / "artifact-root"))
     orch = SandboxOrchestrator()
     orch._store = _FakeArtifactStore()  # type: ignore[assignment]
@@ -35,6 +45,7 @@ def _orchestrator_with_artifact_root(monkeypatch: pytest.MonkeyPatch, tmp_path: 
 
 @pytest.mark.unit
 def test_store_artifacts_rejects_symlink_parent_escape(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Writing through a symlinked artifact parent must not reach outside storage."""
     orch = _orchestrator_with_artifact_root(monkeypatch, tmp_path)
     run_id = "run-artifact-link-parent"
     art_dir = orch._artifact_dir("artifact-user", run_id)
@@ -54,6 +65,7 @@ def test_store_artifacts_rejects_symlink_parent_escape(monkeypatch: pytest.Monke
 
 @pytest.mark.unit
 def test_store_artifacts_rejects_symlink_artifact_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A symlinked artifact root must be rejected before any artifact write."""
     orch = _orchestrator_with_artifact_root(monkeypatch, tmp_path)
     run_id = "run-artifact-root-link"
     art_dir = orch._artifact_dir("artifact-user", run_id)
@@ -73,6 +85,7 @@ def test_store_artifacts_rejects_symlink_artifact_root(monkeypatch: pytest.Monke
 
 @pytest.mark.unit
 def test_get_artifact_path_rejects_symlink_file_escape(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Artifact reads and path resolution must reject symlinked files."""
     orch = _orchestrator_with_artifact_root(monkeypatch, tmp_path)
     run_id = "run-artifact-link-file"
     art_dir = orch._artifact_dir("artifact-user", run_id)
@@ -86,3 +99,54 @@ def test_get_artifact_path_rejects_symlink_file_escape(monkeypatch: pytest.Monke
 
     assert orch.get_artifact(run_id, "leak.txt") is None
     assert orch.get_artifact_path(run_id, "leak.txt") is None
+
+
+@pytest.mark.unit
+def test_store_artifacts_resists_parent_swap_during_open(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Replacing a checked parent with a symlink during open must not escape."""
+    orch = _orchestrator_with_artifact_root(monkeypatch, tmp_path)
+    run_id = "run-artifact-parent-race"
+    art_dir = orch._artifact_dir("artifact-user", run_id)
+    race_dir = art_dir / "race"
+    race_dir.mkdir(parents=True, exist_ok=True)
+    outside = tmp_path / "outside-race-target"
+    outside.mkdir()
+    original_open = orchestrator_module.os.open
+    swapped = False
+
+    probe = tmp_path / "symlink-probe"
+    try:
+        os.symlink(str(outside), str(probe))
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+    finally:
+        with contextlib.suppress(OSError):
+            probe.unlink()
+
+    def _racing_open(path: str | bytes | os.PathLike[str], flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
+        nonlocal swapped
+        path_text = os.fspath(path)
+        should_swap = (
+            not swapped
+            and (
+                path_text.endswith(f"{os.sep}race{os.sep}leaked.txt")
+                or (path_text == "leaked.txt" and dir_fd is not None)
+            )
+        )
+        if should_swap:
+            race_dir.rmdir()
+            os.symlink(str(outside), str(race_dir))
+            swapped = True
+        if dir_fd is None:
+            return original_open(path, flags, mode)
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(orchestrator_module.os, "open", _racing_open)
+
+    orch.store_artifacts(run_id, {"race/leaked.txt": b"secret"})
+
+    assert swapped
+    assert not (outside / "leaked.txt").exists()

--- a/tldw_Server_API/tests/sandbox/test_orchestrator_artifact_security.py
+++ b/tldw_Server_API/tests/sandbox/test_orchestrator_artifact_security.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.Sandbox.orchestrator import SandboxOrchestrator
+
+
+class _FakeArtifactStore:
+    def __init__(self, owner: str = "artifact-user") -> None:
+        self.owner = owner
+        self.adjustments: list[int] = []
+
+    def get_run_owner(self, run_id: str) -> str:
+        del run_id
+        return self.owner
+
+    def try_reserve_user_artifact_bytes(self, owner: str, size: int, cap_user: int) -> bool:
+        del owner, size, cap_user
+        return True
+
+    def increment_user_artifact_bytes(self, owner: str, delta: int) -> None:
+        del owner
+        self.adjustments.append(delta)
+
+
+def _orchestrator_with_artifact_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> SandboxOrchestrator:
+    monkeypatch.setenv("SANDBOX_SHARED_ARTIFACTS_DIR", str(tmp_path / "artifact-root"))
+    orch = SandboxOrchestrator()
+    orch._store = _FakeArtifactStore()  # type: ignore[assignment]
+    return orch
+
+
+@pytest.mark.unit
+def test_store_artifacts_rejects_symlink_parent_escape(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    orch = _orchestrator_with_artifact_root(monkeypatch, tmp_path)
+    run_id = "run-artifact-link-parent"
+    art_dir = orch._artifact_dir("artifact-user", run_id)
+    art_dir.mkdir(parents=True, exist_ok=True)
+    outside = tmp_path / "outside-artifacts"
+    outside.mkdir()
+    try:
+        os.symlink(str(outside), str(art_dir / "escape"))
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    orch.store_artifacts(run_id, {"escape/leaked.txt": b"secret"})
+
+    assert not (outside / "leaked.txt").exists()
+    assert orch.get_artifact(run_id, "escape/leaked.txt") is None
+
+
+@pytest.mark.unit
+def test_store_artifacts_rejects_symlink_artifact_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    orch = _orchestrator_with_artifact_root(monkeypatch, tmp_path)
+    run_id = "run-artifact-root-link"
+    art_dir = orch._artifact_dir("artifact-user", run_id)
+    art_dir.parent.mkdir(parents=True, exist_ok=True)
+    outside = tmp_path / "outside-artifact-root"
+    outside.mkdir()
+    try:
+        os.symlink(str(outside), str(art_dir))
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    orch.store_artifacts(run_id, {"leaked.txt": b"secret"})
+
+    assert not (outside / "leaked.txt").exists()
+    assert orch.get_artifact(run_id, "leaked.txt") is None
+
+
+@pytest.mark.unit
+def test_get_artifact_path_rejects_symlink_file_escape(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    orch = _orchestrator_with_artifact_root(monkeypatch, tmp_path)
+    run_id = "run-artifact-link-file"
+    art_dir = orch._artifact_dir("artifact-user", run_id)
+    art_dir.mkdir(parents=True, exist_ok=True)
+    outside = tmp_path / "outside-secret.txt"
+    outside.write_bytes(b"outside")
+    try:
+        os.symlink(str(outside), str(art_dir / "leak.txt"))
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    assert orch.get_artifact(run_id, "leak.txt") is None
+    assert orch.get_artifact_path(run_id, "leak.txt") is None

--- a/tldw_Server_API/tests/sandbox/test_snapshot_manager_restore_security.py
+++ b/tldw_Server_API/tests/sandbox/test_snapshot_manager_restore_security.py
@@ -74,6 +74,30 @@ def test_restore_snapshot_rejects_symlink_member(tmp_path: Path) -> None:
     assert (workspace / "keep.txt").read_text(encoding="utf-8") == "safe"
 
 
+def test_restore_snapshot_rejects_symlink_workspace_root_before_touching_target(tmp_path: Path) -> None:
+    manager = SnapshotManager(storage_path=str(tmp_path / "snapshots"))
+    source_workspace = tmp_path / "source-workspace"
+    source_workspace.mkdir(parents=True, exist_ok=True)
+    (source_workspace / "restored.txt").write_text("snapshot", encoding="utf-8")
+    snapshot = manager.create_snapshot("sess-root-link", str(source_workspace))
+
+    outside_target = tmp_path / "outside-target"
+    outside_target.mkdir(parents=True, exist_ok=True)
+    outside_file = outside_target / "keep.txt"
+    outside_file.write_text("do not touch", encoding="utf-8")
+    symlink_root = tmp_path / "workspace-link"
+    try:
+        os.symlink(str(outside_target), str(symlink_root))
+    except OSError as exc:
+        pytest.skip(f"symlink creation not supported in this environment: {exc}")
+
+    with pytest.raises(ValueError, match="Refusing symlink workspace root"):
+        manager.restore_snapshot("sess-root-link", snapshot["snapshot_id"], str(symlink_root))
+
+    assert outside_file.read_text(encoding="utf-8") == "do not touch"
+    assert not (outside_target / "restored.txt").exists()
+
+
 def test_create_snapshot_during_concurrent_atomic_writes_is_consistent(tmp_path: Path) -> None:
     manager = SnapshotManager(storage_path=str(tmp_path / "snapshots"))
     workspace = tmp_path / "workspace"

--- a/tldw_Server_API/tests/sandbox/test_snapshot_manager_restore_security.py
+++ b/tldw_Server_API/tests/sandbox/test_snapshot_manager_restore_security.py
@@ -98,6 +98,31 @@ def test_restore_snapshot_rejects_symlink_workspace_root_before_touching_target(
     assert not (outside_target / "restored.txt").exists()
 
 
+def test_restore_snapshot_rejects_symlink_workspace_ancestor_before_touching_target(tmp_path: Path) -> None:
+    manager = SnapshotManager(storage_path=str(tmp_path / "snapshots"))
+    source_workspace = tmp_path / "source-workspace"
+    source_workspace.mkdir(parents=True, exist_ok=True)
+    (source_workspace / "restored.txt").write_text("snapshot", encoding="utf-8")
+    snapshot = manager.create_snapshot("sess-ancestor-link", str(source_workspace))
+
+    outside_parent = tmp_path / "outside-parent"
+    outside_workspace = outside_parent / "workspace"
+    outside_workspace.mkdir(parents=True, exist_ok=True)
+    outside_file = outside_workspace / "keep.txt"
+    outside_file.write_text("do not touch", encoding="utf-8")
+    symlink_parent = tmp_path / "workspace-parent-link"
+    try:
+        os.symlink(str(outside_parent), str(symlink_parent))
+    except OSError as exc:
+        pytest.skip(f"symlink creation not supported in this environment: {exc}")
+
+    with pytest.raises(ValueError, match="Refusing symlink workspace ancestor"):
+        manager.restore_snapshot("sess-ancestor-link", snapshot["snapshot_id"], str(symlink_parent / "workspace"))
+
+    assert outside_file.read_text(encoding="utf-8") == "do not touch"
+    assert not (outside_workspace / "restored.txt").exists()
+
+
 def test_create_snapshot_during_concurrent_atomic_writes_is_consistent(tmp_path: Path) -> None:
     manager = SnapshotManager(storage_path=str(tmp_path / "snapshots"))
     workspace = tmp_path / "workspace"


### PR DESCRIPTION
## Summary
- Harden Sandbox snapshot and artifact handling against symlink escapes.
- Fail closed when Docker security options or granular egress setup fail.
- Preserve VM runner nonzero status reporting and quote env files safely.

## Backlog
- TASK-9929

## Verification
- `python -m pytest -q --confcutdir=tldw_Server_API/tests/sandbox tldw_Server_API/tests/sandbox/test_snapshot_manager_restore_security.py tldw_Server_API/tests/sandbox/test_docker_runner_hardening_defaults.py tldw_Server_API/tests/sandbox/test_docker_egress_enforcement.py tldw_Server_API/tests/sandbox/test_orchestrator_artifact_security.py tldw_Server_API/tests/sandbox/test_cross_runtime_cleanup_contracts.py` -> 34 passed, 1 skipped
- `python -m compileall -q ...Sandbox touched files...` -> passed
- `git diff --check` -> passed
- `python -m bandit -r ...Sandbox touched production files... -f json -o /tmp/bandit_sandbox_review_hardening_worktree.json` -> existing low-severity Sandbox subprocess baseline remains; JSON had 0 errors, 0 high, 0 medium, and no readiness-gate findings

## Merge Gate
- AI-authored PR: per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`, the human requester still needs to provide/confirm a human-written Change summary before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Sandbox to block symlink escapes (including ancestor links), enforce fail‑closed egress with cleanup, and secure env/log handling across Docker, Lima, and Firecracker. Addresses TASK-9929.

- **Bug Fixes**
  - Snapshots: reject symlink workspace roots and ancestors; validate tree before restore.
  - Artifacts: block symlink escapes (root/ancestors/dirs/files); fd‑relative writes with `O_NOFOLLOW`; safe listing.
  - Docker: do not drop required security opts; granular allowlist egress now fails closed, cleans partial fallback rules, resets empty ENTRYPOINT for readiness gating, and redacts env values in debug logs and failure messages while preserving `--env` names.
  - Lima/Firecracker: entry scripts record non‑zero exits; env files shell‑quote values, validate keys, and export vars to child commands.
  - Tests: added focused regression covering ancestor symlink cases, egress cleanup, ENTRYPOINT reset, env redaction, and env propagation.

<sup>Written for commit e39fdfa563d8d7059cc769d9c05db032473bdf6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

