### PR TITLE
Add context integrity enforcement for skills and prompts

### DIFF
--- a/Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** Build the first enforceable Context Integrity foundation for prompt-bearing assets, proving signed manifests, anti-rollback policy, quarantine resolution, startup warnings, Skills enforcement, and config prompt-loader enforcement.
 
-**Backlog:** Design `TASK-2363`; implementation planning `TASK-2365`; create or reuse a new implementation Backlog task before code edits.
+**Backlog:** Design `TASK-12015`; implementation planning `TASK-12016`; create or reuse a new implementation Backlog task before code edits.
 
 **Architecture:** Add a focused `tldw_Server_API.app.core.Context_Integrity` package with pure canonicalization, manifest, verifier, resolver, and inventory modules. Wire it into startup through the existing `StartupWarningRegistry`, expose admin status/findings through the existing admin router, and add thin resolver checks to Skills and prompt loading. This first slice protects filesystem skills and config prompt files; DB prompt-version and MCP prompt-catalog enforcement are represented by interfaces and explicit follow-up tests so they can plug into the same resolver without changing the core model.
 

--- a/Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
@@ -2122,6 +2122,14 @@ git commit -m "feat: enforce context integrity for skills"
 
 ## Task 7: Prompt Loader Enforcement With Single-Read Semantics
 
+**Status**: Complete. Implemented single-read prompt-file verification for Markdown, YAML, JSON, and environment override prompt files.
+
+**Verification**:
+- RED run: `.venv/bin/python -m pytest tldw_Server_API/tests/Utils/test_prompt_loader_paths.py -q` failed before implementation with the three new prompt-loader integrity tests failing.
+- Focused Task 7 suite: `.venv/bin/python -m pytest tldw_Server_API/tests/Utils/test_prompt_loader_paths.py tldw_Server_API/tests/Utils/test_prompt_loader_env_overrides.py -q` passed with `10 passed, 6 warnings`.
+- Bandit: `.venv/bin/python -m bandit -r tldw_Server_API/app/core/Utils/prompt_loader.py -f json -o /tmp/bandit_context_integrity_task7.json` exited 0 with zero findings.
+- Formatter/whitespace: `.venv/bin/python -m black ...` completed; `git diff --check` clean.
+
 **Files:**
 - Modify: `tldw_Server_API/app/core/Utils/prompt_loader.py`
 - Modify: `tldw_Server_API/tests/Utils/test_prompt_loader_paths.py`

--- a/Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
@@ -2362,6 +2362,14 @@ git commit -m "feat: enforce context integrity for prompt loader"
 
 ## Task 8: Admin Status And Findings Endpoint
 
+**Status**: Complete. Added current-process admin status/finding inspection endpoint.
+
+**Verification**:
+- RED run: `.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ_SQLite/test_admin_context_integrity_sqlite.py -q` failed before implementation with 404 responses.
+- Focused Task 8 suite: `.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ_SQLite/test_admin_context_integrity_sqlite.py tldw_Server_API/tests/AuthNZ_SQLite/test_admin_startup_warnings_sqlite.py -q` passed with `5 passed, 7 warnings`.
+- Bandit: `.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/admin/context_integrity.py tldw_Server_API/app/api/v1/schemas/admin_schemas.py -f json -o /tmp/bandit_context_integrity_task8.json` exited 0 with zero findings.
+- Formatter/whitespace: `.venv/bin/python -m black ...` completed for new endpoint/test files; unrelated schema formatting was reverted; `git diff --check` clean.
+
 **Files:**
 - Create: `tldw_Server_API/app/api/v1/endpoints/admin/context_integrity.py`
 - Modify: `tldw_Server_API/app/api/v1/endpoints/admin/__init__.py`

--- a/Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
@@ -1,0 +1,2164 @@
+# Context Integrity Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the first enforceable Context Integrity foundation for prompt-bearing assets, proving signed manifests, anti-rollback policy, quarantine resolution, startup warnings, Skills enforcement, and config prompt-loader enforcement.
+
+**Architecture:** Add a focused `tldw_Server_API.app.core.Context_Integrity` package with pure canonicalization, manifest, verifier, resolver, and inventory modules. Wire it into startup through the existing `StartupWarningRegistry`, expose admin status/findings through the existing admin router, and add thin resolver checks to Skills and prompt loading. This first slice protects filesystem skills and config prompt files; DB prompt-version and MCP prompt-catalog enforcement are represented by interfaces and explicit follow-up tests so they can plug into the same resolver without changing the core model.
+
+**Tech Stack:** Python 3.10+, FastAPI, Pydantic, Loguru, SQLite-backed existing DB layers, pytest, Bandit.
+
+---
+
+## File Structure
+
+Create:
+
+- `tldw_Server_API/app/core/Context_Integrity/__init__.py` - package exports for the context integrity subsystem.
+- `tldw_Server_API/app/core/Context_Integrity/models.py` - dataclasses and enums for asset descriptors, manifests, findings, resolver decisions, and boot state.
+- `tldw_Server_API/app/core/Context_Integrity/canonicalization.py` - deterministic filesystem and DB-prompt canonical hashing helpers.
+- `tldw_Server_API/app/core/Context_Integrity/manifest.py` - signed manifest serialization, HMAC signing provider, signature verification, and anti-rollback checks.
+- `tldw_Server_API/app/core/Context_Integrity/inventory.py` - filesystem inventory adapters for user skills and config prompt files.
+- `tldw_Server_API/app/core/Context_Integrity/verifier.py` - manifest-versus-inventory comparison and finding generation.
+- `tldw_Server_API/app/core/Context_Integrity/resolver.py` - in-memory resolver used by runtime call sites.
+- `tldw_Server_API/app/services/startup_context_integrity.py` - startup producer that builds inventory, verifies manifest state, sets `app.state.context_integrity_resolver`, and emits startup warnings.
+- `tldw_Server_API/app/api/v1/endpoints/admin/context_integrity.py` - admin status and findings endpoint.
+- `tldw_Server_API/tests/Context_Integrity/unit/test_canonicalization.py`
+- `tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py`
+- `tldw_Server_API/tests/Context_Integrity/unit/test_verifier_resolver.py`
+- `tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py`
+- `tldw_Server_API/tests/Services/test_startup_context_integrity.py`
+- `tldw_Server_API/tests/AuthNZ_SQLite/test_admin_context_integrity_sqlite.py`
+
+Modify:
+
+- `tldw_Server_API/app/services/lifespan_startup_sequence.py` - call the Context Integrity startup producer after core initialization and before startup blockers are evaluated.
+- `tldw_Server_API/app/api/v1/endpoints/admin/__init__.py` - include the admin Context Integrity router.
+- `tldw_Server_API/app/api/v1/schemas/admin_schemas.py` - add admin response schemas for current-process Context Integrity status.
+- `tldw_Server_API/app/core/Skills/skills_service.py` - add resolver dependency, filter quarantined skills from listings/context, and block direct content/execution access.
+- `tldw_Server_API/app/api/v1/endpoints/skills.py` - map quarantine errors to deterministic HTTP errors without leaking asset content.
+- `tldw_Server_API/app/core/Utils/prompt_loader.py` - enforce resolver checks for loaded prompt-file bytes with single-read semantics.
+- `tldw_Server_API/tests/Skills/unit/test_skills_service.py` - cover quarantined skill filtering and blocking.
+- `tldw_Server_API/tests/Skills/integration/test_skills_api.py` - cover API error mapping for quarantined skills.
+- `tldw_Server_API/tests/Utils/test_prompt_loader_paths.py` - cover prompt-loader quarantine blocking and at-use verified bytes behavior.
+
+## Task 1: Canonical Asset Models And Hashing
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Context_Integrity/__init__.py`
+- Create: `tldw_Server_API/app/core/Context_Integrity/models.py`
+- Create: `tldw_Server_API/app/core/Context_Integrity/canonicalization.py`
+- Create: `tldw_Server_API/tests/Context_Integrity/unit/test_canonicalization.py`
+
+- [ ] **Step 1: Write failing canonicalization tests**
+
+Create `tldw_Server_API/tests/Context_Integrity/unit/test_canonicalization.py`:
+
+```python
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_filesystem_digest_is_stable_for_sorted_paths() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+        canonical_filesystem_digest,
+    )
+
+    first = canonical_filesystem_digest(
+        source_type="skill_file",
+        asset_id="skill:user:1/demo",
+        files={
+            "SKILL.md": b"hello\r\n",
+            "refs/notes.md": b"reference",
+        },
+        metadata={"context": "inline"},
+    )
+    second = canonical_filesystem_digest(
+        source_type="skill_file",
+        asset_id="skill:user:1/demo",
+        files={
+            "refs/notes.md": b"reference",
+            "SKILL.md": b"hello\r\n",
+        },
+        metadata={"context": "inline"},
+    )
+
+    assert first == second
+    assert first.startswith("sha256:")
+
+
+def test_filesystem_digest_detects_formatting_edits() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+        canonical_filesystem_digest,
+    )
+
+    original = canonical_filesystem_digest(
+        source_type="prompt_file",
+        asset_id="config_prompt:rag.prompts.yaml",
+        files={"rag.prompts.yaml": b"answer: one\n"},
+    )
+    edited = canonical_filesystem_digest(
+        source_type="prompt_file",
+        asset_id="config_prompt:rag.prompts.yaml",
+        files={"rag.prompts.yaml": b"answer: one\n# changed\n"},
+    )
+
+    assert original != edited
+
+
+def test_db_prompt_digest_normalizes_unicode_and_line_endings() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+        canonical_db_prompt_digest,
+    )
+
+    composed = canonical_db_prompt_digest(
+        {
+            "uuid": "prompt-1",
+            "version": 3,
+            "name": "Cafe",
+            "system": "caf\u00e9\r\nline",
+            "user": "body",
+            "structured": {"b": 2, "a": 1},
+        }
+    )
+    decomposed = canonical_db_prompt_digest(
+        {
+            "structured": {"a": 1, "b": 2},
+            "user": "body",
+            "system": "cafe\u0301\nline",
+            "name": "Cafe",
+            "version": 3,
+            "uuid": "prompt-1",
+        }
+    )
+
+    assert composed == decomposed
+    payload = json.loads(composed.canonical_json)
+    assert payload["system"] == "caf\u00e9\nline"
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Context_Integrity/unit/test_canonicalization.py -v
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'tldw_Server_API.app.core.Context_Integrity'`.
+
+- [ ] **Step 3: Add models and hashing implementation**
+
+Create `tldw_Server_API/app/core/Context_Integrity/models.py`:
+
+```python
+"""Shared models for context integrity verification."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+ContextAssetSource = Literal["skill_file", "prompt_file", "db_prompt"]
+ContextAssetState = Literal[
+    "trusted",
+    "changed_approved_executable",
+    "changed_approved_non_executable",
+    "new_unapproved",
+    "missing_required",
+    "missing_optional",
+    "signature_invalid",
+    "manifest_rollback_detected",
+    "verification_error",
+    "degraded_integrity",
+    "quarantined",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalDigest:
+    """Canonical digest plus optional JSON payload used to produce it."""
+
+    digest: str
+    canonical_json: str = ""
+
+    def __str__(self) -> str:
+        return self.digest
+
+
+@dataclass(frozen=True, slots=True)
+class ContextAssetDescriptor:
+    """One prompt-bearing asset discovered by an inventory adapter."""
+
+    asset_id: str
+    source_type: ContextAssetSource
+    digest: str
+    display_name: str
+    executable: bool = False
+    required: bool = False
+    owner_scope: str = "system"
+    path: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ContextIntegrityFinding:
+    """Verification finding for one asset or source scope."""
+
+    asset_id: str
+    state: ContextAssetState
+    severity: Literal["info", "warning", "error"]
+    summary: str
+    remediation: str
+    source_type: ContextAssetSource | Literal["manifest"]
+    current_digest: str | None = None
+    approved_digest: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+    detected_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+@dataclass(frozen=True, slots=True)
+class ContextIntegrityBootState:
+    """Current-process context integrity verification result."""
+
+    mode: Literal["audit_only", "enforce", "hardened"]
+    degraded: bool
+    manifest_sequence: int | None
+    manifest_digest: str | None
+    approved_digests_by_asset_id: dict[str, str] = field(default_factory=dict)
+    findings: tuple[ContextIntegrityFinding, ...] = ()
+```
+
+Create `tldw_Server_API/app/core/Context_Integrity/canonicalization.py`:
+
+```python
+"""Canonical hashing helpers for prompt-bearing assets."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import unicodedata
+from typing import Any, Mapping
+
+from tldw_Server_API.app.core.Context_Integrity.models import CanonicalDigest
+
+
+def _normalize_text(value: str) -> str:
+    return unicodedata.normalize("NFC", value.replace("\r\n", "\n").replace("\r", "\n"))
+
+
+def _normalize_json_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return _normalize_text(value)
+    if isinstance(value, Mapping):
+        return {str(key): _normalize_json_value(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        return [_normalize_json_value(item) for item in value]
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    return _normalize_text(str(value))
+
+
+def _stable_json(payload: Mapping[str, Any]) -> str:
+    normalized = _normalize_json_value(payload)
+    return json.dumps(normalized, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _sha256(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def canonical_filesystem_digest(
+    *,
+    source_type: str,
+    asset_id: str,
+    files: Mapping[str, bytes],
+    metadata: Mapping[str, Any] | None = None,
+) -> str:
+    """Hash raw file bytes plus deterministic identity metadata."""
+    hasher = hashlib.sha256()
+    identity = _stable_json(
+        {
+            "asset_id": asset_id,
+            "source_type": source_type,
+            "metadata": dict(metadata or {}),
+        }
+    ).encode("utf-8")
+    hasher.update(len(identity).to_bytes(8, "big"))
+    hasher.update(identity)
+    for relative_path in sorted(files):
+        path_bytes = relative_path.replace("\\", "/").encode("utf-8")
+        content = files[relative_path]
+        hasher.update(len(path_bytes).to_bytes(8, "big"))
+        hasher.update(path_bytes)
+        hasher.update(len(content).to_bytes(8, "big"))
+        hasher.update(content)
+    return "sha256:" + hasher.hexdigest()
+
+
+def canonical_db_prompt_digest(record: Mapping[str, Any]) -> CanonicalDigest:
+    """Hash a stable prompt-version JSON representation."""
+    canonical_json = _stable_json(dict(record))
+    return CanonicalDigest(
+        digest=_sha256(canonical_json.encode("utf-8")),
+        canonical_json=canonical_json,
+    )
+```
+
+Create `tldw_Server_API/app/core/Context_Integrity/__init__.py`:
+
+```python
+"""Context integrity controls for prompt-bearing assets."""
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Context_Integrity/unit/test_canonicalization.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add tldw_Server_API/app/core/Context_Integrity/__init__.py \
+  tldw_Server_API/app/core/Context_Integrity/models.py \
+  tldw_Server_API/app/core/Context_Integrity/canonicalization.py \
+  tldw_Server_API/tests/Context_Integrity/unit/test_canonicalization.py
+git commit -m "feat: add context integrity canonical hashing"
+```
+
+## Task 2: Manifest Signing And Anti-Rollback Policy
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Context_Integrity/manifest.py`
+- Modify: `tldw_Server_API/app/core/Context_Integrity/models.py`
+- Create: `tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py`
+
+- [ ] **Step 1: Write failing manifest tests**
+
+Create `tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _entry(asset_id: str, digest: str = "sha256:a") -> dict[str, object]:
+    return {
+        "asset_id": asset_id,
+        "source_type": "skill_file",
+        "digest": digest,
+        "display_name": asset_id,
+        "executable": True,
+        "required": False,
+        "owner_scope": "user:1",
+    }
+
+
+def test_manifest_roundtrip_verifies_signature() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        HmacManifestSigner,
+        create_signed_manifest,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed = create_signed_manifest(sequence=1, entries=[_entry("skill:user:1/demo")], signer=signer)
+
+    verified = verify_signed_manifest(signed, signer=signer)
+
+    assert verified.sequence == 1
+    assert verified.entries[0]["asset_id"] == "skill:user:1/demo"
+
+
+def test_manifest_tamper_is_rejected() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        HmacManifestSigner,
+        ManifestSignatureError,
+        create_signed_manifest,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed = create_signed_manifest(sequence=1, entries=[_entry("skill:user:1/demo")], signer=signer)
+    signed["manifest"]["entries"][0]["digest"] = "sha256:evil"
+
+    with pytest.raises(ManifestSignatureError):
+        verify_signed_manifest(signed, signer=signer)
+
+
+def test_anti_rollback_anchor_rejects_older_valid_manifest() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        AntiRollbackAnchor,
+        HmacManifestSigner,
+        ManifestRollbackError,
+        create_signed_manifest,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed = create_signed_manifest(sequence=2, entries=[_entry("skill:user:1/demo")], signer=signer)
+    anchor = AntiRollbackAnchor(sequence=3, manifest_digest="sha256:newer")
+
+    with pytest.raises(ManifestRollbackError):
+        verify_signed_manifest(signed, signer=signer, anti_rollback_anchor=anchor)
+
+
+def test_anti_rollback_anchor_rejects_same_sequence_with_different_digest() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        AntiRollbackAnchor,
+        HmacManifestSigner,
+        ManifestRollbackError,
+        create_signed_manifest,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed = create_signed_manifest(sequence=3, entries=[_entry("skill:user:1/demo")], signer=signer)
+    anchor = AntiRollbackAnchor(sequence=3, manifest_digest="sha256:different")
+
+    with pytest.raises(ManifestRollbackError):
+        verify_signed_manifest(signed, signer=signer, anti_rollback_anchor=anchor)
+```
+
+- [ ] **Step 2: Run failing manifest tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py -v
+```
+
+Expected: FAIL with `ModuleNotFoundError` or missing manifest functions.
+
+- [ ] **Step 3: Add manifest implementation**
+
+Create `tldw_Server_API/app/core/Context_Integrity/manifest.py`:
+
+```python
+"""Signed context integrity manifest helpers."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+class ManifestSignatureError(ValueError):
+    """Raised when a manifest signature cannot be verified."""
+
+
+class ManifestRollbackError(ValueError):
+    """Raised when a valid manifest is older than the anti-rollback anchor."""
+
+
+@dataclass(frozen=True, slots=True)
+class AntiRollbackAnchor:
+    """Last accepted manifest identity from a non-DB trust anchor."""
+
+    sequence: int
+    manifest_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedManifest:
+    """Verified signed manifest payload."""
+
+    sequence: int
+    manifest_digest: str
+    key_id: str
+    entries: tuple[dict[str, Any], ...]
+
+
+class HmacManifestSigner:
+    """Test and deployment signer backed by an externally supplied secret."""
+
+    def __init__(self, *, key_id: str, secret: bytes) -> None:
+        if not key_id:
+            raise ValueError("key_id is required")
+        if not secret:
+            raise ValueError("secret is required")
+        self.key_id = key_id
+        self._secret = secret
+
+    def sign(self, payload: bytes) -> str:
+        digest = hmac.new(self._secret, payload, hashlib.sha256).digest()
+        return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+    def verify(self, payload: bytes, signature: str) -> bool:
+        return hmac.compare_digest(self.sign(payload), signature)
+
+
+def _stable_json(payload: Mapping[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _manifest_digest(payload: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def create_signed_manifest(
+    *,
+    sequence: int,
+    entries: list[dict[str, Any]],
+    signer: HmacManifestSigner,
+    schema_version: int = 1,
+) -> dict[str, Any]:
+    manifest = {
+        "schema_version": schema_version,
+        "sequence": sequence,
+        "entries": sorted(entries, key=lambda item: str(item["asset_id"])),
+    }
+    payload = _stable_json(manifest)
+    return {
+        "manifest": manifest,
+        "signature": {
+            "alg": "hmac-sha256",
+            "key_id": signer.key_id,
+            "value": signer.sign(payload),
+        },
+        "manifest_digest": _manifest_digest(payload),
+    }
+
+
+def verify_signed_manifest(
+    signed_manifest: Mapping[str, Any],
+    *,
+    signer: HmacManifestSigner,
+    anti_rollback_anchor: AntiRollbackAnchor | None = None,
+) -> VerifiedManifest:
+    manifest = signed_manifest.get("manifest")
+    signature = signed_manifest.get("signature")
+    if not isinstance(manifest, dict) or not isinstance(signature, dict):
+        raise ManifestSignatureError("signed manifest is malformed")
+    if signature.get("key_id") != signer.key_id:
+        raise ManifestSignatureError("manifest key id mismatch")
+    payload = _stable_json(manifest)
+    expected_digest = _manifest_digest(payload)
+    if signed_manifest.get("manifest_digest") != expected_digest:
+        raise ManifestSignatureError("manifest digest mismatch")
+    signature_value = signature.get("value")
+    if not isinstance(signature_value, str) or not signer.verify(payload, signature_value):
+        raise ManifestSignatureError("manifest signature mismatch")
+    sequence = int(manifest.get("sequence") or 0)
+    if anti_rollback_anchor and (
+        sequence < anti_rollback_anchor.sequence
+        or (sequence == anti_rollback_anchor.sequence and expected_digest != anti_rollback_anchor.manifest_digest)
+    ):
+        raise ManifestRollbackError("manifest rollback detected")
+    entries = manifest.get("entries") or []
+    if not isinstance(entries, list):
+        raise ManifestSignatureError("manifest entries must be a list")
+    return VerifiedManifest(
+        sequence=sequence,
+        manifest_digest=expected_digest,
+        key_id=signer.key_id,
+        entries=tuple(dict(item) for item in entries),
+    )
+```
+
+- [ ] **Step 4: Run manifest tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add tldw_Server_API/app/core/Context_Integrity/manifest.py \
+  tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
+git commit -m "feat: add context integrity signed manifests"
+```
+
+## Task 3: Verifier And Runtime Resolver
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Context_Integrity/verifier.py`
+- Create: `tldw_Server_API/app/core/Context_Integrity/resolver.py`
+- Modify: `tldw_Server_API/app/core/Context_Integrity/models.py`
+- Create: `tldw_Server_API/tests/Context_Integrity/unit/test_verifier_resolver.py`
+
+- [ ] **Step 1: Write failing verifier and resolver tests**
+
+Create `tldw_Server_API/tests/Context_Integrity/unit/test_verifier_resolver.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _asset(asset_id: str, digest: str, *, executable: bool = False):
+    from tldw_Server_API.app.core.Context_Integrity.models import ContextAssetDescriptor
+
+    return ContextAssetDescriptor(
+        asset_id=asset_id,
+        source_type="skill_file",
+        digest=digest,
+        display_name=asset_id,
+        executable=executable,
+        owner_scope="user:1",
+    )
+
+
+def test_verifier_detects_changed_executable_asset() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.verifier import verify_inventory
+
+    findings = verify_inventory(
+        current_assets=[_asset("skill:user:1/demo", "sha256:current", executable=True)],
+        approved_entries=[
+            {
+                "asset_id": "skill:user:1/demo",
+                "source_type": "skill_file",
+                "digest": "sha256:approved",
+                "display_name": "demo",
+                "executable": True,
+                "required": False,
+                "owner_scope": "user:1",
+            }
+        ],
+    )
+
+    assert len(findings) == 1
+    assert findings[0].state == "changed_approved_executable"
+    assert findings[0].severity == "error"
+
+
+def test_verifier_detects_new_unapproved_asset() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.verifier import verify_inventory
+
+    findings = verify_inventory(
+        current_assets=[_asset("skill:user:1/new", "sha256:new")],
+        approved_entries=[],
+    )
+
+    assert findings[0].state == "new_unapproved"
+
+
+def test_resolver_blocks_quarantined_asset() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.models import (
+        ContextIntegrityBootState,
+        ContextIntegrityFinding,
+    )
+    from tldw_Server_API.app.core.Context_Integrity.resolver import (
+        ContextIntegrityBlocked,
+        ContextIntegrityResolver,
+    )
+
+    finding = ContextIntegrityFinding(
+        asset_id="skill:user:1/demo",
+        state="changed_approved_executable",
+        severity="error",
+        summary="changed",
+        remediation="review",
+        source_type="skill_file",
+    )
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="enforce",
+            degraded=False,
+            manifest_sequence=1,
+            manifest_digest="sha256:manifest",
+            findings=(finding,),
+        )
+    )
+
+    with pytest.raises(ContextIntegrityBlocked, match="quarantined"):
+        resolver.require_allowed("skill:user:1/demo", purpose="skill_execution")
+
+
+def test_resolver_detects_live_digest_mismatch_at_use() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.models import ContextIntegrityBootState
+    from tldw_Server_API.app.core.Context_Integrity.resolver import (
+        ContextIntegrityBlocked,
+        ContextIntegrityResolver,
+    )
+
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="enforce",
+            degraded=False,
+            manifest_sequence=1,
+            manifest_digest="sha256:manifest",
+            approved_digests_by_asset_id={"skill:user:1/demo": "sha256:approved"},
+        )
+    )
+
+    with pytest.raises(ContextIntegrityBlocked, match="quarantined"):
+        resolver.require_digest_allowed(
+            "skill:user:1/demo",
+            current_digest="sha256:changed",
+            purpose="skill_execution",
+        )
+
+
+def test_resolver_allows_matching_digest_at_use() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.models import ContextIntegrityBootState
+    from tldw_Server_API.app.core.Context_Integrity.resolver import ContextIntegrityResolver
+
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="enforce",
+            degraded=False,
+            manifest_sequence=1,
+            manifest_digest="sha256:manifest",
+            approved_digests_by_asset_id={"prompt_file:demo.prompts.md": "sha256:approved"},
+        )
+    )
+
+    resolver.require_digest_allowed(
+        "prompt_file:demo.prompts.md",
+        current_digest="sha256:approved",
+        purpose="prompt_load",
+    )
+
+
+def test_global_resolver_can_be_set_and_cleared() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.models import ContextIntegrityBootState
+    from tldw_Server_API.app.core.Context_Integrity.resolver import (
+        ContextIntegrityResolver,
+        clear_global_context_integrity_resolver,
+        get_global_context_integrity_resolver,
+        set_global_context_integrity_resolver,
+    )
+
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="enforce",
+            degraded=False,
+            manifest_sequence=1,
+            manifest_digest="sha256:manifest",
+        )
+    )
+    set_global_context_integrity_resolver(resolver)
+    assert get_global_context_integrity_resolver() is resolver
+    clear_global_context_integrity_resolver()
+    assert get_global_context_integrity_resolver() is None
+```
+
+- [ ] **Step 2: Run failing verifier tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Context_Integrity/unit/test_verifier_resolver.py -v
+```
+
+Expected: FAIL with missing verifier/resolver modules.
+
+- [ ] **Step 3: Add verifier and resolver**
+
+Create `tldw_Server_API/app/core/Context_Integrity/verifier.py`:
+
+```python
+"""Verification of current context assets against approved manifest entries."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+from tldw_Server_API.app.core.Context_Integrity.models import (
+    ContextAssetDescriptor,
+    ContextIntegrityFinding,
+)
+
+
+def _entry_by_asset_id(entries: Iterable[Mapping[str, Any]]) -> dict[str, Mapping[str, Any]]:
+    return {str(entry["asset_id"]): entry for entry in entries}
+
+
+def verify_inventory(
+    *,
+    current_assets: Iterable[ContextAssetDescriptor],
+    approved_entries: Iterable[Mapping[str, Any]],
+) -> tuple[ContextIntegrityFinding, ...]:
+    """Compare current inventory against approved manifest entries."""
+    approved = _entry_by_asset_id(approved_entries)
+    current = {asset.asset_id: asset for asset in current_assets}
+    findings: list[ContextIntegrityFinding] = []
+
+    for asset_id, asset in current.items():
+        entry = approved.get(asset_id)
+        if entry is None:
+            findings.append(
+                ContextIntegrityFinding(
+                    asset_id=asset_id,
+                    state="new_unapproved",
+                    severity="warning",
+                    summary=f"Unapproved context asset detected: {asset.display_name}",
+                    remediation="Review and approve the asset before model use.",
+                    source_type=asset.source_type,
+                    current_digest=asset.digest,
+                )
+            )
+            continue
+        if str(entry.get("digest")) != asset.digest:
+            state = "changed_approved_executable" if asset.executable else "changed_approved_non_executable"
+            findings.append(
+                ContextIntegrityFinding(
+                    asset_id=asset_id,
+                    state=state,
+                    severity="error" if asset.executable else "warning",
+                    summary=f"Approved context asset changed: {asset.display_name}",
+                    remediation="Review the diff and approve a new manifest version or restore the asset.",
+                    source_type=asset.source_type,
+                    current_digest=asset.digest,
+                    approved_digest=str(entry.get("digest")),
+                )
+            )
+
+    for asset_id, entry in approved.items():
+        if asset_id in current:
+            continue
+        required = bool(entry.get("required", False))
+        findings.append(
+            ContextIntegrityFinding(
+                asset_id=asset_id,
+                state="missing_required" if required else "missing_optional",
+                severity="error" if required else "warning",
+                summary=f"Approved context asset is missing: {entry.get('display_name') or asset_id}",
+                remediation="Restore the asset or approve a manifest that removes it.",
+                source_type=str(entry.get("source_type", "skill_file")),  # type: ignore[arg-type]
+                approved_digest=str(entry.get("digest")),
+            )
+        )
+
+    return tuple(findings)
+```
+
+Create `tldw_Server_API/app/core/Context_Integrity/resolver.py`:
+
+```python
+"""Runtime resolver for context integrity enforcement."""
+
+from __future__ import annotations
+
+from tldw_Server_API.app.core.Context_Integrity.models import (
+    ContextIntegrityBootState,
+    ContextIntegrityFinding,
+)
+
+
+class ContextIntegrityBlocked(RuntimeError):
+    """Raised when a prompt-bearing asset is quarantined or unavailable."""
+
+    def __init__(self, asset_id: str, state: str) -> None:
+        self.asset_id = asset_id
+        self.state = state
+        super().__init__("Asset is quarantined pending admin review.")
+
+
+class ContextIntegrityResolver:
+    """Current-process resolver backed by verified boot state."""
+
+    def __init__(self, boot_state: ContextIntegrityBootState) -> None:
+        self.boot_state = boot_state
+        self._findings_by_asset_id: dict[str, ContextIntegrityFinding] = {
+            finding.asset_id: finding for finding in boot_state.findings
+        }
+
+    def finding_for(self, asset_id: str) -> ContextIntegrityFinding | None:
+        return self._findings_by_asset_id.get(asset_id)
+
+    def require_allowed(self, asset_id: str, *, purpose: str) -> None:
+        finding = self.finding_for(asset_id)
+        if finding is None:
+            return
+        if self.boot_state.mode == "audit_only":
+            return
+        raise ContextIntegrityBlocked(asset_id=asset_id, state=finding.state)
+
+    def require_digest_allowed(self, asset_id: str, *, current_digest: str, purpose: str) -> None:
+        self.require_allowed(asset_id, purpose=purpose)
+        if self.boot_state.mode == "audit_only":
+            return
+        approved_digest = self.boot_state.approved_digests_by_asset_id.get(asset_id)
+        if approved_digest is None:
+            raise ContextIntegrityBlocked(asset_id=asset_id, state="new_unapproved")
+        if approved_digest != current_digest:
+            raise ContextIntegrityBlocked(asset_id=asset_id, state="changed_approved_executable")
+
+
+_global_resolver: ContextIntegrityResolver | None = None
+
+
+def set_global_context_integrity_resolver(resolver: ContextIntegrityResolver | None) -> None:
+    global _global_resolver
+    _global_resolver = resolver
+
+
+def get_global_context_integrity_resolver() -> ContextIntegrityResolver | None:
+    return _global_resolver
+
+
+def clear_global_context_integrity_resolver() -> None:
+    set_global_context_integrity_resolver(None)
+```
+
+- [ ] **Step 4: Run verifier/resolver tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Context_Integrity/unit/test_verifier_resolver.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add tldw_Server_API/app/core/Context_Integrity/verifier.py \
+  tldw_Server_API/app/core/Context_Integrity/resolver.py \
+  tldw_Server_API/tests/Context_Integrity/unit/test_verifier_resolver.py
+git commit -m "feat: add context integrity verifier resolver"
+```
+
+## Task 4: Filesystem Inventory Adapters
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Context_Integrity/inventory.py`
+- Create: `tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py`
+
+- [ ] **Step 1: Write failing inventory tests**
+
+Create `tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_inventory_user_skill_directory_includes_supporting_files(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import inventory_user_skills
+
+    skill_dir = tmp_path / "skills" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: demo\n---\nBody", encoding="utf-8")
+    (skill_dir / "ref.md").write_text("reference", encoding="utf-8")
+
+    assets = inventory_user_skills(user_id=1, skills_root=tmp_path / "skills")
+
+    assert len(assets) == 1
+    assert assets[0].asset_id == "skill:user:1/demo"
+    assert assets[0].executable is True
+    assert assets[0].source_type == "skill_file"
+
+
+def test_inventory_prompt_files_finds_supported_extensions(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import inventory_prompt_files
+
+    prompts = tmp_path / "Prompts"
+    prompts.mkdir()
+    (prompts / "rag.prompts.yaml").write_text("answer: prompt", encoding="utf-8")
+    (prompts / "ignore.bin").write_bytes(b"no")
+
+    assets = inventory_prompt_files(prompts_dir=prompts)
+
+    assert [asset.asset_id for asset in assets] == ["prompt_file:rag.prompts.yaml"]
+    assert assets[0].executable is False
+```
+
+- [ ] **Step 2: Run failing inventory tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py -v
+```
+
+Expected: FAIL with missing `inventory.py`.
+
+- [ ] **Step 3: Add inventory implementation**
+
+Create `tldw_Server_API/app/core/Context_Integrity/inventory.py`:
+
+```python
+"""Filesystem inventory adapters for Context Integrity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+    canonical_filesystem_digest,
+)
+from tldw_Server_API.app.core.Context_Integrity.models import ContextAssetDescriptor
+
+_PROMPT_SUFFIXES = {".md", ".yaml", ".yml", ".json", ".txt"}
+_SKILL_TEXT_SUFFIXES = {".md", ".txt", ".json", ".yaml", ".yml", ".py", ".sh"}
+
+
+def _read_file_map(root: Path, suffixes: set[str]) -> dict[str, bytes]:
+    files: dict[str, bytes] = {}
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix.lower() not in suffixes:
+            continue
+        relative = path.relative_to(root).as_posix()
+        files[relative] = path.read_bytes()
+    return files
+
+
+def inventory_user_skills(*, user_id: int, skills_root: Path) -> list[ContextAssetDescriptor]:
+    """Inventory per-user skill directories."""
+    if not skills_root.exists():
+        return []
+    assets: list[ContextAssetDescriptor] = []
+    for skill_dir in sorted(path for path in skills_root.iterdir() if path.is_dir()):
+        skill_file = skill_dir / "SKILL.md"
+        if not skill_file.exists():
+            continue
+        files = _read_file_map(skill_dir, _SKILL_TEXT_SUFFIXES)
+        asset_id = f"skill:user:{user_id}/{skill_dir.name}"
+        digest = canonical_filesystem_digest(
+            source_type="skill_file",
+            asset_id=asset_id,
+            files=files,
+            metadata={"skill_name": skill_dir.name},
+        )
+        assets.append(
+            ContextAssetDescriptor(
+                asset_id=asset_id,
+                source_type="skill_file",
+                digest=digest,
+                display_name=skill_dir.name,
+                executable=True,
+                owner_scope=f"user:{user_id}",
+                path=str(skill_dir),
+            )
+        )
+    return assets
+
+
+def inventory_prompt_files(*, prompts_dir: Path) -> list[ContextAssetDescriptor]:
+    """Inventory config prompt files under a Prompts directory."""
+    if not prompts_dir.exists():
+        return []
+    assets: list[ContextAssetDescriptor] = []
+    for path in sorted(prompts_dir.iterdir()):
+        if not path.is_file() or path.suffix.lower() not in _PROMPT_SUFFIXES:
+            continue
+        relative = path.name
+        asset_id = f"prompt_file:{relative}"
+        digest = canonical_filesystem_digest(
+            source_type="prompt_file",
+            asset_id=asset_id,
+            files={relative: path.read_bytes()},
+            metadata={"path": relative},
+        )
+        assets.append(
+            ContextAssetDescriptor(
+                asset_id=asset_id,
+                source_type="prompt_file",
+                digest=digest,
+                display_name=relative,
+                executable=False,
+                owner_scope="system",
+                path=str(path),
+            )
+        )
+    return assets
+```
+
+- [ ] **Step 4: Run inventory tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add tldw_Server_API/app/core/Context_Integrity/inventory.py \
+  tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
+git commit -m "feat: add context integrity filesystem inventory"
+```
+
+## Task 5: Startup Verification Producer
+
+**Files:**
+- Create: `tldw_Server_API/app/services/startup_context_integrity.py`
+- Modify: `tldw_Server_API/app/services/lifespan_startup_sequence.py`
+- Create: `tldw_Server_API/tests/Services/test_startup_context_integrity.py`
+- Modify: `tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py`
+
+- [ ] **Step 1: Write failing startup producer tests**
+
+Create `tldw_Server_API/tests/Services/test_startup_context_integrity.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_startup_context_integrity_sets_resolver_and_warning(tmp_path, monkeypatch) -> None:
+    from tldw_Server_API.app.services.startup_context_integrity import (
+        produce_context_integrity_startup_warnings,
+    )
+    from tldw_Server_API.app.services.startup_warning_registry import StartupWarningRegistry
+
+    prompts = tmp_path / "Prompts"
+    prompts.mkdir()
+    (prompts / "rag.prompts.yaml").write_text("answer: changed", encoding="utf-8")
+
+    registry = StartupWarningRegistry(startup_id="boot-1")
+    app_state = type("State", (), {})()
+
+    findings = produce_context_integrity_startup_warnings(
+        app_state=app_state,
+        registry=registry,
+        prompts_dir=prompts,
+        user_skill_roots=[],
+        approved_entries=[],
+        mode="enforce",
+    )
+
+    assert len(findings) == 1
+    assert registry.summary(component_prefix="context_integrity")["total"] == 1
+    assert app_state.context_integrity_resolver.finding_for("prompt_file:rag.prompts.yaml") is not None
+```
+
+- [ ] **Step 2: Run failing startup producer tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Services/test_startup_context_integrity.py -v
+```
+
+Expected: FAIL with missing `startup_context_integrity.py`.
+
+- [ ] **Step 3: Add startup producer**
+
+Create `tldw_Server_API/app/services/startup_context_integrity.py`:
+
+```python
+"""Startup producer for Context Integrity warnings and resolver state."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Mapping
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Context_Integrity.inventory import (
+    inventory_prompt_files,
+    inventory_user_skills,
+)
+from tldw_Server_API.app.core.Context_Integrity.models import (
+    ContextAssetDescriptor,
+    ContextIntegrityBootState,
+    ContextIntegrityFinding,
+)
+from tldw_Server_API.app.core.Context_Integrity.resolver import (
+    ContextIntegrityResolver,
+    set_global_context_integrity_resolver,
+)
+from tldw_Server_API.app.core.Context_Integrity.verifier import verify_inventory
+from tldw_Server_API.app.core.config_paths import resolve_prompts_dir
+from tldw_Server_API.app.services.startup_warning_models import StartupWarningRecord
+from tldw_Server_API.app.services.startup_warning_registry import StartupWarningRegistry
+
+
+def _finding_to_warning(finding: ContextIntegrityFinding) -> StartupWarningRecord:
+    action = "warn"
+    return StartupWarningRecord(
+        component=f"context_integrity.{finding.source_type}",
+        severity=finding.severity,
+        startup_action=action,
+        code=finding.state,
+        summary=finding.summary,
+        remediation=finding.remediation,
+        details={
+            "asset_id": finding.asset_id,
+            "current_digest": finding.current_digest,
+            "approved_digest": finding.approved_digest,
+        },
+        detected_at=finding.detected_at,
+    )
+
+
+def produce_context_integrity_startup_warnings(
+    *,
+    app_state: object,
+    registry: StartupWarningRegistry,
+    prompts_dir: Path | None = None,
+    user_skill_roots: Iterable[tuple[int, Path]] = (),
+    approved_entries: Iterable[Mapping[str, object]] = (),
+    mode: str = "enforce",
+) -> tuple[ContextIntegrityFinding, ...]:
+    """Build startup inventory, register warnings, and attach resolver state."""
+    current_assets: list[ContextAssetDescriptor] = []
+    current_assets.extend(inventory_prompt_files(prompts_dir=prompts_dir or resolve_prompts_dir()))
+    for user_id, skills_root in user_skill_roots:
+        current_assets.extend(inventory_user_skills(user_id=user_id, skills_root=skills_root))
+
+    findings = verify_inventory(current_assets=current_assets, approved_entries=approved_entries)
+    approved_digests_by_asset_id = {
+        str(entry["asset_id"]): str(entry["digest"])
+        for entry in approved_entries
+        if "asset_id" in entry and "digest" in entry
+    }
+    boot_state = ContextIntegrityBootState(
+        mode=mode,  # type: ignore[arg-type]
+        degraded=False,
+        manifest_sequence=None,
+        manifest_digest=None,
+        approved_digests_by_asset_id=approved_digests_by_asset_id,
+        findings=findings,
+    )
+    resolver = ContextIntegrityResolver(boot_state)
+    setattr(app_state, "context_integrity_resolver", resolver)
+    setattr(app_state, "context_integrity_boot_state", boot_state)
+    set_global_context_integrity_resolver(resolver)
+
+    for finding in findings:
+        registry.add_warning(_finding_to_warning(finding))
+        logger.warning("Context integrity startup finding: {} {}", finding.state, finding.asset_id)
+    return findings
+```
+
+- [ ] **Step 4: Wire lifespan startup**
+
+Modify `tldw_Server_API/app/services/lifespan_startup_sequence.py`:
+
+```python
+def _run_startup_warning_producers(*, app: Any, startup_core_handles: Any) -> None:
+    from tldw_Server_API.app.services.startup_context_integrity import (
+        produce_context_integrity_startup_warnings,
+    )
+    from tldw_Server_API.app.services.startup_warning_sandbox import (
+        produce_sandbox_startup_warnings,
+    )
+
+    registry = app.state.startup_warning_registry
+    produce_context_integrity_startup_warnings(
+        app_state=app.state,
+        registry=registry,
+    )
+    produce_sandbox_startup_warnings(
+        orchestrator=getattr(startup_core_handles, "startup_sandbox_orchestrator", None),
+        registry=registry,
+    )
+```
+
+- [ ] **Step 5: Update lifespan test expectation**
+
+Modify `test_startup_initializes_registry_and_runs_sandbox_producer` in `tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py` to monkeypatch the new producer:
+
+```python
+from tldw_Server_API.app.services import startup_context_integrity
+
+context_calls: list[dict[str, object]] = []
+
+def _fake_produce_context_integrity_startup_warnings(**kwargs):
+    context_calls.append(kwargs)
+    return []
+
+monkeypatch.setattr(
+    startup_context_integrity,
+    "produce_context_integrity_startup_warnings",
+    _fake_produce_context_integrity_startup_warnings,
+)
+
+assert context_calls == [{"app_state": app.state, "registry": registry}]
+```
+
+- [ ] **Step 6: Run startup tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Services/test_startup_context_integrity.py \
+  tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 5**
+
+```bash
+git add tldw_Server_API/app/services/startup_context_integrity.py \
+  tldw_Server_API/app/services/lifespan_startup_sequence.py \
+  tldw_Server_API/tests/Services/test_startup_context_integrity.py \
+  tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py
+git commit -m "feat: wire context integrity startup checks"
+```
+
+## Task 6: Skills Enforcement
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Skills/skills_service.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/skills.py`
+- Modify: `tldw_Server_API/tests/Skills/unit/test_skills_service.py`
+- Modify: `tldw_Server_API/tests/Skills/integration/test_skills_api.py`
+
+- [ ] **Step 1: Add failing service tests for quarantined skills**
+
+Append to `TestSkillsService` in `tldw_Server_API/tests/Skills/unit/test_skills_service.py`:
+
+```python
+    @pytest.mark.asyncio
+    async def test_quarantined_skill_is_filtered_from_context(self, service):
+        from tldw_Server_API.app.core.Context_Integrity.models import (
+            ContextIntegrityBootState,
+            ContextIntegrityFinding,
+        )
+        from tldw_Server_API.app.core.Context_Integrity.resolver import ContextIntegrityResolver
+
+        await service.create_skill("blocked-skill", "---\ndescription: Blocked\n---\nBody")
+        finding = ContextIntegrityFinding(
+            asset_id="skill:user:1/blocked-skill",
+            state="changed_approved_executable",
+            severity="error",
+            summary="changed",
+            remediation="review",
+            source_type="skill_file",
+        )
+        service.integrity_resolver = ContextIntegrityResolver(
+            ContextIntegrityBootState(
+                mode="enforce",
+                degraded=False,
+                manifest_sequence=1,
+                manifest_digest="sha256:manifest",
+                findings=(finding,),
+            )
+        )
+
+        payload = service.get_context_payload()
+
+        assert payload["available_skills"] == []
+        assert "blocked-skill" not in payload["context_text"]
+
+    @pytest.mark.asyncio
+    async def test_quarantined_skill_get_is_blocked(self, service):
+        from tldw_Server_API.app.core.Context_Integrity.models import (
+            ContextIntegrityBootState,
+            ContextIntegrityFinding,
+        )
+        from tldw_Server_API.app.core.Context_Integrity.resolver import (
+            ContextIntegrityBlocked,
+            ContextIntegrityResolver,
+        )
+
+        await service.create_skill("blocked-skill", "Body")
+        service.integrity_resolver = ContextIntegrityResolver(
+            ContextIntegrityBootState(
+                mode="enforce",
+                degraded=False,
+                manifest_sequence=1,
+                manifest_digest="sha256:manifest",
+                findings=(
+                    ContextIntegrityFinding(
+                        asset_id="skill:user:1/blocked-skill",
+                        state="changed_approved_executable",
+                        severity="error",
+                        summary="changed",
+                        remediation="review",
+                        source_type="skill_file",
+                    ),
+                ),
+            )
+        )
+
+        with pytest.raises(ContextIntegrityBlocked):
+            await service.get_skill("blocked-skill")
+
+    @pytest.mark.asyncio
+    async def test_live_skill_edit_after_boot_is_blocked(self, service):
+        from tldw_Server_API.app.core.Context_Integrity.inventory import inventory_user_skills
+        from tldw_Server_API.app.core.Context_Integrity.models import ContextIntegrityBootState
+        from tldw_Server_API.app.core.Context_Integrity.resolver import (
+            ContextIntegrityBlocked,
+            ContextIntegrityResolver,
+        )
+
+        await service.create_skill("live-skill", "---\ndescription: Live\n---\nOriginal")
+        asset = inventory_user_skills(user_id=1, skills_root=service.skills_dir)[0]
+        service.integrity_resolver = ContextIntegrityResolver(
+            ContextIntegrityBootState(
+                mode="enforce",
+                degraded=False,
+                manifest_sequence=1,
+                manifest_digest="sha256:manifest",
+                approved_digests_by_asset_id={asset.asset_id: asset.digest},
+            )
+        )
+        (service.skills_dir / "live-skill" / "SKILL.md").write_text(
+            "---\ndescription: Live\n---\nModified",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ContextIntegrityBlocked):
+            await service.get_skill("live-skill")
+```
+
+- [ ] **Step 2: Run failing skills service tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Skills/unit/test_skills_service.py::TestSkillsService::test_quarantined_skill_is_filtered_from_context \
+  tldw_Server_API/tests/Skills/unit/test_skills_service.py::TestSkillsService::test_quarantined_skill_get_is_blocked \
+  tldw_Server_API/tests/Skills/unit/test_skills_service.py::TestSkillsService::test_live_skill_edit_after_boot_is_blocked -v
+```
+
+Expected: FAIL because `SkillsService` does not have integrity resolver logic.
+
+- [ ] **Step 3: Add resolver support to SkillsService**
+
+Modify `SkillsService.__init__` in `tldw_Server_API/app/core/Skills/skills_service.py`:
+
+```python
+from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+    canonical_filesystem_digest,
+)
+from tldw_Server_API.app.core.Context_Integrity.resolver import (
+    ContextIntegrityBlocked,
+    ContextIntegrityResolver,
+    get_global_context_integrity_resolver,
+)
+```
+
+Add parameter and attribute:
+
+```python
+        integrity_resolver: ContextIntegrityResolver | None = None,
+```
+
+Inside `__init__`:
+
+```python
+        self.integrity_resolver = integrity_resolver or get_global_context_integrity_resolver()
+```
+
+Add helper methods:
+
+```python
+    def _skill_asset_id(self, name: str) -> str:
+        return f"skill:user:{self.user_id}/{name}"
+
+    def _read_skill_file_map(self, skill_dir: Path) -> dict[str, bytes]:
+        files: dict[str, bytes] = {}
+        for path in sorted(skill_dir.rglob("*")):
+            if not path.is_file():
+                continue
+            if path.suffix.lower() not in (".md", ".txt", ".json", ".yaml", ".yml", ".py", ".sh"):
+                continue
+            files[path.relative_to(skill_dir).as_posix()] = path.read_bytes()
+        return files
+
+    def _skill_digest(self, name: str, skill_dir: Path, files: dict[str, bytes]) -> str:
+        return canonical_filesystem_digest(
+            source_type="skill_file",
+            asset_id=self._skill_asset_id(name),
+            files=files,
+            metadata={"skill_name": name},
+        )
+
+    def _is_skill_allowed(self, name: str, *, purpose: str) -> bool:
+        if self.integrity_resolver is None:
+            return True
+        try:
+            self.integrity_resolver.require_allowed(self._skill_asset_id(name), purpose=purpose)
+            return True
+        except ContextIntegrityBlocked:
+            return False
+
+    def _require_skill_allowed(
+        self,
+        name: str,
+        *,
+        purpose: str,
+        current_digest: str | None = None,
+    ) -> None:
+        if self.integrity_resolver is not None:
+            asset_id = self._skill_asset_id(name)
+            if current_digest is None:
+                self.integrity_resolver.require_allowed(asset_id, purpose=purpose)
+            else:
+                self.integrity_resolver.require_digest_allowed(
+                    asset_id,
+                    current_digest=current_digest,
+                    purpose=purpose,
+                )
+
+    def _parse_verified_skill_directory(self, name: str, skill_dir: Path):
+        files = self._read_skill_file_map(skill_dir)
+        if "SKILL.md" not in files:
+            raise SkillNotFoundError(name, detail="SKILL.md not found")
+        current_digest = self._skill_digest(name, skill_dir, files)
+        self._require_skill_allowed(name, purpose="skill_read", current_digest=current_digest)
+        raw_skill = files["SKILL.md"].decode("utf-8")
+        parsed = self._parser.parse_content(raw_skill, default_name=name)
+        parsed.supporting_files = {
+            relative_path: content.decode("utf-8")
+            for relative_path, content in files.items()
+            if relative_path != "SKILL.md"
+        }
+        return parsed
+```
+
+In `get_skill`, replace `self._parser.parse_directory(skill_dir)` with `self._parse_verified_skill_directory(name, skill_dir)`. This reads the files once, hashes those exact bytes, asks the resolver about that digest, and parses only the already-read content.
+
+Filter `list_skills`, `get_context_payload`, and `get_context_payload_async` so blocked skills are excluded:
+
+```python
+        return [
+            self._metadata_from_row(row)
+            for row in rows
+            if self._is_skill_allowed(str(row.get("name") or ""), purpose="skill_discovery")
+        ]
+```
+
+- [ ] **Step 4: Map blocked skills in API endpoints**
+
+Modify `tldw_Server_API/app/api/v1/endpoints/skills.py` imports:
+
+```python
+from tldw_Server_API.app.core.Context_Integrity.resolver import ContextIntegrityBlocked
+```
+
+In `get_skill` and `execute_skill`, add:
+
+```python
+    except ContextIntegrityBlocked as e:
+        raise HTTPException(
+            status_code=status.HTTP_423_LOCKED,
+            detail=str(e),
+        ) from e
+```
+
+- [ ] **Step 5: Add API regression test**
+
+Append to `tldw_Server_API/tests/Skills/integration/test_skills_api.py`:
+
+```python
+    def test_get_quarantined_skill_returns_423(self, client, monkeypatch):
+        from tldw_Server_API.app.core.Context_Integrity.resolver import ContextIntegrityBlocked
+        from tldw_Server_API.app.core.Skills.skills_service import SkillsService
+
+        async def _blocked(self, name):
+            raise ContextIntegrityBlocked(asset_id=f"skill:user:1/{name}", state="changed_approved_executable")
+
+        monkeypatch.setattr(SkillsService, "get_skill", _blocked)
+
+        response = client.get(f"{SKILLS_PREFIX}/blocked-skill")
+
+        assert response.status_code == 423
+        assert response.json()["detail"] == "Asset is quarantined pending admin review."
+```
+
+- [ ] **Step 6: Run focused Skills tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Skills/unit/test_skills_service.py \
+  tldw_Server_API/tests/Skills/integration/test_skills_api.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 6**
+
+```bash
+git add tldw_Server_API/app/core/Skills/skills_service.py \
+  tldw_Server_API/app/api/v1/endpoints/skills.py \
+  tldw_Server_API/tests/Skills/unit/test_skills_service.py \
+  tldw_Server_API/tests/Skills/integration/test_skills_api.py
+git commit -m "feat: enforce context integrity for skills"
+```
+
+## Task 7: Prompt Loader Enforcement With Single-Read Semantics
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Utils/prompt_loader.py`
+- Modify: `tldw_Server_API/tests/Utils/test_prompt_loader_paths.py`
+
+- [ ] **Step 1: Add failing prompt loader tests**
+
+Append to `tldw_Server_API/tests/Utils/test_prompt_loader_paths.py`:
+
+```python
+def test_load_prompt_blocks_quarantined_prompt_file(tmp_path, monkeypatch):
+    from tldw_Server_API.app.core.Context_Integrity.models import (
+        ContextIntegrityBootState,
+        ContextIntegrityFinding,
+    )
+    from tldw_Server_API.app.core.Context_Integrity.resolver import (
+        ContextIntegrityResolver,
+        set_global_context_integrity_resolver,
+        clear_global_context_integrity_resolver,
+    )
+    from tldw_Server_API.app.core.Utils import prompt_loader as pl
+
+    cfg_dir = tmp_path / "cfg"
+    prompts = cfg_dir / "Prompts"
+    prompts.mkdir(parents=True)
+    (prompts / "demo.prompts.md").write_text("# Existing Key\n```\nfrom-md\n```\n", encoding="utf-8")
+    monkeypatch.setenv("TLDW_CONFIG_DIR", str(cfg_dir))
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="enforce",
+            degraded=False,
+            manifest_sequence=1,
+            manifest_digest="sha256:manifest",
+            findings=(
+                ContextIntegrityFinding(
+                    asset_id="prompt_file:demo.prompts.md",
+                    state="changed_approved_non_executable",
+                    severity="warning",
+                    summary="changed",
+                    remediation="review",
+                    source_type="prompt_file",
+                ),
+            ),
+        )
+    )
+    set_global_context_integrity_resolver(resolver)
+    try:
+        assert pl.load_prompt("demo", "Existing Key") is None
+    finally:
+        clear_global_context_integrity_resolver()
+
+
+def test_load_prompt_uses_verified_bytes_without_second_read(tmp_path, monkeypatch):
+    from tldw_Server_API.app.core.Utils import prompt_loader as pl
+
+    cfg_dir = tmp_path / "cfg"
+    prompts = cfg_dir / "Prompts"
+    prompts.mkdir(parents=True)
+    prompt_file = prompts / "demo.prompts.md"
+    prompt_file.write_text("# Existing Key\n```\nfrom-md\n```\n", encoding="utf-8")
+    monkeypatch.setenv("TLDW_CONFIG_DIR", str(cfg_dir))
+
+    read_count = {"count": 0}
+    original_read_text = pl._read_prompt_file_text
+
+    def _counting_read(path):
+        read_count["count"] += 1
+        return original_read_text(path)
+
+    monkeypatch.setattr(pl, "_read_prompt_file_text", _counting_read)
+
+    assert pl.load_prompt("demo", "Existing Key") == "from-md"
+    assert read_count["count"] == 1
+
+
+def test_load_prompt_blocks_live_edit_after_boot(tmp_path, monkeypatch):
+    from tldw_Server_API.app.core.Context_Integrity.inventory import inventory_prompt_files
+    from tldw_Server_API.app.core.Context_Integrity.models import ContextIntegrityBootState
+    from tldw_Server_API.app.core.Context_Integrity.resolver import (
+        clear_global_context_integrity_resolver,
+        ContextIntegrityResolver,
+        set_global_context_integrity_resolver,
+    )
+    from tldw_Server_API.app.core.Utils import prompt_loader as pl
+
+    cfg_dir = tmp_path / "cfg"
+    prompts = cfg_dir / "Prompts"
+    prompts.mkdir(parents=True)
+    prompt_file = prompts / "demo.prompts.md"
+    prompt_file.write_text("# Existing Key\n```\nfrom-md\n```\n", encoding="utf-8")
+    monkeypatch.setenv("TLDW_CONFIG_DIR", str(cfg_dir))
+    asset = inventory_prompt_files(prompts_dir=prompts)[0]
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="enforce",
+            degraded=False,
+            manifest_sequence=1,
+            manifest_digest="sha256:manifest",
+            approved_digests_by_asset_id={asset.asset_id: asset.digest},
+        )
+    )
+    prompt_file.write_text("# Existing Key\n```\nmodified\n```\n", encoding="utf-8")
+    set_global_context_integrity_resolver(resolver)
+    try:
+        assert pl.load_prompt("demo", "Existing Key") is None
+    finally:
+        clear_global_context_integrity_resolver()
+```
+
+- [ ] **Step 2: Run failing prompt loader tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Utils/test_prompt_loader_paths.py -v
+```
+
+Expected: FAIL because `_read_prompt_file_text` and resolver checks do not exist.
+
+- [ ] **Step 3: Add prompt-loader read helper and resolver guard**
+
+Modify `tldw_Server_API/app/core/Utils/prompt_loader.py` imports:
+
+```python
+from pathlib import Path
+
+from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+    canonical_filesystem_digest,
+)
+from tldw_Server_API.app.core.Context_Integrity.resolver import (
+    ContextIntegrityBlocked,
+    get_global_context_integrity_resolver,
+)
+```
+
+Add helper:
+
+```python
+def _prompt_asset_id(path: str, *, source_label: str | None = None) -> str:
+    filename = Path(path).name
+    if source_label:
+        return f"prompt_file:{source_label}:{filename}"
+    return f"prompt_file:{filename}"
+
+
+def _read_prompt_file_text(path: str, *, source_label: str | None = None) -> str:
+    prompt_path = Path(path)
+    asset_id = _prompt_asset_id(path, source_label=source_label)
+    with open(path, "rb") as f:
+        raw = f.read()
+    metadata = {"path": prompt_path.name}
+    if source_label is not None:
+        metadata = {"path": str(prompt_path), "source_label": source_label}
+    current_digest = canonical_filesystem_digest(
+        source_type="prompt_file",
+        asset_id=asset_id,
+        files={prompt_path.name: raw},
+        metadata=metadata,
+    )
+    resolver = get_global_context_integrity_resolver()
+    if resolver is not None:
+        resolver.require_digest_allowed(
+            asset_id,
+            current_digest=current_digest,
+            purpose="prompt_load",
+        )
+    return raw.decode("utf-8")
+```
+
+Update `_load_env_prompt_file`, `_load_yaml`, `_load_json`, and markdown loading to read once through `_read_prompt_file_text`. Environment override files are prompt-bearing sources too; if enforcement is enabled and no manifest entry approves the override path, the resolver blocks them as `new_unapproved`.
+
+For environment override files:
+
+```python
+    try:
+        return _read_prompt_file_text(path, source_label=f"env:{env_name}").strip()
+    except (OSError, UnicodeDecodeError, ContextIntegrityBlocked) as exc:
+        logger.warning(
+            "Prompt override file read failed for env '{}' (module='{}', key='{}', error_type='{}')",
+            env_name,
+            module,
+            key,
+            exc.__class__.__name__,
+        )
+        return None
+```
+
+For YAML:
+
+```python
+raw = _read_prompt_file_text(path)
+data = yaml.safe_load(raw)
+```
+
+For JSON:
+
+```python
+raw = _read_prompt_file_text(path)
+data = json.loads(raw)
+```
+
+For markdown:
+
+```python
+try:
+    text = _read_prompt_file_text(md_path)
+except (OSError, UnicodeDecodeError, ContextIntegrityBlocked):
+    text = ""
+```
+
+Catch `ContextIntegrityBlocked` and `UnicodeDecodeError` in YAML/JSON helpers and return `None` without logging untrusted content. Because `_read_prompt_file_text` reads bytes once, computes the digest over those bytes, and returns the same bytes decoded to text, parsing cannot use a different file version than the resolver checked.
+
+- [ ] **Step 4: Run prompt loader tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Utils/test_prompt_loader_paths.py tldw_Server_API/tests/Utils/test_prompt_loader_env_overrides.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 7**
+
+```bash
+git add tldw_Server_API/app/core/Utils/prompt_loader.py \
+  tldw_Server_API/tests/Utils/test_prompt_loader_paths.py
+git commit -m "feat: enforce context integrity for prompt loader"
+```
+
+## Task 8: Admin Status And Findings Endpoint
+
+**Files:**
+- Create: `tldw_Server_API/app/api/v1/endpoints/admin/context_integrity.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/admin/__init__.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/admin_schemas.py`
+- Create: `tldw_Server_API/tests/AuthNZ_SQLite/test_admin_context_integrity_sqlite.py`
+
+- [ ] **Step 1: Write failing admin endpoint tests**
+
+Create `tldw_Server_API/tests/AuthNZ_SQLite/test_admin_context_integrity_sqlite.py`:
+
+```python
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _build_app(*, roles: list[str]) -> FastAPI:
+    from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+    from tldw_Server_API.app.api.v1.endpoints.admin import router as admin_router
+    from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
+
+    app = FastAPI()
+    app.include_router(admin_router, prefix="/api/v1")
+
+    async def _principal_override(request=None):  # type: ignore[override]
+        principal = AuthPrincipal(
+            kind="user",
+            user_id=1,
+            api_key_id=None,
+            subject="adminuser",
+            token_type="access",
+            jti=None,
+            roles=roles,
+            permissions=["system.configure"],
+            is_admin="admin" in roles,
+            org_ids=[],
+            team_ids=[],
+        )
+        if request is not None:
+            request.state.auth = AuthContext(principal=principal, ip=None, user_agent=None, request_id=None)
+        return principal
+
+    app.dependency_overrides[get_auth_principal] = _principal_override
+    return app
+
+
+def test_admin_context_integrity_returns_boot_state() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.models import (
+        ContextIntegrityBootState,
+        ContextIntegrityFinding,
+    )
+
+    app = _build_app(roles=["admin"])
+    app.state.context_integrity_boot_state = ContextIntegrityBootState(
+        mode="enforce",
+        degraded=False,
+        manifest_sequence=7,
+        manifest_digest="sha256:manifest",
+        findings=(
+            ContextIntegrityFinding(
+                asset_id="prompt_file:rag.prompts.yaml",
+                state="new_unapproved",
+                severity="warning",
+                summary="new",
+                remediation="review",
+                source_type="prompt_file",
+            ),
+        ),
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/api/v1/admin/context-integrity")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["scope"] == "current_process"
+    assert body["mode"] == "enforce"
+    assert body["manifest_sequence"] == 7
+    assert body["findings"][0]["asset_id"] == "prompt_file:rag.prompts.yaml"
+
+
+def test_admin_context_integrity_is_admin_only() -> None:
+    app = _build_app(roles=["user"])
+
+    with TestClient(app) as client:
+        response = client.get("/api/v1/admin/context-integrity")
+
+    assert response.status_code == 403
+```
+
+- [ ] **Step 2: Run failing admin tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/AuthNZ_SQLite/test_admin_context_integrity_sqlite.py -v
+```
+
+Expected: FAIL with 404 or missing schemas.
+
+- [ ] **Step 3: Add schemas**
+
+Append to `tldw_Server_API/app/api/v1/schemas/admin_schemas.py` near the startup warning schemas:
+
+```python
+class AdminContextIntegrityFinding(BaseModel):
+    """One current-process Context Integrity finding."""
+
+    asset_id: str
+    state: str
+    severity: str
+    summary: str
+    remediation: str
+    source_type: str
+    current_digest: str | None = None
+    approved_digest: str | None = None
+    details: dict[str, Any] = Field(default_factory=dict)
+    detected_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AdminContextIntegrityResponse(BaseModel):
+    """Current-process Context Integrity state for admin inspection."""
+
+    scope: Literal["current_process"] = "current_process"
+    mode: str
+    degraded: bool
+    manifest_sequence: int | None = None
+    manifest_digest: str | None = None
+    findings_present: bool
+    findings: list[AdminContextIntegrityFinding] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)
+```
+
+- [ ] **Step 4: Add endpoint and include router**
+
+Create `tldw_Server_API/app/api/v1/endpoints/admin/context_integrity.py`:
+
+```python
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
+    AdminContextIntegrityFinding,
+    AdminContextIntegrityResponse,
+)
+
+router = APIRouter()
+
+
+@router.get(
+    "/context-integrity",
+    response_model=AdminContextIntegrityResponse,
+)
+async def get_context_integrity_status(request: Request) -> AdminContextIntegrityResponse:
+    """Return current-process Context Integrity boot state."""
+    boot_state = getattr(request.app.state, "context_integrity_boot_state", None)
+    if boot_state is None:
+        return AdminContextIntegrityResponse(
+            mode="uninitialized",
+            degraded=True,
+            manifest_sequence=None,
+            manifest_digest=None,
+            findings_present=False,
+            findings=[],
+        )
+    findings = [
+        AdminContextIntegrityFinding.model_validate(finding)
+        for finding in boot_state.findings
+    ]
+    return AdminContextIntegrityResponse(
+        mode=str(boot_state.mode),
+        degraded=bool(boot_state.degraded),
+        manifest_sequence=boot_state.manifest_sequence,
+        manifest_digest=boot_state.manifest_digest,
+        findings_present=bool(findings),
+        findings=findings,
+    )
+```
+
+Modify `tldw_Server_API/app/api/v1/endpoints/admin/__init__.py`:
+
+```python
+from . import context_integrity as context_integrity_endpoints
+```
+
+and include:
+
+```python
+router.include_router(context_integrity_endpoints.router)
+```
+
+- [ ] **Step 5: Run admin tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_admin_context_integrity_sqlite.py \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_admin_startup_warnings_sqlite.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 8**
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/admin/context_integrity.py \
+  tldw_Server_API/app/api/v1/endpoints/admin/__init__.py \
+  tldw_Server_API/app/api/v1/schemas/admin_schemas.py \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_admin_context_integrity_sqlite.py
+git commit -m "feat: expose context integrity admin status"
+```
+
+## Task 9: Focused Integration And Security Verification
+
+**Files:**
+- Modify only files touched by prior tasks if verification reveals defects.
+
+- [ ] **Step 1: Run core Context Integrity tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Context_Integrity/unit -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run service and endpoint tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Services/test_startup_context_integrity.py \
+  tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_admin_context_integrity_sqlite.py \
+  tldw_Server_API/tests/Skills/unit/test_skills_service.py \
+  tldw_Server_API/tests/Skills/integration/test_skills_api.py \
+  tldw_Server_API/tests/Utils/test_prompt_loader_paths.py \
+  tldw_Server_API/tests/Utils/test_prompt_loader_env_overrides.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run Bandit on touched Python scope**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m bandit -r \
+  tldw_Server_API/app/core/Context_Integrity \
+  tldw_Server_API/app/services/startup_context_integrity.py \
+  tldw_Server_API/app/services/lifespan_startup_sequence.py \
+  tldw_Server_API/app/core/Skills/skills_service.py \
+  tldw_Server_API/app/api/v1/endpoints/skills.py \
+  tldw_Server_API/app/core/Utils/prompt_loader.py \
+  tldw_Server_API/app/api/v1/endpoints/admin/context_integrity.py \
+  -f json -o /tmp/bandit_context_integrity_foundation.json
+```
+
+Expected: exit 0 or only pre-existing accepted findings outside changed code. Fix any new findings in touched code before continuing.
+
+- [ ] **Step 4: Commit verification fixes if needed**
+
+If Step 1, 2, or 3 required code fixes:
+
+```bash
+git add <fixed-files>
+git commit -m "fix: stabilize context integrity foundation"
+```
+
+If no fixes were needed, do not create an empty commit.
+
+## Follow-Up Plan Boundaries
+
+This plan intentionally makes DB prompt-version and MCP prompt-catalog enforcement pluggable but does not fully enforce them. After this foundation lands, create separate implementation plans for:
+
+1. DB prompt-version inventory and approval workflow in `Prompts_DB` and prompt APIs.
+2. MCP prompt-catalog resolver checks in `tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_catalog.py`.
+3. OS/hardware-backed key provider integration beyond the first HMAC signer.
+4. Admin approval/import/export endpoints for signed manifest lifecycle.
+5. Frontend review UI for source-grouped baseline approval and canonical diffs.
+
+## Plan Self-Review
+
+Spec coverage:
+
+- Threat model and degraded integrity: Tasks 2, 3, 5, 8, and 9.
+- Canonical hashing: Task 1.
+- Signed manifest and anti-rollback: Task 2.
+- Resolver and TOCTOU-safe runtime use: Tasks 3, 6, and 7.
+- Startup warnings: Task 5.
+- Skills enforcement: Task 6.
+- Prompt loader enforcement: Task 7.
+- Admin status/audit visibility: Task 8.
+- Security verification: Task 9.
+- DB/MCP/full manifest lifecycle: explicitly bounded follow-up plans so the first slice remains reviewable.
+
+Red-flag term scan:
+
+- No banned planning-token sections are intentionally present.
+- Commands include exact paths and expected outcomes.
+
+Type consistency:
+
+- `ContextIntegrityBootState`, `ContextIntegrityFinding`, `ContextIntegrityResolver`, `ContextIntegrityBlocked`, and `ContextAssetDescriptor` are introduced before later tasks use them.
+- Asset IDs use `skill:user:{user_id}/{skill_name}` and `prompt_file:{filename}` consistently across tests, resolver checks, and inventory adapters.
+
+Verification for this plan artifact:
+
+- Documentation-only plan creation. Run `rg -n "TB[D]|TO[D]O|FIXM[E]|placeholde[r]|implement late[r]|fill in detail[s]|add appropriat[e]|handle edge case[s]|Write tests for the abov[e]|Similar t[o]" Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md` after saving.
+- Bandit is not applicable to this plan artifact itself; implementation tasks include Bandit for touched Python code.

--- a/Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
@@ -1243,6 +1243,8 @@ git commit -m "feat: add context integrity filesystem inventory"
 
 ## Task 5: Startup Verification Producer
 
+**Status**: Complete. Implemented in `9727db3f28` with no-create discovery review fix in `a14388fd51`.
+
 **Files:**
 - Create: `tldw_Server_API/app/services/startup_context_integrity.py`
 - Modify: `tldw_Server_API/app/services/lifespan_startup_sequence.py`
@@ -1616,6 +1618,14 @@ git commit -m "feat: wire context integrity startup checks"
 ```
 
 ## Task 6: Skills Enforcement
+
+**Status**: Complete. Implemented with an additional manual review correction: default `SkillsService` instances now honor degraded global resolver state, and symlinked skill directories are skipped/rejected at runtime.
+
+**Verification**:
+- RED run for review regressions: `.venv/bin/python -m pytest tldw_Server_API/tests/Skills/unit/test_skills_service.py::TestSkillsService::test_degraded_global_resolver_blocks_default_service tldw_Server_API/tests/Skills/unit/test_skills_service.py::TestSkillsService::test_symlinked_skill_directory_is_not_read_without_resolver -q` failed before the correction with both tests failing.
+- Focused Task 6 suite: `.venv/bin/python -m pytest tldw_Server_API/tests/Skills/unit/test_skills_service.py tldw_Server_API/tests/Skills/integration/test_skills_api.py tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py -q` passed with `133 passed, 6 warnings`.
+- Bandit: `.venv/bin/python -m bandit -r tldw_Server_API/app/core/Skills/skills_service.py tldw_Server_API/app/core/Skills/context_integration.py tldw_Server_API/app/core/Chat/command_router.py tldw_Server_API/app/api/v1/endpoints/skills.py -f json -o /tmp/bandit_context_integrity_task6.json` exited 0 with zero findings.
+- Formatter/whitespace: `.venv/bin/python -m black ...` completed; `git diff --check` clean.
 
 **Files:**
 - Modify: `tldw_Server_API/app/core/Skills/skills_service.py`

--- a/Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
@@ -2590,6 +2590,13 @@ git commit -m "feat: expose context integrity admin status"
 
 ## Task 9: Focused Integration And Security Verification
 
+**Status**: Complete. No verification fixes were needed.
+
+**Verification**:
+- Core Context Integrity unit suite: `.venv/bin/python -m pytest tldw_Server_API/tests/Context_Integrity/unit -q` passed with `116 passed, 6 warnings`.
+- Broader focused suite: `.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_context_integrity.py tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/AuthNZ_SQLite/test_admin_context_integrity_sqlite.py tldw_Server_API/tests/Skills/unit/test_skills_service.py tldw_Server_API/tests/Skills/integration/test_skills_api.py tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py tldw_Server_API/tests/Utils/test_prompt_loader_paths.py tldw_Server_API/tests/Utils/test_prompt_loader_env_overrides.py -q` passed with `158 passed, 7 warnings`.
+- Combined Bandit touched scope: `.venv/bin/python -m bandit -r tldw_Server_API/app/core/Context_Integrity tldw_Server_API/app/services/startup_context_integrity.py tldw_Server_API/app/services/lifespan_startup_sequence.py tldw_Server_API/app/services/lifespan_shutdown_sequence.py tldw_Server_API/app/core/Skills/skills_service.py tldw_Server_API/app/core/Skills/context_integration.py tldw_Server_API/app/core/Chat/command_router.py tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/core/Utils/prompt_loader.py tldw_Server_API/app/api/v1/endpoints/admin/context_integrity.py -f json -o /tmp/bandit_context_integrity_foundation.json` exited 0 with zero findings.
+
 **Files:**
 - Modify only files touched by prior tasks if verification reveals defects.
 

--- a/Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
@@ -4,6 +4,8 @@
 
 **Goal:** Build the first enforceable Context Integrity foundation for prompt-bearing assets, proving signed manifests, anti-rollback policy, quarantine resolution, startup warnings, Skills enforcement, and config prompt-loader enforcement.
 
+**Backlog:** Design `TASK-2363`; implementation planning `TASK-2365`; create or reuse a new implementation Backlog task before code edits.
+
 **Architecture:** Add a focused `tldw_Server_API.app.core.Context_Integrity` package with pure canonicalization, manifest, verifier, resolver, and inventory modules. Wire it into startup through the existing `StartupWarningRegistry`, expose admin status/findings through the existing admin router, and add thin resolver checks to Skills and prompt loading. This first slice protects filesystem skills and config prompt files; DB prompt-version and MCP prompt-catalog enforcement are represented by interfaces and explicit follow-up tests so they can plug into the same resolver without changing the core model.
 
 **Tech Stack:** Python 3.10+, FastAPI, Pydantic, Loguru, SQLite-backed existing DB layers, pytest, Bandit.
@@ -33,6 +35,7 @@ Create:
 Modify:
 
 - `tldw_Server_API/app/services/lifespan_startup_sequence.py` - call the Context Integrity startup producer after core initialization and before startup blockers are evaluated.
+- `tldw_Server_API/app/services/lifespan_shutdown_sequence.py` - clear global Context Integrity resolver state during shutdown.
 - `tldw_Server_API/app/api/v1/endpoints/admin/__init__.py` - include the admin Context Integrity router.
 - `tldw_Server_API/app/api/v1/schemas/admin_schemas.py` - add admin response schemas for current-process Context Integrity status.
 - `tldw_Server_API/app/core/Skills/skills_service.py` - add resolver dependency, filter quarantined skills from listings/context, and block direct content/execution access.
@@ -41,6 +44,24 @@ Modify:
 - `tldw_Server_API/tests/Skills/unit/test_skills_service.py` - cover quarantined skill filtering and blocking.
 - `tldw_Server_API/tests/Skills/integration/test_skills_api.py` - cover API error mapping for quarantined skills.
 - `tldw_Server_API/tests/Utils/test_prompt_loader_paths.py` - cover prompt-loader quarantine blocking and at-use verified bytes behavior.
+
+## Pre-Execution Review Amendments
+
+The following review fixes supersede any narrower snippets later in this plan:
+
+- New code must preserve Python 3.10 support. Use `datetime.now(timezone.utc)`, not `datetime.UTC`.
+- Startup must distinguish "no manifest loaded" from "valid empty manifest." No manifest means `degraded=True`, a `degraded_integrity` finding, and runtime context/execution reads fail closed.
+- Runtime resolver checks must fail closed for:
+  - any non-`audit_only` degraded state except static admin inspection paths;
+  - assets with no approved digest in the verified boot state;
+  - at-use digest mismatches.
+- Skills discovery/context paths must rehash the exact current skill file map and call `require_digest_allowed()`. A skill added or modified after startup must not appear in `available_skills`, skill tool availability, or system-message context.
+- Skills write paths (`create_skill`, `update_skill`, `import_skill`, `import_from_zip`) must still succeed under enforcement by returning a write-response snapshot that is not eligible for injection/execution until approved. Do not route write responses through the normal guarded `get_skill()` path.
+- Startup must discover existing user skill roots from `DatabasePaths.get_user_db_base_dir(allow_legacy_alias=True)` in addition to test-injected roots.
+- Inventory must not follow symlinks outside the asset root. Unreadable files, path escapes, and permission errors should emit `verification_error` findings and quarantine the narrowest asset/scope, not crash startup.
+- API and chat/tool paths that expose or execute full skill content must map `ContextIntegrityBlocked` to stable content-free failures, including direct get, execute, export, `context_integration.handle_skill_tool_call()`, `add_skill_tool_to_tools_list()`, and chat slash-command execution.
+- Environment prompt override files are protected only after they are inventoried. This slice should inventory currently configured `TLDW_PROMPT_FILE_*` paths; otherwise they must be explicitly excluded from enforcement. The plan chooses inventory.
+- The global resolver must be cleared during lifespan shutdown/test cleanup. App-state resolver injection remains preferred for request services; the global resolver is only a compatibility bridge for current non-request prompt loading.
 
 ## Task 1: Canonical Asset Models And Hashing
 
@@ -99,12 +120,12 @@ def test_filesystem_digest_detects_formatting_edits() -> None:
 
     original = canonical_filesystem_digest(
         source_type="prompt_file",
-        asset_id="config_prompt:rag.prompts.yaml",
+        asset_id="prompt_file:rag.prompts.yaml",
         files={"rag.prompts.yaml": b"answer: one\n"},
     )
     edited = canonical_filesystem_digest(
         source_type="prompt_file",
-        asset_id="config_prompt:rag.prompts.yaml",
+        asset_id="prompt_file:rag.prompts.yaml",
         files={"rag.prompts.yaml": b"answer: one\n# changed\n"},
     )
 
@@ -162,7 +183,7 @@ Create `tldw_Server_API/app/core/Context_Integrity/models.py`:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any, Literal
 
 ContextAssetSource = Literal["skill_file", "prompt_file", "db_prompt"]
@@ -220,7 +241,7 @@ class ContextIntegrityFinding:
     current_digest: str | None = None
     approved_digest: str | None = None
     details: dict[str, Any] = field(default_factory=dict)
-    detected_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    detected_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 @dataclass(frozen=True, slots=True)
@@ -717,6 +738,52 @@ def test_resolver_detects_live_digest_mismatch_at_use() -> None:
         )
 
 
+def test_resolver_blocks_unknown_asset_in_enforce_mode() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.models import ContextIntegrityBootState
+    from tldw_Server_API.app.core.Context_Integrity.resolver import (
+        ContextIntegrityBlocked,
+        ContextIntegrityResolver,
+    )
+
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="enforce",
+            degraded=False,
+            manifest_sequence=1,
+            manifest_digest="sha256:manifest",
+            approved_digests_by_asset_id={"skill:user:1/known": "sha256:approved"},
+        )
+    )
+
+    with pytest.raises(ContextIntegrityBlocked) as exc_info:
+        resolver.require_allowed("skill:user:1/live-added", purpose="skill_discovery")
+
+    assert exc_info.value.state == "new_unapproved"
+
+
+def test_resolver_blocks_degraded_injection_use() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.models import ContextIntegrityBootState
+    from tldw_Server_API.app.core.Context_Integrity.resolver import (
+        ContextIntegrityBlocked,
+        ContextIntegrityResolver,
+    )
+
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="enforce",
+            degraded=True,
+            manifest_sequence=None,
+            manifest_digest=None,
+            approved_digests_by_asset_id={"prompt_file:demo.prompts.md": "sha256:approved"},
+        )
+    )
+
+    with pytest.raises(ContextIntegrityBlocked) as exc_info:
+        resolver.require_allowed("prompt_file:demo.prompts.md", purpose="prompt_load")
+
+    assert exc_info.value.state == "degraded_integrity"
+
+
 def test_resolver_allows_matching_digest_at_use() -> None:
     from tldw_Server_API.app.core.Context_Integrity.models import ContextIntegrityBootState
     from tldw_Server_API.app.core.Context_Integrity.resolver import ContextIntegrityResolver
@@ -886,14 +953,28 @@ class ContextIntegrityResolver:
         return self._findings_by_asset_id.get(asset_id)
 
     def require_allowed(self, asset_id: str, *, purpose: str) -> None:
+        if self.boot_state.mode != "audit_only" and self.boot_state.degraded:
+            if not purpose.startswith("admin_review"):
+                raise ContextIntegrityBlocked(asset_id=asset_id, state="degraded_integrity")
         finding = self.finding_for(asset_id)
         if finding is None:
+            if self.boot_state.mode == "audit_only":
+                return
+            if asset_id not in self.boot_state.approved_digests_by_asset_id:
+                raise ContextIntegrityBlocked(asset_id=asset_id, state="new_unapproved")
             return
         if self.boot_state.mode == "audit_only":
             return
         raise ContextIntegrityBlocked(asset_id=asset_id, state=finding.state)
 
-    def require_digest_allowed(self, asset_id: str, *, current_digest: str, purpose: str) -> None:
+    def require_digest_allowed(
+        self,
+        asset_id: str,
+        *,
+        current_digest: str,
+        purpose: str,
+        changed_state: str = "changed_approved_executable",
+    ) -> None:
         self.require_allowed(asset_id, purpose=purpose)
         if self.boot_state.mode == "audit_only":
             return
@@ -901,7 +982,7 @@ class ContextIntegrityResolver:
         if approved_digest is None:
             raise ContextIntegrityBlocked(asset_id=asset_id, state="new_unapproved")
         if approved_digest != current_digest:
-            raise ContextIntegrityBlocked(asset_id=asset_id, state="changed_approved_executable")
+            raise ContextIntegrityBlocked(asset_id=asset_id, state=changed_state)
 
 
 _global_resolver: ContextIntegrityResolver | None = None
@@ -985,6 +1066,22 @@ def test_inventory_prompt_files_finds_supported_extensions(tmp_path) -> None:
 
     assert [asset.asset_id for asset in assets] == ["prompt_file:rag.prompts.yaml"]
     assert assets[0].executable is False
+
+
+def test_inventory_env_prompt_overrides_finds_configured_files(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import inventory_env_prompt_overrides
+
+    override = tmp_path / "override.md"
+    override.write_text("override prompt", encoding="utf-8")
+
+    assets = inventory_env_prompt_overrides(
+        environ={"TLDW_PROMPT_FILE_CHAT__SYSTEM": str(override)}
+    )
+
+    assert [asset.asset_id for asset in assets] == [
+        "prompt_file:env:TLDW_PROMPT_FILE_CHAT__SYSTEM:override.md"
+    ]
+    assert assets[0].metadata["source_label"] == "env:TLDW_PROMPT_FILE_CHAT__SYSTEM"
 ```
 
 - [ ] **Step 2: Run failing inventory tests**
@@ -1006,7 +1103,9 @@ Create `tldw_Server_API/app/core/Context_Integrity/inventory.py`:
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from typing import Mapping
 
 from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
     canonical_filesystem_digest,
@@ -1086,6 +1185,42 @@ def inventory_prompt_files(*, prompts_dir: Path) -> list[ContextAssetDescriptor]
             )
         )
     return assets
+
+
+def inventory_env_prompt_overrides(
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> list[ContextAssetDescriptor]:
+    """Inventory configured prompt override files from TLDW_PROMPT_FILE_* vars."""
+    source = environ if environ is not None else os.environ
+    assets: list[ContextAssetDescriptor] = []
+    for env_name, raw_path in sorted(source.items()):
+        if not env_name.startswith("TLDW_PROMPT_FILE_") or not raw_path.strip():
+            continue
+        path = Path(raw_path).expanduser()
+        if not path.is_file():
+            continue
+        source_label = f"env:{env_name}"
+        asset_id = f"prompt_file:{source_label}:{path.name}"
+        digest = canonical_filesystem_digest(
+            source_type="prompt_file",
+            asset_id=asset_id,
+            files={path.name: path.read_bytes()},
+            metadata={"path": str(path), "source_label": source_label},
+        )
+        assets.append(
+            ContextAssetDescriptor(
+                asset_id=asset_id,
+                source_type="prompt_file",
+                digest=digest,
+                display_name=env_name,
+                executable=False,
+                owner_scope="system",
+                path=str(path),
+                metadata={"source_label": source_label},
+            )
+        )
+    return assets
 ```
 
 - [ ] **Step 4: Run inventory tests**
@@ -1111,6 +1246,7 @@ git commit -m "feat: add context integrity filesystem inventory"
 **Files:**
 - Create: `tldw_Server_API/app/services/startup_context_integrity.py`
 - Modify: `tldw_Server_API/app/services/lifespan_startup_sequence.py`
+- Modify: `tldw_Server_API/app/services/lifespan_shutdown_sequence.py`
 - Create: `tldw_Server_API/tests/Services/test_startup_context_integrity.py`
 - Modify: `tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py`
 
@@ -1150,8 +1286,10 @@ def test_startup_context_integrity_sets_resolver_and_warning(tmp_path, monkeypat
         mode="enforce",
     )
 
-    assert len(findings) == 1
-    assert registry.summary(component_prefix="context_integrity")["total"] == 1
+    assert len(findings) == 2
+    assert registry.summary(component_prefix="context_integrity")["total"] == 2
+    assert app_state.context_integrity_boot_state.degraded is True
+    assert any(finding.state == "degraded_integrity" for finding in findings)
     assert app_state.context_integrity_resolver.finding_for("prompt_file:rag.prompts.yaml") is not None
 ```
 
@@ -1174,12 +1312,16 @@ Create `tldw_Server_API/app/services/startup_context_integrity.py`:
 
 from __future__ import annotations
 
+import json
+import os
 from pathlib import Path
 from typing import Iterable, Mapping
 
 from loguru import logger
 
+from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Context_Integrity.inventory import (
+    inventory_env_prompt_overrides,
     inventory_prompt_files,
     inventory_user_skills,
 )
@@ -1187,6 +1329,10 @@ from tldw_Server_API.app.core.Context_Integrity.models import (
     ContextAssetDescriptor,
     ContextIntegrityBootState,
     ContextIntegrityFinding,
+)
+from tldw_Server_API.app.core.Context_Integrity.manifest import (
+    HmacManifestSigner,
+    verify_signed_manifest,
 )
 from tldw_Server_API.app.core.Context_Integrity.resolver import (
     ContextIntegrityResolver,
@@ -1196,6 +1342,63 @@ from tldw_Server_API.app.core.Context_Integrity.verifier import verify_inventory
 from tldw_Server_API.app.core.config_paths import resolve_prompts_dir
 from tldw_Server_API.app.services.startup_warning_models import StartupWarningRecord
 from tldw_Server_API.app.services.startup_warning_registry import StartupWarningRegistry
+
+
+def _load_startup_manifest_from_env() -> tuple[
+    tuple[Mapping[str, object], ...],
+    int | None,
+    str | None,
+    bool,
+    ContextIntegrityFinding | None,
+]:
+    """Load an operator-provided signed manifest from environment configuration."""
+    manifest_path = os.getenv("CONTEXT_INTEGRITY_MANIFEST_PATH")
+    secret = os.getenv("CONTEXT_INTEGRITY_HMAC_SECRET")
+    key_id = os.getenv("CONTEXT_INTEGRITY_HMAC_KEY_ID") or "local-hmac"
+    if not manifest_path or not secret:
+        return (), None, None, False, None
+    try:
+        signed_manifest = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+        verified = verify_signed_manifest(
+            signed_manifest,
+            signer=HmacManifestSigner(key_id=key_id, secret=secret.encode("utf-8")),
+        )
+        return verified.entries, verified.sequence, verified.manifest_digest, True, None
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        return (
+            (),
+            None,
+            None,
+            False,
+            ContextIntegrityFinding(
+                asset_id="manifest:env",
+                state="signature_invalid",
+                severity="error",
+                summary="Configured Context Integrity manifest could not be verified.",
+                remediation="Fix the manifest path/key or import a valid admin-held manifest.",
+                source_type="manifest",
+                details={"error_type": exc.__class__.__name__},
+            ),
+        )
+
+
+def _discover_user_skill_roots() -> list[tuple[int, Path]]:
+    """Discover existing per-user skill roots without creating directories."""
+    roots: list[tuple[int, Path]] = []
+    try:
+        base_dir = DatabasePaths.get_user_db_base_dir(allow_legacy_alias=True)
+    except Exception as exc:
+        logger.warning("Context Integrity could not discover user skill roots: {}", exc)
+        return roots
+    if not base_dir.exists():
+        return roots
+    for user_dir in sorted(path for path in base_dir.iterdir() if path.is_dir()):
+        if not user_dir.name.isdigit():
+            continue
+        skills_root = user_dir / "skills"
+        if skills_root.is_dir():
+            roots.append((int(user_dir.name), skills_root))
+    return roots
 
 
 def _finding_to_warning(finding: ContextIntegrityFinding) -> StartupWarningRecord:
@@ -1221,27 +1424,93 @@ def produce_context_integrity_startup_warnings(
     app_state: object,
     registry: StartupWarningRegistry,
     prompts_dir: Path | None = None,
-    user_skill_roots: Iterable[tuple[int, Path]] = (),
-    approved_entries: Iterable[Mapping[str, object]] = (),
+    user_skill_roots: Iterable[tuple[int, Path]] | None = None,
+    approved_entries: Iterable[Mapping[str, object]] | None = None,
+    manifest_loaded: bool | None = None,
+    manifest_sequence: int | None = None,
+    manifest_digest: str | None = None,
     mode: str = "enforce",
 ) -> tuple[ContextIntegrityFinding, ...]:
     """Build startup inventory, register warnings, and attach resolver state."""
     current_assets: list[ContextAssetDescriptor] = []
-    current_assets.extend(inventory_prompt_files(prompts_dir=prompts_dir or resolve_prompts_dir()))
-    for user_id, skills_root in user_skill_roots:
-        current_assets.extend(inventory_user_skills(user_id=user_id, skills_root=skills_root))
+    inventory_findings: list[ContextIntegrityFinding] = []
+    try:
+        current_assets.extend(inventory_prompt_files(prompts_dir=prompts_dir or resolve_prompts_dir()))
+        current_assets.extend(inventory_env_prompt_overrides())
+    except OSError as exc:
+        inventory_findings.append(
+            ContextIntegrityFinding(
+                asset_id="prompt_file:*",
+                state="verification_error",
+                severity="error",
+                summary="Prompt file inventory failed.",
+                remediation="Fix file permissions or remove unsafe prompt paths, then restart.",
+                source_type="prompt_file",
+                details={"error_type": exc.__class__.__name__},
+            )
+        )
+    roots = list(user_skill_roots) if user_skill_roots is not None else _discover_user_skill_roots()
+    for user_id, skills_root in roots:
+        try:
+            current_assets.extend(inventory_user_skills(user_id=user_id, skills_root=skills_root))
+        except OSError as exc:
+            inventory_findings.append(
+                ContextIntegrityFinding(
+                    asset_id=f"skill:user:{user_id}:*",
+                    state="verification_error",
+                    severity="error",
+                    summary=f"Skill inventory failed for user {user_id}.",
+                    remediation="Fix file permissions or remove unsafe skill paths, then restart.",
+                    source_type="skill_file",
+                    details={"error_type": exc.__class__.__name__},
+                )
+            )
 
-    findings = verify_inventory(current_assets=current_assets, approved_entries=approved_entries)
+    manifest_finding: ContextIntegrityFinding | None = None
+    if approved_entries is None:
+        (
+            approved_entries_tuple,
+            manifest_sequence,
+            manifest_digest,
+            loaded_from_env,
+            manifest_finding,
+        ) = _load_startup_manifest_from_env()
+        manifest_loaded = loaded_from_env
+    else:
+        approved_entries_tuple = tuple(approved_entries)
+        manifest_loaded = bool(manifest_loaded)
+    findings_list = list(inventory_findings)
+    if manifest_finding is not None:
+        findings_list.append(manifest_finding)
+    findings_list.extend(
+        verify_inventory(
+            current_assets=current_assets,
+            approved_entries=approved_entries_tuple,
+        )
+    )
+    degraded = not manifest_loaded
+    if degraded:
+        findings_list.append(
+            ContextIntegrityFinding(
+                asset_id="manifest:none",
+                state="degraded_integrity",
+                severity="error",
+                summary="No approved Context Integrity manifest was loaded.",
+                remediation="Import or approve a signed manifest before protected assets are used.",
+                source_type="manifest",
+            )
+        )
+    findings = tuple(findings_list)
     approved_digests_by_asset_id = {
         str(entry["asset_id"]): str(entry["digest"])
-        for entry in approved_entries
+        for entry in approved_entries_tuple
         if "asset_id" in entry and "digest" in entry
     }
     boot_state = ContextIntegrityBootState(
         mode=mode,  # type: ignore[arg-type]
-        degraded=False,
-        manifest_sequence=None,
-        manifest_digest=None,
+        degraded=degraded,
+        manifest_sequence=manifest_sequence,
+        manifest_digest=manifest_digest,
         approved_digests_by_asset_id=approved_digests_by_asset_id,
         findings=findings,
     )
@@ -1280,7 +1549,26 @@ def _run_startup_warning_producers(*, app: Any, startup_core_handles: Any) -> No
     )
 ```
 
-- [ ] **Step 5: Update lifespan test expectation**
+- [ ] **Step 5: Clear resolver on shutdown**
+
+Modify `tldw_Server_API/app/services/lifespan_shutdown_sequence.py` near the start of `run_lifespan_shutdown_sequence`:
+
+```python
+    try:
+        from tldw_Server_API.app.core.Context_Integrity.resolver import (
+            clear_global_context_integrity_resolver,
+        )
+
+        clear_global_context_integrity_resolver()
+        if hasattr(app.state, "context_integrity_resolver"):
+            delattr(app.state, "context_integrity_resolver")
+        if hasattr(app.state, "context_integrity_boot_state"):
+            delattr(app.state, "context_integrity_boot_state")
+    except startup_guard_exceptions:
+        pass
+```
+
+- [ ] **Step 6: Update lifespan test expectation**
 
 Modify `test_startup_initializes_registry_and_runs_sandbox_producer` in `tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py` to monkeypatch the new producer:
 
@@ -1302,25 +1590,28 @@ monkeypatch.setattr(
 assert context_calls == [{"app_state": app.state, "registry": registry}]
 ```
 
-- [ ] **Step 6: Run startup tests**
+- [ ] **Step 7: Run startup tests**
 
 Run:
 
 ```bash
 source .venv/bin/activate && python -m pytest \
   tldw_Server_API/tests/Services/test_startup_context_integrity.py \
-  tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py -v
+  tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py \
+  tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py -v
 ```
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit Task 5**
+- [ ] **Step 8: Commit Task 5**
 
 ```bash
 git add tldw_Server_API/app/services/startup_context_integrity.py \
   tldw_Server_API/app/services/lifespan_startup_sequence.py \
+  tldw_Server_API/app/services/lifespan_shutdown_sequence.py \
   tldw_Server_API/tests/Services/test_startup_context_integrity.py \
-  tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py
+  tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py \
+  tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py
 git commit -m "feat: wire context integrity startup checks"
 ```
 
@@ -1328,9 +1619,13 @@ git commit -m "feat: wire context integrity startup checks"
 
 **Files:**
 - Modify: `tldw_Server_API/app/core/Skills/skills_service.py`
+- Modify: `tldw_Server_API/app/core/Skills/context_integration.py`
+- Modify: `tldw_Server_API/app/core/Chat/command_router.py`
 - Modify: `tldw_Server_API/app/api/v1/endpoints/skills.py`
 - Modify: `tldw_Server_API/tests/Skills/unit/test_skills_service.py`
 - Modify: `tldw_Server_API/tests/Skills/integration/test_skills_api.py`
+- Modify: `tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py`
+- Modify: `tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py`
 
 - [ ] **Step 1: Add failing service tests for quarantined skills**
 
@@ -1430,6 +1725,58 @@ Append to `TestSkillsService` in `tldw_Server_API/tests/Skills/unit/test_skills_
 
         with pytest.raises(ContextIntegrityBlocked):
             await service.get_skill("live-skill")
+
+    @pytest.mark.asyncio
+    async def test_live_skill_edit_after_boot_is_filtered_from_context(self, service):
+        from tldw_Server_API.app.core.Context_Integrity.inventory import inventory_user_skills
+        from tldw_Server_API.app.core.Context_Integrity.models import ContextIntegrityBootState
+        from tldw_Server_API.app.core.Context_Integrity.resolver import ContextIntegrityResolver
+
+        await service.create_skill("context-skill", "---\ndescription: Safe\n---\nOriginal")
+        asset = inventory_user_skills(user_id=1, skills_root=service.skills_dir)[0]
+        service.integrity_resolver = ContextIntegrityResolver(
+            ContextIntegrityBootState(
+                mode="enforce",
+                degraded=False,
+                manifest_sequence=1,
+                manifest_digest="sha256:manifest",
+                approved_digests_by_asset_id={asset.asset_id: asset.digest},
+            )
+        )
+        (service.skills_dir / "context-skill" / "SKILL.md").write_text(
+            "---\ndescription: Backdoored\n---\nModified",
+            encoding="utf-8",
+        )
+
+        payload = service.get_context_payload()
+
+        assert payload["available_skills"] == []
+        assert "Backdoored" not in payload["context_text"]
+
+    @pytest.mark.asyncio
+    async def test_create_skill_returns_write_response_under_enforce(self, service):
+        from tldw_Server_API.app.core.Context_Integrity.models import ContextIntegrityBootState
+        from tldw_Server_API.app.core.Context_Integrity.resolver import (
+            ContextIntegrityBlocked,
+            ContextIntegrityResolver,
+        )
+
+        service.integrity_resolver = ContextIntegrityResolver(
+            ContextIntegrityBootState(
+                mode="enforce",
+                degraded=False,
+                manifest_sequence=1,
+                manifest_digest="sha256:manifest",
+                approved_digests_by_asset_id={},
+            )
+        )
+
+        created = await service.create_skill("pending-skill", "---\ndescription: Pending\n---\nBody")
+
+        assert created["name"] == "pending-skill"
+        assert created["description"] == "Pending"
+        with pytest.raises(ContextIntegrityBlocked):
+            await service.get_skill("pending-skill")
 ```
 
 - [ ] **Step 2: Run failing skills service tests**
@@ -1440,7 +1787,9 @@ Run:
 source .venv/bin/activate && python -m pytest \
   tldw_Server_API/tests/Skills/unit/test_skills_service.py::TestSkillsService::test_quarantined_skill_is_filtered_from_context \
   tldw_Server_API/tests/Skills/unit/test_skills_service.py::TestSkillsService::test_quarantined_skill_get_is_blocked \
-  tldw_Server_API/tests/Skills/unit/test_skills_service.py::TestSkillsService::test_live_skill_edit_after_boot_is_blocked -v
+  tldw_Server_API/tests/Skills/unit/test_skills_service.py::TestSkillsService::test_live_skill_edit_after_boot_is_blocked \
+  tldw_Server_API/tests/Skills/unit/test_skills_service.py::TestSkillsService::test_live_skill_edit_after_boot_is_filtered_from_context \
+  tldw_Server_API/tests/Skills/unit/test_skills_service.py::TestSkillsService::test_create_skill_returns_write_response_under_enforce -v
 ```
 
 Expected: FAIL because `SkillsService` does not have integrity resolver logic.
@@ -1500,9 +1849,16 @@ Add helper methods:
         if self.integrity_resolver is None:
             return True
         try:
-            self.integrity_resolver.require_allowed(self._skill_asset_id(name), purpose=purpose)
+            skill_dir = self._get_skill_dir(name)
+            files = self._read_skill_file_map(skill_dir)
+            current_digest = self._skill_digest(name, skill_dir, files)
+            self.integrity_resolver.require_digest_allowed(
+                self._skill_asset_id(name),
+                current_digest=current_digest,
+                purpose=purpose,
+            )
             return True
-        except ContextIntegrityBlocked:
+        except (ContextIntegrityBlocked, OSError, UnicodeDecodeError):
             return False
 
     def _require_skill_allowed(
@@ -1523,12 +1879,16 @@ Add helper methods:
                     purpose=purpose,
                 )
 
-    def _parse_verified_skill_directory(self, name: str, skill_dir: Path):
-        files = self._read_skill_file_map(skill_dir)
+    def _parse_unchecked_skill_directory(
+        self,
+        name: str,
+        skill_dir: Path,
+        files: dict[str, bytes] | None = None,
+    ):
+        if files is None:
+            files = self._read_skill_file_map(skill_dir)
         if "SKILL.md" not in files:
             raise SkillNotFoundError(name, detail="SKILL.md not found")
-        current_digest = self._skill_digest(name, skill_dir, files)
-        self._require_skill_allowed(name, purpose="skill_read", current_digest=current_digest)
         raw_skill = files["SKILL.md"].decode("utf-8")
         parsed = self._parser.parse_content(raw_skill, default_name=name)
         parsed.supporting_files = {
@@ -1537,9 +1897,17 @@ Add helper methods:
             if relative_path != "SKILL.md"
         }
         return parsed
+
+    def _parse_verified_skill_directory(self, name: str, skill_dir: Path):
+        files = self._read_skill_file_map(skill_dir)
+        current_digest = self._skill_digest(name, skill_dir, files)
+        self._require_skill_allowed(name, purpose="skill_read", current_digest=current_digest)
+        return self._parse_unchecked_skill_directory(name, skill_dir, files=files)
 ```
 
-In `get_skill`, replace `self._parser.parse_directory(skill_dir)` with `self._parse_verified_skill_directory(name, skill_dir)`. This reads the files once, hashes those exact bytes, asks the resolver about that digest, and parses only the already-read content.
+Add an `enforce_integrity: bool = True` keyword-only parameter to `get_skill`. When `True`, replace `self._parser.parse_directory(skill_dir)` with `self._parse_verified_skill_directory(name, skill_dir)`. When `False`, use `_parse_unchecked_skill_directory(name, skill_dir)` and return the response only to the write caller.
+
+Update `create_skill`, `update_skill`, `import_skill`, and `import_from_zip` write-return paths to call `await self.get_skill(name, enforce_integrity=False)` after a successful write. Direct API reads, execution, exports, context injection, and tool use must keep the default `enforce_integrity=True`.
 
 Filter `list_skills`, `get_context_payload`, and `get_context_payload_async` so blocked skills are excluded:
 
@@ -1559,7 +1927,7 @@ Modify `tldw_Server_API/app/api/v1/endpoints/skills.py` imports:
 from tldw_Server_API.app.core.Context_Integrity.resolver import ContextIntegrityBlocked
 ```
 
-In `get_skill` and `execute_skill`, add:
+In `get_skill`, `export_skill`, and `execute_skill`, add:
 
 ```python
     except ContextIntegrityBlocked as e:
@@ -1587,6 +1955,131 @@ Append to `tldw_Server_API/tests/Skills/integration/test_skills_api.py`:
 
         assert response.status_code == 423
         assert response.json()["detail"] == "Asset is quarantined pending admin review."
+
+    def test_export_quarantined_skill_returns_423(self, client, monkeypatch):
+        from tldw_Server_API.app.core.Context_Integrity.resolver import ContextIntegrityBlocked
+        from tldw_Server_API.app.core.Skills.skills_service import SkillsService
+
+        async def _blocked(self, name):
+            raise ContextIntegrityBlocked(asset_id=f"skill:user:1/{name}", state="changed_approved_executable")
+
+        monkeypatch.setattr(SkillsService, "export_skill", _blocked)
+
+        response = client.get(f"{SKILLS_PREFIX}/blocked-skill/export")
+
+        assert response.status_code == 423
+        assert response.json()["detail"] == "Asset is quarantined pending admin review."
+```
+
+- [ ] **Step 6: Run focused Skills tests**
+
+Append to `tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_handle_skill_tool_call_returns_content_free_integrity_error(tmp_path):
+    from tldw_Server_API.app.core.Context_Integrity.models import (
+        ContextIntegrityBootState,
+        ContextIntegrityFinding,
+    )
+    from tldw_Server_API.app.core.Context_Integrity.resolver import (
+        ContextIntegrityResolver,
+        set_global_context_integrity_resolver,
+        clear_global_context_integrity_resolver,
+    )
+    from tldw_Server_API.app.core.Skills.context_integration import handle_skill_tool_call
+
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="enforce",
+            degraded=False,
+            manifest_sequence=1,
+            manifest_digest="sha256:manifest",
+            findings=(
+                ContextIntegrityFinding(
+                    asset_id="skill:user:1/blocked-skill",
+                    state="changed_approved_executable",
+                    severity="error",
+                    summary="changed",
+                    remediation="review",
+                    source_type="skill_file",
+                ),
+            ),
+        )
+    )
+    set_global_context_integrity_resolver(resolver)
+    try:
+        result = await handle_skill_tool_call(
+            skill_name="blocked-skill",
+            args="",
+            user_id=1,
+            base_path=tmp_path,
+            db=None,
+        )
+    finally:
+        clear_global_context_integrity_resolver()
+
+    assert result == {
+        "success": False,
+        "error": "context_integrity_blocked",
+    }
+```
+
+Modify `tldw_Server_API/app/core/Skills/context_integration.py`:
+
+```python
+from tldw_Server_API.app.core.Context_Integrity.resolver import ContextIntegrityBlocked
+```
+
+Add `except ContextIntegrityBlocked` before the existing `SkillsError` handler in `handle_skill_tool_call()`:
+
+```python
+    except ContextIntegrityBlocked:
+        logger.warning("Blocked quarantined skill invocation: {}", skill_name)
+        return {
+            "success": False,
+            "error": "context_integrity_blocked",
+        }
+```
+
+`add_skill_tool_to_tools_list()` already calls `service.get_context_payload()`; after `_is_skill_allowed()` rehashes current files, quarantined or live-edited skills must not cause the `Skill` tool to be advertised.
+
+Append to `tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_skill_command_reports_context_integrity_block(monkeypatch):
+    async def fake_exec(ctx, skill_name, skill_args):
+        return {"success": False, "error": "context_integrity_blocked"}
+
+    monkeypatch.setattr(command_router, "_execute_skill", fake_exec)
+    ctx = command_router.CommandContext(user_id="u1", auth_user_id=1)
+
+    res = await command_router.async_dispatch_command(ctx, "skill", "blocked-skill x")
+
+    assert not res.ok
+    assert "quarantined pending admin review" in res.content
+    assert res.metadata["error"] == "context_integrity_blocked"
+```
+
+Modify `tldw_Server_API/app/core/Chat/command_router.py`:
+
+```python
+from tldw_Server_API.app.core.Context_Integrity.resolver import ContextIntegrityBlocked
+```
+
+Catch `ContextIntegrityBlocked` in `_execute_skill()` before `SkillsError`:
+
+```python
+    except ContextIntegrityBlocked:
+        return {"success": False, "error": "context_integrity_blocked"}
+```
+
+Handle the stable error in `_skill_handler()`:
+
+```python
+        elif error == "context_integrity_blocked":
+            message = "Skill is quarantined pending admin review."
 ```
 
 - [ ] **Step 6: Run focused Skills tests**
@@ -1596,7 +2089,9 @@ Run:
 ```bash
 source .venv/bin/activate && python -m pytest \
   tldw_Server_API/tests/Skills/unit/test_skills_service.py \
-  tldw_Server_API/tests/Skills/integration/test_skills_api.py -v
+  tldw_Server_API/tests/Skills/integration/test_skills_api.py \
+  tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py \
+  tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py -v
 ```
 
 Expected: PASS.
@@ -1605,9 +2100,13 @@ Expected: PASS.
 
 ```bash
 git add tldw_Server_API/app/core/Skills/skills_service.py \
+  tldw_Server_API/app/core/Skills/context_integration.py \
+  tldw_Server_API/app/core/Chat/command_router.py \
   tldw_Server_API/app/api/v1/endpoints/skills.py \
   tldw_Server_API/tests/Skills/unit/test_skills_service.py \
-  tldw_Server_API/tests/Skills/integration/test_skills_api.py
+  tldw_Server_API/tests/Skills/integration/test_skills_api.py \
+  tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py \
+  tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py
 git commit -m "feat: enforce context integrity for skills"
 ```
 
@@ -1777,6 +2276,7 @@ def _read_prompt_file_text(path: str, *, source_label: str | None = None) -> str
             asset_id,
             current_digest=current_digest,
             purpose="prompt_load",
+            changed_state="changed_approved_non_executable",
         )
     return raw.decode("utf-8")
 ```
@@ -2085,9 +2585,12 @@ Run:
 source .venv/bin/activate && python -m pytest \
   tldw_Server_API/tests/Services/test_startup_context_integrity.py \
   tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py \
+  tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py \
   tldw_Server_API/tests/AuthNZ_SQLite/test_admin_context_integrity_sqlite.py \
   tldw_Server_API/tests/Skills/unit/test_skills_service.py \
   tldw_Server_API/tests/Skills/integration/test_skills_api.py \
+  tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py \
+  tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py \
   tldw_Server_API/tests/Utils/test_prompt_loader_paths.py \
   tldw_Server_API/tests/Utils/test_prompt_loader_env_overrides.py -v
 ```
@@ -2103,7 +2606,10 @@ source .venv/bin/activate && python -m bandit -r \
   tldw_Server_API/app/core/Context_Integrity \
   tldw_Server_API/app/services/startup_context_integrity.py \
   tldw_Server_API/app/services/lifespan_startup_sequence.py \
+  tldw_Server_API/app/services/lifespan_shutdown_sequence.py \
   tldw_Server_API/app/core/Skills/skills_service.py \
+  tldw_Server_API/app/core/Skills/context_integration.py \
+  tldw_Server_API/app/core/Chat/command_router.py \
   tldw_Server_API/app/api/v1/endpoints/skills.py \
   tldw_Server_API/app/core/Utils/prompt_loader.py \
   tldw_Server_API/app/api/v1/endpoints/admin/context_integrity.py \
@@ -2129,9 +2635,10 @@ This plan intentionally makes DB prompt-version and MCP prompt-catalog enforceme
 
 1. DB prompt-version inventory and approval workflow in `Prompts_DB` and prompt APIs.
 2. MCP prompt-catalog resolver checks in `tldw_Server_API/app/core/MCP_unified/modules/implementations/prompts_catalog.py`.
-3. OS/hardware-backed key provider integration beyond the first HMAC signer.
-4. Admin approval/import/export endpoints for signed manifest lifecycle.
-5. Frontend review UI for source-grouped baseline approval and canonical diffs.
+3. Bundled/plugin/repo skill inventory adapters, including repo prompt-skill files such as `Docs/Prompts/Skills/*`.
+4. OS/hardware-backed key provider integration beyond the first HMAC signer.
+5. Admin approval/import/export endpoints for signed manifest lifecycle.
+6. Frontend review UI for source-grouped baseline approval and canonical diffs.
 
 ## Plan Self-Review
 

--- a/Docs/superpowers/specs/2026-06-25-context-integrity-skills-prompts-design.md
+++ b/Docs/superpowers/specs/2026-06-25-context-integrity-skills-prompts-design.md
@@ -1,0 +1,271 @@
+# Context Integrity For Skills And Prompts Design
+
+**Date:** 2026-06-25
+**Status:** Draft for review
+**Backlog Task:** TASK-2363
+**Scope:** Skills, bundled/plugin skills, prompt-bearing files, DB-backed prompt versions, MCP prompt exposure, prompt loaders, startup warnings, admin review, and trust manifest operations.
+
+## Summary
+
+This design adds a shared Context Integrity subsystem for prompt-bearing assets that can influence model context or tool-capable behavior. The first protected assets are:
+
+- user-managed skills under per-user `skills/` directories
+- bundled, plugin, and repo skill files
+- config prompt YAML/Markdown files
+- repo prompt-skill files such as `Docs/Prompts/Skills/*`
+- DB-backed prompt records and specific prompt versions that can be injected into model context
+
+The subsystem compares current asset digests against an approved signed manifest. The server continues booting when unexpected changes are detected, but affected assets are quarantined and cannot be injected, exposed through MCP, or executed until an operator approves a new manifest version.
+
+The default policy is: **server boots, context use fails closed**.
+
+## Threat Model
+
+The default design assumes an attacker may be able to modify skill files, prompt files, and app databases while the server is offline. The attacker cannot access an external/admin-held trust manifest or an OS/hardware-backed signing key.
+
+This design does not claim to detect full filesystem compromise when the only trust anchor is stored on the same compromised filesystem. Hardened deployments require an external/admin-held manifest, an external key, or OS/hardware-backed key storage that survives app-data tampering.
+
+## Goals
+
+1. Detect offline and live tampering of prompt-bearing assets.
+2. Prevent changed or unapproved assets from influencing model context or tools.
+3. Cover both user-managed and bundled/plugin/repo skill and prompt assets.
+4. Support explicit operator approval for new baselines.
+5. Reuse the existing startup warning framework for boot-time findings.
+6. Provide a hardened mode for deployments that require an external/admin-held trust anchor.
+
+## Non-Goals
+
+1. Proving system integrity after full host compromise without an external trust anchor.
+2. Blocking server startup for every changed optional skill or prompt.
+3. Replacing package manager or plugin signature verification.
+4. Building a general-purpose file integrity monitoring system for all repository files.
+5. Letting model-assisted workflows approve their own prompt-bearing assets.
+
+## Architecture
+
+The protected unit is a prompt-bearing asset: any file or DB version that can be injected into model context, alter prompt assembly, appear through MCP prompt discovery, or drive skill execution.
+
+The subsystem stores approved asset state in a signed trust manifest. The manifest records canonical hashes, asset IDs, source type, owner scope, trust tier, signer/key ID, approval event, manifest schema version, and manifest sequence number. Runtime code compares current assets against the latest approved manifest. It never treats the live filesystem or app DB as automatically trusted.
+
+The default trust anchor is an OS/hardware-backed signing key. If that is unavailable, the server must either use an admin-held manifest or run in clearly labeled degraded integrity mode. Hardened deployments require an external/admin-held manifest or external key. Full filesystem compromise is only detectable with that external trust anchor.
+
+Startup integrity verification runs before any protected asset can be injected, executed, exposed through MCP, or included in skill discovery. Unexpected additions, deletions, or modifications create startup warning records and quarantine affected assets. The server continues booting, but quarantined assets are excluded from all context-injection and execution paths until reviewed through a static, prompt-independent admin workflow.
+
+## Components
+
+### Asset Inventory Adapters
+
+Adapters emit normalized `ContextAssetDescriptor` records with stable IDs, source metadata, and canonical bytes for hashing.
+
+- `SkillsFilesystemAdapter`: user skill directories plus bundled/plugin/repo skill directories.
+- `PromptFilesAdapter`: config prompt YAML/Markdown and repo prompt-skill files.
+- `PromptDatabaseAdapter`: DB-backed prompt records and immutable prompt versions.
+
+Adapters should be narrow and read-only. They should parse only enough metadata to identify and hash an asset. Trust decisions belong to the verifier and resolver.
+
+### Canonicalization And Hashing
+
+The shared hasher produces `sha256` over deterministic canonical payloads.
+
+Filesystem assets include:
+
+- source type
+- normalized asset ID
+- normalized relative path
+- file bytes
+- support-file bytes when a skill is directory-backed
+- metadata that affects model context or execution behavior
+
+DB prompt assets use stable JSON over fields that affect context, such as prompt UUID, prompt version, name, system content, user content, structured fields, model/tool-affecting metadata, and deleted state when it affects availability. The hash approves a specific version/content digest, not all future edits to a prompt UUID.
+
+### Trust Manifest Store
+
+The manifest store owns approved manifest versions, signatures, key IDs, approval metadata, and import/export.
+
+Required behavior:
+
+- verify manifest signatures before using manifest contents
+- select the newest valid manifest
+- fall back to the newest prior valid manifest if the latest manifest signature is invalid
+- export admin-held manifests for hardened deployments
+- import external/admin-held manifests
+- enter degraded integrity mode when no strong trust anchor is available
+
+### Integrity Verifier And Runtime Resolver
+
+The verifier compares current inventory to approved manifest entries and emits asset states:
+
+- `trusted`
+- `changed_approved_executable`
+- `changed_approved_non_executable`
+- `new_unapproved`
+- `missing_required`
+- `missing_optional`
+- `signature_invalid`
+- `verification_error`
+- `degraded_integrity`
+- `quarantined`
+
+The runtime resolver is the centralized enforcement point. Skills, prompt loaders, MCP prompt catalog code, DB prompt access, and chat slash skill invocation must ask the resolver before returning or using protected content.
+
+The resolver either verifies the current digest at use time or serves content from a boot-verified immutable snapshot. This avoids trusting a startup-only scan after files change while the server is running.
+
+### Admin And Audit Surfaces
+
+Boot-time findings reuse `StartupWarningRecord` with component names such as:
+
+- `context_integrity.skills`
+- `context_integrity.prompt_files`
+- `context_integrity.prompt_db`
+- `context_integrity.manifest`
+
+Durable audit records cover verification findings, quarantine events, approval, rejection, manifest import/export, degraded-mode entry, and break-glass configuration. Material audit events should be signed or hash-chained. Local audit rows are operational evidence, not proof against an attacker who can modify app DBs; hardened deployments should export audit events to an external sink.
+
+Review UI and API responses must not render untrusted prompt content as rich HTML or feed it into model-assisted review. The review path uses static server/UI strings and escaped canonical diffs.
+
+## Data Flow
+
+### Startup
+
+1. Build current inventory from filesystem skills, prompt files, and DB prompt versions.
+2. Load and verify the latest approved signed manifest before trusting any manifest content.
+3. Fall back to the newest prior valid manifest if the newest manifest is invalid.
+4. Compare current assets to approved digests.
+5. Record current-boot verification state and signed/hash-chained audit events for material findings.
+6. Register startup warnings for changed, missing, unapproved, signature-invalid, or degraded assets.
+7. Quarantine unsafe assets.
+8. Continue booting with unsafe assets unavailable.
+
+### Runtime Use
+
+Every context-injection or execution path asks the integrity resolver before using an asset.
+
+- `trusted` assets proceed.
+- quarantined, signature-invalid, changed, missing, and unapproved assets are hidden from discovery and blocked from injection/execution.
+- degraded mode defaults to blocking executable and context-injection use.
+- unsafe read-only visibility requires an explicit break-glass config and must never allow injection or execution.
+
+### Edit And Import
+
+Saving creates a draft or pending asset version. The new version is visible as pending, but not eligible for model context, MCP prompt exposure, or skill execution.
+
+Operator review uses escaped canonical diffs. Approval re-checks the current digest and manifest version, signs a new manifest version, and records a signed audit event. If the asset digest changed between review and approval, approval fails with `asset changed during review`.
+
+In single-user mode, the local operator is the admin, but approval still requires explicit non-model confirmation.
+
+### Upgrade
+
+Bundled and plugin assets are matched to package identity and update metadata. Verified trusted updates can use a lower-friction update flow only when:
+
+- the previous package identity was already trusted
+- the update source signature validates
+- the updated asset digest matches signed package metadata
+
+Unverified changed bundled assets are treated as possible tampering and quarantined.
+
+### Recovery
+
+Operators can:
+
+- restore from the last approved manifest
+- approve a new baseline after reviewing diffs
+- import an external/admin-held manifest
+- rotate the OS/hardware-backed key
+- keep assets quarantined
+
+Full compromise recovery guidance must direct operators to external manifest verification, key rotation, and restoring from known-good backups.
+
+## Policy
+
+Default policy is **server boots, context use fails closed**. Suspicious assets cannot influence model context, MCP prompt exposure, or tool-capable skill execution.
+
+Actions:
+
+- `signature_invalid`: try the newest prior valid manifest. If none exists, quarantine the protected scope and enter degraded integrity. Requires key or manifest recovery.
+- `changed_approved_executable`: high severity, quarantine immediately.
+- `changed_approved_non_executable`: medium or high severity based on source tier, quarantine for injection.
+- `new_unapproved`: pending review, not usable for injection or execution.
+- `missing_required`: high severity only for required assets.
+- `missing_optional`: warn and keep unavailable.
+- `degraded_integrity`: no injection or execution. Admin review may show escaped metadata and canonical diffs only.
+- `verification_error`: quarantine the narrowest source scope that cannot be verified. If the scope cannot be determined, quarantine all protected assets.
+
+Runtime errors are stable and content-free:
+
+- `Asset is quarantined pending admin review.`
+- `Integrity manifest signature is invalid.`
+- `Asset version is not approved for execution.`
+- `Asset changed during review; reload before approving.`
+
+Break-glass configuration must be intentionally named and noisy, for example `CONTEXT_INTEGRITY_UNSAFE_ALLOW_DEGRADED_READONLY=true`. It must log and audit on startup. It must never allow injection or execution in degraded mode.
+
+## Initial Enrollment And Migration
+
+Initial enrollment is the riskiest moment. The server must not silently bless all current files and DB prompt rows.
+
+First run produces a source-grouped baseline report:
+
+- package-signed bundled/plugin assets may be pre-trusted when package identity and signature metadata validate
+- user assets require explicit local operator approval or imported manifest
+- unknown external files remain pending
+- DB prompt versions require explicit approval unless imported from a trusted manifest
+
+Migration can run in `audit_only` mode, but the UI/API must label it as non-enforcing. `audit_only` is for diagnostics and rollout only, not the recommended steady state.
+
+## Rollout Modes
+
+### audit_only
+
+Verification runs and findings are audited, but assets are not quarantined by default. UI and admin API status must say that integrity findings are not enforced.
+
+### enforce
+
+Default mode. Changed or unapproved context-injection assets are quarantined while the server continues booting.
+
+### hardened
+
+Requires an external/admin-held manifest or external key. Local-only fallback is not allowed. If no valid external trust anchor is available, protected assets are unavailable for injection and execution.
+
+## Testing
+
+Backend unit tests should cover:
+
+- deterministic canonical hashing for filesystem and DB prompt-version assets
+- manifest signing and signature verification
+- invalid-latest-manifest fallback to prior valid manifest
+- changed, missing, new, restored, degraded, and verification-error outcomes
+- approval race locking on manifest version and current digest
+- runtime resolver enforcement for trusted versus quarantined assets
+- degraded mode blocking injection and execution
+- tamper-evident audit chain verification
+
+Integration tests should cover:
+
+- startup detection after modifying an approved `SKILL.md`
+- live runtime detection after modifying a skill while the server is running
+- config prompt file modification blocked through `prompt_loader`
+- DB prompt-version modification blocked through prompt APIs and MCP prompt catalog
+- chat slash skill invocation blocked for quarantined skills
+- MCP prompt catalog hiding quarantined prompts
+- external manifest import trusting matching assets
+- invalid latest manifest falling back to prior valid manifest
+
+Performance tests should cover:
+
+- large skill and prompt inventories
+- boot-verified immutable snapshot resolver mode
+- at-use digest recheck resolver mode
+- worst-case latency for skill context payload and prompt catalog listing
+
+Security validation should include Bandit on the new integrity subsystem and touched Skills/Prompt paths.
+
+## Open Design Decisions For Implementation Planning
+
+1. Which OS key stores are supported in the first implementation slice.
+2. Whether filesystem assets use immutable boot snapshots, at-use rehashing, or a hybrid.
+3. The exact DB schema split between trust manifests, verification state, and audit events.
+4. How package/plugin signature metadata is discovered for bundled and plugin skills.
+5. Which prompt DB fields are included in the first canonical prompt-version payload.
+
+These are implementation planning decisions, not blockers for the design direction.

--- a/Docs/superpowers/specs/2026-06-25-context-integrity-skills-prompts-design.md
+++ b/Docs/superpowers/specs/2026-06-25-context-integrity-skills-prompts-design.md
@@ -14,6 +14,7 @@ This design adds a shared Context Integrity subsystem for prompt-bearing assets 
 - config prompt YAML/Markdown files
 - repo prompt-skill files such as `Docs/Prompts/Skills/*`
 - DB-backed prompt records and specific prompt versions that can be injected into model context
+- persona, character, voice-command, profile-default, and other prompt sources when they can enter model context or tool instructions
 
 The subsystem compares current asset digests against an approved signed manifest. The server continues booting when unexpected changes are detected, but affected assets are quarantined and cannot be injected, exposed through MCP, or executed until an operator approves a new manifest version.
 
@@ -46,7 +47,11 @@ This design does not claim to detect full filesystem compromise when the only tr
 
 The protected unit is a prompt-bearing asset: any file or DB version that can be injected into model context, alter prompt assembly, appear through MCP prompt discovery, or drive skill execution.
 
+The inclusion rule is capability-based: if an asset can affect system/user/developer instructions, prompt assembly, tool instructions, MCP prompt discovery, or skill execution, it must be treated as protected once that source is wired into Context Integrity. The first implementation can stage adapters, but new prompt-bearing surfaces should default to protected rather than relying on per-feature opt-in.
+
 The subsystem stores approved asset state in a signed trust manifest. The manifest records canonical hashes, asset IDs, source type, owner scope, trust tier, signer/key ID, approval event, manifest schema version, and manifest sequence number. Runtime code compares current assets against the latest approved manifest. It never treats the live filesystem or app DB as automatically trusted.
+
+Manifest signatures protect manifest contents, but they do not by themselves prevent rollback to an older valid manifest. The latest accepted manifest sequence number and digest must be anchored outside mutable app DB state. Acceptable anchors include OS/hardware-backed key storage metadata, an external/admin-held manifest ledger, or hardened-mode external verification. If no anti-rollback anchor is available, the system must report degraded integrity and avoid claiming rollback protection.
 
 The default trust anchor is an OS/hardware-backed signing key. If that is unavailable, the server must either use an admin-held manifest or run in clearly labeled degraded integrity mode. Hardened deployments require an external/admin-held manifest or external key. Full filesystem compromise is only detectable with that external trust anchor.
 
@@ -77,7 +82,11 @@ Filesystem assets include:
 - support-file bytes when a skill is directory-backed
 - metadata that affects model context or execution behavior
 
-DB prompt assets use stable JSON over fields that affect context, such as prompt UUID, prompt version, name, system content, user content, structured fields, model/tool-affecting metadata, and deleted state when it affects availability. The hash approves a specific version/content digest, not all future edits to a prompt UUID.
+Filesystem hashing defaults to raw file bytes, sorted by normalized POSIX-style relative path for directory-backed assets. This intentionally detects comment-only and formatting-only edits in protected files. Any source-specific semantic hash may be added for review display, but enforcement must use the raw canonical asset digest unless a source explicitly defines a safer canonical form.
+
+DB prompt assets use stable JSON over fields that affect context, such as prompt UUID, prompt version, name, system content, user content, structured fields, model/tool-affecting metadata, and deleted state when it affects availability. DB canonical JSON must use deterministic field ordering, Unicode NFC normalization for text fields, and LF line endings for text values before hashing. The hash approves a specific version/content digest, not all future edits to a prompt UUID.
+
+YAML/Markdown prompt-file review may show parsed semantic diffs, but enforcement still hashes the canonical file payload. This avoids a parser bug or comment channel becoming a place to hide unapproved instructions.
 
 ### Trust Manifest Store
 
@@ -88,6 +97,7 @@ Required behavior:
 - verify manifest signatures before using manifest contents
 - select the newest valid manifest
 - fall back to the newest prior valid manifest if the latest manifest signature is invalid
+- reject rollback to an older valid manifest when the external anti-rollback anchor says a newer accepted manifest exists
 - export admin-held manifests for hardened deployments
 - import external/admin-held manifests
 - enter degraded integrity mode when no strong trust anchor is available
@@ -109,7 +119,9 @@ The verifier compares current inventory to approved manifest entries and emits a
 
 The runtime resolver is the centralized enforcement point. Skills, prompt loaders, MCP prompt catalog code, DB prompt access, and chat slash skill invocation must ask the resolver before returning or using protected content.
 
-The resolver either verifies the current digest at use time or serves content from a boot-verified immutable snapshot. This avoids trusting a startup-only scan after files change while the server is running.
+The resolver derives enforcement from verified in-memory boot state, a boot-verified immutable snapshot, or signed state. It must not trust mutable app DB quarantine flags as the source of enforcement truth; DB flags are operational metadata only.
+
+The resolver either verifies the current digest at use time or serves content from a boot-verified immutable snapshot. This avoids trusting a startup-only scan after files change while the server is running. At-use verification must hash the exact bytes or DB row version that will be injected or executed. Filesystem at-use mode therefore needs single-read semantics, such as reading bytes once and passing those bytes onward after digest verification. DB at-use mode needs transaction or version discipline so the verified row version is the row version used. Implementations that cannot guarantee this should use immutable snapshots.
 
 ### Admin And Audit Surfaces
 
@@ -130,12 +142,13 @@ Review UI and API responses must not render untrusted prompt content as rich HTM
 
 1. Build current inventory from filesystem skills, prompt files, and DB prompt versions.
 2. Load and verify the latest approved signed manifest before trusting any manifest content.
-3. Fall back to the newest prior valid manifest if the newest manifest is invalid.
-4. Compare current assets to approved digests.
-5. Record current-boot verification state and signed/hash-chained audit events for material findings.
-6. Register startup warnings for changed, missing, unapproved, signature-invalid, or degraded assets.
-7. Quarantine unsafe assets.
-8. Continue booting with unsafe assets unavailable.
+3. Validate the manifest sequence and digest against the external anti-rollback anchor when one is configured.
+4. Fall back to the newest prior valid manifest if the newest manifest is invalid and rollback policy permits that fallback.
+5. Compare current assets to approved digests.
+6. Record current-boot verification state and signed/hash-chained audit events for material findings.
+7. Register startup warnings for changed, missing, unapproved, signature-invalid, rollback, or degraded assets.
+8. Quarantine unsafe assets.
+9. Continue booting with unsafe assets unavailable.
 
 ### Runtime Use
 
@@ -145,6 +158,7 @@ Every context-injection or execution path asks the integrity resolver before usi
 - quarantined, signature-invalid, changed, missing, and unapproved assets are hidden from discovery and blocked from injection/execution.
 - degraded mode defaults to blocking executable and context-injection use.
 - unsafe read-only visibility requires an explicit break-glass config and must never allow injection or execution.
+- at-use verification must pass through the verified content bytes or verified DB row version, not re-open or re-fetch content after the check.
 
 ### Edit And Import
 
@@ -183,6 +197,7 @@ Default policy is **server boots, context use fails closed**. Suspicious assets 
 Actions:
 
 - `signature_invalid`: try the newest prior valid manifest. If none exists, quarantine the protected scope and enter degraded integrity. Requires key or manifest recovery.
+- `manifest_rollback_detected`: high severity, quarantine the protected scope unless an operator imports a valid external manifest or resolves the anchor mismatch. A locally valid older signature is not sufficient.
 - `changed_approved_executable`: high severity, quarantine immediately.
 - `changed_approved_non_executable`: medium or high severity based on source tier, quarantine for injection.
 - `new_unapproved`: pending review, not usable for injection or execution.
@@ -195,6 +210,7 @@ Runtime errors are stable and content-free:
 
 - `Asset is quarantined pending admin review.`
 - `Integrity manifest signature is invalid.`
+- `Integrity manifest rollback detected.`
 - `Asset version is not approved for execution.`
 - `Asset changed during review; reload before approving.`
 
@@ -233,10 +249,13 @@ Backend unit tests should cover:
 
 - deterministic canonical hashing for filesystem and DB prompt-version assets
 - manifest signing and signature verification
+- manifest anti-rollback anchor verification
 - invalid-latest-manifest fallback to prior valid manifest
+- rollback detection when a valid older manifest conflicts with the anti-rollback anchor
 - changed, missing, new, restored, degraded, and verification-error outcomes
 - approval race locking on manifest version and current digest
-- runtime resolver enforcement for trusted versus quarantined assets
+- runtime resolver enforcement from verified in-memory or signed state, not mutable DB flags
+- at-use verification using the exact bytes or row version consumed by the caller
 - degraded mode blocking injection and execution
 - tamper-evident audit chain verification
 
@@ -250,6 +269,7 @@ Integration tests should cover:
 - MCP prompt catalog hiding quarantined prompts
 - external manifest import trusting matching assets
 - invalid latest manifest falling back to prior valid manifest
+- older valid manifest replay being rejected when the anti-rollback anchor records a newer accepted manifest
 
 Performance tests should cover:
 

--- a/Docs/superpowers/specs/2026-06-25-context-integrity-skills-prompts-design.md
+++ b/Docs/superpowers/specs/2026-06-25-context-integrity-skills-prompts-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-25
 **Status:** Draft for review
-**Backlog Task:** TASK-2363
+**Backlog Task:** TASK-12015
 **Scope:** Skills, bundled/plugin skills, prompt-bearing files, DB-backed prompt versions, MCP prompt exposure, prompt loaders, startup warnings, admin review, and trust manifest operations.
 
 ## Summary

--- a/backlog/tasks/task-12014 - Address-PR-2523-context-integrity-review-feedback.md
+++ b/backlog/tasks/task-12014 - Address-PR-2523-context-integrity-review-feedback.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-12014
 title: Address PR 2523 context integrity review feedback
-status: In Progress
+status: Done
 assignee: []
 created_date: ''
 updated_date: '2026-06-26 05:03'
@@ -24,10 +24,10 @@ Address live CodeRabbit and Qodo review feedback on PR #2523 for context integri
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All live CodeRabbit context-integrity comments are fixed or dispositioned with technical rationale.
-- [ ] #2 All live Qodo context-integrity findings are fixed or dispositioned with technical rationale.
-- [ ] #3 Targeted tests and Bandit are run on the touched scope after fixes.
-- [ ] #4 PR #2523 branch is updated with review-fix commit(s) and reviewer threads/comments are answered where appropriate.
+- [x] #1 All live CodeRabbit context-integrity comments are fixed or dispositioned with technical rationale.
+- [x] #2 All live Qodo context-integrity findings are fixed or dispositioned with technical rationale.
+- [x] #3 Targeted tests and Bandit are run on the touched scope after fixes.
+- [x] #4 PR #2523 branch is updated with review-fix commit(s) and reviewer threads/comments are answered where appropriate.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -38,21 +38,23 @@ Address live CodeRabbit and Qodo review feedback on PR #2523 for context integri
 - Fixed valid Qodo items: added admin module and manifest helper docstrings; narrowed startup settings exception handling with debug logging; added the missing fixture return type; hardened prompt and skill runtime file reads with no-follow lstat/fstat checks; skipped symlinked SKILL.md during registry sync; and added a short file-fingerprint cache for repeated discovery decisions.
 - Backlog hygiene follow-up: renumbered branch-local context tasks from TASK-2363/TASK-2365/TASK-2366 to TASK-12015/TASK-12016/TASK-12017 after the dev rebase exposed ID collisions, updated references, and completed missing AC/DoD fields.
 - Reviewed but did not centralize Context Integrity exceptions because this codebase already uses feature-local exceptions in core modules (for example Skills and MCP); local resolver exceptions match the surrounding package boundary. Reviewed but did not remove the global resolver because it is the current compatibility bridge for legacy runtime paths without app/request DI, while SkillsService still supports explicit resolver injection.
-- Verification so far: focused 88-test regression run passed; broader focused suite passed with 318 passed and 6 warnings; Bandit on touched app scope exited 0 with zero findings; final quick regression run passed with 8 passed; git diff --check is clean.
+- Verification: focused 88-test regression run passed; broader focused suite passed with 318 passed and 6 warnings; Bandit on touched app scope exited 0 with zero findings; final quick regression run passed with 8 passed; git diff --check is clean.
+- PR follow-up: pushed commit 947e92c16c, replied to all 9 current non-outdated unresolved review threads, resolved those threads through GitHub, and confirmed the current non-outdated unresolved review-thread list is empty. PR checks were pending at finalization time with no current failed GitHub Actions checks reported by `gh pr checks`.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #2523 review feedback in commit 947e92c16c. The fix set hardens Context Integrity hashing, manifest verification, boot-state immutability, duplicate inventory handling, startup mode validation, symlink/no-follow runtime reads, Skills listing/count filtering, and test isolation. It also repairs the Backlog task-ID collisions introduced by the dev rebase and adds missing auditable AC/DoD fields. Qodo exception-centralization and global-resolver suggestions were reviewed and dispositioned with codebase-specific rationale in the PR threads. Verification passed locally: 318 broader focused tests, 8 final focused regressions, Bandit zero findings on touched app scope, and git diff whitespace checks. All current non-outdated unresolved review threads were answered and resolved.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12014 - Address-PR-2523-context-integrity-review-feedback.md
+++ b/backlog/tasks/task-12014 - Address-PR-2523-context-integrity-review-feedback.md
@@ -1,0 +1,58 @@
+---
+id: TASK-12014
+title: Address PR 2523 context integrity review feedback
+status: In Progress
+assignee: []
+created_date: ''
+updated_date: '2026-06-26 05:03'
+labels:
+  - security
+  - review
+  - context-integrity
+dependencies: []
+references:
+  - PR-2523
+  - TASK-12017
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address live CodeRabbit and Qodo review feedback on PR #2523 for context integrity foundation, including valid security/correctness/docstring/test-isolation items and documented technical disposition for non-actionable items.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All live CodeRabbit context-integrity comments are fixed or dispositioned with technical rationale.
+- [ ] #2 All live Qodo context-integrity findings are fixed or dispositioned with technical rationale.
+- [ ] #3 Targeted tests and Bandit are run on the touched scope after fixes.
+- [ ] #4 PR #2523 branch is updated with review-fix commit(s) and reviewer threads/comments are answered where appropriate.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Fixed valid CodeRabbit items: Unicode-normalized filesystem digest paths with collision detection; accepted mapping-backed signed manifest payloads; froze boot-state findings; detected duplicate live asset IDs as verification errors; rejected unknown startup modes; cleared global resolver before TestClient startup; and filtered integrity-allowed skills before pagination/counting.
+- Fixed valid Qodo items: added admin module and manifest helper docstrings; narrowed startup settings exception handling with debug logging; added the missing fixture return type; hardened prompt and skill runtime file reads with no-follow lstat/fstat checks; skipped symlinked SKILL.md during registry sync; and added a short file-fingerprint cache for repeated discovery decisions.
+- Backlog hygiene follow-up: renumbered branch-local context tasks from TASK-2363/TASK-2365/TASK-2366 to TASK-12015/TASK-12016/TASK-12017 after the dev rebase exposed ID collisions, updated references, and completed missing AC/DoD fields.
+- Reviewed but did not centralize Context Integrity exceptions because this codebase already uses feature-local exceptions in core modules (for example Skills and MCP); local resolver exceptions match the surrounding package boundary. Reviewed but did not remove the global resolver because it is the current compatibility bridge for legacy runtime paths without app/request DI, while SkillsService still supports explicit resolver injection.
+- Verification so far: focused 88-test regression run passed; broader focused suite passed with 318 passed and 6 warnings; Bandit on touched app scope exited 0 with zero findings; final quick regression run passed with 8 passed; git diff --check is clean.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12015 - Design-context-integrity-controls-for-skills-and-prompts.md
+++ b/backlog/tasks/task-12015 - Design-context-integrity-controls-for-skills-and-prompts.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-2363
+id: TASK-12015
 title: Design context integrity controls for skills and prompts
 status: Done
 labels:
@@ -21,16 +21,18 @@ Create a design spec for signed trust manifests, quarantine, and audit controls 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Spec covers user and bundled/plugin/repo skill files plus prompt-bearing files and DB prompt records.
-- [ ] #2 Spec defines the default threat model, trust anchors, quarantine policy, data flow, and rollout modes.
-- [ ] #3 Spec documents limitations for full filesystem compromise and the need for external/admin-held manifests or OS/hardware-backed keys.
-- [ ] #4 Spec is self-reviewed for placeholders, contradictions, ambiguity, and scope.
+- [x] #1 Spec covers user and bundled/plugin/repo skill files plus prompt-bearing files and DB prompt records.
+- [x] #2 Spec defines the default threat model, trust anchors, quarantine policy, data flow, and rollout modes.
+- [x] #3 Spec documents limitations for full filesystem compromise and the need for external/admin-held manifests or OS/hardware-backed keys.
+- [x] #4 Spec is self-reviewed for placeholders, contradictions, ambiguity, and scope.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Brainstorming approved architecture, components, data flow, policy, testing, and rollout sections with user review on 2026-06-25.
+
+PR #2523 review follow-up: renumbered from TASK-2363 to TASK-12015 after the dev rebase exposed a duplicate TASK-2363 record, and marked completed AC/DoD to match the recorded final summary.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -41,10 +43,10 @@ Created and amended Docs/superpowers/specs/2026-06-25-context-integrity-skills-p
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12016 - Plan-context-integrity-implementation-for-skills-and-prompts.md
+++ b/backlog/tasks/task-12016 - Plan-context-integrity-implementation-for-skills-and-prompts.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-2365
+id: TASK-12016
 title: Plan context integrity implementation for skills and prompts
 status: Done
 assignee: []
@@ -16,13 +16,13 @@ documentation:
 - Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
 modified_files:
 - Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
-- backlog/tasks/task-2365 - Plan-context-integrity-implementation-for-skills-and-prompts.md
+- backlog/tasks/task-12016 - Plan-context-integrity-implementation-for-skills-and-prompts.md
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Create an implementation plan for the context integrity foundation defined in TASK-2363, covering signed manifests, canonical hashing, anti-rollback policy, runtime resolver, startup verification, and first enforcement hooks for Skills and prompt loading.
+Create an implementation plan for the context integrity foundation defined in TASK-12015, covering signed manifests, canonical hashing, anti-rollback policy, runtime resolver, startup verification, and first enforcement hooks for Skills and prompt loading.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -44,6 +44,8 @@ Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-pl
 <!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Created after user approved the amended context integrity design spec on 2026-06-25.
+
+PR #2523 review follow-up: renumbered from TASK-2365 to TASK-12016 after the dev rebase exposed a duplicate TASK-2365 record.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 <!-- SECTION:NOTES:END -->
 

--- a/backlog/tasks/task-12017 - Implement-context-integrity-foundation-for-skills-and-prompts.md
+++ b/backlog/tasks/task-12017 - Implement-context-integrity-foundation-for-skills-and-prompts.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-2366
+id: TASK-12017
 title: Implement context integrity foundation for skills and prompts
 status: Done
 assignee: []
@@ -12,8 +12,8 @@ labels:
   - implementation
 dependencies: []
 references:
-  - TASK-2363
-  - TASK-2365
+  - TASK-12015
+  - TASK-12016
 priority: high
 ---
 
@@ -25,6 +25,11 @@ Implement the reviewed context integrity foundation for skill and prompt files, 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
+- [x] #1 Core Context Integrity hashing, manifest signing/verification, inventory comparison, and resolver enforcement are implemented with focused unit coverage.
+- [x] #2 Startup verification inventories prompt files, environment prompt overrides, and user skill roots; loads signed manifests; publishes boot state/warnings; and cleans resolver state on shutdown.
+- [x] #3 Skills runtime and prompt-loader chokepoints rehash live bytes, reject unsafe symlinked prompt-bearing paths, and block quarantined or unapproved assets without leaking content.
+- [x] #4 Admin inspection exposes content-free Context Integrity boot state behind existing admin authorization.
+- [x] #5 Focused pytest, Bandit, formatter, and whitespace verification results are recorded for the touched scope.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -37,7 +42,7 @@ Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-pl
 
 <!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+PR #2523 review follow-up: renumbered from TASK-2366 to TASK-12017 after the dev rebase exposed a duplicate TASK-2366 record, and added explicit acceptance criteria matching the completed implementation slices and recorded verification.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 <!-- SECTION:NOTES:END -->
 

--- a/backlog/tasks/task-12018 - Fix-PR-2523-coverage-required-refresh-token-test-failure.md
+++ b/backlog/tasks/task-12018 - Fix-PR-2523-coverage-required-refresh-token-test-failure.md
@@ -1,0 +1,48 @@
+---
+id: TASK-12018
+title: Fix PR 2523 coverage-required refresh token test failure
+status: In Progress
+labels:
+- ci
+- tests
+- pr-2523
+priority: High
+modified_files:
+- tldw_Server_API/tests/unit/test_mcp_unified_error_mapping.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Reproduce the coverage-required failure locally.
+- [ ] #2 Update the failing unit test to match the current MCP refresh endpoint contract.
+- [ ] #3 Run the exact failing test and relevant local verification successfully.
+- [ ] #4 Push the fix and re-check PR CI for remaining failures.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Reproduced the CI failure locally with `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/unit/test_mcp_unified_error_mapping.py::test_refresh_token_sanitizes_rotation_failure_log -q` (failed with missing `request`). Updated the direct endpoint test to pass a loopback Request and set the demo-auth env prerequisites required by the route. Verification now passes: exact failing test `1 passed`; full file `10 passed`. `git diff --check` is clean. Bandit skipped because only test/backlog files were changed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12018 - Fix-PR-2523-coverage-required-refresh-token-test-failure.md
+++ b/backlog/tasks/task-12018 - Fix-PR-2523-coverage-required-refresh-token-test-failure.md
@@ -1,48 +1,53 @@
 ---
 id: TASK-12018
 title: Fix PR 2523 coverage-required refresh token test failure
-status: In Progress
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-26 06:31'
 labels:
-- ci
-- tests
-- pr-2523
-priority: High
-modified_files:
-- tldw_Server_API/tests/unit/test_mcp_unified_error_mapping.py
+  - ci
+  - tests
+  - pr-2523
+dependencies: []
+priority: high
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Reproduce the coverage-required failure locally.
-- [ ] #2 Update the failing unit test to match the current MCP refresh endpoint contract.
-- [ ] #3 Run the exact failing test and relevant local verification successfully.
-- [ ] #4 Push the fix and re-check PR CI for remaining failures.
+- [x] #1 Reproduce the coverage-required failure locally.
+- [x] #2 Update the failing unit test to match the current MCP refresh endpoint contract.
+- [x] #3 Run the exact failing test and relevant local verification successfully.
+- [x] #4 Push the fix and re-check PR CI for remaining failures.
 <!-- AC:END -->
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Reproduced the CI failure locally with `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/unit/test_mcp_unified_error_mapping.py::test_refresh_token_sanitizes_rotation_failure_log -q` (failed with missing `request`). Updated the direct endpoint test to pass a loopback Request and set the demo-auth env prerequisites required by the route. Verification now passes: exact failing test `1 passed`; full file `10 passed`. `git diff --check` is clean. Bandit skipped because only test/backlog files were changed.
+Completion note: AC #4 was satisfied up to push and initial PR check re-check. Remaining current CI checks were intentionally not waited on further because the user explicitly instructed: "Ignore the current CI checks."
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+Original reproduction/verification: exact CI-failing test failed locally with the missing request argument, then passed after the test update. Full tldw_Server_API/tests/unit/test_mcp_unified_error_mapping.py passed 10/10. Bandit was skipped because only test/backlog files changed.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Fixed the PR #2523 coverage-required failure cause by updating the direct MCP refresh-token error-mapping unit test to match the current endpoint contract. The test now passes a loopback Request and enables the explicit demo-auth test prerequisites before exercising the sanitized rotation-failure path. Local verification passed for the exact failing test (`1 passed`) and the full error-mapping file (`10 passed`); `git diff --check` was clean. The fix was committed as 417bde9a34 and pushed. Current CI monitoring was stopped per user instruction to ignore the remaining pending checks.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2363 - Design-context-integrity-controls-for-skills-and-prompts.md
+++ b/backlog/tasks/task-2363 - Design-context-integrity-controls-for-skills-and-prompts.md
@@ -36,7 +36,7 @@ Brainstorming approved architecture, components, data flow, policy, testing, and
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Created Docs/superpowers/specs/2026-06-25-context-integrity-skills-prompts-design.md covering shared context integrity controls for skills, prompt-bearing files, and DB prompt versions. The spec defines the threat model, signed trust manifest, OS/external trust anchors, quarantine policy, startup/runtime flows, initial enrollment, rollout modes, and verification strategy. Verification: searched the spec for TBD/TODO/FIXME/placeholder markers and self-reviewed for contradictions, ambiguity, and scope. Bandit skipped: documentation-only design change.
+Created and amended Docs/superpowers/specs/2026-06-25-context-integrity-skills-prompts-design.md covering shared context integrity controls for skills, prompt-bearing files, and DB prompt versions. The spec defines the threat model, signed trust manifest, OS/external trust anchors, anti-rollback anchoring, TOCTOU-safe runtime resolver requirements, quarantine policy, startup/runtime flows, initial enrollment, rollout modes, and verification strategy. Verification: searched the spec for TBD/TODO/FIXME/placeholder markers and self-reviewed for contradictions, ambiguity, and scope. Bandit skipped: documentation-only design change.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2363 - Design-context-integrity-controls-for-skills-and-prompts.md
+++ b/backlog/tasks/task-2363 - Design-context-integrity-controls-for-skills-and-prompts.md
@@ -1,0 +1,50 @@
+---
+id: TASK-2363
+title: Design context integrity controls for skills and prompts
+status: Done
+labels:
+- security
+- skills
+- prompts
+- design
+documentation:
+- Docs/superpowers/specs/2026-06-25-context-integrity-skills-prompts-design.md
+modified_files:
+- Docs/superpowers/specs/2026-06-25-context-integrity-skills-prompts-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a design spec for signed trust manifests, quarantine, and audit controls around skill files and prompt-bearing assets so users can detect and contain offline tampering across server restarts.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Spec covers user and bundled/plugin/repo skill files plus prompt-bearing files and DB prompt records.
+- [ ] #2 Spec defines the default threat model, trust anchors, quarantine policy, data flow, and rollout modes.
+- [ ] #3 Spec documents limitations for full filesystem compromise and the need for external/admin-held manifests or OS/hardware-backed keys.
+- [ ] #4 Spec is self-reviewed for placeholders, contradictions, ambiguity, and scope.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Brainstorming approved architecture, components, data flow, policy, testing, and rollout sections with user review on 2026-06-25.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created Docs/superpowers/specs/2026-06-25-context-integrity-skills-prompts-design.md covering shared context integrity controls for skills, prompt-bearing files, and DB prompt versions. The spec defines the threat model, signed trust manifest, OS/external trust anchors, quarantine policy, startup/runtime flows, initial enrollment, rollout modes, and verification strategy. Verification: searched the spec for TBD/TODO/FIXME/placeholder markers and self-reviewed for contradictions, ambiguity, and scope. Bandit skipped: documentation-only design change.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2365 - Plan-context-integrity-implementation-for-skills-and-prompts.md
+++ b/backlog/tasks/task-2365 - Plan-context-integrity-implementation-for-skills-and-prompts.md
@@ -1,0 +1,62 @@
+---
+id: TASK-2365
+title: Plan context integrity implementation for skills and prompts
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-25 17:18'
+labels:
+  - security
+  - skills
+  - prompts
+  - planning
+dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-06-25-context-integrity-skills-prompts-design.md
+  - >-
+    Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create an implementation plan for the context integrity foundation defined in TASK-2363, covering signed manifests, canonical hashing, anti-rollback policy, runtime resolver, startup verification, and first enforcement hooks for Skills and prompt loading.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Plan starts with the required superpowers implementation-plan header.
+- [x] #2 Plan decomposes the design into bite-sized TDD tasks with concrete files, commands, and expected results.
+- [x] #3 Plan covers core manifest/hash/verifier/resolver, startup wiring, Skills enforcement, prompt loader enforcement, admin/audit surfaces, and follow-up integration points.
+- [x] #4 Plan self-review records spec coverage, placeholder scan, type consistency, and docs-only verification.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Created after user approved the amended context integrity design spec on 2026-06-25.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created the Context Integrity Foundation implementation plan from TASK-2363. The plan decomposes the approved design into nine TDD tasks covering canonical hashing, signed manifests, anti-rollback checks, verifier/resolver behavior, filesystem inventory, startup warnings, Skills enforcement, prompt-loader enforcement, admin status, and focused verification. During review, strengthened the plan with digest-at-use checks for skills and prompt files, single-read prompt parsing, distinct env-override prompt asset IDs, and same-sequence anti-rollback digest validation. Verification: ran a red-flag term scan against the plan artifact; no matches. Bandit not applicable because this task only adds documentation.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2365 - Plan-context-integrity-implementation-for-skills-and-prompts.md
+++ b/backlog/tasks/task-2365 - Plan-context-integrity-implementation-for-skills-and-prompts.md
@@ -4,17 +4,19 @@ title: Plan context integrity implementation for skills and prompts
 status: Done
 assignee: []
 created_date: ''
-updated_date: '2026-06-25 17:18'
+updated_date: 2026-06-25 17:18
 labels:
-  - security
-  - skills
-  - prompts
-  - planning
+- security
+- skills
+- prompts
+- planning
 dependencies: []
 documentation:
-  - Docs/superpowers/specs/2026-06-25-context-integrity-skills-prompts-design.md
-  - >-
-    Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
+- Docs/superpowers/specs/2026-06-25-context-integrity-skills-prompts-design.md
+- Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
+modified_files:
+- Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
+- backlog/tasks/task-2365 - Plan-context-integrity-implementation-for-skills-and-prompts.md
 ---
 
 ## Description
@@ -48,7 +50,7 @@ Created after user approved the amended context integrity design spec on 2026-06
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Created the Context Integrity Foundation implementation plan from TASK-2363. The plan decomposes the approved design into nine TDD tasks covering canonical hashing, signed manifests, anti-rollback checks, verifier/resolver behavior, filesystem inventory, startup warnings, Skills enforcement, prompt-loader enforcement, admin status, and focused verification. During review, strengthened the plan with digest-at-use checks for skills and prompt files, single-read prompt parsing, distinct env-override prompt asset IDs, and same-sequence anti-rollback digest validation. Verification: ran a red-flag term scan against the plan artifact; no matches. Bandit not applicable because this task only adds documentation.
+Pre-execution review completed before subagent-driven implementation. Updated the plan to address review findings: added Python 3.10-safe timestamp guidance, explicit env-backed signed manifest loading, degraded no-manifest fail-closed behavior, resolver blocking for degraded and unknown assets, live-digest checks for skill discovery/context, startup discovery of user skill roots, inventory error findings, env prompt override inventory, write-path pending responses for skill CRUD, export/tool/slash-command integrity handling, global resolver shutdown cleanup, final verification scope updates, and follow-up boundaries for bundled/plugin/repo skill adapters. Verification: red-flag term scan and ASCII scan both returned no matches. Bandit not applicable because this task only edits documentation.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2366 - Implement-context-integrity-foundation-for-skills-and-prompts.md
+++ b/backlog/tasks/task-2366 - Implement-context-integrity-foundation-for-skills-and-prompts.md
@@ -26,6 +26,9 @@ modified_files:
 - tldw_Server_API/tests/Skills/integration/test_skills_api.py
 - tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py
 - tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py
+- tldw_Server_API/app/core/Utils/prompt_loader.py
+- tldw_Server_API/tests/Utils/test_prompt_loader_paths.py
+- tldw_Server_API/tests/Utils/test_prompt_loader_env_overrides.py
 ---
 
 ## Description
@@ -72,6 +75,14 @@ Verification recorded for Task 6:
 - RED run for review regressions: `.venv/bin/python -m pytest tldw_Server_API/tests/Skills/unit/test_skills_service.py::TestSkillsService::test_degraded_global_resolver_blocks_default_service tldw_Server_API/tests/Skills/unit/test_skills_service.py::TestSkillsService::test_symlinked_skill_directory_is_not_read_without_resolver -q` failed before the correction with both tests failing.
 - Focused Task 6 suite: `.venv/bin/python -m pytest tldw_Server_API/tests/Skills/unit/test_skills_service.py tldw_Server_API/tests/Skills/integration/test_skills_api.py tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py -q` passed with `133 passed, 6 warnings`.
 - Bandit: `.venv/bin/python -m bandit -r tldw_Server_API/app/core/Skills/skills_service.py tldw_Server_API/app/core/Skills/context_integration.py tldw_Server_API/app/core/Chat/command_router.py tldw_Server_API/app/api/v1/endpoints/skills.py -f json -o /tmp/bandit_context_integrity_task6.json` exited 0 with zero findings.
+- Formatter/whitespace: `.venv/bin/python -m black ...` completed; `git diff --check` clean.
+
+Task 7 slice enforced Context Integrity in the prompt loader. Markdown, YAML, JSON, and `TLDW_PROMPT_FILE_*` override reads now flow through `_read_prompt_file_text()`, which reads bytes once, computes the canonical digest over those exact bytes using the same asset IDs and metadata as inventory, asks the global resolver, and only then decodes the same bytes for parsing. Quarantined files, unapproved files under enforcement, live edits after boot, invalid UTF-8, and symlinked prompt files fail closed without logging prompt content.
+
+Verification recorded for Task 7:
+- RED run: `.venv/bin/python -m pytest tldw_Server_API/tests/Utils/test_prompt_loader_paths.py -q` failed before implementation with the three new prompt-loader integrity tests failing.
+- Focused Task 7 suite: `.venv/bin/python -m pytest tldw_Server_API/tests/Utils/test_prompt_loader_paths.py tldw_Server_API/tests/Utils/test_prompt_loader_env_overrides.py -q` passed with `10 passed, 6 warnings`.
+- Bandit: `.venv/bin/python -m bandit -r tldw_Server_API/app/core/Utils/prompt_loader.py -f json -o /tmp/bandit_context_integrity_task7.json` exited 0 with zero findings.
 - Formatter/whitespace: `.venv/bin/python -m black ...` completed; `git diff --check` clean.
 <!-- SECTION:FINAL_SUMMARY:END -->
 

--- a/backlog/tasks/task-2366 - Implement-context-integrity-foundation-for-skills-and-prompts.md
+++ b/backlog/tasks/task-2366 - Implement-context-integrity-foundation-for-skills-and-prompts.md
@@ -1,0 +1,66 @@
+---
+id: TASK-2366
+title: Implement context integrity foundation for skills and prompts
+status: In Progress
+labels:
+- security
+- skills
+- prompts
+- implementation
+priority: high
+references:
+- TASK-2363
+- TASK-2365
+modified_files:
+- tldw_Server_API/app/services/startup_context_integrity.py
+- tldw_Server_API/app/services/lifespan_startup_sequence.py
+- tldw_Server_API/app/services/lifespan_shutdown_sequence.py
+- tldw_Server_API/tests/Services/test_startup_context_integrity.py
+- tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py
+- tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the reviewed context integrity foundation for skill and prompt files, including manifests, startup verification, resolver enforcement, integration chokepoints, admin reporting, tests, docs, and verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-plan.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Task 5 slice implemented the startup verification producer and lifecycle wiring. Startup now inventories prompt files, env prompt overrides, and discovered/test-injected user skill roots through rich InventoryResult APIs; loads optional signed HMAC manifests from environment; distinguishes no manifest from valid empty manifests; attaches ContextIntegrityBootState and ContextIntegrityResolver to app state; sets the global resolver; registers context_integrity.* startup warnings; and clears app/global resolver state during lifespan shutdown.
+
+Verification recorded for Task 5:
+- RED run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Services/test_startup_context_integrity.py tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py -v` failed as expected before implementation with missing startup_context_integrity imports and shutdown resolver cleanup assertion failure.
+- Focused Services suite: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Services/test_startup_context_integrity.py tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py -v` passed with `12 passed, 6 warnings`.
+- Context_Integrity unit suite: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Context_Integrity/unit -v` passed with `116 passed, 6 warnings`.
+- Formatter: `source .venv/bin/activate && python -m black ...` completed; 2 files reformatted.
+- Bandit: `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/services/startup_context_integrity.py tldw_Server_API/app/services/lifespan_startup_sequence.py tldw_Server_API/app/services/lifespan_shutdown_sequence.py -f json -o /tmp/bandit_context_integrity_task5.json` exited 0 with zero findings.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2366 - Implement-context-integrity-foundation-for-skills-and-prompts.md
+++ b/backlog/tasks/task-2366 - Implement-context-integrity-foundation-for-skills-and-prompts.md
@@ -1,38 +1,20 @@
 ---
 id: TASK-2366
 title: Implement context integrity foundation for skills and prompts
-status: In Progress
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-25 23:08'
 labels:
-- security
-- skills
-- prompts
-- implementation
-priority: high
+  - security
+  - skills
+  - prompts
+  - implementation
+dependencies: []
 references:
-- TASK-2363
-- TASK-2365
-modified_files:
-- tldw_Server_API/app/services/startup_context_integrity.py
-- tldw_Server_API/app/services/lifespan_startup_sequence.py
-- tldw_Server_API/app/services/lifespan_shutdown_sequence.py
-- tldw_Server_API/tests/Services/test_startup_context_integrity.py
-- tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py
-- tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py
-- tldw_Server_API/app/core/Skills/skills_service.py
-- tldw_Server_API/app/core/Skills/context_integration.py
-- tldw_Server_API/app/core/Chat/command_router.py
-- tldw_Server_API/app/api/v1/endpoints/skills.py
-- tldw_Server_API/tests/Skills/unit/test_skills_service.py
-- tldw_Server_API/tests/Skills/integration/test_skills_api.py
-- tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py
-- tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py
-- tldw_Server_API/app/core/Utils/prompt_loader.py
-- tldw_Server_API/tests/Utils/test_prompt_loader_paths.py
-- tldw_Server_API/tests/Utils/test_prompt_loader_env_overrides.py
-- tldw_Server_API/app/api/v1/endpoints/admin/context_integrity.py
-- tldw_Server_API/app/api/v1/endpoints/admin/__init__.py
-- tldw_Server_API/app/api/v1/schemas/admin_schemas.py
-- tldw_Server_API/tests/AuthNZ_SQLite/test_admin_context_integrity_sqlite.py
+  - TASK-2363
+  - TASK-2365
+priority: high
 ---
 
 ## Description
@@ -53,9 +35,11 @@ Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-pl
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
@@ -96,14 +80,21 @@ Verification recorded for Task 8:
 - Focused Task 8 suite: `.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ_SQLite/test_admin_context_integrity_sqlite.py tldw_Server_API/tests/AuthNZ_SQLite/test_admin_startup_warnings_sqlite.py -q` passed with `5 passed, 7 warnings`.
 - Bandit: `.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/admin/context_integrity.py tldw_Server_API/app/api/v1/schemas/admin_schemas.py -f json -o /tmp/bandit_context_integrity_task8.json` exited 0 with zero findings.
 - Formatter/whitespace: `.venv/bin/python -m black ...` completed for new endpoint/test files; unrelated schema formatting was reverted; `git diff --check` clean.
+
+Task 9 final verification found no defects and required no code fixes.
+
+Verification recorded for Task 9:
+- Core Context Integrity unit suite: `.venv/bin/python -m pytest tldw_Server_API/tests/Context_Integrity/unit -q` passed with `116 passed, 6 warnings`.
+- Broader focused suite: `.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_context_integrity.py tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/AuthNZ_SQLite/test_admin_context_integrity_sqlite.py tldw_Server_API/tests/Skills/unit/test_skills_service.py tldw_Server_API/tests/Skills/integration/test_skills_api.py tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py tldw_Server_API/tests/Utils/test_prompt_loader_paths.py tldw_Server_API/tests/Utils/test_prompt_loader_env_overrides.py -q` passed with `158 passed, 7 warnings`.
+- Combined Bandit touched scope: `.venv/bin/python -m bandit -r tldw_Server_API/app/core/Context_Integrity tldw_Server_API/app/services/startup_context_integrity.py tldw_Server_API/app/services/lifespan_startup_sequence.py tldw_Server_API/app/services/lifespan_shutdown_sequence.py tldw_Server_API/app/core/Skills/skills_service.py tldw_Server_API/app/core/Skills/context_integration.py tldw_Server_API/app/core/Chat/command_router.py tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/core/Utils/prompt_loader.py tldw_Server_API/app/api/v1/endpoints/admin/context_integrity.py -f json -o /tmp/bandit_context_integrity_foundation.json` exited 0 with zero findings.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2366 - Implement-context-integrity-foundation-for-skills-and-prompts.md
+++ b/backlog/tasks/task-2366 - Implement-context-integrity-foundation-for-skills-and-prompts.md
@@ -29,6 +29,10 @@ modified_files:
 - tldw_Server_API/app/core/Utils/prompt_loader.py
 - tldw_Server_API/tests/Utils/test_prompt_loader_paths.py
 - tldw_Server_API/tests/Utils/test_prompt_loader_env_overrides.py
+- tldw_Server_API/app/api/v1/endpoints/admin/context_integrity.py
+- tldw_Server_API/app/api/v1/endpoints/admin/__init__.py
+- tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+- tldw_Server_API/tests/AuthNZ_SQLite/test_admin_context_integrity_sqlite.py
 ---
 
 ## Description
@@ -84,6 +88,14 @@ Verification recorded for Task 7:
 - Focused Task 7 suite: `.venv/bin/python -m pytest tldw_Server_API/tests/Utils/test_prompt_loader_paths.py tldw_Server_API/tests/Utils/test_prompt_loader_env_overrides.py -q` passed with `10 passed, 6 warnings`.
 - Bandit: `.venv/bin/python -m bandit -r tldw_Server_API/app/core/Utils/prompt_loader.py -f json -o /tmp/bandit_context_integrity_task7.json` exited 0 with zero findings.
 - Formatter/whitespace: `.venv/bin/python -m black ...` completed; `git diff --check` clean.
+
+Task 8 slice added admin inspection for current-process Context Integrity state. The admin router now exposes `GET /api/v1/admin/context-integrity`, returning boot mode, degraded state, manifest sequence/digest, and content-free finding metadata from `app.state.context_integrity_boot_state`; non-admin callers receive the existing admin-router 403. Response schemas live beside startup-warning admin schemas.
+
+Verification recorded for Task 8:
+- RED run: `.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ_SQLite/test_admin_context_integrity_sqlite.py -q` failed before implementation with 404 responses.
+- Focused Task 8 suite: `.venv/bin/python -m pytest tldw_Server_API/tests/AuthNZ_SQLite/test_admin_context_integrity_sqlite.py tldw_Server_API/tests/AuthNZ_SQLite/test_admin_startup_warnings_sqlite.py -q` passed with `5 passed, 7 warnings`.
+- Bandit: `.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/admin/context_integrity.py tldw_Server_API/app/api/v1/schemas/admin_schemas.py -f json -o /tmp/bandit_context_integrity_task8.json` exited 0 with zero findings.
+- Formatter/whitespace: `.venv/bin/python -m black ...` completed for new endpoint/test files; unrelated schema formatting was reverted; `git diff --check` clean.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2366 - Implement-context-integrity-foundation-for-skills-and-prompts.md
+++ b/backlog/tasks/task-2366 - Implement-context-integrity-foundation-for-skills-and-prompts.md
@@ -18,6 +18,14 @@ modified_files:
 - tldw_Server_API/tests/Services/test_startup_context_integrity.py
 - tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py
 - tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py
+- tldw_Server_API/app/core/Skills/skills_service.py
+- tldw_Server_API/app/core/Skills/context_integration.py
+- tldw_Server_API/app/core/Chat/command_router.py
+- tldw_Server_API/app/api/v1/endpoints/skills.py
+- tldw_Server_API/tests/Skills/unit/test_skills_service.py
+- tldw_Server_API/tests/Skills/integration/test_skills_api.py
+- tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py
+- tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py
 ---
 
 ## Description
@@ -47,12 +55,24 @@ Docs/superpowers/plans/2026-06-25-context-integrity-foundation-implementation-pl
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Task 5 slice implemented the startup verification producer and lifecycle wiring. Startup now inventories prompt files, env prompt overrides, and discovered/test-injected user skill roots through rich InventoryResult APIs; loads optional signed HMAC manifests from environment; distinguishes no manifest from valid empty manifests; attaches ContextIntegrityBootState and ContextIntegrityResolver to app state; sets the global resolver; registers context_integrity.* startup warnings; and clears app/global resolver state during lifespan shutdown.
 
+Task 5 review follow-up fixed read-only skill-root discovery: Context Integrity now resolves the user database base path for discovery without calling DatabasePaths.get_user_db_base_dir(), avoiding the helper's directory creation side effect. A regression test verifies a missing USER_DB_BASE_DIR is not created during discovery.
+
 Verification recorded for Task 5:
 - RED run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Services/test_startup_context_integrity.py tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py -v` failed as expected before implementation with missing startup_context_integrity imports and shutdown resolver cleanup assertion failure.
-- Focused Services suite: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Services/test_startup_context_integrity.py tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py -v` passed with `12 passed, 6 warnings`.
-- Context_Integrity unit suite: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Context_Integrity/unit -v` passed with `116 passed, 6 warnings`.
-- Formatter: `source .venv/bin/activate && python -m black ...` completed; 2 files reformatted.
-- Bandit: `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/services/startup_context_integrity.py tldw_Server_API/app/services/lifespan_startup_sequence.py tldw_Server_API/app/services/lifespan_shutdown_sequence.py -f json -o /tmp/bandit_context_integrity_task5.json` exited 0 with zero findings.
+- Focused Services suite after follow-up fix: `.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_context_integrity.py tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py -q` passed with `13 passed, 6 warnings`.
+- Context_Integrity unit suite: `.venv/bin/python -m pytest tldw_Server_API/tests/Context_Integrity/unit -q` passed with `116 passed, 6 warnings`.
+- Bandit: `.venv/bin/python -m bandit -r tldw_Server_API/app/services/startup_context_integrity.py tldw_Server_API/app/services/lifespan_startup_sequence.py tldw_Server_API/app/services/lifespan_shutdown_sequence.py -f json -o /tmp/bandit_context_integrity_task5_manual_review.json` exited 0 with zero findings.
+- Formatter/whitespace: `git diff --check HEAD~1..HEAD` clean.
+
+Task 6 slice enforced Context Integrity in Skills runtime paths. SkillsService now uses the current global or injected resolver, rehashes prompt-bearing skill files at use time, blocks direct reads/exports/execution for quarantined or live-edited skills, filters blocked skills from model context/discovery, returns write-response snapshots without approving newly written skills, and rejects symlinked skill directories or prompt-bearing symlink paths. The REST API maps blocked get/export/execute requests to content-free HTTP 423 responses; MCP skill tool calls and chat slash-command execution return stable content-free integrity errors.
+
+Task 6 manual review follow-up removed an unsafe degraded-resolver fallback. Default SkillsService construction now honors degraded global resolver state and fails closed; non-integrity skills API tests clear the global resolver explicitly in their fixtures.
+
+Verification recorded for Task 6:
+- RED run for review regressions: `.venv/bin/python -m pytest tldw_Server_API/tests/Skills/unit/test_skills_service.py::TestSkillsService::test_degraded_global_resolver_blocks_default_service tldw_Server_API/tests/Skills/unit/test_skills_service.py::TestSkillsService::test_symlinked_skill_directory_is_not_read_without_resolver -q` failed before the correction with both tests failing.
+- Focused Task 6 suite: `.venv/bin/python -m pytest tldw_Server_API/tests/Skills/unit/test_skills_service.py tldw_Server_API/tests/Skills/integration/test_skills_api.py tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py -q` passed with `133 passed, 6 warnings`.
+- Bandit: `.venv/bin/python -m bandit -r tldw_Server_API/app/core/Skills/skills_service.py tldw_Server_API/app/core/Skills/context_integration.py tldw_Server_API/app/core/Chat/command_router.py tldw_Server_API/app/api/v1/endpoints/skills.py -f json -o /tmp/bandit_context_integrity_task6.json` exited 0 with zero findings.
+- Formatter/whitespace: `.venv/bin/python -m black ...` completed; `git diff --check` clean.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/endpoints/admin/__init__.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/__init__.py
@@ -51,6 +51,7 @@ from . import admin_tenant_provisioning as admin_tenant_provisioning_endpoints
 from . import admin_tools as admin_tools_endpoints
 from . import admin_usage as admin_usage_endpoints
 from . import admin_user as admin_user_endpoints
+from . import context_integrity as context_integrity_endpoints
 from . import startup_warnings as startup_warnings_endpoints
 
 _ADMIN_NONCRITICAL_EXCEPTIONS = (
@@ -141,6 +142,7 @@ router.include_router(admin_identity_providers_endpoints.router)
 router.include_router(admin_storage_quotas_endpoints.router)
 router.include_router(admin_tenant_provisioning_endpoints.router)
 router.include_router(admin_impersonation_endpoints.router)
+router.include_router(context_integrity_endpoints.router)
 router.include_router(startup_warnings_endpoints.router)
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/admin/context_integrity.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/context_integrity.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
+    AdminContextIntegrityFinding,
+    AdminContextIntegrityResponse,
+)
+
+
+router = APIRouter()
+
+
+@router.get(
+    "/context-integrity",
+    response_model=AdminContextIntegrityResponse,
+)
+async def get_context_integrity_status(request: Request) -> AdminContextIntegrityResponse:
+    """Return current-process Context Integrity boot state."""
+    boot_state = getattr(request.app.state, "context_integrity_boot_state", None)
+    if boot_state is None:
+        return AdminContextIntegrityResponse(
+            mode="uninitialized",
+            degraded=True,
+            manifest_sequence=None,
+            manifest_digest=None,
+            findings_present=False,
+            findings=[],
+        )
+
+    findings = [AdminContextIntegrityFinding.model_validate(finding) for finding in boot_state.findings]
+    return AdminContextIntegrityResponse(
+        mode=str(boot_state.mode),
+        degraded=bool(boot_state.degraded),
+        manifest_sequence=boot_state.manifest_sequence,
+        manifest_digest=boot_state.manifest_digest,
+        findings_present=bool(findings),
+        findings=findings,
+    )

--- a/tldw_Server_API/app/api/v1/endpoints/admin/context_integrity.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/context_integrity.py
@@ -1,3 +1,5 @@
+"""Admin endpoint for content-free Context Integrity boot-state inspection."""
+
 from __future__ import annotations
 
 from fastapi import APIRouter, Request

--- a/tldw_Server_API/app/api/v1/endpoints/skills.py
+++ b/tldw_Server_API/app/api/v1/endpoints/skills.py
@@ -51,6 +51,7 @@ from tldw_Server_API.app.api.v1.schemas.skills_schemas import (
 )
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+from tldw_Server_API.app.core.Context_Integrity.resolver import ContextIntegrityBlocked
 from tldw_Server_API.app.core.Skills.exceptions import (
     SkillConflictError,
     SkillNotFoundError,
@@ -64,6 +65,7 @@ router = APIRouter()
 
 MAX_SKILL_IMPORT_PREVIEW_UPLOAD_BYTES = 6 * 1024 * 1024
 _ZIP_UPLOAD_SIGNATURES = (b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")
+CONTEXT_INTEGRITY_LOCKED_DETAIL = "Asset is quarantined pending admin review."
 
 
 async def _read_skill_import_preview_upload(file: UploadFile) -> bytes:
@@ -141,6 +143,13 @@ def _metadata_to_summary(metadata) -> SkillSummary:
         disable_model_invocation=metadata.disable_model_invocation,
         context=metadata.context,
     )
+
+
+def _raise_context_integrity_locked(exc: ContextIntegrityBlocked) -> None:
+    raise HTTPException(
+        status_code=status.HTTP_423_LOCKED,
+        detail=CONTEXT_INTEGRITY_LOCKED_DETAIL,
+    ) from exc
 
 
 @router.get("/", response_model=SkillsListResponse)
@@ -240,9 +249,7 @@ async def get_skills_context(
     try:
         payload = await service.get_context_payload_async()
         return SkillContextPayload(
-            available_skills=[
-                SkillSummary(**s) for s in payload["available_skills"]
-            ],
+            available_skills=[SkillSummary(**s) for s in payload["available_skills"]],
             context_text=payload["context_text"],
         )
     except SkillsError as e:
@@ -266,6 +273,8 @@ async def get_skill(
     try:
         skill_data = await service.get_skill(skill_name)
         return _skill_data_to_response(skill_data)
+    except ContextIntegrityBlocked as e:
+        _raise_context_integrity_locked(e)
     except SkillNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -585,6 +594,8 @@ async def export_skill(
                 "Content-Disposition": f'attachment; filename="{skill_name}.zip"',
             },
         )
+    except ContextIntegrityBlocked as e:
+        _raise_context_integrity_locked(e)
     except SkillNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -620,11 +631,13 @@ async def execute_skill(
             # Populate full RequestContext for fork mode support
             try:
                 from tldw_Server_API.app.api.v1.schemas.chat_request_schemas import DEFAULT_LLM_PROVIDER
+
                 default_provider = DEFAULT_LLM_PROVIDER
             except Exception:
                 default_provider = "openai"
             try:
                 from tldw_Server_API.app.core.config import load_and_log_configs
+
                 app_config = load_and_log_configs()
             except Exception:
                 app_config = None
@@ -650,6 +663,8 @@ async def execute_skill(
             fork_output=result.fork_output,
             dry_run=result.dry_run,
         )
+    except ContextIntegrityBlocked as e:
+        _raise_context_integrity_locked(e)
     except SkillNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -268,6 +268,37 @@ class AdminStartupWarningsResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class AdminContextIntegrityFinding(BaseModel):
+    """One current-process Context Integrity finding."""
+
+    asset_id: str
+    state: str
+    severity: str
+    summary: str
+    remediation: str
+    source_type: str
+    current_digest: str | None = None
+    approved_digest: str | None = None
+    details: dict[str, Any] = Field(default_factory=dict)
+    detected_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AdminContextIntegrityResponse(BaseModel):
+    """Current-process Context Integrity state for admin inspection."""
+
+    scope: Literal["current_process"] = "current_process"
+    mode: str
+    degraded: bool
+    manifest_sequence: int | None = None
+    manifest_digest: str | None = None
+    findings_present: bool
+    findings: list[AdminContextIntegrityFinding] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 #######################################################################################################################
 #
 # Registration Code Schemas

--- a/tldw_Server_API/app/core/Chat/command_router.py
+++ b/tldw_Server_API/app/core/Chat/command_router.py
@@ -37,6 +37,7 @@ from loguru import logger
 
 from tldw_Server_API.app.core.Chat.rate_limiter import TokenBucket
 from tldw_Server_API.app.core.config import load_comprehensive_config
+from tldw_Server_API.app.core.Context_Integrity.resolver import ContextIntegrityBlocked
 from tldw_Server_API.app.core.Integrations import weather_providers
 from tldw_Server_API.app.core.Metrics import increment_counter
 from tldw_Server_API.app.core.Metrics.metrics_logger import log_counter
@@ -63,6 +64,7 @@ _COMMAND_ROUTER_NONCRITICAL_EXCEPTIONS = (
 try:
     from tldw_Server_API.app.core.AuthNZ.rbac import user_has_permission as _user_has_permission
 except ImportError:  # pragma: no cover - fallback if AuthNZ is trimmed in tests
+
     def _user_has_permission(user_id: int, permission: str) -> bool:  # type: ignore
         logger.warning("AuthNZ RBAC unavailable; denying chat command permission check for {}", permission)
         return False
@@ -87,9 +89,9 @@ def _cfg_bool(env_name: str, cfg_key: str, fallback: bool) -> bool:
     if isinstance(v, str) and v.strip():
         return is_truthy(v)
     cp = _cfg()
-    if cp and cp.has_section('Chat-Commands'):
+    if cp and cp.has_section("Chat-Commands"):
         try:
-            raw = cp.get('Chat-Commands', cfg_key, fallback=str(fallback))
+            raw = cp.get("Chat-Commands", cfg_key, fallback=str(fallback))
             return is_truthy(raw)
         except _COMMAND_ROUTER_NONCRITICAL_EXCEPTIONS:
             return fallback
@@ -104,9 +106,9 @@ def _cfg_int(env_name: str, cfg_key: str, fallback: int) -> int:
         except (TypeError, ValueError):
             return fallback
     cp = _cfg()
-    if cp and cp.has_section('Chat-Commands'):
+    if cp and cp.has_section("Chat-Commands"):
         try:
-            raw = cp.get('Chat-Commands', cfg_key, fallback=str(fallback))
+            raw = cp.get("Chat-Commands", cfg_key, fallback=str(fallback))
             return max(1, int(str(raw)))
         except (TypeError, ValueError):
             return fallback
@@ -118,9 +120,9 @@ def _cfg_str(env_name: str, cfg_key: str, fallback: str) -> str:
     if isinstance(v, str) and v.strip():
         return v.strip()
     cp = _cfg()
-    if cp and cp.has_section('Chat-Commands'):
+    if cp and cp.has_section("Chat-Commands"):
         try:
-            raw = cp.get('Chat-Commands', cfg_key, fallback=fallback)
+            raw = cp.get("Chat-Commands", cfg_key, fallback=fallback)
             return str(raw).strip()
         except _COMMAND_ROUTER_NONCRITICAL_EXCEPTIONS:
             return fallback
@@ -349,9 +351,7 @@ def list_commands() -> list[dict[str, Any]]:
             "requires_api_key": bool(spec.requires_api_key),
             "rate_limit": spec.rate_limit or default_rate_limit,
             "rbac_required": (
-                bool(spec.required_permission)
-                if spec.rbac_required is None
-                else bool(spec.rbac_required)
+                bool(spec.required_permission) if spec.rbac_required is None else bool(spec.rbac_required)
             ),
         }
         for spec in _registry.values()
@@ -560,8 +560,10 @@ async def async_dispatch_command(ctx: CommandContext, command: str, args: str | 
 # Built-in command handlers
 # -----------------------------
 
+
 def _time_handler(ctx: CommandContext, args: str | None) -> CommandResult:
     from datetime import datetime
+
     try:
         # Optional timezone support via zoneinfo
         tzlabel = (args or "").strip() if args else None
@@ -570,6 +572,7 @@ def _time_handler(ctx: CommandContext, args: str | None) -> CommandResult:
         if tzlabel:
             try:
                 from zoneinfo import ZoneInfo  # Python 3.9+
+
                 dt = datetime.now(ZoneInfo(tzlabel))
                 tzused = tzlabel
             except _COMMAND_ROUTER_NONCRITICAL_EXCEPTIONS:
@@ -585,7 +588,9 @@ def _time_handler(ctx: CommandContext, args: str | None) -> CommandResult:
             metadata={"tz": tzused},
         )
     except _COMMAND_ROUTER_NONCRITICAL_EXCEPTIONS as e:
-        return CommandResult(ok=False, command="time", content=f"Time lookup failed: {e}", metadata={"error": "time_error"})
+        return CommandResult(
+            ok=False, command="time", content=f"Time lookup failed: {e}", metadata={"error": "time_error"}
+        )
 
 
 async def _weather_handler(ctx: CommandContext, args: str | None) -> CommandResult:
@@ -607,7 +612,9 @@ async def _weather_handler(ctx: CommandContext, args: str | None) -> CommandResu
         return CommandResult(ok=False, command="weather", content=result.summary, metadata=metadata)
     except _COMMAND_ROUTER_NONCRITICAL_EXCEPTIONS as e:
         logger.error(f"Weather provider error: {e}", exc_info=True)
-        return CommandResult(ok=False, command="weather", content=f"Weather unavailable: {e}", metadata={"error": "exception"})
+        return CommandResult(
+            ok=False, command="weather", content=f"Weather unavailable: {e}", metadata={"error": "exception"}
+        )
 
 
 def _request_meta(ctx: CommandContext) -> dict[str, Any]:
@@ -670,7 +677,8 @@ def _filter_skills_for_query(skills: list[dict[str, Any]], query: str | None) ->
     if not q:
         return list(skills)
     return [
-        skill for skill in skills
+        skill
+        for skill in skills
         if (
             q in str(skill.get("name") or "").lower()
             or q in str(skill.get("description") or "").lower()
@@ -756,6 +764,8 @@ async def _execute_skill(ctx: CommandContext, skill_name: str, skill_args: str) 
         user_id, base_path, db = await _resolve_skills_runtime(ctx)
         service = SkillsService(user_id=user_id, base_path=base_path, db=db)
         skill_data = await service.get_skill(normalized_name)
+    except ContextIntegrityBlocked:
+        return {"success": False, "error": "context_integrity_blocked"}
     except SkillNotFoundError:
         return {"success": False, "error": "skill_not_found"}
     except SkillsError as e:
@@ -869,6 +879,8 @@ async def _skill_handler(ctx: CommandContext, args: str | None) -> CommandResult
             message = f"Skill '{skill_name}' not found."
         elif error == "skill_not_invocable":
             message = f"Skill '{skill_name}' is not invocable."
+        elif error == "context_integrity_blocked":
+            message = "Skill is quarantined pending admin review."
         else:
             detail = str(result.get("detail") or "Skill execution failed.")
             message = f"Skill execution failed: {detail}"
@@ -936,6 +948,7 @@ register_command(
     requires_api_key=True,
     rbac_required=True,
 )
+
 
 # --- Test seam helpers ---
 def get_weather_client(ctx: CommandContext | None = None):

--- a/tldw_Server_API/app/core/Context_Integrity/__init__.py
+++ b/tldw_Server_API/app/core/Context_Integrity/__init__.py
@@ -1,0 +1,1 @@
+"""Context integrity controls for prompt-bearing assets."""

--- a/tldw_Server_API/app/core/Context_Integrity/canonicalization.py
+++ b/tldw_Server_API/app/core/Context_Integrity/canonicalization.py
@@ -1,0 +1,72 @@
+"""Canonical hashing helpers for prompt-bearing assets."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import unicodedata
+from typing import Any, Mapping
+
+from tldw_Server_API.app.core.Context_Integrity.models import CanonicalDigest
+
+
+def _normalize_text(value: str) -> str:
+    return unicodedata.normalize("NFC", value.replace("\r\n", "\n").replace("\r", "\n"))
+
+
+def _normalize_json_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return _normalize_text(value)
+    if isinstance(value, Mapping):
+        return {str(key): _normalize_json_value(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        return [_normalize_json_value(item) for item in value]
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    return _normalize_text(str(value))
+
+
+def _stable_json(payload: Mapping[str, Any]) -> str:
+    normalized = _normalize_json_value(payload)
+    return json.dumps(normalized, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _sha256(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def canonical_filesystem_digest(
+    *,
+    source_type: str,
+    asset_id: str,
+    files: Mapping[str, bytes],
+    metadata: Mapping[str, Any] | None = None,
+) -> str:
+    """Hash raw file bytes plus deterministic identity metadata."""
+    hasher = hashlib.sha256()
+    identity = _stable_json(
+        {
+            "asset_id": asset_id,
+            "source_type": source_type,
+            "metadata": dict(metadata or {}),
+        }
+    ).encode("utf-8")
+    hasher.update(len(identity).to_bytes(8, "big"))
+    hasher.update(identity)
+    for relative_path in sorted(files):
+        path_bytes = relative_path.replace("\\", "/").encode("utf-8")
+        content = files[relative_path]
+        hasher.update(len(path_bytes).to_bytes(8, "big"))
+        hasher.update(path_bytes)
+        hasher.update(len(content).to_bytes(8, "big"))
+        hasher.update(content)
+    return "sha256:" + hasher.hexdigest()
+
+
+def canonical_db_prompt_digest(record: Mapping[str, Any]) -> CanonicalDigest:
+    """Hash a stable prompt-version JSON representation."""
+    canonical_json = _stable_json(dict(record))
+    return CanonicalDigest(
+        digest=_sha256(canonical_json.encode("utf-8")),
+        canonical_json=canonical_json,
+    )

--- a/tldw_Server_API/app/core/Context_Integrity/canonicalization.py
+++ b/tldw_Server_API/app/core/Context_Integrity/canonicalization.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import hashlib
 import json
+import math
 import unicodedata
-from typing import Any, Mapping
+from typing import Any
 
 from tldw_Server_API.app.core.Context_Integrity.models import CanonicalDigest
 
@@ -17,18 +19,33 @@ def _normalize_text(value: str) -> str:
 def _normalize_json_value(value: Any) -> Any:
     if isinstance(value, str):
         return _normalize_text(value)
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("Non-finite floats are not supported in canonical JSON")
+        return value
     if isinstance(value, Mapping):
-        return {str(key): _normalize_json_value(value[key]) for key in sorted(value)}
+        for key in value:
+            if not isinstance(key, str):
+                raise TypeError("Canonical JSON mapping keys must be strings")
+        return {key: _normalize_json_value(value[key]) for key in sorted(value)}
     if isinstance(value, list):
         return [_normalize_json_value(item) for item in value]
-    if value is None or isinstance(value, (bool, int, float)):
-        return value
-    return _normalize_text(str(value))
+    raise TypeError(f"Unsupported canonical JSON value type: {type(value).__name__}")
 
 
 def _stable_json(payload: Mapping[str, Any]) -> str:
     normalized = _normalize_json_value(payload)
-    return json.dumps(normalized, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return json.dumps(
+        normalized,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
 
 
 def _sha256(data: bytes) -> str:

--- a/tldw_Server_API/app/core/Context_Integrity/canonicalization.py
+++ b/tldw_Server_API/app/core/Context_Integrity/canonicalization.py
@@ -70,9 +70,15 @@ def canonical_filesystem_digest(
     ).encode("utf-8")
     hasher.update(len(identity).to_bytes(8, "big"))
     hasher.update(identity)
-    for relative_path in sorted(files):
-        path_bytes = relative_path.replace("\\", "/").encode("utf-8")
-        content = files[relative_path]
+    normalized_files: dict[str, bytes] = {}
+    for relative_path, content in files.items():
+        normalized_path = _normalize_text(relative_path).replace("\\", "/")
+        if normalized_path in normalized_files:
+            raise ValueError(f"Duplicate canonical file path after normalization: {normalized_path}")
+        normalized_files[normalized_path] = content
+    for relative_path in sorted(normalized_files):
+        path_bytes = relative_path.encode("utf-8")
+        content = normalized_files[relative_path]
         hasher.update(len(path_bytes).to_bytes(8, "big"))
         hasher.update(path_bytes)
         hasher.update(len(content).to_bytes(8, "big"))

--- a/tldw_Server_API/app/core/Context_Integrity/inventory.py
+++ b/tldw_Server_API/app/core/Context_Integrity/inventory.py
@@ -1,0 +1,467 @@
+"""Filesystem inventory adapters for Context Integrity."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import os
+from pathlib import Path
+
+from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+    canonical_filesystem_digest,
+)
+from tldw_Server_API.app.core.Context_Integrity.models import (
+    ContextAssetDescriptor,
+    ContextAssetSource,
+    ContextIntegrityFinding,
+)
+
+_PROMPT_SUFFIXES = {".md", ".yaml", ".yml", ".json", ".txt"}
+_SKILL_TEXT_SUFFIXES = {".md", ".txt", ".json", ".yaml", ".yml", ".py", ".sh"}
+
+
+@dataclass(frozen=True, slots=True)
+class InventoryResult:
+    """Inventory assets plus non-fatal discovery findings."""
+
+    assets: tuple[ContextAssetDescriptor, ...]
+    findings: tuple[ContextIntegrityFinding, ...] = ()
+
+
+def _verification_error(
+    *,
+    asset_id: str,
+    source_type: ContextAssetSource,
+    summary: str,
+    path: Path,
+    details: Mapping[str, str] | None = None,
+) -> ContextIntegrityFinding:
+    finding_details = {"path": str(path)}
+    if details:
+        finding_details.update(details)
+    return ContextIntegrityFinding(
+        asset_id=asset_id,
+        state="verification_error",
+        severity="error",
+        summary=summary,
+        remediation="Review the filesystem path and quarantine or restore the affected asset.",
+        source_type=source_type,
+        details=finding_details,
+    )
+
+
+def _path_resolves_within(path: Path, root: Path) -> bool:
+    try:
+        path.resolve(strict=False).relative_to(root.resolve(strict=False))
+    except (OSError, RuntimeError, ValueError):
+        return False
+    return True
+
+
+def _symlink_finding(
+    *,
+    asset_id: str,
+    source_type: ContextAssetSource,
+    path: Path,
+    root: Path | None,
+) -> ContextIntegrityFinding:
+    escaped = root is not None and not _path_resolves_within(path, root)
+    summary = (
+        "Symlinked context path escapes the inventory root and was skipped."
+        if escaped
+        else "Symlinked context path was skipped."
+    )
+    details = {"root": str(root)} if root is not None else None
+    return _verification_error(
+        asset_id=asset_id,
+        source_type=source_type,
+        summary=summary,
+        path=path,
+        details=details,
+    )
+
+
+def _read_regular_file(
+    *,
+    path: Path,
+    asset_id: str,
+    source_type: ContextAssetSource,
+    findings: list[ContextIntegrityFinding],
+) -> bytes | None:
+    if path.is_symlink():
+        findings.append(
+            _symlink_finding(
+                asset_id=asset_id,
+                source_type=source_type,
+                path=path,
+                root=None,
+            )
+        )
+        return None
+
+    try:
+        if not path.is_file():
+            findings.append(
+                _verification_error(
+                    asset_id=asset_id,
+                    source_type=source_type,
+                    summary="Configured context file is missing or is not a regular file.",
+                    path=path,
+                )
+            )
+            return None
+        return path.read_bytes()
+    except OSError as exc:
+        findings.append(
+            _verification_error(
+                asset_id=asset_id,
+                source_type=source_type,
+                summary=f"Unable to read context file: {exc.__class__.__name__}.",
+                path=path,
+                details={"error": str(exc)},
+            )
+        )
+        return None
+
+
+def _read_skill_file_map(
+    *,
+    skill_dir: Path,
+    asset_id: str,
+    findings: list[ContextIntegrityFinding],
+) -> dict[str, bytes]:
+    files: dict[str, bytes] = {}
+
+    def _on_walk_error(exc: OSError) -> None:
+        error_path = Path(exc.filename) if exc.filename else skill_dir
+        findings.append(
+            _verification_error(
+                asset_id=asset_id,
+                source_type="skill_file",
+                summary=f"Unable to scan skill directory: {exc.__class__.__name__}.",
+                path=error_path,
+                details={"error": str(exc)},
+            )
+        )
+
+    for current_root, dirnames, filenames in os.walk(
+        skill_dir,
+        topdown=True,
+        onerror=_on_walk_error,
+        followlinks=False,
+    ):
+        current_path = Path(current_root)
+        for dirname in list(dirnames):
+            child = current_path / dirname
+            if child.is_symlink():
+                findings.append(
+                    _symlink_finding(
+                        asset_id=asset_id,
+                        source_type="skill_file",
+                        path=child,
+                        root=skill_dir,
+                    )
+                )
+                dirnames.remove(dirname)
+
+        for filename in filenames:
+            path = current_path / filename
+            if path.is_symlink():
+                findings.append(
+                    _symlink_finding(
+                        asset_id=asset_id,
+                        source_type="skill_file",
+                        path=path,
+                        root=skill_dir,
+                    )
+                )
+                continue
+            if path.suffix.lower() not in _SKILL_TEXT_SUFFIXES:
+                continue
+            try:
+                relative = path.relative_to(skill_dir).as_posix()
+            except ValueError:
+                findings.append(
+                    _verification_error(
+                        asset_id=asset_id,
+                        source_type="skill_file",
+                        summary="Skill file path escaped the skill directory and was skipped.",
+                        path=path,
+                        details={"root": str(skill_dir)},
+                    )
+                )
+                continue
+            try:
+                files[relative] = path.read_bytes()
+            except OSError as exc:
+                findings.append(
+                    _verification_error(
+                        asset_id=asset_id,
+                        source_type="skill_file",
+                        summary=f"Unable to read skill file: {exc.__class__.__name__}.",
+                        path=path,
+                        details={"error": str(exc)},
+                    )
+                )
+
+    return files
+
+
+def inventory_user_skills_with_findings(*, user_id: int, skills_root: Path) -> InventoryResult:
+    """Inventory per-user skill directories with non-fatal discovery findings."""
+    if not skills_root.exists():
+        return InventoryResult(assets=())
+
+    assets: list[ContextAssetDescriptor] = []
+    findings: list[ContextIntegrityFinding] = []
+    try:
+        with os.scandir(skills_root) as iterator:
+            entries = sorted(iterator, key=lambda entry: entry.name)
+    except OSError as exc:
+        return InventoryResult(
+            assets=(),
+            findings=(
+                _verification_error(
+                    asset_id=f"skill:user:{user_id}",
+                    source_type="skill_file",
+                    summary=f"Unable to scan user skills root: {exc.__class__.__name__}.",
+                    path=skills_root,
+                    details={"error": str(exc)},
+                ),
+            ),
+        )
+
+    for entry in entries:
+        skill_dir = Path(entry.path)
+        asset_id = f"skill:user:{user_id}/{entry.name}"
+        try:
+            if entry.is_symlink():
+                findings.append(
+                    _symlink_finding(
+                        asset_id=asset_id,
+                        source_type="skill_file",
+                        path=skill_dir,
+                        root=skills_root,
+                    )
+                )
+                continue
+            if not entry.is_dir(follow_symlinks=False):
+                continue
+        except OSError as exc:
+            findings.append(
+                _verification_error(
+                    asset_id=asset_id,
+                    source_type="skill_file",
+                    summary=f"Unable to inspect skill directory: {exc.__class__.__name__}.",
+                    path=skill_dir,
+                    details={"error": str(exc)},
+                )
+            )
+            continue
+
+        skill_file = skill_dir / "SKILL.md"
+        if skill_file.is_symlink():
+            findings.append(
+                _symlink_finding(
+                    asset_id=asset_id,
+                    source_type="skill_file",
+                    path=skill_file,
+                    root=skill_dir,
+                )
+            )
+            continue
+        if not skill_file.exists():
+            continue
+
+        files = _read_skill_file_map(
+            skill_dir=skill_dir,
+            asset_id=asset_id,
+            findings=findings,
+        )
+        if "SKILL.md" not in files:
+            continue
+
+        metadata = {"skill_name": entry.name}
+        digest = canonical_filesystem_digest(
+            source_type="skill_file",
+            asset_id=asset_id,
+            files=files,
+            metadata=metadata,
+        )
+        assets.append(
+            ContextAssetDescriptor(
+                asset_id=asset_id,
+                source_type="skill_file",
+                digest=digest,
+                display_name=entry.name,
+                executable=True,
+                owner_scope=f"user:{user_id}",
+                path=str(skill_dir),
+                metadata=metadata,
+            )
+        )
+
+    return InventoryResult(assets=tuple(assets), findings=tuple(findings))
+
+
+def inventory_user_skills(*, user_id: int, skills_root: Path) -> list[ContextAssetDescriptor]:
+    """Inventory per-user skill directories."""
+    return list(inventory_user_skills_with_findings(user_id=user_id, skills_root=skills_root).assets)
+
+
+def inventory_prompt_files_with_findings(*, prompts_dir: Path) -> InventoryResult:
+    """Inventory config prompt files under a Prompts directory with findings."""
+    if not prompts_dir.exists():
+        return InventoryResult(assets=())
+
+    assets: list[ContextAssetDescriptor] = []
+    findings: list[ContextIntegrityFinding] = []
+    try:
+        entries = sorted(prompts_dir.iterdir(), key=lambda path: path.name)
+    except OSError as exc:
+        return InventoryResult(
+            assets=(),
+            findings=(
+                _verification_error(
+                    asset_id=f"prompt_file:{prompts_dir.name}",
+                    source_type="prompt_file",
+                    summary=f"Unable to scan prompt directory: {exc.__class__.__name__}.",
+                    path=prompts_dir,
+                    details={"error": str(exc)},
+                ),
+            ),
+        )
+
+    for path in entries:
+        asset_id = f"prompt_file:{path.name}"
+        if path.is_symlink():
+            findings.append(
+                _symlink_finding(
+                    asset_id=asset_id,
+                    source_type="prompt_file",
+                    path=path,
+                    root=prompts_dir,
+                )
+            )
+            continue
+        if path.is_dir():
+            continue
+        if path.suffix.lower() not in _PROMPT_SUFFIXES:
+            continue
+
+        prompt_bytes = _read_regular_file(
+            path=path,
+            asset_id=asset_id,
+            source_type="prompt_file",
+            findings=findings,
+        )
+        if prompt_bytes is None:
+            continue
+
+        metadata = {"path": path.name}
+        digest = canonical_filesystem_digest(
+            source_type="prompt_file",
+            asset_id=asset_id,
+            files={path.name: prompt_bytes},
+            metadata=metadata,
+        )
+        assets.append(
+            ContextAssetDescriptor(
+                asset_id=asset_id,
+                source_type="prompt_file",
+                digest=digest,
+                display_name=path.name,
+                executable=False,
+                owner_scope="system",
+                path=str(path),
+                metadata=metadata,
+            )
+        )
+
+    return InventoryResult(assets=tuple(assets), findings=tuple(findings))
+
+
+def inventory_prompt_files(*, prompts_dir: Path) -> list[ContextAssetDescriptor]:
+    """Inventory config prompt files under a Prompts directory."""
+    return list(inventory_prompt_files_with_findings(prompts_dir=prompts_dir).assets)
+
+
+def inventory_env_prompt_overrides_with_findings(
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> InventoryResult:
+    """Inventory configured prompt override files from TLDW_PROMPT_FILE_* vars."""
+    source = environ if environ is not None else os.environ
+    assets: list[ContextAssetDescriptor] = []
+    findings: list[ContextIntegrityFinding] = []
+
+    for env_name, raw_path in sorted(source.items()):
+        if not env_name.startswith("TLDW_PROMPT_FILE_") or not raw_path.strip():
+            continue
+
+        try:
+            path = Path(raw_path.strip()).expanduser()
+        except RuntimeError as exc:
+            path = Path(raw_path.strip())
+            findings.append(
+                _verification_error(
+                    asset_id=f"prompt_file:env:{env_name}:{path.name}",
+                    source_type="prompt_file",
+                    summary=f"Unable to expand prompt override path: {exc.__class__.__name__}.",
+                    path=path,
+                    details={"error": str(exc)},
+                )
+            )
+            continue
+
+        source_label = f"env:{env_name}"
+        asset_id = f"prompt_file:{source_label}:{path.name}"
+        metadata = {"path": str(path), "source_label": source_label}
+        if path.is_symlink():
+            findings.append(
+                _symlink_finding(
+                    asset_id=asset_id,
+                    source_type="prompt_file",
+                    path=path,
+                    root=None,
+                )
+            )
+            continue
+
+        prompt_bytes = _read_regular_file(
+            path=path,
+            asset_id=asset_id,
+            source_type="prompt_file",
+            findings=findings,
+        )
+        if prompt_bytes is None:
+            continue
+
+        digest = canonical_filesystem_digest(
+            source_type="prompt_file",
+            asset_id=asset_id,
+            files={path.name: prompt_bytes},
+            metadata=metadata,
+        )
+        assets.append(
+            ContextAssetDescriptor(
+                asset_id=asset_id,
+                source_type="prompt_file",
+                digest=digest,
+                display_name=env_name,
+                executable=False,
+                owner_scope="system",
+                path=str(path),
+                metadata=metadata,
+            )
+        )
+
+    return InventoryResult(assets=tuple(assets), findings=tuple(findings))
+
+
+def inventory_env_prompt_overrides(
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> list[ContextAssetDescriptor]:
+    """Inventory configured prompt override files from TLDW_PROMPT_FILE_* vars."""
+    return list(inventory_env_prompt_overrides_with_findings(environ=environ).assets)

--- a/tldw_Server_API/app/core/Context_Integrity/inventory.py
+++ b/tldw_Server_API/app/core/Context_Integrity/inventory.py
@@ -140,6 +140,10 @@ def _not_directory_error(path: Path) -> OSError:
     return OSError(errno.ENOTDIR, "Path is not a directory", str(path))
 
 
+def _symlink_directory_component_error(path: Path) -> OSError:
+    return OSError(errno.ELOOP, "Directory path component is a symlink", str(path))
+
+
 def _unsupported_fd_error(feature: str) -> OSError:
     return OSError(errno.ENOTSUP, f"Required fd-relative filesystem support is unavailable: {feature}")
 
@@ -203,6 +207,20 @@ def _open_dir_no_follow_fd(path: Path) -> int:
             os.close(fd)
 
 
+def _open_cwd_no_follow_fd() -> int:
+    fd = os.open(".", _dir_open_flags())
+    opened_successfully = False
+    try:
+        opened_stat = os.fstat(fd)
+        if not stat.S_ISDIR(opened_stat.st_mode):
+            raise _not_directory_error(Path("."))
+        opened_successfully = True
+        return fd
+    finally:
+        if not opened_successfully:
+            os.close(fd)
+
+
 def _stat_child_no_follow(*, dir_fd: int, name: str, path: Path) -> os.stat_result:
     _require_fd_traversal_support()
     try:
@@ -227,6 +245,45 @@ def _open_child_dir_no_follow_fd(dir_fd: int, name: str, path: Path) -> int:
             initial_stat.st_ino,
         ):
             raise _path_changed_error(path)
+        opened_successfully = True
+        return fd
+    finally:
+        if not opened_successfully:
+            os.close(fd)
+
+
+def _open_directory_path_no_follow_fd(path: Path) -> int:
+    _require_fd_traversal_support()
+    if path.is_absolute():
+        fd = _open_dir_no_follow_fd(Path(path.anchor))
+        parts = path.parts[1:]
+        current_path = Path(path.anchor)
+    else:
+        fd = _open_cwd_no_follow_fd()
+        parts = path.parts
+        current_path = Path(".")
+
+    opened_successfully = False
+    try:
+        for part in parts:
+            if part in ("", "."):
+                continue
+            if part == "..":
+                raise OSError(errno.EINVAL, "Parent path traversal is not supported", str(path))
+
+            child_path = current_path / part
+            child_stat = _stat_child_no_follow(dir_fd=fd, name=part, path=child_path)
+            if stat.S_ISLNK(child_stat.st_mode):
+                raise _symlink_directory_component_error(child_path)
+            if not stat.S_ISDIR(child_stat.st_mode):
+                raise _not_directory_error(child_path)
+
+            child_fd = _open_child_dir_no_follow_fd(fd, part, child_path)
+            old_fd = fd
+            fd = child_fd
+            os.close(old_fd)
+            current_path = child_path
+
         opened_successfully = True
         return fd
     finally:
@@ -687,28 +744,14 @@ def inventory_env_prompt_overrides_with_findings(
         asset_id = f"prompt_file:{source_label}:{path.name}"
         metadata = {"path": str(path), "source_label": source_label}
         try:
-            parent = path.parent.resolve(strict=True)
-        except OSError as exc:
-            findings.append(
-                _verification_error(
-                    asset_id=asset_id,
-                    source_type="prompt_file",
-                    summary=f"Unable to resolve prompt override parent: {exc.__class__.__name__}.",
-                    path=path.parent,
-                    details={"error": str(exc)},
-                )
-            )
-            continue
-
-        try:
-            parent_fd = _open_dir_no_follow_fd(parent)
+            parent_fd = _open_directory_path_no_follow_fd(path.parent)
         except OSError as exc:
             findings.append(
                 _verification_error(
                     asset_id=asset_id,
                     source_type="prompt_file",
                     summary=f"Unable to open prompt override parent: {exc.__class__.__name__}.",
-                    path=parent,
+                    path=path.parent,
                     details={"error": str(exc)},
                 )
             )

--- a/tldw_Server_API/app/core/Context_Integrity/inventory.py
+++ b/tldw_Server_API/app/core/Context_Integrity/inventory.py
@@ -304,7 +304,7 @@ def inventory_user_skills_with_findings(*, user_id: int, skills_root: Path) -> I
     return InventoryResult(assets=tuple(assets), findings=tuple(findings))
 
 
-def inventory_user_skills(*, user_id: int, skills_root: Path) -> list[ContextAssetDescriptor]:
+def inventory_user_skills(user_id: int, skills_root: Path) -> list[ContextAssetDescriptor]:
     """Inventory per-user skill directories."""
     return list(inventory_user_skills_with_findings(user_id=user_id, skills_root=skills_root).assets)
 
@@ -381,7 +381,7 @@ def inventory_prompt_files_with_findings(*, prompts_dir: Path) -> InventoryResul
     return InventoryResult(assets=tuple(assets), findings=tuple(findings))
 
 
-def inventory_prompt_files(*, prompts_dir: Path) -> list[ContextAssetDescriptor]:
+def inventory_prompt_files(prompts_dir: Path) -> list[ContextAssetDescriptor]:
     """Inventory config prompt files under a Prompts directory."""
     return list(inventory_prompt_files_with_findings(prompts_dir=prompts_dir).assets)
 
@@ -460,7 +460,6 @@ def inventory_env_prompt_overrides_with_findings(
 
 
 def inventory_env_prompt_overrides(
-    *,
     environ: Mapping[str, str] | None = None,
 ) -> list[ContextAssetDescriptor]:
     """Inventory configured prompt override files from TLDW_PROMPT_FILE_* vars."""

--- a/tldw_Server_API/app/core/Context_Integrity/inventory.py
+++ b/tldw_Server_API/app/core/Context_Integrity/inventory.py
@@ -52,14 +52,6 @@ def _verification_error(
     )
 
 
-def _path_resolves_within(path: Path, root: Path) -> bool:
-    try:
-        path.resolve(strict=False).relative_to(root.resolve(strict=False))
-    except (OSError, RuntimeError, ValueError):
-        return False
-    return True
-
-
 def _symlink_finding(
     *,
     asset_id: str,
@@ -67,43 +59,14 @@ def _symlink_finding(
     path: Path,
     root: Path | None,
 ) -> ContextIntegrityFinding:
-    escaped = root is not None and not _path_resolves_within(path, root)
-    summary = (
-        "Symlinked context path escapes the inventory root and was skipped."
-        if escaped
-        else "Symlinked context path was skipped."
-    )
     details = {"root": str(root)} if root is not None else None
     return _verification_error(
         asset_id=asset_id,
         source_type=source_type,
-        summary=summary,
+        summary="Symlinked context path was skipped.",
         path=path,
         details=details,
     )
-
-
-def _find_symlink_component(path: Path) -> Path | None:
-    if path.is_absolute():
-        current = Path(path.anchor)
-        parts = path.parts[1:]
-    else:
-        current = Path(".")
-        parts = path.parts
-
-    for part in parts:
-        if part in ("", "."):
-            continue
-        current = current / part
-        try:
-            component_stat = current.lstat()
-        except FileNotFoundError:
-            return None
-        except OSError:
-            return None
-        if stat.S_ISLNK(component_stat.st_mode):
-            return current
-    return None
 
 
 def _validate_inventory_root(
@@ -112,54 +75,54 @@ def _validate_inventory_root(
     asset_id: str,
     source_type: ContextAssetSource,
 ) -> tuple[bool, ContextIntegrityFinding | None]:
-    try:
-        root_stat = root.lstat()
-    except FileNotFoundError:
-        symlink_component = _find_symlink_component(root)
-        if symlink_component is not None:
+    if root.is_absolute():
+        current = Path(root.anchor)
+        parts = root.parts[1:]
+    else:
+        current = Path(".")
+        parts = root.parts
+
+    if any(part == ".." for part in parts):
+        return (
+            False,
+            _verification_error(
+                asset_id=asset_id,
+                source_type=source_type,
+                summary="Context inventory root contains parent traversal and was skipped.",
+                path=root,
+            ),
+        )
+
+    for part in parts:
+        if part in ("", "."):
+            continue
+        current = current / part
+        try:
+            component_stat = current.lstat()
+        except FileNotFoundError:
+            return False, None
+        except OSError as exc:
+            return (
+                False,
+                _verification_error(
+                    asset_id=asset_id,
+                    source_type=source_type,
+                    summary=f"Unable to inspect context inventory root component: {exc.__class__.__name__}.",
+                    path=current,
+                    details={"root": str(root), "error": str(exc)},
+                ),
+            )
+        if stat.S_ISLNK(component_stat.st_mode):
             return (
                 False,
                 _verification_error(
                     asset_id=asset_id,
                     source_type=source_type,
                     summary="Context inventory root contains a symlink component and was skipped.",
-                    path=symlink_component,
+                    path=current,
                     details={"root": str(root)},
                 ),
             )
-        return False, None
-    except OSError as exc:
-        return (
-            False,
-            _verification_error(
-                asset_id=asset_id,
-                source_type=source_type,
-                summary=f"Unable to inspect context inventory root: {exc.__class__.__name__}.",
-                path=root,
-                details={"error": str(exc)},
-            ),
-        )
-
-    if stat.S_ISLNK(root_stat.st_mode):
-        return (
-            False,
-            _verification_error(
-                asset_id=asset_id,
-                source_type=source_type,
-                summary="Context inventory root is a symlink and was skipped.",
-                path=root,
-            ),
-        )
-    if not stat.S_ISDIR(root_stat.st_mode):
-        return (
-            False,
-            _verification_error(
-                asset_id=asset_id,
-                source_type=source_type,
-                summary="Context inventory root is not a directory and was skipped.",
-                path=root,
-            ),
-        )
     return True, None
 
 

--- a/tldw_Server_API/app/core/Context_Integrity/inventory.py
+++ b/tldw_Server_API/app/core/Context_Integrity/inventory.py
@@ -137,19 +137,24 @@ def _path_changed_error(path: Path) -> OSError:
 
 
 def _open_no_follow(path: Path) -> int:
-    flags = os.O_RDONLY
-    nofollow = getattr(os, "O_NOFOLLOW", None)
-    if nofollow is not None:
-        return os.open(path, flags | nofollow)
-
     initial_stat = path.lstat()
     if not stat.S_ISREG(initial_stat.st_mode):
         raise _not_regular_error(path)
+
+    flags = os.O_RDONLY
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    if nofollow is not None:
+        flags |= nofollow
+    nonblock = getattr(os, "O_NONBLOCK", None)
+    if nonblock is not None:
+        flags |= nonblock
 
     fd = os.open(path, flags)
     opened_successfully = False
     try:
         opened_stat = os.fstat(fd)
+        if not stat.S_ISREG(opened_stat.st_mode):
+            raise _not_regular_error(path)
         if (opened_stat.st_dev, opened_stat.st_ino) != (
             initial_stat.st_dev,
             initial_stat.st_ino,

--- a/tldw_Server_API/app/core/Context_Integrity/inventory.py
+++ b/tldw_Server_API/app/core/Context_Integrity/inventory.py
@@ -469,7 +469,7 @@ def _open_root_fd_or_result(
         )
 
     try:
-        return _open_dir_no_follow_fd(root), None
+        return _open_directory_path_no_follow_fd(root), None
     except OSError as exc:
         return (
             None,

--- a/tldw_Server_API/app/core/Context_Integrity/inventory.py
+++ b/tldw_Server_API/app/core/Context_Integrity/inventory.py
@@ -83,50 +83,6 @@ def _symlink_finding(
     )
 
 
-def _safe_is_symlink(
-    *,
-    path: Path,
-    asset_id: str,
-    source_type: ContextAssetSource,
-    findings: list[ContextIntegrityFinding],
-) -> bool | None:
-    try:
-        return path.is_symlink()
-    except OSError as exc:
-        findings.append(
-            _verification_error(
-                asset_id=asset_id,
-                source_type=source_type,
-                summary=f"Unable to inspect context path symlink status: {exc.__class__.__name__}.",
-                path=path,
-                details={"error": str(exc)},
-            )
-        )
-        return None
-
-
-def _safe_is_dir(
-    *,
-    path: Path,
-    asset_id: str,
-    source_type: ContextAssetSource,
-    findings: list[ContextIntegrityFinding],
-) -> bool | None:
-    try:
-        return path.is_dir()
-    except OSError as exc:
-        findings.append(
-            _verification_error(
-                asset_id=asset_id,
-                source_type=source_type,
-                summary=f"Unable to inspect context path directory status: {exc.__class__.__name__}.",
-                path=path,
-                details={"error": str(exc)},
-            )
-        )
-        return None
-
-
 def _validate_inventory_root(
     *,
     root: Path,
@@ -180,20 +136,110 @@ def _path_changed_error(path: Path) -> OSError:
     return OSError(errno.ELOOP, "Path changed while opening", str(path))
 
 
-def _open_no_follow(path: Path) -> int:
-    initial_stat = path.lstat()
-    if not stat.S_ISREG(initial_stat.st_mode):
-        raise _not_regular_error(path)
+def _not_directory_error(path: Path) -> OSError:
+    return OSError(errno.ENOTDIR, "Path is not a directory", str(path))
 
-    flags = os.O_RDONLY
-    nofollow = getattr(os, "O_NOFOLLOW", None)
-    if nofollow is not None:
-        flags |= nofollow
+
+def _unsupported_fd_error(feature: str) -> OSError:
+    return OSError(errno.ENOTSUP, f"Required fd-relative filesystem support is unavailable: {feature}")
+
+
+def _require_fd_traversal_support() -> None:
+    if os.listdir not in getattr(os, "supports_fd", set()):
+        raise _unsupported_fd_error("os.listdir(fd)")
+    if os.open not in os.supports_dir_fd:
+        raise _unsupported_fd_error("os.open(dir_fd=...)")
+    if os.stat not in os.supports_dir_fd:
+        raise _unsupported_fd_error("os.stat(dir_fd=...)")
+    if os.stat not in os.supports_follow_symlinks:
+        raise _unsupported_fd_error("os.stat(follow_symlinks=False)")
+    if getattr(os, "O_NOFOLLOW", None) is None:
+        raise _unsupported_fd_error("O_NOFOLLOW")
+    if getattr(os, "O_DIRECTORY", None) is None:
+        raise _unsupported_fd_error("O_DIRECTORY")
+
+
+def _dir_open_flags() -> int:
+    _require_fd_traversal_support()
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    cloexec = getattr(os, "O_CLOEXEC", None)
+    if cloexec is not None:
+        flags |= cloexec
+    return flags
+
+
+def _file_open_flags() -> int:
+    _require_fd_traversal_support()
+    flags = os.O_RDONLY | os.O_NOFOLLOW
     nonblock = getattr(os, "O_NONBLOCK", None)
     if nonblock is not None:
         flags |= nonblock
+    cloexec = getattr(os, "O_CLOEXEC", None)
+    if cloexec is not None:
+        flags |= cloexec
+    return flags
 
-    fd = os.open(path, flags)
+
+def _open_dir_no_follow_fd(path: Path) -> int:
+    initial_stat = path.lstat()
+    if not stat.S_ISDIR(initial_stat.st_mode):
+        raise _not_directory_error(path)
+
+    fd = os.open(path, _dir_open_flags())
+    opened_successfully = False
+    try:
+        opened_stat = os.fstat(fd)
+        if not stat.S_ISDIR(opened_stat.st_mode):
+            raise _not_directory_error(path)
+        if (opened_stat.st_dev, opened_stat.st_ino) != (
+            initial_stat.st_dev,
+            initial_stat.st_ino,
+        ):
+            raise _path_changed_error(path)
+        opened_successfully = True
+        return fd
+    finally:
+        if not opened_successfully:
+            os.close(fd)
+
+
+def _stat_child_no_follow(*, dir_fd: int, name: str, path: Path) -> os.stat_result:
+    _require_fd_traversal_support()
+    try:
+        return os.stat(name, dir_fd=dir_fd, follow_symlinks=False)
+    except TypeError as exc:
+        raise _unsupported_fd_error("os.stat(dir_fd=..., follow_symlinks=False)") from exc
+
+
+def _open_child_dir_no_follow_fd(dir_fd: int, name: str, path: Path) -> int:
+    initial_stat = _stat_child_no_follow(dir_fd=dir_fd, name=name, path=path)
+    if not stat.S_ISDIR(initial_stat.st_mode):
+        raise _not_directory_error(path)
+
+    fd = os.open(name, _dir_open_flags(), dir_fd=dir_fd)
+    opened_successfully = False
+    try:
+        opened_stat = os.fstat(fd)
+        if not stat.S_ISDIR(opened_stat.st_mode):
+            raise _not_directory_error(path)
+        if (opened_stat.st_dev, opened_stat.st_ino) != (
+            initial_stat.st_dev,
+            initial_stat.st_ino,
+        ):
+            raise _path_changed_error(path)
+        opened_successfully = True
+        return fd
+    finally:
+        if not opened_successfully:
+            os.close(fd)
+
+
+def _open_file_no_follow_fd(*, dir_fd: int, name: str, path: Path) -> int:
+    initial_stat = _stat_child_no_follow(dir_fd=dir_fd, name=name, path=path)
+    if not stat.S_ISREG(initial_stat.st_mode):
+        raise _not_regular_error(path)
+
+    fd = os.open(name, _file_open_flags(), dir_fd=dir_fd)
     opened_successfully = False
     try:
         opened_stat = os.fstat(fd)
@@ -211,13 +257,9 @@ def _open_no_follow(path: Path) -> int:
             os.close(fd)
 
 
-def _read_no_follow_bytes(path: Path) -> bytes:
-    fd = _open_no_follow(path)
+def _read_no_follow_bytes_fd(*, dir_fd: int, name: str, path: Path) -> bytes:
+    fd = _open_file_no_follow_fd(dir_fd=dir_fd, name=name, path=path)
     try:
-        opened_stat = os.fstat(fd)
-        if not stat.S_ISREG(opened_stat.st_mode):
-            raise _not_regular_error(path)
-
         chunks: list[bytes] = []
         while True:
             chunk = os.read(fd, 1024 * 1024)
@@ -228,15 +270,17 @@ def _read_no_follow_bytes(path: Path) -> bytes:
         os.close(fd)
 
 
-def _read_regular_file(
+def _read_regular_file_from_dir_fd(
     *,
+    dir_fd: int,
+    name: str,
     path: Path,
     asset_id: str,
     source_type: ContextAssetSource,
     findings: list[ContextIntegrityFinding],
 ) -> bytes | None:
     try:
-        return _read_no_follow_bytes(path)
+        return _read_no_follow_bytes_fd(dir_fd=dir_fd, name=name, path=path)
     except OSError as exc:
         findings.append(
             _verification_error(
@@ -250,139 +294,194 @@ def _read_regular_file(
         return None
 
 
-def _read_skill_file_map(
+def _read_skill_file_map_fd(
     *,
+    dir_fd: int,
     skill_dir: Path,
     asset_id: str,
     findings: list[ContextIntegrityFinding],
+    relative_prefix: str = "",
 ) -> dict[str, bytes]:
     files: dict[str, bytes] = {}
-
-    def _on_walk_error(exc: OSError) -> None:
-        error_path = Path(exc.filename) if exc.filename else skill_dir
+    try:
+        names = sorted(os.listdir(dir_fd))
+    except OSError as exc:
         findings.append(
             _verification_error(
                 asset_id=asset_id,
                 source_type="skill_file",
                 summary=f"Unable to scan skill directory: {exc.__class__.__name__}.",
-                path=error_path,
+                path=skill_dir / relative_prefix if relative_prefix else skill_dir,
                 details={"error": str(exc)},
             )
         )
+        return files
 
-    for current_root, dirnames, filenames in os.walk(
-        skill_dir,
-        topdown=True,
-        onerror=_on_walk_error,
-        followlinks=False,
-    ):
-        current_path = Path(current_root)
-        for dirname in list(dirnames):
-            child = current_path / dirname
-            is_symlink = _safe_is_symlink(
-                path=child,
-                asset_id=asset_id,
-                source_type="skill_file",
-                findings=findings,
-            )
-            if is_symlink is None:
-                dirnames.remove(dirname)
-                continue
-            if is_symlink:
-                findings.append(
-                    _symlink_finding(
-                        asset_id=asset_id,
-                        source_type="skill_file",
-                        path=child,
-                        root=skill_dir,
-                    )
+    for name in names:
+        relative = f"{relative_prefix}{name}"
+        path = skill_dir / relative
+        try:
+            child_stat = _stat_child_no_follow(dir_fd=dir_fd, name=name, path=path)
+        except OSError as exc:
+            findings.append(
+                _verification_error(
+                    asset_id=asset_id,
+                    source_type="skill_file",
+                    summary=f"Unable to inspect skill path: {exc.__class__.__name__}.",
+                    path=path,
+                    details={"error": str(exc)},
                 )
-                dirnames.remove(dirname)
+            )
+            continue
 
-        for filename in filenames:
-            path = current_path / filename
-            is_symlink = _safe_is_symlink(
-                path=path,
-                asset_id=asset_id,
-                source_type="skill_file",
-                findings=findings,
-            )
-            if is_symlink is None:
-                continue
-            if is_symlink:
-                findings.append(
-                    _symlink_finding(
-                        asset_id=asset_id,
-                        source_type="skill_file",
-                        path=path,
-                        root=skill_dir,
-                    )
+        if stat.S_ISLNK(child_stat.st_mode):
+            findings.append(
+                _symlink_finding(
+                    asset_id=asset_id,
+                    source_type="skill_file",
+                    path=path,
+                    root=skill_dir,
                 )
-                continue
-            if path.suffix.lower() not in _SKILL_TEXT_SUFFIXES:
-                continue
+            )
+            continue
+
+        if stat.S_ISDIR(child_stat.st_mode):
             try:
-                relative = path.relative_to(skill_dir).as_posix()
-            except ValueError:
+                child_fd = _open_child_dir_no_follow_fd(dir_fd, name, path)
+            except OSError as exc:
                 findings.append(
                     _verification_error(
                         asset_id=asset_id,
                         source_type="skill_file",
-                        summary="Skill file path escaped the skill directory and was skipped.",
+                        summary=f"Unable to open skill directory: {exc.__class__.__name__}.",
                         path=path,
-                        details={"root": str(skill_dir)},
+                        details={"error": str(exc)},
                     )
                 )
                 continue
-            content = _read_regular_file(
-                path=path,
-                asset_id=asset_id,
-                source_type="skill_file",
-                findings=findings,
-            )
-            if content is not None:
-                files[relative] = content
+            try:
+                files.update(
+                    _read_skill_file_map_fd(
+                        dir_fd=child_fd,
+                        skill_dir=skill_dir,
+                        asset_id=asset_id,
+                        findings=findings,
+                        relative_prefix=f"{relative}/",
+                    )
+                )
+            finally:
+                os.close(child_fd)
+            continue
+
+        if path.suffix.lower() not in _SKILL_TEXT_SUFFIXES:
+            continue
+
+        content = _read_regular_file_from_dir_fd(
+            dir_fd=dir_fd,
+            name=name,
+            path=path,
+            asset_id=asset_id,
+            source_type="skill_file",
+            findings=findings,
+        )
+        if content is not None:
+            files[relative] = content
 
     return files
 
 
-def inventory_user_skills_with_findings(*, user_id: int, skills_root: Path) -> InventoryResult:
-    """Inventory per-user skill directories with non-fatal discovery findings."""
+def _open_root_fd_or_result(
+    *,
+    root: Path,
+    asset_id: str,
+    source_type: ContextAssetSource,
+    scan_label: str,
+) -> tuple[int | None, InventoryResult | None]:
     root_ok, root_finding = _validate_inventory_root(
-        root=skills_root,
-        asset_id=f"skill:user:{user_id}",
-        source_type="skill_file",
+        root=root,
+        asset_id=asset_id,
+        source_type=source_type,
     )
     if not root_ok:
-        return InventoryResult(
-            assets=(),
-            findings=(root_finding,) if root_finding is not None else (),
+        return (
+            None,
+            InventoryResult(
+                assets=(),
+                findings=(root_finding,) if root_finding is not None else (),
+            ),
         )
 
-    assets: list[ContextAssetDescriptor] = []
-    findings: list[ContextIntegrityFinding] = []
     try:
-        with os.scandir(skills_root) as iterator:
-            entries = sorted(iterator, key=lambda entry: entry.name)
+        return _open_dir_no_follow_fd(root), None
     except OSError as exc:
-        return InventoryResult(
-            assets=(),
-            findings=(
-                _verification_error(
-                    asset_id=f"skill:user:{user_id}",
-                    source_type="skill_file",
-                    summary=f"Unable to scan user skills root: {exc.__class__.__name__}.",
-                    path=skills_root,
-                    details={"error": str(exc)},
+        return (
+            None,
+            InventoryResult(
+                assets=(),
+                findings=(
+                    _verification_error(
+                        asset_id=asset_id,
+                        source_type=source_type,
+                        summary=f"Unable to open {scan_label}: {exc.__class__.__name__}.",
+                        path=root,
+                        details={"error": str(exc)},
+                    ),
                 ),
             ),
         )
 
-    for entry in entries:
-        skill_dir = Path(entry.path)
-        asset_id = f"skill:user:{user_id}/{entry.name}"
+
+def inventory_user_skills_with_findings(*, user_id: int, skills_root: Path) -> InventoryResult:
+    """Inventory per-user skill directories with non-fatal discovery findings."""
+    root_asset_id = f"skill:user:{user_id}"
+    root_fd, root_result = _open_root_fd_or_result(
+        root=skills_root,
+        asset_id=root_asset_id,
+        source_type="skill_file",
+        scan_label="user skills root",
+    )
+    if root_result is not None:
+        return root_result
+    if root_fd is None:
+        return InventoryResult(assets=(), findings=())
+
+    assets: list[ContextAssetDescriptor] = []
+    findings: list[ContextIntegrityFinding] = []
+    try:
         try:
-            if entry.is_symlink():
+            names = sorted(os.listdir(root_fd))
+        except OSError as exc:
+            return InventoryResult(
+                assets=(),
+                findings=(
+                    _verification_error(
+                        asset_id=root_asset_id,
+                        source_type="skill_file",
+                        summary=f"Unable to scan user skills root: {exc.__class__.__name__}.",
+                        path=skills_root,
+                        details={"error": str(exc)},
+                    ),
+                ),
+            )
+
+        for name in names:
+            skill_dir = skills_root / name
+            asset_id = f"skill:user:{user_id}/{name}"
+            try:
+                entry_stat = _stat_child_no_follow(dir_fd=root_fd, name=name, path=skill_dir)
+            except OSError as exc:
+                findings.append(
+                    _verification_error(
+                        asset_id=asset_id,
+                        source_type="skill_file",
+                        summary=f"Unable to inspect skill directory: {exc.__class__.__name__}.",
+                        path=skill_dir,
+                        details={"error": str(exc)},
+                    )
+                )
+                continue
+
+            if stat.S_ISLNK(entry_stat.st_mode):
                 findings.append(
                     _symlink_finding(
                         asset_id=asset_id,
@@ -392,69 +491,56 @@ def inventory_user_skills_with_findings(*, user_id: int, skills_root: Path) -> I
                     )
                 )
                 continue
-            if not entry.is_dir(follow_symlinks=False):
+            if not stat.S_ISDIR(entry_stat.st_mode):
                 continue
-        except OSError as exc:
-            findings.append(
-                _verification_error(
-                    asset_id=asset_id,
-                    source_type="skill_file",
-                    summary=f"Unable to inspect skill directory: {exc.__class__.__name__}.",
-                    path=skill_dir,
-                    details={"error": str(exc)},
+
+            try:
+                skill_fd = _open_child_dir_no_follow_fd(root_fd, name, skill_dir)
+            except OSError as exc:
+                findings.append(
+                    _verification_error(
+                        asset_id=asset_id,
+                        source_type="skill_file",
+                        summary=f"Unable to open skill directory: {exc.__class__.__name__}.",
+                        path=skill_dir,
+                        details={"error": str(exc)},
+                    )
                 )
-            )
-            continue
+                continue
 
-        skill_file = skill_dir / "SKILL.md"
-        skill_file_is_symlink = _safe_is_symlink(
-            path=skill_file,
-            asset_id=asset_id,
-            source_type="skill_file",
-            findings=findings,
-        )
-        if skill_file_is_symlink is None:
-            continue
-        if skill_file_is_symlink:
-            findings.append(
-                _symlink_finding(
+            try:
+                files = _read_skill_file_map_fd(
+                    dir_fd=skill_fd,
+                    skill_dir=skill_dir,
                     asset_id=asset_id,
-                    source_type="skill_file",
-                    path=skill_file,
-                    root=skill_dir,
+                    findings=findings,
                 )
-            )
-            continue
-        if not skill_file.exists():
-            continue
+            finally:
+                os.close(skill_fd)
+            if "SKILL.md" not in files:
+                continue
 
-        files = _read_skill_file_map(
-            skill_dir=skill_dir,
-            asset_id=asset_id,
-            findings=findings,
-        )
-        if "SKILL.md" not in files:
-            continue
-
-        metadata = {"skill_name": entry.name}
-        digest = canonical_filesystem_digest(
-            source_type="skill_file",
-            asset_id=asset_id,
-            files=files,
-            metadata=metadata,
-        )
-        assets.append(
-            ContextAssetDescriptor(
-                asset_id=asset_id,
+            metadata = {"skill_name": name}
+            digest = canonical_filesystem_digest(
                 source_type="skill_file",
-                digest=digest,
-                display_name=entry.name,
-                executable=True,
-                owner_scope=f"user:{user_id}",
-                path=str(skill_dir),
+                asset_id=asset_id,
+                files=files,
                 metadata=metadata,
             )
-        )
+            assets.append(
+                ContextAssetDescriptor(
+                    asset_id=asset_id,
+                    source_type="skill_file",
+                    digest=digest,
+                    display_name=name,
+                    executable=True,
+                    owner_scope=f"user:{user_id}",
+                    path=str(skill_dir),
+                    metadata=metadata,
+                )
+            )
+    finally:
+        os.close(root_fd)
 
     return InventoryResult(assets=tuple(assets), findings=tuple(findings))
 
@@ -466,96 +552,100 @@ def inventory_user_skills(user_id: int, skills_root: Path) -> list[ContextAssetD
 
 def inventory_prompt_files_with_findings(*, prompts_dir: Path) -> InventoryResult:
     """Inventory config prompt files under a Prompts directory with findings."""
-    root_ok, root_finding = _validate_inventory_root(
+    root_asset_id = f"prompt_file:{prompts_dir.name}"
+    root_fd, root_result = _open_root_fd_or_result(
         root=prompts_dir,
-        asset_id=f"prompt_file:{prompts_dir.name}",
+        asset_id=root_asset_id,
         source_type="prompt_file",
+        scan_label="prompt directory",
     )
-    if not root_ok:
-        return InventoryResult(
-            assets=(),
-            findings=(root_finding,) if root_finding is not None else (),
-        )
+    if root_result is not None:
+        return root_result
+    if root_fd is None:
+        return InventoryResult(assets=(), findings=())
 
     assets: list[ContextAssetDescriptor] = []
     findings: list[ContextIntegrityFinding] = []
     try:
-        entries = sorted(prompts_dir.iterdir(), key=lambda path: path.name)
-    except OSError as exc:
-        return InventoryResult(
-            assets=(),
-            findings=(
-                _verification_error(
-                    asset_id=f"prompt_file:{prompts_dir.name}",
-                    source_type="prompt_file",
-                    summary=f"Unable to scan prompt directory: {exc.__class__.__name__}.",
-                    path=prompts_dir,
-                    details={"error": str(exc)},
+        try:
+            names = sorted(os.listdir(root_fd))
+        except OSError as exc:
+            return InventoryResult(
+                assets=(),
+                findings=(
+                    _verification_error(
+                        asset_id=root_asset_id,
+                        source_type="prompt_file",
+                        summary=f"Unable to scan prompt directory: {exc.__class__.__name__}.",
+                        path=prompts_dir,
+                        details={"error": str(exc)},
+                    ),
                 ),
-            ),
-        )
-
-    for path in entries:
-        asset_id = f"prompt_file:{path.name}"
-        is_symlink = _safe_is_symlink(
-            path=path,
-            asset_id=asset_id,
-            source_type="prompt_file",
-            findings=findings,
-        )
-        if is_symlink is None:
-            continue
-        if is_symlink:
-            findings.append(
-                _symlink_finding(
-                    asset_id=asset_id,
-                    source_type="prompt_file",
-                    path=path,
-                    root=prompts_dir,
-                )
             )
-            continue
-        is_dir = _safe_is_dir(
-            path=path,
-            asset_id=asset_id,
-            source_type="prompt_file",
-            findings=findings,
-        )
-        if is_dir is None:
-            continue
-        if is_dir:
-            continue
-        if path.suffix.lower() not in _PROMPT_SUFFIXES:
-            continue
+        for name in names:
+            path = prompts_dir / name
+            asset_id = f"prompt_file:{name}"
+            try:
+                entry_stat = _stat_child_no_follow(dir_fd=root_fd, name=name, path=path)
+            except OSError as exc:
+                findings.append(
+                    _verification_error(
+                        asset_id=asset_id,
+                        source_type="prompt_file",
+                        summary=f"Unable to inspect prompt path: {exc.__class__.__name__}.",
+                        path=path,
+                        details={"error": str(exc)},
+                    )
+                )
+                continue
 
-        prompt_bytes = _read_regular_file(
-            path=path,
-            asset_id=asset_id,
-            source_type="prompt_file",
-            findings=findings,
-        )
-        if prompt_bytes is None:
-            continue
+            if stat.S_ISLNK(entry_stat.st_mode):
+                findings.append(
+                    _symlink_finding(
+                        asset_id=asset_id,
+                        source_type="prompt_file",
+                        path=path,
+                        root=prompts_dir,
+                    )
+                )
+                continue
+            if stat.S_ISDIR(entry_stat.st_mode):
+                continue
+            if path.suffix.lower() not in _PROMPT_SUFFIXES:
+                continue
 
-        metadata = {"path": path.name}
-        digest = canonical_filesystem_digest(
-            source_type="prompt_file",
-            asset_id=asset_id,
-            files={path.name: prompt_bytes},
-            metadata=metadata,
-        )
-        assets.append(
-            ContextAssetDescriptor(
+            prompt_bytes = _read_regular_file_from_dir_fd(
+                dir_fd=root_fd,
+                name=name,
+                path=path,
                 asset_id=asset_id,
                 source_type="prompt_file",
-                digest=digest,
-                display_name=path.name,
-                executable=False,
-                owner_scope="system",
-                path=str(path),
+                findings=findings,
+            )
+            if prompt_bytes is None:
+                continue
+
+            metadata = {"path": name}
+            digest = canonical_filesystem_digest(
+                source_type="prompt_file",
+                asset_id=asset_id,
+                files={name: prompt_bytes},
                 metadata=metadata,
             )
-        )
+            assets.append(
+                ContextAssetDescriptor(
+                    asset_id=asset_id,
+                    source_type="prompt_file",
+                    digest=digest,
+                    display_name=name,
+                    executable=False,
+                    owner_scope="system",
+                    path=str(path),
+                    metadata=metadata,
+                )
+            )
+    finally:
+        os.close(root_fd)
 
     return InventoryResult(assets=tuple(assets), findings=tuple(findings))
 
@@ -596,33 +686,72 @@ def inventory_env_prompt_overrides_with_findings(
         source_label = f"env:{env_name}"
         asset_id = f"prompt_file:{source_label}:{path.name}"
         metadata = {"path": str(path), "source_label": source_label}
-        is_symlink = _safe_is_symlink(
-            path=path,
-            asset_id=asset_id,
-            source_type="prompt_file",
-            findings=findings,
-        )
-        if is_symlink is None:
-            continue
-        if is_symlink:
+        try:
+            parent = path.parent.resolve(strict=True)
+        except OSError as exc:
             findings.append(
-                _symlink_finding(
+                _verification_error(
                     asset_id=asset_id,
                     source_type="prompt_file",
-                    path=path,
-                    root=None,
+                    summary=f"Unable to resolve prompt override parent: {exc.__class__.__name__}.",
+                    path=path.parent,
+                    details={"error": str(exc)},
                 )
             )
             continue
 
-        prompt_bytes = _read_regular_file(
-            path=path,
-            asset_id=asset_id,
-            source_type="prompt_file",
-            findings=findings,
-        )
-        if prompt_bytes is None:
+        try:
+            parent_fd = _open_dir_no_follow_fd(parent)
+        except OSError as exc:
+            findings.append(
+                _verification_error(
+                    asset_id=asset_id,
+                    source_type="prompt_file",
+                    summary=f"Unable to open prompt override parent: {exc.__class__.__name__}.",
+                    path=parent,
+                    details={"error": str(exc)},
+                )
+            )
             continue
+
+        try:
+            try:
+                entry_stat = _stat_child_no_follow(dir_fd=parent_fd, name=path.name, path=path)
+            except OSError as exc:
+                findings.append(
+                    _verification_error(
+                        asset_id=asset_id,
+                        source_type="prompt_file",
+                        summary=f"Unable to inspect prompt override path: {exc.__class__.__name__}.",
+                        path=path,
+                        details={"error": str(exc)},
+                    )
+                )
+                continue
+
+            if stat.S_ISLNK(entry_stat.st_mode):
+                findings.append(
+                    _symlink_finding(
+                        asset_id=asset_id,
+                        source_type="prompt_file",
+                        path=path,
+                        root=None,
+                    )
+                )
+                continue
+
+            prompt_bytes = _read_regular_file_from_dir_fd(
+                dir_fd=parent_fd,
+                name=path.name,
+                path=path,
+                asset_id=asset_id,
+                source_type="prompt_file",
+                findings=findings,
+            )
+            if prompt_bytes is None:
+                continue
+        finally:
+            os.close(parent_fd)
 
         digest = canonical_filesystem_digest(
             source_type="prompt_file",

--- a/tldw_Server_API/app/core/Context_Integrity/inventory.py
+++ b/tldw_Server_API/app/core/Context_Integrity/inventory.py
@@ -83,6 +83,29 @@ def _symlink_finding(
     )
 
 
+def _find_symlink_component(path: Path) -> Path | None:
+    if path.is_absolute():
+        current = Path(path.anchor)
+        parts = path.parts[1:]
+    else:
+        current = Path(".")
+        parts = path.parts
+
+    for part in parts:
+        if part in ("", "."):
+            continue
+        current = current / part
+        try:
+            component_stat = current.lstat()
+        except FileNotFoundError:
+            return None
+        except OSError:
+            return None
+        if stat.S_ISLNK(component_stat.st_mode):
+            return current
+    return None
+
+
 def _validate_inventory_root(
     *,
     root: Path,
@@ -92,6 +115,18 @@ def _validate_inventory_root(
     try:
         root_stat = root.lstat()
     except FileNotFoundError:
+        symlink_component = _find_symlink_component(root)
+        if symlink_component is not None:
+            return (
+                False,
+                _verification_error(
+                    asset_id=asset_id,
+                    source_type=source_type,
+                    summary="Context inventory root contains a symlink component and was skipped.",
+                    path=symlink_component,
+                    details={"root": str(root)},
+                ),
+            )
         return False, None
     except OSError as exc:
         return (
@@ -362,7 +397,7 @@ def _read_skill_file_map_fd(
     files: dict[str, bytes] = {}
     try:
         names = sorted(os.listdir(dir_fd))
-    except OSError as exc:
+    except (OSError, TypeError) as exc:
         findings.append(
             _verification_error(
                 asset_id=asset_id,
@@ -507,7 +542,7 @@ def inventory_user_skills_with_findings(*, user_id: int, skills_root: Path) -> I
     try:
         try:
             names = sorted(os.listdir(root_fd))
-        except OSError as exc:
+        except (OSError, TypeError) as exc:
             return InventoryResult(
                 assets=(),
                 findings=(
@@ -626,7 +661,7 @@ def inventory_prompt_files_with_findings(*, prompts_dir: Path) -> InventoryResul
     try:
         try:
             names = sorted(os.listdir(root_fd))
-        except OSError as exc:
+        except (OSError, TypeError) as exc:
             return InventoryResult(
                 assets=(),
                 findings=(

--- a/tldw_Server_API/app/core/Context_Integrity/inventory.py
+++ b/tldw_Server_API/app/core/Context_Integrity/inventory.py
@@ -83,6 +83,50 @@ def _symlink_finding(
     )
 
 
+def _safe_is_symlink(
+    *,
+    path: Path,
+    asset_id: str,
+    source_type: ContextAssetSource,
+    findings: list[ContextIntegrityFinding],
+) -> bool | None:
+    try:
+        return path.is_symlink()
+    except OSError as exc:
+        findings.append(
+            _verification_error(
+                asset_id=asset_id,
+                source_type=source_type,
+                summary=f"Unable to inspect context path symlink status: {exc.__class__.__name__}.",
+                path=path,
+                details={"error": str(exc)},
+            )
+        )
+        return None
+
+
+def _safe_is_dir(
+    *,
+    path: Path,
+    asset_id: str,
+    source_type: ContextAssetSource,
+    findings: list[ContextIntegrityFinding],
+) -> bool | None:
+    try:
+        return path.is_dir()
+    except OSError as exc:
+        findings.append(
+            _verification_error(
+                asset_id=asset_id,
+                source_type=source_type,
+                summary=f"Unable to inspect context path directory status: {exc.__class__.__name__}.",
+                path=path,
+                details={"error": str(exc)},
+            )
+        )
+        return None
+
+
 def _validate_inventory_root(
     *,
     root: Path,
@@ -235,7 +279,16 @@ def _read_skill_file_map(
         current_path = Path(current_root)
         for dirname in list(dirnames):
             child = current_path / dirname
-            if child.is_symlink():
+            is_symlink = _safe_is_symlink(
+                path=child,
+                asset_id=asset_id,
+                source_type="skill_file",
+                findings=findings,
+            )
+            if is_symlink is None:
+                dirnames.remove(dirname)
+                continue
+            if is_symlink:
                 findings.append(
                     _symlink_finding(
                         asset_id=asset_id,
@@ -248,7 +301,15 @@ def _read_skill_file_map(
 
         for filename in filenames:
             path = current_path / filename
-            if path.is_symlink():
+            is_symlink = _safe_is_symlink(
+                path=path,
+                asset_id=asset_id,
+                source_type="skill_file",
+                findings=findings,
+            )
+            if is_symlink is None:
+                continue
+            if is_symlink:
                 findings.append(
                     _symlink_finding(
                         asset_id=asset_id,
@@ -346,7 +407,15 @@ def inventory_user_skills_with_findings(*, user_id: int, skills_root: Path) -> I
             continue
 
         skill_file = skill_dir / "SKILL.md"
-        if skill_file.is_symlink():
+        skill_file_is_symlink = _safe_is_symlink(
+            path=skill_file,
+            asset_id=asset_id,
+            source_type="skill_file",
+            findings=findings,
+        )
+        if skill_file_is_symlink is None:
+            continue
+        if skill_file_is_symlink:
             findings.append(
                 _symlink_finding(
                     asset_id=asset_id,
@@ -428,7 +497,15 @@ def inventory_prompt_files_with_findings(*, prompts_dir: Path) -> InventoryResul
 
     for path in entries:
         asset_id = f"prompt_file:{path.name}"
-        if path.is_symlink():
+        is_symlink = _safe_is_symlink(
+            path=path,
+            asset_id=asset_id,
+            source_type="prompt_file",
+            findings=findings,
+        )
+        if is_symlink is None:
+            continue
+        if is_symlink:
             findings.append(
                 _symlink_finding(
                     asset_id=asset_id,
@@ -438,7 +515,15 @@ def inventory_prompt_files_with_findings(*, prompts_dir: Path) -> InventoryResul
                 )
             )
             continue
-        if path.is_dir():
+        is_dir = _safe_is_dir(
+            path=path,
+            asset_id=asset_id,
+            source_type="prompt_file",
+            findings=findings,
+        )
+        if is_dir is None:
+            continue
+        if is_dir:
             continue
         if path.suffix.lower() not in _PROMPT_SUFFIXES:
             continue
@@ -511,7 +596,15 @@ def inventory_env_prompt_overrides_with_findings(
         source_label = f"env:{env_name}"
         asset_id = f"prompt_file:{source_label}:{path.name}"
         metadata = {"path": str(path), "source_label": source_label}
-        if path.is_symlink():
+        is_symlink = _safe_is_symlink(
+            path=path,
+            asset_id=asset_id,
+            source_type="prompt_file",
+            findings=findings,
+        )
+        if is_symlink is None:
+            continue
+        if is_symlink:
             findings.append(
                 _symlink_finding(
                     asset_id=asset_id,

--- a/tldw_Server_API/app/core/Context_Integrity/inventory.py
+++ b/tldw_Server_API/app/core/Context_Integrity/inventory.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+import errno
 import os
 from pathlib import Path
+import stat
 
 from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
     canonical_filesystem_digest,
@@ -81,6 +83,102 @@ def _symlink_finding(
     )
 
 
+def _validate_inventory_root(
+    *,
+    root: Path,
+    asset_id: str,
+    source_type: ContextAssetSource,
+) -> tuple[bool, ContextIntegrityFinding | None]:
+    try:
+        root_stat = root.lstat()
+    except FileNotFoundError:
+        return False, None
+    except OSError as exc:
+        return (
+            False,
+            _verification_error(
+                asset_id=asset_id,
+                source_type=source_type,
+                summary=f"Unable to inspect context inventory root: {exc.__class__.__name__}.",
+                path=root,
+                details={"error": str(exc)},
+            ),
+        )
+
+    if stat.S_ISLNK(root_stat.st_mode):
+        return (
+            False,
+            _verification_error(
+                asset_id=asset_id,
+                source_type=source_type,
+                summary="Context inventory root is a symlink and was skipped.",
+                path=root,
+            ),
+        )
+    if not stat.S_ISDIR(root_stat.st_mode):
+        return (
+            False,
+            _verification_error(
+                asset_id=asset_id,
+                source_type=source_type,
+                summary="Context inventory root is not a directory and was skipped.",
+                path=root,
+            ),
+        )
+    return True, None
+
+
+def _not_regular_error(path: Path) -> OSError:
+    return OSError(errno.EINVAL, "Path is not a regular file", str(path))
+
+
+def _path_changed_error(path: Path) -> OSError:
+    return OSError(errno.ELOOP, "Path changed while opening", str(path))
+
+
+def _open_no_follow(path: Path) -> int:
+    flags = os.O_RDONLY
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    if nofollow is not None:
+        return os.open(path, flags | nofollow)
+
+    initial_stat = path.lstat()
+    if not stat.S_ISREG(initial_stat.st_mode):
+        raise _not_regular_error(path)
+
+    fd = os.open(path, flags)
+    opened_successfully = False
+    try:
+        opened_stat = os.fstat(fd)
+        if (opened_stat.st_dev, opened_stat.st_ino) != (
+            initial_stat.st_dev,
+            initial_stat.st_ino,
+        ):
+            raise _path_changed_error(path)
+        opened_successfully = True
+        return fd
+    finally:
+        if not opened_successfully:
+            os.close(fd)
+
+
+def _read_no_follow_bytes(path: Path) -> bytes:
+    fd = _open_no_follow(path)
+    try:
+        opened_stat = os.fstat(fd)
+        if not stat.S_ISREG(opened_stat.st_mode):
+            raise _not_regular_error(path)
+
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(fd, 1024 * 1024)
+            if not chunk:
+                return b"".join(chunks)
+            chunks.append(chunk)
+    finally:
+        os.close(fd)
+
+
 def _read_regular_file(
     *,
     path: Path,
@@ -88,29 +186,8 @@ def _read_regular_file(
     source_type: ContextAssetSource,
     findings: list[ContextIntegrityFinding],
 ) -> bytes | None:
-    if path.is_symlink():
-        findings.append(
-            _symlink_finding(
-                asset_id=asset_id,
-                source_type=source_type,
-                path=path,
-                root=None,
-            )
-        )
-        return None
-
     try:
-        if not path.is_file():
-            findings.append(
-                _verification_error(
-                    asset_id=asset_id,
-                    source_type=source_type,
-                    summary="Configured context file is missing or is not a regular file.",
-                    path=path,
-                )
-            )
-            return None
-        return path.read_bytes()
+        return _read_no_follow_bytes(path)
     except OSError as exc:
         findings.append(
             _verification_error(
@@ -191,26 +268,30 @@ def _read_skill_file_map(
                     )
                 )
                 continue
-            try:
-                files[relative] = path.read_bytes()
-            except OSError as exc:
-                findings.append(
-                    _verification_error(
-                        asset_id=asset_id,
-                        source_type="skill_file",
-                        summary=f"Unable to read skill file: {exc.__class__.__name__}.",
-                        path=path,
-                        details={"error": str(exc)},
-                    )
-                )
+            content = _read_regular_file(
+                path=path,
+                asset_id=asset_id,
+                source_type="skill_file",
+                findings=findings,
+            )
+            if content is not None:
+                files[relative] = content
 
     return files
 
 
 def inventory_user_skills_with_findings(*, user_id: int, skills_root: Path) -> InventoryResult:
     """Inventory per-user skill directories with non-fatal discovery findings."""
-    if not skills_root.exists():
-        return InventoryResult(assets=())
+    root_ok, root_finding = _validate_inventory_root(
+        root=skills_root,
+        asset_id=f"skill:user:{user_id}",
+        source_type="skill_file",
+    )
+    if not root_ok:
+        return InventoryResult(
+            assets=(),
+            findings=(root_finding,) if root_finding is not None else (),
+        )
 
     assets: list[ContextAssetDescriptor] = []
     findings: list[ContextIntegrityFinding] = []
@@ -311,8 +392,16 @@ def inventory_user_skills(user_id: int, skills_root: Path) -> list[ContextAssetD
 
 def inventory_prompt_files_with_findings(*, prompts_dir: Path) -> InventoryResult:
     """Inventory config prompt files under a Prompts directory with findings."""
-    if not prompts_dir.exists():
-        return InventoryResult(assets=())
+    root_ok, root_finding = _validate_inventory_root(
+        root=prompts_dir,
+        asset_id=f"prompt_file:{prompts_dir.name}",
+        source_type="prompt_file",
+    )
+    if not root_ok:
+        return InventoryResult(
+            assets=(),
+            findings=(root_finding,) if root_finding is not None else (),
+        )
 
     assets: list[ContextAssetDescriptor] = []
     findings: list[ContextIntegrityFinding] = []

--- a/tldw_Server_API/app/core/Context_Integrity/manifest.py
+++ b/tldw_Server_API/app/core/Context_Integrity/manifest.py
@@ -16,6 +16,9 @@ from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
 _SIGNATURE_ALGORITHM = "hmac-sha256"
 _SUPPORTED_SCHEMA_VERSION = 1
 _BASE64URL_SIGNATURE_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+_REQUIRED_ENTRY_STRING_FIELDS = ("asset_id", "source_type", "digest", "display_name", "owner_scope")
+_NON_EMPTY_ENTRY_STRING_FIELDS = frozenset(("asset_id", "source_type", "digest", "display_name"))
+_REQUIRED_ENTRY_BOOL_FIELDS = ("executable", "required")
 
 
 class ManifestSignatureError(ValueError):
@@ -91,6 +94,48 @@ def _require_int_field(manifest: Mapping[str, Any], field_name: str) -> int:
     return value
 
 
+def _require_entry_string(entry: Mapping[str, Any], field_name: str) -> None:
+    if field_name not in entry:
+        raise ManifestSignatureError(f"manifest entry {field_name} is required")
+    value = entry[field_name]
+    if not isinstance(value, str):
+        raise ManifestSignatureError(f"manifest entry {field_name} must be a string")
+    if field_name in _NON_EMPTY_ENTRY_STRING_FIELDS and not value:
+        raise ManifestSignatureError(f"manifest entry {field_name} must not be empty")
+
+
+def _require_entry_bool(entry: Mapping[str, Any], field_name: str) -> None:
+    if field_name not in entry:
+        raise ManifestSignatureError(f"manifest entry {field_name} is required")
+    if not isinstance(entry[field_name], bool):
+        raise ManifestSignatureError(f"manifest entry {field_name} must be a boolean")
+
+
+def _validate_optional_entry_fields(entry: Mapping[str, Any]) -> None:
+    if "path" in entry and entry["path"] is not None and not isinstance(entry["path"], str):
+        raise ManifestSignatureError("manifest entry path must be a string or null")
+    if "metadata" in entry:
+        metadata = entry["metadata"]
+        if not isinstance(metadata, Mapping):
+            raise ManifestSignatureError("manifest entry metadata must be an object")
+        for key in metadata:
+            if not isinstance(key, str):
+                raise ManifestSignatureError("manifest entry metadata keys must be strings")
+        try:
+            _stable_json({"metadata": metadata})
+        except (TypeError, ValueError) as exc:
+            raise ManifestSignatureError("manifest entry metadata is not canonicalizable") from exc
+
+
+def _validate_entry_schema(entry: Mapping[str, Any]) -> dict[str, Any]:
+    for field_name in _REQUIRED_ENTRY_STRING_FIELDS:
+        _require_entry_string(entry, field_name)
+    for field_name in _REQUIRED_ENTRY_BOOL_FIELDS:
+        _require_entry_bool(entry, field_name)
+    _validate_optional_entry_fields(entry)
+    return dict(entry)
+
+
 def _require_entries(manifest: Mapping[str, Any]) -> tuple[dict[str, Any], ...]:
     if "entries" not in manifest:
         raise ManifestSignatureError("manifest entries are required")
@@ -104,7 +149,7 @@ def _require_entries(manifest: Mapping[str, Any]) -> tuple[dict[str, Any], ...]:
         for key in entry:
             if not isinstance(key, str):
                 raise ManifestSignatureError("manifest entry keys must be strings")
-        verified_entries.append(dict(entry))
+        verified_entries.append(_validate_entry_schema(entry))
     return tuple(verified_entries)
 
 

--- a/tldw_Server_API/app/core/Context_Integrity/manifest.py
+++ b/tldw_Server_API/app/core/Context_Integrity/manifest.py
@@ -177,10 +177,11 @@ def _require_entries(manifest: Mapping[str, Any]) -> tuple[Mapping[str, Any], ..
 def create_signed_manifest(
     *,
     sequence: int,
-    entries: list[dict[str, Any]],
+    entries: list[Mapping[str, Any]],
     signer: HmacManifestSigner,
     schema_version: int = _SUPPORTED_SCHEMA_VERSION,
 ) -> dict[str, Any]:
+    """Create a canonical signed manifest payload from approved asset entries."""
     manifest_entries = [dict(entry) for entry in entries]
     manifest = {
         "schema_version": schema_version,
@@ -205,12 +206,13 @@ def verify_signed_manifest(
     signer: HmacManifestSigner,
     anti_rollback_anchor: AntiRollbackAnchor | None = None,
 ) -> VerifiedManifest:
+    """Verify a signed manifest and return an immutable normalized snapshot."""
     if not isinstance(signed_manifest, Mapping):
         raise ManifestSignatureError("signed manifest is malformed")
 
     manifest = signed_manifest.get("manifest")
     signature = signed_manifest.get("signature")
-    if not isinstance(manifest, dict) or not isinstance(signature, dict):
+    if not isinstance(manifest, Mapping) or not isinstance(signature, Mapping):
         raise ManifestSignatureError("signed manifest is malformed")
     if signature.get("alg") != _SIGNATURE_ALGORITHM:
         raise ManifestSignatureError("manifest signature algorithm mismatch")

--- a/tldw_Server_API/app/core/Context_Integrity/manifest.py
+++ b/tldw_Server_API/app/core/Context_Integrity/manifest.py
@@ -7,6 +7,7 @@ import hashlib
 import hmac
 from collections.abc import Mapping
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Any
 
 from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
@@ -44,7 +45,7 @@ class VerifiedManifest:
     sequence: int
     manifest_digest: str
     key_id: str
-    entries: tuple[dict[str, Any], ...]
+    entries: tuple[Mapping[str, Any], ...]
 
 
 class HmacManifestSigner:
@@ -83,6 +84,20 @@ def _stable_json(payload: Mapping[str, Any]) -> bytes:
 
 def _manifest_digest(payload: bytes) -> str:
     return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _freeze_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return _freeze_mapping(value)
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_value(item) for item in value)
+    if isinstance(value, set):
+        return frozenset(_freeze_value(item) for item in value)
+    return value
+
+
+def _freeze_mapping(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    return MappingProxyType({key: _freeze_value(item) for key, item in value.items()})
 
 
 def _require_int_field(manifest: Mapping[str, Any], field_name: str) -> int:
@@ -127,22 +142,22 @@ def _validate_optional_entry_fields(entry: Mapping[str, Any]) -> None:
             raise ManifestSignatureError("manifest entry metadata is not canonicalizable") from exc
 
 
-def _validate_entry_schema(entry: Mapping[str, Any]) -> dict[str, Any]:
+def _validate_entry_schema(entry: Mapping[str, Any]) -> Mapping[str, Any]:
     for field_name in _REQUIRED_ENTRY_STRING_FIELDS:
         _require_entry_string(entry, field_name)
     for field_name in _REQUIRED_ENTRY_BOOL_FIELDS:
         _require_entry_bool(entry, field_name)
     _validate_optional_entry_fields(entry)
-    return dict(entry)
+    return _freeze_mapping(entry)
 
 
-def _require_entries(manifest: Mapping[str, Any]) -> tuple[dict[str, Any], ...]:
+def _require_entries(manifest: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
     if "entries" not in manifest:
         raise ManifestSignatureError("manifest entries are required")
     entries = manifest["entries"]
     if not isinstance(entries, list):
         raise ManifestSignatureError("manifest entries must be a list")
-    verified_entries: list[dict[str, Any]] = []
+    verified_entries: list[Mapping[str, Any]] = []
     for entry in entries:
         if not isinstance(entry, Mapping):
             raise ManifestSignatureError("manifest entries must be objects")
@@ -153,6 +168,8 @@ def _require_entries(manifest: Mapping[str, Any]) -> tuple[dict[str, Any], ...]:
     asset_ids = [entry["asset_id"] for entry in verified_entries]
     if asset_ids != sorted(asset_ids):
         raise ManifestSignatureError("manifest entries must be sorted by asset_id")
+    if len(asset_ids) != len(set(asset_ids)):
+        raise ManifestSignatureError("manifest entries must have unique asset_id values")
     return tuple(verified_entries)
 
 

--- a/tldw_Server_API/app/core/Context_Integrity/manifest.py
+++ b/tldw_Server_API/app/core/Context_Integrity/manifest.py
@@ -13,6 +13,8 @@ from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
     _stable_json as _canonical_stable_json,
 )
 
+_SIGNATURE_ALGORITHM = "hmac-sha256"
+
 
 class ManifestSignatureError(ValueError):
     """Raised when a manifest signature cannot be verified."""
@@ -67,6 +69,24 @@ def _manifest_digest(payload: bytes) -> str:
     return "sha256:" + hashlib.sha256(payload).hexdigest()
 
 
+def _require_int_field(manifest: Mapping[str, Any], field_name: str) -> int:
+    if field_name not in manifest:
+        raise ManifestSignatureError(f"manifest {field_name} is required")
+    value = manifest[field_name]
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ManifestSignatureError(f"manifest {field_name} must be an integer")
+    return value
+
+
+def _require_entries(manifest: Mapping[str, Any]) -> list[Any]:
+    if "entries" not in manifest:
+        raise ManifestSignatureError("manifest entries are required")
+    entries = manifest["entries"]
+    if not isinstance(entries, list):
+        raise ManifestSignatureError("manifest entries must be a list")
+    return entries
+
+
 def create_signed_manifest(
     *,
     sequence: int,
@@ -84,7 +104,7 @@ def create_signed_manifest(
     return {
         "manifest": manifest,
         "signature": {
-            "alg": "hmac-sha256",
+            "alg": _SIGNATURE_ALGORITHM,
             "key_id": signer.key_id,
             "value": signer.sign(payload),
         },
@@ -102,6 +122,8 @@ def verify_signed_manifest(
     signature = signed_manifest.get("signature")
     if not isinstance(manifest, dict) or not isinstance(signature, dict):
         raise ManifestSignatureError("signed manifest is malformed")
+    if signature.get("alg") != _SIGNATURE_ALGORITHM:
+        raise ManifestSignatureError("manifest signature algorithm mismatch")
     if signature.get("key_id") != signer.key_id:
         raise ManifestSignatureError("manifest key id mismatch")
 
@@ -114,16 +136,15 @@ def verify_signed_manifest(
     if not isinstance(signature_value, str) or not signer.verify(payload, signature_value):
         raise ManifestSignatureError("manifest signature mismatch")
 
-    sequence = int(manifest.get("sequence") or 0)
+    _require_int_field(manifest, "schema_version")
+    sequence = _require_int_field(manifest, "sequence")
     if anti_rollback_anchor and (
         sequence < anti_rollback_anchor.sequence
         or (sequence == anti_rollback_anchor.sequence and expected_digest != anti_rollback_anchor.manifest_digest)
     ):
         raise ManifestRollbackError("manifest rollback detected")
 
-    entries = manifest.get("entries") or []
-    if not isinstance(entries, list):
-        raise ManifestSignatureError("manifest entries must be a list")
+    entries = _require_entries(manifest)
     return VerifiedManifest(
         sequence=sequence,
         manifest_digest=expected_digest,

--- a/tldw_Server_API/app/core/Context_Integrity/manifest.py
+++ b/tldw_Server_API/app/core/Context_Integrity/manifest.py
@@ -14,6 +14,8 @@ from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
 )
 
 _SIGNATURE_ALGORITHM = "hmac-sha256"
+_SUPPORTED_SCHEMA_VERSION = 1
+_BASE64URL_SIGNATURE_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
 
 
 class ManifestSignatureError(ValueError):
@@ -58,7 +60,16 @@ class HmacManifestSigner:
         return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
 
     def verify(self, payload: bytes, signature: str) -> bool:
-        return hmac.compare_digest(self.sign(payload), signature)
+        try:
+            signature.encode("ascii")
+        except UnicodeEncodeError:
+            return False
+        if not signature or any(char not in _BASE64URL_SIGNATURE_CHARS for char in signature):
+            return False
+        try:
+            return hmac.compare_digest(self.sign(payload), signature)
+        except TypeError:
+            return False
 
 
 def _stable_json(payload: Mapping[str, Any]) -> bytes:
@@ -78,13 +89,21 @@ def _require_int_field(manifest: Mapping[str, Any], field_name: str) -> int:
     return value
 
 
-def _require_entries(manifest: Mapping[str, Any]) -> list[Any]:
+def _require_entries(manifest: Mapping[str, Any]) -> tuple[dict[str, Any], ...]:
     if "entries" not in manifest:
         raise ManifestSignatureError("manifest entries are required")
     entries = manifest["entries"]
     if not isinstance(entries, list):
         raise ManifestSignatureError("manifest entries must be a list")
-    return entries
+    verified_entries: list[dict[str, Any]] = []
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            raise ManifestSignatureError("manifest entries must be objects")
+        for key in entry:
+            if not isinstance(key, str):
+                raise ManifestSignatureError("manifest entry keys must be strings")
+        verified_entries.append(dict(entry))
+    return tuple(verified_entries)
 
 
 def create_signed_manifest(
@@ -92,7 +111,7 @@ def create_signed_manifest(
     sequence: int,
     entries: list[dict[str, Any]],
     signer: HmacManifestSigner,
-    schema_version: int = 1,
+    schema_version: int = _SUPPORTED_SCHEMA_VERSION,
 ) -> dict[str, Any]:
     manifest_entries = [dict(entry) for entry in entries]
     manifest = {
@@ -136,7 +155,9 @@ def verify_signed_manifest(
     if not isinstance(signature_value, str) or not signer.verify(payload, signature_value):
         raise ManifestSignatureError("manifest signature mismatch")
 
-    _require_int_field(manifest, "schema_version")
+    schema_version = _require_int_field(manifest, "schema_version")
+    if schema_version != _SUPPORTED_SCHEMA_VERSION:
+        raise ManifestSignatureError("unsupported manifest schema version")
     sequence = _require_int_field(manifest, "sequence")
     if anti_rollback_anchor and (
         sequence < anti_rollback_anchor.sequence
@@ -149,5 +170,5 @@ def verify_signed_manifest(
         sequence=sequence,
         manifest_digest=expected_digest,
         key_id=signer.key_id,
-        entries=tuple(dict(item) for item in entries),
+        entries=entries,
     )

--- a/tldw_Server_API/app/core/Context_Integrity/manifest.py
+++ b/tldw_Server_API/app/core/Context_Integrity/manifest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
+import json
 from collections.abc import Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
@@ -218,8 +219,11 @@ def verify_signed_manifest(
 
     try:
         payload = _stable_json(manifest)
+        normalized_manifest = json.loads(payload.decode("utf-8"))
     except (TypeError, ValueError) as exc:
         raise ManifestSignatureError("manifest payload is not canonicalizable") from exc
+    if not isinstance(normalized_manifest, dict):
+        raise ManifestSignatureError("manifest payload is malformed")
     expected_digest = _manifest_digest(payload)
     if signed_manifest.get("manifest_digest") != expected_digest:
         raise ManifestSignatureError("manifest digest mismatch")
@@ -228,11 +232,11 @@ def verify_signed_manifest(
     if not isinstance(signature_value, str) or not signer.verify(payload, signature_value):
         raise ManifestSignatureError("manifest signature mismatch")
 
-    schema_version = _require_int_field(manifest, "schema_version")
+    schema_version = _require_int_field(normalized_manifest, "schema_version")
     if schema_version != _SUPPORTED_SCHEMA_VERSION:
         raise ManifestSignatureError("unsupported manifest schema version")
-    sequence = _require_int_field(manifest, "sequence")
-    entries = _require_entries(manifest)
+    sequence = _require_int_field(normalized_manifest, "sequence")
+    entries = _require_entries(normalized_manifest)
     if anti_rollback_anchor and (
         sequence < anti_rollback_anchor.sequence
         or (sequence == anti_rollback_anchor.sequence and expected_digest != anti_rollback_anchor.manifest_digest)

--- a/tldw_Server_API/app/core/Context_Integrity/manifest.py
+++ b/tldw_Server_API/app/core/Context_Integrity/manifest.py
@@ -59,7 +59,9 @@ class HmacManifestSigner:
         digest = hmac.new(self._secret, payload, hashlib.sha256).digest()
         return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
 
-    def verify(self, payload: bytes, signature: str) -> bool:
+    def verify(self, payload: bytes, signature: object) -> bool:
+        if not isinstance(signature, str):
+            return False
         try:
             signature.encode("ascii")
         except UnicodeEncodeError:
@@ -137,6 +139,9 @@ def verify_signed_manifest(
     signer: HmacManifestSigner,
     anti_rollback_anchor: AntiRollbackAnchor | None = None,
 ) -> VerifiedManifest:
+    if not isinstance(signed_manifest, Mapping):
+        raise ManifestSignatureError("signed manifest is malformed")
+
     manifest = signed_manifest.get("manifest")
     signature = signed_manifest.get("signature")
     if not isinstance(manifest, dict) or not isinstance(signature, dict):
@@ -146,7 +151,10 @@ def verify_signed_manifest(
     if signature.get("key_id") != signer.key_id:
         raise ManifestSignatureError("manifest key id mismatch")
 
-    payload = _stable_json(manifest)
+    try:
+        payload = _stable_json(manifest)
+    except (TypeError, ValueError) as exc:
+        raise ManifestSignatureError("manifest payload is not canonicalizable") from exc
     expected_digest = _manifest_digest(payload)
     if signed_manifest.get("manifest_digest") != expected_digest:
         raise ManifestSignatureError("manifest digest mismatch")

--- a/tldw_Server_API/app/core/Context_Integrity/manifest.py
+++ b/tldw_Server_API/app/core/Context_Integrity/manifest.py
@@ -1,0 +1,132 @@
+"""Signed context integrity manifest helpers."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+    _stable_json as _canonical_stable_json,
+)
+
+
+class ManifestSignatureError(ValueError):
+    """Raised when a manifest signature cannot be verified."""
+
+
+class ManifestRollbackError(ValueError):
+    """Raised when a valid manifest is older than the anti-rollback anchor."""
+
+
+@dataclass(frozen=True, slots=True)
+class AntiRollbackAnchor:
+    """Last accepted manifest identity from a non-DB trust anchor."""
+
+    sequence: int
+    manifest_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedManifest:
+    """Verified signed manifest payload."""
+
+    sequence: int
+    manifest_digest: str
+    key_id: str
+    entries: tuple[dict[str, Any], ...]
+
+
+class HmacManifestSigner:
+    """Test and deployment signer backed by an externally supplied secret."""
+
+    def __init__(self, *, key_id: str, secret: bytes) -> None:
+        if not key_id:
+            raise ValueError("key_id is required")
+        if not secret:
+            raise ValueError("secret is required")
+        self.key_id = key_id
+        self._secret = secret
+
+    def sign(self, payload: bytes) -> str:
+        digest = hmac.new(self._secret, payload, hashlib.sha256).digest()
+        return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+    def verify(self, payload: bytes, signature: str) -> bool:
+        return hmac.compare_digest(self.sign(payload), signature)
+
+
+def _stable_json(payload: Mapping[str, Any]) -> bytes:
+    return _canonical_stable_json(payload).encode("utf-8")
+
+
+def _manifest_digest(payload: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def create_signed_manifest(
+    *,
+    sequence: int,
+    entries: list[dict[str, Any]],
+    signer: HmacManifestSigner,
+    schema_version: int = 1,
+) -> dict[str, Any]:
+    manifest_entries = [dict(entry) for entry in entries]
+    manifest = {
+        "schema_version": schema_version,
+        "sequence": sequence,
+        "entries": sorted(manifest_entries, key=lambda item: str(item["asset_id"])),
+    }
+    payload = _stable_json(manifest)
+    return {
+        "manifest": manifest,
+        "signature": {
+            "alg": "hmac-sha256",
+            "key_id": signer.key_id,
+            "value": signer.sign(payload),
+        },
+        "manifest_digest": _manifest_digest(payload),
+    }
+
+
+def verify_signed_manifest(
+    signed_manifest: Mapping[str, Any],
+    *,
+    signer: HmacManifestSigner,
+    anti_rollback_anchor: AntiRollbackAnchor | None = None,
+) -> VerifiedManifest:
+    manifest = signed_manifest.get("manifest")
+    signature = signed_manifest.get("signature")
+    if not isinstance(manifest, dict) or not isinstance(signature, dict):
+        raise ManifestSignatureError("signed manifest is malformed")
+    if signature.get("key_id") != signer.key_id:
+        raise ManifestSignatureError("manifest key id mismatch")
+
+    payload = _stable_json(manifest)
+    expected_digest = _manifest_digest(payload)
+    if signed_manifest.get("manifest_digest") != expected_digest:
+        raise ManifestSignatureError("manifest digest mismatch")
+
+    signature_value = signature.get("value")
+    if not isinstance(signature_value, str) or not signer.verify(payload, signature_value):
+        raise ManifestSignatureError("manifest signature mismatch")
+
+    sequence = int(manifest.get("sequence") or 0)
+    if anti_rollback_anchor and (
+        sequence < anti_rollback_anchor.sequence
+        or (sequence == anti_rollback_anchor.sequence and expected_digest != anti_rollback_anchor.manifest_digest)
+    ):
+        raise ManifestRollbackError("manifest rollback detected")
+
+    entries = manifest.get("entries") or []
+    if not isinstance(entries, list):
+        raise ManifestSignatureError("manifest entries must be a list")
+    return VerifiedManifest(
+        sequence=sequence,
+        manifest_digest=expected_digest,
+        key_id=signer.key_id,
+        entries=tuple(dict(item) for item in entries),
+    )

--- a/tldw_Server_API/app/core/Context_Integrity/manifest.py
+++ b/tldw_Server_API/app/core/Context_Integrity/manifest.py
@@ -150,6 +150,9 @@ def _require_entries(manifest: Mapping[str, Any]) -> tuple[dict[str, Any], ...]:
             if not isinstance(key, str):
                 raise ManifestSignatureError("manifest entry keys must be strings")
         verified_entries.append(_validate_entry_schema(entry))
+    asset_ids = [entry["asset_id"] for entry in verified_entries]
+    if asset_ids != sorted(asset_ids):
+        raise ManifestSignatureError("manifest entries must be sorted by asset_id")
     return tuple(verified_entries)
 
 
@@ -212,13 +215,13 @@ def verify_signed_manifest(
     if schema_version != _SUPPORTED_SCHEMA_VERSION:
         raise ManifestSignatureError("unsupported manifest schema version")
     sequence = _require_int_field(manifest, "sequence")
+    entries = _require_entries(manifest)
     if anti_rollback_anchor and (
         sequence < anti_rollback_anchor.sequence
         or (sequence == anti_rollback_anchor.sequence and expected_digest != anti_rollback_anchor.manifest_digest)
     ):
         raise ManifestRollbackError("manifest rollback detected")
 
-    entries = _require_entries(manifest)
     return VerifiedManifest(
         sequence=sequence,
         manifest_digest=expected_digest,

--- a/tldw_Server_API/app/core/Context_Integrity/models.py
+++ b/tldw_Server_API/app/core/Context_Integrity/models.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from types import MappingProxyType
 from typing import Any, Literal
 
 ContextAssetSource = Literal["skill_file", "prompt_file", "db_prompt"]
@@ -20,6 +22,20 @@ ContextAssetState = Literal[
     "degraded_integrity",
     "quarantined",
 ]
+
+
+def _freeze_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return _freeze_mapping(value)
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_value(item) for item in value)
+    if isinstance(value, set):
+        return frozenset(_freeze_value(item) for item in value)
+    return value
+
+
+def _freeze_mapping(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    return MappingProxyType({key: _freeze_value(item) for key, item in value.items()})
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,7 +61,10 @@ class ContextAssetDescriptor:
     required: bool = False
     owner_scope: str = "system"
     path: str | None = None
-    metadata: dict[str, Any] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "metadata", _freeze_mapping(self.metadata))
 
 
 @dataclass(frozen=True, slots=True)
@@ -60,8 +79,11 @@ class ContextIntegrityFinding:
     source_type: ContextAssetSource | Literal["manifest"]
     current_digest: str | None = None
     approved_digest: str | None = None
-    details: dict[str, Any] = field(default_factory=dict)
+    details: Mapping[str, Any] = field(default_factory=dict)
     detected_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "details", _freeze_mapping(self.details))
 
 
 @dataclass(frozen=True, slots=True)
@@ -72,5 +94,12 @@ class ContextIntegrityBootState:
     degraded: bool
     manifest_sequence: int | None
     manifest_digest: str | None
-    approved_digests_by_asset_id: dict[str, str] = field(default_factory=dict)
+    approved_digests_by_asset_id: Mapping[str, str] = field(default_factory=dict)
     findings: tuple[ContextIntegrityFinding, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "approved_digests_by_asset_id",
+            _freeze_mapping(self.approved_digests_by_asset_id),
+        )

--- a/tldw_Server_API/app/core/Context_Integrity/models.py
+++ b/tldw_Server_API/app/core/Context_Integrity/models.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from types import MappingProxyType
 from typing import Any, Literal
 
+ContextIntegrityMode = Literal["audit_only", "enforce", "hardened"]
 ContextAssetSource = Literal["skill_file", "prompt_file", "db_prompt"]
 ContextAssetState = Literal[
     "trusted",
@@ -90,7 +91,7 @@ class ContextIntegrityFinding:
 class ContextIntegrityBootState:
     """Current-process context integrity verification result."""
 
-    mode: Literal["audit_only", "enforce", "hardened"]
+    mode: ContextIntegrityMode
     degraded: bool
     manifest_sequence: int | None
     manifest_digest: str | None
@@ -103,3 +104,4 @@ class ContextIntegrityBootState:
             "approved_digests_by_asset_id",
             _freeze_mapping(self.approved_digests_by_asset_id),
         )
+        object.__setattr__(self, "findings", tuple(self.findings))

--- a/tldw_Server_API/app/core/Context_Integrity/models.py
+++ b/tldw_Server_API/app/core/Context_Integrity/models.py
@@ -1,0 +1,76 @@
+"""Shared models for context integrity verification."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+ContextAssetSource = Literal["skill_file", "prompt_file", "db_prompt"]
+ContextAssetState = Literal[
+    "trusted",
+    "changed_approved_executable",
+    "changed_approved_non_executable",
+    "new_unapproved",
+    "missing_required",
+    "missing_optional",
+    "signature_invalid",
+    "manifest_rollback_detected",
+    "verification_error",
+    "degraded_integrity",
+    "quarantined",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalDigest:
+    """Canonical digest plus optional JSON payload used to produce it."""
+
+    digest: str
+    canonical_json: str = ""
+
+    def __str__(self) -> str:
+        return self.digest
+
+
+@dataclass(frozen=True, slots=True)
+class ContextAssetDescriptor:
+    """One prompt-bearing asset discovered by an inventory adapter."""
+
+    asset_id: str
+    source_type: ContextAssetSource
+    digest: str
+    display_name: str
+    executable: bool = False
+    required: bool = False
+    owner_scope: str = "system"
+    path: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ContextIntegrityFinding:
+    """Verification finding for one asset or source scope."""
+
+    asset_id: str
+    state: ContextAssetState
+    severity: Literal["info", "warning", "error"]
+    summary: str
+    remediation: str
+    source_type: ContextAssetSource | Literal["manifest"]
+    current_digest: str | None = None
+    approved_digest: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+    detected_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass(frozen=True, slots=True)
+class ContextIntegrityBootState:
+    """Current-process context integrity verification result."""
+
+    mode: Literal["audit_only", "enforce", "hardened"]
+    degraded: bool
+    manifest_sequence: int | None
+    manifest_digest: str | None
+    approved_digests_by_asset_id: dict[str, str] = field(default_factory=dict)
+    findings: tuple[ContextIntegrityFinding, ...] = ()

--- a/tldw_Server_API/app/core/Context_Integrity/resolver.py
+++ b/tldw_Server_API/app/core/Context_Integrity/resolver.py
@@ -1,0 +1,90 @@
+"""Runtime resolver for context integrity enforcement."""
+
+from __future__ import annotations
+
+from tldw_Server_API.app.core.Context_Integrity.models import (
+    ContextAssetState,
+    ContextIntegrityBootState,
+    ContextIntegrityFinding,
+)
+
+_ENFORCING_MODES = frozenset(("enforce", "hardened"))
+
+
+class ContextIntegrityBlocked(RuntimeError):
+    """Raised when a prompt-bearing asset is quarantined or unavailable."""
+
+    def __init__(self, asset_id: str, state: ContextAssetState) -> None:
+        self.asset_id = asset_id
+        self.state = state
+        super().__init__(f"Context integrity quarantined asset {asset_id!r}; state={state}.")
+
+
+class ContextIntegrityResolver:
+    """Current-process resolver backed by verified boot state."""
+
+    def __init__(self, boot_state: ContextIntegrityBootState) -> None:
+        self.boot_state = boot_state
+        self._findings_by_asset_id: dict[str, ContextIntegrityFinding] = {
+            finding.asset_id: finding for finding in boot_state.findings
+        }
+
+    def finding_for(self, asset_id: str) -> ContextIntegrityFinding | None:
+        """Return the current boot finding for an asset, if any."""
+        return self._findings_by_asset_id.get(asset_id)
+
+    def require_allowed(self, asset_id: str, *, purpose: str) -> None:
+        """Raise if the asset is not allowed for the requested runtime purpose."""
+        if self.boot_state.mode == "audit_only":
+            return
+
+        if self.boot_state.degraded and not purpose.startswith("admin_review"):
+            raise ContextIntegrityBlocked(
+                asset_id=asset_id,
+                state="degraded_integrity",
+            )
+
+        finding = self.finding_for(asset_id)
+        if finding is not None and finding.state != "trusted":
+            raise ContextIntegrityBlocked(asset_id=asset_id, state=finding.state)
+
+        if self.boot_state.mode in _ENFORCING_MODES and asset_id not in self.boot_state.approved_digests_by_asset_id:
+            raise ContextIntegrityBlocked(asset_id=asset_id, state="new_unapproved")
+
+    def require_digest_allowed(
+        self,
+        asset_id: str,
+        *,
+        current_digest: str,
+        purpose: str,
+        changed_state: ContextAssetState = "changed_approved_executable",
+    ) -> None:
+        """Raise if the asset is disallowed or its live digest is no longer approved."""
+        self.require_allowed(asset_id, purpose=purpose)
+        if self.boot_state.mode == "audit_only":
+            return
+
+        approved_digest = self.boot_state.approved_digests_by_asset_id.get(asset_id)
+        if approved_digest is None:
+            raise ContextIntegrityBlocked(asset_id=asset_id, state="new_unapproved")
+        if approved_digest != current_digest:
+            raise ContextIntegrityBlocked(asset_id=asset_id, state=changed_state)
+
+
+_global_resolver: ContextIntegrityResolver | None = None
+
+
+def set_global_context_integrity_resolver(resolver: ContextIntegrityResolver | None) -> None:
+    """Set the process-wide Context Integrity resolver compatibility bridge."""
+    global _global_resolver
+    _global_resolver = resolver
+
+
+def get_global_context_integrity_resolver() -> ContextIntegrityResolver | None:
+    """Return the process-wide Context Integrity resolver, if configured."""
+    return _global_resolver
+
+
+def clear_global_context_integrity_resolver() -> None:
+    """Clear the process-wide Context Integrity resolver."""
+    set_global_context_integrity_resolver(None)

--- a/tldw_Server_API/app/core/Context_Integrity/resolver.py
+++ b/tldw_Server_API/app/core/Context_Integrity/resolver.py
@@ -71,6 +71,8 @@ class ContextIntegrityResolver:
             raise ContextIntegrityBlocked(asset_id=asset_id, state=changed_state)
 
 
+# Compatibility bridge for legacy runtime paths that are not yet request/app scoped
+# (notably prompt loading). New service code should prefer explicit injection.
 _global_resolver: ContextIntegrityResolver | None = None
 
 

--- a/tldw_Server_API/app/core/Context_Integrity/verifier.py
+++ b/tldw_Server_API/app/core/Context_Integrity/verifier.py
@@ -50,12 +50,13 @@ def verify_inventory(
         if approved_digest == asset.digest:
             continue
 
-        state = "changed_approved_executable" if asset.executable else "changed_approved_non_executable"
+        approved_executable = bool(entry.get("executable", False))
+        state = "changed_approved_executable" if approved_executable else "changed_approved_non_executable"
         findings.append(
             ContextIntegrityFinding(
                 asset_id=asset_id,
                 state=state,
-                severity="error" if asset.executable else "warning",
+                severity="error" if approved_executable else "warning",
                 summary=f"Approved context asset changed: {asset.display_name}",
                 remediation="Review the diff and approve a new manifest version or restore the asset.",
                 source_type=asset.source_type,

--- a/tldw_Server_API/app/core/Context_Integrity/verifier.py
+++ b/tldw_Server_API/app/core/Context_Integrity/verifier.py
@@ -1,0 +1,83 @@
+"""Verification of current context assets against approved manifest entries."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any, cast
+
+from tldw_Server_API.app.core.Context_Integrity.models import (
+    ContextAssetDescriptor,
+    ContextAssetSource,
+    ContextIntegrityFinding,
+)
+
+
+def _entry_by_asset_id(entries: Iterable[Mapping[str, Any]]) -> dict[str, Mapping[str, Any]]:
+    return {str(entry["asset_id"]): entry for entry in entries}
+
+
+def _entry_source_type(entry: Mapping[str, Any]) -> ContextAssetSource:
+    return cast(ContextAssetSource, str(entry.get("source_type", "skill_file")))
+
+
+def verify_inventory(
+    *,
+    current_assets: Iterable[ContextAssetDescriptor],
+    approved_entries: Iterable[Mapping[str, Any]],
+) -> tuple[ContextIntegrityFinding, ...]:
+    """Compare current inventory against approved manifest entries."""
+    approved = _entry_by_asset_id(approved_entries)
+    current = {asset.asset_id: asset for asset in current_assets}
+    findings: list[ContextIntegrityFinding] = []
+
+    for asset_id, asset in current.items():
+        entry = approved.get(asset_id)
+        if entry is None:
+            findings.append(
+                ContextIntegrityFinding(
+                    asset_id=asset_id,
+                    state="new_unapproved",
+                    severity="warning",
+                    summary=f"Unapproved context asset detected: {asset.display_name}",
+                    remediation="Review and approve the asset before model use.",
+                    source_type=asset.source_type,
+                    current_digest=asset.digest,
+                )
+            )
+            continue
+
+        approved_digest = str(entry.get("digest"))
+        if approved_digest == asset.digest:
+            continue
+
+        state = "changed_approved_executable" if asset.executable else "changed_approved_non_executable"
+        findings.append(
+            ContextIntegrityFinding(
+                asset_id=asset_id,
+                state=state,
+                severity="error" if asset.executable else "warning",
+                summary=f"Approved context asset changed: {asset.display_name}",
+                remediation="Review the diff and approve a new manifest version or restore the asset.",
+                source_type=asset.source_type,
+                current_digest=asset.digest,
+                approved_digest=approved_digest,
+            )
+        )
+
+    for asset_id, entry in approved.items():
+        if asset_id in current:
+            continue
+        required = bool(entry.get("required", False))
+        findings.append(
+            ContextIntegrityFinding(
+                asset_id=asset_id,
+                state="missing_required" if required else "missing_optional",
+                severity="error" if required else "warning",
+                summary=f"Approved context asset is missing: {entry.get('display_name') or asset_id}",
+                remediation="Restore the asset or approve a manifest that removes it.",
+                source_type=_entry_source_type(entry),
+                approved_digest=str(entry.get("digest")),
+            )
+        )
+
+    return tuple(findings)

--- a/tldw_Server_API/app/core/Context_Integrity/verifier.py
+++ b/tldw_Server_API/app/core/Context_Integrity/verifier.py
@@ -16,6 +16,34 @@ def _entry_by_asset_id(entries: Iterable[Mapping[str, Any]]) -> dict[str, Mappin
     return {str(entry["asset_id"]): entry for entry in entries}
 
 
+def _current_assets_by_asset_id(
+    assets: Iterable[ContextAssetDescriptor],
+) -> tuple[dict[str, ContextAssetDescriptor], list[ContextIntegrityFinding]]:
+    current: dict[str, ContextAssetDescriptor] = {}
+    duplicate_findings: list[ContextIntegrityFinding] = []
+    for asset in assets:
+        existing = current.get(asset.asset_id)
+        if existing is None:
+            current[asset.asset_id] = asset
+            continue
+        duplicate_findings.append(
+            ContextIntegrityFinding(
+                asset_id=asset.asset_id,
+                state="verification_error",
+                severity="error",
+                summary=f"Duplicate context asset id detected: {asset.asset_id}",
+                remediation="Ensure each discovered context asset has a unique asset ID before approving a manifest.",
+                source_type=asset.source_type,
+                current_digest=asset.digest,
+                details={
+                    "first_display_name": existing.display_name,
+                    "duplicate_display_name": asset.display_name,
+                },
+            )
+        )
+    return current, duplicate_findings
+
+
 def _entry_source_type(entry: Mapping[str, Any]) -> ContextAssetSource:
     return cast(ContextAssetSource, str(entry.get("source_type", "skill_file")))
 
@@ -27,8 +55,8 @@ def verify_inventory(
 ) -> tuple[ContextIntegrityFinding, ...]:
     """Compare current inventory against approved manifest entries."""
     approved = _entry_by_asset_id(approved_entries)
-    current = {asset.asset_id: asset for asset in current_assets}
-    findings: list[ContextIntegrityFinding] = []
+    current, duplicate_findings = _current_assets_by_asset_id(current_assets)
+    findings: list[ContextIntegrityFinding] = list(duplicate_findings)
 
     for asset_id, asset in current.items():
         entry = approved.get(asset_id)

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -15952,7 +15952,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         model: str | None = None,
         sort: str = "name",
         order: str = "asc",
-        limit: int = 100,
+        limit: int | None = 100,
         offset: int = 0,
     ) -> list[dict[str, Any]]:
         """List skill registry entries with optional filters."""
@@ -15971,9 +15971,11 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         query = (
             "SELECT * FROM skill_registry "  # nosec B608
             f"{where_sql} "
-            f"{order_sql} LIMIT ? OFFSET ?"
+            f"{order_sql}"
         )
-        params.extend([limit, offset])
+        if limit is not None:
+            query += " LIMIT ? OFFSET ?"
+            params.extend([limit, offset])
         try:
             cursor = self.execute_query(query, tuple(params))
             return [item for row in cursor.fetchall() if (item := self._skill_row_to_dict(row))]

--- a/tldw_Server_API/app/core/Skills/context_integration.py
+++ b/tldw_Server_API/app/core/Skills/context_integration.py
@@ -17,6 +17,7 @@ from typing import Any, Optional
 
 from loguru import logger
 
+from tldw_Server_API.app.core.Context_Integrity.resolver import ContextIntegrityBlocked
 from tldw_Server_API.app.core.Skills.skill_executor import (
     SKILL_TOOL_DEFINITION,
     RequestContext,
@@ -164,6 +165,12 @@ async def handle_skill_tool_call(
         return {
             "success": False,
             "error": f"Skill '{skill_name}' not found",
+        }
+    except ContextIntegrityBlocked:
+        logger.warning("Blocked quarantined skill invocation: {}", skill_name)
+        return {
+            "success": False,
+            "error": "context_integrity_blocked",
         }
     except SkillsError:
         logger.error("Error executing skill '{}'", skill_name)

--- a/tldw_Server_API/app/core/Skills/skills_service.py
+++ b/tldw_Server_API/app/core/Skills/skills_service.py
@@ -34,6 +34,14 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     ConflictError,
     InputError,
 )
+from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+    canonical_filesystem_digest,
+)
+from tldw_Server_API.app.core.Context_Integrity.resolver import (
+    ContextIntegrityBlocked,
+    ContextIntegrityResolver,
+    get_global_context_integrity_resolver,
+)
 from tldw_Server_API.app.core.Skills.exceptions import (
     SkillConflictError,
     SkillNotFoundError,
@@ -45,14 +53,15 @@ from tldw_Server_API.app.core.Skills.exceptions import (
 from tldw_Server_API.app.core.Skills.skill_parser import SkillFrontmatter, SkillParser
 
 # Skill name validation pattern (same as in schemas)
-SKILL_NAME_PATTERN = re.compile(r'^[a-z][a-z0-9-]{0,63}$')
+SKILL_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
 # Supporting file name validation pattern (same as in schemas)
-SUPPORTING_FILE_NAME_PATTERN = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}$')
+SUPPORTING_FILE_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}$")
 MAX_SUPPORTING_FILES_COUNT = 20
 MAX_SUPPORTING_FILE_BYTES = 500000
 MAX_SUPPORTING_FILES_TOTAL_BYTES = 5 * 1024 * 1024  # 5MB
 MAX_SKILL_MD_BYTES = 500000
 MAX_ZIP_IMPORT_ENTRIES = 100
+SKILL_INTEGRITY_TEXT_SUFFIXES = {".md", ".txt", ".json", ".yaml", ".yml", ".py", ".sh"}
 
 
 class SkillMetadata:
@@ -145,6 +154,7 @@ class SkillsService:
         base_path: Path,
         db: CharactersRAGDB | None = None,
         sync_interval: float = 5.0,
+        integrity_resolver: ContextIntegrityResolver | None = None,
     ):
         """
         Initialize the SkillsService.
@@ -162,6 +172,9 @@ class SkillsService:
         self._parser = SkillParser()
         self._sync_interval = sync_interval
         self._last_sync_time: float = 0.0
+        self.integrity_resolver = (
+            integrity_resolver if integrity_resolver is not None else get_global_context_integrity_resolver()
+        )
         self._ensure_skills_directory()
         self._ensure_registry_ready()
 
@@ -192,6 +205,119 @@ class SkillsService:
     def _get_skill_dir(self, name: str) -> Path:
         """Get the directory path for a skill."""
         return self.skills_dir / name
+
+    def _skill_asset_id(self, name: str) -> str:
+        """Return the Context Integrity asset id for a user skill."""
+        return f"skill:user:{self.user_id}/{name}"
+
+    def _read_skill_file_map(self, skill_dir: Path) -> dict[str, bytes]:
+        """Read prompt-bearing skill files without following symlinks."""
+        if skill_dir.is_symlink():
+            raise OSError(f"Symlinked skill directory is not allowed: {skill_dir}")
+
+        files: dict[str, bytes] = {}
+
+        def _walk(directory: Path, relative_prefix: str = "") -> None:
+            for path in sorted(directory.iterdir(), key=lambda item: item.name):
+                if path.is_symlink():
+                    raise OSError(f"Symlinked skill path is not allowed: {path}")
+
+                relative_path = f"{relative_prefix}{path.name}"
+                if path.is_dir():
+                    _walk(path, f"{relative_path}/")
+                    continue
+
+                if not path.is_file():
+                    continue
+                if path.suffix.lower() not in SKILL_INTEGRITY_TEXT_SUFFIXES:
+                    continue
+                files[relative_path] = path.read_bytes()
+
+        _walk(skill_dir)
+        return files
+
+    def _skill_digest(self, name: str, files: dict[str, bytes]) -> str:
+        """Compute the same canonical digest used by startup skill inventory."""
+        return canonical_filesystem_digest(
+            source_type="skill_file",
+            asset_id=self._skill_asset_id(name),
+            files=files,
+            metadata={"skill_name": name},
+        )
+
+    def _is_skill_allowed(self, name: str, *, purpose: str) -> bool:
+        """Return whether a skill can be advertised for a model-facing purpose."""
+        if self.integrity_resolver is None:
+            return True
+
+        try:
+            skill_dir = self._get_skill_dir(name)
+            files = self._read_skill_file_map(skill_dir)
+            if "SKILL.md" not in files:
+                return False
+            current_digest = self._skill_digest(name, files)
+            self.integrity_resolver.require_digest_allowed(
+                self._skill_asset_id(name),
+                current_digest=current_digest,
+                purpose=purpose,
+            )
+            return True
+        except (ContextIntegrityBlocked, OSError, UnicodeDecodeError):
+            return False
+
+    def _require_skill_allowed(
+        self,
+        name: str,
+        *,
+        purpose: str,
+        current_digest: str | None = None,
+    ) -> None:
+        """Raise when a skill is not allowed by the current integrity resolver."""
+        if self.integrity_resolver is None:
+            return
+
+        asset_id = self._skill_asset_id(name)
+        if current_digest is None:
+            self.integrity_resolver.require_allowed(asset_id, purpose=purpose)
+            return
+
+        self.integrity_resolver.require_digest_allowed(
+            asset_id,
+            current_digest=current_digest,
+            purpose=purpose,
+        )
+
+    def _parse_unchecked_skill_directory(
+        self,
+        name: str,
+        skill_dir: Path,
+        *,
+        files: dict[str, bytes] | None = None,
+    ) -> Any:
+        """Parse a skill from an already-read file map without integrity checks."""
+        files = files if files is not None else self._read_skill_file_map(skill_dir)
+        raw_skill = files.get("SKILL.md")
+        if raw_skill is None:
+            raise SkillNotFoundError(name, detail="SKILL.md not found")
+
+        parsed = self._parser.parse_content(raw_skill.decode("utf-8"), default_name=name)
+        parsed.supporting_files = {
+            relative_path: content.decode("utf-8")
+            for relative_path, content in files.items()
+            if relative_path != "SKILL.md"
+        }
+        return parsed
+
+    def _parse_verified_skill_directory(self, name: str, skill_dir: Path) -> Any:
+        """Read, verify, and parse a skill using one file snapshot."""
+        files = self._read_skill_file_map(skill_dir)
+        current_digest = self._skill_digest(name, files)
+        self._require_skill_allowed(
+            name,
+            purpose="skill_read",
+            current_digest=current_digest,
+        )
+        return self._parse_unchecked_skill_directory(name, skill_dir, files=files)
 
     def _normalize_and_validate_skill_name(self, name: str, *, source: str = "skill name") -> str:
         """Normalize and validate a skill name."""
@@ -350,6 +476,9 @@ class SkillsService:
         disk_names: set[str] = set()
         if self.skills_dir.exists():
             for item in self.skills_dir.iterdir():
+                if item.is_symlink():
+                    logger.warning("Skipping symlinked skill directory '{}'", item)
+                    continue
                 if not item.is_dir():
                     continue
                 if not (item / "SKILL.md").exists():
@@ -488,9 +617,13 @@ class SkillsService:
             limit=limit,
             offset=offset,
         )
-        return [self._metadata_from_row(row) for row in rows]
+        return [
+            self._metadata_from_row(row)
+            for row in rows
+            if self._is_skill_allowed(str(row.get("name") or ""), purpose="skill_discovery")
+        ]
 
-    async def get_skill(self, name: str) -> dict[str, Any]:
+    async def get_skill(self, name: str, *, enforce_integrity: bool = True) -> dict[str, Any]:
         """
         Get full skill content.
 
@@ -519,7 +652,12 @@ class SkillsService:
             raise SkillNotFoundError(name, detail="Skill directory not found")
 
         try:
-            parsed = self._parser.parse_directory(skill_dir)
+            if enforce_integrity:
+                parsed = self._parse_verified_skill_directory(name, skill_dir)
+            else:
+                parsed = self._parse_unchecked_skill_directory(name, skill_dir)
+        except ContextIntegrityBlocked:
+            raise
         except Exception as e:
             raise SkillsError(f"Failed to parse skill: {e}") from e
 
@@ -534,6 +672,7 @@ class SkillsService:
             "model": parsed.frontmatter.model,
             "context": parsed.frontmatter.context,
             "content": parsed.content,
+            "raw_content": parsed.raw_content,
             "supporting_files": parsed.supporting_files,
             "directory_path": str(skill_dir),
             "created_at": metadata.created_at,
@@ -645,7 +784,7 @@ class SkillsService:
 
         logger.info(f"Created skill '{name}' for user {self.user_id}")
 
-        return await self.get_skill(name)
+        return await self.get_skill(name, enforce_integrity=False)
 
     async def update_skill(
         self,
@@ -814,7 +953,7 @@ class SkillsService:
 
         logger.info(f"Updated skill '{name}' for user {self.user_id}")
 
-        return await self.get_skill(name)
+        return await self.get_skill(name, enforce_integrity=False)
 
     async def delete_skill(self, name: str, expected_version: Optional[int] = None) -> None:
         """
@@ -909,10 +1048,14 @@ class SkillsService:
             raise SkillValidationError("Skill name must be specified in frontmatter or as parameter")
 
         skill_name = self._normalize_and_validate_skill_name(skill_name)
-        normalized_supporting_files = self._normalize_supporting_files(
-            supporting_files,
-            allow_deletes=False,
-        ) if supporting_files else None
+        normalized_supporting_files = (
+            self._normalize_supporting_files(
+                supporting_files,
+                allow_deletes=False,
+            )
+            if supporting_files
+            else None
+        )
 
         await self._sync_registry_async(force=True)
         db = self._get_db()
@@ -1072,9 +1215,7 @@ class SkillsService:
 
                         relative_path = PurePosixPath(relative_name)
                         if relative_path.is_absolute() or ".." in relative_path.parts:
-                            raise SkillValidationError(
-                                f"Zip contains path traversal entry: '{name}'"
-                            )
+                            raise SkillValidationError(f"Zip contains path traversal entry: '{name}'")
 
                         # Ignore nested directories; supporting files are top-level only.
                         if relative_path.name != relative_name:
@@ -1180,11 +1321,8 @@ class SkillsService:
         buffer = BytesIO()
         with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
             # Write SKILL.md with full content (including frontmatter)
-            skill_dir = self._get_skill_dir(name)
-            skill_file = skill_dir / "SKILL.md"
-            if skill_file.exists():
-                full_content = skill_file.read_text(encoding="utf-8")
-            else:
+            full_content = skill_data.get("raw_content")
+            if not isinstance(full_content, str):
                 # Reconstruct from parsed data
                 fm = SkillFrontmatter(
                     name=skill_data["name"],
@@ -1210,8 +1348,11 @@ class SkillsService:
     def _build_context_payload(self, rows: list[dict[str, Any]]) -> dict[str, Any]:
         """Build a context payload from skill registry rows."""
         skills = [
-            row for row in rows
-            if row.get("user_invocable") and not row.get("disable_model_invocation")
+            row
+            for row in rows
+            if row.get("user_invocable")
+            and not row.get("disable_model_invocation")
+            and self._is_skill_allowed(str(row.get("name") or ""), purpose="skill_context")
         ]
 
         if not skills:

--- a/tldw_Server_API/app/core/Skills/skills_service.py
+++ b/tldw_Server_API/app/core/Skills/skills_service.py
@@ -17,8 +17,10 @@ Provides:
 
 import asyncio
 import contextlib
+import os
 import re
 import shutil
+import stat
 import time
 import zipfile
 from datetime import datetime, timezone
@@ -62,6 +64,58 @@ MAX_SUPPORTING_FILES_TOTAL_BYTES = 5 * 1024 * 1024  # 5MB
 MAX_SKILL_MD_BYTES = 500000
 MAX_ZIP_IMPORT_ENTRIES = 100
 SKILL_INTEGRITY_TEXT_SUFFIXES = {".md", ".txt", ".json", ".yaml", ".yml", ".py", ".sh"}
+SkillFileFingerprint = tuple[tuple[str, int, int, int, int, int], ...]
+
+
+def _same_file_identity(left: os.stat_result, right: os.stat_result) -> bool:
+    return (
+        left.st_dev,
+        left.st_ino,
+        stat.S_IFMT(left.st_mode),
+    ) == (
+        right.st_dev,
+        right.st_ino,
+        stat.S_IFMT(right.st_mode),
+    )
+
+
+def _stat_mtime_ns(value: os.stat_result) -> int:
+    return int(getattr(value, "st_mtime_ns", int(value.st_mtime * 1_000_000_000)))
+
+
+def _fingerprint_entry(relative_path: str, value: os.stat_result) -> tuple[str, int, int, int, int, int]:
+    return (
+        relative_path,
+        int(value.st_dev),
+        int(value.st_ino),
+        int(stat.S_IFMT(value.st_mode)),
+        int(value.st_size),
+        _stat_mtime_ns(value),
+    )
+
+
+def _fd_relative_walk_supported() -> bool:
+    supports_dir_fd = getattr(os, "supports_dir_fd", set())
+    return bool(hasattr(os, "fwalk") and os.open in supports_dir_fd and os.stat in supports_dir_fd)
+
+
+def _read_regular_file_bytes_no_follow(path: Path) -> bytes:
+    expected = path.lstat()
+    if not stat.S_ISREG(expected.st_mode):
+        raise OSError(f"Skill file is not a regular file: {path}")
+
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(path, flags)
+    try:
+        opened = os.fstat(fd)
+        if not stat.S_ISREG(opened.st_mode) or not _same_file_identity(expected, opened):
+            raise OSError(f"Skill file changed while being opened: {path}")
+        with os.fdopen(fd, "rb", closefd=True) as file_obj:
+            fd = -1
+            return file_obj.read()
+    finally:
+        if fd >= 0:
+            os.close(fd)
 
 
 class SkillMetadata:
@@ -175,6 +229,7 @@ class SkillsService:
         self.integrity_resolver = (
             integrity_resolver if integrity_resolver is not None else get_global_context_integrity_resolver()
         )
+        self._integrity_decision_cache: dict[tuple[str, str], tuple[float, SkillFileFingerprint, bool]] = {}
         self._ensure_skills_directory()
         self._ensure_registry_ready()
 
@@ -210,31 +265,144 @@ class SkillsService:
         """Return the Context Integrity asset id for a user skill."""
         return f"skill:user:{self.user_id}/{name}"
 
-    def _read_skill_file_map(self, skill_dir: Path) -> dict[str, bytes]:
-        """Read prompt-bearing skill files without following symlinks."""
-        if skill_dir.is_symlink():
-            raise OSError(f"Symlinked skill directory is not allowed: {skill_dir}")
+    def _relative_skill_path(self, skill_dir: Path, path: Path) -> str:
+        try:
+            return path.relative_to(skill_dir).as_posix()
+        except ValueError:
+            return path.resolve().relative_to(skill_dir.resolve()).as_posix()
+
+    def _read_skill_file_map_fd_walk(self, skill_dir: Path) -> dict[str, bytes]:
+        root_stat = skill_dir.lstat()
+        if not stat.S_ISDIR(root_stat.st_mode):
+            raise OSError(f"Skill directory is not a directory: {skill_dir}")
+
+        files: dict[str, bytes] = {}
+        flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        for directory, dirnames, filenames, dirfd in os.fwalk(skill_dir, topdown=True, follow_symlinks=False):
+            dirnames.sort()
+            for dirname in list(dirnames):
+                entry_path = Path(directory) / dirname
+                entry_stat = os.stat(dirname, dir_fd=dirfd, follow_symlinks=False)
+                if stat.S_ISLNK(entry_stat.st_mode):
+                    raise OSError(f"Symlinked skill path is not allowed: {entry_path}")
+                if not stat.S_ISDIR(entry_stat.st_mode):
+                    dirnames.remove(dirname)
+
+            for filename in sorted(filenames):
+                entry_path = Path(directory) / filename
+                entry_stat = os.stat(filename, dir_fd=dirfd, follow_symlinks=False)
+                if stat.S_ISLNK(entry_stat.st_mode):
+                    raise OSError(f"Symlinked skill path is not allowed: {entry_path}")
+                if not stat.S_ISREG(entry_stat.st_mode):
+                    continue
+                if Path(filename).suffix.lower() not in SKILL_INTEGRITY_TEXT_SUFFIXES:
+                    continue
+
+                fd = os.open(filename, flags, dir_fd=dirfd)
+                try:
+                    opened_stat = os.fstat(fd)
+                    if not stat.S_ISREG(opened_stat.st_mode) or not _same_file_identity(entry_stat, opened_stat):
+                        raise OSError(f"Skill file changed while being opened: {entry_path}")
+                    with os.fdopen(fd, "rb", closefd=True) as file_obj:
+                        fd = -1
+                        files[self._relative_skill_path(skill_dir, entry_path)] = file_obj.read()
+                finally:
+                    if fd >= 0:
+                        os.close(fd)
+        return files
+
+    def _read_skill_file_map_path_walk(self, skill_dir: Path) -> dict[str, bytes]:
+        root_stat = skill_dir.lstat()
+        if not stat.S_ISDIR(root_stat.st_mode):
+            raise OSError(f"Skill directory is not a directory: {skill_dir}")
 
         files: dict[str, bytes] = {}
 
         def _walk(directory: Path, relative_prefix: str = "") -> None:
             for path in sorted(directory.iterdir(), key=lambda item: item.name):
-                if path.is_symlink():
+                entry_stat = path.lstat()
+                if stat.S_ISLNK(entry_stat.st_mode):
                     raise OSError(f"Symlinked skill path is not allowed: {path}")
 
                 relative_path = f"{relative_prefix}{path.name}"
-                if path.is_dir():
+                if stat.S_ISDIR(entry_stat.st_mode):
                     _walk(path, f"{relative_path}/")
                     continue
 
-                if not path.is_file():
+                if not stat.S_ISREG(entry_stat.st_mode):
                     continue
                 if path.suffix.lower() not in SKILL_INTEGRITY_TEXT_SUFFIXES:
                     continue
-                files[relative_path] = path.read_bytes()
+                files[relative_path] = _read_regular_file_bytes_no_follow(path)
 
         _walk(skill_dir)
         return files
+
+    def _read_skill_file_map(self, skill_dir: Path) -> dict[str, bytes]:
+        """Read prompt-bearing skill files without following symlinks."""
+        if _fd_relative_walk_supported():
+            return self._read_skill_file_map_fd_walk(skill_dir)
+        return self._read_skill_file_map_path_walk(skill_dir)
+
+    def _skill_file_fingerprint_fd_walk(self, skill_dir: Path) -> SkillFileFingerprint:
+        root_stat = skill_dir.lstat()
+        if not stat.S_ISDIR(root_stat.st_mode):
+            raise OSError(f"Skill directory is not a directory: {skill_dir}")
+
+        entries: list[tuple[str, int, int, int, int, int]] = []
+        for directory, dirnames, filenames, dirfd in os.fwalk(skill_dir, topdown=True, follow_symlinks=False):
+            dirnames.sort()
+            for dirname in list(dirnames):
+                entry_path = Path(directory) / dirname
+                entry_stat = os.stat(dirname, dir_fd=dirfd, follow_symlinks=False)
+                if stat.S_ISLNK(entry_stat.st_mode):
+                    raise OSError(f"Symlinked skill path is not allowed: {entry_path}")
+                if not stat.S_ISDIR(entry_stat.st_mode):
+                    dirnames.remove(dirname)
+
+            for filename in sorted(filenames):
+                entry_path = Path(directory) / filename
+                entry_stat = os.stat(filename, dir_fd=dirfd, follow_symlinks=False)
+                if stat.S_ISLNK(entry_stat.st_mode):
+                    raise OSError(f"Symlinked skill path is not allowed: {entry_path}")
+                if not stat.S_ISREG(entry_stat.st_mode):
+                    continue
+                if Path(filename).suffix.lower() not in SKILL_INTEGRITY_TEXT_SUFFIXES:
+                    continue
+                entries.append(_fingerprint_entry(self._relative_skill_path(skill_dir, entry_path), entry_stat))
+        return tuple(entries)
+
+    def _skill_file_fingerprint_path_walk(self, skill_dir: Path) -> SkillFileFingerprint:
+        root_stat = skill_dir.lstat()
+        if not stat.S_ISDIR(root_stat.st_mode):
+            raise OSError(f"Skill directory is not a directory: {skill_dir}")
+
+        entries: list[tuple[str, int, int, int, int, int]] = []
+
+        def _walk(directory: Path, relative_prefix: str = "") -> None:
+            for path in sorted(directory.iterdir(), key=lambda item: item.name):
+                entry_stat = path.lstat()
+                if stat.S_ISLNK(entry_stat.st_mode):
+                    raise OSError(f"Symlinked skill path is not allowed: {path}")
+
+                relative_path = f"{relative_prefix}{path.name}"
+                if stat.S_ISDIR(entry_stat.st_mode):
+                    _walk(path, f"{relative_path}/")
+                    continue
+
+                if not stat.S_ISREG(entry_stat.st_mode):
+                    continue
+                if path.suffix.lower() not in SKILL_INTEGRITY_TEXT_SUFFIXES:
+                    continue
+                entries.append(_fingerprint_entry(relative_path, entry_stat))
+
+        _walk(skill_dir)
+        return tuple(entries)
+
+    def _skill_file_fingerprint(self, skill_dir: Path) -> SkillFileFingerprint:
+        if _fd_relative_walk_supported():
+            return self._skill_file_fingerprint_fd_walk(skill_dir)
+        return self._skill_file_fingerprint_path_walk(skill_dir)
 
     def _skill_digest(self, name: str, files: dict[str, bytes]) -> str:
         """Compute the same canonical digest used by startup skill inventory."""
@@ -250,10 +418,22 @@ class SkillsService:
         if self.integrity_resolver is None:
             return True
 
+        cache_key = (name, purpose)
+        now = time.monotonic()
         try:
             skill_dir = self._get_skill_dir(name)
+            fingerprint = self._skill_file_fingerprint(skill_dir)
+            cached = self._integrity_decision_cache.get(cache_key)
+            if cached is not None and cached[0] >= now and cached[1] == fingerprint:
+                return cached[2]
+
             files = self._read_skill_file_map(skill_dir)
             if "SKILL.md" not in files:
+                self._integrity_decision_cache[cache_key] = (
+                    now + min(max(self._sync_interval, 0.0), 5.0),
+                    fingerprint,
+                    False,
+                )
                 return False
             current_digest = self._skill_digest(name, files)
             self.integrity_resolver.require_digest_allowed(
@@ -261,8 +441,14 @@ class SkillsService:
                 current_digest=current_digest,
                 purpose=purpose,
             )
+            self._integrity_decision_cache[cache_key] = (
+                now + min(max(self._sync_interval, 0.0), 5.0),
+                fingerprint,
+                True,
+            )
             return True
         except (ContextIntegrityBlocked, OSError, UnicodeDecodeError):
+            self._integrity_decision_cache.pop(cache_key, None)
             return False
 
     def _require_skill_allowed(
@@ -415,11 +601,11 @@ class SkillsService:
     def _parse_skill_file(self, skill_dir: Path) -> Optional[Any]:
         """Parse SKILL.md content without loading supporting files."""
         skill_file = skill_dir / "SKILL.md"
-        if not skill_file.exists():
-            return None
         try:
-            content = skill_file.read_text(encoding="utf-8")
-        except OSError as e:
+            content = _read_regular_file_bytes_no_follow(skill_file).decode("utf-8")
+        except FileNotFoundError:
+            return None
+        except (OSError, UnicodeDecodeError) as e:
             logger.warning(f"Failed to read SKILL.md for {skill_dir.name}: {e}")
             return None
         try:
@@ -476,12 +662,29 @@ class SkillsService:
         disk_names: set[str] = set()
         if self.skills_dir.exists():
             for item in self.skills_dir.iterdir():
-                if item.is_symlink():
+                try:
+                    item_stat = item.lstat()
+                except OSError as e:
+                    logger.warning("Skipping unreadable skill path '{}': {}", item, e)
+                    continue
+                if stat.S_ISLNK(item_stat.st_mode):
                     logger.warning("Skipping symlinked skill directory '{}'", item)
                     continue
-                if not item.is_dir():
+                if not stat.S_ISDIR(item_stat.st_mode):
                     continue
-                if not (item / "SKILL.md").exists():
+
+                skill_file = item / "SKILL.md"
+                try:
+                    skill_file_stat = skill_file.lstat()
+                except FileNotFoundError:
+                    continue
+                except OSError as e:
+                    logger.warning("Skipping unreadable SKILL.md for '{}': {}", item.name, e)
+                    continue
+                if stat.S_ISLNK(skill_file_stat.st_mode):
+                    logger.warning("Skipping skill '{}' because SKILL.md is a symlink", item.name)
+                    continue
+                if not stat.S_ISREG(skill_file_stat.st_mode):
                     continue
 
                 disk_names.add(item.name)
@@ -604,6 +807,25 @@ class SkillsService:
         """
         await self._sync_registry_async()
         db = self._get_db()
+        if self.integrity_resolver is not None:
+            rows = db.list_skill_registry(
+                include_hidden=include_hidden,
+                include_deleted=False,
+                q=q,
+                context=context,
+                user_invocable=user_invocable,
+                has_tools=has_tools,
+                model=model,
+                sort=sort,
+                order=order,
+                limit=None,
+                offset=0,
+            )
+            allowed_rows = [
+                row for row in rows if self._is_skill_allowed(str(row.get("name") or ""), purpose="skill_discovery")
+            ]
+            return [self._metadata_from_row(row) for row in allowed_rows[offset : offset + limit]]
+
         rows = db.list_skill_registry(
             include_hidden=include_hidden,
             include_deleted=False,
@@ -617,11 +839,7 @@ class SkillsService:
             limit=limit,
             offset=offset,
         )
-        return [
-            self._metadata_from_row(row)
-            for row in rows
-            if self._is_skill_allowed(str(row.get("name") or ""), purpose="skill_discovery")
-        ]
+        return [self._metadata_from_row(row) for row in rows]
 
     async def get_skill(self, name: str, *, enforce_integrity: bool = True) -> dict[str, Any]:
         """
@@ -1435,6 +1653,24 @@ class SkillsService:
         """
         await self._sync_registry_async()
         db = self._get_db()
+        if self.integrity_resolver is not None:
+            rows = db.list_skill_registry(
+                include_hidden=include_hidden,
+                include_deleted=False,
+                q=q,
+                context=context,
+                user_invocable=user_invocable,
+                has_tools=has_tools,
+                model=model,
+                sort="name",
+                order="asc",
+                limit=None,
+                offset=0,
+            )
+            return sum(
+                1 for row in rows if self._is_skill_allowed(str(row.get("name") or ""), purpose="skill_discovery")
+            )
+
         return db.count_skill_registry(
             include_hidden=include_hidden,
             include_deleted=False,

--- a/tldw_Server_API/app/core/Utils/prompt_loader.py
+++ b/tldw_Server_API/app/core/Utils/prompt_loader.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import stat
 from pathlib import Path
 from typing import Any, Optional
 
@@ -50,14 +51,41 @@ def _prompt_asset_id(path: str, *, source_label: str | None = None) -> str:
     return f"prompt_file:{filename}"
 
 
+def _same_file_identity(left: os.stat_result, right: os.stat_result) -> bool:
+    return (
+        left.st_dev,
+        left.st_ino,
+        stat.S_IFMT(left.st_mode),
+    ) == (
+        right.st_dev,
+        right.st_ino,
+        stat.S_IFMT(right.st_mode),
+    )
+
+
+def _read_regular_file_bytes_no_follow(path: Path) -> bytes:
+    expected = path.lstat()
+    if not stat.S_ISREG(expected.st_mode):
+        raise OSError(f"Prompt file is not a regular file: {path}")
+
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(path, flags)
+    try:
+        opened = os.fstat(fd)
+        if not stat.S_ISREG(opened.st_mode) or not _same_file_identity(expected, opened):
+            raise OSError(f"Prompt file changed while being opened: {path}")
+        with os.fdopen(fd, "rb", closefd=True) as file_obj:
+            fd = -1
+            return file_obj.read()
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+
 def _read_prompt_file_text(path: str, *, source_label: str | None = None) -> str:
     prompt_path = Path(path)
-    if prompt_path.is_symlink():
-        raise OSError(f"Symlinked prompt file is not allowed: {prompt_path}")
-
     asset_id = _prompt_asset_id(path, source_label=source_label)
-    with open(prompt_path, "rb") as f:
-        raw = f.read()
+    raw = _read_regular_file_bytes_no_follow(prompt_path)
 
     metadata: dict[str, str]
     if source_label is None:

--- a/tldw_Server_API/app/core/Utils/prompt_loader.py
+++ b/tldw_Server_API/app/core/Utils/prompt_loader.py
@@ -1,11 +1,19 @@
 import json
 import os
 import re
+from pathlib import Path
 from typing import Any, Optional
 
 from loguru import logger
 
 from tldw_Server_API.app.core.config_paths import resolve_prompts_dir
+from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+    canonical_filesystem_digest,
+)
+from tldw_Server_API.app.core.Context_Integrity.resolver import (
+    ContextIntegrityBlocked,
+    get_global_context_integrity_resolver,
+)
 
 
 def _prompts_dir() -> str:
@@ -35,6 +43,46 @@ def _prompt_env_file_key(module: str, key: str) -> str:
     return f"TLDW_PROMPT_FILE_{module_token}__{key_token}"
 
 
+def _prompt_asset_id(path: str, *, source_label: str | None = None) -> str:
+    filename = Path(path).name
+    if source_label:
+        return f"prompt_file:{source_label}:{filename}"
+    return f"prompt_file:{filename}"
+
+
+def _read_prompt_file_text(path: str, *, source_label: str | None = None) -> str:
+    prompt_path = Path(path)
+    if prompt_path.is_symlink():
+        raise OSError(f"Symlinked prompt file is not allowed: {prompt_path}")
+
+    asset_id = _prompt_asset_id(path, source_label=source_label)
+    with open(prompt_path, "rb") as f:
+        raw = f.read()
+
+    metadata: dict[str, str]
+    if source_label is None:
+        metadata = {"path": prompt_path.name}
+    else:
+        metadata = {"path": str(prompt_path), "source_label": source_label}
+
+    current_digest = canonical_filesystem_digest(
+        source_type="prompt_file",
+        asset_id=asset_id,
+        files={prompt_path.name: raw},
+        metadata=metadata,
+    )
+    resolver = get_global_context_integrity_resolver()
+    if resolver is not None:
+        resolver.require_digest_allowed(
+            asset_id,
+            current_digest=current_digest,
+            purpose="prompt_load",
+            changed_state="changed_approved_non_executable",
+        )
+
+    return raw.decode("utf-8")
+
+
 def _load_env_prompt_file(module: str, key: str) -> Optional[str]:
     env_name = _prompt_env_file_key(module, key)
     raw_path = os.getenv(env_name)
@@ -43,9 +91,8 @@ def _load_env_prompt_file(module: str, key: str) -> Optional[str]:
 
     path = os.path.expanduser(str(raw_path).strip())
     try:
-        with open(path, encoding="utf-8") as f:
-            return f.read().strip()
-    except OSError as exc:
+        return _read_prompt_file_text(path, source_label=f"env:{env_name}").strip()
+    except (OSError, UnicodeDecodeError, ContextIntegrityBlocked) as exc:
         logger.warning(
             "Prompt override file read failed for env '{}' (module='{}', key='{}', error_type='{}')",
             env_name,
@@ -62,23 +109,23 @@ def _load_yaml(path: str) -> Optional[dict[str, Any]]:
     except ImportError:
         return None
     try:
-        with open(path, encoding="utf-8") as f:
-            data = yaml.safe_load(f)
+        raw = _read_prompt_file_text(path)
+        data = yaml.safe_load(raw)
         if isinstance(data, dict):
             return data
         return None
-    except (OSError, TypeError, ValueError, yaml.YAMLError):
+    except (OSError, UnicodeDecodeError, ContextIntegrityBlocked, TypeError, ValueError, yaml.YAMLError):
         return None
 
 
 def _load_json(path: str) -> Optional[dict[str, Any]]:
     try:
-        with open(path, encoding="utf-8") as f:
-            data = json.load(f)
+        raw = _read_prompt_file_text(path)
+        data = json.loads(raw)
         if isinstance(data, dict):
             return data
         return None
-    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+    except (OSError, UnicodeDecodeError, ContextIntegrityBlocked, TypeError, ValueError, json.JSONDecodeError):
         return None
 
 
@@ -135,9 +182,8 @@ def load_prompt(module: str, key: str) -> Optional[str]:
     md_path = base + ".md"
     if os.path.exists(md_path):
         try:
-            with open(md_path, encoding="utf-8") as f:
-                text = f.read()
-        except OSError:
+            text = _read_prompt_file_text(md_path)
+        except (OSError, UnicodeDecodeError, ContextIntegrityBlocked):
             text = ""
         if text:
             pattern = re.compile(

--- a/tldw_Server_API/app/services/lifespan_shutdown_sequence.py
+++ b/tldw_Server_API/app/services/lifespan_shutdown_sequence.py
@@ -42,6 +42,18 @@ async def run_lifespan_shutdown_sequence(
         app.state._tldw_shutdown_timing_segments = []
     except startup_guard_exceptions:
         pass
+    try:
+        from tldw_Server_API.app.core.Context_Integrity.resolver import (
+            clear_global_context_integrity_resolver,
+        )
+
+        clear_global_context_integrity_resolver()
+        if hasattr(app.state, "context_integrity_resolver"):
+            delattr(app.state, "context_integrity_resolver")
+        if hasattr(app.state, "context_integrity_boot_state"):
+            delattr(app.state, "context_integrity_boot_state")
+    except startup_guard_exceptions + import_exceptions:
+        pass
 
     legacy_shutdown_plan: list[Any] = []
     with timed_shutdown_segment(app, "transition_handoff"):

--- a/tldw_Server_API/app/services/lifespan_startup_sequence.py
+++ b/tldw_Server_API/app/services/lifespan_startup_sequence.py
@@ -114,11 +114,18 @@ async def run_lifespan_startup_sequence(
 
 
 def _run_startup_warning_producers(*, app: Any, startup_core_handles: Any) -> None:
+    from tldw_Server_API.app.services.startup_context_integrity import (
+        produce_context_integrity_startup_warnings,
+    )
     from tldw_Server_API.app.services.startup_warning_sandbox import (
         produce_sandbox_startup_warnings,
     )
 
     registry = app.state.startup_warning_registry
+    produce_context_integrity_startup_warnings(
+        app_state=app.state,
+        registry=registry,
+    )
     produce_sandbox_startup_warnings(
         orchestrator=getattr(startup_core_handles, "startup_sandbox_orchestrator", None),
         registry=registry,
@@ -129,15 +136,9 @@ def _raise_if_startup_blocked(registry: StartupWarningRegistry) -> None:
     if not registry.should_block_startup():
         return
     blocking_warning = next(
-        (
-            item
-            for item in registry.list_warnings()
-            if item.startup_action == "block_startup"
-        ),
+        (item for item in registry.list_warnings() if item.startup_action == "block_startup"),
         None,
     )
     if blocking_warning is None:
         raise RuntimeError("startup blocked by unknown warning")
-    raise RuntimeError(
-        f"startup blocked by {blocking_warning.code}: {blocking_warning.summary}"
-    )
+    raise RuntimeError(f"startup blocked by {blocking_warning.code}: {blocking_warning.summary}")

--- a/tldw_Server_API/app/services/startup_context_integrity.py
+++ b/tldw_Server_API/app/services/startup_context_integrity.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable, Mapping
 import json
 import os
 from pathlib import Path
+import tempfile
 from typing import Any
 
 from loguru import logger
@@ -32,7 +33,7 @@ from tldw_Server_API.app.core.Context_Integrity.resolver import (
     set_global_context_integrity_resolver,
 )
 from tldw_Server_API.app.core.Context_Integrity.verifier import verify_inventory
-from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+from tldw_Server_API.app.core.DB_Management import db_path_utils
 from tldw_Server_API.app.services.startup_warning_models import StartupWarningRecord
 from tldw_Server_API.app.services.startup_warning_registry import (
     StartupWarningRegistry,
@@ -135,10 +136,81 @@ def _load_startup_manifest_from_env() -> tuple[
     )
 
 
+def _settings_value(name: str) -> Any:
+    try:
+        return db_path_utils.settings.get(name)
+    except Exception:
+        return None
+
+
+def _resolve_candidate_like_database_paths(
+    raw_path: str | Path | None,
+    *,
+    project_root: Path,
+) -> Path | None:
+    if not raw_path:
+        return None
+    try:
+        candidate = Path(raw_path).expanduser()
+        if not candidate.is_absolute():
+            return (project_root / candidate).resolve()
+        return candidate.resolve()
+    except Exception:
+        return None
+
+
+def _resolve_user_db_base_dir_for_discovery() -> Path:
+    """Resolve the user DB base path for read-only discovery without creating it."""
+    env_user_db_base = os.getenv("USER_DB_BASE_DIR")
+    settings_user_db_base = _settings_value("USER_DB_BASE_DIR")
+    project_root = Path(db_path_utils.get_project_root())
+    default_base = (project_root / "Databases" / "user_databases").resolve()
+    user_db_base = settings_user_db_base or env_user_db_base
+
+    if db_path_utils._is_test_context() and env_user_db_base:
+        settings_candidate = _resolve_candidate_like_database_paths(
+            settings_user_db_base,
+            project_root=project_root,
+        )
+        if settings_candidate is None or settings_candidate == default_base:
+            user_db_base = env_user_db_base
+
+    if db_path_utils._is_test_context() and not env_user_db_base:
+        settings_candidate = _resolve_candidate_like_database_paths(
+            settings_user_db_base,
+            project_root=project_root,
+        )
+        if settings_candidate is None or settings_candidate == default_base:
+            user_db_base = None
+
+    if not user_db_base:
+        legacy_base = os.getenv("USER_DB_BASE") or _settings_value("USER_DB_BASE")
+        if legacy_base:
+            logger.warning(
+                "USER_DB_BASE is deprecated; use USER_DB_BASE_DIR instead. "
+                "Context Integrity discovery will stop honoring USER_DB_BASE "
+                "in a future release."
+            )
+            user_db_base = legacy_base
+
+    if not user_db_base:
+        if db_path_utils._is_test_context():
+            run_tag = db_path_utils._get_test_fallback_run_tag()
+            safe_run_tag = "".join(ch if ch.isalnum() or ch in "-_." else "_" for ch in str(run_tag))
+            return (Path(tempfile.gettempdir()) / "tldw_user_databases_test" / safe_run_tag).resolve()
+        logger.warning(
+            "USER_DB_BASE_DIR not configured, using fallback for Context Integrity " "discovery: {}",
+            default_base,
+        )
+        return default_base
+
+    return db_path_utils._normalize_user_db_base_dir(Path(user_db_base))
+
+
 def _discover_user_skill_roots() -> list[tuple[int, Path]]:
     """Discover existing per-user skill roots without creating skill folders."""
     try:
-        base_dir = DatabasePaths.get_user_db_base_dir(allow_legacy_alias=True)
+        base_dir = _resolve_user_db_base_dir_for_discovery()
     except Exception as exc:  # pragma: no cover - defensive startup guard
         logger.warning("Context Integrity could not discover user skill roots: {}", exc)
         return []

--- a/tldw_Server_API/app/services/startup_context_integrity.py
+++ b/tldw_Server_API/app/services/startup_context_integrity.py
@@ -7,7 +7,7 @@ import json
 import os
 from pathlib import Path
 import tempfile
-from typing import Any
+from typing import Any, cast
 
 from loguru import logger
 
@@ -27,6 +27,7 @@ from tldw_Server_API.app.core.Context_Integrity.models import (
     ContextAssetSource,
     ContextIntegrityBootState,
     ContextIntegrityFinding,
+    ContextIntegrityMode,
 )
 from tldw_Server_API.app.core.Context_Integrity.resolver import (
     ContextIntegrityResolver,
@@ -38,6 +39,8 @@ from tldw_Server_API.app.services.startup_warning_models import StartupWarningRe
 from tldw_Server_API.app.services.startup_warning_registry import (
     StartupWarningRegistry,
 )
+
+_SUPPORTED_CONTEXT_INTEGRITY_MODES = frozenset(("audit_only", "enforce", "hardened"))
 
 
 def _signature_invalid_finding(
@@ -139,8 +142,23 @@ def _load_startup_manifest_from_env() -> tuple[
 def _settings_value(name: str) -> Any:
     try:
         return db_path_utils.settings.get(name)
-    except Exception:
+    except (AttributeError, KeyError, TypeError) as exc:
+        logger.debug(
+            "Context Integrity could not read setting '{}': {}",
+            name,
+            exc.__class__.__name__,
+        )
         return None
+
+
+def _normalize_context_integrity_mode(mode: str) -> ContextIntegrityMode:
+    normalized = str(mode).strip().lower()
+    if normalized not in _SUPPORTED_CONTEXT_INTEGRITY_MODES:
+        raise ValueError(
+            "Unsupported Context Integrity mode: "
+            f"{mode!r}. Expected one of {sorted(_SUPPORTED_CONTEXT_INTEGRITY_MODES)}."
+        )
+    return cast(ContextIntegrityMode, normalized)
 
 
 def _resolve_candidate_like_database_paths(
@@ -287,6 +305,7 @@ def produce_context_integrity_startup_warnings(
     mode: str = "enforce",
 ) -> tuple[ContextIntegrityFinding, ...]:
     """Build inventory, verify approved state, attach resolver, and emit warnings."""
+    normalized_mode = _normalize_context_integrity_mode(mode)
     current_assets: list[ContextAssetDescriptor] = []
     findings_list: list[ContextIntegrityFinding] = []
     resolved_prompts_dir = prompts_dir or resolve_prompts_dir()
@@ -387,7 +406,7 @@ def produce_context_integrity_startup_warnings(
 
     findings = tuple(findings_list)
     boot_state = ContextIntegrityBootState(
-        mode=mode,  # type: ignore[arg-type]
+        mode=normalized_mode,
         degraded=degraded,
         manifest_sequence=manifest_sequence,
         manifest_digest=manifest_digest,

--- a/tldw_Server_API/app/services/startup_context_integrity.py
+++ b/tldw_Server_API/app/services/startup_context_integrity.py
@@ -1,0 +1,340 @@
+"""Startup producer for Context Integrity warnings and resolver state."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.config_paths import resolve_prompts_dir
+from tldw_Server_API.app.core.Context_Integrity.inventory import (
+    InventoryResult,
+    inventory_env_prompt_overrides_with_findings,
+    inventory_prompt_files_with_findings,
+    inventory_user_skills_with_findings,
+)
+from tldw_Server_API.app.core.Context_Integrity.manifest import (
+    HmacManifestSigner,
+    verify_signed_manifest,
+)
+from tldw_Server_API.app.core.Context_Integrity.models import (
+    ContextAssetDescriptor,
+    ContextAssetSource,
+    ContextIntegrityBootState,
+    ContextIntegrityFinding,
+)
+from tldw_Server_API.app.core.Context_Integrity.resolver import (
+    ContextIntegrityResolver,
+    set_global_context_integrity_resolver,
+)
+from tldw_Server_API.app.core.Context_Integrity.verifier import verify_inventory
+from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+from tldw_Server_API.app.services.startup_warning_models import StartupWarningRecord
+from tldw_Server_API.app.services.startup_warning_registry import (
+    StartupWarningRegistry,
+)
+
+
+def _signature_invalid_finding(
+    *,
+    summary: str,
+    details: Mapping[str, Any] | None = None,
+) -> ContextIntegrityFinding:
+    return ContextIntegrityFinding(
+        asset_id="manifest:env",
+        state="signature_invalid",
+        severity="error",
+        summary=summary,
+        remediation="Fix the configured manifest path/key or import a valid signed manifest.",
+        source_type="manifest",
+        details=details or {},
+    )
+
+
+def _verification_error_finding(
+    *,
+    asset_id: str,
+    source_type: ContextAssetSource,
+    summary: str,
+    details: Mapping[str, Any] | None = None,
+) -> ContextIntegrityFinding:
+    return ContextIntegrityFinding(
+        asset_id=asset_id,
+        state="verification_error",
+        severity="error",
+        summary=summary,
+        remediation="Fix file permissions or remove unsafe context paths, then restart.",
+        source_type=source_type,
+        details=details or {},
+    )
+
+
+def _load_startup_manifest_from_env() -> tuple[
+    tuple[Mapping[str, Any], ...],
+    int | None,
+    str | None,
+    bool,
+    ContextIntegrityFinding | None,
+]:
+    """Load and verify an operator-provided signed manifest from environment."""
+    manifest_path = os.getenv("CONTEXT_INTEGRITY_MANIFEST_PATH")
+    secret = os.getenv("CONTEXT_INTEGRITY_HMAC_SECRET")
+    key_id = os.getenv("CONTEXT_INTEGRITY_HMAC_KEY_ID") or "local-hmac"
+
+    if not manifest_path and not secret:
+        return (), None, None, False, None
+    if not manifest_path or not secret:
+        return (
+            (),
+            None,
+            None,
+            False,
+            _signature_invalid_finding(
+                summary="Context Integrity manifest environment configuration is incomplete.",
+                details={
+                    "has_manifest_path": bool(manifest_path),
+                    "has_hmac_secret": bool(secret),
+                },
+            ),
+        )
+
+    try:
+        signed_manifest = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+        verified = verify_signed_manifest(
+            signed_manifest,
+            signer=HmacManifestSigner(
+                key_id=key_id,
+                secret=secret.encode("utf-8"),
+            ),
+        )
+    except (OSError, ValueError, TypeError) as exc:
+        return (
+            (),
+            None,
+            None,
+            False,
+            _signature_invalid_finding(
+                summary="Configured Context Integrity manifest could not be verified.",
+                details={
+                    "error_type": exc.__class__.__name__,
+                    "manifest_path": manifest_path,
+                },
+            ),
+        )
+
+    return (
+        verified.entries,
+        verified.sequence,
+        verified.manifest_digest,
+        True,
+        None,
+    )
+
+
+def _discover_user_skill_roots() -> list[tuple[int, Path]]:
+    """Discover existing per-user skill roots without creating skill folders."""
+    try:
+        base_dir = DatabasePaths.get_user_db_base_dir(allow_legacy_alias=True)
+    except Exception as exc:  # pragma: no cover - defensive startup guard
+        logger.warning("Context Integrity could not discover user skill roots: {}", exc)
+        return []
+
+    if not base_dir.exists():
+        return []
+
+    roots: list[tuple[int, Path]] = []
+    try:
+        user_dirs = sorted(path for path in base_dir.iterdir() if path.is_dir())
+    except OSError as exc:
+        logger.warning("Context Integrity could not scan user skill roots: {}", exc)
+        return []
+
+    for user_dir in user_dirs:
+        if not user_dir.name.isdigit():
+            continue
+        skills_root = user_dir / "skills"
+        if skills_root.is_dir():
+            roots.append((int(user_dir.name), skills_root))
+    return roots
+
+
+def _finding_to_warning(finding: ContextIntegrityFinding) -> StartupWarningRecord:
+    details = {
+        "asset_id": finding.asset_id,
+        "current_digest": finding.current_digest,
+        "approved_digest": finding.approved_digest,
+    }
+    details.update(dict(finding.details))
+    return StartupWarningRecord(
+        component=f"context_integrity.{finding.source_type}",
+        severity=finding.severity,
+        startup_action="warn",
+        code=finding.state,
+        summary=finding.summary,
+        remediation=finding.remediation,
+        details=details,
+        detected_at=finding.detected_at,
+    )
+
+
+def _collect_inventory_result(
+    result: InventoryResult,
+    *,
+    current_assets: list[ContextAssetDescriptor],
+    findings: list[ContextIntegrityFinding],
+) -> None:
+    current_assets.extend(result.assets)
+    findings.extend(result.findings)
+
+
+def _approved_digests_by_asset_id(
+    approved_entries: Iterable[Mapping[str, Any]],
+) -> dict[str, str]:
+    approved_digests: dict[str, str] = {}
+    for entry in approved_entries:
+        if "asset_id" not in entry or "digest" not in entry:
+            continue
+        approved_digests[str(entry["asset_id"])] = str(entry["digest"])
+    return approved_digests
+
+
+def produce_context_integrity_startup_warnings(
+    *,
+    app_state: object,
+    registry: StartupWarningRegistry,
+    prompts_dir: Path | None = None,
+    user_skill_roots: Iterable[tuple[int, Path]] | None = None,
+    approved_entries: Iterable[Mapping[str, Any]] | None = None,
+    manifest_loaded: bool | None = None,
+    manifest_sequence: int | None = None,
+    manifest_digest: str | None = None,
+    mode: str = "enforce",
+) -> tuple[ContextIntegrityFinding, ...]:
+    """Build inventory, verify approved state, attach resolver, and emit warnings."""
+    current_assets: list[ContextAssetDescriptor] = []
+    findings_list: list[ContextIntegrityFinding] = []
+    resolved_prompts_dir = prompts_dir or resolve_prompts_dir()
+
+    try:
+        _collect_inventory_result(
+            inventory_prompt_files_with_findings(prompts_dir=resolved_prompts_dir),
+            current_assets=current_assets,
+            findings=findings_list,
+        )
+    except OSError as exc:
+        findings_list.append(
+            _verification_error_finding(
+                asset_id="prompt_file:*",
+                source_type="prompt_file",
+                summary="Prompt file inventory failed.",
+                details={
+                    "error_type": exc.__class__.__name__,
+                    "path": str(resolved_prompts_dir),
+                },
+            )
+        )
+
+    try:
+        _collect_inventory_result(
+            inventory_env_prompt_overrides_with_findings(),
+            current_assets=current_assets,
+            findings=findings_list,
+        )
+    except OSError as exc:
+        findings_list.append(
+            _verification_error_finding(
+                asset_id="prompt_file:env:*",
+                source_type="prompt_file",
+                summary="Environment prompt override inventory failed.",
+                details={"error_type": exc.__class__.__name__},
+            )
+        )
+
+    roots = list(user_skill_roots) if user_skill_roots is not None else _discover_user_skill_roots()
+    for user_id, skills_root in roots:
+        try:
+            _collect_inventory_result(
+                inventory_user_skills_with_findings(
+                    user_id=user_id,
+                    skills_root=skills_root,
+                ),
+                current_assets=current_assets,
+                findings=findings_list,
+            )
+        except OSError as exc:
+            findings_list.append(
+                _verification_error_finding(
+                    asset_id=f"skill:user:{user_id}:*",
+                    source_type="skill_file",
+                    summary=f"Skill inventory failed for user {user_id}.",
+                    details={
+                        "error_type": exc.__class__.__name__,
+                        "path": str(skills_root),
+                    },
+                )
+            )
+
+    if approved_entries is None:
+        (
+            approved_entries_tuple,
+            manifest_sequence,
+            manifest_digest,
+            loaded_from_env,
+            manifest_finding,
+        ) = _load_startup_manifest_from_env()
+        manifest_loaded = loaded_from_env
+        if manifest_finding is not None:
+            findings_list.append(manifest_finding)
+    else:
+        approved_entries_tuple = tuple(approved_entries)
+        manifest_loaded = bool(manifest_loaded)
+
+    findings_list.extend(
+        verify_inventory(
+            current_assets=current_assets,
+            approved_entries=approved_entries_tuple,
+        )
+    )
+
+    degraded = not bool(manifest_loaded)
+    if degraded:
+        findings_list.append(
+            ContextIntegrityFinding(
+                asset_id="manifest:none",
+                state="degraded_integrity",
+                severity="error",
+                summary="No approved Context Integrity manifest was loaded.",
+                remediation="Import or approve a signed manifest before protected assets are used.",
+                source_type="manifest",
+            )
+        )
+
+    findings = tuple(findings_list)
+    boot_state = ContextIntegrityBootState(
+        mode=mode,  # type: ignore[arg-type]
+        degraded=degraded,
+        manifest_sequence=manifest_sequence,
+        manifest_digest=manifest_digest,
+        approved_digests_by_asset_id=_approved_digests_by_asset_id(
+            approved_entries_tuple,
+        ),
+        findings=findings,
+    )
+    resolver = ContextIntegrityResolver(boot_state)
+    setattr(app_state, "context_integrity_resolver", resolver)
+    setattr(app_state, "context_integrity_boot_state", boot_state)
+    set_global_context_integrity_resolver(resolver)
+
+    for finding in findings:
+        registry.add_warning(_finding_to_warning(finding))
+        logger.warning(
+            "Context integrity startup finding: {} {}",
+            finding.state,
+            finding.asset_id,
+        )
+
+    return findings

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_admin_context_integrity_sqlite.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_admin_context_integrity_sqlite.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+pytestmark = pytest.mark.unit
+
+
+def _build_app(*, roles: list[str]) -> FastAPI:
+    from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+    from tldw_Server_API.app.api.v1.endpoints.admin import router as admin_router
+    from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
+
+    app = FastAPI()
+    app.include_router(admin_router, prefix="/api/v1")
+
+    async def _principal_override(request=None):  # type: ignore[override]
+        principal = AuthPrincipal(
+            kind="user",
+            user_id=1,
+            api_key_id=None,
+            subject="adminuser",
+            token_type="access",
+            jti=None,
+            roles=roles,
+            permissions=["system.configure"],
+            is_admin="admin" in roles,
+            org_ids=[],
+            team_ids=[],
+        )
+        if request is not None:
+            request.state.auth = AuthContext(
+                principal=principal,
+                ip=None,
+                user_agent=None,
+                request_id=None,
+            )
+        return principal
+
+    app.dependency_overrides[get_auth_principal] = _principal_override
+    return app
+
+
+def test_admin_context_integrity_returns_boot_state() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.models import (
+        ContextIntegrityBootState,
+        ContextIntegrityFinding,
+    )
+
+    app = _build_app(roles=["admin"])
+    app.state.context_integrity_boot_state = ContextIntegrityBootState(
+        mode="enforce",
+        degraded=False,
+        manifest_sequence=7,
+        manifest_digest="sha256:manifest",
+        findings=(
+            ContextIntegrityFinding(
+                asset_id="prompt_file:rag.prompts.yaml",
+                state="new_unapproved",
+                severity="warning",
+                summary="new",
+                remediation="review",
+                source_type="prompt_file",
+            ),
+        ),
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/api/v1/admin/context-integrity")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["scope"] == "current_process"
+    assert body["mode"] == "enforce"
+    assert body["manifest_sequence"] == 7
+    assert body["findings"][0]["asset_id"] == "prompt_file:rag.prompts.yaml"
+
+
+def test_admin_context_integrity_is_admin_only() -> None:
+    app = _build_app(roles=["user"])
+
+    with TestClient(app) as client:
+        response = client.get("/api/v1/admin/context-integrity")
+
+    assert response.status_code == 403

--- a/tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py
+++ b/tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py
@@ -317,6 +317,21 @@ async def test_skill_command_reports_not_found(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_skill_command_reports_context_integrity_block(monkeypatch):
+    async def fake_exec(ctx, skill_name, skill_args):
+        return {"success": False, "error": "context_integrity_blocked"}
+
+    monkeypatch.setattr(command_router, "_execute_skill", fake_exec)
+    ctx = command_router.CommandContext(user_id="u1", auth_user_id=1)
+
+    res = await command_router.async_dispatch_command(ctx, "skill", "blocked-skill x")
+
+    assert not res.ok
+    assert "quarantined pending admin review" in res.content
+    assert res.metadata["error"] == "context_integrity_blocked"
+
+
+@pytest.mark.asyncio
 async def test_skill_command_handles_runtime_resolution_exception(monkeypatch):
     async def fake_resolve(ctx):
         raise Exception("resolver exploded")

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_canonicalization.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_canonicalization.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_filesystem_digest_is_stable_for_sorted_paths() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+        canonical_filesystem_digest,
+    )
+
+    first = canonical_filesystem_digest(
+        source_type="skill_file",
+        asset_id="skill:user:1/demo",
+        files={
+            "SKILL.md": b"hello\r\n",
+            "refs/notes.md": b"reference",
+        },
+        metadata={"context": "inline"},
+    )
+    second = canonical_filesystem_digest(
+        source_type="skill_file",
+        asset_id="skill:user:1/demo",
+        files={
+            "refs/notes.md": b"reference",
+            "SKILL.md": b"hello\r\n",
+        },
+        metadata={"context": "inline"},
+    )
+
+    assert first == second
+    assert first.startswith("sha256:")
+
+
+def test_filesystem_digest_detects_formatting_edits() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+        canonical_filesystem_digest,
+    )
+
+    original = canonical_filesystem_digest(
+        source_type="prompt_file",
+        asset_id="prompt_file:rag.prompts.yaml",
+        files={"rag.prompts.yaml": b"answer: one\n"},
+    )
+    edited = canonical_filesystem_digest(
+        source_type="prompt_file",
+        asset_id="prompt_file:rag.prompts.yaml",
+        files={"rag.prompts.yaml": b"answer: one\n# changed\n"},
+    )
+
+    assert original != edited
+
+
+def test_db_prompt_digest_normalizes_unicode_and_line_endings() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+        canonical_db_prompt_digest,
+    )
+
+    composed = canonical_db_prompt_digest(
+        {
+            "uuid": "prompt-1",
+            "version": 3,
+            "name": "Cafe",
+            "system": "caf\u00e9\r\nline",
+            "user": "body",
+            "structured": {"b": 2, "a": 1},
+        }
+    )
+    decomposed = canonical_db_prompt_digest(
+        {
+            "structured": {"a": 1, "b": 2},
+            "user": "body",
+            "system": "cafe\u0301\nline",
+            "name": "Cafe",
+            "version": 3,
+            "uuid": "prompt-1",
+        }
+    )
+
+    assert composed == decomposed
+    payload = json.loads(composed.canonical_json)
+    assert payload["system"] == "caf\u00e9\nline"

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_canonicalization.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_canonicalization.py
@@ -35,6 +35,41 @@ def test_filesystem_digest_is_stable_for_sorted_paths() -> None:
     assert first.startswith("sha256:")
 
 
+def test_filesystem_digest_normalizes_unicode_paths() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+        canonical_filesystem_digest,
+    )
+
+    composed = canonical_filesystem_digest(
+        source_type="skill_file",
+        asset_id="skill:user:1/demo",
+        files={"refs/caf\u00e9.md": b"reference"},
+    )
+    decomposed = canonical_filesystem_digest(
+        source_type="skill_file",
+        asset_id="skill:user:1/demo",
+        files={"refs/cafe\u0301.md": b"reference"},
+    )
+
+    assert composed == decomposed
+
+
+def test_filesystem_digest_rejects_duplicate_canonical_paths() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+        canonical_filesystem_digest,
+    )
+
+    with pytest.raises(ValueError, match="Duplicate canonical file path"):
+        canonical_filesystem_digest(
+            source_type="skill_file",
+            asset_id="skill:user:1/demo",
+            files={
+                "refs/caf\u00e9.md": b"one",
+                "refs/cafe\u0301.md": b"two",
+            },
+        )
+
+
 def test_filesystem_digest_matches_golden_payload() -> None:
     from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
         canonical_filesystem_digest,
@@ -50,9 +85,7 @@ def test_filesystem_digest_matches_golden_payload() -> None:
         metadata={"owner_scope": "system", "executable": False},
     )
 
-    assert digest == (
-        "sha256:cdc83bc127d0f95e66b891c1be48326e35694860185cef18f5d8af634939f1a3"
-    )
+    assert digest == ("sha256:cdc83bc127d0f95e66b891c1be48326e35694860185cef18f5d8af634939f1a3")
 
 
 def test_filesystem_digest_detects_formatting_edits() -> None:
@@ -138,9 +171,7 @@ def test_db_prompt_digest_matches_golden_payload() -> None:
         }
     )
 
-    assert digest.digest == (
-        "sha256:0b3be0310f6cf7ae29f018ef4a79bbe62e4f6f620b006aedacbb1255d6712234"
-    )
+    assert digest.digest == ("sha256:0b3be0310f6cf7ae29f018ef4a79bbe62e4f6f620b006aedacbb1255d6712234")
 
 
 @pytest.mark.parametrize("bad_float", [float("nan"), float("inf"), float("-inf")])
@@ -159,9 +190,7 @@ def test_db_prompt_digest_rejects_non_string_mapping_keys() -> None:
     )
 
     with pytest.raises(TypeError, match="mapping keys must be strings"):
-        canonical_db_prompt_digest(
-            {"uuid": "prompt-1", "structured": {1: "integer key"}}
-        )
+        canonical_db_prompt_digest({"uuid": "prompt-1", "structured": {1: "integer key"}})
 
 
 def test_db_prompt_digest_rejects_unsupported_json_values() -> None:
@@ -200,12 +229,14 @@ def test_context_integrity_models_freeze_mapping_fields() -> None:
         source_type="skill_file",
         details=details,
     )
+    findings = [finding]
     boot_state = ContextIntegrityBootState(
         mode="audit_only",
         degraded=False,
         manifest_sequence=1,
         manifest_digest="sha256:def",
         approved_digests_by_asset_id=approved,
+        findings=findings,
     )
 
     metadata["context"] = "changed"
@@ -213,12 +244,23 @@ def test_context_integrity_models_freeze_mapping_fields() -> None:
     details["reason"] = "changed again"
     details["nested"]["source"] = "changed"
     approved["asset-1"] = "sha256:changed"
+    findings.append(
+        ContextIntegrityFinding(
+            asset_id="skill:user:1/other",
+            state="new_unapproved",
+            severity="warning",
+            summary="New",
+            remediation="Review",
+            source_type="skill_file",
+        )
+    )
 
     assert descriptor.metadata["context"] == "inline"
     assert descriptor.metadata["nested"]["source"] == "caller"
     assert finding.details["reason"] == "changed"
     assert finding.details["nested"]["source"] == "caller"
     assert boot_state.approved_digests_by_asset_id["asset-1"] == "sha256:abc"
+    assert boot_state.findings == (finding,)
 
     with pytest.raises(TypeError):
         descriptor.metadata["new"] = "value"

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_canonicalization.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_canonicalization.py
@@ -35,6 +35,26 @@ def test_filesystem_digest_is_stable_for_sorted_paths() -> None:
     assert first.startswith("sha256:")
 
 
+def test_filesystem_digest_matches_golden_payload() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+        canonical_filesystem_digest,
+    )
+
+    digest = canonical_filesystem_digest(
+        source_type="skill_file",
+        asset_id="skill:system/context-integrity",
+        files={
+            "SKILL.md": b"# Context Integrity\nVerify prompt-bearing assets.\n",
+            "references/checklist.md": b"- inventory\n- verify\n",
+        },
+        metadata={"owner_scope": "system", "executable": False},
+    )
+
+    assert digest == (
+        "sha256:cdc83bc127d0f95e66b891c1be48326e35694860185cef18f5d8af634939f1a3"
+    )
+
+
 def test_filesystem_digest_detects_formatting_edits() -> None:
     from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
         canonical_filesystem_digest,
@@ -52,6 +72,20 @@ def test_filesystem_digest_detects_formatting_edits() -> None:
     )
 
     assert original != edited
+
+
+def test_filesystem_digest_rejects_non_string_metadata_keys() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+        canonical_filesystem_digest,
+    )
+
+    with pytest.raises(TypeError, match="mapping keys must be strings"):
+        canonical_filesystem_digest(
+            source_type="skill_file",
+            asset_id="skill:user:1/demo",
+            files={"SKILL.md": b"hello\n"},
+            metadata={1: "integer key"},
+        )
 
 
 def test_db_prompt_digest_normalizes_unicode_and_line_endings() -> None:
@@ -83,3 +117,112 @@ def test_db_prompt_digest_normalizes_unicode_and_line_endings() -> None:
     assert composed == decomposed
     payload = json.loads(composed.canonical_json)
     assert payload["system"] == "caf\u00e9\nline"
+
+
+def test_db_prompt_digest_matches_golden_payload() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+        canonical_db_prompt_digest,
+    )
+
+    digest = canonical_db_prompt_digest(
+        {
+            "uuid": "prompt-golden-1",
+            "version": 7,
+            "name": "Golden Prompt",
+            "system": "Use source context only.\r\nReturn concise answers.",
+            "user": "Question: {question}",
+            "structured": {
+                "temperature": 0.2,
+                "tags": ["rag", "verified"],
+            },
+        }
+    )
+
+    assert digest.digest == (
+        "sha256:0b3be0310f6cf7ae29f018ef4a79bbe62e4f6f620b006aedacbb1255d6712234"
+    )
+
+
+@pytest.mark.parametrize("bad_float", [float("nan"), float("inf"), float("-inf")])
+def test_db_prompt_digest_rejects_non_finite_floats(bad_float: float) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+        canonical_db_prompt_digest,
+    )
+
+    with pytest.raises(ValueError, match="Non-finite floats"):
+        canonical_db_prompt_digest({"uuid": "prompt-1", "score": bad_float})
+
+
+def test_db_prompt_digest_rejects_non_string_mapping_keys() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+        canonical_db_prompt_digest,
+    )
+
+    with pytest.raises(TypeError, match="mapping keys must be strings"):
+        canonical_db_prompt_digest(
+            {"uuid": "prompt-1", "structured": {1: "integer key"}}
+        )
+
+
+def test_db_prompt_digest_rejects_unsupported_json_values() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+        canonical_db_prompt_digest,
+    )
+
+    with pytest.raises(TypeError, match="Unsupported canonical JSON value"):
+        canonical_db_prompt_digest({"uuid": "prompt-1", "unsupported": object()})
+
+
+def test_context_integrity_models_freeze_mapping_fields() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.models import (
+        ContextAssetDescriptor,
+        ContextIntegrityBootState,
+        ContextIntegrityFinding,
+    )
+
+    metadata = {"context": "inline", "nested": {"source": "caller"}}
+    details = {"reason": "changed", "nested": {"source": "caller"}}
+    approved = {"asset-1": "sha256:abc"}
+
+    descriptor = ContextAssetDescriptor(
+        asset_id="skill:user:1/demo",
+        source_type="skill_file",
+        digest="sha256:123",
+        display_name="Demo skill",
+        metadata=metadata,
+    )
+    finding = ContextIntegrityFinding(
+        asset_id="skill:user:1/demo",
+        state="trusted",
+        severity="info",
+        summary="Verified",
+        remediation="None",
+        source_type="skill_file",
+        details=details,
+    )
+    boot_state = ContextIntegrityBootState(
+        mode="audit_only",
+        degraded=False,
+        manifest_sequence=1,
+        manifest_digest="sha256:def",
+        approved_digests_by_asset_id=approved,
+    )
+
+    metadata["context"] = "changed"
+    metadata["nested"]["source"] = "changed"
+    details["reason"] = "changed again"
+    details["nested"]["source"] = "changed"
+    approved["asset-1"] = "sha256:changed"
+
+    assert descriptor.metadata["context"] == "inline"
+    assert descriptor.metadata["nested"]["source"] == "caller"
+    assert finding.details["reason"] == "changed"
+    assert finding.details["nested"]["source"] == "caller"
+    assert boot_state.approved_digests_by_asset_id["asset-1"] == "sha256:abc"
+
+    with pytest.raises(TypeError):
+        descriptor.metadata["new"] = "value"
+    with pytest.raises(TypeError):
+        finding.details["new"] = "value"
+    with pytest.raises(TypeError):
+        boot_state.approved_digests_by_asset_id["asset-2"] = "sha256:new"

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
@@ -173,6 +173,30 @@ def test_inventory_user_skill_symlinked_root_reports_error_without_hashing_targe
     assert first.findings[0].asset_id == "skill:user:1"
 
 
+def test_inventory_user_skill_symlinked_root_parent_reports_error_without_hashing_target(
+    tmp_path,
+) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_user_skills_with_findings,
+    )
+
+    outside_parent = tmp_path / "outside_parent"
+    skill_dir = outside_parent / "skills" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: demo\n---\nBody", encoding="utf-8")
+    linked_parent = tmp_path / "linked_parent"
+    _symlink_or_skip(linked_parent, outside_parent, target_is_directory=True)
+    skills_root = linked_parent / "skills"
+
+    first = inventory_user_skills_with_findings(user_id=1, skills_root=skills_root)
+    (skill_dir / "SKILL.md").write_text("changed outside skill", encoding="utf-8")
+    second = inventory_user_skills_with_findings(user_id=1, skills_root=skills_root)
+
+    assert first.assets == second.assets == ()
+    assert [finding.state for finding in first.findings] == ["verification_error"]
+    assert first.findings[0].asset_id == "skill:user:1"
+
+
 def test_inventory_user_skill_broken_symlink_root_reports_error(tmp_path) -> None:
     from tldw_Server_API.app.core.Context_Integrity.inventory import (
         inventory_user_skills_with_findings,
@@ -209,9 +233,12 @@ def test_inventory_user_skill_reports_no_follow_open_error(monkeypatch, tmp_path
     skill_dir = tmp_path / "skills" / "demo"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text("---\nname: demo\n---\nBody", encoding="utf-8")
+    original_open_child_dir = inventory._open_child_dir_no_follow_fd
 
-    def raise_open_error(*args: object, **kwargs: object) -> int:
-        raise OSError("simulated no-follow failure")
+    def raise_open_error(dir_fd: int, name: str, path: Path) -> int:
+        if path == skill_dir:
+            raise OSError("simulated no-follow failure")
+        return original_open_child_dir(dir_fd, name, path)
 
     monkeypatch.setattr(inventory, "_open_child_dir_no_follow_fd", raise_open_error, raising=False)
 
@@ -416,6 +443,30 @@ def test_inventory_prompt_files_symlinked_root_reports_error_without_hashing_tar
     (outside_prompts / "root.md").write_text("outside prompt", encoding="utf-8")
     prompts = tmp_path / "Prompts"
     _symlink_or_skip(prompts, outside_prompts, target_is_directory=True)
+
+    first = inventory_prompt_files_with_findings(prompts_dir=prompts)
+    (outside_prompts / "root.md").write_text("changed outside prompt", encoding="utf-8")
+    second = inventory_prompt_files_with_findings(prompts_dir=prompts)
+
+    assert first.assets == second.assets == ()
+    assert [finding.state for finding in first.findings] == ["verification_error"]
+    assert first.findings[0].asset_id == "prompt_file:Prompts"
+
+
+def test_inventory_prompt_files_symlinked_root_parent_reports_error_without_hashing_target(
+    tmp_path,
+) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_prompt_files_with_findings,
+    )
+
+    outside_parent = tmp_path / "outside_parent"
+    outside_prompts = outside_parent / "Prompts"
+    outside_prompts.mkdir(parents=True)
+    (outside_prompts / "root.md").write_text("outside prompt", encoding="utf-8")
+    linked_parent = tmp_path / "linked_parent"
+    _symlink_or_skip(linked_parent, outside_parent, target_is_directory=True)
+    prompts = linked_parent / "Prompts"
 
     first = inventory_prompt_files_with_findings(prompts_dir=prompts)
     (outside_prompts / "root.md").write_text("changed outside prompt", encoding="utf-8")

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _symlink_or_skip(link: Path, target: Path) -> None:
+    try:
+        link.symlink_to(target)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlinks are unavailable in this environment: {exc}")
+
+
+def test_inventory_user_skill_directory_includes_supporting_files(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import inventory_user_skills
+
+    skill_dir = tmp_path / "skills" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: demo\n---\nBody", encoding="utf-8")
+    (skill_dir / "ref.md").write_text("reference", encoding="utf-8")
+
+    assets = inventory_user_skills(user_id=1, skills_root=tmp_path / "skills")
+
+    assert len(assets) == 1
+    assert assets[0].asset_id == "skill:user:1/demo"
+    assert assets[0].executable is True
+    assert assets[0].source_type == "skill_file"
+
+
+def test_inventory_user_skill_digest_changes_when_supporting_file_changes(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import inventory_user_skills
+
+    skill_dir = tmp_path / "skills" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: demo\n---\nBody", encoding="utf-8")
+    reference = skill_dir / "ref.md"
+    reference.write_text("reference", encoding="utf-8")
+
+    original = inventory_user_skills(user_id=1, skills_root=tmp_path / "skills")
+    reference.write_text("changed reference", encoding="utf-8")
+    changed = inventory_user_skills(user_id=1, skills_root=tmp_path / "skills")
+
+    assert original[0].digest != changed[0].digest
+
+
+def test_inventory_user_skill_reports_symlink_escape_without_hashing_target(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_user_skills_with_findings,
+    )
+
+    skills_root = tmp_path / "skills"
+    skill_dir = skills_root / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: demo\n---\nBody", encoding="utf-8")
+    outside = tmp_path / "outside.md"
+    outside.write_text("outside secret", encoding="utf-8")
+    _symlink_or_skip(skill_dir / "escape.md", outside)
+
+    first = inventory_user_skills_with_findings(user_id=1, skills_root=skills_root)
+    outside.write_text("changed outside secret", encoding="utf-8")
+    second = inventory_user_skills_with_findings(user_id=1, skills_root=skills_root)
+
+    assert len(first.assets) == 1
+    assert first.assets[0].digest == second.assets[0].digest
+    assert [finding.state for finding in first.findings] == ["verification_error"]
+    assert first.findings[0].asset_id == "skill:user:1/demo"
+
+
+def test_inventory_prompt_files_finds_supported_extensions(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import inventory_prompt_files
+
+    prompts = tmp_path / "Prompts"
+    prompts.mkdir()
+    (prompts / "rag.prompts.yaml").write_text("answer: prompt", encoding="utf-8")
+    (prompts / "ignore.bin").write_bytes(b"no")
+
+    assets = inventory_prompt_files(prompts_dir=prompts)
+
+    assert [asset.asset_id for asset in assets] == ["prompt_file:rag.prompts.yaml"]
+    assert assets[0].executable is False
+
+
+def test_inventory_prompt_files_does_not_recurse_or_follow_symlink_escape(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_prompt_files_with_findings,
+    )
+
+    prompts = tmp_path / "Prompts"
+    prompts.mkdir()
+    (prompts / "root.md").write_text("root prompt", encoding="utf-8")
+    nested = prompts / "nested"
+    nested.mkdir()
+    (nested / "nested.md").write_text("nested prompt", encoding="utf-8")
+    outside = tmp_path / "outside.md"
+    outside.write_text("outside prompt", encoding="utf-8")
+    _symlink_or_skip(prompts / "escape.md", outside)
+
+    result = inventory_prompt_files_with_findings(prompts_dir=prompts)
+
+    assert [asset.asset_id for asset in result.assets] == ["prompt_file:root.md"]
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "prompt_file:escape.md"
+
+
+def test_inventory_prompt_files_reports_symlinked_directory_escape(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_prompt_files_with_findings,
+    )
+
+    prompts = tmp_path / "Prompts"
+    prompts.mkdir()
+    outside = tmp_path / "outside_prompts"
+    outside.mkdir()
+    (outside / "outside.md").write_text("outside prompt", encoding="utf-8")
+    _symlink_or_skip(prompts / "linked_prompts", outside)
+
+    result = inventory_prompt_files_with_findings(prompts_dir=prompts)
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "prompt_file:linked_prompts"
+
+
+def test_inventory_env_prompt_overrides_finds_configured_files(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_env_prompt_overrides,
+    )
+
+    override = tmp_path / "override.md"
+    override.write_text("override prompt", encoding="utf-8")
+
+    assets = inventory_env_prompt_overrides(
+        environ={"TLDW_PROMPT_FILE_CHAT__SYSTEM": str(override)}
+    )
+
+    assert [asset.asset_id for asset in assets] == [
+        "prompt_file:env:TLDW_PROMPT_FILE_CHAT__SYSTEM:override.md"
+    ]
+    assert assets[0].metadata["source_label"] == "env:TLDW_PROMPT_FILE_CHAT__SYSTEM"
+
+
+def test_inventory_env_prompt_overrides_reports_missing_and_ignores_other_vars(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_env_prompt_overrides_with_findings,
+    )
+
+    override = tmp_path / "override.md"
+    override.write_text("override prompt", encoding="utf-8")
+    missing = tmp_path / "missing.md"
+
+    result = inventory_env_prompt_overrides_with_findings(
+        environ={
+            "OTHER_PROMPT_FILE": str(missing),
+            "TLDW_PROMPT_FILE_EMPTY": "  ",
+            "TLDW_PROMPT_FILE_CHAT__SYSTEM": str(override),
+            "TLDW_PROMPT_FILE_MISSING": str(missing),
+        }
+    )
+
+    assert [asset.asset_id for asset in result.assets] == [
+        "prompt_file:env:TLDW_PROMPT_FILE_CHAT__SYSTEM:override.md"
+    ]
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "prompt_file:env:TLDW_PROMPT_FILE_MISSING:missing.md"

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
@@ -64,6 +64,20 @@ def _raise_child_stat_for_name(
     monkeypatch.setattr(inventory_module, "_stat_child_no_follow", guarded_child_stat, raising=False)
 
 
+def _raise_fd_listdir_type_error(monkeypatch: pytest.MonkeyPatch, inventory_module: object) -> None:
+    original_listdir = inventory_module.os.listdir
+
+    def guarded_listdir(path: object) -> list[str]:
+        if isinstance(path, int):
+            raise TypeError("simulated fd listdir failure")
+        return original_listdir(path)
+
+    supports_fd = set(inventory_module.os.supports_fd)
+    supports_fd.add(guarded_listdir)
+    monkeypatch.setattr(inventory_module.os, "supports_fd", supports_fd)
+    monkeypatch.setattr(inventory_module.os, "listdir", guarded_listdir)
+
+
 def test_inventory_user_skill_directory_includes_supporting_files(tmp_path) -> None:
     from tldw_Server_API.app.core.Context_Integrity.inventory import inventory_user_skills
 
@@ -197,6 +211,22 @@ def test_inventory_user_skill_symlinked_root_parent_reports_error_without_hashin
     assert first.findings[0].asset_id == "skill:user:1"
 
 
+def test_inventory_user_skill_broken_symlinked_root_parent_reports_error(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_user_skills_with_findings,
+    )
+
+    linked_parent = tmp_path / "linked_parent"
+    _symlink_or_skip(linked_parent, tmp_path / "missing_parent", target_is_directory=True)
+    skills_root = linked_parent / "skills"
+
+    result = inventory_user_skills_with_findings(user_id=1, skills_root=skills_root)
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "skill:user:1"
+
+
 def test_inventory_user_skill_broken_symlink_root_reports_error(tmp_path) -> None:
     from tldw_Server_API.app.core.Context_Integrity.inventory import (
         inventory_user_skills_with_findings,
@@ -263,6 +293,24 @@ def test_inventory_user_skill_root_fd_open_failure_reports_error(monkeypatch, tm
         raise OSError("simulated unsupported fd support")
 
     monkeypatch.setattr(inventory, "_open_dir_no_follow_fd", raise_open_error, raising=False)
+
+    result = inventory.inventory_user_skills_with_findings(
+        user_id=1,
+        skills_root=tmp_path / "skills",
+    )
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "skill:user:1"
+
+
+def test_inventory_user_skill_root_fd_listdir_type_error_reports_error(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity import inventory
+
+    skill_dir = tmp_path / "skills" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: demo\n---\nBody", encoding="utf-8")
+    _raise_fd_listdir_type_error(monkeypatch, inventory)
 
     result = inventory.inventory_user_skills_with_findings(
         user_id=1,
@@ -477,6 +525,22 @@ def test_inventory_prompt_files_symlinked_root_parent_reports_error_without_hash
     assert first.findings[0].asset_id == "prompt_file:Prompts"
 
 
+def test_inventory_prompt_files_broken_symlinked_root_parent_reports_error(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_prompt_files_with_findings,
+    )
+
+    linked_parent = tmp_path / "linked_parent"
+    _symlink_or_skip(linked_parent, tmp_path / "missing_parent", target_is_directory=True)
+    prompts = linked_parent / "Prompts"
+
+    result = inventory_prompt_files_with_findings(prompts_dir=prompts)
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "prompt_file:Prompts"
+
+
 def test_inventory_prompt_files_broken_symlink_root_reports_error(tmp_path) -> None:
     from tldw_Server_API.app.core.Context_Integrity.inventory import (
         inventory_prompt_files_with_findings,
@@ -537,6 +601,21 @@ def test_inventory_prompt_files_root_fd_open_failure_reports_error(monkeypatch, 
         raise OSError("simulated unsupported fd support")
 
     monkeypatch.setattr(inventory, "_open_dir_no_follow_fd", raise_open_error, raising=False)
+
+    result = inventory.inventory_prompt_files_with_findings(prompts_dir=prompts)
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "prompt_file:Prompts"
+
+
+def test_inventory_prompt_files_root_fd_listdir_type_error_reports_error(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity import inventory
+
+    prompts = tmp_path / "Prompts"
+    prompts.mkdir()
+    (prompts / "root.md").write_text("root prompt", encoding="utf-8")
+    _raise_fd_listdir_type_error(monkeypatch, inventory)
 
     result = inventory.inventory_prompt_files_with_findings(prompts_dir=prompts)
 

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
@@ -7,9 +7,14 @@ import pytest
 pytestmark = pytest.mark.unit
 
 
-def _symlink_or_skip(link: Path, target: Path) -> None:
+def _symlink_or_skip(
+    link: Path,
+    target: Path,
+    *,
+    target_is_directory: bool = False,
+) -> None:
     try:
-        link.symlink_to(target)
+        link.symlink_to(target, target_is_directory=target_is_directory)
     except (NotImplementedError, OSError) as exc:
         pytest.skip(f"symlinks are unavailable in this environment: {exc}")
 
@@ -81,6 +86,100 @@ def test_inventory_user_skill_reports_symlink_escape_without_hashing_target(tmp_
     assert first.findings[0].asset_id == "skill:user:1/demo"
 
 
+def test_inventory_user_skill_reports_symlinked_skill_file_without_hashing_target(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_user_skills_with_findings,
+    )
+
+    skills_root = tmp_path / "skills"
+    skill_dir = skills_root / "demo"
+    skill_dir.mkdir(parents=True)
+    outside = tmp_path / "outside_skill.md"
+    outside.write_text("---\nname: outside\n---\nOutside", encoding="utf-8")
+    _symlink_or_skip(skill_dir / "SKILL.md", outside)
+
+    first = inventory_user_skills_with_findings(user_id=1, skills_root=skills_root)
+    outside.write_text("changed outside skill", encoding="utf-8")
+    second = inventory_user_skills_with_findings(user_id=1, skills_root=skills_root)
+
+    assert first.assets == second.assets == ()
+    assert [finding.state for finding in first.findings] == ["verification_error"]
+    assert first.findings[0].asset_id == "skill:user:1/demo"
+
+
+def test_inventory_user_skill_symlinked_root_reports_error_without_hashing_target(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_user_skills_with_findings,
+    )
+
+    outside_root = tmp_path / "outside_skills"
+    skill_dir = outside_root / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: demo\n---\nBody", encoding="utf-8")
+    skills_root = tmp_path / "skills"
+    _symlink_or_skip(skills_root, outside_root, target_is_directory=True)
+
+    first = inventory_user_skills_with_findings(user_id=1, skills_root=skills_root)
+    (skill_dir / "SKILL.md").write_text("changed outside skill", encoding="utf-8")
+    second = inventory_user_skills_with_findings(user_id=1, skills_root=skills_root)
+
+    assert first.assets == second.assets == ()
+    assert [finding.state for finding in first.findings] == ["verification_error"]
+    assert first.findings[0].asset_id == "skill:user:1"
+
+
+def test_inventory_user_skill_broken_symlink_root_reports_error(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_user_skills_with_findings,
+    )
+
+    skills_root = tmp_path / "skills"
+    _symlink_or_skip(skills_root, tmp_path / "missing_skills", target_is_directory=True)
+
+    result = inventory_user_skills_with_findings(user_id=1, skills_root=skills_root)
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "skill:user:1"
+
+
+def test_inventory_user_skill_file_root_reports_error(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_user_skills_with_findings,
+    )
+
+    skills_root = tmp_path / "skills"
+    skills_root.write_text("not a directory", encoding="utf-8")
+
+    result = inventory_user_skills_with_findings(user_id=1, skills_root=skills_root)
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "skill:user:1"
+
+
+def test_inventory_user_skill_reports_no_follow_open_error(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity import inventory
+
+    skill_dir = tmp_path / "skills" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: demo\n---\nBody", encoding="utf-8")
+
+    def raise_open_error(*args: object, **kwargs: object) -> int:
+        raise OSError("simulated no-follow failure")
+
+    monkeypatch.setattr(inventory, "_open_no_follow", raise_open_error, raising=False)
+
+    result = inventory.inventory_user_skills_with_findings(
+        user_id=1,
+        skills_root=tmp_path / "skills",
+    )
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "skill:user:1/demo"
+
+
 def test_inventory_prompt_files_finds_supported_extensions(tmp_path) -> None:
     from tldw_Server_API.app.core.Context_Integrity.inventory import inventory_prompt_files
 
@@ -148,6 +247,75 @@ def test_inventory_prompt_files_reports_symlinked_directory_escape(tmp_path) -> 
     assert result.findings[0].asset_id == "prompt_file:linked_prompts"
 
 
+def test_inventory_prompt_files_symlinked_root_reports_error_without_hashing_target(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_prompt_files_with_findings,
+    )
+
+    outside_prompts = tmp_path / "outside_prompts"
+    outside_prompts.mkdir()
+    (outside_prompts / "root.md").write_text("outside prompt", encoding="utf-8")
+    prompts = tmp_path / "Prompts"
+    _symlink_or_skip(prompts, outside_prompts, target_is_directory=True)
+
+    first = inventory_prompt_files_with_findings(prompts_dir=prompts)
+    (outside_prompts / "root.md").write_text("changed outside prompt", encoding="utf-8")
+    second = inventory_prompt_files_with_findings(prompts_dir=prompts)
+
+    assert first.assets == second.assets == ()
+    assert [finding.state for finding in first.findings] == ["verification_error"]
+    assert first.findings[0].asset_id == "prompt_file:Prompts"
+
+
+def test_inventory_prompt_files_broken_symlink_root_reports_error(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_prompt_files_with_findings,
+    )
+
+    prompts = tmp_path / "Prompts"
+    _symlink_or_skip(prompts, tmp_path / "missing_prompts", target_is_directory=True)
+
+    result = inventory_prompt_files_with_findings(prompts_dir=prompts)
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "prompt_file:Prompts"
+
+
+def test_inventory_prompt_files_file_root_reports_error(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_prompt_files_with_findings,
+    )
+
+    prompts = tmp_path / "Prompts"
+    prompts.write_text("not a directory", encoding="utf-8")
+
+    result = inventory_prompt_files_with_findings(prompts_dir=prompts)
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "prompt_file:Prompts"
+
+
+def test_inventory_prompt_files_reports_no_follow_open_error(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity import inventory
+
+    prompts = tmp_path / "Prompts"
+    prompts.mkdir()
+    (prompts / "root.md").write_text("root prompt", encoding="utf-8")
+
+    def raise_open_error(*args: object, **kwargs: object) -> int:
+        raise OSError("simulated no-follow failure")
+
+    monkeypatch.setattr(inventory, "_open_no_follow", raise_open_error, raising=False)
+
+    result = inventory.inventory_prompt_files_with_findings(prompts_dir=prompts)
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "prompt_file:root.md"
+
+
 def test_inventory_env_prompt_overrides_finds_configured_files(tmp_path) -> None:
     from tldw_Server_API.app.core.Context_Integrity.inventory import (
         inventory_env_prompt_overrides,
@@ -181,6 +349,32 @@ def test_inventory_env_prompt_overrides_accepts_positional_public_argument(tmp_p
     assert [asset.asset_id for asset in assets] == [
         "prompt_file:env:TLDW_PROMPT_FILE_CHAT__SYSTEM:override.md"
     ]
+
+
+def test_inventory_env_prompt_overrides_reports_symlink_without_hashing_target(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_env_prompt_overrides_with_findings,
+    )
+
+    outside = tmp_path / "outside_override.md"
+    outside.write_text("outside prompt", encoding="utf-8")
+    override = tmp_path / "override.md"
+    _symlink_or_skip(override, outside)
+
+    first = inventory_env_prompt_overrides_with_findings(
+        environ={"TLDW_PROMPT_FILE_CHAT__SYSTEM": str(override)}
+    )
+    outside.write_text("changed outside prompt", encoding="utf-8")
+    second = inventory_env_prompt_overrides_with_findings(
+        environ={"TLDW_PROMPT_FILE_CHAT__SYSTEM": str(override)}
+    )
+
+    assert first.assets == second.assets == ()
+    assert [finding.state for finding in first.findings] == ["verification_error"]
+    assert (
+        first.findings[0].asset_id
+        == "prompt_file:env:TLDW_PROMPT_FILE_CHAT__SYSTEM:override.md"
+    )
 
 
 def test_inventory_env_prompt_overrides_reports_missing_and_ignores_other_vars(tmp_path) -> None:

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
@@ -30,6 +30,18 @@ def test_inventory_user_skill_directory_includes_supporting_files(tmp_path) -> N
     assert assets[0].source_type == "skill_file"
 
 
+def test_inventory_user_skills_accepts_positional_public_arguments(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import inventory_user_skills
+
+    skill_dir = tmp_path / "skills" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: demo\n---\nBody", encoding="utf-8")
+
+    assets = inventory_user_skills(1, tmp_path / "skills")
+
+    assert [asset.asset_id for asset in assets] == ["skill:user:1/demo"]
+
+
 def test_inventory_user_skill_digest_changes_when_supporting_file_changes(tmp_path) -> None:
     from tldw_Server_API.app.core.Context_Integrity.inventory import inventory_user_skills
 
@@ -81,6 +93,18 @@ def test_inventory_prompt_files_finds_supported_extensions(tmp_path) -> None:
 
     assert [asset.asset_id for asset in assets] == ["prompt_file:rag.prompts.yaml"]
     assert assets[0].executable is False
+
+
+def test_inventory_prompt_files_accepts_positional_public_argument(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import inventory_prompt_files
+
+    prompts = tmp_path / "Prompts"
+    prompts.mkdir()
+    (prompts / "rag.prompts.yaml").write_text("answer: prompt", encoding="utf-8")
+
+    assets = inventory_prompt_files(prompts)
+
+    assert [asset.asset_id for asset in assets] == ["prompt_file:rag.prompts.yaml"]
 
 
 def test_inventory_prompt_files_does_not_recurse_or_follow_symlink_escape(tmp_path) -> None:
@@ -140,6 +164,23 @@ def test_inventory_env_prompt_overrides_finds_configured_files(tmp_path) -> None
         "prompt_file:env:TLDW_PROMPT_FILE_CHAT__SYSTEM:override.md"
     ]
     assert assets[0].metadata["source_label"] == "env:TLDW_PROMPT_FILE_CHAT__SYSTEM"
+
+
+def test_inventory_env_prompt_overrides_accepts_positional_public_argument(tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_env_prompt_overrides,
+    )
+
+    override = tmp_path / "override.md"
+    override.write_text("override prompt", encoding="utf-8")
+
+    assets = inventory_env_prompt_overrides(
+        {"TLDW_PROMPT_FILE_CHAT__SYSTEM": str(override)}
+    )
+
+    assert [asset.asset_id for asset in assets] == [
+        "prompt_file:env:TLDW_PROMPT_FILE_CHAT__SYSTEM:override.md"
+    ]
 
 
 def test_inventory_env_prompt_overrides_reports_missing_and_ignores_other_vars(tmp_path) -> None:

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -17,6 +18,28 @@ def _symlink_or_skip(
         link.symlink_to(target, target_is_directory=target_is_directory)
     except (NotImplementedError, OSError) as exc:
         pytest.skip(f"symlinks are unavailable in this environment: {exc}")
+
+
+def _mkfifo_or_skip(path: Path) -> None:
+    mkfifo = getattr(os, "mkfifo", None)
+    if mkfifo is None:
+        pytest.skip("os.mkfifo is unavailable in this environment")
+    try:
+        mkfifo(path)
+    except OSError as exc:
+        pytest.skip(f"FIFOs are unavailable in this environment: {exc}")
+
+
+def _fail_if_fifo_opened(monkeypatch: pytest.MonkeyPatch, inventory_module: object, fifo: Path) -> None:
+    original_open = os.open
+
+    def guarded_open(path: object, flags: int, mode: int = 0o777, *args: object, **kwargs: object) -> int:
+        if Path(path).name == fifo.name:
+            pytest.fail(f"FIFO was opened during inventory: {path}")
+        return original_open(path, flags, mode, *args, **kwargs)
+
+    monkeypatch.setattr(inventory_module.os, "O_NOFOLLOW", 0, raising=False)
+    monkeypatch.setattr(inventory_module.os, "open", guarded_open)
 
 
 def test_inventory_user_skill_directory_includes_supporting_files(tmp_path) -> None:
@@ -180,6 +203,29 @@ def test_inventory_user_skill_reports_no_follow_open_error(monkeypatch, tmp_path
     assert result.findings[0].asset_id == "skill:user:1/demo"
 
 
+def test_inventory_user_skill_fifo_supporting_file_reports_error_without_opening(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from tldw_Server_API.app.core.Context_Integrity import inventory
+
+    skill_dir = tmp_path / "skills" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: demo\n---\nBody", encoding="utf-8")
+    fifo = skill_dir / "pipe.md"
+    _mkfifo_or_skip(fifo)
+    _fail_if_fifo_opened(monkeypatch, inventory, fifo)
+
+    result = inventory.inventory_user_skills_with_findings(
+        user_id=1,
+        skills_root=tmp_path / "skills",
+    )
+
+    assert [asset.asset_id for asset in result.assets] == ["skill:user:1/demo"]
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "skill:user:1/demo"
+
+
 def test_inventory_prompt_files_finds_supported_extensions(tmp_path) -> None:
     from tldw_Server_API.app.core.Context_Integrity.inventory import inventory_prompt_files
 
@@ -316,6 +362,22 @@ def test_inventory_prompt_files_reports_no_follow_open_error(monkeypatch, tmp_pa
     assert result.findings[0].asset_id == "prompt_file:root.md"
 
 
+def test_inventory_prompt_files_fifo_reports_error_without_opening(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity import inventory
+
+    prompts = tmp_path / "Prompts"
+    prompts.mkdir()
+    fifo = prompts / "pipe.md"
+    _mkfifo_or_skip(fifo)
+    _fail_if_fifo_opened(monkeypatch, inventory, fifo)
+
+    result = inventory.inventory_prompt_files_with_findings(prompts_dir=prompts)
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "prompt_file:pipe.md"
+
+
 def test_inventory_env_prompt_overrides_finds_configured_files(tmp_path) -> None:
     from tldw_Server_API.app.core.Context_Integrity.inventory import (
         inventory_env_prompt_overrides,
@@ -374,6 +436,28 @@ def test_inventory_env_prompt_overrides_reports_symlink_without_hashing_target(t
     assert (
         first.findings[0].asset_id
         == "prompt_file:env:TLDW_PROMPT_FILE_CHAT__SYSTEM:override.md"
+    )
+
+
+def test_inventory_env_prompt_overrides_fifo_reports_error_without_opening(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from tldw_Server_API.app.core.Context_Integrity import inventory
+
+    fifo = tmp_path / "pipe.md"
+    _mkfifo_or_skip(fifo)
+    _fail_if_fifo_opened(monkeypatch, inventory, fifo)
+
+    result = inventory.inventory_env_prompt_overrides_with_findings(
+        environ={"TLDW_PROMPT_FILE_CHAT__SYSTEM": str(fifo)}
+    )
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert (
+        result.findings[0].asset_id
+        == "prompt_file:env:TLDW_PROMPT_FILE_CHAT__SYSTEM:pipe.md"
     )
 
 

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
@@ -78,6 +78,34 @@ def _raise_fd_listdir_type_error(monkeypatch: pytest.MonkeyPatch, inventory_modu
     monkeypatch.setattr(inventory_module.os, "listdir", guarded_listdir)
 
 
+def _fail_resolve_for_path(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    original_resolve = Path.resolve
+
+    def guarded_resolve(self: Path, *args: object, **kwargs: object) -> Path:
+        try:
+            self.relative_to(root)
+        except ValueError:
+            return original_resolve(self, *args, **kwargs)
+        pytest.fail(f"Path.resolve was called during symlink reporting: {self}")
+
+    monkeypatch.setattr(Path, "resolve", guarded_resolve)
+
+
+def _fail_parent_traversal_lstat(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    original_lstat = Path.lstat
+
+    def guarded_lstat(self: Path) -> os.stat_result:
+        try:
+            self.relative_to(root)
+        except ValueError:
+            return original_lstat(self)
+        if ".." in self.parts:
+            pytest.fail(f"Path.lstat was called before rejecting parent traversal: {self}")
+        return original_lstat(self)
+
+    monkeypatch.setattr(Path, "lstat", guarded_lstat)
+
+
 def test_inventory_user_skill_directory_includes_supporting_files(tmp_path) -> None:
     from tldw_Server_API.app.core.Context_Integrity.inventory import inventory_user_skills
 
@@ -143,6 +171,28 @@ def test_inventory_user_skill_reports_symlink_escape_without_hashing_target(tmp_
     assert first.assets[0].digest == second.assets[0].digest
     assert [finding.state for finding in first.findings] == ["verification_error"]
     assert first.findings[0].asset_id == "skill:user:1/demo"
+
+
+def test_inventory_user_skill_broken_symlink_child_does_not_resolve_target(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_user_skills_with_findings,
+    )
+
+    skills_root = tmp_path / "skills"
+    skill_dir = skills_root / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: demo\n---\nBody", encoding="utf-8")
+    _symlink_or_skip(skill_dir / "missing.md", tmp_path / "missing.md")
+    _fail_resolve_for_path(monkeypatch, tmp_path)
+
+    result = inventory_user_skills_with_findings(user_id=1, skills_root=skills_root)
+
+    assert [asset.asset_id for asset in result.assets] == ["skill:user:1/demo"]
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "skill:user:1/demo"
 
 
 def test_inventory_user_skill_reports_symlinked_skill_file_without_hashing_target(tmp_path) -> None:
@@ -221,6 +271,31 @@ def test_inventory_user_skill_broken_symlinked_root_parent_reports_error(tmp_pat
     skills_root = linked_parent / "skills"
 
     result = inventory_user_skills_with_findings(user_id=1, skills_root=skills_root)
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "skill:user:1"
+
+
+def test_inventory_user_skill_parent_traversal_root_reports_error_before_lstat(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_user_skills_with_findings,
+    )
+
+    root = tmp_path / "root"
+    skill_dir = root / "skills" / "demo"
+    skill_dir.mkdir(parents=True)
+    (root / "child").mkdir()
+    (skill_dir / "SKILL.md").write_text("---\nname: demo\n---\nBody", encoding="utf-8")
+    _fail_parent_traversal_lstat(monkeypatch, tmp_path)
+
+    result = inventory_user_skills_with_findings(
+        user_id=1,
+        skills_root=root / "child" / ".." / "skills",
+    )
 
     assert result.assets == ()
     assert [finding.state for finding in result.findings] == ["verification_error"]
@@ -462,6 +537,26 @@ def test_inventory_prompt_files_does_not_recurse_or_follow_symlink_escape(tmp_pa
     assert result.findings[0].asset_id == "prompt_file:escape.md"
 
 
+def test_inventory_prompt_files_broken_symlink_child_does_not_resolve_target(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_prompt_files_with_findings,
+    )
+
+    prompts = tmp_path / "Prompts"
+    prompts.mkdir()
+    _symlink_or_skip(prompts / "missing.md", tmp_path / "missing.md")
+    _fail_resolve_for_path(monkeypatch, tmp_path)
+
+    result = inventory_prompt_files_with_findings(prompts_dir=prompts)
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "prompt_file:missing.md"
+
+
 def test_inventory_prompt_files_reports_symlinked_directory_escape(tmp_path) -> None:
     from tldw_Server_API.app.core.Context_Integrity.inventory import (
         inventory_prompt_files_with_findings,
@@ -535,6 +630,30 @@ def test_inventory_prompt_files_broken_symlinked_root_parent_reports_error(tmp_p
     prompts = linked_parent / "Prompts"
 
     result = inventory_prompt_files_with_findings(prompts_dir=prompts)
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "prompt_file:Prompts"
+
+
+def test_inventory_prompt_files_parent_traversal_root_reports_error_before_lstat(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_prompt_files_with_findings,
+    )
+
+    root = tmp_path / "root"
+    prompts = root / "Prompts"
+    prompts.mkdir(parents=True)
+    (root / "child").mkdir()
+    (prompts / "root.md").write_text("root prompt", encoding="utf-8")
+    _fail_parent_traversal_lstat(monkeypatch, tmp_path)
+
+    result = inventory_prompt_files_with_findings(
+        prompts_dir=root / "child" / ".." / "Prompts",
+    )
 
     assert result.assets == ()
     assert [finding.state for finding in result.findings] == ["verification_error"]

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
@@ -42,6 +42,17 @@ def _fail_if_fifo_opened(monkeypatch: pytest.MonkeyPatch, inventory_module: obje
     monkeypatch.setattr(inventory_module.os, "open", guarded_open)
 
 
+def _raise_is_symlink_for_path(monkeypatch: pytest.MonkeyPatch, protected_path: Path) -> None:
+    original_is_symlink = Path.is_symlink
+
+    def guarded_is_symlink(self: Path) -> bool:
+        if self == protected_path:
+            raise PermissionError("simulated permission denied")
+        return original_is_symlink(self)
+
+    monkeypatch.setattr(Path, "is_symlink", guarded_is_symlink)
+
+
 def test_inventory_user_skill_directory_includes_supporting_files(tmp_path) -> None:
     from tldw_Server_API.app.core.Context_Integrity.inventory import inventory_user_skills
 
@@ -192,6 +203,28 @@ def test_inventory_user_skill_reports_no_follow_open_error(monkeypatch, tmp_path
         raise OSError("simulated no-follow failure")
 
     monkeypatch.setattr(inventory, "_open_no_follow", raise_open_error, raising=False)
+
+    result = inventory.inventory_user_skills_with_findings(
+        user_id=1,
+        skills_root=tmp_path / "skills",
+    )
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "skill:user:1/demo"
+
+
+def test_inventory_user_skill_symlink_preflight_permission_error_reports_finding(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from tldw_Server_API.app.core.Context_Integrity import inventory
+
+    skill_dir = tmp_path / "skills" / "demo"
+    skill_dir.mkdir(parents=True)
+    skill_file = skill_dir / "SKILL.md"
+    skill_file.write_text("---\nname: demo\n---\nBody", encoding="utf-8")
+    _raise_is_symlink_for_path(monkeypatch, skill_file)
 
     result = inventory.inventory_user_skills_with_findings(
         user_id=1,
@@ -362,6 +395,25 @@ def test_inventory_prompt_files_reports_no_follow_open_error(monkeypatch, tmp_pa
     assert result.findings[0].asset_id == "prompt_file:root.md"
 
 
+def test_inventory_prompt_files_symlink_preflight_permission_error_reports_finding(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from tldw_Server_API.app.core.Context_Integrity import inventory
+
+    prompts = tmp_path / "Prompts"
+    prompts.mkdir()
+    prompt_file = prompts / "root.md"
+    prompt_file.write_text("root prompt", encoding="utf-8")
+    _raise_is_symlink_for_path(monkeypatch, prompt_file)
+
+    result = inventory.inventory_prompt_files_with_findings(prompts_dir=prompts)
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "prompt_file:root.md"
+
+
 def test_inventory_prompt_files_fifo_reports_error_without_opening(monkeypatch, tmp_path) -> None:
     from tldw_Server_API.app.core.Context_Integrity import inventory
 
@@ -458,6 +510,28 @@ def test_inventory_env_prompt_overrides_fifo_reports_error_without_opening(
     assert (
         result.findings[0].asset_id
         == "prompt_file:env:TLDW_PROMPT_FILE_CHAT__SYSTEM:pipe.md"
+    )
+
+
+def test_inventory_env_prompt_overrides_symlink_preflight_permission_error_reports_finding(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from tldw_Server_API.app.core.Context_Integrity import inventory
+
+    override = tmp_path / "override.md"
+    override.write_text("override prompt", encoding="utf-8")
+    _raise_is_symlink_for_path(monkeypatch, override)
+
+    result = inventory.inventory_env_prompt_overrides_with_findings(
+        environ={"TLDW_PROMPT_FILE_CHAT__SYSTEM": str(override)}
+    )
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert (
+        result.findings[0].asset_id
+        == "prompt_file:env:TLDW_PROMPT_FILE_CHAT__SYSTEM:override.md"
     )
 
 

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
@@ -38,19 +38,30 @@ def _fail_if_fifo_opened(monkeypatch: pytest.MonkeyPatch, inventory_module: obje
             pytest.fail(f"FIFO was opened during inventory: {path}")
         return original_open(path, flags, mode, *args, **kwargs)
 
-    monkeypatch.setattr(inventory_module.os, "O_NOFOLLOW", 0, raising=False)
+    supports_dir_fd = set(inventory_module.os.supports_dir_fd)
+    supports_dir_fd.add(guarded_open)
+    monkeypatch.setattr(inventory_module.os, "supports_dir_fd", supports_dir_fd)
     monkeypatch.setattr(inventory_module.os, "open", guarded_open)
 
 
-def _raise_is_symlink_for_path(monkeypatch: pytest.MonkeyPatch, protected_path: Path) -> None:
-    original_is_symlink = Path.is_symlink
+def _raise_child_stat_for_name(
+    monkeypatch: pytest.MonkeyPatch,
+    inventory_module: object,
+    protected_name: str,
+) -> None:
+    original_child_stat = getattr(inventory_module, "_stat_child_no_follow", None)
 
-    def guarded_is_symlink(self: Path) -> bool:
-        if self == protected_path:
+    def guarded_child_stat(*args: object, **kwargs: object) -> os.stat_result:
+        name = kwargs.get("name")
+        if name is None and len(args) >= 2:
+            name = args[1]
+        if name == protected_name:
             raise PermissionError("simulated permission denied")
-        return original_is_symlink(self)
+        if original_child_stat is not None:
+            return original_child_stat(*args, **kwargs)
+        return os.stat_result((0,) * 10)
 
-    monkeypatch.setattr(Path, "is_symlink", guarded_is_symlink)
+    monkeypatch.setattr(inventory_module, "_stat_child_no_follow", guarded_child_stat, raising=False)
 
 
 def test_inventory_user_skill_directory_includes_supporting_files(tmp_path) -> None:
@@ -202,7 +213,7 @@ def test_inventory_user_skill_reports_no_follow_open_error(monkeypatch, tmp_path
     def raise_open_error(*args: object, **kwargs: object) -> int:
         raise OSError("simulated no-follow failure")
 
-    monkeypatch.setattr(inventory, "_open_no_follow", raise_open_error, raising=False)
+    monkeypatch.setattr(inventory, "_open_child_dir_no_follow_fd", raise_open_error, raising=False)
 
     result = inventory.inventory_user_skills_with_findings(
         user_id=1,
@@ -212,6 +223,28 @@ def test_inventory_user_skill_reports_no_follow_open_error(monkeypatch, tmp_path
     assert result.assets == ()
     assert [finding.state for finding in result.findings] == ["verification_error"]
     assert result.findings[0].asset_id == "skill:user:1/demo"
+
+
+def test_inventory_user_skill_root_fd_open_failure_reports_error(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity import inventory
+
+    skill_dir = tmp_path / "skills" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: demo\n---\nBody", encoding="utf-8")
+
+    def raise_open_error(*args: object, **kwargs: object) -> int:
+        raise OSError("simulated unsupported fd support")
+
+    monkeypatch.setattr(inventory, "_open_dir_no_follow_fd", raise_open_error, raising=False)
+
+    result = inventory.inventory_user_skills_with_findings(
+        user_id=1,
+        skills_root=tmp_path / "skills",
+    )
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "skill:user:1"
 
 
 def test_inventory_user_skill_symlink_preflight_permission_error_reports_finding(
@@ -224,7 +257,7 @@ def test_inventory_user_skill_symlink_preflight_permission_error_reports_finding
     skill_dir.mkdir(parents=True)
     skill_file = skill_dir / "SKILL.md"
     skill_file.write_text("---\nname: demo\n---\nBody", encoding="utf-8")
-    _raise_is_symlink_for_path(monkeypatch, skill_file)
+    _raise_child_stat_for_name(monkeypatch, inventory, skill_file.name)
 
     result = inventory.inventory_user_skills_with_findings(
         user_id=1,
@@ -234,6 +267,28 @@ def test_inventory_user_skill_symlink_preflight_permission_error_reports_finding
     assert result.assets == ()
     assert [finding.state for finding in result.findings] == ["verification_error"]
     assert result.findings[0].asset_id == "skill:user:1/demo"
+
+
+def test_inventory_user_skill_reads_files_without_path_reader(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity import inventory
+
+    skill_dir = tmp_path / "skills" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: demo\n---\nBody", encoding="utf-8")
+    (skill_dir / "ref.md").write_text("reference", encoding="utf-8")
+
+    def fail_path_reader(*args: object, **kwargs: object) -> bytes:
+        pytest.fail("path-based inventory reader was called")
+
+    monkeypatch.setattr(inventory, "_read_regular_file", fail_path_reader, raising=False)
+
+    result = inventory.inventory_user_skills_with_findings(
+        user_id=1,
+        skills_root=tmp_path / "skills",
+    )
+
+    assert [asset.asset_id for asset in result.assets] == ["skill:user:1/demo"]
+    assert result.findings == ()
 
 
 def test_inventory_user_skill_fifo_supporting_file_reports_error_without_opening(
@@ -386,13 +441,32 @@ def test_inventory_prompt_files_reports_no_follow_open_error(monkeypatch, tmp_pa
     def raise_open_error(*args: object, **kwargs: object) -> int:
         raise OSError("simulated no-follow failure")
 
-    monkeypatch.setattr(inventory, "_open_no_follow", raise_open_error, raising=False)
+    monkeypatch.setattr(inventory, "_open_file_no_follow_fd", raise_open_error, raising=False)
 
     result = inventory.inventory_prompt_files_with_findings(prompts_dir=prompts)
 
     assert result.assets == ()
     assert [finding.state for finding in result.findings] == ["verification_error"]
     assert result.findings[0].asset_id == "prompt_file:root.md"
+
+
+def test_inventory_prompt_files_root_fd_open_failure_reports_error(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity import inventory
+
+    prompts = tmp_path / "Prompts"
+    prompts.mkdir()
+    (prompts / "root.md").write_text("root prompt", encoding="utf-8")
+
+    def raise_open_error(*args: object, **kwargs: object) -> int:
+        raise OSError("simulated unsupported fd support")
+
+    monkeypatch.setattr(inventory, "_open_dir_no_follow_fd", raise_open_error, raising=False)
+
+    result = inventory.inventory_prompt_files_with_findings(prompts_dir=prompts)
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert result.findings[0].asset_id == "prompt_file:Prompts"
 
 
 def test_inventory_prompt_files_symlink_preflight_permission_error_reports_finding(
@@ -405,13 +479,31 @@ def test_inventory_prompt_files_symlink_preflight_permission_error_reports_findi
     prompts.mkdir()
     prompt_file = prompts / "root.md"
     prompt_file.write_text("root prompt", encoding="utf-8")
-    _raise_is_symlink_for_path(monkeypatch, prompt_file)
+    _raise_child_stat_for_name(monkeypatch, inventory, prompt_file.name)
 
     result = inventory.inventory_prompt_files_with_findings(prompts_dir=prompts)
 
     assert result.assets == ()
     assert [finding.state for finding in result.findings] == ["verification_error"]
     assert result.findings[0].asset_id == "prompt_file:root.md"
+
+
+def test_inventory_prompt_files_reads_files_without_path_reader(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.core.Context_Integrity import inventory
+
+    prompts = tmp_path / "Prompts"
+    prompts.mkdir()
+    (prompts / "root.md").write_text("root prompt", encoding="utf-8")
+
+    def fail_path_reader(*args: object, **kwargs: object) -> bytes:
+        pytest.fail("path-based inventory reader was called")
+
+    monkeypatch.setattr(inventory, "_read_regular_file", fail_path_reader, raising=False)
+
+    result = inventory.inventory_prompt_files_with_findings(prompts_dir=prompts)
+
+    assert [asset.asset_id for asset in result.assets] == ["prompt_file:root.md"]
+    assert result.findings == ()
 
 
 def test_inventory_prompt_files_fifo_reports_error_without_opening(monkeypatch, tmp_path) -> None:
@@ -521,7 +613,33 @@ def test_inventory_env_prompt_overrides_symlink_preflight_permission_error_repor
 
     override = tmp_path / "override.md"
     override.write_text("override prompt", encoding="utf-8")
-    _raise_is_symlink_for_path(monkeypatch, override)
+    _raise_child_stat_for_name(monkeypatch, inventory, override.name)
+
+    result = inventory.inventory_env_prompt_overrides_with_findings(
+        environ={"TLDW_PROMPT_FILE_CHAT__SYSTEM": str(override)}
+    )
+
+    assert result.assets == ()
+    assert [finding.state for finding in result.findings] == ["verification_error"]
+    assert (
+        result.findings[0].asset_id
+        == "prompt_file:env:TLDW_PROMPT_FILE_CHAT__SYSTEM:override.md"
+    )
+
+
+def test_inventory_env_prompt_overrides_parent_fd_open_failure_reports_error(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from tldw_Server_API.app.core.Context_Integrity import inventory
+
+    override = tmp_path / "override.md"
+    override.write_text("override prompt", encoding="utf-8")
+
+    def raise_open_error(*args: object, **kwargs: object) -> int:
+        raise OSError("simulated unsupported fd support")
+
+    monkeypatch.setattr(inventory, "_open_dir_no_follow_fd", raise_open_error, raising=False)
 
     result = inventory.inventory_env_prompt_overrides_with_findings(
         environ={"TLDW_PROMPT_FILE_CHAT__SYSTEM": str(override)}

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_inventory.py
@@ -276,11 +276,35 @@ def test_inventory_user_skill_reads_files_without_path_reader(monkeypatch, tmp_p
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text("---\nname: demo\n---\nBody", encoding="utf-8")
     (skill_dir / "ref.md").write_text("reference", encoding="utf-8")
+    fd_reader_paths: list[Path] = []
+    original_fd_reader = inventory._read_regular_file_from_dir_fd
 
-    def fail_path_reader(*args: object, **kwargs: object) -> bytes:
-        pytest.fail("path-based inventory reader was called")
+    def is_inventory_path(path: Path) -> bool:
+        try:
+            path.relative_to(skill_dir)
+        except ValueError:
+            return False
+        return True
 
-    monkeypatch.setattr(inventory, "_read_regular_file", fail_path_reader, raising=False)
+    def fail_path_read_bytes(self: Path) -> bytes:
+        if is_inventory_path(self):
+            pytest.fail(f"path-based read_bytes was called for {self}")
+        return original_path_read_bytes(self)
+
+    def fail_path_open(self: Path, *args: object, **kwargs: object) -> object:
+        if is_inventory_path(self):
+            pytest.fail(f"path-based open was called for {self}")
+        return original_path_open(self, *args, **kwargs)
+
+    def counting_fd_reader(*args: object, **kwargs: object) -> bytes | None:
+        fd_reader_paths.append(kwargs["path"])
+        return original_fd_reader(*args, **kwargs)
+
+    original_path_read_bytes = Path.read_bytes
+    original_path_open = Path.open
+    monkeypatch.setattr(Path, "read_bytes", fail_path_read_bytes)
+    monkeypatch.setattr(Path, "open", fail_path_open)
+    monkeypatch.setattr(inventory, "_read_regular_file_from_dir_fd", counting_fd_reader)
 
     result = inventory.inventory_user_skills_with_findings(
         user_id=1,
@@ -289,6 +313,7 @@ def test_inventory_user_skill_reads_files_without_path_reader(monkeypatch, tmp_p
 
     assert [asset.asset_id for asset in result.assets] == ["skill:user:1/demo"]
     assert result.findings == ()
+    assert {path.name for path in fd_reader_paths} == {"SKILL.md", "ref.md"}
 
 
 def test_inventory_user_skill_fifo_supporting_file_reports_error_without_opening(
@@ -494,16 +519,41 @@ def test_inventory_prompt_files_reads_files_without_path_reader(monkeypatch, tmp
     prompts = tmp_path / "Prompts"
     prompts.mkdir()
     (prompts / "root.md").write_text("root prompt", encoding="utf-8")
+    fd_reader_paths: list[Path] = []
+    original_fd_reader = inventory._read_regular_file_from_dir_fd
 
-    def fail_path_reader(*args: object, **kwargs: object) -> bytes:
-        pytest.fail("path-based inventory reader was called")
+    def is_inventory_path(path: Path) -> bool:
+        try:
+            path.relative_to(prompts)
+        except ValueError:
+            return False
+        return True
 
-    monkeypatch.setattr(inventory, "_read_regular_file", fail_path_reader, raising=False)
+    def fail_path_read_bytes(self: Path) -> bytes:
+        if is_inventory_path(self):
+            pytest.fail(f"path-based read_bytes was called for {self}")
+        return original_path_read_bytes(self)
+
+    def fail_path_open(self: Path, *args: object, **kwargs: object) -> object:
+        if is_inventory_path(self):
+            pytest.fail(f"path-based open was called for {self}")
+        return original_path_open(self, *args, **kwargs)
+
+    def counting_fd_reader(*args: object, **kwargs: object) -> bytes | None:
+        fd_reader_paths.append(kwargs["path"])
+        return original_fd_reader(*args, **kwargs)
+
+    original_path_read_bytes = Path.read_bytes
+    original_path_open = Path.open
+    monkeypatch.setattr(Path, "read_bytes", fail_path_read_bytes)
+    monkeypatch.setattr(Path, "open", fail_path_open)
+    monkeypatch.setattr(inventory, "_read_regular_file_from_dir_fd", counting_fd_reader)
 
     result = inventory.inventory_prompt_files_with_findings(prompts_dir=prompts)
 
     assert [asset.asset_id for asset in result.assets] == ["prompt_file:root.md"]
     assert result.findings == ()
+    assert [path.name for path in fd_reader_paths] == ["root.md"]
 
 
 def test_inventory_prompt_files_fifo_reports_error_without_opening(monkeypatch, tmp_path) -> None:
@@ -573,6 +623,36 @@ def test_inventory_env_prompt_overrides_reports_symlink_without_hashing_target(t
     outside.write_text("changed outside prompt", encoding="utf-8")
     second = inventory_env_prompt_overrides_with_findings(
         environ={"TLDW_PROMPT_FILE_CHAT__SYSTEM": str(override)}
+    )
+
+    assert first.assets == second.assets == ()
+    assert [finding.state for finding in first.findings] == ["verification_error"]
+    assert (
+        first.findings[0].asset_id
+        == "prompt_file:env:TLDW_PROMPT_FILE_CHAT__SYSTEM:override.md"
+    )
+
+
+def test_inventory_env_prompt_overrides_reports_symlinked_parent_without_hashing_target(
+    tmp_path,
+) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_env_prompt_overrides_with_findings,
+    )
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    override = outside / "override.md"
+    override.write_text("outside prompt", encoding="utf-8")
+    link = tmp_path / "linked_parent"
+    _symlink_or_skip(link, outside, target_is_directory=True)
+
+    first = inventory_env_prompt_overrides_with_findings(
+        environ={"TLDW_PROMPT_FILE_CHAT__SYSTEM": str(link / "override.md")}
+    )
+    override.write_text("changed outside prompt", encoding="utf-8")
+    second = inventory_env_prompt_overrides_with_findings(
+        environ={"TLDW_PROMPT_FILE_CHAT__SYSTEM": str(link / "override.md")}
     )
 
     assert first.assets == second.assets == ()

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
+from types import MappingProxyType
 from typing import Any
 
 import pytest
@@ -80,6 +81,28 @@ def test_manifest_roundtrip_verifies_signature() -> None:
     assert verified.manifest_digest == signed["manifest_digest"]
     assert verified.key_id == signer.key_id
     assert isinstance(verified.entries, tuple)
+    assert verified.entries[0]["asset_id"] == "skill:user:1/demo"
+
+
+def test_manifest_verification_accepts_mapping_payloads() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        HmacManifestSigner,
+        create_signed_manifest,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed = create_signed_manifest(sequence=1, entries=[_entry("skill:user:1/demo")], signer=signer)
+    signed_mapping = MappingProxyType(
+        {
+            "manifest": MappingProxyType(signed["manifest"]),
+            "signature": MappingProxyType(signed["signature"]),
+            "manifest_digest": signed["manifest_digest"],
+        }
+    )
+
+    verified = verify_signed_manifest(signed_mapping, signer=signer)
+
     assert verified.entries[0]["asset_id"] == "skill:user:1/demo"
 
 

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
@@ -83,6 +83,28 @@ def test_manifest_roundtrip_verifies_signature() -> None:
     assert verified.entries[0]["asset_id"] == "skill:user:1/demo"
 
 
+def test_verified_manifest_entries_are_immutable_snapshots() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        HmacManifestSigner,
+        create_signed_manifest,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    entry = _entry("skill:user:1/demo")
+    entry["metadata"] = {"nested": {"flag": True}, "tags": ["demo"]}
+    signed = create_signed_manifest(sequence=1, entries=[entry], signer=signer)
+
+    verified = verify_signed_manifest(signed, signer=signer)
+
+    with pytest.raises(TypeError):
+        verified.entries[0]["digest"] = "sha256:mutated"
+    signed["manifest"]["entries"][0]["digest"] = "sha256:mutated"
+    signed["manifest"]["entries"][0]["metadata"]["nested"]["flag"] = False
+    assert verified.entries[0]["digest"] == "sha256:a"
+    assert verified.entries[0]["metadata"]["nested"]["flag"] is True
+
+
 def test_manifest_tamper_is_rejected() -> None:
     from tldw_Server_API.app.core.Context_Integrity.manifest import (
         HmacManifestSigner,
@@ -412,6 +434,28 @@ def test_manifest_rejects_unsorted_entries_that_are_correctly_signed() -> None:
     assert isinstance(entries, list)
     entries.reverse()
     _resign(signed, signer)
+
+    with pytest.raises(ManifestSignatureError):
+        verify_signed_manifest(signed, signer=signer)
+
+
+def test_manifest_rejects_duplicate_asset_ids_that_are_correctly_signed() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        HmacManifestSigner,
+        ManifestSignatureError,
+        create_signed_manifest,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed = create_signed_manifest(
+        sequence=1,
+        entries=[
+            _entry("skill:user:1/demo", digest="sha256:a"),
+            _entry("skill:user:1/demo", digest="sha256:b"),
+        ],
+        signer=signer,
+    )
 
     with pytest.raises(ManifestSignatureError):
         verify_signed_manifest(signed, signer=signer)

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _entry(asset_id: str, digest: str = "sha256:a") -> dict[str, object]:
+    return {
+        "asset_id": asset_id,
+        "source_type": "skill_file",
+        "digest": digest,
+        "display_name": asset_id,
+        "executable": True,
+        "required": False,
+        "owner_scope": "user:1",
+    }
+
+
+def test_manifest_roundtrip_verifies_signature() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        HmacManifestSigner,
+        create_signed_manifest,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed = create_signed_manifest(sequence=1, entries=[_entry("skill:user:1/demo")], signer=signer)
+
+    verified = verify_signed_manifest(signed, signer=signer)
+
+    assert verified.sequence == 1
+    assert verified.entries[0]["asset_id"] == "skill:user:1/demo"
+
+
+def test_manifest_tamper_is_rejected() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        HmacManifestSigner,
+        ManifestSignatureError,
+        create_signed_manifest,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed = create_signed_manifest(sequence=1, entries=[_entry("skill:user:1/demo")], signer=signer)
+    signed["manifest"]["entries"][0]["digest"] = "sha256:evil"
+
+    with pytest.raises(ManifestSignatureError):
+        verify_signed_manifest(signed, signer=signer)
+
+
+def test_anti_rollback_anchor_rejects_older_valid_manifest() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        AntiRollbackAnchor,
+        HmacManifestSigner,
+        ManifestRollbackError,
+        create_signed_manifest,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed = create_signed_manifest(sequence=2, entries=[_entry("skill:user:1/demo")], signer=signer)
+    anchor = AntiRollbackAnchor(sequence=3, manifest_digest="sha256:newer")
+
+    with pytest.raises(ManifestRollbackError):
+        verify_signed_manifest(signed, signer=signer, anti_rollback_anchor=anchor)
+
+
+def test_anti_rollback_anchor_rejects_same_sequence_with_different_digest() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        AntiRollbackAnchor,
+        HmacManifestSigner,
+        ManifestRollbackError,
+        create_signed_manifest,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed = create_signed_manifest(sequence=3, entries=[_entry("skill:user:1/demo")], signer=signer)
+    anchor = AntiRollbackAnchor(sequence=3, manifest_digest="sha256:different")
+
+    with pytest.raises(ManifestRollbackError):
+        verify_signed_manifest(signed, signer=signer, anti_rollback_anchor=anchor)

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
@@ -221,6 +221,54 @@ def test_manifest_rejects_malformed_entry_that_is_correctly_signed(entry: object
         verify_signed_manifest(signed, signer=signer)
 
 
+@pytest.mark.parametrize(
+    "case",
+    [
+        "missing_digest",
+        "missing_source_type",
+        "asset_id_none",
+        "executable_string",
+        "empty_asset_id",
+        "metadata_scalar",
+    ],
+)
+def test_manifest_rejects_malformed_entry_schema_that_is_correctly_signed(case: str) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        HmacManifestSigner,
+        ManifestSignatureError,
+        create_signed_manifest,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed = create_signed_manifest(sequence=1, entries=[_entry("skill:user:1/demo")], signer=signer)
+    manifest = signed["manifest"]
+    assert isinstance(manifest, dict)
+    entries = manifest["entries"]
+    assert isinstance(entries, list)
+    entry = entries[0]
+    assert isinstance(entry, dict)
+
+    if case == "missing_digest":
+        del entry["digest"]
+    elif case == "missing_source_type":
+        del entry["source_type"]
+    elif case == "asset_id_none":
+        entry["asset_id"] = None
+    elif case == "executable_string":
+        entry["executable"] = "true"
+    elif case == "empty_asset_id":
+        entry["asset_id"] = ""
+    elif case == "metadata_scalar":
+        entry["metadata"] = "not-a-mapping"
+    else:
+        raise AssertionError(f"unhandled case: {case}")
+    _resign(signed, signer)
+
+    with pytest.raises(ManifestSignatureError):
+        verify_signed_manifest(signed, signer=signer)
+
+
 def test_anti_rollback_anchor_rejects_older_valid_manifest() -> None:
     from tldw_Server_API.app.core.Context_Integrity.manifest import (
         AntiRollbackAnchor,

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
@@ -63,6 +63,19 @@ def test_manifest_tamper_is_rejected() -> None:
         verify_signed_manifest(signed, signer=signer)
 
 
+def test_manifest_rejects_non_mapping_signed_manifest() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        HmacManifestSigner,
+        ManifestSignatureError,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+
+    with pytest.raises(ManifestSignatureError):
+        verify_signed_manifest(None, signer=signer)
+
+
 def test_manifest_rejects_unsupported_signature_algorithm() -> None:
     from tldw_Server_API.app.core.Context_Integrity.manifest import (
         HmacManifestSigner,
@@ -79,6 +92,14 @@ def test_manifest_rejects_unsupported_signature_algorithm() -> None:
         verify_signed_manifest(signed, signer=signer)
 
 
+def test_signer_verify_returns_false_for_non_string_signature() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import HmacManifestSigner
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+
+    assert signer.verify(b"payload", None) is False
+
+
 def test_manifest_rejects_non_ascii_signature_value() -> None:
     from tldw_Server_API.app.core.Context_Integrity.manifest import (
         HmacManifestSigner,
@@ -90,6 +111,32 @@ def test_manifest_rejects_non_ascii_signature_value() -> None:
     signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
     signed = create_signed_manifest(sequence=1, entries=[_entry("skill:user:1/demo")], signer=signer)
     signed["signature"]["value"] = "not-ascii-\u00e9"
+
+    with pytest.raises(ManifestSignatureError):
+        verify_signed_manifest(signed, signer=signer)
+
+
+def test_manifest_converts_uncanonicalizable_payload_to_signature_error() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        HmacManifestSigner,
+        ManifestSignatureError,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed = {
+        "manifest": {
+            "schema_version": 1,
+            "sequence": 1,
+            "entries": [{1: "non-string key"}],
+        },
+        "signature": {
+            "alg": "hmac-sha256",
+            "key_id": signer.key_id,
+            "value": "invalid",
+        },
+        "manifest_digest": "sha256:invalid",
+    }
 
     with pytest.raises(ManifestSignatureError):
         verify_signed_manifest(signed, signer=signer)

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 pytestmark = pytest.mark.unit
@@ -15,6 +17,18 @@ def _entry(asset_id: str, digest: str = "sha256:a") -> dict[str, object]:
         "required": False,
         "owner_scope": "user:1",
     }
+
+
+def _resign(signed: dict[str, Any], signer: Any) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import _manifest_digest, _stable_json
+
+    manifest = signed["manifest"]
+    assert isinstance(manifest, dict)
+    payload = _stable_json(manifest)
+    signed["manifest_digest"] = _manifest_digest(payload)
+    signature = signed["signature"]
+    assert isinstance(signature, dict)
+    signature["value"] = signer.sign(payload)
 
 
 def test_manifest_roundtrip_verifies_signature() -> None:
@@ -44,6 +58,72 @@ def test_manifest_tamper_is_rejected() -> None:
     signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
     signed = create_signed_manifest(sequence=1, entries=[_entry("skill:user:1/demo")], signer=signer)
     signed["manifest"]["entries"][0]["digest"] = "sha256:evil"
+
+    with pytest.raises(ManifestSignatureError):
+        verify_signed_manifest(signed, signer=signer)
+
+
+def test_manifest_rejects_unsupported_signature_algorithm() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        HmacManifestSigner,
+        ManifestSignatureError,
+        create_signed_manifest,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed = create_signed_manifest(sequence=1, entries=[_entry("skill:user:1/demo")], signer=signer)
+    signed["signature"]["alg"] = "none"
+
+    with pytest.raises(ManifestSignatureError):
+        verify_signed_manifest(signed, signer=signer)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "missing_schema_version",
+        "non_int_schema_version",
+        "bool_schema_version",
+        "missing_sequence",
+        "non_int_sequence",
+        "bool_sequence",
+        "missing_entries",
+        "none_entries",
+    ],
+)
+def test_manifest_rejects_malformed_payload_that_is_correctly_signed(case: str) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        HmacManifestSigner,
+        ManifestSignatureError,
+        create_signed_manifest,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed = create_signed_manifest(sequence=1, entries=[_entry("skill:user:1/demo")], signer=signer)
+    manifest = signed["manifest"]
+    assert isinstance(manifest, dict)
+
+    if case == "missing_schema_version":
+        del manifest["schema_version"]
+    elif case == "non_int_schema_version":
+        manifest["schema_version"] = "1"
+    elif case == "bool_schema_version":
+        manifest["schema_version"] = True
+    elif case == "missing_sequence":
+        del manifest["sequence"]
+    elif case == "non_int_sequence":
+        manifest["sequence"] = "1"
+    elif case == "bool_sequence":
+        manifest["sequence"] = True
+    elif case == "missing_entries":
+        del manifest["entries"]
+    elif case == "none_entries":
+        manifest["entries"] = None
+    else:
+        raise AssertionError(f"unhandled case: {case}")
+    _resign(signed, signer)
 
     with pytest.raises(ManifestSignatureError):
         verify_signed_manifest(signed, signer=signer)

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import base64
+import hashlib
+import hmac
 from typing import Any
 
 import pytest
@@ -31,6 +34,36 @@ def _resign(signed: dict[str, Any], signer: Any) -> None:
     signature["value"] = signer.sign(payload)
 
 
+def test_hmac_manifest_signer_requires_key_id() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import HmacManifestSigner
+
+    with pytest.raises(ValueError):
+        HmacManifestSigner(key_id="", secret=b"secret")
+
+
+def test_hmac_manifest_signer_requires_secret() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import HmacManifestSigner
+
+    with pytest.raises(ValueError):
+        HmacManifestSigner(key_id="test-key", secret=b"")
+
+
+def test_hmac_manifest_signer_returns_base64url_sha256_signature() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import HmacManifestSigner
+
+    payload = b"payload"
+    secret = b"secret"
+    signer = HmacManifestSigner(key_id="test-key", secret=secret)
+    expected = base64.urlsafe_b64encode(hmac.new(secret, payload, hashlib.sha256).digest()).decode("ascii").rstrip("=")
+
+    signature = signer.sign(payload)
+
+    assert signature == expected
+    assert "=" not in signature
+    assert set(signature) <= set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+    assert signer.verify(payload, signature) is True
+
+
 def test_manifest_roundtrip_verifies_signature() -> None:
     from tldw_Server_API.app.core.Context_Integrity.manifest import (
         HmacManifestSigner,
@@ -44,6 +77,9 @@ def test_manifest_roundtrip_verifies_signature() -> None:
     verified = verify_signed_manifest(signed, signer=signer)
 
     assert verified.sequence == 1
+    assert verified.manifest_digest == signed["manifest_digest"]
+    assert verified.key_id == signer.key_id
+    assert isinstance(verified.entries, tuple)
     assert verified.entries[0]["asset_id"] == "skill:user:1/demo"
 
 
@@ -87,6 +123,44 @@ def test_manifest_rejects_unsupported_signature_algorithm() -> None:
     signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
     signed = create_signed_manifest(sequence=1, entries=[_entry("skill:user:1/demo")], signer=signer)
     signed["signature"]["alg"] = "none"
+
+    with pytest.raises(ManifestSignatureError):
+        verify_signed_manifest(signed, signer=signer)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "key_id_mismatch",
+        "manifest_digest_mismatch",
+        "signature_value_mismatch",
+        "malformed_manifest_shape",
+        "malformed_signature_shape",
+    ],
+)
+def test_manifest_rejects_explicit_malformed_verification_inputs(case: str) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        HmacManifestSigner,
+        ManifestSignatureError,
+        create_signed_manifest,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed = create_signed_manifest(sequence=1, entries=[_entry("skill:user:1/demo")], signer=signer)
+
+    if case == "key_id_mismatch":
+        signed["signature"]["key_id"] = "other-key"
+    elif case == "manifest_digest_mismatch":
+        signed["manifest_digest"] = "sha256:different"
+    elif case == "signature_value_mismatch":
+        signed["signature"]["value"] = "invalid"
+    elif case == "malformed_manifest_shape":
+        signed["manifest"] = []
+    elif case == "malformed_signature_shape":
+        signed["signature"] = []
+    else:
+        raise AssertionError(f"unhandled case: {case}")
 
     with pytest.raises(ManifestSignatureError):
         verify_signed_manifest(signed, signer=signer)
@@ -226,9 +300,16 @@ def test_manifest_rejects_malformed_entry_that_is_correctly_signed(entry: object
     [
         "missing_digest",
         "missing_source_type",
+        "missing_display_name",
+        "display_name_none",
+        "empty_display_name",
+        "missing_owner_scope",
+        "owner_scope_none",
         "asset_id_none",
         "executable_string",
+        "required_string",
         "empty_asset_id",
+        "path_int",
         "metadata_scalar",
     ],
 )
@@ -253,12 +334,26 @@ def test_manifest_rejects_malformed_entry_schema_that_is_correctly_signed(case: 
         del entry["digest"]
     elif case == "missing_source_type":
         del entry["source_type"]
+    elif case == "missing_display_name":
+        del entry["display_name"]
+    elif case == "display_name_none":
+        entry["display_name"] = None
+    elif case == "empty_display_name":
+        entry["display_name"] = ""
+    elif case == "missing_owner_scope":
+        del entry["owner_scope"]
+    elif case == "owner_scope_none":
+        entry["owner_scope"] = None
     elif case == "asset_id_none":
         entry["asset_id"] = None
     elif case == "executable_string":
         entry["executable"] = "true"
+    elif case == "required_string":
+        entry["required"] = "false"
     elif case == "empty_asset_id":
         entry["asset_id"] = ""
+    elif case == "path_int":
+        entry["path"] = 1
     elif case == "metadata_scalar":
         entry["metadata"] = "not-a-mapping"
     else:

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
@@ -105,6 +105,35 @@ def test_verified_manifest_entries_are_immutable_snapshots() -> None:
     assert verified.entries[0]["metadata"]["nested"]["flag"] is True
 
 
+@pytest.mark.parametrize(
+    ("normalized_display_name", "raw_display_name"),
+    [
+        ("line\nname", "line\r\nname"),
+        ("caf\u00e9", "cafe\u0301"),
+    ],
+)
+def test_verified_manifest_entries_use_signed_canonical_string_values(
+    normalized_display_name: str,
+    raw_display_name: str,
+) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        HmacManifestSigner,
+        create_signed_manifest,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    entry = _entry("skill:user:1/demo")
+    entry["display_name"] = normalized_display_name
+    signed = create_signed_manifest(sequence=1, entries=[entry], signer=signer)
+    signed["manifest"]["entries"][0]["display_name"] = raw_display_name
+
+    verified = verify_signed_manifest(signed, signer=signer)
+
+    assert verified.manifest_digest == signed["manifest_digest"]
+    assert verified.entries[0]["display_name"] == normalized_display_name
+
+
 def test_manifest_tamper_is_rejected() -> None:
     from tldw_Server_API.app.core.Context_Integrity.manifest import (
         HmacManifestSigner,

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
@@ -79,12 +79,29 @@ def test_manifest_rejects_unsupported_signature_algorithm() -> None:
         verify_signed_manifest(signed, signer=signer)
 
 
+def test_manifest_rejects_non_ascii_signature_value() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        HmacManifestSigner,
+        ManifestSignatureError,
+        create_signed_manifest,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed = create_signed_manifest(sequence=1, entries=[_entry("skill:user:1/demo")], signer=signer)
+    signed["signature"]["value"] = "not-ascii-\u00e9"
+
+    with pytest.raises(ManifestSignatureError):
+        verify_signed_manifest(signed, signer=signer)
+
+
 @pytest.mark.parametrize(
     "case",
     [
         "missing_schema_version",
         "non_int_schema_version",
         "bool_schema_version",
+        "unsupported_schema_version",
         "missing_sequence",
         "non_int_sequence",
         "bool_sequence",
@@ -111,6 +128,8 @@ def test_manifest_rejects_malformed_payload_that_is_correctly_signed(case: str) 
         manifest["schema_version"] = "1"
     elif case == "bool_schema_version":
         manifest["schema_version"] = True
+    elif case == "unsupported_schema_version":
+        manifest["schema_version"] = 999
     elif case == "missing_sequence":
         del manifest["sequence"]
     elif case == "non_int_sequence":
@@ -123,6 +142,32 @@ def test_manifest_rejects_malformed_payload_that_is_correctly_signed(case: str) 
         manifest["entries"] = None
     else:
         raise AssertionError(f"unhandled case: {case}")
+    _resign(signed, signer)
+
+    with pytest.raises(ManifestSignatureError):
+        verify_signed_manifest(signed, signer=signer)
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        1,
+        [["asset_id", "skill:user:1/demo"], ["digest", "sha256:a"]],
+    ],
+)
+def test_manifest_rejects_malformed_entry_that_is_correctly_signed(entry: object) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        HmacManifestSigner,
+        ManifestSignatureError,
+        create_signed_manifest,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed = create_signed_manifest(sequence=1, entries=[_entry("skill:user:1/demo")], signer=signer)
+    manifest = signed["manifest"]
+    assert isinstance(manifest, dict)
+    manifest["entries"] = [entry]
     _resign(signed, signer)
 
     with pytest.raises(ManifestSignatureError):

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_manifest.py
@@ -269,6 +269,59 @@ def test_manifest_rejects_malformed_entry_schema_that_is_correctly_signed(case: 
         verify_signed_manifest(signed, signer=signer)
 
 
+def test_manifest_entry_validation_runs_before_anti_rollback_check() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        AntiRollbackAnchor,
+        HmacManifestSigner,
+        ManifestSignatureError,
+        create_signed_manifest,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed = create_signed_manifest(sequence=1, entries=[_entry("skill:user:1/demo")], signer=signer)
+    manifest = signed["manifest"]
+    assert isinstance(manifest, dict)
+    entries = manifest["entries"]
+    assert isinstance(entries, list)
+    entry = entries[0]
+    assert isinstance(entry, dict)
+    del entry["digest"]
+    _resign(signed, signer)
+    anchor = AntiRollbackAnchor(sequence=2, manifest_digest="sha256:newer")
+
+    with pytest.raises(ManifestSignatureError):
+        verify_signed_manifest(signed, signer=signer, anti_rollback_anchor=anchor)
+
+
+def test_manifest_rejects_unsorted_entries_that_are_correctly_signed() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        HmacManifestSigner,
+        ManifestSignatureError,
+        create_signed_manifest,
+        verify_signed_manifest,
+    )
+
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed = create_signed_manifest(
+        sequence=1,
+        entries=[
+            _entry("skill:user:1/a"),
+            _entry("skill:user:1/b"),
+        ],
+        signer=signer,
+    )
+    manifest = signed["manifest"]
+    assert isinstance(manifest, dict)
+    entries = manifest["entries"]
+    assert isinstance(entries, list)
+    entries.reverse()
+    _resign(signed, signer)
+
+    with pytest.raises(ManifestSignatureError):
+        verify_signed_manifest(signed, signer=signer)
+
+
 def test_anti_rollback_anchor_rejects_older_valid_manifest() -> None:
     from tldw_Server_API.app.core.Context_Integrity.manifest import (
         AntiRollbackAnchor,

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_verifier_resolver.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_verifier_resolver.py
@@ -98,6 +98,23 @@ def test_verifier_detects_new_unapproved_asset() -> None:
     assert findings[0].state == "new_unapproved"
 
 
+def test_verifier_detects_duplicate_live_asset_ids() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.verifier import verify_inventory
+
+    findings = verify_inventory(
+        current_assets=[
+            _asset("skill:user:1/duplicate", "sha256:first"),
+            _asset("skill:user:1/duplicate", "sha256:second"),
+        ],
+        approved_entries=[],
+    )
+
+    duplicate = [finding for finding in findings if finding.state == "verification_error"]
+    assert len(duplicate) == 1
+    assert duplicate[0].asset_id == "skill:user:1/duplicate"
+    assert duplicate[0].severity == "error"
+
+
 def test_verifier_detects_missing_assets_by_required_flag() -> None:
     from tldw_Server_API.app.core.Context_Integrity.verifier import verify_inventory
 
@@ -345,7 +362,9 @@ def test_global_resolver_can_be_set_and_cleared() -> None:
             manifest_digest="sha256:manifest",
         )
     )
-    set_global_context_integrity_resolver(resolver)
-    assert get_global_context_integrity_resolver() is resolver
-    clear_global_context_integrity_resolver()
+    try:
+        set_global_context_integrity_resolver(resolver)
+        assert get_global_context_integrity_resolver() is resolver
+    finally:
+        clear_global_context_integrity_resolver()
     assert get_global_context_integrity_resolver() is None

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_verifier_resolver.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_verifier_resolver.py
@@ -41,6 +41,29 @@ def test_verifier_detects_changed_executable_asset() -> None:
     assert findings[0].severity == "error"
 
 
+def test_verifier_uses_approved_executable_flag_for_changed_asset() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.verifier import verify_inventory
+
+    findings = verify_inventory(
+        current_assets=[_asset("skill:user:1/demo", "sha256:current", executable=False)],
+        approved_entries=[
+            {
+                "asset_id": "skill:user:1/demo",
+                "source_type": "skill_file",
+                "digest": "sha256:approved",
+                "display_name": "demo",
+                "executable": True,
+                "required": False,
+                "owner_scope": "user:1",
+            }
+        ],
+    )
+
+    assert len(findings) == 1
+    assert findings[0].state == "changed_approved_executable"
+    assert findings[0].severity == "error"
+
+
 def test_verifier_detects_changed_non_executable_asset() -> None:
     from tldw_Server_API.app.core.Context_Integrity.verifier import verify_inventory
 

--- a/tldw_Server_API/tests/Context_Integrity/unit/test_verifier_resolver.py
+++ b/tldw_Server_API/tests/Context_Integrity/unit/test_verifier_resolver.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _asset(asset_id: str, digest: str, *, executable: bool = False):
+    from tldw_Server_API.app.core.Context_Integrity.models import ContextAssetDescriptor
+
+    return ContextAssetDescriptor(
+        asset_id=asset_id,
+        source_type="skill_file",
+        digest=digest,
+        display_name=asset_id,
+        executable=executable,
+        owner_scope="user:1",
+    )
+
+
+def test_verifier_detects_changed_executable_asset() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.verifier import verify_inventory
+
+    findings = verify_inventory(
+        current_assets=[_asset("skill:user:1/demo", "sha256:current", executable=True)],
+        approved_entries=[
+            {
+                "asset_id": "skill:user:1/demo",
+                "source_type": "skill_file",
+                "digest": "sha256:approved",
+                "display_name": "demo",
+                "executable": True,
+                "required": False,
+                "owner_scope": "user:1",
+            }
+        ],
+    )
+
+    assert len(findings) == 1
+    assert findings[0].state == "changed_approved_executable"
+    assert findings[0].severity == "error"
+
+
+def test_verifier_detects_changed_non_executable_asset() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.verifier import verify_inventory
+
+    findings = verify_inventory(
+        current_assets=[_asset("skill:user:1/readme", "sha256:current")],
+        approved_entries=[
+            {
+                "asset_id": "skill:user:1/readme",
+                "source_type": "skill_file",
+                "digest": "sha256:approved",
+                "display_name": "readme",
+                "executable": False,
+                "required": False,
+                "owner_scope": "user:1",
+            }
+        ],
+    )
+
+    assert len(findings) == 1
+    assert findings[0].state == "changed_approved_non_executable"
+    assert findings[0].severity == "warning"
+
+
+def test_verifier_detects_new_unapproved_asset() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.verifier import verify_inventory
+
+    findings = verify_inventory(
+        current_assets=[_asset("skill:user:1/new", "sha256:new")],
+        approved_entries=[],
+    )
+
+    assert findings[0].state == "new_unapproved"
+
+
+def test_verifier_detects_missing_assets_by_required_flag() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.verifier import verify_inventory
+
+    findings = verify_inventory(
+        current_assets=[],
+        approved_entries=[
+            {
+                "asset_id": "skill:user:1/required",
+                "source_type": "skill_file",
+                "digest": "sha256:required",
+                "display_name": "required",
+                "executable": False,
+                "required": True,
+                "owner_scope": "user:1",
+            },
+            {
+                "asset_id": "skill:user:1/optional",
+                "source_type": "skill_file",
+                "digest": "sha256:optional",
+                "display_name": "optional",
+                "executable": False,
+                "required": False,
+                "owner_scope": "user:1",
+            },
+        ],
+    )
+
+    findings_by_asset_id = {finding.asset_id: finding for finding in findings}
+    assert findings_by_asset_id["skill:user:1/required"].state == "missing_required"
+    assert findings_by_asset_id["skill:user:1/required"].severity == "error"
+    assert findings_by_asset_id["skill:user:1/optional"].state == "missing_optional"
+    assert findings_by_asset_id["skill:user:1/optional"].severity == "warning"
+
+
+def test_resolver_blocks_quarantined_asset() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.models import (
+        ContextIntegrityBootState,
+        ContextIntegrityFinding,
+    )
+    from tldw_Server_API.app.core.Context_Integrity.resolver import (
+        ContextIntegrityBlocked,
+        ContextIntegrityResolver,
+    )
+
+    finding = ContextIntegrityFinding(
+        asset_id="skill:user:1/demo",
+        state="changed_approved_executable",
+        severity="error",
+        summary="changed",
+        remediation="review",
+        source_type="skill_file",
+    )
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="enforce",
+            degraded=False,
+            manifest_sequence=1,
+            manifest_digest="sha256:manifest",
+            findings=(finding,),
+        )
+    )
+
+    with pytest.raises(ContextIntegrityBlocked, match="quarantined"):
+        resolver.require_allowed("skill:user:1/demo", purpose="skill_execution")
+
+
+def test_resolver_detects_live_digest_mismatch_at_use() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.models import ContextIntegrityBootState
+    from tldw_Server_API.app.core.Context_Integrity.resolver import (
+        ContextIntegrityBlocked,
+        ContextIntegrityResolver,
+    )
+
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="enforce",
+            degraded=False,
+            manifest_sequence=1,
+            manifest_digest="sha256:manifest",
+            approved_digests_by_asset_id={"skill:user:1/demo": "sha256:approved"},
+        )
+    )
+
+    with pytest.raises(ContextIntegrityBlocked, match="quarantined"):
+        resolver.require_digest_allowed(
+            "skill:user:1/demo",
+            current_digest="sha256:changed",
+            purpose="skill_execution",
+        )
+
+
+def test_resolver_blocks_unknown_asset_in_enforce_mode() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.models import ContextIntegrityBootState
+    from tldw_Server_API.app.core.Context_Integrity.resolver import (
+        ContextIntegrityBlocked,
+        ContextIntegrityResolver,
+    )
+
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="enforce",
+            degraded=False,
+            manifest_sequence=1,
+            manifest_digest="sha256:manifest",
+            approved_digests_by_asset_id={"skill:user:1/known": "sha256:approved"},
+        )
+    )
+
+    with pytest.raises(ContextIntegrityBlocked) as exc_info:
+        resolver.require_allowed("skill:user:1/live-added", purpose="skill_discovery")
+
+    assert exc_info.value.state == "new_unapproved"
+
+
+def test_resolver_blocks_unknown_asset_in_hardened_mode() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.models import ContextIntegrityBootState
+    from tldw_Server_API.app.core.Context_Integrity.resolver import (
+        ContextIntegrityBlocked,
+        ContextIntegrityResolver,
+    )
+
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="hardened",
+            degraded=False,
+            manifest_sequence=1,
+            manifest_digest="sha256:manifest",
+            approved_digests_by_asset_id={"skill:user:1/known": "sha256:approved"},
+        )
+    )
+
+    with pytest.raises(ContextIntegrityBlocked) as exc_info:
+        resolver.require_allowed("skill:user:1/live-added", purpose="skill_discovery")
+
+    assert exc_info.value.state == "new_unapproved"
+
+
+def test_resolver_blocks_degraded_injection_use() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.models import ContextIntegrityBootState
+    from tldw_Server_API.app.core.Context_Integrity.resolver import (
+        ContextIntegrityBlocked,
+        ContextIntegrityResolver,
+    )
+
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="enforce",
+            degraded=True,
+            manifest_sequence=None,
+            manifest_digest=None,
+            approved_digests_by_asset_id={"prompt_file:demo.prompts.md": "sha256:approved"},
+        )
+    )
+
+    with pytest.raises(ContextIntegrityBlocked) as exc_info:
+        resolver.require_allowed("prompt_file:demo.prompts.md", purpose="prompt_load")
+
+    assert exc_info.value.state == "degraded_integrity"
+
+
+def test_resolver_allows_degraded_admin_review_purpose() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.models import ContextIntegrityBootState
+    from tldw_Server_API.app.core.Context_Integrity.resolver import ContextIntegrityResolver
+
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="hardened",
+            degraded=True,
+            manifest_sequence=None,
+            manifest_digest=None,
+            approved_digests_by_asset_id={"prompt_file:demo.prompts.md": "sha256:approved"},
+        )
+    )
+
+    resolver.require_allowed(
+        "prompt_file:demo.prompts.md",
+        purpose="admin_review_status",
+    )
+
+
+def test_resolver_audit_only_allows_quarantined_and_unknown_assets() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.models import (
+        ContextIntegrityBootState,
+        ContextIntegrityFinding,
+    )
+    from tldw_Server_API.app.core.Context_Integrity.resolver import ContextIntegrityResolver
+
+    finding = ContextIntegrityFinding(
+        asset_id="skill:user:1/demo",
+        state="changed_approved_executable",
+        severity="error",
+        summary="changed",
+        remediation="review",
+        source_type="skill_file",
+    )
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="audit_only",
+            degraded=True,
+            manifest_sequence=None,
+            manifest_digest=None,
+            findings=(finding,),
+        )
+    )
+
+    resolver.require_allowed("skill:user:1/demo", purpose="skill_execution")
+    resolver.require_allowed("skill:user:1/unknown", purpose="skill_discovery")
+
+
+def test_resolver_allows_matching_digest_at_use() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.models import ContextIntegrityBootState
+    from tldw_Server_API.app.core.Context_Integrity.resolver import ContextIntegrityResolver
+
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="enforce",
+            degraded=False,
+            manifest_sequence=1,
+            manifest_digest="sha256:manifest",
+            approved_digests_by_asset_id={"prompt_file:demo.prompts.md": "sha256:approved"},
+        )
+    )
+
+    resolver.require_digest_allowed(
+        "prompt_file:demo.prompts.md",
+        current_digest="sha256:approved",
+        purpose="prompt_load",
+    )
+
+
+def test_global_resolver_can_be_set_and_cleared() -> None:
+    from tldw_Server_API.app.core.Context_Integrity.models import ContextIntegrityBootState
+    from tldw_Server_API.app.core.Context_Integrity.resolver import (
+        ContextIntegrityResolver,
+        clear_global_context_integrity_resolver,
+        get_global_context_integrity_resolver,
+        set_global_context_integrity_resolver,
+    )
+
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="enforce",
+            degraded=False,
+            manifest_sequence=1,
+            manifest_digest="sha256:manifest",
+        )
+    )
+    set_global_context_integrity_resolver(resolver)
+    assert get_global_context_integrity_resolver() is resolver
+    clear_global_context_integrity_resolver()
+    assert get_global_context_integrity_resolver() is None

--- a/tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py
+++ b/tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py
@@ -26,6 +26,15 @@ async def test_run_lifespan_shutdown_sequence_stops_lifecycle_phases_in_order(
     from tldw_Server_API.app.services.lifespan_worker_runtime_state import (
         LifespanWorkerRuntimeState,
     )
+    from tldw_Server_API.app.core.Context_Integrity.models import (
+        ContextIntegrityBootState,
+    )
+    from tldw_Server_API.app.core.Context_Integrity.resolver import (
+        ContextIntegrityResolver,
+        clear_global_context_integrity_resolver,
+        get_global_context_integrity_resolver,
+        set_global_context_integrity_resolver,
+    )
 
     app = FastAPI()
 
@@ -52,6 +61,16 @@ async def test_run_lifespan_shutdown_sequence_stops_lifecycle_phases_in_order(
             )
 
     worker_lifecycle_session = _FakeLifecycleSession()
+    boot_state = ContextIntegrityBootState(
+        mode="enforce",
+        degraded=False,
+        manifest_sequence=1,
+        manifest_digest="sha256:manifest",
+    )
+    resolver = ContextIntegrityResolver(boot_state)
+    app.state.context_integrity_resolver = resolver
+    app.state.context_integrity_boot_state = boot_state
+    set_global_context_integrity_resolver(resolver)
     worker_runtime = LifespanWorkerRuntimeState(
         worker_lifecycle_session=worker_lifecycle_session,
     )
@@ -65,6 +84,9 @@ async def test_run_lifespan_shutdown_sequence_stops_lifecycle_phases_in_order(
         yield
 
     async def _fake_transition_handoff(**kwargs):
+        assert get_global_context_integrity_resolver() is None
+        assert not hasattr(app.state, "context_integrity_resolver")
+        assert not hasattr(app.state, "context_integrity_boot_state")
         calls.append(("transition", kwargs))
         return SimpleNamespace(legacy_shutdown_plan=["transition-plan"])
 
@@ -146,26 +168,28 @@ async def test_run_lifespan_shutdown_sequence_stops_lifecycle_phases_in_order(
         "shutdown_final_cleanup_tail",
         _fake_final_cleanup,
     )
-
-    await lifespan_shutdown_sequence.run_lifespan_shutdown_sequence(
-        app=app,
-        worker_runtime=worker_runtime,
-        readiness_state={"ready": True},
-        db_pool="db-pool",
-        session_manager="session-manager",
-        heavy_startup_handles="heavy-handles",
-        build_legacy_shutdown_context=lambda **kwargs: kwargs,
-        apply_shutdown_transition_gate=lambda *_args, **_kwargs: None,
-        quiesce_owned_job_pollers_for_shutdown=lambda *_args, **_kwargs: None,
-        run_coordinated_shutdown=lambda **_kwargs: None,
-        startup_guard_exceptions=(RuntimeError,),
-        import_exceptions=(ImportError,),
-        in_pytest_runtime=True,
-        test_db_instance_ref="test-db-ref",
-        timed_shutdown_segment=_timed_shutdown_segment,
-        record_shutdown_timing_total=lambda _app, total_ms: recorded_totals.append(total_ms),
-        monotonic=lambda: next(monotonic_values),
-    )
+    try:
+        await lifespan_shutdown_sequence.run_lifespan_shutdown_sequence(
+            app=app,
+            worker_runtime=worker_runtime,
+            readiness_state={"ready": True},
+            db_pool="db-pool",
+            session_manager="session-manager",
+            heavy_startup_handles="heavy-handles",
+            build_legacy_shutdown_context=lambda **kwargs: kwargs,
+            apply_shutdown_transition_gate=lambda *_args, **_kwargs: None,
+            quiesce_owned_job_pollers_for_shutdown=lambda *_args, **_kwargs: None,
+            run_coordinated_shutdown=lambda **_kwargs: None,
+            startup_guard_exceptions=(RuntimeError,),
+            import_exceptions=(ImportError,),
+            in_pytest_runtime=True,
+            test_db_instance_ref="test-db-ref",
+            timed_shutdown_segment=_timed_shutdown_segment,
+            record_shutdown_timing_total=lambda _app, total_ms: recorded_totals.append(total_ms),
+            monotonic=lambda: next(monotonic_values),
+        )
+    finally:
+        clear_global_context_integrity_resolver()
 
     assert [name for name, _ in calls] == [
         "segment",

--- a/tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py
+++ b/tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py
@@ -8,6 +8,24 @@ from fastapi import FastAPI
 pytestmark = pytest.mark.unit
 
 
+def _patch_context_integrity_producer(
+    monkeypatch: pytest.MonkeyPatch,
+    calls: list[dict[str, object]] | None = None,
+) -> None:
+    from tldw_Server_API.app.services import startup_context_integrity
+
+    def _fake_produce_context_integrity_startup_warnings(**kwargs):
+        if calls is not None:
+            calls.append(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        startup_context_integrity,
+        "produce_context_integrity_startup_warnings",
+        _fake_produce_context_integrity_startup_warnings,
+    )
+
+
 @pytest.mark.asyncio
 async def test_run_lifespan_startup_sequence_runs_helpers_in_order_and_updates_runtime(
     monkeypatch: pytest.MonkeyPatch,
@@ -58,6 +76,7 @@ async def test_run_lifespan_startup_sequence_runs_helpers_in_order_and_updates_r
         "initialize_startup_worker_bootstrap",
         _fake_initialize_startup_worker_bootstrap,
     )
+    _patch_context_integrity_producer(monkeypatch)
 
     handles = await run_lifespan_startup_sequence(
         app=app,
@@ -121,6 +140,7 @@ async def test_startup_initializes_registry_and_runs_sandbox_producer(
     app = FastAPI()
     worker_runtime = LifespanWorkerRuntimeState()
     producer_calls: list[dict[str, object]] = []
+    context_calls: list[dict[str, object]] = []
 
     async def _fake_prepare_startup_pre_core(**kwargs):
         return True
@@ -162,6 +182,7 @@ async def test_startup_initializes_registry_and_runs_sandbox_producer(
         "produce_sandbox_startup_warnings",
         _fake_produce_sandbox_startup_warnings,
     )
+    _patch_context_integrity_producer(monkeypatch, context_calls)
 
     await run_lifespan_startup_sequence(
         app=app,
@@ -184,6 +205,7 @@ async def test_startup_initializes_registry_and_runs_sandbox_producer(
 
     registry = app.state.startup_warning_registry
     assert registry.summary()["total"] == 0
+    assert context_calls == [{"app_state": app.state, "registry": registry}]
     assert producer_calls == [
         {
             "orchestrator": "orch-sentinel",
@@ -265,6 +287,7 @@ async def test_startup_blocks_on_protocol_mismatch_warning(
         "produce_sandbox_startup_warnings",
         _fake_produce_sandbox_startup_warnings,
     )
+    _patch_context_integrity_producer(monkeypatch)
 
     with pytest.raises(RuntimeError, match="vz_helper_protocol_mismatch"):
         await run_lifespan_startup_sequence(
@@ -346,6 +369,7 @@ async def test_startup_warning_registry_is_available_on_app_state(
         "produce_sandbox_startup_warnings",
         lambda **kwargs: [],
     )
+    _patch_context_integrity_producer(monkeypatch)
 
     await run_lifespan_startup_sequence(
         app=app,

--- a/tldw_Server_API/tests/Services/test_startup_context_integrity.py
+++ b/tldw_Server_API/tests/Services/test_startup_context_integrity.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _clear_context_integrity_environment(monkeypatch: pytest.MonkeyPatch):
+    for env_name in (
+        "CONTEXT_INTEGRITY_MANIFEST_PATH",
+        "CONTEXT_INTEGRITY_HMAC_SECRET",
+        "CONTEXT_INTEGRITY_HMAC_KEY_ID",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
+    for env_name in list(os.environ):
+        if env_name.startswith("TLDW_PROMPT_FILE_"):
+            monkeypatch.delenv(env_name, raising=False)
+
+    from tldw_Server_API.app.core.Context_Integrity.resolver import (
+        clear_global_context_integrity_resolver,
+    )
+
+    clear_global_context_integrity_resolver()
+    yield
+    clear_global_context_integrity_resolver()
+
+
+def _state() -> object:
+    return type("State", (), {})()
+
+
+def _entry_from_asset(asset: Any) -> dict[str, object]:
+    return {
+        "asset_id": asset.asset_id,
+        "source_type": asset.source_type,
+        "digest": asset.digest,
+        "display_name": asset.display_name,
+        "executable": asset.executable,
+        "required": asset.required,
+        "owner_scope": asset.owner_scope,
+        "path": asset.path,
+        "metadata": dict(asset.metadata),
+    }
+
+
+def test_startup_context_integrity_sets_resolver_and_warning(tmp_path: Path) -> None:
+    from tldw_Server_API.app.services.startup_context_integrity import (
+        produce_context_integrity_startup_warnings,
+    )
+    from tldw_Server_API.app.services.startup_warning_registry import (
+        StartupWarningRegistry,
+    )
+
+    prompts = tmp_path / "Prompts"
+    prompts.mkdir()
+    (prompts / "rag.prompts.yaml").write_text("answer: changed", encoding="utf-8")
+
+    registry = StartupWarningRegistry(startup_id="boot-1")
+    app_state = _state()
+
+    findings = produce_context_integrity_startup_warnings(
+        app_state=app_state,
+        registry=registry,
+        prompts_dir=prompts,
+        user_skill_roots=[],
+        approved_entries=[],
+        mode="enforce",
+    )
+
+    assert len(findings) == 2
+    assert registry.summary(component_prefix="context_integrity")["total"] == 2
+    assert app_state.context_integrity_boot_state.degraded is True
+    assert any(finding.state == "degraded_integrity" for finding in findings)
+    assert app_state.context_integrity_resolver.finding_for("prompt_file:rag.prompts.yaml") is not None
+
+
+def test_valid_empty_manifest_does_not_degrade(tmp_path: Path) -> None:
+    from tldw_Server_API.app.services.startup_context_integrity import (
+        produce_context_integrity_startup_warnings,
+    )
+    from tldw_Server_API.app.services.startup_warning_registry import (
+        StartupWarningRegistry,
+    )
+
+    prompts = tmp_path / "Prompts"
+    prompts.mkdir()
+    registry = StartupWarningRegistry(startup_id="boot-2")
+    app_state = _state()
+
+    findings = produce_context_integrity_startup_warnings(
+        app_state=app_state,
+        registry=registry,
+        prompts_dir=prompts,
+        user_skill_roots=[],
+        approved_entries=[],
+        manifest_loaded=True,
+        manifest_sequence=3,
+        manifest_digest="sha256:empty",
+        mode="enforce",
+    )
+
+    assert findings == ()
+    assert registry.summary(component_prefix="context_integrity")["total"] == 0
+    assert app_state.context_integrity_boot_state.degraded is False
+    assert app_state.context_integrity_boot_state.manifest_sequence == 3
+    assert app_state.context_integrity_boot_state.manifest_digest == "sha256:empty"
+    assert not any(finding.state == "degraded_integrity" for finding in findings)
+
+
+def test_missing_env_manifest_degrades_when_approved_entries_not_injected(
+    tmp_path: Path,
+) -> None:
+    from tldw_Server_API.app.services.startup_context_integrity import (
+        produce_context_integrity_startup_warnings,
+    )
+    from tldw_Server_API.app.services.startup_warning_registry import (
+        StartupWarningRegistry,
+    )
+
+    prompts = tmp_path / "Prompts"
+    prompts.mkdir()
+    registry = StartupWarningRegistry(startup_id="boot-3")
+    app_state = _state()
+
+    findings = produce_context_integrity_startup_warnings(
+        app_state=app_state,
+        registry=registry,
+        prompts_dir=prompts,
+        user_skill_roots=[],
+        approved_entries=None,
+        mode="enforce",
+    )
+
+    assert [finding.state for finding in findings] == ["degraded_integrity"]
+    assert app_state.context_integrity_boot_state.degraded is True
+    assert registry.summary(component_prefix="context_integrity")["total"] == 1
+
+
+def test_env_manifest_happy_path_populates_boot_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_prompt_files_with_findings,
+    )
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        HmacManifestSigner,
+        create_signed_manifest,
+    )
+    from tldw_Server_API.app.core.Context_Integrity.resolver import (
+        get_global_context_integrity_resolver,
+    )
+    from tldw_Server_API.app.services.startup_context_integrity import (
+        produce_context_integrity_startup_warnings,
+    )
+    from tldw_Server_API.app.services.startup_warning_registry import (
+        StartupWarningRegistry,
+    )
+
+    prompts = tmp_path / "Prompts"
+    prompts.mkdir()
+    (prompts / "rag.prompts.yaml").write_text("answer: approved", encoding="utf-8")
+    asset = inventory_prompt_files_with_findings(prompts_dir=prompts).assets[0]
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed_manifest = create_signed_manifest(
+        sequence=9,
+        entries=[_entry_from_asset(asset)],
+        signer=signer,
+    )
+    manifest_path = tmp_path / "context-manifest.json"
+    manifest_path.write_text(json.dumps(signed_manifest), encoding="utf-8")
+    monkeypatch.setenv("CONTEXT_INTEGRITY_MANIFEST_PATH", str(manifest_path))
+    monkeypatch.setenv("CONTEXT_INTEGRITY_HMAC_SECRET", "secret")
+    monkeypatch.setenv("CONTEXT_INTEGRITY_HMAC_KEY_ID", "test-key")
+    registry = StartupWarningRegistry(startup_id="boot-4")
+    app_state = _state()
+
+    findings = produce_context_integrity_startup_warnings(
+        app_state=app_state,
+        registry=registry,
+        prompts_dir=prompts,
+        user_skill_roots=[],
+        approved_entries=None,
+        mode="enforce",
+    )
+
+    assert findings == ()
+    assert app_state.context_integrity_boot_state.degraded is False
+    assert app_state.context_integrity_boot_state.manifest_sequence == 9
+    assert app_state.context_integrity_boot_state.manifest_digest == signed_manifest["manifest_digest"]
+    assert app_state.context_integrity_boot_state.approved_digests_by_asset_id == {
+        asset.asset_id: asset.digest,
+    }
+    assert get_global_context_integrity_resolver() is app_state.context_integrity_resolver
+
+
+def test_env_manifest_invalid_signature_degrades(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.manifest import (
+        HmacManifestSigner,
+        create_signed_manifest,
+    )
+    from tldw_Server_API.app.services.startup_context_integrity import (
+        produce_context_integrity_startup_warnings,
+    )
+    from tldw_Server_API.app.services.startup_warning_registry import (
+        StartupWarningRegistry,
+    )
+
+    prompts = tmp_path / "Prompts"
+    prompts.mkdir()
+    signer = HmacManifestSigner(key_id="test-key", secret=b"secret")
+    signed_manifest = create_signed_manifest(sequence=4, entries=[], signer=signer)
+    signed_manifest["manifest"]["sequence"] = 5
+    manifest_path = tmp_path / "context-manifest.json"
+    manifest_path.write_text(json.dumps(signed_manifest), encoding="utf-8")
+    monkeypatch.setenv("CONTEXT_INTEGRITY_MANIFEST_PATH", str(manifest_path))
+    monkeypatch.setenv("CONTEXT_INTEGRITY_HMAC_SECRET", "secret")
+    monkeypatch.setenv("CONTEXT_INTEGRITY_HMAC_KEY_ID", "test-key")
+    registry = StartupWarningRegistry(startup_id="boot-5")
+    app_state = _state()
+
+    findings = produce_context_integrity_startup_warnings(
+        app_state=app_state,
+        registry=registry,
+        prompts_dir=prompts,
+        user_skill_roots=[],
+        approved_entries=None,
+        mode="enforce",
+    )
+
+    assert [finding.state for finding in findings] == [
+        "signature_invalid",
+        "degraded_integrity",
+    ]
+    assert app_state.context_integrity_boot_state.degraded is True
+
+
+def test_rich_inventory_findings_are_preserved(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.Context_Integrity.inventory import InventoryResult
+    from tldw_Server_API.app.core.Context_Integrity.models import (
+        ContextAssetDescriptor,
+        ContextIntegrityFinding,
+    )
+    from tldw_Server_API.app.services import startup_context_integrity
+    from tldw_Server_API.app.services.startup_context_integrity import (
+        produce_context_integrity_startup_warnings,
+    )
+    from tldw_Server_API.app.services.startup_warning_registry import (
+        StartupWarningRegistry,
+    )
+
+    prompt_asset = ContextAssetDescriptor(
+        asset_id="prompt_file:approved.prompts.yaml",
+        source_type="prompt_file",
+        digest="sha256:approved",
+        display_name="approved.prompts.yaml",
+    )
+    prompt_finding = ContextIntegrityFinding(
+        asset_id="prompt_file:broken.prompts.yaml",
+        state="verification_error",
+        severity="error",
+        summary="prompt inventory failed",
+        remediation="fix prompt path",
+        source_type="prompt_file",
+    )
+    env_finding = ContextIntegrityFinding(
+        asset_id="prompt_file:env:TLDW_PROMPT_FILE_BAD:bad.yaml",
+        state="verification_error",
+        severity="error",
+        summary="env prompt inventory failed",
+        remediation="fix env prompt path",
+        source_type="prompt_file",
+    )
+    skill_finding = ContextIntegrityFinding(
+        asset_id="skill:user:42/broken",
+        state="verification_error",
+        severity="error",
+        summary="skill inventory failed",
+        remediation="fix skill path",
+        source_type="skill_file",
+    )
+
+    monkeypatch.setattr(
+        startup_context_integrity,
+        "inventory_prompt_files_with_findings",
+        lambda *, prompts_dir: InventoryResult(
+            assets=(prompt_asset,),
+            findings=(prompt_finding,),
+        ),
+    )
+    monkeypatch.setattr(
+        startup_context_integrity,
+        "inventory_env_prompt_overrides_with_findings",
+        lambda **_kwargs: InventoryResult(assets=(), findings=(env_finding,)),
+    )
+    monkeypatch.setattr(
+        startup_context_integrity,
+        "inventory_user_skills_with_findings",
+        lambda *, user_id, skills_root: InventoryResult(
+            assets=(),
+            findings=(skill_finding,),
+        ),
+    )
+    registry = StartupWarningRegistry(startup_id="boot-6")
+    app_state = _state()
+
+    findings = produce_context_integrity_startup_warnings(
+        app_state=app_state,
+        registry=registry,
+        prompts_dir=tmp_path,
+        user_skill_roots=[(42, tmp_path / "skills")],
+        approved_entries=[_entry_from_asset(prompt_asset)],
+        manifest_loaded=True,
+        mode="enforce",
+    )
+
+    assert tuple(finding.asset_id for finding in findings) == (
+        prompt_finding.asset_id,
+        env_finding.asset_id,
+        skill_finding.asset_id,
+    )
+    assert registry.summary(component_prefix="context_integrity")["total"] == 3
+
+
+def test_discover_user_skill_roots_uses_existing_user_database_tree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.services import startup_context_integrity
+
+    base_dir = tmp_path / "user_databases"
+    (base_dir / "1" / "skills").mkdir(parents=True)
+    (base_dir / "2" / "skills").mkdir(parents=True)
+    (base_dir / "not-a-user" / "skills").mkdir(parents=True)
+    (base_dir / "3").mkdir()
+    calls: list[bool] = []
+
+    def _fake_base_dir(*, allow_legacy_alias: bool = False) -> Path:
+        calls.append(allow_legacy_alias)
+        return base_dir
+
+    monkeypatch.setattr(
+        startup_context_integrity.DatabasePaths,
+        "get_user_db_base_dir",
+        staticmethod(_fake_base_dir),
+    )
+
+    assert startup_context_integrity._discover_user_skill_roots() == [
+        (1, base_dir / "1" / "skills"),
+        (2, base_dir / "2" / "skills"),
+    ]
+    assert calls == [True]

--- a/tldw_Server_API/tests/Services/test_startup_context_integrity.py
+++ b/tldw_Server_API/tests/Services/test_startup_context_integrity.py
@@ -338,6 +338,7 @@ def test_discover_user_skill_roots_uses_existing_user_database_tree(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from tldw_Server_API.app.core.DB_Management import db_path_utils
     from tldw_Server_API.app.services import startup_context_integrity
 
     base_dir = tmp_path / "user_databases"
@@ -345,20 +346,42 @@ def test_discover_user_skill_roots_uses_existing_user_database_tree(
     (base_dir / "2" / "skills").mkdir(parents=True)
     (base_dir / "not-a-user" / "skills").mkdir(parents=True)
     (base_dir / "3").mkdir()
-    calls: list[bool] = []
-
-    def _fake_base_dir(*, allow_legacy_alias: bool = False) -> Path:
-        calls.append(allow_legacy_alias)
-        return base_dir
 
     monkeypatch.setattr(
-        startup_context_integrity.DatabasePaths,
-        "get_user_db_base_dir",
-        staticmethod(_fake_base_dir),
+        db_path_utils,
+        "settings",
+        {
+            "USER_DB_BASE_DIR": None,
+            "USER_DB_BASE": None,
+        },
     )
+    monkeypatch.delenv("USER_DB_BASE_DIR", raising=False)
+    monkeypatch.setenv("USER_DB_BASE", str(base_dir))
 
     assert startup_context_integrity._discover_user_skill_roots() == [
         (1, base_dir / "1" / "skills"),
         (2, base_dir / "2" / "skills"),
     ]
-    assert calls == [True]
+
+
+def test_discover_user_skill_roots_does_not_create_missing_user_database_base(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.DB_Management import db_path_utils
+    from tldw_Server_API.app.services import startup_context_integrity
+
+    missing_base = tmp_path / "missing_user_databases"
+    monkeypatch.setattr(
+        db_path_utils,
+        "settings",
+        {
+            "USER_DB_BASE_DIR": None,
+            "USER_DB_BASE": None,
+        },
+    )
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(missing_base))
+    monkeypatch.delenv("USER_DB_BASE", raising=False)
+
+    assert startup_context_integrity._discover_user_skill_roots() == []
+    assert not missing_base.exists()

--- a/tldw_Server_API/tests/Services/test_startup_context_integrity.py
+++ b/tldw_Server_API/tests/Services/test_startup_context_integrity.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 import json
 import os
 from pathlib import Path
@@ -11,7 +12,7 @@ pytestmark = pytest.mark.unit
 
 
 @pytest.fixture(autouse=True)
-def _clear_context_integrity_environment(monkeypatch: pytest.MonkeyPatch):
+def _clear_context_integrity_environment(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     for env_name in (
         "CONTEXT_INTEGRITY_MANIFEST_PATH",
         "CONTEXT_INTEGRITY_HMAC_SECRET",
@@ -140,6 +141,28 @@ def test_missing_env_manifest_degrades_when_approved_entries_not_injected(
     assert [finding.state for finding in findings] == ["degraded_integrity"]
     assert app_state.context_integrity_boot_state.degraded is True
     assert registry.summary(component_prefix="context_integrity")["total"] == 1
+
+
+def test_invalid_context_integrity_mode_is_rejected(tmp_path: Path) -> None:
+    from tldw_Server_API.app.services.startup_context_integrity import (
+        produce_context_integrity_startup_warnings,
+    )
+    from tldw_Server_API.app.services.startup_warning_registry import (
+        StartupWarningRegistry,
+    )
+
+    prompts = tmp_path / "Prompts"
+    prompts.mkdir()
+
+    with pytest.raises(ValueError, match="Unsupported Context Integrity mode"):
+        produce_context_integrity_startup_warnings(
+            app_state=_state(),
+            registry=StartupWarningRegistry(startup_id="boot-invalid-mode"),
+            prompts_dir=prompts,
+            user_skill_roots=[],
+            approved_entries=[],
+            mode="permissive",
+        )
 
 
 def test_env_manifest_happy_path_populates_boot_state(

--- a/tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py
+++ b/tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py
@@ -42,16 +42,21 @@ def temp_env():
 def env_with_skills(temp_env):
     """Provide temp env with 2 skills already created."""
     import asyncio
+
     service = temp_env["service"]
     loop = asyncio.new_event_loop()
-    loop.run_until_complete(service.create_skill(
-        "summarize",
-        "---\ndescription: Summarize text\nargument-hint: \"[text]\"\n---\nSummarize: $ARGUMENTS",
-    ))
-    loop.run_until_complete(service.create_skill(
-        "review",
-        "---\ndescription: Code review\n---\nReview the code:\n$ARGUMENTS",
-    ))
+    loop.run_until_complete(
+        service.create_skill(
+            "summarize",
+            '---\ndescription: Summarize text\nargument-hint: "[text]"\n---\nSummarize: $ARGUMENTS',
+        )
+    )
+    loop.run_until_complete(
+        service.create_skill(
+            "review",
+            "---\ndescription: Code review\n---\nReview the code:\n$ARGUMENTS",
+        )
+    )
     loop.close()
     return temp_env
 
@@ -188,13 +193,68 @@ class TestHandleSkillToolCall:
 
         assert result == {"success": False, "error": "skill_execution_failed"}
 
+    @pytest.mark.asyncio
+    async def test_returns_content_free_integrity_error(self, temp_env):
+        from tldw_Server_API.app.core.Context_Integrity.models import (
+            ContextIntegrityBootState,
+            ContextIntegrityFinding,
+        )
+        from tldw_Server_API.app.core.Context_Integrity.resolver import (
+            ContextIntegrityResolver,
+            clear_global_context_integrity_resolver,
+            set_global_context_integrity_resolver,
+        )
+
+        env = temp_env
+        await env["service"].create_skill(
+            "blocked-skill",
+            "---\ndescription: Blocked\n---\nBody",
+        )
+        resolver = ContextIntegrityResolver(
+            ContextIntegrityBootState(
+                mode="enforce",
+                degraded=False,
+                manifest_sequence=1,
+                manifest_digest="sha256:manifest",
+                findings=(
+                    ContextIntegrityFinding(
+                        asset_id="skill:user:1/blocked-skill",
+                        state="changed_approved_executable",
+                        severity="error",
+                        summary="changed",
+                        remediation="review",
+                        source_type="skill_file",
+                    ),
+                ),
+            )
+        )
+        set_global_context_integrity_resolver(resolver)
+        try:
+            result = await handle_skill_tool_call(
+                skill_name="blocked-skill",
+                args="",
+                user_id=env["user_id"],
+                base_path=env["base_path"],
+                db=env["db"],
+            )
+        finally:
+            clear_global_context_integrity_resolver()
+
+        assert result == {
+            "success": False,
+            "error": "context_integrity_blocked",
+        }
+
 
 class TestAddSkillToolToToolsList:
     def test_adds_when_skills_exist(self, env_with_skills):
         env = env_with_skills
         tools = [{"type": "function", "function": {"name": "Read"}}]
         result = add_skill_tool_to_tools_list(
-            tools, env["user_id"], env["base_path"], db=env["db"],
+            tools,
+            env["user_id"],
+            env["base_path"],
+            db=env["db"],
         )
 
         tool_names = []
@@ -212,7 +272,10 @@ class TestAddSkillToolToToolsList:
         env = temp_env
         tools = [{"type": "function", "function": {"name": "Read"}}]
         result = add_skill_tool_to_tools_list(
-            tools, env["user_id"], env["base_path"], db=env["db"],
+            tools,
+            env["user_id"],
+            env["base_path"],
+            db=env["db"],
         )
 
         # Skill tool should NOT be added since no skills exist

--- a/tldw_Server_API/tests/Skills/integration/test_skills_api.py
+++ b/tldw_Server_API/tests/Skills/integration/test_skills_api.py
@@ -67,6 +67,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
     fastapi_app.dependency_overrides[get_chacha_db_for_user] = override_chacha_db
 
     try:
+        clear_global_context_integrity_resolver()
         with TestClient(fastapi_app) as c:
             clear_global_context_integrity_resolver()
             yield c
@@ -123,6 +124,7 @@ def principal_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterato
     fastapi_app.dependency_overrides[get_chacha_db_for_user] = override_chacha_db
 
     try:
+        clear_global_context_integrity_resolver()
         with TestClient(fastapi_app) as c:
             clear_global_context_integrity_resolver()
             yield c
@@ -151,6 +153,7 @@ def auth_path_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterato
     fastapi_app.dependency_overrides[get_chacha_db_for_user] = override_chacha_db
 
     try:
+        clear_global_context_integrity_resolver()
         with TestClient(fastapi_app) as c:
             clear_global_context_integrity_resolver()
             yield c

--- a/tldw_Server_API/tests/Skills/integration/test_skills_api.py
+++ b/tldw_Server_API/tests/Skills/integration/test_skills_api.py
@@ -20,9 +20,7 @@ from fastapi.testclient import TestClient
 os.environ.setdefault("MINIMAL_TEST_APP", "1")
 os.environ.setdefault("TEST_MODE", "1")
 _routes_disable = {
-    part.strip()
-    for part in str(os.environ.get("ROUTES_DISABLE", "")).split(",")
-    if part and part.strip()
+    part.strip() for part in str(os.environ.get("ROUTES_DISABLE", "")).split(",") if part and part.strip()
 }
 _routes_disable.update({"media", "audio", "audio-websocket"})
 os.environ["ROUTES_DISABLE"] = ",".join(sorted(_routes_disable))
@@ -32,6 +30,7 @@ from tldw_Server_API.app.api.v1.API_Deps import auth_deps
 from tldw_Server_API.app.api.v1.endpoints.skills import MAX_SKILL_IMPORT_PREVIEW_UPLOAD_BYTES
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
+from tldw_Server_API.app.core.Context_Integrity.resolver import clear_global_context_integrity_resolver
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Skills.exceptions import SkillsError
@@ -69,8 +68,10 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
 
     try:
         with TestClient(fastapi_app) as c:
+            clear_global_context_integrity_resolver()
             yield c
     finally:
+        clear_global_context_integrity_resolver()
         fastapi_app.dependency_overrides.clear()
         chacha_db.close_connection()
 
@@ -123,8 +124,10 @@ def principal_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterato
 
     try:
         with TestClient(fastapi_app) as c:
+            clear_global_context_integrity_resolver()
             yield c
     finally:
+        clear_global_context_integrity_resolver()
         fastapi_app.dependency_overrides.clear()
         chacha_db.close_connection()
 
@@ -149,8 +152,10 @@ def auth_path_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterato
 
     try:
         with TestClient(fastapi_app) as c:
+            clear_global_context_integrity_resolver()
             yield c
     finally:
+        clear_global_context_integrity_resolver()
         fastapi_app.dependency_overrides.clear()
         chacha_db.close_connection()
 
@@ -561,7 +566,9 @@ class TestUpdateSkill:
         assert data["supporting_files"]["keep.md"] == "to keep"
 
     def test_update_skill_sanitizes_skills_error(self, client, monkeypatch):
-        async def _boom(self, *, name, content=None, supporting_files=None, expected_version=None):  # noqa: ANN001, ANN202
+        async def _boom(
+            self, *, name, content=None, supporting_files=None, expected_version=None
+        ):  # noqa: ANN001, ANN202
             raise SkillsError("skills backend exploded at /private/update")
 
         monkeypatch.setattr(SkillsService, "update_skill", _boom)
@@ -1006,6 +1013,42 @@ class TestImportExport:
         assert "skills backend exploded" not in joined
         assert "/private/" not in joined
 
+    def test_get_quarantined_skill_returns_423(self, client, monkeypatch):
+        from tldw_Server_API.app.core.Context_Integrity.resolver import (
+            ContextIntegrityBlocked,
+        )
+
+        async def _blocked(self, name, *args, **kwargs):  # noqa: ANN001, ANN202
+            raise ContextIntegrityBlocked(
+                asset_id=f"skill:user:1/{name}",
+                state="changed_approved_executable",
+            )
+
+        monkeypatch.setattr(SkillsService, "get_skill", _blocked)
+
+        r = client.get(f"{SKILLS_PREFIX}/blocked-skill")
+
+        assert r.status_code == 423
+        assert r.json()["detail"] == "Asset is quarantined pending admin review."
+
+    def test_export_quarantined_skill_returns_423(self, client, monkeypatch):
+        from tldw_Server_API.app.core.Context_Integrity.resolver import (
+            ContextIntegrityBlocked,
+        )
+
+        async def _blocked(self, name, *args, **kwargs):  # noqa: ANN001, ANN202
+            raise ContextIntegrityBlocked(
+                asset_id=f"skill:user:1/{name}",
+                state="changed_approved_executable",
+            )
+
+        monkeypatch.setattr(SkillsService, "export_skill", _blocked)
+
+        r = client.get(f"{SKILLS_PREFIX}/blocked-skill/export")
+
+        assert r.status_code == 423
+        assert r.json()["detail"] == "Asset is quarantined pending admin review."
+
 
 class TestExecuteSkill:
     def test_execute_skill_inline(self, client):
@@ -1090,6 +1133,27 @@ class TestExecuteSkill:
         assert "Error executing skill" in joined
         assert "skills backend exploded" not in joined
         assert "/private/" not in joined
+
+    def test_execute_quarantined_skill_returns_423(self, client, monkeypatch):
+        from tldw_Server_API.app.core.Context_Integrity.resolver import (
+            ContextIntegrityBlocked,
+        )
+
+        async def _blocked(self, name, *args, **kwargs):  # noqa: ANN001, ANN202
+            raise ContextIntegrityBlocked(
+                asset_id=f"skill:user:1/{name}",
+                state="changed_approved_executable",
+            )
+
+        monkeypatch.setattr(SkillsService, "get_skill", _blocked)
+
+        r = client.post(
+            f"{SKILLS_PREFIX}/blocked-skill/execute",
+            json={"args": "my test args"},
+        )
+
+        assert r.status_code == 423
+        assert r.json()["detail"] == "Asset is quarantined pending admin review."
 
     def test_execute_skill_request_context_uses_current_principal_alias(
         self,
@@ -1273,11 +1337,7 @@ class TestSkillsEndToEndWorkflow:
             json={
                 "name": skill_name,
                 "content": (
-                    "---\n"
-                    "description: E2E workflow skill\n"
-                    "context: inline\n"
-                    "---\n\n"
-                    "Analyze: $ARGUMENTS"
+                    "---\n" "description: E2E workflow skill\n" "context: inline\n" "---\n\n" "Analyze: $ARGUMENTS"
                 ),
                 "supporting_files": {
                     "guide.md": "workflow guide",

--- a/tldw_Server_API/tests/Skills/unit/test_skills_service.py
+++ b/tldw_Server_API/tests/Skills/unit/test_skills_service.py
@@ -12,6 +12,7 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGD
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import ConflictError
 from tldw_Server_API.app.core.Skills.exceptions import (
     SkillConflictError,
+    SkillsError,
     SkillNotFoundError,
     SkillParseError,
     SkillsError,
@@ -191,16 +192,22 @@ Skill content here.
     async def test_list_skills_filters_hidden(self, service):
         """Test that hidden skills are filtered by default."""
         # Create a visible skill
-        await service.create_skill("visible", """---
+        await service.create_skill(
+            "visible",
+            """---
 user-invocable: true
 ---
-Content""")
+Content""",
+        )
 
         # Create a hidden skill
-        await service.create_skill("hidden", """---
+        await service.create_skill(
+            "hidden",
+            """---
 user-invocable: false
 ---
-Content""")
+Content""",
+        )
 
         # Default should filter hidden
         skills = await service.list_skills()
@@ -750,16 +757,22 @@ Content here.
     @pytest.mark.asyncio
     async def test_get_context_payload_with_skills(self, service):
         """Test context payload with skills."""
-        await service.create_skill("skill-a", """---
+        await service.create_skill(
+            "skill-a",
+            """---
 description: Skill A does things
 argument-hint: "[arg]"
 ---
-Content A""")
+Content A""",
+        )
 
-        await service.create_skill("skill-b", """---
+        await service.create_skill(
+            "skill-b",
+            """---
 description: Skill B does other things
 ---
-Content B""")
+Content B""",
+        )
 
         payload = service.get_context_payload()
 
@@ -801,21 +814,302 @@ Body""",
     @pytest.mark.asyncio
     async def test_get_context_payload_excludes_model_invocation_disabled(self, service):
         """Test that skills with disable_model_invocation are excluded from context."""
-        await service.create_skill("visible", """---
+        await service.create_skill(
+            "visible",
+            """---
 disable-model-invocation: false
 ---
-Content""")
+Content""",
+        )
 
-        await service.create_skill("hidden", """---
+        await service.create_skill(
+            "hidden",
+            """---
 disable-model-invocation: true
 ---
-Content""")
+Content""",
+        )
 
         payload = service.get_context_payload()
 
         names = [s["name"] for s in payload["available_skills"]]
         assert "visible" in names
         assert "hidden" not in names
+
+    @pytest.mark.asyncio
+    async def test_quarantined_skill_is_filtered_from_context(self, service):
+        """Context payload generation must not advertise quarantined skills."""
+        from tldw_Server_API.app.core.Context_Integrity.models import (
+            ContextIntegrityBootState,
+            ContextIntegrityFinding,
+        )
+        from tldw_Server_API.app.core.Context_Integrity.resolver import (
+            ContextIntegrityResolver,
+        )
+
+        await service.create_skill(
+            "blocked-skill",
+            """---
+description: Blocked
+---
+Body""",
+        )
+        service.integrity_resolver = ContextIntegrityResolver(
+            ContextIntegrityBootState(
+                mode="enforce",
+                degraded=False,
+                manifest_sequence=1,
+                manifest_digest="sha256:manifest",
+                findings=(
+                    ContextIntegrityFinding(
+                        asset_id="skill:user:1/blocked-skill",
+                        state="changed_approved_executable",
+                        severity="error",
+                        summary="changed",
+                        remediation="review",
+                        source_type="skill_file",
+                    ),
+                ),
+            )
+        )
+
+        payload = service.get_context_payload()
+
+        assert payload["available_skills"] == []
+        assert "blocked-skill" not in payload["context_text"]
+
+    @pytest.mark.asyncio
+    async def test_quarantined_skill_get_is_blocked(self, service):
+        """Direct skill reads must fail closed for quarantined assets."""
+        from tldw_Server_API.app.core.Context_Integrity.models import (
+            ContextIntegrityBootState,
+            ContextIntegrityFinding,
+        )
+        from tldw_Server_API.app.core.Context_Integrity.resolver import (
+            ContextIntegrityBlocked,
+            ContextIntegrityResolver,
+        )
+
+        await service.create_skill(
+            "blocked-skill",
+            """---
+description: Blocked
+---
+Body""",
+        )
+        service.integrity_resolver = ContextIntegrityResolver(
+            ContextIntegrityBootState(
+                mode="enforce",
+                degraded=False,
+                manifest_sequence=1,
+                manifest_digest="sha256:manifest",
+                findings=(
+                    ContextIntegrityFinding(
+                        asset_id="skill:user:1/blocked-skill",
+                        state="changed_approved_executable",
+                        severity="error",
+                        summary="changed",
+                        remediation="review",
+                        source_type="skill_file",
+                    ),
+                ),
+            )
+        )
+
+        with pytest.raises(ContextIntegrityBlocked):
+            await service.get_skill("blocked-skill")
+
+    @pytest.mark.asyncio
+    async def test_live_skill_edit_after_boot_is_blocked(self, service):
+        """A skill edited after boot must not be read under an old approval digest."""
+        from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+            canonical_filesystem_digest,
+        )
+        from tldw_Server_API.app.core.Context_Integrity.models import (
+            ContextIntegrityBootState,
+        )
+        from tldw_Server_API.app.core.Context_Integrity.resolver import (
+            ContextIntegrityBlocked,
+            ContextIntegrityResolver,
+        )
+
+        initial_content = """---
+description: Live
+---
+Approved body"""
+        await service.create_skill("live-skill", initial_content)
+        asset_id = "skill:user:1/live-skill"
+        approved_digest = canonical_filesystem_digest(
+            source_type="skill_file",
+            asset_id=asset_id,
+            files={"SKILL.md": initial_content.encode("utf-8")},
+            metadata={"skill_name": "live-skill"},
+        )
+        service.integrity_resolver = ContextIntegrityResolver(
+            ContextIntegrityBootState(
+                mode="enforce",
+                degraded=False,
+                manifest_sequence=1,
+                manifest_digest="sha256:manifest",
+                approved_digests_by_asset_id={asset_id: approved_digest},
+            )
+        )
+        (service.skills_dir / "live-skill" / "SKILL.md").write_text(
+            "---\ndescription: Live\n---\nModified body",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ContextIntegrityBlocked):
+            await service.get_skill("live-skill")
+
+    @pytest.mark.asyncio
+    async def test_live_skill_edit_after_boot_is_filtered_from_context(self, service):
+        """Context payload must omit a skill whose live digest no longer matches approval."""
+        from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+            canonical_filesystem_digest,
+        )
+        from tldw_Server_API.app.core.Context_Integrity.models import (
+            ContextIntegrityBootState,
+        )
+        from tldw_Server_API.app.core.Context_Integrity.resolver import (
+            ContextIntegrityResolver,
+        )
+
+        initial_content = """---
+description: Live
+---
+Approved body"""
+        await service.create_skill("live-skill", initial_content)
+        asset_id = "skill:user:1/live-skill"
+        approved_digest = canonical_filesystem_digest(
+            source_type="skill_file",
+            asset_id=asset_id,
+            files={"SKILL.md": initial_content.encode("utf-8")},
+            metadata={"skill_name": "live-skill"},
+        )
+        service.integrity_resolver = ContextIntegrityResolver(
+            ContextIntegrityBootState(
+                mode="enforce",
+                degraded=False,
+                manifest_sequence=1,
+                manifest_digest="sha256:manifest",
+                approved_digests_by_asset_id={asset_id: approved_digest},
+            )
+        )
+        (service.skills_dir / "live-skill" / "SKILL.md").write_text(
+            "---\ndescription: Live\n---\nModified body",
+            encoding="utf-8",
+        )
+
+        payload = service.get_context_payload()
+
+        assert payload["available_skills"] == []
+        assert "live-skill" not in payload["context_text"]
+
+    @pytest.mark.asyncio
+    async def test_create_skill_returns_write_response_under_enforce(self, service):
+        """Write APIs can return the newly written skill without approving it for reads."""
+        from tldw_Server_API.app.core.Context_Integrity.models import (
+            ContextIntegrityBootState,
+        )
+        from tldw_Server_API.app.core.Context_Integrity.resolver import (
+            ContextIntegrityBlocked,
+            ContextIntegrityResolver,
+        )
+
+        service.integrity_resolver = ContextIntegrityResolver(
+            ContextIntegrityBootState(
+                mode="enforce",
+                degraded=False,
+                manifest_sequence=1,
+                manifest_digest="sha256:manifest",
+                approved_digests_by_asset_id={},
+            )
+        )
+
+        created = await service.create_skill("pending-skill", "---\ndescription: Pending\n---\nBody")
+
+        assert created["name"] == "pending-skill"
+        assert created["description"] == "Pending"
+        with pytest.raises(ContextIntegrityBlocked):
+            await service.get_skill("pending-skill")
+
+    @pytest.mark.asyncio
+    async def test_degraded_global_resolver_blocks_default_service(
+        self,
+        temp_base_path,
+    ):
+        """Degraded boot state from the global resolver must fail closed by default."""
+        from tldw_Server_API.app.core.Context_Integrity.models import (
+            ContextIntegrityBootState,
+            ContextIntegrityFinding,
+        )
+        from tldw_Server_API.app.core.Context_Integrity.resolver import (
+            ContextIntegrityBlocked,
+            ContextIntegrityResolver,
+            clear_global_context_integrity_resolver,
+            set_global_context_integrity_resolver,
+        )
+
+        chacha_db = CharactersRAGDB(
+            db_path=temp_base_path / "ChaChaNotes.db",
+            client_id="test_client",
+        )
+        set_global_context_integrity_resolver(
+            ContextIntegrityResolver(
+                ContextIntegrityBootState(
+                    mode="enforce",
+                    degraded=True,
+                    manifest_sequence=None,
+                    manifest_digest=None,
+                    findings=(
+                        ContextIntegrityFinding(
+                            asset_id="manifest:env",
+                            state="signature_invalid",
+                            severity="error",
+                            summary="bad signature",
+                            remediation="fix manifest",
+                            source_type="manifest",
+                        ),
+                    ),
+                )
+            )
+        )
+        try:
+            service = SkillsService(user_id=1, base_path=temp_base_path, db=chacha_db)
+            created = await service.create_skill(
+                "degraded-global",
+                "---\ndescription: Degraded global\n---\nBody",
+            )
+            with pytest.raises(ContextIntegrityBlocked):
+                await service.get_skill("degraded-global")
+        finally:
+            clear_global_context_integrity_resolver()
+            chacha_db.close_connection()
+
+        assert created["name"] == "degraded-global"
+
+    @pytest.mark.asyncio
+    async def test_symlinked_skill_directory_is_not_read_without_resolver(
+        self,
+        service,
+        temp_base_path,
+    ):
+        """Runtime skill reads must not follow a symlinked skill directory."""
+        outside_skill = temp_base_path / "outside-skill"
+        outside_skill.mkdir()
+        (outside_skill / "SKILL.md").write_text(
+            "---\ndescription: Outside\n---\nOutside body",
+            encoding="utf-8",
+        )
+        skill_link = service.skills_dir / "linked-skill"
+        try:
+            skill_link.symlink_to(outside_skill, target_is_directory=True)
+        except (NotImplementedError, OSError):
+            pytest.skip("symlink creation is unavailable on this platform")
+
+        with pytest.raises(SkillsError):
+            await service.get_skill("linked-skill")
 
     @pytest.mark.asyncio
     async def test_get_total_count(self, service):
@@ -833,11 +1127,13 @@ Content""")
         # Create a skill directly on disk (bypassing service)
         skills_dir = temp_base_path / "skills" / "manual-skill"
         skills_dir.mkdir(parents=True)
-        (skills_dir / "SKILL.md").write_text("""---
+        (skills_dir / "SKILL.md").write_text(
+            """---
 name: manual-skill
 description: Manually created
 ---
-Content""")
+Content"""
+        )
 
         # List should discover it
         skills = await service.list_skills()
@@ -861,6 +1157,7 @@ Content""")
                 original_sync(self_inner, force=force)
 
             import types
+
             service._sync_registry = types.MethodType(counting_sync, service)
 
             # First call triggers sync

--- a/tldw_Server_API/tests/Skills/unit/test_skills_service.py
+++ b/tldw_Server_API/tests/Skills/unit/test_skills_service.py
@@ -1007,6 +1007,44 @@ Approved body"""
         assert "live-skill" not in payload["context_text"]
 
     @pytest.mark.asyncio
+    async def test_list_skills_filters_integrity_before_pagination(self, service):
+        """Integrity filtering must happen before list pagination is applied."""
+        from tldw_Server_API.app.core.Context_Integrity.canonicalization import (
+            canonical_filesystem_digest,
+        )
+        from tldw_Server_API.app.core.Context_Integrity.models import (
+            ContextIntegrityBootState,
+        )
+        from tldw_Server_API.app.core.Context_Integrity.resolver import (
+            ContextIntegrityResolver,
+        )
+
+        await service.create_skill("aaa-blocked", "---\ndescription: Blocked\n---\nBlocked")
+        allowed_content = "---\ndescription: Allowed\n---\nAllowed"
+        await service.create_skill("zzz-allowed", allowed_content)
+        allowed_asset_id = "skill:user:1/zzz-allowed"
+        allowed_digest = canonical_filesystem_digest(
+            source_type="skill_file",
+            asset_id=allowed_asset_id,
+            files={"SKILL.md": allowed_content.encode("utf-8")},
+            metadata={"skill_name": "zzz-allowed"},
+        )
+        service.integrity_resolver = ContextIntegrityResolver(
+            ContextIntegrityBootState(
+                mode="enforce",
+                degraded=False,
+                manifest_sequence=1,
+                manifest_digest="sha256:manifest",
+                approved_digests_by_asset_id={allowed_asset_id: allowed_digest},
+            )
+        )
+
+        skills = await service.list_skills(limit=1, offset=0)
+
+        assert [skill.name for skill in skills] == ["zzz-allowed"]
+        assert await service.get_total_count() == 1
+
+    @pytest.mark.asyncio
     async def test_create_skill_returns_write_response_under_enforce(self, service):
         """Write APIs can return the newly written skill without approving it for reads."""
         from tldw_Server_API.app.core.Context_Integrity.models import (
@@ -1110,6 +1148,26 @@ Approved body"""
 
         with pytest.raises(SkillsError):
             await service.get_skill("linked-skill")
+
+    @pytest.mark.asyncio
+    async def test_sync_registry_skips_symlinked_skill_md(self, service, temp_base_path):
+        """Sync must not index a skill whose SKILL.md is a symlink."""
+        outside_skill_file = temp_base_path / "outside-SKILL.md"
+        outside_skill_file.write_text(
+            "---\ndescription: Outside\n---\nOutside body",
+            encoding="utf-8",
+        )
+        skill_dir = service.skills_dir / "symlinked-file"
+        skill_dir.mkdir()
+        try:
+            (skill_dir / "SKILL.md").symlink_to(outside_skill_file)
+        except (NotImplementedError, OSError):
+            pytest.skip("symlink creation is unavailable on this platform")
+
+        skills = await service.list_skills(include_hidden=True)
+
+        assert [skill.name for skill in skills] == []
+        assert await service.get_total_count(include_hidden=True) == 0
 
     @pytest.mark.asyncio
     async def test_get_total_count(self, service):

--- a/tldw_Server_API/tests/Utils/test_prompt_loader_env_overrides.py
+++ b/tldw_Server_API/tests/Utils/test_prompt_loader_env_overrides.py
@@ -37,3 +37,39 @@ def test_load_env_prompt_file_logs_warning_on_oserror(monkeypatch):
     assert warning_call[1] == env_name
     assert warning_call[2] == "demo"
     assert warning_call[3] == "existing key"
+
+
+def test_env_prompt_override_uses_integrity_source_label(tmp_path, monkeypatch):
+    env_name = "TLDW_PROMPT_FILE_DEMO__EXISTING_KEY"
+    override_file = tmp_path / "override.txt"
+    override_file.write_text("approved-env-file", encoding="utf-8")
+    monkeypatch.setenv(env_name, str(override_file))
+
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_env_prompt_overrides,
+    )
+    from tldw_Server_API.app.core.Context_Integrity.models import ContextIntegrityBootState
+    from tldw_Server_API.app.core.Context_Integrity.resolver import (
+        ContextIntegrityResolver,
+        clear_global_context_integrity_resolver,
+        set_global_context_integrity_resolver,
+    )
+    from tldw_Server_API.app.core.Utils import prompt_loader as pl
+
+    asset = inventory_env_prompt_overrides(environ={env_name: str(override_file)})[0]
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="enforce",
+            degraded=False,
+            manifest_sequence=1,
+            manifest_digest="sha256:manifest",
+            approved_digests_by_asset_id={asset.asset_id: asset.digest},
+        )
+    )
+    set_global_context_integrity_resolver(resolver)
+    try:
+        assert pl.load_prompt("demo", "Existing Key") == "approved-env-file"
+        override_file.write_text("modified-env-file", encoding="utf-8")
+        assert pl.load_prompt("demo", "Existing Key") is None
+    finally:
+        clear_global_context_integrity_resolver()

--- a/tldw_Server_API/tests/Utils/test_prompt_loader_paths.py
+++ b/tldw_Server_API/tests/Utils/test_prompt_loader_paths.py
@@ -22,6 +22,7 @@ def test_prompts_dir_respects_env_override(tmp_path, monkeypatch):
     monkeypatch.setenv("TLDW_CONFIG_DIR", str(cfg_dir))
     try:
         from tldw_Server_API.app.core.Utils import prompt_loader as pl
+
         p = Path(pl._prompts_dir()).resolve()
         assert p == prompts.resolve(), f"Env override not respected: {p} vs {prompts}"
     finally:
@@ -62,3 +63,107 @@ def test_load_prompt_markdown_missing_key_returns_none(tmp_path, monkeypatch):
         assert value is None
     finally:
         monkeypatch.delenv("TLDW_CONFIG_DIR", raising=False)
+
+
+def test_load_prompt_blocks_quarantined_prompt_file(tmp_path, monkeypatch):
+    from tldw_Server_API.app.core.Context_Integrity.models import (
+        ContextIntegrityBootState,
+        ContextIntegrityFinding,
+    )
+    from tldw_Server_API.app.core.Context_Integrity.resolver import (
+        ContextIntegrityResolver,
+        clear_global_context_integrity_resolver,
+        set_global_context_integrity_resolver,
+    )
+    from tldw_Server_API.app.core.Utils import prompt_loader as pl
+
+    cfg_dir = tmp_path / "cfg"
+    prompts = cfg_dir / "Prompts"
+    prompts.mkdir(parents=True)
+    (prompts / "demo.prompts.md").write_text(
+        "# Existing Key\n```\nfrom-md\n```\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TLDW_CONFIG_DIR", str(cfg_dir))
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="enforce",
+            degraded=False,
+            manifest_sequence=1,
+            manifest_digest="sha256:manifest",
+            findings=(
+                ContextIntegrityFinding(
+                    asset_id="prompt_file:demo.prompts.md",
+                    state="changed_approved_non_executable",
+                    severity="warning",
+                    summary="changed",
+                    remediation="review",
+                    source_type="prompt_file",
+                ),
+            ),
+        )
+    )
+    set_global_context_integrity_resolver(resolver)
+    try:
+        assert pl.load_prompt("demo", "Existing Key") is None
+    finally:
+        clear_global_context_integrity_resolver()
+
+
+def test_load_prompt_uses_verified_bytes_without_second_read(tmp_path, monkeypatch):
+    from tldw_Server_API.app.core.Utils import prompt_loader as pl
+
+    cfg_dir = tmp_path / "cfg"
+    prompts = cfg_dir / "Prompts"
+    prompts.mkdir(parents=True)
+    prompt_file = prompts / "demo.prompts.md"
+    prompt_file.write_text("# Existing Key\n```\nfrom-md\n```\n", encoding="utf-8")
+    monkeypatch.setenv("TLDW_CONFIG_DIR", str(cfg_dir))
+
+    read_count = {"count": 0}
+    original_read_text = pl._read_prompt_file_text
+
+    def _counting_read(path, *args, **kwargs):
+        read_count["count"] += 1
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(pl, "_read_prompt_file_text", _counting_read)
+
+    assert pl.load_prompt("demo", "Existing Key") == "from-md"
+    assert read_count["count"] == 1
+
+
+def test_load_prompt_blocks_live_edit_after_boot(tmp_path, monkeypatch):
+    from tldw_Server_API.app.core.Context_Integrity.inventory import (
+        inventory_prompt_files,
+    )
+    from tldw_Server_API.app.core.Context_Integrity.models import ContextIntegrityBootState
+    from tldw_Server_API.app.core.Context_Integrity.resolver import (
+        ContextIntegrityResolver,
+        clear_global_context_integrity_resolver,
+        set_global_context_integrity_resolver,
+    )
+    from tldw_Server_API.app.core.Utils import prompt_loader as pl
+
+    cfg_dir = tmp_path / "cfg"
+    prompts = cfg_dir / "Prompts"
+    prompts.mkdir(parents=True)
+    prompt_file = prompts / "demo.prompts.md"
+    prompt_file.write_text("# Existing Key\n```\nfrom-md\n```\n", encoding="utf-8")
+    monkeypatch.setenv("TLDW_CONFIG_DIR", str(cfg_dir))
+    asset = inventory_prompt_files(prompts_dir=prompts)[0]
+    resolver = ContextIntegrityResolver(
+        ContextIntegrityBootState(
+            mode="enforce",
+            degraded=False,
+            manifest_sequence=1,
+            manifest_digest="sha256:manifest",
+            approved_digests_by_asset_id={asset.asset_id: asset.digest},
+        )
+    )
+    prompt_file.write_text("# Existing Key\n```\nmodified\n```\n", encoding="utf-8")
+    set_global_context_integrity_resolver(resolver)
+    try:
+        assert pl.load_prompt("demo", "Existing Key") is None
+    finally:
+        clear_global_context_integrity_resolver()

--- a/tldw_Server_API/tests/unit/test_mcp_unified_error_mapping.py
+++ b/tldw_Server_API/tests/unit/test_mcp_unified_error_mapping.py
@@ -303,12 +303,24 @@ async def test_batch_request_sanitizes_safe_config_parse_log(monkeypatch: pytest
 @pytest.mark.asyncio
 async def test_refresh_token_sanitizes_rotation_failure_log(monkeypatch: pytest.MonkeyPatch) -> None:
     logger = _LoggerStub()
+    auth_request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/v1/mcp/auth/refresh",
+            "headers": [],
+            "client": ("127.0.0.1", 12345),
+        }
+    )
+    monkeypatch.setenv("MCP_ENABLE_DEMO_AUTH", "1")
+    monkeypatch.setenv("MCP_DEMO_AUTH_SECRET", "supersecretvalue12345")
     monkeypatch.setattr(mcp, "logger", logger)
     monkeypatch.setattr(mcp, "get_jwt_manager", lambda: _FailingJwtManager())
 
     with pytest.raises(HTTPException) as excinfo:
         await mcp.refresh_token(
             auth_request=mcp.AuthRefreshRequest(refresh_token="refresh-token", token_id="token-id"),
+            request=auth_request,
             _guard=None,
         )
 


### PR DESCRIPTION
## Summary
- Adds startup Context Integrity boot verification, manifest loading, resolver wiring, and lifecycle cleanup for skill and prompt assets.
- Enforces integrity at skill runtime chokepoints and prompt-loader reads, including live-edit, quarantine, symlink, and unapproved-file fail-closed behavior.
- Adds admin inspection for current-process context integrity state and records Backlog/plan verification evidence.

## Change summary
Human requester must complete this section before merge per the AI-generated PR policy. Explain what changed and why these implementation choices were made.

## Rebase note
- Rebased onto latest `origin/dev`; PR base updated to `dev`.

## Test Plan
- [x] `git diff --check origin/dev...HEAD`
- [x] `.venv/bin/python -m pytest tldw_Server_API/tests/Context_Integrity/unit -q` (`116 passed, 3 warnings`)
- [x] `.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_context_integrity.py tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/AuthNZ_SQLite/test_admin_context_integrity_sqlite.py tldw_Server_API/tests/Skills/unit/test_skills_service.py tldw_Server_API/tests/Skills/integration/test_skills_api.py tldw_Server_API/tests/Skills/integration/test_skill_mcp_integration.py tldw_Server_API/tests/Chat_NEW/unit/test_command_router.py tldw_Server_API/tests/Utils/test_prompt_loader_paths.py tldw_Server_API/tests/Utils/test_prompt_loader_env_overrides.py -q` (`192 passed, 6 warnings`)
- [x] `.venv/bin/python -m bandit -r tldw_Server_API/app/core/Context_Integrity tldw_Server_API/app/services/startup_context_integrity.py tldw_Server_API/app/services/lifespan_startup_sequence.py tldw_Server_API/app/services/lifespan_shutdown_sequence.py tldw_Server_API/app/core/Skills/skills_service.py tldw_Server_API/app/core/Skills/context_integration.py tldw_Server_API/app/core/Chat/command_router.py tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/core/Utils/prompt_loader.py tldw_Server_API/app/api/v1/endpoints/admin/context_integrity.py tldw_Server_API/app/api/v1/schemas/admin_schemas.py -f json -o /tmp/bandit_context_integrity_foundation_dev_rebase.json` (zero findings)