### PR TITLE
Refactor UserProfiles contract-first flow

### DIFF
--- a/Docs/Published/API-related/User_Registration_API_Documentation.md
+++ b/Docs/Published/API-related/User_Registration_API_Documentation.md
@@ -243,6 +243,11 @@ Authorization: Bearer <access_token>
 }
 ```
 
+**Profile update compatibility**:
+- v1 profile update responses include `applied` and `skipped` for compatibility.
+- v2 profile single-update responses are atomic all-or-reject and omit `skipped`.
+- Bulk profile updates continue to report per-user partial results.
+
 ---
 
 ### POST /users/change-password

--- a/Docs/superpowers/plans/2026-06-29-pr2529-review-rebase.md
+++ b/Docs/superpowers/plans/2026-06-29-pr2529-review-rebase.md
@@ -32,4 +32,4 @@
 **Goal**: Commit, push the rebased branch, reply to/resolved addressed review threads, and report remaining CI status.
 **Success Criteria**: PR branch is updated on GitHub, review threads are resolved, and final status is reported.
 **Tests**: `gh pr view`, `gh pr checks`, and review-thread query.
-**Status**: In Progress
+**Status**: Complete

--- a/Docs/superpowers/plans/2026-06-29-pr2529-review-rebase.md
+++ b/Docs/superpowers/plans/2026-06-29-pr2529-review-rebase.md
@@ -1,0 +1,35 @@
+# PR 2529 Review Rebase Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebase PR #2529 onto latest `dev`, address active review comments, and push the verified branch.
+
+**Architecture:** Keep review fixes local to the UserProfiles contract-first flow and adjacent tests. Preserve existing API/auth patterns, add tests for behavioral fixes, and avoid unrelated cleanup.
+
+**Tech Stack:** FastAPI, Pydantic, pytest, Backlog.md, GitHub CLI.
+
+---
+
+## Stage 1: Rebase And Inventory
+**Goal**: Rebase PR #2529 onto latest `origin/dev` and identify all active review threads.
+**Success Criteria**: Branch rebases cleanly, review comments are mapped to touched files, and Backlog task `TASK-12057` tracks the work.
+**Tests**: Git rebase status and GitHub review-thread query.
+**Status**: Complete
+
+## Stage 2: Review Fixes
+**Goal**: Verify each review comment against current code and implement only valid fixes.
+**Success Criteria**: Each active comment has a code/test change or a documented technical rationale.
+**Tests**: Failing regression tests first where behavior changes are needed, then focused pytest runs.
+**Status**: Complete
+
+## Stage 3: Verification
+**Goal**: Run focused tests and required quality gates for touched scope.
+**Success Criteria**: Focused pytest, compile checks, Bandit for touched production files, and any relevant CI guard pass or are reported with evidence.
+**Tests**: Commands recorded in `TASK-12057`.
+**Status**: Complete
+
+## Stage 4: Push And Resolve
+**Goal**: Commit, push the rebased branch, reply to/resolved addressed review threads, and report remaining CI status.
+**Success Criteria**: PR branch is updated on GitHub, review threads are resolved, and final status is reported.
+**Tests**: `gh pr view`, `gh pr checks`, and review-thread query.
+**Status**: In Progress

--- a/backlog/tasks/task-12057 - Rebase-PR-2529-and-address-UserProfiles-contract-review-comments.md
+++ b/backlog/tasks/task-12057 - Rebase-PR-2529-and-address-UserProfiles-contract-review-comments.md
@@ -1,0 +1,54 @@
+---
+id: TASK-12057
+title: Rebase PR 2529 and address UserProfiles contract review comments
+status: In Progress
+labels:
+  - pr-review
+  - userprofiles
+priority: High
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase PR #2529 on latest dev, inspect all active PR review comments, implement verified fixes, run focused verification, push the updated branch, and resolve addressed review threads.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PR #2529 branch is rebased onto latest origin/dev without unresolved conflicts.
+- [x] #2 All active review comments are inventoried, technically verified, and either fixed or answered with rationale.
+- [x] #3 Focused tests, compile checks, shard coverage or relevant CI guard checks, and Bandit on touched production code are run as applicable.
+- [ ] #4 Updated branch is pushed and review threads are replied to/resolved.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Rebased `codex/userprofiles-contract-refactor` onto `origin/dev` cleanly.
+- Active review threads covered stale transaction version reads, v2 structured errors, endpoint rate limiting, dependency injection, and audit logging.
+- Added regression coverage for transaction-scoped version reads and v2 endpoint review feedback before production changes.
+- Implemented `db_conn` propagation for `ProfileCommandService.get_profile_version()` reads, v2 `ProfileCommandService` dependency injection, `check_rate_limit` dependency, structured v2 error details, and sanitized audit suppression logging.
+- Verification so far:
+  - `python -m pytest tldw_Server_API/tests/UserProfile/test_profile_command_service.py::test_command_service_successful_write_returns_executor_result_and_version tldw_Server_API/tests/UserProfile/test_user_profile_v2_contract.py::test_v2_profile_update_route_has_rate_limit_dependency tldw_Server_API/tests/UserProfile/test_user_profile_v2_contract.py::test_v2_profile_update_uses_injected_command_service_and_structured_errors tldw_Server_API/tests/UserProfile/test_user_profile_v2_contract.py::test_v2_profile_update_logs_audit_failure_without_failing -q` -> 4 passed.
+  - `python -m pytest tldw_Server_API/tests/UserProfile/test_profile_command_service.py tldw_Server_API/tests/UserProfile/test_user_profile_v2_contract.py tldw_Server_API/tests/UserProfile/test_user_profile_updates.py tldw_Server_API/tests/UserProfile/test_admin_profiles_service_update.py -q` -> 37 passed.
+  - `python -m pytest tldw_Server_API/tests/UserProfile tldw_Server_API/tests/AuthNZ/unit/test_user_profile_command_backend_selection.py -q` -> 119 passed.
+  - `python -m compileall tldw_Server_API/app/api/v2/endpoints/user_profiles.py tldw_Server_API/app/core/UserProfiles/command_service.py` -> passed.
+  - `python -m bandit -r tldw_Server_API/app/api/v2/endpoints/user_profiles.py tldw_Server_API/app/core/UserProfiles/command_service.py -f json -o /tmp/bandit_pr2529.json` -> 0 findings.
+  - `python Helper_Scripts/ci/check_shard_coverage.py --ci-file .github/workflows/ci.yml` -> passed.
+  - `git diff --check` -> passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Backlog task and implementation plan are updated with verification evidence.
+- [ ] #2 Code changes are committed with a clear message.
+- [x] #3 No unrelated dirty files are staged or modified.
+- [ ] #4 PR branch is pushed to GitHub and remaining check status is reported.
+<!-- DOD:END -->

--- a/backlog/tasks/task-12057 - Rebase-PR-2529-and-address-UserProfiles-contract-review-comments.md
+++ b/backlog/tasks/task-12057 - Rebase-PR-2529-and-address-UserProfiles-contract-review-comments.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-12057
 title: Rebase PR 2529 and address UserProfiles contract review comments
-status: In Progress
+status: Done
 labels:
   - pr-review
   - userprofiles
@@ -19,7 +19,7 @@ Rebase PR #2529 on latest dev, inspect all active PR review comments, implement 
 - [x] #1 PR #2529 branch is rebased onto latest origin/dev without unresolved conflicts.
 - [x] #2 All active review comments are inventoried, technically verified, and either fixed or answered with rationale.
 - [x] #3 Focused tests, compile checks, shard coverage or relevant CI guard checks, and Bandit on touched production code are run as applicable.
-- [ ] #4 Updated branch is pushed and review threads are replied to/resolved.
+- [x] #4 Updated branch is pushed and review threads are replied to/resolved.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -42,13 +42,13 @@ Rebase PR #2529 on latest dev, inspect all active PR review comments, implement 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Rebased PR #2529 onto `origin/dev`, addressed all active inline review threads, pushed the updated `codex/userprofiles-contract-refactor` branch, and resolved all review threads. Local verification passed for the UserProfile focused suite, compile checks, Bandit on touched production files, shard coverage, and diff whitespace checks. GitHub Actions were queued/pending after the push; CodeRabbit reported review skipped/pass.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Backlog task and implementation plan are updated with verification evidence.
-- [ ] #2 Code changes are committed with a clear message.
+- [x] #2 Code changes are committed with a clear message.
 - [x] #3 No unrelated dirty files are staged or modified.
-- [ ] #4 PR branch is pushed to GitHub and remaining check status is reported.
+- [x] #4 PR branch is pushed to GitHub and remaining check status is reported.
 <!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/users.py
+++ b/tldw_Server_API/app/api/v1/endpoints/users.py
@@ -51,9 +51,6 @@ from tldw_Server_API.app.api.v1.schemas.user_profile_schemas import (
 )
 from tldw_Server_API.app.api.v1.utils.cache import generate_etag, is_not_modified
 from tldw_Server_API.app.api.v1.utils.deprecation import build_deprecation_headers
-from tldw_Server_API.app.api.v1.utils.profile_errors import (
-    classify_profile_update_skips,
-)
 from tldw_Server_API.app.core.Audit.unified_audit_service import MandatoryAuditWriteError
 from tldw_Server_API.app.core.AuthNZ.api_key_manager import get_api_key_manager
 from tldw_Server_API.app.core.AuthNZ.database import (
@@ -70,8 +67,17 @@ from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal, is_si
 from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
 from tldw_Server_API.app.core.AuthNZ.session_manager import SessionManager
 from tldw_Server_API.app.core.testing import is_truthy
+from tldw_Server_API.app.core.UserProfiles.command_service import ProfileCommandService
+from tldw_Server_API.app.core.UserProfiles.contracts import (
+    ProfileContractMode,
+    ProfileReadRequest,
+    ProfileUpdateCommand,
+)
+from tldw_Server_API.app.core.UserProfiles.query_service import ProfileQueryService
+from tldw_Server_API.app.core.UserProfiles.response_mappers import (
+    LegacyProfileCommandResult,
+)
 from tldw_Server_API.app.core.UserProfiles.service import UserProfileService
-from tldw_Server_API.app.core.UserProfiles.update_service import UserProfileUpdateService
 from tldw_Server_API.app.core.UserProfiles.user_profile_catalog import load_user_profile_catalog
 from tldw_Server_API.app.services.storage_quota_service import StorageQuotaService
 
@@ -125,6 +131,23 @@ def _profile_error_response(
         errors=errors or [],
     )
     return JSONResponse(status_code=status_code, content=payload.model_dump())
+
+
+def _legacy_profile_command_response(
+    result: LegacyProfileCommandResult,
+) -> UserProfileUpdateResponse | JSONResponse:
+    if result.status_code != status.HTTP_200_OK:
+        return _profile_error_response(
+            status_code=result.status_code,
+            error_code=result.error_code or "profile_update_invalid",
+            detail=result.detail or "One or more updates failed validation",
+            errors=[UserProfileErrorDetail(**item) for item in result.skipped],
+        )
+    return UserProfileUpdateResponse(
+        profile_version=result.profile_version,
+        applied=list(result.applied),
+        skipped=[UserProfileUpdateError(**item) for item in result.skipped],
+    )
 
 
 def _principal_user_id(principal: AuthPrincipal) -> int:
@@ -397,6 +420,7 @@ async def get_current_user_profile_view(
         )
     db_pool = await get_db_pool()
     service = UserProfileService(db_pool)
+    query_service = ProfileQueryService(service)
     user_context = await _resolve_user_context(principal)
     _require_active_verified_user(user_context)
     user_dict: dict[str, Any] = dict(user_context)
@@ -407,13 +431,18 @@ async def get_current_user_profile_view(
         session_manager=session_manager,
         api_key_manager=api_mgr,
     )
-    profile = await service.build_profile(
+    profile = await query_service.build(
+        ProfileReadRequest(
+            actor_user_id=int(user_context["id"]),
+            target_user_id=int(user_context["id"]),
+            sections=frozenset(requested) if requested is not None else None,
+            include_sources=include_sources,
+            include_raw=include_raw,
+            mask_secrets=mask_secrets,
+            contract_mode=ProfileContractMode.LEGACY_V1,
+        ),
         user=user_dict,
-        sections=requested,
         security=security,
-        include_sources=include_sources,
-        include_raw=include_raw,
-        mask_secrets=mask_secrets,
         metrics_scope="self",
     )
     return UserProfileResponse(**profile)
@@ -441,70 +470,33 @@ async def update_current_user_profile(
     _require_active_verified_user(user_context)
     user_id = int(user_context["id"])
     db_pool = await get_db_pool()
-    profile_service = UserProfileService(db_pool)
-    current_version = await profile_service.get_profile_version(user_id=user_id)
-    if payload.profile_version is not None:
-        if not profile_service.versions_match(current_version, payload.profile_version):
-            return _profile_error_response(
-                status_code=status.HTTP_409_CONFLICT,
-                error_code="profile_version_mismatch",
-                detail="profile_version_mismatch",
-                errors=[UserProfileErrorDetail(key="profile_version", message="mismatch")],
-            )
-
-    service = UserProfileUpdateService(db_pool)
-    updates = [(entry.key, entry.value) for entry in payload.updates]
-    preflight = await service.apply_updates(
-        user_id=user_id,
-        updates=updates,
-        roles={"user"},
-        dry_run=True,
+    command = ProfileUpdateCommand(
+        actor_user_id=user_id,
+        target_user_id=user_id,
+        updates=tuple((entry.key, entry.value) for entry in payload.updates),
+        roles=frozenset({"user"}),
+        dry_run=payload.dry_run,
+        expected_profile_version=payload.profile_version,
+        contract_mode=ProfileContractMode.LEGACY_V1,
+    )
+    result = await ProfileCommandService(db_pool=db_pool).apply(
+        command,
         db_conn=db,
-        updated_by=user_id,
+        scope=None,
     )
-
-    error_payload = classify_profile_update_skips(preflight.skipped)
-    if error_payload:
-        status_code, error_code, detail, errors = error_payload
-        return _profile_error_response(
-            status_code=status_code,
-            error_code=error_code,
-            detail=detail,
-            errors=errors,
-        )
-
-    if payload.dry_run:
-        return UserProfileUpdateResponse(
-            profile_version=current_version,
-            applied=preflight.applied,
-            skipped=[],
-        )
-
-    result = await service.apply_updates(
-        user_id=user_id,
-        updates=updates,
-        roles={"user"},
-        dry_run=False,
-        db_conn=db,
-        updated_by=user_id,
-    )
-
-    current_version = await profile_service.get_profile_version(user_id=user_id)
-    skipped = [UserProfileUpdateError(**item) for item in result.skipped]
-    response = UserProfileUpdateResponse(
-        profile_version=current_version,
-        applied=result.applied,
-        skipped=skipped,
-    )
+    response = _legacy_profile_command_response(result)
+    if isinstance(response, JSONResponse):
+        return response
     with contextlib.suppress(_USERS_AUDIT_EXCEPTIONS):
-        await _emit_user_profile_audit_event(
-            http_request,
-            user_id=user_id,
-            update_keys=[entry.key for entry in payload.updates],
-            applied_count=len(result.applied),
-            skipped_count=len(result.skipped),
-            dry_run=False,
-        )
+        if not payload.dry_run:
+            await _emit_user_profile_audit_event(
+                http_request,
+                user_id=user_id,
+                update_keys=[entry.key for entry in payload.updates],
+                applied_count=len(response.applied),
+                skipped_count=len(response.skipped),
+                dry_run=False,
+            )
     return response
 
 

--- a/tldw_Server_API/app/api/v1/utils/profile_errors.py
+++ b/tldw_Server_API/app/api/v1/utils/profile_errors.py
@@ -6,28 +6,12 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
-from fastapi import status
-
 from tldw_Server_API.app.api.v1.schemas.user_profile_schemas import (
     UserProfileErrorDetail,
 )
-
-_FORBIDDEN_MESSAGES = {
-    "forbidden",
-    "forbidden_scope",
-    "owner_required",
-    "org_membership_required",
-}
-
-_UNKNOWN_MESSAGES = {
-    "unknown_key",
-    "unsupported_key",
-    "unsupported_type",
-}
-
-_NOT_FOUND_MESSAGES = {
-    "user_not_found",
-}
+from tldw_Server_API.app.core.UserProfiles.error_mapping import (
+    classify_legacy_profile_update_skips,
+)
 
 
 def classify_profile_update_skips(
@@ -38,7 +22,6 @@ def classify_profile_update_skips(
     if not skipped_list:
         return None
 
-    messages = {str(item.get("message") or "") for item in skipped_list}
     errors = [
         UserProfileErrorDetail(
             key=str(item.get("key") or ""),
@@ -46,33 +29,13 @@ def classify_profile_update_skips(
         )
         for item in skipped_list
     ]
-
-    if messages & _NOT_FOUND_MESSAGES:
-        return (
-            status.HTTP_404_NOT_FOUND,
-            "profile_update_not_found",
-            "Target user not found",
-            errors,
-        )
-    if messages & _FORBIDDEN_MESSAGES:
-        return (
-            status.HTTP_403_FORBIDDEN,
-            "profile_update_forbidden",
-            "Caller cannot edit one or more fields",
-            errors,
-        )
-    if messages & _UNKNOWN_MESSAGES:
-        return (
-            status.HTTP_400_BAD_REQUEST,
-            "profile_update_unknown_key",
-            "One or more keys are not recognized",
-            errors,
-        )
-
+    mapped = classify_legacy_profile_update_skips(skipped_list)
+    if mapped is None:
+        return None
     return (
-        status.HTTP_422_UNPROCESSABLE_ENTITY,
-        "profile_update_invalid",
-        "One or more updates failed validation",
+        mapped.status_code,
+        mapped.error_code,
+        mapped.detail,
         errors,
     )
 

--- a/tldw_Server_API/app/api/v2/__init__.py
+++ b/tldw_Server_API/app/api/v2/__init__.py
@@ -1,0 +1,1 @@
+"""API v2 package."""

--- a/tldw_Server_API/app/api/v2/endpoints/__init__.py
+++ b/tldw_Server_API/app/api/v2/endpoints/__init__.py
@@ -1,0 +1,1 @@
+"""API v2 endpoint modules."""

--- a/tldw_Server_API/app/api/v2/endpoints/user_profiles.py
+++ b/tldw_Server_API/app/api/v2/endpoints/user_profiles.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import contextlib
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    get_auth_principal,
+    get_db_transaction,
+)
+from tldw_Server_API.app.api.v1.schemas.user_profile_schemas import (
+    UserProfileUpdateRequest,
+)
+from tldw_Server_API.app.api.v1.endpoints.users import (
+    _USERS_AUDIT_EXCEPTIONS,
+    _emit_user_profile_audit_event,
+    _require_principal_active_verified,
+)
+from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.UserProfiles.command_service import ProfileCommandService
+from tldw_Server_API.app.core.UserProfiles.contracts import (
+    ProfileContractMode,
+    ProfileUpdateCommand,
+)
+
+router = APIRouter()
+
+
+class UserProfileV2UpdateResponse(BaseModel):
+    profile_version: datetime = Field(..., description="Profile version timestamp")
+    applied: list[str] = Field(default_factory=list)
+
+
+@router.patch("/users/me/profile", response_model=UserProfileV2UpdateResponse)
+async def update_current_user_profile_v2(
+    payload: UserProfileUpdateRequest,
+    http_request: Request,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    db: Any = Depends(get_db_transaction),
+) -> UserProfileV2UpdateResponse:
+    user_context = await _require_principal_active_verified(principal)
+    user_id = int(user_context["id"])
+
+    db_pool = await get_db_pool()
+    command_service = ProfileCommandService(db_pool=db_pool)
+    command = ProfileUpdateCommand(
+        actor_user_id=user_id,
+        target_user_id=user_id,
+        updates=tuple((entry.key, entry.value) for entry in payload.updates),
+        roles=frozenset({"user"}),
+        dry_run=payload.dry_run,
+        expected_profile_version=payload.profile_version,
+        contract_mode=ProfileContractMode.CLEAN_V2,
+    )
+    result = await command_service.apply(command, db_conn=db, scope=None)
+    if result.status_code != status.HTTP_200_OK:
+        raise HTTPException(
+            status_code=result.status_code,
+            detail=result.detail or result.error_code or "profile_update_failed",
+        )
+
+    with contextlib.suppress(_USERS_AUDIT_EXCEPTIONS):
+        if not payload.dry_run:
+            await _emit_user_profile_audit_event(
+                http_request,
+                user_id=user_id,
+                update_keys=[entry.key for entry in payload.updates],
+                applied_count=len(result.applied),
+                skipped_count=0,
+                dry_run=False,
+            )
+
+    return UserProfileV2UpdateResponse(
+        profile_version=result.profile_version,
+        applied=list(result.applied),
+    )

--- a/tldw_Server_API/app/api/v2/endpoints/user_profiles.py
+++ b/tldw_Server_API/app/api/v2/endpoints/user_profiles.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-import contextlib
 from datetime import datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from loguru import logger
 from pydantic import BaseModel, Field
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    check_rate_limit,
     get_auth_principal,
     get_db_transaction,
 )
@@ -35,18 +36,28 @@ class UserProfileV2UpdateResponse(BaseModel):
     applied: list[str] = Field(default_factory=list)
 
 
-@router.patch("/users/me/profile", response_model=UserProfileV2UpdateResponse)
+async def get_profile_command_service(
+    db_pool: Any = Depends(get_db_pool),
+) -> ProfileCommandService:
+    """Build the profile command service through FastAPI dependency injection."""
+    return ProfileCommandService(db_pool=db_pool)
+
+
+@router.patch(
+    "/users/me/profile",
+    response_model=UserProfileV2UpdateResponse,
+    dependencies=[Depends(check_rate_limit)],
+)
 async def update_current_user_profile_v2(
     payload: UserProfileUpdateRequest,
     http_request: Request,
     principal: AuthPrincipal = Depends(get_auth_principal),
     db: Any = Depends(get_db_transaction),
+    command_service: ProfileCommandService = Depends(get_profile_command_service),
 ) -> UserProfileV2UpdateResponse:
     user_context = await _require_principal_active_verified(principal)
     user_id = int(user_context["id"])
 
-    db_pool = await get_db_pool()
-    command_service = ProfileCommandService(db_pool=db_pool)
     command = ProfileUpdateCommand(
         actor_user_id=user_id,
         target_user_id=user_id,
@@ -60,11 +71,15 @@ async def update_current_user_profile_v2(
     if result.status_code != status.HTTP_200_OK:
         raise HTTPException(
             status_code=result.status_code,
-            detail=result.detail or result.error_code or "profile_update_failed",
+            detail={
+                "error_code": result.error_code or "profile_update_failed",
+                "detail": result.detail or "One or more updates failed validation",
+                "errors": list(result.skipped),
+            },
         )
 
-    with contextlib.suppress(_USERS_AUDIT_EXCEPTIONS):
-        if not payload.dry_run:
+    if not payload.dry_run:
+        try:
             await _emit_user_profile_audit_event(
                 http_request,
                 user_id=user_id,
@@ -73,6 +88,8 @@ async def update_current_user_profile_v2(
                 skipped_count=0,
                 dry_run=False,
             )
+        except _USERS_AUDIT_EXCEPTIONS:
+            logger.debug("User profile v2 audit emission skipped")
 
     return UserProfileV2UpdateResponse(
         profile_version=result.profile_version,

--- a/tldw_Server_API/app/api/v2/router.py
+++ b/tldw_Server_API/app/api/v2/router.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from tldw_Server_API.app.api.v2.endpoints import user_profiles
+
+api_v2_router = APIRouter(prefix="/api/v2")
+api_v2_router.include_router(user_profiles.router, tags=["user-profiles-v2"])

--- a/tldw_Server_API/app/core/UserProfiles/README.md
+++ b/tldw_Server_API/app/core/UserProfiles/README.md
@@ -35,6 +35,14 @@ UserProfiles assembles readable and editable user profile state from AuthNZ iden
 - AuthNZ repositories provide user, membership, permission, and quota context.
 - `app/core/Usage/audio_quota.py` and prompt-studio quota configuration read profile or quota-related state.
 
+## Contract Refactor Notes
+
+The profile API is organized around typed read/update commands, planner output,
+and compatibility response mappers. Existing v1 routes preserve legacy response
+shape. Clean v2 profile routes use atomic single-update semantics and omit
+legacy single-update `skipped` fields. Bulk remains the only public profile
+write surface with per-user partial reporting.
+
 ## Architecture Notes
 
 ### Core Flow

--- a/tldw_Server_API/app/core/UserProfiles/bulk_command_service.py
+++ b/tldw_Server_API/app/core/UserProfiles/bulk_command_service.py
@@ -1,0 +1,58 @@
+"""
+Bulk UserProfiles command helpers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Sequence
+from typing import Any
+
+
+class ProfileBulkCommandService:
+    """Pure helper surface for bulk profile command orchestration."""
+
+    @staticmethod
+    def filter_visible_targets(
+        *,
+        candidate_user_ids: Iterable[int | str],
+        visible_user_ids: Iterable[int | str],
+    ) -> list[int]:
+        visible = {int(user_id) for user_id in visible_user_ids}
+        filtered: list[int] = []
+        seen: set[int] = set()
+        for user_id in candidate_user_ids:
+            coerced = int(user_id)
+            if coerced not in visible or coerced in seen:
+                continue
+            filtered.append(coerced)
+            seen.add(coerced)
+        return filtered
+
+    @staticmethod
+    def requires_confirmation(
+        *,
+        dry_run: bool,
+        total_targets: int,
+        threshold: int,
+        confirmed: bool,
+    ) -> bool:
+        return not dry_run and total_targets > threshold and not confirmed
+
+    @staticmethod
+    def build_diffs(
+        *,
+        updates: Sequence[tuple[str, Any]],
+        applied_keys: Iterable[str],
+        before_values: dict[str, Any],
+        mask_value: Callable[[str, Any], Any],
+    ) -> list[dict[str, Any]]:
+        applied = set(applied_keys)
+        return [
+            {
+                "key": key,
+                "before": before_values.get(key),
+                "after": mask_value(key, value),
+            }
+            for key, value in updates
+            if key in applied
+        ]

--- a/tldw_Server_API/app/core/UserProfiles/command_service.py
+++ b/tldw_Server_API/app/core/UserProfiles/command_service.py
@@ -47,6 +47,7 @@ class ProfileCommandService:
         if command.expected_profile_version is not None:
             current_version = await self._profile_service.get_profile_version(
                 user_id=command.target_user_id,
+                db_conn=db_conn,
             )
             if not self._profile_service.versions_match(
                 current_version,
@@ -78,6 +79,7 @@ class ProfileCommandService:
         if current_version is None:
             current_version = await self._profile_service.get_profile_version(
                 user_id=command.target_user_id,
+                db_conn=db_conn,
             )
         if command.dry_run:
             return LegacyProfileCommandResult(
@@ -115,6 +117,7 @@ class ProfileCommandService:
         )
         current_version = await self._profile_service.get_profile_version(
             user_id=command.target_user_id,
+            db_conn=db_conn,
         )
         return LegacyProfileCommandResult(
             profile_version=current_version,

--- a/tldw_Server_API/app/core/UserProfiles/command_service.py
+++ b/tldw_Server_API/app/core/UserProfiles/command_service.py
@@ -1,0 +1,123 @@
+"""
+Single-update UserProfiles command orchestration.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_Server_API.app.core.UserProfiles.contracts import ProfileUpdateCommand
+from tldw_Server_API.app.core.UserProfiles.effects import ProfileEffectDispatcher
+from tldw_Server_API.app.core.UserProfiles.error_mapping import (
+    classify_legacy_profile_update_skips,
+)
+from tldw_Server_API.app.core.UserProfiles.planner import ProfileUpdatePlanner
+from tldw_Server_API.app.core.UserProfiles.response_mappers import LegacyProfileCommandResult
+from tldw_Server_API.app.core.UserProfiles.service import UserProfileService
+from tldw_Server_API.app.core.UserProfiles.update_service import (
+    ProfileUpdateScope,
+    UserProfileUpdateService,
+)
+
+
+class ProfileCommandService:
+    def __init__(
+        self,
+        *,
+        db_pool: Any,
+        profile_service: Any | None = None,
+        planner: Any | None = None,
+        executor: Any | None = None,
+        effects: ProfileEffectDispatcher | None = None,
+    ) -> None:
+        self._db_pool = db_pool
+        self._profile_service = profile_service or UserProfileService(db_pool)
+        self._planner = planner or ProfileUpdatePlanner(db_pool)
+        self._executor = executor or UserProfileUpdateService(db_pool)
+        self._effects = effects or ProfileEffectDispatcher()
+
+    async def apply(
+        self,
+        command: ProfileUpdateCommand,
+        *,
+        db_conn: Any,
+        scope: ProfileUpdateScope | None,
+    ) -> LegacyProfileCommandResult:
+        current_version = None
+        if command.expected_profile_version is not None:
+            current_version = await self._profile_service.get_profile_version(
+                user_id=command.target_user_id,
+            )
+            if not self._profile_service.versions_match(
+                current_version,
+                command.expected_profile_version,
+            ):
+                return LegacyProfileCommandResult(
+                    status_code=409,
+                    profile_version=current_version,
+                    error_code="profile_version_mismatch",
+                    detail="profile_version_mismatch",
+                    skipped=({"key": "profile_version", "message": "mismatch"},),
+                )
+
+        preflight = await self._planner.plan(command, db_conn=db_conn, scope=scope)
+        if preflight.skipped:
+            mapped = classify_legacy_profile_update_skips(tuple(preflight.skipped))
+            if mapped is None:
+                raise RuntimeError(
+                    "preflight skipped result could not be classified"
+                )
+            return LegacyProfileCommandResult(
+                status_code=mapped.status_code,
+                applied=tuple(preflight.applied),
+                skipped=tuple(preflight.skipped),
+                error_code=mapped.error_code,
+                detail=mapped.detail,
+            )
+
+        if current_version is None:
+            current_version = await self._profile_service.get_profile_version(
+                user_id=command.target_user_id,
+            )
+        if command.dry_run:
+            return LegacyProfileCommandResult(
+                profile_version=current_version,
+                applied=tuple(preflight.applied),
+                skipped=(),
+            )
+
+        if command.expected_profile_version is not None:
+            locked_version = await self._profile_service.get_profile_version(
+                user_id=command.target_user_id,
+                db_conn=db_conn,
+                lock_user=True,
+            )
+            if not self._profile_service.versions_match(
+                locked_version,
+                command.expected_profile_version,
+            ):
+                return LegacyProfileCommandResult(
+                    status_code=409,
+                    profile_version=locked_version,
+                    error_code="profile_version_mismatch",
+                    detail="profile_version_mismatch",
+                    skipped=({"key": "profile_version", "message": "mismatch"},),
+                )
+
+        result = await self._executor.apply_updates(
+            user_id=command.target_user_id,
+            updates=command.updates,
+            roles=set(command.roles),
+            dry_run=False,
+            db_conn=db_conn,
+            updated_by=command.actor_user_id,
+            scope=scope,
+        )
+        current_version = await self._profile_service.get_profile_version(
+            user_id=command.target_user_id,
+        )
+        return LegacyProfileCommandResult(
+            profile_version=current_version,
+            applied=tuple(result.applied),
+            skipped=tuple(result.skipped),
+        )

--- a/tldw_Server_API/app/core/UserProfiles/contracts.py
+++ b/tldw_Server_API/app/core/UserProfiles/contracts.py
@@ -1,0 +1,105 @@
+"""
+Typed internal contracts for UserProfiles read/update orchestration.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from types import MappingProxyType
+from typing import Any
+
+
+def _freeze_contract_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({key: _freeze_contract_value(item) for key, item in value.items()})
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_contract_value(item) for item in value)
+    return value
+
+
+class ProfileContractMode(str, Enum):
+    LEGACY_V1 = "legacy_v1"
+    CLEAN_V2 = "clean_v2"
+
+
+class EffectTiming(str, Enum):
+    PRE_COMMIT = "pre_commit"
+    POST_COMMIT = "post_commit"
+
+
+class EffectPolicy(str, Enum):
+    REQUIRED = "required"
+    BEST_EFFORT = "best_effort"
+
+
+@dataclass(frozen=True)
+class ProfileReadRequest:
+    actor_user_id: int | None
+    target_user_id: int
+    sections: frozenset[str] | None = None
+    include_sources: bool = False
+    include_raw: bool = False
+    mask_secrets: bool = True
+    contract_mode: ProfileContractMode = ProfileContractMode.LEGACY_V1
+
+
+@dataclass(frozen=True)
+class ProfileUpdateCommand:
+    actor_user_id: int | None
+    target_user_id: int
+    updates: tuple[tuple[str, Any], ...]
+    roles: frozenset[str]
+    dry_run: bool
+    expected_profile_version: datetime | None = None
+    active_org_id: int | None = None
+    active_team_id: int | None = None
+    contract_mode: ProfileContractMode = ProfileContractMode.LEGACY_V1
+
+
+@dataclass(frozen=True)
+class UpdateMutation:
+    key: str
+    operation: str
+    payload: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "payload", _freeze_contract_value(self.payload))
+
+
+@dataclass(frozen=True)
+class EffectDescriptor:
+    name: str
+    timing: EffectTiming
+    policy: EffectPolicy
+    payload: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "payload", _freeze_contract_value(self.payload))
+
+
+@dataclass(frozen=True)
+class UpdatePlan:
+    command: ProfileUpdateCommand
+    mutations: tuple[UpdateMutation, ...] = ()
+    effects: tuple[EffectDescriptor, ...] = ()
+
+    @property
+    def pre_commit_effects(self) -> tuple[EffectDescriptor, ...]:
+        return tuple(effect for effect in self.effects if effect.timing == EffectTiming.PRE_COMMIT)
+
+    @property
+    def post_commit_effects(self) -> tuple[EffectDescriptor, ...]:
+        return tuple(effect for effect in self.effects if effect.timing == EffectTiming.POST_COMMIT)
+
+
+@dataclass(frozen=True)
+class PlannedUpdateResult:
+    profile_version: datetime
+    applied: tuple[str, ...] = ()
+    rejected: tuple[Mapping[str, str], ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "rejected", _freeze_contract_value(self.rejected))

--- a/tldw_Server_API/app/core/UserProfiles/effects.py
+++ b/tldw_Server_API/app/core/UserProfiles/effects.py
@@ -1,0 +1,37 @@
+"""
+UserProfiles effect dispatch.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from loguru import logger
+
+from tldw_Server_API.app.core.UserProfiles.contracts import (
+    EffectDescriptor,
+    EffectPolicy,
+    EffectTiming,
+)
+
+
+class ProfileEffectDispatcher:
+    async def run_pre_commit(self, effects: Iterable[EffectDescriptor]) -> None:
+        for effect in effects:
+            if effect.timing != EffectTiming.PRE_COMMIT:
+                continue
+            if effect.policy == EffectPolicy.REQUIRED:
+                logger.debug("Required profile effect completed: {}", effect.name)
+
+    async def run_post_commit(self, effects: Iterable[EffectDescriptor]) -> None:
+        for effect in effects:
+            if effect.timing != EffectTiming.POST_COMMIT:
+                continue
+            try:
+                logger.debug("Best-effort profile effect completed: {}", effect.name)
+            except Exception as exc:
+                logger.debug(
+                    "Best-effort profile effect failed: {} {}",
+                    effect.name,
+                    type(exc).__name__,
+                )

--- a/tldw_Server_API/app/core/UserProfiles/error_mapping.py
+++ b/tldw_Server_API/app/core/UserProfiles/error_mapping.py
@@ -1,0 +1,181 @@
+"""
+Stable error taxonomy for UserProfiles update failures.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from enum import Enum
+
+from fastapi import status
+
+
+class ProfileErrorCode(str, Enum):
+    UNKNOWN_KEY = "unknown_key"
+    UNSUPPORTED_KEY = "unsupported_key"
+    INVALID_PAYLOAD = "invalid_payload"
+    INVALID_ACTION = "invalid_action"
+    INVALID_VALUE = "invalid_value"
+    TYPE_MISMATCH = "type_mismatch"
+    ENUM_VIOLATION = "enum_violation"
+    MIN_VIOLATION = "min_violation"
+    MAX_VIOLATION = "max_violation"
+    INVALID_ROLE = "invalid_role"
+    FORBIDDEN_KEY = "forbidden"
+    FORBIDDEN_SCOPE = "forbidden_scope"
+    FORBIDDEN_ROLE_ESCALATION = "forbidden_role_escalation"
+    TARGET_NOT_FOUND = "user_not_found"
+    MEMBERSHIP_NOT_FOUND = "membership_not_found"
+    TEAM_NOT_FOUND = "team_not_found"
+    ORG_NOT_FOUND = "org_not_found"
+    VERSION_MISMATCH = "profile_version_mismatch"
+
+
+@dataclass(frozen=True)
+class ProfileErrorMapping:
+    status_code: int
+    error_code: str
+    detail: str
+
+
+_UNKNOWN_KEY_MAPPING = ProfileErrorMapping(
+    status_code=status.HTTP_400_BAD_REQUEST,
+    error_code="profile_update_unknown_key",
+    detail="One or more keys are not recognized",
+)
+_INVALID_PAYLOAD_MAPPING = ProfileErrorMapping(
+    status_code=status.HTTP_400_BAD_REQUEST,
+    error_code="profile_update_invalid",
+    detail="Invalid profile update payload",
+)
+_INVALID_ACTION_MAPPING = ProfileErrorMapping(
+    status_code=status.HTTP_400_BAD_REQUEST,
+    error_code="profile_update_invalid",
+    detail="Invalid profile update action",
+)
+_FORBIDDEN_MAPPING = ProfileErrorMapping(
+    status_code=status.HTTP_403_FORBIDDEN,
+    error_code="profile_update_forbidden",
+    detail="Caller cannot edit one or more fields",
+)
+_NOT_FOUND_MAPPING = ProfileErrorMapping(
+    status_code=status.HTTP_404_NOT_FOUND,
+    error_code="profile_update_not_found",
+    detail="Target resource not found",
+)
+_VERSION_MISMATCH_MAPPING = ProfileErrorMapping(
+    status_code=status.HTTP_409_CONFLICT,
+    error_code="profile_version_mismatch",
+    detail="profile_version_mismatch",
+)
+_INVALID_MAPPING = ProfileErrorMapping(
+    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+    error_code="profile_update_invalid",
+    detail="One or more updates failed validation",
+)
+
+_PROFILE_ERROR_MAPPINGS = {
+    ProfileErrorCode.UNKNOWN_KEY: _UNKNOWN_KEY_MAPPING,
+    ProfileErrorCode.UNSUPPORTED_KEY: _UNKNOWN_KEY_MAPPING,
+    ProfileErrorCode.INVALID_PAYLOAD: _INVALID_PAYLOAD_MAPPING,
+    ProfileErrorCode.INVALID_ACTION: _INVALID_ACTION_MAPPING,
+    ProfileErrorCode.INVALID_VALUE: _INVALID_MAPPING,
+    ProfileErrorCode.TYPE_MISMATCH: _INVALID_MAPPING,
+    ProfileErrorCode.ENUM_VIOLATION: _INVALID_MAPPING,
+    ProfileErrorCode.MIN_VIOLATION: _INVALID_MAPPING,
+    ProfileErrorCode.MAX_VIOLATION: _INVALID_MAPPING,
+    ProfileErrorCode.INVALID_ROLE: _INVALID_MAPPING,
+    ProfileErrorCode.FORBIDDEN_KEY: _FORBIDDEN_MAPPING,
+    ProfileErrorCode.FORBIDDEN_SCOPE: _FORBIDDEN_MAPPING,
+    ProfileErrorCode.FORBIDDEN_ROLE_ESCALATION: _FORBIDDEN_MAPPING,
+    ProfileErrorCode.TARGET_NOT_FOUND: _NOT_FOUND_MAPPING,
+    ProfileErrorCode.MEMBERSHIP_NOT_FOUND: _INVALID_MAPPING,
+    ProfileErrorCode.TEAM_NOT_FOUND: _NOT_FOUND_MAPPING,
+    ProfileErrorCode.ORG_NOT_FOUND: _NOT_FOUND_MAPPING,
+    ProfileErrorCode.VERSION_MISMATCH: _VERSION_MISMATCH_MAPPING,
+}
+
+_FORBIDDEN_SKIP_MESSAGES = {
+    "forbidden",
+    "forbidden_scope",
+    "forbidden_role_escalation",
+    "owner_required",
+    "org_membership_required",
+}
+_UNKNOWN_SKIP_MESSAGES = {
+    "unknown_key",
+    "unsupported_key",
+    "unsupported_type",
+}
+_LEGACY_USER_NOT_FOUND_MESSAGES = {
+    "user_not_found",
+}
+_LEGACY_USER_NOT_FOUND_MAPPING = ProfileErrorMapping(
+    status_code=status.HTTP_404_NOT_FOUND,
+    error_code="profile_update_not_found",
+    detail="Target user not found",
+)
+_DOMAIN_CODE_PRECEDENCE = (
+    ProfileErrorCode.TEAM_NOT_FOUND,
+    ProfileErrorCode.ORG_NOT_FOUND,
+    ProfileErrorCode.TARGET_NOT_FOUND,
+    ProfileErrorCode.VERSION_MISMATCH,
+    ProfileErrorCode.FORBIDDEN_KEY,
+    ProfileErrorCode.FORBIDDEN_SCOPE,
+    ProfileErrorCode.FORBIDDEN_ROLE_ESCALATION,
+    ProfileErrorCode.UNKNOWN_KEY,
+    ProfileErrorCode.UNSUPPORTED_KEY,
+    ProfileErrorCode.INVALID_PAYLOAD,
+    ProfileErrorCode.INVALID_ACTION,
+    ProfileErrorCode.MEMBERSHIP_NOT_FOUND,
+    ProfileErrorCode.INVALID_VALUE,
+    ProfileErrorCode.TYPE_MISMATCH,
+    ProfileErrorCode.ENUM_VIOLATION,
+    ProfileErrorCode.MIN_VIOLATION,
+    ProfileErrorCode.MAX_VIOLATION,
+    ProfileErrorCode.INVALID_ROLE,
+)
+
+
+def map_profile_error_code(code: ProfileErrorCode | str) -> ProfileErrorMapping:
+    profile_code = ProfileErrorCode(code)
+    return _PROFILE_ERROR_MAPPINGS[profile_code]
+
+
+def _first_matching_domain_code(messages: set[str]) -> ProfileErrorCode | None:
+    for code in _DOMAIN_CODE_PRECEDENCE:
+        if code.value in messages:
+            return code
+    return None
+
+
+def classify_legacy_profile_update_skips(
+    skipped: Iterable[Mapping[str, str]],
+) -> ProfileErrorMapping | None:
+    """Map legacy per-key skip reasons into the shared update error envelope."""
+    skipped_list = list(skipped)
+    if not skipped_list:
+        return None
+
+    messages = {str(item.get("message") or "") for item in skipped_list}
+    if messages & _LEGACY_USER_NOT_FOUND_MESSAGES:
+        return _LEGACY_USER_NOT_FOUND_MAPPING
+    if messages & _FORBIDDEN_SKIP_MESSAGES:
+        return _FORBIDDEN_MAPPING
+    if messages & _UNKNOWN_SKIP_MESSAGES:
+        return _UNKNOWN_KEY_MAPPING
+
+    mapped_code = _first_matching_domain_code(messages)
+    if mapped_code is not None:
+        return map_profile_error_code(mapped_code)
+
+    return _INVALID_MAPPING
+
+
+__all__ = [
+    "classify_legacy_profile_update_skips",
+    "ProfileErrorCode",
+    "ProfileErrorMapping",
+    "map_profile_error_code",
+]

--- a/tldw_Server_API/app/core/UserProfiles/overrides_repo.py
+++ b/tldw_Server_API/app/core/UserProfiles/overrides_repo.py
@@ -87,13 +87,15 @@ class UserProfileOverridesRepo:
         key: str,
         value: Any,
         updated_by: int | None,
+        db_conn: Any | None = None,
     ) -> None:
         """Insert or update a config override."""
         payload = json.dumps(value)
         ts = datetime.now(timezone.utc)
         try:
+            executor = db_conn or self.db_pool
             if getattr(self.db_pool, "pool", None) is not None:
-                await self.db_pool.execute(
+                await executor.execute(
                     """
                     INSERT INTO user_config_overrides (
                         user_id, key, value_json, created_at, updated_at, created_by, updated_by
@@ -112,7 +114,7 @@ class UserProfileOverridesRepo:
                 )
                 return
 
-            await self.db_pool.execute(
+            await executor.execute(
                 """
                 INSERT INTO user_config_overrides (
                     user_id, key, value_json, created_at, updated_at, created_by, updated_by
@@ -136,18 +138,19 @@ class UserProfileOverridesRepo:
             logger.error(f"UserProfileOverridesRepo.upsert_override failed: {exc}")
             raise
 
-    async def delete_override(self, *, user_id: int, key: str) -> None:
+    async def delete_override(self, *, user_id: int, key: str, db_conn: Any | None = None) -> None:
         """Delete a config override."""
         try:
+            executor = db_conn or self.db_pool
             if getattr(self.db_pool, "pool", None) is not None:
-                await self.db_pool.execute(
+                await executor.execute(
                     "DELETE FROM user_config_overrides WHERE user_id = $1 AND key = $2",
                     user_id,
                     key,
                 )
                 return
 
-            await self.db_pool.execute(
+            await executor.execute(
                 "DELETE FROM user_config_overrides WHERE user_id = ? AND key = ?",
                 (user_id, key),
             )
@@ -155,28 +158,51 @@ class UserProfileOverridesRepo:
             logger.error(f"UserProfileOverridesRepo.delete_override failed: {exc}")
             raise
 
-    async def get_latest_update_for_user(self, user_id: int) -> Any | None:
+    async def get_latest_update_for_user(
+        self,
+        user_id: int,
+        *,
+        db_conn: Any | None = None,
+    ) -> Any | None:
         """Return the latest override update timestamp for a user."""
         try:
+            executor = db_conn or self.db_pool
             if getattr(self.db_pool, "pool", None) is not None:
-                row = await self.db_pool.fetchone(
-                    "SELECT MAX(updated_at) AS updated_at FROM user_config_overrides WHERE user_id = $1",
-                    user_id,
-                )
+                if db_conn is not None and hasattr(executor, "fetchrow"):
+                    row = await executor.fetchrow(
+                        "SELECT MAX(updated_at) AS updated_at FROM user_config_overrides WHERE user_id = $1",
+                        user_id,
+                    )
+                    row = dict(row) if row else None
+                else:
+                    row = await executor.fetchone(
+                        "SELECT MAX(updated_at) AS updated_at FROM user_config_overrides WHERE user_id = $1",
+                        user_id,
+                    )
                 return row.get("updated_at") if row else None
 
-            row = await self.db_pool.fetchone(
-                "SELECT MAX(updated_at) AS updated_at FROM user_config_overrides WHERE user_id = ?",
-                (user_id,),
-            )
+            if db_conn is not None:
+                cursor = await executor.execute(
+                    "SELECT MAX(updated_at) AS updated_at FROM user_config_overrides WHERE user_id = ?",
+                    (user_id,),
+                )
+                row = await cursor.fetchone()
+            else:
+                row = await executor.fetchone(
+                    "SELECT MAX(updated_at) AS updated_at FROM user_config_overrides WHERE user_id = ?",
+                    (user_id,),
+                )
             if row is None:
                 return None
             if isinstance(row, dict):
                 return row.get("updated_at")
             try:
-                return row[0]
-            except Exception:
-                return None
+                return row["updated_at"]
+            except (TypeError, KeyError, IndexError):
+                try:
+                    return row[0]
+                except (TypeError, KeyError, IndexError):
+                    return None
         except Exception as exc:
             logger.error(f"UserProfileOverridesRepo.get_latest_update_for_user failed: {exc}")
             raise

--- a/tldw_Server_API/app/core/UserProfiles/planner.py
+++ b/tldw_Server_API/app/core/UserProfiles/planner.py
@@ -1,0 +1,39 @@
+"""
+UserProfiles update planning.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_Server_API.app.core.UserProfiles.contracts import ProfileUpdateCommand
+from tldw_Server_API.app.core.UserProfiles.update_service import (
+    ProfileUpdateScope,
+    UpdateResult,
+    UserProfileUpdateService,
+)
+
+
+class ProfileUpdatePlanner:
+    """Build an update plan using current catalog validation without mutating state."""
+
+    def __init__(self, db_pool: Any) -> None:
+        self._db_pool = db_pool
+
+    async def plan(
+        self,
+        command: ProfileUpdateCommand,
+        *,
+        db_conn: Any,
+        scope: ProfileUpdateScope | None,
+    ) -> UpdateResult:
+        service = UserProfileUpdateService(self._db_pool)
+        return await service.apply_updates(
+            user_id=command.target_user_id,
+            updates=command.updates,
+            roles=set(command.roles),
+            dry_run=True,
+            db_conn=db_conn,
+            updated_by=command.actor_user_id,
+            scope=scope,
+        )

--- a/tldw_Server_API/app/core/UserProfiles/query_service.py
+++ b/tldw_Server_API/app/core/UserProfiles/query_service.py
@@ -1,0 +1,36 @@
+"""
+Read orchestration service for UserProfiles.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_Server_API.app.core.UserProfiles.contracts import ProfileReadRequest
+from tldw_Server_API.app.core.UserProfiles.service import UserProfileService
+
+
+class ProfileQueryService:
+    """Delegate profile reads through the typed read contract."""
+
+    def __init__(self, profile_service: UserProfileService) -> None:
+        self._profile_service = profile_service
+
+    async def build(
+        self,
+        request: ProfileReadRequest,
+        *,
+        user: dict[str, Any],
+        security: dict[str, Any] | None = None,
+        metrics_scope: str | None = None,
+    ) -> dict[str, Any]:
+        sections = set(request.sections) if request.sections is not None else None
+        return await self._profile_service.build_profile(
+            user=user,
+            sections=sections,
+            security=security,
+            include_sources=request.include_sources,
+            include_raw=request.include_raw,
+            mask_secrets=request.mask_secrets,
+            metrics_scope=metrics_scope,
+        )

--- a/tldw_Server_API/app/core/UserProfiles/response_mappers.py
+++ b/tldw_Server_API/app/core/UserProfiles/response_mappers.py
@@ -1,0 +1,27 @@
+"""
+Response mapping helpers for UserProfiles command flows.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime
+from types import MappingProxyType
+
+
+@dataclass(frozen=True)
+class LegacyProfileCommandResult:
+    status_code: int = 200
+    profile_version: datetime | None = None
+    applied: tuple[str, ...] = ()
+    skipped: tuple[Mapping[str, str], ...] = field(default_factory=tuple)
+    error_code: str | None = None
+    detail: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "skipped",
+            tuple(MappingProxyType(dict(item)) for item in self.skipped),
+        )

--- a/tldw_Server_API/app/core/UserProfiles/service.py
+++ b/tldw_Server_API/app/core/UserProfiles/service.py
@@ -299,6 +299,47 @@ class UserProfileService:
             return ts.replace(tzinfo=timezone.utc)
         return ts.astimezone(timezone.utc)
 
+    @staticmethod
+    def _row_value(row: Any, key: str, index: int = 0) -> Any | None:
+        if row is None:
+            return None
+        if isinstance(row, dict):
+            return row.get(key)
+        try:
+            return row[key]
+        except _PROFILE_NONCRITICAL_EXCEPTIONS:
+            pass
+        try:
+            return row[index]
+        except _PROFILE_NONCRITICAL_EXCEPTIONS:
+            return None
+
+    async def _fetch_user_updated_at_for_version(
+        self,
+        *,
+        user_id: int,
+        db_conn: Any | None,
+        lock_user: bool,
+    ) -> Any | None:
+        is_postgres_backend = bool(getattr(self._db_pool, "pool", None))
+        if is_postgres_backend:
+            query = "SELECT updated_at FROM users WHERE id = $1"
+            if lock_user:
+                query += " FOR UPDATE"
+            if db_conn is not None and hasattr(db_conn, "fetchrow"):
+                row = await db_conn.fetchrow(query, user_id)
+                return self._row_value(row, "updated_at")
+            row = await self._db_pool.fetchone(query, user_id)
+            return self._row_value(row, "updated_at")
+
+        query = "SELECT updated_at FROM users WHERE id = ?"
+        if db_conn is not None:
+            cursor = await db_conn.execute(query, (user_id,))
+            row = await cursor.fetchone()
+            return self._row_value(row, "updated_at")
+        row = await self._db_pool.fetchone(query, (user_id,))
+        return self._row_value(row, "updated_at")
+
     @classmethod
     def versions_match(cls, current: Any, expected: Any) -> bool:
         current_ts = cls._normalize_timestamp(current)
@@ -726,20 +767,23 @@ class UserProfileService:
         *,
         user_id: int,
         user_updated_at: Any | None = None,
+        db_conn: Any | None = None,
+        lock_user: bool = False,
     ) -> datetime:
         user_ts = self._normalize_timestamp(user_updated_at)
         if user_ts is None:
-            row = await self._db_pool.fetchone(
-                "SELECT updated_at FROM users WHERE id = $1",
-                user_id,
+            user_updated_at = await self._fetch_user_updated_at_for_version(
+                user_id=user_id,
+                db_conn=db_conn,
+                lock_user=lock_user,
             )
-            user_ts = self._normalize_timestamp(row.get("updated_at") if row else None)
+            user_ts = self._normalize_timestamp(user_updated_at)
 
         override_ts: datetime | None = None
         try:
             repo = UserProfileOverridesRepo(self._db_pool)
             await repo.ensure_tables()
-            override_raw = await repo.get_latest_update_for_user(user_id)
+            override_raw = await repo.get_latest_update_for_user(user_id, db_conn=db_conn)
             override_ts = self._normalize_timestamp(override_raw)
         except _PROFILE_NONCRITICAL_EXCEPTIONS as exc:
             logger.debug("Overrides timestamp lookup failed for user {}: {}", user_id, exc)

--- a/tldw_Server_API/app/core/UserProfiles/update_service.py
+++ b/tldw_Server_API/app/core/UserProfiles/update_service.py
@@ -110,7 +110,7 @@ class UserProfileUpdateService:
                             repo = UserProfileOverridesRepo(self._db_pool)
                             await repo.ensure_tables()
                             repo_holder["repo"] = repo
-                        await repo.delete_override(user_id=user_id, key=key)
+                        await repo.delete_override(user_id=user_id, key=key, db_conn=db_conn)
                     result.applied.append(key)
                     continue
                 result.skipped.append({"key": key, "message": "null_not_allowed"})
@@ -239,6 +239,7 @@ class UserProfileUpdateService:
                     key=key,
                     value=value,
                     updated_by=updated_by,
+                    db_conn=db_conn,
                 )
             return True
 
@@ -254,6 +255,7 @@ class UserProfileUpdateService:
                     key=key,
                     value=value,
                     updated_by=updated_by,
+                    db_conn=db_conn,
                 )
                 try:
                     from tldw_Server_API.app.core.Evaluations.user_rate_limiter import (
@@ -302,6 +304,7 @@ class UserProfileUpdateService:
                     key=key,
                     value=value,
                     updated_by=updated_by,
+                    db_conn=db_conn,
                 )
             return True
 

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -2551,6 +2551,15 @@ else:
 
     logger.info("Auth router consolidated: endpoints/auth.py")
     # Tools router included above with prefix f"{API_V1_PREFIX}"; avoid duplicate nested path
+
+if not _ULTRA_MINIMAL_APP:
+    try:
+        from tldw_Server_API.app.api.v2.router import api_v2_router
+
+        include_router_idempotent(app, api_v2_router)
+    except _IMPORT_EXCEPTIONS as _api_v2_err:
+        logger.warning(f"Failed to include API v2 router: {_api_v2_err}")
+
 # Register control-plane metrics endpoints (works in both minimal and full modes)
 if _shared_env_flag_enabled("ENABLE_ADMIN_E2E_TEST_MODE"):
     try:

--- a/tldw_Server_API/app/services/admin_profiles_service.py
+++ b/tldw_Server_API/app/services/admin_profiles_service.py
@@ -14,7 +14,6 @@ from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.org_deps import ROLE_HIERARCHY
 from tldw_Server_API.app.api.v1.schemas.user_profile_schemas import (
     UserProfileBatchResponse,
-    UserProfileBulkUpdateDiff,
     UserProfileBulkUpdateRequest,
     UserProfileBulkUpdateResponse,
     UserProfileBulkUpdateUserResult,
@@ -27,7 +26,6 @@ from tldw_Server_API.app.api.v1.schemas.user_profile_schemas import (
     UserProfileUpdateResponse,
 )
 from tldw_Server_API.app.api.v1.utils.pagination import build_page_pagination_meta
-from tldw_Server_API.app.api.v1.utils.profile_errors import classify_profile_update_skips
 from tldw_Server_API.app.core.AuthNZ.api_key_manager import get_api_key_manager
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 from tldw_Server_API.app.core.AuthNZ.exceptions import UserNotFoundError
@@ -40,6 +38,17 @@ from tldw_Server_API.app.core.AuthNZ.orgs_teams import (
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal, is_single_user_principal
 from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
 from tldw_Server_API.app.core.config import load_comprehensive_config
+from tldw_Server_API.app.core.UserProfiles.bulk_command_service import ProfileBulkCommandService
+from tldw_Server_API.app.core.UserProfiles.command_service import ProfileCommandService
+from tldw_Server_API.app.core.UserProfiles.contracts import (
+    ProfileContractMode,
+    ProfileReadRequest,
+    ProfileUpdateCommand,
+)
+from tldw_Server_API.app.core.UserProfiles.query_service import ProfileQueryService
+from tldw_Server_API.app.core.UserProfiles.response_mappers import (
+    LegacyProfileCommandResult,
+)
 from tldw_Server_API.app.core.UserProfiles.service import UserProfileService
 from tldw_Server_API.app.core.UserProfiles.update_service import (
     ProfileUpdateScope,
@@ -134,6 +143,23 @@ def _profile_error_response(
         errors=errors or [],
     )
     return JSONResponse(status_code=status_code, content=payload.model_dump())
+
+
+def _legacy_profile_command_response(
+    result: LegacyProfileCommandResult,
+) -> UserProfileUpdateResponse | JSONResponse:
+    if result.status_code != status.HTTP_200_OK:
+        return _profile_error_response(
+            status_code=result.status_code,
+            error_code=result.error_code or "profile_update_invalid",
+            detail=result.detail or "One or more updates failed validation",
+            errors=[UserProfileErrorDetail(**item) for item in result.skipped],
+        )
+    return UserProfileUpdateResponse(
+        profile_version=result.profile_version,
+        applied=list(result.applied),
+        skipped=[UserProfileUpdateError(**item) for item in result.skipped],
+    )
 
 
 def _mask_profile_diff_value(
@@ -527,6 +553,7 @@ async def list_user_profiles(
 
     db_pool = await get_db_pool()
     service = UserProfileService(db_pool)
+    query_service = ProfileQueryService(service)
     requested = service.parse_sections(sections)
     if requested is None:
         requested = {"identity", "memberships", "quotas"}
@@ -549,13 +576,18 @@ async def list_user_profiles(
                 api_key_manager=api_mgr,
             )
 
-        profile = await service.build_profile(
+        profile = await query_service.build(
+            ProfileReadRequest(
+                actor_user_id=principal.user_id,
+                target_user_id=int(user_id),
+                sections=frozenset(requested) if requested is not None else None,
+                include_sources=include_sources,
+                include_raw=include_raw,
+                mask_secrets=mask_secrets,
+                contract_mode=ProfileContractMode.LEGACY_V1,
+            ),
             user=user_dict,
-            sections=requested,
             security=security,
-            include_sources=include_sources,
-            include_raw=include_raw,
-            mask_secrets=mask_secrets,
             metrics_scope="batch",
         )
         profiles.append(UserProfileResponse(**profile))
@@ -672,6 +704,7 @@ async def get_user_profile(
 
         db_pool = await get_db_pool()
         service = UserProfileService(db_pool)
+        query_service = ProfileQueryService(service)
         requested = service.parse_sections(sections)
         api_mgr = await get_api_key_manager()
         security = await service.build_security(
@@ -679,13 +712,18 @@ async def get_user_profile(
             session_manager=session_manager,
             api_key_manager=api_mgr,
         )
-        profile = await service.build_profile(
+        profile = await query_service.build(
+            ProfileReadRequest(
+                actor_user_id=principal.user_id,
+                target_user_id=int(user_id),
+                sections=frozenset(requested) if requested is not None else None,
+                include_sources=include_sources,
+                include_raw=include_raw,
+                mask_secrets=mask_secrets,
+                contract_mode=ProfileContractMode.LEGACY_V1,
+            ),
             user=user_dict,
-            sections=requested,
             security=security,
-            include_sources=include_sources,
-            include_raw=include_raw,
-            mask_secrets=mask_secrets,
             metrics_scope="admin",
         )
         response = UserProfileResponse(**profile)
@@ -761,76 +799,34 @@ async def update_user_profile(
             ),
             None,
         )
-    profile_service = UserProfileService(db_pool)
-    current_version = await profile_service.get_profile_version(user_id=int(user_id))
-    if payload.profile_version is not None:
-        if not profile_service.versions_match(current_version, payload.profile_version):
-            return (
-                _profile_error_response(
-                    status_code=status.HTTP_409_CONFLICT,
-                    error_code="profile_version_mismatch",
-                    detail="profile_version_mismatch",
-                    errors=[UserProfileErrorDetail(key="profile_version", message="mismatch")],
-                ),
-                None,
-            )
 
     roles = _derive_profile_update_roles(principal)
-    service = UserProfileUpdateService(db_pool)
-    updates = [(entry.key, entry.value) for entry in payload.updates]
-    preflight = await service.apply_updates(
-        user_id=int(user_id),
-        updates=updates,
-        roles=roles,
-        dry_run=True,
-        db_conn=db,
-        updated_by=principal.user_id,
-        scope=ProfileUpdateScope(
-            actor_user_id=principal.user_id,
-            active_org_id=principal.active_org_id,
-            active_team_id=principal.active_team_id,
-        ),
+    scope = ProfileUpdateScope(
+        actor_user_id=principal.user_id,
+        active_org_id=principal.active_org_id,
+        active_team_id=principal.active_team_id,
     )
-
-    error_payload = classify_profile_update_skips(preflight.skipped)
-    if error_payload:
-        status_code, error_code, detail, errors = error_payload
+    command = ProfileUpdateCommand(
+        actor_user_id=principal.user_id,
+        target_user_id=int(user_id),
+        updates=tuple((entry.key, entry.value) for entry in payload.updates),
+        roles=frozenset(roles),
+        dry_run=payload.dry_run,
+        expected_profile_version=payload.profile_version,
+        active_org_id=principal.active_org_id,
+        active_team_id=principal.active_team_id,
+        contract_mode=ProfileContractMode.LEGACY_V1,
+    )
+    result = await ProfileCommandService(db_pool=db_pool).apply(
+        command,
+        db_conn=db,
+        scope=scope,
+    )
+    response = _legacy_profile_command_response(result)
+    if isinstance(response, JSONResponse):
         return (
-            _profile_error_response(
-                status_code=status_code,
-                error_code=error_code,
-                detail=detail,
-                errors=errors,
-            ),
+            response,
             None,
-        )
-
-    if payload.dry_run:
-        response = UserProfileUpdateResponse(
-            profile_version=current_version,
-            applied=preflight.applied,
-            skipped=[],
-        )
-    else:
-        result = await service.apply_updates(
-            user_id=int(user_id),
-            updates=updates,
-            roles=roles,
-            dry_run=False,
-            db_conn=db,
-            updated_by=principal.user_id,
-            scope=ProfileUpdateScope(
-                actor_user_id=principal.user_id,
-                active_org_id=principal.active_org_id,
-                active_team_id=principal.active_team_id,
-            ),
-        )
-        current_version = await profile_service.get_profile_version(user_id=int(user_id))
-        skipped = [UserProfileUpdateError(**item) for item in result.skipped]
-        response = UserProfileUpdateResponse(
-            profile_version=current_version,
-            applied=result.applied,
-            skipped=skipped,
         )
 
     audit_metadata = {
@@ -869,8 +865,14 @@ async def bulk_update_user_profiles(
         user_ids=payload.user_ids,
     )
     total_targets = len(target_ids)
+    bulk_command_service = ProfileBulkCommandService()
     threshold = _get_bulk_confirm_threshold()
-    if not payload.dry_run and total_targets > threshold and not payload.confirm:
+    if bulk_command_service.requires_confirmation(
+        dry_run=payload.dry_run,
+        total_targets=total_targets,
+        threshold=threshold,
+        confirmed=payload.confirm,
+    ):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={
@@ -935,6 +937,11 @@ async def bulk_update_user_profiles(
                 )
             else:
                 async with db_pool.transaction() as conn:
+                    await profile_service.get_profile_version(
+                        user_id=int(user_id),
+                        db_conn=conn,
+                        lock_user=True,
+                    )
                     result = await update_service.apply_updates(
                         user_id=int(user_id),
                         updates=updates,
@@ -951,21 +958,17 @@ async def bulk_update_user_profiles(
 
             profile_version = await profile_service.get_profile_version(user_id=int(user_id))
             skipped_entries = [UserProfileUpdateError(**item) for item in result.skipped]
-            applied_keys = set(result.applied)
-            diffs = [
-                UserProfileBulkUpdateDiff(
-                    key=entry.key,
-                    before=before_values.get(entry.key),
-                    after=_mask_profile_diff_value(
-                        profile_service,
-                        catalog_map,
-                        entry.key,
-                        entry.value,
-                    ),
-                )
-                for entry in payload.updates
-                if entry.key in applied_keys
-            ]
+            diffs = bulk_command_service.build_diffs(
+                updates=updates,
+                applied_keys=result.applied,
+                before_values=before_values,
+                mask_value=lambda key, value: _mask_profile_diff_value(
+                    profile_service,
+                    catalog_map,
+                    key,
+                    value,
+                ),
+            )
             results.append(
                 UserProfileBulkUpdateUserResult(
                     user_id=int(user_id),

--- a/tldw_Server_API/tests/AuthNZ/unit/test_user_profile_command_backend_selection.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_user_profile_command_backend_selection.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.UserProfiles.command_service import ProfileCommandService
+from tldw_Server_API.app.core.UserProfiles.contracts import ProfileUpdateCommand
+from tldw_Server_API.app.core.UserProfiles.update_service import UpdateResult
+
+
+class _ProfileService:
+    def __init__(self) -> None:
+        self.version = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    async def get_profile_version(self, **_kwargs: Any) -> datetime:
+        return self.version
+
+
+class _Planner:
+    async def plan(self, command, *, db_conn, scope):
+        del db_conn, scope
+        return UpdateResult(applied=[key for key, _value in command.updates])
+
+
+class _Executor:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def apply_updates(self, **kwargs: Any) -> UpdateResult:
+        self.calls.append(kwargs)
+        return UpdateResult(applied=["preferences.ui.theme"])
+
+
+@pytest.mark.asyncio
+async def test_profile_command_service_passes_supplied_transaction_connection_to_executor() -> None:
+    executor = _Executor()
+    write_conn = object()
+    command_service = ProfileCommandService(
+        db_pool=object(),
+        profile_service=_ProfileService(),
+        planner=_Planner(),
+        executor=executor,
+    )
+    command = ProfileUpdateCommand(
+        actor_user_id=7,
+        target_user_id=7,
+        updates=(("preferences.ui.theme", "paper"),),
+        roles=frozenset({"user"}),
+        dry_run=False,
+    )
+
+    await command_service.apply(command, db_conn=write_conn, scope=None)
+
+    assert executor.calls
+    assert executor.calls[0]["db_conn"] is write_conn

--- a/tldw_Server_API/tests/AuthNZ_Postgres/test_user_profile_version_locking_pg.py
+++ b/tldw_Server_API/tests/AuthNZ_Postgres/test_user_profile_version_locking_pg.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tldw_Server_API.app.core.UserProfiles.service import UserProfileService
+
+
+pytestmark = pytest.mark.postgres
+
+
+@pytest.mark.asyncio
+async def test_profile_version_lock_uses_transaction_connection(test_db_pool):
+    user_id = await test_db_pool.fetchval(
+        """
+        INSERT INTO users (uuid, username, email, password_hash, is_active)
+        VALUES ($1, $2, $3, $4, TRUE)
+        RETURNING id
+        """,
+        str(uuid.uuid4()),
+        "pg-profile-version-lock",
+        "pg-profile-version-lock@example.com",
+        "hash",
+    )
+    service = UserProfileService(test_db_pool)
+
+    async with test_db_pool.transaction() as conn:
+        version = await service.get_profile_version(
+            user_id=int(user_id),
+            db_conn=conn,
+            lock_user=True,
+        )
+
+    assert version is not None

--- a/tldw_Server_API/tests/UserProfile/test_admin_profiles_service_update.py
+++ b/tldw_Server_API/tests/UserProfile/test_admin_profiles_service_update.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from tldw_Server_API.app.api.v1.schemas.user_profile_schemas import (
+    UserProfileUpdateEntry,
+    UserProfileUpdateRequest,
+)
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.UserProfiles.contracts import ProfileContractMode
+from tldw_Server_API.app.core.UserProfiles.response_mappers import (
+    LegacyProfileCommandResult,
+)
+from tldw_Server_API.app.services import admin_profiles_service
+
+
+def _run_async(coro):
+    return asyncio.run(coro)
+
+
+def _admin_principal() -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=5,
+        username="admin",
+        roles=["admin"],
+        permissions=[],
+        is_admin=True,
+        org_ids=[],
+        team_ids=[],
+        active_org_id=11,
+        active_team_id=22,
+    )
+
+
+def test_admin_profile_update_delegates_to_command_service(monkeypatch) -> None:
+    version = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    write_conn = object()
+    captured: dict[str, object] = {}
+
+    async def _allow_scope(*_args, **_kwargs) -> None:
+        captured["scope_enforced"] = _args, _kwargs
+
+    async def _fake_pool():
+        return object()
+
+    class _Repo:
+        async def get_user_by_id(self, user_id: int) -> dict[str, object]:
+            return {"id": user_id, "updated_at": version}
+
+    async def _repo_from_pool():
+        return _Repo()
+
+    class _CommandService:
+        def __init__(self, *, db_pool) -> None:
+            captured["db_pool"] = db_pool
+
+        async def apply(self, command, *, db_conn, scope):
+            captured["command"] = command
+            captured["db_conn"] = db_conn
+            captured["scope"] = scope
+            return LegacyProfileCommandResult(
+                profile_version=version,
+                applied=("preferences.ui.theme",),
+            )
+
+    class _DirectUpdateServiceTrap:
+        def __init__(self, *_args, **_kwargs) -> None:
+            raise AssertionError("admin service must delegate to ProfileCommandService")
+
+    monkeypatch.setattr(
+        admin_profiles_service.admin_scope_service,
+        "enforce_admin_user_scope",
+        _allow_scope,
+    )
+    monkeypatch.setattr(admin_profiles_service, "get_db_pool", _fake_pool)
+    monkeypatch.setattr(admin_profiles_service.AuthnzUsersRepo, "from_pool", _repo_from_pool)
+    monkeypatch.setattr(admin_profiles_service, "ProfileCommandService", _CommandService, raising=False)
+    monkeypatch.setattr(admin_profiles_service, "UserProfileUpdateService", _DirectUpdateServiceTrap)
+
+    principal = _admin_principal()
+    payload = UserProfileUpdateRequest(
+        profile_version=version,
+        updates=[UserProfileUpdateEntry(key="preferences.ui.theme", value="paper")],
+    )
+
+    response, audit_info = _run_async(
+        admin_profiles_service.update_user_profile(
+            user_id=7,
+            payload=payload,
+            principal=principal,
+            db=write_conn,
+        )
+    )
+
+    command = captured["command"]
+    assert command.actor_user_id == 5
+    assert command.target_user_id == 7
+    assert command.updates == (("preferences.ui.theme", "paper"),)
+    assert "admin" in command.roles
+    assert command.dry_run is False
+    assert command.expected_profile_version == version
+    assert command.active_org_id == 11
+    assert command.active_team_id == 22
+    assert command.contract_mode == ProfileContractMode.LEGACY_V1
+    assert captured["db_conn"] is write_conn
+
+    scope = captured["scope"]
+    assert scope.actor_user_id == 5
+    assert scope.active_org_id == 11
+    assert scope.active_team_id == 22
+
+    assert response.profile_version == version
+    assert response.applied == ["preferences.ui.theme"]
+    assert response.skipped == []
+    assert audit_info["metadata"]["applied_count"] == 1
+    assert audit_info["metadata"]["skipped_count"] == 0
+
+
+def test_admin_profile_update_maps_command_error_to_legacy_error_response(monkeypatch) -> None:
+    version = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    async def _allow_scope(*_args, **_kwargs) -> None:
+        return None
+
+    async def _fake_pool():
+        return object()
+
+    class _Repo:
+        async def get_user_by_id(self, user_id: int) -> dict[str, object]:
+            return {"id": user_id, "updated_at": version}
+
+    async def _repo_from_pool():
+        return _Repo()
+
+    class _CommandService:
+        def __init__(self, *, db_pool) -> None:
+            del db_pool
+
+        async def apply(self, command, *, db_conn, scope):
+            del command, db_conn, scope
+            return LegacyProfileCommandResult(
+                status_code=409,
+                profile_version=version,
+                error_code="profile_version_mismatch",
+                detail="profile_version_mismatch",
+                skipped=({"key": "profile_version", "message": "mismatch"},),
+            )
+
+    monkeypatch.setattr(
+        admin_profiles_service.admin_scope_service,
+        "enforce_admin_user_scope",
+        _allow_scope,
+    )
+    monkeypatch.setattr(admin_profiles_service, "get_db_pool", _fake_pool)
+    monkeypatch.setattr(admin_profiles_service.AuthnzUsersRepo, "from_pool", _repo_from_pool)
+    monkeypatch.setattr(admin_profiles_service, "ProfileCommandService", _CommandService, raising=False)
+
+    response, audit_info = _run_async(
+        admin_profiles_service.update_user_profile(
+            user_id=7,
+            payload=UserProfileUpdateRequest(
+                profile_version=version,
+                updates=[UserProfileUpdateEntry(key="preferences.ui.theme", value="paper")],
+            ),
+            principal=_admin_principal(),
+            db=object(),
+        )
+    )
+
+    assert audit_info is None
+    assert response.status_code == 409
+    body = json.loads(response.body.decode("utf-8"))
+    assert body == {
+        "error_code": "profile_version_mismatch",
+        "detail": "profile_version_mismatch",
+        "errors": [{"key": "profile_version", "message": "mismatch"}],
+    }

--- a/tldw_Server_API/tests/UserProfile/test_profile_bulk_command_service.py
+++ b/tldw_Server_API/tests/UserProfile/test_profile_bulk_command_service.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.UserProfiles.bulk_command_service import (
+    ProfileBulkCommandService,
+)
+
+
+def test_filter_visible_targets_keeps_candidate_order() -> None:
+    service = ProfileBulkCommandService()
+
+    visible = service.filter_visible_targets(
+        candidate_user_ids=[1, 2, 3],
+        visible_user_ids={1, 3},
+    )
+
+    assert visible == [1, 3]
+
+
+def test_filter_visible_targets_coerces_ids_and_drops_duplicates() -> None:
+    service = ProfileBulkCommandService()
+
+    visible = service.filter_visible_targets(
+        candidate_user_ids=["3", 2, "3", 1],
+        visible_user_ids={"1", 3},
+    )
+
+    assert visible == [3, 1]
+
+
+def test_requires_confirmation_only_for_non_dry_run_above_threshold() -> None:
+    service = ProfileBulkCommandService()
+
+    assert service.requires_confirmation(
+        dry_run=False,
+        total_targets=3,
+        threshold=2,
+        confirmed=False,
+    ) is True
+    assert service.requires_confirmation(
+        dry_run=True,
+        total_targets=3,
+        threshold=2,
+        confirmed=False,
+    ) is False
+    assert service.requires_confirmation(
+        dry_run=False,
+        total_targets=2,
+        threshold=2,
+        confirmed=False,
+    ) is False
+    assert service.requires_confirmation(
+        dry_run=False,
+        total_targets=3,
+        threshold=2,
+        confirmed=True,
+    ) is False
+
+
+def test_build_diffs_defaults_missing_before_values_to_none() -> None:
+    service = ProfileBulkCommandService()
+
+    diffs = service.build_diffs(
+        updates=[
+            ("limits.storage_quota_mb", 2048),
+            ("preferences.ui.theme", "paper"),
+        ],
+        applied_keys={"limits.storage_quota_mb"},
+        before_values={},
+        mask_value=lambda key, value: f"{key}:{value}",
+    )
+
+    assert len(diffs) == 1
+    assert diffs == [
+        {
+            "key": "limits.storage_quota_mb",
+            "before": None,
+            "after": "limits.storage_quota_mb:2048",
+        }
+    ]

--- a/tldw_Server_API/tests/UserProfile/test_profile_command_service.py
+++ b/tldw_Server_API/tests/UserProfile/test_profile_command_service.py
@@ -407,6 +407,7 @@ async def test_command_service_successful_write_returns_executor_result_and_vers
     assert result.profile_version == profile_service.after_write
     assert result.applied == ("preferences.ui.theme",)
     assert result.skipped == ()
+    assert profile_service.calls == [(write_conn, False), (write_conn, False)]
     assert executor.calls == [
         {
             "user_id": 9,

--- a/tldw_Server_API/tests/UserProfile/test_profile_command_service.py
+++ b/tldw_Server_API/tests/UserProfile/test_profile_command_service.py
@@ -1,0 +1,420 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.UserProfiles.command_service import ProfileCommandService
+from tldw_Server_API.app.core.UserProfiles.contracts import ProfileUpdateCommand
+from tldw_Server_API.app.core.UserProfiles.response_mappers import (
+    LegacyProfileCommandResult,
+)
+from tldw_Server_API.app.core.UserProfiles.update_service import UpdateResult
+
+
+class _ProfileService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, bool]] = []
+        self.initial = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        self.locked = datetime(2026, 1, 2, tzinfo=timezone.utc)
+        self.after_write = datetime(2026, 1, 3, tzinfo=timezone.utc)
+        self._unlocked_calls = 0
+
+    async def get_profile_version(self, *, user_id: int, db_conn=None, lock_user: bool = False):
+        self.calls.append((db_conn, lock_user))
+        if lock_user:
+            return self.locked
+        self._unlocked_calls += 1
+        return self.initial if self._unlocked_calls == 1 else self.after_write
+
+    def versions_match(self, current, expected) -> bool:
+        return current == expected
+
+
+class _Planner:
+    def __init__(self, result: UpdateResult | None = None) -> None:
+        self.result = result
+        self.calls: list[dict[str, Any]] = []
+
+    async def plan(self, command, *, db_conn, scope):
+        self.calls.append({"command": command, "db_conn": db_conn, "scope": scope})
+        if self.result is not None:
+            return self.result
+        return UpdateResult(applied=[key for key, _value in command.updates])
+
+
+class _Executor:
+    def __init__(self) -> None:
+        self.called = False
+        self.calls: list[dict[str, Any]] = []
+
+    async def apply_updates(self, **kwargs):
+        self.called = True
+        self.calls.append(kwargs)
+        return UpdateResult(applied=["preferences.ui.theme"])
+
+
+@pytest.mark.asyncio
+async def test_command_service_rechecks_version_before_apply() -> None:
+    profile_service = _ProfileService()
+    executor = _Executor()
+    command_service = ProfileCommandService(
+        db_pool=object(),
+        profile_service=profile_service,
+        planner=_Planner(),
+        executor=executor,
+    )
+    write_conn = object()
+    command = ProfileUpdateCommand(
+        actor_user_id=7,
+        target_user_id=7,
+        updates=(("preferences.ui.theme", "paper"),),
+        roles=frozenset({"user"}),
+        dry_run=False,
+        expected_profile_version=profile_service.initial,
+    )
+
+    result = await command_service.apply(command, db_conn=write_conn, scope=None)
+
+    assert result.status_code == 409
+    assert result.error_code == "profile_version_mismatch"
+    assert executor.called is False
+
+
+@pytest.mark.asyncio
+async def test_command_service_dry_run_returns_preflight_without_executor() -> None:
+    profile_service = _ProfileService()
+    executor = _Executor()
+    command_service = ProfileCommandService(
+        db_pool=object(),
+        profile_service=profile_service,
+        planner=_Planner(),
+        executor=executor,
+    )
+    command = ProfileUpdateCommand(
+        actor_user_id=7,
+        target_user_id=7,
+        updates=(("preferences.ui.theme", "paper"),),
+        roles=frozenset({"user"}),
+        dry_run=True,
+    )
+
+    result = await command_service.apply(command, db_conn=object(), scope=None)
+
+    assert result.status_code == 200
+    assert result.profile_version == profile_service.initial
+    assert result.applied == ("preferences.ui.theme",)
+    assert result.skipped == ()
+    assert executor.called is False
+
+
+@pytest.mark.asyncio
+async def test_command_service_preflight_skip_returns_error_without_executor() -> None:
+    executor = _Executor()
+    command_service = ProfileCommandService(
+        db_pool=object(),
+        profile_service=_ProfileService(),
+        planner=_Planner(
+            UpdateResult(
+                applied=["preferences.ui.theme"],
+                skipped=[{"key": "identity.email", "message": "invalid_email"}],
+            )
+        ),
+        executor=executor,
+    )
+    command = ProfileUpdateCommand(
+        actor_user_id=7,
+        target_user_id=7,
+        updates=(("identity.email", "not-an-email"),),
+        roles=frozenset({"user"}),
+        dry_run=False,
+    )
+
+    result = await command_service.apply(command, db_conn=object(), scope=None)
+
+    assert result.status_code == 422
+    assert result.error_code == "profile_update_invalid"
+    assert result.applied == ("preferences.ui.theme",)
+    assert result.skipped == ({"key": "identity.email", "message": "invalid_email"},)
+    assert executor.called is False
+
+
+@pytest.mark.asyncio
+async def test_command_service_unknown_key_skip_maps_to_legacy_bad_request() -> None:
+    executor = _Executor()
+    command_service = ProfileCommandService(
+        db_pool=object(),
+        profile_service=_ProfileService(),
+        planner=_Planner(
+            UpdateResult(
+                skipped=[{"key": "preferences.ui.unknown", "message": "unknown_key"}],
+            )
+        ),
+        executor=executor,
+    )
+    command = ProfileUpdateCommand(
+        actor_user_id=7,
+        target_user_id=7,
+        updates=(("preferences.ui.unknown", "oops"),),
+        roles=frozenset({"user"}),
+        dry_run=False,
+    )
+
+    result = await command_service.apply(command, db_conn=object(), scope=None)
+
+    assert result.status_code == 400
+    assert result.error_code == "profile_update_unknown_key"
+    assert result.detail == "One or more keys are not recognized"
+    assert result.skipped == (
+        {"key": "preferences.ui.unknown", "message": "unknown_key"},
+    )
+    assert executor.called is False
+
+
+@pytest.mark.asyncio
+async def test_command_service_forbidden_skip_maps_to_legacy_forbidden() -> None:
+    executor = _Executor()
+    command_service = ProfileCommandService(
+        db_pool=object(),
+        profile_service=_ProfileService(),
+        planner=_Planner(
+            UpdateResult(
+                skipped=[{"key": "limits.storage_quota_mb", "message": "forbidden"}],
+            )
+        ),
+        executor=executor,
+    )
+    command = ProfileUpdateCommand(
+        actor_user_id=7,
+        target_user_id=7,
+        updates=(("limits.storage_quota_mb", 1024),),
+        roles=frozenset({"user"}),
+        dry_run=False,
+    )
+
+    result = await command_service.apply(command, db_conn=object(), scope=None)
+
+    assert result.status_code == 403
+    assert result.error_code == "profile_update_forbidden"
+    assert result.detail == "Caller cannot edit one or more fields"
+    assert result.skipped == (
+        {"key": "limits.storage_quota_mb", "message": "forbidden"},
+    )
+    assert executor.called is False
+
+
+@pytest.mark.asyncio
+async def test_command_service_generic_preflight_skip_stays_legacy_invalid() -> None:
+    executor = _Executor()
+    command_service = ProfileCommandService(
+        db_pool=object(),
+        profile_service=_ProfileService(),
+        planner=_Planner(
+            UpdateResult(
+                skipped=[{"key": "preferences.ui.theme", "message": "type_mismatch"}],
+            )
+        ),
+        executor=executor,
+    )
+    command = ProfileUpdateCommand(
+        actor_user_id=7,
+        target_user_id=7,
+        updates=(("preferences.ui.theme", 123),),
+        roles=frozenset({"user"}),
+        dry_run=False,
+    )
+
+    result = await command_service.apply(command, db_conn=object(), scope=None)
+
+    assert result.status_code == 422
+    assert result.error_code == "profile_update_invalid"
+    assert result.detail == "One or more updates failed validation"
+    assert executor.called is False
+
+
+@pytest.mark.asyncio
+async def test_command_service_team_not_found_skip_maps_without_executor() -> None:
+    executor = _Executor()
+    command_service = ProfileCommandService(
+        db_pool=object(),
+        profile_service=_ProfileService(),
+        planner=_Planner(
+            UpdateResult(
+                skipped=[
+                    {"key": "memberships.teams.role", "message": "team_not_found"}
+                ],
+            )
+        ),
+        executor=executor,
+    )
+    command = ProfileUpdateCommand(
+        actor_user_id=7,
+        target_user_id=9,
+        updates=(("memberships.teams.role", {"team_id": 42, "role": "member"}),),
+        roles=frozenset({"admin"}),
+        dry_run=False,
+    )
+
+    result = await command_service.apply(command, db_conn=object(), scope=None)
+
+    assert result.status_code == 404
+    assert result.error_code == "profile_update_not_found"
+    assert result.detail == "Target resource not found"
+    assert result.skipped == (
+        {"key": "memberships.teams.role", "message": "team_not_found"},
+    )
+    assert executor.called is False
+
+
+@pytest.mark.asyncio
+async def test_command_service_invalid_payload_skip_maps_without_executor() -> None:
+    executor = _Executor()
+    command_service = ProfileCommandService(
+        db_pool=object(),
+        profile_service=_ProfileService(),
+        planner=_Planner(
+            UpdateResult(
+                skipped=[
+                    {"key": "memberships.teams.role", "message": "invalid_payload"}
+                ],
+            )
+        ),
+        executor=executor,
+    )
+    command = ProfileUpdateCommand(
+        actor_user_id=7,
+        target_user_id=9,
+        updates=(("memberships.teams.role", "not-a-payload"),),
+        roles=frozenset({"admin"}),
+        dry_run=False,
+    )
+
+    result = await command_service.apply(command, db_conn=object(), scope=None)
+
+    assert result.status_code == 400
+    assert result.error_code == "profile_update_invalid"
+    assert result.detail == "Invalid profile update payload"
+    assert result.skipped == (
+        {"key": "memberships.teams.role", "message": "invalid_payload"},
+    )
+    assert executor.called is False
+
+
+@pytest.mark.asyncio
+async def test_command_service_dry_run_rejects_stale_version_before_planning() -> None:
+    profile_service = _ProfileService()
+    planner = _Planner()
+    executor = _Executor()
+    command_service = ProfileCommandService(
+        db_pool=object(),
+        profile_service=profile_service,
+        planner=planner,
+        executor=executor,
+    )
+    command = ProfileUpdateCommand(
+        actor_user_id=7,
+        target_user_id=7,
+        updates=(("preferences.ui.theme", "paper"),),
+        roles=frozenset({"user"}),
+        dry_run=True,
+        expected_profile_version=datetime(2000, 1, 1, tzinfo=timezone.utc),
+    )
+
+    result = await command_service.apply(command, db_conn=object(), scope=None)
+
+    assert result.status_code == 409
+    assert result.profile_version == profile_service.initial
+    assert result.error_code == "profile_version_mismatch"
+    assert result.skipped == ({"key": "profile_version", "message": "mismatch"},)
+    assert planner.calls == []
+    assert executor.called is False
+
+
+@pytest.mark.asyncio
+async def test_command_service_stale_version_wins_over_invalid_preflight_candidate() -> None:
+    profile_service = _ProfileService()
+    planner = _Planner(
+        UpdateResult(
+            skipped=[{"key": "preferences.ui.unknown", "message": "unknown_key"}],
+        )
+    )
+    executor = _Executor()
+    command_service = ProfileCommandService(
+        db_pool=object(),
+        profile_service=profile_service,
+        planner=planner,
+        executor=executor,
+    )
+    command = ProfileUpdateCommand(
+        actor_user_id=7,
+        target_user_id=7,
+        updates=(("preferences.ui.unknown", "oops"),),
+        roles=frozenset({"user"}),
+        dry_run=False,
+        expected_profile_version=datetime(2000, 1, 1, tzinfo=timezone.utc),
+    )
+
+    result = await command_service.apply(command, db_conn=object(), scope=None)
+
+    assert result.status_code == 409
+    assert result.profile_version == profile_service.initial
+    assert result.error_code == "profile_version_mismatch"
+    assert planner.calls == []
+    assert executor.called is False
+
+
+def test_legacy_command_result_error_version_and_skipped_are_defensive() -> None:
+    skipped = {"key": "identity.email", "message": "invalid_email"}
+    result = LegacyProfileCommandResult(
+        status_code=422,
+        skipped=(skipped,),
+        error_code="profile_update_invalid",
+        detail="One or more updates failed validation",
+    )
+
+    skipped["message"] = "mutated"
+
+    assert result.profile_version is None
+    assert result.skipped == ({"key": "identity.email", "message": "invalid_email"},)
+    with pytest.raises(TypeError):
+        result.skipped[0]["message"] = "mutated"
+
+
+@pytest.mark.asyncio
+async def test_command_service_successful_write_returns_executor_result_and_version() -> None:
+    profile_service = _ProfileService()
+    executor = _Executor()
+    scope = object()
+    write_conn = object()
+    command_service = ProfileCommandService(
+        db_pool=object(),
+        profile_service=profile_service,
+        planner=_Planner(),
+        executor=executor,
+    )
+    command = ProfileUpdateCommand(
+        actor_user_id=7,
+        target_user_id=9,
+        updates=(("preferences.ui.theme", "paper"),),
+        roles=frozenset({"user"}),
+        dry_run=False,
+    )
+
+    result = await command_service.apply(command, db_conn=write_conn, scope=scope)
+
+    assert result.status_code == 200
+    assert result.profile_version == profile_service.after_write
+    assert result.applied == ("preferences.ui.theme",)
+    assert result.skipped == ()
+    assert executor.calls == [
+        {
+            "user_id": 9,
+            "updates": (("preferences.ui.theme", "paper"),),
+            "roles": {"user"},
+            "dry_run": False,
+            "db_conn": write_conn,
+            "updated_by": 7,
+            "scope": scope,
+        }
+    ]

--- a/tldw_Server_API/tests/UserProfile/test_profile_contracts.py
+++ b/tldw_Server_API/tests/UserProfile/test_profile_contracts.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tldw_Server_API.app.core.UserProfiles.contracts import (
+    EffectDescriptor,
+    EffectPolicy,
+    EffectTiming,
+    ProfileContractMode,
+    ProfileUpdateCommand,
+    PlannedUpdateResult,
+    UpdateMutation,
+    UpdatePlan,
+)
+
+
+def test_update_plan_separates_pre_commit_and_post_commit_effects() -> None:
+    command = ProfileUpdateCommand(
+        actor_user_id=5,
+        target_user_id=7,
+        updates=(("preferences.ui.theme", "paper"),),
+        roles=frozenset({"user"}),
+        dry_run=False,
+        expected_profile_version=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        contract_mode=ProfileContractMode.LEGACY_V1,
+    )
+
+    plan = UpdatePlan(
+        command=command,
+        mutations=(
+            UpdateMutation(
+                key="preferences.ui.theme",
+                operation="upsert_override",
+                payload={"value": "paper"},
+            ),
+        ),
+        effects=(
+            EffectDescriptor(
+                name="audit_preflight",
+                timing=EffectTiming.PRE_COMMIT,
+                policy=EffectPolicy.REQUIRED,
+            ),
+            EffectDescriptor(
+                name="refresh_cache",
+                timing=EffectTiming.POST_COMMIT,
+                policy=EffectPolicy.BEST_EFFORT,
+            ),
+            EffectDescriptor(
+                name="validate_version",
+                timing=EffectTiming.PRE_COMMIT,
+                policy=EffectPolicy.REQUIRED,
+            ),
+            EffectDescriptor(
+                name="emit_profile_changed",
+                timing=EffectTiming.POST_COMMIT,
+                policy=EffectPolicy.BEST_EFFORT,
+            ),
+        ),
+    )
+
+    assert plan.command.target_user_id == 7
+    assert plan.mutations[0].operation == "upsert_override"
+    assert tuple(effect.name for effect in plan.pre_commit_effects) == (
+        "audit_preflight",
+        "validate_version",
+    )
+    assert tuple(effect.name for effect in plan.post_commit_effects) == (
+        "refresh_cache",
+        "emit_profile_changed",
+    )
+
+
+def test_contract_payloads_are_immutable_copies() -> None:
+    mutation_payload = {
+        "value": {
+            "theme": "paper",
+            "tags": ["reader"],
+        },
+    }
+    effect_payload = {
+        "event": {
+            "kind": "profile.updated",
+            "ids": [7],
+        },
+    }
+    rejected = ({"field": "display_name", "reason": "blank"},)
+
+    mutation = UpdateMutation(
+        key="preferences.ui.theme",
+        operation="upsert_override",
+        payload=mutation_payload,
+    )
+    effect = EffectDescriptor(
+        name="emit_profile_changed",
+        timing=EffectTiming.POST_COMMIT,
+        policy=EffectPolicy.BEST_EFFORT,
+        payload=effect_payload,
+    )
+    result = PlannedUpdateResult(
+        profile_version=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        rejected=rejected,
+    )
+
+    mutation_payload["value"]["theme"] = "dark"
+    mutation_payload["value"]["tags"].append("mutated")
+    effect_payload["event"]["kind"] = "profile.deleted"
+    effect_payload["event"]["ids"].append(9)
+    rejected[0]["reason"] = "changed"
+
+    assert mutation.payload["value"]["theme"] == "paper"
+    assert mutation.payload["value"]["tags"] == ("reader",)
+    assert effect.payload["event"]["kind"] == "profile.updated"
+    assert effect.payload["event"]["ids"] == (7,)
+    assert result.rejected[0]["reason"] == "blank"
+
+    with pytest.raises(TypeError):
+        mutation.payload["value"]["theme"] = "dark"
+    with pytest.raises(TypeError):
+        effect.payload["event"]["ids"] = (9,)
+    with pytest.raises(TypeError):
+        result.rejected[0]["reason"] = "changed"
+
+    default_mutation = UpdateMutation(key="profile", operation="noop")
+    with pytest.raises(TypeError):
+        default_mutation.payload["unexpected"] = True
+
+
+def test_effect_policy_values_are_stable() -> None:
+    assert ProfileContractMode.LEGACY_V1 == "legacy_v1"
+    assert ProfileContractMode.CLEAN_V2 == "clean_v2"
+    assert EffectTiming.PRE_COMMIT.value == "pre_commit"
+    assert EffectTiming.PRE_COMMIT == "pre_commit"
+    assert EffectTiming.POST_COMMIT.value == "post_commit"
+    assert EffectTiming.POST_COMMIT == "post_commit"
+    assert EffectPolicy.REQUIRED.value == "required"
+    assert EffectPolicy.REQUIRED == "required"
+    assert EffectPolicy.BEST_EFFORT.value == "best_effort"
+    assert EffectPolicy.BEST_EFFORT == "best_effort"

--- a/tldw_Server_API/tests/UserProfile/test_profile_error_mapping.py
+++ b/tldw_Server_API/tests/UserProfile/test_profile_error_mapping.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+from fastapi import status
+
+from tldw_Server_API.app.api.v1.utils.profile_errors import (
+    classify_profile_update_skips,
+)
+from tldw_Server_API.app.core.UserProfiles.error_mapping import (
+    ProfileErrorCode,
+    map_profile_error_code,
+)
+
+
+def _classify_mixed_domain_skips() -> tuple[int, str, str]:
+    classified = classify_profile_update_skips(
+        [
+            {"key": "team_id", "message": "team_not_found"},
+            {"key": "profile_type", "message": "type_mismatch"},
+        ]
+    )
+
+    assert classified is not None
+    return classified[0], classified[1], classified[2]
+
+
+def test_profile_error_code_http_mapping() -> None:
+    assert (
+        map_profile_error_code(ProfileErrorCode.UNKNOWN_KEY).status_code
+        == status.HTTP_400_BAD_REQUEST
+    )
+    assert (
+        map_profile_error_code(ProfileErrorCode.INVALID_VALUE).status_code
+        == status.HTTP_422_UNPROCESSABLE_ENTITY
+    )
+    assert (
+        map_profile_error_code(ProfileErrorCode.FORBIDDEN_SCOPE).status_code
+        == status.HTTP_403_FORBIDDEN
+    )
+    assert (
+        map_profile_error_code(ProfileErrorCode.TARGET_NOT_FOUND).status_code
+        == status.HTTP_404_NOT_FOUND
+    )
+    assert (
+        map_profile_error_code(ProfileErrorCode.VERSION_MISMATCH).status_code
+        == status.HTTP_409_CONFLICT
+    )
+
+
+def test_forbidden_role_escalation_maps_to_forbidden_profile_update() -> None:
+    mapped = map_profile_error_code(ProfileErrorCode.FORBIDDEN_ROLE_ESCALATION)
+
+    assert mapped.status_code == status.HTTP_403_FORBIDDEN
+    assert mapped.error_code == "profile_update_forbidden"
+    assert mapped.detail == "Caller cannot edit one or more fields"
+
+
+def test_known_raw_string_maps_to_profile_error_code() -> None:
+    mapped = map_profile_error_code("unsupported_key")
+
+    assert mapped.status_code == status.HTTP_400_BAD_REQUEST
+    assert mapped.error_code == "profile_update_unknown_key"
+    assert mapped.detail == "One or more keys are not recognized"
+
+
+def test_unknown_raw_string_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        map_profile_error_code("not_a_profile_error")
+
+
+def test_mixed_domain_skip_messages_use_deterministic_not_found_precedence() -> None:
+    expected = (
+        status.HTTP_404_NOT_FOUND,
+        "profile_update_not_found",
+        "Target resource not found",
+    )
+
+    assert _classify_mixed_domain_skips() == expected
+
+    script = """
+import json
+
+from tldw_Server_API.app.api.v1.utils.profile_errors import classify_profile_update_skips
+
+result = classify_profile_update_skips(
+    [
+        {"key": "team_id", "message": "team_not_found"},
+        {"key": "profile_type", "message": "type_mismatch"},
+    ]
+)
+
+print(json.dumps(result[:3]))
+"""
+    observed = set()
+    for seed in ("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"):
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            check=True,
+            capture_output=True,
+            env={**os.environ, "PYTHONHASHSEED": seed},
+            text=True,
+        )
+        observed.add(tuple(json.loads(completed.stdout)))
+
+    assert observed == {expected}
+
+
+def test_bad_request_direct_domain_codes_map_to_invalid_details() -> None:
+    invalid_payload = map_profile_error_code(ProfileErrorCode.INVALID_PAYLOAD)
+    invalid_action = map_profile_error_code(ProfileErrorCode.INVALID_ACTION)
+
+    assert invalid_payload.status_code == status.HTTP_400_BAD_REQUEST
+    assert invalid_payload.error_code == "profile_update_invalid"
+    assert invalid_payload.error_code != "profile_update_unknown_key"
+    assert invalid_payload.detail == "Invalid profile update payload"
+
+    assert invalid_action.status_code == status.HTTP_400_BAD_REQUEST
+    assert invalid_action.error_code == "profile_update_invalid"
+    assert invalid_action.error_code != "profile_update_unknown_key"
+    assert invalid_action.detail == "Invalid profile update action"
+
+    assert invalid_payload.detail != invalid_action.detail
+
+
+def test_not_found_details_diverge_for_direct_and_legacy_user_mapping() -> None:
+    direct = map_profile_error_code(ProfileErrorCode.TARGET_NOT_FOUND)
+    legacy = classify_profile_update_skips(
+        [{"key": "user_id", "message": "user_not_found"}]
+    )
+
+    assert direct.status_code == status.HTTP_404_NOT_FOUND
+    assert direct.error_code == "profile_update_not_found"
+    assert direct.detail == "Target resource not found"
+
+    assert legacy is not None
+    legacy_status, legacy_error_code, legacy_detail, _legacy_errors = legacy
+    assert legacy_status == status.HTTP_404_NOT_FOUND
+    assert legacy_error_code == "profile_update_not_found"
+    assert legacy_detail == "Target user not found"
+
+
+def test_core_legacy_skip_classifier_preserves_compatibility_buckets() -> None:
+    from tldw_Server_API.app.core.UserProfiles.error_mapping import (
+        classify_legacy_profile_update_skips,
+    )
+
+    assert classify_legacy_profile_update_skips([]) is None
+
+    unsupported_type = classify_legacy_profile_update_skips(
+        [{"key": "preferences.ui.theme", "message": "unsupported_type"}]
+    )
+    assert unsupported_type is not None
+    assert unsupported_type.status_code == status.HTTP_400_BAD_REQUEST
+    assert unsupported_type.error_code == "profile_update_unknown_key"
+    assert unsupported_type.detail == "One or more keys are not recognized"
+
+    user_not_found = classify_legacy_profile_update_skips(
+        [{"key": "user_id", "message": "user_not_found"}]
+    )
+    assert user_not_found is not None
+    assert user_not_found.status_code == status.HTTP_404_NOT_FOUND
+    assert user_not_found.error_code == "profile_update_not_found"
+    assert user_not_found.detail == "Target user not found"
+
+
+def test_core_legacy_skip_classifier_uses_domain_precedence() -> None:
+    from tldw_Server_API.app.core.UserProfiles.error_mapping import (
+        classify_legacy_profile_update_skips,
+    )
+
+    team_not_found = classify_legacy_profile_update_skips(
+        [
+            {"key": "memberships.teams.role", "message": "team_not_found"},
+            {"key": "profile_type", "message": "type_mismatch"},
+        ]
+    )
+    assert team_not_found is not None
+    assert team_not_found.status_code == status.HTTP_404_NOT_FOUND
+    assert team_not_found.error_code == "profile_update_not_found"
+    assert team_not_found.detail == "Target resource not found"
+
+    invalid_payload = classify_legacy_profile_update_skips(
+        [{"key": "memberships.teams.role", "message": "invalid_payload"}]
+    )
+    assert invalid_payload is not None
+    assert invalid_payload.status_code == status.HTTP_400_BAD_REQUEST
+    assert invalid_payload.error_code == "profile_update_invalid"
+    assert invalid_payload.detail == "Invalid profile update payload"
+
+
+@pytest.mark.parametrize(
+    ("message", "expected_status", "expected_error", "expected_detail"),
+    [
+        (
+            "team_not_found",
+            status.HTTP_404_NOT_FOUND,
+            "profile_update_not_found",
+            "Target resource not found",
+        ),
+        (
+            "invalid_payload",
+            status.HTTP_400_BAD_REQUEST,
+            "profile_update_invalid",
+            "Invalid profile update payload",
+        ),
+        (
+            "unsupported_type",
+            status.HTTP_400_BAD_REQUEST,
+            "profile_update_unknown_key",
+            "One or more keys are not recognized",
+        ),
+        (
+            "user_not_found",
+            status.HTTP_404_NOT_FOUND,
+            "profile_update_not_found",
+            "Target user not found",
+        ),
+    ],
+)
+def test_api_profile_skip_adapter_matches_core_legacy_classifier(
+    message: str,
+    expected_status: int,
+    expected_error: str,
+    expected_detail: str,
+) -> None:
+    from tldw_Server_API.app.core.UserProfiles.error_mapping import (
+        classify_legacy_profile_update_skips,
+    )
+
+    skipped = [{"key": "some.key", "message": message}]
+
+    core_mapping = classify_legacy_profile_update_skips(skipped)
+    api_mapping = classify_profile_update_skips(skipped)
+
+    assert core_mapping is not None
+    assert (core_mapping.status_code, core_mapping.error_code, core_mapping.detail) == (
+        expected_status,
+        expected_error,
+        expected_detail,
+    )
+    assert api_mapping is not None
+    api_status, api_error, api_detail, api_errors = api_mapping
+    assert (api_status, api_error, api_detail) == (
+        core_mapping.status_code,
+        core_mapping.error_code,
+        core_mapping.detail,
+    )
+    assert [(error.key, error.message) for error in api_errors] == [
+        ("some.key", message)
+    ]

--- a/tldw_Server_API/tests/UserProfile/test_profile_query_service.py
+++ b/tldw_Server_API/tests/UserProfile/test_profile_query_service.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.UserProfiles.contracts import (
+    ProfileContractMode,
+    ProfileReadRequest,
+)
+from tldw_Server_API.app.core.UserProfiles.query_service import ProfileQueryService
+
+
+class _ProfileServiceStub:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def build_profile(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return {"user": {"id": kwargs["user"]["id"]}, "catalog_version": "test"}
+
+
+@pytest.mark.asyncio
+async def test_query_service_delegates_profile_read_request_to_user_profile_service() -> None:
+    profile_service = _ProfileServiceStub()
+    query_service = ProfileQueryService(profile_service)
+    request = ProfileReadRequest(
+        actor_user_id=11,
+        target_user_id=22,
+        sections=frozenset({"identity", "security"}),
+        include_sources=True,
+        include_raw=True,
+        mask_secrets=False,
+        contract_mode=ProfileContractMode.LEGACY_V1,
+    )
+    user = {"id": 22, "username": "target-user"}
+    security = {"mfa_enabled": False}
+
+    response = await query_service.build(
+        request,
+        user=user,
+        security=security,
+        metrics_scope="admin",
+    )
+
+    assert response == {"user": {"id": 22}, "catalog_version": "test"}
+    assert profile_service.calls == [
+        {
+            "user": user,
+            "sections": {"identity", "security"},
+            "security": security,
+            "include_sources": True,
+            "include_raw": True,
+            "mask_secrets": False,
+            "metrics_scope": "admin",
+        }
+    ]

--- a/tldw_Server_API/tests/UserProfile/test_profile_update_planner.py
+++ b/tldw_Server_API/tests/UserProfile/test_profile_update_planner.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.UserProfiles.contracts import (
+    ProfileContractMode,
+    ProfileUpdateCommand,
+)
+from tldw_Server_API.app.core.UserProfiles.planner import ProfileUpdatePlanner
+from tldw_Server_API.app.core.UserProfiles.update_service import (
+    ProfileUpdateScope,
+    UpdateResult,
+)
+
+
+@pytest.mark.asyncio
+async def test_planner_rejects_unknown_key_without_mutation() -> None:
+    planner = ProfileUpdatePlanner(db_pool=object())
+    command = ProfileUpdateCommand(
+        actor_user_id=7,
+        target_user_id=7,
+        updates=(("preferences.ui.missing", "paper"),),
+        roles=frozenset({"user"}),
+        dry_run=True,
+        contract_mode=ProfileContractMode.LEGACY_V1,
+    )
+
+    result = await planner.plan(
+        command,
+        db_conn=object(),
+        scope=ProfileUpdateScope(actor_user_id=7),
+    )
+
+    assert result.applied == []
+    assert result.skipped == [
+        {"key": "preferences.ui.missing", "message": "unknown_key"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_planner_accepts_preference_update_without_executing_write() -> None:
+    planner = ProfileUpdatePlanner(db_pool=object())
+    command = ProfileUpdateCommand(
+        actor_user_id=7,
+        target_user_id=7,
+        updates=(("preferences.ui.theme", "paper"),),
+        roles=frozenset({"user"}),
+        dry_run=True,
+        contract_mode=ProfileContractMode.LEGACY_V1,
+    )
+
+    result = await planner.plan(
+        command,
+        db_conn=object(),
+        scope=ProfileUpdateScope(actor_user_id=7),
+    )
+
+    assert result.applied == ["preferences.ui.theme"]
+    assert result.skipped == []
+
+
+@pytest.mark.asyncio
+async def test_planner_forces_dry_run_when_command_requests_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.UserProfiles import planner as planner_module
+
+    db_pool = object()
+    db_conn = object()
+    scope = ProfileUpdateScope(actor_user_id=7)
+    calls: list[dict[str, Any]] = []
+
+    class FakeUpdateService:
+        def __init__(self, db_pool: Any) -> None:
+            self._db_pool = db_pool
+
+        async def apply_updates(
+            self,
+            *,
+            user_id: int,
+            updates: tuple[tuple[str, Any], ...],
+            roles: set[str],
+            dry_run: bool,
+            db_conn: Any,
+            updated_by: int | None,
+            scope: ProfileUpdateScope | None,
+        ) -> UpdateResult:
+            calls.append(
+                {
+                    "db_pool": self._db_pool,
+                    "user_id": user_id,
+                    "updates": updates,
+                    "roles": roles,
+                    "dry_run": dry_run,
+                    "db_conn": db_conn,
+                    "updated_by": updated_by,
+                    "scope": scope,
+                }
+            )
+            return UpdateResult(applied=["preferences.ui.theme"])
+
+    monkeypatch.setattr(planner_module, "UserProfileUpdateService", FakeUpdateService)
+
+    command = ProfileUpdateCommand(
+        actor_user_id=7,
+        target_user_id=9,
+        updates=(("preferences.ui.theme", "paper"),),
+        roles=frozenset({"user"}),
+        dry_run=False,
+        contract_mode=ProfileContractMode.LEGACY_V1,
+    )
+
+    result = await ProfileUpdatePlanner(db_pool=db_pool).plan(
+        command,
+        db_conn=db_conn,
+        scope=scope,
+    )
+
+    assert result.applied == ["preferences.ui.theme"]
+    assert calls == [
+        {
+            "db_pool": db_pool,
+            "user_id": 9,
+            "updates": (("preferences.ui.theme", "paper"),),
+            "roles": {"user"},
+            "dry_run": True,
+            "db_conn": db_conn,
+            "updated_by": 7,
+            "scope": scope,
+        }
+    ]

--- a/tldw_Server_API/tests/UserProfile/test_user_profile_legacy_contract_characterization.py
+++ b/tldw_Server_API/tests/UserProfile/test_user_profile_legacy_contract_characterization.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.main import app
+
+
+def _current_user_id(client: TestClient, auth_headers) -> int:
+    response = client.get("/api/v1/users/me/profile", headers=auth_headers)
+    assert response.status_code == 200
+    return int(response.json()["user"]["id"])
+
+
+def test_legacy_self_update_returns_string_version_applied_and_empty_skipped(
+    auth_headers,
+) -> None:
+    with TestClient(app) as client:
+        response = client.patch(
+            "/api/v1/users/me/profile",
+            headers=auth_headers,
+            json={
+                "updates": [
+                    {"key": "preferences.ui.theme", "value": "legacy-contract"},
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload["profile_version"], str)
+    assert payload["applied"] == ["preferences.ui.theme"]
+    assert payload["skipped"] == []
+
+
+def test_legacy_self_update_with_valid_and_unknown_key_rejects_without_partial_apply(
+    auth_headers,
+) -> None:
+    rejected_value = "legacy-contract-rejected"
+
+    with TestClient(app) as client:
+        response = client.patch(
+            "/api/v1/users/me/profile",
+            headers=auth_headers,
+            json={
+                "updates": [
+                    {"key": "preferences.ui.theme", "value": rejected_value},
+                    {"key": "preferences.ui.missing", "value": "ignored"},
+                ],
+            },
+        )
+
+        profile_response = client.get(
+            "/api/v1/users/me/profile",
+            params={"sections": "preferences"},
+            headers=auth_headers,
+        )
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload["error_code"] == "profile_update_unknown_key"
+    assert payload["errors"] == [
+        {"key": "preferences.ui.missing", "message": "unknown_key"}
+    ]
+
+    assert profile_response.status_code == 200
+    preferences = profile_response.json().get("preferences", {})
+    assert preferences.get("preferences.ui.theme") != rejected_value
+
+
+def test_legacy_admin_update_returns_string_version_applied_and_empty_skipped(
+    auth_headers,
+) -> None:
+    with TestClient(app) as client:
+        user_id = _current_user_id(client, auth_headers)
+        response = client.patch(
+            f"/api/v1/admin/users/{user_id}/profile",
+            headers=auth_headers,
+            json={
+                "updates": [
+                    {"key": "limits.storage_quota_mb", "value": 4096},
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload["profile_version"], str)
+    assert payload["applied"] == ["limits.storage_quota_mb"]
+    assert payload["skipped"] == []
+
+
+def test_legacy_admin_update_with_stale_version_returns_version_mismatch_shape(
+    auth_headers,
+) -> None:
+    with TestClient(app) as client:
+        user_id = _current_user_id(client, auth_headers)
+        response = client.patch(
+            f"/api/v1/admin/users/{user_id}/profile",
+            headers=auth_headers,
+            json={
+                "profile_version": "2000-01-01T00:00:00Z",
+                "updates": [
+                    {"key": "limits.storage_quota_mb", "value": 4096},
+                ],
+            },
+        )
+
+    assert response.status_code == 409
+    payload = response.json()
+    assert payload["error_code"] == "profile_version_mismatch"
+    assert payload["errors"] == [
+        {"key": "profile_version", "message": "mismatch"}
+    ]

--- a/tldw_Server_API/tests/UserProfile/test_user_profile_updates.py
+++ b/tldw_Server_API/tests/UserProfile/test_user_profile_updates.py
@@ -2,11 +2,17 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
+import pytest
 from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.main import app
+from tldw_Server_API.app.api.v1.schemas.user_profile_schemas import (
+    UserProfileUpdateEntry,
+    UserProfileUpdateRequest,
+)
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.orgs_teams import (
     add_org_member,
     add_team_member,
@@ -16,6 +22,11 @@ from tldw_Server_API.app.core.AuthNZ.orgs_teams import (
     list_org_memberships_for_user,
 )
 from tldw_Server_API.app.core.AuthNZ.rate_limiter import get_rate_limiter
+from tldw_Server_API.app.core.UserProfiles import update_service as update_service_module
+from tldw_Server_API.app.core.UserProfiles.contracts import ProfileContractMode
+from tldw_Server_API.app.core.UserProfiles.response_mappers import (
+    LegacyProfileCommandResult,
+)
 
 
 def _run_async(coro):
@@ -61,6 +72,71 @@ def test_user_profile_update_preferences(auth_headers) -> None:
 
     assert profile.get("preferences", {}).get("preferences.ui.theme") == "paper"
     assert effective.get("effective_config", {}).get("preferences.ui.theme") == "paper"
+
+
+@pytest.mark.asyncio
+async def test_user_profile_override_writes_use_transaction_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_conn = object()
+    calls: list[tuple[str, str, object | None]] = []
+
+    class FakeOverridesRepo:
+        def __init__(self, db_pool) -> None:
+            self.db_pool = db_pool
+
+        async def ensure_tables(self) -> None:
+            return None
+
+        async def upsert_override(
+            self,
+            *,
+            user_id: int,
+            key: str,
+            value,
+            updated_by: int | None,
+            db_conn=None,
+        ) -> None:
+            calls.append(("upsert", key, db_conn))
+
+        async def delete_override(
+            self,
+            *,
+            user_id: int,
+            key: str,
+            db_conn=None,
+        ) -> None:
+            calls.append(("delete", key, db_conn))
+
+    monkeypatch.setattr(
+        update_service_module,
+        "UserProfileOverridesRepo",
+        FakeOverridesRepo,
+    )
+
+    result = await update_service_module.UserProfileUpdateService(
+        db_pool=object(),
+    ).apply_updates(
+        user_id=7,
+        updates=(
+            ("preferences.ui.theme", "paper"),
+            ("preferences.chat.default_character_id", None),
+        ),
+        roles={"user"},
+        dry_run=False,
+        db_conn=db_conn,
+        updated_by=7,
+    )
+
+    assert result.applied == [
+        "preferences.ui.theme",
+        "preferences.chat.default_character_id",
+    ]
+    assert result.skipped == []
+    assert calls == [
+        ("upsert", "preferences.ui.theme", db_conn),
+        ("delete", "preferences.chat.default_character_id", db_conn),
+    ]
 
 
 def test_user_profile_preferences_include_sources(auth_headers) -> None:
@@ -442,6 +518,103 @@ def test_user_profile_update_rejects_inactive_user(auth_headers, monkeypatch) ->
         )
 
     assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_user_profile_update_delegates_to_command_service(monkeypatch) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import users as users_endpoints
+
+    version = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    write_conn = object()
+    captured: dict[str, object] = {}
+
+    async def _fake_resolve_user_context(_principal, *, allow_missing: bool = False):
+        del allow_missing
+        return {
+            "id": 7,
+            "username": "delegated-user",
+            "email": "delegated@example.invalid",
+            "role": "user",
+            "is_active": True,
+            "is_verified": True,
+            "storage_quota_mb": 5120,
+            "storage_used_mb": 0.0,
+            "created_at": version,
+            "last_login": None,
+        }
+
+    async def _fake_pool():
+        return object()
+
+    class _CommandService:
+        def __init__(self, *, db_pool) -> None:
+            captured["db_pool"] = db_pool
+
+        async def apply(self, command, *, db_conn, scope):
+            captured["command"] = command
+            captured["db_conn"] = db_conn
+            captured["scope"] = scope
+            return LegacyProfileCommandResult(
+                profile_version=version,
+                applied=("preferences.ui.theme",),
+            )
+
+    class _DirectUpdateServiceTrap:
+        def __init__(self, *_args, **_kwargs) -> None:
+            raise AssertionError("route must delegate to ProfileCommandService")
+
+    async def _audit(*_args, **_kwargs) -> None:
+        captured["audit"] = _kwargs
+
+    monkeypatch.setattr(users_endpoints, "_resolve_user_context", _fake_resolve_user_context)
+    monkeypatch.setattr(users_endpoints, "get_db_pool", _fake_pool)
+    monkeypatch.setattr(users_endpoints, "ProfileCommandService", _CommandService, raising=False)
+    monkeypatch.setattr(
+        users_endpoints,
+        "UserProfileUpdateService",
+        _DirectUpdateServiceTrap,
+        raising=False,
+    )
+    monkeypatch.setattr(users_endpoints, "_emit_user_profile_audit_event", _audit)
+
+    principal = AuthPrincipal(
+        kind="user",
+        user_id=7,
+        username="delegated-user",
+        roles=["user"],
+        permissions=[],
+        is_admin=False,
+        org_ids=[],
+        team_ids=[],
+        active_org_id=None,
+        active_team_id=None,
+    )
+    payload = UserProfileUpdateRequest(
+        profile_version=version,
+        updates=[UserProfileUpdateEntry(key="preferences.ui.theme", value="paper")],
+    )
+
+    response = await users_endpoints.update_current_user_profile(
+        payload,
+        http_request=object(),
+        principal=principal,
+        db=write_conn,
+    )
+
+    command = captured["command"]
+    assert command.actor_user_id == 7
+    assert command.target_user_id == 7
+    assert command.updates == (("preferences.ui.theme", "paper"),)
+    assert command.roles == frozenset({"user"})
+    assert command.dry_run is False
+    assert command.expected_profile_version == version
+    assert command.contract_mode == ProfileContractMode.LEGACY_V1
+    assert captured["db_conn"] is write_conn
+    assert captured["scope"] is None
+    assert response.profile_version == version
+    assert response.applied == ["preferences.ui.theme"]
+    assert response.skipped == []
+    assert captured["audit"]["applied_count"] == 1
 
 
 def test_admin_profile_update_audio_limits(auth_headers) -> None:

--- a/tldw_Server_API/tests/UserProfile/test_user_profile_v2_contract.py
+++ b/tldw_Server_API/tests/UserProfile/test_user_profile_v2_contract.py
@@ -1,8 +1,44 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit
+from tldw_Server_API.app.api.v1.schemas.user_profile_schemas import (
+    UserProfileUpdateRequest,
+)
 from tldw_Server_API.app.main import app
+from tldw_Server_API.app.core.UserProfiles.response_mappers import (
+    LegacyProfileCommandResult,
+)
+
+from tldw_Server_API.app.api.v2.endpoints import user_profiles
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeCommandService:
+    def __init__(self, result: LegacyProfileCommandResult) -> None:
+        self.result = result
+        self.calls: list[dict[str, Any]] = []
+
+    async def apply(self, command, *, db_conn, scope):
+        self.calls.append({"command": command, "db_conn": db_conn, "scope": scope})
+        return self.result
+
+
+class _LoggerStub:
+    def __init__(self) -> None:
+        self.debugs: list[str] = []
+
+    def debug(self, message: str, *args, **kwargs) -> None:
+        self.debugs.append(message)
 
 
 def test_v2_single_update_has_no_skipped_field(auth_headers) -> None:
@@ -21,3 +57,97 @@ def test_v2_single_update_has_no_skipped_field(auth_headers) -> None:
     payload = response.json()
     assert payload["applied"] == ["preferences.ui.theme"]
     assert "skipped" not in payload
+
+
+def test_v2_profile_update_route_has_rate_limit_dependency() -> None:
+    route = next(
+        route
+        for route in user_profiles.router.routes
+        if isinstance(route, APIRoute) and route.path == "/users/me/profile"
+    )
+
+    assert check_rate_limit in [dependency.call for dependency in route.dependant.dependencies]
+
+
+@pytest.mark.asyncio
+async def test_v2_profile_update_uses_injected_command_service_and_structured_errors(
+    monkeypatch,
+) -> None:
+    async def _active_user(_principal):
+        return {"id": "7"}
+
+    monkeypatch.setattr(
+        user_profiles,
+        "_require_principal_active_verified",
+        _active_user,
+    )
+    command_service = _FakeCommandService(
+        LegacyProfileCommandResult(
+            status_code=422,
+            error_code="profile_update_invalid",
+            detail="One or more updates failed validation",
+            skipped=({"key": "identity.email", "message": "invalid_email"},),
+        )
+    )
+    db_conn = object()
+    payload = UserProfileUpdateRequest(
+        updates=[{"key": "identity.email", "value": "not-an-email"}]
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await user_profiles.update_current_user_profile_v2(
+            payload=payload,
+            http_request=SimpleNamespace(),
+            principal=object(),
+            db=db_conn,
+            command_service=command_service,
+        )
+
+    assert command_service.calls[0]["db_conn"] is db_conn
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == {
+        "error_code": "profile_update_invalid",
+        "detail": "One or more updates failed validation",
+        "errors": [{"key": "identity.email", "message": "invalid_email"}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_v2_profile_update_logs_audit_failure_without_failing(monkeypatch) -> None:
+    async def _active_user(_principal):
+        return {"id": "7"}
+
+    async def _failing_audit(*_args, **_kwargs) -> None:
+        raise AttributeError("audit backend exploded at /private/profile-audit.db")
+
+    monkeypatch.setattr(
+        user_profiles,
+        "_require_principal_active_verified",
+        _active_user,
+    )
+    monkeypatch.setattr(user_profiles, "_emit_user_profile_audit_event", _failing_audit)
+    logger_stub = _LoggerStub()
+    monkeypatch.setattr(user_profiles, "logger", logger_stub)
+    profile_version = datetime(2026, 1, 4, tzinfo=timezone.utc)
+    command_service = _FakeCommandService(
+        LegacyProfileCommandResult(
+            profile_version=profile_version,
+            applied=("preferences.ui.theme",),
+        )
+    )
+
+    response = await user_profiles.update_current_user_profile_v2(
+        payload=UserProfileUpdateRequest(
+            updates=[{"key": "preferences.ui.theme", "value": "paper"}]
+        ),
+        http_request=SimpleNamespace(),
+        principal=object(),
+        db=object(),
+        command_service=command_service,
+    )
+
+    assert response.profile_version == profile_version
+    assert response.applied == ["preferences.ui.theme"]
+    assert logger_stub.debugs == ["User profile v2 audit emission skipped"]
+    assert "audit backend exploded" not in str(logger_stub.debugs)
+    assert "/private/profile-audit.db" not in str(logger_stub.debugs)

--- a/tldw_Server_API/tests/UserProfile/test_user_profile_v2_contract.py
+++ b/tldw_Server_API/tests/UserProfile/test_user_profile_v2_contract.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.main import app
+
+
+def test_v2_single_update_has_no_skipped_field(auth_headers) -> None:
+    with TestClient(app) as client:
+        response = client.patch(
+            "/api/v2/users/me/profile",
+            headers=auth_headers,
+            json={
+                "updates": [
+                    {"key": "preferences.ui.theme", "value": "v2-contract"},
+                ]
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["applied"] == ["preferences.ui.theme"]
+    assert "skipped" not in payload


### PR DESCRIPTION
## Summary
- Adds typed UserProfiles read/update contracts plus planner, command/query, bulk command, effect, and response-mapping seams.
- Preserves legacy v1 response behavior through explicit compatibility mappers while adding a clean v2 profile update endpoint.
- Fixes override-backed profile updates to use the command transaction and documents v1/v2 compatibility.

## Verification
- `python -m pytest tldw_Server_API/tests/UserProfile tldw_Server_API/tests/AuthNZ/unit/test_user_profile_command_backend_selection.py -q` -> 115 passed, 2807 warnings.
- `python -m pytest tldw_Server_API/tests/AuthNZ_Postgres/test_user_profile_version_locking_pg.py -q -rs` -> 1 skipped, 9 warnings; PostgreSQL was unavailable after attempted Docker startup.
- `python -m bandit -r tldw_Server_API/app/core/UserProfiles tldw_Server_API/app/api/v1/endpoints/users.py tldw_Server_API/app/api/v1/utils/profile_errors.py tldw_Server_API/app/services/admin_profiles_service.py tldw_Server_API/app/api/v2 tldw_Server_API/app/main.py -f json -o /tmp/bandit_userprofiles_pr_worktree.json` -> 0 findings, 0 errors.
- Post-rebase spot check: `git diff --check origin/dev..HEAD && python -m pytest tldw_Server_API/tests/UserProfile/test_user_profile_v2_contract.py tldw_Server_API/tests/UserProfile/test_user_profile_updates.py::test_user_profile_override_writes_use_transaction_connection -q` -> 2 passed, 151 warnings.

## Notes
- This PR intentionally excludes local Backlog task files because they are absent on current `dev` and including them would resurrect local tracking records.
- Larger UserProfiles refactor brainstorming is deferred until this PR is merged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored UserProfiles to a contract-first flow and added a v2 profile update endpoint with atomic single-update semantics. Preserves v1 responses via mappers, stabilizes error taxonomy, hardens transaction/locking for override-backed writes, and updates published docs to clarify v1/v2 and bulk semantics.

- **New Features**
  - Added `api/v2` router and PATCH `/api/v2/users/me/profile`; atomic single-update responses with no `skipped`.
  - Introduced `ProfileCommandService`, `ProfileQueryService`, `ProfileUpdatePlanner`, `ProfileBulkCommandService`, and effect dispatcher under `tldw_Server_API.app.core.UserProfiles`.
  - Centralized a stable error taxonomy and mapping for profile updates; docs updated to clarify v1/v2 compatibility and bulk partial reporting.

- **Refactors**
  - v1 updates now use the contract-first flow and return legacy `applied`/`skipped` via mappers; legacy skip classification moved to core error mapping.
  - Override-backed writes use the transaction connection; profile version reads support row locking in Postgres.
  - Admin profile updates and bulk orchestration route through the command service; added tests for contracts, planner, command/query path, error mapping, bulk service, v2 endpoint, and Postgres version locking.

<sup>Written for commit 833a877d95b1353dcdaa47a5e555e820282f5547. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

