### PR TITLE
Refactor moderation policy compilation

### DIFF
--- a/Docs/superpowers/plans/2026-06-24-moderation-policy-compiler-refactor-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-24-moderation-policy-compiler-refactor-implementation-plan.md
@@ -1,0 +1,1353 @@
+# Moderation PolicyCompiler Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract deterministic moderation policy assembly into `PolicyCompiler` while preserving `ModerationService`, `ModerationPolicy`, and current endpoint/caller behavior.
+
+**Architecture:** Add a focused `policy_compiler.py` module that receives already-loaded inputs and returns compatible `ModerationPolicy` objects plus sanitized internal diagnostics. Keep file I/O, path resolution, locking, logging, persistence, and public service methods in `ModerationService`. Preserve lint output and service helper compatibility through delegating wrappers.
+
+**Tech Stack:** Python 3, dataclasses, `re`, Loguru, pytest, existing `ModerationPolicy`/`PatternRule` types, existing project virtualenv at `/Users/appledev/Documents/GitHub/tldw_server/.venv`.
+
+---
+
+## Source Spec
+
+Design: `Docs/superpowers/specs/2026-06-24-moderation-policy-compiler-refactor-design.md`
+
+Backlog: `TASK-2431`
+
+## File Structure
+
+- Create: `tldw_Server_API/app/core/Moderation/policy_compiler.py`
+  - Owns `ResolvedModerationConfig`, `PolicyCompilationInput`, `PolicyCompilationIssue`, `PolicyCompilationReport`, `PolicyCompilationResult`, and `PolicyCompiler`.
+  - Owns shared parsing, regex flag, dangerous-regex, category, boolean, and rule compilation helpers.
+- Modify: `tldw_Server_API/app/core/Moderation/moderation_service.py`
+  - Keeps all I/O, path resolution, persistence, locks, logging, and public methods.
+  - Builds `ResolvedModerationConfig`.
+  - Reads blocklist lines and PII rules, then passes loaded inputs to `PolicyCompiler`.
+  - Keeps compatibility wrappers for `_parse_rule_line()`, `_load_block_patterns()`, and `_build_block_patterns()`.
+  - Keeps `lint_blocklist_lines()` endpoint output behavior while delegating parser logic where useful.
+- Create: `tldw_Server_API/tests/unit/test_moderation_policy_compiler.py`
+  - Focused unit tests for compiler-only behavior.
+- Modify: `tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py`
+  - Add/adjust compatibility tests for wrappers and lint output.
+- Modify: `tldw_Server_API/tests/unit/test_moderation_effective_settings.py`
+  - Add/adjust settings and PII effective-policy compatibility tests.
+- Modify: `tldw_Server_API/tests/Guardian/test_supervised_policy.py`
+  - Add/adjust overlay regression coverage only if compiler integration affects policy construction tests.
+- Modify: `backlog/tasks/task-2431 - Plan-Moderation-PolicyCompiler-refactor-implementation.md`
+  - Track implementation progress, modified files, and verification evidence.
+
+## Conventions
+
+Run Python commands from the implementation worktree after activating the main virtualenv:
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+```
+
+Use focused pytest commands during tasks, then run the broader verification command in Task 7.
+
+---
+
+### Task 1: Add Compiler Types And Base Global Compilation
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Moderation/policy_compiler.py`
+- Create: `tldw_Server_API/tests/unit/test_moderation_policy_compiler.py`
+
+- [ ] **Step 1: Write failing compiler smoke tests**
+
+Add this test file:
+
+```python
+import re
+
+from tldw_Server_API.app.core.Moderation.moderation_service import ModerationPolicy, PatternRule
+from tldw_Server_API.app.core.Moderation.policy_compiler import (
+    PolicyCompilationInput,
+    PolicyCompiler,
+    ResolvedModerationConfig,
+)
+
+
+def _config(**overrides):
+    values = {
+        "enabled": True,
+        "input_enabled": True,
+        "output_enabled": True,
+        "input_action": "block",
+        "output_action": "redact",
+        "redact_replacement": "[REDACTED]",
+        "per_user_overrides": True,
+        "categories_enabled": None,
+        "pii_enabled": False,
+    }
+    values.update(overrides)
+    return ResolvedModerationConfig(**values)
+
+
+def test_compile_global_policy_uses_resolved_defaults():
+    result = PolicyCompiler().compile_global(
+        PolicyCompilationInput(
+            config=_config(categories_enabled={"pii", "confidential"}),
+            runtime_override={},
+            blocklist_lines=[],
+            pii_rules=[],
+        )
+    )
+
+    assert isinstance(result.policy, ModerationPolicy)
+    assert result.policy.enabled is True
+    assert result.policy.input_action == "block"
+    assert result.policy.output_action == "redact"
+    assert result.policy.categories_enabled == {"pii", "confidential"}
+    assert result.report.issues == []
+
+
+def test_compile_global_policy_copies_pii_rules_when_enabled():
+    pii_rule = PatternRule(
+        regex=re.compile("email", re.IGNORECASE),
+        action="redact",
+        replacement="[PII]",
+        categories={"pii", "pii_email"},
+    )
+
+    result = PolicyCompiler().compile_global(
+        PolicyCompilationInput(
+            config=_config(pii_enabled=True),
+            runtime_override={},
+            blocklist_lines=[],
+            pii_rules=[pii_rule],
+        )
+    )
+
+    assert result.policy.block_patterns == [pii_rule]
+```
+
+- [ ] **Step 2: Run smoke tests to verify they fail**
+
+Run:
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/unit/test_moderation_policy_compiler.py -q
+```
+
+Expected: FAIL with `ModuleNotFoundError` for `policy_compiler`.
+
+- [ ] **Step 3: Add minimal compiler types and global compile path**
+
+Create `tldw_Server_API/app/core/Moderation/policy_compiler.py`:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from tldw_Server_API.app.core.Moderation.moderation_service import (
+    ModerationPolicy,
+    PatternRule,
+)
+
+
+@dataclass(frozen=True)
+class ResolvedModerationConfig:
+    enabled: bool = False
+    input_enabled: bool = True
+    output_enabled: bool = True
+    input_action: str = "block"
+    output_action: str = "redact"
+    redact_replacement: str = "[REDACTED]"
+    per_user_overrides: bool = True
+    categories_enabled: set[str] | None = None
+    pii_enabled: bool = False
+
+
+@dataclass(frozen=True)
+class PolicyCompilationIssue:
+    source: str
+    reason: str
+    index: int | None = None
+    detail: str | None = None
+
+
+@dataclass
+class PolicyCompilationReport:
+    issues: list[PolicyCompilationIssue] = field(default_factory=list)
+
+    def add(self, source: str, reason: str, *, index: int | None = None, detail: str | None = None) -> None:
+        self.issues.append(PolicyCompilationIssue(source=source, reason=reason, index=index, detail=detail))
+
+
+@dataclass
+class PolicyCompilationInput:
+    config: ResolvedModerationConfig
+    runtime_override: dict[str, object] = field(default_factory=dict)
+    blocklist_lines: list[str] = field(default_factory=list)
+    user_override: dict[str, object] | None = None
+    pii_rules: list[PatternRule] = field(default_factory=list)
+
+
+@dataclass
+class PolicyCompilationResult:
+    policy: ModerationPolicy
+    report: PolicyCompilationReport
+
+
+class PolicyCompiler:
+    def compile_global(self, data: PolicyCompilationInput) -> PolicyCompilationResult:
+        report = PolicyCompilationReport()
+        config = data.config
+        categories_enabled = self._resolve_runtime_categories(
+            data.runtime_override,
+            config.categories_enabled,
+        )
+        pii_enabled = self._resolve_runtime_pii(data.runtime_override, config.pii_enabled)
+        block_patterns: list[PatternRule] = []
+        if pii_enabled:
+            block_patterns.extend(list(data.pii_rules or []))
+
+        policy = ModerationPolicy(
+            enabled=config.enabled,
+            input_enabled=config.input_enabled,
+            output_enabled=config.output_enabled,
+            input_action=str(config.input_action).lower(),
+            output_action=str(config.output_action).lower(),
+            redact_replacement=config.redact_replacement,
+            per_user_overrides=config.per_user_overrides,
+            block_patterns=block_patterns,
+            categories_enabled=categories_enabled,
+        )
+        return PolicyCompilationResult(policy=policy, report=report)
+
+    @staticmethod
+    def _resolve_runtime_pii(runtime_override: dict[str, object], default: bool) -> bool:
+        if "pii_enabled" in runtime_override:
+            return bool(runtime_override.get("pii_enabled"))
+        return bool(default)
+
+    @staticmethod
+    def _resolve_runtime_categories(
+        runtime_override: dict[str, object],
+        default: set[str] | None,
+    ) -> set[str] | None:
+        if "categories_enabled" not in runtime_override:
+            return set(default) if default is not None else None
+        raw = runtime_override.get("categories_enabled") or []
+        if isinstance(raw, (set, list, tuple)):
+            parsed = {str(c).strip().lower() for c in raw if str(c).strip()}
+            return parsed or None
+        if isinstance(raw, str):
+            parsed = {c.strip().lower() for c in raw.split(",") if c.strip()}
+            return parsed or None
+        return set(default) if default is not None else None
+```
+
+- [ ] **Step 4: Run smoke tests to verify they pass**
+
+Run:
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/unit/test_moderation_policy_compiler.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/Moderation/policy_compiler.py tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
+git commit -m "Add moderation policy compiler skeleton"
+```
+
+---
+
+### Task 2: Move Blocklist Parsing And Safe Rule Compilation Into PolicyCompiler
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Moderation/policy_compiler.py`
+- Modify: `tldw_Server_API/tests/unit/test_moderation_policy_compiler.py`
+
+- [ ] **Step 1: Add failing parser and report tests**
+
+Append tests:
+
+```python
+def test_compile_global_policy_compiles_literal_and_regex_blocklist_rules():
+    result = PolicyCompiler().compile_global(
+        PolicyCompilationInput(
+            config=_config(),
+            runtime_override={},
+            blocklist_lines=[
+                "secret -> block #confidential",
+                r"/leak\\d+/i -> redact:[MASK] #pii",
+            ],
+            pii_rules=[],
+        )
+    )
+
+    rules = result.policy.block_patterns
+    assert len(rules) == 2
+    assert rules[0].regex.search("SECRET")
+    assert rules[0].action == "block"
+    assert rules[0].categories == {"confidential"}
+    assert rules[1].regex.search("leak123")
+    assert rules[1].action == "redact"
+    assert rules[1].replacement == "[MASK]"
+    assert rules[1].categories == {"pii"}
+
+
+def test_compile_global_policy_reports_invalid_lines_without_raw_regex():
+    result = PolicyCompiler().compile_global(
+        PolicyCompilationInput(
+            config=_config(),
+            runtime_override={},
+            blocklist_lines=[
+                "secret -> invalid_action",
+                "/(a+)+$/ -> block",
+                "/(unclosed/ -> block",
+            ],
+            pii_rules=[],
+        )
+    )
+
+    assert result.policy.block_patterns == []
+    reasons = [issue.reason for issue in result.report.issues]
+    assert reasons == ["invalid_action", "dangerous_regex", "invalid_regex"]
+    rendered = repr(result.report.issues)
+    assert "(a+)+$" not in rendered
+    assert "(unclosed" not in rendered
+```
+
+- [ ] **Step 2: Run parser tests to verify they fail**
+
+Run:
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/unit/test_moderation_policy_compiler.py::test_compile_global_policy_compiles_literal_and_regex_blocklist_rules tldw_Server_API/tests/unit/test_moderation_policy_compiler.py::test_compile_global_policy_reports_invalid_lines_without_raw_regex -q
+```
+
+Expected: FAIL because blocklist lines are not compiled yet.
+
+- [ ] **Step 3: Add parser, regex, and report helpers**
+
+Update `PolicyCompiler` with these helpers and call `compile_blocklist_lines()` before appending PII rules:
+
+```python
+import re
+
+
+class PolicyCompiler:
+    _ALLOWED_REGEX_FLAGS = {"i", "m", "s", "x"}
+    _ALLOWED_ACTIONS = {"block", "redact", "warn"}
+
+    def compile_global(self, data: PolicyCompilationInput) -> PolicyCompilationResult:
+        report = PolicyCompilationReport()
+        config = data.config
+        categories_enabled = self._resolve_runtime_categories(data.runtime_override, config.categories_enabled)
+        pii_enabled = self._resolve_runtime_pii(data.runtime_override, config.pii_enabled)
+        block_patterns = self.compile_blocklist_lines(data.blocklist_lines, report)
+        if pii_enabled:
+            block_patterns.extend(list(data.pii_rules or []))
+        policy = ModerationPolicy(
+            enabled=config.enabled,
+            input_enabled=config.input_enabled,
+            output_enabled=config.output_enabled,
+            input_action=str(config.input_action).lower(),
+            output_action=str(config.output_action).lower(),
+            redact_replacement=config.redact_replacement,
+            per_user_overrides=config.per_user_overrides,
+            block_patterns=block_patterns,
+            categories_enabled=categories_enabled,
+        )
+        return PolicyCompilationResult(policy=policy, report=report)
+
+    def compile_blocklist_lines(
+        self,
+        lines: list[str],
+        report: PolicyCompilationReport | None = None,
+    ) -> list[PatternRule]:
+        compiled: list[PatternRule] = []
+        active_report = report or PolicyCompilationReport()
+        for idx, raw in enumerate(lines or []):
+            line = str(raw).strip()
+            if not line or line.startswith("#"):
+                continue
+            expr, action, replacement, categories = self.parse_rule_line(line)
+            if expr is None:
+                active_report.add("blocklist", "empty_pattern", index=idx)
+                continue
+            if action and not self.is_valid_action(action):
+                active_report.add("blocklist", "invalid_action", index=idx)
+                continue
+            rule = self.compile_rule_expression(
+                expr,
+                action=action,
+                replacement=replacement,
+                categories=categories,
+                phase="both",
+                report=active_report,
+                source="blocklist",
+                index=idx,
+            )
+            if rule is not None:
+                compiled.append(rule)
+        return compiled
+
+    @classmethod
+    def parse_rule_line(cls, text: str) -> tuple[str | None, str | None, str | None, set[str] | None]:
+        if not text:
+            return None, None, None, None
+        line = text
+        action = None
+        replacement = None
+        categories: set[str] | None = None
+        if "#" in line:
+            cut_index = cls._find_category_suffix(line)
+            if cut_index != -1:
+                after = line[cut_index + 1:]
+                cats = {c.strip().lower() for c in after.split(",") if c.strip()}
+                if cats:
+                    categories = cats
+                    line = line[:cut_index].strip()
+        if "->" in line:
+            lhs, rhs = cls.split_action_directive(line)
+            if rhs is not None:
+                line = lhs
+                if rhs:
+                    rhs_lower = rhs.lower()
+                    if rhs_lower.startswith("redact:"):
+                        action = "redact"
+                        replacement = rhs[len("redact:"):].strip()
+                    elif rhs_lower in cls._ALLOWED_ACTIONS:
+                        action = rhs_lower
+                    else:
+                        action = rhs
+        return line, action, replacement, categories
+```
+
+Add these helper methods to `PolicyCompiler`:
+
+```python
+    @staticmethod
+    def _find_category_suffix(text: str) -> int:
+        if "#" not in text:
+            return -1
+        for i in range(len(text) - 1, -1, -1):
+            if text[i] != "#":
+                continue
+            backslash_count = 0
+            j = i - 1
+            while j >= 0 and text[j] == "\\":
+                backslash_count += 1
+                j -= 1
+            escaped = backslash_count % 2 == 1
+            previous = text[i - 1] if i > 0 else ""
+            if not escaped and (i == 0 or previous.isspace()):
+                return i
+        return -1
+
+    @staticmethod
+    def split_action_directive(text: str) -> tuple[str, str | None]:
+        if "->" not in text:
+            return text, None
+        in_regex = False
+        escape = False
+        for i in range(len(text) - 1):
+            ch = text[i]
+            if escape:
+                escape = False
+                continue
+            if ch == "\\":
+                escape = True
+                continue
+            if ch == "/" and i == 0:
+                in_regex = True
+                continue
+            if ch == "/" and in_regex:
+                in_regex = False
+                continue
+            if not in_regex and text[i:i + 2] == "->":
+                backslash_count = 0
+                j = i - 1
+                while j >= 0 and text[j] == "\\":
+                    backslash_count += 1
+                    j -= 1
+                if backslash_count % 2 == 1:
+                    continue
+                return text[:i].strip(), text[i + 2:].strip()
+        return text, None
+
+    @classmethod
+    def parse_regex_expr(cls, expr: str) -> tuple[str, str] | None:
+        if not expr or not expr.startswith("/"):
+            return None
+        last_slash = expr.rfind("/")
+        if last_slash <= 0:
+            return None
+        flags = expr[last_slash + 1:]
+        if flags:
+            lowered = flags.lower()
+            if any(ch not in cls._ALLOWED_REGEX_FLAGS for ch in lowered):
+                return None
+        raw = expr[1:last_slash]
+        if raw == "":
+            return None
+        return raw, flags
+
+    @classmethod
+    def regex_flags(cls, flags: str | None) -> int:
+        value = re.IGNORECASE
+        lowered = (flags or "").lower()
+        if "i" in lowered:
+            value |= re.IGNORECASE
+        if "m" in lowered:
+            value |= re.MULTILINE
+        if "s" in lowered:
+            value |= re.DOTALL
+        if "x" in lowered:
+            value |= re.VERBOSE
+        return value
+
+    @classmethod
+    def is_valid_action(cls, action: str) -> bool:
+        return str(action).strip().lower() in cls._ALLOWED_ACTIONS
+
+    @staticmethod
+    def has_nested_quantifiers(expr: str) -> bool:
+        try:
+            return bool(re.search(r"\((?:[^)(]|\([^)(]*\))*[+*][^)]*\)\s*[+*]", expr))
+        except (TypeError, ValueError, re.error):
+            return False
+
+    @staticmethod
+    def too_many_groups(expr: str, limit: int = 100) -> bool:
+        try:
+            return expr.count("(") - expr.count("\\(") > limit
+        except (TypeError, ValueError):
+            return False
+
+    def is_regex_dangerous(self, expr: str) -> bool:
+        if not expr:
+            return True
+        if len(expr) > 2000:
+            return True
+        if self.has_nested_quantifiers(expr):
+            return True
+        return self.too_many_groups(expr)
+```
+
+Use this rule compilation body:
+
+```python
+    def compile_rule_expression(
+        self,
+        expr: str,
+        *,
+        action: str | None,
+        replacement: str | None,
+        categories: set[str] | None,
+        phase: str,
+        report: PolicyCompilationReport,
+        source: str,
+        index: int | None,
+    ) -> PatternRule | None:
+        try:
+            regex_parts = self.parse_regex_expr(expr)
+            if regex_parts:
+                raw, flags_str = regex_parts
+                if self.is_regex_dangerous(raw):
+                    report.add(source, "dangerous_regex", index=index)
+                    return None
+                flags = self.regex_flags(flags_str)
+                regex = re.compile(raw, flags=flags)
+            else:
+                regex = re.compile(re.escape(expr.replace("\\#", "#")), flags=re.IGNORECASE)
+        except re.error:
+            report.add(source, "invalid_regex", index=index)
+            return None
+        return PatternRule(
+            regex=regex,
+            action=action or None,
+            replacement=replacement or None,
+            categories=categories or None,
+            phase=phase,
+        )
+```
+
+- [ ] **Step 4: Run parser tests to verify they pass**
+
+Run:
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/unit/test_moderation_policy_compiler.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/Moderation/policy_compiler.py tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
+git commit -m "Move moderation rule compilation into policy compiler"
+```
+
+---
+
+### Task 3: Preserve ModerationService Parser Wrappers And Public Lint Output
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Moderation/moderation_service.py`
+- Modify: `tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py`
+
+- [ ] **Step 1: Add failing compatibility tests for wrappers and lint output**
+
+Add or adjust tests:
+
+```python
+def test_service_parser_wrappers_delegate_to_policy_compiler():
+    svc = ModerationService()
+
+    expr, action, repl, cats = svc._parse_rule_line("/leak\\d+/ -> redact:[MASK] #pii")
+
+    assert expr == "/leak\\d+/"
+    assert action == "redact"
+    assert repl == "[MASK]"
+    assert cats == {"pii"}
+
+
+def test_lint_blocklist_lines_keeps_public_response_shape():
+    svc = ModerationService()
+
+    result = svc.lint_blocklist_lines(["/foo/z", "secret -> block #confidential"])
+
+    assert set(result) == {"items", "valid_count", "invalid_count"}
+    invalid = result["items"][0]
+    valid = result["items"][1]
+    assert invalid["line"] == "/foo/z"
+    assert invalid["ok"] is True
+    assert invalid["pattern_type"] == "literal"
+    assert invalid["warning"] == "invalid regex flags; treating as literal"
+    assert valid["line"] == "secret -> block #confidential"
+    assert valid["ok"] is True
+    assert valid["pattern_type"] == "literal"
+    assert valid["sample"] == "secret"
+    assert valid["categories"] == ["confidential"]
+```
+
+- [ ] **Step 2: Run compatibility tests**
+
+Run:
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py::test_service_parser_wrappers_delegate_to_policy_compiler tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py::test_lint_blocklist_lines_keeps_public_response_shape -q
+```
+
+Expected: The wrapper test may pass before refactor; lint shape should pass before and after. Keep both tests as regression coverage.
+
+- [ ] **Step 3: Add PolicyCompiler dependency and wrapper delegation**
+
+In `moderation_service.py`, import the compiler:
+
+```python
+from tldw_Server_API.app.core.Moderation.policy_compiler import (
+    PolicyCompilationReport,
+    PolicyCompiler,
+    ResolvedModerationConfig,
+)
+```
+
+In `ModerationService.__init__`, create one compiler:
+
+```python
+self._policy_compiler = PolicyCompiler()
+```
+
+Change wrapper methods to delegate:
+
+```python
+def _parse_rule_line(self, s: str) -> tuple[str | None, str | None, str | None, set[str] | None]:
+    return self._policy_compiler.parse_rule_line(s)
+
+@staticmethod
+def _split_action_directive(text: str) -> tuple[str, str | None]:
+    return PolicyCompiler.split_action_directive(text)
+
+@classmethod
+def _parse_regex_expr(cls, expr: str) -> tuple[str, str] | None:
+    return PolicyCompiler.parse_regex_expr(expr)
+
+def _is_regex_dangerous(self, expr: str) -> bool:
+    return self._policy_compiler.is_regex_dangerous(expr)
+```
+
+Keep `lint_blocklist_lines()` response assembly in `ModerationService`. It may call compiler parser helpers, but it must keep existing `line`, `sample`, `error`, `warning`, `valid_count`, and `invalid_count` behavior.
+
+- [ ] **Step 4: Run blocklist parse tests**
+
+Run:
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 3**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/Moderation/moderation_service.py tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py
+git commit -m "Preserve moderation parser and lint compatibility"
+```
+
+---
+
+### Task 4: Integrate Global Policy Compilation Into ModerationService
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Moderation/moderation_service.py`
+- Modify: `tldw_Server_API/tests/unit/test_moderation_policy_compiler.py`
+- Modify: `tldw_Server_API/tests/unit/test_moderation_effective_settings.py`
+
+- [ ] **Step 1: Add failing service integration tests**
+
+Add tests that assert service-built policies match existing behavior:
+
+```python
+def test_service_global_policy_uses_compiler_without_leaking_paths(tmp_path, monkeypatch):
+    blocklist = tmp_path / "blocklist.txt"
+    blocklist.write_text("secret -> block #confidential\n", encoding="utf-8")
+
+    svc = ModerationService()
+    svc._blocklist_path = str(blocklist)
+    svc._runtime_override = {}
+    svc._policy_compiler = PolicyCompiler()
+
+    policy = svc._compile_global_policy_from_resolved_config(
+        ResolvedModerationConfig(
+            enabled=True,
+            input_enabled=True,
+            output_enabled=True,
+            input_action="block",
+            output_action="redact",
+            redact_replacement="[REDACTED]",
+            per_user_overrides=True,
+            categories_enabled=None,
+            pii_enabled=False,
+        )
+    )
+
+    assert policy.enabled is True
+    assert len(policy.block_patterns) == 1
+    assert policy.block_patterns[0].categories == {"confidential"}
+```
+
+Keep the helper name `_compile_global_policy_from_resolved_config()` so this integration test can target a stable service boundary in the implementation branch.
+
+- [ ] **Step 2: Run integration test to verify it fails**
+
+Run:
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/unit/test_moderation_policy_compiler.py::test_service_global_policy_uses_compiler_without_leaking_paths -q
+```
+
+Expected: FAIL because service integration helper is not implemented yet.
+
+- [ ] **Step 3: Build `ResolvedModerationConfig` in the service**
+
+Refactor `_load_global_policy()` into three internal steps:
+
+```python
+def _load_global_policy(self) -> ModerationPolicy:
+    mod_cfg = self._load_moderation_config_section()
+    resolved = self._resolve_moderation_config(mod_cfg)
+    self._user_overrides_path = resolved.user_overrides_path
+    self._blocklist_path = resolved.blocklist_path
+    self._runtime_overrides_path = resolved.runtime_overrides_path
+    return self._compile_global_policy_from_resolved_config(resolved.compiler_config)
+```
+
+Add this service-only dataclass near the existing moderation dataclasses:
+
+```python
+@dataclass(frozen=True)
+class _ResolvedModerationServiceState:
+    compiler_config: ResolvedModerationConfig
+    blocklist_path: str | None
+    user_overrides_path: str | None
+    runtime_overrides_path: str | None
+```
+
+Have `_resolve_moderation_config()` return `_ResolvedModerationServiceState`. Do not put paths in `ResolvedModerationConfig`.
+
+Implement `ResolvedModerationConfig` construction with existing defaults and env fallback semantics:
+
+```python
+compiler_config = ResolvedModerationConfig(
+    enabled=_b("enabled", False),
+    input_enabled=_b("input_enabled", True),
+    output_enabled=_b("output_enabled", True),
+    input_action=str(mod_cfg.get("input_action", "block")).lower(),
+    output_action=str(mod_cfg.get("output_action", "redact")).lower(),
+    redact_replacement=str(mod_cfg.get("redact_replacement", "[REDACTED]")),
+    per_user_overrides=_b("per_user_overrides", True),
+    categories_enabled=categories_enabled or None,
+    pii_enabled=bool(pii_enabled),
+)
+```
+
+- [ ] **Step 4: Read blocklist lines and pass explicit PII rules**
+
+Add a service helper:
+
+```python
+def _read_blocklist_lines_for_compile(self, path: str | None) -> list[str]:
+    if not path:
+        return []
+    if not os.path.exists(path):
+        logger.warning("Moderation blocklist file not found")
+        return []
+    try:
+        return self._read_blocklist_lines_from_path(path)
+    except _MODERATION_NONCRITICAL_EXCEPTIONS:
+        logger.error("Failed to load moderation blocklist")
+        return []
+```
+
+Compile globally with explicit PII rules:
+
+```python
+def _compile_global_policy_from_resolved_config(self, config: ResolvedModerationConfig) -> ModerationPolicy:
+    self._pii_enabled = bool(config.pii_enabled)
+    pii_rules = self._load_builtin_pii_rules() if config.pii_enabled else []
+    lines = self._read_blocklist_lines_for_compile(getattr(self, "_blocklist_path", None))
+    result = self._policy_compiler.compile_global(
+        PolicyCompilationInput(
+            config=config,
+            runtime_override=self._runtime_override,
+            blocklist_lines=lines,
+            pii_rules=pii_rules,
+        )
+    )
+    self._log_compilation_report(result.report)
+    return result.policy
+```
+
+Log sanitized report reasons only:
+
+```python
+def _log_compilation_report(self, report: PolicyCompilationReport) -> None:
+    for issue in report.issues:
+        if issue.reason == "invalid_action":
+            logger.warning("Invalid moderation action in blocklist; skipping line")
+        elif issue.reason == "dangerous_regex":
+            logger.warning("Skipped dangerous regex in blocklist")
+        elif issue.reason == "invalid_regex":
+            logger.warning("Invalid blocklist pattern; skipping line")
+```
+
+- [ ] **Step 5: Keep `_load_block_patterns()` and `_build_block_patterns()` wrappers**
+
+Keep wrappers for tests and adjacent code:
+
+```python
+def _load_block_patterns(self, path: str | None) -> list[PatternRule]:
+    report = PolicyCompilationReport()
+    lines = self._read_blocklist_lines_for_compile(path)
+    rules = self._policy_compiler.compile_blocklist_lines(lines, report)
+    self._log_compilation_report(report)
+    return rules
+
+def _build_block_patterns(self, path: str | None) -> list[PatternRule]:
+    patterns = self._load_block_patterns(path)
+    if self._pii_enabled:
+        try:
+            patterns.extend(self._load_builtin_pii_rules())
+        except _MODERATION_NONCRITICAL_EXCEPTIONS:
+            logger.warning("Failed to load builtin PII rules")
+    return patterns
+```
+
+- [ ] **Step 6: Run global integration tests**
+
+Run:
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/unit/test_moderation_policy_compiler.py tldw_Server_API/tests/unit/test_moderation_effective_settings.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 4**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/Moderation/moderation_service.py tldw_Server_API/app/core/Moderation/policy_compiler.py tldw_Server_API/tests/unit/test_moderation_policy_compiler.py tldw_Server_API/tests/unit/test_moderation_effective_settings.py
+git commit -m "Integrate moderation global policy compiler"
+```
+
+---
+
+### Task 5: Move Per-User Effective Policy Assembly Into PolicyCompiler
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Moderation/policy_compiler.py`
+- Modify: `tldw_Server_API/app/core/Moderation/moderation_service.py`
+- Modify: `tldw_Server_API/tests/unit/test_moderation_policy_compiler.py`
+- Modify: `tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py`
+
+- [ ] **Step 1: Add failing user override compiler tests**
+
+Append tests:
+
+```python
+def test_compile_user_policy_preserves_empty_category_override():
+    base = ModerationPolicy(
+        enabled=True,
+        input_enabled=True,
+        output_enabled=True,
+        input_action="block",
+        output_action="redact",
+        redact_replacement="[REDACTED]",
+        per_user_overrides=True,
+        block_patterns=[],
+        categories_enabled={"pii"},
+    )
+
+    result = PolicyCompiler().compile_user_policy(
+        base,
+        {
+            "enabled": True,
+            "categories_enabled": "",
+            "rules": [],
+        },
+    )
+
+    assert result.policy.categories_enabled == set()
+
+
+def test_compile_user_policy_adds_wildcard_quick_rules():
+    base = ModerationPolicy(enabled=True, block_patterns=[], categories_enabled={"pii"})
+
+    result = PolicyCompiler().compile_user_policy(
+        base,
+        {
+            "rules": [
+                {
+                    "id": "r1",
+                    "pattern": "secret",
+                    "is_regex": False,
+                    "action": "warn",
+                    "phase": "input",
+                }
+            ]
+        },
+    )
+
+    assert len(result.policy.block_patterns) == 1
+    rule = result.policy.block_patterns[0]
+    assert rule.regex.search("secret")
+    assert rule.action == "warn"
+    assert rule.categories == {"*"}
+    assert rule.phase == "input"
+```
+
+- [ ] **Step 2: Run user tests to verify they fail**
+
+Run:
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/unit/test_moderation_policy_compiler.py::test_compile_user_policy_preserves_empty_category_override tldw_Server_API/tests/unit/test_moderation_policy_compiler.py::test_compile_user_policy_adds_wildcard_quick_rules -q
+```
+
+Expected: FAIL because `compile_user_policy()` does not exist.
+
+- [ ] **Step 3: Implement compiler user policy assembly**
+
+Add to `PolicyCompiler`:
+
+```python
+    def compile_user_policy(
+        self,
+        base_policy: ModerationPolicy,
+        override: dict[str, object] | None,
+    ) -> PolicyCompilationResult:
+        report = PolicyCompilationReport()
+        if not override:
+            return PolicyCompilationResult(policy=base_policy, report=report)
+        policy = ModerationPolicy(
+            enabled=self.coalesce_bool(override.get("enabled"), base_policy.enabled),
+            input_enabled=self.coalesce_bool(override.get("input_enabled"), base_policy.input_enabled),
+            output_enabled=self.coalesce_bool(override.get("output_enabled"), base_policy.output_enabled),
+            input_action=str(override.get("input_action", base_policy.input_action)).lower(),
+            output_action=str(override.get("output_action", base_policy.output_action)).lower(),
+            redact_replacement=str(override.get("redact_replacement", base_policy.redact_replacement)),
+            per_user_overrides=base_policy.per_user_overrides,
+            block_patterns=list(base_policy.block_patterns or []),
+            categories_enabled=self.resolve_categories_override(
+                override,
+                base_policy.categories_enabled,
+            ),
+        )
+        rules_raw = override.get("rules")
+        if isinstance(rules_raw, list):
+            for idx, raw_rule in enumerate(rules_raw):
+                compiled = self.compile_user_rule(raw_rule, report, idx)
+                if compiled is not None:
+                    policy.block_patterns.append(compiled)
+        return PolicyCompilationResult(policy=policy, report=report)
+```
+
+Add helper implementations using current service semantics:
+
+```python
+    @staticmethod
+    def coalesce_bool(value: object, default: bool) -> bool:
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return default
+        return str(value).strip().lower() in {"1", "true", "yes", "on", "y"}
+
+    def resolve_categories_override(
+        self,
+        override: dict[str, object],
+        default_categories: set[str] | None,
+    ) -> set[str] | None:
+        if "categories_enabled" not in override:
+            return default_categories
+        parsed = self.parse_categories_override(override.get("categories_enabled"))
+        return parsed if parsed is not None else default_categories
+
+    @staticmethod
+    def parse_categories_override(value: object | None) -> set[str] | None:
+        if value is None:
+            return None
+        if isinstance(value, list):
+            return {str(x).strip().lower() for x in value if str(x).strip()}
+        if isinstance(value, str):
+            text = value.strip()
+            if not text:
+                return set()
+            return {c.strip().lower() for c in text.split(",") if c.strip()}
+        return None
+```
+
+Compile quick rules with existing wildcard categories:
+
+```python
+    def compile_user_rule(
+        self,
+        raw_rule: object,
+        report: PolicyCompilationReport,
+        index: int,
+    ) -> PatternRule | None:
+        if not isinstance(raw_rule, dict):
+            report.add("user_rule", "invalid_rule", index=index)
+            return None
+        pattern = str(raw_rule.get("pattern", "")).strip()
+        action = str(raw_rule.get("action", "")).strip().lower()
+        phase = str(raw_rule.get("phase", "both")).strip().lower()
+        is_regex = raw_rule.get("is_regex", False)
+        if not isinstance(is_regex, bool):
+            report.add("user_rule", "invalid_is_regex", index=index)
+            return None
+        if not pattern or action not in {"block", "warn"}:
+            report.add("user_rule", "invalid_rule", index=index)
+            return None
+        if phase not in {"input", "output", "both"}:
+            phase = "both"
+        try:
+            if is_regex:
+                if self.is_regex_dangerous(pattern):
+                    report.add("user_rule", "dangerous_regex", index=index)
+                    return None
+                regex = re.compile(pattern, flags=re.IGNORECASE)
+            else:
+                regex = re.compile(re.escape(pattern), flags=re.IGNORECASE)
+        except re.error:
+            report.add("user_rule", "invalid_regex", index=index)
+            return None
+        return PatternRule(regex=regex, action=action, replacement=None, categories={"*"}, phase=phase)
+```
+
+- [ ] **Step 4: Wire `get_effective_policy()` to compiler user assembly**
+
+In `ModerationService.get_effective_policy()`:
+
+```python
+def get_effective_policy(self, user_id: str | None) -> ModerationPolicy:
+    policy = self._global_policy
+    if not policy.per_user_overrides or not user_id:
+        return policy
+    override = self._user_overrides.get(str(user_id))
+    if not override:
+        return policy
+    result = self._policy_compiler.compile_user_policy(policy, override)
+    self._log_compilation_report(result.report)
+    return result.policy
+```
+
+Keep `_parse_categories_override()`, `_resolve_categories_override()`, `_coalesce_bool()`, and `_compile_user_rule()` as delegating wrappers if tests or adjacent code call them directly.
+
+- [ ] **Step 5: Run user override tests**
+
+Run:
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/unit/test_moderation_policy_compiler.py tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 5**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/Moderation/policy_compiler.py tldw_Server_API/app/core/Moderation/moderation_service.py tldw_Server_API/tests/unit/test_moderation_policy_compiler.py tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py
+git commit -m "Move moderation user policy assembly into compiler"
+```
+
+---
+
+### Task 6: Preserve Service Behavior Across Reload, Settings, Blocklist, And Supervised Overlay
+
+**Files:**
+- Modify: `tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py`
+- Modify: `tldw_Server_API/tests/unit/test_moderation_effective_settings.py`
+- Modify: `tldw_Server_API/tests/Guardian/test_supervised_policy.py`
+- Modify: `tldw_Server_API/app/core/Moderation/moderation_service.py` only if tests expose integration drift.
+
+- [ ] **Step 1: Add regression tests for recompile triggers**
+
+Add tests that exercise public behavior:
+
+```python
+def test_update_settings_recompiles_global_policy_with_runtime_categories(monkeypatch):
+    svc = ModerationService()
+    svc._global_policy = ModerationPolicy(enabled=True, categories_enabled={"pii"})
+    svc._runtime_override = {}
+
+    result = svc.update_settings(categories_enabled=["confidential"])
+
+    assert result["categories_enabled"] == ["confidential"]
+    assert svc._global_policy.categories_enabled == {"confidential"}
+
+
+def test_set_blocklist_lines_recompiles_policy_from_file(tmp_path):
+    blocklist = tmp_path / "moderation_blocklist.txt"
+    svc = ModerationService()
+    svc._blocklist_path = str(blocklist)
+    svc._global_policy = ModerationPolicy(enabled=True, block_patterns=[])
+
+    assert svc.set_blocklist_lines(["secret -> block #confidential"]) is True
+
+    policy = svc.get_effective_policy(None)
+    assert any(rule.regex.search("secret") for rule in policy.block_patterns)
+```
+
+Adjust fixture setup to match existing test helpers in `test_moderation_blocklist_parse.py`.
+
+- [ ] **Step 2: Add supervised overlay regression if not already covered**
+
+Add or keep this coverage in `test_supervised_policy.py`:
+
+```python
+def test_supervised_overlay_still_accepts_compiler_policy(db):
+    base_policy = ModerationPolicy(
+        enabled=True,
+        input_enabled=True,
+        output_enabled=True,
+        input_action="block",
+        output_action="redact",
+        block_patterns=[],
+        categories_enabled={"pii"},
+    )
+    engine = SupervisedPolicyEngine(db)
+
+    merged = engine.overlay_policy("child1", base_policy)
+
+    assert isinstance(merged, ModerationPolicy)
+    assert merged.input_enabled is base_policy.input_enabled
+    assert merged.output_enabled is base_policy.output_enabled
+```
+
+If existing fixtures require policy creation before overlaying, use the established fixture pattern in the same file and assert the returned type and base settings are preserved.
+
+- [ ] **Step 3: Run behavior regression tests**
+
+Run:
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py tldw_Server_API/tests/unit/test_moderation_effective_settings.py tldw_Server_API/tests/Guardian/test_supervised_policy.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Fix integration drift exposed by tests**
+
+If reload/settings/blocklist tests fail because `_load_global_policy()` no longer sees persisted paths or runtime overrides, update service wiring so:
+
+```python
+def reload(self) -> None:
+    with self._lock:
+        self._config = load_and_log_configs() or {}
+        self._global_policy = self._load_global_policy()
+        try:
+            self._load_runtime_overrides_file()
+            self._global_policy = self._load_global_policy()
+        except _MODERATION_NONCRITICAL_EXCEPTIONS:
+            pass
+        self._user_overrides = self._load_user_overrides()
+```
+
+The method shape should remain behavior-compatible. Do not move file reads into `PolicyCompiler`.
+
+- [ ] **Step 5: Re-run behavior regression tests**
+
+Run:
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py tldw_Server_API/tests/unit/test_moderation_effective_settings.py tldw_Server_API/tests/Guardian/test_supervised_policy.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 6**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/Moderation/moderation_service.py tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py tldw_Server_API/tests/unit/test_moderation_effective_settings.py tldw_Server_API/tests/Guardian/test_supervised_policy.py
+git commit -m "Preserve moderation service behavior with compiler integration"
+```
+
+---
+
+### Task 7: Final Verification And Cleanup
+
+**Files:**
+- Modify: `backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md`
+- Modify: `Docs/superpowers/plans/2026-06-24-moderation-policy-compiler-refactor-implementation-plan.md` only if execution notes reveal plan gaps.
+
+- [ ] **Step 1: Run compile checks**
+
+Run:
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m py_compile \
+  tldw_Server_API/app/core/Moderation/policy_compiler.py \
+  tldw_Server_API/app/core/Moderation/moderation_service.py \
+  tldw_Server_API/app/core/Moderation/supervised_policy.py \
+  tldw_Server_API/tests/unit/test_moderation_policy_compiler.py \
+  tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py \
+  tldw_Server_API/tests/unit/test_moderation_effective_settings.py \
+  tldw_Server_API/tests/Guardian/test_supervised_policy.py
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 2: Run targeted pytest suite**
+
+Run:
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/unit/test_moderation_policy_compiler.py \
+  tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py \
+  tldw_Server_API/tests/unit/test_moderation_effective_settings.py \
+  tldw_Server_API/tests/unit/test_moderation_check_text_snippet.py \
+  tldw_Server_API/tests/unit/test_moderation_redact_categories.py \
+  tldw_Server_API/tests/Guardian/test_supervised_policy.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run whitespace diff check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 4: Run Bandit on touched Moderation code**
+
+Run:
+
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m bandit -r tldw_Server_API/app/core/Moderation -f json -o /tmp/bandit_moderation_policy_compiler.json
+```
+
+Expected: exit code 0 and zero new findings in touched Moderation code.
+
+- [ ] **Step 5: Inspect git diff for scope**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+```
+
+Expected: only planned Moderation code/tests, plan docs, and Backlog task files are changed.
+
+- [ ] **Step 6: Update Backlog implementation task**
+
+Record:
+
+- exact pytest result summary
+- py_compile result
+- Bandit result and output path
+- `git diff --check` result
+- any known skips or blockers
+
+- [ ] **Step 7: Commit final verification notes**
+
+Run:
+
+```bash
+git add 'backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md'
+git commit -m "Record moderation policy compiler verification"
+```
+
+If no task file changed after verification, skip this commit and record the evidence in the final response.
+
+---
+
+## Self-Review Checklist
+
+- [ ] Spec coverage: every design requirement maps to one or more tasks.
+- [ ] Placeholder scan: plan contains no unfinished markers.
+- [ ] Type consistency: names match across tasks: `ResolvedModerationConfig`, `PolicyCompilationInput`, `PolicyCompilationIssue`, `PolicyCompilationReport`, `PolicyCompilationResult`, `PolicyCompiler`.
+- [ ] Scope check: no `PolicyEvaluator` implementation appears in this plan.
+- [ ] Boundary check: no file I/O is assigned to `PolicyCompiler`.
+- [ ] Compatibility check: public service methods and existing policy types remain intact.

--- a/Docs/superpowers/plans/2026-06-24-moderation-policy-compiler-refactor-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-06-24-moderation-policy-compiler-refactor-implementation-plan.md
@@ -14,13 +14,15 @@
 
 Design: `Docs/superpowers/specs/2026-06-24-moderation-policy-compiler-refactor-design.md`
 
-Backlog: `TASK-2431`
+Plan Backlog: `TASK-2431`
+Implementation Backlog: `TASK-2432`
 
 ## File Structure
 
 - Create: `tldw_Server_API/app/core/Moderation/policy_compiler.py`
   - Owns `ResolvedModerationConfig`, `PolicyCompilationInput`, `PolicyCompilationIssue`, `PolicyCompilationReport`, `PolicyCompilationResult`, and `PolicyCompiler`.
   - Owns shared parsing, regex flag, dangerous-regex, category, boolean, and rule compilation helpers.
+  - Must not import `ModerationPolicy` or `PatternRule` from `moderation_service.py` at module import time. Use `TYPE_CHECKING` plus a local runtime import helper to avoid a circular import when `ModerationService` imports `PolicyCompiler`.
 - Modify: `tldw_Server_API/app/core/Moderation/moderation_service.py`
   - Keeps all I/O, path resolution, persistence, locks, logging, and public methods.
   - Builds `ResolvedModerationConfig`.
@@ -35,7 +37,7 @@ Backlog: `TASK-2431`
   - Add/adjust settings and PII effective-policy compatibility tests.
 - Modify: `tldw_Server_API/tests/Guardian/test_supervised_policy.py`
   - Add/adjust overlay regression coverage only if compiler integration affects policy construction tests.
-- Modify: `backlog/tasks/task-2431 - Plan-Moderation-PolicyCompiler-refactor-implementation.md`
+- Modify: `backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md`
   - Track implementation progress, modified files, and verification evidence.
 
 ## Conventions
@@ -144,12 +146,13 @@ Create `tldw_Server_API/app/core/Moderation/policy_compiler.py`:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING
 
-from tldw_Server_API.app.core.Moderation.moderation_service import (
-    ModerationPolicy,
-    PatternRule,
-)
+if TYPE_CHECKING:
+    from tldw_Server_API.app.core.Moderation.moderation_service import (
+        ModerationPolicy,
+        PatternRule,
+    )
 
 
 @dataclass(frozen=True)
@@ -197,14 +200,24 @@ class PolicyCompilationResult:
 
 
 class PolicyCompiler:
+    @staticmethod
+    def policy_types() -> tuple[type[ModerationPolicy], type[PatternRule]]:
+        from tldw_Server_API.app.core.Moderation.moderation_service import (
+            ModerationPolicy,
+            PatternRule,
+        )
+
+        return ModerationPolicy, PatternRule
+
     def compile_global(self, data: PolicyCompilationInput) -> PolicyCompilationResult:
         report = PolicyCompilationReport()
         config = data.config
-        categories_enabled = self._resolve_runtime_categories(
+        ModerationPolicy, PatternRule = self.policy_types()
+        categories_enabled = self.resolve_runtime_categories(
             data.runtime_override,
             config.categories_enabled,
         )
-        pii_enabled = self._resolve_runtime_pii(data.runtime_override, config.pii_enabled)
+        pii_enabled = self.resolve_runtime_pii(data.runtime_override, config.pii_enabled)
         block_patterns: list[PatternRule] = []
         if pii_enabled:
             block_patterns.extend(list(data.pii_rules or []))
@@ -223,13 +236,13 @@ class PolicyCompiler:
         return PolicyCompilationResult(policy=policy, report=report)
 
     @staticmethod
-    def _resolve_runtime_pii(runtime_override: dict[str, object], default: bool) -> bool:
+    def resolve_runtime_pii(runtime_override: dict[str, object], default: bool) -> bool:
         if "pii_enabled" in runtime_override:
             return bool(runtime_override.get("pii_enabled"))
         return bool(default)
 
     @staticmethod
-    def _resolve_runtime_categories(
+    def resolve_runtime_categories(
         runtime_override: dict[str, object],
         default: set[str] | None,
     ) -> set[str] | None:
@@ -350,8 +363,9 @@ class PolicyCompiler:
     def compile_global(self, data: PolicyCompilationInput) -> PolicyCompilationResult:
         report = PolicyCompilationReport()
         config = data.config
-        categories_enabled = self._resolve_runtime_categories(data.runtime_override, config.categories_enabled)
-        pii_enabled = self._resolve_runtime_pii(data.runtime_override, config.pii_enabled)
+        ModerationPolicy, _ = self.policy_types()
+        categories_enabled = self.resolve_runtime_categories(data.runtime_override, config.categories_enabled)
+        pii_enabled = self.resolve_runtime_pii(data.runtime_override, config.pii_enabled)
         block_patterns = self.compile_blocklist_lines(data.blocklist_lines, report)
         if pii_enabled:
             block_patterns.extend(list(data.pii_rules or []))
@@ -558,6 +572,7 @@ Use this rule compilation body:
         source: str,
         index: int | None,
     ) -> PatternRule | None:
+        _, PatternRule = self.policy_types()
         try:
             regex_parts = self.parse_regex_expr(expr)
             if regex_parts:
@@ -661,6 +676,7 @@ In `moderation_service.py`, import the compiler:
 
 ```python
 from tldw_Server_API.app.core.Moderation.policy_compiler import (
+    PolicyCompilationInput,
     PolicyCompilationReport,
     PolicyCompiler,
     ResolvedModerationConfig,
@@ -793,22 +809,98 @@ class _ResolvedModerationServiceState:
     runtime_overrides_path: str | None
 ```
 
-Have `_resolve_moderation_config()` return `_ResolvedModerationServiceState`. Do not put paths in `ResolvedModerationConfig`.
+Have `_resolve_moderation_config()` return `_ResolvedModerationServiceState`. Do not put paths in `ResolvedModerationConfig`. Keep runtime overrides out of `_resolve_moderation_config()`; the compiler applies runtime category and PII overrides so the service can load explicit PII rules from the effective PII state.
 
-Implement `ResolvedModerationConfig` construction with existing defaults and env fallback semantics:
+Implement config loading and resolution with existing defaults and env fallback semantics:
 
 ```python
-compiler_config = ResolvedModerationConfig(
-    enabled=_b("enabled", False),
-    input_enabled=_b("input_enabled", True),
-    output_enabled=_b("output_enabled", True),
-    input_action=str(mod_cfg.get("input_action", "block")).lower(),
-    output_action=str(mod_cfg.get("output_action", "redact")).lower(),
-    redact_replacement=str(mod_cfg.get("redact_replacement", "[REDACTED]")),
-    per_user_overrides=_b("per_user_overrides", True),
-    categories_enabled=categories_enabled or None,
-    pii_enabled=bool(pii_enabled),
-)
+def _load_moderation_config_section(self) -> dict[str, object]:
+    mod_cfg = (self._config.get("moderation") or {}) if isinstance(self._config, dict) else {}
+    if mod_cfg:
+        return dict(mod_cfg)
+    try:
+        parser = load_comprehensive_config()
+        if parser and parser.has_section("Moderation"):
+            return dict(parser.items("Moderation"))
+    except _MODERATION_NONCRITICAL_EXCEPTIONS:
+        return {}
+    return {}
+
+
+def _resolve_moderation_config(self, mod_cfg: dict[str, object]) -> _ResolvedModerationServiceState:
+    def _b(key: str, default: bool) -> bool:
+        val = str(mod_cfg.get(key, default)).strip().lower()
+        return is_truthy(val)
+
+    def _anchor(path_value: str) -> str:
+        try:
+            from pathlib import Path as _Path
+            path = _Path(str(path_value))
+            if path.is_absolute():
+                return str(path)
+            from tldw_Server_API.app.core.Utils.Utils import get_project_root
+            return str((_Path(get_project_root()) / path).resolve())
+        except _MODERATION_NONCRITICAL_EXCEPTIONS:
+            return str(path_value)
+
+    blocklist_path = (
+        mod_cfg.get("blocklist_file")
+        or os.getenv("MODERATION_BLOCKLIST_FILE")
+        or "tldw_Server_API/Config_Files/moderation_blocklist.txt"
+    )
+    user_overrides_path = (
+        mod_cfg.get("user_overrides_file")
+        or os.getenv("MODERATION_USER_OVERRIDES_FILE")
+        or "tldw_Server_API/Config_Files/moderation_user_overrides.json"
+    )
+    runtime_overrides_path = (
+        mod_cfg.get("runtime_overrides_file")
+        or os.getenv("MODERATION_RUNTIME_OVERRIDES_FILE")
+        or "tldw_Server_API/Config_Files/moderation_runtime_overrides.json"
+    )
+
+    with contextlib.suppress(_MODERATION_NONCRITICAL_EXCEPTIONS):
+        self._max_scan_chars = int(mod_cfg.get("max_scan_chars", self._max_scan_chars))
+    with contextlib.suppress(_MODERATION_NONCRITICAL_EXCEPTIONS):
+        self._max_replacements_per_pattern = int(
+            mod_cfg.get("max_replacements_per_pattern", self._max_replacements_per_pattern)
+        )
+    with contextlib.suppress(_MODERATION_NONCRITICAL_EXCEPTIONS):
+        self._match_window_chars = int(mod_cfg.get("match_window_chars", self._match_window_chars))
+    with contextlib.suppress(_MODERATION_NONCRITICAL_EXCEPTIONS):
+        if "blocklist_write_debounce_ms" in mod_cfg:
+            self._write_debounce_ms = int(mod_cfg.get("blocklist_write_debounce_ms", self._write_debounce_ms) or 0)
+
+    cats_val = mod_cfg.get("categories_enabled") if "categories_enabled" in mod_cfg else os.getenv("MODERATION_CATEGORIES_ENABLED", "")
+    categories_enabled: set[str] = set()
+    if isinstance(cats_val, (list, set, tuple)):
+        categories_enabled = {str(c).strip().lower() for c in cats_val if str(c).strip()}
+    elif isinstance(cats_val, str) and cats_val.strip():
+        categories_enabled = {c.strip().lower() for c in cats_val.split(",") if c.strip()}
+    elif cats_val:
+        logger.warning("Invalid moderation categories_enabled type")
+
+    pii_enabled = is_truthy(
+        str(mod_cfg.get("pii_enabled", os.getenv("MODERATION_PII_ENABLED", "false"))).strip().lower()
+    )
+
+    compiler_config = ResolvedModerationConfig(
+        enabled=_b("enabled", False),
+        input_enabled=_b("input_enabled", True),
+        output_enabled=_b("output_enabled", True),
+        input_action=str(mod_cfg.get("input_action", "block")).lower(),
+        output_action=str(mod_cfg.get("output_action", "redact")).lower(),
+        redact_replacement=str(mod_cfg.get("redact_replacement", "[REDACTED]")),
+        per_user_overrides=_b("per_user_overrides", True),
+        categories_enabled=categories_enabled or None,
+        pii_enabled=bool(pii_enabled),
+    )
+    return _ResolvedModerationServiceState(
+        compiler_config=compiler_config,
+        blocklist_path=_anchor(blocklist_path) if blocklist_path else None,
+        user_overrides_path=_anchor(user_overrides_path) if user_overrides_path else None,
+        runtime_overrides_path=_anchor(runtime_overrides_path) if runtime_overrides_path else None,
+    )
 ```
 
 - [ ] **Step 4: Read blocklist lines and pass explicit PII rules**
@@ -833,8 +925,12 @@ Compile globally with explicit PII rules:
 
 ```python
 def _compile_global_policy_from_resolved_config(self, config: ResolvedModerationConfig) -> ModerationPolicy:
-    self._pii_enabled = bool(config.pii_enabled)
-    pii_rules = self._load_builtin_pii_rules() if config.pii_enabled else []
+    effective_pii_enabled = self._policy_compiler.resolve_runtime_pii(
+        self._runtime_override,
+        config.pii_enabled,
+    )
+    self._pii_enabled = bool(effective_pii_enabled)
+    pii_rules = self._load_builtin_pii_rules() if effective_pii_enabled else []
     lines = self._read_blocklist_lines_for_compile(getattr(self, "_blocklist_path", None))
     result = self._policy_compiler.compile_global(
         PolicyCompilationInput(
@@ -967,6 +1063,38 @@ def test_compile_user_policy_adds_wildcard_quick_rules():
     assert rule.action == "warn"
     assert rule.categories == {"*"}
     assert rule.phase == "input"
+
+
+def test_compile_user_policy_accepts_legacy_bool_like_is_regex_values():
+    base = ModerationPolicy(enabled=True, block_patterns=[])
+
+    result = PolicyCompiler().compile_user_policy(
+        base,
+        {
+            "rules": [
+                {
+                    "id": "r1",
+                    "pattern": r"token-\d+",
+                    "is_regex": "yes",
+                    "action": "block",
+                    "phase": "input",
+                },
+                {
+                    "id": "r2",
+                    "pattern": "literal.*",
+                    "is_regex": "false",
+                    "action": "warn",
+                    "phase": "output",
+                },
+            ]
+        },
+    )
+
+    assert len(result.policy.block_patterns) == 2
+    assert result.policy.block_patterns[0].regex.search("token-42")
+    assert result.policy.block_patterns[1].regex.search("literal.*")
+    assert not result.policy.block_patterns[1].regex.search("literalabc")
+    assert result.report.issues == []
 ```
 
 - [ ] **Step 2: Run user tests to verify they fail**
@@ -975,7 +1103,11 @@ Run:
 
 ```bash
 source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
-python -m pytest tldw_Server_API/tests/unit/test_moderation_policy_compiler.py::test_compile_user_policy_preserves_empty_category_override tldw_Server_API/tests/unit/test_moderation_policy_compiler.py::test_compile_user_policy_adds_wildcard_quick_rules -q
+python -m pytest \
+  tldw_Server_API/tests/unit/test_moderation_policy_compiler.py::test_compile_user_policy_preserves_empty_category_override \
+  tldw_Server_API/tests/unit/test_moderation_policy_compiler.py::test_compile_user_policy_adds_wildcard_quick_rules \
+  tldw_Server_API/tests/unit/test_moderation_policy_compiler.py::test_compile_user_policy_accepts_legacy_bool_like_is_regex_values \
+  -q
 ```
 
 Expected: FAIL because `compile_user_policy()` does not exist.
@@ -1027,6 +1159,22 @@ Add helper implementations using current service semantics:
             return default
         return str(value).strip().lower() in {"1", "true", "yes", "on", "y"}
 
+    @staticmethod
+    def parse_bool_value(value: object) -> bool | None:
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            return bool(value)
+        if isinstance(value, str):
+            text = value.strip().lower()
+            if text in {"1", "true", "yes", "on", "y"}:
+                return True
+            if text in {"0", "false", "no", "n", "off"}:
+                return False
+        return None
+
     def resolve_categories_override(
         self,
         override: dict[str, object],
@@ -1066,8 +1214,8 @@ Compile quick rules with existing wildcard categories:
         pattern = str(raw_rule.get("pattern", "")).strip()
         action = str(raw_rule.get("action", "")).strip().lower()
         phase = str(raw_rule.get("phase", "both")).strip().lower()
-        is_regex = raw_rule.get("is_regex", False)
-        if not isinstance(is_regex, bool):
+        is_regex = self.parse_bool_value(raw_rule.get("is_regex", False))
+        if is_regex is None:
             report.add("user_rule", "invalid_is_regex", index=index)
             return None
         if not pattern or action not in {"block", "warn"}:
@@ -1140,25 +1288,48 @@ git commit -m "Move moderation user policy assembly into compiler"
 
 - [ ] **Step 1: Add regression tests for recompile triggers**
 
-Add tests that exercise public behavior:
+Add the settings regression to `test_moderation_effective_settings.py` and the blocklist write regression to `test_moderation_blocklist_parse.py`. If both files need `_tmp_moderation_config()`, define the helper locally in each file or reuse an equivalent helper that already exists in that same file; do not import test helpers across test modules.
 
 ```python
-def test_update_settings_recompiles_global_policy_with_runtime_categories(monkeypatch):
+def _tmp_moderation_config(tmp_path, blocklist_path):
+    return {
+        "moderation": {
+            "enabled": "true",
+            "blocklist_file": str(blocklist_path),
+            "user_overrides_file": str(tmp_path / "moderation_user_overrides.json"),
+            "runtime_overrides_file": str(tmp_path / "moderation_runtime_overrides.json"),
+            "categories_enabled": "pii",
+        }
+    }
+
+
+def test_update_settings_recompiles_global_policy_with_runtime_categories(monkeypatch, tmp_path):
+    blocklist = tmp_path / "moderation_blocklist.txt"
+    blocklist.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        moderation_service_module,
+        "load_and_log_configs",
+        lambda: _tmp_moderation_config(tmp_path, blocklist),
+    )
+
     svc = ModerationService()
-    svc._global_policy = ModerationPolicy(enabled=True, categories_enabled={"pii"})
     svc._runtime_override = {}
 
-    result = svc.update_settings(categories_enabled=["confidential"])
+    result = svc.update_settings(categories_enabled=["confidential"], persist=False)
 
     assert result["categories_enabled"] == ["confidential"]
     assert svc._global_policy.categories_enabled == {"confidential"}
 
 
-def test_set_blocklist_lines_recompiles_policy_from_file(tmp_path):
+def test_set_blocklist_lines_recompiles_policy_from_file(monkeypatch, tmp_path):
     blocklist = tmp_path / "moderation_blocklist.txt"
+    monkeypatch.setattr(
+        moderation_service_module,
+        "load_and_log_configs",
+        lambda: _tmp_moderation_config(tmp_path, blocklist),
+    )
+
     svc = ModerationService()
-    svc._blocklist_path = str(blocklist)
-    svc._global_policy = ModerationPolicy(enabled=True, block_patterns=[])
 
     assert svc.set_blocklist_lines(["secret -> block #confidential"]) is True
 
@@ -1166,7 +1337,7 @@ def test_set_blocklist_lines_recompiles_policy_from_file(tmp_path):
     assert any(rule.regex.search("secret") for rule in policy.block_patterns)
 ```
 
-Adjust fixture setup to match existing test helpers in `test_moderation_blocklist_parse.py`.
+Add `import tldw_Server_API.app.core.Moderation.moderation_service as moderation_service_module` to `test_moderation_effective_settings.py` if it is not already present. `test_moderation_blocklist_parse.py` already has this import. Keep `persist=False` in the settings test so it does not write runtime override files unless the test is explicitly asserting persistence.
 
 - [ ] **Step 2: Add supervised overlay regression if not already covered**
 
@@ -1345,9 +1516,9 @@ If no task file changed after verification, skip this commit and record the evid
 
 ## Self-Review Checklist
 
-- [ ] Spec coverage: every design requirement maps to one or more tasks.
-- [ ] Placeholder scan: plan contains no unfinished markers.
-- [ ] Type consistency: names match across tasks: `ResolvedModerationConfig`, `PolicyCompilationInput`, `PolicyCompilationIssue`, `PolicyCompilationReport`, `PolicyCompilationResult`, `PolicyCompiler`.
-- [ ] Scope check: no `PolicyEvaluator` implementation appears in this plan.
-- [ ] Boundary check: no file I/O is assigned to `PolicyCompiler`.
-- [ ] Compatibility check: public service methods and existing policy types remain intact.
+- [x] Spec coverage: every design requirement maps to one or more tasks.
+- [x] Placeholder scan: plan contains no unfinished markers.
+- [x] Type consistency: names match across tasks: `ResolvedModerationConfig`, `PolicyCompilationInput`, `PolicyCompilationIssue`, `PolicyCompilationReport`, `PolicyCompilationResult`, `PolicyCompiler`.
+- [x] Scope check: no `PolicyEvaluator` implementation appears in this plan.
+- [x] Boundary check: no file I/O is assigned to `PolicyCompiler`.
+- [x] Compatibility check: public service methods and existing policy types remain intact.

--- a/Docs/superpowers/plans/2026-06-29-pr2528-review-rebase.md
+++ b/Docs/superpowers/plans/2026-06-29-pr2528-review-rebase.md
@@ -1,0 +1,35 @@
+# PR 2528 Review Rebase Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebase PR #2528 onto latest `dev`, address active moderation policy compiler review comments, and push the verified branch.
+
+**Architecture:** Keep fixes scoped to the moderation policy compiler design changes and adjacent tests/docs. Verify each review comment against current code before changing behavior, and prefer small regression tests for valid behavioral issues.
+
+**Tech Stack:** Python, pytest, FastAPI project conventions, Backlog.md, GitHub CLI.
+
+---
+
+## Stage 1: Rebase And Inventory
+**Goal**: Rebase PR #2528 onto latest `origin/dev` and identify all active review threads/comments.
+**Success Criteria**: Branch rebases cleanly or conflicts are resolved, review comments are mapped to touched files, and Backlog task `TASK-12015` tracks the work.
+**Tests**: Git rebase status and GitHub review-thread query.
+**Status**: In Progress
+
+## Stage 2: Review Fixes
+**Goal**: Verify each review comment against current code and implement only technically valid fixes.
+**Success Criteria**: Each active comment has a code/test/doc change or a documented technical rationale.
+**Tests**: Failing regression tests first where behavior changes are needed, then focused pytest runs.
+**Status**: Not Started
+
+## Stage 3: Verification
+**Goal**: Run focused tests and required quality gates for touched scope.
+**Success Criteria**: Focused moderation compiler tests/docs checks, compile checks, Bandit for touched production files, and relevant CI guard checks pass or are reported with evidence.
+**Tests**: Commands recorded in `TASK-12015`.
+**Status**: Not Started
+
+## Stage 4: Push And Resolve
+**Goal**: Commit, push the rebased branch, reply to/resolved addressed review threads, and report remaining CI status.
+**Success Criteria**: PR branch is updated on GitHub, review threads are resolved or documented as non-actionable, and final status is reported.
+**Tests**: `gh pr view`, `gh pr checks`, and review-thread query.
+**Status**: Not Started

--- a/Docs/superpowers/plans/2026-06-29-pr2528-review-rebase.md
+++ b/Docs/superpowers/plans/2026-06-29-pr2528-review-rebase.md
@@ -12,7 +12,7 @@
 
 ## Stage 1: Rebase And Inventory
 **Goal**: Rebase PR #2528 onto latest `origin/dev` and identify all active review threads/comments.
-**Success Criteria**: Branch rebases cleanly or conflicts are resolved, review comments are mapped to touched files, and Backlog task `TASK-12015` tracks the work.
+**Success Criteria**: Branch rebases cleanly or conflicts are resolved, review comments are mapped to touched files, and Backlog task `TASK-12022` tracks the work.
 **Tests**: Git rebase status and GitHub review-thread query.
 **Status**: Complete
 
@@ -32,4 +32,4 @@
 **Goal**: Commit, push the rebased branch, reply to/resolved addressed review threads, and report remaining CI status.
 **Success Criteria**: PR branch is updated on GitHub, review threads are resolved or documented as non-actionable, and final status is reported.
 **Tests**: `gh pr view`, `gh pr checks`, and review-thread query.
-**Status**: In Progress
+**Status**: Complete

--- a/Docs/superpowers/plans/2026-06-29-pr2528-review-rebase.md
+++ b/Docs/superpowers/plans/2026-06-29-pr2528-review-rebase.md
@@ -14,22 +14,22 @@
 **Goal**: Rebase PR #2528 onto latest `origin/dev` and identify all active review threads/comments.
 **Success Criteria**: Branch rebases cleanly or conflicts are resolved, review comments are mapped to touched files, and Backlog task `TASK-12015` tracks the work.
 **Tests**: Git rebase status and GitHub review-thread query.
-**Status**: In Progress
+**Status**: Complete
 
 ## Stage 2: Review Fixes
 **Goal**: Verify each review comment against current code and implement only technically valid fixes.
 **Success Criteria**: Each active comment has a code/test/doc change or a documented technical rationale.
 **Tests**: Failing regression tests first where behavior changes are needed, then focused pytest runs.
-**Status**: Not Started
+**Status**: Complete
 
 ## Stage 3: Verification
 **Goal**: Run focused tests and required quality gates for touched scope.
 **Success Criteria**: Focused moderation compiler tests/docs checks, compile checks, Bandit for touched production files, and relevant CI guard checks pass or are reported with evidence.
 **Tests**: Commands recorded in `TASK-12015`.
-**Status**: Not Started
+**Status**: Complete
 
 ## Stage 4: Push And Resolve
 **Goal**: Commit, push the rebased branch, reply to/resolved addressed review threads, and report remaining CI status.
 **Success Criteria**: PR branch is updated on GitHub, review threads are resolved or documented as non-actionable, and final status is reported.
 **Tests**: `gh pr view`, `gh pr checks`, and review-thread query.
-**Status**: Not Started
+**Status**: In Progress

--- a/Docs/superpowers/specs/2026-06-24-moderation-policy-compiler-refactor-design.md
+++ b/Docs/superpowers/specs/2026-06-24-moderation-policy-compiler-refactor-design.md
@@ -50,7 +50,8 @@ Add `tldw_Server_API/app/core/Moderation/policy_compiler.py`.
 The module should contain:
 
 - `PolicyCompiler`: pure policy normalization and rule compilation.
-- `PolicyCompilationInput`: a dataclass containing already-loaded inputs.
+- `ResolvedModerationConfig`: a service-built dataclass containing scalar moderation settings and defaults after config/env fallback resolution, with file paths excluded.
+- `PolicyCompilationInput`: a dataclass containing already-loaded inputs and the resolved config snapshot.
 - `PolicyCompilationResult`: a dataclass containing the compatible `ModerationPolicy` plus `PolicyCompilationReport`.
 - `PolicyCompilationReport`: sanitized internal diagnostics for skipped or normalized inputs.
 
@@ -85,14 +86,15 @@ The compiler should return existing `ModerationPolicy` objects. The optional rep
 
 The compiler receives already-loaded data, not file paths:
 
-- base moderation config mapping
-- environment-derived values that the service has already resolved
+- `ResolvedModerationConfig`, built by `ModerationService` after config, environment, and default resolution
 - runtime override mapping
 - blocklist lines
 - optional user override mapping
-- built-in PII rules supplied by `ModerationService` through a provider callback or explicit list
+- built-in PII `PatternRule` values already resolved by `ModerationService`
 
 The compiler must not call `open()`, inspect filesystem paths, create directories, or persist anything.
+
+`ResolvedModerationConfig` should not carry filesystem paths. `ModerationService` should continue resolving and storing blocklist, runtime override, and user override paths separately so the compiler cannot accidentally become an I/O boundary.
 
 ## Precedence
 
@@ -119,6 +121,8 @@ The design must preserve the current category distinction where `categories_enab
 
 Per-user quick-list rules should remain category-agnostic by using the existing wildcard behavior so they still apply when category filters are enabled.
 
+Existing `ModerationService` helper methods that tests or adjacent code currently call directly, including `_parse_rule_line()`, `_load_block_patterns()`, and `_build_block_patterns()`, should remain as delegating compatibility wrappers for this slice. If an implementation chooses to remove or rename one of these helpers, it must update every internal caller and test in the same branch and document that narrower break from private-helper compatibility in the implementation plan.
+
 ## Invalid Input Handling
 
 The compiler should continue forgiving load-time behavior:
@@ -136,15 +140,19 @@ Strict API validation for user override writes remains separate from forgiving l
 
 `ModerationService` may convert report entries into the same style of warning logs emitted today.
 
+Do not reuse `PolicyCompilationReport` as the public blocklist lint response. `lint_blocklist_lines()` currently returns endpoint-facing fields such as `line`, `sample`, `error`, and `warning`; that contract should remain behavior-compatible. Shared parser helpers may power both linting and compilation, but lint output can include user-submitted lint context while compilation reports stay sanitized for logs and diagnostics.
+
 ## Regex And Parser Ownership
 
 Regex parsing and regex safety checks should have one owner after the refactor. The preferred first-slice shape is for `PolicyCompiler` to own blocklist parsing and rule compilation helpers, while existing service lint and validation methods delegate to the shared compiler/parser helpers where behavior overlaps.
 
 The implementation should avoid copying the same regex flag parsing and dangerous-regex heuristics into multiple modules.
 
+When service linting delegates to shared helpers, preserve its current distinctions between valid ignored lines, invalid lines, regex samples, literal samples, invalid regex flags treated as literals, and dangerous regex errors.
+
 ## PII Rule Boundary
 
-Built-in PII rule loading should stay explicit. The compiler should not import PII detector dependencies implicitly. `ModerationService` should provide PII `PatternRule` values through a small provider callback or by calling an existing service method and passing the resulting rules into the compiler.
+Built-in PII rule loading should stay explicit. The compiler should not import PII detector dependencies implicitly and should not call a provider callback that can hide import or runtime failures. `ModerationService` should resolve PII `PatternRule` values before compilation and pass an explicit list into the compiler.
 
 This keeps compiler tests deterministic and makes dependency failures visible at the service boundary.
 
@@ -162,12 +170,14 @@ Add focused compiler unit tests for:
 - runtime override precedence
 - category parsing for lists, strings, empty strings, and invalid types
 - blocklist literal and regex parsing
+- service lint output compatibility when shared parser helpers are used
 - invalid action, invalid regex, invalid flags, and dangerous regex reports
 - effective PII enablement and appended PII rules
 - user override field precedence
 - user category override empty-string behavior
 - user quick-rule compilation and wildcard categories
 - sanitized report contents
+- `ModerationService` delegating wrappers for existing private helper compatibility
 
 Keep service compatibility tests around:
 

--- a/Docs/superpowers/specs/2026-06-24-moderation-policy-compiler-refactor-design.md
+++ b/Docs/superpowers/specs/2026-06-24-moderation-policy-compiler-refactor-design.md
@@ -1,0 +1,203 @@
+# Moderation PolicyCompiler Refactor Design
+
+Task: TASK-2430
+Date: 2026-06-24
+Status: Draft for user review
+
+## Purpose
+
+Refactor the Moderation module in a compiler-first slice that improves long-term stability without changing public behavior. The first implementation should extract deterministic policy assembly from `ModerationService` into a dedicated `PolicyCompiler`, while preserving `ModerationService` as the public facade and keeping the existing `ModerationPolicy` and `PatternRule` types as the compatibility contract.
+
+This slice intentionally prepares the module for a later mostly pure `PolicyEvaluator`, but does not move evaluation logic yet.
+
+## Current Problem
+
+`moderation_service.py` currently mixes unrelated responsibilities:
+
+- config and environment fallback resolution
+- path anchoring and file reads/writes
+- runtime and user override persistence
+- blocklist parsing and regex compilation
+- PII rule inclusion
+- effective policy construction
+- text evaluation and redaction
+
+That coupling makes precedence hard to reason about and creates risk when changing rule behavior. The most pragmatic first step is to make effective policy construction explicit and testable while leaving the public service and evaluation path intact.
+
+## Goals
+
+- Preserve existing behavior and public method signatures.
+- Keep `ModerationService` as the public facade used by chat, endpoints, workflows, and tests.
+- Keep returning `ModerationPolicy` from `get_effective_policy()`.
+- Extract deterministic policy assembly into a `PolicyCompiler`.
+- Make precedence, invalid-rule handling, and category behavior explicit.
+- Produce sanitized internal compilation diagnostics without creating a new public endpoint contract.
+- Keep file I/O, locking, logging, and persistence in `ModerationService`.
+
+## Non-Goals
+
+- Do not introduce a public `CompiledModerationPolicy` type in this slice.
+- Do not freeze or replace `ModerationPolicy` or `PatternRule`.
+- Do not extract text evaluation, redaction, match ranking, or result building yet.
+- Do not fold guardian/supervised policy overlays into the compiler.
+- Do not change moderation endpoint responses unless required to preserve current behavior.
+- Do not make load-time invalid rule handling stricter than it is today.
+
+## Proposed Structure
+
+Add `tldw_Server_API/app/core/Moderation/policy_compiler.py`.
+
+The module should contain:
+
+- `PolicyCompiler`: pure policy normalization and rule compilation.
+- `PolicyCompilationInput`: a dataclass containing already-loaded inputs.
+- `PolicyCompilationResult`: a dataclass containing the compatible `ModerationPolicy` plus `PolicyCompilationReport`.
+- `PolicyCompilationReport`: sanitized internal diagnostics for skipped or normalized inputs.
+
+The compiler should return existing `ModerationPolicy` objects. The optional report is for service logging and tests, not a public API contract.
+
+## Responsibilities
+
+`ModerationService` keeps:
+
+- config loading from `load_and_log_configs()` and fallback parser loading
+- environment fallback lookup
+- relative path anchoring
+- blocklist, runtime override, and user override file reads
+- all writes and file mutation locks
+- warning and error logging
+- reload behavior
+- public APIs such as `get_effective_policy()`, `effective_policy_snapshot()`, `update_settings()`, `check_text()`, `evaluate_text()`, and `redact_text()`
+
+`PolicyCompiler` owns:
+
+- boolean and category normalization
+- runtime override application
+- blocklist line parsing into `PatternRule`
+- regex flag parsing and safety validation through one shared owner
+- PII rule inclusion when effective PII is enabled
+- user override field application
+- per-user quick-rule compilation
+- effective `ModerationPolicy` construction
+- sanitized report entries for skipped rules and normalization issues
+
+## Inputs
+
+The compiler receives already-loaded data, not file paths:
+
+- base moderation config mapping
+- environment-derived values that the service has already resolved
+- runtime override mapping
+- blocklist lines
+- optional user override mapping
+- built-in PII rules supplied by `ModerationService` through a provider callback or explicit list
+
+The compiler must not call `open()`, inspect filesystem paths, create directories, or persist anything.
+
+## Precedence
+
+The first implementation should preserve the current effective order:
+
+1. Base moderation config and service-resolved defaults.
+2. Runtime overrides for `pii_enabled` and `categories_enabled`.
+3. Blocklist lines compiled into `PatternRule`.
+4. Built-in PII rules appended only when effective PII is enabled.
+5. Global `ModerationPolicy` construction.
+6. User override field application when per-user overrides are enabled and a user override exists.
+7. User category override resolution.
+8. User quick-rule compilation and append.
+
+The service should still cache/store the current global policy as it does today. Recompile points remain reload, runtime setting changes, blocklist mutations, and user override changes.
+
+## Compatibility Details
+
+`get_effective_policy(user_id)` must continue returning `ModerationPolicy`.
+
+Existing callers that construct `ModerationPolicy` directly should continue working. Existing supervised policy overlay behavior should continue composing by receiving and returning `ModerationPolicy`.
+
+The design must preserve the current category distinction where `categories_enabled=None` means no configured filter and user override `categories_enabled=""` normalizes to `set()`. Evaluation currently treats falsy filters as allow-all, but policy construction should not collapse those states earlier than today.
+
+Per-user quick-list rules should remain category-agnostic by using the existing wildcard behavior so they still apply when category filters are enabled.
+
+## Invalid Input Handling
+
+The compiler should continue forgiving load-time behavior:
+
+- invalid blocklist lines are skipped
+- invalid actions are skipped
+- dangerous regexes are skipped
+- invalid regexes are skipped
+- malformed loaded user rules are skipped
+- invalid loaded user override fields are dropped or ignored consistently with current sanitization
+
+Strict API validation for user override writes remains separate from forgiving load-time sanitization. The refactor should not merge these paths into one stricter compiler path.
+
+`PolicyCompilationReport` should record sanitized diagnostics only. Report entries should use reason codes such as `invalid_action`, `invalid_regex`, `dangerous_regex`, `invalid_phase`, or `invalid_is_regex`, plus source kind and line/rule index when useful. They should not store raw dangerous regex text, sensitive matched content, or full filesystem paths.
+
+`ModerationService` may convert report entries into the same style of warning logs emitted today.
+
+## Regex And Parser Ownership
+
+Regex parsing and regex safety checks should have one owner after the refactor. The preferred first-slice shape is for `PolicyCompiler` to own blocklist parsing and rule compilation helpers, while existing service lint and validation methods delegate to the shared compiler/parser helpers where behavior overlaps.
+
+The implementation should avoid copying the same regex flag parsing and dangerous-regex heuristics into multiple modules.
+
+## PII Rule Boundary
+
+Built-in PII rule loading should stay explicit. The compiler should not import PII detector dependencies implicitly. `ModerationService` should provide PII `PatternRule` values through a small provider callback or by calling an existing service method and passing the resulting rules into the compiler.
+
+This keeps compiler tests deterministic and makes dependency failures visible at the service boundary.
+
+## Supervised Policy Boundary
+
+Guardian and supervised policy behavior remains outside this compiler slice. `supervised_policy.py` can continue to overlay guardian rules onto a `ModerationPolicy` returned by `ModerationService`.
+
+This avoids mixing DB-backed guardian schedule/chat-type filtering with local moderation policy assembly. A later design can decide whether supervised overlays should have their own compiler, but this slice should not expand that scope.
+
+## Testing Plan
+
+Add focused compiler unit tests for:
+
+- base config defaults and boolean normalization
+- runtime override precedence
+- category parsing for lists, strings, empty strings, and invalid types
+- blocklist literal and regex parsing
+- invalid action, invalid regex, invalid flags, and dangerous regex reports
+- effective PII enablement and appended PII rules
+- user override field precedence
+- user category override empty-string behavior
+- user quick-rule compilation and wildcard categories
+- sanitized report contents
+
+Keep service compatibility tests around:
+
+- `get_effective_policy()`
+- `effective_policy_snapshot()`
+- `update_settings()`
+- `reload()`
+- blocklist mutation-triggered recompilation
+- user override mutation-triggered recompilation
+- existing evaluation methods consuming compiler-produced `ModerationPolicy`
+
+Keep regression coverage for supervised policy overlays to prove they still consume and return `ModerationPolicy` without behavioral drift.
+
+## Verification Plan
+
+For the implementation branch, run:
+
+- targeted Moderation unit and Guardian tests touched by the refactor
+- Python compile checks for touched Moderation modules and tests
+- `git diff --check`
+- Bandit on `tldw_Server_API/app/core/Moderation`
+
+For this design-only branch, verify:
+
+- the spec has no draft markers or unfinished sections
+- Backlog task acceptance criteria are aligned with this document
+- `git diff --check` passes
+
+## Future Refactor Path
+
+After this compiler slice lands, the next practical slice is a mostly pure `PolicyEvaluator` behind `ModerationService`. That evaluator can consume `ModerationPolicy` produced by the compiler and own rule matching, category/phase gating, redaction decisions, and result construction.
+
+Keeping the compiler slice first reduces the risk of moving evaluation logic while policy construction remains implicit and stateful.

--- a/backlog/tasks/task-12015 - Rebase-PR-2528-and-address-moderation-compiler-review-comments.md
+++ b/backlog/tasks/task-12015 - Rebase-PR-2528-and-address-moderation-compiler-review-comments.md
@@ -26,7 +26,26 @@ Rebase PR #2528 on latest dev, inspect active review comments, implement verifie
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+- Rebased `codex/moderation-policy-compiler-design` onto latest `origin/dev` (`73fc173e9a`) without conflicts.
+- Inventoried active PR #2528 review feedback:
+  - Qodo action required: add module/class/function docstrings in `policy_compiler.py`.
+  - Qodo action required: add actionable context and exception traces when blocklist compilation loads fail.
+  - Qodo review recommended: avoid `readlines()` on the blocklist compilation path.
+  - Qodo optional: remove redundant regex-danger helper implementations from `ModerationService`.
+- Implemented the review fixes:
+  - Added docstrings to the compiler module and all compiler classes/functions.
+  - Let compiler blocklist inputs accept iterables, changed the service compile path to stream file lines, and added regression coverage proving `readlines()` is not used for compilation.
+  - Added path context and `logger.exception` stack traces for blocklist compile load failures while preserving existing fail-open behavior.
+  - Removed the duplicate service regex helper implementations so the compiler remains the single owner.
+  - Added a unit marker to the new compiler test module and fixed Ruff findings in PR-touched Guardian/moderation tests.
+- Verification run:
+  - `python -m pytest tldw_Server_API/tests/unit/test_moderation_policy_compiler.py tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py tldw_Server_API/tests/unit/test_moderation_effective_settings.py tldw_Server_API/tests/Guardian/test_supervised_policy.py -q --tb=short` -> `144 passed`.
+  - `python -m ruff check ...` on touched moderation/guardian files -> passed.
+  - `git diff --check` -> passed.
+  - `python -m compileall tldw_Server_API/app/core/Moderation/policy_compiler.py tldw_Server_API/app/core/Moderation/moderation_service.py` -> passed.
+  - `python Helper_Scripts/ci/check_shard_coverage.py --ci-file .github/workflows/ci.yml` -> passed (`new_uncovered=0`).
+  - `python -m bandit -r tldw_Server_API/app/core/Moderation/policy_compiler.py tldw_Server_API/app/core/Moderation/moderation_service.py -f json -o /tmp/bandit_pr2528.json` -> 0 findings.
+  - AST docstring scan for `policy_compiler.py` -> module docstring present and no missing class/function docstrings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12015 - Rebase-PR-2528-and-address-moderation-compiler-review-comments.md
+++ b/backlog/tasks/task-12015 - Rebase-PR-2528-and-address-moderation-compiler-review-comments.md
@@ -1,0 +1,44 @@
+---
+id: TASK-12015
+title: Rebase PR 2528 and address moderation compiler review comments
+status: In Progress
+labels:
+- pr-review
+- moderation
+- policy-compiler
+priority: High
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase PR #2528 on latest dev, inspect active review comments, implement verified moderation policy compiler fixes, run focused verification, push the updated branch, and resolve addressed review threads.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 PR #2528 branch is rebased onto latest origin/dev without unresolved conflicts.
+- [ ] #2 All active review comments are inventoried, technically verified, and either fixed or answered with rationale.
+- [ ] #3 Focused tests, compile checks, shard coverage or relevant CI guard checks, and Bandit on touched production code are run as applicable.
+- [ ] #4 Updated branch is pushed and review threads are replied to/resolved.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Backlog task and implementation plan are updated with verification evidence.
+- [ ] #2 Code changes are committed with a clear message.
+- [ ] #3 No unrelated dirty files are staged or modified.
+- [ ] #4 PR branch is pushed to GitHub and remaining check status is reported.
+<!-- DOD:END -->

--- a/backlog/tasks/task-12022 - Rebase-PR-2528-and-address-moderation-compiler-review-comments.md
+++ b/backlog/tasks/task-12022 - Rebase-PR-2528-and-address-moderation-compiler-review-comments.md
@@ -1,7 +1,7 @@
 ---
-id: TASK-12015
+id: TASK-12022
 title: Rebase PR 2528 and address moderation compiler review comments
-status: In Progress
+status: Done
 labels:
 - pr-review
 - moderation
@@ -17,10 +17,10 @@ Rebase PR #2528 on latest dev, inspect active review comments, implement verifie
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 PR #2528 branch is rebased onto latest origin/dev without unresolved conflicts.
-- [ ] #2 All active review comments are inventoried, technically verified, and either fixed or answered with rationale.
-- [ ] #3 Focused tests, compile checks, shard coverage or relevant CI guard checks, and Bandit on touched production code are run as applicable.
-- [ ] #4 Updated branch is pushed and review threads are replied to/resolved.
+- [x] #1 PR #2528 branch is rebased onto latest origin/dev without unresolved conflicts.
+- [x] #2 All active review comments are inventoried, technically verified, and either fixed or answered with rationale.
+- [x] #3 Focused tests, compile checks, shard coverage or relevant CI guard checks, and Bandit on touched production code are run as applicable.
+- [x] #4 Updated branch is pushed and review threads are replied to/resolved.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -46,18 +46,19 @@ Rebase PR #2528 on latest dev, inspect active review comments, implement verifie
   - `python Helper_Scripts/ci/check_shard_coverage.py --ci-file .github/workflows/ci.yml` -> passed (`new_uncovered=0`).
   - `python -m bandit -r tldw_Server_API/app/core/Moderation/policy_compiler.py tldw_Server_API/app/core/Moderation/moderation_service.py -f json -o /tmp/bandit_pr2528.json` -> 0 findings.
   - AST docstring scan for `policy_compiler.py` -> module docstring present and no missing class/function docstrings.
+- Pushed the rebased branch with `--force-with-lease`, resolved all 3 inline review threads, and posted a PR comment for the top-level optional redundant-helper item.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+PR #2528 was rebased onto latest `dev`, Qodo review feedback was addressed, focused verification passed, inline review threads were resolved, and a top-level PR summary comment was posted for the non-inline optional item. GitHub checks were restarted by the branch push and were pending at handoff.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Backlog task and implementation plan are updated with verification evidence.
-- [ ] #2 Code changes are committed with a clear message.
-- [ ] #3 No unrelated dirty files are staged or modified.
-- [ ] #4 PR branch is pushed to GitHub and remaining check status is reported.
+- [x] #1 Backlog task and implementation plan are updated with verification evidence.
+- [x] #2 Code changes are committed with a clear message.
+- [x] #3 No unrelated dirty files are staged or modified.
+- [x] #4 PR branch is pushed to GitHub and remaining check status is reported.
 <!-- DOD:END -->

--- a/backlog/tasks/task-2430 - Design-Moderation-PolicyCompiler-refactor.md
+++ b/backlog/tasks/task-2430 - Design-Moderation-PolicyCompiler-refactor.md
@@ -1,0 +1,53 @@
+---
+id: TASK-2430
+title: Design Moderation PolicyCompiler refactor
+status: Done
+created_date: 2026-06-24 18:26
+labels:
+- moderation
+- design
+- refactor
+priority: medium
+documentation:
+- Docs/superpowers/specs/2026-06-24-moderation-policy-compiler-refactor-design.md
+modified_files:
+- Docs/superpowers/specs/2026-06-24-moderation-policy-compiler-refactor-design.md
+- backlog/tasks/task-2430 - Design-Moderation-PolicyCompiler-refactor.md
+updated_date: 2026-06-24 18:30
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create an implementation-ready design spec for a compiler-first refactor of the Moderation module. The design should preserve ModerationService as the public facade, keep existing ModerationPolicy compatibility, extract deterministic policy assembly into a PolicyCompiler, and document compatibility, error handling, testing, and non-goals before implementation planning.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Design spec is written under Docs/superpowers/specs with the approved compiler-first scope.
+- [x] #2 Spec explicitly addresses compatibility with ModerationPolicy/PatternRule, sanitized reports, I/O boundaries, precedence, strict vs forgiving override handling, PII provider boundaries, and supervised-policy non-goals.
+- [x] #3 Spec is self-reviewed for placeholders, contradictions, ambiguity, and scope.
+- [x] #4 Spec commit is ready for user review before implementation planning.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Wrote the compiler-first Moderation refactor spec and self-reviewed it for scope, contradictions, ambiguity, and draft markers. Design-only verification: `git diff --check` passed for the spec/task scope; draft-marker scan found no TODO/TBD/FIXME/unresolved markers after wording cleanup. Bandit is not applicable to this design-only branch because no code is touched.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Design spec written for the compiler-first Moderation refactor. The approved direction keeps ModerationService as the public facade, preserves ModerationPolicy/PatternRule compatibility, moves deterministic policy assembly into PolicyCompiler, keeps I/O/persistence/logging in the service, preserves strict-vs-forgiving validation boundaries, keeps supervised policy out of scope, and defines focused compiler/service/supervised regression tests. Verification for this design-only branch: git diff --check passed; draft-marker scan found no TODO/TBD/FIXME/unresolved markers. Bandit is not applicable because no code is touched.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2430 - Design-Moderation-PolicyCompiler-refactor.md
+++ b/backlog/tasks/task-2430 - Design-Moderation-PolicyCompiler-refactor.md
@@ -13,7 +13,7 @@ documentation:
 modified_files:
 - Docs/superpowers/specs/2026-06-24-moderation-policy-compiler-refactor-design.md
 - backlog/tasks/task-2430 - Design-Moderation-PolicyCompiler-refactor.md
-updated_date: 2026-06-24 18:30
+updated_date: 2026-06-24 19:31
 ---
 
 ## Description
@@ -33,13 +33,17 @@ Create an implementation-ready design spec for a compiler-first refactor of the 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-Wrote the compiler-first Moderation refactor spec and self-reviewed it for scope, contradictions, ambiguity, and draft markers. Design-only verification: `git diff --check` passed for the spec/task scope; draft-marker scan found no TODO/TBD/FIXME/unresolved markers after wording cleanup. Bandit is not applicable to this design-only branch because no code is touched.
+Wrote the compiler-first Moderation refactor spec and self-reviewed it for scope, contradictions, ambiguity, and draft markers. Design-only verification: `git diff --check` passed for the spec/task scope; draft-marker scan found no unfinished-marker matches after wording cleanup. Bandit is not applicable to this design-only branch because no code is touched.
+
+Reopened briefly to address design review clarifications before moving to implementation planning: preserve lint output, prefer explicit PII rule list over callbacks, preserve service helper wrappers or document test/caller migration, and define a resolved config snapshot boundary.
+
+Updated the spec after design review to clarify: PolicyCompilationReport must not replace the public lint response; PII rules are passed as an explicit pre-resolved list, not a compiler callback; service private-helper compatibility wrappers should remain unless all internal callers/tests migrate together; and compiler inputs use a service-built ResolvedModerationConfig with paths excluded.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Design spec written for the compiler-first Moderation refactor. The approved direction keeps ModerationService as the public facade, preserves ModerationPolicy/PatternRule compatibility, moves deterministic policy assembly into PolicyCompiler, keeps I/O/persistence/logging in the service, preserves strict-vs-forgiving validation boundaries, keeps supervised policy out of scope, and defines focused compiler/service/supervised regression tests. Verification for this design-only branch: git diff --check passed; draft-marker scan found no TODO/TBD/FIXME/unresolved markers. Bandit is not applicable because no code is touched.
+Design spec written and revised for the compiler-first Moderation refactor. The approved direction keeps ModerationService as the public facade, preserves ModerationPolicy/PatternRule compatibility, moves deterministic policy assembly into PolicyCompiler, keeps I/O/persistence/logging in the service, preserves strict-vs-forgiving validation boundaries, keeps supervised policy out of scope, preserves public blocklist lint output, requires explicit pre-resolved PII rules, and defines focused compiler/service/supervised regression tests. Verification for this design-only branch: git diff --check passed; draft-marker scan found no unfinished-marker matches. Bandit is not applicable because no code is touched.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2431 - Plan-Moderation-PolicyCompiler-refactor-implementation.md
+++ b/backlog/tasks/task-2431 - Plan-Moderation-PolicyCompiler-refactor-implementation.md
@@ -15,7 +15,7 @@ modified_files:
 - Docs/superpowers/plans/2026-06-24-moderation-policy-compiler-refactor-implementation-plan.md
 - backlog/tasks/task-2431 - Plan-Moderation-PolicyCompiler-refactor-implementation.md
 - backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
-updated_date: 2026-06-24 20:28
+updated_date: 2026-06-24 20:42
 ---
 
 ## Description
@@ -36,6 +36,8 @@ Write an implementation plan for the approved compiler-first Moderation refactor
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Wrote the implementation plan for the approved Moderation PolicyCompiler refactor. Self-review confirmed the plan covers the design spec, uses exact file paths and commands, keeps PolicyEvaluator out of scope, keeps file I/O out of PolicyCompiler, preserves compatibility boundaries, and includes TDD slices plus commit checkpoints. Verification for this plan-only branch: targeted draft-marker scan found no matches; git diff --check passed for the plan/task files. Bandit is not applicable because no code is touched in this planning step.
+Post-plan review tightened the implementation plan for subagent execution: corrected implementation tracking to TASK-2432, added missing PolicyCompilationInput service import, made service config resolution explicit, preserved legacy bool-like quick-rule parsing, and marked the plan self-review checklist complete after the review pass.
+Follow-up plan review also made Task 6 regression tests deterministic by using temporary moderation config paths and persist=False for update_settings coverage.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2431 - Plan-Moderation-PolicyCompiler-refactor-implementation.md
+++ b/backlog/tasks/task-2431 - Plan-Moderation-PolicyCompiler-refactor-implementation.md
@@ -1,0 +1,55 @@
+---
+id: TASK-2431
+title: Plan Moderation PolicyCompiler refactor implementation
+status: Done
+created_date: 2026-06-24 20:22
+labels:
+- moderation
+- planning
+- refactor
+priority: medium
+documentation:
+- Docs/superpowers/specs/2026-06-24-moderation-policy-compiler-refactor-design.md
+- Docs/superpowers/plans/2026-06-24-moderation-policy-compiler-refactor-implementation-plan.md
+modified_files:
+- Docs/superpowers/plans/2026-06-24-moderation-policy-compiler-refactor-implementation-plan.md
+- backlog/tasks/task-2431 - Plan-Moderation-PolicyCompiler-refactor-implementation.md
+- backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
+updated_date: 2026-06-24 20:28
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Write an implementation plan for the approved compiler-first Moderation refactor design. The plan must be actionable task-by-task, preserve ModerationService compatibility, use TDD, cover verification gates, and remain planning-only with no code implementation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Implementation plan is written under Docs/superpowers/plans and references the approved design spec.
+- [x] #2 Plan decomposes the compiler-first refactor into small TDD tasks with exact files, commands, expected outcomes, and commit checkpoints.
+- [x] #3 Plan covers ResolvedModerationConfig, PolicyCompiler/report types, parser/lint compatibility, PII rule boundary, service integration, compatibility wrappers, and regression tests.
+- [x] #4 Plan is self-reviewed for spec coverage, placeholders, type consistency, and scope.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Wrote the implementation plan for the approved Moderation PolicyCompiler refactor. Self-review confirmed the plan covers the design spec, uses exact file paths and commands, keeps PolicyEvaluator out of scope, keeps file I/O out of PolicyCompiler, preserves compatibility boundaries, and includes TDD slices plus commit checkpoints. Verification for this plan-only branch: targeted draft-marker scan found no matches; git diff --check passed for the plan/task files. Bandit is not applicable because no code is touched in this planning step.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implementation plan created for the compiler-first Moderation refactor. The plan decomposes the work into TDD tasks for compiler dataclasses, blocklist parsing, service wrapper/lint compatibility, global service integration, per-user policy assembly, behavior regression coverage, and final verification. Created TASK-2432 as the execution task for the later implementation phase.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
+++ b/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
@@ -15,9 +15,10 @@ documentation:
 - Docs/superpowers/specs/2026-06-24-moderation-policy-compiler-refactor-design.md
 - Docs/superpowers/plans/2026-06-24-moderation-policy-compiler-refactor-implementation-plan.md
 modified_files:
-- Docs/superpowers/plans/2026-06-24-moderation-policy-compiler-refactor-implementation-plan.md
+- tldw_Server_API/app/core/Moderation/policy_compiler.py
+- tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
 - backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
-updated_date: 2026-06-24 20:44
+updated_date: 2026-06-24 20:57
 ---
 
 ## Description
@@ -40,6 +41,7 @@ Implement the approved compiler-first Moderation refactor using the plan in Docs
 Implementation plan reviewed for subagent execution readiness. The plan now directs implementation progress and verification updates to this task, includes explicit service config-resolution code, imports PolicyCompilationInput where service integration uses it, and preserves existing bool-like is_regex behavior for loaded user quick rules.
 Plan review follow-up made Task 6 regression tests deterministic by monkeypatching service config to temporary blocklist/user/runtime override paths and keeping update_settings persistence disabled.
 Starting subagent-driven implementation. First dispatch target is Task 1 from the plan: add compiler dataclasses, base global compile path, and focused smoke tests.
+Task 1 complete and reviewed. Commit dd259bf1b added policy_compiler.py skeleton and test_moderation_policy_compiler.py smoke tests. Controller verification: focused pytest `2 passed, 16 warnings`; py_compile exit 0; git diff --check HEAD~1..HEAD exit 0. Independent spec review: compliant. Independent quality review: approved with no issues.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
+++ b/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
@@ -26,7 +26,9 @@ modified_files:
 - backlog/tasks/task-2430 - Design-Moderation-PolicyCompiler-refactor.md
 - backlog/tasks/task-2431 - Plan-Moderation-PolicyCompiler-refactor-implementation.md
 - backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
-updated_date: 2026-06-24 22:35
+updated_date: 2026-06-26 06:24
+references:
+- https://github.com/rmusser01/tldw_server/pull/2528
 ---
 
 ## Description
@@ -121,6 +123,7 @@ Final verification:
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Implemented the compiler-first Moderation refactor. Added `PolicyCompiler` and supporting dataclasses for deterministic global and per-user policy assembly, blocklist parsing, regex safety checks, category/runtime override handling, quick-rule compilation, and sanitized compilation reports. Kept `ModerationService` as the public facade and I/O/logging/persistence boundary, preserving compatibility wrappers, lint output behavior, reload/settings/blocklist mutation paths, PII inclusion, and supervised overlay composition. Added focused compiler, service compatibility, recompile-trigger, and supervised overlay regression coverage. Final verification passed: compile checks, targeted pytest suite, diff whitespace check, Bandit on Moderation, mergeability check against `origin/dev`, and final independent review.
+Draft PR opened against `dev`: https://github.com/rmusser01/tldw_server/pull/2528
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
+++ b/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
@@ -18,7 +18,7 @@ modified_files:
 - tldw_Server_API/app/core/Moderation/moderation_service.py
 - tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py
 - backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
-updated_date: 2026-06-24 22:11
+updated_date: 2026-06-24 22:22
 ---
 
 ## Description
@@ -78,6 +78,23 @@ Verification:
 - `python -m py_compile tldw_Server_API/app/core/Moderation/policy_compiler.py tldw_Server_API/app/core/Moderation/moderation_service.py tldw_Server_API/tests/unit/test_moderation_policy_compiler.py tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py tldw_Server_API/tests/unit/test_moderation_user_override_validation.py` -> passed
 - `git diff --check HEAD~2..HEAD` -> passed
 - `python -m bandit -r tldw_Server_API/app/core/Moderation/policy_compiler.py tldw_Server_API/app/core/Moderation/moderation_service.py -f json -o /tmp/bandit_moderation_policy_compiler_task5_final.json` -> 0 findings
+Task 6 completed and reviewed.
+
+Implementation commits:
+- b5adac140 Preserve moderation service behavior with compiler integration
+- 26d48dcbd Harden moderation recompile regression tests
+
+Spec review: APPROVE. Verified only test files changed, `update_settings()` regression uses temp config paths and `persist=False`, `set_blocklist_lines()` regression proves the active policy reloads from file contents, and supervised overlay consumes a compiler-produced `ModerationPolicy` while preserving base settings/patterns.
+
+Quality review: APPROVE. No blocking findings. Reviewer suggested adding `blocklist_write_debounce_ms: "0"` to temp config helpers to guard against polluted debounce environment; follow-up commit 26d48dcbd made that test-only hardening.
+
+Verification:
+- Worker initial new-test regression run -> 3 passed
+- `python -m pytest tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py tldw_Server_API/tests/unit/test_moderation_effective_settings.py tldw_Server_API/tests/Guardian/test_supervised_policy.py -q` -> 127 passed
+- `python -m pytest tldw_Server_API/tests/unit/test_moderation*.py -q` -> 125 passed
+- `python -m py_compile tldw_Server_API/app/core/Moderation/moderation_service.py tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py tldw_Server_API/tests/unit/test_moderation_effective_settings.py tldw_Server_API/tests/Guardian/test_supervised_policy.py` -> passed
+- `git diff --check` after follow-up -> passed
+- No production code changed in Task 6; Bandit not rerun for Task 6 specifically.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
+++ b/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
@@ -15,10 +15,10 @@ documentation:
 - Docs/superpowers/specs/2026-06-24-moderation-policy-compiler-refactor-design.md
 - Docs/superpowers/plans/2026-06-24-moderation-policy-compiler-refactor-implementation-plan.md
 modified_files:
-- tldw_Server_API/app/core/Moderation/policy_compiler.py
-- tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
+- tldw_Server_API/app/core/Moderation/moderation_service.py
+- tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py
 - backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
-updated_date: 2026-06-24 21:15
+updated_date: 2026-06-24 21:31
 ---
 
 ## Description
@@ -43,6 +43,7 @@ Plan review follow-up made Task 6 regression tests deterministic by monkeypatchi
 Starting subagent-driven implementation. First dispatch target is Task 1 from the plan: add compiler dataclasses, base global compile path, and focused smoke tests.
 Task 1 complete and reviewed. Commit dd259bf1b added policy_compiler.py skeleton and test_moderation_policy_compiler.py smoke tests. Controller verification: focused pytest `2 passed, 16 warnings`; py_compile exit 0; git diff --check HEAD~1..HEAD exit 0. Independent spec review: compliant. Independent quality review: approved with no issues.
 Task 2 complete and reviewed. Commits 63e2bbd82 and a77c4694a moved blocklist parsing/rule compilation into PolicyCompiler and fixed review-found edge cases for empty parsed patterns and raw regex backslash preservation. Controller verification: focused pytest `6 passed, 24 warnings`; py_compile exit 0; git diff --check HEAD~2..HEAD exit 0. Spec re-review: compliant. Quality review: approved with no issues.
+Task 3 complete and reviewed. Commits c608d5d1d and 1518d154e wired ModerationService parser helpers to PolicyCompiler, preserved lint response assembly, derived service parser constants from compiler constants, and added direct wrapper-delegation coverage. Controller verification: blocklist parse suite `34 passed, 80 warnings`; py_compile exit 0; git diff --check exit 0. Spec re-review: compliant. Quality re-review: approved with no issues.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
+++ b/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
@@ -1,0 +1,53 @@
+---
+id: TASK-2432
+title: Implement Moderation PolicyCompiler refactor
+status: To Do
+created_date: 2026-06-24 20:27
+dependencies:
+- TASK-2430
+- TASK-2431
+labels:
+- moderation
+- implementation
+- refactor
+priority: medium
+documentation:
+- Docs/superpowers/specs/2026-06-24-moderation-policy-compiler-refactor-design.md
+- Docs/superpowers/plans/2026-06-24-moderation-policy-compiler-refactor-implementation-plan.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the approved compiler-first Moderation refactor using the plan in Docs/superpowers/plans/2026-06-24-moderation-policy-compiler-refactor-implementation-plan.md. Preserve ModerationService and ModerationPolicy compatibility, keep I/O/persistence/logging in the service, and move deterministic policy assembly into PolicyCompiler.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 PolicyCompiler and related dataclasses are implemented with deterministic policy assembly and sanitized reports.
+- [ ] #2 ModerationService integrates the compiler while preserving public methods, file I/O boundaries, lint output behavior, helper wrapper compatibility, and existing policy types.
+- [ ] #3 Compiler, service compatibility, blocklist/lint, PII, per-user override, and supervised overlay regression tests are added or updated.
+- [ ] #4 Focused pytest, py_compile, git diff --check, and Bandit verification are recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
+++ b/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2432
 title: Implement Moderation PolicyCompiler refactor
-status: In Progress
+status: Done
 created_date: 2026-06-24 20:27
 dependencies:
 - TASK-2430
@@ -15,10 +15,18 @@ documentation:
 - Docs/superpowers/specs/2026-06-24-moderation-policy-compiler-refactor-design.md
 - Docs/superpowers/plans/2026-06-24-moderation-policy-compiler-refactor-implementation-plan.md
 modified_files:
+- Docs/superpowers/specs/2026-06-24-moderation-policy-compiler-refactor-design.md
+- Docs/superpowers/plans/2026-06-24-moderation-policy-compiler-refactor-implementation-plan.md
 - tldw_Server_API/app/core/Moderation/moderation_service.py
+- tldw_Server_API/app/core/Moderation/policy_compiler.py
+- tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
 - tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py
+- tldw_Server_API/tests/unit/test_moderation_effective_settings.py
+- tldw_Server_API/tests/Guardian/test_supervised_policy.py
+- backlog/tasks/task-2430 - Design-Moderation-PolicyCompiler-refactor.md
+- backlog/tasks/task-2431 - Plan-Moderation-PolicyCompiler-refactor-implementation.md
 - backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
-updated_date: 2026-06-24 22:22
+updated_date: 2026-06-24 22:35
 ---
 
 ## Description
@@ -29,10 +37,10 @@ Implement the approved compiler-first Moderation refactor using the plan in Docs
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 PolicyCompiler and related dataclasses are implemented with deterministic policy assembly and sanitized reports.
-- [ ] #2 ModerationService integrates the compiler while preserving public methods, file I/O boundaries, lint output behavior, helper wrapper compatibility, and existing policy types.
-- [ ] #3 Compiler, service compatibility, blocklist/lint, PII, per-user override, and supervised overlay regression tests are added or updated.
-- [ ] #4 Focused pytest, py_compile, git diff --check, and Bandit verification are recorded.
+- [x] #1 PolicyCompiler and related dataclasses are implemented with deterministic policy assembly and sanitized reports.
+- [x] #2 ModerationService integrates the compiler while preserving public methods, file I/O boundaries, lint output behavior, helper wrapper compatibility, and existing policy types.
+- [x] #3 Compiler, service compatibility, blocklist/lint, PII, per-user override, and supervised overlay regression tests are added or updated.
+- [x] #4 Focused pytest, py_compile, git diff --check, and Bandit verification are recorded.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -95,20 +103,32 @@ Verification:
 - `python -m py_compile tldw_Server_API/app/core/Moderation/moderation_service.py tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py tldw_Server_API/tests/unit/test_moderation_effective_settings.py tldw_Server_API/tests/Guardian/test_supervised_policy.py` -> passed
 - `git diff --check` after follow-up -> passed
 - No production code changed in Task 6; Bandit not rerun for Task 6 specifically.
+Final verification completed.
+
+Final reviewer: APPROVE. No blocking findings across the merge-base branch diff. Reviewer confirmed `PolicyCompiler` owns deterministic parsing/rule compilation/policy assembly/sanitized reports, `ModerationService` keeps config/env fallback, path resolution, I/O, persistence, locking, logging, reload/settings/mutation paths, behavior-sensitive moderation paths remain covered, and scope stays within the moderation compiler slice.
+
+Mergeability: `git merge-tree --write-tree origin/dev HEAD` completed successfully and produced merge tree `24b097219f7437b2cc994fc8a221bea48e52bab2`, indicating the branch merges cleanly with current `origin/dev`.
+
+Final verification:
+- `python -m py_compile tldw_Server_API/app/core/Moderation/policy_compiler.py tldw_Server_API/app/core/Moderation/moderation_service.py tldw_Server_API/app/core/Moderation/supervised_policy.py tldw_Server_API/tests/unit/test_moderation_policy_compiler.py tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py tldw_Server_API/tests/unit/test_moderation_effective_settings.py tldw_Server_API/tests/Guardian/test_supervised_policy.py` -> passed
+- `python -m pytest tldw_Server_API/tests/unit/test_moderation_policy_compiler.py tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py tldw_Server_API/tests/unit/test_moderation_effective_settings.py tldw_Server_API/tests/unit/test_moderation_check_text_snippet.py tldw_Server_API/tests/unit/test_moderation_redact_categories.py tldw_Server_API/tests/Guardian/test_supervised_policy.py -q` -> 151 passed, 314 warnings
+- `git diff --check` -> passed
+- `python -m bandit -r tldw_Server_API/app/core/Moderation -f json -o /tmp/bandit_moderation_policy_compiler.json` -> 0 findings
+- `git diff --stat $(git merge-base HEAD origin/dev)..HEAD` -> 11 files changed, scoped to moderation design/plan/tasks, moderation service/compiler, and focused tests.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Implemented the compiler-first Moderation refactor. Added `PolicyCompiler` and supporting dataclasses for deterministic global and per-user policy assembly, blocklist parsing, regex safety checks, category/runtime override handling, quick-rule compilation, and sanitized compilation reports. Kept `ModerationService` as the public facade and I/O/logging/persistence boundary, preserving compatibility wrappers, lint output behavior, reload/settings/blocklist mutation paths, PII inclusion, and supervised overlay composition. Added focused compiler, service compatibility, recompile-trigger, and supervised overlay regression coverage. Final verification passed: compile checks, targeted pytest suite, diff whitespace check, Bandit on Moderation, mergeability check against `origin/dev`, and final independent review.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
+++ b/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
@@ -18,7 +18,7 @@ modified_files:
 - tldw_Server_API/app/core/Moderation/moderation_service.py
 - tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py
 - backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
-updated_date: 2026-06-24 21:31
+updated_date: 2026-06-24 21:55
 ---
 
 ## Description
@@ -44,6 +44,23 @@ Starting subagent-driven implementation. First dispatch target is Task 1 from th
 Task 1 complete and reviewed. Commit dd259bf1b added policy_compiler.py skeleton and test_moderation_policy_compiler.py smoke tests. Controller verification: focused pytest `2 passed, 16 warnings`; py_compile exit 0; git diff --check HEAD~1..HEAD exit 0. Independent spec review: compliant. Independent quality review: approved with no issues.
 Task 2 complete and reviewed. Commits 63e2bbd82 and a77c4694a moved blocklist parsing/rule compilation into PolicyCompiler and fixed review-found edge cases for empty parsed patterns and raw regex backslash preservation. Controller verification: focused pytest `6 passed, 24 warnings`; py_compile exit 0; git diff --check HEAD~2..HEAD exit 0. Spec re-review: compliant. Quality review: approved with no issues.
 Task 3 complete and reviewed. Commits c608d5d1d and 1518d154e wired ModerationService parser helpers to PolicyCompiler, preserved lint response assembly, derived service parser constants from compiler constants, and added direct wrapper-delegation coverage. Controller verification: blocklist parse suite `34 passed, 80 warnings`; py_compile exit 0; git diff --check exit 0. Spec re-review: compliant. Quality re-review: approved with no issues.
+Task 4 completed and reviewed.
+
+Implementation commits:
+- 46d2d7c7a Integrate moderation global policy compiler
+- cf750905a Fix moderation category env fallback
+
+Spec review: APPROVE. Verified service delegation through `_load_moderation_config_section()`, `_resolve_moderation_config()`, and `_compile_global_policy_from_resolved_config()`; paths remain service-owned; `ResolvedModerationConfig` has no paths; `categories_enabled=None` falls back to `MODERATION_CATEGORIES_ENABLED`; runtime overrides are applied by `PolicyCompiler`; compiler has no file/path ownership.
+
+Quality review: APPROVE. No blocking findings. Non-blocking observation: `_read_blocklist_lines_from_path()` reads the whole blocklist into memory; acceptable for current config-sized files and consistent with current APIs, possible future improvement if externally managed/large blocklists become a goal.
+
+Verification:
+- `python -m pytest tldw_Server_API/tests/unit/test_moderation_policy_compiler.py tldw_Server_API/tests/unit/test_moderation_effective_settings.py -q` -> 10 passed
+- `python -m pytest tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py -q` -> 34 passed
+- `python -m pytest tldw_Server_API/tests/unit/test_moderation*.py -q` -> 115 passed
+- `python -m py_compile tldw_Server_API/app/core/Moderation/moderation_service.py tldw_Server_API/app/core/Moderation/policy_compiler.py tldw_Server_API/tests/unit/test_moderation_policy_compiler.py tldw_Server_API/tests/unit/test_moderation_effective_settings.py` -> passed
+- `git diff --check HEAD~2..HEAD` -> passed
+- `python -m bandit -r tldw_Server_API/app/core/Moderation -f json -o /tmp/bandit_moderation_policy_compiler_task4.json` -> 0 findings
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
+++ b/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
@@ -18,7 +18,7 @@ modified_files:
 - tldw_Server_API/app/core/Moderation/moderation_service.py
 - tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py
 - backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
-updated_date: 2026-06-24 21:55
+updated_date: 2026-06-24 22:11
 ---
 
 ## Description
@@ -61,6 +61,23 @@ Verification:
 - `python -m py_compile tldw_Server_API/app/core/Moderation/moderation_service.py tldw_Server_API/app/core/Moderation/policy_compiler.py tldw_Server_API/tests/unit/test_moderation_policy_compiler.py tldw_Server_API/tests/unit/test_moderation_effective_settings.py` -> passed
 - `git diff --check HEAD~2..HEAD` -> passed
 - `python -m bandit -r tldw_Server_API/app/core/Moderation -f json -o /tmp/bandit_moderation_policy_compiler_task4.json` -> 0 findings
+Task 5 completed and reviewed.
+
+Implementation commits:
+- 09858ee8c Move moderation user policy assembly into compiler
+- 81140de7f Harden moderation user policy compiler tests
+
+Spec review: APPROVE. Verified `PolicyCompiler.compile_user_policy()` returns `PolicyCompilationResult`, owns per-user field/category/quick-rule assembly, and `ModerationService.get_effective_policy()` delegates while keeping compatibility wrappers for private helpers.
+
+Quality review: APPROVE. No blocking findings. Reviewer suggested extra compiler-boundary tests and copying default category sets to avoid shared mutable state. Follow-up commit 81140de7f added tests for `override=None`, non-list rules, invalid category type, invalid phase defaulting, and the mutable-category case; it also copies default category sets when reused.
+
+Verification:
+- Worker red check: mutability test failed before fix because base categories were mutated.
+- `python -m pytest tldw_Server_API/tests/unit/test_moderation_policy_compiler.py tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py tldw_Server_API/tests/unit/test_moderation_user_override_validation.py -q` -> 64 passed
+- `python -m pytest tldw_Server_API/tests/unit/test_moderation*.py -q` -> 123 passed
+- `python -m py_compile tldw_Server_API/app/core/Moderation/policy_compiler.py tldw_Server_API/app/core/Moderation/moderation_service.py tldw_Server_API/tests/unit/test_moderation_policy_compiler.py tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py tldw_Server_API/tests/unit/test_moderation_user_override_validation.py` -> passed
+- `git diff --check HEAD~2..HEAD` -> passed
+- `python -m bandit -r tldw_Server_API/app/core/Moderation/policy_compiler.py tldw_Server_API/app/core/Moderation/moderation_service.py -f json -o /tmp/bandit_moderation_policy_compiler_task5_final.json` -> 0 findings
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
+++ b/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
@@ -14,6 +14,10 @@ priority: medium
 documentation:
 - Docs/superpowers/specs/2026-06-24-moderation-policy-compiler-refactor-design.md
 - Docs/superpowers/plans/2026-06-24-moderation-policy-compiler-refactor-implementation-plan.md
+modified_files:
+- Docs/superpowers/plans/2026-06-24-moderation-policy-compiler-refactor-implementation-plan.md
+- backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
+updated_date: 2026-06-24 20:42
 ---
 
 ## Description
@@ -33,7 +37,8 @@ Implement the approved compiler-first Moderation refactor using the plan in Docs
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Implementation plan reviewed for subagent execution readiness. The plan now directs implementation progress and verification updates to this task, includes explicit service config-resolution code, imports PolicyCompilationInput where service integration uses it, and preserves existing bool-like is_regex behavior for loaded user quick rules.
+Plan review follow-up made Task 6 regression tests deterministic by monkeypatching service config to temporary blocklist/user/runtime override paths and keeping update_settings persistence disabled.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
+++ b/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
@@ -18,7 +18,7 @@ modified_files:
 - tldw_Server_API/app/core/Moderation/policy_compiler.py
 - tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
 - backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
-updated_date: 2026-06-24 20:57
+updated_date: 2026-06-24 21:15
 ---
 
 ## Description
@@ -42,6 +42,7 @@ Implementation plan reviewed for subagent execution readiness. The plan now dire
 Plan review follow-up made Task 6 regression tests deterministic by monkeypatching service config to temporary blocklist/user/runtime override paths and keeping update_settings persistence disabled.
 Starting subagent-driven implementation. First dispatch target is Task 1 from the plan: add compiler dataclasses, base global compile path, and focused smoke tests.
 Task 1 complete and reviewed. Commit dd259bf1b added policy_compiler.py skeleton and test_moderation_policy_compiler.py smoke tests. Controller verification: focused pytest `2 passed, 16 warnings`; py_compile exit 0; git diff --check HEAD~1..HEAD exit 0. Independent spec review: compliant. Independent quality review: approved with no issues.
+Task 2 complete and reviewed. Commits 63e2bbd82 and a77c4694a moved blocklist parsing/rule compilation into PolicyCompiler and fixed review-found edge cases for empty parsed patterns and raw regex backslash preservation. Controller verification: focused pytest `6 passed, 24 warnings`; py_compile exit 0; git diff --check HEAD~2..HEAD exit 0. Spec re-review: compliant. Quality review: approved with no issues.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
+++ b/backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2432
 title: Implement Moderation PolicyCompiler refactor
-status: To Do
+status: In Progress
 created_date: 2026-06-24 20:27
 dependencies:
 - TASK-2430
@@ -17,7 +17,7 @@ documentation:
 modified_files:
 - Docs/superpowers/plans/2026-06-24-moderation-policy-compiler-refactor-implementation-plan.md
 - backlog/tasks/task-2432 - Implement-Moderation-PolicyCompiler-refactor.md
-updated_date: 2026-06-24 20:42
+updated_date: 2026-06-24 20:44
 ---
 
 ## Description
@@ -39,6 +39,7 @@ Implement the approved compiler-first Moderation refactor using the plan in Docs
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Implementation plan reviewed for subagent execution readiness. The plan now directs implementation progress and verification updates to this task, includes explicit service config-resolution code, imports PolicyCompilationInput where service integration uses it, and preserves existing bool-like is_regex behavior for loaded user quick rules.
 Plan review follow-up made Task 6 regression tests deterministic by monkeypatching service config to temporary blocklist/user/runtime override paths and keeping update_settings persistence disabled.
+Starting subagent-driven implementation. First dispatch target is Task 1 from the plan: add compiler dataclasses, base global compile path, and focused smoke tests.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/app/core/Moderation/moderation_service.py
+++ b/tldw_Server_API/app/core/Moderation/moderation_service.py
@@ -289,21 +289,25 @@ class ModerationService:
         )
 
     @staticmethod
-    def _read_blocklist_lines_from_path(path: str) -> list[str]:
-        with open(path, encoding="utf-8") as f:
-            return [ln.rstrip("\r\n") for ln in f.readlines()]
+    def _read_blocklist_lines_from_path(path: str) -> Iterator[str]:
+        """Yield blocklist file lines without trailing newlines."""
 
-    def _read_blocklist_lines_for_compile(self, path: str | None) -> list[str]:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                yield line.rstrip("\r\n")
+
+    def _read_blocklist_lines_for_compile(self, path: str | None) -> Iterator[str]:
+        """Yield blocklist lines for compilation with contextual logging."""
+
         if not path:
-            return []
+            return
         if not os.path.exists(path):
-            logger.warning("Moderation blocklist file not found")
-            return []
+            logger.warning("Moderation blocklist file not found for path={}", path)
+            return
         try:
-            return self._read_blocklist_lines_from_path(path)
+            yield from self._read_blocklist_lines_from_path(path)
         except _MODERATION_NONCRITICAL_EXCEPTIONS:
-            logger.error("Failed to load moderation blocklist")
-            return []
+            logger.exception("Failed to load moderation blocklist from path={}", path)
 
     def _compile_global_policy_from_resolved_config(self, config: ResolvedModerationConfig) -> ModerationPolicy:
         effective_pii_enabled = self._policy_compiler.resolve_runtime_pii(
@@ -394,21 +398,6 @@ class ModerationService:
             except _MODERATION_NONCRITICAL_EXCEPTIONS:
                 return []
         return rules
-
-    @staticmethod
-    def _has_nested_quantifiers(expr: str) -> bool:
-        """Heuristic check for nested quantifiers like (.*)+ or (.+)* that can cause catastrophic backtracking."""
-        try:
-            return bool(re.search(r"\((?:[^)(]|\([^)(]*\))*[+*][^)]*\)\s*[+*]", expr))
-        except _MODERATION_NONCRITICAL_EXCEPTIONS:
-            return False
-
-    @staticmethod
-    def _too_many_groups(expr: str, limit: int = 100) -> bool:
-        try:
-            return expr.count("(") - expr.count("\\(") > limit
-        except _MODERATION_NONCRITICAL_EXCEPTIONS:
-            return False
 
     def _is_regex_dangerous(self, expr: str) -> bool:
         return self._policy_compiler.is_regex_dangerous(expr)
@@ -1163,7 +1152,7 @@ class ModerationService:
                 self._user_overrides = next_overrides
                 logger.info(f"Saved moderation user overrides to {path}")
                 return {"ok": True, "persisted": True}
-            except _MODERATION_NONCRITICAL_EXCEPTIONS as e:
+            except _MODERATION_NONCRITICAL_EXCEPTIONS:
                 logger.error("Failed to save user overrides")
                 return {
                     "ok": False,
@@ -1190,7 +1179,7 @@ class ModerationService:
                         return {"ok": True, "persisted": True}
                     self._user_overrides = next_overrides
                     return {"ok": True, "persisted": False}
-                except _MODERATION_NONCRITICAL_EXCEPTIONS as e:
+                except _MODERATION_NONCRITICAL_EXCEPTIONS:
                     logger.error("Failed to persist user override deletion")
                     return {
                         "ok": False,
@@ -1207,7 +1196,7 @@ class ModerationService:
             return []
         try:
             with self._lock, open(path, encoding="utf-8") as f:
-                return [ln.rstrip("\r\n") for ln in f.readlines()]
+                return [ln.rstrip("\r\n") for ln in f]
         except _MODERATION_NONCRITICAL_EXCEPTIONS:
             logger.error("Failed to read blocklist")
             return []

--- a/tldw_Server_API/app/core/Moderation/moderation_service.py
+++ b/tldw_Server_API/app/core/Moderation/moderation_service.py
@@ -255,11 +255,9 @@ class ModerationService:
             if "blocklist_write_debounce_ms" in mod_cfg:
                 self._write_debounce_ms = int(mod_cfg.get("blocklist_write_debounce_ms", self._write_debounce_ms) or 0)
 
-        cats_val = (
-            mod_cfg.get("categories_enabled")
-            if "categories_enabled" in mod_cfg
-            else os.getenv("MODERATION_CATEGORIES_ENABLED", "")
-        )
+        cats_val = mod_cfg.get("categories_enabled") if "categories_enabled" in mod_cfg else None
+        if cats_val is None:
+            cats_val = os.getenv("MODERATION_CATEGORIES_ENABLED", "")
         categories_enabled: set[str] = set()
         if isinstance(cats_val, (list, set, tuple)):
             categories_enabled = {str(c).strip().lower() for c in cats_val if str(c).strip()}

--- a/tldw_Server_API/app/core/Moderation/moderation_service.py
+++ b/tldw_Server_API/app/core/Moderation/moderation_service.py
@@ -29,7 +29,12 @@ from dataclasses import dataclass, field
 from loguru import logger
 
 from tldw_Server_API.app.core.config import load_and_log_configs, load_comprehensive_config
-from tldw_Server_API.app.core.Moderation.policy_compiler import PolicyCompiler
+from tldw_Server_API.app.core.Moderation.policy_compiler import (
+    PolicyCompilationInput,
+    PolicyCompilationReport,
+    PolicyCompiler,
+    ResolvedModerationConfig,
+)
 from tldw_Server_API.app.core.testing import is_truthy
 
 _MODERATION_NONCRITICAL_EXCEPTIONS = (
@@ -137,6 +142,14 @@ class ModerationEvaluationResult:
     sample: str | None = None
 
 
+@dataclass(frozen=True)
+class _ResolvedModerationServiceState:
+    compiler_config: ResolvedModerationConfig
+    blocklist_path: str | None
+    user_overrides_path: str | None
+    runtime_overrides_path: str | None
+
+
 class ModerationService:
     """Loads moderation configuration and evaluates content against policies."""
     _UNCATEGORIZED_CATEGORY = "uncategorized"
@@ -179,35 +192,41 @@ class ModerationService:
         self._user_overrides: dict[str, dict[str, object]] = self._load_user_overrides()
 
     def _load_global_policy(self) -> ModerationPolicy:
-        # Try modern dict config first
-        mod_cfg = (self._config.get("moderation") or {}) if isinstance(self._config, dict) else {}
-        # If not present, fall back to ConfigParser direct section
-        if not mod_cfg:
-            try:
-                parser = load_comprehensive_config()
-                if parser and parser.has_section('Moderation'):
-                    # Convert to plain dict
-                    mod_cfg = dict(parser.items('Moderation'))
-            except _MODERATION_NONCRITICAL_EXCEPTIONS:
-                mod_cfg = {}
+        mod_cfg = self._load_moderation_config_section()
+        resolved = self._resolve_moderation_config(mod_cfg)
+        self._user_overrides_path = resolved.user_overrides_path
+        self._blocklist_path = resolved.blocklist_path
+        self._runtime_overrides_path = resolved.runtime_overrides_path
+        return self._compile_global_policy_from_resolved_config(resolved.compiler_config)
 
-        # Boolean helpers
+    def _load_moderation_config_section(self) -> dict[str, object]:
+        mod_cfg = (self._config.get("moderation") or {}) if isinstance(self._config, dict) else {}
+        if mod_cfg:
+            return dict(mod_cfg)
+        try:
+            parser = load_comprehensive_config()
+            if parser and parser.has_section("Moderation"):
+                return dict(parser.items("Moderation"))
+        except _MODERATION_NONCRITICAL_EXCEPTIONS:
+            return {}
+        return {}
+
+    def _resolve_moderation_config(self, mod_cfg: dict[str, object]) -> _ResolvedModerationServiceState:
         def _b(key: str, default: bool) -> bool:
             val = str(mod_cfg.get(key, default)).strip().lower()
             return is_truthy(val)
 
-        def _anchor(p: str) -> str:
+        def _anchor(path_value: str) -> str:
             try:
                 from pathlib import Path as _Path
-                pp = _Path(str(p))
-                if pp.is_absolute():
-                    return str(pp)
-                from tldw_Server_API.app.core.Utils.Utils import get_project_root as _gpr
-                return str((_Path(_gpr()) / pp).resolve())
+                path = _Path(str(path_value))
+                if path.is_absolute():
+                    return str(path)
+                from tldw_Server_API.app.core.Utils.Utils import get_project_root
+                return str((_Path(get_project_root()) / path).resolve())
             except _MODERATION_NONCRITICAL_EXCEPTIONS:
-                return str(p)
+                return str(path_value)
 
-        # Paths (defaults set when unset)
         blocklist_path = (
             mod_cfg.get("blocklist_file")
             or os.getenv("MODERATION_BLOCKLIST_FILE")
@@ -218,55 +237,42 @@ class ModerationService:
             or os.getenv("MODERATION_USER_OVERRIDES_FILE")
             or "tldw_Server_API/Config_Files/moderation_user_overrides.json"
         )
-        runtime_overrides_path = mod_cfg.get("runtime_overrides_file") or os.getenv("MODERATION_RUNTIME_OVERRIDES_FILE")
-        blocklist_path = _anchor(blocklist_path) if blocklist_path else blocklist_path
-        user_overrides_path = _anchor(user_overrides_path) if user_overrides_path else user_overrides_path
-        if runtime_overrides_path:
-            runtime_overrides_path = _anchor(runtime_overrides_path)
-        else:
-            runtime_overrides_path = _anchor("tldw_Server_API/Config_Files/moderation_runtime_overrides.json")
-        # Optional safety/perf overrides
+        runtime_overrides_path = (
+            mod_cfg.get("runtime_overrides_file")
+            or os.getenv("MODERATION_RUNTIME_OVERRIDES_FILE")
+            or "tldw_Server_API/Config_Files/moderation_runtime_overrides.json"
+        )
+
         with contextlib.suppress(_MODERATION_NONCRITICAL_EXCEPTIONS):
             self._max_scan_chars = int(mod_cfg.get("max_scan_chars", self._max_scan_chars))
         with contextlib.suppress(_MODERATION_NONCRITICAL_EXCEPTIONS):
-            self._max_replacements_per_pattern = int(mod_cfg.get("max_replacements_per_pattern", self._max_replacements_per_pattern))
+            self._max_replacements_per_pattern = int(
+                mod_cfg.get("max_replacements_per_pattern", self._max_replacements_per_pattern)
+            )
         with contextlib.suppress(_MODERATION_NONCRITICAL_EXCEPTIONS):
             self._match_window_chars = int(mod_cfg.get("match_window_chars", self._match_window_chars))
-        # Optional debounce for blocklist writes (ms)
-        try:
+        with contextlib.suppress(_MODERATION_NONCRITICAL_EXCEPTIONS):
             if "blocklist_write_debounce_ms" in mod_cfg:
                 self._write_debounce_ms = int(mod_cfg.get("blocklist_write_debounce_ms", self._write_debounce_ms) or 0)
-        except _MODERATION_NONCRITICAL_EXCEPTIONS:
-            pass
-        # Categories (list- and string-safe)
-        cats_val = None
-        if isinstance(mod_cfg, dict) and "categories_enabled" in mod_cfg:
-            cats_val = mod_cfg.get("categories_enabled")
-        if cats_val is None:
-            cats_val = os.getenv("MODERATION_CATEGORIES_ENABLED", "")
+
+        cats_val = (
+            mod_cfg.get("categories_enabled")
+            if "categories_enabled" in mod_cfg
+            else os.getenv("MODERATION_CATEGORIES_ENABLED", "")
+        )
         categories_enabled: set[str] = set()
         if isinstance(cats_val, (list, set, tuple)):
             categories_enabled = {str(c).strip().lower() for c in cats_val if str(c).strip()}
-        elif isinstance(cats_val, str):
-            if cats_val.strip():
-                categories_enabled = {c.strip().lower() for c in cats_val.split(',') if c.strip()}
-        else:
-            if cats_val:
-                logger.warning("Invalid moderation categories_enabled type")
-        pii_enabled = is_truthy(str(mod_cfg.get("pii_enabled", os.getenv("MODERATION_PII_ENABLED", "false"))).strip().lower())
-        # Apply runtime overrides if present
-        try:
-            if isinstance(self._runtime_override.get("categories_enabled"), (set, list)):
-                categories_enabled = set(self._runtime_override.get("categories_enabled") or [])
-            if "pii_enabled" in self._runtime_override:
-                pii_enabled = bool(self._runtime_override.get("pii_enabled"))
-        except _MODERATION_NONCRITICAL_EXCEPTIONS:
-            pass
-        # Track effective PII enablement for reuse elsewhere
-        self._pii_enabled = bool(pii_enabled)
+        elif isinstance(cats_val, str) and cats_val.strip():
+            categories_enabled = {c.strip().lower() for c in cats_val.split(",") if c.strip()}
+        elif cats_val:
+            logger.warning("Invalid moderation categories_enabled type")
 
-        # Build policy
-        policy = ModerationPolicy(
+        pii_enabled = is_truthy(
+            str(mod_cfg.get("pii_enabled", os.getenv("MODERATION_PII_ENABLED", "false"))).strip().lower()
+        )
+
+        compiler_config = ResolvedModerationConfig(
             enabled=_b("enabled", False),
             input_enabled=_b("input_enabled", True),
             output_enabled=_b("output_enabled", True),
@@ -274,16 +280,61 @@ class ModerationService:
             output_action=str(mod_cfg.get("output_action", "redact")).lower(),
             redact_replacement=str(mod_cfg.get("redact_replacement", "[REDACTED]")),
             per_user_overrides=_b("per_user_overrides", True),
-            block_patterns=self._build_block_patterns(blocklist_path),
             categories_enabled=categories_enabled or None,
+            pii_enabled=bool(pii_enabled),
+        )
+        return _ResolvedModerationServiceState(
+            compiler_config=compiler_config,
+            blocklist_path=_anchor(str(blocklist_path)) if blocklist_path else None,
+            user_overrides_path=_anchor(str(user_overrides_path)) if user_overrides_path else None,
+            runtime_overrides_path=_anchor(str(runtime_overrides_path)) if runtime_overrides_path else None,
         )
 
-        # Store paths for overrides
-        self._user_overrides_path = user_overrides_path
-        self._blocklist_path = blocklist_path
-        self._runtime_overrides_path = runtime_overrides_path
+    @staticmethod
+    def _read_blocklist_lines_from_path(path: str) -> list[str]:
+        with open(path, encoding="utf-8") as f:
+            return [ln.rstrip("\r\n") for ln in f.readlines()]
 
-        return policy
+    def _read_blocklist_lines_for_compile(self, path: str | None) -> list[str]:
+        if not path:
+            return []
+        if not os.path.exists(path):
+            logger.warning("Moderation blocklist file not found")
+            return []
+        try:
+            return self._read_blocklist_lines_from_path(path)
+        except _MODERATION_NONCRITICAL_EXCEPTIONS:
+            logger.error("Failed to load moderation blocklist")
+            return []
+
+    def _compile_global_policy_from_resolved_config(self, config: ResolvedModerationConfig) -> ModerationPolicy:
+        effective_pii_enabled = self._policy_compiler.resolve_runtime_pii(
+            self._runtime_override,
+            config.pii_enabled,
+        )
+        self._pii_enabled = bool(effective_pii_enabled)
+        pii_rules = self._load_builtin_pii_rules() if effective_pii_enabled else []
+        lines = self._read_blocklist_lines_for_compile(getattr(self, "_blocklist_path", None))
+        result = self._policy_compiler.compile_global(
+            PolicyCompilationInput(
+                config=config,
+                runtime_override=self._runtime_override,
+                blocklist_lines=lines,
+                pii_rules=pii_rules,
+            )
+        )
+        self._log_compilation_report(result.report)
+        return result.policy
+
+    @staticmethod
+    def _log_compilation_report(report: PolicyCompilationReport) -> None:
+        for issue in report.issues:
+            if issue.reason == "invalid_action":
+                logger.warning("Invalid moderation action in blocklist; skipping line")
+            elif issue.reason == "dangerous_regex":
+                logger.warning("Skipped dangerous regex in blocklist")
+            elif issue.reason == "invalid_regex":
+                logger.warning("Invalid blocklist pattern; skipping line")
 
     def _parse_rule_line(self, s: str) -> tuple[str | None, str | None, str | None, set[str] | None]:
         return self._policy_compiler.parse_rule_line(s)
@@ -297,53 +348,11 @@ class ModerationService:
         return PolicyCompiler.parse_regex_expr(expr)
 
     def _load_block_patterns(self, path: str | None) -> list[PatternRule]:
-        patterns: list[PatternRule] = []
-        if not path:
-            return patterns
-        try:
-            if not os.path.exists(path):
-                logger.warning("Moderation blocklist file not found")
-                return patterns
-            with open(path, encoding="utf-8") as f:
-                for line in f:
-                    s = line.strip()
-                    if not s or s.startswith("#"):
-                        continue
-                    try:
-                        expr, action, repl, cats = self._parse_rule_line(s)
-                        if expr is None:
-                            continue
-                        if action and not self._is_valid_action(action):
-                            logger.warning("Invalid moderation action in blocklist; skipping line")
-                            continue
-                        # Treat lines starting and ending with '/' (optional flags) as regex
-                        regex_parts = self._parse_regex_expr(expr)
-                        if regex_parts:
-                            raw, flags_str = regex_parts
-                            if self._is_regex_dangerous(raw):
-                                logger.warning("Skipped dangerous regex in blocklist")
-                                continue
-                            flags = re.IGNORECASE  # default remains case-insensitive
-                            fs = (flags_str or "").lower()
-                            if 'i' in fs:
-                                flags |= re.IGNORECASE
-                            if 'm' in fs:
-                                flags |= re.MULTILINE
-                            if 's' in fs:
-                                flags |= re.DOTALL
-                            if 'x' in fs:
-                                flags |= re.VERBOSE
-                            pat = re.compile(raw, flags=flags)
-                        else:
-                            # Literal pattern: allow escaped '#'
-                            literal = expr.replace("\\#", "#")
-                            pat = re.compile(re.escape(literal), flags=re.IGNORECASE)
-                        patterns.append(PatternRule(regex=pat, action=(action or None), replacement=(repl or None), categories=(cats or None)))
-                    except re.error:
-                        logger.warning("Invalid blocklist pattern; skipping line")
-        except _MODERATION_NONCRITICAL_EXCEPTIONS:
-            logger.error("Failed to load moderation blocklist")
-        return patterns
+        report = PolicyCompilationReport()
+        lines = self._read_blocklist_lines_for_compile(path)
+        rules = self._policy_compiler.compile_blocklist_lines(lines, report)
+        self._log_compilation_report(report)
+        return rules
 
     def _build_block_patterns(self, path: str | None) -> list[PatternRule]:
         """Load blocklist patterns and optionally append built-in PII rules."""

--- a/tldw_Server_API/app/core/Moderation/moderation_service.py
+++ b/tldw_Server_API/app/core/Moderation/moderation_service.py
@@ -140,8 +140,8 @@ class ModerationEvaluationResult:
 class ModerationService:
     """Loads moderation configuration and evaluates content against policies."""
     _UNCATEGORIZED_CATEGORY = "uncategorized"
-    _ALLOWED_REGEX_FLAGS = {"i", "m", "s", "x"}
-    _ALLOWED_ACTIONS = {"block", "redact", "warn"}
+    _ALLOWED_REGEX_FLAGS = set(PolicyCompiler._ALLOWED_REGEX_FLAGS)
+    _ALLOWED_ACTIONS = set(PolicyCompiler._ALLOWED_ACTIONS)
 
     def __init__(self) -> None:
         self._config = load_and_log_configs() or {}

--- a/tldw_Server_API/app/core/Moderation/moderation_service.py
+++ b/tldw_Server_API/app/core/Moderation/moderation_service.py
@@ -327,7 +327,13 @@ class ModerationService:
     @staticmethod
     def _log_compilation_report(report: PolicyCompilationReport) -> None:
         for issue in report.issues:
-            if issue.reason == "invalid_action":
+            if issue.source == "user_rule" and issue.reason == "invalid_is_regex":
+                logger.warning("Skipped per-user rule with invalid is_regex")
+            elif issue.source == "user_rule" and issue.reason == "dangerous_regex":
+                logger.warning("Skipped dangerous per-user regex rule")
+            elif issue.source == "user_rule" and issue.reason == "invalid_regex":
+                logger.warning("Skipped invalid per-user regex rule")
+            elif issue.reason == "invalid_action":
                 logger.warning("Invalid moderation action in blocklist; skipping line")
             elif issue.reason == "dangerous_regex":
                 logger.warning("Skipped dangerous regex in blocklist")
@@ -596,60 +602,26 @@ class ModerationService:
 
     def get_effective_policy(self, user_id: str | None) -> ModerationPolicy:
         """Return policy after applying per-user overrides if enabled."""
-        p = self._global_policy
-        if not p.per_user_overrides or not user_id:
-            return p
-        u = self._user_overrides.get(str(user_id))
-        if not u:
-            return p
-        # Clone and override selected fields
-        policy = ModerationPolicy(
-            enabled=self._coalesce_bool(u.get("enabled"), p.enabled),
-            input_enabled=self._coalesce_bool(u.get("input_enabled"), p.input_enabled),
-            output_enabled=self._coalesce_bool(u.get("output_enabled"), p.output_enabled),
-            input_action=str(u.get("input_action", p.input_action)).lower(),
-            output_action=str(u.get("output_action", p.output_action)).lower(),
-            redact_replacement=str(u.get("redact_replacement", p.redact_replacement)),
-            per_user_overrides=p.per_user_overrides,
-            block_patterns=list(p.block_patterns or []),  # avoid mutating shared list
-            categories_enabled=self._resolve_categories_override(u, p.categories_enabled),
-        )
-        rules_raw = u.get("rules")
-        if isinstance(rules_raw, list):
-            compiled_rules: list[PatternRule] = []
-            for raw_rule in rules_raw:
-                compiled = self._compile_user_rule(raw_rule)
-                if compiled is not None:
-                    compiled_rules.append(compiled)
-            if compiled_rules:
-                policy.block_patterns.extend(compiled_rules)
-        return policy
+        policy = self._global_policy
+        if not policy.per_user_overrides or not user_id:
+            return policy
+        override = self._user_overrides.get(str(user_id))
+        if not override:
+            return policy
+        result = self._policy_compiler.compile_user_policy(policy, override)
+        self._log_compilation_report(result.report)
+        return result.policy
 
     def _resolve_categories_override(
         self,
         overrides: dict[str, object],
         default_categories: set[str] | None,
     ) -> set[str] | None:
-        if "categories_enabled" not in overrides:
-            return default_categories
-        parsed = self._parse_categories_override(overrides.get("categories_enabled"))
-        return parsed if parsed is not None else default_categories
+        return self._policy_compiler.resolve_categories_override(overrides, default_categories)
 
     @staticmethod
     def _parse_categories_override(v: object | None) -> set[str] | None:
-        if v is None:
-            return None
-        try:
-            if isinstance(v, list):
-                return {str(x).strip().lower() for x in v if str(x).strip()}
-            if isinstance(v, str):
-                txt = v.strip()
-                if not txt:
-                    return set()
-                return {c.strip().lower() for c in txt.split(',') if c.strip()}
-        except _MODERATION_NONCRITICAL_EXCEPTIONS:
-            return None
-        return None
+        return PolicyCompiler.parse_categories_override(v)
 
     @classmethod
     def _is_valid_action(cls, action: str) -> bool:
@@ -761,44 +733,10 @@ class ModerationService:
 
     def _compile_user_rule(self, raw_rule: object) -> PatternRule | None:
         """Compile a per-user override rule into a PatternRule."""
-        if not isinstance(raw_rule, dict):
-            return None
-        rule_id = str(raw_rule.get("id", "")).strip()
-        pattern = str(raw_rule.get("pattern", "")).strip()
-        action = str(raw_rule.get("action", "")).strip().lower()
-        phase = str(raw_rule.get("phase", "both")).strip().lower()
-        parsed_is_regex = self._parse_bool_value(raw_rule.get("is_regex", False))
-        if parsed_is_regex is None:
-            logger.warning("Skipped per-user rule with invalid is_regex")
-            return None
-        is_regex = parsed_is_regex
-
-        if not pattern or action not in {"block", "warn"}:
-            return None
-        if phase not in {"input", "output", "both"}:
-            phase = "both"
-
-        try:
-            if is_regex:
-                if self._is_regex_dangerous(pattern):
-                    logger.warning("Skipped dangerous per-user regex rule")
-                    return None
-                compiled = re.compile(pattern, flags=re.IGNORECASE)
-            else:
-                compiled = re.compile(re.escape(pattern), flags=re.IGNORECASE)
-        except re.error:
-            logger.warning("Skipped invalid per-user regex rule")
-            return None
-
-        return PatternRule(
-            regex=compiled,
-            action=action,
-            replacement=None,
-            # Per-user quick-list rules are category-agnostic and should still apply
-            # when category filtering is enabled.
-            categories={"*"},
-            phase=phase,
-        )
+        report = PolicyCompilationReport()
+        compiled = self._policy_compiler.compile_user_rule(raw_rule, report, 0)
+        self._log_compilation_report(report)
+        return compiled
 
     @classmethod
     def _effective_rule_categories(cls, rule: PatternRule) -> set[str]:
@@ -838,28 +776,11 @@ class ModerationService:
 
     @staticmethod
     def _coalesce_bool(v: str | bool | None, default: bool) -> bool:
-        if isinstance(v, bool):
-            return v
-        if v is None:
-            return default
-        return is_truthy(str(v).strip().lower())
+        return PolicyCompiler.coalesce_bool(v, default)
 
     @staticmethod
     def _parse_bool_value(v: object) -> bool | None:
-        if isinstance(v, bool):
-            return v
-        if v is None:
-            return None
-        if isinstance(v, (int, float)):
-            return bool(v)
-        if isinstance(v, str):
-            val = v.strip().lower()
-            if is_truthy(val):
-                return True
-            if val in {"0", "false", "no", "n", "off"}:
-                return False
-            return None
-        return None
+        return PolicyCompiler.parse_bool_value(v)
 
     # --------------- Checking and transformations ---------------
     def check_text(self, text: str, policy: ModerationPolicy, phase: str | None = None) -> tuple[bool, str | None]:

--- a/tldw_Server_API/app/core/Moderation/moderation_service.py
+++ b/tldw_Server_API/app/core/Moderation/moderation_service.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass, field
 from loguru import logger
 
 from tldw_Server_API.app.core.config import load_and_log_configs, load_comprehensive_config
+from tldw_Server_API.app.core.Moderation.policy_compiler import PolicyCompiler
 from tldw_Server_API.app.core.testing import is_truthy
 
 _MODERATION_NONCRITICAL_EXCEPTIONS = (
@@ -145,6 +146,7 @@ class ModerationService:
     def __init__(self) -> None:
         self._config = load_and_log_configs() or {}
         self._lock = threading.RLock()
+        self._policy_compiler = PolicyCompiler()
         def _read_int_env(name: str, default: int) -> int:
             raw = os.getenv(name)
             if raw is None:
@@ -284,114 +286,15 @@ class ModerationService:
         return policy
 
     def _parse_rule_line(self, s: str) -> tuple[str | None, str | None, str | None, set[str] | None]:
-        """Parse a single blocklist line into (pattern_expr, action, replacement).
-        Supported formats:
-          - literal
-          - /regex/
-          - literal -> block|warn
-          - literal -> redact:REPL
-          - /regex/ -> block|warn|redact:REPL
-        Returns (expr, action, repl). expr has slashes for regex, or literal text.
-        """
-        if not s:
-            return None, None, None, None
-        # Work on a copy we can mutate
-        text = s
-        action = None
-        repl = None
-        categories: set[str] | None = None
-        # Extract categories suffix if present (requires preceding whitespace; '\#' escapes a literal '#')
-        if '#' in text:
-            cut_index = -1
-            for i in range(len(text) - 1, -1, -1):
-                if text[i] == '#':
-                    # Determine if this '#' is escaped by an odd number of backslashes
-                    bs = 0
-                    j = i - 1
-                    while j >= 0 and text[j] == '\\':
-                        bs += 1
-                        j -= 1
-                    escaped = (bs % 2 == 1)
-                    prev_char = text[i - 1] if i > 0 else ''
-                    if (not escaped) and (i == 0 or prev_char.isspace()):
-                        cut_index = i
-                        break
-            if cut_index != -1:
-                before = text[:cut_index]
-                after = text[cut_index + 1:]
-                cats = {c.strip().lower() for c in after.split(',') if c.strip()}
-                if cats:
-                    categories = cats
-                    text = before.strip()
-        # Parse action/replacement from the (categories-trimmed) text
-        if '->' in text:
-            lhs, rhs = self._split_action_directive(text)
-            if rhs is not None:
-                text = lhs
-                if rhs:
-                    rhs_l = rhs.lower()
-                    if rhs_l.startswith('redact:'):
-                        action = 'redact'
-                        repl = rhs[len('redact:'):].strip()
-                    elif rhs_l in ('block', 'warn', 'redact'):
-                        action = rhs_l
-                    else:
-                        # Unknown directive; treat as literal action text
-                        action = rhs
-        return text, action, repl, categories
+        return self._policy_compiler.parse_rule_line(s)
 
     @staticmethod
     def _split_action_directive(text: str) -> tuple[str, str | None]:
-        """Split text into (pattern, rhs) on the first unescaped '->' outside /regex/."""
-        if '->' not in text:
-            return text, None
-        in_regex = False
-        escape = False
-        for i in range(len(text) - 1):
-            ch = text[i]
-            if escape:
-                escape = False
-                continue
-            if ch == '\\':
-                escape = True
-                continue
-            if ch == '/' and i == 0:
-                in_regex = True
-                continue
-            if ch == '/' and in_regex:
-                in_regex = False
-                continue
-            if not in_regex and text[i:i + 2] == '->':
-                # Skip escaped separators (e.g., \\->)
-                bs = 0
-                j = i - 1
-                while j >= 0 and text[j] == '\\':
-                    bs += 1
-                    j -= 1
-                if bs % 2 == 1:
-                    continue
-                lhs = text[:i].strip()
-                rhs = text[i + 2:].strip()
-                return lhs, rhs
-        return text, None
+        return PolicyCompiler.split_action_directive(text)
 
     @classmethod
     def _parse_regex_expr(cls, expr: str) -> tuple[str, str] | None:
-        """Return (pattern, flags) if expr is /pattern/flags with allowed flags; otherwise None."""
-        if not expr or not expr.startswith("/"):
-            return None
-        last_slash = expr.rfind("/")
-        if last_slash <= 0:
-            return None
-        flags_str = expr[last_slash + 1:]
-        if flags_str:
-            fs = flags_str.lower()
-            if any(ch not in cls._ALLOWED_REGEX_FLAGS for ch in fs):
-                return None
-        raw = expr[1:last_slash]
-        if raw == "":
-            return None
-        return raw, flags_str
+        return PolicyCompiler.parse_regex_expr(expr)
 
     def _load_block_patterns(self, path: str | None) -> list[PatternRule]:
         patterns: list[PatternRule] = []
@@ -495,13 +398,7 @@ class ModerationService:
             return False
 
     def _is_regex_dangerous(self, expr: str) -> bool:
-        if not expr:
-            return True
-        if len(expr) > 2000:
-            return True
-        if self._has_nested_quantifiers(expr):
-            return True
-        return bool(self._too_many_groups(expr))
+        return self._policy_compiler.is_regex_dangerous(expr)
 
     def _load_user_overrides(self) -> dict[str, dict[str, object]]:
         overrides: dict[str, dict[str, object]] = {}

--- a/tldw_Server_API/app/core/Moderation/policy_compiler.py
+++ b/tldw_Server_API/app/core/Moderation/policy_compiler.py
@@ -120,7 +120,7 @@ class PolicyCompiler:
             if not line or line.startswith("#"):
                 continue
             expr, action, replacement, categories = self.parse_rule_line(line)
-            if expr is None:
+            if expr is None or expr == "":
                 active_report.add("blocklist", "empty_pattern", index=idx)
                 continue
             if action and not self.is_valid_action(action):
@@ -251,10 +251,6 @@ class PolicyCompiler:
             value |= re.VERBOSE
         return value
 
-    @staticmethod
-    def normalize_regex_escapes(expr: str) -> str:
-        return re.sub(r"\\\\([AbBdDsSwWZ])", r"\\\1", expr)
-
     @classmethod
     def is_valid_action(cls, action: str) -> bool:
         return str(action).strip().lower() in cls._ALLOWED_ACTIONS
@@ -299,7 +295,6 @@ class PolicyCompiler:
             regex_parts = self.parse_regex_expr(expr)
             if regex_parts:
                 raw, flags_str = regex_parts
-                raw = self.normalize_regex_escapes(raw)
                 if self.is_regex_dangerous(raw):
                     report.add(source, "dangerous_regex", index=index)
                     return None

--- a/tldw_Server_API/app/core/Moderation/policy_compiler.py
+++ b/tldw_Server_API/app/core/Moderation/policy_compiler.py
@@ -374,9 +374,11 @@ class PolicyCompiler:
         default_categories: set[str] | None,
     ) -> set[str] | None:
         if "categories_enabled" not in override:
-            return default_categories
+            return set(default_categories) if default_categories is not None else None
         parsed = self.parse_categories_override(override.get("categories_enabled"))
-        return parsed if parsed is not None else default_categories
+        if parsed is not None:
+            return parsed
+        return set(default_categories) if default_categories is not None else None
 
     @staticmethod
     def parse_categories_override(value: object | None) -> set[str] | None:

--- a/tldw_Server_API/app/core/Moderation/policy_compiler.py
+++ b/tldw_Server_API/app/core/Moderation/policy_compiler.py
@@ -108,6 +108,37 @@ class PolicyCompiler:
         )
         return PolicyCompilationResult(policy=policy, report=report)
 
+    def compile_user_policy(
+        self,
+        base_policy: ModerationPolicy,
+        override: dict[str, object] | None,
+    ) -> PolicyCompilationResult:
+        report = PolicyCompilationReport()
+        if not override:
+            return PolicyCompilationResult(policy=base_policy, report=report)
+        ModerationPolicy, _ = self.policy_types()
+        policy = ModerationPolicy(
+            enabled=self.coalesce_bool(override.get("enabled"), base_policy.enabled),
+            input_enabled=self.coalesce_bool(override.get("input_enabled"), base_policy.input_enabled),
+            output_enabled=self.coalesce_bool(override.get("output_enabled"), base_policy.output_enabled),
+            input_action=str(override.get("input_action", base_policy.input_action)).lower(),
+            output_action=str(override.get("output_action", base_policy.output_action)).lower(),
+            redact_replacement=str(override.get("redact_replacement", base_policy.redact_replacement)),
+            per_user_overrides=base_policy.per_user_overrides,
+            block_patterns=list(base_policy.block_patterns or []),
+            categories_enabled=self.resolve_categories_override(
+                override,
+                base_policy.categories_enabled,
+            ),
+        )
+        rules_raw = override.get("rules")
+        if isinstance(rules_raw, list):
+            for idx, raw_rule in enumerate(rules_raw):
+                compiled = self.compile_user_rule(raw_rule, report, idx)
+                if compiled is not None:
+                    policy.block_patterns.append(compiled)
+        return PolicyCompilationResult(policy=policy, report=report)
+
     def compile_blocklist_lines(
         self,
         lines: list[str],
@@ -310,6 +341,94 @@ class PolicyCompiler:
             action=action or None,
             replacement=replacement or None,
             categories=categories or None,
+            phase=phase,
+        )
+
+    @staticmethod
+    def coalesce_bool(value: object, default: bool) -> bool:
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return default
+        return str(value).strip().lower() in {"1", "true", "yes", "on", "y"}
+
+    @staticmethod
+    def parse_bool_value(value: object) -> bool | None:
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            return bool(value)
+        if isinstance(value, str):
+            text = value.strip().lower()
+            if text in {"1", "true", "yes", "on", "y"}:
+                return True
+            if text in {"0", "false", "no", "n", "off"}:
+                return False
+        return None
+
+    def resolve_categories_override(
+        self,
+        override: dict[str, object],
+        default_categories: set[str] | None,
+    ) -> set[str] | None:
+        if "categories_enabled" not in override:
+            return default_categories
+        parsed = self.parse_categories_override(override.get("categories_enabled"))
+        return parsed if parsed is not None else default_categories
+
+    @staticmethod
+    def parse_categories_override(value: object | None) -> set[str] | None:
+        if value is None:
+            return None
+        if isinstance(value, list):
+            return {str(x).strip().lower() for x in value if str(x).strip()}
+        if isinstance(value, str):
+            text = value.strip()
+            if not text:
+                return set()
+            return {c.strip().lower() for c in text.split(",") if c.strip()}
+        return None
+
+    def compile_user_rule(
+        self,
+        raw_rule: object,
+        report: PolicyCompilationReport,
+        index: int,
+    ) -> PatternRule | None:
+        if not isinstance(raw_rule, dict):
+            report.add("user_rule", "invalid_rule", index=index)
+            return None
+        pattern = str(raw_rule.get("pattern", "")).strip()
+        action = str(raw_rule.get("action", "")).strip().lower()
+        phase = str(raw_rule.get("phase", "both")).strip().lower()
+        is_regex = self.parse_bool_value(raw_rule.get("is_regex", False))
+        if is_regex is None:
+            report.add("user_rule", "invalid_is_regex", index=index)
+            return None
+        if not pattern or action not in {"block", "warn"}:
+            report.add("user_rule", "invalid_rule", index=index)
+            return None
+        if phase not in {"input", "output", "both"}:
+            phase = "both"
+        _, PatternRule = self.policy_types()
+        try:
+            if is_regex:
+                if self.is_regex_dangerous(pattern):
+                    report.add("user_rule", "dangerous_regex", index=index)
+                    return None
+                regex = re.compile(pattern, flags=re.IGNORECASE)
+            else:
+                regex = re.compile(re.escape(pattern), flags=re.IGNORECASE)
+        except re.error:
+            report.add("user_rule", "invalid_regex", index=index)
+            return None
+        return PatternRule(
+            regex=regex,
+            action=action,
+            replacement=None,
+            categories={"*"},
             phase=phase,
         )
 

--- a/tldw_Server_API/app/core/Moderation/policy_compiler.py
+++ b/tldw_Server_API/app/core/Moderation/policy_compiler.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tldw_Server_API.app.core.Moderation.moderation_service import (
+        ModerationPolicy,
+        PatternRule,
+    )
+
+
+@dataclass(frozen=True)
+class ResolvedModerationConfig:
+    enabled: bool = False
+    input_enabled: bool = True
+    output_enabled: bool = True
+    input_action: str = "block"
+    output_action: str = "redact"
+    redact_replacement: str = "[REDACTED]"
+    per_user_overrides: bool = True
+    categories_enabled: set[str] | None = None
+    pii_enabled: bool = False
+
+
+@dataclass(frozen=True)
+class PolicyCompilationIssue:
+    source: str
+    reason: str
+    index: int | None = None
+    detail: str | None = None
+
+
+@dataclass
+class PolicyCompilationReport:
+    issues: list[PolicyCompilationIssue] = field(default_factory=list)
+
+    def add(
+        self,
+        source: str,
+        reason: str,
+        *,
+        index: int | None = None,
+        detail: str | None = None,
+    ) -> None:
+        self.issues.append(
+            PolicyCompilationIssue(
+                source=source,
+                reason=reason,
+                index=index,
+                detail=detail,
+            )
+        )
+
+
+@dataclass
+class PolicyCompilationInput:
+    config: ResolvedModerationConfig
+    runtime_override: dict[str, object] = field(default_factory=dict)
+    blocklist_lines: list[str] = field(default_factory=list)
+    user_override: dict[str, object] | None = None
+    pii_rules: list[PatternRule] = field(default_factory=list)
+
+
+@dataclass
+class PolicyCompilationResult:
+    policy: ModerationPolicy
+    report: PolicyCompilationReport
+
+
+class PolicyCompiler:
+    @staticmethod
+    def policy_types() -> tuple[type[ModerationPolicy], type[PatternRule]]:
+        from tldw_Server_API.app.core.Moderation.moderation_service import (
+            ModerationPolicy,
+            PatternRule,
+        )
+
+        return ModerationPolicy, PatternRule
+
+    def compile_global(self, data: PolicyCompilationInput) -> PolicyCompilationResult:
+        report = PolicyCompilationReport()
+        config = data.config
+        ModerationPolicy, PatternRule = self.policy_types()
+        categories_enabled = self.resolve_runtime_categories(
+            data.runtime_override,
+            config.categories_enabled,
+        )
+        pii_enabled = self.resolve_runtime_pii(data.runtime_override, config.pii_enabled)
+        block_patterns: list[PatternRule] = []
+        if pii_enabled:
+            block_patterns.extend(list(data.pii_rules or []))
+
+        policy = ModerationPolicy(
+            enabled=config.enabled,
+            input_enabled=config.input_enabled,
+            output_enabled=config.output_enabled,
+            input_action=str(config.input_action).lower(),
+            output_action=str(config.output_action).lower(),
+            redact_replacement=config.redact_replacement,
+            per_user_overrides=config.per_user_overrides,
+            block_patterns=block_patterns,
+            categories_enabled=categories_enabled,
+        )
+        return PolicyCompilationResult(policy=policy, report=report)
+
+    @staticmethod
+    def resolve_runtime_pii(runtime_override: dict[str, object], default: bool) -> bool:
+        if "pii_enabled" in runtime_override:
+            return bool(runtime_override.get("pii_enabled"))
+        return bool(default)
+
+    @staticmethod
+    def resolve_runtime_categories(
+        runtime_override: dict[str, object],
+        default: set[str] | None,
+    ) -> set[str] | None:
+        if "categories_enabled" not in runtime_override:
+            return set(default) if default is not None else None
+        raw = runtime_override.get("categories_enabled") or []
+        if isinstance(raw, (set, list, tuple)):
+            parsed = {str(c).strip().lower() for c in raw if str(c).strip()}
+            return parsed or None
+        if isinstance(raw, str):
+            parsed = {c.strip().lower() for c in raw.split(",") if c.strip()}
+            return parsed or None
+        return set(default) if default is not None else None

--- a/tldw_Server_API/app/core/Moderation/policy_compiler.py
+++ b/tldw_Server_API/app/core/Moderation/policy_compiler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -69,6 +70,9 @@ class PolicyCompilationResult:
 
 
 class PolicyCompiler:
+    _ALLOWED_REGEX_FLAGS = {"i", "m", "s", "x"}
+    _ALLOWED_ACTIONS = {"block", "redact", "warn"}
+
     @staticmethod
     def policy_types() -> tuple[type[ModerationPolicy], type[PatternRule]]:
         from tldw_Server_API.app.core.Moderation.moderation_service import (
@@ -81,13 +85,13 @@ class PolicyCompiler:
     def compile_global(self, data: PolicyCompilationInput) -> PolicyCompilationResult:
         report = PolicyCompilationReport()
         config = data.config
-        ModerationPolicy, PatternRule = self.policy_types()
+        ModerationPolicy, _ = self.policy_types()
         categories_enabled = self.resolve_runtime_categories(
             data.runtime_override,
             config.categories_enabled,
         )
         pii_enabled = self.resolve_runtime_pii(data.runtime_override, config.pii_enabled)
-        block_patterns: list[PatternRule] = []
+        block_patterns = self.compile_blocklist_lines(data.blocklist_lines, report)
         if pii_enabled:
             block_patterns.extend(list(data.pii_rules or []))
 
@@ -103,6 +107,216 @@ class PolicyCompiler:
             categories_enabled=categories_enabled,
         )
         return PolicyCompilationResult(policy=policy, report=report)
+
+    def compile_blocklist_lines(
+        self,
+        lines: list[str],
+        report: PolicyCompilationReport | None = None,
+    ) -> list[PatternRule]:
+        compiled: list[PatternRule] = []
+        active_report = report or PolicyCompilationReport()
+        for idx, raw in enumerate(lines or []):
+            line = str(raw).strip()
+            if not line or line.startswith("#"):
+                continue
+            expr, action, replacement, categories = self.parse_rule_line(line)
+            if expr is None:
+                active_report.add("blocklist", "empty_pattern", index=idx)
+                continue
+            if action and not self.is_valid_action(action):
+                active_report.add("blocklist", "invalid_action", index=idx)
+                continue
+            rule = self.compile_rule_expression(
+                expr,
+                action=action,
+                replacement=replacement,
+                categories=categories,
+                phase="both",
+                report=active_report,
+                source="blocklist",
+                index=idx,
+            )
+            if rule is not None:
+                compiled.append(rule)
+        return compiled
+
+    @classmethod
+    def parse_rule_line(cls, text: str) -> tuple[str | None, str | None, str | None, set[str] | None]:
+        if not text:
+            return None, None, None, None
+        line = text
+        action = None
+        replacement = None
+        categories: set[str] | None = None
+        if "#" in line:
+            cut_index = cls._find_category_suffix(line)
+            if cut_index != -1:
+                after = line[cut_index + 1:]
+                cats = {c.strip().lower() for c in after.split(",") if c.strip()}
+                if cats:
+                    categories = cats
+                    line = line[:cut_index].strip()
+        if "->" in line:
+            lhs, rhs = cls.split_action_directive(line)
+            if rhs is not None:
+                line = lhs
+                if rhs:
+                    rhs_lower = rhs.lower()
+                    if rhs_lower.startswith("redact:"):
+                        action = "redact"
+                        replacement = rhs[len("redact:"):].strip()
+                    elif rhs_lower in cls._ALLOWED_ACTIONS:
+                        action = rhs_lower
+                    else:
+                        action = rhs
+        return line, action, replacement, categories
+
+    @staticmethod
+    def _find_category_suffix(text: str) -> int:
+        if "#" not in text:
+            return -1
+        for i in range(len(text) - 1, -1, -1):
+            if text[i] != "#":
+                continue
+            backslash_count = 0
+            j = i - 1
+            while j >= 0 and text[j] == "\\":
+                backslash_count += 1
+                j -= 1
+            escaped = backslash_count % 2 == 1
+            previous = text[i - 1] if i > 0 else ""
+            if not escaped and (i == 0 or previous.isspace()):
+                return i
+        return -1
+
+    @staticmethod
+    def split_action_directive(text: str) -> tuple[str, str | None]:
+        if "->" not in text:
+            return text, None
+        in_regex = False
+        escape = False
+        for i in range(len(text) - 1):
+            ch = text[i]
+            if escape:
+                escape = False
+                continue
+            if ch == "\\":
+                escape = True
+                continue
+            if ch == "/" and i == 0:
+                in_regex = True
+                continue
+            if ch == "/" and in_regex:
+                in_regex = False
+                continue
+            if not in_regex and text[i:i + 2] == "->":
+                backslash_count = 0
+                j = i - 1
+                while j >= 0 and text[j] == "\\":
+                    backslash_count += 1
+                    j -= 1
+                if backslash_count % 2 == 1:
+                    continue
+                return text[:i].strip(), text[i + 2:].strip()
+        return text, None
+
+    @classmethod
+    def parse_regex_expr(cls, expr: str) -> tuple[str, str] | None:
+        if not expr or not expr.startswith("/"):
+            return None
+        last_slash = expr.rfind("/")
+        if last_slash <= 0:
+            return None
+        flags = expr[last_slash + 1:]
+        if flags:
+            lowered = flags.lower()
+            if any(ch not in cls._ALLOWED_REGEX_FLAGS for ch in lowered):
+                return None
+        raw = expr[1:last_slash]
+        if raw == "":
+            return None
+        return raw, flags
+
+    @classmethod
+    def regex_flags(cls, flags: str | None) -> int:
+        value = re.IGNORECASE
+        lowered = (flags or "").lower()
+        if "i" in lowered:
+            value |= re.IGNORECASE
+        if "m" in lowered:
+            value |= re.MULTILINE
+        if "s" in lowered:
+            value |= re.DOTALL
+        if "x" in lowered:
+            value |= re.VERBOSE
+        return value
+
+    @staticmethod
+    def normalize_regex_escapes(expr: str) -> str:
+        return re.sub(r"\\\\([AbBdDsSwWZ])", r"\\\1", expr)
+
+    @classmethod
+    def is_valid_action(cls, action: str) -> bool:
+        return str(action).strip().lower() in cls._ALLOWED_ACTIONS
+
+    @staticmethod
+    def has_nested_quantifiers(expr: str) -> bool:
+        try:
+            return bool(re.search(r"\((?:[^)(]|\([^)(]*\))*[+*][^)]*\)\s*[+*]", expr))
+        except (TypeError, ValueError, re.error):
+            return False
+
+    @staticmethod
+    def too_many_groups(expr: str, limit: int = 100) -> bool:
+        try:
+            return expr.count("(") - expr.count("\\(") > limit
+        except (TypeError, ValueError):
+            return False
+
+    def is_regex_dangerous(self, expr: str) -> bool:
+        if not expr:
+            return True
+        if len(expr) > 2000:
+            return True
+        if self.has_nested_quantifiers(expr):
+            return True
+        return self.too_many_groups(expr)
+
+    def compile_rule_expression(
+        self,
+        expr: str,
+        *,
+        action: str | None,
+        replacement: str | None,
+        categories: set[str] | None,
+        phase: str,
+        report: PolicyCompilationReport,
+        source: str,
+        index: int | None,
+    ) -> PatternRule | None:
+        _, PatternRule = self.policy_types()
+        try:
+            regex_parts = self.parse_regex_expr(expr)
+            if regex_parts:
+                raw, flags_str = regex_parts
+                raw = self.normalize_regex_escapes(raw)
+                if self.is_regex_dangerous(raw):
+                    report.add(source, "dangerous_regex", index=index)
+                    return None
+                flags = self.regex_flags(flags_str)
+                regex = re.compile(raw, flags=flags)
+            else:
+                regex = re.compile(re.escape(expr.replace("\\#", "#")), flags=re.IGNORECASE)
+        except re.error:
+            report.add(source, "invalid_regex", index=index)
+            return None
+        return PatternRule(
+            regex=regex,
+            action=action or None,
+            replacement=replacement or None,
+            categories=categories or None,
+            phase=phase,
+        )
 
     @staticmethod
     def resolve_runtime_pii(runtime_override: dict[str, object], default: bool) -> bool:

--- a/tldw_Server_API/app/core/Moderation/policy_compiler.py
+++ b/tldw_Server_API/app/core/Moderation/policy_compiler.py
@@ -1,6 +1,9 @@
+"""Deterministic moderation policy compilation helpers."""
+
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -13,6 +16,8 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class ResolvedModerationConfig:
+    """Moderation config values after service config/env resolution."""
+
     enabled: bool = False
     input_enabled: bool = True
     output_enabled: bool = True
@@ -26,6 +31,8 @@ class ResolvedModerationConfig:
 
 @dataclass(frozen=True)
 class PolicyCompilationIssue:
+    """Sanitized issue emitted while compiling moderation policy inputs."""
+
     source: str
     reason: str
     index: int | None = None
@@ -34,6 +41,8 @@ class PolicyCompilationIssue:
 
 @dataclass
 class PolicyCompilationReport:
+    """Collects sanitized policy compilation issues for service logging."""
+
     issues: list[PolicyCompilationIssue] = field(default_factory=list)
 
     def add(
@@ -44,6 +53,8 @@ class PolicyCompilationReport:
         index: int | None = None,
         detail: str | None = None,
     ) -> None:
+        """Append a sanitized issue entry to the report."""
+
         self.issues.append(
             PolicyCompilationIssue(
                 source=source,
@@ -56,25 +67,33 @@ class PolicyCompilationReport:
 
 @dataclass
 class PolicyCompilationInput:
+    """Input bundle for compiling a global moderation policy."""
+
     config: ResolvedModerationConfig
     runtime_override: dict[str, object] = field(default_factory=dict)
-    blocklist_lines: list[str] = field(default_factory=list)
+    blocklist_lines: Iterable[str] = field(default_factory=list)
     user_override: dict[str, object] | None = None
     pii_rules: list[PatternRule] = field(default_factory=list)
 
 
 @dataclass
 class PolicyCompilationResult:
+    """Compiled moderation policy and the sanitized report from compilation."""
+
     policy: ModerationPolicy
     report: PolicyCompilationReport
 
 
 class PolicyCompiler:
+    """Compile moderation policies from resolved config and rule inputs."""
+
     _ALLOWED_REGEX_FLAGS = {"i", "m", "s", "x"}
     _ALLOWED_ACTIONS = {"block", "redact", "warn"}
 
     @staticmethod
     def policy_types() -> tuple[type[ModerationPolicy], type[PatternRule]]:
+        """Load policy dataclasses lazily to avoid import cycles."""
+
         from tldw_Server_API.app.core.Moderation.moderation_service import (
             ModerationPolicy,
             PatternRule,
@@ -83,6 +102,8 @@ class PolicyCompiler:
         return ModerationPolicy, PatternRule
 
     def compile_global(self, data: PolicyCompilationInput) -> PolicyCompilationResult:
+        """Compile the global moderation policy from config and blocklist input."""
+
         report = PolicyCompilationReport()
         config = data.config
         ModerationPolicy, _ = self.policy_types()
@@ -113,6 +134,8 @@ class PolicyCompiler:
         base_policy: ModerationPolicy,
         override: dict[str, object] | None,
     ) -> PolicyCompilationResult:
+        """Compile a per-user policy overlay on top of the base policy."""
+
         report = PolicyCompilationReport()
         if not override:
             return PolicyCompilationResult(policy=base_policy, report=report)
@@ -141,9 +164,11 @@ class PolicyCompiler:
 
     def compile_blocklist_lines(
         self,
-        lines: list[str],
+        lines: Iterable[str] | None,
         report: PolicyCompilationReport | None = None,
     ) -> list[PatternRule]:
+        """Compile blocklist lines into pattern rules without materializing input."""
+
         compiled: list[PatternRule] = []
         active_report = report or PolicyCompilationReport()
         for idx, raw in enumerate(lines or []):
@@ -173,6 +198,8 @@ class PolicyCompiler:
 
     @classmethod
     def parse_rule_line(cls, text: str) -> tuple[str | None, str | None, str | None, set[str] | None]:
+        """Parse one blocklist line into expression, action, replacement, and categories."""
+
         if not text:
             return None, None, None, None
         line = text
@@ -204,6 +231,8 @@ class PolicyCompiler:
 
     @staticmethod
     def _find_category_suffix(text: str) -> int:
+        """Return the index of an unescaped category suffix marker."""
+
         if "#" not in text:
             return -1
         for i in range(len(text) - 1, -1, -1):
@@ -222,6 +251,8 @@ class PolicyCompiler:
 
     @staticmethod
     def split_action_directive(text: str) -> tuple[str, str | None]:
+        """Split a blocklist action directive while preserving regex arrows."""
+
         if "->" not in text:
             return text, None
         in_regex = False
@@ -253,6 +284,8 @@ class PolicyCompiler:
 
     @classmethod
     def parse_regex_expr(cls, expr: str) -> tuple[str, str] | None:
+        """Parse a `/pattern/flags` expression or return ``None`` for literals."""
+
         if not expr or not expr.startswith("/"):
             return None
         last_slash = expr.rfind("/")
@@ -270,6 +303,8 @@ class PolicyCompiler:
 
     @classmethod
     def regex_flags(cls, flags: str | None) -> int:
+        """Convert supported regex flag letters into Python ``re`` flags."""
+
         value = re.IGNORECASE
         lowered = (flags or "").lower()
         if "i" in lowered:
@@ -284,10 +319,14 @@ class PolicyCompiler:
 
     @classmethod
     def is_valid_action(cls, action: str) -> bool:
+        """Return whether an action is allowed in blocklist rules."""
+
         return str(action).strip().lower() in cls._ALLOWED_ACTIONS
 
     @staticmethod
     def has_nested_quantifiers(expr: str) -> bool:
+        """Detect nested quantifiers that can trigger catastrophic backtracking."""
+
         try:
             return bool(re.search(r"\((?:[^)(]|\([^)(]*\))*[+*][^)]*\)\s*[+*]", expr))
         except (TypeError, ValueError, re.error):
@@ -295,12 +334,16 @@ class PolicyCompiler:
 
     @staticmethod
     def too_many_groups(expr: str, limit: int = 100) -> bool:
+        """Return whether a regex expression exceeds the group-count limit."""
+
         try:
             return expr.count("(") - expr.count("\\(") > limit
         except (TypeError, ValueError):
             return False
 
     def is_regex_dangerous(self, expr: str) -> bool:
+        """Return whether a regex should be rejected before compilation."""
+
         if not expr:
             return True
         if len(expr) > 2000:
@@ -321,6 +364,8 @@ class PolicyCompiler:
         source: str,
         index: int | None,
     ) -> PatternRule | None:
+        """Compile one literal or regex expression into a pattern rule."""
+
         _, PatternRule = self.policy_types()
         try:
             regex_parts = self.parse_regex_expr(expr)
@@ -346,6 +391,8 @@ class PolicyCompiler:
 
     @staticmethod
     def coalesce_bool(value: object, default: bool) -> bool:
+        """Parse a truthy/falsy override value, falling back to a default."""
+
         if isinstance(value, bool):
             return value
         if value is None:
@@ -354,6 +401,8 @@ class PolicyCompiler:
 
     @staticmethod
     def parse_bool_value(value: object) -> bool | None:
+        """Parse a bool-like value or return ``None`` when invalid."""
+
         if isinstance(value, bool):
             return value
         if value is None:
@@ -373,6 +422,8 @@ class PolicyCompiler:
         override: dict[str, object],
         default_categories: set[str] | None,
     ) -> set[str] | None:
+        """Resolve per-user category overrides against default categories."""
+
         if "categories_enabled" not in override:
             return set(default_categories) if default_categories is not None else None
         parsed = self.parse_categories_override(override.get("categories_enabled"))
@@ -382,6 +433,8 @@ class PolicyCompiler:
 
     @staticmethod
     def parse_categories_override(value: object | None) -> set[str] | None:
+        """Parse a category override value into a normalized category set."""
+
         if value is None:
             return None
         if isinstance(value, list):
@@ -399,6 +452,8 @@ class PolicyCompiler:
         report: PolicyCompilationReport,
         index: int,
     ) -> PatternRule | None:
+        """Compile one per-user quick rule into a pattern rule."""
+
         if not isinstance(raw_rule, dict):
             report.add("user_rule", "invalid_rule", index=index)
             return None
@@ -436,6 +491,8 @@ class PolicyCompiler:
 
     @staticmethod
     def resolve_runtime_pii(runtime_override: dict[str, object], default: bool) -> bool:
+        """Resolve effective PII enablement from runtime overrides."""
+
         if "pii_enabled" in runtime_override:
             return bool(runtime_override.get("pii_enabled"))
         return bool(default)
@@ -445,6 +502,8 @@ class PolicyCompiler:
         runtime_override: dict[str, object],
         default: set[str] | None,
     ) -> set[str] | None:
+        """Resolve effective categories from runtime overrides."""
+
         if "categories_enabled" not in runtime_override:
             return set(default) if default is not None else None
         raw = runtime_override.get("categories_enabled") or []

--- a/tldw_Server_API/tests/Guardian/test_supervised_policy.py
+++ b/tldw_Server_API/tests/Guardian/test_supervised_policy.py
@@ -23,6 +23,11 @@ from tldw_Server_API.app.core.Moderation.moderation_service import (
     ModerationPolicy,
     PatternRule,
 )
+from tldw_Server_API.app.core.Moderation.policy_compiler import (
+    PolicyCompilationInput,
+    PolicyCompiler,
+    ResolvedModerationConfig,
+)
 
 
 # ── Fixtures ──────────────────────────────────────────────────
@@ -822,6 +827,50 @@ class TestBuildModerationPolicyOverlay:
         assert isinstance(rule, PatternRule)
         assert rule.action == "block"
         assert rule.categories == {"test_cat"}
+
+    def test_overlay_accepts_compiler_policy_and_preserves_base_io_settings(self, db, engine):
+        rel = _setup_active_relationship(db)
+        db.create_policy(
+            relationship_id=rel.id,
+            pattern="supervised_word",
+            action="block",
+            category="supervised",
+        )
+        base = PolicyCompiler().compile_global(
+            PolicyCompilationInput(
+                config=ResolvedModerationConfig(
+                    enabled=True,
+                    input_enabled=False,
+                    output_enabled=True,
+                    input_action="warn",
+                    output_action="block",
+                    redact_replacement="[BASE]",
+                    per_user_overrides=False,
+                    categories_enabled={"base", "supervised"},
+                    pii_enabled=False,
+                ),
+                blocklist_lines=["base-secret -> warn #base"],
+            )
+        ).policy
+
+        result = engine.build_moderation_policy_overlay("child1", base)
+
+        assert isinstance(result, ModerationPolicy)
+        assert result.enabled is True
+        assert result.input_enabled is False
+        assert result.output_enabled is True
+        assert result.input_action == "warn"
+        assert result.output_action == "block"
+        assert result.redact_replacement == "[BASE]"
+        assert result.per_user_overrides is False
+        assert result.categories_enabled == {"base", "supervised"}
+        assert len(result.block_patterns) == 2
+        assert result.block_patterns[0].regex.search("base-secret")
+        assert result.block_patterns[0].action == "warn"
+        assert result.block_patterns[0].categories == {"base"}
+        assert result.block_patterns[1].regex.search("supervised_word")
+        assert result.block_patterns[1].action == "block"
+        assert result.block_patterns[1].categories == {"supervised"}
 
     def test_overlay_appends_to_existing_patterns(self, db, engine):
         rel = _setup_active_relationship(db)

--- a/tldw_Server_API/tests/Guardian/test_supervised_policy.py
+++ b/tldw_Server_API/tests/Guardian/test_supervised_policy.py
@@ -7,18 +7,11 @@ GuardianDB (no mocks). Each test gets a fresh database via tmp_path.
 from __future__ import annotations
 
 import re
-import time
 
 import pytest
 
 import tldw_Server_API.app.core.Moderation.supervised_policy as supervised_module
 from tldw_Server_API.app.core.DB_Management.Guardian_DB import GuardianDB, SupervisedPolicy
-from tldw_Server_API.app.core.Moderation.supervised_policy import (
-    GuardianModerationProxy,
-    SupervisedCheckResult,
-    SupervisedPolicyEngine,
-    dispatch_guardian_notification,
-)
 from tldw_Server_API.app.core.Moderation.moderation_service import (
     ModerationPolicy,
     PatternRule,
@@ -28,7 +21,12 @@ from tldw_Server_API.app.core.Moderation.policy_compiler import (
     PolicyCompiler,
     ResolvedModerationConfig,
 )
-
+from tldw_Server_API.app.core.Moderation.supervised_policy import (
+    GuardianModerationProxy,
+    SupervisedCheckResult,
+    SupervisedPolicyEngine,
+    dispatch_guardian_notification,
+)
 
 # ── Fixtures ──────────────────────────────────────────────────
 
@@ -996,7 +994,7 @@ class TestEdgeCases:
             pattern="restricted",
             action="block",
         )
-        rel2 = _setup_active_relationship(db, "guardian1", "child2")
+        _setup_active_relationship(db, "guardian1", "child2")
         # child2 has no policies
 
         result_child1 = engine.check_text("restricted content", "child1")
@@ -1453,6 +1451,7 @@ class TestTransparentMode:
 class TestGuardianNotificationDispatch:
     def test_dispatches_when_notify_guardian_true(self, db, engine):
         from unittest.mock import MagicMock, patch
+
         from tldw_Server_API.app.core.Moderation.supervised_policy import (
             SupervisedCheckResult,
             dispatch_guardian_notification,

--- a/tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py
+++ b/tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py
@@ -39,6 +39,25 @@ def test_service_parser_wrappers_delegate_to_policy_compiler():
 
 
 @pytest.mark.unit
+def test_service_parse_rule_line_uses_policy_compiler_instance():
+    svc = ModerationService()
+
+    class FakeCompiler:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def parse_rule_line(self, value: str):
+            self.calls.append(value)
+            return "delegated", "warn", None, {"test"}
+
+    fake = FakeCompiler()
+    svc._policy_compiler = fake
+
+    assert svc._parse_rule_line("raw rule") == ("delegated", "warn", None, {"test"})
+    assert fake.calls == ["raw rule"]
+
+
+@pytest.mark.unit
 def test_parse_regex_with_arrow_inside_pattern():
     svc = ModerationService()
     expr, action, repl, cats = svc._parse_rule_line(r"/a->b/ -> block")

--- a/tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py
+++ b/tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py
@@ -21,6 +21,7 @@ def _tmp_moderation_config(tmp_path, blocklist_path):
             "per_user_overrides": "true",
             "categories_enabled": "runtime",
             "pii_enabled": "false",
+            "blocklist_write_debounce_ms": "0",
             "blocklist_file": str(blocklist_path),
             "user_overrides_file": str(tmp_path / "moderation_user_overrides.json"),
             "runtime_overrides_file": str(tmp_path / "moderation_runtime_overrides.json"),

--- a/tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py
+++ b/tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py
@@ -9,6 +9,25 @@ import tldw_Server_API.app.core.Moderation.moderation_service as moderation_serv
 from tldw_Server_API.app.core.Moderation.moderation_service import ModerationService, ModerationPolicy, PatternRule
 
 
+def _tmp_moderation_config(tmp_path, blocklist_path):
+    return {
+        "moderation": {
+            "enabled": "true",
+            "input_enabled": "true",
+            "output_enabled": "true",
+            "input_action": "block",
+            "output_action": "redact",
+            "redact_replacement": "[REDACTED]",
+            "per_user_overrides": "true",
+            "categories_enabled": "runtime",
+            "pii_enabled": "false",
+            "blocklist_file": str(blocklist_path),
+            "user_overrides_file": str(tmp_path / "moderation_user_overrides.json"),
+            "runtime_overrides_file": str(tmp_path / "moderation_runtime_overrides.json"),
+        }
+    }
+
+
 @pytest.mark.unit
 def test_parse_line_with_categories_suffix_after_action():
     svc = ModerationService()
@@ -747,6 +766,45 @@ def test_set_blocklist_lines_empty_writes_empty_file():
             os.unlink(tmp_path)
         except Exception:
             _ = None
+
+
+@pytest.mark.unit
+def test_set_blocklist_lines_recompiles_policy_from_file(monkeypatch, tmp_path):
+    blocklist_path = tmp_path / "moderation_blocklist.txt"
+    blocklist_path.write_text("old-secret -> block #runtime\n", encoding="utf-8")
+    monkeypatch.setattr(
+        moderation_service_module,
+        "load_and_log_configs",
+        lambda: _tmp_moderation_config(tmp_path, blocklist_path),
+    )
+
+    svc = ModerationService()
+
+    old_before, _red_before, _pattern_before, old_cat_before = svc.evaluate_action(
+        "old-secret",
+        svc._global_policy,
+        "input",
+    )
+    assert old_before == "block"
+    assert old_cat_before == "runtime"
+
+    ok = svc.set_blocklist_lines(["new-secret -> block #runtime"])
+
+    assert ok is True
+    assert blocklist_path.read_text(encoding="utf-8") == "new-secret -> block #runtime\n"
+    old_after, _red_old_after, _pattern_old_after, _cat_old_after = svc.evaluate_action(
+        "old-secret",
+        svc._global_policy,
+        "input",
+    )
+    new_after, _red_new_after, _pattern_new_after, new_cat_after = svc.evaluate_action(
+        "new-secret",
+        svc._global_policy,
+        "input",
+    )
+    assert old_after == "pass"
+    assert new_after == "block"
+    assert new_cat_after == "runtime"
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py
+++ b/tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py
@@ -1,12 +1,11 @@
 import os
 import re
 import tempfile
-from typing import Optional, Set
 
 import pytest
 
 import tldw_Server_API.app.core.Moderation.moderation_service as moderation_service_module
-from tldw_Server_API.app.core.Moderation.moderation_service import ModerationService, ModerationPolicy, PatternRule
+from tldw_Server_API.app.core.Moderation.moderation_service import ModerationPolicy, ModerationService, PatternRule
 
 
 def _tmp_moderation_config(tmp_path, blocklist_path):
@@ -273,7 +272,7 @@ def test_blocklist_invalid_action_warning_sanitizes_line_details(tmp_path):
 
 
 @pytest.mark.unit
-def test_load_block_patterns_missing_file_sanitizes_warning_path(tmp_path):
+def test_load_block_patterns_missing_file_logs_path_context(tmp_path):
     svc = ModerationService()
     blocklist_path = tmp_path / "private_moderation_blocklist.txt"
 
@@ -287,12 +286,11 @@ def test_load_block_patterns_missing_file_sanitizes_warning_path(tmp_path):
     joined = "\n".join(messages)
     assert rules == []
     assert "Moderation blocklist file not found" in joined
-    assert "private_moderation_blocklist.txt" not in joined
-    assert str(tmp_path) not in joined
+    assert f"path={blocklist_path}" in joined
 
 
 @pytest.mark.unit
-def test_load_block_patterns_sanitizes_outer_failure_log(monkeypatch, tmp_path):
+def test_load_block_patterns_failure_log_preserves_exception_context(monkeypatch, tmp_path):
     svc = ModerationService()
     blocklist_path = tmp_path / "moderation_blocklist.txt"
     blocklist_path.write_text("secret\n", encoding="utf-8")
@@ -312,8 +310,42 @@ def test_load_block_patterns_sanitizes_outer_failure_log(monkeypatch, tmp_path):
     joined = "\n".join(messages)
     assert rules == []
     assert "Failed to load moderation blocklist" in joined
-    assert "blocklist load failed" not in joined
-    assert "moderation_blocklist.txt" not in joined
+    assert f"path={blocklist_path}" in joined
+    assert "blocklist load failed" in joined
+    assert "Traceback" in joined
+
+
+@pytest.mark.unit
+def test_load_block_patterns_iterates_blocklist_without_readlines(monkeypatch, tmp_path):
+    svc = ModerationService()
+    blocklist_path = tmp_path / "moderation_blocklist.txt"
+    blocklist_path.write_text("ignored by monkeypatch\n", encoding="utf-8")
+
+    class IterOnlyBlocklist:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def __iter__(self):
+            return iter(["secret -> block #confidential\n"])
+
+        def readlines(self):
+            raise AssertionError("readlines should not be used for compilation")
+
+    monkeypatch.setattr(
+        moderation_service_module,
+        "open",
+        lambda *_args, **_kwargs: IterOnlyBlocklist(),
+        raising=False,
+    )
+
+    rules = svc._load_block_patterns(str(blocklist_path))
+
+    assert len(rules) == 1
+    assert rules[0].regex.search("secret")
+    assert rules[0].categories == {"confidential"}
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py
+++ b/tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py
@@ -27,6 +27,18 @@ def test_parse_line_with_categories_suffix_after_action():
 
 
 @pytest.mark.unit
+def test_service_parser_wrappers_delegate_to_policy_compiler():
+    svc = ModerationService()
+
+    expr, action, repl, cats = svc._parse_rule_line("/leak\\d+/ -> redact:[MASK] #pii")
+
+    assert expr == "/leak\\d+/"
+    assert action == "redact"
+    assert repl == "[MASK]"
+    assert cats == {"pii"}
+
+
+@pytest.mark.unit
 def test_parse_regex_with_arrow_inside_pattern():
     svc = ModerationService()
     expr, action, repl, cats = svc._parse_rule_line(r"/a->b/ -> block")
@@ -348,6 +360,26 @@ def test_lint_warns_on_invalid_regex_flags():
     assert item["ok"] is True
     assert item["pattern_type"] == "literal"
     assert "invalid regex flags" in (item.get("warning") or "")
+
+
+@pytest.mark.unit
+def test_lint_blocklist_lines_keeps_public_response_shape():
+    svc = ModerationService()
+
+    result = svc.lint_blocklist_lines(["/foo/z", "secret -> block #confidential"])
+
+    assert set(result) == {"items", "valid_count", "invalid_count"}
+    invalid = result["items"][0]
+    valid = result["items"][1]
+    assert invalid["line"] == "/foo/z"
+    assert invalid["ok"] is True
+    assert invalid["pattern_type"] == "literal"
+    assert invalid["warning"] == "invalid regex flags; treating as literal"
+    assert valid["line"] == "secret -> block #confidential"
+    assert valid["ok"] is True
+    assert valid["pattern_type"] == "literal"
+    assert valid["sample"] == "secret"
+    assert valid["categories"] == ["confidential"]
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/unit/test_moderation_effective_settings.py
+++ b/tldw_Server_API/tests/unit/test_moderation_effective_settings.py
@@ -22,6 +22,7 @@ def _tmp_moderation_config(tmp_path, blocklist_path):
             "per_user_overrides": "true",
             "categories_enabled": "confidential",
             "pii_enabled": "false",
+            "blocklist_write_debounce_ms": "0",
             "blocklist_file": str(blocklist_path),
             "user_overrides_file": str(tmp_path / "moderation_user_overrides.json"),
             "runtime_overrides_file": str(tmp_path / "moderation_runtime_overrides.json"),

--- a/tldw_Server_API/tests/unit/test_moderation_effective_settings.py
+++ b/tldw_Server_API/tests/unit/test_moderation_effective_settings.py
@@ -2,11 +2,31 @@ import re
 
 import pytest
 
+import tldw_Server_API.app.core.Moderation.moderation_service as moderation_service_module
 from tldw_Server_API.app.core.Moderation.moderation_service import (
     ModerationPolicy,
     ModerationService,
     PatternRule,
 )
+
+
+def _tmp_moderation_config(tmp_path, blocklist_path):
+    return {
+        "moderation": {
+            "enabled": "true",
+            "input_enabled": "true",
+            "output_enabled": "true",
+            "input_action": "block",
+            "output_action": "redact",
+            "redact_replacement": "[REDACTED]",
+            "per_user_overrides": "true",
+            "categories_enabled": "confidential",
+            "pii_enabled": "false",
+            "blocklist_file": str(blocklist_path),
+            "user_overrides_file": str(tmp_path / "moderation_user_overrides.json"),
+            "runtime_overrides_file": str(tmp_path / "moderation_runtime_overrides.json"),
+        }
+    }
 
 
 @pytest.mark.unit
@@ -70,3 +90,37 @@ def test_category_reporting_respects_allowlist():
     act, _red, _pattern, cat = svc.evaluate_action("secret", pol, "input")
     assert act == "block"
     assert cat == "pii"
+
+
+@pytest.mark.unit
+def test_update_settings_recompiles_global_policy_with_runtime_categories(monkeypatch, tmp_path):
+    blocklist_path = tmp_path / "moderation_blocklist.txt"
+    blocklist_path.write_text("runtime-secret -> block #runtime\n", encoding="utf-8")
+    monkeypatch.setattr(
+        moderation_service_module,
+        "load_and_log_configs",
+        lambda: _tmp_moderation_config(tmp_path, blocklist_path),
+    )
+
+    svc = ModerationService()
+
+    assert svc._global_policy.categories_enabled == {"confidential"}
+    act_before, _red_before, _pattern_before, _cat_before = svc.evaluate_action(
+        "runtime-secret",
+        svc._global_policy,
+        "input",
+    )
+    assert act_before == "pass"
+
+    settings = svc.update_settings(categories_enabled=["runtime"], persist=False)
+
+    assert settings["effective"]["categories_enabled"] == ["runtime"]
+    assert svc._global_policy.categories_enabled == {"runtime"}
+    act_after, _red_after, _pattern_after, cat_after = svc.evaluate_action(
+        "runtime-secret",
+        svc._global_policy,
+        "input",
+    )
+    assert act_after == "block"
+    assert cat_after == "runtime"
+    assert not (tmp_path / "moderation_runtime_overrides.json").exists()

--- a/tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
+++ b/tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
@@ -1,0 +1,62 @@
+import re
+
+from tldw_Server_API.app.core.Moderation.moderation_service import ModerationPolicy, PatternRule
+from tldw_Server_API.app.core.Moderation.policy_compiler import (
+    PolicyCompilationInput,
+    PolicyCompiler,
+    ResolvedModerationConfig,
+)
+
+
+def _config(**overrides):
+    values = {
+        "enabled": True,
+        "input_enabled": True,
+        "output_enabled": True,
+        "input_action": "block",
+        "output_action": "redact",
+        "redact_replacement": "[REDACTED]",
+        "per_user_overrides": True,
+        "categories_enabled": None,
+        "pii_enabled": False,
+    }
+    values.update(overrides)
+    return ResolvedModerationConfig(**values)
+
+
+def test_compile_global_policy_uses_resolved_defaults():
+    result = PolicyCompiler().compile_global(
+        PolicyCompilationInput(
+            config=_config(categories_enabled={"pii", "confidential"}),
+            runtime_override={},
+            blocklist_lines=[],
+            pii_rules=[],
+        )
+    )
+
+    assert isinstance(result.policy, ModerationPolicy)
+    assert result.policy.enabled is True
+    assert result.policy.input_action == "block"
+    assert result.policy.output_action == "redact"
+    assert result.policy.categories_enabled == {"pii", "confidential"}
+    assert result.report.issues == []
+
+
+def test_compile_global_policy_copies_pii_rules_when_enabled():
+    pii_rule = PatternRule(
+        regex=re.compile("email", re.IGNORECASE),
+        action="redact",
+        replacement="[PII]",
+        categories={"pii", "pii_email"},
+    )
+
+    result = PolicyCompiler().compile_global(
+        PolicyCompilationInput(
+            config=_config(pii_enabled=True),
+            runtime_override={},
+            blocklist_lines=[],
+            pii_rules=[pii_rule],
+        )
+    )
+
+    assert result.policy.block_patterns == [pii_rule]

--- a/tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
+++ b/tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
@@ -1,5 +1,7 @@
 import re
 
+import pytest
+
 from tldw_Server_API.app.core.Moderation.moderation_service import (
     ModerationPolicy,
     ModerationService,
@@ -10,6 +12,8 @@ from tldw_Server_API.app.core.Moderation.policy_compiler import (
     PolicyCompiler,
     ResolvedModerationConfig,
 )
+
+pytestmark = pytest.mark.unit
 
 
 def _config(**overrides):

--- a/tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
+++ b/tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
@@ -267,3 +267,64 @@ def test_compile_user_policy_accepts_legacy_bool_like_is_regex_values():
     assert result.policy.block_patterns[1].regex.search("literal.*")
     assert not result.policy.block_patterns[1].regex.search("literalabc")
     assert result.report.issues == []
+
+
+def test_compile_user_policy_without_override_returns_base_policy_without_issues():
+    base = ModerationPolicy(enabled=True, categories_enabled={"pii"})
+
+    result = PolicyCompiler().compile_user_policy(base, None)
+
+    assert result.policy is base
+    assert result.report.issues == []
+
+
+def test_compile_user_policy_ignores_non_list_rules_without_issues():
+    base = ModerationPolicy(enabled=True, block_patterns=[])
+
+    result = PolicyCompiler().compile_user_policy(base, {"rules": {"pattern": "secret"}})
+
+    assert result.policy.block_patterns == []
+    assert result.report.issues == []
+
+
+def test_compile_user_policy_invalid_categories_type_falls_back_to_default_categories():
+    base = ModerationPolicy(enabled=True, categories_enabled={"pii"})
+
+    result = PolicyCompiler().compile_user_policy(base, {"categories_enabled": 123})
+
+    assert result.policy.categories_enabled == {"pii"}
+    assert result.report.issues == []
+
+
+def test_compile_user_policy_invalid_rule_phase_defaults_to_both():
+    base = ModerationPolicy(enabled=True, block_patterns=[])
+
+    result = PolicyCompiler().compile_user_policy(
+        base,
+        {
+            "rules": [
+                {
+                    "id": "r1",
+                    "pattern": "secret",
+                    "is_regex": False,
+                    "action": "warn",
+                    "phase": "sideways",
+                }
+            ]
+        },
+    )
+
+    assert len(result.policy.block_patterns) == 1
+    assert result.policy.block_patterns[0].phase == "both"
+    assert result.report.issues == []
+
+
+def test_compile_user_policy_copies_default_categories_when_override_omits_categories():
+    base = ModerationPolicy(enabled=True, categories_enabled={"pii"})
+
+    result = PolicyCompiler().compile_user_policy(base, {"enabled": True})
+
+    assert result.policy.categories_enabled == {"pii"}
+    assert result.policy.categories_enabled is not None
+    result.policy.categories_enabled.add("confidential")
+    assert base.categories_enabled == {"pii"}

--- a/tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
+++ b/tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
@@ -69,7 +69,7 @@ def test_compile_global_policy_compiles_literal_and_regex_blocklist_rules():
             runtime_override={},
             blocklist_lines=[
                 "secret -> block #confidential",
-                r"/leak\\d+/i -> redact:[MASK] #pii",
+                r"/leak\d+/i -> redact:[MASK] #pii",
             ],
             pii_rules=[],
         )
@@ -106,3 +106,39 @@ def test_compile_global_policy_reports_invalid_lines_without_raw_regex():
     rendered = repr(result.report.issues)
     assert "(a+)+$" not in rendered
     assert "(unclosed" not in rendered
+
+
+def test_compile_global_policy_reports_empty_pattern_after_parsing():
+    result = PolicyCompiler().compile_global(
+        PolicyCompilationInput(
+            config=_config(),
+            runtime_override={},
+            blocklist_lines=["-> block"],
+            pii_rules=[],
+        )
+    )
+
+    assert result.policy.block_patterns == []
+    reasons = [issue.reason for issue in result.report.issues]
+    assert reasons == ["empty_pattern"]
+
+
+def test_compile_global_policy_preserves_raw_regex_backslashes():
+    result = PolicyCompiler().compile_global(
+        PolicyCompilationInput(
+            config=_config(),
+            runtime_override={},
+            blocklist_lines=[
+                r"/leak\d+/ -> block",
+                r"/leak\\d+/ -> warn",
+            ],
+            pii_rules=[],
+        )
+    )
+
+    rules = result.policy.block_patterns
+    assert len(rules) == 2
+    assert rules[0].regex.search("leak123")
+    assert not rules[0].regex.search(r"leak\d")
+    assert not rules[1].regex.search("leak123")
+    assert rules[1].regex.search(r"leak\d")

--- a/tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
+++ b/tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
@@ -60,3 +60,49 @@ def test_compile_global_policy_copies_pii_rules_when_enabled():
     )
 
     assert result.policy.block_patterns == [pii_rule]
+
+
+def test_compile_global_policy_compiles_literal_and_regex_blocklist_rules():
+    result = PolicyCompiler().compile_global(
+        PolicyCompilationInput(
+            config=_config(),
+            runtime_override={},
+            blocklist_lines=[
+                "secret -> block #confidential",
+                r"/leak\\d+/i -> redact:[MASK] #pii",
+            ],
+            pii_rules=[],
+        )
+    )
+
+    rules = result.policy.block_patterns
+    assert len(rules) == 2
+    assert rules[0].regex.search("SECRET")
+    assert rules[0].action == "block"
+    assert rules[0].categories == {"confidential"}
+    assert rules[1].regex.search("leak123")
+    assert rules[1].action == "redact"
+    assert rules[1].replacement == "[MASK]"
+    assert rules[1].categories == {"pii"}
+
+
+def test_compile_global_policy_reports_invalid_lines_without_raw_regex():
+    result = PolicyCompiler().compile_global(
+        PolicyCompilationInput(
+            config=_config(),
+            runtime_override={},
+            blocklist_lines=[
+                "secret -> invalid_action",
+                "/(a+)+$/ -> block",
+                "/(unclosed/ -> block",
+            ],
+            pii_rules=[],
+        )
+    )
+
+    assert result.policy.block_patterns == []
+    reasons = [issue.reason for issue in result.report.issues]
+    assert reasons == ["invalid_action", "dangerous_regex", "invalid_regex"]
+    rendered = repr(result.report.issues)
+    assert "(a+)+$" not in rendered
+    assert "(unclosed" not in rendered

--- a/tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
+++ b/tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
@@ -184,3 +184,86 @@ def test_service_resolved_config_falls_back_to_env_when_categories_are_none(monk
     resolved = svc._resolve_moderation_config({"categories_enabled": None})
 
     assert resolved.compiler_config.categories_enabled == {"pii", "confidential"}
+
+
+def test_compile_user_policy_preserves_empty_category_override():
+    base = ModerationPolicy(
+        enabled=True,
+        input_enabled=True,
+        output_enabled=True,
+        input_action="block",
+        output_action="redact",
+        redact_replacement="[REDACTED]",
+        per_user_overrides=True,
+        block_patterns=[],
+        categories_enabled={"pii"},
+    )
+
+    result = PolicyCompiler().compile_user_policy(
+        base,
+        {
+            "enabled": True,
+            "categories_enabled": "",
+            "rules": [],
+        },
+    )
+
+    assert result.policy.categories_enabled == set()
+
+
+def test_compile_user_policy_adds_wildcard_quick_rules():
+    base = ModerationPolicy(enabled=True, block_patterns=[], categories_enabled={"pii"})
+
+    result = PolicyCompiler().compile_user_policy(
+        base,
+        {
+            "rules": [
+                {
+                    "id": "r1",
+                    "pattern": "secret",
+                    "is_regex": False,
+                    "action": "warn",
+                    "phase": "input",
+                }
+            ]
+        },
+    )
+
+    assert len(result.policy.block_patterns) == 1
+    rule = result.policy.block_patterns[0]
+    assert rule.regex.search("secret")
+    assert rule.action == "warn"
+    assert rule.categories == {"*"}
+    assert rule.phase == "input"
+
+
+def test_compile_user_policy_accepts_legacy_bool_like_is_regex_values():
+    base = ModerationPolicy(enabled=True, block_patterns=[])
+
+    result = PolicyCompiler().compile_user_policy(
+        base,
+        {
+            "rules": [
+                {
+                    "id": "r1",
+                    "pattern": r"token-\d+",
+                    "is_regex": "yes",
+                    "action": "block",
+                    "phase": "input",
+                },
+                {
+                    "id": "r2",
+                    "pattern": "literal.*",
+                    "is_regex": "false",
+                    "action": "warn",
+                    "phase": "output",
+                },
+            ]
+        },
+    )
+
+    assert len(result.policy.block_patterns) == 2
+    assert result.policy.block_patterns[0].regex.search("token-42")
+    assert result.policy.block_patterns[1].regex.search("literal.*")
+    assert not result.policy.block_patterns[1].regex.search("literalabc")
+    assert result.report.issues == []

--- a/tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
+++ b/tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
@@ -1,6 +1,10 @@
 import re
 
-from tldw_Server_API.app.core.Moderation.moderation_service import ModerationPolicy, PatternRule
+from tldw_Server_API.app.core.Moderation.moderation_service import (
+    ModerationPolicy,
+    ModerationService,
+    PatternRule,
+)
 from tldw_Server_API.app.core.Moderation.policy_compiler import (
     PolicyCompilationInput,
     PolicyCompiler,
@@ -142,3 +146,31 @@ def test_compile_global_policy_preserves_raw_regex_backslashes():
     assert not rules[0].regex.search(r"leak\d")
     assert not rules[1].regex.search("leak123")
     assert rules[1].regex.search(r"leak\d")
+
+
+def test_service_global_policy_uses_compiler_without_leaking_paths(tmp_path, monkeypatch):
+    blocklist = tmp_path / "blocklist.txt"
+    blocklist.write_text("secret -> block #confidential\n", encoding="utf-8")
+
+    svc = ModerationService()
+    svc._blocklist_path = str(blocklist)
+    svc._runtime_override = {}
+    svc._policy_compiler = PolicyCompiler()
+
+    policy = svc._compile_global_policy_from_resolved_config(
+        ResolvedModerationConfig(
+            enabled=True,
+            input_enabled=True,
+            output_enabled=True,
+            input_action="block",
+            output_action="redact",
+            redact_replacement="[REDACTED]",
+            per_user_overrides=True,
+            categories_enabled=None,
+            pii_enabled=False,
+        )
+    )
+
+    assert policy.enabled is True
+    assert len(policy.block_patterns) == 1
+    assert policy.block_patterns[0].categories == {"confidential"}

--- a/tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
+++ b/tldw_Server_API/tests/unit/test_moderation_policy_compiler.py
@@ -174,3 +174,13 @@ def test_service_global_policy_uses_compiler_without_leaking_paths(tmp_path, mon
     assert policy.enabled is True
     assert len(policy.block_patterns) == 1
     assert policy.block_patterns[0].categories == {"confidential"}
+
+
+def test_service_resolved_config_falls_back_to_env_when_categories_are_none(monkeypatch):
+    monkeypatch.setenv("MODERATION_CATEGORIES_ENABLED", "pii, confidential")
+    svc = ModerationService()
+    svc._runtime_override = {"categories_enabled": {"runtime"}}
+
+    resolved = svc._resolve_moderation_config({"categories_enabled": None})
+
+    assert resolved.compiler_config.categories_enabled == {"pii", "confidential"}


### PR DESCRIPTION
## Summary
- Extracted deterministic moderation policy assembly and blocklist parsing into `PolicyCompiler`, with `ModerationService` kept as the facade for I/O, state refresh, logging, and persistence boundaries.
- Preserved effective-settings behavior for runtime thresholds, category rules, PII settings, blocklists, per-user quick rules, reload paths, mutation flows, and supervised overlay compatibility.
- Added focused compiler/service/overlay regression coverage plus design, plan, and Backlog tracking for the refactor.

## Verification
- `python -m py_compile ...` for touched moderation modules and focused tests
- `python -m pytest tldw_Server_API/tests/unit/test_moderation_policy_compiler.py tldw_Server_API/tests/unit/test_moderation_effective_settings.py tldw_Server_API/tests/unit/test_moderation_blocklist_parse.py tldw_Server_API/tests/Guardian/test_supervised_policy.py -q` (`143 passed, 298 warnings`)
- `git diff --check origin/dev...HEAD`
- `python -m bandit -r tldw_Server_API/app/core/Moderation -f json -o /tmp/bandit_moderation_policy_compiler_final.json` (`0 findings`)
- `git merge-tree --write-tree origin/dev HEAD` (`b91fe454b3445388b1bae88c4d2c729af4440eb1`)

## Change Summary
This PR is intentionally opened as a draft. Per repository policy, a human-authored change summary explaining what changed and why these implementation choices were made is required before this AI-authored PR is ready to merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored moderation policy assembly by introducing a `PolicyCompiler` and moving rule parsing and deterministic compilation out of `ModerationService`. Behavior is preserved for global and per-user policies; parser/lint delegation is hardened; category env fallback and parsing edge cases are fixed; rebased onto latest `dev` and addressed review comments.

- **Refactors**
  - Added `policy_compiler.py` with `PolicyCompiler`, `ResolvedModerationConfig`, and compile reports for global and per-user policies, including blocklist parsing.
  - Updated `ModerationService` to delegate compilation while keeping I/O, logging, reloads, persistence, and supervised overlays unchanged.
  - Rebased onto `dev`, resolved review feedback, and added spec/plan/rebase docs; completes TASK-2430, TASK-2431, TASK-2432, TASK-12022.

- **Bug Fixes**
  - Fixed categories env fallback during compilation.
  - Fixed rule parsing edge cases uncovered by tests.

<sup>Written for commit ce2c7d6248030cce059eb4f1acfb4950c66488eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

