### PR TITLE
Harden Scheduler review findings

### DIFF
--- a/backlog/tasks/task-10005 - Harden-Scheduler-module-review-findings.md
+++ b/backlog/tasks/task-10005 - Harden-Scheduler-module-review-findings.md
@@ -1,0 +1,48 @@
+---
+id: TASK-10005
+title: Harden Scheduler module review findings
+status: Done
+assignee: []
+created_date: 2026-06-23 21:55
+updated_date: 2026-06-25 02:06
+labels: []
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix Scheduler review findings around queue status persistence, SQLite timestamp comparisons, lease-scoped acknowledgements, ACP trigger submission, Scheduler startup loops, authorization rate limits, and worker-pool drift.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PostgreSQL enqueue and bulk enqueue persist submitted tasks as queued.
+- [x] #2 SQLite scheduled/deadline and lease-expiry checks parse ISO timestamps correctly.
+- [x] #3 Worker ack/nack paths are lease-scoped so stale workers cannot complete reclaimed tasks.
+- [x] #4 ACP webhook submissions await the global scheduler and include required Scheduler metadata.
+- [x] #5 Scheduler startup loops, authorizer rate limits, and improved worker-pool drift have focused regression coverage.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented Scheduler review hardening. Added red/green regression tests for startup loop races, SQLite ISO timestamp comparisons, stale lease ownership, PostgreSQL queued-state persistence, Scheduler authorizer rate limits, ACP webhook scheduler submission metadata, and the improved worker-pool release path. Adjusted the Unix fallback test to use a temporary home path so it does not write outside the workspace.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed all Scheduler review findings: PostgreSQL now persists new tasks as queued, SQLite timestamp predicates parse ISO strings, ack/nack can require matching lease and worker ownership, workers pass ownership tokens, ACP webhook submissions await the global scheduler and include metadata, startup loops are created after the scheduler is marked started, authorizer rate limits are enforced, and the improved worker pool no longer calls a nonexistent release_task method. Clean worktree verification: Scheduler tests plus ACP webhook trigger tests passed with 115 passed and 1 skipped; Bandit touched production scan reported 0 errors and 0 findings; staged and unstaged git diff --check both passed.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-10005 - Harden-Scheduler-module-review-findings.md
+++ b/backlog/tasks/task-10005 - Harden-Scheduler-module-review-findings.md
@@ -4,7 +4,7 @@ title: Harden Scheduler module review findings
 status: Done
 assignee: []
 created_date: 2026-06-23 21:55
-updated_date: 2026-06-25 02:06
+updated_date: 2026-06-25 02:21
 labels: []
 dependencies: []
 priority: high
@@ -39,10 +39,11 @@ Fix Scheduler review findings around queue status persistence, SQLite timestamp 
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Implemented Scheduler review hardening. Added red/green regression tests for startup loop races, SQLite ISO timestamp comparisons, stale lease ownership, PostgreSQL queued-state persistence, Scheduler authorizer rate limits, ACP webhook scheduler submission metadata, and the improved worker-pool release path. Adjusted the Unix fallback test to use a temporary home path so it does not write outside the workspace.
+PR #2510 review follow-up: moved rate-limit consumption to the end of the non-anonymous authorization path after permission checks, kept admin handler/queue permission bypass while still honoring configured user limits, rejected boolean rate-limit values, changed SQLite time predicates to compare indexed timestamp columns against a normalized ISO current-time expression, and added docstrings/type hints to new test helpers.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixed all Scheduler review findings: PostgreSQL now persists new tasks as queued, SQLite timestamp predicates parse ISO strings, ack/nack can require matching lease and worker ownership, workers pass ownership tokens, ACP webhook submissions await the global scheduler and include metadata, startup loops are created after the scheduler is marked started, authorizer rate limits are enforced, and the improved worker pool no longer calls a nonexistent release_task method. Clean worktree verification: Scheduler tests plus ACP webhook trigger tests passed with 115 passed and 1 skipped; Bandit touched production scan reported 0 errors and 0 findings; staged and unstaged git diff --check both passed.
+Fixed all Scheduler review findings and PR #2510 follow-up issues: PostgreSQL persists new tasks as queued, SQLite timestamp predicates use indexed column comparisons against normalized ISO current time, ack/nack can require matching lease and worker ownership, workers pass ownership tokens, ACP webhook submissions await the global scheduler and include metadata, startup loops are created after the scheduler is marked started, authorizer rate limits are enforced only after permission checks pass, boolean rate-limit values are rejected, and the improved worker pool no longer calls a nonexistent release_task method. Clean worktree verification: focused PR-review regression run passed with 18 passed; Scheduler tests plus ACP webhook trigger tests passed with 118 passed and 1 skipped; Bandit touched production scan reported 0 errors and 0 findings; staged and unstaged git diff --check both passed.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/triggers.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/triggers.py
@@ -484,11 +484,16 @@ class ACPTriggerManager:
         """Submit an ``acp_run`` task via the global scheduler."""
         from tldw_Server_API.app.core.Scheduler import get_global_scheduler
 
-        scheduler = get_global_scheduler()
+        user_id = str(payload.get("user_id") or "").strip()
+        if not user_id:
+            raise ValueError("acp_run payload requires user_id")
+
+        scheduler = await get_global_scheduler()
         task_id = await scheduler.submit(
             handler="acp_run",
             payload=payload,
             queue_name="acp",
+            metadata={"user_id": user_id},
         )
         return task_id
 

--- a/tldw_Server_API/app/core/Scheduler/authorization.py
+++ b/tldw_Server_API/app/core/Scheduler/authorization.py
@@ -129,7 +129,7 @@ class TaskAuthorizer:
             user_id: User ID
             max_per_minute: Maximum tasks per minute
         """
-        if not isinstance(max_per_minute, int) or max_per_minute < 0:
+        if isinstance(max_per_minute, bool) or not isinstance(max_per_minute, int) or max_per_minute < 0:
             raise ValueError("max_per_minute must be a non-negative integer")
 
         self._user_rate_limits[user_id] = max_per_minute
@@ -159,39 +159,36 @@ class TaskAuthorizer:
         if not context.is_authenticated:
             return False, "Authentication required"
 
-        # Check configured per-user rate limits before permission bypasses
-        if context.user_id in self._user_rate_limits:
-            allowed, reason = self._check_user_rate_limit(context.user_id)
-            if not allowed:
-                return False, reason
-
         # Check admin-only handlers
         if handler in self._admin_handlers and not context.is_admin:
             return False, f"Handler '{handler}' requires admin privileges"
 
-        # Admins bypass further permission checks
-        if context.is_admin:
-            return True, None
+        if not context.is_admin:
+            # Check handler-specific permissions
+            required_perms = self._handler_permissions.get(handler, set())
+            if required_perms:
+                # Convert permission enums to strings for comparison
+                required_perm_values = {p.value if isinstance(p, TaskPermission) else p for p in required_perms}
+                user_perms = context.permissions
+                missing_perms = required_perm_values - user_perms
+                if missing_perms:
+                    return False, f"Missing required permissions: {missing_perms}"
 
-        # Check handler-specific permissions
-        required_perms = self._handler_permissions.get(handler, set())
-        if required_perms:
-            # Convert permission enums to strings for comparison
-            required_perm_values = {p.value if isinstance(p, TaskPermission) else p for p in required_perms}
-            user_perms = context.permissions
-            missing_perms = required_perm_values - user_perms
-            if missing_perms:
-                return False, f"Missing required permissions: {missing_perms}"
+            # Check queue-specific permissions
+            queue_perms = self._queue_permissions.get(queue, set())
+            if queue_perms:
+                # Convert permission enums to strings for comparison
+                queue_perm_values = {p.value if isinstance(p, TaskPermission) else p for p in queue_perms}
+                user_perms = context.permissions
+                missing_perms = queue_perm_values - user_perms
+                if missing_perms:
+                    return False, f"Missing queue permissions: {missing_perms}"
 
-        # Check queue-specific permissions
-        queue_perms = self._queue_permissions.get(queue, set())
-        if queue_perms:
-            # Convert permission enums to strings for comparison
-            queue_perm_values = {p.value if isinstance(p, TaskPermission) else p for p in queue_perms}
-            user_perms = context.permissions
-            missing_perms = queue_perm_values - user_perms
-            if missing_perms:
-                return False, f"Missing queue permissions: {missing_perms}"
+        # Check configured per-user rate limits after all permission checks pass.
+        if context.user_id in self._user_rate_limits:
+            allowed, reason = self._check_user_rate_limit(context.user_id)
+            if not allowed:
+                return False, reason
 
         return True, None
 

--- a/tldw_Server_API/app/core/Scheduler/authorization.py
+++ b/tldw_Server_API/app/core/Scheduler/authorization.py
@@ -5,6 +5,7 @@ This module provides authorization checks to ensure users can only
 submit and manage tasks they have permissions for.
 """
 
+import time
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Optional
@@ -66,6 +67,7 @@ class TaskAuthorizer:
 
         # User rate limits: user_id -> max tasks per minute
         self._user_rate_limits: dict[str, int] = {}
+        self._user_rate_windows: dict[str, list[float]] = {}
 
         # Default permissions for unauthenticated users
         self._allow_anonymous = False
@@ -127,7 +129,11 @@ class TaskAuthorizer:
             user_id: User ID
             max_per_minute: Maximum tasks per minute
         """
+        if not isinstance(max_per_minute, int) or max_per_minute < 0:
+            raise ValueError("max_per_minute must be a non-negative integer")
+
         self._user_rate_limits[user_id] = max_per_minute
+        self._user_rate_windows.pop(user_id, None)
         logger.debug(f"Set rate limit for user {user_id}: {max_per_minute}/min")
 
     def can_submit_task(self,
@@ -152,6 +158,12 @@ class TaskAuthorizer:
         # Require authentication for non-anonymous handlers
         if not context.is_authenticated:
             return False, "Authentication required"
+
+        # Check configured per-user rate limits before permission bypasses
+        if context.user_id in self._user_rate_limits:
+            allowed, reason = self._check_user_rate_limit(context.user_id)
+            if not allowed:
+                return False, reason
 
         # Check admin-only handlers
         if handler in self._admin_handlers and not context.is_admin:
@@ -181,12 +193,28 @@ class TaskAuthorizer:
             if missing_perms:
                 return False, f"Missing queue permissions: {missing_perms}"
 
-        # Check rate limits
-        if context.user_id in self._user_rate_limits:
-            # This would need actual rate tracking implementation
-            # For now, just return true
-            pass
+        return True, None
 
+    def _check_user_rate_limit(self, user_id: str) -> tuple[bool, Optional[str]]:
+        """Apply the configured per-minute submission limit for a user."""
+        max_per_minute = self._user_rate_limits.get(user_id)
+        if max_per_minute is None:
+            return True, None
+
+        now = time.monotonic()
+        window_start = now - 60
+        timestamps = [
+            timestamp
+            for timestamp in self._user_rate_windows.get(user_id, [])
+            if timestamp > window_start
+        ]
+
+        if len(timestamps) >= max_per_minute:
+            self._user_rate_windows[user_id] = timestamps
+            return False, f"Rate limit exceeded: {max_per_minute} tasks per minute"
+
+        timestamps.append(now)
+        self._user_rate_windows[user_id] = timestamps
         return True, None
 
     def can_cancel_task(self,

--- a/tldw_Server_API/app/core/Scheduler/backends/memory_backend.py
+++ b/tldw_Server_API/app/core/Scheduler/backends/memory_backend.py
@@ -133,7 +133,14 @@ class MemoryBackend(QueueBackend):
 
             return None
 
-    async def ack(self, task_id: str, result: Optional[Any] = None) -> bool:
+    async def ack(
+        self,
+        task_id: str,
+        result: Optional[Any] = None,
+        *,
+        lease_id: Optional[str] = None,
+        worker_id: Optional[str] = None,
+    ) -> bool:
         """Acknowledge task completion."""
         async with self._lock:
             if task_id not in self.tasks:
@@ -142,16 +149,29 @@ class MemoryBackend(QueueBackend):
             task = self.tasks[task_id]
             if task.status != TaskStatus.RUNNING:
                 return False
+            if lease_id is not None and task.lease_id != lease_id:
+                return False
+            if worker_id is not None and task.worker_id != worker_id:
+                return False
 
             task.status = TaskStatus.COMPLETED
             task.completed_at = datetime.now(timezone.utc).replace(tzinfo=None)
             task.result = result
             task.lease_id = None
             task.lease_expires_at = None
+            task.worker_id = None
 
             return True
 
-    async def nack(self, task_id: str, error: Optional[str] = None, retry: bool = True) -> bool:
+    async def nack(
+        self,
+        task_id: str,
+        error: Optional[str] = None,
+        retry: bool = True,
+        *,
+        lease_id: Optional[str] = None,
+        worker_id: Optional[str] = None,
+    ) -> bool:
         """Negative acknowledge."""
         async with self._lock:
             if task_id not in self.tasks:
@@ -159,6 +179,10 @@ class MemoryBackend(QueueBackend):
 
             task = self.tasks[task_id]
             if task.status != TaskStatus.RUNNING:
+                return False
+            if lease_id is not None and task.lease_id != lease_id:
+                return False
+            if worker_id is not None and task.worker_id != worker_id:
                 return False
 
             task.error = error

--- a/tldw_Server_API/app/core/Scheduler/backends/postgresql_backend.py
+++ b/tldw_Server_API/app/core/Scheduler/backends/postgresql_backend.py
@@ -262,7 +262,7 @@ class PostgreSQLBackend(QueueBackend):
                     RETURNING id
                 """,
                     task.id, task.handler, json.dumps(payload_data) if payload_data else None,
-                    payload_ref, task.status.value, task.priority,
+                    payload_ref, TaskStatus.QUEUED.value, task.priority,
                     task.queue_name or self.config.default_queue_name,
                     task.scheduled_at, task.depends_on, task.idempotency_key,
                     task.max_retries, task.retry_delay, task.timeout,
@@ -303,7 +303,7 @@ class PostgreSQLBackend(QueueBackend):
                 values.append((
                     task.id, task.handler,
                     json.dumps(payload_data) if payload_data else None,
-                    payload_ref, task.status.value, task.priority,
+                    payload_ref, TaskStatus.QUEUED.value, task.priority,
                     task.queue_name or self.config.default_queue_name,
                     task.scheduled_at, task.depends_on, task.idempotency_key,
                     task.max_retries, task.retry_delay, task.timeout,
@@ -374,7 +374,14 @@ class PostgreSQLBackend(QueueBackend):
             # Convert to Task object
             return await self._row_to_task(conn, row)
 
-    async def ack(self, task_id: str, result: Optional[Any] = None) -> bool:
+    async def ack(
+        self,
+        task_id: str,
+        result: Optional[Any] = None,
+        *,
+        lease_id: Optional[str] = None,
+        worker_id: Optional[str] = None,
+    ) -> bool:
         """
         Acknowledge task completion.
         """
@@ -384,14 +391,25 @@ class PostgreSQLBackend(QueueBackend):
                 SET status = 'completed',
                     completed_at = NOW(),
                     result = $1,
+                    worker_id = NULL,
                     lease_id = NULL,
                     lease_expires_at = NULL
                 WHERE id = $2 AND status = 'running'
-            """, json.dumps(result) if result else None, task_id)
+                  AND ($3::text IS NULL OR lease_id = $3)
+                  AND ($4::text IS NULL OR worker_id = $4)
+            """, json.dumps(result) if result is not None else None, task_id, lease_id, worker_id)
 
             return affected != "UPDATE 0"
 
-    async def nack(self, task_id: str, error: Optional[str] = None, retry: bool = True) -> bool:
+    async def nack(
+        self,
+        task_id: str,
+        error: Optional[str] = None,
+        retry: bool = True,
+        *,
+        lease_id: Optional[str] = None,
+        worker_id: Optional[str] = None,
+    ) -> bool:
         """
         Negative acknowledge - task failed but may be retried.
         """
@@ -413,8 +431,10 @@ class PostgreSQLBackend(QueueBackend):
                         ELSE NULL
                     END
                 WHERE id = $2 AND status = 'running'
+                  AND ($4::text IS NULL OR lease_id = $4)
+                  AND ($5::text IS NULL OR worker_id = $5)
                 RETURNING status, queue_name
-            """, error, task_id, retry)
+            """, error, task_id, retry, lease_id, worker_id)
 
             if row and row['status'] == 'queued':
                 # Notify queue for retry
@@ -858,7 +878,7 @@ class PostgreSQLBackend(QueueBackend):
         """
         Send NOTIFY for queue updates.
         """
-        await conn.execute(f"NOTIFY queue_update, '{queue_name}'")
+        await conn.execute("SELECT pg_notify('queue_update', $1)", queue_name)
 
     async def _listen_for_notifications(self) -> None:
         """

--- a/tldw_Server_API/app/core/Scheduler/backends/sqlite_backend.py
+++ b/tldw_Server_API/app/core/Scheduler/backends/sqlite_backend.py
@@ -390,8 +390,8 @@ class SQLiteBackend(QueueBackend):
                     SELECT * FROM tasks
                     WHERE queue_name = ?
                       AND status = 'queued'
-                      AND (scheduled_at IS NULL OR scheduled_at <= datetime('now'))
-                      AND (expires_at IS NULL OR expires_at > datetime('now'))
+                      AND (scheduled_at IS NULL OR datetime(replace(scheduled_at, 'T', ' ')) <= datetime('now'))
+                      AND (expires_at IS NULL OR datetime(replace(expires_at, 'T', ' ')) > datetime('now'))
                       AND NOT EXISTS (
                           SELECT 1
                           FROM json_each(COALESCE(depends_on, '[]')) AS deps
@@ -453,8 +453,8 @@ class SQLiteBackend(QueueBackend):
         query = (
             "SELECT id, depends_on FROM tasks "
             "WHERE status = 'queued' "
-            "AND (scheduled_at IS NULL OR scheduled_at <= datetime('now')) "
-            "AND (expires_at IS NULL OR expires_at > datetime('now'))"
+            "AND (scheduled_at IS NULL OR datetime(replace(scheduled_at, 'T', ' ')) <= datetime('now')) "
+            "AND (expires_at IS NULL OR datetime(replace(expires_at, 'T', ' ')) > datetime('now'))"
         )
         params = []
         if queue_name:
@@ -506,18 +506,37 @@ class SQLiteBackend(QueueBackend):
 
         return ready
 
-    async def ack(self, task_id: str, result: Optional[Any] = None) -> bool:
+    async def ack(
+        self,
+        task_id: str,
+        result: Optional[Any] = None,
+        *,
+        lease_id: Optional[str] = None,
+        worker_id: Optional[str] = None,
+    ) -> bool:
         """Acknowledge task completion"""
         result_json = json.dumps(result) if result is not None else None
 
-        affected = await self.execute("""
+        affected = await self.execute(
+            """
             UPDATE tasks
             SET status = 'completed',
                 completed_at = datetime('now'),
                 result = ?,
-                execution_time = (julianday('now') - julianday(started_at)) * 86400
+                execution_time = (julianday('now') - julianday(started_at)) * 86400,
+                worker_id = NULL,
+                lease_id = NULL
             WHERE id = ? AND status = 'running'
-        """, result_json, task_id)
+              AND (? IS NULL OR lease_id = ?)
+              AND (? IS NULL OR worker_id = ?)
+            """,
+            result_json,
+            task_id,
+            lease_id,
+            lease_id,
+            worker_id,
+            worker_id,
+        )
 
         if affected:
             # Delete lease
@@ -525,7 +544,15 @@ class SQLiteBackend(QueueBackend):
 
         return affected > 0
 
-    async def nack(self, task_id: str, error: str, retry: bool = True) -> bool:
+    async def nack(
+        self,
+        task_id: str,
+        error: str,
+        retry: bool = True,
+        *,
+        lease_id: Optional[str] = None,
+        worker_id: Optional[str] = None,
+    ) -> bool:
         """Handle task failure"""
         task = await self.get_task(task_id)
         if not task:
@@ -536,7 +563,8 @@ class SQLiteBackend(QueueBackend):
             retry_delay = task.calculate_retry_delay()
             scheduled_at = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=retry_delay)
 
-            await self.execute("""
+            affected = await self.execute(
+                """
                 UPDATE tasks
                 SET status = 'queued',
                     retry_count = retry_count + 1,
@@ -544,17 +572,42 @@ class SQLiteBackend(QueueBackend):
                     error = ?,
                     worker_id = NULL,
                     lease_id = NULL
-                WHERE id = ?
-            """, scheduled_at.isoformat(), error, task_id)
+                WHERE id = ? AND status = 'running'
+                  AND (? IS NULL OR lease_id = ?)
+                  AND (? IS NULL OR worker_id = ?)
+                """,
+                scheduled_at.isoformat(),
+                error,
+                task_id,
+                lease_id,
+                lease_id,
+                worker_id,
+                worker_id,
+            )
         else:
             # Move to failed or DLQ
-            await self.execute("""
+            affected = await self.execute(
+                """
                 UPDATE tasks
                 SET status = 'failed',
                     completed_at = datetime('now'),
-                    error = ?
-                WHERE id = ?
-            """, error, task_id)
+                    error = ?,
+                    worker_id = NULL,
+                    lease_id = NULL
+                WHERE id = ? AND status = 'running'
+                  AND (? IS NULL OR lease_id = ?)
+                  AND (? IS NULL OR worker_id = ?)
+                """,
+                error,
+                task_id,
+                lease_id,
+                lease_id,
+                worker_id,
+                worker_id,
+            )
+
+        if affected <= 0:
+            return False
 
         # Delete lease
         await self.execute("DELETE FROM task_leases WHERE task_id = ?", task_id)
@@ -707,7 +760,7 @@ class SQLiteBackend(QueueBackend):
     async def get_expired_leases(self) -> list[dict[str, Any]]:
         """Get expired leases"""
         return await self.fetch(
-            "SELECT * FROM task_leases WHERE expires_at < datetime('now')"
+            "SELECT * FROM task_leases WHERE datetime(replace(expires_at, 'T', ' ')) < datetime('now')"
         )
 
     # Transaction support
@@ -776,7 +829,7 @@ class SQLiteBackend(QueueBackend):
                 # Find all expired leases
                 cursor = await self._connection.execute("""
                     SELECT task_id FROM task_leases
-                    WHERE expires_at < datetime('now')
+                    WHERE datetime(replace(expires_at, 'T', ' ')) < datetime('now')
                 """)
                 expired_rows = await cursor.fetchall()
 

--- a/tldw_Server_API/app/core/Scheduler/backends/sqlite_backend.py
+++ b/tldw_Server_API/app/core/Scheduler/backends/sqlite_backend.py
@@ -390,8 +390,8 @@ class SQLiteBackend(QueueBackend):
                     SELECT * FROM tasks
                     WHERE queue_name = ?
                       AND status = 'queued'
-                      AND (scheduled_at IS NULL OR datetime(replace(scheduled_at, 'T', ' ')) <= datetime('now'))
-                      AND (expires_at IS NULL OR datetime(replace(expires_at, 'T', ' ')) > datetime('now'))
+                      AND (scheduled_at IS NULL OR scheduled_at <= replace(datetime('now'), ' ', 'T'))
+                      AND (expires_at IS NULL OR expires_at > replace(datetime('now'), ' ', 'T'))
                       AND NOT EXISTS (
                           SELECT 1
                           FROM json_each(COALESCE(depends_on, '[]')) AS deps
@@ -453,8 +453,8 @@ class SQLiteBackend(QueueBackend):
         query = (
             "SELECT id, depends_on FROM tasks "
             "WHERE status = 'queued' "
-            "AND (scheduled_at IS NULL OR datetime(replace(scheduled_at, 'T', ' ')) <= datetime('now')) "
-            "AND (expires_at IS NULL OR datetime(replace(expires_at, 'T', ' ')) > datetime('now'))"
+            "AND (scheduled_at IS NULL OR scheduled_at <= replace(datetime('now'), ' ', 'T')) "
+            "AND (expires_at IS NULL OR expires_at > replace(datetime('now'), ' ', 'T'))"
         )
         params = []
         if queue_name:
@@ -760,7 +760,7 @@ class SQLiteBackend(QueueBackend):
     async def get_expired_leases(self) -> list[dict[str, Any]]:
         """Get expired leases"""
         return await self.fetch(
-            "SELECT * FROM task_leases WHERE datetime(replace(expires_at, 'T', ' ')) < datetime('now')"
+            "SELECT * FROM task_leases WHERE expires_at < replace(datetime('now'), ' ', 'T')"
         )
 
     # Transaction support
@@ -829,7 +829,7 @@ class SQLiteBackend(QueueBackend):
                 # Find all expired leases
                 cursor = await self._connection.execute("""
                     SELECT task_id FROM task_leases
-                    WHERE datetime(replace(expires_at, 'T', ' ')) < datetime('now')
+                    WHERE expires_at < replace(datetime('now'), ' ', 'T')
                 """)
                 expired_rows = await cursor.fetchall()
 

--- a/tldw_Server_API/app/core/Scheduler/base/queue_backend.py
+++ b/tldw_Server_API/app/core/Scheduler/base/queue_backend.py
@@ -81,13 +81,22 @@ class QueueBackend(ABC):
         pass
 
     @abstractmethod
-    async def ack(self, task_id: str, result: Optional[Any] = None) -> bool:
+    async def ack(
+        self,
+        task_id: str,
+        result: Optional[Any] = None,
+        *,
+        lease_id: Optional[str] = None,
+        worker_id: Optional[str] = None,
+    ) -> bool:
         """
         Acknowledge successful task completion.
 
         Args:
             task_id: ID of completed task
             result: Task execution result
+            lease_id: Optional lease identifier that must still own the task
+            worker_id: Optional worker identifier that must still own the task
 
         Returns:
             True if task was acknowledged
@@ -95,7 +104,15 @@ class QueueBackend(ABC):
         pass
 
     @abstractmethod
-    async def nack(self, task_id: str, error: str, retry: bool = True) -> bool:
+    async def nack(
+        self,
+        task_id: str,
+        error: str,
+        retry: bool = True,
+        *,
+        lease_id: Optional[str] = None,
+        worker_id: Optional[str] = None,
+    ) -> bool:
         """
         Negative acknowledgment - task failed.
 
@@ -103,6 +120,8 @@ class QueueBackend(ABC):
             task_id: ID of failed task
             error: Error message
             retry: Whether to retry the task
+            lease_id: Optional lease identifier that must still own the task
+            worker_id: Optional worker identifier that must still own the task
 
         Returns:
             True if task was nacked

--- a/tldw_Server_API/app/core/Scheduler/core/improved_worker_pool.py
+++ b/tldw_Server_API/app/core/Scheduler/core/improved_worker_pool.py
@@ -357,7 +357,12 @@ class ImprovedWorker:
                     return False
 
                 # Acknowledge success
-                await self.backend.ack(task.id, result)
+                await self.backend.ack(
+                    task.id,
+                    result,
+                    lease_id=task.lease_id,
+                    worker_id=self.worker_id,
+                )
 
                 # Update metrics
                 processing_time = asyncio.get_event_loop().time() - start_time
@@ -379,7 +384,12 @@ class ImprovedWorker:
 
                 # Don't acknowledge if we're stopping
                 if not self._stop_event.is_set():
-                    await self.backend.nack(task.id, error)
+                    await self.backend.nack(
+                        task.id,
+                        error,
+                        lease_id=task.lease_id,
+                        worker_id=self.worker_id,
+                    )
                 return False
 
         except asyncio.CancelledError:
@@ -394,7 +404,12 @@ class ImprovedWorker:
             # Don't acknowledge if we're stopping
             if not self._stop_event.is_set():
                 try:
-                    await self.backend.nack(task.id, error)
+                    await self.backend.nack(
+                        task.id,
+                        error,
+                        lease_id=task.lease_id,
+                        worker_id=self.worker_id,
+                    )
                 except Exception as nack_error:
                     logger.error(f"Failed to nack task {task.id}: {nack_error}")
 
@@ -421,8 +436,13 @@ class ImprovedWorker:
         logger.warning(f"Force stopping task {self.current_task.id}")
 
         try:
-            # Release the task back to queue
-            await self.backend.release_task(self.current_task.id)
+            await self.backend.nack(
+                self.current_task.id,
+                "Worker stopped before task completion",
+                retry=True,
+                lease_id=self.current_task.lease_id,
+                worker_id=self.worker_id,
+            )
         except Exception as e:
             logger.error(f"Failed to release task {self.current_task.id}: {e}")
 

--- a/tldw_Server_API/app/core/Scheduler/core/worker_pool.py
+++ b/tldw_Server_API/app/core/Scheduler/core/worker_pool.py
@@ -206,20 +206,35 @@ class Worker:
             )
 
             # Acknowledge success
-            await self.backend.ack(task.id, result)
+            await self.backend.ack(
+                task.id,
+                result,
+                lease_id=task.lease_id,
+                worker_id=self.worker_id,
+            )
             logger.info(f"Task {task.id} completed successfully")
             return True
 
         except asyncio.TimeoutError:
             error = f"Task timeout after {timeout} seconds"
             logger.error(f"Task {task.id} failed: {error}")
-            await self.backend.nack(task.id, error)
+            await self.backend.nack(
+                task.id,
+                error,
+                lease_id=task.lease_id,
+                worker_id=self.worker_id,
+            )
             return False
 
         except Exception as e:
             error = str(e)
             logger.error(f"Task {task.id} failed: {error}")
-            await self.backend.nack(task.id, error)
+            await self.backend.nack(
+                task.id,
+                error,
+                lease_id=task.lease_id,
+                worker_id=self.worker_id,
+            )
             return False
 
         finally:

--- a/tldw_Server_API/app/core/Scheduler/scheduler.py
+++ b/tldw_Server_API/app/core/Scheduler/scheduler.py
@@ -105,6 +105,8 @@ class Scheduler:
                 self.worker_pool = WorkerPool(self.backend, self.registry, self.config)
                 await self.worker_pool.start()
 
+            self._started = True
+
             # Start background tasks
             self._cleanup_task = asyncio.create_task(self._cleanup_loop())
             self._monitor_task = asyncio.create_task(self._monitor_loop())
@@ -115,7 +117,6 @@ class Scheduler:
                 callback=self._on_become_cleanup_leader
             )
 
-            self._started = True
             logger.info("Scheduler started successfully")
 
         except (AttributeError, LookupError, OSError, RuntimeError, TypeError, ValueError) as e:

--- a/tldw_Server_API/app/core/Scheduler/tests/test_scheduler.py
+++ b/tldw_Server_API/app/core/Scheduler/tests/test_scheduler.py
@@ -9,7 +9,8 @@ import pytest
 import tempfile
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
-from types import SimpleNamespace
+from types import SimpleNamespace, TracebackType
+from typing import Any
 import uuid
 
 from ..scheduler import Scheduler, create_scheduler
@@ -26,42 +27,63 @@ DEFAULT_METADATA = {"user_id": "test-user"}
 
 
 class _AsyncContext:
-    def __init__(self, value):
+    """Minimal async context manager used by fake PostgreSQL pool objects."""
+
+    def __init__(self, value: Any) -> None:
+        """Store the value returned by the async context manager."""
         self.value = value
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> Any:
+        """Return the configured context value."""
         return self.value
 
-    async def __aexit__(self, exc_type, exc, tb):
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool:
+        """Allow exceptions to propagate out of the context."""
         return False
 
 
 class _FakePostgresConnection:
-    def __init__(self):
-        self.fetchrow_calls = []
-        self.executemany_calls = []
-        self.execute_calls = []
+    """Fake asyncpg connection that records calls made by PostgreSQLBackend."""
 
-    async def fetchrow(self, query, *args):
+    def __init__(self) -> None:
+        """Initialize call recording buffers."""
+        self.fetchrow_calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.executemany_calls: list[tuple[str, list[tuple[Any, ...]]]] = []
+        self.execute_calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    async def fetchrow(self, query: str, *args: Any) -> dict[str, Any]:
+        """Record an insert-returning call and return a minimal row."""
         self.fetchrow_calls.append((query, args))
         return {"id": args[0]}
 
-    async def executemany(self, query, values):
+    async def executemany(self, query: str, values: list[tuple[Any, ...]]) -> None:
+        """Record batched insert values."""
         self.executemany_calls.append((query, list(values)))
 
-    async def execute(self, query, *args):
+    async def execute(self, query: str, *args: Any) -> str:
+        """Record execute calls and return an asyncpg-like status string."""
         self.execute_calls.append((query, args))
         return "SELECT 1"
 
-    def transaction(self):
+    def transaction(self) -> _AsyncContext:
+        """Return an async transaction context."""
         return _AsyncContext(self)
 
 
 class _FakePostgresPool:
-    def __init__(self, connection):
+    """Fake asyncpg pool that returns a single fake connection."""
+
+    def __init__(self, connection: _FakePostgresConnection) -> None:
+        """Store the connection returned by acquire()."""
         self.connection = connection
 
-    def acquire(self):
+    def acquire(self) -> _AsyncContext:
+        """Return an async context wrapping the fake connection."""
         return _AsyncContext(self.connection)
 
 
@@ -110,11 +132,21 @@ async def test_scheduler_lifecycle(test_config):
 
 
 @pytest.mark.asyncio
-async def test_scheduler_background_loops_survive_start_if_leadership_setup_yields(test_config, monkeypatch):
+async def test_scheduler_background_loops_survive_start_if_leadership_setup_yields(
+    test_config: SchedulerConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Background loops should not observe the scheduler as stopped during startup."""
     original = LeaderElection.maintain_leadership
 
-    async def yielding_maintain(self, resource, callback=None, ttl=None, renew_interval=None):
+    async def yielding_maintain(
+        self: LeaderElection,
+        resource: str,
+        callback: Any = None,
+        ttl: int | None = None,
+        renew_interval: float | None = None,
+    ) -> asyncio.Task[Any]:
+        """Yield once before delegating to the real leadership maintainer."""
         await asyncio.sleep(0)
         task = await original(self, resource, callback=callback, ttl=ttl, renew_interval=renew_interval)
         return task
@@ -638,7 +670,7 @@ async def test_sqlite_auto_renew_extends_lease_expiration():
 
 
 @pytest.mark.asyncio
-async def test_sqlite_dequeues_iso_scheduled_task_on_current_day(tmp_path):
+async def test_sqlite_dequeues_iso_scheduled_task_on_current_day(tmp_path: Path) -> None:
     """SQLite should compare ISO scheduled_at values as timestamps, not strings."""
     config = SchedulerConfig(
         database_url=f"sqlite:///{tmp_path}/scheduled.db",
@@ -673,7 +705,7 @@ async def test_sqlite_dequeues_iso_scheduled_task_on_current_day(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_sqlite_reclaims_iso_expired_lease(tmp_path):
+async def test_sqlite_reclaims_iso_expired_lease(tmp_path: Path) -> None:
     """SQLite should compare ISO lease expiry values as timestamps, not strings."""
     config = SchedulerConfig(
         database_url=f"sqlite:///{tmp_path}/lease-expiry.db",
@@ -713,7 +745,7 @@ async def test_sqlite_reclaims_iso_expired_lease(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_sqlite_ack_rejects_stale_lease_owner(tmp_path):
+async def test_sqlite_ack_rejects_stale_lease_owner(tmp_path: Path) -> None:
     """A reclaimed task must not be completed by a stale worker lease."""
     config = SchedulerConfig(
         database_url=f"sqlite:///{tmp_path}/lease-owner.db",
@@ -776,7 +808,7 @@ async def test_sqlite_ack_rejects_stale_lease_owner(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_postgresql_enqueue_normalizes_pending_tasks_to_queued():
+async def test_postgresql_enqueue_normalizes_pending_tasks_to_queued() -> None:
     """PostgreSQL inserts must persist newly submitted tasks as queued."""
     backend = PostgreSQLBackend.__new__(PostgreSQLBackend)
     backend.config = SimpleNamespace(

--- a/tldw_Server_API/app/core/Scheduler/tests/test_scheduler.py
+++ b/tldw_Server_API/app/core/Scheduler/tests/test_scheduler.py
@@ -9,6 +9,7 @@ import pytest
 import tempfile
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 import uuid
 
 from ..scheduler import Scheduler, create_scheduler
@@ -16,10 +17,52 @@ from ..base import Task, TaskStatus, TaskPriority
 from ..base.registry import get_registry
 from ..config import SchedulerConfig
 from ..backends import create_backend
+from ..backends.postgresql_backend import PostgreSQLBackend
+from ..core.leader_election import LeaderElection
 from ..services import LeaseService
 from ..authorization import AuthContext, TaskPermission
 
 DEFAULT_METADATA = {"user_id": "test-user"}
+
+
+class _AsyncContext:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakePostgresConnection:
+    def __init__(self):
+        self.fetchrow_calls = []
+        self.executemany_calls = []
+        self.execute_calls = []
+
+    async def fetchrow(self, query, *args):
+        self.fetchrow_calls.append((query, args))
+        return {"id": args[0]}
+
+    async def executemany(self, query, values):
+        self.executemany_calls.append((query, list(values)))
+
+    async def execute(self, query, *args):
+        self.execute_calls.append((query, args))
+        return "SELECT 1"
+
+    def transaction(self):
+        return _AsyncContext(self)
+
+
+class _FakePostgresPool:
+    def __init__(self, connection):
+        self.connection = connection
+
+    def acquire(self):
+        return _AsyncContext(self.connection)
 
 
 @pytest.fixture
@@ -64,6 +107,30 @@ async def test_scheduler_lifecycle(test_config):
     # Stop scheduler
     await scheduler.stop()
     assert scheduler._started is False
+
+
+@pytest.mark.asyncio
+async def test_scheduler_background_loops_survive_start_if_leadership_setup_yields(test_config, monkeypatch):
+    """Background loops should not observe the scheduler as stopped during startup."""
+    original = LeaderElection.maintain_leadership
+
+    async def yielding_maintain(self, resource, callback=None, ttl=None, renew_interval=None):
+        await asyncio.sleep(0)
+        task = await original(self, resource, callback=callback, ttl=ttl, renew_interval=renew_interval)
+        return task
+
+    monkeypatch.setattr(LeaderElection, "maintain_leadership", yielding_maintain)
+
+    scheduler = Scheduler(test_config)
+    await scheduler.start(start_workers=False)
+    try:
+        await asyncio.sleep(0)
+        assert scheduler._cleanup_task is not None
+        assert scheduler._monitor_task is not None
+        assert scheduler._cleanup_task.done() is False
+        assert scheduler._monitor_task.done() is False
+    finally:
+        await scheduler.stop()
 
 
 @pytest.mark.asyncio
@@ -568,6 +635,176 @@ async def test_sqlite_auto_renew_extends_lease_expiration():
             assert renewed_expires > original_expires, "Lease expiration should extend after renewal"
         finally:
             await backend.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_dequeues_iso_scheduled_task_on_current_day(tmp_path):
+    """SQLite should compare ISO scheduled_at values as timestamps, not strings."""
+    config = SchedulerConfig(
+        database_url=f"sqlite:///{tmp_path}/scheduled.db",
+        base_path=tmp_path / "scheduler",
+        min_workers=0,
+        max_workers=0,
+    )
+    backend = create_backend(config)
+    await backend.connect()
+    try:
+        scheduled_at = datetime.now(timezone.utc).replace(
+            hour=0,
+            minute=0,
+            second=0,
+            microsecond=0,
+            tzinfo=None,
+        )
+        task = Task(
+            handler="test.handler",
+            payload={},
+            scheduled_at=scheduled_at,
+            metadata=DEFAULT_METADATA,
+        )
+        await backend.enqueue(task)
+
+        dequeued = await backend.dequeue_atomic("default", "worker-iso-time")
+
+        assert dequeued is not None
+        assert dequeued.id == task.id
+    finally:
+        await backend.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_reclaims_iso_expired_lease(tmp_path):
+    """SQLite should compare ISO lease expiry values as timestamps, not strings."""
+    config = SchedulerConfig(
+        database_url=f"sqlite:///{tmp_path}/lease-expiry.db",
+        base_path=tmp_path / "scheduler",
+        lease_duration_seconds=30,
+        lease_renewal_interval=5,
+        min_workers=0,
+        max_workers=0,
+    )
+    backend = create_backend(config)
+    await backend.connect()
+    try:
+        task = Task(handler="test.handler", payload={}, metadata=DEFAULT_METADATA)
+        await backend.enqueue(task)
+        dequeued = await backend.dequeue_atomic("default", "worker-expired")
+        assert dequeued is not None
+
+        expired_at = datetime.now(timezone.utc).replace(
+            hour=0,
+            minute=0,
+            second=0,
+            microsecond=0,
+            tzinfo=None,
+        )
+        await backend.execute(
+            "UPDATE task_leases SET expires_at = ? WHERE lease_id = ?",
+            expired_at.isoformat(),
+            dequeued.lease_id,
+        )
+
+        assert await backend.reclaim_expired_leases() == 1
+        reclaimed = await backend.get_task(task.id)
+        assert reclaimed is not None
+        assert reclaimed.status == TaskStatus.QUEUED
+    finally:
+        await backend.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_ack_rejects_stale_lease_owner(tmp_path):
+    """A reclaimed task must not be completed by a stale worker lease."""
+    config = SchedulerConfig(
+        database_url=f"sqlite:///{tmp_path}/lease-owner.db",
+        base_path=tmp_path / "scheduler",
+        lease_duration_seconds=30,
+        lease_renewal_interval=5,
+        min_workers=0,
+        max_workers=0,
+    )
+    backend = create_backend(config)
+    await backend.connect()
+    try:
+        task = Task(handler="test.handler", payload={}, metadata=DEFAULT_METADATA)
+        await backend.enqueue(task)
+
+        first_claim = await backend.dequeue_atomic("default", "worker-1")
+        assert first_claim is not None
+        stale_lease_id = first_claim.lease_id
+
+        expired_at = datetime.now(timezone.utc).replace(
+            hour=0,
+            minute=0,
+            second=0,
+            microsecond=0,
+            tzinfo=None,
+        )
+        await backend.execute(
+            "UPDATE task_leases SET expires_at = ? WHERE lease_id = ?",
+            expired_at.isoformat(),
+            stale_lease_id,
+        )
+        assert await backend.reclaim_expired_leases() == 1
+
+        second_claim = await backend.dequeue_atomic("default", "worker-2")
+        assert second_claim is not None
+        assert second_claim.lease_id != stale_lease_id
+
+        stale_ack = await backend.ack(
+            task.id,
+            {"stale": True},
+            lease_id=stale_lease_id,
+            worker_id="worker-1",
+        )
+        assert stale_ack is False
+
+        still_running = await backend.get_task(task.id)
+        assert still_running is not None
+        assert still_running.status == TaskStatus.RUNNING
+        assert still_running.worker_id == "worker-2"
+
+        current_ack = await backend.ack(
+            task.id,
+            {"ok": True},
+            lease_id=second_claim.lease_id,
+            worker_id="worker-2",
+        )
+        assert current_ack is True
+    finally:
+        await backend.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_postgresql_enqueue_normalizes_pending_tasks_to_queued():
+    """PostgreSQL inserts must persist newly submitted tasks as queued."""
+    backend = PostgreSQLBackend.__new__(PostgreSQLBackend)
+    backend.config = SimpleNamespace(
+        payload_threshold_bytes=10_000_000,
+        payload_compression=False,
+        default_queue_name="default",
+    )
+    connection = _FakePostgresConnection()
+    backend.pool = _FakePostgresPool(connection)
+
+    task = Task(handler="test.handler", payload={"value": 1}, metadata=DEFAULT_METADATA)
+    assert task.status == TaskStatus.PENDING
+
+    await backend.enqueue(task)
+
+    insert_args = connection.fetchrow_calls[0][1]
+    assert insert_args[4] == TaskStatus.QUEUED.value
+
+    await backend.bulk_enqueue([
+        Task(handler="test.handler", payload={"value": 2}, metadata=DEFAULT_METADATA),
+        Task(handler="test.handler", payload={"value": 3}, metadata=DEFAULT_METADATA),
+    ])
+
+    bulk_values = connection.executemany_calls[0][1]
+    assert [value[4] for value in bulk_values] == [
+        TaskStatus.QUEUED.value,
+        TaskStatus.QUEUED.value,
+    ]
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/Scheduler/tests/test_security_fixes.py
+++ b/tldw_Server_API/app/core/Scheduler/tests/test_security_fixes.py
@@ -79,16 +79,17 @@ class TestPathTraversalFixes:
             assert 'scheduler' in str(config.base_path)
             assert config.base_path.exists() or True  # Path creation might be lazy
 
-    def test_unix_permission_fallback(self):
+    def test_unix_permission_fallback(self, tmp_path):
         """Test Unix path fallback when /var/lib is not writable."""
         with patch('platform.system', return_value='Linux'):
             with patch('os.access', return_value=False):
-                config = SchedulerConfig(
-                    base_path=Path('/var/lib/scheduler-security-test'),
-                    database_url=':memory:',
-                )
+                with patch.object(Path, 'home', return_value=tmp_path):
+                    config = SchedulerConfig(
+                        base_path=Path('/var/lib/scheduler-security-test'),
+                        database_url=':memory:',
+                    )
                 # Should use home directory
-                assert '.local/share/scheduler' in str(config.base_path)
+                assert config.base_path == tmp_path / '.local' / 'share' / 'scheduler'
 
 
 class TestPayloadSanitization:
@@ -475,6 +476,27 @@ class TestTaskAuthorization:
 
         can_submit, reason = self.authorizer.can_submit_task('some_task', 'priority_queue', authorized_context)
         assert can_submit is True
+
+    def test_user_rate_limit_is_enforced(self):
+        """Configured per-user task submission limits should reject excess calls."""
+        self.authorizer.set_user_rate_limit('limited-user', 1)
+        user_context = AuthContext(user_id='limited-user')
+
+        first_allowed, first_reason = self.authorizer.can_submit_task(
+            'some_task',
+            'default',
+            user_context,
+        )
+        second_allowed, second_reason = self.authorizer.can_submit_task(
+            'some_task',
+            'default',
+            user_context,
+        )
+
+        assert first_allowed is True
+        assert first_reason is None
+        assert second_allowed is False
+        assert 'Rate limit exceeded' in second_reason
 
     def test_payload_size_validation_for_non_admin(self):
         """Test that non-admin users have payload size limits."""

--- a/tldw_Server_API/app/core/Scheduler/tests/test_security_fixes.py
+++ b/tldw_Server_API/app/core/Scheduler/tests/test_security_fixes.py
@@ -79,7 +79,7 @@ class TestPathTraversalFixes:
             assert 'scheduler' in str(config.base_path)
             assert config.base_path.exists() or True  # Path creation might be lazy
 
-    def test_unix_permission_fallback(self, tmp_path):
+    def test_unix_permission_fallback(self, tmp_path: Path) -> None:
         """Test Unix path fallback when /var/lib is not writable."""
         with patch('platform.system', return_value='Linux'):
             with patch('os.access', return_value=False):
@@ -477,7 +477,7 @@ class TestTaskAuthorization:
         can_submit, reason = self.authorizer.can_submit_task('some_task', 'priority_queue', authorized_context)
         assert can_submit is True
 
-    def test_user_rate_limit_is_enforced(self):
+    def test_user_rate_limit_is_enforced(self) -> None:
         """Configured per-user task submission limits should reject excess calls."""
         self.authorizer.set_user_rate_limit('limited-user', 1)
         user_context = AuthContext(user_id='limited-user')
@@ -495,6 +495,49 @@ class TestTaskAuthorization:
 
         assert first_allowed is True
         assert first_reason is None
+        assert second_allowed is False
+        assert 'Rate limit exceeded' in second_reason
+
+    @pytest.mark.parametrize("limit_value", [True, False])
+    def test_user_rate_limit_rejects_bool_values(self, limit_value: bool) -> None:
+        """Boolean rate-limit values should not be accepted as integers."""
+        with pytest.raises(ValueError, match="non-negative integer"):
+            self.authorizer.set_user_rate_limit('limited-user', limit_value)
+
+    def test_denied_submit_does_not_consume_user_rate_limit(self) -> None:
+        """Permission denials should not spend rate-limit slots for later valid submissions."""
+        self.authorizer.register_queue_permissions(
+            'priority_queue',
+            [TaskPermission.SUBMIT],
+        )
+        self.authorizer.set_user_rate_limit('limited-user', 1)
+
+        denied_context = AuthContext(user_id='limited-user', permissions=set())
+        denied, denied_reason = self.authorizer.can_submit_task(
+            'some_task',
+            'priority_queue',
+            denied_context,
+        )
+
+        allowed_context = AuthContext(
+            user_id='limited-user',
+            permissions={TaskPermission.SUBMIT.value},
+        )
+        allowed, allowed_reason = self.authorizer.can_submit_task(
+            'some_task',
+            'priority_queue',
+            allowed_context,
+        )
+        second_allowed, second_reason = self.authorizer.can_submit_task(
+            'some_task',
+            'priority_queue',
+            allowed_context,
+        )
+
+        assert denied is False
+        assert 'queue permissions' in denied_reason
+        assert allowed is True
+        assert allowed_reason is None
         assert second_allowed is False
         assert 'Rate limit exceeded' in second_reason
 

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_webhook_triggers.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_webhook_triggers.py
@@ -313,19 +313,23 @@ async def test_handle_webhook_submits_acp_run(
 @pytest.mark.asyncio
 async def test_submit_acp_run_awaits_scheduler_and_passes_metadata(
     mgr: ACPTriggerManager,
-    monkeypatch,
-):
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Direct scheduler submission should await the async singleton and include metadata."""
     import tldw_Server_API.app.core.Scheduler as scheduler_module
 
     captured: dict[str, Any] = {}
 
     class FakeScheduler:
+        """Fake scheduler that records submit keyword arguments."""
+
         async def submit(self, **kwargs: Any) -> str:
+            """Capture submission details and return a deterministic task id."""
             captured.update(kwargs)
             return "task-direct-123"
 
-    async def fake_get_global_scheduler():
+    async def fake_get_global_scheduler() -> FakeScheduler:
+        """Return the fake scheduler through the async singleton contract."""
         return FakeScheduler()
 
     monkeypatch.setattr(scheduler_module, "get_global_scheduler", fake_get_global_scheduler)

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_webhook_triggers.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_webhook_triggers.py
@@ -311,6 +311,37 @@ async def test_handle_webhook_submits_acp_run(
 
 
 @pytest.mark.asyncio
+async def test_submit_acp_run_awaits_scheduler_and_passes_metadata(
+    mgr: ACPTriggerManager,
+    monkeypatch,
+):
+    """Direct scheduler submission should await the async singleton and include metadata."""
+    import tldw_Server_API.app.core.Scheduler as scheduler_module
+
+    captured: dict[str, Any] = {}
+
+    class FakeScheduler:
+        async def submit(self, **kwargs: Any) -> str:
+            captured.update(kwargs)
+            return "task-direct-123"
+
+    async def fake_get_global_scheduler():
+        return FakeScheduler()
+
+    monkeypatch.setattr(scheduler_module, "get_global_scheduler", fake_get_global_scheduler)
+
+    task_id = await mgr._submit_acp_run({
+        "user_id": 42,
+        "prompt": "Handle this event",
+    })
+
+    assert task_id == "task-direct-123"
+    assert captured["handler"] == "acp_run"
+    assert captured["queue_name"] == "acp"
+    assert captured["metadata"] == {"user_id": "42"}
+
+
+@pytest.mark.asyncio
 async def test_handle_webhook_github_provider(
     mgr: ACPTriggerManager,
     secret_mgr: TriggerSecretManager,


### PR DESCRIPTION
## Summary

- Harden Scheduler queue state, timestamp parsing, and lease-scoped ack/nack behavior across backends and workers.
- Fix ACP webhook Scheduler submission to await the scheduler and include user metadata.
- Add focused regression coverage and record TASK-10005 verification.

## Verification

- /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m pytest -q tldw_Server_API/app/core/Scheduler/tests tldw_Server_API/tests/Agent_Client_Protocol/test_webhook_triggers.py
- /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/python -m bandit tldw_Server_API/app/core/Scheduler/authorization.py tldw_Server_API/app/core/Scheduler/backends/memory_backend.py tldw_Server_API/app/core/Scheduler/backends/postgresql_backend.py tldw_Server_API/app/core/Scheduler/backends/sqlite_backend.py tldw_Server_API/app/core/Scheduler/base/queue_backend.py tldw_Server_API/app/core/Scheduler/core/worker_pool.py tldw_Server_API/app/core/Scheduler/core/improved_worker_pool.py tldw_Server_API/app/core/Scheduler/scheduler.py tldw_Server_API/app/core/Agent_Client_Protocol/triggers.py -f json -o /tmp/bandit_scheduler_review_clean_worktree.json
- git diff --cached --check
- git diff --check

Note: This PR was prepared by Codex; per repository policy, a human-authored Change summary is still required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the Scheduler to prevent stale completions and timing bugs, and fixes ACP webhook submissions by awaiting the async scheduler and requiring/passing user metadata. Addresses TASK-10005 with changes across backends, worker pools, startup order, and per-user rate limits.

- **Bug Fixes**
  - PostgreSQL `enqueue`/`bulk_enqueue` persist new tasks as `queued` and use safe `pg_notify` for queue updates.
  - SQLite compares ISO timestamps for `scheduled_at`, `expires_at`, and lease expiry; ready-task and lease-reclaim queries fixed.
  - `ack`/`nack` are lease- and worker-scoped; backends validate `lease_id`/`worker_id`, worker pools pass them, and force-stop uses `nack`.
  - Scheduler sets `_started` before starting background loops.
  - ACP webhook submission awaits the global scheduler and includes `metadata={"user_id": ...}`; payload must include `user_id`.
  - Per-user rate limits use a 60s sliding window, enforced after permission checks; boolean limit values are rejected.

- **Migration**
  - Custom backends must update `ack`/`nack` signatures to accept optional `lease_id` and `worker_id` and enforce them when provided.
  - ACP webhook callers must include `user_id` in the payload (stringified in metadata).

<sup>Written for commit 1c26ac8d8ce254ed0c58a896595e4296ec4f5c33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

