### PR TITLE
Fix Search_and_Research package marker casing

### DIFF
--- a/backlog/tasks/task-10001 - Fix-Search_and_Research-package-marker-casing.md
+++ b/backlog/tasks/task-10001 - Fix-Search_and_Research-package-marker-casing.md
@@ -1,0 +1,57 @@
+---
+id: TASK-10001
+title: Fix Search_and_Research package marker casing
+status: Done
+assignee: []
+created_date: '2026-06-23 21:16'
+updated_date: '2026-06-23 21:23'
+labels:
+  - core
+  - docs
+  - review-fix
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address current-state review findings in `tldw_Server_API/app/core/Search_and_Research`: rename the package marker to canonical `__init__.py` casing and make the README references consistent.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Tracked package marker uses canonical `__init__.py` casing.
+- [x] #2 `Search_and_Research` README uses consistent package marker spelling.
+- [x] #3 Focused verification confirms the package can be imported.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+- Rename the empty marker file from `__Init__.py` to `__init__.py`.
+- Update the README to refer consistently to `__init__.py`.
+- Run focused import and text verification, plus Bandit on touched Python files.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the package-marker casing cleanup and README spelling update. Added a focused lint regression test for the canonical marker filename and README reference. Verification passed: isolated focused pytest (`2 passed`), import-spec check resolves to `Search_and_Research/__init__.py`, scoped `git diff --check` passed, and Bandit on touched Python files reported no findings. Repository-wide `git diff --check` remains blocked by an unrelated pre-existing whitespace issue in `tldw_Server_API/tests/FileArtifacts/test_file_artifacts_service_exports.py:317`.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the `Search_and_Research` package marker casing and made the README use the canonical `__init__.py` spelling. Added a small lint regression so future case regressions are caught without loading the app-level pytest fixtures.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-10001 - Fix-Search_and_Research-package-marker-casing.md
+++ b/backlog/tasks/task-10001 - Fix-Search_and_Research-package-marker-casing.md
@@ -4,7 +4,7 @@ title: Fix Search_and_Research package marker casing
 status: Done
 assignee: []
 created_date: '2026-06-23 21:16'
-updated_date: '2026-06-23 21:23'
+updated_date: '2026-06-24 20:51'
 labels:
   - core
   - docs
@@ -37,7 +37,7 @@ Address current-state review findings in `tldw_Server_API/app/core/Search_and_Re
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented the package-marker casing cleanup and README spelling update. Added a focused lint regression test for the canonical marker filename and README reference. Verification passed: isolated focused pytest (`2 passed`), import-spec check resolves to `Search_and_Research/__init__.py`, scoped `git diff --check` passed, and Bandit on touched Python files reported no findings. Repository-wide `git diff --check` remains blocked by an unrelated pre-existing whitespace issue in `tldw_Server_API/tests/FileArtifacts/test_file_artifacts_service_exports.py:317`.
+Implemented the package-marker casing cleanup and README spelling update. Added a focused lint regression test for the canonical marker filename and README reference. Verification passed: isolated focused pytest (`2 passed`), import-spec check resolves to `Search_and_Research/__init__.py`, scoped `git diff --check` passed, and Bandit on touched Python files reported no findings. Repository-wide `git diff --check` remains blocked by an unrelated pre-existing whitespace issue in `tldw_Server_API/tests/FileArtifacts/test_file_artifacts_service_exports.py:317`. Draft PR: https://github.com/rmusser01/tldw_server/pull/2518
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-10001 - Fix-Search_and_Research-package-marker-casing.md
+++ b/backlog/tasks/task-10001 - Fix-Search_and_Research-package-marker-casing.md
@@ -4,7 +4,7 @@ title: Fix Search_and_Research package marker casing
 status: Done
 assignee: []
 created_date: '2026-06-23 21:16'
-updated_date: '2026-06-24 20:51'
+updated_date: '2026-06-25 23:31'
 labels:
   - core
   - docs
@@ -38,6 +38,8 @@ Address current-state review findings in `tldw_Server_API/app/core/Search_and_Re
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented the package-marker casing cleanup and README spelling update. Added a focused lint regression test for the canonical marker filename and README reference. Verification passed: isolated focused pytest (`2 passed`), import-spec check resolves to `Search_and_Research/__init__.py`, scoped `git diff --check` passed, and Bandit on touched Python files reported no findings. Repository-wide `git diff --check` remains blocked by an unrelated pre-existing whitespace issue in `tldw_Server_API/tests/FileArtifacts/test_file_artifacts_service_exports.py:317`. Draft PR: https://github.com/rmusser01/tldw_server/pull/2518
+
+2026-06-25: Rebased PR branch onto latest `origin/dev` (`8020e62779a65c1bf6d4f87b3bd1363eea6c5e9d`) and addressed bot review feedback on the lint test. Added module/function docstrings, `-> None` return annotations, module-level `pytest.mark.unit`, pytest `assert` statements, and relaxed the README positive check to plain `__init__.py`. Verification passed after the review fixes: isolated focused pytest (`2 passed`), import-spec check resolves to `Search_and_Research/__init__.py`, scoped `git diff --check` passed, and Bandit on touched Python files reported no findings.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/app/core/Search_and_Research/README.md
+++ b/tldw_Server_API/app/core/Search_and_Research/README.md
@@ -8,7 +8,7 @@ where the real code lives.
 
 ## Start Here
 
-- Package marker: `__Init__.py`.
+- Package marker: `__init__.py`.
 - Web search endpoint: `app/api/v1/endpoints/research.py` (`/research/websearch`).
 - Paper search endpoint: `app/api/v1/endpoints/paper_search.py`.
 - Web search core: `app/core/WebSearch/` and

--- a/tldw_Server_API/tests/lint/test_search_and_research_package_marker.py
+++ b/tldw_Server_API/tests/lint/test_search_and_research_package_marker.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def test_search_and_research_package_marker_uses_canonical_casing():
+    package_dir = _repo_root() / "tldw_Server_API" / "app" / "core" / "Search_and_Research"
+    filenames = {path.name for path in package_dir.iterdir() if path.is_file()}
+
+    if "__init__.py" not in filenames:
+        raise AssertionError("Search_and_Research must use canonical __init__.py casing")
+    if "__Init__.py" in filenames:
+        raise AssertionError("Search_and_Research must not keep the non-canonical __Init__.py")
+
+
+def test_search_and_research_readme_uses_canonical_package_marker_name():
+    readme_path = (
+        _repo_root()
+        / "tldw_Server_API"
+        / "app"
+        / "core"
+        / "Search_and_Research"
+        / "README.md"
+    )
+
+    readme = readme_path.read_text(encoding="utf-8")
+
+    if "__Init__.py" in readme:
+        raise AssertionError("Search_and_Research README must not mention __Init__.py")
+    if "`__init__.py`" not in readme:
+        raise AssertionError("Search_and_Research README must mention the canonical marker")

--- a/tldw_Server_API/tests/lint/test_search_and_research_package_marker.py
+++ b/tldw_Server_API/tests/lint/test_search_and_research_package_marker.py
@@ -1,23 +1,30 @@
+"""Lint checks for the Search_and_Research package marker and docs."""
+
 from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.unit
+
 
 def _repo_root() -> Path:
+    """Return the repository root for path-based lint checks."""
     return Path(__file__).resolve().parents[3]
 
 
-def test_search_and_research_package_marker_uses_canonical_casing():
+def test_search_and_research_package_marker_uses_canonical_casing() -> None:
+    """Require canonical package marker casing in Search_and_Research."""
     package_dir = _repo_root() / "tldw_Server_API" / "app" / "core" / "Search_and_Research"
     filenames = {path.name for path in package_dir.iterdir() if path.is_file()}
 
-    if "__init__.py" not in filenames:
-        raise AssertionError("Search_and_Research must use canonical __init__.py casing")
-    if "__Init__.py" in filenames:
-        raise AssertionError("Search_and_Research must not keep the non-canonical __Init__.py")
+    assert "__init__.py" in filenames, "Search_and_Research must use canonical __init__.py casing"  # nosec B101
+    assert "__Init__.py" not in filenames, "Search_and_Research must not keep non-canonical __Init__.py"  # nosec B101
 
 
-def test_search_and_research_readme_uses_canonical_package_marker_name():
+def test_search_and_research_readme_uses_canonical_package_marker_name() -> None:
+    """Require the README to mention the canonical marker without stale casing."""
     readme_path = (
         _repo_root()
         / "tldw_Server_API"
@@ -29,7 +36,5 @@ def test_search_and_research_readme_uses_canonical_package_marker_name():
 
     readme = readme_path.read_text(encoding="utf-8")
 
-    if "__Init__.py" in readme:
-        raise AssertionError("Search_and_Research README must not mention __Init__.py")
-    if "`__init__.py`" not in readme:
-        raise AssertionError("Search_and_Research README must mention the canonical marker")
+    assert "__Init__.py" not in readme, "Search_and_Research README must not mention __Init__.py"  # nosec B101
+    assert "__init__.py" in readme, "Search_and_Research README must mention the canonical marker"  # nosec B101


### PR DESCRIPTION
## Summary
- Rename the Search_and_Research package marker to canonical `__init__.py` casing.
- Update the Search_and_Research README to use the same spelling.
- Add a focused lint regression for marker casing and README consistency.

## Test Plan
- `python -m pytest -p no:unraisableexception --confcutdir=tldw_Server_API/tests/lint tldw_Server_API/tests/lint/test_search_and_research_package_marker.py -q`
- `python -m bandit -q tldw_Server_API/app/core/Search_and_Research/__init__.py tldw_Server_API/tests/lint/test_search_and_research_package_marker.py`
- `python - <<PY` import-spec check resolves to `Search_and_Research/__init__.py`
- `git diff --check -- tldw_Server_API/app/core/Search_and_Research tldw_Server_API/tests/lint/test_search_and_research_package_marker.py "backlog/tasks/task-10001 - Fix-Search_and_Research-package-marker-casing.md"`

## Change Summary
Human-authored change summary required before merge per repository AI-generated PR policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the `Search_and_Research` package marker to the canonical `__init__.py` and updated the README accordingly. Added a focused lint test that enforces marker and README casing, addressed review feedback, and recorded the cleanup (with PR link) in `backlog/tasks/task-10001 - Fix-Search_and_Research-package-marker-casing.md`.

<sup>Written for commit 3074f3f95c3006b7aee9a50d60fba2d8ce0d4b57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

