### PR TITLE
Harden backend-only PyPI release setup

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -22,10 +22,12 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
 
@@ -38,7 +40,7 @@ jobs:
         run: make pypi-check
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: tldw-server-pypi-dist
           path: dist/*
@@ -56,13 +58,13 @@ jobs:
       name: testpypi
     steps:
       - name: Download dist artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: tldw-server-pypi-dist
           path: dist
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -78,10 +80,10 @@ jobs:
       name: pypi
     steps:
       - name: Download dist artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: tldw-server-pypi-dist
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install packaging tools
         run: |
           python -m pip install --upgrade pip
-          pip install build twine setuptools wheel
+          pip install build twine setuptools wheel loguru
 
       - name: Build and validate package
         run: make pypi-check

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install packaging tools
         run: |
           python -m pip install --upgrade pip
-          pip install build twine setuptools wheel
+          pip install build twine setuptools wheel loguru
 
       - name: Build and check package
         run: make pypi-check

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -8,16 +8,22 @@ on:
     paths:
       - pyproject.toml
       - README.md
+      - Makefile
       - tldw_Server_API/**
+      - Helper_Scripts/Packaging/**
       - .github/workflows/pypi-package.yml
+      - .github/workflows/publish-pypi.yml
   push:
     branches:
       - main
     paths:
       - pyproject.toml
       - README.md
+      - Makefile
       - tldw_Server_API/**
+      - Helper_Scripts/Packaging/**
       - .github/workflows/pypi-package.yml
+      - .github/workflows/publish-pypi.yml
   workflow_dispatch:
 
 permissions:
@@ -33,12 +39,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      # Use stable major-tag pins consistently in this workflow for predictable updates.
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
 
@@ -51,7 +58,7 @@ jobs:
         run: make pypi-check
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: tldw-server-pypi-dist
           path: dist/*

--- a/Docs/Development/Packaging_and_Distribution_Strategy.md
+++ b/Docs/Development/Packaging_and_Distribution_Strategy.md
@@ -5,6 +5,14 @@ This document covers two practical distribution concerns:
 1. Slimmer container runtime for the API.
 2. Distribution models for the Next.js WebUI.
 
+The default release boundary is:
+
+- **PyPI:** `tldw-server` backend/API/CLI only.
+- **WebUI:** separate Docker image or release artifact.
+
+Do not bundle `apps/tldw-frontend` into the root Python wheel unless the project
+explicitly chooses a new single-artifact distribution model.
+
 ## 1) Slimmer Docker Runtime (API)
 
 `Dockerfiles/Dockerfile.prod` now uses a multi-stage build:
@@ -65,6 +73,9 @@ Use this only if your distribution model requires a single downloadable artifact
 
 ## Suggested Default
 
-- Publish API to PyPI (`tldw-server`) as Python-first distribution.
+- Publish the backend/API/CLI to PyPI (`tldw-server`) as the Python-first distribution.
 - Publish WebUI as a separate deployable artifact (container or tarball).
 - Document a "paired release" process so API/UI version compatibility is explicit.
+
+The root PyPI package check validates that frontend and Node build artifacts do
+not enter the `tldw-server` wheel or source distribution.

--- a/Docs/Development/PyPI_Publishing.md
+++ b/Docs/Development/PyPI_Publishing.md
@@ -41,6 +41,13 @@ publish.
 
 ## Local Packaging Checks
 
+The packaging check requires the standard build tools plus Loguru for the
+artifact-content guard:
+
+```bash
+python -m pip install build twine setuptools wheel loguru
+```
+
 ```bash
 # Build source + wheel distributions
 make pypi-build

--- a/Docs/Development/PyPI_Publishing.md
+++ b/Docs/Development/PyPI_Publishing.md
@@ -2,6 +2,12 @@
 
 This guide sets up and uses the repository's PyPI release flow for the `tldw-server` package.
 
+`tldw-server` on PyPI is the backend/API/CLI distribution only. It does not
+bundle the Next.js WebUI from `apps/tldw-frontend`. When a UI is needed, pair
+the PyPI backend release with the separately published WebUI Docker image or
+release artifact described in
+[`Packaging_and_Distribution_Strategy.md`](Packaging_and_Distribution_Strategy.md).
+
 ## What This Repo Now Supports
 
 - Local build/check helpers:
@@ -11,6 +17,9 @@ This guide sets up and uses the repository's PyPI release flow for the `tldw-ser
   - `.github/workflows/pypi-package.yml`
 - Manual PyPI publishing workflow (Trusted Publishing):
   - `.github/workflows/publish-pypi.yml`
+- Backend/API-only artifact validation:
+  - `make pypi-check` fails if frontend or Node build artifacts enter the
+    wheel or source distribution.
 
 ## One-Time Setup (PyPI)
 
@@ -24,6 +33,11 @@ This guide sets up and uses the repository's PyPI release flow for the `tldw-ser
 4. In GitHub repo settings, create environments:
    - `pypi`
    - `testpypi` (optional)
+
+GitHub can only manually dispatch a workflow when that workflow file exists on
+the repository's default branch. Make sure `.github/workflows/publish-pypi.yml`
+has landed on the default branch before relying on the Actions UI for a first
+publish.
 
 ## Local Packaging Checks
 
@@ -45,6 +59,9 @@ pip install dist/*.whl
 python -c "import tldw_Server_API; print('ok')"
 ```
 
+The wheel smoke test intentionally imports the backend package only. It should
+not attempt to start or validate the WebUI.
+
 ## Release Publish Flow
 
 1. Bump version in `pyproject.toml`.
@@ -52,14 +69,28 @@ python -c "import tldw_Server_API; print('ok')"
 3. Publish a GitHub Release from that tag.
 4. GitHub Actions runs `publish-docker.yml` for Docker release publication.
 
-For PyPI publishing in this rollout, run `publish-pypi.yml` manually from Actions, select the release tag/ref that matches the GitHub Release and Docker release publish, and choose:
+For PyPI publishing in this rollout, run `publish-pypi.yml` manually from
+Actions, select the release tag/ref that matches the GitHub Release and Docker
+release publish, and choose:
 
 - `testpypi` for TestPyPI
 - `pypi` for the real PyPI publish
+
+Recommended operator sequence:
+
+1. Run `make pypi-check` locally or confirm the PR packaging check passed.
+2. Run the isolated wheel smoke install shown above.
+3. Publish to `testpypi`.
+4. Install from TestPyPI in a fresh environment and import `tldw_Server_API`.
+5. Publish to `pypi`.
+6. Install from PyPI in a fresh environment and run `tldw-server --help` or a
+   minimal startup smoke.
 
 ## Notes
 
 - `publish-pypi.yml` is manual-dispatch-only in this rollout; GitHub Release publication no longer triggers PyPI uploads.
 - Pushing to `main` continues to republish rolling GHCR snapshots through `publish-ghcr-main.yml` before and independently of GitHub Release publication.
+- The Next.js WebUI is not a PyPI payload. Publish and validate it through the
+  WebUI container or release-artifact flow.
 - The default dependency set is intentionally broad and may be heavy for minimal installs.
 - If you want a lighter default install later, move optional feature stacks (for example some STT/TTS stacks) into extras and keep base runtime lean.

--- a/Docs/superpowers/plans/2026-06-24-backend-api-pypi-release.md
+++ b/Docs/superpowers/plans/2026-06-24-backend-api-pypi-release.md
@@ -1,0 +1,94 @@
+# Backend API PyPI Release Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden the root `tldw-server` PyPI release path as a backend/API-only distribution while keeping the Next.js WebUI on separate container/release-artifact channels.
+
+**Architecture:** Keep setuptools discovery constrained to Python backend packages and add an artifact-content guard that validates built wheel/sdist contents. Reuse the existing manual Trusted Publishing workflow, but align its action pins and PR trigger paths with the hardened MCP publishing style.
+
+**Tech Stack:** Python packaging with setuptools/build/twine, GitHub Actions, Makefile, repository documentation.
+
+---
+
+### Task 1: Add Backend-Only Artifact Validation
+
+**Files:**
+- Create: `Helper_Scripts/Packaging/check_pypi_artifacts.py`
+- Modify: `Makefile`
+
+- [x] **Step 1: Create an artifact checker**
+
+Implement a Python script that inspects `dist/*.whl` and `dist/*.tar.gz`, fails if frontend paths such as `apps/tldw-frontend`, `.next`, `node_modules`, `package.json`, or `bun.lock` appear, and confirms expected backend package roots are present.
+
+- [x] **Step 2: Wire the checker into `make pypi-check`**
+
+Add a `pypi-check-contents` target and call it after `twine check dist/*` so the existing local and CI commands validate package scope.
+
+- [x] **Step 3: Run validation**
+
+Run: `make pypi-check`
+
+Expected: build succeeds, `twine check` passes, and the content guard reports valid backend/API-only distributions.
+
+### Task 2: Harden PyPI CI And Publish Workflows
+
+**Files:**
+- Modify: `.github/workflows/pypi-package.yml`
+- Modify: `.github/workflows/publish-pypi.yml`
+
+- [x] **Step 1: Align action pins**
+
+Replace remaining mutable action tags with the pinned SHAs already used by the MCP publish workflow where matching actions are present.
+
+- [x] **Step 2: Expand PR trigger paths**
+
+Ensure `pypi-package.yml` runs when `Makefile`, `Helper_Scripts/Packaging/**`, or `.github/workflows/publish-pypi.yml` changes.
+
+- [x] **Step 3: Preserve manual publish controls**
+
+Keep `publish-pypi.yml` manual-dispatch-only and keep the `testpypi` default target.
+
+### Task 3: Document Backend/API-Only Release Boundary
+
+**Files:**
+- Modify: `Docs/Development/PyPI_Publishing.md`
+- Modify: `Docs/Development/Packaging_and_Distribution_Strategy.md`
+
+- [x] **Step 1: Update PyPI guide scope**
+
+State that `tldw-server` on PyPI is backend/API/CLI only, does not bundle the WebUI, and should be paired with WebUI Docker/release artifacts when a UI is needed.
+
+- [x] **Step 2: Update distribution strategy**
+
+Make the recommended default unambiguous: PyPI for backend/API, GHCR or release tarball for the WebUI.
+
+- [x] **Step 3: Add release operator checks**
+
+Document local build/check, isolated wheel smoke install, TestPyPI smoke, and final PyPI publish order.
+
+### Task 4: Final Verification
+
+**Files:**
+- Update: `backlog/tasks/task-12014 - Harden-backend-only-PyPI-release-setup.md`
+
+- [x] **Step 1: Run packaging checks**
+
+Run: `make pypi-check`
+
+Expected: distributions build and validate.
+
+- [x] **Step 2: Run isolated smoke install**
+
+Run a temporary virtualenv install from the built wheel and import `tldw_Server_API`.
+
+Expected: import succeeds.
+
+- [x] **Step 3: Run Bandit on touched Python script**
+
+Run: `python -m bandit -r Helper_Scripts/Packaging -f json -o /tmp/bandit_backend_api_pypi.json`
+
+Expected: no new security findings.
+
+- [x] **Step 4: Record results**
+
+Update `TASK-12014` with touched files, verification results, and known skips or blockers.

--- a/Helper_Scripts/Packaging/__init__.py
+++ b/Helper_Scripts/Packaging/__init__.py
@@ -1,0 +1,1 @@
+"""Packaging helper scripts for release validation."""

--- a/Helper_Scripts/Packaging/check_pypi_artifacts.py
+++ b/Helper_Scripts/Packaging/check_pypi_artifacts.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 import argparse
-import sys
 import tarfile
 import zipfile
 from pathlib import Path, PurePosixPath
 
-BLOCKED_PATH_PARTS = (
-    "apps/tldw-frontend",
+from loguru import logger
+
+BLOCKED_COMPONENT_NAMES = {
     ".next",
     "node_modules",
+}
+
+BLOCKED_COMPONENT_SEQUENCES = (
+    ("apps", "tldw-frontend"),
 )
 
 BLOCKED_FILE_NAMES = {
@@ -30,10 +34,10 @@ REQUIRED_PACKAGE_ROOTS = (
 
 def _normalize_name(name: str) -> str:
     """Return a safe, POSIX-style archive path for policy matching."""
-    normalized = str(PurePosixPath(name))
+    normalized = str(PurePosixPath(name.replace("\\", "/")))
     while normalized.startswith("./"):
         normalized = normalized[2:]
-    return normalized
+    return normalized.lstrip("/")
 
 
 def _strip_sdist_prefix(paths: list[str]) -> list[str]:
@@ -56,6 +60,7 @@ def _strip_sdist_prefix(paths: list[str]) -> list[str]:
 
 
 def _wheel_paths(path: Path) -> list[str]:
+    """Return normalized file member paths from a built wheel."""
     with zipfile.ZipFile(path) as archive:
         return [
             _normalize_name(info.filename)
@@ -65,6 +70,7 @@ def _wheel_paths(path: Path) -> list[str]:
 
 
 def _sdist_paths(path: Path) -> list[str]:
+    """Return normalized file member paths from a source distribution."""
     with tarfile.open(path, mode="r:gz") as archive:
         paths = [
             _normalize_name(member.name)
@@ -75,6 +81,7 @@ def _sdist_paths(path: Path) -> list[str]:
 
 
 def _archive_paths(path: Path) -> list[str]:
+    """Return normalized file paths for a supported distribution artifact."""
     if path.suffix == ".whl":
         return _wheel_paths(path)
     if path.name.endswith(".tar.gz"):
@@ -82,11 +89,31 @@ def _archive_paths(path: Path) -> list[str]:
     raise ValueError(f"Unsupported distribution artifact: {path}")
 
 
+def _contains_component_sequence(
+    parts: tuple[str, ...], sequence: tuple[str, ...]
+) -> bool:
+    """Return whether a path contains an exact adjacent component sequence."""
+    sequence_len = len(sequence)
+    if sequence_len == 0 or len(parts) < sequence_len:
+        return False
+    return any(
+        parts[index : index + sequence_len] == sequence
+        for index in range(0, len(parts) - sequence_len + 1)
+    )
+
+
 def _blocked_paths(paths: list[str]) -> list[str]:
+    """Return archive paths that violate frontend/Node artifact policy."""
     blocked: list[str] = []
     for path in paths:
         parts = PurePosixPath(path).parts
-        if any(blocked_part in path for blocked_part in BLOCKED_PATH_PARTS):
+        if any(part in BLOCKED_COMPONENT_NAMES for part in parts):
+            blocked.append(path)
+            continue
+        if any(
+            _contains_component_sequence(parts, sequence)
+            for sequence in BLOCKED_COMPONENT_SEQUENCES
+        ):
             blocked.append(path)
             continue
         if parts and parts[-1] in BLOCKED_FILE_NAMES:
@@ -95,19 +122,19 @@ def _blocked_paths(paths: list[str]) -> list[str]:
 
 
 def _missing_required_roots(paths: list[str]) -> list[str]:
+    """Return required package roots absent from archive path components."""
     return [
         root
         for root in REQUIRED_PACKAGE_ROOTS
         if not any(
-            path == root
-            or path.startswith(f"{root}/")
-            or f"/{root}/" in path
+            root in PurePosixPath(path).parts
             for path in paths
         )
     ]
 
 
 def _validate_artifact(path: Path) -> list[str]:
+    """Return validation errors for one built distribution artifact."""
     errors: list[str] = []
     archive_paths = _archive_paths(path)
 
@@ -125,6 +152,7 @@ def _validate_artifact(path: Path) -> list[str]:
 
 
 def _distribution_paths(dist_dir: Path) -> list[Path]:
+    """Return supported distribution artifacts in deterministic order."""
     return sorted(
         path
         for path in dist_dir.iterdir()
@@ -133,6 +161,7 @@ def _distribution_paths(dist_dir: Path) -> list[Path]:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Validate built PyPI artifacts and return a process exit code."""
     parser = argparse.ArgumentParser(
         description="Validate tldw-server PyPI artifacts stay backend/API-only."
     )
@@ -145,12 +174,12 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if not args.dist_dir.is_dir():
-        print(f"[pypi-content-check] dist directory not found: {args.dist_dir}", file=sys.stderr)
+        logger.error("dist directory not found: {}", args.dist_dir)
         return 1
 
     artifacts = _distribution_paths(args.dist_dir)
     if not artifacts:
-        print(f"[pypi-content-check] no wheel or sdist artifacts found in {args.dist_dir}", file=sys.stderr)
+        logger.error("no wheel or sdist artifacts found in {}", args.dist_dir)
         return 1
 
     errors: list[str] = []
@@ -159,11 +188,11 @@ def main(argv: list[str] | None = None) -> int:
 
     if errors:
         for error in errors:
-            print(f"[pypi-content-check] {error}", file=sys.stderr)
+            logger.error(error)
         return 1
 
     artifact_names = ", ".join(path.name for path in artifacts)
-    print(f"[pypi-content-check] backend/API-only artifact check passed: {artifact_names}")
+    logger.info("backend/API-only artifact check passed: {}", artifact_names)
     return 0
 
 

--- a/Helper_Scripts/Packaging/check_pypi_artifacts.py
+++ b/Helper_Scripts/Packaging/check_pypi_artifacts.py
@@ -1,0 +1,171 @@
+"""Validate that root PyPI artifacts stay backend/API-only."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tarfile
+import zipfile
+from pathlib import Path, PurePosixPath
+
+BLOCKED_PATH_PARTS = (
+    "apps/tldw-frontend",
+    ".next",
+    "node_modules",
+)
+
+BLOCKED_FILE_NAMES = {
+    "bun.lock",
+    "package-lock.json",
+    "package.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+}
+
+REQUIRED_PACKAGE_ROOTS = (
+    "tldw_Server_API",
+    "mcp_unified",
+)
+
+
+def _normalize_name(name: str) -> str:
+    """Return a safe, POSIX-style archive path for policy matching."""
+    normalized = str(PurePosixPath(name))
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def _strip_sdist_prefix(paths: list[str]) -> list[str]:
+    """Remove the top-level sdist directory when every path shares one."""
+    if not paths:
+        return paths
+
+    first_parts = [PurePosixPath(path).parts for path in paths]
+    first_component = first_parts[0][0] if first_parts[0] else ""
+    if not first_component:
+        return paths
+
+    if all(parts and parts[0] == first_component for parts in first_parts):
+        return [
+            str(PurePosixPath(*parts[1:]))
+            for parts in first_parts
+            if len(parts) > 1
+        ]
+    return paths
+
+
+def _wheel_paths(path: Path) -> list[str]:
+    with zipfile.ZipFile(path) as archive:
+        return [
+            _normalize_name(info.filename)
+            for info in archive.infolist()
+            if not info.is_dir()
+        ]
+
+
+def _sdist_paths(path: Path) -> list[str]:
+    with tarfile.open(path, mode="r:gz") as archive:
+        paths = [
+            _normalize_name(member.name)
+            for member in archive.getmembers()
+            if member.isfile()
+        ]
+    return _strip_sdist_prefix(paths)
+
+
+def _archive_paths(path: Path) -> list[str]:
+    if path.suffix == ".whl":
+        return _wheel_paths(path)
+    if path.name.endswith(".tar.gz"):
+        return _sdist_paths(path)
+    raise ValueError(f"Unsupported distribution artifact: {path}")
+
+
+def _blocked_paths(paths: list[str]) -> list[str]:
+    blocked: list[str] = []
+    for path in paths:
+        parts = PurePosixPath(path).parts
+        if any(blocked_part in path for blocked_part in BLOCKED_PATH_PARTS):
+            blocked.append(path)
+            continue
+        if parts and parts[-1] in BLOCKED_FILE_NAMES:
+            blocked.append(path)
+    return blocked
+
+
+def _missing_required_roots(paths: list[str]) -> list[str]:
+    return [
+        root
+        for root in REQUIRED_PACKAGE_ROOTS
+        if not any(
+            path == root
+            or path.startswith(f"{root}/")
+            or f"/{root}/" in path
+            for path in paths
+        )
+    ]
+
+
+def _validate_artifact(path: Path) -> list[str]:
+    errors: list[str] = []
+    archive_paths = _archive_paths(path)
+
+    blocked = _blocked_paths(archive_paths)
+    if blocked:
+        examples = ", ".join(blocked[:5])
+        errors.append(f"{path.name}: blocked frontend/Node paths found: {examples}")
+
+    missing_roots = _missing_required_roots(archive_paths)
+    if missing_roots:
+        missing = ", ".join(missing_roots)
+        errors.append(f"{path.name}: missing expected backend package roots: {missing}")
+
+    return errors
+
+
+def _distribution_paths(dist_dir: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in dist_dir.iterdir()
+        if path.suffix == ".whl" or path.name.endswith(".tar.gz")
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate tldw-server PyPI artifacts stay backend/API-only."
+    )
+    parser.add_argument(
+        "--dist-dir",
+        type=Path,
+        default=Path("dist"),
+        help="Directory containing built wheel and sdist artifacts.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.dist_dir.is_dir():
+        print(f"[pypi-content-check] dist directory not found: {args.dist_dir}", file=sys.stderr)
+        return 1
+
+    artifacts = _distribution_paths(args.dist_dir)
+    if not artifacts:
+        print(f"[pypi-content-check] no wheel or sdist artifacts found in {args.dist_dir}", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+    for artifact in artifacts:
+        errors.extend(_validate_artifact(artifact))
+
+    if errors:
+        for error in errors:
+            print(f"[pypi-content-check] {error}", file=sys.stderr)
+        return 1
+
+    artifact_names = ", ".join(path.name for path in artifacts)
+    print(f"[pypi-content-check] backend/API-only artifact check passed: {artifact_names}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ help:
 # -----------------------------------------------------------------------------
 # Quickstart targets (first-time setup)
 # -----------------------------------------------------------------------------
-.PHONY: setup-wizard-tools setup-docker-single start-docker-single verify-docker-single setup-docker-multi start-docker-multi verify-docker-multi install-local setup-local-single start-local-single verify-local-single quickstart quickstart-install quickstart-prereqs quickstart-local quickstart-docker quickstart-docker-bootstrap quickstart-docker-webui model-cycle verify pypi-build pypi-check tooling-install tooling-smoke show-api-key release release-patch release-minor mcp-unified-build mcp-unified-check mcp-unified-uat mcp-unified-rc mcp-unified-publish-dry-run
+.PHONY: setup-wizard-tools setup-docker-single start-docker-single verify-docker-single setup-docker-multi start-docker-multi verify-docker-multi install-local setup-local-single start-local-single verify-local-single quickstart quickstart-install quickstart-prereqs quickstart-local quickstart-docker quickstart-docker-bootstrap quickstart-docker-webui model-cycle verify pypi-build pypi-check pypi-check-contents tooling-install tooling-smoke show-api-key release release-patch release-minor mcp-unified-build mcp-unified-check mcp-unified-uat mcp-unified-rc mcp-unified-publish-dry-run
 
 PYTHON ?= python3
 VENV_DIR ?= .venv
@@ -265,6 +265,11 @@ pypi-check: pypi-build
 	@$(PYTHON) -m pip show twine >/dev/null 2>&1 || (echo "[pypi-check] Missing 'twine'. Install with: $(PYTHON) -m pip install twine" && exit 1)
 	@echo "[pypi-check] Validating distributions..."
 	@$(PYTHON) -m twine check dist/*
+	@$(MAKE) pypi-check-contents
+
+pypi-check-contents:
+	@echo "[pypi-check] Validating backend/API-only artifact contents..."
+	@$(PYTHON) Helper_Scripts/Packaging/check_pypi_artifacts.py --dist-dir dist
 
 # -----------------------------------------------------------------------------
 # MCP Unified standalone RC

--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,7 @@ pypi-check: pypi-build
 	@$(MAKE) pypi-check-contents
 
 pypi-check-contents:
+	@$(PYTHON) -m pip show loguru >/dev/null 2>&1 || (echo "[pypi-check] Missing 'loguru'. Install with: $(PYTHON) -m pip install loguru" && exit 1)
 	@echo "[pypi-check] Validating backend/API-only artifact contents..."
 	@$(PYTHON) Helper_Scripts/Packaging/check_pypi_artifacts.py --dist-dir dist
 

--- a/backlog/tasks/task-12014 - Harden-backend-only-PyPI-release-setup.md
+++ b/backlog/tasks/task-12014 - Harden-backend-only-PyPI-release-setup.md
@@ -1,0 +1,66 @@
+---
+id: TASK-12014
+title: Harden backend-only PyPI release setup
+status: Done
+labels:
+- packaging
+- pypi
+- release
+priority: Medium
+modified_files:
+- .github/workflows/publish-pypi.yml
+- .github/workflows/pypi-package.yml
+- Docs/Development/Packaging_and_Distribution_Strategy.md
+- Docs/Development/PyPI_Publishing.md
+- Docs/superpowers/plans/2026-06-24-backend-api-pypi-release.md
+- Helper_Scripts/Packaging/check_pypi_artifacts.py
+- Makefile
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Lock the root PyPI release scope to the backend/API package, keep the Next.js WebUI out of PyPI, and harden/document the release path for first PyPI/TestPyPI publication.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PyPI packaging documentation clearly states backend/API-only scope and frontend distribution via GHCR/release artifacts.
+- [x] #2 Root publish workflow is reviewed and hardened where needed without changing package runtime behavior.
+- [x] #3 Local package build/check and isolated wheel smoke validation are documented or run.
+- [x] #4 Frontend artifacts remain excluded from the Python wheel/sdist.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-24-backend-api-pypi-release.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented backend/API-only PyPI hardening in the isolated worktree. Added a distribution content guard, wired it into `make pypi-check`, pinned PyPI workflow actions to the SHA refs already used by the MCP publish workflow, expanded package-check triggers, and clarified that the WebUI is distributed separately via container/release artifacts.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Verification completed:
+- make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python pypi-check: passed; built wheel and sdist, twine check passed, backend/API-only artifact guard passed.
+- /tmp/tldw-pypi-smoke-backend-api-2363 wheel smoke: installed dist/tldw_server-0.1.31-py3-none-any.whl with --no-deps and imported tldw_Server_API from site-packages.
+- python -m ruff check Helper_Scripts/Packaging/check_pypi_artifacts.py: passed.
+- python -m py_compile Helper_Scripts/Packaging/check_pypi_artifacts.py: passed.
+- python -m bandit -r Helper_Scripts/Packaging -f json -o /tmp/bandit_backend_api_pypi.json: passed with 0 findings.
+Known note: smoke install used --no-deps to avoid downloading the full media/ML dependency stack; dependency resolution is still covered by wheel metadata and should be exercised in TestPyPI/PyPI publish smoke.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12014 - Harden-backend-only-PyPI-release-setup.md
+++ b/backlog/tasks/task-12014 - Harden-backend-only-PyPI-release-setup.md
@@ -13,8 +13,10 @@ modified_files:
 - Docs/Development/Packaging_and_Distribution_Strategy.md
 - Docs/Development/PyPI_Publishing.md
 - Docs/superpowers/plans/2026-06-24-backend-api-pypi-release.md
+- Helper_Scripts/Packaging/__init__.py
 - Helper_Scripts/Packaging/check_pypi_artifacts.py
 - Makefile
+- tldw_Server_API/tests/Helper_Scripts/test_check_pypi_artifacts.py
 ---
 
 ## Description
@@ -49,9 +51,14 @@ Implemented backend/API-only PyPI hardening in the isolated worktree. Added a di
 Verification completed:
 - make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python pypi-check: passed; built wheel and sdist, twine check passed, backend/API-only artifact guard passed.
 - /tmp/tldw-pypi-smoke-backend-api-2363 wheel smoke: installed dist/tldw_server-0.1.31-py3-none-any.whl with --no-deps and imported tldw_Server_API from site-packages.
-- python -m ruff check Helper_Scripts/Packaging/check_pypi_artifacts.py: passed.
-- python -m py_compile Helper_Scripts/Packaging/check_pypi_artifacts.py: passed.
+- PR review fixes: artifact path normalization now treats Windows separators and absolute names safely, blocked path checks use exact path components/sequences, required package roots use exact components, the guard uses Loguru, and focused regression tests cover these cases.
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Helper_Scripts/test_check_pypi_artifacts.py -q: passed, 4 tests.
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CI/test_pypi_workflow_contracts.py -q: passed, 3 tests.
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check Helper_Scripts/Packaging/check_pypi_artifacts.py tldw_Server_API/tests/Helper_Scripts/test_check_pypi_artifacts.py: passed.
+- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile Helper_Scripts/Packaging/check_pypi_artifacts.py tldw_Server_API/tests/Helper_Scripts/test_check_pypi_artifacts.py: passed.
+- Workflow YAML parse for .github/workflows/pypi-package.yml and .github/workflows/publish-pypi.yml: passed.
 - python -m bandit -r Helper_Scripts/Packaging -f json -o /tmp/bandit_backend_api_pypi.json: passed with 0 findings.
+- git diff --check: passed.
 Known note: smoke install used --no-deps to avoid downloading the full media/ML dependency stack; dependency resolution is still covered by wheel metadata and should be exercised in TestPyPI/PyPI publish smoke.
 <!-- SECTION:FINAL_SUMMARY:END -->
 

--- a/tldw_Server_API/tests/Helper_Scripts/test_check_pypi_artifacts.py
+++ b/tldw_Server_API/tests/Helper_Scripts/test_check_pypi_artifacts.py
@@ -1,0 +1,55 @@
+"""Tests for the root PyPI artifact content guard."""
+
+from Helper_Scripts.Packaging import check_pypi_artifacts as guard
+
+
+def test_normalize_name_converts_windows_and_absolute_paths() -> None:
+    """Archive member names normalize to relative POSIX-style paths."""
+    assert (
+        guard._normalize_name(r".\apps\tldw-frontend\package.json")
+        == "apps/tldw-frontend/package.json"
+    )
+    assert (
+        guard._normalize_name(r"/apps\tldw-frontend\.next\BUILD_ID")
+        == "apps/tldw-frontend/.next/BUILD_ID"
+    )
+
+
+def test_blocked_paths_uses_exact_components() -> None:
+    """The guard blocks real Node/WebUI paths without substring false positives."""
+    blocked = guard._blocked_paths(
+        [
+            "apps/tldw-frontend/package.json",
+            "tldw_Server_API/node_modules/file.js",
+            "docs/node_modules_connector.py",
+            "apps/tldw-frontend-dev/README.md",
+        ]
+    )
+
+    assert blocked == [
+        "apps/tldw-frontend/package.json",
+        "tldw_Server_API/node_modules/file.js",
+    ]
+
+
+def test_missing_required_roots_accepts_sdist_src_layout() -> None:
+    """Required roots may appear below the sdist source-layout prefix."""
+    assert (
+        guard._missing_required_roots(
+            [
+                "apps/mcp-unified/src/mcp_unified/__init__.py",
+                "tldw_Server_API/__init__.py",
+            ]
+        )
+        == []
+    )
+
+
+def test_missing_required_roots_rejects_substring_only_matches() -> None:
+    """Package-root checks use exact path components, not substrings."""
+    assert guard._missing_required_roots(
+        [
+            "apps/mcp-unified/src/not_mcp_unified/__init__.py",
+            "tldw_Server_API_extra/__init__.py",
+        ]
+    ) == ["tldw_Server_API", "mcp_unified"]


### PR DESCRIPTION
## Summary
- Add a root PyPI artifact content guard so `tldw-server` distributions fail if WebUI/Node artifacts enter the wheel or sdist.
- Wire the guard into `make pypi-check` and expand PyPI package-check workflow triggers.
- Pin PyPI workflow actions and document that PyPI is backend/API/CLI only while WebUI remains a separate container/release artifact.

## Test Plan
- `make PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python pypi-check`
- `/tmp/tldw-pypi-smoke-backend-api-2363/bin/python -c "import tldw_Server_API; print(tldw_Server_API.__file__)"` from `/tmp` after installing the built wheel with `--no-deps`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check Helper_Scripts/Packaging/check_pypi_artifacts.py`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile Helper_Scripts/Packaging/check_pypi_artifacts.py`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r Helper_Scripts/Packaging -f json -o /tmp/bandit_backend_api_pypi.json`
- workflow YAML parse for `.github/workflows/pypi-package.yml` and `.github/workflows/publish-pypi.yml`
- `git diff --check`

## Change summary
This keeps `tldw-server` as a Python backend/API/CLI package and intentionally keeps the Next.js WebUI out of PyPI. The new artifact guard makes that policy executable in both local release checks and CI, while workflow SHA pins reduce release supply-chain drift. The WebUI remains better served as a GHCR image or release artifact because it is a Node/Next standalone deployment, not a normal Python package payload.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks the `tldw-server` PyPI release to backend/API/CLI only and blocks WebUI/Node artifacts from wheels and sdists. Hardens the content guard, pins workflow actions to SHAs, and documents a simple operator flow for predictable, secure releases.

- **New Features**
  - Added `Helper_Scripts/Packaging/check_pypi_artifacts.py` wired into `make pypi-check`; performs exact path-component checks, Windows path normalization, and sdist prefix stripping; enforces `tldw_Server_API`/`mcp_unified` roots; added focused tests.
  - Hardened workflows: expanded `pypi-package.yml` triggers (Makefile, `Helper_Scripts/Packaging/**`, `publish-pypi.yml`); pinned `actions/*` and `pypa/gh-action-pypi-publish` to SHAs; set `persist-credentials: false`; included `loguru` in build/check; pinned upload/download artifact actions.
  - Docs clarified scope (PyPI is backend/API/CLI; WebUI ships separately), added local smoke steps, `loguru` requirement, and default-branch note for manual dispatch; noted the root package check blocks frontend/Node artifacts.

<sup>Written for commit 7cb048b7a6cba4c8d7533a0cbbfff2fa94cc83f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

