### PR TITLE
Harden infrastructure review follow-ups

### DIFF
--- a/backlog/tasks/task-12021 - Address-follow-up-infrastructure-and-security-review-findings.md
+++ b/backlog/tasks/task-12021 - Address-follow-up-infrastructure-and-security-review-findings.md
@@ -1,0 +1,90 @@
+---
+id: TASK-12021
+title: Address follow-up infrastructure and security review findings
+status: Done
+created_date: 2026-06-26 18:18
+labels:
+- backend
+- security
+- infrastructure
+- review-fix
+priority: high
+references:
+- tldw_Server_API/app/core/Infrastructure/distributed_lock.py
+- tldw_Server_API/app/core/Security/egress.py
+- tldw_Server_API/app/core/Infrastructure/redis_factory.py
+- tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
+modified_files:
+- tldw_Server_API/app/core/Infrastructure/distributed_lock.py
+- tldw_Server_API/app/core/Security/egress.py
+- tldw_Server_API/app/core/Infrastructure/redis_factory.py
+- tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
+- tldw_Server_API/tests/Infrastructure/test_distributed_lock.py
+- tldw_Server_API/tests/Security/test_egress.py
+- tldw_Server_API/tests/Infrastructure/test_redis_factory.py
+- tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py
+- tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py
+updated_date: 2026-06-26 18:23
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix follow-up code review findings in infrastructure and security hardening: file lock ownership races, bounded DNS resolver behavior, explicit Redis fake fallback policy, Redis migration lock exception handling, and embeddings tenant quota fail-closed behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 FileLock release cannot delete a newer active lock and has focused regression coverage.
+- [x] #2 FileLock residual files do not break native lock ownership and stale-file unlinking is not used for active locks.
+- [x] #3 acquire_migration_lock preserves exceptions raised inside the protected body while still failing closed on Redis setup errors.
+- [x] #4 Egress DNS timeout handling has bounded outstanding resolver work and focused regression coverage.
+- [x] #5 Redis factory fake fallback is explicit for production-sensitive callers and missing-package behavior has focused regression coverage.
+- [x] #6 Embeddings tenant RPS quota fails closed when Redis quota state is unavailable.
+- [x] #7 Focused tests, diff check, py_compile, and Bandit touched-scope scan are recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Port the reviewed fixes into a clean branch based on origin/dev. 2. Run focused regression tests and related suites in the clean worktree. 3. Run py_compile, diff hygiene, and Bandit on touched production files. 4. Mark the task Done with verification evidence before opening the PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Clean PR branch created from origin/dev at 6fe09bb972 in .worktrees/task-12021-followup-review-fixes.
+
+Implemented fixes:
+- FileLock keeps lock files as durable metadata and no longer unlinks them on normal release.
+- FileLock no longer attempts stale-file unlinking on failed acquisition; native platform locks determine ownership.
+- acquire_migration_lock already separated Redis setup errors from protected-body exceptions on the clean base; retained and verified that behavior.
+- Redis factory fake fallback is disabled by default for async and sync factories; callers must opt in explicitly.
+- Egress DNS resolution uses bounded resolver slots so stuck resolver calls cannot create unbounded outstanding work.
+- Embeddings tenant RPS quota fails closed with HTTP 503 and Retry-After when Redis quota state is unavailable.
+
+Verification in clean worktree:
+- Baseline before patch: `python -m pytest tldw_Server_API/tests/Infrastructure/test_distributed_lock.py tldw_Server_API/tests/Security/test_egress.py tldw_Server_API/tests/Infrastructure/test_redis_factory.py tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py tldw_Server_API/tests/test_minimal_deploy.py tldw_Server_API/tests/Resource_Governance/test_rg_fail_modes_across_categories.py -q` -> 49 passed.
+- After patch: `python -m pytest tldw_Server_API/tests/Infrastructure/test_distributed_lock.py tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py tldw_Server_API/tests/Security/test_egress.py tldw_Server_API/tests/Infrastructure/test_redis_factory.py tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py tldw_Server_API/tests/test_minimal_deploy.py tldw_Server_API/tests/Resource_Governance/test_rg_fail_modes_across_categories.py -q` -> 60 passed.
+- `python -m py_compile tldw_Server_API/app/core/Infrastructure/distributed_lock.py tldw_Server_API/app/core/Security/egress.py tldw_Server_API/app/core/Infrastructure/redis_factory.py tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py` -> passed.
+- `git diff --check -- ...touched files...` -> passed.
+- `python -m bandit -r tldw_Server_API/app/core/Infrastructure/distributed_lock.py tldw_Server_API/app/core/Security/egress.py tldw_Server_API/app/core/Infrastructure/redis_factory.py tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py -f json -o /tmp/bandit_task_12021_clean_pr.json` -> 0 errors, 0 findings.
+
+Documentation: no user-facing docs change needed; this is internal hardening.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created a clean PR branch from origin/dev and ported the TASK-12021 review fixes. The branch keeps file locks from unlinking active successors, preserves migration body exceptions, defaults Redis helper fallbacks to fail-closed behavior unless explicitly enabled, bounds egress DNS resolver work, and fails closed for embeddings tenant quota Redis outages. Focused tests, compile, diff hygiene, and Bandit all passed in the clean worktree.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12021 - Address-follow-up-infrastructure-and-security-review-findings.md
+++ b/backlog/tasks/task-12021 - Address-follow-up-infrastructure-and-security-review-findings.md
@@ -26,7 +26,7 @@ modified_files:
 - tldw_Server_API/tests/Infrastructure/test_redis_factory.py
 - tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py
 - tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py
-updated_date: 2026-06-26 21:52
+updated_date: 2026-06-26 22:22
 ---
 
 ## Description
@@ -78,12 +78,27 @@ Verification in clean worktree:
 - `python -m bandit -r tldw_Server_API/app/core/Infrastructure/distributed_lock.py tldw_Server_API/app/core/Security/egress.py tldw_Server_API/app/core/Infrastructure/redis_factory.py tldw_Server_API/app/api/v1/API_Deps/backpressure.py tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py -f json -o /tmp/bandit_task_12021_pr_comments.json` -> 0 errors, 0 findings.
 
 Known skips/blockers: None.
+Reopened for latest PR issue pass: Qodo still flags ingest quota warning as insufficiently structured, and added a README contract-test brittleness recommendation. Also restore PR draft state after pushing because the human-authored change summary gate remains.
+Latest PR issue pass addressed after user request to address all PR issues:
+- Changed ingest tenant quota Redis-unavailable warning to use Loguru bound structured fields for tenant_id, exception_type, and event, while retaining exception traceback context via logger.opt(exception=exc).
+- Mirrored the structured warning pattern on embeddings tenant quota Redis-unavailable logging for consistency.
+- Made the Redis factory README contract test resilient to harmless formatting changes by using regex checks for documented explicit fallback examples rather than exact snippet strings.
+- Extended the ingest quota fail-closed regression test to assert structured log context and exception capture.
+
+Latest verification:
+- `python -m pytest tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py::test_ingest_tenant_quota_fails_closed_when_redis_unavailable tldw_Server_API/tests/Infrastructure/test_redis_factory.py::test_redis_factory_readme_documents_fail_closed_defaults -q` -> 2 passed.
+- `python -m pytest tldw_Server_API/tests/Infrastructure/test_distributed_lock.py tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py tldw_Server_API/tests/Security/test_egress.py tldw_Server_API/tests/Infrastructure/test_redis_factory.py tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py tldw_Server_API/tests/test_minimal_deploy.py tldw_Server_API/tests/Resource_Governance/test_rg_fail_modes_across_categories.py -q` -> 63 passed.
+- `python -m py_compile tldw_Server_API/app/api/v1/API_Deps/backpressure.py tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py tldw_Server_API/app/core/Infrastructure/redis_factory.py` -> passed.
+- `git diff --check -- ...latest touched files...` -> passed.
+- `python -m bandit -r tldw_Server_API/app/api/v1/API_Deps/backpressure.py tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py -f json -o /tmp/bandit_task_12021_all_pr_issues.json` -> 0 errors, 0 findings.
+
+Remaining external state at start of this pass: GitHub full-suite checks had many pending shards; no local code change was made for pending-only checks. CodeRabbit docstring coverage warning appears global/non-actionable for this narrow PR. PR must remain draft until the human-authored change summary gate is satisfied.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Created a clean PR branch from origin/dev, ported the TASK-12021 review fixes, and addressed the latest PR review comments. The branch keeps file locks from unlinking active successors, removes now-unused FileLock metadata writes, verifies the existing clean-base migration-lock body-exception behavior, defaults Redis helper fallbacks to fail-closed behavior unless explicitly enabled, makes egress DNS saturation observable/configurable, fails closed for embeddings and ingest tenant quota Redis outages with contextual warning logs, and updates Redis factory docs/tests to match the fallback contract. Focused tests, compile, diff hygiene, and Bandit all passed in the clean worktree.
+Created a clean PR branch from origin/dev, ported the TASK-12021 review fixes, addressed the latest PR review comments, and completed the follow-up all-issues pass. The branch keeps file locks from unlinking active successors, removes now-unused FileLock metadata writes, verifies the existing clean-base migration-lock body-exception behavior, defaults Redis helper fallbacks to fail-closed behavior unless explicitly enabled, makes egress DNS saturation observable/configurable, fails closed for embeddings and ingest tenant quota Redis outages with structured contextual warning logs, and updates Redis factory docs/tests to match the fallback contract without brittle exact-snippet assertions. Focused tests, compile, diff hygiene, and Bandit all passed in the clean worktree.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12021 - Address-follow-up-infrastructure-and-security-review-findings.md
+++ b/backlog/tasks/task-12021 - Address-follow-up-infrastructure-and-security-review-findings.md
@@ -26,7 +26,7 @@ modified_files:
 - tldw_Server_API/tests/Infrastructure/test_redis_factory.py
 - tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py
 - tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py
-updated_date: 2026-06-26 22:33
+updated_date: 2026-06-26 22:40
 ---
 
 ## Description
@@ -106,12 +106,23 @@ Latest verification after these changes:
 - `python -m py_compile tldw_Server_API/app/core/Security/egress.py` -> passed.
 - `git diff --check -- tldw_Server_API/app/core/Security/egress.py tldw_Server_API/tests/Security/test_egress.py backlog/tasks/task-12021\ -\ Address-follow-up-infrastructure-and-security-review-findings.md` -> passed.
 - `python -m bandit -r tldw_Server_API/app/core/Security/egress.py -f json -o /tmp/bandit_task_12021_egress_final.json` -> 0 errors, 0 findings.
+Reopened for scoped PR pre-merge docstring warning pass. The remaining CodeRabbit warning is broad docstring coverage; apply concise docstrings only to new helper/test constructs introduced by this PR, avoiding unrelated repository-wide docstring churn.
+Scoped docstring warning pass:
+- Added concise docstrings to new egress DNS helper functions, the blocking resolver worker, new regression tests, and captured-logger fakes introduced by this PR.
+- Did not perform unrelated repository-wide docstring churn.
+
+Verification after docstring pass:
+- `python -m pytest tldw_Server_API/tests/Infrastructure/test_distributed_lock.py tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py tldw_Server_API/tests/Security/test_egress.py tldw_Server_API/tests/Infrastructure/test_redis_factory.py tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py tldw_Server_API/tests/test_minimal_deploy.py tldw_Server_API/tests/Resource_Governance/test_rg_fail_modes_across_categories.py -q` -> 65 passed.
+- `python -m py_compile tldw_Server_API/app/core/Security/egress.py tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py tldw_Server_API/tests/Infrastructure/test_distributed_lock.py tldw_Server_API/tests/Infrastructure/test_redis_factory.py tldw_Server_API/tests/Security/test_egress.py` -> passed.
+- `git diff --check -- ...latest touched files...` -> passed.
+- `python -m ruff check tldw_Server_API/app/core/Security/egress.py tldw_Server_API/tests/Security/test_egress.py` -> passed.
+- `python -m bandit -r tldw_Server_API/app/core/Security/egress.py -f json -o /tmp/bandit_task_12021_docstring_pass.json` -> 0 errors, 0 findings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Created a clean PR branch from origin/dev, ported the TASK-12021 review fixes, and addressed the latest PR review comments through the egress DNS follow-up pass. The branch keeps file locks from unlinking active successors, verifies clean-base migration-lock body-exception behavior, defaults Redis helper fallbacks to fail-closed behavior unless explicitly enabled, fails closed for embeddings and ingest tenant quota Redis outages with structured contextual warning logs, updates Redis factory docs/tests to match the fallback contract without brittle exact-snippet assertions, and hardens egress DNS handling with structured logs, finite config validation, and timeout budgeting that accounts for resolver-slot wait time. Focused tests, Ruff, compile, diff hygiene, and Bandit passed in the clean worktree.
+Created a clean PR branch from origin/dev, ported the TASK-12021 review fixes, and addressed PR review comments through the egress DNS and docstring follow-up passes. The branch keeps file locks from unlinking active successors, verifies clean-base migration-lock body-exception behavior, defaults Redis helper fallbacks to fail-closed behavior unless explicitly enabled, fails closed for embeddings and ingest tenant quota Redis outages with structured contextual warning logs, updates Redis factory docs/tests to match the fallback contract without brittle exact-snippet assertions, hardens egress DNS handling with structured logs, finite config validation, and timeout budgeting that accounts for resolver-slot wait time, and adds concise docstrings to new helper/regression constructs introduced by the PR. Focused tests, Ruff, compile, diff hygiene, and Bandit passed in the clean worktree.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12021 - Address-follow-up-infrastructure-and-security-review-findings.md
+++ b/backlog/tasks/task-12021 - Address-follow-up-infrastructure-and-security-review-findings.md
@@ -18,13 +18,15 @@ modified_files:
 - tldw_Server_API/app/core/Infrastructure/distributed_lock.py
 - tldw_Server_API/app/core/Security/egress.py
 - tldw_Server_API/app/core/Infrastructure/redis_factory.py
+- tldw_Server_API/app/core/Infrastructure/README.md
+- tldw_Server_API/app/api/v1/API_Deps/backpressure.py
 - tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
 - tldw_Server_API/tests/Infrastructure/test_distributed_lock.py
 - tldw_Server_API/tests/Security/test_egress.py
 - tldw_Server_API/tests/Infrastructure/test_redis_factory.py
 - tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py
 - tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py
-updated_date: 2026-06-26 18:23
+updated_date: 2026-06-26 18:45
 ---
 
 ## Description
@@ -71,12 +73,30 @@ Verification in clean worktree:
 - `python -m bandit -r tldw_Server_API/app/core/Infrastructure/distributed_lock.py tldw_Server_API/app/core/Security/egress.py tldw_Server_API/app/core/Infrastructure/redis_factory.py tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py -f json -o /tmp/bandit_task_12021_clean_pr.json` -> 0 errors, 0 findings.
 
 Documentation: no user-facing docs change needed; this is internal hardening.
+Reopened after self-review before merge. Review follow-up items:
+- Ingest tenant quota path must convert Redis quota outages into controlled 503 responses after Redis fallback default changed to fail closed.
+- Redis factory README must reflect fallback_to_fake=False defaults and explicit opt-in examples.
+- Remove unused FileLock instance owner token state while retaining lock-file owner token metadata.
+Addressed all self-review findings before continuing:
+- Added red regression test for ingest tenant quota Redis outage; confirmed it failed with raw RuntimeError before the fix.
+- Added red README contract test for Redis factory fail-closed defaults and explicit fallback opt-in example; confirmed it failed before the docs update.
+- Changed ingest quota enforcement to raise controlled HTTP 503 with Retry-After when Redis quota state is unavailable.
+- Updated Infrastructure Redis factory README to document fallback_to_fake=False defaults and explicit fallback_to_fake=True examples.
+- Removed unused FileLock `_owner_token` instance state while retaining per-acquire token metadata in the lock file.
+
+Review follow-up verification:
+- Red run: `python -m pytest tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py::test_ingest_tenant_quota_fails_closed_when_redis_unavailable tldw_Server_API/tests/Infrastructure/test_redis_factory.py::test_redis_factory_readme_documents_fail_closed_defaults -q` -> 2 failed for expected reasons.
+- Green focused run: same command -> 2 passed.
+- Full focused run: `python -m pytest tldw_Server_API/tests/Infrastructure/test_distributed_lock.py tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py tldw_Server_API/tests/Security/test_egress.py tldw_Server_API/tests/Infrastructure/test_redis_factory.py tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py tldw_Server_API/tests/test_minimal_deploy.py tldw_Server_API/tests/Resource_Governance/test_rg_fail_modes_across_categories.py -q` -> 62 passed.
+- `python -m py_compile tldw_Server_API/app/core/Infrastructure/distributed_lock.py tldw_Server_API/app/core/Security/egress.py tldw_Server_API/app/core/Infrastructure/redis_factory.py tldw_Server_API/app/api/v1/API_Deps/backpressure.py tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py` -> passed.
+- `git diff --check -- ...touched files...` -> passed.
+- `python -m bandit -r tldw_Server_API/app/core/Infrastructure/distributed_lock.py tldw_Server_API/app/core/Security/egress.py tldw_Server_API/app/core/Infrastructure/redis_factory.py tldw_Server_API/app/api/v1/API_Deps/backpressure.py tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py -f json -o /tmp/bandit_task_12021_review_followup.json` -> 0 errors, 0 findings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Created a clean PR branch from origin/dev and ported the TASK-12021 review fixes. The branch keeps file locks from unlinking active successors, preserves migration body exceptions, defaults Redis helper fallbacks to fail-closed behavior unless explicitly enabled, bounds egress DNS resolver work, and fails closed for embeddings tenant quota Redis outages. Focused tests, compile, diff hygiene, and Bandit all passed in the clean worktree.
+Created a clean PR branch from origin/dev, ported the TASK-12021 review fixes, and addressed the follow-up self-review findings. The branch keeps file locks from unlinking active successors, preserves migration body exceptions, defaults Redis helper fallbacks to fail-closed behavior unless explicitly enabled, bounds egress DNS resolver work, fails closed for embeddings and ingest tenant quota Redis outages, and updates Redis factory docs to match the new fallback contract. Focused tests, compile, diff hygiene, and Bandit all passed in the clean worktree.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12021 - Address-follow-up-infrastructure-and-security-review-findings.md
+++ b/backlog/tasks/task-12021 - Address-follow-up-infrastructure-and-security-review-findings.md
@@ -26,13 +26,13 @@ modified_files:
 - tldw_Server_API/tests/Infrastructure/test_redis_factory.py
 - tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py
 - tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py
-updated_date: 2026-06-26 18:45
+updated_date: 2026-06-26 21:52
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Fix follow-up code review findings in infrastructure and security hardening: file lock ownership races, bounded DNS resolver behavior, explicit Redis fake fallback policy, Redis migration lock exception handling, and embeddings tenant quota fail-closed behavior.
+Fix follow-up code review findings in infrastructure and security hardening: file lock ownership races, bounded DNS resolver behavior, explicit Redis fake fallback policy, and embeddings/ingest tenant quota fail-closed behavior. Verify the existing Redis migration-lock exception handling on the clean base.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -58,45 +58,32 @@ Fix follow-up code review findings in infrastructure and security hardening: fil
 Clean PR branch created from origin/dev at 6fe09bb972 in .worktrees/task-12021-followup-review-fixes.
 
 Implemented fixes:
-- FileLock keeps lock files as durable metadata and no longer unlinks them on normal release.
+- FileLock keeps lock files in place on normal release so a prior owner cannot unlink a newer active lock.
 - FileLock no longer attempts stale-file unlinking on failed acquisition; native platform locks determine ownership.
-- acquire_migration_lock already separated Redis setup errors from protected-body exceptions on the clean base; retained and verified that behavior.
+- FileLock acquisition no longer rewrites PID/UUID metadata or fsyncs the lock file because that metadata is not used for ownership after stale unlinking was removed.
+- acquire_migration_lock already separated Redis setup errors from protected-body exceptions on the clean base; this task verified that existing behavior.
 - Redis factory fake fallback is disabled by default for async and sync factories; callers must opt in explicitly.
-- Egress DNS resolution uses bounded resolver slots so stuck resolver calls cannot create unbounded outstanding work.
-- Embeddings tenant RPS quota fails closed with HTTP 503 and Retry-After when Redis quota state is unavailable.
+- Egress DNS resolution bounds outstanding resolver work, defaults the cap to 64, allows WORKFLOWS_EGRESS_DNS_MAX_OUTSTANDING and WORKFLOWS_EGRESS_DNS_SLOT_WAIT_SECONDS overrides, waits briefly for a slot, and logs slot exhaustion, timeouts, worker-start failures, and resolver errors.
+- Embeddings and ingest tenant RPS quota paths fail closed with HTTP 503 and Retry-After when Redis quota state is unavailable, with safe tenant/user/request context and exception details in warning logs.
+- New/modified tests were adjusted to use approved unit markers and typed signatures where review comments flagged policy issues.
 
 Verification in clean worktree:
 - Baseline before patch: `python -m pytest tldw_Server_API/tests/Infrastructure/test_distributed_lock.py tldw_Server_API/tests/Security/test_egress.py tldw_Server_API/tests/Infrastructure/test_redis_factory.py tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py tldw_Server_API/tests/test_minimal_deploy.py tldw_Server_API/tests/Resource_Governance/test_rg_fail_modes_across_categories.py -q` -> 49 passed.
-- After patch: `python -m pytest tldw_Server_API/tests/Infrastructure/test_distributed_lock.py tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py tldw_Server_API/tests/Security/test_egress.py tldw_Server_API/tests/Infrastructure/test_redis_factory.py tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py tldw_Server_API/tests/test_minimal_deploy.py tldw_Server_API/tests/Resource_Governance/test_rg_fail_modes_across_categories.py -q` -> 60 passed.
-- `python -m py_compile tldw_Server_API/app/core/Infrastructure/distributed_lock.py tldw_Server_API/app/core/Security/egress.py tldw_Server_API/app/core/Infrastructure/redis_factory.py tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py` -> passed.
-- `git diff --check -- ...touched files...` -> passed.
-- `python -m bandit -r tldw_Server_API/app/core/Infrastructure/distributed_lock.py tldw_Server_API/app/core/Security/egress.py tldw_Server_API/app/core/Infrastructure/redis_factory.py tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py -f json -o /tmp/bandit_task_12021_clean_pr.json` -> 0 errors, 0 findings.
-
-Documentation: no user-facing docs change needed; this is internal hardening.
-Reopened after self-review before merge. Review follow-up items:
-- Ingest tenant quota path must convert Redis quota outages into controlled 503 responses after Redis fallback default changed to fail closed.
-- Redis factory README must reflect fallback_to_fake=False defaults and explicit opt-in examples.
-- Remove unused FileLock instance owner token state while retaining lock-file owner token metadata.
-Addressed all self-review findings before continuing:
-- Added red regression test for ingest tenant quota Redis outage; confirmed it failed with raw RuntimeError before the fix.
-- Added red README contract test for Redis factory fail-closed defaults and explicit fallback opt-in example; confirmed it failed before the docs update.
-- Changed ingest quota enforcement to raise controlled HTTP 503 with Retry-After when Redis quota state is unavailable.
-- Updated Infrastructure Redis factory README to document fallback_to_fake=False defaults and explicit fallback_to_fake=True examples.
-- Removed unused FileLock `_owner_token` instance state while retaining per-acquire token metadata in the lock file.
-
-Review follow-up verification:
-- Red run: `python -m pytest tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py::test_ingest_tenant_quota_fails_closed_when_redis_unavailable tldw_Server_API/tests/Infrastructure/test_redis_factory.py::test_redis_factory_readme_documents_fail_closed_defaults -q` -> 2 failed for expected reasons.
-- Green focused run: same command -> 2 passed.
-- Full focused run: `python -m pytest tldw_Server_API/tests/Infrastructure/test_distributed_lock.py tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py tldw_Server_API/tests/Security/test_egress.py tldw_Server_API/tests/Infrastructure/test_redis_factory.py tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py tldw_Server_API/tests/test_minimal_deploy.py tldw_Server_API/tests/Resource_Governance/test_rg_fail_modes_across_categories.py -q` -> 62 passed.
+- Initial clean-branch patch: focused suite -> 60 passed.
+- Self-review follow-up: targeted red run for ingest quota outage and README contract -> 2 failed for expected reasons before fixes; green run -> 2 passed; full focused suite -> 62 passed.
+- Latest PR comment pass targeted tests: `python -m pytest ...review-comment-focused test selection... -q` -> 8 passed.
+- Latest PR comment pass full focused suite: `python -m pytest tldw_Server_API/tests/Infrastructure/test_distributed_lock.py tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py tldw_Server_API/tests/Security/test_egress.py tldw_Server_API/tests/Infrastructure/test_redis_factory.py tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py tldw_Server_API/tests/test_minimal_deploy.py tldw_Server_API/tests/Resource_Governance/test_rg_fail_modes_across_categories.py -q` -> 63 passed.
 - `python -m py_compile tldw_Server_API/app/core/Infrastructure/distributed_lock.py tldw_Server_API/app/core/Security/egress.py tldw_Server_API/app/core/Infrastructure/redis_factory.py tldw_Server_API/app/api/v1/API_Deps/backpressure.py tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py` -> passed.
 - `git diff --check -- ...touched files...` -> passed.
-- `python -m bandit -r tldw_Server_API/app/core/Infrastructure/distributed_lock.py tldw_Server_API/app/core/Security/egress.py tldw_Server_API/app/core/Infrastructure/redis_factory.py tldw_Server_API/app/api/v1/API_Deps/backpressure.py tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py -f json -o /tmp/bandit_task_12021_review_followup.json` -> 0 errors, 0 findings.
+- `python -m bandit -r tldw_Server_API/app/core/Infrastructure/distributed_lock.py tldw_Server_API/app/core/Security/egress.py tldw_Server_API/app/core/Infrastructure/redis_factory.py tldw_Server_API/app/api/v1/API_Deps/backpressure.py tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py -f json -o /tmp/bandit_task_12021_pr_comments.json` -> 0 errors, 0 findings.
+
+Known skips/blockers: None.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Created a clean PR branch from origin/dev, ported the TASK-12021 review fixes, and addressed the follow-up self-review findings. The branch keeps file locks from unlinking active successors, preserves migration body exceptions, defaults Redis helper fallbacks to fail-closed behavior unless explicitly enabled, bounds egress DNS resolver work, fails closed for embeddings and ingest tenant quota Redis outages, and updates Redis factory docs to match the new fallback contract. Focused tests, compile, diff hygiene, and Bandit all passed in the clean worktree.
+Created a clean PR branch from origin/dev, ported the TASK-12021 review fixes, and addressed the latest PR review comments. The branch keeps file locks from unlinking active successors, removes now-unused FileLock metadata writes, verifies the existing clean-base migration-lock body-exception behavior, defaults Redis helper fallbacks to fail-closed behavior unless explicitly enabled, makes egress DNS saturation observable/configurable, fails closed for embeddings and ingest tenant quota Redis outages with contextual warning logs, and updates Redis factory docs/tests to match the fallback contract. Focused tests, compile, diff hygiene, and Bandit all passed in the clean worktree.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-12021 - Address-follow-up-infrastructure-and-security-review-findings.md
+++ b/backlog/tasks/task-12021 - Address-follow-up-infrastructure-and-security-review-findings.md
@@ -26,7 +26,7 @@ modified_files:
 - tldw_Server_API/tests/Infrastructure/test_redis_factory.py
 - tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py
 - tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py
-updated_date: 2026-06-26 22:22
+updated_date: 2026-06-26 22:33
 ---
 
 ## Description
@@ -93,12 +93,25 @@ Latest verification:
 - `python -m bandit -r tldw_Server_API/app/api/v1/API_Deps/backpressure.py tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py -f json -o /tmp/bandit_task_12021_all_pr_issues.json` -> 0 errors, 0 findings.
 
 Remaining external state at start of this pass: GitHub full-suite checks had many pending shards; no local code change was made for pending-only checks. CodeRabbit docstring coverage warning appears global/non-actionable for this narrow PR. PR must remain draft until the human-authored change summary gate is satisfied.
+Reopened again after Qodo posted new egress DNS comments on commit 0791e67cfa: structure DNS warning logs with bound fields, keep total DNS timeout within timeout_s when waiting for resolver slots, and reject NaN/inf slot-wait configuration.
+Latest egress DNS PR issue pass:
+- Replaced remaining DNS warning/debug log calls in egress resolver helpers with bound structured Loguru context for config validation, slot exhaustion, timeout budget exhaustion, timeouts, worker-start failure, slot release failure, and resolver errors.
+- Rejected non-finite DNS timeout and slot-wait values so NaN/inf configuration cannot bypass timeout budgeting.
+- Bounded total DNS resolution wall-clock budget by subtracting resolver-slot wait/elapsed time before joining the resolver worker.
+- Added/updated egress regressions for structured DNS log context, NaN slot-wait fallback, and slot-wait-aware join timeout budgeting.
+
+Latest verification after these changes:
+- `python -m pytest tldw_Server_API/tests/Infrastructure/test_distributed_lock.py tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py tldw_Server_API/tests/Security/test_egress.py tldw_Server_API/tests/Infrastructure/test_redis_factory.py tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py tldw_Server_API/tests/test_minimal_deploy.py tldw_Server_API/tests/Resource_Governance/test_rg_fail_modes_across_categories.py -q` -> 65 passed.
+- `python -m ruff check tldw_Server_API/app/core/Security/egress.py tldw_Server_API/tests/Security/test_egress.py` -> passed.
+- `python -m py_compile tldw_Server_API/app/core/Security/egress.py` -> passed.
+- `git diff --check -- tldw_Server_API/app/core/Security/egress.py tldw_Server_API/tests/Security/test_egress.py backlog/tasks/task-12021\ -\ Address-follow-up-infrastructure-and-security-review-findings.md` -> passed.
+- `python -m bandit -r tldw_Server_API/app/core/Security/egress.py -f json -o /tmp/bandit_task_12021_egress_final.json` -> 0 errors, 0 findings.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Created a clean PR branch from origin/dev, ported the TASK-12021 review fixes, addressed the latest PR review comments, and completed the follow-up all-issues pass. The branch keeps file locks from unlinking active successors, removes now-unused FileLock metadata writes, verifies the existing clean-base migration-lock body-exception behavior, defaults Redis helper fallbacks to fail-closed behavior unless explicitly enabled, makes egress DNS saturation observable/configurable, fails closed for embeddings and ingest tenant quota Redis outages with structured contextual warning logs, and updates Redis factory docs/tests to match the fallback contract without brittle exact-snippet assertions. Focused tests, compile, diff hygiene, and Bandit all passed in the clean worktree.
+Created a clean PR branch from origin/dev, ported the TASK-12021 review fixes, and addressed the latest PR review comments through the egress DNS follow-up pass. The branch keeps file locks from unlinking active successors, verifies clean-base migration-lock body-exception behavior, defaults Redis helper fallbacks to fail-closed behavior unless explicitly enabled, fails closed for embeddings and ingest tenant quota Redis outages with structured contextual warning logs, updates Redis factory docs/tests to match the fallback contract without brittle exact-snippet assertions, and hardens egress DNS handling with structured logs, finite config validation, and timeout budgeting that accounts for resolver-slot wait time. Focused tests, Ruff, compile, diff hygiene, and Bandit passed in the clean worktree.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/API_Deps/backpressure.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/backpressure.py
@@ -200,6 +200,13 @@ async def guard_backpressure_and_quota(
                     response.headers["X-RateLimit-Remaining"] = str(remaining)
                 except _BACKPRESSURE_NONCRITICAL_EXCEPTIONS:
                     pass
+        except _BACKPRESSURE_NONCRITICAL_EXCEPTIONS as exc:
+            logger.warning("Ingest tenant quota Redis unavailable; failing closed")
+            raise HTTPException(
+                status_code=503,
+                detail="Tenant quota temporarily unavailable",
+                headers={"Retry-After": "1"},
+            ) from exc
         finally:
             try:
                 if client2 is not None:

--- a/tldw_Server_API/app/api/v1/API_Deps/backpressure.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/backpressure.py
@@ -202,10 +202,11 @@ async def guard_backpressure_and_quota(
                     pass
         except _BACKPRESSURE_NONCRITICAL_EXCEPTIONS as exc:
             tenant_id = getattr(current_user, "id", "anon")
-            logger.opt(exception=exc).warning(
-                "Ingest tenant quota Redis unavailable for tenant_id={}; failing closed",
-                tenant_id,
-            )
+            logger.bind(
+                tenant_id=str(tenant_id),
+                exception_type=type(exc).__name__,
+                event="ingest_tenant_quota_redis_unavailable",
+            ).opt(exception=exc).warning("Ingest tenant quota Redis unavailable; failing closed")
             raise HTTPException(
                 status_code=503,
                 detail="Tenant quota temporarily unavailable",

--- a/tldw_Server_API/app/api/v1/API_Deps/backpressure.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/backpressure.py
@@ -201,7 +201,11 @@ async def guard_backpressure_and_quota(
                 except _BACKPRESSURE_NONCRITICAL_EXCEPTIONS:
                     pass
         except _BACKPRESSURE_NONCRITICAL_EXCEPTIONS as exc:
-            logger.warning("Ingest tenant quota Redis unavailable; failing closed")
+            tenant_id = getattr(current_user, "id", "anon")
+            logger.opt(exception=exc).warning(
+                "Ingest tenant quota Redis unavailable for tenant_id={}; failing closed",
+                tenant_id,
+            )
             raise HTTPException(
                 status_code=503,
                 detail="Tenant quota temporarily unavailable",

--- a/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
+++ b/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
@@ -567,8 +567,9 @@ async def _check_backpressure_and_quotas(request: Request, user: User) -> HTTPEx
         tenant_rps = _tenant_rps_runtime()
 
         if _should_enforce_tenant_rps(request) and tenant_rps > 0:
-            client2 = await _get_redis_client()
+            client2 = None
             try:
+                client2 = await _get_redis_client()
                 # Use a single rolling key with 1-second TTL to avoid flakiness across second boundaries
                 key = f"embeddings:tenant:rps:{getattr(user, 'id', 'anon')}"
                 current = await client2.incr(key)
@@ -587,9 +588,15 @@ async def _check_backpressure_and_quotas(request: Request, user: User) -> HTTPEx
                             pass
             finally:
                 with suppress(_EMBEDDINGS_NONCRITICAL_EXCEPTIONS):
-                    await ensure_async_client_closed(client2)
+                    if client2 is not None:
+                        await ensure_async_client_closed(client2)
     except _EMBEDDINGS_NONCRITICAL_EXCEPTIONS:
-        pass
+        logger.warning("Embeddings tenant quota Redis unavailable; failing closed")
+        return HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Tenant quota temporarily unavailable",
+            headers={"Retry-After": "1"},
+        )
     return None
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
+++ b/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
@@ -590,8 +590,15 @@ async def _check_backpressure_and_quotas(request: Request, user: User) -> HTTPEx
                 with suppress(_EMBEDDINGS_NONCRITICAL_EXCEPTIONS):
                     if client2 is not None:
                         await ensure_async_client_closed(client2)
-    except _EMBEDDINGS_NONCRITICAL_EXCEPTIONS:
-        logger.warning("Embeddings tenant quota Redis unavailable; failing closed")
+    except _EMBEDDINGS_NONCRITICAL_EXCEPTIONS as exc:
+        user_id = getattr(user, "id", "anon")
+        request_state = getattr(request, "state", None)
+        request_id = getattr(request_state, "request_id", None)
+        logger.opt(exception=exc).warning(
+            "Embeddings tenant quota Redis unavailable for user_id={} request_id={}; failing closed",
+            user_id,
+            request_id,
+        )
         return HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Tenant quota temporarily unavailable",

--- a/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
+++ b/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
@@ -594,11 +594,12 @@ async def _check_backpressure_and_quotas(request: Request, user: User) -> HTTPEx
         user_id = getattr(user, "id", "anon")
         request_state = getattr(request, "state", None)
         request_id = getattr(request_state, "request_id", None)
-        logger.opt(exception=exc).warning(
-            "Embeddings tenant quota Redis unavailable for user_id={} request_id={}; failing closed",
-            user_id,
-            request_id,
-        )
+        logger.bind(
+            user_id=str(user_id),
+            request_id=str(request_id) if request_id is not None else None,
+            exception_type=type(exc).__name__,
+            event="embeddings_tenant_quota_redis_unavailable",
+        ).opt(exception=exc).warning("Embeddings tenant quota Redis unavailable; failing closed")
         return HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Tenant quota temporarily unavailable",

--- a/tldw_Server_API/app/core/Infrastructure/README.md
+++ b/tldw_Server_API/app/core/Infrastructure/README.md
@@ -26,8 +26,8 @@ Centralized helpers for shared runtime infrastructure. Today this module focuses
   - Factory resolves the URL (config/env precedence), attempts to connect/ping real Redis, and records metrics.
   - On failure (or if redis is not installed) and when `fallback_to_fake=True`, it returns an in‑memory stub implementing the subset of Redis features used by the application.
 - Key Classes/Functions (entry points):
-  - `create_async_redis_client(preferred_url=None, decode_responses=True, fallback_to_fake=True, context="default", redis_kwargs=None)`
-  - `create_sync_redis_client(preferred_url=None, decode_responses=True, fallback_to_fake=True, context="default", redis_kwargs=None)`
+  - `create_async_redis_client(preferred_url=None, decode_responses=True, fallback_to_fake=False, context="default", redis_kwargs=None)`
+  - `create_sync_redis_client(preferred_url=None, decode_responses=True, fallback_to_fake=False, context="default", redis_kwargs=None)`
   - `ensure_async_client_closed(client)`, `ensure_sync_client_closed(client)`
   - In‑memory clients: `InMemoryAsyncRedis`, `InMemorySyncRedis` (with thin pipeline helpers)
 - Dependencies:
@@ -46,7 +46,7 @@ Centralized helpers for shared runtime infrastructure. Today this module focuses
   - In‑memory stubs are protected by an `asyncio.Lock` (async) or `threading.Lock` (sync) to avoid races when used concurrently.
   - Streams and sorted‑set operations in the stub are implemented for the project’s use cases (XRANGE/XLEN/XADD; ZADD/ZCARD/ZREMRANGEBYSCORE), adequate for tests and single‑node dev.
 - Error Handling:
-  - Connection errors emit metrics and fall back to stub when allowed; callers can disable fallback via `fallback_to_fake=False` (raises the original error).
+  - Connection errors emit metrics and raise by default; callers that explicitly support per-process memory can enable stub fallback with `fallback_to_fake=True`.
   - Close helpers are best‑effort and safe to call on both real and stub clients.
 - Security:
   - Secrets come from env or config; do not log credentials. Logs include a `context` label only.
@@ -73,14 +73,14 @@ Centralized helpers for shared runtime infrastructure. Today this module focuses
   - Metrics behavior tests: tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py:17, tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py:60, tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py:108
   - Embeddings orchestrator tests exercise streams/queues against the stub (e.g., DLQ/orchestrator snapshot): see tests under `tldw_Server_API/tests/Embeddings/`.
 - Local Dev Tips:
-  - No Redis running? Do nothing — the factory falls back to an in‑memory client automatically.
+  - No Redis running? Pass `fallback_to_fake=True` only for local/cache/test paths that can tolerate per-process in-memory state.
   - To use a real Redis, set `REDIS_URL` (or `EMBEDDINGS_REDIS_URL`) and ensure `redis` extras are installed.
   - Example (async):
 
     ```python
     from tldw_Server_API.app.core.Infrastructure.redis_factory import create_async_redis_client, ensure_async_client_closed
 
-    client = await create_async_redis_client(context="demo")
+    client = await create_async_redis_client(context="demo", fallback_to_fake=True)
     try:
         await client.xadd("embeddings:embedding", {"doc_id": "123", "ev": "enqueue"})
         depth = await client.xlen("embeddings:embedding")
@@ -93,13 +93,13 @@ Centralized helpers for shared runtime infrastructure. Today this module focuses
     ```python
     from tldw_Server_API.app.core.Infrastructure.redis_factory import create_sync_redis_client
 
-    client = create_sync_redis_client(context="demo-sync")
+    client = create_sync_redis_client(context="demo-sync", fallback_to_fake=True)
     client.incr("rl:req:demo:0")
     ```
 - Pitfalls & Gotchas:
   - In‑memory client does not implement full Redis feature parity. Pub/Sub is not available in the stub.
   - If you rely on strict Redis behavior (e.g., exact stream IDs, ordering guarantees, Lua semantics), add integration tests with a real Redis and gate them via env.
-  - When `fallback_to_fake=False`, be prepared to handle connection exceptions during startup.
+  - The default `fallback_to_fake=False` fails closed. Production-sensitive callers should handle connection exceptions or return a controlled service-unavailable response.
 - Follow-up candidates:
   - Consider factories for additional infra (Postgres pool, object storage) following the same pattern.
   - Expand metrics (pool usage, cache hit/miss) if/when additional factories are introduced.

--- a/tldw_Server_API/app/core/Infrastructure/distributed_lock.py
+++ b/tldw_Server_API/app/core/Infrastructure/distributed_lock.py
@@ -85,7 +85,6 @@ class FileLock:
         self.timeout = timeout
         self.stale_timeout = stale_timeout
         self._fd: Optional[int] = None
-        self._owner_token: Optional[str] = None
 
     # ------------------------------------------------------------------
     # Public API
@@ -118,7 +117,6 @@ class FileLock:
                 os.write(fd, f"{owner_token}\n".encode())
                 os.fsync(fd)
                 self._fd = fd
-                self._owner_token = owner_token
                 logger.debug("FileLock acquired: {}", self.path)
                 return True
             except OSError:
@@ -151,7 +149,6 @@ class FileLock:
             except OSError:
                 pass
             self._fd = None
-        self._owner_token = None
 
     # ------------------------------------------------------------------
     # Context manager

--- a/tldw_Server_API/app/core/Infrastructure/distributed_lock.py
+++ b/tldw_Server_API/app/core/Infrastructure/distributed_lock.py
@@ -109,13 +109,6 @@ class FileLock:
                     0o644,
                 )
                 _acquire_platform_file_lock(fd)
-                # Include the PID for stale detection and a per-acquire token so
-                # same-process reacquisition cannot be mistaken for this owner.
-                owner_token = f"{os.getpid()}:{uuid.uuid4().hex}"
-                os.ftruncate(fd, 0)
-                os.lseek(fd, 0, os.SEEK_SET)
-                os.write(fd, f"{owner_token}\n".encode())
-                os.fsync(fd)
                 self._fd = fd
                 logger.debug("FileLock acquired: {}", self.path)
                 return True

--- a/tldw_Server_API/app/core/Infrastructure/distributed_lock.py
+++ b/tldw_Server_API/app/core/Infrastructure/distributed_lock.py
@@ -71,8 +71,8 @@ class FileLock:
     Parameters:
         path: Path to the lock file.
         timeout: Maximum seconds to wait for lock acquisition.
-        stale_timeout: Retained for API compatibility. File locks are only
-            broken when the recorded owning PID is confirmed dead.
+        stale_timeout: Retained for API compatibility. Native file locks are
+            expected to be released by the platform when the owner exits.
     """
 
     def __init__(
@@ -85,6 +85,7 @@ class FileLock:
         self.timeout = timeout
         self.stale_timeout = stale_timeout
         self._fd: Optional[int] = None
+        self._owner_token: Optional[str] = None
 
     # ------------------------------------------------------------------
     # Public API
@@ -109,12 +110,15 @@ class FileLock:
                     0o644,
                 )
                 _acquire_platform_file_lock(fd)
-                # Write our PID so stale detection works from other processes.
+                # Include the PID for stale detection and a per-acquire token so
+                # same-process reacquisition cannot be mistaken for this owner.
+                owner_token = f"{os.getpid()}:{uuid.uuid4().hex}"
                 os.ftruncate(fd, 0)
                 os.lseek(fd, 0, os.SEEK_SET)
-                os.write(fd, f"{os.getpid()}\n".encode())
+                os.write(fd, f"{owner_token}\n".encode())
                 os.fsync(fd)
                 self._fd = fd
+                self._owner_token = owner_token
                 logger.debug("FileLock acquired: {}", self.path)
                 return True
             except OSError:
@@ -125,18 +129,18 @@ class FileLock:
                 except OSError:
                     pass
 
-                # Try to break stale locks on first failure.
-                if attempt == 1:
-                    self._break_stale_lock()
-
                 if time.monotonic() >= deadline:
                     return False
 
                 time.sleep(min(0.1, max(0, deadline - time.monotonic())))
 
     def release(self) -> None:
-        """Release the lock and remove the lock file."""
-        owned_pid = str(os.getpid())
+        """Release the lock.
+
+        The lock file is intentionally left in place. Removing it during normal
+        release creates a race where another owner can acquire the path and then
+        have its active lock file unlinked by the previous releaser.
+        """
         if self._fd is not None:
             try:
                 _release_platform_file_lock(self._fd)
@@ -147,43 +151,7 @@ class FileLock:
             except OSError:
                 pass
             self._fd = None
-        # Best-effort removal of the lock file, without unlinking a file that
-        # another process already acquired and rewrote after our unlock.
-        try:
-            if self.path.read_text().strip() == owned_pid:
-                self.path.unlink(missing_ok=True)
-        except OSError:
-            pass
-
-    # ------------------------------------------------------------------
-    # Stale lock detection
-    # ------------------------------------------------------------------
-
-    def _break_stale_lock(self) -> None:
-        """Remove the lock file only when the recorded owning PID is dead."""
-        try:
-            if not self.path.exists():
-                return
-
-            # Check if the PID is still alive.
-            try:
-                content = self.path.read_text().strip()
-                pid = int(content)
-            except (OSError, ValueError):
-                return
-
-            try:
-                os.kill(pid, 0)  # Signal 0 — just check existence.
-            except ProcessLookupError:
-                logger.warning(
-                    "Breaking stale lock (PID {} dead): {}", pid, self.path
-                )
-                self.path.unlink(missing_ok=True)
-            except PermissionError:
-                # Process exists but we can't signal it — lock is NOT stale.
-                pass
-        except OSError:
-            pass
+        self._owner_token = None
 
     # ------------------------------------------------------------------
     # Context manager

--- a/tldw_Server_API/app/core/Infrastructure/redis_factory.py
+++ b/tldw_Server_API/app/core/Infrastructure/redis_factory.py
@@ -160,7 +160,7 @@ async def create_async_redis_client(
     *,
     preferred_url: str | None = None,
     decode_responses: bool = True,
-    fallback_to_fake: bool = True,
+    fallback_to_fake: bool = False,
     context: str = "default",
     redis_kwargs: dict | None = None,
 ):
@@ -171,7 +171,8 @@ async def create_async_redis_client(
         preferred_url: Explicit URL to prioritize (e.g., embeddings queue).
         decode_responses: Whether to decode bytes into str.
         fallback_to_fake: If True, transparently fallback to an in-memory stub when
-            the real server is unreachable.
+            the real server is unreachable. Production-sensitive callers should
+            leave this disabled unless they explicitly support per-process memory.
         context: Human-readable label for logging (helps trace callers).
 
     Returns:
@@ -279,7 +280,7 @@ def create_sync_redis_client(
     *,
     preferred_url: str | None = None,
     decode_responses: bool = True,
-    fallback_to_fake: bool = True,
+    fallback_to_fake: bool = False,
     context: str = "default",
     redis_kwargs: dict | None = None,
 ):

--- a/tldw_Server_API/app/core/Security/egress.py
+++ b/tldw_Server_API/app/core/Security/egress.py
@@ -8,6 +8,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
+from loguru import logger
+
 from tldw_Server_API.app.core.testing import is_truthy
 
 DEFAULT_ALLOWED_SCHEMES = {"http", "https"}
@@ -23,8 +25,47 @@ PROFILENAME = "WORKFLOWS_EGRESS_PROFILE"  # strict | permissive | custom
 # Webhook-specific per-tenant allow/deny controls
 WEBHOOK_ALLOWLIST_ENV = "WORKFLOWS_WEBHOOK_ALLOWLIST"
 WEBHOOK_DENYLIST_ENV = "WORKFLOWS_WEBHOOK_DENYLIST"
+DNS_RESOLVER_MAX_OUTSTANDING_ENV = "WORKFLOWS_EGRESS_DNS_MAX_OUTSTANDING"
+DNS_RESOLVER_SLOT_WAIT_SECONDS_ENV = "WORKFLOWS_EGRESS_DNS_SLOT_WAIT_SECONDS"
 
-_DNS_RESOLVER_MAX_OUTSTANDING = 8
+_DNS_RESOLVER_MAX_OUTSTANDING_DEFAULT = 64
+_DNS_RESOLVER_SLOT_WAIT_SECONDS_DEFAULT = 0.05
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    try:
+        value = int(str(raw).strip())
+    except (TypeError, ValueError):
+        logger.warning("Invalid {} value {!r}; using {}", name, raw, default)
+        return default
+    if value < 1:
+        logger.warning("Invalid {} value {}; using {}", name, value, default)
+        return default
+    return value
+
+
+def _nonnegative_float_env(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    try:
+        value = float(str(raw).strip())
+    except (TypeError, ValueError):
+        logger.warning("Invalid {} value {!r}; using {}", name, raw, default)
+        return default
+    if value < 0:
+        logger.warning("Invalid {} value {}; using {}", name, value, default)
+        return default
+    return value
+
+
+_DNS_RESOLVER_MAX_OUTSTANDING = _positive_int_env(
+    DNS_RESOLVER_MAX_OUTSTANDING_ENV,
+    _DNS_RESOLVER_MAX_OUTSTANDING_DEFAULT,
+)
 _DNS_RESOLVER_SLOTS = threading.BoundedSemaphore(_DNS_RESOLVER_MAX_OUTSTANDING)
 
 
@@ -102,8 +143,41 @@ def _host_matches_allowlist(host: str, allowlist: Sequence[str]) -> bool:
     return False
 
 
+def _dns_slot_wait_seconds(timeout_s: float) -> float:
+    if timeout_s <= 0:
+        return 0.0
+    configured = _nonnegative_float_env(
+        DNS_RESOLVER_SLOT_WAIT_SECONDS_ENV,
+        _DNS_RESOLVER_SLOT_WAIT_SECONDS_DEFAULT,
+    )
+    return min(configured, timeout_s)
+
+
+def _release_dns_resolver_slot(host: str, reason: str) -> None:
+    try:
+        _DNS_RESOLVER_SLOTS.release()
+    except ValueError as exc:
+        logger.debug(
+            "DNS resolver slot release failed for host {} after {}: {}",
+            host,
+            reason,
+            type(exc).__name__,
+        )
+
+
 def _getaddrinfo_with_timeout(host: str, timeout_s: float = 2.0) -> list[tuple]:
-    if not _DNS_RESOLVER_SLOTS.acquire(blocking=False):
+    slot_wait_s = _dns_slot_wait_seconds(timeout_s)
+    acquired = (
+        _DNS_RESOLVER_SLOTS.acquire(blocking=False)
+        if slot_wait_s <= 0
+        else _DNS_RESOLVER_SLOTS.acquire(timeout=slot_wait_s)
+    )
+    if not acquired:
+        logger.warning(
+            "DNS resolver slots exhausted for host {}; failing closed after {:.3f}s wait",
+            host,
+            slot_wait_s,
+        )
         return []
 
     result: list[list[tuple]] = []
@@ -122,22 +196,34 @@ def _getaddrinfo_with_timeout(host: str, timeout_s: float = 2.0) -> list[tuple]:
         except (OSError, ValueError) as exc:
             error.append(exc)
         finally:
-            try:
-                _DNS_RESOLVER_SLOTS.release()
-            except ValueError:
-                pass
+            _release_dns_resolver_slot(host, "worker completion")
 
     thread = threading.Thread(target=_worker, daemon=True)
     try:
         thread.start()
-    except RuntimeError:
-        try:
-            _DNS_RESOLVER_SLOTS.release()
-        except ValueError:
-            pass
+    except RuntimeError as exc:
+        _release_dns_resolver_slot(host, "thread start failure")
+        logger.opt(exception=exc).warning(
+            "DNS resolver worker could not start for host {}; failing closed",
+            host,
+        )
         return []
     thread.join(timeout_s)
-    if thread.is_alive() or error:
+    if thread.is_alive():
+        logger.warning(
+            "DNS resolver timed out for host {} after {:.3f}s; failing closed",
+            host,
+            timeout_s,
+        )
+        return []
+    if error:
+        exc = error[0]
+        logger.debug(
+            "DNS resolver failed for host {} with {}: {}; failing closed",
+            host,
+            type(exc).__name__,
+            exc,
+        )
         return []
     return result[0] if result else []
 
@@ -163,7 +249,12 @@ def _resolve_host_ips(host: str) -> list[str]:
                 continue
         # Preserve order but deduplicate
         return list(dict.fromkeys(addrs))
-    except (OSError, TypeError, ValueError):
+    except (OSError, TypeError, ValueError) as exc:
+        logger.debug(
+            "Host resolution failed for {} with {}; treating as unsafe",
+            host,
+            type(exc).__name__,
+        )
         return []
 
 

--- a/tldw_Server_API/app/core/Security/egress.py
+++ b/tldw_Server_API/app/core/Security/egress.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import ipaddress
+import math
 import os
 import socket
 import threading
+import time
 from collections.abc import Sequence
 from dataclasses import dataclass
 from urllib.parse import urlparse
@@ -32,6 +34,16 @@ _DNS_RESOLVER_MAX_OUTSTANDING_DEFAULT = 64
 _DNS_RESOLVER_SLOT_WAIT_SECONDS_DEFAULT = 0.05
 
 
+def _log_invalid_dns_config(name: str, raw: object, default: int | float, reason: str) -> None:
+    logger.bind(
+        env_var=name,
+        raw_value=str(raw),
+        default_value=default,
+        reason=reason,
+        event="invalid_egress_dns_config",
+    ).warning("Invalid egress DNS configuration; using default")
+
+
 def _positive_int_env(name: str, default: int) -> int:
     raw = os.getenv(name)
     if raw is None or str(raw).strip() == "":
@@ -39,10 +51,10 @@ def _positive_int_env(name: str, default: int) -> int:
     try:
         value = int(str(raw).strip())
     except (TypeError, ValueError):
-        logger.warning("Invalid {} value {!r}; using {}", name, raw, default)
+        _log_invalid_dns_config(name, raw, default, "invalid_integer")
         return default
     if value < 1:
-        logger.warning("Invalid {} value {}; using {}", name, value, default)
+        _log_invalid_dns_config(name, raw, default, "not_positive")
         return default
     return value
 
@@ -54,10 +66,10 @@ def _nonnegative_float_env(name: str, default: float) -> float:
     try:
         value = float(str(raw).strip())
     except (TypeError, ValueError):
-        logger.warning("Invalid {} value {!r}; using {}", name, raw, default)
+        _log_invalid_dns_config(name, raw, default, "invalid_float")
         return default
-    if value < 0:
-        logger.warning("Invalid {} value {}; using {}", name, value, default)
+    if not math.isfinite(value) or value < 0:
+        _log_invalid_dns_config(name, raw, default, "not_finite_or_negative")
         return default
     return value
 
@@ -144,7 +156,7 @@ def _host_matches_allowlist(host: str, allowlist: Sequence[str]) -> bool:
 
 
 def _dns_slot_wait_seconds(timeout_s: float) -> float:
-    if timeout_s <= 0:
+    if not math.isfinite(timeout_s) or timeout_s <= 0:
         return 0.0
     configured = _nonnegative_float_env(
         DNS_RESOLVER_SLOT_WAIT_SECONDS_ENV,
@@ -157,15 +169,28 @@ def _release_dns_resolver_slot(host: str, reason: str) -> None:
     try:
         _DNS_RESOLVER_SLOTS.release()
     except ValueError as exc:
-        logger.debug(
-            "DNS resolver slot release failed for host {} after {}: {}",
-            host,
-            reason,
-            type(exc).__name__,
-        )
+        logger.bind(
+            host=host,
+            reason=reason,
+            exception_type=type(exc).__name__,
+            event="dns_resolver_slot_release_failed",
+        ).debug("DNS resolver slot release failed")
+
+
+def _remaining_dns_budget(start_time: float, timeout_s: float) -> float:
+    return max(0.0, timeout_s - (time.monotonic() - start_time))
 
 
 def _getaddrinfo_with_timeout(host: str, timeout_s: float = 2.0) -> list[tuple]:
+    if not math.isfinite(timeout_s) or timeout_s <= 0:
+        logger.bind(
+            host=host,
+            timeout_s=timeout_s,
+            event="dns_resolver_invalid_timeout",
+        ).warning("Invalid DNS resolver timeout; failing closed")
+        return []
+
+    start_time = time.monotonic()
     slot_wait_s = _dns_slot_wait_seconds(timeout_s)
     acquired = (
         _DNS_RESOLVER_SLOTS.acquire(blocking=False)
@@ -173,11 +198,24 @@ def _getaddrinfo_with_timeout(host: str, timeout_s: float = 2.0) -> list[tuple]:
         else _DNS_RESOLVER_SLOTS.acquire(timeout=slot_wait_s)
     )
     if not acquired:
-        logger.warning(
-            "DNS resolver slots exhausted for host {}; failing closed after {:.3f}s wait",
-            host,
-            slot_wait_s,
-        )
+        logger.bind(
+            host=host,
+            slot_wait_s=slot_wait_s,
+            elapsed_s=time.monotonic() - start_time,
+            timeout_s=timeout_s,
+            event="dns_resolver_slots_exhausted",
+        ).warning("DNS resolver slots exhausted; failing closed")
+        return []
+
+    remaining_s = _remaining_dns_budget(start_time, timeout_s)
+    if remaining_s <= 0:
+        _release_dns_resolver_slot(host, "timeout budget exhausted before worker start")
+        logger.bind(
+            host=host,
+            elapsed_s=time.monotonic() - start_time,
+            timeout_s=timeout_s,
+            event="dns_resolver_timeout_budget_exhausted",
+        ).warning("DNS resolver timeout budget exhausted before worker start; failing closed")
         return []
 
     result: list[list[tuple]] = []
@@ -203,27 +241,38 @@ def _getaddrinfo_with_timeout(host: str, timeout_s: float = 2.0) -> list[tuple]:
         thread.start()
     except RuntimeError as exc:
         _release_dns_resolver_slot(host, "thread start failure")
-        logger.opt(exception=exc).warning(
-            "DNS resolver worker could not start for host {}; failing closed",
-            host,
-        )
+        logger.bind(
+            host=host,
+            exception_type=type(exc).__name__,
+            event="dns_resolver_worker_start_failed",
+        ).opt(exception=exc).warning("DNS resolver worker could not start; failing closed")
         return []
-    thread.join(timeout_s)
+
+    remaining_s = _remaining_dns_budget(start_time, timeout_s)
+    if remaining_s <= 0:
+        logger.bind(
+            host=host,
+            elapsed_s=time.monotonic() - start_time,
+            timeout_s=timeout_s,
+            event="dns_resolver_timeout",
+        ).warning("DNS resolver timed out before waiting for worker; failing closed")
+        return []
+    thread.join(remaining_s)
     if thread.is_alive():
-        logger.warning(
-            "DNS resolver timed out for host {} after {:.3f}s; failing closed",
-            host,
-            timeout_s,
-        )
+        logger.bind(
+            host=host,
+            elapsed_s=time.monotonic() - start_time,
+            timeout_s=timeout_s,
+            event="dns_resolver_timeout",
+        ).warning("DNS resolver timed out; failing closed")
         return []
     if error:
         exc = error[0]
-        logger.debug(
-            "DNS resolver failed for host {} with {}: {}; failing closed",
-            host,
-            type(exc).__name__,
-            exc,
-        )
+        logger.bind(
+            host=host,
+            exception_type=type(exc).__name__,
+            event="dns_resolver_error",
+        ).debug("DNS resolver failed; failing closed")
         return []
     return result[0] if result else []
 

--- a/tldw_Server_API/app/core/Security/egress.py
+++ b/tldw_Server_API/app/core/Security/egress.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import ipaddress
 import os
 import socket
-from concurrent import futures
+import threading
 from collections.abc import Sequence
 from dataclasses import dataclass
 from urllib.parse import urlparse
@@ -23,11 +23,9 @@ PROFILENAME = "WORKFLOWS_EGRESS_PROFILE"  # strict | permissive | custom
 # Webhook-specific per-tenant allow/deny controls
 WEBHOOK_ALLOWLIST_ENV = "WORKFLOWS_WEBHOOK_ALLOWLIST"
 WEBHOOK_DENYLIST_ENV = "WORKFLOWS_WEBHOOK_DENYLIST"
-DNS_RESOLVER_MAX_WORKERS = 4
-_DNS_RESOLVER_EXECUTOR = futures.ThreadPoolExecutor(
-    max_workers=DNS_RESOLVER_MAX_WORKERS,
-    thread_name_prefix="tldw-egress-dns",
-)
+
+_DNS_RESOLVER_MAX_OUTSTANDING = 8
+_DNS_RESOLVER_SLOTS = threading.BoundedSemaphore(_DNS_RESOLVER_MAX_OUTSTANDING)
 
 
 PRIVATE_RANGES = [
@@ -105,18 +103,43 @@ def _host_matches_allowlist(host: str, allowlist: Sequence[str]) -> bool:
 
 
 def _getaddrinfo_with_timeout(host: str, timeout_s: float = 2.0) -> list[tuple]:
-    future = _DNS_RESOLVER_EXECUTOR.submit(
-        socket.getaddrinfo,
-        host,
-        None,
-        family=socket.AF_UNSPEC,  # both IPv4 and IPv6
-        type=socket.SOCK_STREAM,
-    )
-    try:
-        return list(future.result(timeout=timeout_s))
-    except (futures.TimeoutError, OSError, ValueError):
-        future.cancel()
+    if not _DNS_RESOLVER_SLOTS.acquire(blocking=False):
         return []
+
+    result: list[list[tuple]] = []
+    error: list[BaseException] = []
+
+    def _worker() -> None:
+        try:
+            result.append(
+                socket.getaddrinfo(
+                    host,
+                    None,
+                    family=socket.AF_UNSPEC,  # both IPv4 and IPv6
+                    type=socket.SOCK_STREAM,
+                )
+            )
+        except (OSError, ValueError) as exc:
+            error.append(exc)
+        finally:
+            try:
+                _DNS_RESOLVER_SLOTS.release()
+            except ValueError:
+                pass
+
+    thread = threading.Thread(target=_worker, daemon=True)
+    try:
+        thread.start()
+    except RuntimeError:
+        try:
+            _DNS_RESOLVER_SLOTS.release()
+        except ValueError:
+            pass
+        return []
+    thread.join(timeout_s)
+    if thread.is_alive() or error:
+        return []
+    return result[0] if result else []
 
 
 def _resolve_host_ips(host: str) -> list[str]:

--- a/tldw_Server_API/app/core/Security/egress.py
+++ b/tldw_Server_API/app/core/Security/egress.py
@@ -35,6 +35,7 @@ _DNS_RESOLVER_SLOT_WAIT_SECONDS_DEFAULT = 0.05
 
 
 def _log_invalid_dns_config(name: str, raw: object, default: int | float, reason: str) -> None:
+    """Log invalid DNS resolver environment configuration with queryable fields."""
     logger.bind(
         env_var=name,
         raw_value=str(raw),
@@ -45,6 +46,7 @@ def _log_invalid_dns_config(name: str, raw: object, default: int | float, reason
 
 
 def _positive_int_env(name: str, default: int) -> int:
+    """Return a positive integer env override or the supplied default."""
     raw = os.getenv(name)
     if raw is None or str(raw).strip() == "":
         return default
@@ -60,6 +62,7 @@ def _positive_int_env(name: str, default: int) -> int:
 
 
 def _nonnegative_float_env(name: str, default: float) -> float:
+    """Return a finite non-negative float env override or the supplied default."""
     raw = os.getenv(name)
     if raw is None or str(raw).strip() == "":
         return default
@@ -156,6 +159,7 @@ def _host_matches_allowlist(host: str, allowlist: Sequence[str]) -> bool:
 
 
 def _dns_slot_wait_seconds(timeout_s: float) -> float:
+    """Bound DNS slot wait time by the caller's resolver timeout budget."""
     if not math.isfinite(timeout_s) or timeout_s <= 0:
         return 0.0
     configured = _nonnegative_float_env(
@@ -166,6 +170,7 @@ def _dns_slot_wait_seconds(timeout_s: float) -> float:
 
 
 def _release_dns_resolver_slot(host: str, reason: str) -> None:
+    """Release one DNS resolver slot and log impossible double-release cases."""
     try:
         _DNS_RESOLVER_SLOTS.release()
     except ValueError as exc:
@@ -178,10 +183,12 @@ def _release_dns_resolver_slot(host: str, reason: str) -> None:
 
 
 def _remaining_dns_budget(start_time: float, timeout_s: float) -> float:
+    """Return the remaining DNS timeout budget after elapsed wall-clock time."""
     return max(0.0, timeout_s - (time.monotonic() - start_time))
 
 
 def _getaddrinfo_with_timeout(host: str, timeout_s: float = 2.0) -> list[tuple]:
+    """Resolve a host with fail-closed timeout and DNS worker saturation guards."""
     if not math.isfinite(timeout_s) or timeout_s <= 0:
         logger.bind(
             host=host,
@@ -222,6 +229,7 @@ def _getaddrinfo_with_timeout(host: str, timeout_s: float = 2.0) -> list[tuple]:
     error: list[BaseException] = []
 
     def _worker() -> None:
+        """Run the blocking OS resolver and always release the resolver slot."""
         try:
             result.append(
                 socket.getaddrinfo(

--- a/tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py
+++ b/tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py
@@ -139,7 +139,13 @@ async def test_tenant_quota_429(monkeypatch):
     monkeypatch.setenv("AUTH_MODE", "multi_user")
     monkeypatch.setenv("EMBEDDINGS_TENANT_RPS", "1")
 
-    user = User(id="tenant1", username="tenant1", email="tenant1@example.test", is_active=True, is_admin=False)
+    user = User(
+        id="tenant1",
+        username="tenant1",
+        email="tenant1@example.test",
+        is_active=True,
+        is_admin=False,
+    )
     request = SimpleNamespace(state=SimpleNamespace())
 
     assert await ep._check_backpressure_and_quotas(request, user) is None
@@ -178,6 +184,33 @@ async def test_tenant_quota_fails_closed_when_redis_unavailable(monkeypatch):
     assert result is not None
     assert result.status_code == 503
     assert "tenant quota" in str(result.detail).lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_ingest_tenant_quota_fails_closed_when_redis_unavailable(monkeypatch):
+    from fastapi import HTTPException, Response
+
+    from tldw_Server_API.app.api.v1.API_Deps import backpressure as bp
+    from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+
+    async def _redis_unavailable():
+        raise RuntimeError("redis unavailable")
+
+    monkeypatch.setenv("INGEST_TENANT_RPS", "1")
+    monkeypatch.delenv("EMBEDDINGS_TENANT_RPS", raising=False)
+    monkeypatch.setattr(bp, "_get_redis_client", _redis_unavailable)
+    monkeypatch.setattr(bp, "is_single_user_profile_mode", lambda: False)
+
+    user = User(id="tenant1", username="tenant1", email="tenant1@example.test", is_active=True, is_admin=False)
+    request = SimpleNamespace(state=SimpleNamespace())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await bp.guard_backpressure_and_quota(request, Response(), user)
+
+    assert exc_info.value.status_code == 503
+    assert "tenant quota" in str(exc_info.value.detail).lower()
+    assert exc_info.value.headers == {"Retry-After": "1"}
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py
+++ b/tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py
@@ -156,13 +156,14 @@ async def test_tenant_quota_429(monkeypatch):
     assert second.headers.get("Retry-After") == "1"
 
 
-@pytest.mark.asyncio
 @pytest.mark.unit
-async def test_tenant_quota_fails_closed_when_redis_unavailable(monkeypatch):
+async def test_tenant_quota_fails_closed_when_redis_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from tldw_Server_API.app.api.v1.endpoints import embeddings_v5_production_enhanced as ep
     from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
 
-    async def _redis_unavailable():
+    async def _redis_unavailable() -> None:
         raise RuntimeError("redis unavailable")
 
     monkeypatch.setattr(ep, "_is_embeddings_backpressure_redis_enabled", lambda: False)
@@ -183,18 +184,20 @@ async def test_tenant_quota_fails_closed_when_redis_unavailable(monkeypatch):
 
     assert result is not None
     assert result.status_code == 503
+    assert result.headers["Retry-After"] == "1"
     assert "tenant quota" in str(result.detail).lower()
 
 
-@pytest.mark.asyncio
 @pytest.mark.unit
-async def test_ingest_tenant_quota_fails_closed_when_redis_unavailable(monkeypatch):
+async def test_ingest_tenant_quota_fails_closed_when_redis_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from fastapi import HTTPException, Response
 
     from tldw_Server_API.app.api.v1.API_Deps import backpressure as bp
     from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
 
-    async def _redis_unavailable():
+    async def _redis_unavailable() -> None:
         raise RuntimeError("redis unavailable")
 
     monkeypatch.setenv("INGEST_TENANT_RPS", "1")

--- a/tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py
+++ b/tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py
@@ -200,10 +200,29 @@ async def test_ingest_tenant_quota_fails_closed_when_redis_unavailable(
     async def _redis_unavailable() -> None:
         raise RuntimeError("redis unavailable")
 
+    class _CapturedLogger:
+        def __init__(self) -> None:
+            self.bound: dict[str, object] = {}
+            self.opt_kwargs: dict[str, object] = {}
+            self.warning_message: str | None = None
+
+        def bind(self, **kwargs: object) -> "_CapturedLogger":
+            self.bound.update(kwargs)
+            return self
+
+        def opt(self, **kwargs: object) -> "_CapturedLogger":
+            self.opt_kwargs.update(kwargs)
+            return self
+
+        def warning(self, message: str, *_args: object, **_kwargs: object) -> None:
+            self.warning_message = message
+
+    captured_logger = _CapturedLogger()
     monkeypatch.setenv("INGEST_TENANT_RPS", "1")
     monkeypatch.delenv("EMBEDDINGS_TENANT_RPS", raising=False)
     monkeypatch.setattr(bp, "_get_redis_client", _redis_unavailable)
     monkeypatch.setattr(bp, "is_single_user_profile_mode", lambda: False)
+    monkeypatch.setattr(bp, "logger", captured_logger)
 
     user = User(id="tenant1", username="tenant1", email="tenant1@example.test", is_active=True, is_admin=False)
     request = SimpleNamespace(state=SimpleNamespace())
@@ -214,6 +233,11 @@ async def test_ingest_tenant_quota_fails_closed_when_redis_unavailable(
     assert exc_info.value.status_code == 503
     assert "tenant quota" in str(exc_info.value.detail).lower()
     assert exc_info.value.headers == {"Retry-After": "1"}
+    assert captured_logger.bound["tenant_id"] == "tenant1"
+    assert captured_logger.bound["exception_type"] == "RuntimeError"
+    assert captured_logger.bound["event"] == "ingest_tenant_quota_redis_unavailable"
+    assert isinstance(captured_logger.opt_kwargs["exception"], RuntimeError)
+    assert captured_logger.warning_message == "Ingest tenant quota Redis unavailable; failing closed"
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py
+++ b/tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py
@@ -160,10 +160,12 @@ async def test_tenant_quota_429(monkeypatch):
 async def test_tenant_quota_fails_closed_when_redis_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Embeddings tenant quota returns 503 when Redis quota state is unavailable."""
     from tldw_Server_API.app.api.v1.endpoints import embeddings_v5_production_enhanced as ep
     from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
 
     async def _redis_unavailable() -> None:
+        """Simulate quota Redis being unavailable."""
         raise RuntimeError("redis unavailable")
 
     monkeypatch.setattr(ep, "_is_embeddings_backpressure_redis_enabled", lambda: False)
@@ -192,29 +194,36 @@ async def test_tenant_quota_fails_closed_when_redis_unavailable(
 async def test_ingest_tenant_quota_fails_closed_when_redis_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Ingest tenant quota returns 503 with structured logs when Redis is unavailable."""
     from fastapi import HTTPException, Response
 
     from tldw_Server_API.app.api.v1.API_Deps import backpressure as bp
     from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
 
     async def _redis_unavailable() -> None:
+        """Simulate quota Redis being unavailable."""
         raise RuntimeError("redis unavailable")
 
     class _CapturedLogger:
+        """Capture Loguru bind/opt/warning calls for structured-log assertions."""
+
         def __init__(self) -> None:
             self.bound: dict[str, object] = {}
             self.opt_kwargs: dict[str, object] = {}
             self.warning_message: str | None = None
 
         def bind(self, **kwargs: object) -> "_CapturedLogger":
+            """Store structured fields passed through logger.bind."""
             self.bound.update(kwargs)
             return self
 
         def opt(self, **kwargs: object) -> "_CapturedLogger":
+            """Store options passed through logger.opt."""
             self.opt_kwargs.update(kwargs)
             return self
 
         def warning(self, message: str, *_args: object, **_kwargs: object) -> None:
+            """Store the warning message for assertions."""
             self.warning_message = message
 
     captured_logger = _CapturedLogger()

--- a/tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py
+++ b/tldw_Server_API/tests/Embeddings/test_backpressure_and_quotas.py
@@ -150,6 +150,36 @@ async def test_tenant_quota_429(monkeypatch):
     assert second.headers.get("Retry-After") == "1"
 
 
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_tenant_quota_fails_closed_when_redis_unavailable(monkeypatch):
+    from tldw_Server_API.app.api.v1.endpoints import embeddings_v5_production_enhanced as ep
+    from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+
+    async def _redis_unavailable():
+        raise RuntimeError("redis unavailable")
+
+    monkeypatch.setattr(ep, "_is_embeddings_backpressure_redis_enabled", lambda: False)
+    monkeypatch.setattr(ep, "_tenant_rps_runtime", lambda: 1)
+    monkeypatch.setattr(ep, "_should_enforce_tenant_rps", lambda _request: True)
+    monkeypatch.setattr(ep, "_get_redis_client", _redis_unavailable)
+
+    user = User(
+        id="tenant1",
+        username="tenant1",
+        email="tenant1@example.test",
+        is_active=True,
+        is_admin=False,
+    )
+    request = SimpleNamespace(state=SimpleNamespace())
+
+    result = await ep._check_backpressure_and_quotas(request, user)
+
+    assert result is not None
+    assert result.status_code == 503
+    assert "tenant quota" in str(result.detail).lower()
+
+
 @pytest.mark.unit
 def test_embeddings_batch_route_has_rbac_rate_limit_parity():
     app = reload_app_main().app

--- a/tldw_Server_API/tests/Infrastructure/test_distributed_lock.py
+++ b/tldw_Server_API/tests/Infrastructure/test_distributed_lock.py
@@ -31,15 +31,15 @@ class TestFileLockAcquireRelease:
 
         assert lock.acquire() is True
         assert lock_path.exists()
-        # Lock file should contain our PID.
+        # Lock file should contain a per-owner token prefixed by our PID.
         assert lock._fd is not None
         os.lseek(lock._fd, 0, os.SEEK_SET)
         content = os.read(lock._fd, 64).decode().strip()
-        assert content == str(os.getpid())
+        assert content.startswith(f"{os.getpid()}:")
 
         lock.release()
-        # Lock file removed after release.
-        assert not lock_path.exists()
+        # Lock file is kept so release cannot unlink a new owner.
+        assert lock_path.exists()
 
     def test_acquire_creates_parent_dirs(self, tmp_path: Path) -> None:
         lock_path = tmp_path / "sub" / "dir" / "test.lock"
@@ -53,6 +53,45 @@ class TestFileLockAcquireRelease:
         lock.release()
         lock.release()  # Should not raise.
 
+    def test_release_leaves_lock_file_to_avoid_reacquire_unlink_race(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        lock_path = tmp_path / "release-keeps-file.lock"
+        lock = FileLock(lock_path, timeout=2)
+
+        assert lock.acquire() is True
+        lock.release()
+
+        assert lock_path.exists()
+
+    def test_release_does_not_unlink_same_process_reacquired_lock(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        lock_path = tmp_path / "same-process-reacquire.lock"
+        first = FileLock(lock_path, timeout=2)
+        second = FileLock(lock_path, timeout=2)
+        assert first.acquire() is True
+        first_fd = first._fd
+        assert first_fd is not None
+        reacquired: list[bool] = []
+        real_close = distributed_lock_module.os.close
+
+        def _close_and_reacquire(fd: int) -> None:
+            real_close(fd)
+            if fd == first_fd and not reacquired:
+                reacquired.append(second.acquire())
+
+        monkeypatch.setattr(distributed_lock_module.os, "close", _close_and_reacquire)
+        try:
+            first.release()
+            assert reacquired == [True]
+            assert lock_path.exists()
+        finally:
+            second.release()
+
 
 class TestFileLockContextManager:
     """Context manager protocol."""
@@ -62,7 +101,7 @@ class TestFileLockContextManager:
         with FileLock(lock_path, timeout=5) as lock:
             assert lock_path.exists()
             assert isinstance(lock, FileLock)
-        assert not lock_path.exists()
+        assert lock_path.exists()
 
     def test_context_manager_raises_on_timeout(self, tmp_path: Path) -> None:
         lock_path = tmp_path / "timeout.lock"
@@ -97,10 +136,13 @@ class TestFileLockConcurrency:
         lock2.release()
 
 
-class TestFileLockStaleLock:
-    """Stale lock detection based on dead PID."""
+class TestFileLockResidualFiles:
+    """Residual lock files should not affect native lock ownership."""
 
-    def test_breaks_stale_lock_dead_pid(self, tmp_path: Path) -> None:
+    def test_acquires_when_previous_lock_file_has_dead_pid_record(
+        self,
+        tmp_path: Path,
+    ) -> None:
         lock_path = tmp_path / "stale.lock"
         # Write a PID that almost certainly doesn't exist.
         lock_path.write_text("999999999\n")
@@ -109,7 +151,7 @@ class TestFileLockStaleLock:
         assert lock.acquire() is True
         lock.release()
 
-    def test_breaks_stale_lock_old_file(self, tmp_path: Path) -> None:
+    def test_acquires_when_previous_lock_file_is_old(self, tmp_path: Path) -> None:
         lock_path = tmp_path / "old.lock"
         lock_path.write_text(f"{os.getpid()}\n")
         # Set mtime far in the past.
@@ -120,12 +162,31 @@ class TestFileLockStaleLock:
         assert lock.acquire() is True
         lock.release()
 
-    def test_does_not_break_old_lock_when_owner_pid_is_alive(self, tmp_path: Path) -> None:
+    def test_does_not_break_old_lock_when_owner_pid_is_alive(
+        self,
+        tmp_path: Path,
+    ) -> None:
         lock_path = tmp_path / "live-old.lock"
         holder = FileLock(lock_path, timeout=2, stale_timeout=9999)
         assert holder.acquire() is True
         old_time = time.time() - 1000
         os.utime(str(lock_path), (old_time, old_time))
+
+        try:
+            contender = FileLock(lock_path, timeout=0.2, stale_timeout=0.01)
+            assert contender.acquire() is False
+            assert lock_path.exists()
+        finally:
+            holder.release()
+
+    def test_does_not_unlink_locked_file_even_when_recorded_pid_is_dead(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        lock_path = tmp_path / "locked-dead-pid.lock"
+        holder = FileLock(lock_path, timeout=2, stale_timeout=9999)
+        assert holder.acquire() is True
+        lock_path.write_text("999999999\n")
 
         try:
             contender = FileLock(lock_path, timeout=0.2, stale_timeout=0.01)

--- a/tldw_Server_API/tests/Infrastructure/test_distributed_lock.py
+++ b/tldw_Server_API/tests/Infrastructure/test_distributed_lock.py
@@ -31,11 +31,7 @@ class TestFileLockAcquireRelease:
 
         assert lock.acquire() is True
         assert lock_path.exists()
-        # Lock file should contain a per-owner token prefixed by our PID.
         assert lock._fd is not None
-        os.lseek(lock._fd, 0, os.SEEK_SET)
-        content = os.read(lock._fd, 64).decode().strip()
-        assert content.startswith(f"{os.getpid()}:")
 
         lock.release()
         # Lock file is kept so release cannot unlink a new owner.

--- a/tldw_Server_API/tests/Infrastructure/test_distributed_lock.py
+++ b/tldw_Server_API/tests/Infrastructure/test_distributed_lock.py
@@ -53,6 +53,7 @@ class TestFileLockAcquireRelease:
         self,
         tmp_path: Path,
     ) -> None:
+        """Release keeps the lock path so later owners cannot lose their inode."""
         lock_path = tmp_path / "release-keeps-file.lock"
         lock = FileLock(lock_path, timeout=2)
 
@@ -66,6 +67,7 @@ class TestFileLockAcquireRelease:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        """A prior owner cannot unlink a lock reacquired during its close path."""
         lock_path = tmp_path / "same-process-reacquire.lock"
         first = FileLock(lock_path, timeout=2)
         second = FileLock(lock_path, timeout=2)
@@ -139,6 +141,7 @@ class TestFileLockResidualFiles:
         self,
         tmp_path: Path,
     ) -> None:
+        """Dead PID file contents do not prevent native lock acquisition."""
         lock_path = tmp_path / "stale.lock"
         # Write a PID that almost certainly doesn't exist.
         lock_path.write_text("999999999\n")
@@ -179,6 +182,7 @@ class TestFileLockResidualFiles:
         self,
         tmp_path: Path,
     ) -> None:
+        """A locked file is preserved even if its legacy PID record is stale."""
         lock_path = tmp_path / "locked-dead-pid.lock"
         holder = FileLock(lock_path, timeout=2, stale_timeout=9999)
         assert holder.acquire() is True

--- a/tldw_Server_API/tests/Infrastructure/test_redis_factory.py
+++ b/tldw_Server_API/tests/Infrastructure/test_redis_factory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 import time
 from types import SimpleNamespace
 
@@ -43,6 +44,16 @@ def test_sync_stub_core_commands():
     assert client.dbsize() >= 4
 
     assert client.delete("k1", "k2") == 2
+
+
+def test_redis_factory_readme_documents_fail_closed_defaults():
+    readme_path = Path(rf.__file__).with_name("README.md")
+    readme = readme_path.read_text(encoding="utf-8")
+
+    assert "fallback_to_fake=False" in readme
+    assert "fallback_to_fake=True" in readme
+    assert "create_async_redis_client(context=\"demo\", fallback_to_fake=True)" in readme
+    assert "create_sync_redis_client(context=\"demo-sync\", fallback_to_fake=True)" in readme
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Infrastructure/test_redis_factory.py
+++ b/tldw_Server_API/tests/Infrastructure/test_redis_factory.py
@@ -46,7 +46,8 @@ def test_sync_stub_core_commands():
     assert client.delete("k1", "k2") == 2
 
 
-def test_redis_factory_readme_documents_fail_closed_defaults():
+@pytest.mark.unit
+def test_redis_factory_readme_documents_fail_closed_defaults() -> None:
     readme_path = Path(rf.__file__).with_name("README.md")
     readme = readme_path.read_text(encoding="utf-8")
 
@@ -120,8 +121,10 @@ async def test_async_factory_raises_when_redis_package_missing_and_fallback_disa
         )
 
 
-@pytest.mark.asyncio
-async def test_async_factory_raises_when_redis_package_missing_by_default(monkeypatch):
+@pytest.mark.unit
+async def test_async_factory_raises_when_redis_package_missing_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(rf, "aioredis", None)
     monkeypatch.setattr(rf, "_import_error", ImportError("redis missing"))
 
@@ -143,7 +146,10 @@ def test_sync_factory_falls_back_when_redis_package_missing(monkeypatch):
     assert client.get("missing:sync") == "ok"
 
 
-def test_sync_factory_raises_when_redis_package_missing_by_default(monkeypatch):
+@pytest.mark.unit
+def test_sync_factory_raises_when_redis_package_missing_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(rf, "redis", None)
     monkeypatch.setattr(rf, "_import_error", ImportError("redis missing"))
 

--- a/tldw_Server_API/tests/Infrastructure/test_redis_factory.py
+++ b/tldw_Server_API/tests/Infrastructure/test_redis_factory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 import time
 from types import SimpleNamespace
 
@@ -53,8 +54,16 @@ def test_redis_factory_readme_documents_fail_closed_defaults() -> None:
 
     assert "fallback_to_fake=False" in readme
     assert "fallback_to_fake=True" in readme
-    assert "create_async_redis_client(context=\"demo\", fallback_to_fake=True)" in readme
-    assert "create_sync_redis_client(context=\"demo-sync\", fallback_to_fake=True)" in readme
+    assert re.search(
+        r"create_async_redis_client\s*\([^)]*fallback_to_fake\s*=\s*True[^)]*\)",
+        readme,
+        re.DOTALL,
+    )
+    assert re.search(
+        r"create_sync_redis_client\s*\([^)]*fallback_to_fake\s*=\s*True[^)]*\)",
+        readme,
+        re.DOTALL,
+    )
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Infrastructure/test_redis_factory.py
+++ b/tldw_Server_API/tests/Infrastructure/test_redis_factory.py
@@ -49,6 +49,7 @@ def test_sync_stub_core_commands():
 
 @pytest.mark.unit
 def test_redis_factory_readme_documents_fail_closed_defaults() -> None:
+    """README examples document fail-closed defaults and explicit fake fallback."""
     readme_path = Path(rf.__file__).with_name("README.md")
     readme = readme_path.read_text(encoding="utf-8")
 
@@ -134,6 +135,7 @@ async def test_async_factory_raises_when_redis_package_missing_and_fallback_disa
 async def test_async_factory_raises_when_redis_package_missing_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Async Redis factory fails closed by default when redis is unavailable."""
     monkeypatch.setattr(rf, "aioredis", None)
     monkeypatch.setattr(rf, "_import_error", ImportError("redis missing"))
 
@@ -159,6 +161,7 @@ def test_sync_factory_falls_back_when_redis_package_missing(monkeypatch):
 def test_sync_factory_raises_when_redis_package_missing_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Sync Redis factory fails closed by default when redis is unavailable."""
     monkeypatch.setattr(rf, "redis", None)
     monkeypatch.setattr(rf, "_import_error", ImportError("redis missing"))
 

--- a/tldw_Server_API/tests/Infrastructure/test_redis_factory.py
+++ b/tldw_Server_API/tests/Infrastructure/test_redis_factory.py
@@ -109,6 +109,15 @@ async def test_async_factory_raises_when_redis_package_missing_and_fallback_disa
         )
 
 
+@pytest.mark.asyncio
+async def test_async_factory_raises_when_redis_package_missing_by_default(monkeypatch):
+    monkeypatch.setattr(rf, "aioredis", None)
+    monkeypatch.setattr(rf, "_import_error", ImportError("redis missing"))
+
+    with pytest.raises(RuntimeError, match="redis\\[asyncio\\] is required"):
+        await rf.create_async_redis_client(context="missing_package")
+
+
 def test_sync_factory_falls_back_when_redis_package_missing(monkeypatch):
     monkeypatch.setattr(rf, "redis", None)
     monkeypatch.setattr(rf, "_import_error", ImportError("redis missing"))
@@ -121,6 +130,14 @@ def test_sync_factory_falls_back_when_redis_package_missing(monkeypatch):
     assert client.ping() is True
     client.set("missing:sync", "ok")
     assert client.get("missing:sync") == "ok"
+
+
+def test_sync_factory_raises_when_redis_package_missing_by_default(monkeypatch):
+    monkeypatch.setattr(rf, "redis", None)
+    monkeypatch.setattr(rf, "_import_error", ImportError("redis missing"))
+
+    with pytest.raises(RuntimeError, match="redis client is required"):
+        rf.create_sync_redis_client(context="missing_package")
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py
+++ b/tldw_Server_API/tests/Infrastructure/test_redis_factory_metrics.py
@@ -85,7 +85,10 @@ async def test_async_client_fallback_records_metrics(monkeypatch):
     )
     before_fallbacks = len(_metric_entries(registry, "infra_redis_fallback_total"))
 
-    client = await rf.create_async_redis_client(context="tests-async-fallback")
+    client = await rf.create_async_redis_client(
+        context="tests-async-fallback",
+        fallback_to_fake=True,
+    )
 
     assert isinstance(client, rf.InMemoryAsyncRedis)
 

--- a/tldw_Server_API/tests/Security/test_egress.py
+++ b/tldw_Server_API/tests/Security/test_egress.py
@@ -10,6 +10,8 @@ pytestmark = pytest.mark.unit
 
 
 class _CapturedLogger:
+    """Capture Loguru bind/opt calls and messages for egress log assertions."""
+
     def __init__(self) -> None:
         self.current_bound: dict[str, object] = {}
         self.warning_logs: list[tuple[dict[str, object], str]] = []
@@ -17,17 +19,21 @@ class _CapturedLogger:
         self.opt_kwargs: list[dict[str, object]] = []
 
     def bind(self, **kwargs: object) -> "_CapturedLogger":
+        """Store fields from the latest logger.bind call."""
         self.current_bound = dict(kwargs)
         return self
 
     def opt(self, **kwargs: object) -> "_CapturedLogger":
+        """Store options from logger.opt calls."""
         self.opt_kwargs.append(dict(kwargs))
         return self
 
     def warning(self, message: str, *_args: object, **_kwargs: object) -> None:
+        """Record a warning with the current bound fields."""
         self.warning_logs.append((dict(self.current_bound), message))
 
     def debug(self, message: str, *_args: object, **_kwargs: object) -> None:
+        """Record a debug message with the current bound fields."""
         self.debug_logs.append((dict(self.current_bound), message))
 
 
@@ -132,6 +138,7 @@ class TestEgressPolicy:
         self: "TestEgressPolicy",
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        """DNS resolution fails closed when all resolver worker slots are occupied."""
         release = threading.Event()
         started = 0
         started_lock = threading.Lock()
@@ -171,6 +178,7 @@ class TestEgressPolicy:
         self: "TestEgressPolicy",
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        """Resolver exceptions are logged with structured host and exception fields."""
         captured_logger = _CapturedLogger()
 
         def _failing_getaddrinfo(*_args: object, **_kwargs: object) -> list[object]:
@@ -191,6 +199,7 @@ class TestEgressPolicy:
         self: "TestEgressPolicy",
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        """NaN DNS slot wait configuration falls back to the safe default."""
         captured_logger = _CapturedLogger()
         monkeypatch.setenv(egress.DNS_RESOLVER_SLOT_WAIT_SECONDS_ENV, "nan")
         monkeypatch.setattr(egress, "logger", captured_logger)
@@ -207,6 +216,7 @@ class TestEgressPolicy:
         self: "TestEgressPolicy",
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        """The resolver worker join only receives the remaining timeout budget."""
         captured_logger = _CapturedLogger()
         join_timeouts: list[float | None] = []
 

--- a/tldw_Server_API/tests/Security/test_egress.py
+++ b/tldw_Server_API/tests/Security/test_egress.py
@@ -108,13 +108,17 @@ class TestEgressPolicy:
         assert egress._resolve_host_ips("example.com") == ["93.184.216.34"]
         assert calls == []
 
-    def test_dns_timeout_limits_outstanding_resolver_threads(self, monkeypatch):
+    def test_dns_timeout_limits_outstanding_resolver_threads(
+        self: "TestEgressPolicy",
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         release = threading.Event()
         started = 0
         started_lock = threading.Lock()
         resolver_slots = threading.BoundedSemaphore(2)
+        warnings: list[tuple[str, tuple[object, ...]]] = []
 
-        def _blocked_getaddrinfo(*_args, **_kwargs):
+        def _blocked_getaddrinfo(*_args: object, **_kwargs: object) -> list[object]:
             nonlocal started
             with started_lock:
                 started += 1
@@ -123,6 +127,11 @@ class TestEgressPolicy:
 
         monkeypatch.setattr(egress, "_DNS_RESOLVER_SLOTS", resolver_slots, raising=False)
         monkeypatch.setattr(egress.socket, "getaddrinfo", _blocked_getaddrinfo)
+        monkeypatch.setattr(
+            egress.logger,
+            "warning",
+            lambda message, *args, **_kwargs: warnings.append((message, args)),
+        )
 
         try:
             results = [
@@ -134,5 +143,25 @@ class TestEgressPolicy:
             ]
             assert results == [[], [], [], [], []]
             assert started <= 2
+            assert any("slots exhausted" in message for message, _args in warnings)
         finally:
             release.set()
+
+    def test_dns_timeout_logs_resolver_errors(
+        self: "TestEgressPolicy",
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        debug_logs: list[tuple[str, tuple[object, ...]]] = []
+
+        def _failing_getaddrinfo(*_args: object, **_kwargs: object) -> list[object]:
+            raise OSError("resolver failed")
+
+        monkeypatch.setattr(egress.socket, "getaddrinfo", _failing_getaddrinfo)
+        monkeypatch.setattr(
+            egress.logger,
+            "debug",
+            lambda message, *args, **_kwargs: debug_logs.append((message, args)),
+        )
+
+        assert egress._getaddrinfo_with_timeout("example.invalid", timeout_s=0.5) == []
+        assert any("DNS resolver failed" in message for message, _args in debug_logs)

--- a/tldw_Server_API/tests/Security/test_egress.py
+++ b/tldw_Server_API/tests/Security/test_egress.py
@@ -1,4 +1,5 @@
 import os
+import threading
 
 import pytest
 from fastapi import HTTPException
@@ -107,26 +108,31 @@ class TestEgressPolicy:
         assert egress._resolve_host_ips("example.com") == ["93.184.216.34"]
         assert calls == []
 
-    def test_getaddrinfo_uses_bounded_executor(self, monkeypatch):
-        seen: dict[str, object] = {}
-        expected = [
-            (egress.socket.AF_INET, egress.socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443)),
-        ]
+    def test_dns_timeout_limits_outstanding_resolver_threads(self, monkeypatch):
+        release = threading.Event()
+        started = 0
+        started_lock = threading.Lock()
+        resolver_slots = threading.BoundedSemaphore(2)
 
-        class _FakeFuture:
-            def result(self, timeout):
-                seen["timeout"] = timeout
-                return expected
+        def _blocked_getaddrinfo(*_args, **_kwargs):
+            nonlocal started
+            with started_lock:
+                started += 1
+            release.wait(timeout=5)
+            return []
 
-        class _FakeExecutor:
-            _max_workers = 2
+        monkeypatch.setattr(egress, "_DNS_RESOLVER_SLOTS", resolver_slots, raising=False)
+        monkeypatch.setattr(egress.socket, "getaddrinfo", _blocked_getaddrinfo)
 
-            def submit(self, func, *args, **kwargs):
-                seen["submitted"] = (func, args, kwargs)
-                return _FakeFuture()
-
-        monkeypatch.setattr(egress, "_DNS_RESOLVER_EXECUTOR", _FakeExecutor())
-
-        assert egress._getaddrinfo_with_timeout("example.com", timeout_s=0.25) == expected
-        assert seen["timeout"] == 0.25
-        assert seen["submitted"]
+        try:
+            results = [
+                egress._getaddrinfo_with_timeout(
+                    f"example-{idx}.invalid",
+                    timeout_s=0.01,
+                )
+                for idx in range(5)
+            ]
+            assert results == [[], [], [], [], []]
+            assert started <= 2
+        finally:
+            release.set()

--- a/tldw_Server_API/tests/Security/test_egress.py
+++ b/tldw_Server_API/tests/Security/test_egress.py
@@ -1,4 +1,3 @@
-import os
 import threading
 
 import pytest
@@ -7,8 +6,29 @@ from fastapi import HTTPException
 from tldw_Server_API.app.core.Security import egress
 from tldw_Server_API.app.core.Security.url_validation import assert_url_safe
 
-
 pytestmark = pytest.mark.unit
+
+
+class _CapturedLogger:
+    def __init__(self) -> None:
+        self.current_bound: dict[str, object] = {}
+        self.warning_logs: list[tuple[dict[str, object], str]] = []
+        self.debug_logs: list[tuple[dict[str, object], str]] = []
+        self.opt_kwargs: list[dict[str, object]] = []
+
+    def bind(self, **kwargs: object) -> "_CapturedLogger":
+        self.current_bound = dict(kwargs)
+        return self
+
+    def opt(self, **kwargs: object) -> "_CapturedLogger":
+        self.opt_kwargs.append(dict(kwargs))
+        return self
+
+    def warning(self, message: str, *_args: object, **_kwargs: object) -> None:
+        self.warning_logs.append((dict(self.current_bound), message))
+
+    def debug(self, message: str, *_args: object, **_kwargs: object) -> None:
+        self.debug_logs.append((dict(self.current_bound), message))
 
 
 def _always_public(host: str):
@@ -116,7 +136,7 @@ class TestEgressPolicy:
         started = 0
         started_lock = threading.Lock()
         resolver_slots = threading.BoundedSemaphore(2)
-        warnings: list[tuple[str, tuple[object, ...]]] = []
+        captured_logger = _CapturedLogger()
 
         def _blocked_getaddrinfo(*_args: object, **_kwargs: object) -> list[object]:
             nonlocal started
@@ -127,11 +147,7 @@ class TestEgressPolicy:
 
         monkeypatch.setattr(egress, "_DNS_RESOLVER_SLOTS", resolver_slots, raising=False)
         monkeypatch.setattr(egress.socket, "getaddrinfo", _blocked_getaddrinfo)
-        monkeypatch.setattr(
-            egress.logger,
-            "warning",
-            lambda message, *args, **_kwargs: warnings.append((message, args)),
-        )
+        monkeypatch.setattr(egress, "logger", captured_logger)
 
         try:
             results = [
@@ -143,7 +159,11 @@ class TestEgressPolicy:
             ]
             assert results == [[], [], [], [], []]
             assert started <= 2
-            assert any("slots exhausted" in message for message, _args in warnings)
+            assert any(
+                fields.get("event") == "dns_resolver_slots_exhausted"
+                and fields.get("host") == "example-2.invalid"
+                for fields, _message in captured_logger.warning_logs
+            )
         finally:
             release.set()
 
@@ -151,17 +171,77 @@ class TestEgressPolicy:
         self: "TestEgressPolicy",
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        debug_logs: list[tuple[str, tuple[object, ...]]] = []
+        captured_logger = _CapturedLogger()
 
         def _failing_getaddrinfo(*_args: object, **_kwargs: object) -> list[object]:
             raise OSError("resolver failed")
 
         monkeypatch.setattr(egress.socket, "getaddrinfo", _failing_getaddrinfo)
-        monkeypatch.setattr(
-            egress.logger,
-            "debug",
-            lambda message, *args, **_kwargs: debug_logs.append((message, args)),
-        )
+        monkeypatch.setattr(egress, "logger", captured_logger)
 
         assert egress._getaddrinfo_with_timeout("example.invalid", timeout_s=0.5) == []
-        assert any("DNS resolver failed" in message for message, _args in debug_logs)
+        assert any(
+            fields.get("event") == "dns_resolver_error"
+            and fields.get("host") == "example.invalid"
+            and fields.get("exception_type") == "OSError"
+            for fields, _message in captured_logger.debug_logs
+        )
+
+    def test_dns_slot_wait_rejects_nan_config(
+        self: "TestEgressPolicy",
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured_logger = _CapturedLogger()
+        monkeypatch.setenv(egress.DNS_RESOLVER_SLOT_WAIT_SECONDS_ENV, "nan")
+        monkeypatch.setattr(egress, "logger", captured_logger)
+
+        assert egress._dns_slot_wait_seconds(1.0) == egress._DNS_RESOLVER_SLOT_WAIT_SECONDS_DEFAULT
+        assert any(
+            fields.get("event") == "invalid_egress_dns_config"
+            and fields.get("env_var") == egress.DNS_RESOLVER_SLOT_WAIT_SECONDS_ENV
+            and fields.get("reason") == "not_finite_or_negative"
+            for fields, _message in captured_logger.warning_logs
+        )
+
+    def test_dns_timeout_budget_subtracts_slot_wait(
+        self: "TestEgressPolicy",
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured_logger = _CapturedLogger()
+        join_timeouts: list[float | None] = []
+
+        class _FakeSlots:
+            def acquire(self, blocking: bool = True, timeout: float | None = None) -> bool:
+                return True
+
+            def release(self) -> None:
+                return None
+
+        class _FakeThread:
+            def __init__(self, target: object, daemon: bool) -> None:
+                self._target = target
+                self._daemon = daemon
+
+            def start(self) -> None:
+                return None
+
+            def join(self, timeout: float | None = None) -> None:
+                join_timeouts.append(timeout)
+
+            def is_alive(self) -> bool:
+                return True
+
+        times = iter([100.0, 100.03, 100.04, 100.05])
+        monkeypatch.setattr(egress, "_DNS_RESOLVER_SLOTS", _FakeSlots(), raising=False)
+        monkeypatch.setattr(egress.threading, "Thread", _FakeThread)
+        monkeypatch.setattr(egress.time, "monotonic", lambda: next(times))
+        monkeypatch.setattr(egress, "logger", captured_logger)
+
+        assert egress._getaddrinfo_with_timeout("example.invalid", timeout_s=0.1) == []
+        assert len(join_timeouts) == 1
+        assert join_timeouts[0] == pytest.approx(0.06)
+        assert any(
+            fields.get("event") == "dns_resolver_timeout"
+            and fields.get("host") == "example.invalid"
+            for fields, _message in captured_logger.warning_logs
+        )


### PR DESCRIPTION
## Summary
- Keeps FileLock lock files in place on release, removes stale-file unlinking, and removes now-unused per-acquire metadata writes/fsync.
- Makes Redis helper fallback fail closed by default, and fails closed for embeddings and ingest tenant quota when Redis quota state is unavailable with structured contextual warning logs.
- Hardens egress DNS handling with configurable resolver slots, structured bound logging, finite timeout/config validation, and timeout budgeting that subtracts resolver-slot wait time before joining the worker.
- Updates Redis factory docs/tests, egress regressions, task tracking, and new helper/regression docstrings to match the latest review comments.

## Change summary
Human-authored change summary required before this PR is marked ready for merge.

## Risk & Rollback
Risk level: Medium. This changes fail-closed behavior for Redis-backed quota paths and egress DNS timeout handling, so the main risk is stricter denial during Redis or DNS resolver degradation. Rollback plan: revert this PR branch or the latest hardening commits to restore the previous Redis fallback and DNS resolver behavior.

## Test Plan
- [x] Latest full focused post-change suite: 65 passed.
- [x] Ruff check on latest egress production/test files.
- [x] py_compile on latest egress production and touched regression test files.
- [x] git diff --check on latest touched files.
- [x] Bandit touched-scope scan for egress.py: 0 errors, 0 findings.

## Rebase
- [x] PR base is dev at 6fe09bb972eae6b3ad75559426a6f54ea7a65ff5; branch includes that base.

## Backlog
- TASK-12021