### PR TITLE
Fix Parakeet ONNX graph bundle loading

### DIFF
--- a/Docs/superpowers/plans/2026-06-25-parakeet-onnx-transcription-runtime.md
+++ b/Docs/superpowers/plans/2026-06-25-parakeet-onnx-transcription-runtime.md
@@ -1,0 +1,60 @@
+## Stage 1: Reproduce And Trace
+**Goal**: Prove the Parakeet ONNX transcription error comes from loading the wrong ONNX graph and feeding it the wrong inputs.
+**Success Criteria**: Direct execution shows the current loader picks `decoder_joint-model.onnx` and raises the missing `encoder_outputs` / decoder-state input error.
+**Tests**: Direct local ONNX Runtime probe against the cached Parakeet ONNX export.
+**Status**: Complete
+
+## Stage 2: Red Tests
+**Goal**: Capture the broken contract in focused automated tests.
+**Success Criteria**: Tests fail on current code because multi-graph Parakeet exports are not loaded or dispatched as a bundle.
+**Tests**: Unit tests for sidecar download patterns, multi-graph loader selection, and transcription dispatch to a multi-graph runner.
+**Status**: Complete
+
+## Stage 3: Multi-Graph Runner
+**Goal**: Replace first-file ONNX loading for Parakeet TDT exports with a real preprocessor + encoder + decoder/joint runner.
+**Success Criteria**: Loader detects the `nemo128.onnx`, `encoder-model*.onnx`, `decoder_joint-model*.onnx`, and `vocab.txt` layout; transcription no longer sends waveform data to decoder `targets`.
+**Tests**: Red tests from Stage 2 pass; existing Parakeet ONNX tests remain green.
+**Status**: Complete
+
+## Stage 4: Verification
+**Goal**: Verify the fix with automated tests and a no-mock local ONNX Runtime smoke.
+**Success Criteria**: Targeted tests pass, `git diff --check` passes, Bandit has no new findings, and a direct cached-graph smoke returns a normal transcript string or `[No speech detected]` instead of a runtime input-feed error.
+**Tests**: Pytest, Bandit, direct ONNX Runtime smoke.
+**Status**: Complete
+
+Verification recorded:
+- `python -m pytest tldw_Server_API/tests/Media_Ingestion_Modification/test_parakeet_onnx.py -q`
+- `python -m pytest tldw_Server_API/tests/Audio/test_parakeet_onnx_failfast.py tldw_Server_API/tests/Audio/test_transcription_model_parsing.py tldw_Server_API/tests/Audio/test_model_variant_normalization.py -q`
+- `git diff --check`
+- `python -m bandit -r tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Parakeet_ONNX.py -f json -o /tmp/bandit_parakeet_onnx_runtime.json`
+- No-mock upstream smoke against local cached Parakeet graphs loaded through `onnx-asr`; silence returned `[No speech detected]`, and an artificial sine tone returned `Oh.` without the decoder missing-input error.
+- `python -m pip check` still reports the existing local venv conflict: `typer-slim 0.24.0` requires `typer>=0.24.0`, but the venv has `typer 0.16.1`.
+- `python -m bandit -r tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Parakeet_ONNX.py -f json -o /tmp/bandit_parakeet_onnx_runtime.json`
+- No-mock ONNX Runtime smoke against local cached Parakeet graphs using silence and sine inputs; both returned `[No speech detected]` without the decoder missing-input error.
+
+## Stage 5: Upstream Runtime Adapter
+**Goal**: Replace the local greedy TDT decoder with the upstream `onnx-asr` implementation for Parakeet TDT graph bundles.
+**Success Criteria**: Bundle detection routes to an `onnx_asr.load_model("nemo-conformer-tdt", path=...)` adapter; missing `onnx-asr` fails with a clear dependency error; generic single-session ONNX fallback remains available only for non-bundle exports.
+**Tests**: Red tests for upstream adapter selection, adapter transcription, and missing-dependency failure.
+**Status**: Complete
+
+Verification recorded:
+- `python -m pytest tldw_Server_API/tests/Media_Ingestion_Modification/test_parakeet_onnx.py -q`
+- `python -m pytest tldw_Server_API/tests/Audio/test_parakeet_onnx_failfast.py tldw_Server_API/tests/Audio/test_transcription_model_parsing.py tldw_Server_API/tests/Audio/test_model_variant_normalization.py -q`
+- `git diff --check`
+- `python -m bandit -r tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Parakeet_ONNX.py -f json -o /tmp/bandit_parakeet_onnx_runtime.json`
+- Installed `onnx-asr[hub]` 0.11.0 into the venv and ran a no-mock upstream smoke against local cached Parakeet graphs; silence and sine returned `[No speech detected]`.
+- `python -m pip check` reports an existing local venv conflict: `typer-slim 0.24.0` requires `typer>=0.24.0`, but the venv has `typer 0.16.1`.
+
+## Stage 6: PR Review Rebase
+**Goal**: Rebase PR #2524 onto current `dev` and address active review findings without reintroducing local TDT decoding.
+**Success Criteria**: Existing local Parakeet artifact directories are never treated as Hugging Face repo ids, missing bundle `vocab.txt` fails closed with a clear log, upstream bundle chunking respects `merge_algo="middle"`, and new tests have explicit type hints.
+**Tests**: Red/green pytest coverage for local-path download prevention and upstream bundle middle merging; focused Parakeet and adjacent audio tests.
+**Status**: Complete
+
+Verification recorded:
+- `git rebase --autostash origin/dev`
+- `python -m pytest tldw_Server_API/tests/Media_Ingestion_Modification/test_parakeet_onnx.py -q -k "local_parakeet_bundle_missing_vocab or upstream_bundle_chunking_respects_middle_merge"` failed before the fix and passed after it.
+- `python -m pytest tldw_Server_API/tests/Media_Ingestion_Modification/test_parakeet_onnx.py -q`
+- `python -m pytest tldw_Server_API/tests/Audio/test_parakeet_onnx_failfast.py tldw_Server_API/tests/Audio/test_transcription_model_parsing.py tldw_Server_API/tests/Audio/test_model_variant_normalization.py -q`
+- `git diff --check`

--- a/backlog/tasks/task-12014 - Fix-Parakeet-ONNX-transcription-runtime-selection.md
+++ b/backlog/tasks/task-12014 - Fix-Parakeet-ONNX-transcription-runtime-selection.md
@@ -1,0 +1,51 @@
+---
+id: TASK-12014
+title: Fix Parakeet ONNX transcription runtime selection
+status: Done
+labels:
+- audio
+- transcription
+- onnx
+- parakeet
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Investigate and fix the Parakeet ONNX transcription failure where the runtime loads the wrong ONNX graph from a multi-graph RNNT export and raises missing input feed errors such as required inputs ['encoder_outputs', 'input_states_1', 'input_states_2'] missing from ['targets', 'target_length'].
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] Loader downloads Parakeet ONNX sidecars needed for runtime and decoding, including external data files and vocab/config metadata.
+- [x] Multi-graph Parakeet TDT exports load through upstream `onnx-asr` instead of selecting the first `.onnx` file.
+- [x] Transcription dispatches multi-graph bundles through the upstream adapter and does not feed waveform/features into decoder-only inputs such as `targets`.
+- [x] Existing single-session ONNX fallback remains available for non-bundle exports.
+- [x] Verification includes automated tests, Bandit, and a no-mock local ONNX Runtime smoke.
+- [x] Multi-graph Parakeet TDT decoding uses upstream `onnx-asr` instead of a locally maintained greedy TDT decoder.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Rebased PR #2524 onto latest dev and addressed active review comments. Existing local Parakeet artifact directories no longer trigger Hugging Face downloads, missing TDT bundle vocab fails closed with a clear log, upstream bundle chunking now honors middle overlap trimming, and new review tests have explicit type hints.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+- Fixed the Parakeet ONNX transcription runtime selection issue by treating official Parakeet TDT exports as upstream `onnx-asr` model bundles instead of arbitrary single ONNX sessions.
+- Removed the locally maintained greedy TDT decoder path; graph bundles now use `onnx_asr.load_model("nemo-conformer-tdt", path=..., quantization=...)` behind a small project adapter.
+- Rebased PR #2524 onto current `dev` and addressed active review comments: existing local artifact directories are not passed as Hugging Face repo ids, missing bundle `vocab.txt` fails closed with a clear log, upstream bundle chunking honors `merge_algo="middle"`, and new tests have explicit type hints.
+- Verified with focused pytest coverage, Bandit, `git diff --check`, and a no-mock upstream smoke against local cached Parakeet graphs. `pip check` still reports an unrelated local venv conflict between `typer-slim 0.24.0` and `typer 0.16.1`.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ dependencies = [
 
   # LLM/ML Integration
   "flashrank>=0.2.0",
+  "onnx-asr[hub]>=0.11.0",
   "onnxruntime>=1.14.0",
   "openai>=1.0.0",
   "optimum>=1.13.0",

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Parakeet_ONNX.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Parakeet_ONNX.py
@@ -40,6 +40,15 @@ except ImportError:
 
 # Global cache for model and tokenizer
 _onnx_model_cache: dict[str, Any] = {}
+_PARAKEET_ONNX_ALLOW_PATTERNS = [
+    "*.onnx",
+    "**/*.onnx",
+    "*.onnx.data",
+    "**/*.onnx.data",
+    "vocab.txt",
+    "config.json",
+]
+_PARAKEET_ONNX_SILENCE_ABS_THRESHOLD = 1e-6
 
 logger = logger
 
@@ -178,7 +187,10 @@ class ParakeetONNXTokenizer:
             if token_id in self.inv_vocab:
                 token = self.inv_vocab[token_id]
                 # Skip special tokens
-                if token not in ['<pad>', '<s>', '</s>', '<blank>', '<unk>']:
+                if (
+                    token not in ['<pad>', '<s>', '</s>', '<blank>', '<blk>', '<unk>']
+                    and not token.startswith("<|")
+                ):
                     tokens.append(token)
 
         # Join tokens and clean up
@@ -188,6 +200,30 @@ class ParakeetONNXTokenizer:
         # Clean up multiple spaces
         text = ' '.join(text.split())
         return text.strip()
+
+
+class ParakeetOnnxAsrRuntime:
+    """Thin adapter around upstream onnx-asr for Parakeet TDT exports."""
+
+    def __init__(self, upstream_model: Any) -> None:
+        self.upstream_model = upstream_model
+
+    def transcribe(self, audio_data: np.ndarray, sample_rate: int = 16000) -> str:
+        """Transcribe with upstream onnx-asr instead of local TDT decoding."""
+        waveform = np.asarray(audio_data, dtype=np.float32)
+        if waveform.size == 0:
+            return "[No speech detected]"
+        if float(np.max(np.abs(waveform))) <= _PARAKEET_ONNX_SILENCE_ABS_THRESHOLD:
+            return "[No speech detected]"
+        text = self.upstream_model.recognize(
+            waveform,
+            sample_rate=int(sample_rate),
+            channel="mean",
+        )
+        if isinstance(text, list):
+            text = " ".join(str(part).strip() for part in text if str(part).strip())
+        result = str(text).strip()
+        return result if result else "[No speech detected]"
 
 
 def get_mel_features(audio: np.ndarray, sample_rate: int = 16000) -> np.ndarray:
@@ -312,6 +348,13 @@ def _is_raw_waveform_input(input_meta: Any) -> bool:
     rank = _onnx_input_rank(input_meta)
     if _is_length_input_name(name):
         return False
+    if (
+        lname in {"targets", "target"}
+        or lname.startswith("input_state")
+        or lname.startswith("output_state")
+        or "encoder_output" in lname
+    ):
+        return False
     if "feature" in lname or "mel" in lname or "encoder" in lname or "processed_signal" in lname:
         return False
     if "waveform" in lname or "audio_signal" in lname or "raw_audio" in lname or lname in {"audio", "samples"}:
@@ -324,6 +367,8 @@ def _is_feature_input(input_meta: Any) -> bool:
     lname = name.lower()
     rank = _onnx_input_rank(input_meta)
     if _is_length_input_name(name):
+        return False
+    if lname in {"targets", "target"} or lname.startswith("input_state") or lname.startswith("output_state"):
         return False
     return (
         "feature" in lname
@@ -419,6 +464,87 @@ def _prepare_onnx_inputs(
     return prepared
 
 
+def _existing_path(path: Path) -> Path | None:
+    """Return a path only when it exists."""
+    return path if path.exists() else None
+
+
+def _select_graph_path(model_dir: Path, candidates: list[str]) -> Path | None:
+    """Pick the first available ONNX graph from an ordered candidate list."""
+    for candidate in candidates:
+        path = _existing_path(model_dir / candidate)
+        if path is not None:
+            return path
+    return None
+
+
+def _resolve_parakeet_tdt_bundle_paths(model_dir: Path) -> dict[str, Path] | None:
+    """Resolve the multi-graph Parakeet TDT ONNX export layout when present."""
+    preprocessor_path = _select_graph_path(model_dir, ["nemo128.onnx", "nemo80.onnx"])
+    encoder_path = _select_graph_path(model_dir, ["encoder-model.int8.onnx", "encoder-model.onnx"])
+    decoder_joint_path = _select_graph_path(
+        model_dir,
+        ["decoder_joint-model.int8.onnx", "decoder_joint-model.onnx"],
+    )
+    vocab_path = _existing_path(model_dir / "vocab.txt")
+
+    if preprocessor_path and encoder_path and decoder_joint_path and vocab_path:
+        return {
+            "preprocessor": preprocessor_path,
+            "encoder": encoder_path,
+            "decoder_joint": decoder_joint_path,
+            "vocab": vocab_path,
+        }
+    if preprocessor_path and encoder_path and decoder_joint_path:
+        logger.error(
+            "Parakeet ONNX multi-graph export found in {} but vocab.txt is missing; "
+            "cannot decode tokens safely.",
+            model_dir,
+        )
+    return None
+
+
+def _resolve_parakeet_tdt_quantization(model_dir: Path) -> str | None:
+    """Return the preferred onnx-asr quantization suffix for available graph files."""
+    if (
+        (model_dir / "encoder-model.int8.onnx").exists()
+        and (model_dir / "decoder_joint-model.int8.onnx").exists()
+    ):
+        return "int8"
+    return None
+
+
+def _resolve_onnx_asr_load_model() -> Callable[..., Any] | None:
+    """Resolve upstream onnx-asr load_model when installed."""
+    try:
+        import importlib
+
+        onnx_asr = importlib.import_module("onnx_asr")
+    except (ImportError, ModuleNotFoundError, RuntimeError):
+        return None
+    load_model = getattr(onnx_asr, "load_model", None)
+    return load_model if callable(load_model) else None
+
+
+def _has_parakeet_tdt_graphs(model_dir: Path) -> bool:
+    """Return True when a directory has the Parakeet TDT multi-graph ONNX files."""
+    return bool(
+        _select_graph_path(model_dir, ["nemo128.onnx", "nemo80.onnx"])
+        and _select_graph_path(model_dir, ["encoder-model.int8.onnx", "encoder-model.onnx"])
+        and _select_graph_path(model_dir, ["decoder_joint-model.int8.onnx", "decoder_joint-model.onnx"])
+    )
+
+
+def _middle_trimmed_chunk_text(text: str, chunk_duration: float, overlap_duration: float) -> str:
+    """Trim the start of a chunk transcript using the existing middle-merge heuristic."""
+    if chunk_duration <= 0 or overlap_duration <= 0:
+        return text
+    overlap_chars = int(len(text) * overlap_duration / chunk_duration)
+    if overlap_chars <= 0:
+        return text
+    return text[overlap_chars // 2:]
+
+
 def load_parakeet_onnx_model(model_path: Optional[str] = None, device: str = 'cpu'):
     """
     Load Parakeet ONNX model and tokenizer.
@@ -477,7 +603,8 @@ def load_parakeet_onnx_model(model_path: Optional[str] = None, device: str = 'cp
 
         download_fn = _resolve_snapshot_download()
 
-        if not model_dir.exists() and download_fn:
+        is_existing_local_dir = model_dir.exists() and model_dir.is_dir()
+        if not is_existing_local_dir and download_fn:
             # Download from HuggingFace
             logger.info(f"Downloading ONNX model from HuggingFace: {model_path}")
             cache_dir = Path.home() / '.cache' / 'parakeet_onnx'
@@ -488,14 +615,69 @@ def load_parakeet_onnx_model(model_path: Optional[str] = None, device: str = 'cp
             )
             model_dir = cache_dir / f"{model_path.replace('/', '_')}_{revision_token}"
 
-            if not model_dir.exists():
-                # Limit download to ONNX files only to avoid fetching entire repositories
+            # Limit download to model artifacts and required decoding sidecars.
+            # Existing caches may have only the ONNX graphs from older builds, so
+            # call snapshot_download when required sidecars are missing too.
+            if not model_dir.exists() or not (model_dir / "vocab.txt").exists():
                 download_fn(
                     repo_id=model_path,
                     local_dir=str(model_dir),
                     revision=revision,
-                    allow_patterns=["*.onnx", "**/*.onnx"],
+                    allow_patterns=_PARAKEET_ONNX_ALLOW_PATTERNS,
                 )  # nosec B615
+
+        # Set up providers
+        providers = []
+        if device == 'cuda':
+            providers.append('CUDAExecutionProvider')
+        providers.append('CPUExecutionProvider')
+
+        # Create ONNX sessions. Use a fresh import so patched attributes are respected.
+        try:
+            import importlib as _importlib
+            _runtime = _importlib.import_module('onnxruntime')
+        except (ImportError, ModuleNotFoundError, RuntimeError):
+            _runtime = ort
+
+        session_options = _runtime.SessionOptions()
+        session_options.graph_optimization_level = _runtime.GraphOptimizationLevel.ORT_ENABLE_ALL
+
+        bundle_paths = _resolve_parakeet_tdt_bundle_paths(model_dir)
+        if bundle_paths is not None:
+            load_onnx_asr_model = _resolve_onnx_asr_load_model()
+            if load_onnx_asr_model is None:
+                logger.error(
+                    "Parakeet ONNX TDT export found in {} but onnx-asr is not installed. "
+                    "Install with: pip install 'onnx-asr[hub]'",
+                    model_dir,
+                )
+                return None, None
+
+            logger.info(
+                "Loading Parakeet TDT ONNX graph bundle through upstream onnx-asr from: {}",
+                model_dir,
+            )
+            quantization = _resolve_parakeet_tdt_quantization(model_dir)
+            upstream_model = load_onnx_asr_model(
+                "nemo-conformer-tdt",
+                path=model_dir,
+                quantization=quantization,
+                sess_options=session_options,
+                providers=providers,
+                preprocessor_config={"use_numpy_preprocessors": True},
+            )
+            tokenizer = ParakeetONNXTokenizer(bundle_paths["vocab"])
+            session = ParakeetOnnxAsrRuntime(upstream_model)
+            _onnx_model_cache[cache_key] = (session, tokenizer)
+            logger.info("Successfully loaded Parakeet TDT ONNX graph bundle through onnx-asr")
+            return session, tokenizer
+        if _has_parakeet_tdt_graphs(model_dir):
+            logger.error(
+                "Parakeet ONNX TDT graph bundle found in {} but vocab.txt is missing. "
+                "Add vocab.txt beside the ONNX graphs or use the upstream Hugging Face repo id.",
+                model_dir,
+            )
+            return None, None
 
         # Find ONNX files
         onnx_files = list(model_dir.glob("*.onnx"))
@@ -507,23 +689,6 @@ def load_parakeet_onnx_model(model_path: Optional[str] = None, device: str = 'cp
             # Use the first ONNX file (usually encoder.onnx or model.onnx)
             onnx_path = onnx_files[0]
         logger.info(f"Loading ONNX model from: {onnx_path}")
-
-        # Set up providers
-        providers = []
-        if device == 'cuda':
-            providers.append('CUDAExecutionProvider')
-        providers.append('CPUExecutionProvider')
-
-        # Create ONNX session
-        # Use a fresh import so patched attributes are respected
-        try:
-            import importlib as _importlib
-            _runtime = _importlib.import_module('onnxruntime')
-        except (ImportError, ModuleNotFoundError, RuntimeError):
-            _runtime = ort
-
-        session_options = _runtime.SessionOptions()
-        session_options.graph_optimization_level = _runtime.GraphOptimizationLevel.ORT_ENABLE_ALL
 
         session = _runtime.InferenceSession(
             str(onnx_path),
@@ -610,6 +775,48 @@ def transcribe_with_parakeet_onnx(
 
     # Check if we need chunking
     audio_duration = len(audio_data) / sample_rate
+
+    bundle_transcribe = getattr(session, "transcribe", None)
+    session_run = getattr(session, "run", None)
+    if isinstance(session, ParakeetOnnxAsrRuntime) or (
+        callable(bundle_transcribe) and not callable(session_run)
+    ):
+        try:
+            if chunk_duration and audio_duration > chunk_duration:
+                chunk_samples = int(chunk_duration * sample_rate)
+                overlap_samples = int(overlap_duration * sample_rate)
+                stride_samples = max(1, chunk_samples - overlap_samples)
+                transcripts: list[str] = []
+                total_samples = len(audio_data)
+                num_chunks = max(
+                    1,
+                    int(np.ceil(max(1, total_samples - overlap_samples) / stride_samples)),
+                )
+                for i in range(num_chunks):
+                    start = i * stride_samples
+                    end = min(start + chunk_samples, total_samples)
+                    chunk = audio_data[start:end]
+                    text = bundle_transcribe(chunk, sample_rate)
+                    if text and not text.startswith("["):
+                        if merge_algo == "middle" and i > 0 and overlap_samples > 0:
+                            text = _middle_trimmed_chunk_text(
+                                text,
+                                chunk_duration,
+                                overlap_duration,
+                            )
+                        transcripts.append(text)
+                    if chunk_callback:
+                        chunk_callback(i + 1, num_chunks)
+                result = (
+                    merge_with_overlap_removal(transcripts)
+                    if merge_algo == "overlap"
+                    else " ".join(transcripts)
+                )
+                return result.strip() if result.strip() else "[No speech detected]"
+            return bundle_transcribe(audio_data, sample_rate)
+        except Exception as e:
+            logger.exception(f"Parakeet TDT ONNX graph bundle transcription error: {e}")
+            return "[Error: Parakeet ONNX transcription failed]"
 
     if chunk_duration and audio_duration > chunk_duration:
         # Use chunked transcription
@@ -766,12 +973,11 @@ def transcribe_chunked_onnx(
 
                 if text:
                     if merge_algo == 'middle' and i > 0 and overlap_samples > 0:
-                        # For middle merge, trim overlapping parts
-                        # This is a simplified version - real implementation would
-                        # align tokens at boundaries
-                        overlap_chars = int(len(text) * overlap_duration / chunk_duration)
-                        if overlap_chars > 0:
-                            text = text[overlap_chars // 2:]
+                        text = _middle_trimmed_chunk_text(
+                            text,
+                            chunk_duration,
+                            overlap_duration,
+                        )
 
                     transcripts.append(text)
 

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_parakeet_onnx.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_parakeet_onnx.py
@@ -6,6 +6,8 @@ import pytest
 import numpy as np
 import tempfile
 import os
+import sys
+import types
 from pathlib import Path
 from unittest.mock import Mock, patch, MagicMock, call
 import soundfile as sf
@@ -101,39 +103,24 @@ class TestParakeetONNX:
             pytest.skip(f"ONNX module not available: {e}")
 
     @patch('onnxruntime.InferenceSession')
-    @patch('huggingface_hub.snapshot_download')
-    def test_model_loading(self, mock_download, mock_ort_session, mock_onnx_session):
+    def test_model_loading(self, mock_ort_session, mock_onnx_session, tmp_path):
         """Test ONNX model loading."""
         from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_ONNX import (
             load_parakeet_onnx_model,
             unload_onnx_models
         )
 
-        # Setup mocks
-        mock_download.return_value = "path/to/model"
         mock_ort_session.return_value = mock_onnx_session
 
-        # Create mock vocab file
-        with tempfile.TemporaryDirectory() as tmpdir:
-            vocab_path = Path(tmpdir) / "vocab.txt"
-            with open(vocab_path, 'w') as f:
-                for i in range(100):
-                    f.write(f"token_{i} {i}\n")
+        (tmp_path / "model.onnx").write_bytes(b"placeholder")
+        (tmp_path / "vocab.json").write_text(json.dumps({"token_0": 0}), encoding="utf-8")
 
-            with patch('pathlib.Path.exists', return_value=True):
-                with patch('builtins.open', create=True) as mock_open:
-                    mock_open.return_value.__enter__.return_value.readlines.return_value = [
-                        f"token_{i} {i}\n" for i in range(100)
-                    ]
+        unload_onnx_models()
+        session, tokenizer = load_parakeet_onnx_model(model_path=str(tmp_path))
 
-                    # Clear cache to ensure a fresh session is created
-                    unload_onnx_models()
-                    session, tokenizer = load_parakeet_onnx_model()
-
-                    assert session is not None
-                    assert tokenizer is not None
-                    # Be tolerant to patch interactions; ensure it was invoked
-                    assert mock_ort_session.called
+        assert session is not None
+        assert tokenizer is not None
+        assert mock_ort_session.called
 
     @patch('onnxruntime.InferenceSession')
     @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_ONNX.snapshot_download')
@@ -202,6 +189,167 @@ class TestParakeetONNX:
         kwargs = mock_download.call_args.kwargs
         assert kwargs.get("repo_id") == "org/custom-parakeet-onnx"
         assert kwargs.get("revision") is None
+
+    @patch('onnxruntime.InferenceSession')
+    @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_ONNX.snapshot_download')
+    def test_loader_downloads_parakeet_onnx_sidecars(
+        self,
+        mock_download: MagicMock,
+        mock_ort_session: MagicMock,
+        mock_onnx_session: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Downloads must include vocab/config/external-data sidecars, not only .onnx graphs."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio import Audio_Transcription_Parakeet_ONNX as onnx_mod
+
+        monkeypatch.setattr(
+            onnx_mod,
+            "get_stt_config",
+            lambda: {"parakeet_onnx_model_id": "org/custom-parakeet-onnx"},
+            raising=True,
+        )
+        mock_download.return_value = "path/to/model"
+        mock_ort_session.return_value = mock_onnx_session
+        onnx_mod.unload_onnx_models()
+
+        with patch('pathlib.Path.exists', return_value=False):
+            onnx_mod.load_parakeet_onnx_model(model_path=None, device='cpu')
+
+        allow_patterns = mock_download.call_args.kwargs.get("allow_patterns")
+        assert "*.onnx" in allow_patterns
+        assert "**/*.onnx" in allow_patterns
+        assert "*.onnx.data" in allow_patterns
+        assert "**/*.onnx.data" in allow_patterns
+        assert "vocab.txt" in allow_patterns
+        assert "config.json" in allow_patterns
+
+    @patch(
+        'tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.'
+        'Audio_Transcription_Parakeet_ONNX.snapshot_download'
+    )
+    def test_loader_does_not_download_existing_local_parakeet_bundle_missing_vocab(
+        self,
+        mock_download: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Existing local artifact directories should never be reused as HF repo ids."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio import Audio_Transcription_Parakeet_ONNX as onnx_mod
+
+        for filename in (
+            "decoder_joint-model.int8.onnx",
+            "encoder-model.int8.onnx",
+            "nemo128.onnx",
+        ):
+            (tmp_path / filename).write_bytes(b"placeholder")
+        monkeypatch.setattr(
+            onnx_mod,
+            "get_stt_config",
+            lambda: {"parakeet_onnx_model_id": str(tmp_path)},
+            raising=True,
+        )
+        onnx_mod.unload_onnx_models()
+
+        session, tokenizer = onnx_mod.load_parakeet_onnx_model(model_path=None, device='cpu')
+
+        assert session is None
+        assert tokenizer is None
+        mock_download.assert_not_called()
+
+    def test_loader_uses_upstream_onnx_asr_for_parakeet_tdt_export(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A Parakeet TDT export should use upstream onnx-asr instead of local decoder code."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio import Audio_Transcription_Parakeet_ONNX as onnx_mod
+
+        for filename in (
+            "decoder_joint-model.onnx",
+            "decoder_joint-model.int8.onnx",
+            "encoder-model.onnx",
+            "encoder-model.int8.onnx",
+            "nemo128.onnx",
+        ):
+            (tmp_path / filename).write_bytes(b"placeholder")
+        (tmp_path / "vocab.txt").write_text("<unk> 0\nhello 1\n<blk> 2\n", encoding="utf-8")
+        upstream_model = MagicMock()
+        load_model = MagicMock(return_value=upstream_model)
+        monkeypatch.setitem(sys.modules, "onnx_asr", types.SimpleNamespace(load_model=load_model))
+        onnx_mod.unload_onnx_models()
+
+        session, tokenizer = onnx_mod.load_parakeet_onnx_model(model_path=str(tmp_path), device='cpu')
+
+        assert tokenizer is not None
+        assert isinstance(session, onnx_mod.ParakeetOnnxAsrRuntime)
+        load_model.assert_called_once()
+        args, kwargs = load_model.call_args
+        assert args == ("nemo-conformer-tdt",)
+        assert kwargs["path"] == tmp_path
+        assert kwargs["quantization"] == "int8"
+        assert kwargs["providers"] == ["CPUExecutionProvider"]
+        assert kwargs["preprocessor_config"] == {"use_numpy_preprocessors": True}
+
+    def test_upstream_onnx_asr_runtime_transcribes_with_recognize(
+        self,
+        sample_audio_data: tuple[np.ndarray, int],
+    ) -> None:
+        """The upstream adapter should call onnx-asr recognize directly."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_ONNX import (
+            ParakeetOnnxAsrRuntime,
+        )
+
+        audio_data, sample_rate = sample_audio_data
+        upstream_model = MagicMock()
+        upstream_model.recognize.return_value = " upstream transcript "
+
+        runtime = ParakeetOnnxAsrRuntime(upstream_model)
+        result = runtime.transcribe(audio_data, sample_rate)
+
+        assert result == "upstream transcript"
+        upstream_model.recognize.assert_called_once()
+        args, kwargs = upstream_model.recognize.call_args
+        assert args[0].shape == audio_data.shape
+        assert args[0].dtype == np.float32
+        assert kwargs == {"sample_rate": sample_rate, "channel": "mean"}
+
+    def test_upstream_onnx_asr_runtime_skips_literal_silence(self) -> None:
+        """Literal silence should not be sent to Parakeet because it can hallucinate speech."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_ONNX import (
+            ParakeetOnnxAsrRuntime,
+        )
+
+        upstream_model = MagicMock()
+        upstream_model.recognize.return_value = "Yeah."
+        runtime = ParakeetOnnxAsrRuntime(upstream_model)
+
+        result = runtime.transcribe(np.zeros(16000, dtype=np.float32), 16000)
+
+        assert result == "[No speech detected]"
+        upstream_model.recognize.assert_not_called()
+
+    def test_loader_fails_closed_when_onnx_asr_missing_for_parakeet_bundle(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A Parakeet TDT bundle without onnx-asr should not fall back to generic ONNX inference."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio import Audio_Transcription_Parakeet_ONNX as onnx_mod
+
+        for filename in (
+            "decoder_joint-model.int8.onnx",
+            "encoder-model.int8.onnx",
+            "nemo128.onnx",
+        ):
+            (tmp_path / filename).write_bytes(b"placeholder")
+        (tmp_path / "vocab.txt").write_text("<unk> 0\nhello 1\n<blk> 2\n", encoding="utf-8")
+        monkeypatch.setattr(onnx_mod, "_resolve_onnx_asr_load_model", lambda: None, raising=False)
+        onnx_mod.unload_onnx_models()
+
+        session, tokenizer = onnx_mod.load_parakeet_onnx_model(model_path=str(tmp_path), device='cpu')
+
+        assert session is None
+        assert tokenizer is None
 
     @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_ONNX.load_parakeet_onnx_model')
     def test_transcribe_simple(self, mock_load_model, sample_audio_data, mock_onnx_session, mock_tokenizer):
@@ -311,6 +459,46 @@ class TestParakeetONNX:
 
         assert result == "chunk ok chunk ok chunk ok"  # nosec B101
         assert seen_lens == [sample_rate, sample_rate, sample_rate // 2]  # nosec B101
+
+    @patch(
+        'tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.'
+        'Audio_Transcription_Parakeet_ONNX.load_parakeet_onnx_model'
+    )
+    def test_upstream_bundle_chunking_respects_middle_merge(
+        self,
+        mock_load_model: MagicMock,
+    ) -> None:
+        """Upstream bundle chunking should use the single-session middle trim."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_ONNX import (
+            transcribe_with_parakeet_onnx
+        )
+
+        class FakeUpstreamBundle:
+            """Callable bundle stand-in without an ONNX-style run method."""
+
+            def __init__(self, transcripts: list[str]) -> None:
+                self.transcripts = transcripts
+                self.calls: list[tuple[tuple[int, ...], int]] = []
+
+            def transcribe(self, waveform: np.ndarray, sample_rate: int) -> str:
+                self.calls.append((waveform.shape, sample_rate))
+                return self.transcripts[len(self.calls) - 1]
+
+        bundle = FakeUpstreamBundle(["abcde", "fghij", "klmno", "pqrst"])
+        tokenizer = MagicMock()
+        mock_load_model.return_value = (bundle, tokenizer)
+        audio_data = np.ones(25, dtype=np.float32)
+
+        result = transcribe_with_parakeet_onnx(
+            audio_data,
+            sample_rate=10,
+            chunk_duration=1.0,
+            overlap_duration=0.5,
+            merge_algo="middle",
+        )
+
+        assert result == "abcde ghij lmno qrst"
+        assert len(bundle.calls) == 4
 
     def test_preprocessing(self):
 


### PR DESCRIPTION
## Change summary

Fixes the Parakeet ONNX transcription runtime error by routing official Parakeet TDT multi-graph exports through upstream `onnx-asr` instead of treating the directory as a generic single-session ONNX model.

This avoids maintaining a local RNNT/TDT decoder in this project. The code now detects the Parakeet graph bundle layout, loads it with `onnx_asr.load_model("nemo-conformer-tdt", path=..., quantization=...)`, keeps the generic ONNX fallback only for non-bundle exports, and fails closed with a clear dependency error if `onnx-asr` is unavailable. It also adds a small literal-silence guard because direct Parakeet recognition can hallucinate speech on zero audio.

The review pass also fixes local artifact handling and chunked bundle merging:
- Existing local model directories are never reused as Hugging Face repo ids.
- Local Parakeet TDT graph bundles missing `vocab.txt` fail closed with a clear log instead of falling through to generic ONNX loading.
- Upstream bundle chunking now honors `merge_algo="middle"` with the same trimming heuristic as the single-session path.
- Newly added review tests include explicit parameter and return type hints.

`onnx-asr[hub]>=0.11.0` is now declared as a project dependency so this supported STT path has its runtime available in normal installs.

## Verification

- `../../.venv/bin/python -m pytest tldw_Server_API/tests/Media_Ingestion_Modification/test_parakeet_onnx.py -q` -> 21 passed, 3 skipped
- `../../.venv/bin/python -m pytest tldw_Server_API/tests/Audio/test_parakeet_onnx_failfast.py tldw_Server_API/tests/Audio/test_transcription_model_parsing.py tldw_Server_API/tests/Audio/test_model_variant_normalization.py -q` -> 22 passed
- `git diff --check` -> passed
- `../../.venv/bin/python -m bandit -r tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Parakeet_ONNX.py -f json -o /tmp/bandit_parakeet_onnx_runtime.json` -> 0 findings
- No-mock upstream smoke against local cached Parakeet graphs loaded through `onnx-asr`; silence returned `[No speech detected]`, and an artificial sine tone returned `Oh.` without the decoder missing-input error.

## Notes

`python -m pip check` reports an existing local venv conflict: `typer-slim 0.24.0` requires `typer>=0.24.0`, while the venv has `typer 0.16.1`. `onnx-asr` itself only required `numpy` in the installed package and did not introduce that conflict.
