### PR TITLE
Harden Streaming module review findings

### DIFF
--- a/backlog/tasks/task-12011 - Harden-Streaming-module-review-findings.md
+++ b/backlog/tasks/task-12011 - Harden-Streaming-module-review-findings.md
@@ -4,7 +4,7 @@ title: Harden Streaming module review findings
 status: Done
 assignee: []
 created_date: '2026-06-24'
-updated_date: '2026-06-24'
+updated_date: '2026-06-25'
 labels:
   - streaming
   - security
@@ -42,6 +42,13 @@ Implemented:
 - SSE raw provider lines now use the shared provider-line normalizer and honor provider control passthrough/filter settings.
 - WebSocket streams now propagate real accept failures, tolerate known already-accepted Starlette state errors, and stop ping/idle background tasks on terminal frames.
 - SSE heartbeat enqueue uses forced enqueue to avoid deadlock under a full queue.
+
+PR review follow-up:
+- Rebased `codex/streaming-module-hardening` onto latest `origin/dev`.
+- Made speech-chat LLM extra-param filtering case-insensitive and blocked `api_url`, `*_api_url`, `http_client_factory`, `http_fetcher`, `extra_headers`, and `extra_body` override keys.
+- Added an encoded-size guard so oversized base64 input is rejected before decoded bytes are allocated.
+- Broadened already-accepted WebSocket RuntimeError detection while preserving propagation for generic accept failures.
+- Reworked new tests to add docstrings/return annotations, avoid new direct action-helper coverage where public `run_speech_chat_turn` can verify behavior, and use event-driven ping waiting.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 <!-- SECTION:NOTES:END -->
 
@@ -54,6 +61,8 @@ Verification:
 - Initial focused red run: 10 expected failures in speech-chat and stream lifecycle tests.
 - Clean-worktree focused final run: `python -m pytest tldw_Server_API/tests/Audio/test_speech_chat_service.py tldw_Server_API/tests/Streaming/test_streams.py -q` -> 52 passed.
 - Clean-worktree touched-scope security scan: `python -m bandit -r tldw_Server_API/app/core/Streaming -f json -o /tmp/bandit_streaming_12011_worktree.json` -> 0 findings.
+- Rebased-review focused run: `python -m pytest tldw_Server_API/tests/Audio/test_speech_chat_service.py tldw_Server_API/tests/Streaming/test_streams.py -q` -> 55 passed.
+- Rebased-review touched-scope security scan: `python -m bandit -r tldw_Server_API/app/core/Streaming -f json -o /tmp/bandit_streaming_12011_rebased.json` -> 0 findings.
 
 Residual note: the optional audio WebSocket ping checks still fail in the clean worktree even with `MINIMAL_TEST_INCLUDE_AUDIO=1`, because `/api/v1/audio/stream/transcribe` explicitly constructs its `WebSocketStream` with `heartbeat_interval_s=0`. That endpoint-level behavior is outside this `app/core/Streaming` hardening change.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-12011 - Harden-Streaming-module-review-findings.md
+++ b/backlog/tasks/task-12011 - Harden-Streaming-module-review-findings.md
@@ -1,0 +1,67 @@
+---
+id: TASK-12011
+title: Harden Streaming module review findings
+status: Done
+assignee: []
+created_date: '2026-06-24'
+updated_date: '2026-06-24'
+labels:
+  - streaming
+  - security
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the accepted code review findings for `tldw_Server_API/app/core/Streaming`, focusing on the current module code rather than git diffs.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Speech chat action execution fails closed unless an explicit allowlist is configured.
+- [x] #2 Audio request size and format limits are checked before decoding/parsing audio content.
+- [x] #3 Speech chat STT/LLM configuration fields are passed through to the underlying providers where supported.
+- [x] #4 TTS exception mapping does not return internal paths or raw provider details to clients.
+- [x] #5 SSE provider control-line filtering honors the configured passthrough/filter policy.
+- [x] #6 WebSocket stream lifecycle handles accept failures and terminal states without leaked background tasks.
+- [x] #7 Focused regression tests and touched-scope security scan pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Manual Backlog task file created because the Backlog MCP was unavailable and the CLI hung on search/list/create operations. The user approved a manual task-file exception for this review fix.
+
+Implemented:
+- Speech chat actions now require `AUDIO_CHAT_ALLOWED_ACTIONS` to explicitly include the requested action before any MCP module lookup occurs.
+- Speech chat validates declared input format before base64 decoding and enforces byte size before parsing audio with soundfile.
+- Speech chat passes supported STT model configuration via `whisper_model` and forwards guarded LLM extra params while blocking internal/security-sensitive keys.
+- Speech chat TTS validation and voice-reference failures now return generic client details instead of raw exception text.
+- SSE raw provider lines now use the shared provider-line normalizer and honor provider control passthrough/filter settings.
+- WebSocket streams now propagate real accept failures, tolerate known already-accepted Starlette state errors, and stop ping/idle background tasks on terminal frames.
+- SSE heartbeat enqueue uses forced enqueue to avoid deadlock under a full queue.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hardened the Streaming module review findings and added focused regression coverage.
+
+Verification:
+- Initial focused red run: 10 expected failures in speech-chat and stream lifecycle tests.
+- Clean-worktree focused final run: `python -m pytest tldw_Server_API/tests/Audio/test_speech_chat_service.py tldw_Server_API/tests/Streaming/test_streams.py -q` -> 52 passed.
+- Clean-worktree touched-scope security scan: `python -m bandit -r tldw_Server_API/app/core/Streaming -f json -o /tmp/bandit_streaming_12011_worktree.json` -> 0 findings.
+
+Residual note: the optional audio WebSocket ping checks still fail in the clean worktree even with `MINIMAL_TEST_INCLUDE_AUDIO=1`, because `/api/v1/audio/stream/transcribe` explicitly constructs its `WebSocketStream` with `heartbeat_interval_s=0`. That endpoint-level behavior is outside this `app/core/Streaming` hardening change.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests passing
+- [x] #3 Security scan run on touched scope
+- [x] #4 Final summary recorded
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/Streaming/speech_chat_service.py
+++ b/tldw_Server_API/app/core/Streaming/speech_chat_service.py
@@ -86,6 +86,43 @@ from tldw_Server_API.app.core.TTS.tts_request_resolution import (
 from tldw_Server_API.app.core.TTS.tts_service_v2 import TTSServiceV2
 
 _ALLOWED_AUDIO_FORMATS = {"wav", "mp3", "ogg", "opus", "aac", "flac", "webm", "m4a"}
+_STT_EXTRA_PARAM_KEYS = {"whisper_model"}
+_LLM_EXTRA_PARAM_RESERVED_KEYS = {
+    "action",
+    "api_base_url",
+    "api_endpoint",
+    "api_key",
+    "api_provider",
+    "app_config",
+    "auth_user",
+    "base_url",
+    "caller_request",
+    "frequency_penalty",
+    "function_call",
+    "functions",
+    "max_tokens",
+    "maxp",
+    "messages",
+    "messages_payload",
+    "model",
+    "presence_penalty",
+    "principal",
+    "provider",
+    "request",
+    "response_format",
+    "stream",
+    "streaming",
+    "system_message",
+    "temp",
+    "temperature",
+    "tool_choice",
+    "tools",
+    "topk",
+    "topp",
+    "trusted_base_url_override",
+    "user",
+    "user_identifier",
+}
 
 
 def _normalize_audio_format(input_format: str) -> str:
@@ -200,20 +237,52 @@ def _actions_enabled() -> bool:
     return is_truthy(os.getenv("AUDIO_CHAT_ENABLE_ACTIONS"))
 
 
+def _allowed_audio_chat_actions() -> set[str]:
+    """Return the explicit audio-chat action allowlist."""
+    allow_env = os.getenv("AUDIO_CHAT_ALLOWED_ACTIONS", "")
+    return {action.strip() for action in allow_env.split(",") if action.strip()}
+
+
+def _provider_llm_extra_params(extra_params: dict[str, Any] | None) -> dict[str, Any]:
+    """Return provider-bound LLM params without internal or security-sensitive fields."""
+    if not isinstance(extra_params, dict):
+        return {}
+
+    safe_params: dict[str, Any] = {}
+    for raw_key, value in extra_params.items():
+        if not isinstance(raw_key, str):
+            continue
+        key = raw_key.strip()
+        if not key or key.startswith("_") or key in _LLM_EXTRA_PARAM_RESERVED_KEYS:
+            continue
+        safe_params[key] = value
+    return safe_params
+
+
+def _stt_extra_params(stt_extra_params: dict[str, Any] | None) -> dict[str, Any]:
+    """Return STT params supported by the shared transcription entrypoint."""
+    if not isinstance(stt_extra_params, dict):
+        return {}
+    return {
+        key: value
+        for key, value in stt_extra_params.items()
+        if isinstance(key, str) and key in _STT_EXTRA_PARAM_KEYS and value is not None
+    }
+
+
 async def _execute_action(action_name: str, transcript: str, current_user: User) -> dict[str, Any]:
     """
     Execute a tool/workflow via MCP modules when available; fail soft with status.
     """
-    allow_env = os.getenv("AUDIO_CHAT_ALLOWED_ACTIONS", "")
-    if allow_env:
-        allowed = {a.strip() for a in allow_env.split(",") if a.strip()}
-        if allowed and action_name not in allowed:
-            return {
-                "action": action_name,
-                "status": "not_allowed",
-                "message": "Action not allowed",
-                "user_id": getattr(current_user, "id", None),
-            }
+    action_name = str(action_name or "").strip()
+    allowed = _allowed_audio_chat_actions()
+    if not action_name or action_name not in allowed:
+        return {
+            "action": action_name,
+            "status": "not_allowed",
+            "message": "Action not allowed",
+            "user_id": getattr(current_user, "id", None),
+        }
     user_id = getattr(current_user, "id", None)
     ctx = RequestContext(
         request_id=str(uuid.uuid4()),
@@ -319,10 +388,13 @@ def _map_tts_exception(exc: Exception) -> HTTPException:
     """Map TTS exceptions to HTTPException consistent with /audio/speech."""
     if isinstance(exc, TTSInvalidVoiceReferenceError):
         logger.warning("TTS voice reference error in speech chat")
-        return HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
+        return HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Invalid TTS voice reference",
+        )
     if isinstance(exc, TTSValidationError):
         logger.warning("TTS validation error in speech chat")
-        return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+        return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid TTS request")
     if isinstance(exc, TTSProviderNotConfiguredError):
         logger.error("TTS provider not configured in speech chat")
         return HTTPException(
@@ -384,7 +456,17 @@ async def run_speech_chat_turn(
     """
     # --- Decode audio ---
     req_start = time.time()
+    _validate_audio_constraints(
+        audio_bytes=b"",
+        duration_sec=0.0,
+        input_format=request_data.input_audio_format,
+    )
     raw_audio_bytes = _decode_base64_audio(request_data.input_audio)
+    _validate_audio_constraints(
+        audio_bytes=raw_audio_bytes,
+        duration_sec=0.0,
+        input_format=request_data.input_audio_format,
+    )
     audio_np, sample_rate = _load_audio_to_mono_np(raw_audio_bytes)
     duration_sec = float(len(audio_np) / float(sample_rate or 16000))
     _validate_audio_constraints(
@@ -397,9 +479,13 @@ async def run_speech_chat_turn(
     stt_start = time.time()
     stt_provider = None
     stt_language = None
+    stt_kwargs: dict[str, Any] = {}
     if request_data.stt_config is not None:
         stt_provider = request_data.stt_config.provider
         stt_language = request_data.stt_config.language
+        stt_kwargs.update(_stt_extra_params(request_data.stt_config.extra_params))
+        if request_data.stt_config.model:
+            stt_kwargs["whisper_model"] = request_data.stt_config.model
     try:
         transcript = await asyncio.to_thread(
             transcribe_audio,
@@ -407,6 +493,7 @@ async def run_speech_chat_turn(
             transcription_provider=stt_provider,
             sample_rate=sample_rate,
             speaker_lang=stt_language,
+            **stt_kwargs,
         )
     except HTTPException:
         raise
@@ -504,6 +591,7 @@ async def run_speech_chat_turn(
         or DEFAULT_LLM_PROVIDER
     )
     llm_model = request_data.llm_config.model
+    llm_extra_params = _provider_llm_extra_params(request_data.llm_config.extra_params)
 
     messages_payload = list(history_messages)
     messages_payload.append({"role": "user", "content": transcript})
@@ -567,6 +655,7 @@ async def run_speech_chat_turn(
                 "user": str(getattr(current_user, "id", client_id)),
                 "app_config": app_config,
             }
+            request_payload.update(llm_extra_params)
             try:
                 llm_response = await adapter.achat(request_payload)
             except NotImplementedError:
@@ -587,6 +676,7 @@ async def run_speech_chat_turn(
                 user_identifier=str(getattr(current_user, "id", client_id)),
                 system_message=system_message,
                 app_config=app_config,
+                **llm_extra_params,
             )
     except HTTPException:
         raise

--- a/tldw_Server_API/app/core/Streaming/speech_chat_service.py
+++ b/tldw_Server_API/app/core/Streaming/speech_chat_service.py
@@ -93,13 +93,18 @@ _LLM_EXTRA_PARAM_RESERVED_KEYS = {
     "api_endpoint",
     "api_key",
     "api_provider",
+    "api_url",
     "app_config",
     "auth_user",
     "base_url",
     "caller_request",
+    "extra_body",
+    "extra_headers",
     "frequency_penalty",
     "function_call",
     "functions",
+    "http_client_factory",
+    "http_fetcher",
     "max_tokens",
     "maxp",
     "messages",
@@ -123,6 +128,17 @@ _LLM_EXTRA_PARAM_RESERVED_KEYS = {
     "user",
     "user_identifier",
 }
+
+
+def _audio_chat_max_bytes() -> int:
+    """Return the configured speech-chat audio byte limit."""
+    raw_max_bytes = os.getenv("AUDIO_CHAT_MAX_BYTES")
+    if raw_max_bytes is not None:
+        try:
+            return int(raw_max_bytes)
+        except (ValueError, TypeError):
+            logger.debug("AUDIO_CHAT_MAX_BYTES parse failed; using default 20MB")
+    return 20 * 1024 * 1024
 
 
 def _normalize_audio_format(input_format: str) -> str:
@@ -149,6 +165,23 @@ def _decode_base64_audio(data: str) -> bytes:
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid base64 encoding for input_audio",
         ) from e
+
+
+def _estimate_base64_decoded_size(data: str) -> int:
+    """Estimate decoded byte length without allocating the decoded payload."""
+    encoded = str(data or "").strip()
+    padding = min(2, len(encoded) - len(encoded.rstrip("=")))
+    return max(0, (len(encoded) * 3) // 4 - padding)
+
+
+def _validate_encoded_audio_size(input_audio: str) -> None:
+    """Reject base64 payloads that would decode above the speech-chat byte limit."""
+    max_bytes = _audio_chat_max_bytes()
+    if _estimate_base64_decoded_size(input_audio) > max_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="input_audio exceeds size limit for speech chat",
+        )
 
 
 def _load_audio_to_mono_np(audio_bytes: bytes) -> tuple[np.ndarray, int]:
@@ -198,17 +231,8 @@ def _validate_audio_constraints(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Unsupported input_audio_format '{input_format}'",
         )
-    # Size limit (bytes): allow env override but fall back safely on parse errors.
-    _raw_max_bytes = os.getenv("AUDIO_CHAT_MAX_BYTES")
-    if _raw_max_bytes is not None:
-        try:
-            max_bytes = int(_raw_max_bytes)
-        except (ValueError, TypeError):
-            logger.debug("AUDIO_CHAT_MAX_BYTES parse failed; using default 20MB")
-            max_bytes = 20 * 1024 * 1024
-    else:
-        max_bytes = 20 * 1024 * 1024
 
+    max_bytes = _audio_chat_max_bytes()
     if audio_bytes and len(audio_bytes) > max_bytes:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
@@ -253,7 +277,13 @@ def _provider_llm_extra_params(extra_params: dict[str, Any] | None) -> dict[str,
         if not isinstance(raw_key, str):
             continue
         key = raw_key.strip()
-        if not key or key.startswith("_") or key in _LLM_EXTRA_PARAM_RESERVED_KEYS:
+        key_lower = key.lower()
+        if (
+            not key
+            or key.startswith("_")
+            or key_lower in _LLM_EXTRA_PARAM_RESERVED_KEYS
+            or key_lower.endswith("_api_url")
+        ):
             continue
         safe_params[key] = value
     return safe_params
@@ -461,6 +491,7 @@ async def run_speech_chat_turn(
         duration_sec=0.0,
         input_format=request_data.input_audio_format,
     )
+    _validate_encoded_audio_size(request_data.input_audio)
     raw_audio_bytes = _decode_base64_audio(request_data.input_audio)
     _validate_audio_constraints(
         audio_bytes=raw_audio_bytes,

--- a/tldw_Server_API/app/core/Streaming/streams.py
+++ b/tldw_Server_API/app/core/Streaming/streams.py
@@ -10,6 +10,7 @@ from loguru import logger
 from tldw_Server_API.app.core.LLM_Calls.sse import (
     ensure_sse_control_line,
     ensure_sse_line,
+    normalize_provider_line,
     sse_data,
     sse_done,
 )
@@ -22,7 +23,6 @@ from tldw_Server_API.app.core.Metrics.metrics_manager import (
 _STREAM_METRICS_REGISTERED = False
 
 _STREAMING_NONCRITICAL_EXCEPTIONS = (
-    asyncio.CancelledError,
     AssertionError,
     AttributeError,
     ConnectionError,
@@ -103,6 +103,16 @@ def _ensure_stream_metrics_registered() -> None:
         _STREAM_METRICS_REGISTERED = True
     except _STREAMING_NONCRITICAL_EXCEPTIONS:
         logger.debug("Stream metrics registration failed or already registered")
+
+
+def _is_already_accepted_websocket_error(exc: RuntimeError) -> bool:
+    """Return True for Starlette's double-accept state error."""
+    message = str(exc)
+    return (
+        "websocket.accept" in message
+        and "websocket.send" in message
+        and "websocket.close" in message
+    )
 
 
 class SSEStream:
@@ -192,19 +202,14 @@ class SSEStream:
         await self._enqueue(sse_data(payload), force=force)
 
     async def send_raw_sse_line(self, line: str) -> None:
-        if "\n" in line:
-            lower = line.lower()
-            if "data:" in lower:
-                await self._enqueue(ensure_sse_line(line))
-            else:
-                await self._enqueue(ensure_sse_control_line(line))
-            return
-        stripped = line.lstrip()
-        lower = stripped.lower()
-        if lower.startswith(("event:", "id:", "retry:", ":")):
-            await self._enqueue(ensure_sse_control_line(line))
-        else:
-            await self._enqueue(ensure_sse_line(line))
+        for raw_line in str(line).splitlines() or [str(line)]:
+            normalized = normalize_provider_line(
+                raw_line,
+                provider_control_passthru=self.provider_control_passthru,
+                control_filter=self.control_filter,
+            )
+            if normalized is not None:
+                await self._enqueue(normalized)
 
     async def error(
         self,
@@ -304,10 +309,10 @@ class SSEStream:
                                 f"SSEStream heartbeat emit mode={self.heartbeat_mode} interval_s={self.heartbeat_interval_s}"
                             )
                         if self.heartbeat_mode == "data":
-                            await self._enqueue(sse_data({"heartbeat": True}))
+                            await self._enqueue(sse_data({"heartbeat": True}), force=True)
                         else:
                             # Comment heartbeat
-                            await self._enqueue(ensure_sse_line(":"))
+                            await self._enqueue(ensure_sse_line(":"), force=True)
                         last_hb_ts = time.monotonic()
                         # Drain immediately
                         continue
@@ -400,9 +405,17 @@ class WebSocketStream:
             except _STREAMING_NONCRITICAL_EXCEPTIONS:
                 already_accepted = False
             if hasattr(self.ws, "accept") and not already_accepted:
-                await maybe_await(self.ws.accept())
+                try:
+                    await maybe_await(self.ws.accept())
+                except RuntimeError as exc:
+                    if not _is_already_accepted_websocket_error(exc):
+                        raise
+        except asyncio.CancelledError:
+            self._running = False
+            raise
         except _STREAMING_NONCRITICAL_EXCEPTIONS:
-            pass
+            self._running = False
+            raise
         if self.heartbeat_interval_s and self.heartbeat_interval_s > 0:
             self._ping_task = asyncio.create_task(self._ping_loop())
         if self.idle_timeout_s and self.idle_timeout_s > 0:
@@ -410,8 +423,12 @@ class WebSocketStream:
 
     async def stop(self) -> None:
         self._running = False
-        for task in (self._ping_task, self._idle_task):
+        current_task = asyncio.current_task()
+        for attr in ("_ping_task", "_idle_task"):
+            task = getattr(self, attr)
             if task:
+                if task is current_task:
+                    continue
                 task.cancel()
                 try:
                     await task
@@ -420,6 +437,7 @@ class WebSocketStream:
                     pass
                 except _STREAMING_NONCRITICAL_EXCEPTIONS:
                     pass
+                setattr(self, attr, None)
 
     def mark_activity(self) -> None:
         self._last_activity = time.monotonic()
@@ -449,10 +467,13 @@ class WebSocketStream:
         await self._send_json_with_metrics(payload, kind="json")
 
     async def done(self, *, close_code: int = 1000) -> None:
-        await self._send_json_with_metrics({"type": "done"}, kind="done")
-        if self.close_on_done:
-            with contextlib.suppress(_STREAMING_NONCRITICAL_EXCEPTIONS):
-                await maybe_await(self.ws.close(code=close_code))
+        try:
+            await self._send_json_with_metrics({"type": "done"}, kind="done")
+            if self.close_on_done:
+                with contextlib.suppress(_STREAMING_NONCRITICAL_EXCEPTIONS):
+                    await maybe_await(self.ws.close(code=close_code))
+        finally:
+            await self.stop()
 
     async def error(self, code: str, message: str, *, data: Optional[dict[str, Any]] = None) -> None:
         payload: dict[str, Any] = {"type": "error", "code": code, "message": message}
@@ -466,10 +487,13 @@ class WebSocketStream:
                     payload["quota"] = data.get("quota")
             except _STREAMING_NONCRITICAL_EXCEPTIONS:
                 pass
-        await self._send_json_with_metrics(payload, kind="error")
         close_code = self._map_close_code(code)
-        with contextlib.suppress(_STREAMING_NONCRITICAL_EXCEPTIONS):
-            await maybe_await(self.ws.close(code=close_code))
+        try:
+            await self._send_json_with_metrics(payload, kind="error")
+            with contextlib.suppress(_STREAMING_NONCRITICAL_EXCEPTIONS):
+                await maybe_await(self.ws.close(code=close_code))
+        finally:
+            await self.stop()
 
     async def _send_json_with_metrics(self, payload: dict[str, Any], *, kind: str) -> None:
         t0 = time.monotonic()
@@ -492,6 +516,8 @@ class WebSocketStream:
         try:
             while self._running:
                 await asyncio.sleep(self.heartbeat_interval_s)
+                if not self._running:
+                    break
                 try:
                     await self._send_json_with_metrics({"type": "ping"}, kind="ping")
                     reg.increment("ws_pings_total", 1, self._labels)
@@ -507,6 +533,8 @@ class WebSocketStream:
         try:
             while self._running:
                 await asyncio.sleep(max(0.05, min(self.idle_timeout_s or 60.0, 1.0)))
+                if not self._running:
+                    break
                 now = time.monotonic()
                 if self.idle_timeout_s and now - self._last_activity >= self.idle_timeout_s:
                     # Close with 1001 and increment counter

--- a/tldw_Server_API/app/core/Streaming/streams.py
+++ b/tldw_Server_API/app/core/Streaming/streams.py
@@ -107,11 +107,15 @@ def _ensure_stream_metrics_registered() -> None:
 
 def _is_already_accepted_websocket_error(exc: RuntimeError) -> bool:
     """Return True for Starlette's double-accept state error."""
-    message = str(exc)
+    message = str(exc).lower()
     return (
-        "websocket.accept" in message
-        and "websocket.send" in message
-        and "websocket.close" in message
+        (
+            "websocket.accept" in message
+            and ("websocket.send" in message or "websocket.close" in message)
+        )
+        or "already accepted" in message
+        or ('cannot call "accept"' in message and "connection is established" in message)
+        or ("accept" in message and "already" in message and "connection" in message)
     )
 
 

--- a/tldw_Server_API/tests/Audio/test_speech_chat_service.py
+++ b/tldw_Server_API/tests/Audio/test_speech_chat_service.py
@@ -1,7 +1,7 @@
 import base64
 import io
 from types import SimpleNamespace
-from typing import Any, Dict
+from typing import Any, AsyncIterator, Dict
 
 import numpy as np
 import pytest
@@ -100,24 +100,33 @@ class _StubTTSService:
 
 
 class _RecordingTTSService:
+    """TTS service stub that records synthesized speech requests."""
+
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
 
-    async def generate_speech(self, request, **kwargs):
+    async def generate_speech(self, request: Any, **kwargs: Any) -> AsyncIterator[bytes]:
+        """Record the request and yield deterministic audio bytes."""
         self.calls.append({"request": request, "kwargs": kwargs})
         yield b"stub-audio"
 
 
 class _NoAdapterRegistry:
-    def get_adapter(self, _name: str):
+    """Adapter registry stub that forces the fallback LLM call path."""
+
+    def get_adapter(self, _name: str) -> None:
+        """Return no adapter for every provider name."""
         return None
 
 
 class _RecordingAdapter:
+    """LLM adapter stub that records adapter request payloads."""
+
     def __init__(self) -> None:
         self.requests: list[dict[str, Any]] = []
 
     async def achat(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Record an async chat request and return a deterministic response."""
         self.requests.append(request)
         return {
             "choices": [
@@ -128,15 +137,20 @@ class _RecordingAdapter:
 
 
 class _RecordingAdapterRegistry:
+    """Adapter registry stub that returns one recording adapter."""
+
     def __init__(self, adapter: _RecordingAdapter) -> None:
         self.adapter = adapter
 
-    def get_adapter(self, _name: str):
+    def get_adapter(self, _name: str) -> _RecordingAdapter:
+        """Return the configured recording adapter."""
         return self.adapter
 
 
 class _DummyActionModule(BaseModule):
-    def __init__(self, config: ModuleConfig):
+    """MCP module stub exposing a deterministic action tool."""
+
+    def __init__(self, config: ModuleConfig) -> None:
         super().__init__(config)
 
     async def on_initialize(self) -> None:
@@ -506,13 +520,19 @@ def test_map_tts_exception_sanitizes_mapping_logs(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_execute_action_requires_explicit_allowlist_before_registry_lookup(monkeypatch):
+async def test_run_speech_chat_turn_requires_explicit_action_allowlist_before_registry_lookup(monkeypatch):
+    """Action execution should fail closed before any module registry lookup."""
     from tldw_Server_API.app.core.Streaming import speech_chat_service
 
+    _patch_speech_chat_success_path(monkeypatch, speech_chat_service, transcript="action transcript")
+    monkeypatch.setenv("AUDIO_CHAT_ENABLE_ACTIONS", "1")
     monkeypatch.delenv("AUDIO_CHAT_ALLOWED_ACTIONS", raising=False)
 
     class _RegistryShouldNotBeUsed:
-        async def find_module_for_tool(self, _action_name):
+        """Registry stub that fails the test if action lookup is attempted."""
+
+        async def find_module_for_tool(self, _action_name: str) -> Any:
+            """Fail when the service reaches module lookup without an allowlist."""
             pytest.fail("registry lookup should not run without an action allowlist")
 
     monkeypatch.setattr(
@@ -521,18 +541,32 @@ async def test_execute_action_requires_explicit_allowlist_before_registry_lookup
         lambda: _RegistryShouldNotBeUsed(),
     )
 
-    result = await speech_chat_service._execute_action(
-        "play_music",
-        "transcript",
-        _StubUser(),
+    req = SpeechChatRequest(
+        session_id=None,
+        input_audio=_encode_silence_base64(),
+        input_audio_format="wav",
+        llm_config=SpeechChatLLMConfig(
+            model="gpt-4o-mini",
+            api_provider="openai",
+            extra_params={"action": "play_music"},
+        ),
     )
 
-    assert result["status"] == "not_allowed"
-    assert result["message"] == "Action not allowed"
+    resp = await run_speech_chat_turn(
+        request_data=req,
+        current_user=_StubUser(),
+        chat_db=_StubChatDB(),
+        tts_service=_StubTTSService(),
+    )
+
+    assert resp.action_result is not None
+    assert resp.action_result["status"] == "not_allowed"
+    assert resp.action_result["message"] == "Action not allowed"
 
 
 @pytest.mark.asyncio
 async def test_run_speech_chat_turn_rejects_unsupported_format_before_decoding(monkeypatch):
+    """Unsupported formats should fail before base64 decoding is attempted."""
     from tldw_Server_API.app.core.Streaming import speech_chat_service
 
     monkeypatch.setattr(
@@ -561,7 +595,38 @@ async def test_run_speech_chat_turn_rejects_unsupported_format_before_decoding(m
 
 
 @pytest.mark.asyncio
+async def test_run_speech_chat_turn_rejects_large_encoded_audio_before_decoding(monkeypatch):
+    """Oversized base64 payloads should fail before allocating decoded bytes."""
+    from tldw_Server_API.app.core.Streaming import speech_chat_service
+
+    monkeypatch.setenv("AUDIO_CHAT_MAX_BYTES", "4")
+    monkeypatch.setattr(
+        speech_chat_service,
+        "_decode_base64_audio",
+        lambda *_args, **_kwargs: pytest.fail("base64 decode should not run for oversized payloads"),
+    )
+
+    req = SpeechChatRequest(
+        session_id=None,
+        input_audio=base64.b64encode(b"too-large").decode("ascii"),
+        input_audio_format="wav",
+        llm_config=SpeechChatLLMConfig(model="gpt-4o-mini", api_provider="openai"),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await run_speech_chat_turn(
+            request_data=req,
+            current_user=_StubUser(),
+            chat_db=_StubChatDB(),
+            tts_service=_StubTTSService(),
+        )
+
+    assert exc_info.value.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+
+
+@pytest.mark.asyncio
 async def test_run_speech_chat_turn_rejects_large_audio_before_soundfile_parse(monkeypatch):
+    """Decoded audio that exceeds the byte limit should fail before soundfile parsing."""
     from tldw_Server_API.app.core.Streaming import speech_chat_service
 
     monkeypatch.setenv("AUDIO_CHAT_MAX_BYTES", "4")
@@ -591,6 +656,7 @@ async def test_run_speech_chat_turn_rejects_large_audio_before_soundfile_parse(m
 
 @pytest.mark.asyncio
 async def test_run_speech_chat_turn_passes_stt_model_to_transcriber(monkeypatch):
+    """Explicit STT models should be passed through as whisper_model."""
     from tldw_Server_API.app.core.Streaming import speech_chat_service
 
     _patch_speech_chat_success_path(monkeypatch, speech_chat_service)
@@ -629,6 +695,7 @@ async def test_run_speech_chat_turn_passes_stt_model_to_transcriber(monkeypatch)
 
 @pytest.mark.asyncio
 async def test_run_speech_chat_turn_passes_llm_extra_params_to_adapter(monkeypatch):
+    """Adapter path should forward safe LLM params and drop unsafe override keys."""
     from tldw_Server_API.app.core.Streaming import speech_chat_service
 
     _patch_speech_chat_success_path(monkeypatch, speech_chat_service)
@@ -652,6 +719,11 @@ async def test_run_speech_chat_turn_passes_llm_extra_params_to_adapter(monkeypat
                 "seed": 123,
                 "action": "play_music",
                 "api_key": "client-supplied-key",
+                "Api_Key": "mixed-case-key",
+                "api_url": "http://127.0.0.1:9",
+                "local_api_url": "http://127.0.0.1:10",
+                "http_client_factory": "hook",
+                "extra_headers": {"Authorization": "Bearer client"},
             },
         ),
     )
@@ -669,6 +741,68 @@ async def test_run_speech_chat_turn_passes_llm_extra_params_to_adapter(monkeypat
     assert adapter.requests[0]["seed"] == 123
     assert "action" not in adapter.requests[0]
     assert adapter.requests[0]["api_key"] != "client-supplied-key"
+    assert "Api_Key" not in adapter.requests[0]
+    assert "api_url" not in adapter.requests[0]
+    assert "local_api_url" not in adapter.requests[0]
+    assert "http_client_factory" not in adapter.requests[0]
+    assert "extra_headers" not in adapter.requests[0]
+
+
+@pytest.mark.asyncio
+async def test_run_speech_chat_turn_filters_llm_extra_params_for_fallback_call(monkeypatch):
+    """Fallback LLM path should drop URL and internal override keys from extra params."""
+    from tldw_Server_API.app.core.Streaming import speech_chat_service
+
+    _patch_speech_chat_success_path(monkeypatch, speech_chat_service)
+    recorded_kwargs: dict[str, Any] = {}
+
+    async def _recording_chat_api_call_async(**kwargs: Any) -> dict[str, Any]:
+        """Record fallback LLM kwargs and return a deterministic response."""
+        recorded_kwargs.update(kwargs)
+        return {
+            "choices": [
+                {"message": {"role": "assistant", "content": "fallback assistant reply"}}
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+
+    monkeypatch.setattr(speech_chat_service, "chat_api_call_async", _recording_chat_api_call_async)
+
+    req = SpeechChatRequest(
+        session_id=None,
+        input_audio=_encode_silence_base64(),
+        input_audio_format="wav",
+        llm_config=SpeechChatLLMConfig(
+            model="gpt-4o-mini",
+            api_provider="openai",
+            extra_params={
+                "top_p": 0.25,
+                "seed": 123,
+                "Api_Key": "mixed-case-key",
+                "api_url": "http://127.0.0.1:9",
+                "custom_api_url": "http://127.0.0.1:10",
+                "http_fetcher": "hook",
+                "extra_body": {"stream": True},
+            },
+        ),
+    )
+
+    resp = await run_speech_chat_turn(
+        request_data=req,
+        current_user=_StubUser(),
+        chat_db=_StubChatDB(),
+        tts_service=_StubTTSService(),
+    )
+
+    assert resp.assistant_text == "fallback assistant reply"
+    assert recorded_kwargs["top_p"] == 0.25
+    assert recorded_kwargs["seed"] == 123
+    assert recorded_kwargs["api_key"] != "mixed-case-key"
+    assert "Api_Key" not in recorded_kwargs
+    assert "api_url" not in recorded_kwargs
+    assert "custom_api_url" not in recorded_kwargs
+    assert "http_fetcher" not in recorded_kwargs
+    assert "extra_body" not in recorded_kwargs
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Audio/test_speech_chat_service.py
+++ b/tldw_Server_API/tests/Audio/test_speech_chat_service.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException, status
 from tldw_Server_API.app.api.v1.schemas.audio_schemas import (
     SpeechChatRequest,
     SpeechChatLLMConfig,
+    SpeechChatSTTConfig,
 )
 from tldw_Server_API.app.core.Streaming.speech_chat_service import run_speech_chat_turn
 from tldw_Server_API.app.core.Metrics.metrics_manager import get_metrics_registry
@@ -110,6 +111,28 @@ class _RecordingTTSService:
 class _NoAdapterRegistry:
     def get_adapter(self, _name: str):
         return None
+
+
+class _RecordingAdapter:
+    def __init__(self) -> None:
+        self.requests: list[dict[str, Any]] = []
+
+    async def achat(self, request: dict[str, Any]) -> dict[str, Any]:
+        self.requests.append(request)
+        return {
+            "choices": [
+                {"message": {"role": "assistant", "content": "adapter assistant reply"}}
+            ],
+            "usage": {"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5},
+        }
+
+
+class _RecordingAdapterRegistry:
+    def __init__(self, adapter: _RecordingAdapter) -> None:
+        self.adapter = adapter
+
+    def get_adapter(self, _name: str):
+        return self.adapter
 
 
 class _DummyActionModule(BaseModule):
@@ -328,6 +351,7 @@ async def test_execute_action_sanitizes_lookup_failure_warning(monkeypatch):
 
     logger_stub = _LoggerStub()
     monkeypatch.setattr(speech_chat_service, "logger", logger_stub, raising=True)
+    monkeypatch.setenv("AUDIO_CHAT_ALLOWED_ACTIONS", "action-/private-token")
 
     class _FailingLookupRegistry:
         async def find_module_for_tool(self, _action_name):
@@ -360,6 +384,7 @@ async def test_execute_action_sanitizes_execution_failure_warning(monkeypatch):
 
     logger_stub = _LoggerStub()
     monkeypatch.setattr(speech_chat_service, "logger", logger_stub, raising=True)
+    monkeypatch.setenv("AUDIO_CHAT_ALLOWED_ACTIONS", "action-/private-token")
 
     class _FailingActionModule:
         async def execute_tool(self, _action_name, arguments, context=None):
@@ -413,14 +438,14 @@ def test_map_tts_exception_sanitizes_mapping_logs(monkeypatch):
             logger_stub.warning_calls,
             "TTS voice reference error in speech chat",
             status.HTTP_422_UNPROCESSABLE_ENTITY,
-            "voice exploded at /private/tmp/voice.wav",
+            "Invalid TTS voice reference",
         ),
         (
             TTSValidationError("validation exploded at /private/tmp/request.json"),
             logger_stub.warning_calls,
             "TTS validation error in speech chat",
             status.HTTP_400_BAD_REQUEST,
-            "validation exploded at /private/tmp/request.json",
+            "Invalid TTS request",
         ),
         (
             TTSProviderNotConfiguredError("provider exploded at /private/tmp/config.json"),
@@ -471,11 +496,179 @@ def test_map_tts_exception_sanitizes_mapping_logs(monkeypatch):
 
         assert mapped.status_code == expected_status
         assert mapped.detail == expected_detail
+        assert "/private/" not in str(mapped.detail)
+        assert "tts-secret" not in str(mapped.detail)
         _assert_log_sanitized(
             calls,
             expected_log,
             forbidden_terms=("tts-secret", "voice.wav", "request.json", "provider.log"),
         )
+
+
+@pytest.mark.asyncio
+async def test_execute_action_requires_explicit_allowlist_before_registry_lookup(monkeypatch):
+    from tldw_Server_API.app.core.Streaming import speech_chat_service
+
+    monkeypatch.delenv("AUDIO_CHAT_ALLOWED_ACTIONS", raising=False)
+
+    class _RegistryShouldNotBeUsed:
+        async def find_module_for_tool(self, _action_name):
+            pytest.fail("registry lookup should not run without an action allowlist")
+
+    monkeypatch.setattr(
+        speech_chat_service,
+        "get_module_registry",
+        lambda: _RegistryShouldNotBeUsed(),
+    )
+
+    result = await speech_chat_service._execute_action(
+        "play_music",
+        "transcript",
+        _StubUser(),
+    )
+
+    assert result["status"] == "not_allowed"
+    assert result["message"] == "Action not allowed"
+
+
+@pytest.mark.asyncio
+async def test_run_speech_chat_turn_rejects_unsupported_format_before_decoding(monkeypatch):
+    from tldw_Server_API.app.core.Streaming import speech_chat_service
+
+    monkeypatch.setattr(
+        speech_chat_service,
+        "_decode_base64_audio",
+        lambda *_args, **_kwargs: pytest.fail("base64 decode should not run for unsupported formats"),
+    )
+
+    req = SpeechChatRequest(
+        session_id=None,
+        input_audio="not-read",
+        input_audio_format="application/x-msdownload",
+        llm_config=SpeechChatLLMConfig(model="gpt-4o-mini", api_provider="openai"),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await run_speech_chat_turn(
+            request_data=req,
+            current_user=_StubUser(),
+            chat_db=_StubChatDB(),
+            tts_service=_StubTTSService(),
+        )
+
+    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Unsupported input_audio_format" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_run_speech_chat_turn_rejects_large_audio_before_soundfile_parse(monkeypatch):
+    from tldw_Server_API.app.core.Streaming import speech_chat_service
+
+    monkeypatch.setenv("AUDIO_CHAT_MAX_BYTES", "4")
+    monkeypatch.setattr(
+        speech_chat_service,
+        "_load_audio_to_mono_np",
+        lambda *_args, **_kwargs: pytest.fail("soundfile parse should not run for oversized audio"),
+    )
+
+    req = SpeechChatRequest(
+        session_id=None,
+        input_audio=base64.b64encode(b"too-large").decode("ascii"),
+        input_audio_format="wav",
+        llm_config=SpeechChatLLMConfig(model="gpt-4o-mini", api_provider="openai"),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await run_speech_chat_turn(
+            request_data=req,
+            current_user=_StubUser(),
+            chat_db=_StubChatDB(),
+            tts_service=_StubTTSService(),
+        )
+
+    assert exc_info.value.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+
+
+@pytest.mark.asyncio
+async def test_run_speech_chat_turn_passes_stt_model_to_transcriber(monkeypatch):
+    from tldw_Server_API.app.core.Streaming import speech_chat_service
+
+    _patch_speech_chat_success_path(monkeypatch, speech_chat_service)
+    recorded_kwargs: dict[str, Any] = {}
+
+    def _recording_transcribe_audio(*_args, **kwargs):
+        recorded_kwargs.update(kwargs)
+        return "hello from audio"
+
+    monkeypatch.setattr(speech_chat_service, "transcribe_audio", _recording_transcribe_audio)
+
+    req = SpeechChatRequest(
+        session_id=None,
+        input_audio=_encode_silence_base64(),
+        input_audio_format="wav",
+        stt_config=SpeechChatSTTConfig(
+            provider="faster-whisper",
+            model="tiny.en",
+            language="en",
+            extra_params={"whisper_model": "base.en"},
+        ),
+        llm_config=SpeechChatLLMConfig(model="gpt-4o-mini", api_provider="openai"),
+    )
+
+    await run_speech_chat_turn(
+        request_data=req,
+        current_user=_StubUser(),
+        chat_db=_StubChatDB(),
+        tts_service=_StubTTSService(),
+    )
+
+    assert recorded_kwargs["transcription_provider"] == "faster-whisper"
+    assert recorded_kwargs["speaker_lang"] == "en"
+    assert recorded_kwargs["whisper_model"] == "tiny.en"
+
+
+@pytest.mark.asyncio
+async def test_run_speech_chat_turn_passes_llm_extra_params_to_adapter(monkeypatch):
+    from tldw_Server_API.app.core.Streaming import speech_chat_service
+
+    _patch_speech_chat_success_path(monkeypatch, speech_chat_service)
+    adapter = _RecordingAdapter()
+    monkeypatch.setattr(
+        speech_chat_service,
+        "get_registry",
+        lambda: _RecordingAdapterRegistry(adapter),
+        raising=True,
+    )
+
+    req = SpeechChatRequest(
+        session_id=None,
+        input_audio=_encode_silence_base64(),
+        input_audio_format="wav",
+        llm_config=SpeechChatLLMConfig(
+            model="gpt-4o-mini",
+            api_provider="openai",
+            extra_params={
+                "top_p": 0.25,
+                "seed": 123,
+                "action": "play_music",
+                "api_key": "client-supplied-key",
+            },
+        ),
+    )
+
+    resp = await run_speech_chat_turn(
+        request_data=req,
+        current_user=_StubUser(),
+        chat_db=_StubChatDB(),
+        tts_service=_StubTTSService(),
+    )
+
+    assert resp.assistant_text == "adapter assistant reply"
+    assert len(adapter.requests) == 1
+    assert adapter.requests[0]["top_p"] == 0.25
+    assert adapter.requests[0]["seed"] == 123
+    assert "action" not in adapter.requests[0]
+    assert adapter.requests[0]["api_key"] != "client-supplied-key"
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Streaming/test_streams.py
+++ b/tldw_Server_API/tests/Streaming/test_streams.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import time
 from contextlib import contextmanager
+from typing import Any
 
 import pytest
 
@@ -170,9 +171,11 @@ async def test_sse_stream_send_json_and_raw_line():
 
 @pytest.mark.asyncio
 async def test_sse_stream_drops_provider_control_lines_by_default():
+    """Raw provider control lines should be filtered unless passthrough is enabled."""
     stream = SSEStream(heartbeat_interval_s=10.0)
 
-    async def producer():
+    async def producer() -> None:
+        """Send provider-style raw SSE lines into the stream."""
         await stream.send_raw_sse_line("event: provider-event")
         await stream.send_raw_sse_line("id: provider-id")
         await stream.send_raw_sse_line("retry: 1000")
@@ -182,7 +185,8 @@ async def test_sse_stream_drops_provider_control_lines_by_default():
 
     out = []
 
-    async def consumer():
+    async def consumer() -> None:
+        """Collect stream output until the done event is emitted."""
         async for ln in stream.iter_sse():
             out.append(ln)
 
@@ -198,7 +202,10 @@ async def test_sse_stream_drops_provider_control_lines_by_default():
 
 @pytest.mark.asyncio
 async def test_sse_stream_applies_control_filter_when_passthru_enabled():
-    def control_filter(name: str, value: str):
+    """Control filters should map or drop provider control lines."""
+
+    def control_filter(name: str, value: str) -> tuple[str, str] | None:
+        """Map event names and drop provider IDs for this test."""
         if name.lower() == "event":
             return ("event", f"mapped-{value}")
         if name.lower() == "id":
@@ -211,7 +218,8 @@ async def test_sse_stream_applies_control_filter_when_passthru_enabled():
         control_filter=control_filter,
     )
 
-    async def producer():
+    async def producer() -> None:
+        """Send mixed control and data lines through the stream."""
         await stream.send_raw_sse_line("event: original")
         await stream.send_raw_sse_line("id: hidden")
         await stream.send_raw_sse_line("data: {\"ok\": true}")
@@ -398,36 +406,62 @@ def test_parse_float_env_invalid_value_debug_log_is_sanitized(monkeypatch):
 
 
 class _StubWebSocket:
-    def __init__(self):
-        self.sent = []
+    """Minimal websocket stub for WebSocketStream tests."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
         self.accepted = False
         self.closed = False
-        self.close_code = None
+        self.close_code: int | None = None
 
-    async def accept(self):
+    async def accept(self) -> None:
+        """Record that the websocket was accepted."""
         self.accepted = True
 
-    async def send_json(self, payload):
+    async def send_json(self, payload: dict[str, Any]) -> None:
+        """Record outbound JSON payloads."""
         self.sent.append(payload)
 
-    async def close(self, code: int = 1000):
+    async def close(self, code: int = 1000) -> None:
+        """Record close state and close code."""
         self.closed = True
         self.close_code = code
 
 
 class _AcceptFailWebSocket(_StubWebSocket):
-    async def accept(self):
+    """Websocket stub that raises a generic accept failure."""
+
+    async def accept(self) -> None:
+        """Raise a generic accept failure."""
         raise RuntimeError("accept failed")
+
+
+class _AlreadyAcceptedWebSocket(_StubWebSocket):
+    """Websocket stub that raises Starlette's double-accept state error."""
+
+    async def accept(self) -> None:
+        """Raise the already-accepted RuntimeError variant."""
+        raise RuntimeError(
+            'Expected ASGI message "websocket.send" or "websocket.close", '
+            'but got "websocket.accept".'
+        )
 
 
 @pytest.mark.asyncio
 async def test_ws_stream_send_done_and_ping_metrics():
+    """Terminal done should stop later ping sends while preserving ping metrics."""
     ws = _StubWebSocket()
     reg = get_metrics_registry()
     stream = WebSocketStream(ws, heartbeat_interval_s=0.05, labels={"component": "test", "endpoint": "ws"})
     await stream.start()
+
+    async def wait_for_ping() -> None:
+        """Wait until the stream emits at least one ping frame."""
+        while not any(msg.get("type") == "ping" for msg in ws.sent):
+            await asyncio.sleep(0.01)
+
     # Let the ping loop run at least once before the stream reaches a terminal state.
-    await asyncio.sleep(0.07)
+    await asyncio.wait_for(wait_for_ping(), timeout=1.0)
     await stream.send_json({"hello": "world"})
     await stream.done()
     sent_after_done = len(ws.sent)
@@ -436,7 +470,6 @@ async def test_ws_stream_send_done_and_ping_metrics():
     assert ws.accepted is True
     assert any(msg.get("type") == "done" for msg in ws.sent)
     assert len(ws.sent) == sent_after_done
-    assert stream._running is False
 
     # Metrics assertions
     ws_latency_stats = reg.get_metric_stats("ws_send_latency_ms")
@@ -449,15 +482,32 @@ async def test_ws_stream_send_done_and_ping_metrics():
 
 @pytest.mark.asyncio
 async def test_ws_stream_accept_failure_propagates_and_does_not_start_background_tasks():
+    """Generic accept failures should propagate without observable background sends."""
     ws = _AcceptFailWebSocket()
     stream = WebSocketStream(ws, heartbeat_interval_s=0.05, idle_timeout_s=0.05)
 
     with pytest.raises(RuntimeError, match="accept failed"):
         await stream.start()
 
-    assert stream._running is False
-    assert stream._ping_task is None
-    assert stream._idle_task is None
+    await asyncio.sleep(0.12)
+    assert ws.accepted is False
+    assert ws.sent == []
+    assert ws.closed is False
+
+
+@pytest.mark.asyncio
+async def test_ws_stream_suppresses_starlette_double_accept_error():
+    """Already-accepted Starlette state errors should not fail stream startup."""
+    ws = _AlreadyAcceptedWebSocket()
+    stream = WebSocketStream(ws, heartbeat_interval_s=0, idle_timeout_s=0)
+
+    await stream.start()
+    await stream.send_json({"hello": "world"})
+    await stream.done()
+
+    assert ws.sent[0] == {"hello": "world"}
+    assert any(msg.get("type") == "done" for msg in ws.sent)
+    assert ws.closed is True
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Streaming/test_streams.py
+++ b/tldw_Server_API/tests/Streaming/test_streams.py
@@ -145,7 +145,7 @@ async def test_sse_stream_max_duration_triggers_error_then_done():
 
 @pytest.mark.asyncio
 async def test_sse_stream_send_json_and_raw_line():
-    stream = SSEStream(heartbeat_interval_s=0.5)
+    stream = SSEStream(heartbeat_interval_s=0.5, provider_control_passthru=True)
 
     async def producer():
         await stream.send_json({"hello": "world"})
@@ -166,6 +166,68 @@ async def test_sse_stream_send_json_and_raw_line():
     assert any(x.startswith("event: summary") for x in out)
     assert any("data: {\"summary\": true}" in x.lower() for x in out)
     assert out[-1].strip().lower() == "data: [done]"
+
+
+@pytest.mark.asyncio
+async def test_sse_stream_drops_provider_control_lines_by_default():
+    stream = SSEStream(heartbeat_interval_s=10.0)
+
+    async def producer():
+        await stream.send_raw_sse_line("event: provider-event")
+        await stream.send_raw_sse_line("id: provider-id")
+        await stream.send_raw_sse_line("retry: 1000")
+        await stream.send_raw_sse_line(": provider heartbeat")
+        await stream.send_raw_sse_line("data: {\"ok\": true}")
+        await stream.done()
+
+    out = []
+
+    async def consumer():
+        async for ln in stream.iter_sse():
+            out.append(ln)
+
+    await asyncio.gather(producer(), consumer())
+
+    assert not any(x.startswith("event:") for x in out)
+    assert not any(x.startswith("id:") for x in out)
+    assert not any(x.startswith("retry:") for x in out)
+    assert not any(x.startswith(":") for x in out)
+    assert any(x.startswith("data: {\"ok\": true}") for x in out)
+    assert out[-1].strip().lower() == "data: [done]"
+
+
+@pytest.mark.asyncio
+async def test_sse_stream_applies_control_filter_when_passthru_enabled():
+    def control_filter(name: str, value: str):
+        if name.lower() == "event":
+            return ("event", f"mapped-{value}")
+        if name.lower() == "id":
+            return None
+        return (name, value)
+
+    stream = SSEStream(
+        heartbeat_interval_s=10.0,
+        provider_control_passthru=True,
+        control_filter=control_filter,
+    )
+
+    async def producer():
+        await stream.send_raw_sse_line("event: original")
+        await stream.send_raw_sse_line("id: hidden")
+        await stream.send_raw_sse_line("data: {\"ok\": true}")
+        await stream.done()
+
+    out = []
+
+    async def consumer():
+        async for ln in stream.iter_sse():
+            out.append(ln)
+
+    await asyncio.gather(producer(), consumer())
+
+    assert any(x.startswith("event: mapped-original") for x in out)
+    assert not any(x.startswith("id: hidden") for x in out)
+    assert any(x.startswith("data: {\"ok\": true}") for x in out)
 
 
 @pytest.mark.asyncio
@@ -353,20 +415,28 @@ class _StubWebSocket:
         self.close_code = code
 
 
+class _AcceptFailWebSocket(_StubWebSocket):
+    async def accept(self):
+        raise RuntimeError("accept failed")
+
+
 @pytest.mark.asyncio
 async def test_ws_stream_send_done_and_ping_metrics():
     ws = _StubWebSocket()
     reg = get_metrics_registry()
     stream = WebSocketStream(ws, heartbeat_interval_s=0.05, labels={"component": "test", "endpoint": "ws"})
     await stream.start()
+    # Let the ping loop run at least once before the stream reaches a terminal state.
+    await asyncio.sleep(0.07)
     await stream.send_json({"hello": "world"})
     await stream.done()
-    # Allow a couple of pings
+    sent_after_done = len(ws.sent)
     await asyncio.sleep(0.12)
-    await stream.stop()
 
     assert ws.accepted is True
     assert any(msg.get("type") == "done" for msg in ws.sent)
+    assert len(ws.sent) == sent_after_done
+    assert stream._running is False
 
     # Metrics assertions
     ws_latency_stats = reg.get_metric_stats("ws_send_latency_ms")
@@ -375,6 +445,19 @@ async def test_ws_stream_send_done_and_ping_metrics():
     assert pings_stats.get("count", 0) >= 1
     ping_fail_stats = reg.get_metric_stats("ws_ping_failures_total")
     assert ping_fail_stats.get("count", 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_ws_stream_accept_failure_propagates_and_does_not_start_background_tasks():
+    ws = _AcceptFailWebSocket()
+    stream = WebSocketStream(ws, heartbeat_interval_s=0.05, idle_timeout_s=0.05)
+
+    with pytest.raises(RuntimeError, match="accept failed"):
+        await stream.start()
+
+    assert stream._running is False
+    assert stream._ping_task is None
+    assert stream._idle_task is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Harden speech-chat action execution behind an explicit allowlist.
- Add pre-decode audio format and encoded-size validation, plus post-decode defense-in-depth size checks.
- Sanitize TTS client-facing errors and tighten SSE/WebSocket lifecycle behavior.
- Address PR review feedback for case-insensitive reserved-key filtering, URL/internal override blocking, broader double-accept handling, and test stability/type/docstring cleanup.

## Verification
- `python -m pytest tldw_Server_API/tests/Audio/test_speech_chat_service.py tldw_Server_API/tests/Streaming/test_streams.py -q` -> 55 passed in the rebased clean worktree.
- `python -m bandit -r tldw_Server_API/app/core/Streaming -f json -o /tmp/bandit_streaming_12011_final.json` -> 0 findings.
- `git diff --check` -> clean.

## Notes
- Repository AI-generated PR policy still requires a human-written Change summary before merge readiness.
- Optional audio WebSocket ping checks still fail outside this touched scope because `/api/v1/audio/stream/transcribe` constructs its stream with `heartbeat_interval_s=0`.