### PR TITLE
Refactor MCP tool execution pipeline

### DIFF
--- a/Docs/superpowers/plans/2026-06-24-mcp-protocol-tool-execution-refactor.md
+++ b/Docs/superpowers/plans/2026-06-24-mcp-protocol-tool-execution-refactor.md
@@ -1,0 +1,1612 @@
+# MCP Protocol Tool Execution Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the security-sensitive `tools/call` path from `tldw_Server_API/app/core/MCP_unified/protocol.py` into focused tool-execution modules while preserving public behavior.
+
+**Architecture:** `MCPProtocol` remains the public JSON-RPC facade. Tool execution moves behind a `ToolExecutionCoordinator` that depends on explicit services, a reporter facade, and focused security/hooks/runtime helpers. Early stages use a compatibility callback ledger so temporary protocol-bound behavior is visible and removed deliberately.
+
+**Tech Stack:** Python, pytest, Pydantic, Loguru, existing MCP Unified module registry/RBAC/rate limiter/telemetry/tool-use reporting interfaces.
+
+---
+
+## Source Spec
+
+- `Docs/superpowers/specs/2026-06-23-mcp-protocol-tool-execution-refactor-design.md`
+- Backlog task: `TASK-2424`
+
+## File Structure
+
+- Create `tldw_Server_API/app/core/MCP_unified/protocol_types.py`
+  - Shared protocol/tool-execution types and compatibility-auth helpers:
+    `RequestContext`, `PreparedToolCall`, `InvalidParamsException`,
+    `GovernanceDeniedError`, `ApprovalRequiredError`,
+    `_trusted_compat_claims_metadata`, and `_has_trusted_compat_claims`.
+- Create `tldw_Server_API/app/core/MCP_unified/tool_execution/__init__.py`
+  - Package marker with explicit exports for coordinator, dependencies, reporter, security, hooks, and runtime classes.
+- Create `tldw_Server_API/app/core/MCP_unified/tool_execution/models.py`
+  - Internal stage result types used only by the extracted package.
+- Create `tldw_Server_API/app/core/MCP_unified/tool_execution/dependencies.py`
+  - `ToolExecutionDependencies` dataclass and `CompatibilityCallbackLedgerEntry`.
+- Create `tldw_Server_API/app/core/MCP_unified/tool_execution/reporting.py`
+  - `ToolExecutionReporter` facade first, then reporting internals in Stage 6.
+- Create `tldw_Server_API/app/core/MCP_unified/tool_execution/coordinator.py`
+  - `ToolExecutionCoordinator` that owns `tools/call` stage ordering and public nested prepare/execute flows.
+- Create `tldw_Server_API/app/core/MCP_unified/tool_execution/security.py`
+  - `ToolExecutionSecurity` for validation, resolution, hardening, write classification, RBAC/API scopes, effective policy, external access, path scope, approval, governance preflight, prepared-call integrity, and input schema validation.
+- Create `tldw_Server_API/app/core/MCP_unified/tool_execution/hooks.py`
+  - `ToolExecutionHooks` for pre/post hook context construction, hook decision coercion, hook payload shaping, and hook execution.
+- Create `tldw_Server_API/app/core/MCP_unified/tool_execution/runtime.py`
+  - `ToolExecutionRuntime` for rate limiting, idempotency, circuit-breaker execution, result formatting, execution eval metadata, audit/metrics calls through the reporter, and post-hooks.
+- Modify `tldw_Server_API/app/core/MCP_unified/protocol.py`
+  - Re-export compatibility symbols, construct dependencies/coordinator/reporter, delegate `tools/call`, keep JSON-RPC parsing, coarse authorization, non-tool handlers, and response models.
+- Modify `tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py`
+  - Add compatibility import and import-boundary tests.
+- Modify or add focused tests under `tldw_Server_API/app/core/MCP_unified/tests/`
+  - Characterization, coordinator, security, hooks, runtime, reporting, idempotency, and boundary tests.
+
+## Temporary Compatibility Callback Ledger
+
+Final active ledger state: empty. The table below is retained as resolved history for auditability; each behavior now has an extracted owner, with protocol wrappers kept only for compatibility and test monkeypatch seams where current callers still exist.
+
+| Callback | Original owner | Final owner | Resolved in | Parity test |
+| --- | --- | --- | --- | --- |
+| `prepare_tool_call_impl` | `MCPProtocol._prepare_tool_call_inline` | `ToolExecutionSecurity.prepare_tool_call` | Stage 4c | `test_tool_execution_coordinator_delegates_prepare_then_execute` |
+| `execute_prepared_tool_call_impl` | `MCPProtocol._execute_prepared_tool_call_inline` | `ToolExecutionRuntime.execute_prepared_tool_call` | Stage 5 | `test_tool_execution_coordinator_delegates_prepare_then_execute` |
+| `validate_input_schema` | `MCPProtocol._validate_input_schema` | `ToolExecutionSecurity.validate_input_schema` | Stage 4a | `test_protocol_invalid_tool_arguments_remain_invalid_params` |
+| `generic_exception_like` | `MCPProtocol._generic_exception_like` | `ToolExecutionRuntime._generic_exception_like` | Stage 5 | `test_runtime_sanitizes_tool_execution_errors` |
+| `make_idempotency_cache_key` | `MCPProtocol._make_idempotency_cache_key` | `ToolExecutionRuntime.make_idempotency_cache_key` | Stage 5 | `test_idempotency_key_isolated_across_users` |
+| `extract_eval_profile_id` | `MCPProtocol._extract_eval_profile_id` | `ToolExecutionRuntime.extract_eval_profile_id` | Stage 5 | `test_protocol_tool_use_reporting_includes_execution_eval_metadata` |
+| `tool_use_event_builder` | `MCPProtocol._build_tool_use_event` | `ToolExecutionReporter.build_tool_use_event` | Stage 6 | `test_protocol_records_successful_tool_use_event` |
+| `record_process_request_failure` | `MCPProtocol._record_process_request_tool_use_failure` | `ToolExecutionReporter.record_process_request_failure` | Stage 6 | `test_tools_call_coarse_authorization_denial_records_denied_tool_use` |
+
+## Stage 1: Characterization And Boundary Tests
+
+**Goal:** Lock down current behavior before moving code.
+
+**Success Criteria:** New tests fail only where the future extraction package does not exist yet; existing behavior tests continue to pass.
+
+**Tests:** `test_extraction_contracts.py`, `test_tool_execution_coordinator.py`, `test_tool_use_reporting_protocol.py`, `test_idempotency_and_category.py`.
+
+### Task 1: Add Compatibility Import And Import-Boundary Tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py`
+
+- [x] **Step 1: Add the failing tests**
+
+Append these tests after `test_protocol_instances_do_not_share_prepared_call_secrets`:
+
+```python
+def test_protocol_reexports_tool_execution_shared_symbols() -> None:
+    from tldw_Server_API.app.core.MCP_unified import protocol
+
+    expected = {
+        "RequestContext",
+        "PreparedToolCall",
+        "InvalidParamsException",
+        "GovernanceDeniedError",
+        "ApprovalRequiredError",
+        "IdempotencyManager",
+        "_trusted_compat_claims_metadata",
+    }
+
+    missing = sorted(name for name in expected if not hasattr(protocol, name))
+    assert missing == []
+
+
+def test_tool_execution_package_does_not_import_protocol_facade() -> None:
+    package_dir = MCP_ROOT / "tool_execution"
+    assert package_dir.is_dir()
+    forbidden = {
+        f"{MCP_PACKAGE}.protocol",
+        "tldw_Server_API.app.core.MCP_unified.protocol",
+    }
+    offenders: dict[str, list[str]] = {}
+
+    def package_for(path: Path) -> str:
+        relative_parent = path.relative_to(MCP_ROOT).parent
+        return ".".join((MCP_PACKAGE, *relative_parent.parts))
+
+    for path in package_dir.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        current_package = package_for(path)
+        imports = _resolved_import_sources_for(path, current_package)
+        bad_imports = [
+            source
+            for source in imports
+            if source in forbidden
+            or source.endswith(".MCP_unified.protocol")
+        ]
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                source = _resolve_import_from_source(current_package, node.module, node.level)
+                if source == MCP_PACKAGE and any(alias.name == "protocol" for alias in node.names):
+                    bad_imports.append(f"{source}.protocol")
+        if bad_imports:
+            offenders[str(path.relative_to(MCP_ROOT))] = bad_imports
+
+        uses_facade = [
+            "MCPProtocol"
+            for node in ast.walk(tree)
+            if (
+                isinstance(node, ast.Name)
+                and node.id == "MCPProtocol"
+            )
+            or (
+                isinstance(node, ast.Attribute)
+                and node.attr == "MCPProtocol"
+            )
+        ]
+        if uses_facade:
+            offenders.setdefault(str(path.relative_to(MCP_ROOT)), []).append("MCPProtocol")
+
+    assert offenders == {}
+```
+
+- [x] **Step 2: Run the tests to verify they fail for missing package**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=true ENABLE_TRACING=false OTEL_METRICS_EXPORTER=none python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py::test_protocol_reexports_tool_execution_shared_symbols tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py::test_tool_execution_package_does_not_import_protocol_facade -q
+```
+
+Expected: the re-export test passes and the package-boundary test fails because `tool_execution/` does not exist yet.
+
+- [x] **Step 3: Leave the failing test in place for Stage 2**
+
+Do not skip or xfail this test. Stage 2 creates the package and makes it pass.
+
+### Task 2: Add Coordinator Characterization Tests
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/tests/test_tool_execution_coordinator.py`
+
+- [x] **Step 1: Write the failing coordinator tests**
+
+Create the file with:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+
+
+@dataclass
+class _Prepared:
+    name: str
+    context: RequestContext
+
+
+class _Reporter:
+    def __init__(self) -> None:
+        self.prepare_failures: list[dict[str, Any]] = []
+
+    def should_record(self, context: RequestContext) -> bool:
+        return context.metadata.get("mcp_tool_use_observed") is not True
+
+    async def record_prepare_failure(
+        self,
+        *,
+        context: RequestContext,
+        params: dict[str, Any],
+        exc: Exception,
+        start_ts: float,
+    ) -> None:
+        del start_ts
+        self.prepare_failures.append(
+            {
+                "request_id": context.request_id,
+                "name": params.get("name"),
+                "error_type": exc.__class__.__name__,
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_tool_execution_coordinator_delegates_prepare_then_execute() -> None:
+    from tldw_Server_API.app.core.MCP_unified.tool_execution.coordinator import (
+        ToolExecutionCoordinator,
+    )
+
+    calls: list[str] = []
+    context = RequestContext(request_id="coord-ok", user_id="u1", client_id="c1")
+    prepared = _Prepared(name="demo.echo", context=context)
+
+    async def prepare_impl(
+        *,
+        params: dict[str, Any],
+        context: RequestContext,
+        idempotency_key: str | None = None,
+    ) -> _Prepared:
+        assert params == {"name": "demo.echo", "arguments": {"value": "x"}}
+        assert idempotency_key is None
+        calls.append("prepare")
+        return prepared
+
+    async def execute_impl(prepared_call: _Prepared) -> dict[str, Any]:
+        assert prepared_call is prepared
+        calls.append("execute")
+        return {"content": [{"type": "text", "text": "ok"}], "tool": prepared_call.name}
+
+    coordinator = ToolExecutionCoordinator(
+        prepare_tool_call_impl=prepare_impl,
+        execute_prepared_tool_call_impl=execute_impl,
+        reporter=_Reporter(),
+    )
+
+    result = await coordinator.handle_tools_call(
+        {"name": "demo.echo", "arguments": {"value": "x"}},
+        context,
+    )
+
+    assert calls == ["prepare", "execute"]
+    assert result["tool"] == "demo.echo"
+
+
+@pytest.mark.asyncio
+async def test_tool_execution_coordinator_reports_prepare_failure_before_reraising() -> None:
+    from tldw_Server_API.app.core.MCP_unified.protocol import InvalidParamsException
+    from tldw_Server_API.app.core.MCP_unified.tool_execution.coordinator import (
+        ToolExecutionCoordinator,
+    )
+
+    reporter = _Reporter()
+    context = RequestContext(request_id="coord-fail", user_id="u1", client_id="c1")
+
+    async def prepare_impl(
+        *,
+        params: dict[str, Any],
+        context: RequestContext,
+        idempotency_key: str | None = None,
+    ) -> _Prepared:
+        del params, context, idempotency_key
+        raise InvalidParamsException("bad arguments")
+
+    async def execute_impl(prepared_call: _Prepared) -> dict[str, Any]:
+        del prepared_call
+        raise AssertionError("execute should not run")
+
+    coordinator = ToolExecutionCoordinator(
+        prepare_tool_call_impl=prepare_impl,
+        execute_prepared_tool_call_impl=execute_impl,
+        reporter=reporter,
+    )
+
+    with pytest.raises(InvalidParamsException):
+        await coordinator.handle_tools_call({"name": "demo.echo"}, context)
+
+    assert reporter.prepare_failures == [
+        {
+            "request_id": "coord-fail",
+            "name": "demo.echo",
+            "error_type": "InvalidParamsException",
+        }
+    ]
+```
+
+- [x] **Step 2: Run the tests to verify they fail for missing coordinator**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=true ENABLE_TRACING=false OTEL_METRICS_EXPORTER=none python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_tool_execution_coordinator.py -q
+```
+
+Expected: import failure for `tool_execution.coordinator`.
+
+### Task 3: Add Authorization Boundary Characterization Tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py`
+
+- [x] **Step 1: Add coarse and deep authorization tests**
+
+Append:
+
+```python
+@pytest.mark.asyncio
+async def test_tools_call_coarse_authorization_denial_records_denied_tool_use() -> None:
+    from tldw_Server_API.app.core.MCP_unified.protocol import MCPRequest
+
+    recorder = _RecordingToolUseRecorder()
+    protocol = MCPProtocol()
+    protocol._tool_use_recorder = recorder
+
+    async def deny_request(_request: MCPRequest, _context: RequestContext) -> bool:
+        return False
+
+    protocol._check_authorization = deny_request  # type: ignore[method-assign]
+    context = RequestContext(request_id="coarse-deny", user_id="u1", client_id="c1")
+    request = MCPRequest(
+        method="tools/call",
+        params={"name": "test.read", "arguments": {"value": "x"}},
+        id="coarse-deny",
+    )
+
+    response = await protocol.process_request(request, context)
+
+    assert response.error is not None
+    assert response.error.code == ErrorCode.AUTHORIZATION_ERROR
+    assert recorder.events
+    event = recorder.events[-1]
+    assert event.status == "denied"
+    assert event.reason_code == "permission_denied"
+    assert event.execution_origin == "failed_before_execution"
+
+
+@pytest.mark.asyncio
+async def test_tools_call_deep_authorization_denial_records_prepare_failure() -> None:
+    recorder = _RecordingToolUseRecorder()
+    protocol = MCPProtocol()
+    protocol._tool_use_recorder = recorder
+
+    async def allow_request(_request: Any, _context: RequestContext) -> bool:
+        return True
+
+    async def deny_prepare(
+        *,
+        params: dict[str, Any],
+        context: RequestContext,
+        idempotency_key: str | None = None,
+    ) -> Any:
+        del params, context, idempotency_key
+        raise PermissionError("Permission denied for tool: test.read")
+
+    protocol._check_authorization = allow_request  # type: ignore[method-assign]
+    protocol.prepare_tool_call = deny_prepare  # type: ignore[method-assign]
+    context = RequestContext(request_id="deep-deny", user_id="u1", client_id="c1")
+
+    response = await protocol.process_request(
+        {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": "test.read", "arguments": {"value": "x"}},
+            "id": "deep-deny",
+        },
+        context,
+    )
+
+    assert response.error is not None
+    assert response.error.code == ErrorCode.AUTHORIZATION_ERROR
+    assert recorder.events
+    event = recorder.events[-1]
+    assert event.status == "denied"
+    assert event.reason_code == "permission_denied"
+    assert event.execution_origin == "failed_before_execution"
+```
+
+- [x] **Step 2: Run the authorization tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=true ENABLE_TRACING=false OTEL_METRICS_EXPORTER=none python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py::test_tools_call_coarse_authorization_denial_records_denied_tool_use tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py::test_tools_call_deep_authorization_denial_records_prepare_failure -q
+```
+
+Expected: both tests pass before extraction and continue passing after each stage.
+
+## Stage 2: Shared Types And Package Skeleton
+
+**Goal:** Create import-safe shared types and an empty extraction package.
+
+**Success Criteria:** Compatibility imports from `protocol.py` still work; the package-boundary test passes.
+
+**Tests:** Stage 1 tests plus focused py_compile.
+
+### Task 4: Move Shared Types Into `protocol_types.py`
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/protocol_types.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/protocol.py`
+
+- [x] **Step 1: Create `protocol_types.py`**
+
+Move these exact existing definitions from `protocol.py` into the new file:
+
+```python
+class InvalidParamsException(Exception):
+    """Raised when tool parameters fail validation or validators are missing for write tools."""
+    pass
+
+
+class GovernanceDeniedError(PermissionError):
+    """Permission error carrying structured governance decision details."""
+
+    def __init__(self, message: str, governance: Optional[dict[str, Any]] = None):
+        super().__init__(message)
+        self.governance = governance or {}
+
+
+class ApprovalRequiredError(PermissionError):
+    """Permission error carrying structured MCP Hub approval request details."""
+
+    def __init__(self, message: str, approval: Optional[dict[str, Any]] = None):
+        super().__init__(message)
+        self.approval = approval or {}
+```
+
+Also move the existing `RequestContext`, `_TrustedCompatClaimsSentinel`, `_trusted_compat_claims_metadata`, `_has_trusted_compat_claims`, and `PreparedToolCall` definitions unchanged. Include these imports at the top:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from loguru import logger
+
+from .modules.base import BaseModule
+```
+
+- [x] **Step 2: Re-export from `protocol.py`**
+
+Replace the moved definitions in `protocol.py` with:
+
+```python
+from .protocol_types import (
+    ApprovalRequiredError,
+    GovernanceDeniedError,
+    InvalidParamsException,
+    PreparedToolCall,
+    RequestContext,
+    _has_trusted_compat_claims,
+    _trusted_compat_claims_metadata,
+)
+```
+
+- [x] **Step 3: Run compatibility tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=true ENABLE_TRACING=false OTEL_METRICS_EXPORTER=none python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py::test_protocol_reexports_tool_execution_shared_symbols tldw_Server_API/app/core/MCP_unified/tests/test_protocol_scope_enforcement.py -q
+```
+
+Expected: all selected tests pass.
+
+### Task 5: Create Tool-Execution Package Skeleton
+
+**Files:**
+- Create: `tldw_Server_API/app/core/MCP_unified/tool_execution/__init__.py`
+- Create: `tldw_Server_API/app/core/MCP_unified/tool_execution/models.py`
+- Create: `tldw_Server_API/app/core/MCP_unified/tool_execution/reporting.py`
+- Create: `tldw_Server_API/app/core/MCP_unified/tool_execution/dependencies.py`
+- Create: `tldw_Server_API/app/core/MCP_unified/tool_execution/coordinator.py`
+- Create: `tldw_Server_API/app/core/MCP_unified/tool_execution/security.py`
+- Create: `tldw_Server_API/app/core/MCP_unified/tool_execution/hooks.py`
+- Create: `tldw_Server_API/app/core/MCP_unified/tool_execution/runtime.py`
+
+- [x] **Step 1: Add package marker**
+
+Use:
+
+```python
+"""Tool execution pipeline for the MCP protocol facade."""
+
+from .coordinator import ToolExecutionCoordinator
+from .dependencies import CompatibilityCallbackLedgerEntry, ToolExecutionDependencies
+from .reporting import ToolExecutionReporter
+
+__all__ = [
+    "CompatibilityCallbackLedgerEntry",
+    "ToolExecutionCoordinator",
+    "ToolExecutionDependencies",
+    "ToolExecutionReporter",
+]
+```
+
+- [x] **Step 2: Add internal models**
+
+Use:
+
+```python
+"""Internal models for staged MCP tool execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class ToolResolution:
+    tool_name: str
+    tool_args: Any
+    module: Any
+    module_id: str | None
+    tool_def: dict[str, Any] | None
+    is_write: bool | None
+
+
+@dataclass(slots=True)
+class PolicyEvaluation:
+    effective_policy: dict[str, Any] | None
+    external_access_result: dict[str, Any] = field(default_factory=dict)
+    path_scope_result: dict[str, Any] = field(default_factory=dict)
+    scope_payload: dict[str, Any] | None = None
+    within_effective_policy: bool = True
+    within_resolved_scope: bool = True
+```
+
+- [x] **Step 3: Add reporter facade**
+
+Use:
+
+```python
+"""Tool-use reporting facade for MCP tool execution."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from mcp_unified.tool_use_reporting.models import ToolUseEvent
+
+from ..protocol_types import RequestContext
+
+
+@dataclass(slots=True)
+class ToolExecutionReporter:
+    should_record: Callable[[RequestContext], bool]
+    record_event: Callable[[ToolUseEvent], Awaitable[None]]
+    build_event: Callable[..., ToolUseEvent]
+    duration_ms: Callable[[float], float]
+    execution_origin_for_failure: Callable[[str], str]
+    record_process_request_failure_impl: Callable[..., Awaitable[None]]
+
+    async def record_process_request_failure(self, **kwargs: Any) -> None:
+        await self.record_process_request_failure_impl(**kwargs)
+
+    async def record_prepare_failure(
+        self,
+        *,
+        context: RequestContext,
+        params: dict[str, Any],
+        exc: Exception,
+        start_ts: float,
+    ) -> None:
+        from mcp_unified.tool_use_reporting.builders import classify_tool_use_exception
+
+        from ..protocol_types import GovernanceDeniedError
+
+        if not self.should_record(context):
+            return
+        status, reason_code = classify_tool_use_exception(exc)
+        scope_payload = None
+        if isinstance(exc, GovernanceDeniedError) and isinstance(exc.governance, dict):
+            path_scope = exc.governance.get("path_scope")
+            if isinstance(path_scope, dict):
+                scope_payload = path_scope
+        event = self.build_event(
+            context=context,
+            requested_tool_name=params.get("name") if isinstance(params, dict) else None,
+            status=status,
+            execution_origin="failed_before_execution",
+            duration_ms=self.duration_ms(start_ts),
+            reason_code=reason_code,
+            tool_args=params.get("arguments") if isinstance(params, dict) else None,
+            scope_payload=scope_payload,
+        )
+        await self.record_event(event)
+```
+
+- [x] **Step 4: Add dependencies dataclasses**
+
+Use:
+
+```python
+"""Explicit dependencies for the MCP tool execution pipeline."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from .reporting import ToolExecutionReporter
+
+
+@dataclass(frozen=True, slots=True)
+class CompatibilityCallbackLedgerEntry:
+    callback: str
+    current_owner: str
+    target_owner: str
+    removal_stage: str
+    parity_test: str
+
+
+@dataclass(slots=True)
+class ToolExecutionDependencies:
+    module_registry: Any
+    rbac_policy: Any
+    rate_limiter: Any
+    metrics: Any
+    telemetry: Any
+    hook_manager: Any
+    tool_use_recorder: Any
+    idempotency: Any
+    config_provider: Callable[[], Any]
+    effective_policy_resolver: Any
+    path_scope_enforcer: Any
+    approval_evaluator: Any
+    external_access_evaluator: Any
+    reporter: ToolExecutionReporter
+```
+
+- [x] **Step 5: Add coordinator**
+
+Use:
+
+```python
+"""Coordinator for the MCP tools/call execution path."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from loguru import logger
+
+from ..protocol_types import RequestContext
+from .reporting import ToolExecutionReporter
+
+
+@dataclass(slots=True)
+class ToolExecutionCoordinator:
+    prepare_tool_call_impl: Callable[..., Awaitable[Any]]
+    execute_prepared_tool_call_impl: Callable[[Any], Awaitable[dict[str, Any]]]
+    reporter: ToolExecutionReporter
+
+    async def handle_tools_call(
+        self,
+        params: dict[str, Any],
+        context: RequestContext,
+    ) -> dict[str, Any]:
+        start_ts = time.time()
+        try:
+            prepared = await self.prepare_tool_call(params=params, context=context)
+        except Exception as exc:
+            try:
+                await self.reporter.record_prepare_failure(
+                    context=context,
+                    params=params,
+                    exc=exc,
+                    start_ts=start_ts,
+                )
+            except Exception as record_exc:
+                logger.warning(
+                    "Failed to build or record prepare-failure tool-use event: {}",
+                    record_exc.__class__.__name__,
+                )
+            raise
+        return await self.execute_prepared_tool_call(prepared)
+
+    async def prepare_tool_call(
+        self,
+        params: dict[str, Any],
+        context: RequestContext,
+        idempotency_key: str | None = None,
+    ) -> Any:
+        return await self.prepare_tool_call_impl(
+            params=params,
+            context=context,
+            idempotency_key=idempotency_key,
+        )
+
+    async def execute_prepared_tool_call(self, prepared: Any) -> dict[str, Any]:
+        return await self.execute_prepared_tool_call_impl(prepared)
+```
+
+- [x] **Step 6: Add empty implementation modules**
+
+Use this for `security.py`, `hooks.py`, and `runtime.py`:
+
+```python
+"""Focused helper module for MCP tool execution."""
+
+from __future__ import annotations
+```
+
+- [x] **Step 7: Run skeleton tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=true ENABLE_TRACING=false OTEL_METRICS_EXPORTER=none python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py::test_tool_execution_package_does_not_import_protocol_facade tldw_Server_API/app/core/MCP_unified/tests/test_tool_execution_coordinator.py -q
+```
+
+Expected: all selected tests pass.
+
+## Stage 3: Coordinator Delegation In `MCPProtocol`
+
+**Goal:** Route `tools/call`, `prepare_tool_call()`, and `execute_prepared_tool_call()` through the coordinator while the original logic remains in protocol-private compatibility methods.
+
+**Success Criteria:** Public methods still exist and behavior is unchanged; the compatibility ledger has exactly two high-value behavior callbacks at the end of this stage.
+
+**Tests:** Coordinator tests, authorization boundary tests, idempotency tests, tool-use reporting tests.
+
+### Task 6: Wire Coordinator Into `MCPProtocol`
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/protocol.py`
+
+- [x] **Step 1: Import tool-execution classes**
+
+Add:
+
+```python
+from .tool_execution import ToolExecutionCoordinator, ToolExecutionDependencies, ToolExecutionReporter
+```
+
+- [x] **Step 2: Build reporter and dependency objects in `__init__`**
+
+After `_governance_lock` is initialized, add:
+
+```python
+        self._tool_execution_reporter = ToolExecutionReporter(
+            should_record=self._should_record_tool_use,
+            record_event=self._record_tool_use_event,
+            build_event=self._build_tool_use_event,
+            duration_ms=self._tool_use_duration_ms,
+            execution_origin_for_failure=self._tool_use_execution_origin_for_failure,
+            record_process_request_failure_impl=self._record_process_request_tool_use_failure,
+        )
+        self._tool_execution_dependencies = ToolExecutionDependencies(
+            module_registry=self.module_registry,
+            rbac_policy=self.rbac_policy,
+            rate_limiter=self.rate_limiter,
+            metrics=self.metrics,
+            telemetry=self.telemetry,
+            hook_manager=self._tool_call_hook_manager,
+            tool_use_recorder=self._tool_use_recorder,
+            idempotency=self._idempotency,
+            config_provider=get_config,
+            effective_policy_resolver=self.dependencies.effective_policy_resolver,
+            path_scope_enforcer=self.dependencies.path_scope_enforcer,
+            approval_evaluator=self.dependencies.approval_evaluator,
+            external_access_evaluator=self.dependencies.external_access_evaluator,
+            reporter=self._tool_execution_reporter,
+        )
+        self._tool_execution = ToolExecutionCoordinator(
+            prepare_tool_call_impl=self._prepare_tool_call_inline,
+            execute_prepared_tool_call_impl=self._execute_prepared_tool_call_inline,
+            reporter=self._tool_execution_reporter,
+        )
+```
+
+- [x] **Step 3: Rename original implementation methods**
+
+Rename:
+
+```python
+async def prepare_tool_call(
+```
+
+to:
+
+```python
+async def _prepare_tool_call_inline(
+```
+
+Rename:
+
+```python
+async def execute_prepared_tool_call(self, prepared: PreparedToolCall) -> dict[str, Any]:
+```
+
+to:
+
+```python
+async def _execute_prepared_tool_call_inline(self, prepared: PreparedToolCall) -> dict[str, Any]:
+```
+
+- [x] **Step 4: Replace public methods with delegators**
+
+Add public methods where the renamed methods used to be:
+
+```python
+    async def prepare_tool_call(
+        self,
+        params: dict[str, Any],
+        context: RequestContext,
+        idempotency_key: str | None = None,
+    ) -> PreparedToolCall:
+        """Prepare a tool invocation through protocol policy, validation, and governance checks."""
+        return await self._tool_execution.prepare_tool_call(
+            params=params,
+            context=context,
+            idempotency_key=idempotency_key,
+        )
+
+    async def execute_prepared_tool_call(self, prepared: PreparedToolCall) -> dict[str, Any]:
+        """Execute a previously prepared tool invocation."""
+        return await self._tool_execution.execute_prepared_tool_call(prepared)
+```
+
+- [x] **Step 5: Replace `_handle_tools_call` body with coordinator delegation**
+
+Use:
+
+```python
+    async def _handle_tools_call(
+        self,
+        params: dict[str, Any],
+        context: RequestContext
+    ) -> dict[str, Any]:
+        """Execute a tool."""
+        return await self._tool_execution.handle_tools_call(params, context)
+```
+
+- [x] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=true ENABLE_TRACING=false OTEL_METRICS_EXPORTER=none python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_tool_execution_coordinator.py tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py::test_tools_call_coarse_authorization_denial_records_denied_tool_use tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py::test_tools_call_deep_authorization_denial_records_prepare_failure tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py::test_idempotency_dedupes_write_calls -q
+```
+
+Expected: all selected tests pass.
+
+## Stage 4a: Extract Validation, Resolution, Hardening, And Integrity
+
+**Goal:** Move pure and near-pure tool preparation helpers into `ToolExecutionSecurity`.
+
+**Success Criteria:** `protocol.py` wrappers delegate to `ToolExecutionSecurity`; no extracted module imports `protocol.py`.
+
+**Tests:** validation/sanitization, prepared integrity, import-boundary tests.
+
+### Task 7: Implement `ToolExecutionSecurity` Core Helpers
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tool_execution/security.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/protocol.py`
+
+- [x] **Step 1: Add `ToolExecutionSecurity` constructor**
+
+Use:
+
+```python
+"""Security stages for MCP tool execution."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import hmac
+import json
+import re
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+from ..modules.base import BaseModule
+from ..protocol_types import InvalidParamsException, PreparedToolCall, RequestContext
+from .dependencies import ToolExecutionDependencies
+
+
+class ToolExecutionSecurity:
+    def __init__(
+        self,
+        *,
+        dependencies: ToolExecutionDependencies,
+        tool_name_re: re.Pattern[str],
+        prepared_call_secret: bytes,
+        noncritical_exceptions: tuple[type[BaseException], ...],
+    ) -> None:
+        self.dependencies = dependencies
+        self.module_registry = dependencies.module_registry
+        self.rbac_policy = dependencies.rbac_policy
+        self.metrics = dependencies.metrics
+        self._tool_name_re = tool_name_re
+        self._prepared_call_secret = prepared_call_secret
+        self._noncritical_exceptions = noncritical_exceptions
+```
+
+- [x] **Step 2: Move helper methods unchanged into the class**
+
+Move these existing methods from `MCPProtocol` into `ToolExecutionSecurity` and update `self.metrics`, `self.module_registry`, and `self.dependencies` references to the class attributes above:
+
+```text
+_hash_arguments
+_resolve_tool_definition
+_classify_write_tool_call
+_resolve_write_classification
+_strip_forbidden_tool_argument_overrides
+_harden_and_sanitize_tool_arguments
+_prepared_tool_call_payload
+_build_prepared_tool_call_integrity_tag
+_verify_prepared_tool_call_integrity
+_fingerprint_request_context
+_context_json_safe
+_normalize_idempotency_key
+_validate_input_schema
+```
+
+- [x] **Step 3: Construct security helper in protocol `__init__`**
+
+After `_tool_execution_dependencies`, add:
+
+```python
+        from .tool_execution.security import ToolExecutionSecurity
+
+        self._tool_execution_security = ToolExecutionSecurity(
+            dependencies=self._tool_execution_dependencies,
+            tool_name_re=self._tool_name_re,
+            prepared_call_secret=self._prepared_call_secret,
+            noncritical_exceptions=_MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS,
+        )
+```
+
+- [x] **Step 4: Keep compatibility wrappers in `protocol.py`**
+
+Replace each moved method body with a direct wrapper:
+
+```python
+    @staticmethod
+    def _hash_arguments(arguments: dict[str, Any]) -> Optional[str]:
+        return ToolExecutionSecurity.hash_arguments(arguments)
+```
+
+For instance methods, use:
+
+```python
+    async def _resolve_tool_definition(
+        self,
+        module: BaseModule,
+        tool_name: str,
+    ) -> Optional[dict[str, Any]]:
+        return await self._tool_execution_security.resolve_tool_definition(module, tool_name)
+```
+
+Apply this same wrapper pattern for all moved helpers. Preserve public compatibility for existing tests that access private protocol helpers.
+
+- [x] **Step 5: Update inline prepare/execute calls to use security helper directly**
+
+Inside `_prepare_tool_call_inline` and `_execute_prepared_tool_call_inline`, replace `self._resolve_tool_definition`, `self._harden_and_sanitize_tool_arguments`, `self._resolve_write_classification`, `self._validate_input_schema`, `self._normalize_idempotency_key`, `self._hash_arguments`, and integrity calls with `self._tool_execution_security.<method_name>`.
+
+- [x] **Step 6: Run tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=true ENABLE_TRACING=false OTEL_METRICS_EXPORTER=none python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_validation_and_sanitization.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py::test_tool_execution_package_does_not_import_protocol_facade tldw_Server_API/tests/MCP_unified/test_phase3_3_small_core_sanitizers.py -q
+```
+
+Expected: all selected tests pass.
+
+## Stage 4b: Extract Tool Authorization And Scope Checks
+
+**Goal:** Move tool-specific RBAC, MCP scope, API-key scope, and alias authorization helpers into `ToolExecutionSecurity`.
+
+**Success Criteria:** Tool preparation uses security helper methods for module/tool permission gates; protocol resource/prompt handlers keep behavior through wrappers.
+
+**Tests:** allowed-tools, scope enforcement, sandbox auth binding, HTTP auth paths.
+
+### Task 8: Move Tool Authorization Helpers
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tool_execution/security.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/protocol.py`
+
+- [x] **Step 1: Move helper methods into `ToolExecutionSecurity`**
+
+Move these existing methods and keep behavior unchanged:
+
+```text
+_rbac_check
+_scoped_permissions
+_mcp_scopes
+_api_key_scopes
+_api_key_scope_level
+_api_key_allows
+_scope_matches
+_scope_allows
+_has_module_permission
+_has_tool_permission
+_extract_allowed_tools
+_extract_tool_command
+_matches_allowed_tool_pattern
+_tool_authorization_names
+_matches_tool_authorization_pattern
+_scope_allows_tool_name
+_is_tool_allowed_by_context
+```
+
+Import these in `security.py`:
+
+```python
+from ..auth.rbac import Action, Resource
+from ..protocol_types import _has_trusted_compat_claims
+```
+
+- [x] **Step 2: Keep protocol compatibility wrappers**
+
+For each moved method, leave a `protocol.py` wrapper. Example:
+
+```python
+    async def _has_tool_permission(
+        self,
+        context: RequestContext,
+        tool_name: str,
+        *,
+        is_write: Optional[bool] = None,
+    ) -> bool:
+        return await self._tool_execution_security.has_tool_permission(
+            context,
+            tool_name,
+            is_write=is_write,
+        )
+```
+
+- [x] **Step 3: Update `_check_authorization` and `_handle_tools_list`**
+
+Replace direct protocol calls for tool and scope logic with wrapper calls that delegate to security. Keep `_has_resource_permission`, `_has_prompt_permission`, and `_has_namespaced_prompt_permission` in `protocol.py` because non-tool handlers still own resource and prompt behavior.
+
+- [x] **Step 4: Run tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=true ENABLE_TRACING=false OTEL_METRICS_EXPORTER=none python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_scope_enforcement.py tldw_Server_API/tests/MCP_unified/test_sandbox_module_auth_binding.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py::test_tool_execution_package_does_not_import_protocol_facade -q
+```
+
+Expected: all selected tests pass.
+
+## Stage 4c: Extract Effective Policy, External Access, Path Scope, Approval, Governance, And Pre-Hooks
+
+**Goal:** Finish prepare-phase extraction so `ToolExecutionSecurity.prepare_tool_call()` owns the full security gate order.
+
+**Success Criteria:** `prepare_tool_call_impl` ledger entry is removed; coordinator calls `ToolExecutionSecurity.prepare_tool_call` directly.
+
+**Tests:** governance preflight, path scope, external federation, tool hooks, stage-order tests.
+
+### Task 9: Extract Hook Helper
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tool_execution/hooks.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/protocol.py`
+
+- [x] **Step 1: Implement `ToolExecutionHooks`**
+
+Move these existing methods from `MCPProtocol` into `ToolExecutionHooks`:
+
+```text
+_hook_safe_copy
+_hook_safe_metadata
+_hook_safe_tool_args
+_redact_hook_visible_tool_args
+_hook_safe_scope_payload
+_build_tool_hook_context
+_coerce_tool_hook_action
+_coerce_tool_hook_decision
+_tool_hook_payload
+_run_pre_tool_hooks
+_run_post_tool_hooks
+```
+
+Use this constructor:
+
+```python
+class ToolExecutionHooks:
+    def __init__(
+        self,
+        *,
+        hook_manager: Any,
+        reporter: Any,
+        noncritical_exceptions: tuple[type[BaseException], ...],
+    ) -> None:
+        self._tool_call_hook_manager = hook_manager
+        self._reporter = reporter
+        self._noncritical_exceptions = noncritical_exceptions
+```
+
+- [x] **Step 2: Construct hooks helper in protocol `__init__`**
+
+Add:
+
+```python
+        from .tool_execution.hooks import ToolExecutionHooks
+
+        self._tool_execution_hooks = ToolExecutionHooks(
+            hook_manager=self._tool_call_hook_manager,
+            reporter=self._tool_execution_reporter,
+            noncritical_exceptions=_MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS,
+        )
+```
+
+- [x] **Step 3: Keep protocol wrappers**
+
+Replace moved hook methods in `protocol.py` with wrappers that call `self._tool_execution_hooks`.
+
+- [x] **Step 4: Run hook tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=true ENABLE_TRACING=false OTEL_METRICS_EXPORTER=none python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_protocol_tool_hooks.py tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py::test_protocol_records_pre_hook_denial_metadata_without_raw_payload -q
+```
+
+Expected: all selected tests pass.
+
+### Task 10: Move Policy And Governance Helpers
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tool_execution/security.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/protocol.py`
+
+- [x] **Step 1: Move policy/governance methods into `ToolExecutionSecurity`**
+
+Move:
+
+```text
+_resolve_effective_tool_policy
+_is_tool_allowed_by_effective_policy
+_evaluate_runtime_approval
+_evaluate_path_scope
+_extract_path_scope_candidates
+_evaluate_external_access
+_governance_preflight_bypassed
+_governance_summary
+_resolve_governance_category
+_resolve_governance_rollout_mode
+_record_governance_check
+_serialize_governance_decision
+_ensure_governance_service
+_run_governance_preflight
+```
+
+Add these instance fields to `ToolExecutionSecurity.__init__`:
+
+```python
+        self._governance_service: Any | None = None
+        self._governance_store: Any | None = None
+        self._governance_lock = asyncio.Lock()
+```
+
+- [x] **Step 2: Move prepare implementation into `ToolExecutionSecurity.prepare_tool_call`**
+
+Move the complete body of `_prepare_tool_call_inline` into a new method with this exact signature:
+
+```python
+    async def prepare_tool_call(
+        self,
+        params: dict[str, Any],
+        context: RequestContext,
+        idempotency_key: str | None = None,
+        hooks: Any | None = None,
+    ) -> PreparedToolCall:
+        """Prepare a tool invocation through protocol policy, validation, and governance checks."""
+```
+
+Inside the moved method, replace the old pre-hook call:
+
+```python
+await self._run_pre_tool_hooks(
+    tool_name=tool_name,
+    tool_args=tool_args,
+    module_id=module_id,
+    tool_def=tool_def if isinstance(tool_def, dict) else None,
+    is_write=is_write,
+    arguments_hash=args_hash,
+    context=context,
+    scope_payload=scope_payload,
+)
+```
+
+with:
+
+```python
+if hooks is None:
+    raise RuntimeError("ToolExecutionHooks dependency is required")
+await hooks.run_pre_tool_hooks(
+    tool_name=tool_name,
+    tool_args=tool_args,
+    module_id=module_id,
+    tool_def=tool_def if isinstance(tool_def, dict) else None,
+    is_write=is_write,
+    arguments_hash=args_hash,
+    context=context,
+    scope_payload=scope_payload,
+)
+```
+
+- [x] **Step 3: Remove `prepare_tool_call_impl` callback from coordinator construction**
+
+Create a wrapper in `MCPProtocol.__init__` before coordinator construction so the extracted prepare method always receives the hook dependency:
+
+```python
+        async def _prepare_with_hooks(
+            *,
+            params: dict[str, Any],
+            context: RequestContext,
+            idempotency_key: str | None = None,
+        ) -> PreparedToolCall:
+            return await self._tool_execution_security.prepare_tool_call(
+                params=params,
+                context=context,
+                idempotency_key=idempotency_key,
+                hooks=self._tool_execution_hooks,
+            )
+```
+
+Then pass `prepare_tool_call_impl=_prepare_with_hooks`.
+
+- [x] **Step 4: Leave `_prepare_tool_call_inline` as a compatibility delegator**
+
+Use:
+
+```python
+    async def _prepare_tool_call_inline(
+        self,
+        params: dict[str, Any],
+        context: RequestContext,
+        idempotency_key: str | None = None,
+    ) -> PreparedToolCall:
+        return await self._tool_execution_security.prepare_tool_call(
+            params=params,
+            context=context,
+            idempotency_key=idempotency_key,
+            hooks=self._tool_execution_hooks,
+        )
+```
+
+- [x] **Step 5: Run policy and hook tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=true ENABLE_TRACING=false OTEL_METRICS_EXPORTER=none python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_protocol_governance_preflight.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_path_scope_candidates.py tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py tldw_Server_API/tests/MCP_unified/test_mcp_protocol_external_federation.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_tool_hooks.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py::test_tool_execution_package_does_not_import_protocol_facade -q
+```
+
+Expected: all selected tests pass.
+
+## Stage 5: Extract Runtime And Idempotency
+
+**Goal:** Move execution-phase behavior into `ToolExecutionRuntime`.
+
+**Success Criteria:** `execute_prepared_tool_call_impl` ledger entry is removed; `IdempotencyManager` stays import-compatible from `protocol.py` and is injected into runtime through `ToolExecutionDependencies`; nested `run` behavior still works.
+
+**Tests:** idempotency/category, run command module, reporting, execution errors.
+
+### Task 11: Move Runtime Execution
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tool_execution/runtime.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/protocol.py`
+
+- [x] **Step 1: Implement `ToolExecutionRuntime` constructor**
+
+Use:
+
+```python
+"""Runtime execution phase for prepared MCP tool calls."""
+
+from __future__ import annotations
+
+import contextlib
+import time
+from typing import Any
+
+from loguru import logger
+
+from mcp_unified.tool_use_reporting.builders import classify_tool_use_exception
+
+from ..auth.rate_limiter import RateLimitExceeded
+from ..execution_eval import (
+    attach_execution_eval_metadata,
+    execution_eval_metadata_from_tool_definition,
+    sanitize_eval_profile_id,
+)
+from ..protocol_types import InvalidParamsException, PreparedToolCall, RequestContext
+from .dependencies import ToolExecutionDependencies
+
+
+class ToolExecutionRuntime:
+    def __init__(
+        self,
+        *,
+        dependencies: ToolExecutionDependencies,
+        security: Any,
+        hooks: Any,
+        noncritical_exceptions: tuple[type[BaseException], ...],
+        tool_execution_error: str,
+        generic_exception_like: Any,
+        make_idempotency_cache_key: Any,
+    ) -> None:
+        self.dependencies = dependencies
+        self.security = security
+        self.hooks = hooks
+        self.rate_limiter = dependencies.rate_limiter
+        self.metrics = dependencies.metrics
+        self.telemetry = dependencies.telemetry
+        self.idempotency = dependencies.idempotency
+        self.reporter = dependencies.reporter
+        self.config_provider = dependencies.config_provider
+        self._noncritical_exceptions = noncritical_exceptions
+        self._tool_execution_error = tool_execution_error
+        self._generic_exception_like = generic_exception_like
+        self._make_idempotency_cache_key = make_idempotency_cache_key
+```
+
+- [x] **Step 2: Move runtime helpers**
+
+Move from `MCPProtocol` into `ToolExecutionRuntime`:
+
+```text
+_extract_eval_profile_id
+```
+
+Move the complete body of `_execute_prepared_tool_call_inline` into a new method with this exact signature:
+
+```python
+    async def execute_prepared_tool_call(self, prepared: PreparedToolCall) -> dict[str, Any]:
+        """Execute a previously prepared tool invocation."""
+```
+
+Replace:
+
+```python
+self._verify_prepared_tool_call_integrity(prepared)
+```
+
+with:
+
+```python
+self.security.verify_prepared_tool_call_integrity(prepared)
+```
+
+Replace `get_config()` with `self.config_provider()`.
+
+- [x] **Step 3: Construct runtime helper in protocol `__init__`**
+
+Add:
+
+```python
+        from .tool_execution.runtime import ToolExecutionRuntime
+
+        self._tool_execution_runtime = ToolExecutionRuntime(
+            dependencies=self._tool_execution_dependencies,
+            security=self._tool_execution_security,
+            hooks=self._tool_execution_hooks,
+            noncritical_exceptions=_MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS,
+            tool_execution_error=_MCP_TOOL_EXECUTION_ERROR,
+            generic_exception_like=self._generic_exception_like,
+            make_idempotency_cache_key=self._make_idempotency_cache_key,
+        )
+```
+
+- [x] **Step 4: Point coordinator at runtime**
+
+Change coordinator construction to:
+
+```python
+            execute_prepared_tool_call_impl=self._tool_execution_runtime.execute_prepared_tool_call,
+```
+
+- [x] **Step 5: Keep public compatibility wrappers**
+
+Use:
+
+```python
+    async def _execute_prepared_tool_call_inline(self, prepared: PreparedToolCall) -> dict[str, Any]:
+        return await self._tool_execution_runtime.execute_prepared_tool_call(prepared)
+```
+
+Keep `IdempotencyManager` defined or re-exported from `protocol.py`. Move `_make_idempotency_cache_key` behavior into `ToolExecutionRuntime.make_idempotency_cache_key`, and leave `MCPProtocol._make_idempotency_cache_key` as a compatibility wrapper that calls runtime.
+
+- [x] **Step 6: Run runtime tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=true ENABLE_TRACING=false OTEL_METRICS_EXPORTER=none python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py::test_tool_execution_package_does_not_import_protocol_facade -q
+```
+
+Expected: all selected tests pass.
+
+## Stage 6: Extract Reporting Internals
+
+**Goal:** Move reporting/audit helper internals behind `ToolExecutionReporter` while preserving all event fields and failure swallowing.
+
+**Success Criteria:** Protocol owns only reporter construction and process-level error mapping; event construction lives in `reporting.py`.
+
+**Tests:** full tool-use reporting matrix, logging redaction, process-request failure tests.
+
+### Task 12: Move Tool-Use Reporting Helpers
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/tool_execution/reporting.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/protocol.py`
+
+- [x] **Step 1: Convert `ToolExecutionReporter` from callback facade to implementation class**
+
+Move these existing methods from `MCPProtocol` into `ToolExecutionReporter`:
+
+```text
+_should_record_tool_use
+_record_tool_use_event
+_safe_tool_use_name
+_tool_use_duration_ms
+_tool_use_execution_origin_for_failure
+_tool_use_eval_metadata
+_tool_use_file_policy_decisions
+_tool_use_hook_results
+_tool_hook_summary_items
+_append_tool_hook_summary
+_tool_use_decision_grant_outcome
+_tool_use_value_present
+_tool_use_contains_key
+_tool_use_category
+_build_tool_use_event
+_record_process_request_tool_use_failure
+_audit_tool_event
+```
+
+Use this constructor:
+
+```python
+class ToolExecutionReporter:
+    def __init__(
+        self,
+        *,
+        recorder: Any,
+        metrics: Any,
+        tool_name_re: Any,
+        noncritical_exceptions: tuple[type[BaseException], ...],
+    ) -> None:
+        self._tool_use_recorder = recorder
+        self.metrics = metrics
+        self._tool_name_re = tool_name_re
+        self._noncritical_exceptions = noncritical_exceptions
+```
+
+- [x] **Step 2: Update reporter construction**
+
+Replace the callback-style reporter construction with:
+
+```python
+        self._tool_execution_reporter = ToolExecutionReporter(
+            recorder=self._tool_use_recorder,
+            metrics=self.metrics,
+            tool_name_re=self._tool_name_re,
+            noncritical_exceptions=_MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS,
+        )
+```
+
+- [x] **Step 3: Keep protocol wrappers**
+
+For each moved method, leave a wrapper in `protocol.py`. Example:
+
+```python
+    def _should_record_tool_use(self, context: RequestContext) -> bool:
+        return self._tool_execution_reporter.should_record_tool_use(context)
+```
+
+Use wrapper names that preserve current protocol-private call sites until Stage 7 removes dead wrappers.
+
+- [x] **Step 4: Run reporting tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=true ENABLE_TRACING=false OTEL_METRICS_EXPORTER=none python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py tldw_Server_API/app/core/MCP_unified/tests/test_log_redaction.py tldw_Server_API/app/core/MCP_unified/tests/test_jsonrpc_notifications.py -q
+```
+
+Expected: all selected tests pass.
+
+## Stage 7: Clean Protocol Facade
+
+**Goal:** Remove dead tool-path helpers from `protocol.py` while keeping compatibility exports and non-tool handlers intact.
+
+**Success Criteria:** `protocol.py` owns JSON-RPC facade responsibilities only; no ledger entries remain.
+
+**Tests:** focused MCP protocol/tool slice, py_compile, Bandit.
+
+### Task 13: Remove Dead Tool-Path Helpers
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/protocol.py`
+- Modify: `Docs/superpowers/plans/2026-06-24-mcp-protocol-tool-execution-refactor.md`
+- Modify: `backlog/tasks/task-2424 - Verify-and-remediate-MCP-Unified-review-findings.md`
+
+- [x] **Step 1: Remove wrappers with no in-repo callers**
+
+Use `rg` to confirm each wrapper has no caller outside tests or compatibility imports before removing it:
+
+```bash
+rg -n "_prepare_tool_call_inline|_execute_prepared_tool_call_inline|_build_tool_use_event|_run_pre_tool_hooks|_run_post_tool_hooks|_resolve_effective_tool_policy|_evaluate_path_scope|_evaluate_external_access|_evaluate_runtime_approval" tldw_Server_API/app/core/MCP_unified tldw_Server_API/tests/MCP_unified
+```
+
+Remove only wrappers that are not required by existing tests or external compatibility.
+
+Final check: no wrappers were removed because each searched wrapper is still used by an in-repo test, compatibility monkeypatch seam, or run-command integration.
+
+- [x] **Step 2: Keep compatibility exports**
+
+Ensure `protocol.py` still imports and exposes:
+
+```python
+ApprovalRequiredError
+GovernanceDeniedError
+IdempotencyManager
+InvalidParamsException
+MCPError
+MCPProtocol
+MCPRequest
+MCPResponse
+PreparedToolCall
+RequestContext
+_trusted_compat_claims_metadata
+```
+
+- [x] **Step 3: Update the ledger**
+
+Mark every compatibility callback as removed or resolved in the task notes. The final ledger state must be empty.
+
+- [x] **Step 4: Run final verification**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m py_compile tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/protocol_types.py tldw_Server_API/app/core/MCP_unified/tool_execution/*.py
+```
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=true ENABLE_TRACING=false OTEL_METRICS_EXPORTER=none python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py tldw_Server_API/app/core/MCP_unified/tests/test_tool_execution_coordinator.py tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_scope_enforcement.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_governance_preflight.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_tool_hooks.py tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py -q
+```
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/protocol_types.py tldw_Server_API/app/core/MCP_unified/tool_execution -f json -o /tmp/bandit_mcp_tool_execution_refactor.json
+```
+
+Expected:
+
+```text
+py_compile exits 0
+focused pytest slice passes
+Bandit reports 0 findings for the touched scope
+```
+
+## Final Self-Review Checklist
+
+- [x] Every spec goal maps to a stage in this plan.
+- [x] The plan does not change JSON-RPC response shapes or HTTP error mappings.
+- [x] `MCPProtocol` remains the JSON-RPC facade and owns non-tool handlers.
+- [x] Extracted modules do not import `MCPProtocol` or `MCP_unified.protocol`.
+- [x] Coarse authorization and deep tool authorization are both tested.
+- [x] `ToolExecutionReporter` is present before coordinator extraction changes reporting call sites.
+- [x] `IdempotencyManager` is injected into runtime and remains import-compatible from `protocol.py` before Stage 5 completes.
+- [x] The callback ledger is empty by the end of Stage 7.
+- [x] Focused tests and Bandit are recorded in `TASK-2424`.

--- a/Docs/superpowers/specs/2026-06-23-mcp-protocol-tool-execution-refactor-design.md
+++ b/Docs/superpowers/specs/2026-06-23-mcp-protocol-tool-execution-refactor-design.md
@@ -1,0 +1,238 @@
+# MCP Protocol Tool Execution Refactor Design
+
+## Context
+
+`tldw_Server_API/app/core/MCP_unified/protocol.py` is currently a 4,300-line protocol facade that also owns the security-sensitive `tools/call` execution path. The file combines JSON-RPC request routing, coarse authorization, tool-specific authorization, effective policy checks, external access checks, path-scope enforcement, approval evaluation, governance preflight, hooks, idempotency, rate limiting, execution formatting, metrics, audit, tool-use reporting, resources, prompts, and module handlers.
+
+The refactor goal is not cosmetic file splitting. The goal is easier security review, lower risk for future tool-execution changes, and long-term stability while preserving current public behavior.
+
+## Goals
+
+- Keep `MCPProtocol` as the stable public JSON-RPC facade.
+- Make the `tools/call` security pipeline explicit and reviewable.
+- Preserve current gate order, error mapping, telemetry, audit, tool-use reporting, nested execution, and compatibility imports.
+- Move behavior in small parity-preserving stages backed by characterization tests.
+- Avoid extracting resources, prompts, and module handlers in this spec.
+
+## Non-Goals
+
+- Do not rewrite the whole protocol kernel.
+- Do not change JSON-RPC response shapes or HTTP error mappings.
+- Do not redesign AuthNZ, RBAC, MCP Hub policies, path-scope semantics, approval semantics, hooks, idempotency, or module execution contracts.
+- Do not make broad cleanup edits outside the tool-call path.
+
+## Recommended Approach
+
+Use a security-pipeline extraction. `MCPProtocol` remains the public facade and delegates the tool-call path into a new `tool_execution` package. The first implementation should mostly move code, not reinterpret behavior.
+
+The extraction should be stage-first rather than file-count-first. Small files are useful only when the boundaries make the security flow easier to audit.
+
+## Package Shape
+
+Create:
+
+- `tldw_Server_API/app/core/MCP_unified/protocol_types.py`
+- `tldw_Server_API/app/core/MCP_unified/tool_execution/models.py`
+- `tldw_Server_API/app/core/MCP_unified/tool_execution/dependencies.py`
+- `tldw_Server_API/app/core/MCP_unified/tool_execution/coordinator.py`
+- `tldw_Server_API/app/core/MCP_unified/tool_execution/security.py`
+- `tldw_Server_API/app/core/MCP_unified/tool_execution/hooks.py`
+- `tldw_Server_API/app/core/MCP_unified/tool_execution/idempotency.py` if `IdempotencyManager` needs to move out of `protocol.py`
+- `tldw_Server_API/app/core/MCP_unified/tool_execution/runtime.py`
+- `tldw_Server_API/app/core/MCP_unified/tool_execution/reporting.py`
+
+`protocol.py` must keep compatibility re-exports for public symbols that existing tests and modules import from it.
+
+`tool_execution/models.py` is for internal stage result types only. Public shared types should live in `protocol_types.py` to avoid circular imports.
+
+## Shared Types
+
+Move shared protocol/tool-execution types to `protocol_types.py`:
+
+- `RequestContext`
+- `PreparedToolCall`
+- `InvalidParamsException`
+- `GovernanceDeniedError`
+- `ApprovalRequiredError`
+
+Keep these importable from `protocol.py` by re-exporting them there.
+
+Keep `MCPRequest`, `MCPResponse`, `MCPError`, and `ErrorCode` in `protocol.py` initially because they belong to the JSON-RPC facade and are not required by extracted tool execution code.
+
+`IdempotencyManager` may remain import-compatible from `protocol.py`, but extracted runtime code must not import `protocol.py` to reach it. During early stages, pass the current manager instance through `ToolExecutionDependencies`. Before or during Stage 5, either keep that dependency-object boundary or move the class to `tool_execution/idempotency.py` and re-export it from `protocol.py` because tests import it there today.
+
+## Tool Execution Dependencies
+
+Introduce a `ToolExecutionDependencies` dataclass. It should hold explicit services and callables rather than the whole `MCPProtocol` object.
+
+Dependencies include:
+
+- module registry
+- RBAC policy
+- rate limiter
+- metrics collector
+- telemetry provider
+- hook manager
+- tool-use recorder
+- idempotency manager
+- config provider callable
+- effective policy resolver
+- path scope enforcer
+- approval evaluator
+- external access evaluator
+- reporter facade
+- narrow compatibility callables that are still being migrated
+
+Temporary bound method callables are acceptable during migration. The coordinator must not import or store an `MCPProtocol` instance.
+
+Before Stage 3 implementation, create a temporary compatibility callback ledger in the implementation plan. Each callback must have:
+
+- current protocol helper or bound method name
+- target module/function that should own the behavior
+- removal stage
+- parity test that protects the migration
+
+The ledger is part of the security review surface. Do not add a new callback without updating the ledger, and remove ledger entries as callbacks are replaced by extracted module functions.
+
+Introduce a `ToolExecutionReporter` facade in Stage 3 even if its first implementation delegates to existing protocol helpers. The coordinator should depend on this facade for success, denial, failure, replay, audit, and metrics reporting paths from the first extraction stage. Stage 6 then moves the reporter internals rather than changing coordinator call sites again.
+
+## Security Pipeline Contract
+
+The current gate order is a security contract. It should be preserved and covered by tests at the named-gate level.
+
+The preflight/prepare phase is policy-active, not side-effect-free. It may run governance preflight and pre-tool hooks, and hooks can deny execution.
+
+Prepare phase order:
+
+1. Tool name and idempotency key validation.
+2. Context allow-list checks.
+3. Effective policy lookup.
+4. External access checks.
+5. Module lookup.
+6. Tool definition resolution.
+7. Argument hardening and sanitization.
+8. Write classification.
+9. Module/tool permission checks.
+10. Scoped permission and API-key scope checks.
+11. Input schema validation.
+12. Global write-disable policy.
+13. Module argument validator.
+14. Idempotency cache key preparation.
+15. Path-scope checks.
+16. Approval evaluation.
+17. Governance preflight.
+18. Pre-tool hooks.
+19. Prepared-call integrity tag creation.
+
+Execution phase order:
+
+1. Prepared-call integrity verification.
+2. Per-tool/category rate limiting.
+3. Idempotency binding and cache execution for writes.
+4. Circuit-breaker tool execution.
+5. Result formatting and execution eval metadata.
+6. Audit and metrics.
+7. Post-tool hooks.
+8. Tool-use reporting for success, failure, and replay cases.
+
+`process_request()` keeps coarse method authorization through `_check_authorization()`. The extracted tool pipeline performs deeper tool-specific authorization. This two-layer model should be documented in code comments near the delegation point.
+
+The authorization boundary is part of the contract. Characterization tests must cover coarse method authorization denial before the tool pipeline starts and deep tool-specific denial inside the prepare pipeline. Both cases should assert caller-visible error mapping and reporting/audit classification where reporting currently occurs.
+
+## Component Responsibilities
+
+`coordinator.py`
+
+- Owns stage ordering.
+- Delegates actual logic to `security.py`, `hooks.py`, `runtime.py`, and `reporting.py`.
+- Supports both full JSON-RPC calls and direct nested `prepare_tool_call()` plus `execute_prepared_tool_call()` usage.
+- Stays small enough to review in one sitting.
+
+`security.py`
+
+- Owns validation, module/tool resolution, argument hardening entry points, write classification, RBAC checks, scoped permissions, API-key gates, effective policy, external access, path scope, approval, and governance preflight.
+- Should be organized internally by stage groups before splitting further.
+
+`hooks.py`
+
+- Owns pre-hook and post-hook context creation, payload shaping, hook action coercion, and hook execution.
+- Pre-hooks remain part of preflight because they can deny execution.
+
+`runtime.py`
+
+- Owns rate category selection, per-tool/category rate limiting, idempotency binding/cache behavior, circuit-breaker execution, result formatting, and execution eval metadata attachment.
+- Receives a config provider instead of importing `get_config()` directly.
+
+`reporting.py`
+
+- Owns tool-use event construction, audit helpers, metrics helpers, and error/reporting classification glue.
+- Provides the `ToolExecutionReporter` facade from Stage 3.
+- Internal helper extraction should happen late because reporting has many parity-sensitive paths.
+
+`protocol.py`
+
+- Owns JSON-RPC parsing and response objects.
+- Owns method dispatch, notifications, top-level rate limiting, and coarse method authorization.
+- Owns non-tool handlers: initialize, ping, tools/list, resources, prompts, and modules.
+- Re-exports compatibility symbols.
+
+No extracted module should import `MCPProtocol`.
+
+## Testing Strategy
+
+Use characterization tests before moving behavior. Extraction is successful only if behavior stays the same.
+
+Required tests:
+
+- Stage-order tests that assert named security gates run in order: validate, context allow-list, policy/external, resolve/harden/classify, RBAC/API scope, schema/write validation, path scope/approval, governance/hooks, execution/reporting.
+- Authorization-boundary tests that separately cover coarse `_check_authorization()` denial before the tool pipeline and deep tool-specific denial inside `prepare_tool_call()`.
+- Compatibility import tests for all re-exported symbols.
+- Import-boundary tests that assert `tool_execution/*` does not import `MCPProtocol` or `MCP_unified.protocol`.
+- Error mapping tests for invalid params, permission denial, governance denial, approval required, rate limit, tool execution failure, and notification behavior.
+- Tool-use reporting matrix tests for success, preflight failure, denied, invalid params, execution failure, and idempotency replay.
+- Nested execution tests for direct `prepare_tool_call()` plus `execute_prepared_tool_call()` flows, especially the virtual `run` command.
+- Lightweight fake-module/fake-policy/fake-hook tests that avoid full FastAPI startup unless HTTP mapping is explicitly under test.
+
+Error mapping tests should check caller-visible JSON-RPC behavior and reporting/audit classification where relevant, because those can drift independently.
+
+Compatibility import tests should include `IdempotencyManager` if it remains publicly importable from `protocol.py`.
+
+## Error Handling Rules
+
+- Preserve existing exception classes and JSON-RPC error codes.
+- Preserve `asyncio.CancelledError` behavior; do not accidentally catch it under broad exception handling.
+- Keep security denials structured as denials rather than generic failures.
+- Avoid moving broad `except Exception` blocks unless the caller-visible response, telemetry attributes, audit classification, and tool-use event behavior remain equivalent.
+- Extract error classification only after parity tests cover current behavior.
+
+## Staged Rollout
+
+Stage 1: Characterization and compatibility tests.
+
+Stage 2: Move shared types into `protocol_types.py` and re-export them from `protocol.py`.
+
+Stage 3: Introduce `ToolExecutionDependencies`, `ToolExecutionCoordinator`, `ToolExecutionReporter`, and the compatibility callback ledger. The coordinator may initially use explicit bound-method callables for behavior not yet moved, but it must not store or import the whole protocol object. Each temporary callback must be listed in the ledger with its removal stage and parity test.
+
+Stage 4a: Extract validation, module/tool resolution, argument hardening, and write classification.
+
+Stage 4b: Extract RBAC, scoped permissions, and API-key scope checks.
+
+Stage 4c: Extract effective policy, external access, path scope, approval, governance preflight, and pre-hooks.
+
+Stage 5: Extract runtime behavior: rate limits, idempotency, circuit-breaker execution, result formatting, execution eval metadata. At this point, `IdempotencyManager` ownership must be resolved by either dependency-object injection or moving the class to `tool_execution/idempotency.py` with a `protocol.py` compatibility re-export.
+
+Stage 6: Extract reporting internals behind the Stage 3 `ToolExecutionReporter` facade: tool-use events, audit helpers, metrics helpers, and reporting classifications.
+
+Stage 7: Clean the protocol facade by removing only dead tool-path helpers. Do not refactor non-tool handlers in this stage.
+
+Each stage should run focused MCP protocol/tool tests before proceeding. The final stage should run Bandit on the touched scope.
+
+## Success Criteria
+
+- `protocol.py` keeps the public API stable while delegating tool execution.
+- The tool security gate order is readable from coordinator code and covered by tests.
+- Extracted modules depend on explicit services/callables, not `MCPProtocol`.
+- Existing nested execution and virtual `run` behavior continue to work.
+- Existing JSON-RPC and HTTP error behavior remains stable.
+- Tool-use reporting, audit, metrics, hooks, idempotency, and cancellation behavior remain equivalent.
+- No resource/prompt/module handler refactor is included in this implementation plan.

--- a/backlog/tasks/task-2424 - Verify-and-remediate-MCP-Unified-review-findings.md
+++ b/backlog/tasks/task-2424 - Verify-and-remediate-MCP-Unified-review-findings.md
@@ -4,7 +4,7 @@ title: Verify and remediate MCP Unified review findings
 status: Done
 assignee: []
 created_date: 2026-06-23 18:27
-updated_date: 2026-06-25 02:22
+updated_date: 2026-06-25 02:47
 labels:
 - review
 - mcp
@@ -107,6 +107,7 @@ Task 12 complete: ToolExecutionReporter now owns tool-use reporting internals, p
 Task 13 cleanup/final review complete. Usage search found the remaining protocol.py wrapper methods are still used by in-repo callers, compatibility imports, or monkeypatch seams, so no additional wrappers were removed. Compatibility exports were verified, the plan ledger was updated to a final empty active state with resolved history, and all plan checklist stages were marked complete. Final review follow-ups fixed two validated issues: ToolExecutionSecurity now delegates governance rollout mode resolution through the shared server config resolver with fallback, and ToolExecutionHooks no longer exposes raw hook decision messages or arbitrary hook metadata in caller-facing denial/approval responses while preserving sanitized hook reporting metadata. Additional final-contract fixes removed a direct AuthNZ exception import from server.py and corrected the standalone MCP extraction-contract root path. Final verification passed: py_compile for touched MCP modules, focused pytest slice 217 passed, Ruff F/I/UP passed, Bandit touched implementation scope reported 0 findings, and git diff --check passed. Final quality reviewer approved with no remaining Critical/Important/Minor findings.
 Integration cleanup before commit: expanded the verification scope to include the earlier validated MCP Unified fixes and the protocol.py refactor together. Fixed a brittle fs.glob size-unavailable test shim so it raises on the intended follow_symlinks=False metadata read, and applied Ruff import/type cleanup in the expanded MCP touched test scope. Verification passed after cleanup: py_compile for touched MCP implementation files, expanded pytest slice 384 passed, Ruff F/I/UP passed, and Bandit commit-scope scan wrote /tmp/bandit_mcp_unified_final_commit_scope.json with no command-level failures.
 PR opened against dev: https://github.com/rmusser01/tldw_server/pull/2513
+PR #2513 rebased onto latest origin/dev and review comments addressed. Validated/fixed: Loguru formatting comments in server/runtime/reporting/security/protocol touched paths; config now uses sys.stderr instead of os.sys.stderr; runtime/reporting no longer silently pass on noncritical rate-limit/metrics/audit failures; RedisError fallback no longer defines a local custom exception; new tool_execution classes/dependency bundles gained docstrings; new async coordinator/idempotency tests gained required unit markers and missing type hints; fs.write_text now advertises and explicitly enforces the overwrite preimage contract. Verification after rebase and fixes passed: py_compile, expanded MCP pytest slice 384 passed, Ruff F/I/UP, Bandit 0 findings, and git diff --check origin/dev..HEAD.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2424 - Verify-and-remediate-MCP-Unified-review-findings.md
+++ b/backlog/tasks/task-2424 - Verify-and-remediate-MCP-Unified-review-findings.md
@@ -1,0 +1,113 @@
+---
+id: TASK-2424
+title: Verify and remediate MCP Unified review findings
+status: Done
+assignee: []
+created_date: 2026-06-23 18:27
+updated_date: 2026-06-25 02:08
+labels:
+- review
+- mcp
+- security
+- refactor
+dependencies: []
+modified_files:
+- Docs/superpowers/plans/2026-06-24-mcp-protocol-tool-execution-refactor.md
+- Docs/superpowers/specs/2026-06-23-mcp-protocol-tool-execution-refactor-design.md
+- tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
+- tldw_Server_API/app/core/MCP_unified/auth/rbac.py
+- tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py
+- tldw_Server_API/app/core/MCP_unified/command_runtime/registry.py
+- tldw_Server_API/app/core/MCP_unified/config.py
+- tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+- tldw_Server_API/app/core/MCP_unified/protocol.py
+- tldw_Server_API/app/core/MCP_unified/protocol_types.py
+- tldw_Server_API/app/core/MCP_unified/server.py
+- tldw_Server_API/app/core/MCP_unified/tool_execution/__init__.py
+- tldw_Server_API/app/core/MCP_unified/tool_execution/coordinator.py
+- tldw_Server_API/app/core/MCP_unified/tool_execution/dependencies.py
+- tldw_Server_API/app/core/MCP_unified/tool_execution/hooks.py
+- tldw_Server_API/app/core/MCP_unified/tool_execution/models.py
+- tldw_Server_API/app/core/MCP_unified/tool_execution/reporting.py
+- tldw_Server_API/app/core/MCP_unified/tool_execution/runtime.py
+- tldw_Server_API/app/core/MCP_unified/tool_execution/security.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_protocol_governance_preflight.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_protocol_tool_hooks.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_security_hardening.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_tool_execution_coordinator.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_validation_and_sanitization.py
+- tldw_Server_API/app/core/MCP_unified/tests/test_ws_per_ip_caps.py
+- tldw_Server_API/tests/MCP_unified/test_mcp_config_sanitization.py
+- tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py
+- tldw_Server_API/tests/MCP_unified/test_phase3_3_small_core_sanitizers.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify current MCP Unified module review findings, address validated issues with focused tests and security verification, and capture the protocol.py refactor brainstorming/spec workflow separately before implementation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Validated review findings are recorded as accepted or rejected with evidence
+- [x] #2 Accepted bug/security/reliability findings have regression tests written before production changes
+- [x] #3 Focused MCP Unified tests, diff check, and Bandit touched-scope verification are recorded
+- [x] #4 protocol.py refactor brainstorming produces an approved design/spec before implementation planning
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verification pass completed before implementation. Validated findings: MCP legacy refresh/revocation state is process-local; fs.write_text bypasses structured fs.write preimage/receipt protections and virtual CLI write maps to it; metadata category web/utility falls back to read rate bucket; fallback RBAC USER role wildcard-executes arbitrary tools; stale WebSocket cleanup removes connections without decrementing per-IP counts; MCP configure_logging removes existing global Loguru sinks; invalid tool names return INTERNAL_ERROR despite being invalid params. Focused existing suite: selected MCP tests passed 9/9 in 229.16s, with live WebSocket test slow but completed.
+
+Implemented remediation for validated MCP Unified findings: gated legacy refresh behind demo auth, routed fs.write_text through structured preimage-checked writer, moved virtual CLI write to fs.write create mode, preserved network/utility metadata categories for rate limiting, narrowed fallback RBAC user/moderator tool execution, decremented WS per-IP counts during stale cleanup, preserved non-MCP Loguru sinks, and mapped invalid tool names to INVALID_PARAMS. Verification: focused MCP regression slice passed (21 passed); HTTP refresh gate tests passed (2 passed); touched modules py_compile passed; direct logging preservation check passed; Bandit on touched implementation files passed with 0 findings.
+
+Protocol.py refactor brainstorming completed. Approved direction: security-pipeline extraction for tools/call, keeping MCPProtocol as JSON-RPC facade. Design spec written at Docs/superpowers/specs/2026-06-23-mcp-protocol-tool-execution-refactor-design.md and self-reviewed for placeholders, contradictions, scope drift, and ambiguity.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Spec review fixes applied to Docs/superpowers/specs/2026-06-23-mcp-protocol-tool-execution-refactor-design.md: added a compatibility callback ledger requirement, made Stage 3 introduce a ToolExecutionReporter facade, clarified coarse-vs-deep authorization characterization tests, and resolved IdempotencyManager ownership expectations before/during runtime extraction.
+Follow-up spec review fixes applied: added the reporter facade to ToolExecutionDependencies and required an import-boundary test so tool_execution modules cannot import MCPProtocol or MCP_unified.protocol.
+Implementation plan written at Docs/superpowers/plans/2026-06-24-mcp-protocol-tool-execution-refactor.md. Plan covers characterization tests, shared type extraction, coordinator delegation, security/hooks/runtime/reporting extraction, callback ledger removal, focused verification, and Bandit. Idempotency ownership is resolved by keeping IdempotencyManager import-compatible from protocol.py while injecting the manager instance into runtime.
+Implementation Task 1 completed via subagent workflow: added protocol compatibility export and tool_execution import-boundary tests to test_extraction_contracts.py. Verification intentionally red at this stage: selected tests produced 1 passed, 1 failed because tool_execution/ is created in a later task. Spec review passed; code-quality re-review found no Critical/Important issues aside from the planned missing package directory.
+Implementation Task 2 completed via subagent workflow: added coordinator characterization tests in test_tool_execution_coordinator.py. Verification intentionally red at this stage: pytest collected 2 tests and both failed with ModuleNotFoundError because tool_execution.coordinator is created later. Spec review passed; code-quality review found no Critical/Important issues.
+Implementation Task 3 completed via subagent workflow: added coarse and deep tools/call authorization-boundary reporting tests in test_tool_use_reporting_protocol.py. Focused verification passed (2 passed). Spec review passed; code-quality review suggestions were applied by switching to _protocol(recorder=...), asserting exactly one event, and checking runtime_surface/requested_tool_name; final quality re-review found no Critical/Important issues.
+Task 4 protocol type extraction completed: moved InvalidParamsException, GovernanceDeniedError, ApprovalRequiredError, RequestContext, trusted compatibility-claims sentinels/helpers, and PreparedToolCall into tldw_Server_API/app/core/MCP_unified/protocol_types.py. protocol.py now imports/re-exports the moved names, keeps MCPRequest/MCPResponse/MCPError/ErrorCode/IdempotencyManager in place, and preserves earlier local protocol.py remediation edits. Verification: `source .venv/bin/activate; python -m py_compile tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/protocol_types.py; TEST_MODE=true ENABLE_TRACING=false OTEL_METRICS_EXPORTER=none python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py::test_protocol_reexports_tool_execution_shared_symbols tldw_Server_API/app/core/MCP_unified/tests/test_protocol_scope_enforcement.py -q` exited 0 with 8 passed, 3 warnings. Touched-scope Bandit: `python -m bandit -r tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/app/core/MCP_unified/protocol_types.py -f json -o /tmp/bandit_mcp_protocol_types_task4.json` exited 0 with `errors: []` and `results: []`.
+Task 4 complete: shared protocol helper/types moved into protocol_types.py with protocol.py re-exports preserved. Spec review approved. Code-quality review initially found a PreparedToolCall runtime annotation regression; fixed by restoring runtime BaseModule import and adding a get_type_hints regression assertion. Focused py_compile, pytest subset, Ruff F/I/UP, and reviewer Bandit check passed.
+Implementation Task 5 completed via subagent workflow: created the tool_execution package skeleton with coordinator, dependency, reporting, model, and placeholder modules. Focused verification passed: import-boundary/coordinator tests 3 passed, py_compile on all new files passed, and Ruff F/I/UP on tool_execution passed. Spec review passed. Code-quality review found no Critical/Important issues; minor notes are to use or defer execution_origin_for_failure and tighten callback typing in later extraction steps.
+Implementation Task 6 completed via subagent workflow: MCPProtocol now constructs ToolExecutionReporter/ToolExecutionDependencies/ToolExecutionCoordinator, delegates _handle_tools_call plus public prepare/execute methods through the coordinator, and preserves original bodies as _prepare_tool_call_inline/_execute_prepared_tool_call_inline. Direct external_access_evaluator wiring was enforced and incomplete test dependency bundles were updated. Code-quality review identified a monkeypatch restore recursion trap in __setattr__; fixed with failing-first regression test test_restoring_public_prepare_tool_call_does_not_recurse. Verification passed: focused Task 6 slice 14 passed, py_compile passed, Ruff F/I/UP passed; spec and quality re-reviews approved.
+Implementation Task 7 completed via subagent workflow: ToolExecutionSecurity now owns core validation/resolution/hardening/integrity helpers, MCPProtocol constructs it and keeps compatibility wrappers, and prepare/execute inline paths call it directly. Spec review found class-level MCPProtocol._hash_arguments compatibility regression; fixed with failing-first test test_protocol_hash_arguments_supports_class_level_compatibility_call and shared ToolExecutionSecurity.hash_arguments_with_exceptions helper. Verification passed: focused Task 7 suite 13 passed, py_compile passed, Ruff F/I/UP passed, and worker Bandit touched-scope scan reported zero findings. Spec and code-quality re-reviews approved.
+Implementation Task 8 completed via subagent workflow: ToolExecutionSecurity now owns tool RBAC/scope/API-key/allowed-tools/alias authorization helpers, protocol private wrappers remain for compatibility and monkeypatch seams, _prepare_tool_call_inline still uses wrappers for context/module/tool gates, and ToolExecutionDependencies gained optional api_key_scope_normalizer with fallback parsing preserved. Verification passed: required focused authorization/scope/sandbox/import-boundary slice 25 passed, py_compile passed, Ruff F/I/UP passed; worker Bandit touched-scope scan reported zero findings and optional scope/fallback tests passed. Spec and code-quality reviews approved.
+Implementation Task 9 completed via subagent workflow: ToolExecutionHooks now owns pre/post hook context construction, hook decision coercion, payload shaping, hook-visible metadata copying/redaction, and hook execution; MCPProtocol constructs the helper and keeps compatibility wrappers. Code-quality review found two Important issues, both fixed with regression tests: composite hook_results are sanitized/allowlisted before being stored in request metadata, and replacing protocol._tool_call_hook_manager now syncs the extracted helper. Verification passed: new red tests now pass, focused Task 9 slice passed (13 passed locally; reviewer rerun 16 passed), py_compile passed for protocol.py/hooks.py, Ruff F/I/UP passed, and import-boundary review confirmed no tool_execution import/reference to MCPProtocol.
+Implementation Task 10 completed via subagent workflow: ToolExecutionSecurity now owns policy/governance/path/external helpers plus prepare_tool_call, with governance service/store/lock state moved into the security helper. MCPProtocol now routes coordinator prepare through a hooks-aware wrapper and keeps compatibility delegators/wrappers for moved methods. Existing protocol monkeypatch seams are preserved through late-bound prepare callbacks and dependency sync. During verification, the required suite initially had one failure in the run-chain path-scope fixture; root cause was a stale test fixture still advertising legacy fs.write_text while the current virtual CLI write adapter intentionally uses structured fs.write with mode=create from the earlier security remediation. Updated that fixture to fs.write. Verification passed: exact failing test passed, required Task 10 suite passed (57 passed), py_compile passed for protocol.py/security.py/hooks.py and the touched path-scope test, Ruff F/I/UP passed for protocol.py/security.py/hooks.py, and Ruff F/UP passed for the touched path-scope test. Spec and code-quality reviews approved.
+Task 11 complete: extracted prepared-call runtime execution into ToolExecutionRuntime, wired coordinator execution to runtime, kept protocol compatibility wrappers, and added runtime post-hook/config/idempotency seam regressions. Review follow-up fixed _idempotency dependency sync, dynamic get_config provider resolution, and protocol post-hook wrapper compatibility. Verification: 150 selected MCP Unified tests passed; py_compile passed for touched protocol/runtime/hooks/tests; ruff F,I,UP passed on touched files; production Bandit passed with 0 findings; git diff --check passed. Reviewer recheck approved.
+Task 12 complete: ToolExecutionReporter now owns tool-use reporting internals, process-request failure recording, event construction helpers, and audit logging; protocol.py keeps compatibility wrappers and constructs/syncs the reporter. Review follow-ups fixed runtime audit boundary so runtime calls reporter.audit_tool_event, synced _tool_name_re into ToolExecutionSecurity after regex replacement, added regressions for event-builder restoration and regex sync, and cleaned Bandit B110 fallback pass sites in security.py with sanitized debug logging. Verification: 63 selected MCP Unified reporting/runtime tests passed; py_compile passed; ruff F,I,UP passed; production Bandit passed with 0 findings; git diff --check passed. Reviewer rechecks approved.
+Task 13 cleanup/final review complete. Usage search found the remaining protocol.py wrapper methods are still used by in-repo callers, compatibility imports, or monkeypatch seams, so no additional wrappers were removed. Compatibility exports were verified, the plan ledger was updated to a final empty active state with resolved history, and all plan checklist stages were marked complete. Final review follow-ups fixed two validated issues: ToolExecutionSecurity now delegates governance rollout mode resolution through the shared server config resolver with fallback, and ToolExecutionHooks no longer exposes raw hook decision messages or arbitrary hook metadata in caller-facing denial/approval responses while preserving sanitized hook reporting metadata. Additional final-contract fixes removed a direct AuthNZ exception import from server.py and corrected the standalone MCP extraction-contract root path. Final verification passed: py_compile for touched MCP modules, focused pytest slice 217 passed, Ruff F/I/UP passed, Bandit touched implementation scope reported 0 findings, and git diff --check passed. Final quality reviewer approved with no remaining Critical/Important/Minor findings.
+Integration cleanup before commit: expanded the verification scope to include the earlier validated MCP Unified fixes and the protocol.py refactor together. Fixed a brittle fs.glob size-unavailable test shim so it raises on the intended follow_symlinks=False metadata read, and applied Ruff import/type cleanup in the expanded MCP touched test scope. Verification passed after cleanup: py_compile for touched MCP implementation files, expanded pytest slice 384 passed, Ruff F/I/UP passed, and Bandit commit-scope scan wrote /tmp/bandit_mcp_unified_final_commit_scope.json with no command-level failures.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Validated and remediated the MCP Unified review findings, completed the protocol.py tool-execution refactor into focused tool_execution helpers, preserved compatibility seams through wrappers/re-exports, and recorded the design/plan/review history. Final expanded verification passed: 384 focused MCP tests, py_compile, Ruff F/I/UP, Bandit touched-scope 0 findings, git diff --check, and final reviewer approval.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-2424 - Verify-and-remediate-MCP-Unified-review-findings.md
+++ b/backlog/tasks/task-2424 - Verify-and-remediate-MCP-Unified-review-findings.md
@@ -4,7 +4,7 @@ title: Verify and remediate MCP Unified review findings
 status: Done
 assignee: []
 created_date: 2026-06-23 18:27
-updated_date: 2026-06-25 02:47
+updated_date: 2026-06-25 03:00
 labels:
 - review
 - mcp
@@ -108,6 +108,8 @@ Task 13 cleanup/final review complete. Usage search found the remaining protocol
 Integration cleanup before commit: expanded the verification scope to include the earlier validated MCP Unified fixes and the protocol.py refactor together. Fixed a brittle fs.glob size-unavailable test shim so it raises on the intended follow_symlinks=False metadata read, and applied Ruff import/type cleanup in the expanded MCP touched test scope. Verification passed after cleanup: py_compile for touched MCP implementation files, expanded pytest slice 384 passed, Ruff F/I/UP passed, and Bandit commit-scope scan wrote /tmp/bandit_mcp_unified_final_commit_scope.json with no command-level failures.
 PR opened against dev: https://github.com/rmusser01/tldw_server/pull/2513
 PR #2513 rebased onto latest origin/dev and review comments addressed. Validated/fixed: Loguru formatting comments in server/runtime/reporting/security/protocol touched paths; config now uses sys.stderr instead of os.sys.stderr; runtime/reporting no longer silently pass on noncritical rate-limit/metrics/audit failures; RedisError fallback no longer defines a local custom exception; new tool_execution classes/dependency bundles gained docstrings; new async coordinator/idempotency tests gained required unit markers and missing type hints; fs.write_text now advertises and explicitly enforces the overwrite preimage contract. Verification after rebase and fixes passed: py_compile, expanded MCP pytest slice 384 passed, Ruff F/I/UP, Bandit 0 findings, and git diff --check origin/dev..HEAD.
+Reopened after PR #2513 follow-up check: GitHub review threads still show unresolved conversations. Re-verifying code-backed fixes and applying a small marker/type-hint cleanup in the changed idempotency/category tests before resolving threads and waiting for checks.
+Follow-up PR issue cleanup completed: verified unresolved GitHub review threads against the current code, tightened idempotency/category test marker and type-hint coverage, and reran verification. Results: py_compile on the edited test file passed; test_idempotency_and_category.py passed 14 tests; expanded focused MCP slice passed 384 tests; Ruff F/I/UP passed for the edited test file; git diff --check passed; Bandit touched production scope reported 0 findings in /tmp/bandit_mcp_unified_pr_all_issues.json.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2424 - Verify-and-remediate-MCP-Unified-review-findings.md
+++ b/backlog/tasks/task-2424 - Verify-and-remediate-MCP-Unified-review-findings.md
@@ -4,7 +4,7 @@ title: Verify and remediate MCP Unified review findings
 status: Done
 assignee: []
 created_date: 2026-06-23 18:27
-updated_date: 2026-06-25 02:08
+updated_date: 2026-06-25 02:22
 labels:
 - review
 - mcp
@@ -47,6 +47,8 @@ modified_files:
 - tldw_Server_API/tests/MCP_unified/test_mcp_config_sanitization.py
 - tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py
 - tldw_Server_API/tests/MCP_unified/test_phase3_3_small_core_sanitizers.py
+references:
+- https://github.com/rmusser01/tldw_server/pull/2513
 ---
 
 ## Description
@@ -104,6 +106,7 @@ Task 11 complete: extracted prepared-call runtime execution into ToolExecutionRu
 Task 12 complete: ToolExecutionReporter now owns tool-use reporting internals, process-request failure recording, event construction helpers, and audit logging; protocol.py keeps compatibility wrappers and constructs/syncs the reporter. Review follow-ups fixed runtime audit boundary so runtime calls reporter.audit_tool_event, synced _tool_name_re into ToolExecutionSecurity after regex replacement, added regressions for event-builder restoration and regex sync, and cleaned Bandit B110 fallback pass sites in security.py with sanitized debug logging. Verification: 63 selected MCP Unified reporting/runtime tests passed; py_compile passed; ruff F,I,UP passed; production Bandit passed with 0 findings; git diff --check passed. Reviewer rechecks approved.
 Task 13 cleanup/final review complete. Usage search found the remaining protocol.py wrapper methods are still used by in-repo callers, compatibility imports, or monkeypatch seams, so no additional wrappers were removed. Compatibility exports were verified, the plan ledger was updated to a final empty active state with resolved history, and all plan checklist stages were marked complete. Final review follow-ups fixed two validated issues: ToolExecutionSecurity now delegates governance rollout mode resolution through the shared server config resolver with fallback, and ToolExecutionHooks no longer exposes raw hook decision messages or arbitrary hook metadata in caller-facing denial/approval responses while preserving sanitized hook reporting metadata. Additional final-contract fixes removed a direct AuthNZ exception import from server.py and corrected the standalone MCP extraction-contract root path. Final verification passed: py_compile for touched MCP modules, focused pytest slice 217 passed, Ruff F/I/UP passed, Bandit touched implementation scope reported 0 findings, and git diff --check passed. Final quality reviewer approved with no remaining Critical/Important/Minor findings.
 Integration cleanup before commit: expanded the verification scope to include the earlier validated MCP Unified fixes and the protocol.py refactor together. Fixed a brittle fs.glob size-unavailable test shim so it raises on the intended follow_symlinks=False metadata read, and applied Ruff import/type cleanup in the expanded MCP touched test scope. Verification passed after cleanup: py_compile for touched MCP implementation files, expanded pytest slice 384 passed, Ruff F/I/UP passed, and Bandit commit-scope scan wrote /tmp/bandit_mcp_unified_final_commit_scope.json with no command-level failures.
+PR opened against dev: https://github.com/rmusser01/tldw_server/pull/2513
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
@@ -252,6 +252,44 @@ def _single_user_test_key_compat_allowed() -> bool:
     return True
 
 
+def _require_demo_auth_enabled(request: Request) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
+    """Require the direct MCP demo-auth surface to be explicitly enabled."""
+    if not env_flag_enabled("MCP_ENABLE_DEMO_AUTH"):
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="Direct MCP auth is disabled. Use AuthNZ bearer tokens.",
+        )
+
+    cfg = get_config()
+    test_mode = is_test_mode()
+    if not cfg.debug_mode and not test_mode:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Demo auth is restricted to debug/test environments.",
+        )
+
+    demo_secret = os.getenv("MCP_DEMO_AUTH_SECRET", "")
+    if len(demo_secret) < 16:
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="Demo auth secret not configured; set MCP_DEMO_AUTH_SECRET to enable.",
+        )
+
+    client_host = getattr(request.client, "host", None)
+    if client_host == "testclient" and test_mode:
+        client_host = "127.0.0.1"
+    try:
+        peer_ip = ipaddress.ip_address(client_host) if client_host else None
+    except ValueError:
+        peer_ip = None
+    if not peer_ip or (not peer_ip.is_loopback and not peer_ip.is_private):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Demo auth is only available from loopback/private addresses.",
+        )
+    return peer_ip
+
+
 def _get_client_ip(request: Optional[Request]) -> Optional[str]:
     """Extract client IP from the incoming request."""
     if request is None:
@@ -1563,37 +1601,8 @@ async def create_token(
     Use the primary AuthNZ login flow to obtain a JWT, or enable this endpoint
     explicitly via MCP_ENABLE_DEMO_AUTH=1 for development/testing only.
     """
-    if not env_flag_enabled("MCP_ENABLE_DEMO_AUTH"):
-        raise HTTPException(
-            status_code=status.HTTP_501_NOT_IMPLEMENTED,
-            detail="Direct MCP auth is disabled. Use AuthNZ bearer tokens.",
-        )
-
-    cfg = get_config()
-    test_mode = is_test_mode()
-    if not cfg.debug_mode and not test_mode:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Demo auth is restricted to debug/test environments.",
-        )
-
+    peer_ip = _require_demo_auth_enabled(request)
     demo_secret = os.getenv("MCP_DEMO_AUTH_SECRET", "")
-    if len(demo_secret) < 16:
-        raise HTTPException(
-            status_code=status.HTTP_501_NOT_IMPLEMENTED,
-            detail="Demo auth secret not configured; set MCP_DEMO_AUTH_SECRET to enable.",
-        )
-
-    client_host = getattr(request.client, "host", None)
-    try:
-        peer_ip = ipaddress.ip_address(client_host) if client_host else None
-    except ValueError:
-        peer_ip = None
-    if not peer_ip or (not peer_ip.is_loopback and not peer_ip.is_private):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Demo auth is only available from loopback/private addresses.",
-        )
 
     provided_secret = auth_request.api_key or auth_request.password or ""
     if not provided_secret or not secrets.compare_digest(provided_secret, demo_secret):
@@ -1635,6 +1644,7 @@ async def create_token(
 @router.post("/auth/refresh", response_model=AuthTokenResponse)
 async def refresh_token(
     auth_request: AuthRefreshRequest,
+    request: Request,
     _guard: None = Depends(enforce_http_security),
 ):
     """
@@ -1645,6 +1655,8 @@ async def refresh_token(
     If `token_id` is not provided, the system attempts to locate it by scanning
     active refresh tokens (acceptable for in-memory DEV mode).
     """
+    _require_demo_auth_enabled(request)
+
     jwt_manager = get_jwt_manager()
     refresh_token_value = auth_request.refresh_token
     token_id = auth_request.token_id

--- a/tldw_Server_API/app/core/MCP_unified/auth/rbac.py
+++ b/tldw_Server_API/app/core/MCP_unified/auth/rbac.py
@@ -156,8 +156,6 @@ class RBACPolicy:
                 # Can view conversations
                 Permission(Resource.CONVERSATION, Action.READ),
                 Permission(Resource.CONVERSATION, Action.DELETE),
-                # Can execute tools
-                Permission(Resource.TOOL, Action.EXECUTE),
             },
             inherits_from={UserRole.USER.value}
         )
@@ -167,8 +165,10 @@ class RBACPolicy:
             name=UserRole.USER.value,
             description="Standard user with read/write access to own content",
             permissions={
-                # Can execute most tools
-                Permission(Resource.TOOL, Action.EXECUTE),
+                # Can execute explicitly safe tools
+                Permission(Resource.TOOL, Action.EXECUTE, "search_media"),
+                Permission(Resource.TOOL, Action.EXECUTE, "get_transcript"),
+                Permission(Resource.TOOL, Action.EXECUTE, "chat_completion"),
                 # Can read resources
                 Permission(Resource.RESOURCE, Action.READ),
                 # Can use prompts

--- a/tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py
+++ b/tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py
@@ -298,8 +298,8 @@ class PhaseOneCommandAdapters:
             if isinstance(path, _UsageError):
                 return path
             return _GovernedCallPlan(
-                tool_name="fs.write_text",
-                arguments={"path": path, "content": " ".join(argv[2:])},
+                tool_name="fs.write",
+                arguments={"path": path, "content": " ".join(argv[2:]), "mode": "create"},
                 renderer=self._render_write,
             )
         if command == "write-create":

--- a/tldw_Server_API/app/core/MCP_unified/command_runtime/registry.py
+++ b/tldw_Server_API/app/core/MCP_unified/command_runtime/registry.py
@@ -65,8 +65,8 @@ _DEFAULT_COMMANDS: Final[tuple[CommandDescriptor, ...]] = (
     ),
     CommandDescriptor(
         name="write",
-        summary="Write a UTF-8 text file in the current workspace scope.",
-        backend_tools=("fs.write_text",),
+        summary="Create a UTF-8 text file in the current workspace scope.",
+        backend_tools=("fs.write",),
     ),
     CommandDescriptor(
         name="write-create",

--- a/tldw_Server_API/app/core/MCP_unified/config.py
+++ b/tldw_Server_API/app/core/MCP_unified/config.py
@@ -33,6 +33,18 @@ _MCP_CONFIG_NONCRITICAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
     ValueError,
     json.JSONDecodeError,
 )
+_MCP_LOGGER_HANDLER_IDS: set[int] = set()
+
+
+def _remove_mcp_logger_handlers() -> None:
+    """Remove only handlers installed by MCP logging configuration."""
+    for handler_id in list(_MCP_LOGGER_HANDLER_IDS):
+        try:
+            logger.remove(handler_id)
+        except (RuntimeError, ValueError):
+            pass
+        finally:
+            _MCP_LOGGER_HANDLER_IDS.discard(handler_id)
 
 
 def _default_ws_allowed_origins() -> list[str]:
@@ -425,6 +437,7 @@ class MCPConfig(BaseSettings):
         try:
             # Optional opt-out to inherit global logger configuration
             if env_flag_enabled("MCP_INHERIT_GLOBAL_LOGGER"):
+                _remove_mcp_logger_handlers()
                 return
         except _MCP_CONFIG_NONCRITICAL_EXCEPTIONS:
             pass
@@ -436,22 +449,20 @@ class MCPConfig(BaseSettings):
             "{name}:{function}:{line} - {message}"
         )
 
-        try:
-            logger.remove()  # Reset to avoid duplicate/default handlers
-        except (RuntimeError, ValueError):
-            pass
+        _remove_mcp_logger_handlers()
 
         # Console logging (safe format, no color)
-        logger.add(
+        handler_id = logger.add(
             sink=os.sys.stderr,
             format=_fmt_template,
             level=self.log_level,
             colorize=False,
         )
+        _MCP_LOGGER_HANDLER_IDS.add(handler_id)
 
         # File logging if configured (safe format)
         if self.log_file:
-            logger.add(
+            handler_id = logger.add(
                 sink=self.log_file,
                 format=_fmt_template,
                 level=self.log_level,
@@ -459,10 +470,11 @@ class MCPConfig(BaseSettings):
                 retention=self.log_retention,
                 compression="zip",
             )
+            _MCP_LOGGER_HANDLER_IDS.add(handler_id)
 
         # Audit logging if enabled (plain format)
         if self.audit_enabled:
-            logger.add(
+            handler_id = logger.add(
                 sink=self.audit_log_file,
                 format="{time:YYYY-MM-DD HH:mm:ss.SSS} | AUDIT | {message}",
                 level="INFO",
@@ -471,6 +483,7 @@ class MCPConfig(BaseSettings):
                 retention="90 days",
                 compression="zip",
             )
+            _MCP_LOGGER_HANDLER_IDS.add(handler_id)
 
 
 @lru_cache

--- a/tldw_Server_API/app/core/MCP_unified/config.py
+++ b/tldw_Server_API/app/core/MCP_unified/config.py
@@ -6,8 +6,8 @@ No hardcoded secrets allowed.
 """
 
 import json
-import os
 import secrets
+import sys
 from functools import lru_cache
 from ipaddress import ip_address, ip_network
 from typing import Any, Optional
@@ -453,7 +453,7 @@ class MCPConfig(BaseSettings):
 
         # Console logging (safe format, no color)
         handler_id = logger.add(
-            sink=os.sys.stderr,
+            sink=sys.stderr,
             format=_fmt_template,
             level=self.log_level,
             colorize=False,

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -32,7 +32,6 @@ from pathlib import Path
 from typing import Any
 
 import pathspec
-from pathspec.patterns.gitwildmatch import GitWildMatchPatternError
 from loguru import logger
 from mcp_unified.filesystem_locks import (
     FilesystemLockConflict,
@@ -42,6 +41,7 @@ from mcp_unified.filesystem_locks import (
 )
 from mcp_unified.interfaces.file_policy_actions import get_file_policy_action_metadata
 from mcp_unified.interfaces.path_scope import PathScopeCandidate
+from pathspec.patterns.gitwildmatch import GitWildMatchPatternError
 
 from tldw_Server_API.app.services.mcp_hub_workspace_root_resolver import (
     McpHubWorkspaceRootResolver,
@@ -372,11 +372,15 @@ class FilesystemModule(BaseModule):
 
         write_text_tool = create_tool_definition(
             name="fs.write_text",
-            description="Write UTF-8 text content to a file under the active trusted workspace root.",
+            description="Create or replace UTF-8 text content under the active trusted workspace root.",
             parameters={
                 "properties": {
                     "path": {"type": "string", "description": "Workspace-relative or absolute file path"},
                     "content": {"type": "string"},
+                    "expected_sha256": {"type": "string"},
+                    "read_receipt": {"type": "string"},
+                    "lock_lease_id": {"type": "string"},
+                    "dry_run": {"type": "boolean", "default": False},
                 },
                 "required": ["path", "content"],
             },
@@ -676,13 +680,22 @@ class FilesystemModule(BaseModule):
             )
 
         if tool_name == "fs.write_text":
-            target = self._resolve_workspace_path(workspace_root, str(args.get("path")))
-            content = args.get("content")
-            write_result = await asyncio.to_thread(self._write_text_file, target, str(content))
-            return {
-                "path": self._to_workspace_relative_path(workspace_root, target),
-                "bytes_written": write_result["bytes_written"],
-            }
+            target = self._resolve_workspace_path_no_follow(workspace_root, str(args.get("path")))
+            mode = "replace" if target.exists() or target.is_symlink() else "create"
+            return await asyncio.to_thread(
+                self._write_file,
+                workspace_root,
+                target,
+                str(args.get("content")),
+                mode,
+                args.get("expected_sha256"),
+                args.get("read_receipt"),
+                args.get("lock_lease_id"),
+                bool(args.get("dry_run", False)),
+                self._setting_positive_int("write_max_bytes", 5_000_000),
+                self._setting_positive_int("write_preimage_max_bytes", 5_000_000),
+                context,
+            )
 
         if tool_name == "fs.stat":
             target = self._resolve_workspace_path_no_follow(workspace_root, str(args.get("path")))
@@ -993,7 +1006,17 @@ class FilesystemModule(BaseModule):
             return
 
         if tool_name == "fs.write_text":
-            unknown = sorted(set(arguments) - {"path", "content"})
+            unknown = sorted(
+                set(arguments)
+                - {
+                    "path",
+                    "content",
+                    "expected_sha256",
+                    "read_receipt",
+                    "lock_lease_id",
+                    "dry_run",
+                }
+            )
             if unknown:
                 raise ValueError(f"unknown arguments: {', '.join(unknown)}")
             path = arguments.get("path")
@@ -1002,6 +1025,12 @@ class FilesystemModule(BaseModule):
                 raise ValueError("path is required")
             if not isinstance(content, str):
                 raise ValueError("content must be a string")
+            for key in ("expected_sha256", "read_receipt"):
+                value = arguments.get(key)
+                if value is not None and not isinstance(value, str):
+                    raise ValueError(f"{key} must be a string")
+            self._validate_optional_nonempty_string_argument(arguments, "lock_lease_id")
+            self._validate_bool_argument(arguments, "dry_run")
             return
 
         if tool_name == "fs.stat":
@@ -2835,10 +2864,3 @@ class FilesystemModule(BaseModule):
         except UnicodeDecodeError as exc:
             raise ValueError("binary content is not supported by fs.read_text") from exc
         return {"text": text}
-
-    @staticmethod
-    def _write_text_file(target: Path, content: str) -> dict[str, Any]:
-        target.parent.mkdir(parents=True, exist_ok=True)
-        data = content.encode("utf-8")
-        target.write_bytes(data)
-        return {"bytes_written": len(data)}

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -372,13 +372,22 @@ class FilesystemModule(BaseModule):
 
         write_text_tool = create_tool_definition(
             name="fs.write_text",
-            description="Create or replace UTF-8 text content under the active trusted workspace root.",
+            description=(
+                "Create UTF-8 text content under the active trusted workspace root. "
+                "Replacing an existing file requires expected_sha256 or read_receipt."
+            ),
             parameters={
                 "properties": {
                     "path": {"type": "string", "description": "Workspace-relative or absolute file path"},
                     "content": {"type": "string"},
-                    "expected_sha256": {"type": "string"},
-                    "read_receipt": {"type": "string"},
+                    "expected_sha256": {
+                        "type": "string",
+                        "description": "Required when replacing an existing file unless read_receipt is supplied.",
+                    },
+                    "read_receipt": {
+                        "type": "string",
+                        "description": "Required when replacing an existing file unless expected_sha256 is supplied.",
+                    },
                     "lock_lease_id": {"type": "string"},
                     "dry_run": {"type": "boolean", "default": False},
                 },
@@ -682,6 +691,8 @@ class FilesystemModule(BaseModule):
         if tool_name == "fs.write_text":
             target = self._resolve_workspace_path_no_follow(workspace_root, str(args.get("path")))
             mode = "replace" if target.exists() or target.is_symlink() else "create"
+            if mode == "replace" and not args.get("expected_sha256") and not args.get("read_receipt"):
+                raise ValueError("write_preimage_required")
             return await asyncio.to_thread(
                 self._write_file,
                 workspace_root,

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -6,9 +6,6 @@ Implements JSON-RPC 2.0 with enhanced error handling and request routing.
 
 import asyncio
 import contextlib
-import copy
-import hashlib
-import hmac
 import inspect
 import json
 import re
@@ -16,11 +13,9 @@ import secrets
 import time
 import uuid
 from collections import OrderedDict
-from dataclasses import asdict, dataclass, is_dataclass
 from datetime import datetime, timezone
 from enum import IntEnum
-from pathlib import Path
-from typing import Any, Callable, Literal, Optional, Union, cast
+from typing import Any, Callable, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -36,26 +31,13 @@ except ImportError:  # Fallback for v1
         model_validator = None  # type: ignore
 
 from loguru import logger
-from mcp_unified.interfaces.path_scope import (
-    PathScopeCandidate,
-    normalize_path_scope_candidates,
-)
-from mcp_unified.tool_use_reporting.builders import (
-    classify_tool_use_exception,
-    extract_safe_context_dimensions,
-)
-from mcp_unified.tool_use_reporting.models import (
-    MAX_FILE_POLICY_DECISIONS,
-    MAX_TOOL_HOOK_RESULTS,
-    ToolUseEvent,
-    ToolUseStatus,
-)
-from mcp_unified.tool_use_reporting.recorder import record_tool_use_safely
+from mcp_unified.interfaces.path_scope import PathScopeCandidate
+from mcp_unified.tool_use_reporting.models import ToolUseEvent, ToolUseStatus
 
+from ..exception_types import PromptCatalogError
 from .auth.authnz_rbac import Action, Resource
 from .auth.rate_limiter import RateLimitExceeded
 from .config import get_config
-from ..exception_types import PromptCatalogError
 from .interfaces.runtime import (
     MCPRuntimeDependencies,
     NoopToolCallHookManager,
@@ -65,18 +47,49 @@ from .interfaces.runtime import (
     ToolHookCallContext,
     ToolHookDecision,
 )
+from .modules.base import BaseModule
 from .modules.implementations.prompts_catalog import (
     CONFIG_PROMPT_PREFIX,
     LIBRARY_PROMPT_PREFIX,
     decode_prompt_cursor,
 )
-from .modules.base import BaseModule
-from .tool_observability import (
-    attach_execution_eval_metadata,
-    ensure_tool_definition_eval_metadata,
-    execution_eval_metadata_from_tool_definition,
-    sanitize_eval_profile_id,
+from .protocol_types import (
+    _TRUSTED_COMPAT_AUTH_VIA as _TRUSTED_COMPAT_AUTH_VIA,
 )
+from .protocol_types import (
+    _TRUSTED_COMPAT_CLAIMS_SENTINEL as _TRUSTED_COMPAT_CLAIMS_SENTINEL,
+)
+from .protocol_types import (
+    _TRUSTED_COMPAT_CLAIMS_SENTINEL_KEY as _TRUSTED_COMPAT_CLAIMS_SENTINEL_KEY,
+)
+from .protocol_types import (
+    _TRUSTED_COMPAT_CLAIMS_SOURCES as _TRUSTED_COMPAT_CLAIMS_SOURCES,
+)
+from .protocol_types import (
+    ApprovalRequiredError,
+    GovernanceDeniedError,
+    InvalidParamsException,
+    PreparedToolCall,
+    RequestContext,
+    _has_trusted_compat_claims,
+)
+from .protocol_types import (
+    _metadata_claim_values as _metadata_claim_values,
+)
+from .protocol_types import (
+    _metadata_has_admin_claims as _metadata_has_admin_claims,
+)
+from .protocol_types import (
+    _trusted_compat_claims_metadata as _trusted_compat_claims_metadata,
+)
+from .protocol_types import (
+    _TrustedCompatClaimsSentinel as _TrustedCompatClaimsSentinel,
+)
+from .tool_execution import ToolExecutionCoordinator, ToolExecutionDependencies, ToolExecutionReporter
+from .tool_execution.hooks import ToolExecutionHooks
+from .tool_execution.runtime import ToolExecutionRuntime
+from .tool_execution.security import ToolExecutionSecurity
+from .tool_observability import ensure_tool_definition_eval_metadata
 
 try:  # pragma: no cover - optional dependency
     from redis.exceptions import RedisError
@@ -108,27 +121,6 @@ class ErrorCode(IntEnum):
     TIMEOUT_ERROR = -32004
 
 
-class InvalidParamsException(Exception):
-    """Raised when tool parameters fail validation or validators are missing for write tools."""
-    pass
-
-
-class GovernanceDeniedError(PermissionError):
-    """Permission error carrying structured governance decision details."""
-
-    def __init__(self, message: str, governance: Optional[dict[str, Any]] = None):
-        super().__init__(message)
-        self.governance = governance or {}
-
-
-class ApprovalRequiredError(PermissionError):
-    """Permission error carrying structured MCP Hub approval request details."""
-
-    def __init__(self, message: str, approval: Optional[dict[str, Any]] = None):
-        super().__init__(message)
-        self.approval = approval or {}
-
-
 _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS = (
     asyncio.CancelledError,
     asyncio.TimeoutError,
@@ -154,10 +146,6 @@ _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS = (
 )
 
 _MCP_TOOL_EXECUTION_ERROR = "tool_execution_error"
-_TOOL_AUTHORIZATION_ALIASES = {
-    "bash": "run",
-    "shell": "run",
-}
 _TRUTHY_VALUES = {"1", "true", "yes", "y", "on"}
 
 
@@ -278,132 +266,6 @@ class MCPResponse(BaseModel):
             if self.error is not None and self.result is not None:
                 raise ValueError("Response cannot have both result and error")
             return self
-
-
-class RequestContext:
-    """Context for request processing.
-
-    Request contexts store caller metadata and explicit database path mappings
-    only. Host-specific database path resolution is owned by MCPProtocol or
-    MCPServer dependencies so standalone callers do not import tldw_server
-    adapters through this neutral context object.
-    """
-    def __init__(
-        self,
-        request_id: str,
-        user_id: Optional[str] = None,
-        client_id: Optional[str] = None,
-        session_id: Optional[str] = None,
-        metadata: Optional[dict[str, Any]] = None,
-        db_paths: Optional[dict[str, str]] = None,
-    ):
-        self.request_id = request_id
-        self.user_id = user_id
-        self.client_id = client_id
-        self.session_id = session_id
-        self.metadata = metadata or {}
-        self.start_time = datetime.now(timezone.utc)
-        self.db_paths = dict(db_paths or {})
-        # Build a bound logger for this request
-        self.logger = logger.bind(
-            request_id=request_id,
-            user_id=user_id,
-            client_id=client_id,
-            session_id=session_id,
-        )
-
-
-class _TrustedCompatClaimsSentinel:
-    """Object-identity marker for server-created mounted auth compatibility claims."""
-
-    def __repr__(self) -> str:
-        return "<trusted_mcp_compat_auth>"
-
-
-_TRUSTED_COMPAT_CLAIMS_SENTINEL = _TrustedCompatClaimsSentinel()
-_TRUSTED_COMPAT_CLAIMS_SENTINEL_KEY = "_server_auth_compat_sentinel"
-_TRUSTED_COMPAT_AUTH_VIA = frozenset({"single_user_api_key", "single_user_test_api_key"})
-_TRUSTED_COMPAT_CLAIMS_SOURCES = frozenset({"mounted_http", "mounted_ws"})
-
-
-def _metadata_claim_values(value: Any) -> tuple[Any, ...]:
-    """Return metadata claim values without iterating strings character-by-character."""
-    if isinstance(value, str):
-        return (value,)
-    if isinstance(value, (list, tuple, set, frozenset)):
-        return tuple(value)
-    return ()
-
-
-def _trusted_compat_claims_metadata(*, auth_via: str, compat_claims_source: str) -> dict[str, Any]:
-    """Return server-only metadata for mounted single-user compatibility claims."""
-    if auth_via not in _TRUSTED_COMPAT_AUTH_VIA:
-        raise ValueError("Unsupported compatibility auth source")
-    if compat_claims_source not in _TRUSTED_COMPAT_CLAIMS_SOURCES:
-        raise ValueError("Unsupported compatibility claims source")
-    return {
-        "auth_via": auth_via,
-        "trusted_auth_claims": True,
-        "compat_claims_source": compat_claims_source,
-        _TRUSTED_COMPAT_CLAIMS_SENTINEL_KEY: _TRUSTED_COMPAT_CLAIMS_SENTINEL,
-    }
-
-
-def _metadata_has_admin_claims(metadata: dict[str, Any]) -> bool:
-    """Return True when trusted metadata carries wildcard or admin claims."""
-    roles = {
-        str(role).strip().lower()
-        for role in _metadata_claim_values(metadata.get("roles"))
-        if str(role).strip()
-    }
-    permissions = {
-        str(permission).strip().lower()
-        for permission in _metadata_claim_values(metadata.get("permissions"))
-        if str(permission).strip()
-    }
-    return "admin" in roles or "*" in permissions
-
-
-def _has_trusted_compat_claims(context: RequestContext) -> bool:
-    """Return True only for server-created mounted compatibility auth claims."""
-    metadata = getattr(context, "metadata", None)
-    if not isinstance(metadata, dict):
-        return False
-    server_auth_keys = {
-        key
-        for key in metadata
-        if isinstance(key, str) and key.startswith("_server_auth_")
-    }
-    if server_auth_keys != {_TRUSTED_COMPAT_CLAIMS_SENTINEL_KEY}:
-        return False
-    if metadata.get(_TRUSTED_COMPAT_CLAIMS_SENTINEL_KEY) is not _TRUSTED_COMPAT_CLAIMS_SENTINEL:
-        return False
-    if metadata.get("trusted_auth_claims") is not True:
-        return False
-    if metadata.get("auth_via") not in _TRUSTED_COMPAT_AUTH_VIA:
-        return False
-    if metadata.get("compat_claims_source") not in _TRUSTED_COMPAT_CLAIMS_SOURCES:
-        return False
-    return _metadata_has_admin_claims(metadata)
-
-
-@dataclass(frozen=True, slots=True)
-class PreparedToolCall:
-    """Prepared tool execution context reused by nested tool orchestration."""
-
-    tool_name: str
-    tool_args: Any
-    module: BaseModule
-    module_id: Optional[str]
-    tool_def: Optional[dict[str, Any]]
-    is_write: Optional[bool]
-    normalized_idempotency_key: Optional[str]
-    idempotency_cache_key: Optional[str]
-    arguments_hash: Optional[str]
-    context_fingerprint: str
-    integrity_tag: str
-    context: RequestContext
-    scope_payload: Optional[dict[str, Any]] = None
 
 
 class IdempotencyManager:
@@ -718,6 +580,54 @@ class MCPProtocol:
     - Request tracing
     """
 
+    def __setattr__(self, name: str, value: Any) -> None:
+        object.__setattr__(self, name, value)
+        if name == "prepare_tool_call" and callable(value) and hasattr(self, "_tool_execution"):
+            if (
+                getattr(value, "__self__", None) is self
+                and getattr(value, "__func__", None) is type(self).prepare_tool_call
+            ):
+                self._tool_execution.prepare_tool_call_impl = self._prepare_tool_call_inline
+            else:
+                self._tool_execution.prepare_tool_call_impl = value
+        elif name == "execute_prepared_tool_call" and callable(value) and hasattr(self, "_tool_execution"):
+            if (
+                getattr(value, "__self__", None) is self
+                and getattr(value, "__func__", None) is type(self).execute_prepared_tool_call
+            ):
+                self._tool_execution.execute_prepared_tool_call_impl = self._execute_prepared_tool_call_inline
+            else:
+                self._tool_execution.execute_prepared_tool_call_impl = value
+        elif name == "_tool_call_hook_manager" and hasattr(self, "_tool_execution_hooks"):
+            self._tool_execution_hooks._tool_call_hook_manager = value
+            if hasattr(self, "_tool_execution_security"):
+                self._sync_tool_execution_dependencies()
+        elif (
+            name in {
+                "module_registry",
+                "rbac_policy",
+                "rate_limiter",
+                "metrics",
+                "_tool_use_recorder",
+                "_idempotency",
+                "_tool_name_re",
+            }
+            and hasattr(self, "_tool_execution_security")
+        ):
+            self._sync_tool_execution_dependencies()
+        elif name == "_build_tool_use_event" and hasattr(self, "_tool_execution_reporter"):
+            if (
+                getattr(value, "__self__", None) is self
+                and getattr(value, "__func__", None) is type(self)._build_tool_use_event
+            ):
+                self._tool_execution_reporter.build_event = self._tool_execution_reporter.build_tool_use_event
+            else:
+                self._tool_execution_reporter.build_event = value
+        elif name == "_record_tool_use_event" and hasattr(self, "_tool_execution_reporter"):
+            self._tool_execution_reporter.record_event = value
+        elif name == "_should_record_tool_use" and hasattr(self, "_tool_execution_reporter"):
+            self._tool_execution_reporter.should_record = value
+
     def __init__(self, dependencies: MCPRuntimeDependencies | None = None):
         if dependencies is None:
             from .adapters.tldw_runtime import build_default_runtime_dependencies
@@ -754,10 +664,99 @@ class MCPProtocol:
         )
         # Integrity secret for prepared tool call execution
         self._prepared_call_secret = secrets.token_bytes(32)
-        # Governance preflight state
-        self._governance_service: Any | None = None
-        self._governance_store: Any | None = None
-        self._governance_lock = asyncio.Lock()
+        self._tool_execution_reporter = ToolExecutionReporter(
+            recorder=self._tool_use_recorder,
+            metrics=self.metrics,
+            tool_name_re=self._tool_name_re,
+            noncritical_exceptions=_MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS,
+        )
+        self._tool_execution_hooks = ToolExecutionHooks(
+            hook_manager=self._tool_call_hook_manager,
+            reporter=self._tool_execution_reporter,
+            noncritical_exceptions=_MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS,
+        )
+        self._tool_execution_dependencies = ToolExecutionDependencies(
+            module_registry=self.module_registry,
+            rbac_policy=self.rbac_policy,
+            rate_limiter=self.rate_limiter,
+            metrics=self.metrics,
+            telemetry=self.telemetry,
+            hook_manager=self._tool_call_hook_manager,
+            tool_use_recorder=self._tool_use_recorder,
+            idempotency=self._idempotency,
+            config_provider=lambda: get_config(),
+            effective_policy_resolver=self.dependencies.effective_policy_resolver,
+            path_scope_enforcer=self.dependencies.path_scope_enforcer,
+            approval_evaluator=self.dependencies.approval_evaluator,
+            external_access_evaluator=self.dependencies.external_access_evaluator,
+            reporter=self._tool_execution_reporter,
+            api_key_scope_normalizer=getattr(self.dependencies, "api_key_scope_normalizer", None),
+        )
+        self._tool_execution_security = ToolExecutionSecurity(
+            dependencies=self._tool_execution_dependencies,
+            tool_name_re=self._tool_name_re,
+            prepared_call_secret=self._prepared_call_secret,
+            noncritical_exceptions=_MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS,
+        )
+        self._tool_execution_security.configure_prepare_compatibility_callbacks(
+            module_registry=lambda: self.module_registry,
+            is_tool_allowed_by_context=(
+                lambda tool_name, tool_args, context: self._is_tool_allowed_by_context(tool_name, tool_args, context)
+            ),
+            resolve_effective_tool_policy=lambda context: self._resolve_effective_tool_policy(context),
+            is_tool_allowed_by_effective_policy=(
+                lambda tool_name, tool_args, policy: self._is_tool_allowed_by_effective_policy(
+                    tool_name,
+                    tool_args,
+                    policy,
+                )
+            ),
+            evaluate_external_access=lambda **kwargs: self._evaluate_external_access(**kwargs),
+            has_module_permission=lambda context, module_id: self._has_module_permission(context, module_id),
+            has_tool_permission=lambda context, tool_name, **kwargs: self._has_tool_permission(
+                context,
+                tool_name,
+                **kwargs,
+            ),
+            make_idempotency_cache_key=lambda context, module_name, tool_name, idempotency_key: (
+                self._make_idempotency_cache_key(context, module_name, tool_name, idempotency_key)
+            ),
+            extract_path_scope_candidates=lambda **kwargs: self._extract_path_scope_candidates(**kwargs),
+            evaluate_path_scope=lambda **kwargs: self._evaluate_path_scope(**kwargs),
+            evaluate_runtime_approval=lambda **kwargs: self._evaluate_runtime_approval(**kwargs),
+            run_governance_preflight=lambda **kwargs: self._run_governance_preflight(**kwargs),
+        )
+
+        async def _prepare_with_hooks(
+            *,
+            params: dict[str, Any],
+            context: RequestContext,
+            idempotency_key: str | None = None,
+        ) -> PreparedToolCall:
+            self._sync_tool_execution_dependencies()
+            return await self._tool_execution_security.prepare_tool_call(
+                params=params,
+                context=context,
+                idempotency_key=idempotency_key,
+                hooks=self._tool_execution_hooks,
+            )
+
+        self._prepare_with_hooks = _prepare_with_hooks
+        self._tool_execution_runtime = ToolExecutionRuntime(
+            dependencies=self._tool_execution_dependencies,
+            security=self._tool_execution_security,
+            hooks=self._tool_execution_hooks,
+            noncritical_exceptions=_MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS,
+            tool_execution_error=_MCP_TOOL_EXECUTION_ERROR,
+            generic_exception_like=self._generic_exception_like,
+            make_idempotency_cache_key=ToolExecutionRuntime.make_idempotency_cache_key,
+            run_post_tool_hooks=lambda **kwargs: self._run_post_tool_hooks(**kwargs),
+        )
+        self._tool_execution = ToolExecutionCoordinator(
+            prepare_tool_call_impl=_prepare_with_hooks,
+            execute_prepared_tool_call_impl=self._tool_execution_runtime.execute_prepared_tool_call,
+            reporter=self._tool_execution_reporter,
+        )
 
         # Method handlers — telemetry is accessed via a property so that
         # a shutdown/re-init cycle is picked up automatically.
@@ -776,6 +775,39 @@ class MCPProtocol:
         }
 
         logger.info("MCP Protocol handler initialized")
+
+    def _sync_tool_execution_dependencies(self) -> None:
+        """Keep extracted tool-execution helpers aligned with mutable protocol test seams."""
+
+        if not hasattr(self, "_tool_execution_security"):
+            return
+        deps = self._tool_execution_security.dependencies
+        deps.module_registry = self.module_registry
+        deps.rbac_policy = self.rbac_policy
+        deps.rate_limiter = self.rate_limiter
+        deps.metrics = self.metrics
+        deps.telemetry = self.telemetry
+        deps.hook_manager = self._tool_call_hook_manager
+        deps.tool_use_recorder = self._tool_use_recorder
+        deps.idempotency = self._idempotency
+        deps.config_provider = lambda: get_config()
+        deps.effective_policy_resolver = self.dependencies.effective_policy_resolver
+        deps.path_scope_enforcer = self.dependencies.path_scope_enforcer
+        deps.approval_evaluator = self.dependencies.approval_evaluator
+        deps.external_access_evaluator = self.dependencies.external_access_evaluator
+        self._tool_execution_reporter._tool_use_recorder = self._tool_use_recorder
+        self._tool_execution_reporter.metrics = self.metrics
+        self._tool_execution_reporter._tool_name_re = self._tool_name_re
+        deps.reporter = self._tool_execution_reporter
+        self._tool_execution_security.module_registry = self.module_registry
+        self._tool_execution_security.rbac_policy = self.rbac_policy
+        self._tool_execution_security.metrics = self.metrics
+        self._tool_execution_security._tool_name_re = self._tool_name_re
+        if hasattr(self, "_tool_execution_runtime"):
+            self._tool_execution_runtime.dependencies = deps
+            self._tool_execution_runtime.security = self._tool_execution_security
+            self._tool_execution_runtime.hooks = self._tool_execution_hooks
+            self._tool_execution_runtime.sync_from_dependencies()
 
     @staticmethod
     def _module_declares_prompts(module: BaseModule) -> bool:
@@ -802,32 +834,25 @@ class MCPProtocol:
 
     def _should_record_tool_use(self, context: RequestContext) -> bool:
         """Return whether this protocol path should record tool-use metadata."""
-        metadata = getattr(context, "metadata", {})
-        if not isinstance(metadata, dict):
-            return True
-        return metadata.get("mcp_tool_use_observed") is not True
+        return self._tool_execution_reporter.should_record_tool_use(context)
 
     async def _record_tool_use_event(self, event: ToolUseEvent) -> None:
         """Record a tool-use event through the configured recorder."""
-        await record_tool_use_safely(self._tool_use_recorder, event)
+        await self._tool_execution_reporter.record_tool_use_event(event)
 
     def _safe_tool_use_name(self, value: Any) -> str:
         """Return a safe tool name or the unknown sentinel."""
-        if isinstance(value, str) and self._tool_name_re.match(value):
-            return value
-        return "unknown"
+        return self._tool_execution_reporter.safe_tool_use_name(value)
 
     @staticmethod
     def _tool_use_duration_ms(start_ts: float) -> float:
         """Return elapsed milliseconds from a monotonic-ish wall clock sample."""
-        return max(0.0, (time.time() - start_ts) * 1000.0)
+        return ToolExecutionReporter.tool_use_duration_ms(start_ts)
 
     @staticmethod
     def _tool_use_execution_origin_for_failure(status: ToolUseStatus) -> str:
         """Return execution-origin metadata for a failed tool path."""
-        if status == "unavailable":
-            return "unavailable"
-        return "failed_before_execution"
+        return ToolExecutionReporter.tool_use_execution_origin_for_failure(status)
 
     @staticmethod
     def _tool_use_eval_metadata(
@@ -836,117 +861,37 @@ class MCPProtocol:
         tool_def: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Extract safe eval metadata from response payload or tool definition."""
-        if isinstance(payload, dict) and isinstance(payload.get("eval"), dict):
-            return dict(payload["eval"])
-        metadata = (tool_def or {}).get("metadata") if isinstance(tool_def, dict) else None
-        if isinstance(metadata, dict) and isinstance(metadata.get("eval"), dict):
-            return dict(metadata["eval"])
-        return {}
+        return ToolExecutionReporter.tool_use_eval_metadata(payload=payload, tool_def=tool_def)
 
     @staticmethod
     def _tool_use_file_policy_decisions(scope_payload: dict[str, Any] | None) -> list[dict[str, Any]]:
         """Extract redacted file-policy path decisions from a scope payload."""
-
-        if not isinstance(scope_payload, dict):
-            return []
-        raw_decisions = scope_payload.get("path_decisions")
-        if not isinstance(raw_decisions, list):
-            return []
-        bounded_decisions = raw_decisions[:MAX_FILE_POLICY_DECISIONS]
-        return [dict(decision) for decision in bounded_decisions if isinstance(decision, dict)]
+        return ToolExecutionReporter.tool_use_file_policy_decisions(scope_payload)
 
     @staticmethod
     def _tool_use_hook_results(metadata: dict[str, Any] | None) -> list[dict[str, Any]]:
         """Consume bounded tool-hook result metadata from request metadata."""
-
-        if not isinstance(metadata, dict):
-            return []
-        raw_results = metadata.pop("mcp_tool_hook_results", None)
-        if not isinstance(raw_results, list):
-            return []
-        bounded_results = raw_results[:MAX_TOOL_HOOK_RESULTS]
-        return [dict(result) for result in bounded_results if isinstance(result, dict)]
+        return ToolExecutionReporter.tool_use_hook_results(metadata)
 
     @staticmethod
     def _tool_hook_summary_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
         """Return sanitized hook summary rows from a protocol hook payload."""
-
-        metadata = payload.get("metadata")
-        if isinstance(metadata, dict):
-            hook_results = metadata.get("hook_results")
-            if isinstance(hook_results, list):
-                return [
-                    dict(item)
-                    for item in hook_results[:MAX_TOOL_HOOK_RESULTS]
-                    if isinstance(item, dict)
-                ]
-
-        row: dict[str, Any] = {
-            "phase": payload.get("phase"),
-            "action": payload.get("action"),
-            "status": payload.get("status"),
-        }
-        if payload.get("reason_code") is not None:
-            row["reason_code"] = payload.get("reason_code")
-        if payload.get("error_type") is not None:
-            row["error_type"] = payload.get("error_type")
-        if isinstance(metadata, dict):
-            if metadata.get("hook_id") is not None:
-                row["hook_id"] = metadata.get("hook_id")
-            if metadata.get("hook_order") is not None:
-                row["hook_order"] = metadata.get("hook_order")
-        elif payload.get("hook_id") is not None:
-            row["hook_id"] = payload.get("hook_id")
-            if payload.get("hook_order") is not None:
-                row["hook_order"] = payload.get("hook_order")
-        return [row]
+        return ToolExecutionReporter.tool_hook_summary_items(payload)
 
     @staticmethod
     def _append_tool_hook_summary(context: RequestContext, payload: dict[str, Any]) -> None:
         """Append safe hook metadata for tool-use reporting."""
-
-        metadata = getattr(context, "metadata", None)
-        if not isinstance(metadata, dict):
-            return
-        existing = metadata.get("mcp_tool_hook_results")
-        if not isinstance(existing, list):
-            existing = []
-            metadata["mcp_tool_hook_results"] = existing
-        remaining = max(0, MAX_TOOL_HOOK_RESULTS - len(existing))
-        if remaining <= 0:
-            return
-        existing.extend(MCPProtocol._tool_hook_summary_items(payload)[:remaining])
+        ToolExecutionReporter.append_tool_hook_summary(context, payload)
 
     @staticmethod
     def _tool_use_decision_grant_outcome(file_policy_decisions: list[dict[str, Any]]) -> str | None:
         """Summarize path-decision grant outcomes with denial precedence."""
-
-        outcomes = [
-            outcome.strip()
-            for decision in file_policy_decisions
-            if isinstance(decision, dict)
-            and isinstance(outcome := decision.get("grant_outcome"), str)
-            and outcome.strip()
-        ]
-        if "denied" in outcomes:
-            return "denied"
-        if "not_granted" in outcomes:
-            return "not_granted"
-        if outcomes:
-            return "allowed"
-        return None
+        return ToolExecutionReporter.tool_use_decision_grant_outcome(file_policy_decisions)
 
     @staticmethod
     def _tool_use_value_present(value: Any) -> bool:
         """Return whether a sensitive value marker contains actual data."""
-
-        if value is None:
-            return False
-        if isinstance(value, str):
-            return bool(value.strip())
-        if isinstance(value, (dict, list, tuple, set)):
-            return bool(value)
-        return True
+        return ToolExecutionReporter.tool_use_value_present(value)
 
     @staticmethod
     def _tool_use_contains_key(
@@ -956,37 +901,12 @@ class MCPProtocol:
         _depth: int = 0,
     ) -> bool:
         """Return whether a nested tool payload/args object contains any key."""
-
-        if _depth > 4:
-            return False
-        if isinstance(value, dict):
-            for key, nested in value.items():
-                if key in keys and MCPProtocol._tool_use_value_present(nested):
-                    return True
-                if isinstance(nested, (dict, list)) and MCPProtocol._tool_use_contains_key(
-                    nested,
-                    keys,
-                    _depth=_depth + 1,
-                ):
-                    return True
-        elif isinstance(value, list):
-            for item in value:
-                if isinstance(item, (dict, list)) and MCPProtocol._tool_use_contains_key(
-                    item,
-                    keys,
-                    _depth=_depth + 1,
-                ):
-                    return True
-        return False
+        return ToolExecutionReporter.tool_use_contains_key(value, keys, _depth=_depth)
 
     @staticmethod
     def _tool_use_category(tool_def: dict[str, Any] | None) -> str | None:
         """Return the metadata category from a tool definition when present."""
-        metadata = (tool_def or {}).get("metadata") if isinstance(tool_def, dict) else None
-        if not isinstance(metadata, dict):
-            return None
-        category = metadata.get("category")
-        return str(category) if isinstance(category, str) and category.strip() else None
+        return ToolExecutionReporter.tool_use_category(tool_def)
 
     def _build_tool_use_event(
         self,
@@ -1007,67 +927,21 @@ class MCPProtocol:
         idempotency_replay: bool = False,
     ) -> ToolUseEvent:
         """Build a metadata-only tool-use event."""
-        metadata = getattr(context, "metadata", {})
-        dimensions = extract_safe_context_dimensions(metadata if isinstance(metadata, dict) else None)
-        nested = isinstance(metadata, dict) and metadata.get("mcp_tool_use_nested") is True
-        hook_results = self._tool_use_hook_results(metadata if isinstance(metadata, dict) else None)
-        eval_metadata = self._tool_use_eval_metadata(payload=payload, tool_def=tool_def)
-        safe_requested_name = self._safe_tool_use_name(requested_tool_name)
-        safe_effective_name = self._safe_tool_use_name(effective_tool_name or safe_requested_name)
-        file_policy_decisions = self._tool_use_file_policy_decisions(scope_payload)
-        file_policy_related = bool(file_policy_decisions) or safe_effective_name.startswith("fs.")
-        sha256_before_keys = {"sha256_before", "expected_sha256", "expected_sha256_by_path"}
-        file_policy_sha256_before_present = (
-            (
-                self._tool_use_contains_key(payload, sha256_before_keys)
-                or self._tool_use_contains_key(tool_args, sha256_before_keys)
-            )
-            if file_policy_related
-            else None
-        )
-        file_policy_sha256_after_present = (
-            self._tool_use_contains_key(payload, {"sha256_after"})
-            if file_policy_related
-            else None
-        )
-        file_policy_lock_lease_present = (
-            (
-                self._tool_use_contains_key(payload, {"lock_lease_id", "lock_lease_id_by_path"})
-                or self._tool_use_contains_key(tool_args, {"lock_lease_id", "lock_lease_id_by_path"})
-            )
-            if file_policy_related
-            else None
-        )
-        decision_grant_outcome = self._tool_use_decision_grant_outcome(file_policy_decisions)
-        return ToolUseEvent(
-            runtime_surface="protocol",
-            execution_origin=execution_origin,  # type: ignore[arg-type]
-            nested=nested,
-            requested_tool_name=safe_requested_name,
-            effective_tool_name=safe_effective_name,
-            module_id=module_id,
-            category=self._tool_use_category(tool_def),
-            read_only=(not is_write) if is_write is not None else None,
-            is_write=is_write,
-            source_kind="local",
+        return self._tool_execution_reporter.build_event(
+            context=context,
+            requested_tool_name=requested_tool_name,
             status=status,
-            reason_code=reason_code,
+            execution_origin=execution_origin,
             duration_ms=duration_ms,
+            effective_tool_name=effective_tool_name,
+            module_id=module_id,
+            tool_def=tool_def,
+            payload=payload,
+            tool_args=tool_args,
+            scope_payload=scope_payload,
+            is_write=is_write,
+            reason_code=reason_code,
             idempotency_replay=idempotency_replay,
-            tool_prompt_id=eval_metadata.get("tool_prompt_id"),
-            tool_prompt_version=eval_metadata.get("tool_prompt_version"),
-            prompt_variant=eval_metadata.get("prompt_variant"),
-            action_family=eval_metadata.get("action_family"),
-            result_kind=eval_metadata.get("result_kind") or eval_metadata.get("expected_result_kind"),
-            path_filter_used=eval_metadata.get("path_filter_used"),
-            grant_outcome=eval_metadata.get("grant_outcome") or decision_grant_outcome,
-            truncated=eval_metadata.get("truncated"),
-            file_policy_decisions=file_policy_decisions,
-            tool_hook_results=hook_results,
-            file_policy_sha256_before_present=file_policy_sha256_before_present,
-            file_policy_sha256_after_present=file_policy_sha256_after_present,
-            file_policy_lock_lease_present=file_policy_lock_lease_present,
-            **dimensions,
         )
 
     async def _record_process_request_tool_use_failure(
@@ -1081,98 +955,41 @@ class MCPProtocol:
         requested_tool_name: Any = None,
     ) -> None:
         """Record a tools/call failure that occurs before handler dispatch."""
-        if request.method != "tools/call" or not self._should_record_tool_use(context):
-            return
-        params = request.params if isinstance(request.params, dict) else {}
-        requested = (
-            requested_tool_name
-            if requested_tool_name is not None
-            else params.get("name")
+        await self._tool_execution_reporter.record_process_request_failure(
+            request=request,
+            context=context,
+            status=status,
+            reason_code=reason_code,
+            start_ts=start_ts,
+            requested_tool_name=requested_tool_name,
+            should_record=self._should_record_tool_use,
+            build_event=self._build_tool_use_event,
+            record_event=self._record_tool_use_event,
+            duration_ms=self._tool_use_duration_ms,
+            execution_origin_for_failure=self._tool_use_execution_origin_for_failure,
         )
-        try:
-            event = self._build_tool_use_event(
-                context=context,
-                requested_tool_name=requested,
-                status=status,
-                execution_origin=self._tool_use_execution_origin_for_failure(status),
-                duration_ms=self._tool_use_duration_ms(start_ts),
-                reason_code=reason_code,
-            )
-            await self._record_tool_use_event(event)
-        except Exception as exc:  # noqa: BLE001 - reporting must not affect requests.
-            logger.warning(
-                "Failed to build or record process-request tool-use event: {}",
-                exc.__class__.__name__,
-            )
 
     async def _rbac_check(self, user_id: Optional[str], resource: Resource, action: Action, resource_id: Optional[str] = None) -> bool:
-        if not user_id:
-            return False
-        fn = getattr(self.rbac_policy, "check_permission", None)
-        if not fn:
-            return False
-        try:
-            if inspect.iscoroutinefunction(fn):
-                return await fn(user_id, resource, action, resource_id)
-            return fn(user_id, resource, action, resource_id)
-        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-            return False
+        return await self._tool_execution_security.rbac_check(
+            user_id,
+            resource,
+            action,
+            resource_id,
+            rbac_policy=self.rbac_policy,
+        )
 
     def _scoped_permissions(self, context: RequestContext) -> list[str]:
-        metadata = getattr(context, "metadata", {})
-        if not isinstance(metadata, dict):
-            return []
-        raw = metadata.get("permissions") or []
-        if isinstance(raw, str):
-            return [raw]
-        if isinstance(raw, list):
-            return [str(item) for item in raw if isinstance(item, str)]
-        return []
+        return self._tool_execution_security.scoped_permissions(context)
 
     def _mcp_scopes(self, context: RequestContext) -> list[str]:
-        scopes: list[str] = []
-        for scope in self._scoped_permissions(context):
-            try:
-                if scope.lower().startswith("mcp:"):
-                    scopes.append(scope)
-            except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-                continue
-        return scopes
+        return self._tool_execution_security.mcp_scopes(
+            context,
+            scoped_permissions=self._scoped_permissions,
+        )
 
     def _api_key_scopes(self, context: RequestContext) -> Optional[set[str]]:
         """Return normalized API key scopes when present on the request context."""
-        metadata = getattr(context, "metadata", {})
-        if not isinstance(metadata, dict):
-            return None
-        raw = metadata.get("api_key_scopes")
-        if raw is None:
-            return None
-        try:
-            return set(self.dependencies.api_key_scope_normalizer.normalize(raw))
-        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
-            logger.debug(
-                "MCP API key scope normalization failed; using local fallback: {}",
-                exc.__class__.__name__,
-            )
-
-        if isinstance(raw, str):
-            stripped = raw.strip()
-            if stripped.startswith("["):
-                try:
-                    parsed = json.loads(stripped)
-                except json.JSONDecodeError:
-                    pass
-                else:
-                    if isinstance(parsed, list):
-                        return {
-                            item.strip().lower()
-                            for item in parsed
-                            if isinstance(item, str) and item.strip()
-                        }
-            return {stripped.lower()} if stripped else set()
-        if isinstance(raw, (list, tuple, set)):
-            return {str(item).strip().lower() for item in raw if str(item).strip()}
-        return set()
+        return self._tool_execution_security.api_key_scopes(context)
 
     def _resolve_user_db_paths(self, user_id: Optional[str]) -> dict[str, str]:
         try:
@@ -1181,93 +998,49 @@ class MCPProtocol:
             return {}
 
     def _api_key_scope_level(self, context: RequestContext) -> Optional[str]:
-        scopes = self._api_key_scopes(context)
-        if not scopes:
-            return None
-        if "admin" in scopes or "service" in scopes:
-            return "admin"
-        if "write" in scopes:
-            return "write"
-        if "read" in scopes:
-            return "read"
-        return None
+        return self._tool_execution_security.api_key_scope_level(
+            context,
+            api_key_scopes=self._api_key_scopes,
+        )
 
     def _api_key_allows(self, context: RequestContext, *, is_write: Optional[bool] = None) -> bool:
         """Gate MCP operations by API key scopes when present."""
-        level = self._api_key_scope_level(context)
-        if level is None:
-            return True
-        if level == "admin":
-            return True
-        if is_write is None:
-            return level in {"read", "write"}
-        if is_write:
-            return level == "write"
-        return level in {"read", "write"}
+        return self._tool_execution_security.api_key_allows(
+            context,
+            is_write=is_write,
+            api_key_scope_level=self._api_key_scope_level,
+        )
 
     def _scope_matches(self, scope: str, resource_kind: str, identifier: Optional[str]) -> bool:
-        scope = scope.strip().lower()
-        if not scope.startswith("mcp:"):
-            return False
-        parts = scope.split(":")
-        if len(parts) == 2 and parts[1] == "*":
-            return True
-        if len(parts) < 3:
-            return False
-        kind = parts[1]
-        value = ":".join(parts[2:])
-        if kind == "*":
-            return True
-        if kind != resource_kind:
-            return False
-        if value in {"*", ""}:
-            return True
-        if identifier is None:
-            return False
-        return value == identifier.lower()
+        return self._tool_execution_security.scope_matches(scope, resource_kind, identifier)
 
     def _scope_allows(self, context: RequestContext, resource_kind: str, identifier: Optional[str]) -> bool:
-        scopes = self._mcp_scopes(context)
-        if not scopes:
-            return True
-        identifier_norm = identifier.lower() if isinstance(identifier, str) else None
-        if identifier_norm is None:
-            # Allow listing/browsing when any scoped permission exists for this resource kind.
-            for scope in scopes:
-                try:
-                    parts = scope.strip().lower().split(":")
-                except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-                    continue
-                if len(parts) >= 2 and parts[0] == "mcp":
-                    if parts[1] == "*" or parts[1] == resource_kind:
-                        return True
-        return any(self._scope_matches(scope, resource_kind, identifier_norm) for scope in scopes)
+        return self._tool_execution_security.scope_allows(
+            context,
+            resource_kind,
+            identifier,
+            mcp_scopes=self._mcp_scopes,
+            scope_matches=self._scope_matches,
+        )
 
     async def _has_module_permission(self, context: RequestContext, module_id: Optional[str]) -> bool:
-        module_id_norm = module_id or ""
-        if _has_trusted_compat_claims(context):
-            return self._scope_allows(context, Resource.MODULE.value, module_id_norm or None)
-        if not await self._rbac_check(context.user_id, Resource.MODULE, Action.READ, module_id_norm):
-            return False
-        return self._scope_allows(context, Resource.MODULE.value, module_id_norm or None)
+        return await self._tool_execution_security.has_module_permission(
+            context,
+            module_id,
+            rbac_check=self._rbac_check,
+            scope_allows=self._scope_allows,
+        )
 
     async def _has_tool_permission(self, context: RequestContext, tool_name: str, *, is_write: Optional[bool] = None) -> bool:
-        if _has_trusted_compat_claims(context):
-            for auth_name in self._tool_authorization_names(tool_name):
-                if self._scope_allows(context, Resource.TOOL.value, auth_name):
-                    return self._api_key_allows(context, is_write=is_write)
-            return False
-        has_named_permission = False
-        for auth_name in self._tool_authorization_names(tool_name):
-            if not await self._rbac_check(context.user_id, Resource.TOOL, Action.EXECUTE, auth_name):
-                continue
-            if not self._scope_allows(context, Resource.TOOL.value, auth_name):
-                continue
-            has_named_permission = True
-            break
-        if not has_named_permission:
-            return False
-        return self._api_key_allows(context, is_write=is_write)
+        return await self._tool_execution_security.has_tool_permission(
+            context,
+            tool_name,
+            is_write=is_write,
+            rbac_check=self._rbac_check,
+            scope_allows=self._scope_allows,
+            api_key_allows=self._api_key_allows,
+            tool_authorization_names=self._tool_authorization_names,
+        )
 
     async def _has_resource_permission(self, context: RequestContext, resource_uri: str, module_id: Optional[str]) -> bool:
         if await self._rbac_check(context.user_id, Resource.RESOURCE, Action.READ, resource_uri):
@@ -1374,119 +1147,67 @@ class MCPProtocol:
         return decoded.library_after_name is not None or decoded.library_after_uuid is not None
 
     @staticmethod
-    def _hash_arguments(arguments: dict[str, Any]) -> Optional[str]:
-        try:
-            payload = json.dumps(arguments or {}, sort_keys=True, default=str).encode("utf-8")
-            import hashlib
-            return hashlib.sha256(payload).hexdigest()
-        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-            return None
+    def _hash_arguments(arguments: dict[str, Any]) -> str | None:
+        return ToolExecutionSecurity.hash_arguments_with_exceptions(
+            arguments,
+            noncritical_exceptions=_MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS,
+        )
 
     async def _resolve_tool_definition(
         self,
         module: BaseModule,
         tool_name: str,
-    ) -> Optional[dict[str, Any]]:
-        """Resolve a tool definition for a module/tool pair."""
-        try:
-            get_def = getattr(module, "get_tool_def", None)
-            if callable(get_def):
-                tool_def = await get_def(tool_name)  # type: ignore[misc]
-                if isinstance(tool_def, dict):
-                    return tool_def
-            tool_defs = await module.get_tools()
-            for candidate in tool_defs:
-                if isinstance(candidate, dict) and candidate.get("name") == tool_name:
-                    return candidate
-        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-            return None
-        return None
+    ) -> dict[str, Any] | None:
+        return await self._tool_execution_security.resolve_tool_definition(module, tool_name)
 
     def _classify_write_tool_call(
         self,
         module: BaseModule,
         tool_name: str,
         tool_args: Any,
-        tool_def: Optional[dict[str, Any]],
-    ) -> Optional[bool]:
-        """Best-effort write classification using per-call module hook."""
-        try:
-            normalized_args = tool_args if isinstance(tool_args, dict) else {}
-            return module.is_write_tool_call(tool_name, normalized_args, tool_def=tool_def)
-        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-            return None
+        tool_def: dict[str, Any] | None,
+    ) -> bool | None:
+        return self._tool_execution_security.classify_write_tool_call(module, tool_name, tool_args, tool_def)
 
     def _resolve_write_classification(
         self,
         module: BaseModule,
         tool_name: str,
         tool_args: Any,
-        tool_def: Optional[dict[str, Any]],
+        tool_def: dict[str, Any] | None,
         *,
         fallback_to_name_heuristic: bool,
     ) -> bool:
-        """Resolve write classification with optional legacy fallback."""
-        is_write = self._classify_write_tool_call(module, tool_name, tool_args, tool_def)
-        if is_write is not None:
-            return bool(is_write)
-        if fallback_to_name_heuristic:
-            return bool(re.search(r"(ingest|update|delete|create|import)", str(tool_name).lower()))
-        return False
+        return self._tool_execution_security.resolve_write_classification(
+            module,
+            tool_name,
+            tool_args,
+            tool_def,
+            fallback_to_name_heuristic=fallback_to_name_heuristic,
+        )
 
     @staticmethod
     def _strip_forbidden_tool_argument_overrides(tool_args: dict[str, Any]) -> dict[str, Any]:
-        """Remove tool argument fields that could override request ownership/db scope."""
-        forbidden = {"user_id", "db_path", "db_paths", "chacha_db", "media_db", "prompts_db"}
-        sanitized = dict(tool_args)
-        for key in forbidden:
-            sanitized.pop(key, None)
-        return sanitized
+        return ToolExecutionSecurity.strip_forbidden_tool_argument_overrides(tool_args)
 
     def _harden_and_sanitize_tool_arguments(
         self,
         module: BaseModule,
         tool_args: Any,
     ) -> Any:
-        """Normalize tool arguments before policy and execution checks."""
-        if not isinstance(tool_args, dict):
-            return tool_args
-        hardened_args = self._strip_forbidden_tool_argument_overrides(tool_args)
-        try:
-            return module.sanitize_input(hardened_args)
-        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as san_err:
-            raise InvalidParamsException(f"Invalid arguments: {str(san_err)}") from san_err
+        return self._tool_execution_security.harden_and_sanitize_tool_arguments(module, tool_args)
 
     def _prepared_tool_call_payload(
         self,
         *,
         tool_name: str,
-        module_id: Optional[str],
-        is_write: Optional[bool],
-        idempotency_cache_key: Optional[str],
-        arguments_hash: Optional[str],
+        module_id: str | None,
+        is_write: bool | None,
+        idempotency_cache_key: str | None,
+        arguments_hash: str | None,
         context_fingerprint: str,
     ) -> bytes:
-        payload = {
-            "tool_name": str(tool_name),
-            "module_id": str(module_id or ""),
-            "is_write": bool(is_write),
-            "idempotency_cache_key": str(idempotency_cache_key or ""),
-            "arguments_hash": str(arguments_hash or ""),
-            "context_fingerprint": str(context_fingerprint or ""),
-        }
-        return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
-
-    def _build_prepared_tool_call_integrity_tag(
-        self,
-        *,
-        tool_name: str,
-        module_id: Optional[str],
-        is_write: Optional[bool],
-        idempotency_cache_key: Optional[str],
-        arguments_hash: Optional[str],
-        context_fingerprint: str,
-    ) -> str:
-        payload = self._prepared_tool_call_payload(
+        return ToolExecutionSecurity.prepared_tool_call_payload(
             tool_name=tool_name,
             module_id=module_id,
             is_write=is_write,
@@ -1494,96 +1215,44 @@ class MCPProtocol:
             arguments_hash=arguments_hash,
             context_fingerprint=context_fingerprint,
         )
-        return hmac.new(self._prepared_call_secret, payload, digestmod="sha256").hexdigest()
+
+    def _build_prepared_tool_call_integrity_tag(
+        self,
+        *,
+        tool_name: str,
+        module_id: str | None,
+        is_write: bool | None,
+        idempotency_cache_key: str | None,
+        arguments_hash: str | None,
+        context_fingerprint: str,
+    ) -> str:
+        return self._tool_execution_security.build_prepared_tool_call_integrity_tag(
+            tool_name=tool_name,
+            module_id=module_id,
+            is_write=is_write,
+            idempotency_cache_key=idempotency_cache_key,
+            arguments_hash=arguments_hash,
+            context_fingerprint=context_fingerprint,
+        )
 
     def _verify_prepared_tool_call_integrity(
         self,
         prepared: PreparedToolCall,
     ) -> None:
-        if not isinstance(prepared.tool_name, str) or not self._tool_name_re.match(prepared.tool_name):
-            raise InvalidParamsException("Prepared tool call integrity check failed: invalid tool name")
-
-        expected_hash = self._hash_arguments(prepared.tool_args if isinstance(prepared.tool_args, dict) else {})
-        if expected_hash != prepared.arguments_hash:
-            raise InvalidParamsException("Prepared tool call integrity check failed: argument fingerprint mismatch")
-
-        expected_context_fingerprint = self._fingerprint_request_context(prepared.context)
-        if expected_context_fingerprint != prepared.context_fingerprint:
-            raise InvalidParamsException("Prepared tool call integrity check failed: context fingerprint mismatch")
-
-        expected_write = self._resolve_write_classification(
-            prepared.module,
-            prepared.tool_name,
-            prepared.tool_args,
-            prepared.tool_def,
-            fallback_to_name_heuristic=True,
-        )
-        if bool(expected_write) != bool(prepared.is_write):
-            raise InvalidParamsException("Prepared tool call integrity check failed: write classification mismatch")
-
-        expected_tag = self._build_prepared_tool_call_integrity_tag(
-            tool_name=prepared.tool_name,
-            module_id=prepared.module_id,
-            is_write=prepared.is_write,
-            idempotency_cache_key=prepared.idempotency_cache_key,
-            arguments_hash=prepared.arguments_hash,
-            context_fingerprint=prepared.context_fingerprint,
-        )
-        if not hmac.compare_digest(prepared.integrity_tag, expected_tag):
-            raise InvalidParamsException("Prepared tool call integrity check failed: signature mismatch")
+        self._tool_execution_security.verify_prepared_tool_call_integrity(prepared)
 
     def _fingerprint_request_context(self, context: RequestContext) -> str:
-        payload = {
-            "request_id": str(context.request_id or ""),
-            "user_id": str(context.user_id or ""),
-            "client_id": str(context.client_id or ""),
-            "session_id": str(context.session_id or ""),
-            "metadata": self._context_json_safe(getattr(context, "metadata", {})),
-            "db_paths": self._context_json_safe(getattr(context, "db_paths", {})),
-        }
-        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
-        return hashlib.sha256(encoded).hexdigest()
+        return self._tool_execution_security.fingerprint_request_context(context)
 
     def _context_json_safe(self, value: Any) -> Any:
-        if value is None or isinstance(value, (bool, int, float, str)):
-            return value
-        if isinstance(value, Path):
-            return str(value)
-        if isinstance(value, dict):
-            return {str(key): self._context_json_safe(item) for key, item in sorted(value.items(), key=lambda kv: str(kv[0]))}
-        if isinstance(value, (list, tuple, set)):
-            return [self._context_json_safe(item) for item in value]
-        if is_dataclass(value):
-            return self._context_json_safe(asdict(value))
-        return str(value)
+        return self._tool_execution_security.context_json_safe(value)
 
     @staticmethod
     def _normalize_idempotency_key(
         params: dict[str, Any],
         idempotency_key: str | None = None,
-    ) -> Optional[str]:
-        """Normalize idempotency key from explicit argument or request params."""
-        raw_idempotency_key = idempotency_key
-        if raw_idempotency_key is None:
-            raw_idempotency_key = params.get("idempotencyKey")
-            if raw_idempotency_key is None:
-                raw_idempotency_key = params.get("idempotency_key")
-        if raw_idempotency_key is None:
-            arguments = params.get("arguments")
-            if isinstance(arguments, dict):
-                raw_idempotency_key = arguments.get("idempotencyKey")
-                if raw_idempotency_key is None:
-                    raw_idempotency_key = arguments.get("idempotency_key")
-
-        if raw_idempotency_key is None:
-            return None
-        if not isinstance(raw_idempotency_key, str):
-            raise InvalidParamsException("idempotencyKey must be a string")
-
-        normalized = raw_idempotency_key.strip()
-        if not normalized:
-            raise InvalidParamsException("idempotencyKey must not be empty")
-        return normalized
+    ) -> str | None:
+        return ToolExecutionSecurity.normalize_idempotency_key(params, idempotency_key=idempotency_key)
 
     def _audit_tool_event(
         self,
@@ -1595,90 +1264,31 @@ class MCPProtocol:
         arguments_hash: Optional[str],
         error: Optional[Exception] = None,
     ) -> None:
-        try:
-            log = logger.bind(
-                audit=True,
-                request_id=context.request_id,
-                user_id=context.user_id,
-                client_id=context.client_id,
-                session_id=context.session_id,
-                tool=tool_name,
-                module=module_id or "unknown",
-                duration_ms=round(duration_ms, 2),
-                arguments_hash=arguments_hash,
-                status=status,
-            )
-            if error:
-                log.error("MCP tool execution failed", error_type=error.__class__.__name__)
-            else:
-                log.info("MCP tool executed")
-        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-            pass
+        self._tool_execution_reporter.audit_tool_event(
+            context,
+            tool_name,
+            module_id,
+            status,
+            duration_ms,
+            arguments_hash,
+            error=error,
+        )
 
     @staticmethod
     def _governance_preflight_bypassed(tool_name: str, context: RequestContext) -> bool:
-        if str(tool_name or "").startswith("governance."):
-            return True
+        return ToolExecutionSecurity._governance_preflight_bypassed(tool_name, context)
 
-        metadata = getattr(context, "metadata", None)
-        if not isinstance(metadata, dict):
-            return False
-
-        raw = metadata.get("governance_bypass")
-        if isinstance(raw, bool):
-            return raw
-        if isinstance(raw, (int, float)):
-            return bool(raw)
-        if isinstance(raw, str):
-            return _is_truthy(raw)
-        return False
-
-    @staticmethod
-    def _governance_summary(tool_name: str, tool_args: dict[str, Any]) -> str:
-        rendered_args = ""
-        try:
-            rendered_args = json.dumps(tool_args or {}, sort_keys=True, default=str)
-        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-            rendered_args = str(tool_args)
-        if len(rendered_args) > 1200:
-            rendered_args = rendered_args[:1200]
-        return f"tool={tool_name}; args={rendered_args}"
+    def _governance_summary(self, tool_name: str, tool_args: dict[str, Any]) -> str:
+        return self._tool_execution_security._governance_summary(tool_name, tool_args)
 
     @staticmethod
     def _resolve_governance_category(tool_name: str, tool_def: Optional[dict[str, Any]]) -> str:
-        try:
-            if isinstance(tool_def, dict):
-                meta = tool_def.get("metadata")
-                if isinstance(meta, dict):
-                    category = str(meta.get("category") or "").strip().lower()
-                    if category:
-                        return category
-        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-            pass
+        return ToolExecutionSecurity._resolve_governance_category(tool_name, tool_def)
 
-        if isinstance(tool_name, str) and "." in tool_name:
-            prefix = tool_name.split(".", 1)[0].strip().lower()
-            if prefix:
-                return prefix
-        return "general"
-
-    @staticmethod
-    def _resolve_governance_rollout_mode(metadata: Optional[dict[str, Any]] = None) -> str:
+    def _resolve_governance_rollout_mode(self, metadata: Optional[dict[str, Any]] = None) -> str:
         """Resolve governance rollout mode from metadata override and server config."""
-        raw_mode = None
-        if isinstance(metadata, dict):
-            raw_mode = metadata.get("governance_rollout_mode")
-
-        try:
-            from tldw_Server_API.app.core import config as app_config
-
-            return app_config.resolve_governance_rollout_mode(
-                str(raw_mode) if raw_mode is not None else None
-            )
-        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
-            logger.debug(f"Unable to resolve governance rollout mode from config: {exc}")
-            candidate = str(raw_mode or "").strip().lower()
-            return candidate if candidate in {"off", "shadow", "enforce"} else "off"
+        self._sync_tool_execution_dependencies()
+        return self._tool_execution_security._resolve_governance_rollout_mode(metadata)
 
     def _record_governance_check(
         self,
@@ -1689,67 +1299,21 @@ class MCPProtocol:
         rollout_mode: str,
     ) -> None:
         """Emit one governance check metric entry, failing open on metric errors."""
-        with contextlib.suppress(_MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS):
-            self.metrics.record_governance_check(
-                surface=surface,
-                category=category,
-                status=status,
-                rollout_mode=rollout_mode,
-            )
+        self._sync_tool_execution_dependencies()
+        self._tool_execution_security._record_governance_check(
+            surface=surface,
+            category=category,
+            status=status,
+            rollout_mode=rollout_mode,
+        )
 
     @classmethod
     def _serialize_governance_decision(cls, decision: Any) -> dict[str, Any]:
-        if decision is None:
-            return {}
-        if isinstance(decision, dict):
-            return {str(k): v for k, v in decision.items()}
-        if is_dataclass(decision):
-            return cls._serialize_governance_decision(asdict(decision))
-        dump = getattr(decision, "model_dump", None)
-        if callable(dump):
-            try:
-                dumped = dump()
-                if isinstance(dumped, dict):
-                    return {str(k): v for k, v in dumped.items()}
-            except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-                pass
-        payload: dict[str, Any] = {}
-        for key in ("action", "status", "category", "category_source", "fallback_reason", "matched_rules"):
-            value = getattr(decision, key, None)
-            if value is not None:
-                payload[key] = value
-        return payload
+        return ToolExecutionSecurity._serialize_governance_decision(decision)
 
     async def _ensure_governance_service(self) -> Any | None:
-        if self._governance_service is not None:
-            return self._governance_service
-
-        async with self._governance_lock:
-            if self._governance_service is not None:
-                return self._governance_service
-            try:
-                from tldw_Server_API.app.core.Governance.service import GovernanceService
-                from tldw_Server_API.app.core.Governance.store import GovernanceStore
-            except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
-                logger.debug(f"MCP governance preflight unavailable (import failure): {exc}")
-                return None
-
-            try:
-                cfg = get_config()
-                configured_path = getattr(cfg, "governance_db_path", None)
-                sqlite_path = str(configured_path or "Databases/governance.db")
-                db_path = Path(sqlite_path).expanduser()
-                db_path.parent.mkdir(parents=True, exist_ok=True)
-
-                self._governance_store = GovernanceStore(sqlite_path=str(db_path))
-                await self._governance_store.ensure_schema()
-                self._governance_service = GovernanceService(store=self._governance_store)
-                return self._governance_service
-            except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
-                logger.debug(f"MCP governance preflight disabled (service init failure): {exc}")
-                self._governance_service = None
-                self._governance_store = None
-                return None
+        self._sync_tool_execution_dependencies()
+        return await self._tool_execution_security._ensure_governance_service()
 
     async def _run_governance_preflight(
         self,
@@ -1759,124 +1323,46 @@ class MCPProtocol:
         tool_def: Optional[dict[str, Any]],
         context: RequestContext,
     ) -> Optional[dict[str, Any]]:
-        if self._governance_preflight_bypassed(tool_name, context):
-            return None
-
-        metadata = context.metadata if isinstance(getattr(context, "metadata", None), dict) else {}
-        rollout_mode = self._resolve_governance_rollout_mode(metadata)
-        category = self._resolve_governance_category(tool_name, tool_def)
-
-        if rollout_mode == "off":
-            self._record_governance_check(
-                surface="mcp_tool",
-                category=category,
-                status="unknown",
-                rollout_mode=rollout_mode,
-            )
-            return {"status": "unknown", "rollout_mode": rollout_mode}
-
-        service = await self._ensure_governance_service()
-        if service is None:
-            self._record_governance_check(
-                surface="mcp_tool",
-                category=category,
-                status="error",
-                rollout_mode=rollout_mode,
-            )
-            return None
-
-        try:
-            decision = await service.validate_change(
-                surface="mcp_tool",
-                summary=self._governance_summary(tool_name, tool_args),
-                category=category,
-                metadata=metadata,
-            )
-            payload = self._serialize_governance_decision(decision)
-            payload.setdefault("rollout_mode", rollout_mode)
-            if isinstance(context.metadata, dict):
-                context.metadata["governance_preflight"] = payload
-            action = str(payload.get("action") or payload.get("status") or "").strip().lower() or "unknown"
-            self._record_governance_check(
-                surface="mcp_tool",
-                category=category,
-                status=action,
-                rollout_mode=rollout_mode,
-            )
-            if action == "deny" and rollout_mode == "enforce":
-                raise GovernanceDeniedError(
-                    "Permission denied by governance policy",
-                    governance=payload,
-                )
-            return payload
-        except GovernanceDeniedError:
-            raise
-        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
-            self._record_governance_check(
-                surface="mcp_tool",
-                category=category,
-                status="error",
-                rollout_mode=rollout_mode,
-            )
-            try:
-                context.logger.debug(f"Governance preflight failed open: {exc}")
-            except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-                pass
-            return None
+        self._sync_tool_execution_dependencies()
+        return await self._tool_execution_security._run_governance_preflight(
+            tool_name=tool_name,
+            tool_args=tool_args,
+            tool_def=tool_def,
+            context=context,
+            governance_preflight_bypassed=self._governance_preflight_bypassed,
+            resolve_governance_rollout_mode=self._resolve_governance_rollout_mode,
+            resolve_governance_category=self._resolve_governance_category,
+            record_governance_check=self._record_governance_check,
+            governance_summary=self._governance_summary,
+            serialize_governance_decision=self._serialize_governance_decision,
+            ensure_governance_service=self._ensure_governance_service,
+        )
 
     @staticmethod
     def _hook_safe_copy(value: Any) -> Any:
         """Return a detached copy of hook-visible metadata without failing tool preparation."""
-        try:
-            return copy.deepcopy(value)
-        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-            try:
-                return json.loads(json.dumps(value, default=str))
-            except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-                return str(value)
+        return ToolExecutionHooks._hook_safe_copy(value)
 
     @staticmethod
     def _hook_safe_metadata(context: RequestContext) -> dict[str, Any]:
         """Return request metadata safe for local lifecycle hook decisions."""
-        metadata = getattr(context, "metadata", None)
-        if not isinstance(metadata, dict):
-            return {}
-        return {
-            str(key): MCPProtocol._hook_safe_copy(value)
-            for key, value in metadata.items()
-            if isinstance(key, str) and not key.startswith("_") and key not in {"governance_preflight"}
-        }
+        return ToolExecutionHooks._hook_safe_metadata(context)
 
     @staticmethod
     def _hook_safe_tool_args(tool_args: Any, *, tool_name: str | None = None) -> dict[str, Any] | None:
         """Return detached sanitized tool arguments for hook evaluation."""
-        if not isinstance(tool_args, dict):
-            return None
-        copied = MCPProtocol._hook_safe_copy(tool_args)
-        if not isinstance(copied, dict):
-            return None
-        return MCPProtocol._redact_hook_visible_tool_args(copied, tool_name=tool_name)
+        return ToolExecutionHooks._hook_safe_tool_args(tool_args, tool_name=tool_name)
 
     @staticmethod
     def _redact_hook_visible_tool_args(tool_args: dict[str, Any], *, tool_name: str | None = None) -> dict[str, Any]:
         """Redact secret-bearing argument values from hook-visible metadata."""
 
-        if str(tool_name or "") != "sandbox.run":
-            return tool_args
-        env = tool_args.get("env")
-        if not isinstance(env, dict):
-            return tool_args
-        redacted = dict(tool_args)
-        redacted["env"] = {str(key): "[redacted]" for key in env}
-        return redacted
+        return ToolExecutionHooks._redact_hook_visible_tool_args(tool_args, tool_name=tool_name)
 
     @staticmethod
     def _hook_safe_scope_payload(scope_payload: dict[str, Any] | None) -> dict[str, Any] | None:
         """Return detached path/external scope metadata for hooks."""
-        if not isinstance(scope_payload, dict):
-            return None
-        copied = MCPProtocol._hook_safe_copy(scope_payload)
-        return copied if isinstance(copied, dict) else None
+        return ToolExecutionHooks._hook_safe_scope_payload(scope_payload)
 
     def _build_tool_hook_context(
         self,
@@ -1895,68 +1381,32 @@ class MCPProtocol:
         error: Exception | None = None,
     ) -> ToolHookCallContext:
         """Build a bounded, detached context object for lifecycle hook evaluation."""
-        return ToolHookCallContext(
-            phase="post" if phase == "post" else "pre",
-            tool_name=str(tool_name),
+        return self._tool_execution_hooks._build_tool_hook_context(
+            phase=phase,
+            tool_name=tool_name,
             module_id=module_id,
+            tool_def=tool_def,
+            tool_args=tool_args,
             is_write=is_write,
-            tool_category=self._tool_use_category(tool_def),
             arguments_hash=arguments_hash,
-            request_id=str(context.request_id),
-            user_id=context.user_id,
-            client_id=context.client_id,
-            session_id=context.session_id,
-            metadata=self._hook_safe_metadata(context),
-            tool_args=self._hook_safe_tool_args(tool_args, tool_name=tool_name),
+            context=context,
+            scope_payload=scope_payload,
             status=status,
             duration_ms=duration_ms,
-            error_type=error.__class__.__name__ if error is not None else None,
-            scope_payload=self._hook_safe_scope_payload(scope_payload),
+            error=error,
         )
 
     @staticmethod
     def _coerce_tool_hook_action(action: Any) -> ToolHookAction | None:
         """Normalize a runtime hook action into the public literal contract."""
-        normalized = str(action or "allow").strip().lower()
-        if normalized in {"allow", "deny", "ask", "approval_required"}:
-            return cast(ToolHookAction, normalized)
-        return None
+        return ToolExecutionHooks._coerce_tool_hook_action(action)
 
     @staticmethod
     def _coerce_tool_hook_decision(
         decision: ToolHookDecision | dict[str, Any] | None,
     ) -> ToolHookDecision:
         """Normalize hook decision values from typed or dict-based embedders."""
-        if decision is None:
-            return ToolHookDecision(action="allow")
-        if isinstance(decision, ToolHookDecision):
-            return decision
-        if isinstance(decision, dict):
-            metadata = decision.get("metadata")
-            action = MCPProtocol._coerce_tool_hook_action(
-                decision.get("action") or decision.get("status") or "allow"
-            )
-            if action is None:
-                return ToolHookDecision(
-                    action="deny",
-                    reason_code="invalid_tool_hook_action",
-                    message="Invalid MCP tool hook action",
-                )
-            return ToolHookDecision(
-                action=action,
-                reason_code=(
-                    str(decision.get("reason_code"))
-                    if decision.get("reason_code") is not None
-                    else None
-                ),
-                message=str(decision.get("message")) if decision.get("message") is not None else None,
-                metadata=dict(metadata) if isinstance(metadata, dict) else {},
-            )
-        return ToolHookDecision(
-            action="deny",
-            reason_code="invalid_tool_hook_decision",
-            message="Invalid MCP tool hook decision",
-        )
+        return ToolExecutionHooks._coerce_tool_hook_decision(decision)
 
     @staticmethod
     def _tool_hook_payload(
@@ -1966,22 +1416,11 @@ class MCPProtocol:
         fallback_reason_code: str | None = None,
     ) -> dict[str, Any]:
         """Serialize a normalized hook decision into response-safe metadata."""
-        action = str(decision.action or "allow").strip().lower()
-        if action == "approval_required":
-            action = "ask"
-        payload: dict[str, Any] = {
-            "phase": phase,
-            "action": action,
-            "status": action,
-        }
-        reason_code = decision.reason_code or fallback_reason_code
-        if reason_code:
-            payload["reason_code"] = str(reason_code)
-        if decision.message:
-            payload["message"] = str(decision.message)
-        if isinstance(decision.metadata, dict) and decision.metadata:
-            payload["metadata"] = dict(decision.metadata)
-        return payload
+        return ToolExecutionHooks._tool_hook_payload(
+            decision,
+            phase=phase,
+            fallback_reason_code=fallback_reason_code,
+        )
 
     async def _run_pre_tool_hooks(
         self,
@@ -1996,8 +1435,7 @@ class MCPProtocol:
         scope_payload: dict[str, Any] | None,
     ) -> dict[str, Any]:
         """Run pre-tool hooks and map enforcement decisions to protocol errors."""
-        hook_context = self._build_tool_hook_context(
-            phase="pre",
+        return await self._tool_execution_hooks._run_pre_tool_hooks(
             tool_name=tool_name,
             module_id=module_id,
             tool_def=tool_def,
@@ -2006,78 +1444,6 @@ class MCPProtocol:
             arguments_hash=arguments_hash,
             context=context,
             scope_payload=scope_payload,
-        )
-        try:
-            raw_decision = await self._tool_call_hook_manager.before_tool_call(hook_context)
-        except asyncio.CancelledError:
-            raise
-        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
-            logger.exception(
-                "MCP pre-tool hook failed closed: tool_name={} module_id={} request_id={} error_type={}",
-                tool_name,
-                module_id,
-                context.request_id,
-                exc.__class__.__name__,
-            )
-            payload = {
-                "phase": "pre",
-                "action": "deny",
-                "status": "deny",
-                "reason_code": "tool_hook_unavailable",
-                "error_type": exc.__class__.__name__,
-            }
-            hook_id = getattr(exc, "hook_id", None)
-            if hook_id is not None:
-                payload["hook_id"] = hook_id
-            hook_order = getattr(exc, "hook_order", None)
-            if hook_order is not None:
-                payload["hook_order"] = hook_order
-            self._append_tool_hook_summary(context, payload)
-            raise GovernanceDeniedError(
-                "Permission denied by MCP tool hook",
-                governance={
-                    "action": "deny",
-                    "status": "deny",
-                    "reason_code": "tool_hook_unavailable",
-                    "hook": payload,
-                },
-            ) from exc
-
-        decision = self._coerce_tool_hook_decision(raw_decision)
-        payload = self._tool_hook_payload(decision, phase="pre")
-        if raw_decision is not None:
-            self._append_tool_hook_summary(context, payload)
-        action = str(payload.get("action") or "allow").strip().lower()
-        if action == "allow":
-            return payload
-        if action == "ask":
-            raise ApprovalRequiredError(
-                "Approval required by MCP tool hook",
-                approval={
-                    "source": "tool_hook",
-                    "reason_code": payload.get("reason_code") or "tool_hook_approval_required",
-                    "message": payload.get("message"),
-                    "hook": payload,
-                },
-            )
-        if action != "deny":
-            payload = self._tool_hook_payload(
-                ToolHookDecision(
-                    action="deny",
-                    reason_code="invalid_tool_hook_action",
-                    message=f"Unsupported MCP tool hook action: {action}",
-                    metadata={"requested_action": action},
-                ),
-                phase="pre",
-            )
-        raise GovernanceDeniedError(
-            "Permission denied by MCP tool hook",
-            governance={
-                "action": "deny",
-                "status": "deny",
-                "reason_code": payload.get("reason_code") or "tool_hook_denied",
-                "hook": payload,
-            },
         )
 
     async def _run_post_tool_hooks(
@@ -2096,12 +1462,11 @@ class MCPProtocol:
         error: Exception | None = None,
     ) -> None:
         """Notify post-tool hooks while preserving the original tool outcome."""
-        hook_context = self._build_tool_hook_context(
-            phase="post",
+        await self._tool_execution_hooks._run_post_tool_hooks(
             tool_name=tool_name,
+            tool_args=tool_args,
             module_id=module_id,
             tool_def=tool_def,
-            tool_args=tool_args,
             is_write=is_write,
             arguments_hash=arguments_hash,
             context=context,
@@ -2110,39 +1475,6 @@ class MCPProtocol:
             duration_ms=duration_ms,
             error=error,
         )
-        try:
-            raw_decision = await self._tool_call_hook_manager.after_tool_call(hook_context)
-        except asyncio.CancelledError:
-            raise
-        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
-            logger.exception(
-                "MCP post-tool hook failed; suppressed to preserve tool outcome: "
-                "tool_name={} module_id={} request_id={} status={} error_type={}",
-                tool_name,
-                module_id,
-                context.request_id,
-                status,
-                exc.__class__.__name__,
-            )
-            payload = {
-                "phase": "post",
-                "action": "deny",
-                "status": "error",
-                "reason_code": "tool_hook_unavailable",
-                "error_type": exc.__class__.__name__,
-            }
-            hook_id = getattr(exc, "hook_id", None)
-            if hook_id is not None:
-                payload["hook_id"] = hook_id
-            hook_order = getattr(exc, "hook_order", None)
-            if hook_order is not None:
-                payload["hook_order"] = hook_order
-            self._append_tool_hook_summary(context, payload)
-            return
-        if raw_decision is not None:
-            decision = self._coerce_tool_hook_decision(raw_decision)
-            payload = self._tool_hook_payload(decision, phase="post")
-            self._append_tool_hook_summary(context, payload)
 
     async def process_request(
         self,
@@ -2289,7 +1621,6 @@ class MCPProtocol:
                             request.id,
                         )
                     if not self._tool_name_re.match(_name):
-                        # Regex violation treated as internal error per legacy expectation
                         await self._record_process_request_tool_use_failure(
                             request=request,
                             context=context,
@@ -2299,7 +1630,7 @@ class MCPProtocol:
                             requested_tool_name=_name,
                         )
                         return pre_dispatch_error(
-                            ErrorCode.INTERNAL_ERROR,
+                            ErrorCode.INVALID_PARAMS,
                             "Invalid tool name",
                             request.id,
                         )
@@ -2663,11 +1994,33 @@ class MCPProtocol:
                         resource_id = name
             except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
                 resource_id = None
+            if resource == Resource.TOOL and action == Action.EXECUTE:
+                if not isinstance(resource_id, str):
+                    return False
+                tool_def = None
+                module = None
+                is_write = None
+                try:
+                    tool_args = params.get("arguments", {}) if isinstance(params, dict) else {}
+                    module = await self.module_registry.find_module_for_tool(resource_id)
+                    if module is not None:
+                        tool_def = await self._resolve_tool_definition(module, resource_id)
+                        tool_args = self._harden_and_sanitize_tool_arguments(module, tool_args)
+                        is_write = self._resolve_write_classification(
+                            module,
+                            resource_id,
+                            tool_args,
+                            tool_def,
+                            fallback_to_name_heuristic=True,
+                        )
+                    else:
+                        is_write = bool(re.search(r"(ingest|update|delete|create|import)", resource_id.lower()))
+                except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
+                    is_write = None
+                return await self._has_tool_permission(context, resource_id, is_write=is_write)
             trusted_compat_allowed = False
             if _has_trusted_compat_claims(context):
-                if resource == Resource.TOOL and action == Action.EXECUTE and isinstance(resource_id, str):
-                    trusted_compat_allowed = await self._has_tool_permission(context, resource_id)
-                elif resource == Resource.MODULE:
+                if resource == Resource.MODULE:
                     trusted_compat_allowed = await self._has_module_permission(
                         context,
                         resource_id if isinstance(resource_id, str) else None,
@@ -2689,32 +2042,7 @@ class MCPProtocol:
             if not self._scope_allows(context, resource.value, resource_id):
                 return False
             # Apply API key scope gating for read-style methods
-            if method != "tools/call":
-                return self._api_key_allows(context, is_write=None)
-            # For tools/call, evaluate write vs read-only tool when possible
-            tool_name = resource_id if isinstance(resource_id, str) else None
-            tool_def = None
-            module = None
-            is_write = None
-            try:
-                tool_args = params.get("arguments", {}) if isinstance(params, dict) else {}
-                if tool_name:
-                    module = await self.module_registry.find_module_for_tool(tool_name)
-                if module is not None and tool_name:
-                    tool_def = await self._resolve_tool_definition(module, tool_name)
-                    tool_args = self._harden_and_sanitize_tool_arguments(module, tool_args)
-                    is_write = self._resolve_write_classification(
-                        module,
-                        tool_name,
-                        tool_args,
-                        tool_def,
-                        fallback_to_name_heuristic=True,
-                    )
-                elif tool_name:
-                    is_write = bool(re.search(r"(ingest|update|delete|create|import)", tool_name.lower()))
-            except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-                is_write = None
-            return self._api_key_allows(context, is_write=is_write)
+            return self._api_key_allows(context, is_write=None)
 
         # Unknown method - deny by default
         return False
@@ -2876,141 +2204,65 @@ class MCPProtocol:
 
     def _extract_allowed_tools(self, context: RequestContext) -> list[str] | None:
         """Extract allowed-tools list from request context metadata."""
-        try:
-            metadata = context.metadata or {}
-            allowed = metadata.get("allowed_tools")
-        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-            return None
-
-        if allowed is None:
-            return None
-        if isinstance(allowed, list):
-            cleaned = [str(item).strip() for item in allowed if str(item).strip()]
-            return cleaned or None
-        if isinstance(allowed, str):
-            try:
-                parsed = json.loads(allowed)
-                if isinstance(parsed, list):
-                    cleaned = [str(item).strip() for item in parsed if str(item).strip()]
-                    return cleaned or None
-            except json.JSONDecodeError:
-                pass
-            cleaned = [part.strip() for part in allowed.split(",") if part.strip()]
-            return cleaned or None
-        return None
+        return self._tool_execution_security.extract_allowed_tools(context)
 
     def _extract_eval_profile_id(self, context: RequestContext) -> str | None:
         """Extract a non-sensitive profile identifier for execution eval metadata."""
-        metadata = getattr(context, "metadata", {})
-        if not isinstance(metadata, dict):
-            return None
-        for key in ("profile_id", "mcp_profile_id", "gateway_profile_id"):
-            value = metadata.get(key)
-            clean_value = sanitize_eval_profile_id(value)
-            if clean_value is not None:
-                return clean_value
-        return None
+        return self._tool_execution_runtime.extract_eval_profile_id(context)
 
     def _extract_tool_command(self, tool_args: Any) -> str | None:
         """Extract command-like string from tool arguments for pattern matching."""
-        if not isinstance(tool_args, dict):
-            return None
-        for key in ("command", "cmd", "args", "arguments"):
-            if key not in tool_args:
-                continue
-            value = tool_args.get(key)
-            if isinstance(value, str):
-                return value
-            if isinstance(value, list):
-                return " ".join(str(part) for part in value)
-        return None
+        return self._tool_execution_security.extract_tool_command(tool_args)
 
     def _matches_allowed_tool_pattern(self, tool_name: str, tool_args: Any, pattern: str) -> bool:
         """Check if tool invocation matches an allowed-tools pattern."""
-        pattern = str(pattern or "").strip()
-        if not pattern:
-            return False
-        if "(" not in pattern:
-            return tool_name == pattern
-        if not pattern.endswith(")"):
-            return False
-
-        base_name, cmd_pattern = pattern.split("(", 1)
-        cmd_pattern = cmd_pattern[:-1]
-        base_name = base_name.strip()
-        if tool_name != base_name:
-            return False
-
-        command = self._extract_tool_command(tool_args)
-        if command is None:
-            return False
-
-        regex_pattern = re.escape(cmd_pattern)
-        regex_pattern = regex_pattern.replace(r"\*", ".*")
-        try:
-            return bool(re.match(f"^{regex_pattern}$", command.strip()))
-        except re.error:
-            return False
+        return self._tool_execution_security.matches_allowed_tool_pattern(
+            tool_name,
+            tool_args,
+            pattern,
+            extract_tool_command=self._extract_tool_command,
+        )
 
     @staticmethod
     def _tool_authorization_names(tool_name: str) -> tuple[str, ...]:
         """Return invoked and canonical names that may authorize a tool call."""
 
-        canonical_name = _TOOL_AUTHORIZATION_ALIASES.get(tool_name)
-        if canonical_name and canonical_name != tool_name:
-            return (tool_name, canonical_name)
-        return (tool_name,)
+        return ToolExecutionSecurity.tool_authorization_names(tool_name)
 
     def _matches_tool_authorization_pattern(self, tool_name: str, tool_args: Any, pattern: str) -> bool:
         """Match a policy pattern against the invoked name and any canonical alias."""
 
-        return any(
-            self._matches_allowed_tool_pattern(auth_name, tool_args, pattern)
-            for auth_name in self._tool_authorization_names(tool_name)
+        return self._tool_execution_security.matches_tool_authorization_pattern(
+            tool_name,
+            tool_args,
+            pattern,
+            matches_allowed_tool_pattern=self._matches_allowed_tool_pattern,
+            tool_authorization_names=self._tool_authorization_names,
         )
 
     def _scope_allows_tool_name(self, context: RequestContext, tool_name: str) -> bool:
         """Return True when scopes allow the invoked tool name or canonical alias."""
 
-        return any(
-            self._scope_allows(context, Resource.TOOL.value, auth_name)
-            for auth_name in self._tool_authorization_names(tool_name)
+        return self._tool_execution_security.scope_allows_tool_name(
+            context,
+            tool_name,
+            scope_allows=self._scope_allows,
+            tool_authorization_names=self._tool_authorization_names,
         )
 
     def _is_tool_allowed_by_context(self, tool_name: str, tool_args: Any, context: RequestContext) -> bool:
         """Return True when tool usage is allowed by context metadata."""
-        allowed_tools = self._extract_allowed_tools(context)
-        if not allowed_tools:
-            return True
-        return any(self._matches_tool_authorization_pattern(tool_name, tool_args, pattern) for pattern in allowed_tools)
+        return self._tool_execution_security.is_tool_allowed_by_context(
+            tool_name,
+            tool_args,
+            context,
+            extract_allowed_tools=self._extract_allowed_tools,
+            matches_tool_authorization_pattern=self._matches_tool_authorization_pattern,
+        )
 
     async def _resolve_effective_tool_policy(self, context: RequestContext) -> dict[str, Any] | None:
-        metadata = getattr(context, "metadata", None)
-        if not isinstance(metadata, dict):
-            return None
-        if not _is_truthy(metadata.get("mcp_policy_context_enabled")):
-            return None
-        cached = metadata.get("_mcp_effective_tool_policy")
-        if isinstance(cached, dict):
-            return cached
-        try:
-            policy = await self.dependencies.effective_policy_resolver.resolve_for_context(
-                user_id=context.user_id,
-                metadata=metadata,
-            )
-        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
-            logger.warning("Failed to resolve MCP Hub effective policy: {}", exc)
-            policy = {
-                "enabled": True,
-                "allowed_tools": [],
-                "denied_tools": [],
-                "capabilities": [],
-                "sources": [],
-                "resolution_error": "policy_resolution_failed",
-            }
-        if policy is not None:
-            metadata["_mcp_effective_tool_policy"] = policy
-        return policy
+        self._sync_tool_execution_dependencies()
+        return await self._tool_execution_security._resolve_effective_tool_policy(context)
 
     def _is_tool_allowed_by_effective_policy(
         self,
@@ -3018,25 +2270,12 @@ class MCPProtocol:
         tool_args: Any,
         policy: dict[str, Any] | None,
     ) -> bool:
-        if not isinstance(policy, dict) or not bool(policy.get("enabled", False)):
-            return True
-        if str(policy.get("resolution_error") or "").strip():
-            return False
-        denied_tools = [
-            str(pattern).strip()
-            for pattern in (policy.get("denied_tools") or [])
-            if str(pattern).strip()
-        ]
-        if any(self._matches_tool_authorization_pattern(tool_name, tool_args, pattern) for pattern in denied_tools):
-            return False
-        allowed_tools = [
-            str(pattern).strip()
-            for pattern in (policy.get("allowed_tools") or [])
-            if str(pattern).strip()
-        ]
-        if not allowed_tools:
-            return True
-        return any(self._matches_tool_authorization_pattern(tool_name, tool_args, pattern) for pattern in allowed_tools)
+        return self._tool_execution_security._is_tool_allowed_by_effective_policy(
+            tool_name,
+            tool_args,
+            policy,
+            matches_tool_authorization_pattern=self._matches_tool_authorization_pattern,
+        )
 
     async def _evaluate_runtime_approval(
         self,
@@ -3052,29 +2291,19 @@ class MCPProtocol:
         approval_reason: str | None = None,
         scope_payload: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        policy = dict(effective_policy or {})
-        if not bool(policy.get("enabled", False)):
-            return {"status": "allow", "reason": "policy_disabled"}
-        if str(policy.get("resolution_error") or "").strip():
-            return {"status": "deny", "reason": "policy_unavailable"}
-        try:
-            return await self.dependencies.approval_evaluator.evaluate_tool_call(
-                effective_policy=policy,
-                tool_name=tool_name,
-                tool_args=tool_args,
-                context=context,
-                tool_def=tool_def,
-                is_write=is_write,
-                within_effective_policy=within_effective_policy,
-                force_approval=force_approval,
-                approval_reason=approval_reason,
-                scope_payload=scope_payload,
-            )
-        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
-            logger.debug("Failed to evaluate MCP Hub runtime approval: {}", exc)
-            if policy.get("approval_policy_id") is not None or policy.get("approval_mode"):
-                return {"status": "deny", "reason": "approval_unavailable"}
-            return {"status": "allow" if within_effective_policy else "deny", "reason": "approval_not_configured"}
+        self._sync_tool_execution_dependencies()
+        return await self._tool_execution_security._evaluate_runtime_approval(
+            effective_policy=effective_policy,
+            tool_name=tool_name,
+            tool_args=tool_args,
+            context=context,
+            tool_def=tool_def,
+            is_write=is_write,
+            within_effective_policy=within_effective_policy,
+            force_approval=force_approval,
+            approval_reason=approval_reason,
+            scope_payload=scope_payload,
+        )
 
     async def _evaluate_path_scope(
         self,
@@ -3086,63 +2315,15 @@ class MCPProtocol:
         tool_def: dict[str, Any] | None,
         path_scope_candidates: list[PathScopeCandidate] | None = None,
     ) -> dict[str, Any]:
-        policy = dict(effective_policy or {})
-        policy_document = dict(policy.get("policy_document") or {})
-        path_scope_mode = str(policy_document.get("path_scope_mode") or "").strip()
-        if not bool(policy.get("enabled", False)) or not path_scope_mode or path_scope_mode == "none":
-            return {
-                "enabled": False,
-                "within_scope": True,
-                "reason": None,
-                "force_approval": False,
-                "normalized_paths": [],
-                "scope_payload": None,
-            }
-        if str(policy.get("resolution_error") or "").strip():
-            return {
-                "enabled": True,
-                "within_scope": False,
-                "reason": "policy_unavailable",
-                "force_approval": False,
-                "normalized_paths": [],
-                "scope_payload": {"path_scope_mode": path_scope_mode, "reason": "policy_unavailable"},
-            }
-        try:
-            try:
-                return await self.dependencies.path_scope_enforcer.evaluate_tool_call(
-                    effective_policy=policy,
-                    context=context,
-                    tool_name=tool_name,
-                    tool_args=tool_args,
-                    tool_def=tool_def,
-                    path_scope_candidates=path_scope_candidates,
-                )
-            except TypeError as exc:
-                if not _is_unexpected_keyword_type_error(exc, "path_scope_candidates"):
-                    raise
-                if path_scope_candidates:
-                    raise PermissionError("path_scope_candidates_unsupported") from exc
-                return await self.dependencies.path_scope_enforcer.evaluate_tool_call(
-                    effective_policy=policy,
-                    context=context,
-                    tool_name=tool_name,
-                    tool_args=tool_args,
-                    tool_def=tool_def,
-                )
-        except PermissionError:
-            raise
-        except TypeError:
-            raise
-        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
-            logger.debug("Failed to evaluate MCP Hub path scope: {}", exc)
-            return {
-                "enabled": True,
-                "within_scope": False,
-                "reason": "path_scope_unavailable",
-                "force_approval": True,
-                "normalized_paths": [],
-                "scope_payload": {"path_scope_mode": path_scope_mode, "reason": "path_scope_unavailable"},
-            }
+        self._sync_tool_execution_dependencies()
+        return await self._tool_execution_security._evaluate_path_scope(
+            effective_policy=effective_policy,
+            tool_name=tool_name,
+            tool_args=tool_args,
+            context=context,
+            tool_def=tool_def,
+            path_scope_candidates=path_scope_candidates,
+        )
 
     async def _extract_path_scope_candidates(
         self,
@@ -3153,25 +2334,14 @@ class MCPProtocol:
         context: RequestContext,
         tool_def: dict[str, Any] | None,
     ) -> list[PathScopeCandidate] | None:
-        metadata = tool_def.get("metadata") if isinstance(tool_def, dict) else None
-        if not isinstance(metadata, dict) or metadata.get("path_scope_candidate_source") != "module":
-            return None
-        if not isinstance(tool_args, dict):
-            raise PermissionError("path_scope_candidates_unavailable")
-        extractor = getattr(module, "extract_path_scope_candidates", None)
-        if not callable(extractor):
-            raise PermissionError("path_scope_candidates_unavailable")
-        try:
-            candidates = normalize_path_scope_candidates(
-                await extractor(tool_name, tool_args, context)
-            )
-        except NotImplementedError as exc:
-            raise PermissionError("path_scope_candidates_unavailable") from exc
-        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
-            raise InvalidParamsException(str(exc)) from exc
-        if not candidates:
-            raise PermissionError("path_scope_candidates_unavailable")
-        return candidates
+        self._sync_tool_execution_dependencies()
+        return await self._tool_execution_security._extract_path_scope_candidates(
+            module=module,
+            tool_name=tool_name,
+            tool_args=tool_args,
+            context=context,
+            tool_def=tool_def,
+        )
 
     async def _evaluate_external_access(
         self,
@@ -3180,158 +2350,12 @@ class MCPProtocol:
         tool_name: str,
         context: RequestContext,
     ) -> dict[str, Any]:
-        deny_only_reasons = {
-            "external_access_unavailable",
-            "external_server_not_bound",
-            "invalid_external_tool_name",
-            "required_slot_not_granted",
-            "required_slot_secret_missing",
-        }
-        if not str(tool_name or "").startswith("ext."):
-            return {
-                "enabled": False,
-                "within_scope": True,
-                "reason": None,
-                "scope_payload": None,
-                "hard_deny": False,
-            }
-        policy = dict(effective_policy or {})
-        if not bool(policy.get("enabled", False)):
-            return {
-                "enabled": False,
-                "within_scope": True,
-                "reason": None,
-                "scope_payload": None,
-                "hard_deny": False,
-            }
-        sources = policy.get("sources")
-        if not isinstance(sources, list):
-            return {
-                "enabled": True,
-                "within_scope": False,
-                "reason": "external_access_unavailable",
-                "scope_payload": {
-                    "server_id": tool_name.split(".", 2)[1],
-                    "reason": "external_access_unavailable",
-                    "blocked_reason": "external_access_unavailable",
-                    "requested_slots": [],
-                    "missing_bound_slots": [],
-                    "missing_secret_slots": [],
-                },
-                "hard_deny": True,
-            }
-        parts = str(tool_name or "").split(".", 2)
-        if len(parts) != 3 or not parts[1]:
-            return {
-                "enabled": True,
-                "within_scope": False,
-                "reason": "invalid_external_tool_name",
-                "scope_payload": {
-                    "reason": "invalid_external_tool_name",
-                    "blocked_reason": "invalid_external_tool_name",
-                    "requested_slots": [],
-                    "missing_bound_slots": [],
-                    "missing_secret_slots": [],
-                },
-                "hard_deny": True,
-            }
-        server_id = parts[1]
-        metadata = context.metadata if isinstance(getattr(context, "metadata", None), dict) else {}
-        cached = metadata.get("_mcp_effective_external_access")
-        if not isinstance(cached, dict):
-            try:
-                cached = await self.dependencies.external_access_evaluator.resolve_for_sources(
-                    sources=[dict(item) for item in sources if isinstance(item, dict)],
-                    effective_policy=policy,
-                )
-                metadata["_mcp_effective_external_access"] = cached
-            except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
-                logger.debug("Failed to evaluate MCP Hub external access: {}", exc)
-                return {
-                    "enabled": True,
-                    "within_scope": False,
-                    "reason": "external_access_unavailable",
-                    "scope_payload": {
-                        "server_id": server_id,
-                        "reason": "external_access_unavailable",
-                        "blocked_reason": "external_access_unavailable",
-                        "requested_slots": [],
-                        "missing_bound_slots": [],
-                        "missing_secret_slots": [],
-                    },
-                    "hard_deny": True,
-                }
-
-        rows = cached.get("servers") if isinstance(cached, dict) else None
-        server_row = next(
-            (
-                row for row in rows
-                if isinstance(row, dict) and str(row.get("server_id") or "") == server_id
-            ),
-            None,
-        ) if isinstance(rows, list) else None
-        if not isinstance(server_row, dict):
-            return {
-                "enabled": True,
-                "within_scope": False,
-                "reason": "external_server_not_bound",
-                "scope_payload": {
-                    "server_id": server_id,
-                    "reason": "external_server_not_bound",
-                    "blocked_reason": "external_server_not_bound",
-                    "requested_slots": [],
-                    "missing_bound_slots": [],
-                    "missing_secret_slots": [],
-                },
-                "hard_deny": True,
-            }
-        runtime_executable = bool(server_row.get("runtime_executable"))
-        reason = str(server_row.get("blocked_reason") or "").strip() or None
-        requested_slots = [
-            str(slot).strip()
-            for slot in (server_row.get("requested_slots") or [])
-            if str(slot).strip()
-        ]
-        bound_slots = [
-            str(slot).strip()
-            for slot in (server_row.get("bound_slots") or [])
-            if str(slot).strip()
-        ]
-        missing_bound_slots = [
-            str(slot).strip()
-            for slot in (server_row.get("missing_bound_slots") or [])
-            if str(slot).strip()
-        ]
-        missing_secret_slots = [
-            str(slot).strip()
-            for slot in (server_row.get("missing_secret_slots") or [])
-            if str(slot).strip()
-        ]
-        scope_payload = {
-            "server_id": server_id,
-            "server_name": str(server_row.get("server_name") or "").strip() or None,
-            "reason": reason or ("external_server_allowed" if runtime_executable else "external_server_not_bound"),
-            "blocked_reason": reason or ("external_server_allowed" if runtime_executable else "external_server_not_bound"),
-            "requested_slots": requested_slots,
-            "bound_slots": bound_slots,
-            "missing_bound_slots": missing_bound_slots,
-            "missing_secret_slots": missing_secret_slots,
-        }
-        if not runtime_executable:
-            return {
-                "enabled": True,
-                "within_scope": False,
-                "reason": reason or "external_server_not_bound",
-                "scope_payload": scope_payload,
-                "hard_deny": (reason or "external_server_not_bound") in deny_only_reasons,
-            }
-        return {
-            "enabled": True,
-            "within_scope": True,
-            "reason": None,
-            "scope_payload": scope_payload,
-            "hard_deny": False,
-        }
+        self._sync_tool_execution_dependencies()
+        return await self._tool_execution_security._evaluate_external_access(
+            effective_policy=effective_policy,
+            tool_name=tool_name,
+            context=context,
+        )
 
     async def _handle_tools_call(
         self,
@@ -3339,40 +2363,7 @@ class MCPProtocol:
         context: RequestContext
     ) -> dict[str, Any]:
         """Execute a tool."""
-        start_ts = time.time()
-        try:
-            prepared = await self.prepare_tool_call(params=params, context=context)
-        except Exception as exc:
-            if self._should_record_tool_use(context):
-                try:
-                    status, reason_code = classify_tool_use_exception(exc)
-                    scope_payload = None
-                    if isinstance(exc, GovernanceDeniedError) and isinstance(exc.governance, dict):
-                        path_scope = exc.governance.get("path_scope")
-                        if isinstance(path_scope, dict):
-                            scope_payload = path_scope
-                    event = self._build_tool_use_event(
-                        context=context,
-                        requested_tool_name=(
-                            params.get("name") if isinstance(params, dict) else None
-                        ),
-                        status=status,
-                        execution_origin="failed_before_execution",
-                        duration_ms=self._tool_use_duration_ms(start_ts),
-                        reason_code=reason_code,
-                        tool_args=(
-                            params.get("arguments") if isinstance(params, dict) else None
-                        ),
-                        scope_payload=scope_payload,
-                    )
-                    await self._record_tool_use_event(event)
-                except Exception as record_exc:  # noqa: BLE001 - preserve original exception.
-                    logger.warning(
-                        "Failed to build or record prepare-failure tool-use event: {}",
-                        record_exc.__class__.__name__,
-                    )
-            raise
-        return await self.execute_prepared_tool_call(prepared)
+        return await self._tool_execution.handle_tools_call(params, context)
 
     async def prepare_tool_call(
         self,
@@ -3381,648 +2372,58 @@ class MCPProtocol:
         idempotency_key: str | None = None,
     ) -> PreparedToolCall:
         """Prepare a tool invocation through protocol policy, validation, and governance checks."""
-        tool_name = params.get("name")
-        tool_args = params.get("arguments", {})
-        normalized_idempotency_key = self._normalize_idempotency_key(params, idempotency_key=idempotency_key)
-
-        if not tool_name:
-            raise InvalidParamsException("Tool name is required")
-
-        # Strictly validate tool name
-        if not self._tool_name_re.match(tool_name):
-            raise InvalidParamsException("Invalid tool name")
-
-        # Enforce allowed-tools constraints from context metadata (skill execution)
-        if not self._is_tool_allowed_by_context(tool_name, tool_args, context):
-            raise PermissionError(f"Tool '{tool_name}' not allowed by execution context")
-        effective_policy = await self._resolve_effective_tool_policy(context)
-        within_effective_policy = self._is_tool_allowed_by_effective_policy(tool_name, tool_args, effective_policy)
-        external_access_result = await self._evaluate_external_access(
-            effective_policy=effective_policy,
-            tool_name=tool_name,
+        return await self._tool_execution.prepare_tool_call(
+            params=params,
             context=context,
-        )
-        external_block_reason = str(external_access_result.get("reason") or "").strip()
-        if bool(external_access_result.get("hard_deny")) or external_block_reason in {
-            "required_slot_not_granted",
-            "required_slot_secret_missing",
-        }:
-            external_scope = (
-                dict(external_access_result.get("scope_payload") or {})
-                if isinstance(external_access_result.get("scope_payload"), dict)
-                else {}
-            )
-            blocked_reason = external_block_reason or "external_access_denied"
-            raise GovernanceDeniedError(
-                "Blocked external credential use",
-                governance={
-                    "action": "deny",
-                    "status": "deny",
-                    "reason_code": blocked_reason,
-                    "external_access": external_scope,
-                },
-            )
-
-        # Find module for tool
-        module = await self.module_registry.find_module_for_tool(tool_name)
-        if not module:
-            raise InvalidParamsException(f"Tool not found: {tool_name}")
-
-        module_id = self.module_registry.get_module_id_for_tool(tool_name) or getattr(module, "name", None)
-
-        # Look up tool definition early for scope gating and validation
-        tool_def = await self._resolve_tool_definition(module, tool_name)
-        if isinstance(tool_def, dict):
-            try:
-                tool_def = ensure_tool_definition_eval_metadata(tool_def)
-            except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
-                context.logger.opt(exception=exc).debug(
-                    "Failed to attach eval metadata to resolved tool definition",
-                    module_id=module_id,
-                    tool_name=tool_name,
-                    error_type=exc.__class__.__name__,
-                )
-        tool_args = self._harden_and_sanitize_tool_arguments(module, tool_args)
-
-        # Determine write-capable status from sanitized arguments.
-        is_write = self._resolve_write_classification(
-            module,
-            tool_name,
-            tool_args,
-            tool_def,
-            fallback_to_name_heuristic=True,
+            idempotency_key=idempotency_key,
         )
 
-        module_allowed = await self._has_module_permission(context, module_id)
-        tool_allowed = await self._has_tool_permission(context, tool_name, is_write=is_write)
-
-        if not module_allowed and not tool_allowed:
-            raise PermissionError(f"Permission denied for module: {module_id}")
-
-        if not tool_allowed:
-            raise PermissionError(f"Permission denied for tool: {tool_name}")
-
-        # Protocol-level pre-execution validation for write-capable tools
-        # Ensures that modules validate arguments even if they forgot to call
-        # validate_tool_arguments inside execute_tool.
-        # Look up tool definition from module cache where possible
-        if tool_def is None:
-            tool_def = await self._resolve_tool_definition(module, tool_name)
-
-        idempotency_cache_key = None
-        try:
-            # Lightweight inputSchema validation (config-gated)
-            cfg = get_config()
-            if cfg.validate_input_schema and isinstance(tool_def, dict):
-                schema = tool_def.get("inputSchema") or {}
-                try:
-                    self._validate_input_schema(schema, tool_args)
-                except InvalidParamsException:
-                    with contextlib.suppress(_MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS):
-                        self.metrics.record_tool_invalid_params(getattr(module, "name", "unknown"), str(tool_name))
-                    raise
-
-            # Optional policy: disable write-capable tools entirely
-            if is_write:
-                if get_config().disable_write_tools:
-                    raise PermissionError("Write tools are disabled by server policy")
-                # Check module overrides validator
-                if module.__class__.validate_tool_arguments is BaseModule.validate_tool_arguments:
-                    with contextlib.suppress(_MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS):
-                        self.metrics.record_tool_validator_missing(getattr(module, "name", "unknown"), str(tool_name))
-                    raise ValueError(
-                        "Write-capable tool requires module.validate_tool_arguments override"
-                    )
-                # Run validator
-                try:
-                    module.validate_tool_arguments(tool_name, tool_args)
-                except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as ve:
-                    with contextlib.suppress(_MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS):
-                        self.metrics.record_tool_invalid_params(getattr(module, "name", "unknown"), str(tool_name))
-                    raise ValueError(f"Invalid parameters for tool {tool_name}: {ve}") from ve
-
-                if normalized_idempotency_key:
-                    idempotency_cache_key = self._make_idempotency_cache_key(
-                        context,
-                        module_id or getattr(module, "name", "unknown"),
-                        tool_name,
-                        normalized_idempotency_key,
-                    )
-        except ValueError as ve:
-            # Surface as JSON-RPC INVALID_PARAMS at the protocol layer
-            # by raising a sentinel exception handled by process_request
-            raise InvalidParamsException(str(ve)) from ve
-
-        policy_document = (effective_policy or {}).get("policy_document")
-        path_scope_mode = ""
-        if isinstance(policy_document, dict):
-            path_scope_mode = str(policy_document.get("path_scope_mode") or "").strip()
-        elif isinstance(policy_document, BaseModel):
-            if hasattr(policy_document, "model_dump"):
-                policy_document_payload = policy_document.model_dump()
-            else:  # pragma: no cover - pydantic v1 compatibility
-                policy_document_payload = policy_document.dict()
-            path_scope_mode = str(policy_document_payload.get("path_scope_mode") or "").strip()
-        path_scope_candidates = None
-        if bool((effective_policy or {}).get("enabled")) and path_scope_mode not in {"", "none"}:
-            path_scope_candidates = await self._extract_path_scope_candidates(
-                module=module,
-                tool_name=tool_name,
-                tool_args=tool_args,
-                context=context,
-                tool_def=tool_def if isinstance(tool_def, dict) else None,
-            )
-        path_scope_result = await self._evaluate_path_scope(
-            effective_policy=effective_policy,
-            tool_name=tool_name,
-            tool_args=tool_args,
+    async def _prepare_tool_call_inline(
+        self,
+        params: dict[str, Any],
+        context: RequestContext,
+        idempotency_key: str | None = None,
+    ) -> PreparedToolCall:
+        """Prepare a tool invocation through protocol policy, validation, and governance checks."""
+        self._sync_tool_execution_dependencies()
+        return await self._tool_execution_security.prepare_tool_call(
+            params=params,
             context=context,
-            tool_def=tool_def if isinstance(tool_def, dict) else None,
-            path_scope_candidates=path_scope_candidates,
-        )
-        within_resolved_scope = bool(path_scope_result.get("within_scope", True)) and bool(
-            external_access_result.get("within_scope", True)
-        )
-        approval_reason = str(path_scope_result.get("reason") or "").strip() or None
-        if approval_reason is None:
-            approval_reason = str(external_access_result.get("reason") or "").strip() or None
-        scope_payload: dict[str, Any] | None = None
-        for payload in (
-            path_scope_result.get("scope_payload"),
-            external_access_result.get("scope_payload"),
-        ):
-            if isinstance(payload, dict):
-                scope_payload = dict(scope_payload or {})
-                scope_payload.update(payload)
-
-        path_scope_block_reason = str(path_scope_result.get("reason") or "").strip()
-        if path_scope_block_reason and not bool(path_scope_result.get("within_scope", True)):
-            requires_approval = bool(path_scope_result.get("force_approval", False))
-            if not requires_approval or path_scope_block_reason == "workspace_unresolvable_for_trust_source":
-                raise GovernanceDeniedError(
-                    "Blocked path-scoped tool use",
-                    governance={
-                        "action": "deny",
-                        "status": "deny",
-                        "reason_code": path_scope_block_reason,
-                        "path_scope": dict(scope_payload or {}),
-                    },
-                )
-
-        approval_result = await self._evaluate_runtime_approval(
-            effective_policy=effective_policy,
-            tool_name=tool_name,
-            tool_args=tool_args,
-            context=context,
-            tool_def=tool_def if isinstance(tool_def, dict) else None,
-            is_write=is_write,
-            within_effective_policy=within_effective_policy and within_resolved_scope,
-            force_approval=bool(path_scope_result.get("force_approval", False)),
-            approval_reason=approval_reason,
-            scope_payload=scope_payload,
-        )
-        approval_status = str(approval_result.get("status") or "allow").strip().lower()
-        if approval_status == "approval_required":
-            raise ApprovalRequiredError(
-                "Approval required by MCP Hub policy",
-                approval=approval_result.get("approval") if isinstance(approval_result.get("approval"), dict) else None,
-            )
-        if approval_status != "allow":
-            raise PermissionError(f"Tool '{tool_name}' not allowed by MCP Hub policy")
-
-        args_hash = self._hash_arguments(tool_args if isinstance(tool_args, dict) else {})
-        await self._run_governance_preflight(
-            tool_name=tool_name,
-            tool_args=tool_args if isinstance(tool_args, dict) else {},
-            tool_def=tool_def if isinstance(tool_def, dict) else None,
-            context=context,
-        )
-        await self._run_pre_tool_hooks(
-            tool_name=tool_name,
-            tool_args=tool_args,
-            module_id=module_id,
-            tool_def=tool_def if isinstance(tool_def, dict) else None,
-            is_write=is_write,
-            arguments_hash=args_hash,
-            context=context,
-            scope_payload=scope_payload,
-        )
-        context_fingerprint = self._fingerprint_request_context(context)
-        integrity_tag = self._build_prepared_tool_call_integrity_tag(
-            tool_name=tool_name,
-            module_id=module_id,
-            is_write=is_write,
-            idempotency_cache_key=idempotency_cache_key,
-            arguments_hash=args_hash,
-            context_fingerprint=context_fingerprint,
-        )
-
-        return PreparedToolCall(
-            tool_name=tool_name,
-            tool_args=tool_args,
-            module=module,
-            module_id=module_id,
-            tool_def=tool_def if isinstance(tool_def, dict) else None,
-            is_write=is_write,
-            normalized_idempotency_key=normalized_idempotency_key,
-            idempotency_cache_key=idempotency_cache_key,
-            arguments_hash=args_hash,
-            context_fingerprint=context_fingerprint,
-            integrity_tag=integrity_tag,
-            context=context,
-            scope_payload=scope_payload,
+            idempotency_key=idempotency_key,
+            hooks=self._tool_execution_hooks,
         )
 
     async def execute_prepared_tool_call(self, prepared: PreparedToolCall) -> dict[str, Any]:
         """Execute a previously prepared tool invocation."""
-        self._verify_prepared_tool_call_integrity(prepared)
-        tool_name = prepared.tool_name
-        tool_args = prepared.tool_args
-        module = prepared.module
-        module_id = prepared.module_id
-        tool_def = prepared.tool_def
-        is_write = prepared.is_write
-        normalized_idempotency_key = prepared.normalized_idempotency_key
-        idempotency_cache_key = prepared.idempotency_cache_key
-        args_hash = prepared.arguments_hash
-        context = prepared.context
-        execution_start_ts = time.time()
+        self._sync_tool_execution_dependencies()
+        return await self._tool_execution.execute_prepared_tool_call(prepared)
 
-        async def _record_prepared_event(
-            *,
-            status: ToolUseStatus,
-            execution_origin: str,
-            reason_code: str | None = None,
-            payload: dict[str, Any] | None = None,
-            idempotency_replay: bool = False,
-        ) -> None:
-            try:
-                if not self._should_record_tool_use(context):
-                    return
-                event = self._build_tool_use_event(
-                    context=context,
-                    requested_tool_name=tool_name,
-                    effective_tool_name=tool_name,
-                    status=status,
-                    execution_origin=execution_origin,
-                    duration_ms=self._tool_use_duration_ms(execution_start_ts),
-                    module_id=module_id or getattr(module, "name", None),
-                    tool_def=tool_def if isinstance(tool_def, dict) else None,
-                    payload=payload,
-                    tool_args=tool_args,
-                    scope_payload=prepared.scope_payload,
-                    is_write=is_write,
-                    reason_code=reason_code,
-                    idempotency_replay=idempotency_replay,
-                )
-                await self._record_tool_use_event(event)
-            except Exception as exc:  # noqa: BLE001 - reporting must not affect tool calls.
-                logger.warning(
-                    "Failed to build or record prepared tool-use event: {}",
-                    exc.__class__.__name__,
-                )
-
-        async def _execute_tool_call() -> dict[str, Any]:
-            # Optional per-tool/category rate limits (ingestion vs read)
-            try:
-                # Categorization for per-category rate limiting
-                cfg = get_config()
-                category = None
-                # 1) Prefer tool metadata.category if available
-                try:
-                    meta = (tool_def or {}).get("metadata") or {}
-                    cat = str(meta.get("category") or "").lower()
-                    if cat in {"ingestion", "management", "read"}:
-                        category = cat
-                except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-                    category = None
-                # 2) Config-driven mapping
-                if not category:
-                    try:
-                        if isinstance(cfg.tool_category_map, dict) and tool_name in cfg.tool_category_map:
-                            category = str(cfg.tool_category_map.get(tool_name))
-                    except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-                        category = None
-                # 3) Heuristic fallback
-                if not category:
-                    ingestion_tools = {'ingest_media', 'update_media', 'delete_media'}
-                    category = 'ingestion' if tool_name in ingestion_tools else 'read'
-                key_owner = f"user:{context.user_id}" if context.user_id else (f"client:{context.client_id}" if context.client_id else "anon")
-                rl_key = f"{key_owner}:tool:{tool_name}:cat:{category}"
-                await self.rate_limiter.check_rate_limit(rl_key, category=category)
-            except RateLimitExceeded:
-                raise
-            except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-                # Best-effort; do not block on limiter errors
-                pass
-
-            # Execute tool with circuit breaker (pass context through)
-            t0 = time.time()
-
-            try:
-                # Trace the tool call with OTEL
-                with self.telemetry.trace_context(
-                    "mcp.tool_call",
-                    {
-                        "mcp.tool": tool_name,
-                        "mcp.module": getattr(module, "name", "unknown"),
-                        "mcp.user_id": str(context.user_id or ""),
-                        "mcp.client_id": str(context.client_id or ""),
-                    },
-                ) as span:
-                    try:
-                        execution_args = tool_args
-                        tool_schema_props = (
-                            (tool_def or {}).get("inputSchema", {}).get("properties", {})
-                            if isinstance(tool_def, dict)
-                            else {}
-                        )
-                        if (
-                            normalized_idempotency_key
-                            and isinstance(tool_args, dict)
-                            and isinstance(tool_schema_props, dict)
-                            and "idempotencyKey" in tool_schema_props
-                            and "idempotencyKey" not in tool_args
-                        ):
-                            execution_args = dict(tool_args)
-                            execution_args["idempotencyKey"] = normalized_idempotency_key
-                        result = await module.execute_with_circuit_breaker(
-                            module.execute_tool,
-                            tool_name,
-                            execution_args,
-                            context
-                        )
-                        span.set_attribute("mcp.status", "success")
-                    except InvalidParamsException as _tool_e:
-                        span.set_attribute("mcp.status", "failure")
-                        span.set_attribute("mcp.error_type", _tool_e.__class__.__name__)
-                        span.set_attribute("mcp.error_message", str(_tool_e)[:200])
-                        with contextlib.suppress(_MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS):
-                            self.metrics.record_tool_invalid_params(getattr(module, "name", "unknown"), str(tool_name))
-                        raise
-                    except (TypeError, ValueError) as _tool_e:
-                        # Module argument validators often raise ValueError/TypeError.
-                        # Normalize those to INVALID_PARAMS so HTTP callers receive 400.
-                        span.set_attribute("mcp.status", "failure")
-                        span.set_attribute("mcp.error_type", _tool_e.__class__.__name__)
-                        span.set_attribute("mcp.error_message", str(_tool_e)[:200])
-                        with contextlib.suppress(_MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS):
-                            self.metrics.record_tool_invalid_params(getattr(module, "name", "unknown"), str(tool_name))
-                        raise InvalidParamsException(str(_tool_e)) from _tool_e
-                    except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as _tool_e:
-                        sanitized_tool_error = self._generic_exception_like(
-                            _tool_e,
-                            _MCP_TOOL_EXECUTION_ERROR,
-                        )
-                        span.set_attribute("mcp.status", "failure")
-                        span.set_attribute("mcp.error_type", sanitized_tool_error.__class__.__name__)
-                        span.set_attribute("mcp.error_message", _MCP_TOOL_EXECUTION_ERROR)
-                        raise sanitized_tool_error from None
-                    finally:
-                        span.set_attribute("mcp.duration_ms", max(0.0, (time.time() - t0) * 1000.0))
-
-                # Format result
-                duration_ms = max(0.0, (time.time() - t0) * 1000.0)
-                profile_id = self._extract_eval_profile_id(context)
-                result = attach_execution_eval_metadata(
-                    result,
-                    tool_name=tool_name,
-                    tool_def=tool_def,
-                    profile_id=profile_id,
-                    duration_ms=duration_ms,
-                )
-                execution_eval = execution_eval_metadata_from_tool_definition(
-                    tool_name=tool_name,
-                    tool_def=tool_def,
-                    profile_id=profile_id,
-                    duration_ms=duration_ms,
-                )
-                result_eval = self._tool_use_eval_metadata(payload=result if isinstance(result, dict) else None)
-                for key in (
-                    "tool_prompt_id",
-                    "tool_prompt_version",
-                    "action_family",
-                    "result_kind",
-                    "path_filter_used",
-                    "truncated",
-                    "reason_code",
-                ):
-                    if key in result_eval:
-                        execution_eval[key] = result_eval[key]
-                if isinstance(result, str):
-                    content = [{"type": "text", "text": result}]
-                elif isinstance(result, list):
-                    content = result
-                elif isinstance(result, dict):
-                    # Preserve structured tool results as JSON content instead of stringifying.
-                    content = [{"type": "json", "json": result}]
-                else:
-                    content = [{"type": "text", "text": str(result)}]
-
-                module_name = module_id or getattr(module, "name", None)
-                # Record module operation metrics
-                try:
-                    duration = max(0.0, time.time() - t0)
-                    self.metrics.record_module_operation(module=module_name or "unknown", operation="tools_call", duration=duration, success=True)
-                except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-                    pass
-                self._audit_tool_event(
-                    context,
-                    tool_name,
-                    module_name,
-                    status="success",
-                    duration_ms=duration_ms,
-                    arguments_hash=args_hash,
-                )
-                response_payload = {
-                    "content": content,
-                    "module": module_name,
-                    "tool": tool_name,
-                    "eval": execution_eval,
-                }
-                await self._run_post_tool_hooks(
-                    tool_name=tool_name,
-                    tool_args=tool_args,
-                    module_id=module_name,
-                    tool_def=tool_def if isinstance(tool_def, dict) else None,
-                    is_write=is_write,
-                    arguments_hash=args_hash,
-                    context=context,
-                    scope_payload=prepared.scope_payload,
-                    status="success",
-                    duration_ms=duration_ms,
-                )
-                return response_payload
-
-            except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as e:
-                duration_ms = max(0.0, (time.time() - t0) * 1000.0)
-                context.logger.error(  # noqa: TRY400 - structured audit log records sanitized type only.
-                    "Tool execution failed",
-                    error_type=e.__class__.__name__,
-                )
-                try:
-                    duration = max(0.0, time.time() - t0)
-                    self.metrics.record_module_operation(module=getattr(module, "name", "unknown"), operation="tools_call", duration=duration, success=False)
-                except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-                    pass
-                self._audit_tool_event(
-                    context,
-                    tool_name,
-                    module_id or getattr(module, "name", None),
-                    status="failure",
-                    duration_ms=duration_ms,
-                    arguments_hash=args_hash,
-                    error=e,
-                )
-                await self._run_post_tool_hooks(
-                    tool_name=tool_name,
-                    tool_args=tool_args,
-                    module_id=module_id or getattr(module, "name", None),
-                    tool_def=tool_def if isinstance(tool_def, dict) else None,
-                    is_write=is_write,
-                    arguments_hash=args_hash,
-                    context=context,
-                    scope_payload=prepared.scope_payload,
-                    status="failure",
-                    duration_ms=duration_ms,
-                    error=e,
-                )
-                raise
-
-        if is_write and idempotency_cache_key:
-            try:
-                cfg = get_config()
-                ttl = max(1, int(getattr(cfg, "idempotency_ttl_seconds", 300)))
-                max_size = max(1, int(getattr(cfg, "idempotency_cache_size", 512)))
-                if args_hash is None:
-                    raise InvalidParamsException("Unable to fingerprint tool arguments for idempotency")
-                arguments_bound = await self._idempotency.bind_arguments(
-                    idempotency_cache_key,
-                    args_hash,
-                    ttl=ttl,
-                    max_size=max_size,
-                )
-                if not arguments_bound:
-                    raise InvalidParamsException("Idempotency key was already used with different arguments")
-                module_timeout = int(getattr(getattr(module, "config", None), "timeout_seconds", cfg.module_timeout))
-                lock_ttl = max(ttl, module_timeout * 2)
-                payload, from_cache = await self._idempotency.run(
-                    idempotency_cache_key,
-                    _execute_tool_call,
-                    ttl=ttl,
-                    max_size=max_size,
-                    lock_ttl=lock_ttl,
-                )
-                try:
-                    if from_cache:
-                        self.metrics.record_idempotency_hit(module_id or getattr(module, "name", "unknown"), str(tool_name))
-                    else:
-                        self.metrics.record_idempotency_miss(module_id or getattr(module, "name", "unknown"), str(tool_name))
-                except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-                    pass
-            except Exception as exc:
-                status, reason_code = classify_tool_use_exception(exc)
-                await _record_prepared_event(
-                    status=status,
-                    execution_origin=(
-                        self._tool_use_execution_origin_for_failure(status)
-                        if status != "error"
-                        else "executed"
-                    ),
-                    reason_code=reason_code,
-                )
-                raise
-            await _record_prepared_event(
-                status="success",
-                execution_origin="cached" if from_cache else "executed",
-                payload=payload if isinstance(payload, dict) else None,
-                idempotency_replay=from_cache,
-            )
-            return payload
-
-        try:
-            payload = await _execute_tool_call()
-        except Exception as exc:
-            status, reason_code = classify_tool_use_exception(exc)
-            await _record_prepared_event(
-                status=status,
-                execution_origin=(
-                    self._tool_use_execution_origin_for_failure(status)
-                    if status != "error"
-                    else "executed"
-                ),
-                reason_code=reason_code,
-            )
-            raise
-        await _record_prepared_event(
-            status="success",
-            execution_origin="executed",
-            payload=payload if isinstance(payload, dict) else None,
-        )
-        return payload
+    async def _execute_prepared_tool_call_inline(self, prepared: PreparedToolCall) -> dict[str, Any]:
+        """Execute a previously prepared tool invocation."""
+        self._sync_tool_execution_dependencies()
+        return await self._tool_execution_runtime.execute_prepared_tool_call(prepared)
 
     # -------------------------
     # Idempotency cache helpers
     # -------------------------
     def _make_idempotency_cache_key(self, context: RequestContext, module_name: str, tool_name: str, idempotency_key: str) -> str:
-        owner = f"user:{context.user_id}" if context.user_id else (f"client:{context.client_id}" if context.client_id else "anon")
-        return f"{owner}|module:{module_name}|tool:{tool_name}|key:{idempotency_key}"
+        runtime = getattr(self, "_tool_execution_runtime", None)
+        if runtime is None:
+            return ToolExecutionRuntime.make_idempotency_cache_key(
+                context,
+                module_name,
+                tool_name,
+                idempotency_key,
+            )
+        return runtime.make_idempotency_cache_key(
+            context,
+            module_name,
+            tool_name,
+            idempotency_key,
+        )
 
     def _validate_input_schema(self, schema: dict[str, Any], args: dict[str, Any]) -> None:
-        """Quick JSON Schema checks: required keys, primitive types, unknown fields.
-        Only applies when schema.type == object.
-        """
-        try:
-            if not isinstance(schema, dict):
-                return
-            if schema.get("type") != "object":
-                return
-            if not isinstance(args, dict):
-                raise InvalidParamsException("Arguments must be an object")
-            props = schema.get("properties") or {}
-            required = schema.get("required") or []
-            addl = schema.get("additionalProperties", True)
-
-            # Required
-            for key in required:
-                if key not in args or args.get(key) is None:
-                    raise InvalidParamsException(f"Missing required parameter: {key}")
-
-            # Unknown fields
-            if addl is False:
-                unknown = [k for k in args if k not in props]
-                if unknown:
-                    raise InvalidParamsException(f"Unknown parameters: {', '.join(unknown)}")
-
-            # Primitive type checks
-            def _type_ok(expected: str, value: Any) -> bool:
-                mapping = {
-                    "string": str,
-                    "number": (int, float),
-                    "integer": int,
-                    "boolean": bool,
-                    "object": dict,
-                    "array": list,
-                }
-                py = mapping.get(expected)
-                if py is None:
-                    return True
-                # number should not reject ints; python isinstance(True, int) caveat
-                if expected in {"number", "integer"} and isinstance(value, bool):
-                    return False
-                return isinstance(value, py)
-
-            for k, v in args.items():
-                if k in props:
-                    p = props.get(k) or {}
-                    t = p.get("type")
-                    if isinstance(t, str) and not _type_ok(t, v):
-                        raise InvalidParamsException(f"Invalid type for '{k}': expected {t}")
-        except InvalidParamsException:
-            raise
-        except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS:
-            # Be forgiving on schema format errors
-            return
+        self._tool_execution_security.validate_input_schema(schema, args)
 
     async def _handle_resources_list(
         self,

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -1568,7 +1568,7 @@ class MCPProtocol:
                     skip_rate_limit = True
             except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
                 log.debug(
-                    "Failed to read rg_ingress_enforced from metadata; rate limit will be enforced",
+                    "Failed to read rg_ingress_enforced from metadata; rate limit will be enforced: {error_type}",
                     error_type=type(exc).__name__,
                 )
                 skip_rate_limit = False
@@ -2172,7 +2172,8 @@ class MCPProtocol:
                             tool_copy = ensure_tool_definition_eval_metadata(tool_copy)
                         except _MCP_PROTOCOL_NONCRITICAL_EXCEPTIONS as exc:
                             context.logger.opt(exception=exc).debug(
-                                "Failed to attach eval metadata to listed tool",
+                                "Failed to attach eval metadata to listed tool: module_id={module_id} "
+                                "tool_name={tool_name} error_type={error_type}",
                                 module_id=module_id,
                                 tool_name=name,
                                 error_type=exc.__class__.__name__,

--- a/tldw_Server_API/app/core/MCP_unified/protocol_types.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol_types.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from loguru import logger
+
+from .modules.base import BaseModule
+
+
+class InvalidParamsException(Exception):
+    """Raised when tool parameters fail validation or validators are missing for write tools."""
+    pass
+
+
+class GovernanceDeniedError(PermissionError):
+    """Permission error carrying structured governance decision details."""
+
+    def __init__(self, message: str, governance: dict[str, Any] | None = None):
+        super().__init__(message)
+        self.governance = governance or {}
+
+
+class ApprovalRequiredError(PermissionError):
+    """Permission error carrying structured MCP Hub approval request details."""
+
+    def __init__(self, message: str, approval: dict[str, Any] | None = None):
+        super().__init__(message)
+        self.approval = approval or {}
+
+
+class RequestContext:
+    """Context for request processing.
+
+    Request contexts store caller metadata and explicit database path mappings
+    only. Host-specific database path resolution is owned by MCPProtocol or
+    MCPServer dependencies so standalone callers do not import tldw_server
+    adapters through this neutral context object.
+    """
+    def __init__(
+        self,
+        request_id: str,
+        user_id: str | None = None,
+        client_id: str | None = None,
+        session_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        db_paths: dict[str, str] | None = None,
+    ):
+        self.request_id = request_id
+        self.user_id = user_id
+        self.client_id = client_id
+        self.session_id = session_id
+        self.metadata = metadata or {}
+        self.start_time = datetime.now(timezone.utc)
+        self.db_paths = dict(db_paths or {})
+        # Build a bound logger for this request
+        self.logger = logger.bind(
+            request_id=request_id,
+            user_id=user_id,
+            client_id=client_id,
+            session_id=session_id,
+        )
+
+
+class _TrustedCompatClaimsSentinel:
+    """Object-identity marker for server-created mounted auth compatibility claims."""
+
+    def __repr__(self) -> str:
+        return "<trusted_mcp_compat_auth>"
+
+
+_TRUSTED_COMPAT_CLAIMS_SENTINEL = _TrustedCompatClaimsSentinel()
+_TRUSTED_COMPAT_CLAIMS_SENTINEL_KEY = "_server_auth_compat_sentinel"
+_TRUSTED_COMPAT_AUTH_VIA = frozenset({"single_user_api_key", "single_user_test_api_key"})
+_TRUSTED_COMPAT_CLAIMS_SOURCES = frozenset({"mounted_http", "mounted_ws"})
+
+
+def _metadata_claim_values(value: Any) -> tuple[Any, ...]:
+    """Return metadata claim values without iterating strings character-by-character."""
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return tuple(value)
+    return ()
+
+
+def _trusted_compat_claims_metadata(*, auth_via: str, compat_claims_source: str) -> dict[str, Any]:
+    """Return server-only metadata for mounted single-user compatibility claims."""
+    if auth_via not in _TRUSTED_COMPAT_AUTH_VIA:
+        raise ValueError("Unsupported compatibility auth source")
+    if compat_claims_source not in _TRUSTED_COMPAT_CLAIMS_SOURCES:
+        raise ValueError("Unsupported compatibility claims source")
+    return {
+        "auth_via": auth_via,
+        "trusted_auth_claims": True,
+        "compat_claims_source": compat_claims_source,
+        _TRUSTED_COMPAT_CLAIMS_SENTINEL_KEY: _TRUSTED_COMPAT_CLAIMS_SENTINEL,
+    }
+
+
+def _metadata_has_admin_claims(metadata: dict[str, Any]) -> bool:
+    """Return True when trusted metadata carries wildcard or admin claims."""
+    roles = {
+        str(role).strip().lower()
+        for role in _metadata_claim_values(metadata.get("roles"))
+        if str(role).strip()
+    }
+    permissions = {
+        str(permission).strip().lower()
+        for permission in _metadata_claim_values(metadata.get("permissions"))
+        if str(permission).strip()
+    }
+    return "admin" in roles or "*" in permissions
+
+
+def _has_trusted_compat_claims(context: RequestContext) -> bool:
+    """Return True only for server-created mounted compatibility auth claims."""
+    metadata = getattr(context, "metadata", None)
+    if not isinstance(metadata, dict):
+        return False
+    server_auth_keys = {
+        key
+        for key in metadata
+        if isinstance(key, str) and key.startswith("_server_auth_")
+    }
+    if server_auth_keys != {_TRUSTED_COMPAT_CLAIMS_SENTINEL_KEY}:
+        return False
+    if metadata.get(_TRUSTED_COMPAT_CLAIMS_SENTINEL_KEY) is not _TRUSTED_COMPAT_CLAIMS_SENTINEL:
+        return False
+    if metadata.get("trusted_auth_claims") is not True:
+        return False
+    if metadata.get("auth_via") not in _TRUSTED_COMPAT_AUTH_VIA:
+        return False
+    if metadata.get("compat_claims_source") not in _TRUSTED_COMPAT_CLAIMS_SOURCES:
+        return False
+    return _metadata_has_admin_claims(metadata)
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedToolCall:
+    """Prepared tool execution context reused by nested tool orchestration."""
+
+    tool_name: str
+    tool_args: Any
+    module: BaseModule
+    module_id: str | None
+    tool_def: dict[str, Any] | None
+    is_write: bool | None
+    normalized_idempotency_key: str | None
+    idempotency_cache_key: str | None
+    arguments_hash: str | None
+    context_fingerprint: str
+    integrity_tag: str
+    context: RequestContext
+    scope_payload: dict[str, Any] | None = None

--- a/tldw_Server_API/app/core/MCP_unified/server.py
+++ b/tldw_Server_API/app/core/MCP_unified/server.py
@@ -88,7 +88,7 @@ def _is_authnz_access_token(token: str) -> bool:
     except Exception as exc:  # noqa: BLE001 - AuthNZ exception types stay behind runtime providers.
         if not _is_authnz_exception(exc):
             raise
-        logger.debug("MCP AuthNZ provider token detection failed", error_type=exc.__class__.__name__)
+        logger.debug("MCP AuthNZ provider token detection failed: {error_type}", error_type=exc.__class__.__name__)
 
     try:
         payload = get_jwt_service().decode_access_token(token)

--- a/tldw_Server_API/app/core/MCP_unified/server.py
+++ b/tldw_Server_API/app/core/MCP_unified/server.py
@@ -19,7 +19,6 @@ from typing import Any, Optional
 from fastapi import HTTPException, WebSocket, WebSocketDisconnect
 from loguru import logger
 
-from tldw_Server_API.app.core.AuthNZ.exceptions import AuthenticationError
 from tldw_Server_API.app.core.AuthNZ.ip_allowlist import is_single_user_ip_allowed
 from tldw_Server_API.app.core.AuthNZ.jwt_service import get_jwt_service
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings, is_single_user_profile_mode
@@ -62,10 +61,17 @@ _MCP_SERVER_NONCRITICAL_EXCEPTIONS = (
     WebSocketDisconnect,
     RateLimitExceeded,
 )
-_AUTHNZ_TOKEN_DETECTION_EXCEPTIONS = _MCP_SERVER_NONCRITICAL_EXCEPTIONS + (AuthenticationError,)
+_AUTHNZ_TOKEN_DETECTION_EXCEPTIONS = _MCP_SERVER_NONCRITICAL_EXCEPTIONS
 
 _ENV_PLACEHOLDER_RE = re.compile(r"^\$\{(?P<name>[A-Z0-9_]+)(?::-(?P<default>.*))?\}$")
 _JSONRPC_EXPLICIT_NULL_ID_PREFIX = "__tldw_ws_jsonrpc_explicit_null_id_"
+
+
+def _is_authnz_exception(exc: Exception) -> bool:
+    module = exc.__class__.__module__
+    return module == "tldw_Server_API.app.core.AuthNZ.exceptions" or module.startswith(
+        "tldw_Server_API.app.core.AuthNZ.exceptions."
+    )
 
 
 def _is_authnz_access_token(token: str) -> bool:
@@ -78,11 +84,19 @@ def _is_authnz_access_token(token: str) -> bool:
         if TldwServerAuthProvider().is_authnz_access_token(token):
             return True
     except _AUTHNZ_TOKEN_DETECTION_EXCEPTIONS:
-        pass
+        logger.debug("MCP AuthNZ provider token detection unavailable")
+    except Exception as exc:  # noqa: BLE001 - AuthNZ exception types stay behind runtime providers.
+        if not _is_authnz_exception(exc):
+            raise
+        logger.debug("MCP AuthNZ provider token detection failed", error_type=exc.__class__.__name__)
 
     try:
         payload = get_jwt_service().decode_access_token(token)
     except _AUTHNZ_TOKEN_DETECTION_EXCEPTIONS:
+        return False
+    except Exception as exc:  # noqa: BLE001 - AuthNZ exception types stay behind runtime providers.
+        if not _is_authnz_exception(exc):
+            raise
         return False
     return isinstance(payload, dict) and bool(payload.get("sub"))
 
@@ -884,9 +898,23 @@ class MCPServer:
                 connection = self.connections[conn_id]
                 await connection.close(code=1001, reason="Connection timeout")
                 del self.connections[conn_id]
+                client_ip = str((connection.metadata or {}).get("client_ip") or "")
+                self._decrement_ip_connection_count(client_ip)
             # Update connection gauge
             with suppress(_MCP_SERVER_NONCRITICAL_EXCEPTIONS):
                 self.metrics_collector.update_connection_count("websocket", len(self.connections))
+
+    def _decrement_ip_connection_count(self, client_ip: str | None) -> None:
+        """Release one reserved per-IP WebSocket slot."""
+        if not client_ip:
+            return
+        try:
+            if client_ip in self._ip_connection_counts and self._ip_connection_counts[client_ip] > 0:
+                self._ip_connection_counts[client_ip] -= 1
+                if self._ip_connection_counts[client_ip] == 0:
+                    del self._ip_connection_counts[client_ip]
+        except _MCP_SERVER_NONCRITICAL_EXCEPTIONS:
+            pass
 
     async def _metrics_collection_loop(self):
         """Periodically collect and log metrics"""
@@ -1237,6 +1265,7 @@ class MCPServer:
             metadata["workspace_id"] = workspace_key
         if cwd_key:
             metadata["cwd"] = cwd_key
+        metadata["client_ip"] = client_ip
 
         if not await self._guard_websocket_start(websocket):
             return
@@ -1322,16 +1351,9 @@ class MCPServer:
                     await stream.stop()
             # Remove connection
             async with self.connection_lock:
-                if connection_id in self.connections:
-                    del self.connections[connection_id]
-                # Decrement per-IP count
-                try:
-                    if client_ip in self._ip_connection_counts and self._ip_connection_counts[client_ip] > 0:
-                        self._ip_connection_counts[client_ip] -= 1
-                        if self._ip_connection_counts[client_ip] == 0:
-                            del self._ip_connection_counts[client_ip]
-                except _MCP_SERVER_NONCRITICAL_EXCEPTIONS:
-                    pass
+                removed = self.connections.pop(connection_id, None)
+                if removed is not None:
+                    self._decrement_ip_connection_count(client_ip)
 
             logger.bind(connection_id=connection_id).info(f"WebSocket cleanup complete: {connection_id}")
             # Update connection gauge

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py
@@ -42,7 +42,7 @@ def test_registry_exposes_phase_one_mappings():
 
     assert registry.get_command("ls").backend_tools == ("fs.list",)
     assert registry.get_command("cat").backend_tools == ("fs.read", "fs.read_text")
-    assert registry.get_command("write").backend_tools == ("fs.write_text",)
+    assert registry.get_command("write").backend_tools == ("fs.write",)
     assert registry.get_command("write-create").backend_tools == ("fs.write",)
     assert registry.get_command("knowledge").backend_tools == ("knowledge.search", "knowledge.get")
     assert registry.get_command("media").backend_tools == ("media.search", "media.get")
@@ -72,8 +72,12 @@ def test_registry_filters_visible_backend_tools_for_multi_backend_commands() -> 
     assert visible["cat"].backend_tools == ("fs.read_text",)
 
     visible = registry.visible_commands(allowed_tools={"fs.write"})
+    assert "write" in visible
     assert "write-create" in visible
+
+    visible = registry.visible_commands(allowed_tools={"fs.write_text"})
     assert "write" not in visible
+    assert "write-create" not in visible
 
 
 def test_registry_filters_visible_backend_tools_for_mcp_catalogs() -> None:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_extraction_contracts.py
@@ -12,7 +12,7 @@ import pytest
 
 MCP_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = Path(__file__).resolve().parents[5]
-STANDALONE_MCP_ROOT = REPO_ROOT / "mcp_unified"
+STANDALONE_MCP_ROOT = REPO_ROOT / "apps" / "mcp-unified" / "src" / "mcp_unified"
 MCP_PACKAGE = "tldw_Server_API.app.core.MCP_unified"
 EXPECTED_INTERFACE_FILES = {"runtime.py", "policy.py", "storage.py"}
 
@@ -991,3 +991,73 @@ def test_protocol_instances_do_not_share_prepared_call_secrets() -> None:
     second = MCPProtocol()
     assert first is not second
     assert first._prepared_call_secret != second._prepared_call_secret  # noqa: SLF001
+
+
+def test_protocol_reexports_tool_execution_shared_symbols() -> None:
+    from tldw_Server_API.app.core.MCP_unified import protocol
+    from tldw_Server_API.app.core.MCP_unified.modules.base import BaseModule
+
+    expected = {
+        "RequestContext",
+        "PreparedToolCall",
+        "InvalidParamsException",
+        "GovernanceDeniedError",
+        "ApprovalRequiredError",
+        "IdempotencyManager",
+        "_trusted_compat_claims_metadata",
+    }
+
+    missing = sorted(name for name in expected if not hasattr(protocol, name))
+    assert missing == []
+
+    hints = get_type_hints(protocol.PreparedToolCall)
+    assert hints["module"] is BaseModule
+
+
+def test_tool_execution_package_does_not_import_protocol_facade() -> None:
+    package_dir = MCP_ROOT / "tool_execution"
+    assert package_dir.is_dir()
+    forbidden = {
+        f"{MCP_PACKAGE}.protocol",
+        "tldw_Server_API.app.core.MCP_unified.protocol",
+    }
+    offenders: dict[str, list[str]] = {}
+
+    def package_for(path: Path) -> str:
+        relative_parent = path.relative_to(MCP_ROOT).parent
+        return ".".join((MCP_PACKAGE, *relative_parent.parts))
+
+    for path in package_dir.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        current_package = package_for(path)
+        imports = _resolved_import_sources_for(path, current_package)
+        bad_imports = [
+            source
+            for source in imports
+            if source in forbidden
+            or source.endswith(".MCP_unified.protocol")
+        ]
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                source = _resolve_import_from_source(current_package, node.module, node.level)
+                if source == MCP_PACKAGE and any(alias.name == "protocol" for alias in node.names):
+                    bad_imports.append(f"{source}.protocol")
+        if bad_imports:
+            offenders[str(path.relative_to(MCP_ROOT))] = bad_imports
+
+        uses_facade = [
+            "MCPProtocol"
+            for node in ast.walk(tree)
+            if (
+                isinstance(node, ast.Name)
+                and node.id == "MCPProtocol"
+            )
+            or (
+                isinstance(node, ast.Attribute)
+                and node.attr == "MCPProtocol"
+            )
+        ]
+        if uses_facade:
+            offenders.setdefault(str(path.relative_to(MCP_ROOT)), []).append("MCPProtocol")
+
+    assert offenders == {}

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -1978,6 +1978,26 @@ async def test_filesystem_write_replace_requires_preimage(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
+async def test_filesystem_write_text_replace_requires_preimage(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    target = workspace_root / "story.txt"
+    target.write_text("old\n", encoding="utf-8")
+    resolver = _FakeWorkspaceRootResolver({"workspace_root": str(workspace_root)})
+    mod = FilesystemModule(ModuleConfig(name="filesystem"), workspace_root_resolver=resolver)
+    context = RequestContext(request_id="req-fs-write-text-preimage", user_id="1", metadata={})
+
+    with pytest.raises(ValueError, match="write_preimage_required"):
+        await mod.execute_tool(
+            "fs.write_text",
+            {"path": "story.txt", "content": "new\n"},
+            context=context,
+        )
+
+    assert target.read_text(encoding="utf-8") == "old\n"  # nosec B101
+
+
+@pytest.mark.asyncio
 async def test_filesystem_write_replace_rejects_large_preimage_before_reading(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir(parents=True, exist_ok=True)
@@ -2639,11 +2659,9 @@ async def test_filesystem_glob_marks_file_size_unavailable(
         metadata={"workspace_id": "workspace-1"},
     )
     original_stat = Path.stat
-    stat_calls_by_path: dict[Path, int] = {}
 
     def _raise_for_source_file(self: Path, *args: Any, **kwargs: Any):
-        stat_calls_by_path[self] = stat_calls_by_path.get(self, 0) + 1
-        if self == source_file and stat_calls_by_path[self] > 1:
+        if self == source_file and kwargs.get("follow_symlinks") is False:
             raise OSError("metadata unavailable")
         return original_stat(self, *args, **kwargs)
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -293,6 +293,10 @@ async def test_filesystem_tools_include_path_scope_metadata() -> None:
     assert write_text_metadata["replacement_tools"] == ["fs.patch", "fs.write"]  # nosec B101
     assert write_text_metadata["path_scope_action"] == "write"  # nosec B101
     assert by_name["fs.write_text"]["metadata"]["category"] == "management"  # nosec B101
+    write_text_schema = by_name["fs.write_text"]["inputSchema"]
+    assert "Replacing an existing file requires expected_sha256 or read_receipt" in by_name["fs.write_text"]["description"]  # nosec B101
+    assert "Required when replacing an existing file" in write_text_schema["properties"]["expected_sha256"]["description"]  # nosec B101
+    assert "Required when replacing an existing file" in write_text_schema["properties"]["read_receipt"]["description"]  # nosec B101
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_http_mapping.py
@@ -1,9 +1,9 @@
-import os
 import base64
-import json
-import pytest
 import ipaddress
+import json
+import os
 
+import pytest
 from fastapi.testclient import TestClient
 
 
@@ -21,6 +21,7 @@ def _setup_env():
 
 def _build_mcp_client():
     from fastapi import FastAPI
+
     from tldw_Server_API.app.api.v1.endpoints.mcp_unified_endpoint import router as mcp_router
 
     app = FastAPI()
@@ -31,10 +32,10 @@ def _build_mcp_client():
 @pytest.fixture(scope="module")
 def client():
     _setup_env()
-    from fastapi import FastAPI
-    from fastapi import Request, HTTPException, status
-    from tldw_Server_API.app.api.v1.endpoints.mcp_unified_endpoint import router as mcp_router
+    from fastapi import FastAPI, HTTPException, Request, status
+
     from tldw_Server_API.app.api.v1.API_Deps import auth_deps
+    from tldw_Server_API.app.api.v1.endpoints.mcp_unified_endpoint import router as mcp_router
     from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
     app = FastAPI()
     app.include_router(mcp_router, prefix="/api/v1")
@@ -228,8 +229,10 @@ def test_demo_auth_issues_token_with_secret(monkeypatch):
 
 def test_refresh_endpoint_rejects_query_token_and_accepts_body(monkeypatch):
     _setup_env()
-    from tldw_Server_API.app.core.MCP_unified.auth.jwt_manager import get_jwt_manager
+    monkeypatch.setenv("MCP_ENABLE_DEMO_AUTH", "1")
+    monkeypatch.setenv("MCP_DEMO_AUTH_SECRET", "supersecretvalue12345")
     from tldw_Server_API.app.core.MCP_unified import config as config_module
+    from tldw_Server_API.app.core.MCP_unified.auth.jwt_manager import get_jwt_manager
     from tldw_Server_API.app.core.MCP_unified.security import ip_filter
 
     try:
@@ -257,6 +260,30 @@ def test_refresh_endpoint_rejects_query_token_and_accepts_body(monkeypatch):
         assert r_body.status_code == 200
         data = r_body.json()
         assert "access_token" in data and data["token_type"] == "bearer"
+
+
+def test_refresh_endpoint_disabled_without_demo_auth(monkeypatch):
+    _setup_env()
+    monkeypatch.delenv("MCP_ENABLE_DEMO_AUTH", raising=False)
+    from tldw_Server_API.app.core.MCP_unified import config as config_module
+    from tldw_Server_API.app.core.MCP_unified.auth.jwt_manager import get_jwt_manager
+    from tldw_Server_API.app.core.MCP_unified.security import ip_filter
+
+    try:
+        config_module.get_config.cache_clear()  # type: ignore[attr-defined]
+        ip_filter.get_ip_access_controller.cache_clear()  # type: ignore[attr-defined]
+    except Exception:
+        _ = None
+
+    refresh, token_id = get_jwt_manager().create_refresh_token(subject="1")
+
+    with _build_mcp_client() as temp_client:
+        r_body = temp_client.post(
+            "/api/v1/mcp/auth/refresh",
+            json={"refresh_token": refresh, "token_id": token_id},
+        )
+
+    assert r_body.status_code == 501
 
 
 def test_request_guard_enforces_body_size_limit(monkeypatch):

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py
@@ -1,4 +1,5 @@
 from collections.abc import Awaitable, Callable
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -18,12 +19,13 @@ from tldw_Server_API.app.core.MCP_unified.protocol import IdempotencyManager, MC
 
 
 class AllowAllRBAC:
-    async def check_permission(self, *args, **kwargs):
+    async def check_permission(self, *args: Any, **kwargs: Any) -> bool:
+        del args, kwargs
         return True
 
 
 class _CountingWriteModule(BaseModule):
-    def __init__(self, config: ModuleConfig):
+    def __init__(self, config: ModuleConfig) -> None:
         super().__init__(config)
         self.counter = 0
 
@@ -46,11 +48,17 @@ class _CountingWriteModule(BaseModule):
             )
         ]
 
-    def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]):
+    def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]) -> None:
         if tool_name == "write_count" and (not isinstance(arguments, dict) or "x" not in arguments):
             raise ValueError("x required")
 
-    async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context=None):
+    async def execute_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: RequestContext | None = None,
+    ) -> str:
+        del tool_name, context
         # Side effect: increment counter when actually executed
         self.counter += 1
         return f"count:{self.counter}:{arguments.get('x')}"
@@ -80,6 +88,7 @@ class _ProbeIdempotencyManager:
         return await execute(), False
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_idempotency_dedupes_write_calls() -> None:
     registry = get_module_registry()
@@ -149,8 +158,9 @@ async def test_replaced_idempotency_manager_is_used_by_runtime() -> None:
     assert probe.run_keys == probe.bound_keys
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
-async def test_idempotency_key_reuse_with_different_arguments_rejected():
+async def test_idempotency_key_reuse_with_different_arguments_rejected() -> None:
     registry = get_module_registry()
     await registry.register_module("counting_write_diff_args", _CountingWriteModule, ModuleConfig(name="counting_write_diff_args"))
 
@@ -181,8 +191,9 @@ async def test_idempotency_key_reuse_with_different_arguments_rejected():
     assert "idempotency key" in resp2.error.message.lower()
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
-async def test_idempotency_key_isolated_across_users():
+async def test_idempotency_key_isolated_across_users() -> None:
     registry = get_module_registry()
     await registry.register_module("counting_write_user_isolation", _CountingWriteModule, ModuleConfig(name="counting_write_user_isolation"))
 
@@ -214,10 +225,11 @@ async def test_idempotency_key_isolated_across_users():
 
 
 class _CategoryProbeLimiter:
-    def __init__(self):
-        self.last_category = None
+    def __init__(self) -> None:
+        self.last_category: str | None = None
 
-    async def check_rate_limit(self, *args, **kwargs):
+    async def check_rate_limit(self, *args: Any, **kwargs: Any) -> bool:
+        del args
         self.last_category = kwargs.get("category")
         return True
 
@@ -241,11 +253,18 @@ class _CategoryModule(BaseModule):
             metadata={"category": "ingestion"},
         )]
 
-    def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]):
+    def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]) -> None:
+        del tool_name
         if "m" not in arguments:
             raise ValueError("m required")
 
-    async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context=None):
+    async def execute_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: RequestContext | None = None,
+    ) -> Any:
+        del tool_name, context
         return arguments.get("m")
 
 
@@ -273,11 +292,18 @@ class _MetadataCategoryModule(BaseModule):
             )
         ]
 
-    def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]):
+    def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]) -> None:
+        del tool_name
         if "m" not in arguments:
             raise ValueError("m required")
 
-    async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context=None):
+    async def execute_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: RequestContext | None = None,
+    ) -> Any:
+        del tool_name, context
         return arguments.get("m")
 
 
@@ -301,16 +327,24 @@ class _ConfigMappedCategoryModule(BaseModule):
             )
         ]
 
-    def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]):
+    def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]) -> None:
+        del tool_name
         if "m" not in arguments:
             raise ValueError("m required")
 
-    async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context=None):
+    async def execute_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: RequestContext | None = None,
+    ) -> Any:
+        del tool_name, context
         return arguments.get("m")
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
-async def test_category_prefers_metadata_over_config_mapping(monkeypatch):
+async def test_category_prefers_metadata_over_config_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
     registry = get_module_registry()
     await registry.register_module("category_probe", _CategoryModule, ModuleConfig(name="category_probe"))
 
@@ -329,8 +363,11 @@ async def test_category_prefers_metadata_over_config_mapping(monkeypatch):
     assert probe.last_category == "ingestion"
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
-async def test_runtime_config_provider_observes_post_construction_get_config_patch(monkeypatch):
+async def test_runtime_config_provider_observes_post_construction_get_config_patch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     registry = get_module_registry()
     await registry.register_module(
         "category_config_patch",
@@ -360,6 +397,7 @@ async def test_runtime_config_provider_observes_post_construction_get_config_pat
     assert probe.last_category == "management"
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("metadata_category", "uses_network", "expected_category"),
@@ -400,11 +438,12 @@ async def test_category_preserves_non_legacy_metadata_categories(
     assert probe.last_category == expected_category
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
-async def test_idempotency_local_lock_map_prunes_with_cache_bounds():
+async def test_idempotency_local_lock_map_prunes_with_cache_bounds() -> None:
     manager = IdempotencyManager()
 
-    async def _execute(value: str):
+    async def _execute(value: str) -> dict[str, list[dict[str, str]]]:
         return {"content": [{"type": "text", "text": value}]}
 
     for idx in range(10):
@@ -422,8 +461,9 @@ async def test_idempotency_local_lock_map_prunes_with_cache_bounds():
     assert len(manager._local_locks) <= 3
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
-async def test_idempotency_warns_when_redis_factory_returns_none(monkeypatch):
+async def test_idempotency_warns_when_redis_factory_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
     from tldw_Server_API.app.core.MCP_unified import protocol as protocol_mod
 
     class _Config:
@@ -453,7 +493,8 @@ async def test_idempotency_warns_when_redis_factory_returns_none(monkeypatch):
     assert any("returned None" in message for message, _args, _kwargs in warnings)
 
 
-def test_nested_step_idempotency_is_stable_and_content_derived():
+@pytest.mark.unit
+def test_nested_step_idempotency_is_stable_and_content_derived() -> None:
     first = derive_step_idempotency_key("parent-1", ["write", "notes.txt", "hello"], 0)
     second = derive_step_idempotency_key("parent-1", ["write", "notes.txt", "hello"], 0)
     different = derive_step_idempotency_key("parent-1", ["write", "notes.txt", "hello"], 1)
@@ -466,8 +507,11 @@ def test_nested_step_idempotency_is_stable_and_content_derived():
     assert first != changed_args
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
-async def test_run_prepare_tool_call_classifies_write_chain_dynamically(monkeypatch):
+async def test_run_prepare_tool_call_classifies_write_chain_dynamically(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("MCP_DISABLE_WRITE_TOOLS", "true")
     try:
         get_config.cache_clear()  # type: ignore[attr-defined]
@@ -498,8 +542,11 @@ async def test_run_prepare_tool_call_classifies_write_chain_dynamically(monkeypa
     assert prepared.is_write is False
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
-async def test_protocol_idempotency_key_is_forwarded_to_run_nested_steps(monkeypatch):
+async def test_protocol_idempotency_key_is_forwarded_to_run_nested_steps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("MCP_DISABLE_WRITE_TOOLS", "false")
     try:
         get_config.cache_clear()  # type: ignore[attr-defined]
@@ -507,7 +554,7 @@ async def test_protocol_idempotency_key_is_forwarded_to_run_nested_steps(monkeyp
         _ = None
 
     class _PreparedCall:
-        def __init__(self, params: dict[str, Any], idempotency_key: str | None = None):
+        def __init__(self, params: dict[str, Any], idempotency_key: str | None = None) -> None:
             self.params = dict(params)
             self.idempotency_key = idempotency_key
 
@@ -568,8 +615,12 @@ async def test_protocol_idempotency_key_is_forwarded_to_run_nested_steps(monkeyp
     )
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
-async def test_prepare_tool_call_accepts_run_idempotency_key_inside_arguments(monkeypatch, tmp_path):
+async def test_prepare_tool_call_accepts_run_idempotency_key_inside_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     monkeypatch.setenv("MCP_DISABLE_WRITE_TOOLS", "false")
     monkeypatch.setenv("MCP_AUDIT_LOG_FILE", str(tmp_path / "audit.log"))
     try:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py
@@ -1,3 +1,4 @@
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import pytest
@@ -65,14 +66,22 @@ class _ProbeIdempotencyManager:
         self.bound_keys.append(key)
         return True
 
-    async def run(self, key: str, execute, *, ttl: int, max_size: int, lock_ttl: int):
+    async def run(
+        self,
+        key: str,
+        execute: Callable[[], Awaitable[Any]],
+        *,
+        ttl: int,
+        max_size: int,
+        lock_ttl: int,
+    ) -> tuple[Any, bool]:
         del ttl, max_size, lock_ttl
         self.run_keys.append(key)
         return await execute(), False
 
 
 @pytest.mark.asyncio
-async def test_idempotency_dedupes_write_calls():
+async def test_idempotency_dedupes_write_calls() -> None:
     registry = get_module_registry()
     await registry.register_module("counting_write", _CountingWriteModule, ModuleConfig(name="counting_write"))
 
@@ -111,8 +120,9 @@ async def test_idempotency_dedupes_write_calls():
     assert misses and any(getattr(e, "labels", {}).get("tool") == "write_count" for e in misses)
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
-async def test_replaced_idempotency_manager_is_used_by_runtime():
+async def test_replaced_idempotency_manager_is_used_by_runtime() -> None:
     registry = get_module_registry()
     await registry.register_module(
         "counting_write_replaced_idempotency",

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import pytest
 
+from tldw_Server_API.app.core.MCP_unified import protocol as protocol_module
 from tldw_Server_API.app.core.MCP_unified.command_runtime.adapters import (
     derive_step_idempotency_key,
 )
@@ -54,6 +55,22 @@ class _CountingWriteModule(BaseModule):
         return f"count:{self.counter}:{arguments.get('x')}"
 
 
+class _ProbeIdempotencyManager:
+    def __init__(self) -> None:
+        self.bound_keys: list[str] = []
+        self.run_keys: list[str] = []
+
+    async def bind_arguments(self, key: str, arguments_hash: str, *, ttl: int, max_size: int) -> bool:
+        del arguments_hash, ttl, max_size
+        self.bound_keys.append(key)
+        return True
+
+    async def run(self, key: str, execute, *, ttl: int, max_size: int, lock_ttl: int):
+        del ttl, max_size, lock_ttl
+        self.run_keys.append(key)
+        return await execute(), False
+
+
 @pytest.mark.asyncio
 async def test_idempotency_dedupes_write_calls():
     registry = get_module_registry()
@@ -92,6 +109,34 @@ async def test_idempotency_dedupes_write_calls():
     misses = metrics._metrics.get("idempotency_miss")
     assert hits and any(getattr(e, "labels", {}).get("tool") == "write_count" for e in hits)
     assert misses and any(getattr(e, "labels", {}).get("tool") == "write_count" for e in misses)
+
+
+@pytest.mark.asyncio
+async def test_replaced_idempotency_manager_is_used_by_runtime():
+    registry = get_module_registry()
+    await registry.register_module(
+        "counting_write_replaced_idempotency",
+        _CountingWriteModule,
+        ModuleConfig(name="counting_write_replaced_idempotency"),
+    )
+
+    proto = MCPProtocol()
+    proto.rbac_policy = AllowAllRBAC()
+    probe = _ProbeIdempotencyManager()
+    proto._idempotency = probe
+
+    ctx = RequestContext(request_id="id-replaced", user_id="u1", client_id="c1")
+    req = MCPRequest(method="tools/call", params={
+        "name": "write_count",
+        "arguments": {"x": "A"},
+        "idempotencyKey": "k-replaced",
+    }, id="r-replaced")
+
+    resp = await proto.process_request(req, ctx)
+
+    assert resp.error is None
+    assert probe.bound_keys
+    assert probe.run_keys == probe.bound_keys
 
 
 @pytest.mark.asyncio
@@ -194,6 +239,66 @@ class _CategoryModule(BaseModule):
         return arguments.get("m")
 
 
+class _MetadataCategoryModule(BaseModule):
+    async def on_initialize(self) -> None:
+        return None
+
+    async def on_shutdown(self) -> None:
+        return None
+
+    async def check_health(self) -> dict[str, bool]:
+        return {"ok": True}
+
+    async def get_tools(self) -> list[dict[str, Any]]:
+        category = str(self.config.settings["category"])
+        metadata = {"category": category}
+        if self.config.settings.get("uses_network"):
+            metadata["uses_network"] = True
+        return [
+            create_tool_definition(
+                name=f"echo_meta_{category}",
+                description="echo",
+                parameters={"properties": {"m": {"type": "string"}}, "required": ["m"]},
+                metadata=metadata,
+            )
+        ]
+
+    def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]):
+        if "m" not in arguments:
+            raise ValueError("m required")
+
+    async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context=None):
+        return arguments.get("m")
+
+
+class _ConfigMappedCategoryModule(BaseModule):
+    async def on_initialize(self) -> None:
+        return None
+
+    async def on_shutdown(self) -> None:
+        return None
+
+    async def check_health(self) -> dict[str, bool]:
+        return {"ok": True}
+
+    async def get_tools(self) -> list[dict[str, Any]]:
+        return [
+            create_tool_definition(
+                name="echo_config_mapped",
+                description="echo",
+                parameters={"properties": {"m": {"type": "string"}}, "required": ["m"]},
+                metadata={},
+            )
+        ]
+
+    def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]):
+        if "m" not in arguments:
+            raise ValueError("m required")
+
+    async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context=None):
+        return arguments.get("m")
+
+
 @pytest.mark.asyncio
 async def test_category_prefers_metadata_over_config_mapping(monkeypatch):
     registry = get_module_registry()
@@ -212,6 +317,77 @@ async def test_category_prefers_metadata_over_config_mapping(monkeypatch):
     assert resp.error is None
     # The category should be 'ingestion' from metadata
     assert probe.last_category == "ingestion"
+
+
+@pytest.mark.asyncio
+async def test_runtime_config_provider_observes_post_construction_get_config_patch(monkeypatch):
+    registry = get_module_registry()
+    await registry.register_module(
+        "category_config_patch",
+        _ConfigMappedCategoryModule,
+        ModuleConfig(name="category_config_patch"),
+    )
+
+    proto = MCPProtocol()
+    proto.rbac_policy = AllowAllRBAC()
+    probe = _CategoryProbeLimiter()
+    proto.rate_limiter = probe
+
+    class _Config:
+        tool_category_map = {"echo_config_mapped": "management"}
+
+    monkeypatch.setattr(protocol_module, "get_config", lambda: _Config())
+
+    ctx = RequestContext(request_id="cx-config-patch", user_id="u1", client_id="c1")
+    req = MCPRequest(
+        method="tools/call",
+        params={"name": "echo_config_mapped", "arguments": {"m": "ok"}},
+        id="cx-config-patch",
+    )
+    resp = await proto.process_request(req, ctx)
+
+    assert resp.error is None
+    assert probe.last_category == "management"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("metadata_category", "uses_network", "expected_category"),
+    [
+        ("web", True, "network"),
+        ("utility", False, "utility"),
+    ],
+)
+async def test_category_preserves_non_legacy_metadata_categories(
+    metadata_category: str,
+    uses_network: bool,
+    expected_category: str,
+) -> None:
+    registry = get_module_registry()
+    await registry.register_module(
+        f"category_probe_{metadata_category}",
+        _MetadataCategoryModule,
+        ModuleConfig(
+            name=f"category_probe_{metadata_category}",
+            settings={"category": metadata_category, "uses_network": uses_network},
+        ),
+    )
+
+    proto = MCPProtocol()
+    proto.rbac_policy = AllowAllRBAC()
+    probe = _CategoryProbeLimiter()
+    proto.rate_limiter = probe
+
+    ctx = RequestContext(request_id=f"cx-{metadata_category}", user_id="u1", client_id="c1")
+    req = MCPRequest(
+        method="tools/call",
+        params={"name": f"echo_meta_{metadata_category}", "arguments": {"m": "ok"}},
+        id=f"cx-{metadata_category}",
+    )
+    resp = await proto.process_request(req, ctx)
+
+    assert resp.error is None
+    assert probe.last_category == expected_category
 
 
 @pytest.mark.asyncio
@@ -330,7 +506,7 @@ async def test_protocol_idempotency_key_is_forwarded_to_run_nested_steps(monkeyp
             self.prepare_calls: list[_PreparedCall] = []
 
         async def _handle_tools_list(self, params: dict[str, Any], context: RequestContext) -> dict[str, Any]:
-            return {"tools": [{"name": "fs.write_text", "module": "filesystem", "canExecute": True}]}
+            return {"tools": [{"name": "fs.write", "module": "filesystem", "canExecute": True}]}
 
         async def prepare_tool_call(
             self,

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_governance_preflight.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_governance_preflight.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 
+from tldw_Server_API.app.core import config as app_config
 from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol, MCPRequest, RequestContext
 
 
@@ -98,6 +99,41 @@ class _GovernanceServiceStub:
             status=self.action,
             category=str(kwargs.get("category") or "general"),
         )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rollout_mode_delegates_to_shared_server_config_resolver(monkeypatch):
+    proto = MCPProtocol()
+    proto.rbac_policy = _AllowAllRBAC()
+    proto.module_registry = _RegistryStub(_ToolModuleStub())
+
+    service = _GovernanceServiceStub(action="allow")
+
+    async def _fake_ensure_service():
+        return service
+
+    proto._ensure_governance_service = _fake_ensure_service  # type: ignore[attr-defined]
+    monkeypatch.setattr(
+        app_config,
+        "resolve_governance_rollout_mode",
+        lambda raw_mode=None: "shadow" if raw_mode is None else str(raw_mode),
+    )
+
+    metric_calls: list[dict[str, str]] = []
+    monkeypatch.setattr(
+        proto.metrics,
+        "record_governance_check",
+        lambda **kwargs: metric_calls.append({k: str(v) for k, v in kwargs.items()}),
+    )
+
+    ctx = RequestContext(request_id="gov-config-1", user_id="1", metadata={})
+    result = await proto._handle_tools_call({"name": "stub.echo", "arguments": {"x": 1}}, ctx)
+
+    assert result["tool"] == "stub.echo"
+    assert service.called is True
+    assert metric_calls
+    assert metric_calls[-1]["rollout_mode"] == "shadow"
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_tool_hooks.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_protocol_tool_hooks.py
@@ -9,6 +9,7 @@ import pytest
 from mcp_unified.interfaces.runtime import ToolHookCallContext, ToolHookDecision
 
 from tldw_Server_API.app.core.MCP_unified.protocol import (
+    GovernanceDeniedError,
     MCPProtocol,
     MCPRequest,
     RequestContext,
@@ -38,6 +39,45 @@ class _Span:
 class _Telemetry:
     def trace_context(self, *_args: Any, **_kwargs: Any) -> contextlib.AbstractContextManager[_Span]:
         return contextlib.nullcontext(_Span())
+
+
+class _StaticEffectivePolicyResolver:
+    async def resolve_for_context(
+        self,
+        *,
+        user_id: str | None,
+        metadata: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        del user_id, metadata
+        return None
+
+
+class _AllowApprovalEvaluator:
+    async def evaluate_tool_call(self, **_kwargs: Any) -> dict[str, Any]:
+        return {"status": "allow", "reason": "test_allow"}
+
+
+class _AllowPathScopeEnforcer:
+    async def evaluate_tool_call(self, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "enabled": False,
+            "within_scope": True,
+            "reason": None,
+            "force_approval": False,
+            "normalized_paths": [],
+            "scope_payload": None,
+        }
+
+
+class _NoopExternalAccessEvaluator:
+    async def resolve_for_sources(
+        self,
+        *,
+        sources: list[dict[str, Any]],
+        effective_policy: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        del sources, effective_policy
+        return {"servers": []}
 
 
 class _ToolModuleStub:
@@ -207,6 +247,10 @@ def _protocol(
         metrics_collector=_NoopMetrics(),
         telemetry_provider=_Telemetry(),
         tool_catalog_provider=object(),
+        effective_policy_resolver=_StaticEffectivePolicyResolver(),
+        approval_evaluator=_AllowApprovalEvaluator(),
+        path_scope_enforcer=_AllowPathScopeEnforcer(),
+        external_access_evaluator=_NoopExternalAccessEvaluator(),
         redis_client_factory=lambda **_kwargs: None,
         tool_call_hook_manager=hook_manager,
     )
@@ -307,8 +351,13 @@ async def test_pre_hook_deny_maps_to_authorization_error_and_skips_execution() -
         before_decision=ToolHookDecision(
             action="deny",
             reason_code="blocked_by_test_hook",
-            message="blocked by hook",
-            metadata={"hook_id": "local-policy"},
+            message="blocked /Users/example/private.txt token=secret",
+            metadata={
+                "hook_id": "local-policy",
+                "hook_order": "7",
+                "path": "/Users/example/private.txt",
+                "token": "secret",
+            },
         )
     )
     protocol, module, _ = _protocol(hook_manager=hooks)
@@ -324,8 +373,88 @@ async def test_pre_hook_deny_maps_to_authorization_error_and_skips_execution() -
     assert response.error is not None
     assert response.error.code == -32001
     assert isinstance(response.error.data, dict)
-    assert response.error.data["governance"]["hook"]["reason_code"] == "blocked_by_test_hook"
-    assert response.error.data["governance"]["hook"]["metadata"] == {"hook_id": "local-policy"}
+    assert response.error.data["governance"]["hook"] == {
+        "phase": "pre",
+        "action": "deny",
+        "status": "deny",
+        "reason_code": "blocked_by_test_hook",
+        "hook_id": "local-policy",
+        "hook_order": 7,
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_pre_hook_summary_strips_untrusted_composite_hook_payload_fields() -> None:
+    hooks = _RecordingToolHookManager(
+        before_decision=ToolHookDecision(
+            action="deny",
+            reason_code="blocked_by_composite_hook",
+            metadata={
+                "hook_results": [
+                    {
+                        "phase": "pre",
+                        "hook_id": "profile-policy",
+                        "hook_order": 8,
+                        "action": "deny",
+                        "status": "deny",
+                        "reason_code": "blocked_by_composite_hook",
+                        "message": "raw /Users/example/private.txt should not be retained",
+                        "metadata": {"path": "/Users/example/private.txt"},
+                        "raw_args": {"token": "super-secret"},
+                    }
+                ]
+            },
+        )
+    )
+    protocol, _, _ = _protocol(hook_manager=hooks)
+    context = _context()
+
+    with pytest.raises(GovernanceDeniedError):
+        await protocol._run_pre_tool_hooks(
+            tool_name="stub.echo",
+            tool_args={"target": "beta"},
+            module_id="stub",
+            tool_def={"metadata": {"category": "read"}},
+            is_write=False,
+            arguments_hash="abc123",
+            context=context,
+            scope_payload=None,
+        )
+
+    assert context.metadata["mcp_tool_hook_results"] == [
+        {
+            "phase": "pre",
+            "hook_id": "profile-policy",
+            "hook_order": 8,
+            "action": "deny",
+            "status": "deny",
+            "reason_code": "blocked_by_composite_hook",
+        }
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_replacing_protocol_hook_manager_updates_hook_execution_helper() -> None:
+    protocol, module, original_hooks = _protocol()
+    replacement_hooks = _RecordingToolHookManager(
+        before_decision=ToolHookDecision(
+            action="deny",
+            reason_code="blocked_after_replacement",
+        )
+    )
+    protocol._tool_call_hook_manager = replacement_hooks
+
+    with pytest.raises(GovernanceDeniedError):
+        await protocol._handle_tools_call(
+            {"name": "stub.echo", "arguments": {"target": "beta"}},
+            _context(),
+        )
+
+    assert module.executions == 0
+    assert original_hooks.before_contexts == []
+    assert len(replacement_hooks.before_contexts) == 1
 
 
 @pytest.mark.unit
@@ -335,7 +464,13 @@ async def test_pre_hook_ask_maps_to_approval_error_and_skips_execution() -> None
         before_decision=ToolHookDecision(
             action="ask",
             reason_code="operator_review_required",
-            message="needs approval",
+            message="needs approval for /Users/example/private.txt token=secret",
+            metadata={
+                "hook_id": "approval-policy",
+                "hook_order": "3",
+                "path": "/Users/example/private.txt",
+                "token": "secret",
+            },
         )
     )
     protocol, module, _ = _protocol(hook_manager=hooks)
@@ -353,6 +488,15 @@ async def test_pre_hook_ask_maps_to_approval_error_and_skips_execution() -> None
     assert isinstance(response.error.data, dict)
     assert response.error.data["approval"]["source"] == "tool_hook"
     assert response.error.data["approval"]["reason_code"] == "operator_review_required"
+    assert response.error.data["approval"]["message"] is None
+    assert response.error.data["approval"]["hook"] == {
+        "phase": "pre",
+        "action": "ask",
+        "status": "ask",
+        "reason_code": "operator_review_required",
+        "hook_id": "approval-policy",
+        "hook_order": 3,
+    }
 
 
 @pytest.mark.unit
@@ -400,6 +544,30 @@ async def test_post_hook_failure_preserves_success_result() -> None:
     assert hooks.after_contexts[0].tool_name == "stub.echo"
     assert hooks.after_contexts[0].module_id == "stub"
     assert hooks.after_contexts[0].status == "success"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_replacing_protocol_post_hook_wrapper_controls_runtime_post_hooks() -> None:
+    protocol, module, hooks = _protocol()
+    wrapper_calls: list[dict[str, Any]] = []
+
+    async def replacement_post_hook_wrapper(**kwargs: Any) -> None:
+        wrapper_calls.append(kwargs)
+
+    protocol._run_post_tool_hooks = replacement_post_hook_wrapper
+
+    result = await protocol._handle_tools_call(
+        {"name": "stub.echo", "arguments": {"target": "theta"}},
+        _context(),
+    )
+
+    assert module.executions == 1
+    assert result["tool"] == "stub.echo"
+    assert len(wrapper_calls) == 1
+    assert wrapper_calls[0]["tool_name"] == "stub.echo"
+    assert wrapper_calls[0]["status"] == "success"
+    assert hooks.after_contexts == []
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
@@ -345,13 +345,13 @@ async def test_run_applies_cwd_to_relative_workspace_file_arguments() -> None:
 
     assert [call.params["name"] for call in protocol.prepare_calls] == [
         "fs.read",
-        "fs.write_text",
+        "fs.write",
         "fs.list",
         "fs.grep",
     ]
     assert [call.params["arguments"] for call in protocol.prepare_calls] == [
         {"path": "docs/notes.txt"},
-        {"path": "docs/out.txt", "content": "hello"},
+        {"path": "docs/out.txt", "content": "hello", "mode": "create"},
         {"path": "docs"},
         {"pattern": "TODO", "base_path": "docs"},
     ]
@@ -373,7 +373,7 @@ async def test_run_cwd_preserves_whitespace_in_relative_file_arguments() -> None
 
     assert [call.params["arguments"] for call in protocol.prepare_calls] == [
         {"path": "docs/ notes.txt "},
-        {"path": "docs/ out.txt ", "content": "hello"},
+        {"path": "docs/ out.txt ", "content": "hello", "mode": "create"},
         {"path": "docs/ sub dir "},
     ]
 
@@ -1268,7 +1268,7 @@ async def test_run_help_policy_filters_filesystem_aliases() -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_help_shows_write_create_only_when_structured_write_is_visible() -> None:
+async def test_run_help_shows_write_commands_when_structured_write_is_visible() -> None:
     class _StructuredWriteProtocolStub(_ProtocolStub):
         async def _handle_tools_list(self, params: dict[str, Any], context: RequestContext) -> dict[str, Any]:
             del params, context
@@ -1284,12 +1284,12 @@ async def test_run_help_shows_write_create_only_when_structured_write_is_visible
     rendered = await module.execute_tool("run", {"command": "--help"}, context=context)
 
     commands = {line.split()[0] for line in rendered.splitlines() if line.startswith("  ")}
+    assert "write" in commands
     assert "write-create" in commands
-    assert "write" not in commands
 
 
 @pytest.mark.asyncio
-async def test_run_help_shows_legacy_write_only_when_legacy_write_text_is_visible() -> None:
+async def test_run_help_hides_write_commands_when_only_legacy_write_text_is_visible() -> None:
     class _LegacyWriteProtocolStub(_ProtocolStub):
         async def _handle_tools_list(self, params: dict[str, Any], context: RequestContext) -> dict[str, Any]:
             del params, context
@@ -1305,7 +1305,7 @@ async def test_run_help_shows_legacy_write_only_when_legacy_write_text_is_visibl
     rendered = await module.execute_tool("run", {"command": "--help"}, context=context)
 
     commands = {line.split()[0] for line in rendered.splitlines() if line.startswith("  ")}
-    assert "write" in commands
+    assert "write" not in commands
     assert "write-create" not in commands
 
 
@@ -1407,7 +1407,7 @@ async def test_run_write_create_uses_structured_write_create_mode() -> None:
 @pytest.mark.asyncio
 async def test_run_preflights_write_chain_before_executing_first_step() -> None:
     protocol = _ProtocolStub()
-    protocol.prepare_errors["fs.write_text"] = PermissionError("blocked by policy")
+    protocol.prepare_errors["fs.write"] = PermissionError("blocked by policy")
     module = _build_module(protocol)
     context = RequestContext(request_id="run-preflight", user_id="1", client_id="unit")
 
@@ -1415,7 +1415,7 @@ async def test_run_preflights_write_chain_before_executing_first_step() -> None:
 
     assert "blocked by policy" in rendered
     assert "[exit:1 |" in rendered
-    assert [call.params["name"] for call in protocol.prepare_calls] == ["fs.list", "fs.write_text"]
+    assert [call.params["name"] for call in protocol.prepare_calls] == ["fs.list", "fs.write"]
     assert protocol.execute_calls == []
 
 
@@ -1440,7 +1440,7 @@ async def test_run_derives_step_idempotency_from_parent_key() -> None:
     assert "[exit:0 |" in first
     assert "[exit:0 |" in second
     assert len(protocol.prepare_calls) == 2
-    assert protocol.prepare_calls[0].params["name"] == "fs.write_text"
+    assert protocol.prepare_calls[0].params["name"] == "fs.write"
     assert protocol.prepare_calls[0].idempotency_key == derive_step_idempotency_key(
         "parent-idem-1",
         ["write", "notes.txt", "hello"],
@@ -1468,12 +1468,12 @@ async def test_run_uses_lexical_preflighted_step_for_identical_command_after_ski
     assert "[exit:0 |" in rendered
     assert [call.params["name"] for call in protocol.prepare_calls] == [
         "fs.read",
-        "fs.write_text",
-        "fs.write_text",
+        "fs.write",
+        "fs.write",
     ]
     assert [call.params["name"] for call in protocol.execute_calls] == [
         "fs.read",
-        "fs.write_text",
+        "fs.write",
     ]
     assert protocol.execute_calls[1].idempotency_key == derive_step_idempotency_key(
         "parent-idem-skip-1",
@@ -1498,7 +1498,7 @@ async def test_run_converts_governed_file_errors_into_cli_result() -> None:
 @pytest.mark.asyncio
 async def test_run_preserves_approval_required_errors() -> None:
     protocol = _ProtocolStub()
-    protocol.prepare_errors["fs.write_text"] = ApprovalRequiredError(
+    protocol.prepare_errors["fs.write"] = ApprovalRequiredError(
         "approval required",
         approval={"reason": "path_outside_current_folder_scope"},
     )

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_security_hardening.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_security_hardening.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi import WebSocketDisconnect
 
 from tldw_Server_API.app.core.AuthNZ.exceptions import InvalidTokenError
+from tldw_Server_API.app.core.MCP_unified.auth import rbac as legacy_rbac
 from tldw_Server_API.app.core.MCP_unified.auth.authnz_rbac import Action, AuthNZRBAC, Resource
 from tldw_Server_API.app.core.MCP_unified.auth.jwt_manager import get_jwt_manager
 from tldw_Server_API.app.core.MCP_unified.config import get_config
@@ -261,3 +262,27 @@ async def test_rbac_does_not_seed_permission_for_unknown_tool(monkeypatch):
 
     assert allowed is False
     assert seeded is False
+
+
+def test_fallback_rbac_user_role_does_not_wildcard_execute_arbitrary_tools():
+    policy = legacy_rbac.RBACPolicy()
+    policy.assign_role("user-1", legacy_rbac.UserRole.USER.value)
+
+    assert (
+        policy.check_permission(
+            "user-1",
+            legacy_rbac.Resource.TOOL,
+            legacy_rbac.Action.EXECUTE,
+            "search_media",
+        )
+        is True
+    )
+    assert (
+        policy.check_permission(
+            "user-1",
+            legacy_rbac.Resource.TOOL,
+            legacy_rbac.Action.EXECUTE,
+            "definitely_missing_tool",
+        )
+        is False
+    )

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_tool_execution_coordinator.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_tool_execution_coordinator.py
@@ -39,6 +39,7 @@ class _Reporter:
         )
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_tool_execution_coordinator_delegates_prepare_then_execute() -> None:
     from tldw_Server_API.app.core.MCP_unified.tool_execution.coordinator import (
@@ -80,6 +81,7 @@ async def test_tool_execution_coordinator_delegates_prepare_then_execute() -> No
     assert result["tool"] == "demo.echo"
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_tool_execution_coordinator_reports_prepare_failure_before_reraising() -> None:
     from tldw_Server_API.app.core.MCP_unified.protocol import InvalidParamsException

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_tool_execution_coordinator.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_tool_execution_coordinator.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+
+
+@dataclass
+class _Prepared:
+    name: str
+    context: RequestContext
+
+
+class _Reporter:
+    def __init__(self) -> None:
+        self.prepare_failures: list[dict[str, Any]] = []
+
+    def should_record(self, context: RequestContext) -> bool:
+        return context.metadata.get("mcp_tool_use_observed") is not True
+
+    async def record_prepare_failure(
+        self,
+        *,
+        context: RequestContext,
+        params: dict[str, Any],
+        exc: Exception,
+        start_ts: float,
+    ) -> None:
+        del start_ts
+        self.prepare_failures.append(
+            {
+                "request_id": context.request_id,
+                "name": params.get("name"),
+                "error_type": exc.__class__.__name__,
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_tool_execution_coordinator_delegates_prepare_then_execute() -> None:
+    from tldw_Server_API.app.core.MCP_unified.tool_execution.coordinator import (
+        ToolExecutionCoordinator,
+    )
+
+    calls: list[str] = []
+    context = RequestContext(request_id="coord-ok", user_id="u1", client_id="c1")
+    prepared = _Prepared(name="demo.echo", context=context)
+
+    async def prepare_impl(
+        *,
+        params: dict[str, Any],
+        context: RequestContext,
+        idempotency_key: str | None = None,
+    ) -> _Prepared:
+        assert params == {"name": "demo.echo", "arguments": {"value": "x"}}
+        assert idempotency_key is None
+        calls.append("prepare")
+        return prepared
+
+    async def execute_impl(prepared_call: _Prepared) -> dict[str, Any]:
+        assert prepared_call is prepared
+        calls.append("execute")
+        return {"content": [{"type": "text", "text": "ok"}], "tool": prepared_call.name}
+
+    coordinator = ToolExecutionCoordinator(
+        prepare_tool_call_impl=prepare_impl,
+        execute_prepared_tool_call_impl=execute_impl,
+        reporter=_Reporter(),
+    )
+
+    result = await coordinator.handle_tools_call(
+        {"name": "demo.echo", "arguments": {"value": "x"}},
+        context,
+    )
+
+    assert calls == ["prepare", "execute"]
+    assert result["tool"] == "demo.echo"
+
+
+@pytest.mark.asyncio
+async def test_tool_execution_coordinator_reports_prepare_failure_before_reraising() -> None:
+    from tldw_Server_API.app.core.MCP_unified.protocol import InvalidParamsException
+    from tldw_Server_API.app.core.MCP_unified.tool_execution.coordinator import (
+        ToolExecutionCoordinator,
+    )
+
+    reporter = _Reporter()
+    context = RequestContext(request_id="coord-fail", user_id="u1", client_id="c1")
+
+    async def prepare_impl(
+        *,
+        params: dict[str, Any],
+        context: RequestContext,
+        idempotency_key: str | None = None,
+    ) -> _Prepared:
+        del params, context, idempotency_key
+        raise InvalidParamsException("bad arguments")
+
+    async def execute_impl(prepared_call: _Prepared) -> dict[str, Any]:
+        del prepared_call
+        raise AssertionError("execute should not run")
+
+    coordinator = ToolExecutionCoordinator(
+        prepare_tool_call_impl=prepare_impl,
+        execute_prepared_tool_call_impl=execute_impl,
+        reporter=reporter,
+    )
+
+    with pytest.raises(InvalidParamsException):
+        await coordinator.handle_tools_call({"name": "demo.echo"}, context)
+
+    assert reporter.prepare_failures == [
+        {
+            "request_id": "coord-fail",
+            "name": "demo.echo",
+            "error_type": "InvalidParamsException",
+        }
+    ]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_tool_use_reporting_protocol.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
+import re
 from types import SimpleNamespace
 from typing import Any
 
@@ -108,6 +109,19 @@ class _AllowApprovalEvaluator:
 
     async def evaluate_tool_call(self, **_kwargs: Any) -> dict[str, Any]:
         return {"status": "allow", "reason": "test_allow"}
+
+
+class _NoopExternalAccessEvaluator:
+    """Test double with no external server credential grants."""
+
+    async def resolve_for_sources(
+        self,
+        *,
+        sources: list[dict[str, Any]],
+        effective_policy: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        del sources, effective_policy
+        return {"servers": []}
 
 
 class _FilePolicyPathScopeEnforcer:
@@ -405,6 +419,7 @@ def _protocol(
         effective_policy_resolver=_StaticEffectivePolicyResolver(effective_policy),
         approval_evaluator=_AllowApprovalEvaluator(),
         path_scope_enforcer=path_scope_enforcer or _FilePolicyPathScopeEnforcer(),
+        external_access_evaluator=_NoopExternalAccessEvaluator(),
         redis_client_factory=lambda **kwargs: None,
         tool_use_recorder=recorder,
         tool_call_hook_manager=hook_manager,
@@ -430,6 +445,7 @@ def _run_command_protocol() -> tuple[MCPProtocol, _RecordingToolUseRecorder]:
         effective_policy_resolver=_StaticEffectivePolicyResolver(None),
         approval_evaluator=_AllowApprovalEvaluator(),
         path_scope_enforcer=_FilePolicyPathScopeEnforcer(),
+        external_access_evaluator=_NoopExternalAccessEvaluator(),
         redis_client_factory=lambda **kwargs: None,
         tool_use_recorder=recorder,
         tool_call_hook_manager=None,
@@ -592,6 +608,44 @@ def test_protocol_consumes_hook_results_per_tool_use_event() -> None:
     assert first_event.tool_hook_results[0].hook_id == "policy-hook"
     assert "mcp_tool_hook_results" not in context.metadata
     assert len(second_event.tool_hook_results) == 0
+
+
+@pytest.mark.asyncio
+async def test_tool_execution_reporter_records_process_request_failure_directly() -> None:
+    from tldw_Server_API.app.core.MCP_unified.protocol import MCPRequest
+    from tldw_Server_API.app.core.MCP_unified.tool_execution.reporting import (
+        ToolExecutionReporter,
+    )
+
+    recorder = _RecordingToolUseRecorder()
+    reporter = ToolExecutionReporter(
+        recorder=recorder,
+        metrics=_NoopMetrics(),
+        tool_name_re=re.compile(r"^[A-Za-z0-9_.:-]{1,100}$"),
+        noncritical_exceptions=(Exception,),
+    )
+    context = _request_context(metadata={"profile_id": "architect"})
+    request = MCPRequest(
+        method="tools/call",
+        params={"name": "test.read", "arguments": {"value": "ok"}},
+        id="req-reporter",
+    )
+
+    await reporter.record_process_request_failure(
+        request=request,
+        context=context,
+        status="denied",
+        reason_code="permission_denied",
+        start_ts=0,
+    )
+
+    event = recorder.events[-1]
+    assert event.runtime_surface == "protocol"
+    assert event.requested_tool_name == "test.read"
+    assert event.status == "denied"
+    assert event.reason_code == "permission_denied"
+    assert event.execution_origin == "failed_before_execution"
+    assert event.profile_id == "architect"
 
 
 @pytest.mark.asyncio
@@ -892,7 +946,7 @@ async def test_protocol_records_early_process_request_tool_name_error() -> None:
         _request_context(),
     )
 
-    assert response.error.code == ErrorCode.INTERNAL_ERROR
+    assert response.error.code == ErrorCode.INVALID_PARAMS
     event = recorder.events[-1]
     assert event.runtime_surface == "protocol"
     assert event.requested_tool_name == "unknown"
@@ -935,7 +989,7 @@ async def test_protocol_event_build_failure_preserves_process_request_error(
         _request_context(),
     )
 
-    assert response.error.code == ErrorCode.INTERNAL_ERROR
+    assert response.error.code == ErrorCode.INVALID_PARAMS
     assert "Invalid tool name" in response.error.message
     assert recorder.events == []
 
@@ -978,6 +1032,29 @@ async def test_protocol_event_build_failure_preserves_tool_response(
 
     assert response["tool"] == "test.read"
     assert recorder.events == []
+
+
+@pytest.mark.asyncio
+async def test_restoring_protocol_tool_use_event_builder_does_not_recurse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    protocol, recorder = _protocol()
+    original_build_event = protocol._build_tool_use_event
+
+    def fail_event(**_kwargs: Any) -> ToolUseEvent:
+        raise ValueError("telemetry build failed")
+
+    monkeypatch.setattr(protocol, "_build_tool_use_event", fail_event)
+    protocol._build_tool_use_event = original_build_event
+
+    response = await protocol._handle_tools_call(
+        {"name": "test.read", "arguments": {}},
+        _request_context(),
+    )
+
+    assert response["tool"] == "test.read"
+    assert len(recorder.events) == 1
+    assert recorder.events[0].requested_tool_name == "test.read"
 
 
 @pytest.mark.asyncio
@@ -1089,3 +1166,120 @@ async def test_protocol_process_request_does_not_double_record_handler_rate_limi
     ]
     assert len(rate_limited_events) == 1
     assert rate_limited_events[0].execution_origin == "failed_before_execution"
+
+
+@pytest.mark.asyncio
+async def test_tools_call_coarse_authorization_denial_records_denied_tool_use() -> None:
+    from tldw_Server_API.app.core.MCP_unified.protocol import MCPRequest
+
+    recorder = _RecordingToolUseRecorder()
+    protocol, _ = _protocol(recorder=recorder)
+
+    async def deny_request(_request: MCPRequest, _context: RequestContext) -> bool:
+        return False
+
+    protocol._check_authorization = deny_request  # type: ignore[method-assign]
+    context = RequestContext(request_id="coarse-deny", user_id="u1", client_id="c1")
+    request = MCPRequest(
+        method="tools/call",
+        params={"name": "test.read", "arguments": {"value": "x"}},
+        id="coarse-deny",
+    )
+
+    response = await protocol.process_request(request, context)
+
+    assert response.error is not None
+    assert response.error.code == ErrorCode.AUTHORIZATION_ERROR
+    assert len(recorder.events) == 1
+    event = recorder.events[-1]
+    assert event.runtime_surface == "protocol"
+    assert event.requested_tool_name == "test.read"
+    assert event.status == "denied"
+    assert event.reason_code == "permission_denied"
+    assert event.execution_origin == "failed_before_execution"
+
+
+@pytest.mark.asyncio
+async def test_tools_call_deep_authorization_denial_records_prepare_failure() -> None:
+    recorder = _RecordingToolUseRecorder()
+    protocol, _ = _protocol(recorder=recorder)
+
+    async def allow_request(_request: Any, _context: RequestContext) -> bool:
+        return True
+
+    async def deny_prepare(
+        *,
+        params: dict[str, Any],
+        context: RequestContext,
+        idempotency_key: str | None = None,
+    ) -> Any:
+        del params, context, idempotency_key
+        raise PermissionError("Permission denied for tool: test.read")
+
+    protocol._check_authorization = allow_request  # type: ignore[method-assign]
+    protocol.prepare_tool_call = deny_prepare  # type: ignore[method-assign]
+    context = RequestContext(request_id="deep-deny", user_id="u1", client_id="c1")
+
+    response = await protocol.process_request(
+        {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": "test.read", "arguments": {"value": "x"}},
+            "id": "deep-deny",
+        },
+        context,
+    )
+
+    assert response.error is not None
+    assert response.error.code == ErrorCode.AUTHORIZATION_ERROR
+    assert len(recorder.events) == 1
+    event = recorder.events[-1]
+    assert event.runtime_surface == "protocol"
+    assert event.requested_tool_name == "test.read"
+    assert event.status == "denied"
+    assert event.reason_code == "permission_denied"
+    assert event.execution_origin == "failed_before_execution"
+
+
+@pytest.mark.asyncio
+async def test_restoring_public_prepare_tool_call_does_not_recurse() -> None:
+    protocol, _ = _protocol()
+    original_prepare = protocol.prepare_tool_call
+
+    async def patched_prepare(
+        *,
+        params: dict[str, Any],
+        context: RequestContext,
+        idempotency_key: str | None = None,
+    ) -> Any:
+        return await original_prepare(
+            params=params,
+            context=context,
+            idempotency_key=idempotency_key,
+        )
+
+    protocol.prepare_tool_call = patched_prepare  # type: ignore[method-assign]
+    protocol.prepare_tool_call = original_prepare  # type: ignore[method-assign]
+
+    result = await protocol._handle_tools_call(
+        {"name": "test.read", "arguments": {"value": "x"}},
+        RequestContext(request_id="restore-prepare", user_id="u1", client_id="c1"),
+    )
+
+    assert result["tool"] == "test.read"
+
+
+@pytest.mark.asyncio
+async def test_replaced_tool_name_regex_syncs_reporting_and_security_helpers() -> None:
+    protocol, _ = _protocol()
+    protocol._tool_name_re = re.compile(r"^test:[A-Za-z]+$")
+    context = RequestContext(request_id="regex-sync", user_id="u1", client_id="c1")
+
+    assert protocol._safe_tool_use_name("test.read") == "unknown"
+    with pytest.raises(InvalidParamsException, match="Invalid tool name"):
+        await protocol.prepare_tool_call(
+            params={"name": "test.read", "arguments": {"value": "x"}},
+            context=context,
+        )
+
+    assert protocol._safe_tool_use_name("test:read") == "test:read"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_validation_and_sanitization.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_validation_and_sanitization.py
@@ -3,17 +3,17 @@ Validation and sanitization tests for MCP Unified (tool name regex, deep arg san
 """
 
 import os
+from typing import Any
+
 import pytest
-import os as _os
 
 # Minimize startup side-effects for tests
-_os.environ.setdefault("TEST_MODE", "true")
-_os.environ.setdefault("ENABLE_TRACING", "false")
-_os.environ.setdefault("OTEL_METRICS_EXPORTER", "console")
-from typing import Dict, Any
+os.environ.setdefault("TEST_MODE", "true")
+os.environ.setdefault("ENABLE_TRACING", "false")
+os.environ.setdefault("OTEL_METRICS_EXPORTER", "console")
 
-from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol, RequestContext
 from tldw_Server_API.app.core.MCP_unified.modules.base import BaseModule, ModuleConfig
+from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol, RequestContext
 
 
 class InlineSanitizeModule(BaseModule):
@@ -23,10 +23,10 @@ class InlineSanitizeModule(BaseModule):
     async def on_shutdown(self) -> None:
         return None
 
-    async def check_health(self) -> Dict[str, bool]:
+    async def check_health(self) -> dict[str, bool]:
         return {"ok": True}
 
-    async def get_tools(self) -> list[Dict[str, Any]]:
+    async def get_tools(self) -> list[dict[str, Any]]:
         return [{
             "name": "echo_sanitize",
             "description": "Echo a message with deep sanitization",
@@ -37,7 +37,7 @@ class InlineSanitizeModule(BaseModule):
             }
         }]
 
-    async def execute_tool(self, tool_name: str, arguments: Dict[str, Any], context: Any | None = None) -> Any:
+    async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context: Any | None = None) -> Any:
         args = self.sanitize_input(arguments)
         if tool_name == "echo_sanitize":
             return args.get("message")
@@ -57,7 +57,7 @@ async def test_tool_name_strict_regex_blocks_invalid():
     }
     resp = await proto.process_request(req, ctx)
     assert resp is not None and resp.error is not None  # nosec B101
-    assert resp.error.code == -32603  # nosec B101
+    assert resp.error.code == -32602  # nosec B101
     assert "Invalid tool name" in (resp.error.message or "")  # nosec B101
 
 

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_ws_per_ip_caps.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_ws_per_ip_caps.py
@@ -3,12 +3,14 @@ Tests for per-IP WebSocket connection caps in MCP Unified.
 """
 
 import os
-import pytest
 import os as _os
+from datetime import datetime, timedelta, timezone
 
+import pytest
 from starlette.websockets import WebSocketDisconnect
 
 from tldw_Server_API.app.core.MCP_unified import get_mcp_server, reset_mcp_server
+from tldw_Server_API.app.core.MCP_unified.server import WebSocketConnection
 
 # Minimize startup side-effects for tests
 _os.environ.setdefault("TEST_MODE", "true")
@@ -33,6 +35,7 @@ async def test_ws_per_ip_cap_enforced(monkeypatch):
         _ = None
 
     from fastapi.testclient import TestClient
+
     from tldw_Server_API.app.main import app
 
     await reset_mcp_server()
@@ -74,3 +77,35 @@ async def test_ws_per_ip_cap_enforced(monkeypatch):
     else:
         assert internal["ws_rejection"]["type"] == "counter"
         assert internal["ws_rejection"]["value"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_stale_connection_cleanup_decrements_per_ip_count():
+    await reset_mcp_server()
+    server = get_mcp_server()
+    server.connections.clear()
+    server._ip_connection_counts.clear()
+
+    class _CloseOnlyWebSocket:
+        def __init__(self) -> None:
+            self.close_calls: list[tuple[int, str]] = []
+
+        async def close(self, code: int = 1000, reason: str = "") -> None:
+            self.close_calls.append((code, reason))
+
+    websocket = _CloseOnlyWebSocket()
+    connection = WebSocketConnection(
+        websocket=websocket,  # type: ignore[arg-type]
+        connection_id="stale-1",
+        client_id="c1",
+        metadata={"client_ip": "127.0.0.1"},
+    )
+    connection.last_activity = datetime.now(timezone.utc) - timedelta(seconds=301)
+    server.connections[connection.connection_id] = connection
+    server._ip_connection_counts["127.0.0.1"] = 1
+
+    await server._cleanup_stale_connections()
+
+    assert connection.connection_id not in server.connections
+    assert websocket.close_calls == [(1001, "Connection timeout")]
+    assert server._ip_connection_counts == {}

--- a/tldw_Server_API/app/core/MCP_unified/tool_execution/__init__.py
+++ b/tldw_Server_API/app/core/MCP_unified/tool_execution/__init__.py
@@ -1,0 +1,12 @@
+"""Tool execution pipeline for the MCP protocol facade."""
+
+from .coordinator import ToolExecutionCoordinator
+from .dependencies import CompatibilityCallbackLedgerEntry, ToolExecutionDependencies
+from .reporting import ToolExecutionReporter
+
+__all__ = [
+    "CompatibilityCallbackLedgerEntry",
+    "ToolExecutionCoordinator",
+    "ToolExecutionDependencies",
+    "ToolExecutionReporter",
+]

--- a/tldw_Server_API/app/core/MCP_unified/tool_execution/coordinator.py
+++ b/tldw_Server_API/app/core/MCP_unified/tool_execution/coordinator.py
@@ -15,6 +15,8 @@ from .reporting import ToolExecutionReporter
 
 @dataclass(slots=True)
 class ToolExecutionCoordinator:
+    """Coordinate prepare, execution, and prepare-failure reporting for tools/call."""
+
     prepare_tool_call_impl: Callable[..., Awaitable[Any]]
     execute_prepared_tool_call_impl: Callable[[Any], Awaitable[dict[str, Any]]]
     reporter: ToolExecutionReporter
@@ -24,6 +26,8 @@ class ToolExecutionCoordinator:
         params: dict[str, Any],
         context: RequestContext,
     ) -> dict[str, Any]:
+        """Prepare and execute a tools/call request, reporting prepare failures."""
+
         start_ts = time.time()
         try:
             prepared = await self.prepare_tool_call(params=params, context=context)
@@ -49,6 +53,8 @@ class ToolExecutionCoordinator:
         context: RequestContext,
         idempotency_key: str | None = None,
     ) -> Any:
+        """Delegate prepare-time validation and policy checks to the configured implementation."""
+
         return await self.prepare_tool_call_impl(
             params=params,
             context=context,
@@ -56,4 +62,6 @@ class ToolExecutionCoordinator:
         )
 
     async def execute_prepared_tool_call(self, prepared: Any) -> dict[str, Any]:
+        """Delegate runtime execution for an already prepared tool call."""
+
         return await self.execute_prepared_tool_call_impl(prepared)

--- a/tldw_Server_API/app/core/MCP_unified/tool_execution/coordinator.py
+++ b/tldw_Server_API/app/core/MCP_unified/tool_execution/coordinator.py
@@ -1,0 +1,59 @@
+"""Coordinator for the MCP tools/call execution path."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from loguru import logger
+
+from ..protocol_types import RequestContext
+from .reporting import ToolExecutionReporter
+
+
+@dataclass(slots=True)
+class ToolExecutionCoordinator:
+    prepare_tool_call_impl: Callable[..., Awaitable[Any]]
+    execute_prepared_tool_call_impl: Callable[[Any], Awaitable[dict[str, Any]]]
+    reporter: ToolExecutionReporter
+
+    async def handle_tools_call(
+        self,
+        params: dict[str, Any],
+        context: RequestContext,
+    ) -> dict[str, Any]:
+        start_ts = time.time()
+        try:
+            prepared = await self.prepare_tool_call(params=params, context=context)
+        except Exception as exc:
+            try:
+                await self.reporter.record_prepare_failure(
+                    context=context,
+                    params=params,
+                    exc=exc,
+                    start_ts=start_ts,
+                )
+            except Exception as record_exc:
+                logger.warning(
+                    "Failed to build or record prepare-failure tool-use event: {}",
+                    record_exc.__class__.__name__,
+                )
+            raise
+        return await self.execute_prepared_tool_call(prepared)
+
+    async def prepare_tool_call(
+        self,
+        params: dict[str, Any],
+        context: RequestContext,
+        idempotency_key: str | None = None,
+    ) -> Any:
+        return await self.prepare_tool_call_impl(
+            params=params,
+            context=context,
+            idempotency_key=idempotency_key,
+        )
+
+    async def execute_prepared_tool_call(self, prepared: Any) -> dict[str, Any]:
+        return await self.execute_prepared_tool_call_impl(prepared)

--- a/tldw_Server_API/app/core/MCP_unified/tool_execution/dependencies.py
+++ b/tldw_Server_API/app/core/MCP_unified/tool_execution/dependencies.py
@@ -1,0 +1,37 @@
+"""Explicit dependencies for the MCP tool execution pipeline."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from .reporting import ToolExecutionReporter
+
+
+@dataclass(frozen=True, slots=True)
+class CompatibilityCallbackLedgerEntry:
+    callback: str
+    current_owner: str
+    target_owner: str
+    removal_stage: str
+    parity_test: str
+
+
+@dataclass(slots=True)
+class ToolExecutionDependencies:
+    module_registry: Any
+    rbac_policy: Any
+    rate_limiter: Any
+    metrics: Any
+    telemetry: Any
+    hook_manager: Any
+    tool_use_recorder: Any
+    idempotency: Any
+    config_provider: Callable[[], Any]
+    effective_policy_resolver: Any
+    path_scope_enforcer: Any
+    approval_evaluator: Any
+    external_access_evaluator: Any
+    reporter: ToolExecutionReporter
+    api_key_scope_normalizer: Any = None

--- a/tldw_Server_API/app/core/MCP_unified/tool_execution/dependencies.py
+++ b/tldw_Server_API/app/core/MCP_unified/tool_execution/dependencies.py
@@ -11,6 +11,8 @@ from .reporting import ToolExecutionReporter
 
 @dataclass(frozen=True, slots=True)
 class CompatibilityCallbackLedgerEntry:
+    """Document a temporary protocol compatibility callback during extraction."""
+
     callback: str
     current_owner: str
     target_owner: str
@@ -20,6 +22,8 @@ class CompatibilityCallbackLedgerEntry:
 
 @dataclass(slots=True)
 class ToolExecutionDependencies:
+    """Dependency bundle shared by extracted MCP tool-execution stages."""
+
     module_registry: Any
     rbac_policy: Any
     rate_limiter: Any

--- a/tldw_Server_API/app/core/MCP_unified/tool_execution/hooks.py
+++ b/tldw_Server_API/app/core/MCP_unified/tool_execution/hooks.py
@@ -1,0 +1,556 @@
+"""Lifecycle hook helpers for MCP tool execution."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+from typing import Any, cast
+
+from loguru import logger
+from mcp_unified.tool_use_reporting.models import MAX_TOOL_HOOK_RESULTS
+from mcp_unified.tool_use_reporting.sanitization import (
+    sanitize_reason_code,
+    sanitize_safe_id,
+)
+
+from ..auth.rate_limiter import RateLimitExceeded
+from ..interfaces.runtime import ToolHookAction, ToolHookCallContext, ToolHookDecision
+from ..protocol_types import (
+    ApprovalRequiredError,
+    GovernanceDeniedError,
+    InvalidParamsException,
+    RequestContext,
+)
+
+try:  # pragma: no cover - optional dependency
+    from redis.exceptions import RedisError
+except ImportError:  # pragma: no cover - redis not installed
+    class RedisError(Exception):
+        """Fallback RedisError when redis-py is unavailable."""
+        pass
+
+
+_HOOK_HELPER_NONCRITICAL_EXCEPTIONS = (
+    asyncio.CancelledError,
+    asyncio.TimeoutError,
+    AssertionError,
+    AttributeError,
+    ConnectionError,
+    FileNotFoundError,
+    ImportError,
+    IndexError,
+    KeyError,
+    LookupError,
+    OSError,
+    PermissionError,
+    RuntimeError,
+    TimeoutError,
+    TypeError,
+    ValueError,
+    UnicodeDecodeError,
+    json.JSONDecodeError,
+    RedisError,
+    RateLimitExceeded,
+    InvalidParamsException,
+)
+
+_TOOL_HOOK_SUMMARY_ID_FIELDS = (
+    "phase",
+    "hook_id",
+    "action",
+    "status",
+    "error_type",
+)
+
+
+class ToolExecutionHooks:
+    def __init__(
+        self,
+        *,
+        hook_manager: Any,
+        reporter: Any,
+        noncritical_exceptions: tuple[type[BaseException], ...],
+    ) -> None:
+        self._tool_call_hook_manager = hook_manager
+        self._reporter = reporter
+        self._noncritical_exceptions = noncritical_exceptions
+
+    @staticmethod
+    def _tool_use_category(tool_def: dict[str, Any] | None) -> str | None:
+        """Return the metadata category from a tool definition when present."""
+        metadata = (tool_def or {}).get("metadata") if isinstance(tool_def, dict) else None
+        if not isinstance(metadata, dict):
+            return None
+        category = metadata.get("category")
+        return str(category) if isinstance(category, str) and category.strip() else None
+
+    @staticmethod
+    def _tool_hook_summary_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
+        """Return sanitized hook summary rows from a protocol hook payload."""
+
+        metadata = payload.get("metadata")
+        if isinstance(metadata, dict):
+            hook_results = metadata.get("hook_results")
+            if isinstance(hook_results, list):
+                return [
+                    item
+                    for item in (
+                        ToolExecutionHooks._sanitize_tool_hook_summary_item(raw_item)
+                        for raw_item in hook_results[:MAX_TOOL_HOOK_RESULTS]
+                    )
+                    if item
+                ]
+
+        row = ToolExecutionHooks._sanitize_tool_hook_summary_item(
+            {
+                "phase": payload.get("phase"),
+                "action": payload.get("action"),
+                "status": payload.get("status"),
+                "reason_code": payload.get("reason_code"),
+                "error_type": payload.get("error_type"),
+                "hook_id": metadata.get("hook_id") if isinstance(metadata, dict) else payload.get("hook_id"),
+                "hook_order": (
+                    metadata.get("hook_order") if isinstance(metadata, dict) else payload.get("hook_order")
+                ),
+            }
+        )
+        return [row] if row else []
+
+    @staticmethod
+    def _sanitize_tool_hook_summary_item(item: Any) -> dict[str, Any]:
+        """Return allowlisted, sanitized hook result metadata for request context storage."""
+
+        if not isinstance(item, dict):
+            return {}
+
+        row: dict[str, Any] = {}
+        for field in _TOOL_HOOK_SUMMARY_ID_FIELDS:
+            safe_value = sanitize_safe_id(item.get(field), field=field)
+            if safe_value is not None:
+                row[field] = safe_value
+
+        reason_code = sanitize_reason_code(item.get("reason_code"))
+        if reason_code is not None:
+            row["reason_code"] = reason_code
+
+        hook_order = item.get("hook_order")
+        if hook_order is not None:
+            try:
+                row["hook_order"] = int(hook_order)
+            except (TypeError, ValueError):
+                pass
+
+        if "redacted" in item:
+            row["redacted"] = bool(item.get("redacted"))
+
+        return row
+
+    @staticmethod
+    def _append_tool_hook_summary(context: RequestContext, payload: dict[str, Any]) -> None:
+        """Append safe hook metadata for tool-use reporting."""
+
+        metadata = getattr(context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return
+        existing = metadata.get("mcp_tool_hook_results")
+        if not isinstance(existing, list):
+            existing = []
+            metadata["mcp_tool_hook_results"] = existing
+        remaining = max(0, MAX_TOOL_HOOK_RESULTS - len(existing))
+        if remaining <= 0:
+            return
+        existing.extend(ToolExecutionHooks._tool_hook_summary_items(payload)[:remaining])
+
+    @staticmethod
+    def _hook_safe_copy(value: Any) -> Any:
+        """Return a detached copy of hook-visible metadata without failing tool preparation."""
+        try:
+            return copy.deepcopy(value)
+        except _HOOK_HELPER_NONCRITICAL_EXCEPTIONS:
+            try:
+                return json.loads(json.dumps(value, default=str))
+            except _HOOK_HELPER_NONCRITICAL_EXCEPTIONS:
+                return str(value)
+
+    @staticmethod
+    def _hook_safe_metadata(context: RequestContext) -> dict[str, Any]:
+        """Return request metadata safe for local lifecycle hook decisions."""
+        metadata = getattr(context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return {}
+        return {
+            str(key): ToolExecutionHooks._hook_safe_copy(value)
+            for key, value in metadata.items()
+            if isinstance(key, str) and not key.startswith("_") and key not in {"governance_preflight"}
+        }
+
+    @staticmethod
+    def _hook_safe_tool_args(tool_args: Any, *, tool_name: str | None = None) -> dict[str, Any] | None:
+        """Return detached sanitized tool arguments for hook evaluation."""
+        if not isinstance(tool_args, dict):
+            return None
+        copied = ToolExecutionHooks._hook_safe_copy(tool_args)
+        if not isinstance(copied, dict):
+            return None
+        return ToolExecutionHooks._redact_hook_visible_tool_args(copied, tool_name=tool_name)
+
+    @staticmethod
+    def _redact_hook_visible_tool_args(tool_args: dict[str, Any], *, tool_name: str | None = None) -> dict[str, Any]:
+        """Redact secret-bearing argument values from hook-visible metadata."""
+
+        if str(tool_name or "") != "sandbox.run":
+            return tool_args
+        env = tool_args.get("env")
+        if not isinstance(env, dict):
+            return tool_args
+        redacted = dict(tool_args)
+        redacted["env"] = {str(key): "[redacted]" for key in env}
+        return redacted
+
+    @staticmethod
+    def _hook_safe_scope_payload(scope_payload: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Return detached path/external scope metadata for hooks."""
+        if not isinstance(scope_payload, dict):
+            return None
+        copied = ToolExecutionHooks._hook_safe_copy(scope_payload)
+        return copied if isinstance(copied, dict) else None
+
+    def _build_tool_hook_context(
+        self,
+        *,
+        phase: str,
+        tool_name: str,
+        module_id: str | None,
+        tool_def: dict[str, Any] | None,
+        tool_args: Any,
+        is_write: bool | None,
+        arguments_hash: str | None,
+        context: RequestContext,
+        scope_payload: dict[str, Any] | None = None,
+        status: str | None = None,
+        duration_ms: float | None = None,
+        error: Exception | None = None,
+    ) -> ToolHookCallContext:
+        """Build a bounded, detached context object for lifecycle hook evaluation."""
+        return ToolHookCallContext(
+            phase="post" if phase == "post" else "pre",
+            tool_name=str(tool_name),
+            module_id=module_id,
+            is_write=is_write,
+            tool_category=self._tool_use_category(tool_def),
+            arguments_hash=arguments_hash,
+            request_id=str(context.request_id),
+            user_id=context.user_id,
+            client_id=context.client_id,
+            session_id=context.session_id,
+            metadata=self._hook_safe_metadata(context),
+            tool_args=self._hook_safe_tool_args(tool_args, tool_name=tool_name),
+            status=status,
+            duration_ms=duration_ms,
+            error_type=error.__class__.__name__ if error is not None else None,
+            scope_payload=self._hook_safe_scope_payload(scope_payload),
+        )
+
+    @staticmethod
+    def _coerce_tool_hook_action(action: Any) -> ToolHookAction | None:
+        """Normalize a runtime hook action into the public literal contract."""
+        normalized = str(action or "allow").strip().lower()
+        if normalized in {"allow", "deny", "ask", "approval_required"}:
+            return cast(ToolHookAction, normalized)
+        return None
+
+    @staticmethod
+    def _coerce_tool_hook_decision(
+        decision: ToolHookDecision | dict[str, Any] | None,
+    ) -> ToolHookDecision:
+        """Normalize hook decision values from typed or dict-based embedders."""
+        if decision is None:
+            return ToolHookDecision(action="allow")
+        if isinstance(decision, ToolHookDecision):
+            return decision
+        if isinstance(decision, dict):
+            metadata = decision.get("metadata")
+            action = ToolExecutionHooks._coerce_tool_hook_action(
+                decision.get("action") or decision.get("status") or "allow"
+            )
+            if action is None:
+                return ToolHookDecision(
+                    action="deny",
+                    reason_code="invalid_tool_hook_action",
+                    message="Invalid MCP tool hook action",
+                )
+            return ToolHookDecision(
+                action=action,
+                reason_code=(
+                    str(decision.get("reason_code"))
+                    if decision.get("reason_code") is not None
+                    else None
+                ),
+                message=str(decision.get("message")) if decision.get("message") is not None else None,
+                metadata=dict(metadata) if isinstance(metadata, dict) else {},
+            )
+        return ToolHookDecision(
+            action="deny",
+            reason_code="invalid_tool_hook_decision",
+            message="Invalid MCP tool hook decision",
+        )
+
+    @staticmethod
+    def _tool_hook_payload(
+        decision: ToolHookDecision,
+        *,
+        phase: str,
+        fallback_reason_code: str | None = None,
+    ) -> dict[str, Any]:
+        """Serialize a normalized hook decision into response-safe metadata."""
+        action = str(decision.action or "allow").strip().lower()
+        if action == "approval_required":
+            action = "ask"
+        payload: dict[str, Any] = {
+            "phase": phase,
+            "action": action,
+            "status": action,
+        }
+        reason_code = sanitize_reason_code(decision.reason_code or fallback_reason_code)
+        if reason_code:
+            payload["reason_code"] = reason_code
+        if isinstance(decision.metadata, dict) and decision.metadata:
+            metadata_payload = {
+                key: decision.metadata[key]
+                for key in ("hook_id", "hook_order", "redacted")
+                if key in decision.metadata
+            }
+            payload.update(ToolExecutionHooks._sanitize_tool_hook_summary_item(metadata_payload))
+        return payload
+
+    @staticmethod
+    def _tool_hook_reporting_payload(
+        decision: ToolHookDecision,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Return payload used only for sanitized reporting summaries."""
+
+        summary_payload = dict(payload)
+        if isinstance(decision.metadata, dict):
+            hook_results = decision.metadata.get("hook_results")
+            if isinstance(hook_results, list):
+                summary_payload["metadata"] = {"hook_results": hook_results}
+        return summary_payload
+
+    async def _run_pre_tool_hooks(
+        self,
+        *,
+        tool_name: str,
+        tool_args: Any,
+        module_id: str | None,
+        tool_def: dict[str, Any] | None,
+        is_write: bool | None,
+        arguments_hash: str | None,
+        context: RequestContext,
+        scope_payload: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Run pre-tool hooks and map enforcement decisions to protocol errors."""
+        hook_context = self._build_tool_hook_context(
+            phase="pre",
+            tool_name=tool_name,
+            module_id=module_id,
+            tool_def=tool_def,
+            tool_args=tool_args,
+            is_write=is_write,
+            arguments_hash=arguments_hash,
+            context=context,
+            scope_payload=scope_payload,
+        )
+        try:
+            raw_decision = await self._tool_call_hook_manager.before_tool_call(hook_context)
+        except asyncio.CancelledError:
+            raise
+        except self._noncritical_exceptions as exc:
+            logger.exception(
+                "MCP pre-tool hook failed closed: tool_name={} module_id={} request_id={} error_type={}",
+                tool_name,
+                module_id,
+                context.request_id,
+                exc.__class__.__name__,
+            )
+            payload = {
+                "phase": "pre",
+                "action": "deny",
+                "status": "deny",
+                "reason_code": "tool_hook_unavailable",
+                "error_type": exc.__class__.__name__,
+            }
+            hook_id = getattr(exc, "hook_id", None)
+            if hook_id is not None:
+                payload["hook_id"] = hook_id
+            hook_order = getattr(exc, "hook_order", None)
+            if hook_order is not None:
+                payload["hook_order"] = hook_order
+            self._append_tool_hook_summary(context, payload)
+            raise GovernanceDeniedError(
+                "Permission denied by MCP tool hook",
+                governance={
+                    "action": "deny",
+                    "status": "deny",
+                    "reason_code": "tool_hook_unavailable",
+                    "hook": payload,
+                },
+            ) from exc
+
+        decision = self._coerce_tool_hook_decision(raw_decision)
+        payload = self._tool_hook_payload(decision, phase="pre")
+        if raw_decision is not None:
+            self._append_tool_hook_summary(context, self._tool_hook_reporting_payload(decision, payload))
+        action = str(payload.get("action") or "allow").strip().lower()
+        if action == "allow":
+            return payload
+        if action == "ask":
+            raise ApprovalRequiredError(
+                "Approval required by MCP tool hook",
+                approval={
+                    "source": "tool_hook",
+                    "reason_code": payload.get("reason_code") or "tool_hook_approval_required",
+                    "message": payload.get("message"),
+                    "hook": payload,
+                },
+            )
+        if action != "deny":
+            payload = self._tool_hook_payload(
+                ToolHookDecision(
+                    action="deny",
+                    reason_code="invalid_tool_hook_action",
+                    message=f"Unsupported MCP tool hook action: {action}",
+                    metadata={"requested_action": action},
+                ),
+                phase="pre",
+            )
+        raise GovernanceDeniedError(
+            "Permission denied by MCP tool hook",
+            governance={
+                "action": "deny",
+                "status": "deny",
+                "reason_code": payload.get("reason_code") or "tool_hook_denied",
+                "hook": payload,
+            },
+        )
+
+    async def run_pre_tool_hooks(
+        self,
+        *,
+        tool_name: str,
+        tool_args: Any,
+        module_id: str | None,
+        tool_def: dict[str, Any] | None,
+        is_write: bool | None,
+        arguments_hash: str | None,
+        context: RequestContext,
+        scope_payload: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Run pre-tool hooks through the public tool-execution security API."""
+
+        return await self._run_pre_tool_hooks(
+            tool_name=tool_name,
+            tool_args=tool_args,
+            module_id=module_id,
+            tool_def=tool_def,
+            is_write=is_write,
+            arguments_hash=arguments_hash,
+            context=context,
+            scope_payload=scope_payload,
+        )
+
+    async def _run_post_tool_hooks(
+        self,
+        *,
+        tool_name: str,
+        tool_args: Any,
+        module_id: str | None,
+        tool_def: dict[str, Any] | None,
+        is_write: bool | None,
+        arguments_hash: str | None,
+        context: RequestContext,
+        scope_payload: dict[str, Any] | None,
+        status: str,
+        duration_ms: float,
+        error: Exception | None = None,
+    ) -> None:
+        """Notify post-tool hooks while preserving the original tool outcome."""
+        hook_context = self._build_tool_hook_context(
+            phase="post",
+            tool_name=tool_name,
+            module_id=module_id,
+            tool_def=tool_def,
+            tool_args=tool_args,
+            is_write=is_write,
+            arguments_hash=arguments_hash,
+            context=context,
+            scope_payload=scope_payload,
+            status=status,
+            duration_ms=duration_ms,
+            error=error,
+        )
+        try:
+            raw_decision = await self._tool_call_hook_manager.after_tool_call(hook_context)
+        except asyncio.CancelledError:
+            raise
+        except self._noncritical_exceptions as exc:
+            logger.exception(
+                "MCP post-tool hook failed; suppressed to preserve tool outcome: "
+                "tool_name={} module_id={} request_id={} status={} error_type={}",
+                tool_name,
+                module_id,
+                context.request_id,
+                status,
+                exc.__class__.__name__,
+            )
+            payload = {
+                "phase": "post",
+                "action": "deny",
+                "status": "error",
+                "reason_code": "tool_hook_unavailable",
+                "error_type": exc.__class__.__name__,
+            }
+            hook_id = getattr(exc, "hook_id", None)
+            if hook_id is not None:
+                payload["hook_id"] = hook_id
+            hook_order = getattr(exc, "hook_order", None)
+            if hook_order is not None:
+                payload["hook_order"] = hook_order
+            self._append_tool_hook_summary(context, payload)
+            return
+        if raw_decision is not None:
+            decision = self._coerce_tool_hook_decision(raw_decision)
+            payload = self._tool_hook_payload(decision, phase="post")
+            self._append_tool_hook_summary(context, self._tool_hook_reporting_payload(decision, payload))
+
+    async def run_post_tool_hooks(
+        self,
+        *,
+        tool_name: str,
+        tool_args: Any,
+        module_id: str | None,
+        tool_def: dict[str, Any] | None,
+        is_write: bool | None,
+        arguments_hash: str | None,
+        context: RequestContext,
+        scope_payload: dict[str, Any] | None,
+        status: str,
+        duration_ms: float,
+        error: Exception | None = None,
+    ) -> None:
+        """Run post-tool hooks through the public tool-execution runtime API."""
+
+        await self._run_post_tool_hooks(
+            tool_name=tool_name,
+            tool_args=tool_args,
+            module_id=module_id,
+            tool_def=tool_def,
+            is_write=is_write,
+            arguments_hash=arguments_hash,
+            context=context,
+            scope_payload=scope_payload,
+            status=status,
+            duration_ms=duration_ms,
+            error=error,
+        )

--- a/tldw_Server_API/app/core/MCP_unified/tool_execution/hooks.py
+++ b/tldw_Server_API/app/core/MCP_unified/tool_execution/hooks.py
@@ -24,11 +24,9 @@ from ..protocol_types import (
 )
 
 try:  # pragma: no cover - optional dependency
-    from redis.exceptions import RedisError
+    from redis.exceptions import RedisError as _RedisError
 except ImportError:  # pragma: no cover - redis not installed
-    class RedisError(Exception):
-        """Fallback RedisError when redis-py is unavailable."""
-        pass
+    _RedisError = RuntimeError
 
 
 _HOOK_HELPER_NONCRITICAL_EXCEPTIONS = (
@@ -50,7 +48,7 @@ _HOOK_HELPER_NONCRITICAL_EXCEPTIONS = (
     ValueError,
     UnicodeDecodeError,
     json.JSONDecodeError,
-    RedisError,
+    _RedisError,
     RateLimitExceeded,
     InvalidParamsException,
 )

--- a/tldw_Server_API/app/core/MCP_unified/tool_execution/models.py
+++ b/tldw_Server_API/app/core/MCP_unified/tool_execution/models.py
@@ -1,0 +1,26 @@
+"""Internal models for staged MCP tool execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class ToolResolution:
+    tool_name: str
+    tool_args: Any
+    module: Any
+    module_id: str | None
+    tool_def: dict[str, Any] | None
+    is_write: bool | None
+
+
+@dataclass(slots=True)
+class PolicyEvaluation:
+    effective_policy: dict[str, Any] | None
+    external_access_result: dict[str, Any] = field(default_factory=dict)
+    path_scope_result: dict[str, Any] = field(default_factory=dict)
+    scope_payload: dict[str, Any] | None = None
+    within_effective_policy: bool = True
+    within_resolved_scope: bool = True

--- a/tldw_Server_API/app/core/MCP_unified/tool_execution/reporting.py
+++ b/tldw_Server_API/app/core/MCP_unified/tool_execution/reporting.py
@@ -1,0 +1,410 @@
+"""Tool-use reporting helpers for MCP tool execution."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from loguru import logger
+from mcp_unified.tool_use_reporting.builders import (
+    classify_tool_use_exception,
+    extract_safe_context_dimensions,
+)
+from mcp_unified.tool_use_reporting.models import (
+    MAX_FILE_POLICY_DECISIONS,
+    MAX_TOOL_HOOK_RESULTS,
+    ToolUseEvent,
+    ToolUseStatus,
+)
+from mcp_unified.tool_use_reporting.recorder import record_tool_use_safely
+
+from ..protocol_types import GovernanceDeniedError, RequestContext
+from .hooks import ToolExecutionHooks
+
+
+class ToolExecutionReporter:
+    def __init__(
+        self,
+        *,
+        recorder: Any,
+        metrics: Any,
+        tool_name_re: Any,
+        noncritical_exceptions: tuple[type[BaseException], ...],
+    ) -> None:
+        self._tool_use_recorder = recorder
+        self.metrics = metrics
+        self._tool_name_re = tool_name_re
+        self._noncritical_exceptions = noncritical_exceptions
+
+    def should_record_tool_use(self, context: RequestContext) -> bool:
+        """Return whether this protocol path should record tool-use metadata."""
+        metadata = getattr(context, "metadata", {})
+        if not isinstance(metadata, dict):
+            return True
+        return metadata.get("mcp_tool_use_observed") is not True
+
+    should_record = should_record_tool_use
+
+    async def record_tool_use_event(self, event: ToolUseEvent) -> None:
+        """Record a tool-use event through the configured recorder."""
+        await record_tool_use_safely(self._tool_use_recorder, event)
+
+    record_event = record_tool_use_event
+
+    def safe_tool_use_name(self, value: Any) -> str:
+        """Return a safe tool name or the unknown sentinel."""
+        if isinstance(value, str) and self._tool_name_re.match(value):
+            return value
+        return "unknown"
+
+    _safe_tool_use_name = safe_tool_use_name
+
+    @staticmethod
+    def tool_use_duration_ms(start_ts: float) -> float:
+        """Return elapsed milliseconds from a monotonic-ish wall clock sample."""
+        return max(0.0, (time.time() - start_ts) * 1000.0)
+
+    duration_ms = tool_use_duration_ms
+    _tool_use_duration_ms = tool_use_duration_ms
+
+    @staticmethod
+    def tool_use_execution_origin_for_failure(status: ToolUseStatus) -> str:
+        """Return execution-origin metadata for a failed tool path."""
+        if status == "unavailable":
+            return "unavailable"
+        return "failed_before_execution"
+
+    execution_origin_for_failure = tool_use_execution_origin_for_failure
+    _tool_use_execution_origin_for_failure = tool_use_execution_origin_for_failure
+
+    @staticmethod
+    def tool_use_eval_metadata(
+        *,
+        payload: dict[str, Any] | None = None,
+        tool_def: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Extract safe eval metadata from response payload or tool definition."""
+        if isinstance(payload, dict) and isinstance(payload.get("eval"), dict):
+            return dict(payload["eval"])
+        metadata = (tool_def or {}).get("metadata") if isinstance(tool_def, dict) else None
+        if isinstance(metadata, dict) and isinstance(metadata.get("eval"), dict):
+            return dict(metadata["eval"])
+        return {}
+
+    _tool_use_eval_metadata = tool_use_eval_metadata
+
+    @staticmethod
+    def tool_use_file_policy_decisions(scope_payload: dict[str, Any] | None) -> list[dict[str, Any]]:
+        """Extract redacted file-policy path decisions from a scope payload."""
+
+        if not isinstance(scope_payload, dict):
+            return []
+        raw_decisions = scope_payload.get("path_decisions")
+        if not isinstance(raw_decisions, list):
+            return []
+        bounded_decisions = raw_decisions[:MAX_FILE_POLICY_DECISIONS]
+        return [dict(decision) for decision in bounded_decisions if isinstance(decision, dict)]
+
+    _tool_use_file_policy_decisions = tool_use_file_policy_decisions
+
+    @staticmethod
+    def tool_use_hook_results(metadata: dict[str, Any] | None) -> list[dict[str, Any]]:
+        """Consume bounded tool-hook result metadata from request metadata."""
+
+        if not isinstance(metadata, dict):
+            return []
+        raw_results = metadata.pop("mcp_tool_hook_results", None)
+        if not isinstance(raw_results, list):
+            return []
+        bounded_results = raw_results[:MAX_TOOL_HOOK_RESULTS]
+        return [dict(result) for result in bounded_results if isinstance(result, dict)]
+
+    _tool_use_hook_results = tool_use_hook_results
+
+    @staticmethod
+    def tool_hook_summary_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
+        """Return sanitized hook summary rows from a protocol hook payload."""
+
+        return ToolExecutionHooks._tool_hook_summary_items(payload)
+
+    _tool_hook_summary_items = tool_hook_summary_items
+
+    @staticmethod
+    def append_tool_hook_summary(context: RequestContext, payload: dict[str, Any]) -> None:
+        """Append safe hook metadata for tool-use reporting."""
+
+        ToolExecutionHooks._append_tool_hook_summary(context, payload)
+
+    _append_tool_hook_summary = append_tool_hook_summary
+
+    @staticmethod
+    def tool_use_decision_grant_outcome(file_policy_decisions: list[dict[str, Any]]) -> str | None:
+        """Summarize path-decision grant outcomes with denial precedence."""
+
+        outcomes = [
+            outcome.strip()
+            for decision in file_policy_decisions
+            if isinstance(decision, dict)
+            and isinstance(outcome := decision.get("grant_outcome"), str)
+            and outcome.strip()
+        ]
+        if "denied" in outcomes:
+            return "denied"
+        if "not_granted" in outcomes:
+            return "not_granted"
+        if outcomes:
+            return "allowed"
+        return None
+
+    _tool_use_decision_grant_outcome = tool_use_decision_grant_outcome
+
+    @staticmethod
+    def tool_use_value_present(value: Any) -> bool:
+        """Return whether a sensitive value marker contains actual data."""
+
+        if value is None:
+            return False
+        if isinstance(value, str):
+            return bool(value.strip())
+        if isinstance(value, (dict, list, tuple, set)):
+            return bool(value)
+        return True
+
+    _tool_use_value_present = tool_use_value_present
+
+    @staticmethod
+    def tool_use_contains_key(
+        value: Any,
+        keys: set[str],
+        *,
+        _depth: int = 0,
+    ) -> bool:
+        """Return whether a nested tool payload/args object contains any key."""
+
+        if _depth > 4:
+            return False
+        if isinstance(value, dict):
+            for key, nested in value.items():
+                if key in keys and ToolExecutionReporter.tool_use_value_present(nested):
+                    return True
+                if isinstance(nested, (dict, list)) and ToolExecutionReporter.tool_use_contains_key(
+                    nested,
+                    keys,
+                    _depth=_depth + 1,
+                ):
+                    return True
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, (dict, list)) and ToolExecutionReporter.tool_use_contains_key(
+                    item,
+                    keys,
+                    _depth=_depth + 1,
+                ):
+                    return True
+        return False
+
+    _tool_use_contains_key = tool_use_contains_key
+
+    @staticmethod
+    def tool_use_category(tool_def: dict[str, Any] | None) -> str | None:
+        """Return the metadata category from a tool definition when present."""
+        metadata = (tool_def or {}).get("metadata") if isinstance(tool_def, dict) else None
+        if not isinstance(metadata, dict):
+            return None
+        category = metadata.get("category")
+        return str(category) if isinstance(category, str) and category.strip() else None
+
+    _tool_use_category = tool_use_category
+
+    def build_tool_use_event(
+        self,
+        *,
+        context: RequestContext,
+        requested_tool_name: Any,
+        status: ToolUseStatus,
+        execution_origin: str,
+        duration_ms: float,
+        effective_tool_name: Any | None = None,
+        module_id: str | None = None,
+        tool_def: dict[str, Any] | None = None,
+        payload: dict[str, Any] | None = None,
+        tool_args: Any | None = None,
+        scope_payload: dict[str, Any] | None = None,
+        is_write: bool | None = None,
+        reason_code: str | None = None,
+        idempotency_replay: bool = False,
+    ) -> ToolUseEvent:
+        """Build a metadata-only tool-use event."""
+        metadata = getattr(context, "metadata", {})
+        dimensions = extract_safe_context_dimensions(metadata if isinstance(metadata, dict) else None)
+        nested = isinstance(metadata, dict) and metadata.get("mcp_tool_use_nested") is True
+        hook_results = self.tool_use_hook_results(metadata if isinstance(metadata, dict) else None)
+        eval_metadata = self.tool_use_eval_metadata(payload=payload, tool_def=tool_def)
+        safe_requested_name = self.safe_tool_use_name(requested_tool_name)
+        safe_effective_name = self.safe_tool_use_name(effective_tool_name or safe_requested_name)
+        file_policy_decisions = self.tool_use_file_policy_decisions(scope_payload)
+        file_policy_related = bool(file_policy_decisions) or safe_effective_name.startswith("fs.")
+        sha256_before_keys = {"sha256_before", "expected_sha256", "expected_sha256_by_path"}
+        file_policy_sha256_before_present = (
+            (
+                self.tool_use_contains_key(payload, sha256_before_keys)
+                or self.tool_use_contains_key(tool_args, sha256_before_keys)
+            )
+            if file_policy_related
+            else None
+        )
+        file_policy_sha256_after_present = (
+            self.tool_use_contains_key(payload, {"sha256_after"})
+            if file_policy_related
+            else None
+        )
+        file_policy_lock_lease_present = (
+            (
+                self.tool_use_contains_key(payload, {"lock_lease_id", "lock_lease_id_by_path"})
+                or self.tool_use_contains_key(tool_args, {"lock_lease_id", "lock_lease_id_by_path"})
+            )
+            if file_policy_related
+            else None
+        )
+        decision_grant_outcome = self.tool_use_decision_grant_outcome(file_policy_decisions)
+        return ToolUseEvent(
+            runtime_surface="protocol",
+            execution_origin=execution_origin,  # type: ignore[arg-type]
+            nested=nested,
+            requested_tool_name=safe_requested_name,
+            effective_tool_name=safe_effective_name,
+            module_id=module_id,
+            category=self.tool_use_category(tool_def),
+            read_only=(not is_write) if is_write is not None else None,
+            is_write=is_write,
+            source_kind="local",
+            status=status,
+            reason_code=reason_code,
+            duration_ms=duration_ms,
+            idempotency_replay=idempotency_replay,
+            tool_prompt_id=eval_metadata.get("tool_prompt_id"),
+            tool_prompt_version=eval_metadata.get("tool_prompt_version"),
+            prompt_variant=eval_metadata.get("prompt_variant"),
+            action_family=eval_metadata.get("action_family"),
+            result_kind=eval_metadata.get("result_kind") or eval_metadata.get("expected_result_kind"),
+            path_filter_used=eval_metadata.get("path_filter_used"),
+            grant_outcome=eval_metadata.get("grant_outcome") or decision_grant_outcome,
+            truncated=eval_metadata.get("truncated"),
+            file_policy_decisions=file_policy_decisions,
+            tool_hook_results=hook_results,
+            file_policy_sha256_before_present=file_policy_sha256_before_present,
+            file_policy_sha256_after_present=file_policy_sha256_after_present,
+            file_policy_lock_lease_present=file_policy_lock_lease_present,
+            **dimensions,
+        )
+
+    build_event = build_tool_use_event
+    _build_tool_use_event = build_tool_use_event
+
+    async def record_process_request_failure(
+        self,
+        *,
+        request: Any,
+        context: RequestContext,
+        status: ToolUseStatus,
+        reason_code: str,
+        start_ts: float,
+        requested_tool_name: Any = None,
+        should_record: Callable[[RequestContext], bool] | None = None,
+        build_event: Callable[..., ToolUseEvent] | None = None,
+        record_event: Callable[[ToolUseEvent], Awaitable[None]] | None = None,
+        duration_ms: Callable[[float], float] | None = None,
+        execution_origin_for_failure: Callable[[ToolUseStatus], str] | None = None,
+    ) -> None:
+        """Record a tools/call failure that occurs before handler dispatch."""
+        should_record = should_record or self.should_record
+        if getattr(request, "method", None) != "tools/call" or not should_record(context):
+            return
+        params = request.params if isinstance(getattr(request, "params", None), dict) else {}
+        requested = (
+            requested_tool_name
+            if requested_tool_name is not None
+            else params.get("name")
+        )
+        build_event = build_event or self.build_event
+        record_event = record_event or self.record_event
+        duration_ms = duration_ms or self.duration_ms
+        execution_origin_for_failure = execution_origin_for_failure or self.execution_origin_for_failure
+        try:
+            event = build_event(
+                context=context,
+                requested_tool_name=requested,
+                status=status,
+                execution_origin=execution_origin_for_failure(status),
+                duration_ms=duration_ms(start_ts),
+                reason_code=reason_code,
+            )
+            await record_event(event)
+        except Exception as exc:  # noqa: BLE001 - reporting must not affect requests.
+            logger.warning(
+                "Failed to build or record process-request tool-use event: {}",
+                exc.__class__.__name__,
+            )
+
+    _record_process_request_tool_use_failure = record_process_request_failure
+
+    async def record_prepare_failure(
+        self,
+        *,
+        context: RequestContext,
+        params: dict[str, Any],
+        exc: Exception,
+        start_ts: float,
+    ) -> None:
+        if not self.should_record(context):
+            return
+        status, reason_code = classify_tool_use_exception(exc)
+        scope_payload = None
+        if isinstance(exc, GovernanceDeniedError) and isinstance(exc.governance, dict):
+            path_scope = exc.governance.get("path_scope")
+            if isinstance(path_scope, dict):
+                scope_payload = path_scope
+        event = self.build_event(
+            context=context,
+            requested_tool_name=params.get("name") if isinstance(params, dict) else None,
+            status=status,
+            execution_origin="failed_before_execution",
+            duration_ms=self.duration_ms(start_ts),
+            reason_code=reason_code,
+            tool_args=params.get("arguments") if isinstance(params, dict) else None,
+            scope_payload=scope_payload,
+        )
+        await self.record_event(event)
+
+    def audit_tool_event(
+        self,
+        context: RequestContext,
+        tool_name: str,
+        module_id: str | None,
+        status: str,
+        duration_ms: float,
+        arguments_hash: str | None,
+        error: Exception | None = None,
+    ) -> None:
+        try:
+            log = logger.bind(
+                audit=True,
+                request_id=context.request_id,
+                user_id=context.user_id,
+                client_id=context.client_id,
+                session_id=context.session_id,
+                tool=tool_name,
+                module=module_id or "unknown",
+                duration_ms=round(duration_ms, 2),
+                arguments_hash=arguments_hash,
+                status=status,
+            )
+            if error:
+                log.error("MCP tool execution failed", error_type=error.__class__.__name__)
+            else:
+                log.info("MCP tool executed")
+        except self._noncritical_exceptions:
+            pass
+
+    _audit_tool_event = audit_tool_event

--- a/tldw_Server_API/app/core/MCP_unified/tool_execution/reporting.py
+++ b/tldw_Server_API/app/core/MCP_unified/tool_execution/reporting.py
@@ -24,6 +24,8 @@ from .hooks import ToolExecutionHooks
 
 
 class ToolExecutionReporter:
+    """Build and emit MCP tool-use reporting, metrics, and audit records."""
+
     def __init__(
         self,
         *,
@@ -32,6 +34,8 @@ class ToolExecutionReporter:
         tool_name_re: Any,
         noncritical_exceptions: tuple[type[BaseException], ...],
     ) -> None:
+        """Store recorder, metrics, and validation dependencies for reporting."""
+
         self._tool_use_recorder = recorder
         self.metrics = metrics
         self._tool_name_re = tool_name_re
@@ -387,6 +391,8 @@ class ToolExecutionReporter:
         arguments_hash: str | None,
         error: Exception | None = None,
     ) -> None:
+        """Emit a best-effort structured audit log for a completed tool execution."""
+
         try:
             log = logger.bind(
                 audit=True,
@@ -401,10 +407,13 @@ class ToolExecutionReporter:
                 status=status,
             )
             if error:
-                log.error("MCP tool execution failed", error_type=error.__class__.__name__)
+                log.error("MCP tool execution failed: {error_type}", error_type=error.__class__.__name__)
             else:
                 log.info("MCP tool executed")
-        except self._noncritical_exceptions:
-            pass
+        except self._noncritical_exceptions as exc:
+            logger.debug(
+                "MCP audit log emission skipped after noncritical failure: {error_type}",
+                error_type=exc.__class__.__name__,
+            )
 
     _audit_tool_event = audit_tool_event

--- a/tldw_Server_API/app/core/MCP_unified/tool_execution/runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/tool_execution/runtime.py
@@ -21,6 +21,8 @@ from .dependencies import ToolExecutionDependencies
 
 
 class ToolExecutionRuntime:
+    """Execute validated MCP tool calls and record runtime side effects."""
+
     def __init__(
         self,
         *,
@@ -33,6 +35,8 @@ class ToolExecutionRuntime:
         make_idempotency_cache_key: Any,
         run_post_tool_hooks: Any | None = None,
     ) -> None:
+        """Store dependencies and protocol compatibility callbacks for runtime execution."""
+
         self.dependencies = dependencies
         self.security = security
         self.hooks = hooks
@@ -65,6 +69,8 @@ class ToolExecutionRuntime:
         tool_name: str,
         idempotency_key: str,
     ) -> str:
+        """Build the owner-scoped idempotency cache key for a tool call."""
+
         owner = f"user:{context.user_id}" if context.user_id else (f"client:{context.client_id}" if context.client_id else "anon")
         return f"{owner}|module:{module_name}|tool:{tool_name}|key:{idempotency_key}"
 
@@ -98,6 +104,8 @@ class ToolExecutionRuntime:
         return {}
 
     async def _run_post_hooks(self, **kwargs: Any) -> None:
+        """Run post-tool hooks through either a protocol seam or the extracted hook helper."""
+
         if self._run_post_tool_hooks is not None:
             await self._run_post_tool_hooks(**kwargs)
             return
@@ -192,9 +200,11 @@ class ToolExecutionRuntime:
                 await self.rate_limiter.check_rate_limit(rl_key, category=category)
             except RateLimitExceeded:
                 raise
-            except self._noncritical_exceptions:
-                # Best-effort; do not block on limiter errors
-                pass
+            except self._noncritical_exceptions as exc:
+                logger.debug(
+                    "MCP tool rate limit check skipped after noncritical failure: {error_type}",
+                    error_type=exc.__class__.__name__,
+                )
 
             # Execute tool with circuit breaker (pass context through)
             t0 = time.time()
@@ -304,8 +314,11 @@ class ToolExecutionRuntime:
                 try:
                     duration = max(0.0, time.time() - t0)
                     self.metrics.record_module_operation(module=module_name or "unknown", operation="tools_call", duration=duration, success=True)
-                except self._noncritical_exceptions:
-                    pass
+                except self._noncritical_exceptions as metrics_exc:
+                    logger.debug(
+                        "MCP tool success metrics skipped after noncritical failure: {error_type}",
+                        error_type=metrics_exc.__class__.__name__,
+                    )
                 self.reporter.audit_tool_event(
                     context,
                     tool_name,
@@ -337,14 +350,17 @@ class ToolExecutionRuntime:
             except self._noncritical_exceptions as e:
                 duration_ms = max(0.0, (time.time() - t0) * 1000.0)
                 context.logger.error(  # noqa: TRY400 - structured audit log records sanitized type only.
-                    "Tool execution failed",
+                    "Tool execution failed: {error_type}",
                     error_type=e.__class__.__name__,
                 )
                 try:
                     duration = max(0.0, time.time() - t0)
                     self.metrics.record_module_operation(module=getattr(module, "name", "unknown"), operation="tools_call", duration=duration, success=False)
-                except self._noncritical_exceptions:
-                    pass
+                except self._noncritical_exceptions as metrics_exc:
+                    logger.debug(
+                        "MCP tool failure metrics skipped after noncritical failure: {error_type}",
+                        error_type=metrics_exc.__class__.__name__,
+                    )
                 self.reporter.audit_tool_event(
                     context,
                     tool_name,
@@ -398,8 +414,11 @@ class ToolExecutionRuntime:
                         self.metrics.record_idempotency_hit(module_id or getattr(module, "name", "unknown"), str(tool_name))
                     else:
                         self.metrics.record_idempotency_miss(module_id or getattr(module, "name", "unknown"), str(tool_name))
-                except self._noncritical_exceptions:
-                    pass
+                except self._noncritical_exceptions as metrics_exc:
+                    logger.debug(
+                        "MCP idempotency metrics skipped after noncritical failure: {error_type}",
+                        error_type=metrics_exc.__class__.__name__,
+                    )
             except Exception as exc:
                 status, reason_code = classify_tool_use_exception(exc)
                 await _record_prepared_event(

--- a/tldw_Server_API/app/core/MCP_unified/tool_execution/runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/tool_execution/runtime.py
@@ -1,0 +1,442 @@
+"""Runtime execution stage for prepared MCP tool calls."""
+
+from __future__ import annotations
+
+import contextlib
+import time
+from typing import Any
+
+from loguru import logger
+from mcp_unified.tool_use_reporting.builders import classify_tool_use_exception
+from mcp_unified.tool_use_reporting.models import ToolUseStatus
+
+from ..auth.rate_limiter import RateLimitExceeded
+from ..protocol_types import InvalidParamsException, PreparedToolCall, RequestContext
+from ..tool_observability import (
+    attach_execution_eval_metadata,
+    execution_eval_metadata_from_tool_definition,
+    sanitize_eval_profile_id,
+)
+from .dependencies import ToolExecutionDependencies
+
+
+class ToolExecutionRuntime:
+    def __init__(
+        self,
+        *,
+        dependencies: ToolExecutionDependencies,
+        security: Any,
+        hooks: Any,
+        noncritical_exceptions: tuple[type[BaseException], ...],
+        tool_execution_error: str,
+        generic_exception_like: Any,
+        make_idempotency_cache_key: Any,
+        run_post_tool_hooks: Any | None = None,
+    ) -> None:
+        self.dependencies = dependencies
+        self.security = security
+        self.hooks = hooks
+        self.rate_limiter = dependencies.rate_limiter
+        self.metrics = dependencies.metrics
+        self.telemetry = dependencies.telemetry
+        self.idempotency = dependencies.idempotency
+        self.reporter = dependencies.reporter
+        self.config_provider = dependencies.config_provider
+        self._noncritical_exceptions = noncritical_exceptions
+        self._tool_execution_error = tool_execution_error
+        self._generic_exception_like = generic_exception_like
+        self._make_idempotency_cache_key = make_idempotency_cache_key
+        self._run_post_tool_hooks = run_post_tool_hooks
+
+    def sync_from_dependencies(self) -> None:
+        """Refresh cached runtime references after protocol test seams mutate."""
+
+        self.rate_limiter = self.dependencies.rate_limiter
+        self.metrics = self.dependencies.metrics
+        self.telemetry = self.dependencies.telemetry
+        self.idempotency = self.dependencies.idempotency
+        self.reporter = self.dependencies.reporter
+        self.config_provider = self.dependencies.config_provider
+
+    @staticmethod
+    def make_idempotency_cache_key(
+        context: RequestContext,
+        module_name: str,
+        tool_name: str,
+        idempotency_key: str,
+    ) -> str:
+        owner = f"user:{context.user_id}" if context.user_id else (f"client:{context.client_id}" if context.client_id else "anon")
+        return f"{owner}|module:{module_name}|tool:{tool_name}|key:{idempotency_key}"
+
+    @staticmethod
+    def extract_eval_profile_id(context: RequestContext) -> str | None:
+        """Extract a non-sensitive profile identifier for execution eval metadata."""
+
+        metadata = getattr(context, "metadata", {})
+        if not isinstance(metadata, dict):
+            return None
+        for key in ("profile_id", "mcp_profile_id", "gateway_profile_id"):
+            value = metadata.get(key)
+            clean_value = sanitize_eval_profile_id(value)
+            if clean_value is not None:
+                return clean_value
+        return None
+
+    @staticmethod
+    def _tool_use_eval_metadata(
+        *,
+        payload: dict[str, Any] | None = None,
+        tool_def: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Extract safe eval metadata from response payload or tool definition."""
+
+        if isinstance(payload, dict) and isinstance(payload.get("eval"), dict):
+            return dict(payload["eval"])
+        metadata = (tool_def or {}).get("metadata") if isinstance(tool_def, dict) else None
+        if isinstance(metadata, dict) and isinstance(metadata.get("eval"), dict):
+            return dict(metadata["eval"])
+        return {}
+
+    async def _run_post_hooks(self, **kwargs: Any) -> None:
+        if self._run_post_tool_hooks is not None:
+            await self._run_post_tool_hooks(**kwargs)
+            return
+        await self.hooks.run_post_tool_hooks(**kwargs)
+
+    async def execute_prepared_tool_call(self, prepared: PreparedToolCall) -> dict[str, Any]:
+        """Execute a previously prepared tool invocation."""
+
+        self.security.verify_prepared_tool_call_integrity(prepared)
+        tool_name = prepared.tool_name
+        tool_args = prepared.tool_args
+        module = prepared.module
+        module_id = prepared.module_id
+        tool_def = prepared.tool_def
+        is_write = prepared.is_write
+        normalized_idempotency_key = prepared.normalized_idempotency_key
+        idempotency_cache_key = prepared.idempotency_cache_key
+        args_hash = prepared.arguments_hash
+        context = prepared.context
+        execution_start_ts = time.time()
+
+        async def _record_prepared_event(
+            *,
+            status: ToolUseStatus,
+            execution_origin: str,
+            reason_code: str | None = None,
+            payload: dict[str, Any] | None = None,
+            idempotency_replay: bool = False,
+        ) -> None:
+            try:
+                if not self.reporter.should_record(context):
+                    return
+                event = self.reporter.build_event(
+                    context=context,
+                    requested_tool_name=tool_name,
+                    effective_tool_name=tool_name,
+                    status=status,
+                    execution_origin=execution_origin,
+                    duration_ms=self.reporter.duration_ms(execution_start_ts),
+                    module_id=module_id or getattr(module, "name", None),
+                    tool_def=tool_def if isinstance(tool_def, dict) else None,
+                    payload=payload,
+                    tool_args=tool_args,
+                    scope_payload=prepared.scope_payload,
+                    is_write=is_write,
+                    reason_code=reason_code,
+                    idempotency_replay=idempotency_replay,
+                )
+                await self.reporter.record_event(event)
+            except Exception as exc:  # noqa: BLE001 - reporting must not affect tool calls.
+                logger.warning(
+                    "Failed to build or record prepared tool-use event: {}",
+                    exc.__class__.__name__,
+                )
+
+        async def _execute_tool_call() -> dict[str, Any]:
+            # Optional per-tool/category rate limits (ingestion vs read)
+            try:
+                cfg = self.config_provider()
+                category = None
+                try:
+                    meta = (tool_def or {}).get("metadata") or {}
+                    cat = str(meta.get("category") or "").lower().replace("-", "_")
+                    if bool(meta.get("uses_network")) or cat in {"web", "network", "external", "external_network"}:
+                        category = "network"
+                    elif cat in {
+                        "ingestion",
+                        "management",
+                        "read",
+                        "utility",
+                        "browser",
+                        "code",
+                        "filesystem",
+                        "shell",
+                        "search",
+                        "tool_discovery",
+                    }:
+                        category = cat
+                except self._noncritical_exceptions:
+                    category = None
+                if not category:
+                    try:
+                        if isinstance(cfg.tool_category_map, dict) and tool_name in cfg.tool_category_map:
+                            category = str(cfg.tool_category_map.get(tool_name))
+                    except self._noncritical_exceptions:
+                        category = None
+                if not category:
+                    ingestion_tools = {"ingest_media", "update_media", "delete_media"}
+                    category = "ingestion" if tool_name in ingestion_tools else "read"
+                key_owner = f"user:{context.user_id}" if context.user_id else (f"client:{context.client_id}" if context.client_id else "anon")
+                rl_key = f"{key_owner}:tool:{tool_name}:cat:{category}"
+                await self.rate_limiter.check_rate_limit(rl_key, category=category)
+            except RateLimitExceeded:
+                raise
+            except self._noncritical_exceptions:
+                # Best-effort; do not block on limiter errors
+                pass
+
+            # Execute tool with circuit breaker (pass context through)
+            t0 = time.time()
+
+            try:
+                # Trace the tool call with OTEL
+                with self.telemetry.trace_context(
+                    "mcp.tool_call",
+                    {
+                        "mcp.tool": tool_name,
+                        "mcp.module": getattr(module, "name", "unknown"),
+                        "mcp.user_id": str(context.user_id or ""),
+                        "mcp.client_id": str(context.client_id or ""),
+                    },
+                ) as span:
+                    try:
+                        execution_args = tool_args
+                        tool_schema_props = (
+                            (tool_def or {}).get("inputSchema", {}).get("properties", {})
+                            if isinstance(tool_def, dict)
+                            else {}
+                        )
+                        if (
+                            normalized_idempotency_key
+                            and isinstance(tool_args, dict)
+                            and isinstance(tool_schema_props, dict)
+                            and "idempotencyKey" in tool_schema_props
+                            and "idempotencyKey" not in tool_args
+                        ):
+                            execution_args = dict(tool_args)
+                            execution_args["idempotencyKey"] = normalized_idempotency_key
+                        result = await module.execute_with_circuit_breaker(
+                            module.execute_tool,
+                            tool_name,
+                            execution_args,
+                            context,
+                        )
+                        span.set_attribute("mcp.status", "success")
+                    except InvalidParamsException as _tool_e:
+                        span.set_attribute("mcp.status", "failure")
+                        span.set_attribute("mcp.error_type", _tool_e.__class__.__name__)
+                        span.set_attribute("mcp.error_message", str(_tool_e)[:200])
+                        with contextlib.suppress(self._noncritical_exceptions):
+                            self.metrics.record_tool_invalid_params(getattr(module, "name", "unknown"), str(tool_name))
+                        raise
+                    except (TypeError, ValueError) as _tool_e:
+                        # Module argument validators often raise ValueError/TypeError.
+                        # Normalize those to INVALID_PARAMS so HTTP callers receive 400.
+                        span.set_attribute("mcp.status", "failure")
+                        span.set_attribute("mcp.error_type", _tool_e.__class__.__name__)
+                        span.set_attribute("mcp.error_message", str(_tool_e)[:200])
+                        with contextlib.suppress(self._noncritical_exceptions):
+                            self.metrics.record_tool_invalid_params(getattr(module, "name", "unknown"), str(tool_name))
+                        raise InvalidParamsException(str(_tool_e)) from _tool_e
+                    except self._noncritical_exceptions as _tool_e:
+                        sanitized_tool_error = self._generic_exception_like(
+                            _tool_e,
+                            self._tool_execution_error,
+                        )
+                        span.set_attribute("mcp.status", "failure")
+                        span.set_attribute("mcp.error_type", sanitized_tool_error.__class__.__name__)
+                        span.set_attribute("mcp.error_message", self._tool_execution_error)
+                        raise sanitized_tool_error from None
+                    finally:
+                        span.set_attribute("mcp.duration_ms", max(0.0, (time.time() - t0) * 1000.0))
+
+                # Format result
+                duration_ms = max(0.0, (time.time() - t0) * 1000.0)
+                profile_id = self.extract_eval_profile_id(context)
+                result = attach_execution_eval_metadata(
+                    result,
+                    tool_name=tool_name,
+                    tool_def=tool_def,
+                    profile_id=profile_id,
+                    duration_ms=duration_ms,
+                )
+                execution_eval = execution_eval_metadata_from_tool_definition(
+                    tool_name=tool_name,
+                    tool_def=tool_def,
+                    profile_id=profile_id,
+                    duration_ms=duration_ms,
+                )
+                result_eval = self._tool_use_eval_metadata(payload=result if isinstance(result, dict) else None)
+                for key in (
+                    "tool_prompt_id",
+                    "tool_prompt_version",
+                    "action_family",
+                    "result_kind",
+                    "path_filter_used",
+                    "truncated",
+                    "reason_code",
+                ):
+                    if key in result_eval:
+                        execution_eval[key] = result_eval[key]
+                if isinstance(result, str):
+                    content = [{"type": "text", "text": result}]
+                elif isinstance(result, list):
+                    content = result
+                elif isinstance(result, dict):
+                    # Preserve structured tool results as JSON content instead of stringifying.
+                    content = [{"type": "json", "json": result}]
+                else:
+                    content = [{"type": "text", "text": str(result)}]
+
+                module_name = module_id or getattr(module, "name", None)
+                # Record module operation metrics
+                try:
+                    duration = max(0.0, time.time() - t0)
+                    self.metrics.record_module_operation(module=module_name or "unknown", operation="tools_call", duration=duration, success=True)
+                except self._noncritical_exceptions:
+                    pass
+                self.reporter.audit_tool_event(
+                    context,
+                    tool_name,
+                    module_name,
+                    status="success",
+                    duration_ms=duration_ms,
+                    arguments_hash=args_hash,
+                )
+                response_payload = {
+                    "content": content,
+                    "module": module_name,
+                    "tool": tool_name,
+                    "eval": execution_eval,
+                }
+                await self._run_post_hooks(
+                    tool_name=tool_name,
+                    tool_args=tool_args,
+                    module_id=module_name,
+                    tool_def=tool_def if isinstance(tool_def, dict) else None,
+                    is_write=is_write,
+                    arguments_hash=args_hash,
+                    context=context,
+                    scope_payload=prepared.scope_payload,
+                    status="success",
+                    duration_ms=duration_ms,
+                )
+                return response_payload
+
+            except self._noncritical_exceptions as e:
+                duration_ms = max(0.0, (time.time() - t0) * 1000.0)
+                context.logger.error(  # noqa: TRY400 - structured audit log records sanitized type only.
+                    "Tool execution failed",
+                    error_type=e.__class__.__name__,
+                )
+                try:
+                    duration = max(0.0, time.time() - t0)
+                    self.metrics.record_module_operation(module=getattr(module, "name", "unknown"), operation="tools_call", duration=duration, success=False)
+                except self._noncritical_exceptions:
+                    pass
+                self.reporter.audit_tool_event(
+                    context,
+                    tool_name,
+                    module_id or getattr(module, "name", None),
+                    status="failure",
+                    duration_ms=duration_ms,
+                    arguments_hash=args_hash,
+                    error=e,
+                )
+                await self._run_post_hooks(
+                    tool_name=tool_name,
+                    tool_args=tool_args,
+                    module_id=module_id or getattr(module, "name", None),
+                    tool_def=tool_def if isinstance(tool_def, dict) else None,
+                    is_write=is_write,
+                    arguments_hash=args_hash,
+                    context=context,
+                    scope_payload=prepared.scope_payload,
+                    status="failure",
+                    duration_ms=duration_ms,
+                    error=e,
+                )
+                raise
+
+        if is_write and idempotency_cache_key:
+            try:
+                cfg = self.config_provider()
+                ttl = max(1, int(getattr(cfg, "idempotency_ttl_seconds", 300)))
+                max_size = max(1, int(getattr(cfg, "idempotency_cache_size", 512)))
+                if args_hash is None:
+                    raise InvalidParamsException("Unable to fingerprint tool arguments for idempotency")
+                arguments_bound = await self.idempotency.bind_arguments(
+                    idempotency_cache_key,
+                    args_hash,
+                    ttl=ttl,
+                    max_size=max_size,
+                )
+                if not arguments_bound:
+                    raise InvalidParamsException("Idempotency key was already used with different arguments")
+                module_timeout = int(getattr(getattr(module, "config", None), "timeout_seconds", cfg.module_timeout))
+                lock_ttl = max(ttl, module_timeout * 2)
+                payload, from_cache = await self.idempotency.run(
+                    idempotency_cache_key,
+                    _execute_tool_call,
+                    ttl=ttl,
+                    max_size=max_size,
+                    lock_ttl=lock_ttl,
+                )
+                try:
+                    if from_cache:
+                        self.metrics.record_idempotency_hit(module_id or getattr(module, "name", "unknown"), str(tool_name))
+                    else:
+                        self.metrics.record_idempotency_miss(module_id or getattr(module, "name", "unknown"), str(tool_name))
+                except self._noncritical_exceptions:
+                    pass
+            except Exception as exc:
+                status, reason_code = classify_tool_use_exception(exc)
+                await _record_prepared_event(
+                    status=status,
+                    execution_origin=(
+                        self.reporter.execution_origin_for_failure(status)
+                        if status != "error"
+                        else "executed"
+                    ),
+                    reason_code=reason_code,
+                )
+                raise
+            await _record_prepared_event(
+                status="success",
+                execution_origin="cached" if from_cache else "executed",
+                payload=payload if isinstance(payload, dict) else None,
+                idempotency_replay=from_cache,
+            )
+            return payload
+
+        try:
+            payload = await _execute_tool_call()
+        except Exception as exc:
+            status, reason_code = classify_tool_use_exception(exc)
+            await _record_prepared_event(
+                status=status,
+                execution_origin=(
+                    self.reporter.execution_origin_for_failure(status)
+                    if status != "error"
+                    else "executed"
+                ),
+                reason_code=reason_code,
+            )
+            raise
+        await _record_prepared_event(
+            status="success",
+            execution_origin="executed",
+            payload=payload if isinstance(payload, dict) else None,
+        )
+        return payload

--- a/tldw_Server_API/app/core/MCP_unified/tool_execution/security.py
+++ b/tldw_Server_API/app/core/MCP_unified/tool_execution/security.py
@@ -63,6 +63,8 @@ def _is_unexpected_keyword_type_error(exc: TypeError, keyword: str) -> bool:
 
 
 class ToolExecutionSecurity:
+    """Perform validation, authorization, policy, and preparation for MCP tools/call."""
+
     def __init__(
         self,
         *,
@@ -71,6 +73,8 @@ class ToolExecutionSecurity:
         prepared_call_secret: bytes,
         noncritical_exceptions: tuple[type[BaseException], ...],
     ) -> None:
+        """Store security dependencies and mutable governance state."""
+
         self.dependencies = dependencies
         self.module_registry = dependencies.module_registry
         self.rbac_policy = dependencies.rbac_policy
@@ -93,6 +97,8 @@ class ToolExecutionSecurity:
         }
 
     def _prepare_callback(self, name: str, default: Callable[..., Any]) -> Callable[..., Any]:
+        """Return a late-bound compatibility callback or the extracted default."""
+
         callback = self._prepare_compatibility_callbacks.get(name)
         return callback if callable(callback) else default
 
@@ -105,6 +111,8 @@ class ToolExecutionSecurity:
         *,
         rbac_policy: Any | None = None,
     ) -> bool:
+        """Evaluate RBAC permissions through the configured policy adapter."""
+
         if not user_id:
             return False
         fn = getattr(rbac_policy or self.rbac_policy, "check_permission", None)
@@ -1133,7 +1141,7 @@ class ToolExecutionSecurity:
                     if category:
                         return category
         except Exception as exc:  # noqa: BLE001 - category fallback should not fail preflight.
-            logger.debug("Falling back to tool-name governance category", error_type=exc.__class__.__name__)
+            logger.debug("Falling back to tool-name governance category: {error_type}", error_type=exc.__class__.__name__)
 
         if isinstance(tool_name, str) and "." in tool_name:
             prefix = tool_name.split(".", 1)[0].strip().lower()
@@ -1159,7 +1167,10 @@ class ToolExecutionSecurity:
             candidate = str(raw_mode or "").strip().lower()
             return candidate if candidate in {"off", "shadow", "enforce"} else "off"
         except Exception as exc:  # noqa: BLE001 - config resolver exceptions should not block tools.
-            logger.debug("Unable to resolve governance rollout mode from app config", error_type=exc.__class__.__name__)
+            logger.debug(
+                "Unable to resolve governance rollout mode from app config: {error_type}",
+                error_type=exc.__class__.__name__,
+            )
             candidate = str(raw_mode or "").strip().lower()
             return candidate if candidate in {"off", "shadow", "enforce"} else "off"
 
@@ -1195,7 +1206,10 @@ class ToolExecutionSecurity:
                 if isinstance(dumped, dict):
                     return {str(k): v for k, v in dumped.items()}
             except Exception as exc:  # noqa: BLE001 - decision fallback handles noncritical model errors.
-                logger.debug("Falling back to attribute governance decision serialization", error_type=exc.__class__.__name__)
+                logger.debug(
+                    "Falling back to attribute governance decision serialization: {error_type}",
+                    error_type=exc.__class__.__name__,
+                )
         payload: dict[str, Any] = {}
         for key in ("action", "status", "category", "category_source", "fallback_reason", "matched_rules"):
             value = getattr(decision, key, None)
@@ -1424,7 +1438,8 @@ class ToolExecutionSecurity:
                 tool_def = ensure_tool_definition_eval_metadata(tool_def)
             except self._noncritical_exceptions as exc:
                 context.logger.opt(exception=exc).debug(
-                    "Failed to attach eval metadata to resolved tool definition",
+                    "Failed to attach eval metadata to resolved tool definition: module_id={module_id} "
+                    "tool_name={tool_name} error_type={error_type}",
                     module_id=module_id,
                     tool_name=tool_name,
                     error_type=exc.__class__.__name__,

--- a/tldw_Server_API/app/core/MCP_unified/tool_execution/security.py
+++ b/tldw_Server_API/app/core/MCP_unified/tool_execution/security.py
@@ -1,0 +1,1641 @@
+"""Security stages for MCP tool execution."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import hmac
+import inspect
+import json
+import re
+from collections.abc import Awaitable, Callable
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+from mcp_unified.interfaces.path_scope import (
+    PathScopeCandidate,
+    normalize_path_scope_candidates,
+)
+from pydantic import BaseModel
+
+from ..auth.authnz_rbac import Action, Resource
+from ..modules.base import BaseModule
+from ..protocol_types import (
+    ApprovalRequiredError,
+    GovernanceDeniedError,
+    InvalidParamsException,
+    PreparedToolCall,
+    RequestContext,
+    _has_trusted_compat_claims,
+)
+from ..tool_observability import ensure_tool_definition_eval_metadata
+from .dependencies import ToolExecutionDependencies
+
+_TOOL_AUTHORIZATION_ALIASES = {
+    "bash": "run",
+    "shell": "run",
+}
+_TRUTHY_VALUES = {"1", "true", "yes", "y", "on"}
+
+_AsyncBoolCallback = Callable[..., bool | Awaitable[bool]]
+_SyncBoolCallback = Callable[..., bool]
+
+
+def _is_truthy(value: Any) -> bool:
+    """Parse host-neutral truthy flags without importing protocol helpers."""
+    try:
+        return str(value or "").strip().lower() in _TRUTHY_VALUES
+    except Exception:  # noqa: BLE001 - best-effort normalization must fail closed.
+        return False
+
+
+def _is_unexpected_keyword_type_error(exc: TypeError, keyword: str) -> bool:
+    """Return True when a TypeError reports an unsupported keyword argument."""
+
+    message = str(exc)
+    return (
+        f"unexpected keyword argument '{keyword}'" in message
+        or f'unexpected keyword argument "{keyword}"' in message
+    )
+
+
+class ToolExecutionSecurity:
+    def __init__(
+        self,
+        *,
+        dependencies: ToolExecutionDependencies,
+        tool_name_re: re.Pattern[str],
+        prepared_call_secret: bytes,
+        noncritical_exceptions: tuple[type[BaseException], ...],
+    ) -> None:
+        self.dependencies = dependencies
+        self.module_registry = dependencies.module_registry
+        self.rbac_policy = dependencies.rbac_policy
+        self.metrics = dependencies.metrics
+        self._tool_name_re = tool_name_re
+        self._prepared_call_secret = prepared_call_secret
+        self._noncritical_exceptions = noncritical_exceptions
+        self._governance_service: Any | None = None
+        self._governance_store: Any | None = None
+        self._governance_lock = asyncio.Lock()
+        self._prepare_compatibility_callbacks: dict[str, Callable[..., Any]] = {}
+
+    def configure_prepare_compatibility_callbacks(self, **callbacks: Callable[..., Any]) -> None:
+        """Install late-bound protocol compatibility callbacks for prepare_tool_call."""
+
+        self._prepare_compatibility_callbacks = {
+            name: callback
+            for name, callback in callbacks.items()
+            if callable(callback)
+        }
+
+    def _prepare_callback(self, name: str, default: Callable[..., Any]) -> Callable[..., Any]:
+        callback = self._prepare_compatibility_callbacks.get(name)
+        return callback if callable(callback) else default
+
+    async def rbac_check(
+        self,
+        user_id: str | None,
+        resource: Resource,
+        action: Action,
+        resource_id: str | None = None,
+        *,
+        rbac_policy: Any | None = None,
+    ) -> bool:
+        if not user_id:
+            return False
+        fn = getattr(rbac_policy or self.rbac_policy, "check_permission", None)
+        if not fn:
+            return False
+        try:
+            if inspect.iscoroutinefunction(fn):
+                return await fn(user_id, resource, action, resource_id)
+            return fn(user_id, resource, action, resource_id)
+        except self._noncritical_exceptions:
+            return False
+
+    def scoped_permissions(self, context: RequestContext) -> list[str]:
+        metadata = getattr(context, "metadata", {})
+        if not isinstance(metadata, dict):
+            return []
+        raw = metadata.get("permissions") or []
+        if isinstance(raw, str):
+            return [raw]
+        if isinstance(raw, list):
+            return [str(item) for item in raw if isinstance(item, str)]
+        return []
+
+    def mcp_scopes(
+        self,
+        context: RequestContext,
+        *,
+        scoped_permissions: Callable[[RequestContext], list[str]] | None = None,
+    ) -> list[str]:
+        scopes: list[str] = []
+        scoped_permissions_fn = scoped_permissions or self.scoped_permissions
+        for scope in scoped_permissions_fn(context):
+            try:
+                if scope.lower().startswith("mcp:"):
+                    scopes.append(scope)
+            except self._noncritical_exceptions:
+                continue
+        return scopes
+
+    def api_key_scopes(self, context: RequestContext) -> set[str] | None:
+        """Return normalized API key scopes when present on the request context."""
+        metadata = getattr(context, "metadata", {})
+        if not isinstance(metadata, dict):
+            return None
+        raw = metadata.get("api_key_scopes")
+        if raw is None:
+            return None
+
+        normalizer = getattr(self.dependencies, "api_key_scope_normalizer", None)
+        normalize = getattr(normalizer, "normalize", None) if normalizer is not None else None
+        if callable(normalize):
+            try:
+                return set(normalize(raw))
+            except self._noncritical_exceptions as exc:
+                logger.debug(
+                    "MCP API key scope normalization failed; using local fallback: {}",
+                    exc.__class__.__name__,
+                )
+
+        if isinstance(raw, str):
+            stripped = raw.strip()
+            if stripped.startswith("["):
+                try:
+                    parsed = json.loads(stripped)
+                except json.JSONDecodeError:
+                    pass
+                else:
+                    if isinstance(parsed, list):
+                        return {
+                            item.strip().lower()
+                            for item in parsed
+                            if isinstance(item, str) and item.strip()
+                        }
+            return {stripped.lower()} if stripped else set()
+        if isinstance(raw, (list, tuple, set)):
+            return {str(item).strip().lower() for item in raw if str(item).strip()}
+        return set()
+
+    def api_key_scope_level(
+        self,
+        context: RequestContext,
+        *,
+        api_key_scopes: Callable[[RequestContext], set[str] | None] | None = None,
+    ) -> str | None:
+        scopes = (api_key_scopes or self.api_key_scopes)(context)
+        if not scopes:
+            return None
+        if "admin" in scopes or "service" in scopes:
+            return "admin"
+        if "write" in scopes:
+            return "write"
+        if "read" in scopes:
+            return "read"
+        return None
+
+    def api_key_allows(
+        self,
+        context: RequestContext,
+        *,
+        is_write: bool | None = None,
+        api_key_scope_level: Callable[[RequestContext], str | None] | None = None,
+    ) -> bool:
+        """Gate MCP operations by API key scopes when present."""
+        level = (api_key_scope_level or self.api_key_scope_level)(context)
+        if level is None:
+            return True
+        if level == "admin":
+            return True
+        if is_write is None:
+            return level in {"read", "write"}
+        if is_write:
+            return level == "write"
+        return level in {"read", "write"}
+
+    @staticmethod
+    def scope_matches(scope: str, resource_kind: str, identifier: str | None) -> bool:
+        scope = scope.strip().lower()
+        if not scope.startswith("mcp:"):
+            return False
+        parts = scope.split(":")
+        if len(parts) == 2 and parts[1] == "*":
+            return True
+        if len(parts) < 3:
+            return False
+        kind = parts[1]
+        value = ":".join(parts[2:])
+        if kind == "*":
+            return True
+        if kind != resource_kind:
+            return False
+        if value in {"*", ""}:
+            return True
+        if identifier is None:
+            return False
+        return value == identifier.lower()
+
+    def scope_allows(
+        self,
+        context: RequestContext,
+        resource_kind: str,
+        identifier: str | None,
+        *,
+        mcp_scopes: Callable[[RequestContext], list[str]] | None = None,
+        scope_matches: _SyncBoolCallback | None = None,
+    ) -> bool:
+        scopes = (mcp_scopes or self.mcp_scopes)(context)
+        if not scopes:
+            return True
+        identifier_norm = identifier.lower() if isinstance(identifier, str) else None
+        if identifier_norm is None:
+            # Allow listing/browsing when any scoped permission exists for this resource kind.
+            for scope in scopes:
+                try:
+                    parts = scope.strip().lower().split(":")
+                except self._noncritical_exceptions:
+                    continue
+                if len(parts) >= 2 and parts[0] == "mcp":
+                    if parts[1] == "*" or parts[1] == resource_kind:
+                        return True
+        scope_matches_fn = scope_matches or self.scope_matches
+        return any(scope_matches_fn(scope, resource_kind, identifier_norm) for scope in scopes)
+
+    @staticmethod
+    async def _call_bool(callback: _AsyncBoolCallback, *args: Any, **kwargs: Any) -> bool:
+        result = callback(*args, **kwargs)
+        if inspect.isawaitable(result):
+            result = await result
+        return bool(result)
+
+    async def has_module_permission(
+        self,
+        context: RequestContext,
+        module_id: str | None,
+        *,
+        rbac_check: _AsyncBoolCallback | None = None,
+        scope_allows: _SyncBoolCallback | None = None,
+    ) -> bool:
+        module_id_norm = module_id or ""
+        scope_allows_fn = scope_allows or self.scope_allows
+        if _has_trusted_compat_claims(context):
+            return scope_allows_fn(context, Resource.MODULE.value, module_id_norm or None)
+        rbac_check_fn = rbac_check or self.rbac_check
+        if not await self._call_bool(rbac_check_fn, context.user_id, Resource.MODULE, Action.READ, module_id_norm):
+            return False
+        return scope_allows_fn(context, Resource.MODULE.value, module_id_norm or None)
+
+    async def has_tool_permission(
+        self,
+        context: RequestContext,
+        tool_name: str,
+        *,
+        is_write: bool | None = None,
+        rbac_check: _AsyncBoolCallback | None = None,
+        scope_allows: _SyncBoolCallback | None = None,
+        api_key_allows: Callable[..., bool] | None = None,
+        tool_authorization_names: Callable[[str], tuple[str, ...]] | None = None,
+    ) -> bool:
+        scope_allows_fn = scope_allows or self.scope_allows
+        api_key_allows_fn = api_key_allows or self.api_key_allows
+        tool_authorization_names_fn = tool_authorization_names or self.tool_authorization_names
+        if _has_trusted_compat_claims(context):
+            for auth_name in tool_authorization_names_fn(tool_name):
+                if scope_allows_fn(context, Resource.TOOL.value, auth_name):
+                    return api_key_allows_fn(context, is_write=is_write)
+            return False
+        has_named_permission = False
+        rbac_check_fn = rbac_check or self.rbac_check
+        for auth_name in tool_authorization_names_fn(tool_name):
+            if not await self._call_bool(rbac_check_fn, context.user_id, Resource.TOOL, Action.EXECUTE, auth_name):
+                continue
+            if not scope_allows_fn(context, Resource.TOOL.value, auth_name):
+                continue
+            has_named_permission = True
+            break
+        if not has_named_permission:
+            return False
+        return api_key_allows_fn(context, is_write=is_write)
+
+    def extract_allowed_tools(self, context: RequestContext) -> list[str] | None:
+        """Extract allowed-tools list from request context metadata."""
+        try:
+            metadata = context.metadata or {}
+            allowed = metadata.get("allowed_tools")
+        except self._noncritical_exceptions:
+            return None
+
+        if allowed is None:
+            return None
+        if isinstance(allowed, list):
+            cleaned = [str(item).strip() for item in allowed if str(item).strip()]
+            return cleaned or None
+        if isinstance(allowed, str):
+            try:
+                parsed = json.loads(allowed)
+                if isinstance(parsed, list):
+                    cleaned = [str(item).strip() for item in parsed if str(item).strip()]
+                    return cleaned or None
+            except json.JSONDecodeError:
+                pass
+            cleaned = [part.strip() for part in allowed.split(",") if part.strip()]
+            return cleaned or None
+        return None
+
+    @staticmethod
+    def extract_tool_command(tool_args: Any) -> str | None:
+        """Extract command-like string from tool arguments for pattern matching."""
+        if not isinstance(tool_args, dict):
+            return None
+        for key in ("command", "cmd", "args", "arguments"):
+            if key not in tool_args:
+                continue
+            value = tool_args.get(key)
+            if isinstance(value, str):
+                return value
+            if isinstance(value, list):
+                return " ".join(str(part) for part in value)
+        return None
+
+    def matches_allowed_tool_pattern(
+        self,
+        tool_name: str,
+        tool_args: Any,
+        pattern: str,
+        *,
+        extract_tool_command: Callable[[Any], str | None] | None = None,
+    ) -> bool:
+        """Check if tool invocation matches an allowed-tools pattern."""
+        pattern = str(pattern or "").strip()
+        if not pattern:
+            return False
+        if "(" not in pattern:
+            return tool_name == pattern
+        if not pattern.endswith(")"):
+            return False
+
+        base_name, cmd_pattern = pattern.split("(", 1)
+        cmd_pattern = cmd_pattern[:-1]
+        base_name = base_name.strip()
+        if tool_name != base_name:
+            return False
+
+        command = (extract_tool_command or self.extract_tool_command)(tool_args)
+        if command is None:
+            return False
+
+        regex_pattern = re.escape(cmd_pattern)
+        regex_pattern = regex_pattern.replace(r"\*", ".*")
+        try:
+            return bool(re.match(f"^{regex_pattern}$", command.strip()))
+        except re.error:
+            return False
+
+    @staticmethod
+    def tool_authorization_names(tool_name: str) -> tuple[str, ...]:
+        """Return invoked and canonical names that may authorize a tool call."""
+
+        canonical_name = _TOOL_AUTHORIZATION_ALIASES.get(tool_name)
+        if canonical_name and canonical_name != tool_name:
+            return (tool_name, canonical_name)
+        return (tool_name,)
+
+    def matches_tool_authorization_pattern(
+        self,
+        tool_name: str,
+        tool_args: Any,
+        pattern: str,
+        *,
+        matches_allowed_tool_pattern: Callable[[str, Any, str], bool] | None = None,
+        tool_authorization_names: Callable[[str], tuple[str, ...]] | None = None,
+    ) -> bool:
+        """Match a policy pattern against the invoked name and any canonical alias."""
+
+        matches_allowed_tool_pattern_fn = matches_allowed_tool_pattern or self.matches_allowed_tool_pattern
+        tool_authorization_names_fn = tool_authorization_names or self.tool_authorization_names
+        return any(
+            matches_allowed_tool_pattern_fn(auth_name, tool_args, pattern)
+            for auth_name in tool_authorization_names_fn(tool_name)
+        )
+
+    def scope_allows_tool_name(
+        self,
+        context: RequestContext,
+        tool_name: str,
+        *,
+        scope_allows: _SyncBoolCallback | None = None,
+        tool_authorization_names: Callable[[str], tuple[str, ...]] | None = None,
+    ) -> bool:
+        """Return True when scopes allow the invoked tool name or canonical alias."""
+
+        scope_allows_fn = scope_allows or self.scope_allows
+        tool_authorization_names_fn = tool_authorization_names or self.tool_authorization_names
+        return any(
+            scope_allows_fn(context, Resource.TOOL.value, auth_name)
+            for auth_name in tool_authorization_names_fn(tool_name)
+        )
+
+    def is_tool_allowed_by_context(
+        self,
+        tool_name: str,
+        tool_args: Any,
+        context: RequestContext,
+        *,
+        extract_allowed_tools: Callable[[RequestContext], list[str] | None] | None = None,
+        matches_tool_authorization_pattern: Callable[[str, Any, str], bool] | None = None,
+    ) -> bool:
+        """Return True when tool usage is allowed by context metadata."""
+        allowed_tools = (extract_allowed_tools or self.extract_allowed_tools)(context)
+        if not allowed_tools:
+            return True
+        matches_tool_authorization_pattern_fn = (
+            matches_tool_authorization_pattern or self.matches_tool_authorization_pattern
+        )
+        return any(
+            matches_tool_authorization_pattern_fn(tool_name, tool_args, pattern)
+            for pattern in allowed_tools
+        )
+
+    def hash_arguments(self, arguments: dict[str, Any]) -> str | None:
+        return self.hash_arguments_with_exceptions(
+            arguments,
+            noncritical_exceptions=self._noncritical_exceptions,
+        )
+
+    @staticmethod
+    def hash_arguments_with_exceptions(
+        arguments: dict[str, Any],
+        *,
+        noncritical_exceptions: tuple[type[BaseException], ...],
+    ) -> str | None:
+        try:
+            payload = json.dumps(arguments or {}, sort_keys=True, default=str).encode("utf-8")
+            return hashlib.sha256(payload).hexdigest()
+        except noncritical_exceptions:
+            return None
+
+    async def resolve_tool_definition(
+        self,
+        module: BaseModule,
+        tool_name: str,
+    ) -> dict[str, Any] | None:
+        """Resolve a tool definition for a module/tool pair."""
+        try:
+            get_def = getattr(module, "get_tool_def", None)
+            if callable(get_def):
+                tool_def = await get_def(tool_name)  # type: ignore[misc]
+                if isinstance(tool_def, dict):
+                    return tool_def
+            tool_defs = await module.get_tools()
+            for candidate in tool_defs:
+                if isinstance(candidate, dict) and candidate.get("name") == tool_name:
+                    return candidate
+        except self._noncritical_exceptions:
+            return None
+        return None
+
+    def classify_write_tool_call(
+        self,
+        module: BaseModule,
+        tool_name: str,
+        tool_args: Any,
+        tool_def: dict[str, Any] | None,
+    ) -> bool | None:
+        """Best-effort write classification using per-call module hook."""
+        try:
+            normalized_args = tool_args if isinstance(tool_args, dict) else {}
+            return module.is_write_tool_call(tool_name, normalized_args, tool_def=tool_def)
+        except self._noncritical_exceptions:
+            return None
+
+    def resolve_write_classification(
+        self,
+        module: BaseModule,
+        tool_name: str,
+        tool_args: Any,
+        tool_def: dict[str, Any] | None,
+        *,
+        fallback_to_name_heuristic: bool,
+    ) -> bool:
+        """Resolve write classification with optional legacy fallback."""
+        is_write = self.classify_write_tool_call(module, tool_name, tool_args, tool_def)
+        if is_write is not None:
+            return bool(is_write)
+        if fallback_to_name_heuristic:
+            return bool(re.search(r"(ingest|update|delete|create|import)", str(tool_name).lower()))
+        return False
+
+    @staticmethod
+    def strip_forbidden_tool_argument_overrides(tool_args: dict[str, Any]) -> dict[str, Any]:
+        """Remove tool argument fields that could override request ownership/db scope."""
+        forbidden = {"user_id", "db_path", "db_paths", "chacha_db", "media_db", "prompts_db"}
+        sanitized = dict(tool_args)
+        for key in forbidden:
+            sanitized.pop(key, None)
+        return sanitized
+
+    def harden_and_sanitize_tool_arguments(
+        self,
+        module: BaseModule,
+        tool_args: Any,
+    ) -> Any:
+        """Normalize tool arguments before policy and execution checks."""
+        if not isinstance(tool_args, dict):
+            return tool_args
+        hardened_args = self.strip_forbidden_tool_argument_overrides(tool_args)
+        try:
+            return module.sanitize_input(hardened_args)
+        except self._noncritical_exceptions as san_err:
+            raise InvalidParamsException(f"Invalid arguments: {str(san_err)}") from san_err
+
+    @staticmethod
+    def prepared_tool_call_payload(
+        *,
+        tool_name: str,
+        module_id: str | None,
+        is_write: bool | None,
+        idempotency_cache_key: str | None,
+        arguments_hash: str | None,
+        context_fingerprint: str,
+    ) -> bytes:
+        payload = {
+            "tool_name": str(tool_name),
+            "module_id": str(module_id or ""),
+            "is_write": bool(is_write),
+            "idempotency_cache_key": str(idempotency_cache_key or ""),
+            "arguments_hash": str(arguments_hash or ""),
+            "context_fingerprint": str(context_fingerprint or ""),
+        }
+        return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+    def build_prepared_tool_call_integrity_tag(
+        self,
+        *,
+        tool_name: str,
+        module_id: str | None,
+        is_write: bool | None,
+        idempotency_cache_key: str | None,
+        arguments_hash: str | None,
+        context_fingerprint: str,
+    ) -> str:
+        payload = self.prepared_tool_call_payload(
+            tool_name=tool_name,
+            module_id=module_id,
+            is_write=is_write,
+            idempotency_cache_key=idempotency_cache_key,
+            arguments_hash=arguments_hash,
+            context_fingerprint=context_fingerprint,
+        )
+        return hmac.new(self._prepared_call_secret, payload, digestmod="sha256").hexdigest()
+
+    def verify_prepared_tool_call_integrity(
+        self,
+        prepared: PreparedToolCall,
+    ) -> None:
+        if not isinstance(prepared.tool_name, str) or not self._tool_name_re.match(prepared.tool_name):
+            raise InvalidParamsException("Prepared tool call integrity check failed: invalid tool name")
+
+        expected_hash = self.hash_arguments(prepared.tool_args if isinstance(prepared.tool_args, dict) else {})
+        if expected_hash != prepared.arguments_hash:
+            raise InvalidParamsException("Prepared tool call integrity check failed: argument fingerprint mismatch")
+
+        expected_context_fingerprint = self.fingerprint_request_context(prepared.context)
+        if expected_context_fingerprint != prepared.context_fingerprint:
+            raise InvalidParamsException("Prepared tool call integrity check failed: context fingerprint mismatch")
+
+        expected_write = self.resolve_write_classification(
+            prepared.module,
+            prepared.tool_name,
+            prepared.tool_args,
+            prepared.tool_def,
+            fallback_to_name_heuristic=True,
+        )
+        if bool(expected_write) != bool(prepared.is_write):
+            raise InvalidParamsException("Prepared tool call integrity check failed: write classification mismatch")
+
+        expected_tag = self.build_prepared_tool_call_integrity_tag(
+            tool_name=prepared.tool_name,
+            module_id=prepared.module_id,
+            is_write=prepared.is_write,
+            idempotency_cache_key=prepared.idempotency_cache_key,
+            arguments_hash=prepared.arguments_hash,
+            context_fingerprint=prepared.context_fingerprint,
+        )
+        if not hmac.compare_digest(prepared.integrity_tag, expected_tag):
+            raise InvalidParamsException("Prepared tool call integrity check failed: signature mismatch")
+
+    def fingerprint_request_context(self, context: RequestContext) -> str:
+        payload = {
+            "request_id": str(context.request_id or ""),
+            "user_id": str(context.user_id or ""),
+            "client_id": str(context.client_id or ""),
+            "session_id": str(context.session_id or ""),
+            "metadata": self.context_json_safe(getattr(context, "metadata", {})),
+            "db_paths": self.context_json_safe(getattr(context, "db_paths", {})),
+        }
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def context_json_safe(self, value: Any) -> Any:
+        if value is None or isinstance(value, (bool, int, float, str)):
+            return value
+        if isinstance(value, Path):
+            return str(value)
+        if isinstance(value, dict):
+            return {
+                str(key): self.context_json_safe(item)
+                for key, item in sorted(value.items(), key=lambda kv: str(kv[0]))
+            }
+        if isinstance(value, (list, tuple, set)):
+            return [self.context_json_safe(item) for item in value]
+        if is_dataclass(value):
+            return self.context_json_safe(asdict(value))
+        return str(value)
+
+    @staticmethod
+    def normalize_idempotency_key(
+        params: dict[str, Any],
+        idempotency_key: str | None = None,
+    ) -> str | None:
+        """Normalize idempotency key from explicit argument or request params."""
+        raw_idempotency_key = idempotency_key
+        if raw_idempotency_key is None:
+            raw_idempotency_key = params.get("idempotencyKey")
+            if raw_idempotency_key is None:
+                raw_idempotency_key = params.get("idempotency_key")
+        if raw_idempotency_key is None:
+            arguments = params.get("arguments")
+            if isinstance(arguments, dict):
+                raw_idempotency_key = arguments.get("idempotencyKey")
+                if raw_idempotency_key is None:
+                    raw_idempotency_key = arguments.get("idempotency_key")
+
+        if raw_idempotency_key is None:
+            return None
+        if not isinstance(raw_idempotency_key, str):
+            raise InvalidParamsException("idempotencyKey must be a string")
+
+        normalized = raw_idempotency_key.strip()
+        if not normalized:
+            raise InvalidParamsException("idempotencyKey must not be empty")
+        return normalized
+
+    def validate_input_schema(self, schema: dict[str, Any], args: dict[str, Any]) -> None:
+        """Quick JSON Schema checks: required keys, primitive types, unknown fields.
+
+        Only applies when schema.type == object.
+        """
+        try:
+            if not isinstance(schema, dict):
+                return
+            if schema.get("type") != "object":
+                return
+            if not isinstance(args, dict):
+                raise InvalidParamsException("Arguments must be an object")
+            props = schema.get("properties") or {}
+            required = schema.get("required") or []
+            addl = schema.get("additionalProperties", True)
+
+            # Required
+            for key in required:
+                if key not in args or args.get(key) is None:
+                    raise InvalidParamsException(f"Missing required parameter: {key}")
+
+            # Unknown fields
+            if addl is False:
+                unknown = [k for k in args if k not in props]
+                if unknown:
+                    raise InvalidParamsException(f"Unknown parameters: {', '.join(unknown)}")
+
+            # Primitive type checks
+            def _type_ok(expected: str, value: Any) -> bool:
+                mapping = {
+                    "string": str,
+                    "number": (int, float),
+                    "integer": int,
+                    "boolean": bool,
+                    "object": dict,
+                    "array": list,
+                }
+                py = mapping.get(expected)
+                if py is None:
+                    return True
+                # number should not reject ints; python isinstance(True, int) caveat
+                if expected in {"number", "integer"} and isinstance(value, bool):
+                    return False
+                return isinstance(value, py)
+
+            for k, v in args.items():
+                if k in props:
+                    p = props.get(k) or {}
+                    t = p.get("type")
+                    if isinstance(t, str) and not _type_ok(t, v):
+                        raise InvalidParamsException(f"Invalid type for '{k}': expected {t}")
+        except InvalidParamsException:
+            raise
+        except self._noncritical_exceptions:
+            # Be forgiving on schema format errors
+            return
+
+    async def _resolve_effective_tool_policy(self, context: RequestContext) -> dict[str, Any] | None:
+        metadata = getattr(context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return None
+        if not _is_truthy(metadata.get("mcp_policy_context_enabled")):
+            return None
+        cached = metadata.get("_mcp_effective_tool_policy")
+        if isinstance(cached, dict):
+            return cached
+        try:
+            policy = await self.dependencies.effective_policy_resolver.resolve_for_context(
+                user_id=context.user_id,
+                metadata=metadata,
+            )
+        except self._noncritical_exceptions as exc:
+            logger.warning("Failed to resolve MCP Hub effective policy: {}", exc)
+            policy = {
+                "enabled": True,
+                "allowed_tools": [],
+                "denied_tools": [],
+                "capabilities": [],
+                "sources": [],
+                "resolution_error": "policy_resolution_failed",
+            }
+        if policy is not None:
+            metadata["_mcp_effective_tool_policy"] = policy
+        return policy
+
+    def _is_tool_allowed_by_effective_policy(
+        self,
+        tool_name: str,
+        tool_args: Any,
+        policy: dict[str, Any] | None,
+        *,
+        matches_tool_authorization_pattern: Callable[[str, Any, str], bool] | None = None,
+    ) -> bool:
+        if not isinstance(policy, dict) or not bool(policy.get("enabled", False)):
+            return True
+        if str(policy.get("resolution_error") or "").strip():
+            return False
+        denied_tools = [
+            str(pattern).strip()
+            for pattern in (policy.get("denied_tools") or [])
+            if str(pattern).strip()
+        ]
+        matcher = matches_tool_authorization_pattern or self.matches_tool_authorization_pattern
+        if any(matcher(tool_name, tool_args, pattern) for pattern in denied_tools):
+            return False
+        allowed_tools = [
+            str(pattern).strip()
+            for pattern in (policy.get("allowed_tools") or [])
+            if str(pattern).strip()
+        ]
+        if not allowed_tools:
+            return True
+        return any(matcher(tool_name, tool_args, pattern) for pattern in allowed_tools)
+
+    async def _evaluate_runtime_approval(
+        self,
+        *,
+        effective_policy: dict[str, Any] | None,
+        tool_name: str,
+        tool_args: Any,
+        context: RequestContext,
+        tool_def: dict[str, Any] | None,
+        is_write: bool | None,
+        within_effective_policy: bool,
+        force_approval: bool = False,
+        approval_reason: str | None = None,
+        scope_payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        policy = dict(effective_policy or {})
+        if not bool(policy.get("enabled", False)):
+            return {"status": "allow", "reason": "policy_disabled"}
+        if str(policy.get("resolution_error") or "").strip():
+            return {"status": "deny", "reason": "policy_unavailable"}
+        try:
+            return await self.dependencies.approval_evaluator.evaluate_tool_call(
+                effective_policy=policy,
+                tool_name=tool_name,
+                tool_args=tool_args,
+                context=context,
+                tool_def=tool_def,
+                is_write=is_write,
+                within_effective_policy=within_effective_policy,
+                force_approval=force_approval,
+                approval_reason=approval_reason,
+                scope_payload=scope_payload,
+            )
+        except self._noncritical_exceptions as exc:
+            logger.debug("Failed to evaluate MCP Hub runtime approval: {}", exc)
+            if policy.get("approval_policy_id") is not None or policy.get("approval_mode"):
+                return {"status": "deny", "reason": "approval_unavailable"}
+            return {"status": "allow" if within_effective_policy else "deny", "reason": "approval_not_configured"}
+
+    async def _evaluate_path_scope(
+        self,
+        *,
+        effective_policy: dict[str, Any] | None,
+        tool_name: str,
+        tool_args: Any,
+        context: RequestContext,
+        tool_def: dict[str, Any] | None,
+        path_scope_candidates: list[PathScopeCandidate] | None = None,
+    ) -> dict[str, Any]:
+        policy = dict(effective_policy or {})
+        policy_document = dict(policy.get("policy_document") or {})
+        path_scope_mode = str(policy_document.get("path_scope_mode") or "").strip()
+        if not bool(policy.get("enabled", False)) or not path_scope_mode or path_scope_mode == "none":
+            return {
+                "enabled": False,
+                "within_scope": True,
+                "reason": None,
+                "force_approval": False,
+                "normalized_paths": [],
+                "scope_payload": None,
+            }
+        if str(policy.get("resolution_error") or "").strip():
+            return {
+                "enabled": True,
+                "within_scope": False,
+                "reason": "policy_unavailable",
+                "force_approval": False,
+                "normalized_paths": [],
+                "scope_payload": {"path_scope_mode": path_scope_mode, "reason": "policy_unavailable"},
+            }
+        try:
+            try:
+                return await self.dependencies.path_scope_enforcer.evaluate_tool_call(
+                    effective_policy=policy,
+                    context=context,
+                    tool_name=tool_name,
+                    tool_args=tool_args,
+                    tool_def=tool_def,
+                    path_scope_candidates=path_scope_candidates,
+                )
+            except TypeError as exc:
+                if not _is_unexpected_keyword_type_error(exc, "path_scope_candidates"):
+                    raise
+                if path_scope_candidates:
+                    raise PermissionError("path_scope_candidates_unsupported") from exc
+                return await self.dependencies.path_scope_enforcer.evaluate_tool_call(
+                    effective_policy=policy,
+                    context=context,
+                    tool_name=tool_name,
+                    tool_args=tool_args,
+                    tool_def=tool_def,
+                )
+        except PermissionError:
+            raise
+        except TypeError:
+            raise
+        except self._noncritical_exceptions as exc:
+            logger.debug("Failed to evaluate MCP Hub path scope: {}", exc)
+            return {
+                "enabled": True,
+                "within_scope": False,
+                "reason": "path_scope_unavailable",
+                "force_approval": True,
+                "normalized_paths": [],
+                "scope_payload": {"path_scope_mode": path_scope_mode, "reason": "path_scope_unavailable"},
+            }
+
+    async def _extract_path_scope_candidates(
+        self,
+        *,
+        module: BaseModule,
+        tool_name: str,
+        tool_args: Any,
+        context: RequestContext,
+        tool_def: dict[str, Any] | None,
+    ) -> list[PathScopeCandidate] | None:
+        metadata = tool_def.get("metadata") if isinstance(tool_def, dict) else None
+        if not isinstance(metadata, dict) or metadata.get("path_scope_candidate_source") != "module":
+            return None
+        if not isinstance(tool_args, dict):
+            raise PermissionError("path_scope_candidates_unavailable")
+        extractor = getattr(module, "extract_path_scope_candidates", None)
+        if not callable(extractor):
+            raise PermissionError("path_scope_candidates_unavailable")
+        try:
+            candidates = normalize_path_scope_candidates(
+                await extractor(tool_name, tool_args, context)
+            )
+        except NotImplementedError as exc:
+            raise PermissionError("path_scope_candidates_unavailable") from exc
+        except self._noncritical_exceptions as exc:
+            raise InvalidParamsException(str(exc)) from exc
+        if not candidates:
+            raise PermissionError("path_scope_candidates_unavailable")
+        return candidates
+
+    async def _evaluate_external_access(
+        self,
+        *,
+        effective_policy: dict[str, Any] | None,
+        tool_name: str,
+        context: RequestContext,
+    ) -> dict[str, Any]:
+        deny_only_reasons = {
+            "external_access_unavailable",
+            "external_server_not_bound",
+            "invalid_external_tool_name",
+            "required_slot_not_granted",
+            "required_slot_secret_missing",
+        }
+        if not str(tool_name or "").startswith("ext."):
+            return {
+                "enabled": False,
+                "within_scope": True,
+                "reason": None,
+                "scope_payload": None,
+                "hard_deny": False,
+            }
+        policy = dict(effective_policy or {})
+        if not bool(policy.get("enabled", False)):
+            return {
+                "enabled": False,
+                "within_scope": True,
+                "reason": None,
+                "scope_payload": None,
+                "hard_deny": False,
+            }
+        sources = policy.get("sources")
+        if not isinstance(sources, list):
+            return {
+                "enabled": True,
+                "within_scope": False,
+                "reason": "external_access_unavailable",
+                "scope_payload": {
+                    "server_id": tool_name.split(".", 2)[1],
+                    "reason": "external_access_unavailable",
+                    "blocked_reason": "external_access_unavailable",
+                    "requested_slots": [],
+                    "missing_bound_slots": [],
+                    "missing_secret_slots": [],
+                },
+                "hard_deny": True,
+            }
+        parts = str(tool_name or "").split(".", 2)
+        if len(parts) != 3 or not parts[1]:
+            return {
+                "enabled": True,
+                "within_scope": False,
+                "reason": "invalid_external_tool_name",
+                "scope_payload": {
+                    "reason": "invalid_external_tool_name",
+                    "blocked_reason": "invalid_external_tool_name",
+                    "requested_slots": [],
+                    "missing_bound_slots": [],
+                    "missing_secret_slots": [],
+                },
+                "hard_deny": True,
+            }
+        server_id = parts[1]
+        metadata = context.metadata if isinstance(getattr(context, "metadata", None), dict) else {}
+        cached = metadata.get("_mcp_effective_external_access")
+        if not isinstance(cached, dict):
+            try:
+                cached = await self.dependencies.external_access_evaluator.resolve_for_sources(
+                    sources=[dict(item) for item in sources if isinstance(item, dict)],
+                    effective_policy=policy,
+                )
+                metadata["_mcp_effective_external_access"] = cached
+            except self._noncritical_exceptions as exc:
+                logger.debug("Failed to evaluate MCP Hub external access: {}", exc)
+                return {
+                    "enabled": True,
+                    "within_scope": False,
+                    "reason": "external_access_unavailable",
+                    "scope_payload": {
+                        "server_id": server_id,
+                        "reason": "external_access_unavailable",
+                        "blocked_reason": "external_access_unavailable",
+                        "requested_slots": [],
+                        "missing_bound_slots": [],
+                        "missing_secret_slots": [],
+                    },
+                    "hard_deny": True,
+                }
+
+        rows = cached.get("servers") if isinstance(cached, dict) else None
+        server_row = next(
+            (
+                row for row in rows
+                if isinstance(row, dict) and str(row.get("server_id") or "") == server_id
+            ),
+            None,
+        ) if isinstance(rows, list) else None
+        if not isinstance(server_row, dict):
+            return {
+                "enabled": True,
+                "within_scope": False,
+                "reason": "external_server_not_bound",
+                "scope_payload": {
+                    "server_id": server_id,
+                    "reason": "external_server_not_bound",
+                    "blocked_reason": "external_server_not_bound",
+                    "requested_slots": [],
+                    "missing_bound_slots": [],
+                    "missing_secret_slots": [],
+                },
+                "hard_deny": True,
+            }
+        runtime_executable = bool(server_row.get("runtime_executable"))
+        reason = str(server_row.get("blocked_reason") or "").strip() or None
+        requested_slots = [
+            str(slot).strip()
+            for slot in (server_row.get("requested_slots") or [])
+            if str(slot).strip()
+        ]
+        bound_slots = [
+            str(slot).strip()
+            for slot in (server_row.get("bound_slots") or [])
+            if str(slot).strip()
+        ]
+        missing_bound_slots = [
+            str(slot).strip()
+            for slot in (server_row.get("missing_bound_slots") or [])
+            if str(slot).strip()
+        ]
+        missing_secret_slots = [
+            str(slot).strip()
+            for slot in (server_row.get("missing_secret_slots") or [])
+            if str(slot).strip()
+        ]
+        scope_payload = {
+            "server_id": server_id,
+            "server_name": str(server_row.get("server_name") or "").strip() or None,
+            "reason": reason or ("external_server_allowed" if runtime_executable else "external_server_not_bound"),
+            "blocked_reason": reason or ("external_server_allowed" if runtime_executable else "external_server_not_bound"),
+            "requested_slots": requested_slots,
+            "bound_slots": bound_slots,
+            "missing_bound_slots": missing_bound_slots,
+            "missing_secret_slots": missing_secret_slots,
+        }
+        if not runtime_executable:
+            return {
+                "enabled": True,
+                "within_scope": False,
+                "reason": reason or "external_server_not_bound",
+                "scope_payload": scope_payload,
+                "hard_deny": (reason or "external_server_not_bound") in deny_only_reasons,
+            }
+        return {
+            "enabled": True,
+            "within_scope": True,
+            "reason": None,
+            "scope_payload": scope_payload,
+            "hard_deny": False,
+        }
+
+    @staticmethod
+    def _governance_preflight_bypassed(tool_name: str, context: RequestContext) -> bool:
+        if str(tool_name or "").startswith("governance."):
+            return True
+
+        metadata = getattr(context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return False
+
+        raw = metadata.get("governance_bypass")
+        if isinstance(raw, bool):
+            return raw
+        if isinstance(raw, (int, float)):
+            return bool(raw)
+        if isinstance(raw, str):
+            return _is_truthy(raw)
+        return False
+
+    def _governance_summary(self, tool_name: str, tool_args: dict[str, Any]) -> str:
+        rendered_args = ""
+        try:
+            rendered_args = json.dumps(tool_args or {}, sort_keys=True, default=str)
+        except self._noncritical_exceptions:
+            rendered_args = str(tool_args)
+        if len(rendered_args) > 1200:
+            rendered_args = rendered_args[:1200]
+        return f"tool={tool_name}; args={rendered_args}"
+
+    @staticmethod
+    def _resolve_governance_category(tool_name: str, tool_def: dict[str, Any] | None) -> str:
+        try:
+            if isinstance(tool_def, dict):
+                meta = tool_def.get("metadata")
+                if isinstance(meta, dict):
+                    category = str(meta.get("category") or "").strip().lower()
+                    if category:
+                        return category
+        except Exception as exc:  # noqa: BLE001 - category fallback should not fail preflight.
+            logger.debug("Falling back to tool-name governance category", error_type=exc.__class__.__name__)
+
+        if isinstance(tool_name, str) and "." in tool_name:
+            prefix = tool_name.split(".", 1)[0].strip().lower()
+            if prefix:
+                return prefix
+        return "general"
+
+    def _resolve_governance_rollout_mode(self, metadata: dict[str, Any] | None = None) -> str:
+        """Resolve governance rollout mode from metadata override and server config."""
+
+        raw_mode = None
+        if isinstance(metadata, dict):
+            raw_mode = metadata.get("governance_rollout_mode")
+
+        try:
+            from tldw_Server_API.app.core import config as app_config
+
+            return app_config.resolve_governance_rollout_mode(
+                str(raw_mode) if raw_mode is not None else None
+            )
+        except self._noncritical_exceptions as exc:
+            logger.debug("Unable to resolve governance rollout mode from config: {}", exc)
+            candidate = str(raw_mode or "").strip().lower()
+            return candidate if candidate in {"off", "shadow", "enforce"} else "off"
+        except Exception as exc:  # noqa: BLE001 - config resolver exceptions should not block tools.
+            logger.debug("Unable to resolve governance rollout mode from app config", error_type=exc.__class__.__name__)
+            candidate = str(raw_mode or "").strip().lower()
+            return candidate if candidate in {"off", "shadow", "enforce"} else "off"
+
+    def _record_governance_check(
+        self,
+        *,
+        surface: str,
+        category: str,
+        status: str,
+        rollout_mode: str,
+    ) -> None:
+        """Emit one governance check metric entry, failing open on metric errors."""
+        with contextlib.suppress(self._noncritical_exceptions):
+            self.metrics.record_governance_check(
+                surface=surface,
+                category=category,
+                status=status,
+                rollout_mode=rollout_mode,
+            )
+
+    @classmethod
+    def _serialize_governance_decision(cls, decision: Any) -> dict[str, Any]:
+        if decision is None:
+            return {}
+        if isinstance(decision, dict):
+            return {str(k): v for k, v in decision.items()}
+        if is_dataclass(decision):
+            return cls._serialize_governance_decision(asdict(decision))
+        dump = getattr(decision, "model_dump", None)
+        if callable(dump):
+            try:
+                dumped = dump()
+                if isinstance(dumped, dict):
+                    return {str(k): v for k, v in dumped.items()}
+            except Exception as exc:  # noqa: BLE001 - decision fallback handles noncritical model errors.
+                logger.debug("Falling back to attribute governance decision serialization", error_type=exc.__class__.__name__)
+        payload: dict[str, Any] = {}
+        for key in ("action", "status", "category", "category_source", "fallback_reason", "matched_rules"):
+            value = getattr(decision, key, None)
+            if value is not None:
+                payload[key] = value
+        return payload
+
+    async def _ensure_governance_service(self) -> Any | None:
+        if self._governance_service is not None:
+            return self._governance_service
+
+        async with self._governance_lock:
+            if self._governance_service is not None:
+                return self._governance_service
+            try:
+                from tldw_Server_API.app.core.Governance.service import GovernanceService
+                from tldw_Server_API.app.core.Governance.store import GovernanceStore
+            except self._noncritical_exceptions as exc:
+                logger.debug("MCP governance preflight unavailable (import failure): {}", exc)
+                return None
+
+            try:
+                cfg = self.dependencies.config_provider()
+                configured_path = getattr(cfg, "governance_db_path", None)
+                sqlite_path = str(configured_path or "Databases/governance.db")
+                db_path = Path(sqlite_path).expanduser()
+                db_path.parent.mkdir(parents=True, exist_ok=True)
+
+                self._governance_store = GovernanceStore(sqlite_path=str(db_path))
+                await self._governance_store.ensure_schema()
+                self._governance_service = GovernanceService(store=self._governance_store)
+                return self._governance_service
+            except self._noncritical_exceptions as exc:
+                logger.debug("MCP governance preflight disabled (service init failure): {}", exc)
+                self._governance_service = None
+                self._governance_store = None
+                return None
+
+    async def _run_governance_preflight(
+        self,
+        *,
+        tool_name: str,
+        tool_args: dict[str, Any],
+        tool_def: dict[str, Any] | None,
+        context: RequestContext,
+        governance_preflight_bypassed: Callable[[str, RequestContext], bool] | None = None,
+        resolve_governance_rollout_mode: Callable[[dict[str, Any] | None], str] | None = None,
+        resolve_governance_category: Callable[[str, dict[str, Any] | None], str] | None = None,
+        record_governance_check: Callable[..., None] | None = None,
+        governance_summary: Callable[[str, dict[str, Any]], str] | None = None,
+        serialize_governance_decision: Callable[[Any], dict[str, Any]] | None = None,
+        ensure_governance_service: Callable[[], Awaitable[Any | None]] | None = None,
+    ) -> dict[str, Any] | None:
+        bypassed = governance_preflight_bypassed or self._governance_preflight_bypassed
+        if bypassed(tool_name, context):
+            return None
+
+        metadata = context.metadata if isinstance(getattr(context, "metadata", None), dict) else {}
+        rollout_mode = (resolve_governance_rollout_mode or self._resolve_governance_rollout_mode)(metadata)
+        category = (resolve_governance_category or self._resolve_governance_category)(tool_name, tool_def)
+        record_check = record_governance_check or self._record_governance_check
+
+        if rollout_mode == "off":
+            record_check(
+                surface="mcp_tool",
+                category=category,
+                status="unknown",
+                rollout_mode=rollout_mode,
+            )
+            return {"status": "unknown", "rollout_mode": rollout_mode}
+
+        service = await (ensure_governance_service or self._ensure_governance_service)()
+        if service is None:
+            record_check(
+                surface="mcp_tool",
+                category=category,
+                status="error",
+                rollout_mode=rollout_mode,
+            )
+            return None
+
+        try:
+            decision = await service.validate_change(
+                surface="mcp_tool",
+                summary=(governance_summary or self._governance_summary)(tool_name, tool_args),
+                category=category,
+                metadata=metadata,
+            )
+            payload = (serialize_governance_decision or self._serialize_governance_decision)(decision)
+            payload.setdefault("rollout_mode", rollout_mode)
+            if isinstance(context.metadata, dict):
+                context.metadata["governance_preflight"] = payload
+            action = str(payload.get("action") or payload.get("status") or "").strip().lower() or "unknown"
+            record_check(
+                surface="mcp_tool",
+                category=category,
+                status=action,
+                rollout_mode=rollout_mode,
+            )
+            if action == "deny" and rollout_mode == "enforce":
+                raise GovernanceDeniedError(
+                    "Permission denied by governance policy",
+                    governance=payload,
+                )
+            return payload
+        except GovernanceDeniedError:
+            raise
+        except self._noncritical_exceptions as exc:
+            record_check(
+                surface="mcp_tool",
+                category=category,
+                status="error",
+                rollout_mode=rollout_mode,
+            )
+            try:
+                context.logger.debug(f"Governance preflight failed open: {exc}")
+            except self._noncritical_exceptions:
+                pass
+            return None
+
+    @staticmethod
+    def _make_idempotency_cache_key(
+        context: RequestContext,
+        module_name: str,
+        tool_name: str,
+        idempotency_key: str,
+    ) -> str:
+        owner = f"user:{context.user_id}" if context.user_id else (f"client:{context.client_id}" if context.client_id else "anon")
+        return f"{owner}|module:{module_name}|tool:{tool_name}|key:{idempotency_key}"
+
+    @staticmethod
+    def _policy_document_path_scope_mode(policy_document: Any) -> str:
+        if isinstance(policy_document, dict):
+            return str(policy_document.get("path_scope_mode") or "").strip()
+        if isinstance(policy_document, BaseModel):
+            if hasattr(policy_document, "model_dump"):
+                policy_document_payload = policy_document.model_dump()
+            else:  # pragma: no cover - pydantic v1 compatibility
+                policy_document_payload = policy_document.dict()
+            return str(policy_document_payload.get("path_scope_mode") or "").strip()
+        return ""
+
+    async def prepare_tool_call(
+        self,
+        params: dict[str, Any],
+        context: RequestContext,
+        idempotency_key: str | None = None,
+        hooks: Any | None = None,
+    ) -> PreparedToolCall:
+        """Prepare a tool invocation through protocol policy, validation, and governance checks."""
+
+        tool_name = params.get("name")
+        tool_args = params.get("arguments", {})
+        normalized_idempotency_key = self.normalize_idempotency_key(
+            params,
+            idempotency_key=idempotency_key,
+        )
+
+        if not tool_name:
+            raise InvalidParamsException("Tool name is required")
+
+        # Strictly validate tool name
+        if not self._tool_name_re.match(tool_name):
+            raise InvalidParamsException("Invalid tool name")
+
+        is_tool_allowed_by_context = self._prepare_callback(
+            "is_tool_allowed_by_context",
+            self.is_tool_allowed_by_context,
+        )
+        if not is_tool_allowed_by_context(tool_name, tool_args, context):
+            raise PermissionError(f"Tool '{tool_name}' not allowed by execution context")
+
+        resolve_effective_tool_policy = self._prepare_callback(
+            "resolve_effective_tool_policy",
+            self._resolve_effective_tool_policy,
+        )
+        effective_policy = await resolve_effective_tool_policy(context)
+
+        is_tool_allowed_by_effective_policy = self._prepare_callback(
+            "is_tool_allowed_by_effective_policy",
+            self._is_tool_allowed_by_effective_policy,
+        )
+        within_effective_policy = is_tool_allowed_by_effective_policy(tool_name, tool_args, effective_policy)
+
+        evaluate_external_access = self._prepare_callback(
+            "evaluate_external_access",
+            self._evaluate_external_access,
+        )
+        external_access_result = await evaluate_external_access(
+            effective_policy=effective_policy,
+            tool_name=tool_name,
+            context=context,
+        )
+        external_block_reason = str(external_access_result.get("reason") or "").strip()
+        if bool(external_access_result.get("hard_deny")) or external_block_reason in {
+            "required_slot_not_granted",
+            "required_slot_secret_missing",
+        }:
+            external_scope = (
+                dict(external_access_result.get("scope_payload") or {})
+                if isinstance(external_access_result.get("scope_payload"), dict)
+                else {}
+            )
+            blocked_reason = external_block_reason or "external_access_denied"
+            raise GovernanceDeniedError(
+                "Blocked external credential use",
+                governance={
+                    "action": "deny",
+                    "status": "deny",
+                    "reason_code": blocked_reason,
+                    "external_access": external_scope,
+                },
+            )
+
+        module_registry = self._prepare_callback("module_registry", lambda: self.module_registry)()
+        module = await module_registry.find_module_for_tool(tool_name)
+        if not module:
+            raise InvalidParamsException(f"Tool not found: {tool_name}")
+
+        module_id = module_registry.get_module_id_for_tool(tool_name) or getattr(module, "name", None)
+
+        # Look up tool definition early for scope gating and validation
+        tool_def = await self.resolve_tool_definition(module, tool_name)
+        if isinstance(tool_def, dict):
+            try:
+                tool_def = ensure_tool_definition_eval_metadata(tool_def)
+            except self._noncritical_exceptions as exc:
+                context.logger.opt(exception=exc).debug(
+                    "Failed to attach eval metadata to resolved tool definition",
+                    module_id=module_id,
+                    tool_name=tool_name,
+                    error_type=exc.__class__.__name__,
+                )
+        tool_args = self.harden_and_sanitize_tool_arguments(module, tool_args)
+
+        # Determine write-capable status from sanitized arguments.
+        is_write = self.resolve_write_classification(
+            module,
+            tool_name,
+            tool_args,
+            tool_def,
+            fallback_to_name_heuristic=True,
+        )
+
+        has_module_permission = self._prepare_callback(
+            "has_module_permission",
+            self.has_module_permission,
+        )
+        has_tool_permission = self._prepare_callback(
+            "has_tool_permission",
+            self.has_tool_permission,
+        )
+        module_allowed = await has_module_permission(context, module_id)
+        tool_allowed = await has_tool_permission(context, tool_name, is_write=is_write)
+
+        if not module_allowed and not tool_allowed:
+            raise PermissionError(f"Permission denied for module: {module_id}")
+
+        if not tool_allowed:
+            raise PermissionError(f"Permission denied for tool: {tool_name}")
+
+        # Protocol-level pre-execution validation for write-capable tools
+        # Ensures that modules validate arguments even if they forgot to call
+        # validate_tool_arguments inside execute_tool.
+        # Look up tool definition from module cache where possible
+        if tool_def is None:
+            tool_def = await self.resolve_tool_definition(module, tool_name)
+
+        idempotency_cache_key = None
+        try:
+            cfg = self.dependencies.config_provider()
+            if getattr(cfg, "validate_input_schema", False) and isinstance(tool_def, dict):
+                schema = tool_def.get("inputSchema") or {}
+                try:
+                    self.validate_input_schema(schema, tool_args)
+                except InvalidParamsException:
+                    with contextlib.suppress(self._noncritical_exceptions):
+                        self.metrics.record_tool_invalid_params(getattr(module, "name", "unknown"), str(tool_name))
+                    raise
+
+            if is_write:
+                if getattr(cfg, "disable_write_tools", False):
+                    raise PermissionError("Write tools are disabled by server policy")
+                # Check module overrides validator
+                if module.__class__.validate_tool_arguments is BaseModule.validate_tool_arguments:
+                    with contextlib.suppress(self._noncritical_exceptions):
+                        self.metrics.record_tool_validator_missing(getattr(module, "name", "unknown"), str(tool_name))
+                    raise ValueError(
+                        "Write-capable tool requires module.validate_tool_arguments override"
+                    )
+                # Run validator
+                try:
+                    module.validate_tool_arguments(tool_name, tool_args)
+                except self._noncritical_exceptions as ve:
+                    with contextlib.suppress(self._noncritical_exceptions):
+                        self.metrics.record_tool_invalid_params(getattr(module, "name", "unknown"), str(tool_name))
+                    raise ValueError(f"Invalid parameters for tool {tool_name}: {ve}") from ve
+
+                if normalized_idempotency_key:
+                    make_idempotency_cache_key = self._prepare_callback(
+                        "make_idempotency_cache_key",
+                        self._make_idempotency_cache_key,
+                    )
+                    idempotency_cache_key = make_idempotency_cache_key(
+                        context,
+                        module_id or getattr(module, "name", "unknown"),
+                        tool_name,
+                        normalized_idempotency_key,
+                    )
+        except ValueError as ve:
+            # Surface as JSON-RPC INVALID_PARAMS at the protocol layer
+            # by raising a sentinel exception handled by process_request
+            raise InvalidParamsException(str(ve)) from ve
+
+        policy_document = (effective_policy or {}).get("policy_document")
+        path_scope_mode = self._policy_document_path_scope_mode(policy_document)
+        path_scope_candidates = None
+        if bool((effective_policy or {}).get("enabled")) and path_scope_mode not in {"", "none"}:
+            extract_path_scope_candidates = self._prepare_callback(
+                "extract_path_scope_candidates",
+                self._extract_path_scope_candidates,
+            )
+            path_scope_candidates = await extract_path_scope_candidates(
+                module=module,
+                tool_name=tool_name,
+                tool_args=tool_args,
+                context=context,
+                tool_def=tool_def if isinstance(tool_def, dict) else None,
+            )
+        evaluate_path_scope = self._prepare_callback(
+            "evaluate_path_scope",
+            self._evaluate_path_scope,
+        )
+        path_scope_result = await evaluate_path_scope(
+            effective_policy=effective_policy,
+            tool_name=tool_name,
+            tool_args=tool_args,
+            context=context,
+            tool_def=tool_def if isinstance(tool_def, dict) else None,
+            path_scope_candidates=path_scope_candidates,
+        )
+        within_resolved_scope = bool(path_scope_result.get("within_scope", True)) and bool(
+            external_access_result.get("within_scope", True)
+        )
+        approval_reason = str(path_scope_result.get("reason") or "").strip() or None
+        if approval_reason is None:
+            approval_reason = str(external_access_result.get("reason") or "").strip() or None
+        scope_payload: dict[str, Any] | None = None
+        for payload in (
+            path_scope_result.get("scope_payload"),
+            external_access_result.get("scope_payload"),
+        ):
+            if isinstance(payload, dict):
+                scope_payload = dict(scope_payload or {})
+                scope_payload.update(payload)
+
+        path_scope_block_reason = str(path_scope_result.get("reason") or "").strip()
+        if path_scope_block_reason and not bool(path_scope_result.get("within_scope", True)):
+            requires_approval = bool(path_scope_result.get("force_approval", False))
+            if not requires_approval or path_scope_block_reason == "workspace_unresolvable_for_trust_source":
+                raise GovernanceDeniedError(
+                    "Blocked path-scoped tool use",
+                    governance={
+                        "action": "deny",
+                        "status": "deny",
+                        "reason_code": path_scope_block_reason,
+                        "path_scope": dict(scope_payload or {}),
+                    },
+                )
+
+        evaluate_runtime_approval = self._prepare_callback(
+            "evaluate_runtime_approval",
+            self._evaluate_runtime_approval,
+        )
+        approval_result = await evaluate_runtime_approval(
+            effective_policy=effective_policy,
+            tool_name=tool_name,
+            tool_args=tool_args,
+            context=context,
+            tool_def=tool_def if isinstance(tool_def, dict) else None,
+            is_write=is_write,
+            within_effective_policy=within_effective_policy and within_resolved_scope,
+            force_approval=bool(path_scope_result.get("force_approval", False)),
+            approval_reason=approval_reason,
+            scope_payload=scope_payload,
+        )
+        approval_status = str(approval_result.get("status") or "allow").strip().lower()
+        if approval_status == "approval_required":
+            raise ApprovalRequiredError(
+                "Approval required by MCP Hub policy",
+                approval=approval_result.get("approval") if isinstance(approval_result.get("approval"), dict) else None,
+            )
+        if approval_status != "allow":
+            raise PermissionError(f"Tool '{tool_name}' not allowed by MCP Hub policy")
+
+        args_hash = self.hash_arguments(tool_args if isinstance(tool_args, dict) else {})
+        run_governance_preflight = self._prepare_callback(
+            "run_governance_preflight",
+            self._run_governance_preflight,
+        )
+        await run_governance_preflight(
+            tool_name=tool_name,
+            tool_args=tool_args if isinstance(tool_args, dict) else {},
+            tool_def=tool_def if isinstance(tool_def, dict) else None,
+            context=context,
+        )
+        if hooks is None:
+            raise RuntimeError("ToolExecutionHooks dependency is required")
+        await hooks.run_pre_tool_hooks(
+            tool_name=tool_name,
+            tool_args=tool_args,
+            module_id=module_id,
+            tool_def=tool_def if isinstance(tool_def, dict) else None,
+            is_write=is_write,
+            arguments_hash=args_hash,
+            context=context,
+            scope_payload=scope_payload,
+        )
+        context_fingerprint = self.fingerprint_request_context(context)
+        integrity_tag = self.build_prepared_tool_call_integrity_tag(
+            tool_name=tool_name,
+            module_id=module_id,
+            is_write=is_write,
+            idempotency_cache_key=idempotency_cache_key,
+            arguments_hash=args_hash,
+            context_fingerprint=context_fingerprint,
+        )
+
+        return PreparedToolCall(
+            tool_name=tool_name,
+            tool_args=tool_args,
+            module=module,
+            module_id=module_id,
+            tool_def=tool_def if isinstance(tool_def, dict) else None,
+            is_write=is_write,
+            normalized_idempotency_key=normalized_idempotency_key,
+            idempotency_cache_key=idempotency_cache_key,
+            arguments_hash=args_hash,
+            context_fingerprint=context_fingerprint,
+            integrity_tag=integrity_tag,
+            context=context,
+            scope_payload=scope_payload,
+        )

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_config_sanitization.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_config_sanitization.py
@@ -55,3 +55,20 @@ def test_validate_config_failure_log_is_sanitized(monkeypatch):
     assert "Configuration validation failed" in rendered_logs
     assert sensitive_detail not in rendered_logs
     assert "sk-mcp-secret" not in rendered_logs
+
+
+def test_configure_logging_preserves_existing_loguru_sinks(monkeypatch):
+    monkeypatch.setenv("MCP_AUDIT_ENABLED", "false")
+    messages: list[str] = []
+    sink_id = mcp_config.logger.add(
+        lambda message: messages.append(str(message.record.get("message") or "")),
+        level="INFO",
+    )
+
+    try:
+        assert sink_id in mcp_config.logger._core.handlers  # nosec B101, SLF001
+        mcp_config.MCPConfig().configure_logging()
+        assert sink_id in mcp_config.logger._core.handlers  # nosec B101, SLF001
+    finally:
+        if sink_id in mcp_config.logger._core.handlers:  # nosec B101, SLF001
+            mcp_config.logger.remove(sink_id)

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py
@@ -139,9 +139,7 @@ def _effective_path_policy(path_grants: list[dict]) -> dict:
 
 @pytest.mark.asyncio
 async def test_handle_tools_call_raises_approval_for_path_scope_violation(monkeypatch) -> None:
-    from tldw_Server_API.app.core.MCP_unified.protocol import ApprovalRequiredError
-    from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol
-    from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+    from tldw_Server_API.app.core.MCP_unified.protocol import ApprovalRequiredError, MCPProtocol, RequestContext
     from tldw_Server_API.app.services import mcp_hub_approval_service as approval_service_mod
     from tldw_Server_API.app.services import mcp_hub_path_enforcement_service as path_service_mod
 
@@ -237,9 +235,7 @@ async def test_handle_tools_call_raises_approval_for_path_scope_violation(monkey
 
 @pytest.mark.asyncio
 async def test_handle_tools_call_raises_approval_for_path_allowlist_violation(monkeypatch) -> None:
-    from tldw_Server_API.app.core.MCP_unified.protocol import ApprovalRequiredError
-    from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol
-    from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+    from tldw_Server_API.app.core.MCP_unified.protocol import ApprovalRequiredError, MCPProtocol, RequestContext
     from tldw_Server_API.app.services import mcp_hub_approval_service as approval_service_mod
     from tldw_Server_API.app.services import mcp_hub_path_enforcement_service as path_service_mod
 
@@ -335,9 +331,7 @@ async def test_handle_tools_call_raises_approval_for_path_allowlist_violation(mo
 async def test_handle_tools_call_requires_approval_for_fs_write_text_out_of_scope_before_execution(
     monkeypatch,
 ) -> None:
-    from tldw_Server_API.app.core.MCP_unified.protocol import ApprovalRequiredError
-    from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol
-    from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+    from tldw_Server_API.app.core.MCP_unified.protocol import ApprovalRequiredError, MCPProtocol, RequestContext
     from tldw_Server_API.app.services import mcp_hub_approval_service as approval_service_mod
     from tldw_Server_API.app.services import mcp_hub_path_enforcement_service as path_service_mod
 
@@ -437,20 +431,19 @@ async def test_handle_tools_call_requires_approval_for_run_chain_preflight_path_
     from tldw_Server_API.app.core.MCP_unified.modules.implementations.run_command_module import (
         RunCommandModule,
     )
-    from tldw_Server_API.app.core.MCP_unified.protocol import ApprovalRequiredError
-    from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol
-    from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+    from tldw_Server_API.app.core.MCP_unified.protocol import ApprovalRequiredError, MCPProtocol, RequestContext
     from tldw_Server_API.app.services import mcp_hub_approval_service as approval_service_mod
     from tldw_Server_API.app.services import mcp_hub_path_enforcement_service as path_service_mod
 
     fs_write_tool = {
-        "name": "fs.write_text",
+        "name": "fs.write",
         "description": "Write text",
         "inputSchema": {
             "type": "object",
             "properties": {
                 "path": {"type": "string"},
                 "content": {"type": "string"},
+                "mode": {"type": "string"},
             },
             "required": ["path", "content"],
             "additionalProperties": False,
@@ -491,14 +484,14 @@ async def test_handle_tools_call_requires_approval_for_run_chain_preflight_path_
             return [dict(fs_write_tool), dict(fs_read_tool)]
 
         async def get_tool_def(self, tool_name: str) -> dict | None:
-            if tool_name == "fs.write_text":
+            if tool_name == "fs.write":
                 return dict(fs_write_tool)
             if tool_name == "fs.read_text":
                 return dict(fs_read_tool)
             return None
 
         def is_write_tool_def(self, tool_def: dict) -> bool:
-            return tool_def.get("name") == "fs.write_text"
+            return tool_def.get("name") == "fs.write"
 
         def sanitize_input(self, input_data):  # noqa: ANN001
             return input_data
@@ -542,7 +535,7 @@ async def test_handle_tools_call_requires_approval_for_run_chain_preflight_path_
 
         async def evaluate_tool_call(self, **kwargs) -> dict:  # noqa: ANN003
             self.calls.append(dict(kwargs))
-            if kwargs.get("tool_name") == "fs.write_text":
+            if kwargs.get("tool_name") == "fs.write":
                 return {
                     "enabled": True,
                     "within_scope": False,
@@ -572,12 +565,12 @@ async def test_handle_tools_call_requires_approval_for_run_chain_preflight_path_
 
         async def evaluate_tool_call(self, **kwargs) -> dict:  # noqa: ANN003
             self.calls.append(dict(kwargs))
-            if kwargs.get("tool_name") == "fs.write_text":
+            if kwargs.get("tool_name") == "fs.write":
                 return {
                     "status": "approval_required",
                     "approval": {
                         "approval_policy_id": 1,
-                        "tool_name": "fs.write_text",
+                        "tool_name": "fs.write",
                         "reason": kwargs.get("approval_reason"),
                         "scope_context": dict(kwargs.get("scope_payload") or {}),
                     },
@@ -603,7 +596,7 @@ async def test_handle_tools_call_requires_approval_for_run_chain_preflight_path_
         modules={"run_command": run_module, "filesystem": filesystem_module},
         tool_to_module={
             "run": "run_command",
-            "fs.write_text": "filesystem",
+            "fs.write": "filesystem",
             "fs.read_text": "filesystem",
         },
     )
@@ -611,7 +604,7 @@ async def test_handle_tools_call_requires_approval_for_run_chain_preflight_path_
     async def _resolve_effective_policy(_context):
         return {
             "enabled": True,
-            "allowed_tools": ["run", "fs.write_text", "fs.read_text"],
+            "allowed_tools": ["run", "fs.write", "fs.read_text"],
             "approval_policy_id": 1,
             "policy_document": {
                 "path_scope_mode": "cwd_descendants",
@@ -642,7 +635,7 @@ async def test_handle_tools_call_requires_approval_for_run_chain_preflight_path_
         )
 
     assert filesystem_module.execute_calls == []
-    assert [call.get("tool_name") for call in path_service.calls] == ["run", "fs.write_text"]
+    assert [call.get("tool_name") for call in path_service.calls] == ["run", "fs.write"]
 
 
 @pytest.mark.asyncio
@@ -674,8 +667,7 @@ async def test_handle_tools_call_hard_denies_external_slot_blockers_without_appr
     blocked_reason: str,
     scope_payload: dict,
 ) -> None:
-    from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol
-    from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+    from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol, RequestContext
     from tldw_Server_API.app.services import mcp_hub_approval_service as approval_service_mod
 
     tool_def = {
@@ -993,8 +985,7 @@ async def test_path_grants_patch_bundle_fails_closed_when_create_needs_write(tmp
 
 @pytest.mark.asyncio
 async def test_handle_tools_call_allows_direct_workspace_scoped_reader(monkeypatch) -> None:
-    from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol
-    from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+    from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol, RequestContext
     from tldw_Server_API.app.services import mcp_hub_path_enforcement_service as path_service_mod
     from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
         McpHubPathEnforcementService,
@@ -1079,9 +1070,7 @@ async def test_handle_tools_call_allows_direct_workspace_scoped_reader(monkeypat
 async def test_handle_tools_call_hard_denies_workspace_not_allowed_for_assignment_without_approval(
     monkeypatch,
 ) -> None:
-    from tldw_Server_API.app.core.MCP_unified.protocol import GovernanceDeniedError
-    from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol
-    from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+    from tldw_Server_API.app.core.MCP_unified.protocol import GovernanceDeniedError, MCPProtocol, RequestContext
     from tldw_Server_API.app.services import mcp_hub_approval_service as approval_service_mod
 
     tool_def = {
@@ -1166,9 +1155,7 @@ async def test_handle_tools_call_hard_denies_workspace_not_allowed_for_assignmen
 async def test_handle_tools_call_hard_denies_shared_registry_workspace_without_approval(
     monkeypatch,
 ) -> None:
-    from tldw_Server_API.app.core.MCP_unified.protocol import GovernanceDeniedError
-    from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol
-    from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+    from tldw_Server_API.app.core.MCP_unified.protocol import GovernanceDeniedError, MCPProtocol, RequestContext
     from tldw_Server_API.app.services import mcp_hub_approval_service as approval_service_mod
 
     tool_def = {
@@ -1254,9 +1241,7 @@ async def test_handle_tools_call_hard_denies_shared_registry_workspace_without_a
 async def test_handle_tools_call_requires_approval_for_trusted_workspace_not_allowed_by_assignment(
     monkeypatch,
 ) -> None:
-    from tldw_Server_API.app.core.MCP_unified.protocol import ApprovalRequiredError
-    from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol
-    from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+    from tldw_Server_API.app.core.MCP_unified.protocol import ApprovalRequiredError, MCPProtocol, RequestContext
     from tldw_Server_API.app.services import mcp_hub_approval_service as approval_service_mod
 
     tool_def = {
@@ -1346,9 +1331,7 @@ async def test_handle_tools_call_requires_approval_for_trusted_workspace_not_all
 async def test_handle_tools_call_hard_denies_unresolvable_workspace_for_trust_source_without_approval(
     monkeypatch,
 ) -> None:
-    from tldw_Server_API.app.core.MCP_unified.protocol import GovernanceDeniedError
-    from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol
-    from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+    from tldw_Server_API.app.core.MCP_unified.protocol import GovernanceDeniedError, MCPProtocol, RequestContext
     from tldw_Server_API.app.services import mcp_hub_approval_service as approval_service_mod
 
     tool_def = {
@@ -1437,9 +1420,7 @@ async def test_handle_tools_call_hard_denies_unresolvable_workspace_for_trust_so
 async def test_handle_tools_call_requires_approval_when_direct_workspace_root_missing(
     monkeypatch,
 ) -> None:
-    from tldw_Server_API.app.core.MCP_unified.protocol import ApprovalRequiredError
-    from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol
-    from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+    from tldw_Server_API.app.core.MCP_unified.protocol import ApprovalRequiredError, MCPProtocol, RequestContext
     from tldw_Server_API.app.services import mcp_hub_approval_service as approval_service_mod
     from tldw_Server_API.app.services import mcp_hub_path_enforcement_service as path_service_mod
     from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (
@@ -1534,9 +1515,7 @@ async def test_handle_tools_call_requires_approval_when_direct_workspace_root_mi
 async def test_handle_tools_call_direct_cwd_descendants_stays_narrower_than_workspace_root(
     monkeypatch,
 ) -> None:
-    from tldw_Server_API.app.core.MCP_unified.protocol import ApprovalRequiredError
-    from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol
-    from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+    from tldw_Server_API.app.core.MCP_unified.protocol import ApprovalRequiredError, MCPProtocol, RequestContext
     from tldw_Server_API.app.services import mcp_hub_approval_service as approval_service_mod
     from tldw_Server_API.app.services import mcp_hub_path_enforcement_service as path_service_mod
     from tldw_Server_API.app.services.mcp_hub_path_enforcement_service import (

--- a/tldw_Server_API/tests/MCP_unified/test_phase3_3_small_core_sanitizers.py
+++ b/tldw_Server_API/tests/MCP_unified/test_phase3_3_small_core_sanitizers.py
@@ -22,8 +22,14 @@ from tldw_Server_API.app.core.MCP_unified.protocol import (
     RequestContext,
 )
 
-
 LEAKED_DETAIL = "backend exploded /tmp/mcp-secret-token token=sk-mcp-secret"
+
+
+def test_protocol_hash_arguments_supports_class_level_compatibility_call() -> None:
+    actual = MCPProtocol._hash_arguments({"query": "safe"})
+    expected = "4fdcf0050a6fe4924da3ffad2b978fcc6683b329fba85041e1b7ce687b5a4a23"
+    if actual != expected:
+        pytest.fail(f"Expected legacy class-level hash {expected}, got {actual}")
 
 
 def _assert_safe_text(value: object) -> None:


### PR DESCRIPTION
## Summary
- Remediate validated MCP Unified security and reliability findings, including safer write routing, tighter fallback RBAC behavior, stale WebSocket accounting, logging preservation, and invalid tool-name error mapping.
- Extract protocol.py tool execution responsibilities into focused tool_execution helpers while preserving compatibility wrappers and import seams.
- Add focused regression coverage and record the approved refactor spec, implementation plan, and Backlog task history.

## Test Plan
- PYTHONDONTWRITEBYTECODE=1 python -m py_compile touched MCP implementation files
- TEST_MODE=true ENABLE_TRACING=false OTEL_METRICS_EXPORTER=none python -m pytest focused MCP slice: 384 passed
- python -m ruff check touched MCP files --select F,I,UP
- python -m bandit -r touched MCP implementation scope -f json: 0 findings
- git diff --check origin/dev..HEAD

## Merge Note
- Per project policy, a human-written Change summary is required before merging AI-authored work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the MCP `tools/call` path into a dedicated `tool_execution` pipeline with explicit security, hooks, runtime, and reporting while preserving `MCPProtocol` behavior. Addresses TASK-2424 with safer writes, tighter RBAC, sturdier WS accounting, preserved `loguru` sinks, and hard‑gated demo auth.

- **Refactors**
  - Moved execution from `protocol.py` to `tool_execution/{coordinator,security,hooks,runtime,reporting,dependencies}` with explicit dependencies; kept compatibility seams.
  - Added `protocol_types.py` (`RequestContext`, `InvalidParamsException`, `GovernanceDeniedError`, `ApprovalRequiredError`, `PreparedToolCall`) and re‑exported; preserved legacy parameter hashing.
  - Updated command runtime/registry to prefer `fs.write` with explicit `mode` (e.g., `create`); kept `fs.write_text` for compat and refreshed summaries/mappings/schemas.
  - Centralized tool‑use reporting via `ToolExecutionReporter` with best‑effort logging and Redis‑down fallbacks; recorded the approved spec and plan docs.

- **Bug Fixes**
  - Tightened fallback RBAC: `USER` role whitelists safe tools; no wildcard `EXECUTE`.
  - Safer writes: replacing a file via `fs.write_text`/`fs.write` requires `expected_sha256` or `read_receipt`; description/schema updated.
  - Logging and server stability: preserve existing `loguru` sinks; when `MCP_INHERIT_GLOBAL_LOGGER` is set, remove only MCP‑added handlers; cleaned stale WebSocket connections to fix per‑IP counters.
  - Auth and governance: demo auth requires `MCP_ENABLE_DEMO_AUTH`, debug/test envs, and a strong secret; token errors detected by module name to avoid hard imports; governance rollout delegates to the shared config resolver.

<sup>Written for commit f1f3f93b9e712b211203e9f5cb519b3e1e21d865. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

