### PR TITLE
Use trusted publishing for MCP Unified PyPI

### DIFF
--- a/.github/workflows/mcp-unified-publish.yml
+++ b/.github/workflows/mcp-unified-publish.yml
@@ -104,31 +104,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
+      actions: read
       contents: read
       id-token: write
     environment:
       name: pypi
     steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Download MCP Unified distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          persist-credentials: false
-
-      - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
-        with:
-          python-version: "3.12"
-
-      - name: Install packaging tools
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install build twine setuptools wheel pytest pytest-asyncio bandit
-          python -m pip install "pydantic>=2.0.0" "loguru>=0.7.0" "PyYAML>=6.0.0" "httpx>=0.24.0" "websockets>=12.0"
-
-      - name: Build MCP Unified distributions
-        run: python Helper_Scripts/mcp_unified_rc.py build
+          name: mcp-unified-publish-plan
+          path: .artifacts/mcp-unified-rc
 
       - name: Publish MCP Unified to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           packages-dir: .artifacts/mcp-unified-rc/dist/

--- a/.github/workflows/mcp-unified-publish.yml
+++ b/.github/workflows/mcp-unified-publish.yml
@@ -105,11 +105,9 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
+      id-token: write
     environment:
       name: pypi
-    env:
-      TWINE_USERNAME: __token__
-      TWINE_PASSWORD: ${{ secrets.MCP_UNIFIED_PYPI_API_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -127,7 +125,10 @@ jobs:
           python -m pip install build twine setuptools wheel pytest pytest-asyncio bandit
           python -m pip install "pydantic>=2.0.0" "loguru>=0.7.0" "PyYAML>=6.0.0" "httpx>=0.24.0" "websockets>=12.0"
 
-      - name: Build and upload to PyPI
-        run: |
-          python Helper_Scripts/mcp_unified_rc.py build
-          MCP_UNIFIED_ALLOW_PUBLISH=1 python Helper_Scripts/mcp_unified_rc.py publish-plan --target pypi --execute
+      - name: Build MCP Unified distributions
+        run: python Helper_Scripts/mcp_unified_rc.py build
+
+      - name: Publish MCP Unified to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.13.0
+        with:
+          packages-dir: .artifacts/mcp-unified-rc/dist/

--- a/backlog/tasks/task-12013 - Convert-MCP-Unified-PyPI-publish-workflow-to-trusted-publishing.md
+++ b/backlog/tasks/task-12013 - Convert-MCP-Unified-PyPI-publish-workflow-to-trusted-publishing.md
@@ -1,0 +1,56 @@
+---
+id: TASK-12013
+title: Convert MCP Unified PyPI publish workflow to trusted publishing
+status: Done
+labels:
+- mcp
+- packaging
+- pypi
+- ci
+priority: high
+modified_files:
+- .github/workflows/mcp-unified-publish.yml
+- tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+- backlog/tasks/task-12013 - Convert-MCP-Unified-PyPI-publish-workflow-to-trusted-publishing.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Update the standalone MCP Unified production PyPI publish workflow to use the pending PyPI trusted publisher configured for repository rmusser01/tldw_server, workflow mcp-unified-publish.yml, environment pypi, instead of a long-lived PyPI API token.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 GitHub Actions environment pypi exists for the publish workflow.
+- [ ] #2 Production publish-pypi job requests id-token: write and keeps environment name pypi.
+- [ ] #3 Production publish-pypi job no longer references MCP_UNIFIED_PYPI_API_TOKEN or TWINE_PASSWORD.
+- [ ] #4 Production publish-pypi job publishes .artifacts/mcp-unified-rc/dist with pypa/gh-action-pypi-publish.
+- [ ] #5 TestPyPI publish path remains token-based and unchanged.
+- [ ] #6 Workflow boundary tests cover the trusted publishing shape.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Validation:
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q -k publish_workflow` -> 3 passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q` -> 47 passed.
+- `make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python mcp-unified-publish-dry-run` -> passed; helper build and TestPyPI dry-run plan still work.
+- `git diff --check` -> passed.
+- Full Bandit on touched test file exits nonzero for existing low-severity pytest/subprocess/test-secret baseline; filtered touched-scope Bandit with `-s B101,B404,B603,B105` -> no findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Focused workflow tests pass.
+- [ ] #2 MCP Unified publish workflow is YAML-valid under existing test helpers.
+- [ ] #3 Bandit run for touched code when applicable or documented non-code skip.
+- [ ] #4 PR opened against dev with validation summary.
+<!-- DOD:END -->

--- a/backlog/tasks/task-12013 - Convert-MCP-Unified-PyPI-publish-workflow-to-trusted-publishing.md
+++ b/backlog/tasks/task-12013 - Convert-MCP-Unified-PyPI-publish-workflow-to-trusted-publishing.md
@@ -12,6 +12,8 @@ modified_files:
 - .github/workflows/mcp-unified-publish.yml
 - tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
 - backlog/tasks/task-12013 - Convert-MCP-Unified-PyPI-publish-workflow-to-trusted-publishing.md
+references:
+- https://github.com/rmusser01/tldw_server/pull/2514
 ---
 
 ## Description
@@ -39,7 +41,10 @@ Update the standalone MCP Unified production PyPI publish workflow to use the pe
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+PR: https://github.com/rmusser01/tldw_server/pull/2514
+
 Validation:
+- GitHub Actions environment `pypi` verified via `gh api`: id `17193755583`.
 - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q -k publish_workflow` -> 3 passed.
 - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q` -> 47 passed.
 - `make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python mcp-unified-publish-dry-run` -> passed; helper build and TestPyPI dry-run plan still work.

--- a/backlog/tasks/task-12013 - Convert-MCP-Unified-PyPI-publish-workflow-to-trusted-publishing.md
+++ b/backlog/tasks/task-12013 - Convert-MCP-Unified-PyPI-publish-workflow-to-trusted-publishing.md
@@ -24,12 +24,12 @@ Update the standalone MCP Unified production PyPI publish workflow to use the pe
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 GitHub Actions environment pypi exists for the publish workflow.
-- [ ] #2 Production publish-pypi job requests id-token: write and keeps environment name pypi.
-- [ ] #3 Production publish-pypi job no longer references MCP_UNIFIED_PYPI_API_TOKEN or TWINE_PASSWORD.
-- [ ] #4 Production publish-pypi job publishes .artifacts/mcp-unified-rc/dist with pypa/gh-action-pypi-publish.
-- [ ] #5 TestPyPI publish path remains token-based and unchanged.
-- [ ] #6 Workflow boundary tests cover the trusted publishing shape.
+- [x] #1 GitHub Actions environment pypi exists for the publish workflow.
+- [x] #2 Production publish-pypi job requests id-token: write and keeps environment name pypi.
+- [x] #3 Production publish-pypi job no longer references MCP_UNIFIED_PYPI_API_TOKEN or TWINE_PASSWORD.
+- [x] #4 Production publish-pypi job publishes .artifacts/mcp-unified-rc/dist with pypa/gh-action-pypi-publish.
+- [x] #5 TestPyPI publish path remains token-based and unchanged.
+- [x] #6 Workflow boundary tests cover the trusted publishing shape.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -45,17 +45,21 @@ PR: https://github.com/rmusser01/tldw_server/pull/2514
 
 Validation:
 - GitHub Actions environment `pypi` verified via `gh api`: id `17193755583`.
-- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q -k publish_workflow` -> 3 passed.
-- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q` -> 47 passed.
-- `make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python mcp-unified-publish-dry-run` -> passed; helper build and TestPyPI dry-run plan still work.
+- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q -k publish_workflow` -> 3 passed.
+- `python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q` -> 47 passed.
+- `make PYTHON=python mcp-unified-publish-dry-run` -> passed; helper build and TestPyPI dry-run plan still work.
+- `python -m ruff check tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py` -> passed.
 - `git diff --check` -> passed.
 - Full Bandit on touched test file exits nonzero for existing low-severity pytest/subprocess/test-secret baseline; filtered touched-scope Bandit with `-s B101,B404,B603,B105` -> no findings.
+- Review follow-up validation: rebased on latest `origin/dev`; production PyPI publish now downloads the prebuilt publish-plan artifact, uses SHA-pinned artifact download and PyPI publish actions, and keeps the OIDC job free of checkout/build/run steps.
+- Skipped Qodo marker item as already satisfied: `test_runtime_package_boundary.py` has module-level `pytestmark = pytest.mark.unit`, so the touched tests already have exactly one effective approved classification marker.
+- Local `actionlint` check was attempted but unavailable in this environment (`command not found`); the PR's GitHub actionlint check remains the workflow validation source.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Focused workflow tests pass.
-- [ ] #2 MCP Unified publish workflow is YAML-valid under existing test helpers.
-- [ ] #3 Bandit run for touched code when applicable or documented non-code skip.
-- [ ] #4 PR opened against dev with validation summary.
+- [x] #1 Focused workflow tests pass.
+- [x] #2 MCP Unified publish workflow is YAML-valid under existing test helpers.
+- [x] #3 Bandit run for touched code when applicable or documented non-code skip.
+- [x] #4 PR opened against dev with validation summary.
 <!-- DOD:END -->

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -1080,6 +1080,8 @@ def test_mcp_unified_publish_workflow_is_manual_and_gated() -> None:
     serialized_workflow = yaml.safe_dump(workflow, sort_keys=True)
     run_blocks = "\n".join(_workflow_run_blocks(workflow))
     jobs = workflow["jobs"]
+    testpypi_job = jobs["publish-testpypi"]
+    pypi_job = jobs["publish-pypi"]
 
     assert set(triggers) == {"workflow_dispatch"}  # nosec B101
     inputs = triggers["workflow_dispatch"]["inputs"]
@@ -1097,20 +1099,24 @@ def test_mcp_unified_publish_workflow_is_manual_and_gated() -> None:
     assert plan_job["permissions"] == {"contents": "read"}  # nosec B101
     for job_name, environment_name, permissions in (
         ("publish-testpypi", "testpypi", {"contents": "read"}),
-        ("publish-pypi", "pypi", {"contents": "read", "id-token": "write"}),
+        (
+            "publish-pypi",
+            "pypi",
+            {"actions": "read", "contents": "read", "id-token": "write"},
+        ),
     ):
         job = jobs[job_name]
         assert job["needs"] == "publish-plan"  # nosec B101
         assert "inputs.confirm_publish == 'MCP_UNIFIED_PUBLISH'" in job["if"]  # nosec B101
         assert job["permissions"] == permissions  # nosec B101
         assert job["environment"]["name"] == environment_name  # nosec B101
-    testpypi_job_text = yaml.safe_dump(jobs["publish-testpypi"], sort_keys=True)
-    pypi_job_text = yaml.safe_dump(jobs["publish-pypi"], sort_keys=True)
-    assert "MCP_UNIFIED_TESTPYPI_API_TOKEN" in testpypi_job_text  # nosec B101
-    assert "TWINE_USERNAME: __token__" in testpypi_job_text  # nosec B101
-    assert "MCP_UNIFIED_PYPI_API_TOKEN" not in pypi_job_text  # nosec B101
-    assert "TWINE_USERNAME: __token__" not in pypi_job_text  # nosec B101
-    assert "pypa/gh-action-pypi-publish" in pypi_job_text  # nosec B101
+    assert testpypi_job["env"]["TWINE_USERNAME"] == "__token__"  # nosec B101
+    assert "MCP_UNIFIED_TESTPYPI_API_TOKEN" in testpypi_job["env"]["TWINE_PASSWORD"]  # nosec B101
+    assert "env" not in pypi_job  # nosec B101
+    assert any(  # nosec B101
+        step.get("uses", "").startswith("pypa/gh-action-pypi-publish@")
+        for step in pypi_job["steps"]
+    )
 
 
 def test_mcp_unified_make_targets_do_not_call_root_pypi_check() -> None:
@@ -1191,21 +1197,43 @@ def test_mcp_unified_publish_workflow_uses_trusted_publishing_for_pypi() -> None
     """Production MCP Unified publishing must use the configured PyPI OIDC publisher."""
 
     workflow_path = REPO_ROOT / ".github" / "workflows" / "mcp-unified-publish.yml"
+    workflow_text = workflow_path.read_text(encoding="utf-8")
     workflow = _load_workflow(workflow_path)
 
     testpypi_job = workflow["jobs"]["publish-testpypi"]
     pypi_job = workflow["jobs"]["publish-pypi"]
-    pypi_serialized = yaml.safe_dump(pypi_job, sort_keys=True)
-    pypi_uses_steps = [step.get("uses") for step in pypi_job["steps"] if "uses" in step]
+    pypi_steps = {step["name"]: step for step in pypi_job["steps"]}
+    download_step = pypi_steps["Download MCP Unified distributions"]
+    publish_step = pypi_steps["Publish MCP Unified to PyPI"]
 
     assert testpypi_job["env"]["TWINE_USERNAME"] == "__token__"  # nosec B101
     assert "MCP_UNIFIED_TESTPYPI_API_TOKEN" in testpypi_job["env"]["TWINE_PASSWORD"]  # nosec B101
     assert pypi_job["environment"]["name"] == "pypi"  # nosec B101
-    assert pypi_job["permissions"] == {"contents": "read", "id-token": "write"}  # nosec B101
-    assert "MCP_UNIFIED_PYPI_API_TOKEN" not in pypi_serialized  # nosec B101
-    assert "TWINE_PASSWORD" not in pypi_serialized  # nosec B101
-    assert any("pypa/gh-action-pypi-publish" in str(step) for step in pypi_uses_steps)  # nosec B101
-    assert ".artifacts/mcp-unified-rc/dist/" in pypi_serialized  # nosec B101
+    assert pypi_job["permissions"] == {  # nosec B101
+        "actions": "read",
+        "contents": "read",
+        "id-token": "write",
+    }
+    assert [step["name"] for step in pypi_job["steps"]] == [  # nosec B101
+        "Download MCP Unified distributions",
+        "Publish MCP Unified to PyPI",
+    ]
+    assert "env" not in pypi_job  # nosec B101
+    assert all("run" not in step for step in pypi_job["steps"])  # nosec B101
+    assert download_step["uses"] == (  # nosec B101
+        "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
+    )
+    assert download_step["with"] == {  # nosec B101
+        "name": "mcp-unified-publish-plan",
+        "path": ".artifacts/mcp-unified-rc",
+    }
+    assert publish_step["uses"] == (  # nosec B101
+        "pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e"
+    )
+    assert publish_step["with"]["packages-dir"] == ".artifacts/mcp-unified-rc/dist/"  # nosec B101
+    assert "MCP_UNIFIED_PYPI_API_TOKEN" not in workflow_text  # nosec B101
+    assert "TWINE_PASSWORD: ${{ secrets.MCP_UNIFIED_PYPI_API_TOKEN }}" not in workflow_text  # nosec B101
+    assert "pypa/gh-action-pypi-publish@v1.13.0" not in workflow_text  # nosec B101
 
 
 @pytest.mark.smoke

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py
@@ -1095,18 +1095,22 @@ def test_mcp_unified_publish_workflow_is_manual_and_gated() -> None:
 
     plan_job = jobs["publish-plan"]
     assert plan_job["permissions"] == {"contents": "read"}  # nosec B101
-    for job_name, environment_name, token_secret in (
-        ("publish-testpypi", "testpypi", "MCP_UNIFIED_TESTPYPI_API_TOKEN"),
-        ("publish-pypi", "pypi", "MCP_UNIFIED_PYPI_API_TOKEN"),
+    for job_name, environment_name, permissions in (
+        ("publish-testpypi", "testpypi", {"contents": "read"}),
+        ("publish-pypi", "pypi", {"contents": "read", "id-token": "write"}),
     ):
         job = jobs[job_name]
         assert job["needs"] == "publish-plan"  # nosec B101
         assert "inputs.confirm_publish == 'MCP_UNIFIED_PUBLISH'" in job["if"]  # nosec B101
-        assert job["permissions"] == {"contents": "read"}  # nosec B101
+        assert job["permissions"] == permissions  # nosec B101
         assert job["environment"]["name"] == environment_name  # nosec B101
-        job_text = yaml.safe_dump(job, sort_keys=True)
-        assert token_secret in job_text  # nosec B101
-        assert "TWINE_USERNAME: __token__" in job_text  # nosec B101
+    testpypi_job_text = yaml.safe_dump(jobs["publish-testpypi"], sort_keys=True)
+    pypi_job_text = yaml.safe_dump(jobs["publish-pypi"], sort_keys=True)
+    assert "MCP_UNIFIED_TESTPYPI_API_TOKEN" in testpypi_job_text  # nosec B101
+    assert "TWINE_USERNAME: __token__" in testpypi_job_text  # nosec B101
+    assert "MCP_UNIFIED_PYPI_API_TOKEN" not in pypi_job_text  # nosec B101
+    assert "TWINE_USERNAME: __token__" not in pypi_job_text  # nosec B101
+    assert "pypa/gh-action-pypi-publish" in pypi_job_text  # nosec B101
 
 
 def test_mcp_unified_make_targets_do_not_call_root_pypi_check() -> None:
@@ -1181,6 +1185,27 @@ def test_root_pypi_publish_workflow_is_labeled_for_tldw_server() -> None:
     assert workflow["name"] == "Publish tldw-server PyPI Package"  # nosec B101
     assert "mcp-unified" not in serialized_workflow  # nosec B101
     assert "tldw-server-pypi-dist" in serialized_workflow  # nosec B101
+
+
+def test_mcp_unified_publish_workflow_uses_trusted_publishing_for_pypi() -> None:
+    """Production MCP Unified publishing must use the configured PyPI OIDC publisher."""
+
+    workflow_path = REPO_ROOT / ".github" / "workflows" / "mcp-unified-publish.yml"
+    workflow = _load_workflow(workflow_path)
+
+    testpypi_job = workflow["jobs"]["publish-testpypi"]
+    pypi_job = workflow["jobs"]["publish-pypi"]
+    pypi_serialized = yaml.safe_dump(pypi_job, sort_keys=True)
+    pypi_uses_steps = [step.get("uses") for step in pypi_job["steps"] if "uses" in step]
+
+    assert testpypi_job["env"]["TWINE_USERNAME"] == "__token__"  # nosec B101
+    assert "MCP_UNIFIED_TESTPYPI_API_TOKEN" in testpypi_job["env"]["TWINE_PASSWORD"]  # nosec B101
+    assert pypi_job["environment"]["name"] == "pypi"  # nosec B101
+    assert pypi_job["permissions"] == {"contents": "read", "id-token": "write"}  # nosec B101
+    assert "MCP_UNIFIED_PYPI_API_TOKEN" not in pypi_serialized  # nosec B101
+    assert "TWINE_PASSWORD" not in pypi_serialized  # nosec B101
+    assert any("pypa/gh-action-pypi-publish" in str(step) for step in pypi_uses_steps)  # nosec B101
+    assert ".artifacts/mcp-unified-rc/dist/" in pypi_serialized  # nosec B101
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
Change summary
- Switches the MCP Unified production PyPI publish job to GitHub/PyPI Trusted Publishing with the `pypi` environment, `id-token: write`, and `pypa/gh-action-pypi-publish@v1.13.0` publishing `.artifacts/mcp-unified-rc/dist/`.
- Removes the production PyPI long-lived token path from the workflow while leaving TestPyPI token publishing unchanged for smoke releases.
- Updates workflow boundary tests so the two live publish targets have distinct authentication contracts.

Why
- PyPI is configured with a pending trusted publisher for repository `rmusser01/tldw_server`, workflow `mcp-unified-publish.yml`, environment `pypi`. The workflow needs to request an OIDC token and use the PyPI publish action for the pending publisher to activate.
- Keeping TestPyPI token-based avoids mixing two publishing changes at once and preserves the already-working smoke path.

Validation
- GitHub Actions environment `pypi` verified via `gh api`: id `17193755583`.
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q -k publish_workflow` -> 3 passed.
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_runtime_package_boundary.py -q` -> 47 passed.
- `make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python mcp-unified-publish-dry-run` -> passed.
- `git diff --check` -> passed.
- Bandit full run on the touched test file exits nonzero only for existing low-severity pytest/subprocess/test-secret baseline; filtered touched-scope run with `-s B101,B404,B603,B105` -> no findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move MCP Unified production PyPI publishing to GitHub/PyPI Trusted Publishing (OIDC) with SHA‑pinned actions, removing the long‑lived token and keeping the TestPyPI token path. Updates tests and documentation to match and satisfy TASK-12013.

- **Refactors**
  - `publish-pypi`: adds `actions: read`, `contents: read`, `id-token: write`; removes TWINE env; replaces build steps with `actions/download-artifact` + `pypa/gh-action-pypi-publish` (both SHA‑pinned) publishing from `.artifacts/mcp-unified-rc/dist/`.
  - TestPyPI unchanged (`TWINE_USERNAME: __token__`, `MCP_UNIFIED_TESTPYPI_API_TOKEN`).
  - Boundary tests assert OIDC permissions, exact step names/order, packages dir, SHA‑pinned actions, and absence of the production token and tag-based publish action.
  - Adds TASK-12013 backlog entry with acceptance criteria and validation notes.

<sup>Written for commit 2b70ce5917299a78c0df389c3b0a052a25ca8ffb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

