### PR TITLE
Harden Skills core review findings

### DIFF
--- a/IMPLEMENTATION_PLAN_skills_core_review_hardening_12003.md
+++ b/IMPLEMENTATION_PLAN_skills_core_review_hardening_12003.md
@@ -1,0 +1,31 @@
+# Skills Core Review Hardening Implementation Plan
+
+## Stage 1: Regression Coverage
+**Goal**: Add focused tests for the validated Skills review findings before changing implementation.
+**Success Criteria**: Tests fail against current code for unsafe file/registry mutation ordering, fork skills with no allowed tools, oversized zip import payloads, supporting-file-only versioning/I/O failure handling, and async context integration.
+**Tests**: `tldw_Server_API/tests/Skills/unit/test_skills_service.py`, `tldw_Server_API/tests/Skills/unit/test_skill_executor.py`, `tldw_Server_API/tests/Skills/integration/test_skills_api.py`.
+**Status**: Complete
+
+## Stage 2: File And Registry Consistency
+**Goal**: Make update/delete operations avoid publishing filesystem changes when optimistic registry writes conflict or fail.
+**Success Criteria**: SKILL.md updates are staged and restored on registry conflicts, deletes mark the registry before removing files with safe rollback behavior, supporting-file changes bump skill versions, and supporting-file write/delete failures raise domain errors.
+**Tests**: Focused Skills service tests pass.
+**Status**: Complete
+
+## Stage 3: Tool And Zip Safety
+**Goal**: Deny fork skill tool access by default and reject abusive zip imports before unbounded reads.
+**Success Criteria**: Fork skills without `allowed-tools` advertise no tools and do not execute tool calls; zip imports enforce entry count, SKILL.md size, supporting-file size, and aggregate size guards using ZipInfo before reads.
+**Tests**: Focused executor and zip import tests pass.
+**Status**: Complete
+
+## Stage 4: Async Context Integration
+**Goal**: Keep async chat request paths off synchronous Skills registry/filesystem scans.
+**Success Criteria**: Async helpers use `get_context_payload_async()` for tool injection and system-message context, and chat endpoint callers await those helpers.
+**Tests**: Focused Skills API/chat integration tests pass.
+**Status**: Complete
+
+## Stage 5: Verification And Closeout
+**Goal**: Verify the touched scope and record task evidence.
+**Success Criteria**: Focused pytest suites pass, compile check passes for touched Python files, Bandit scans touched production paths, and Backlog task records final files, verification, and summary.
+**Tests**: Focused Skills tests plus `python -m compileall` and `python -m bandit -r` on touched production paths.
+**Status**: Complete

--- a/backlog/tasks/task-12003 - Harden-Skills-core-review-findings.md
+++ b/backlog/tasks/task-12003 - Harden-Skills-core-review-findings.md
@@ -1,0 +1,70 @@
+---
+id: TASK-12003
+title: Harden Skills core review findings
+status: Done
+created_date: 2026-06-24 01:46
+labels:
+- skills
+- backend
+- security
+priority: high
+references:
+- Review findings from current thread
+modified_files:
+- IMPLEMENTATION_PLAN_skills_core_review_hardening_12003.md
+- backlog/tasks/task-12003 - Harden-Skills-core-review-findings.md
+- tldw_Server_API/app/api/v1/endpoints/chat.py
+- tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+- tldw_Server_API/app/core/Skills/__init__.py
+- tldw_Server_API/app/core/Skills/context_integration.py
+- tldw_Server_API/app/core/Skills/skill_executor.py
+- tldw_Server_API/app/core/Skills/skills_service.py
+- tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py
+- tldw_Server_API/tests/Skills/unit/test_skill_executor.py
+- tldw_Server_API/tests/Skills/unit/test_skill_registry_queries.py
+- tldw_Server_API/tests/Skills/unit/test_skills_service.py
+updated_date: 2026-06-25 03:10
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the current-module Skills core review findings: make skill file/registry mutations safer under conflicts, deny tools by default for fork skills without allowed-tools, bound zip import reads before decompression, version and fail supporting-file updates correctly, and provide async context integration for async chat paths.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Skills updates and deletes do not leave SKILL.md/supporting files mutated when optimistic registry updates conflict or fail.
+- [x] #2 Fork-mode skills with no allowed-tools do not receive advertised tools and cannot execute arbitrary tools by default.
+- [x] #3 Zip import rejects oversized SKILL.md/supporting files and suspicious archive payloads before unbounded reads.
+- [x] #4 Supporting-file-only updates surface I/O failures and bump skill versions.
+- [x] #5 Async chat/context call paths avoid synchronous Skills registry/filesystem scans.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented review hardening for Skills core: file updates now snapshot and restore touched files on registry conflicts/failures; deletes mark the registry before removing files; fork-mode skills deny tools by default and ignore model tool calls when no tools were advertised; zip import validates SKILL.md/supporting-file sizes and aggregate limits from ZipInfo before reads; supporting-file-only updates raise storage errors and bump registry versions; async Skills context helpers are wired into chat request handling. Verification: targeted regressions passed (10 passed); broader Skills suite passed (155 passed); compileall passed for Skills core and chat endpoint; Bandit passed on touched production paths with zero findings, report at /tmp/bandit_skills_core_review_12003.json.
+Final verification after adding the zip entry-count guard: targeted zip tests passed (2 passed), broader Skills selection passed (156 passed), compileall passed, and Bandit passed again with zero findings at /tmp/bandit_skills_core_review_12003.json.
+PR review follow-up started: rechecked branch against latest origin/dev, collected Gemini/Qodo review comments, and will address rollback robustness, async filesystem offloading, deleted-skill restore behavior, helper docstrings, and tool-denial observability.
+PR review follow-up completed: verified branch is based on latest origin/dev; addressed Gemini/Qodo comments by adding restore_skill_registry for deleted row recovery, wiring sync restore/delete rollback through it, offloading new async-path filesystem work through asyncio.to_thread, adding helper docstrings, using missing_ok unlink, catching unexpected registry update failures with rollback, and returning a non-empty denied-tools fork output. Verification: targeted review-fix tests passed (4 passed); broader Skills/registry/API selection passed (162 passed); compileall passed; git diff --check passed; Bandit passed on expanded touched production scope with zero JSON results at /tmp/bandit_skills_core_review_12003_rebased.json.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed all reviewed Skills core findings plus PR review follow-up comments. Verified against latest origin/dev with targeted review regressions, the broader Skills/registry/API suite (162 passed), compileall, diff check, and Bandit with zero findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+- [x] #7 Focused Skills unit/integration tests cover the fixed behaviors and pass.
+- [x] #8 Bandit scans touched backend Python paths with no new findings.
+- [x] #9 Implementation plan is created and updated through completion.
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/chat.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chat.py
@@ -203,8 +203,8 @@ from tldw_Server_API.app.core.Moderation.supervised_policy import (
     bootstrap_guardian_moderation_runtime,
 )
 from tldw_Server_API.app.core.Skills.context_integration import (
-    add_skill_tool_to_tools_list,
-    build_system_message_with_skills,
+    add_skill_tool_to_tools_list_async,
+    build_system_message_with_skills_async,
 )
 from tldw_Server_API.app.core.Utils.chunked_image_processor import get_image_processor
 
@@ -2437,7 +2437,7 @@ async def create_chat_completion(
             provider_hint = request_data.api_provider or _get_default_provider()
             request_data.tools = validate_tool_definitions(tools_as_dicts, provider=provider_hint)
         if user_base_dir is not None and current_user and getattr(current_user, "id", None) is not None:
-            request_data.tools = add_skill_tool_to_tools_list(
+            request_data.tools = await add_skill_tool_to_tools_list_async(
                 request_data.tools,
                 user_id=current_user.id,
                 base_path=user_base_dir,
@@ -3621,7 +3621,7 @@ async def create_chat_completion(
                     persona_debug_meta["budget_adjustment_reason"] = persona_budget_adjustment_reason
 
             if user_base_dir is not None and current_user and getattr(current_user, "id", None) is not None:
-                final_system_message = build_system_message_with_skills(
+                final_system_message = await build_system_message_with_skills_async(
                     final_system_message,
                     current_user.id,
                     user_base_dir,

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -16224,6 +16224,90 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             logger.error(f"Database error deleting skill '{name}': {exc}")
             raise
 
+    def restore_skill_registry(
+        self,
+        name: str,
+        update_data: dict[str, Any] | None,
+        expected_version: int,
+    ) -> bool:
+        """Restore a soft-deleted skill registry row using optimistic locking."""
+        self._ensure_skill_registry_table()
+        now = self._get_current_utc_timestamp_iso()
+        allowed_fields = {
+            "description",
+            "argument_hint",
+            "disable_model_invocation",
+            "user_invocable",
+            "allowed_tools",
+            "model",
+            "context",
+            "directory_path",
+            "file_hash",
+        }
+
+        set_parts: list[str] = []
+        params: list[Any] = []
+        for key, value in (update_data or {}).items():
+            if key not in allowed_fields:
+                continue
+            if key == "allowed_tools":
+                params.append(self._ensure_json_string(value))
+                set_parts.append("allowed_tools = ?")
+            elif key in {"disable_model_invocation", "user_invocable"}:
+                params.append(self._skill_bool_value(bool(value)))
+                set_parts.append(f"{key} = ?")
+            else:
+                params.append(value)
+                set_parts.append(f"{key} = ?")
+
+        set_parts.extend(["deleted = ?", "last_modified = ?", "version = version + 1"])
+        params.extend([self._skill_bool_value(False), now, name, expected_version])
+        query = (
+            f"UPDATE skill_registry SET {', '.join(set_parts)} "  # nosec B608
+            "WHERE name = ? AND version = ? AND deleted = ?"
+        )
+        params.append(self._skill_bool_value(True))
+
+        try:
+            with self.transaction() as conn:
+                row = conn.execute(
+                    "SELECT version, deleted FROM skill_registry WHERE name = ?",
+                    (name,),
+                ).fetchone()
+                if not row:
+                    raise ConflictError(
+                        f"Skill '{name}' restore target was not found.",
+                        entity="skill_registry",
+                        entity_id=name,
+                    )
+
+                current_db_version = int(row["version"])
+                if current_db_version != expected_version:
+                    raise ConflictError(
+                        f"Skill '{name}' version mismatch (db has {current_db_version}, expected {expected_version}).",
+                        entity="skill_registry",
+                        entity_id=name,
+                    )
+
+                if not row["deleted"]:
+                    logger.info("Skill '{}' already active; restore is idempotent.", name)
+                    return True
+
+                prepared_query, prepared_params = self._prepare_backend_statement(query, tuple(params))
+                cursor = conn.execute(prepared_query, prepared_params)
+                if cursor.rowcount == 0:
+                    raise ConflictError(
+                        f"Skill '{name}' restore affected 0 rows.",
+                        entity="skill_registry",
+                        entity_id=name,
+                    )
+                return True
+        except ConflictError:
+            raise
+        except CharactersRAGDBError as exc:
+            logger.error(f"Database error restoring skill '{name}': {exc}")
+            raise
+
     def _deserialize_row_fields(self, row: sqlite3.Row, json_fields: list[str]) -> dict[str, Any] | None:
         """
         Converts a sqlite3.Row object to a dictionary, deserializing specified JSON fields.

--- a/tldw_Server_API/app/core/Skills/__init__.py
+++ b/tldw_Server_API/app/core/Skills/__init__.py
@@ -34,9 +34,12 @@ Usage:
 
 from tldw_Server_API.app.core.Skills.context_integration import (
     add_skill_tool_to_tools_list,
+    add_skill_tool_to_tools_list_async,
     build_system_message_with_skills,
+    build_system_message_with_skills_async,
     get_skill_tool_definition,
     get_skills_context_text,
+    get_skills_context_text_async,
     handle_skill_tool_call,
 )
 from tldw_Server_API.app.core.Skills.exceptions import (
@@ -69,8 +72,11 @@ __all__ = [
     "SkillExecutionError",
     # Context integration
     "get_skills_context_text",
+    "get_skills_context_text_async",
     "build_system_message_with_skills",
+    "build_system_message_with_skills_async",
     "get_skill_tool_definition",
     "handle_skill_tool_call",
     "add_skill_tool_to_tools_list",
+    "add_skill_tool_to_tools_list_async",
 ]

--- a/tldw_Server_API/app/core/Skills/context_integration.py
+++ b/tldw_Server_API/app/core/Skills/context_integration.py
@@ -45,6 +45,22 @@ def get_skills_context_text(user_id: int, base_path: Path, db: Any | None = None
         return ""
 
 
+async def get_skills_context_text_async(user_id: int, base_path: Path, db: Any | None = None) -> str:
+    """
+    Async variant of get_skills_context_text for request handlers.
+
+    Uses the service's thread-offloaded context loading path so chat endpoints do
+    not perform filesystem scans directly on the event loop.
+    """
+    try:
+        service = SkillsService(user_id=user_id, base_path=base_path, db=db)
+        payload = await service.get_context_payload_async()
+        return payload.get("context_text", "")
+    except Exception as e:
+        logger.warning(f"Failed to get skills context for user {user_id}: {e}")
+        return ""
+
+
 def build_system_message_with_skills(
     base_system_message: Optional[str],
     user_id: int,
@@ -63,6 +79,24 @@ def build_system_message_with_skills(
         System message with skills context appended
     """
     skills_context = get_skills_context_text(user_id, base_path, db=db)
+
+    parts = []
+    if base_system_message:
+        parts.append(base_system_message)
+    if skills_context:
+        parts.append(skills_context)
+
+    return "\n\n".join(parts) if parts else ""
+
+
+async def build_system_message_with_skills_async(
+    base_system_message: Optional[str],
+    user_id: int,
+    base_path: Path,
+    db: Any | None = None,
+) -> str:
+    """Async variant of build_system_message_with_skills."""
+    skills_context = await get_skills_context_text_async(user_id, base_path, db=db)
 
     parts = []
     if base_system_message:
@@ -164,6 +198,37 @@ def add_skill_tool_to_tools_list(
         skills = service.get_context_payload().get("available_skills", [])
         if skills:
             # Add Skill tool if not already present
+            skill_tool = get_skill_tool_definition()
+            tool_names = []
+            for tool in result:
+                if not isinstance(tool, dict):
+                    continue
+                func = tool.get("function")
+                if isinstance(func, dict) and func.get("name"):
+                    tool_names.append(func.get("name"))
+                elif tool.get("name"):
+                    tool_names.append(tool.get("name"))
+            if "Skill" not in tool_names:
+                result.append(skill_tool)
+    except Exception as e:
+        logger.warning(f"Failed to check skills for user {user_id}: {e}")
+
+    return result
+
+
+async def add_skill_tool_to_tools_list_async(
+    tools: Optional[list[dict[str, Any]]],
+    user_id: int,
+    base_path: Path,
+    db: Any | None = None,
+) -> list[dict[str, Any]]:
+    """Async variant of add_skill_tool_to_tools_list."""
+    result = list(tools) if tools else []
+
+    try:
+        service = SkillsService(user_id=user_id, base_path=base_path, db=db)
+        skills = (await service.get_context_payload_async()).get("available_skills", [])
+        if skills:
             skill_tool = get_skill_tool_definition()
             tool_names = []
             for tool in result:

--- a/tldw_Server_API/app/core/Skills/skill_executor.py
+++ b/tldw_Server_API/app/core/Skills/skill_executor.py
@@ -169,7 +169,7 @@ class SkillExecutor:
             Filtered list of tool definitions
         """
         if not allowed_tools:
-            return all_tools  # No restriction
+            return []
 
         # Extract base tool names from patterns
         allowed_base_names = set()
@@ -415,8 +415,7 @@ class SkillExecutor:
             t for t in tool_defs
             if not isinstance(t, dict) or t.get("canExecute", True)
         ]
-        if allowed_tools:
-            tool_defs = self.filter_tools_for_skill(tool_defs, allowed_tools)
+        tool_defs = self.filter_tools_for_skill(tool_defs, allowed_tools)
         llm_tools = self._normalize_tool_definitions(tool_defs)
 
         system_prompt = (
@@ -449,6 +448,14 @@ class SkillExecutor:
                 final_output = self._extract_response_text(response)
                 break
 
+            if not llm_tools:
+                final_output = (
+                    self._extract_response_text(response)
+                    or "Tool calls were requested but no tools are allowed for this skill."
+                )
+                logger.warning(f"Tool calls requested but no tools are allowed for skill fork '{skill_name}'.")
+                break
+
             if tool_executor is None:
                 final_output = self._extract_response_text(response)
                 logger.warning("Tool calls requested but no executor available for skill fork.")
@@ -471,7 +478,7 @@ class SkillExecutor:
                         client_id=context.client_id if context else None,
                         tool_name=tool_name,
                         arguments=tool_args,
-                        allowed_tools=allowed_tools or None,
+                        allowed_tools=allowed_tools,
                     )
                     result_payload = json.dumps(result, default=str)
                 except ToolExecutionError as e:

--- a/tldw_Server_API/app/core/Skills/skills_service.py
+++ b/tldw_Server_API/app/core/Skills/skills_service.py
@@ -51,6 +51,8 @@ SUPPORTING_FILE_NAME_PATTERN = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}$')
 MAX_SUPPORTING_FILES_COUNT = 20
 MAX_SUPPORTING_FILE_BYTES = 500000
 MAX_SUPPORTING_FILES_TOTAL_BYTES = 5 * 1024 * 1024  # 5MB
+MAX_SKILL_MD_BYTES = 500000
+MAX_ZIP_IMPORT_ENTRIES = 100
 
 
 class SkillMetadata:
@@ -393,10 +395,9 @@ class SkillsService:
                         "context": parsed.frontmatter.context,
                         "directory_path": str(item),
                         "file_hash": parsed.content_hash,
-                        "deleted": 0,
                     }
                     try:
-                        db.update_skill_registry(item.name, update_data, expected_version=existing.get("version", 1))
+                        db.restore_skill_registry(item.name, update_data, expected_version=existing.get("version", 1))
                         logger.info(f"Restored deleted skill '{item.name}' from disk")
                     except ConflictError as e:
                         logger.warning(f"Conflict restoring skill '{item.name}': {e}")
@@ -687,12 +688,38 @@ class SkillsService:
             )
 
         skill_dir = self._get_skill_dir(name)
-        if not skill_dir.exists():
+        if not await asyncio.to_thread(skill_dir.exists):
             with contextlib.suppress(Exception):
                 db.mark_skill_registry_deleted(name, expected_version=current_version)
             raise SkillNotFoundError(name, detail="Skill directory not found")
 
         update_data: dict[str, Any] = {}
+        touched_files: dict[Path, Optional[str]] = {}
+
+        async def snapshot_file(file_path: Path) -> None:
+            """Capture a file's current text content before mutating it."""
+            if file_path in touched_files:
+                return
+            try:
+                if await asyncio.to_thread(file_path.exists):
+                    touched_files[file_path] = await asyncio.to_thread(file_path.read_text, encoding="utf-8")
+                else:
+                    touched_files[file_path] = None
+            except OSError as e:
+                raise SkillStorageError(f"Failed to read existing file before update: {e}", path=str(file_path)) from e
+
+        async def restore_touched_files() -> None:
+            """Restore files captured by snapshot_file after a failed update."""
+            for file_path, original_content in touched_files.items():
+                try:
+                    if original_content is None:
+                        await asyncio.to_thread(file_path.unlink, missing_ok=True)
+                    else:
+                        await asyncio.to_thread(file_path.parent.mkdir, parents=True, exist_ok=True)
+                        await asyncio.to_thread(file_path.write_text, original_content, encoding="utf-8")
+                except OSError as e:
+                    logger.error(f"Failed to restore skill file {file_path}: {e}")
+
         if content is not None:
             try:
                 parsed = self._parser.parse_content(content, default_name=name)
@@ -701,8 +728,13 @@ class SkillsService:
 
             skill_file = skill_dir / "SKILL.md"
             try:
-                skill_file.write_text(content, encoding="utf-8")
+                await snapshot_file(skill_file)
+                await asyncio.to_thread(skill_file.write_text, content, encoding="utf-8")
+            except SkillStorageError:
+                await restore_touched_files()
+                raise
             except OSError as e:
+                await restore_touched_files()
                 raise SkillStorageError(f"Failed to write SKILL.md: {e}", path=str(skill_file)) from e
 
             update_data.update(
@@ -728,24 +760,57 @@ class SkillsService:
             for filename, file_content in normalized_supporting_files.items():
                 file_path = self._safe_supporting_path(skill_dir, filename)
                 if file_content is None:
-                    if file_path.exists():
+                    if await asyncio.to_thread(file_path.exists):
                         try:
-                            file_path.unlink()
+                            await snapshot_file(file_path)
+                            await asyncio.to_thread(file_path.unlink, missing_ok=True)
+                        except SkillStorageError:
+                            await restore_touched_files()
+                            raise
                         except OSError as e:
-                            logger.warning(f"Failed to delete supporting file {filename}: {e}")
+                            await restore_touched_files()
+                            raise SkillStorageError(
+                                f"Failed to delete supporting file '{filename}': {e}",
+                                path=str(file_path),
+                            ) from e
                 else:
                     try:
-                        file_path.write_text(file_content, encoding="utf-8")
+                        await snapshot_file(file_path)
+                        await asyncio.to_thread(file_path.write_text, file_content, encoding="utf-8")
+                    except SkillStorageError:
+                        await restore_touched_files()
+                        raise
                     except OSError as e:
-                        logger.warning(f"Failed to write supporting file {filename}: {e}")
+                        await restore_touched_files()
+                        raise SkillStorageError(
+                            f"Failed to write supporting file '{filename}': {e}",
+                            path=str(file_path),
+                        ) from e
+
+            if normalized_supporting_files and not update_data:
+                parsed = await asyncio.to_thread(self._parse_skill_file, skill_dir)
+                if not parsed:
+                    await restore_touched_files()
+                    raise SkillsError(f"Failed to parse skill '{name}' after supporting file update")
+                update_data.update(
+                    {
+                        "directory_path": str(skill_dir),
+                        "file_hash": parsed.content_hash,
+                    }
+                )
 
         if update_data:
             try:
                 db.update_skill_registry(name, update_data, expected_version=current_version)
             except ConflictError as e:
+                await restore_touched_files()
                 raise SkillConflictError(str(e), skill_name=name) from e
             except (CharactersRAGDBError, InputError) as e:
+                await restore_touched_files()
                 raise SkillsError(f"Failed to update skill '{name}' in registry: {e}") from e
+            except Exception as e:
+                await restore_touched_files()
+                raise SkillsError(f"Unexpected error updating skill '{name}' in registry: {e}") from e
 
         logger.info(f"Updated skill '{name}' for user {self.user_id}")
 
@@ -780,14 +845,6 @@ class SkillsService:
                 actual_version=current_version,
             )
 
-        # Delete skill directory
-        skill_dir = self._get_skill_dir(name)
-        if skill_dir.exists():
-            try:
-                shutil.rmtree(skill_dir)
-            except OSError as e:
-                raise SkillStorageError(f"Failed to delete skill directory: {e}", path=str(skill_dir)) from e
-
         if not row.get("deleted"):
             try:
                 db.mark_skill_registry_deleted(name, expected_version=current_version)
@@ -795,6 +852,23 @@ class SkillsService:
                 raise SkillConflictError(str(e), skill_name=name) from e
             except CharactersRAGDBError as e:
                 raise SkillsError(f"Failed to delete skill '{name}' in registry: {e}") from e
+
+        # Delete skill directory after the registry accepts the versioned delete.
+        skill_dir = self._get_skill_dir(name)
+        if await asyncio.to_thread(skill_dir.exists):
+            try:
+                await asyncio.to_thread(shutil.rmtree, skill_dir)
+            except OSError as e:
+                if not row.get("deleted"):
+                    try:
+                        db.restore_skill_registry(
+                            name,
+                            {"directory_path": str(skill_dir)},
+                            expected_version=current_version + 1,
+                        )
+                    except Exception as restore_error:
+                        logger.error(f"Failed to restore skill registry after delete failure: {restore_error}")
+                raise SkillStorageError(f"Failed to delete skill directory: {e}", path=str(skill_dir)) from e
 
         logger.info(f"Deleted skill '{name}' for user {self.user_id}")
 
@@ -948,25 +1022,34 @@ class SkillsService:
         """Extract SKILL.md content, name, and supporting files from zip bytes."""
         try:
             with zipfile.ZipFile(BytesIO(zip_data), "r") as zf:
+                entries = zf.infolist()
+                if len(entries) > MAX_ZIP_IMPORT_ENTRIES:
+                    raise SkillValidationError(
+                        f"Zip file contains too many entries: maximum {MAX_ZIP_IMPORT_ENTRIES} allowed"
+                    )
                 # Find SKILL.md
-                skill_md_path = None
+                skill_md_info = None
                 base_dir = ""
 
-                for name in zf.namelist():
+                for info in entries:
+                    name = info.filename
                     if name.endswith("SKILL.md"):
-                        skill_md_path = name
+                        skill_md_info = info
                         # Get the base directory
                         parts = name.split("/")
                         if len(parts) > 1:
                             base_dir = "/".join(parts[:-1]) + "/"
                         break
 
-                if not skill_md_path:
+                if not skill_md_info:
                     raise SkillValidationError("Zip file does not contain SKILL.md")
 
+                skill_md_path = skill_md_info.filename
                 skill_md_posix_path = PurePosixPath(skill_md_path)
                 if skill_md_posix_path.is_absolute() or ".." in skill_md_posix_path.parts:
                     raise SkillValidationError(f"Invalid SKILL.md path in zip: '{skill_md_path}'")
+                if skill_md_info.file_size > MAX_SKILL_MD_BYTES:
+                    raise SkillValidationError("SKILL.md exceeds 500KB limit")
 
                 # Read SKILL.md
                 try:
@@ -976,10 +1059,13 @@ class SkillsService:
 
                 # Read supporting files
                 supporting_files: dict[str, str] = {}
-                for name in zf.namelist():
+                supporting_count = 0
+                supporting_total_bytes = 0
+                for info in entries:
+                    name = info.filename
                     if name == skill_md_path:
                         continue
-                    if name.startswith(base_dir) and not name.endswith("/"):
+                    if name.startswith(base_dir) and not info.is_dir():
                         relative_name = name[len(base_dir) :]
                         if not relative_name:
                             continue
@@ -995,6 +1081,24 @@ class SkillsService:
                             continue
 
                         safe_filename = self._validate_supporting_filename(relative_name)
+                        supporting_count += 1
+                        if supporting_count > MAX_SUPPORTING_FILES_COUNT:
+                            raise SkillValidationError(
+                                f"Too many supporting files: maximum {MAX_SUPPORTING_FILES_COUNT} allowed",
+                                field="supporting_files",
+                            )
+                        if info.file_size > MAX_SUPPORTING_FILE_BYTES:
+                            raise SkillValidationError(
+                                f"Supporting file '{safe_filename}' exceeds 500KB limit",
+                                field="supporting_files",
+                            )
+                        supporting_total_bytes += info.file_size
+                        if supporting_total_bytes > MAX_SUPPORTING_FILES_TOTAL_BYTES:
+                            raise SkillValidationError(
+                                "Supporting files exceed "
+                                f"{MAX_SUPPORTING_FILES_TOTAL_BYTES // (1024 * 1024)}MB limit",
+                                field="supporting_files",
+                            )
                         try:
                             file_content = zf.read(name).decode("utf-8")
                             supporting_files[safe_filename] = file_content

--- a/tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py
+++ b/tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py
@@ -96,6 +96,35 @@ class TestBuildSystemMessageWithSkills:
         )
         assert result == "Base message"
 
+    @pytest.mark.asyncio
+    async def test_async_variant_uses_async_context_payload(self, monkeypatch, temp_env):
+        """Async chat paths should not call the synchronous Skills context scan."""
+        env = temp_env
+
+        async def _fake_async_payload(self):
+            return {
+                "available_skills": [{"name": "async-skill"}],
+                "context_text": "<available-skills>\n- async-skill: Async context\n</available-skills>",
+            }
+
+        def _unexpected_sync_payload(self):
+            raise AssertionError("async Skills context must not call sync payload")
+
+        monkeypatch.setattr(SkillsService, "get_context_payload_async", _fake_async_payload)
+        monkeypatch.setattr(SkillsService, "get_context_payload", _unexpected_sync_payload)
+
+        from tldw_Server_API.app.core.Skills.context_integration import build_system_message_with_skills_async
+
+        result = await build_system_message_with_skills_async(
+            "Base message",
+            env["user_id"],
+            env["base_path"],
+            db=env["db"],
+        )
+
+        assert result.startswith("Base message")
+        assert "async-skill" in result
+
 
 class TestGetSkillToolDefinition:
     def test_has_correct_schema(self):
@@ -196,3 +225,39 @@ class TestAddSkillToolToToolsList:
 
         assert "Skill" not in tool_names
         assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_async_variant_uses_async_context_payload(self, monkeypatch, temp_env):
+        """Async tool injection should use the async Skills service method."""
+        env = temp_env
+
+        async def _fake_async_payload(self):
+            return {
+                "available_skills": [{"name": "async-tool-skill"}],
+                "context_text": "<available-skills />",
+            }
+
+        def _unexpected_sync_payload(self):
+            raise AssertionError("async Skills tool injection must not call sync payload")
+
+        monkeypatch.setattr(SkillsService, "get_context_payload_async", _fake_async_payload)
+        monkeypatch.setattr(SkillsService, "get_context_payload", _unexpected_sync_payload)
+
+        from tldw_Server_API.app.core.Skills.context_integration import add_skill_tool_to_tools_list_async
+
+        result = await add_skill_tool_to_tools_list_async(
+            [{"type": "function", "function": {"name": "Read"}}],
+            env["user_id"],
+            env["base_path"],
+            db=env["db"],
+        )
+
+        tool_names = []
+        for tool in result:
+            func = tool.get("function", {})
+            name = func.get("name") or tool.get("name")
+            if name:
+                tool_names.append(name)
+
+        assert "Skill" in tool_names
+        assert "Read" in tool_names

--- a/tldw_Server_API/tests/Skills/unit/test_skill_executor.py
+++ b/tldw_Server_API/tests/Skills/unit/test_skill_executor.py
@@ -185,7 +185,7 @@ class TestSkillExecutor:
             return SkillExecutor()
 
         def test_filter_tools_no_restrictions(self, executor):
-            """Test that all tools pass with no restrictions."""
+            """Skills without allowed-tools should not receive tools by default."""
             tools = [
                 {"name": "Read"},
                 {"name": "Write"},
@@ -193,7 +193,7 @@ class TestSkillExecutor:
             ]
             result = executor.filter_tools_for_skill(tools, [])
 
-            assert len(result) == 3
+            assert result == []
 
         def test_filter_tools_with_restrictions(self, executor):
             """Test filtering tools based on allowed list."""
@@ -349,6 +349,67 @@ class TestSkillExecution:
 
         assert result.model_override == "claude-3-opus"
 
+    @pytest.mark.asyncio
+    async def test_fork_without_allowed_tools_does_not_advertise_or_execute_tools(self, executor, monkeypatch):
+        """Forked skills must deny tools unless allowed-tools explicitly grants them."""
+        skill_data = {
+            "name": "fork-no-tools",
+            "content": "Do isolated work",
+            "context": "fork",
+            "allowed_tools": [],
+            "model": None,
+        }
+
+        observed_tools = []
+        chat_calls = 0
+
+        async def _fake_chat_call(**kwargs):
+            nonlocal chat_calls
+            chat_calls += 1
+            observed_tools.append(kwargs.get("tools"))
+            return {
+                "choices": [{
+                    "message": {
+                        "content": None,
+                        "tool_calls": [{
+                            "id": "call_1",
+                            "function": {
+                                "name": "DangerTool",
+                                "arguments": "{}",
+                            },
+                        }],
+                    }
+                }]
+            }
+
+        from tldw_Server_API.app.core.Chat import chat_service as chat_service_mod
+        monkeypatch.setattr(chat_service_mod, "perform_chat_api_call_async", _fake_chat_call)
+
+        class _ToolExecutorStub:
+            def __init__(self):
+                self.execute_calls = 0
+
+            async def execute(self, **_kwargs):
+                self.execute_calls += 1
+                return {"ok": True}
+
+        tool_executor = _ToolExecutorStub()
+        ctx = RequestContext(
+            user_id=1,
+            default_provider="openai",
+            tool_executor=tool_executor,
+            tool_definitions=[{"name": "DangerTool", "description": "", "inputSchema": {}}],
+            max_tool_calls=1,
+        )
+
+        result = await executor.execute(skill_data, "", context=ctx)
+
+        assert result.execution_mode == "fork"
+        assert observed_tools == [None]
+        assert chat_calls == 1
+        assert tool_executor.execute_calls == 0
+        assert result.fork_output == "Tool calls were requested but no tools are allowed for this skill."
+
 
 class TestForkExceptionLogging:
     """Regression tests for fork mode exception handling (Bug 4)."""
@@ -369,7 +430,7 @@ class TestForkExceptionLogging:
             "name": "fork-error-skill",
             "content": "Do something",
             "context": "fork",
-            "allowed_tools": [],
+            "allowed_tools": ["SomeTool"],
             "model": None,
         }
 
@@ -410,8 +471,9 @@ class TestForkExceptionLogging:
         ctx = RequestContext(
             user_id=1,
             default_provider="openai",
+            available_tools=["SomeTool"],
             tool_executor=_BrokenToolExecutor(),
-            tool_definitions=[],
+            tool_definitions=[{"name": "SomeTool", "description": "", "inputSchema": {}}],
         )
 
         # Capture loguru output

--- a/tldw_Server_API/tests/Skills/unit/test_skill_registry_queries.py
+++ b/tldw_Server_API/tests/Skills/unit/test_skill_registry_queries.py
@@ -94,3 +94,22 @@ def test_skill_registry_rejects_unapproved_sort_fields(skills_db: CharactersRAGD
 
     with pytest.raises(InputError, match="Unsupported skill registry sort field"):
         skills_db.list_skill_registry(sort="directory_path")
+
+
+def test_restore_skill_registry_reactivates_soft_deleted_row(skills_db: CharactersRAGDB) -> None:
+    _insert_skill(skills_db, "restorable", description="Before")
+
+    skills_db.mark_skill_registry_deleted("restorable", expected_version=1)
+    assert skills_db.get_skill_registry("restorable", include_deleted=False) is None
+
+    skills_db.restore_skill_registry(
+        "restorable",
+        {"description": "After"},
+        expected_version=2,
+    )
+
+    restored = skills_db.get_skill_registry("restorable", include_deleted=False)
+    assert restored is not None
+    assert restored["description"] == "After"
+    assert not restored["deleted"]
+    assert restored["version"] == 3

--- a/tldw_Server_API/tests/Skills/unit/test_skills_service.py
+++ b/tldw_Server_API/tests/Skills/unit/test_skills_service.py
@@ -9,10 +9,13 @@ from pathlib import Path
 import pytest
 
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import ConflictError
 from tldw_Server_API.app.core.Skills.exceptions import (
     SkillConflictError,
     SkillNotFoundError,
     SkillParseError,
+    SkillsError,
+    SkillStorageError,
     SkillValidationError,
 )
 from tldw_Server_API.app.core.Skills.skills_service import SkillMetadata, SkillsService
@@ -394,6 +397,48 @@ New content here.
             await service.update_skill("version-test", content="Again", expected_version=1)
 
     @pytest.mark.asyncio
+    async def test_update_skill_registry_conflict_restores_original_skill_file(self, service, monkeypatch):
+        """A registry conflict must not leave the staged SKILL.md content on disk."""
+        created = await service.create_skill("rollback-test", "Original content")
+        skill_file = service._get_skill_dir("rollback-test") / "SKILL.md"
+        original_disk_content = skill_file.read_text(encoding="utf-8")
+
+        def _conflict_update(*_args, **_kwargs):
+            raise ConflictError("simulated stale version", entity="skill_registry", entity_id="rollback-test")
+
+        monkeypatch.setattr(service._get_db(), "update_skill_registry", _conflict_update)
+
+        with pytest.raises(SkillConflictError):
+            await service.update_skill(
+                "rollback-test",
+                content="Updated content",
+                expected_version=created["version"],
+            )
+
+        assert skill_file.read_text(encoding="utf-8") == original_disk_content
+
+    @pytest.mark.asyncio
+    async def test_update_skill_unexpected_registry_error_restores_original_skill_file(self, service, monkeypatch):
+        """Unexpected registry failures must also restore staged SKILL.md content."""
+        created = await service.create_skill("rollback-unexpected", "Original content")
+        skill_file = service._get_skill_dir("rollback-unexpected") / "SKILL.md"
+        original_disk_content = skill_file.read_text(encoding="utf-8")
+
+        def _unexpected_update(*_args, **_kwargs):
+            raise RuntimeError("simulated registry timeout")
+
+        monkeypatch.setattr(service._get_db(), "update_skill_registry", _unexpected_update)
+
+        with pytest.raises(SkillsError, match="simulated registry timeout"):
+            await service.update_skill(
+                "rollback-unexpected",
+                content="Updated content",
+                expected_version=created["version"],
+            )
+
+        assert skill_file.read_text(encoding="utf-8") == original_disk_content
+
+    @pytest.mark.asyncio
     async def test_delete_skill(self, service):
         """Test deleting a skill."""
         await service.create_skill("delete-test", "Content")
@@ -425,6 +470,80 @@ New content here.
         # Try to delete with stale version
         with pytest.raises(SkillConflictError):
             await service.delete_skill("delete-version", expected_version=1)
+
+    @pytest.mark.asyncio
+    async def test_delete_skill_registry_conflict_keeps_skill_directory(self, service, monkeypatch):
+        """A delete conflict must not remove the skill directory before the DB delete lands."""
+        created = await service.create_skill("delete-rollback", "Content")
+        skill_dir = service._get_skill_dir("delete-rollback")
+
+        def _conflict_delete(*_args, **_kwargs):
+            raise ConflictError("simulated stale delete", entity="skill_registry", entity_id="delete-rollback")
+
+        monkeypatch.setattr(service._get_db(), "mark_skill_registry_deleted", _conflict_delete)
+
+        with pytest.raises(SkillConflictError):
+            await service.delete_skill("delete-rollback", expected_version=created["version"])
+
+        assert skill_dir.exists()
+        assert (skill_dir / "SKILL.md").read_text(encoding="utf-8") == "Content"
+
+    @pytest.mark.asyncio
+    async def test_delete_skill_directory_failure_restores_registry(self, service, monkeypatch):
+        """A directory deletion failure must not leave the skill hidden in the registry."""
+        created = await service.create_skill("delete-restore", "Content")
+        skill_dir = service._get_skill_dir("delete-restore")
+
+        from tldw_Server_API.app.core.Skills import skills_service as skills_service_mod
+
+        original_rmtree = skills_service_mod.shutil.rmtree
+
+        def _fail_rmtree(path, *args, **kwargs):
+            if Path(path) == skill_dir:
+                raise OSError("simulated directory lock")
+            return original_rmtree(path, *args, **kwargs)
+
+        monkeypatch.setattr(skills_service_mod.shutil, "rmtree", _fail_rmtree)
+
+        with pytest.raises(SkillStorageError, match="simulated directory lock"):
+            await service.delete_skill("delete-restore", expected_version=created["version"])
+
+        row = service._get_db().get_skill_registry("delete-restore", include_deleted=False)
+        assert row is not None
+        assert skill_dir.exists()
+        assert (skill_dir / "SKILL.md").read_text(encoding="utf-8") == "Content"
+
+    @pytest.mark.asyncio
+    async def test_update_skill_supporting_files_only_bumps_version(self, service):
+        """Supporting-file-only changes are skill bundle mutations and must be versioned."""
+        created = await service.create_skill(
+            "support-version",
+            "Content",
+            supporting_files={"guide.md": "v1"},
+        )
+
+        updated = await service.update_skill(
+            "support-version",
+            supporting_files={"guide.md": "v2"},
+            expected_version=created["version"],
+        )
+
+        assert updated["version"] == created["version"] + 1
+        assert updated["supporting_files"]["guide.md"] == "v2"
+
+    @pytest.mark.asyncio
+    async def test_update_skill_supporting_file_write_failure_raises_storage_error(self, service, monkeypatch):
+        """Supporting-file write failures must not be reported as successful updates."""
+        await service.create_skill("support-failure", "Content")
+        bad_path = service.skills_dir / "missing-parent" / "new.md"
+
+        monkeypatch.setattr(service, "_safe_supporting_path", lambda *_args, **_kwargs: bad_path)
+
+        with pytest.raises(SkillStorageError):
+            await service.update_skill(
+                "support-failure",
+                supporting_files={"new.md": "new content"},
+            )
 
     @pytest.mark.asyncio
     async def test_import_skill(self, service):
@@ -781,6 +900,36 @@ Content""")
         zip_data = buffer.getvalue()
 
         with pytest.raises(SkillValidationError, match="path traversal"):
+            await service.import_from_zip(zip_data)
+
+    @pytest.mark.asyncio
+    async def test_import_from_zip_rejects_oversized_skill_md(self, service):
+        """Zip import must enforce the SKILL.md content cap before writing files."""
+        import zipfile
+        from io import BytesIO
+
+        buffer = BytesIO()
+        with zipfile.ZipFile(buffer, "w") as zf:
+            zf.writestr("large-skill/SKILL.md", "x" * 500_001)
+        zip_data = buffer.getvalue()
+
+        with pytest.raises(SkillValidationError, match="SKILL.md.*500KB"):
+            await service.import_from_zip(zip_data)
+
+    @pytest.mark.asyncio
+    async def test_import_from_zip_rejects_too_many_entries(self, service):
+        """Zip import should reject archives with excessive entry counts before reads."""
+        import zipfile
+        from io import BytesIO
+
+        buffer = BytesIO()
+        with zipfile.ZipFile(buffer, "w") as zf:
+            zf.writestr("many-entries/SKILL.md", "Content")
+            for i in range(100):
+                zf.writestr(f"many-entries/extra-{i}.md", "x")
+        zip_data = buffer.getvalue()
+
+        with pytest.raises(SkillValidationError, match="too many entries"):
             await service.import_from_zip(zip_data)
 
 


### PR DESCRIPTION
## Change summary

This hardens the Skills core review findings in a clean branch based on `origin/dev`:

- Keeps skill files and registry state consistent by snapshotting touched files and restoring them on optimistic registry conflicts or DB failures.
- Denies fork-mode skill tools by default when `allowed-tools` is empty, and ignores unexpected model tool calls when no tools were advertised.
- Validates zip import entry counts and SKILL.md/supporting-file sizes from ZipInfo before reading archive contents.
- Makes supporting-file-only updates fail visibly on storage errors and bump skill versions.
- Adds async Skills context helpers and wires chat request paths to await them.

Note: this PR body was drafted by Codex. Per the repo AI-generated PR policy, a human maintainer should review and own the Change summary before merge.

## Test plan

- [x] `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && PYTHONPATH=/Users/appledev/Documents/GitHub/tldw_server/.worktrees/skills-core-review-hardening-12003 python -m pytest tldw_Server_API/tests/Skills/unit/test_skill_executor.py tldw_Server_API/tests/Skills/unit/test_skills_service.py tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py tldw_Server_API/tests/Skills/integration/test_skills_api.py -q` (`156 passed`)
- [x] `python -m compileall tldw_Server_API/app/core/Skills tldw_Server_API/app/api/v1/endpoints/chat.py`
- [x] `python -m bandit -r tldw_Server_API/app/core/Skills tldw_Server_API/app/api/v1/endpoints/chat.py -f json -o /tmp/bandit_skills_core_review_12003_worktree.json` (`results: []`)
- [x] `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Skills core to keep the registry and on-disk files consistent, lock down tool use in forked skills, and bound zip imports. Added async context and tool-injection helpers and updated `chat.py` to await them to avoid blocking. Addresses Linear TASK-12003.

- **Bug Fixes**
  - Snapshot and restore SKILL.md/supporting files on registry conflicts or DB failures to keep state consistent.
  - Delete now marks the registry first; if directory removal fails, the registry row is restored. Sync also reactivates soft-deleted rows when skill files exist.
  - Supporting-file-only changes bump version and raise storage errors instead of silently succeeding; async chat paths offload file I/O.
  - Fork-mode skills deny tools by default when `allowed_tools` is empty, do not advertise tools, and return a clear message if the model requests tool calls; executor enforces filtering.
  - Zip import enforces 100-entry cap, 500KB SKILL.md cap, per-file and total size limits via ZipInfo before reads; rejects path traversal and directory entries.

- **Refactors**
  - Added async helpers (`get_skills_context_text_async`, `build_system_message_with_skills_async`, `add_skill_tool_to_tools_list_async`) and updated `chat.py` to use them; introduced `restore_skill_registry` and used it for resync and delete rollback.

<sup>Written for commit 85b482638bec9b0fac9684b3fe2688861333567b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

