### PR TITLE
Continue Research Workspace UAT remaining certification

### DIFF
--- a/Docs/Plans/IMPLEMENTATION_PLAN_research_workspace_llamacpp_uat_retry_TASK_12020_35.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_research_workspace_llamacpp_uat_retry_TASK_12020_35.md
@@ -1,0 +1,17 @@
+## Stage 1: Llama.cpp Runtime Mapping
+**Goal**: Use the backend-advertised chat provider for llama.cpp models and send raw model ids in Studio and RAG requests.
+**Success Criteria**: Focused unit tests fail before the change and pass after; llama.cpp metadata maps to `llama.cpp` while request bodies use the GGUF filename without a provider prefix.
+**Tests**: `e2e-fixture-models.test.ts`, `StudioPane.stage1.test.tsx`, `ragMode.sanitization.test.ts`
+**Status**: Complete
+
+## Stage 2: Queryable Live UAT Sources
+**Goal**: Seed real-backend Research Workspace UAT documents with chunking enabled so selected sources become queryable before grounded chat assertions.
+**Success Criteria**: Failed live RAG waits observe `/api/v1/rag/search` instead of stalling on non-queryable `Processing` sources.
+**Tests**: Targeted real-backend Playwright rerun for the previously failing grounded chat/search/Studio scenarios.
+**Status**: Complete
+
+## Stage 3: Full Llama.cpp UAT Retry
+**Goal**: Re-run the standalone Research Workspace UAT matrix against the local llama.cpp provider.
+**Success Criteria**: UAT no longer fails due provider reachability, non-queryable seeded sources, or llama.cpp request shaping; any residual failures are classified with fresh evidence.
+**Tests**: `bun run e2e:research-workspace:uat` with `/tmp/pr2535-research-workspace-uat-report-llamacpp*.json` evidence.
+**Status**: Complete

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/hooks/useArtifactGeneration.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/hooks/useArtifactGeneration.tsx
@@ -3,6 +3,7 @@ import type { MessageInstance } from "antd/es/message/interface"
 import { tldwClient, type VisualStyleRecord } from "@/services/tldw/TldwApiClient"
 import { tldwModels, type ModelInfo } from "@/services/tldw"
 import { trackResearchWorkspaceTelemetry } from "@/utils/research-workspace-telemetry"
+import { parseProviderQualifiedModelSelection } from "@/utils/resolve-api-provider"
 import {
   createQuestion,
   createQuiz,
@@ -64,6 +65,7 @@ import {
 // ─────────────────────────────────────────────────────────────────────────────
 
 const STUDIO_GENERATION_RAG_TIMEOUT_MS = 120000
+const STUDIO_GENERATION_CHAT_TIMEOUT_MS = 180000
 const STUDIO_SOURCE_CHAR_LIMIT = 6000
 const STUDIO_TOTAL_SOURCE_CHAR_LIMIT = 18000
 const FLASHCARD_GENERATION_TEXT_LIMIT = 8000
@@ -132,6 +134,17 @@ const normalizeStudioApiProviderForRequest = (
   }
 
   return rawProvider
+}
+
+const resolveStudioModelSelection = (value: unknown) => {
+  const normalized = normalizeStudioChatModelId(value)
+  const parsed = parseProviderQualifiedModelSelection(normalized)
+  const modelId = normalizeStudioChatModelId(parsed.modelId || normalized)
+  return {
+    rawModelId: normalized,
+    modelId,
+    provider: parsed.provider
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -262,6 +275,11 @@ const buildQuizSourceBundle = (
 const buildBundledQuizQuestionCount = (mediaCount: number): number => {
   const normalizedMediaCount = Math.max(1, mediaCount)
   return Math.min(8, Math.max(6, normalizedMediaCount * 3))
+}
+
+const buildBundledFlashcardCount = (sourceCount: number): number => {
+  const normalizedSourceCount = Math.max(1, sourceCount)
+  return Math.min(10, Math.max(6, normalizedSourceCount * 3))
 }
 
 const extractJsonPayloadText = (value: string): string => {
@@ -1039,7 +1057,10 @@ ${sourceText}`
       top_p: options.topP,
       max_tokens: options.maxTokens
     },
-    { signal: options.abortSignal }
+    {
+      signal: options.abortSignal,
+      timeoutMs: STUDIO_GENERATION_CHAT_TIMEOUT_MS
+    }
   )
 
   const { content: rawContent, usage } =
@@ -1090,7 +1111,10 @@ ${sourceText}`
           ? Math.min(options.maxTokens, options.maxOutputTokens)
           : options.maxTokens
     },
-    { signal: options.abortSignal }
+    {
+      signal: options.abortSignal,
+      timeoutMs: STUDIO_GENERATION_CHAT_TIMEOUT_MS
+    }
   )
 
   const { content: rawContent, usage } =
@@ -1296,7 +1320,10 @@ ${sourceText}`
       top_p: options.topP,
       max_tokens: quizMaxTokens
     },
-    { signal: options.abortSignal }
+    {
+      signal: options.abortSignal,
+      timeoutMs: STUDIO_GENERATION_CHAT_TIMEOUT_MS
+    }
   )
 
   const { content: rawContent, usage } = await readChatCompletionResponsePayload(response)
@@ -1442,7 +1469,7 @@ async function generateFlashcards(
 
   const generationRequest: FlashcardsGenerateRequest = {
     text: sourceText,
-    num_cards: 12,
+    num_cards: buildBundledFlashcardCount(sourceContexts.length),
     difficulty: "mixed",
     provider: options.apiProvider,
     model:
@@ -1600,7 +1627,10 @@ ${sourceContexts
     temperature: options.temperature,
     top_p: options.topP,
     max_tokens: options.maxTokens
-  }, { signal: options.abortSignal })
+  }, {
+    signal: options.abortSignal,
+    timeoutMs: STUDIO_GENERATION_CHAT_TIMEOUT_MS
+  })
 
   const content = (await readChatCompletionResponseText(response)).trim()
   if (!content) {
@@ -1658,7 +1688,10 @@ ${sourceText}`
       top_p: options.topP,
       max_tokens: options.maxTokens
     },
-    { signal: options.abortSignal }
+    {
+      signal: options.abortSignal,
+      timeoutMs: STUDIO_GENERATION_CHAT_TIMEOUT_MS
+    }
   )
   const { content: rawScript, usage } = await readChatCompletionResponsePayload(response)
   const script = rawScript.trim()
@@ -1852,7 +1885,10 @@ async function generateLiteratureMatrix(
       max_tokens: options.maxTokens,
       response_format: { type: "json_object" }
     },
-    { signal: options.abortSignal }
+    {
+      signal: options.abortSignal,
+      timeoutMs: STUDIO_GENERATION_CHAT_TIMEOUT_MS
+    }
   )
 
   const { content: rawContent, usage } =
@@ -1925,7 +1961,10 @@ async function generateCorpusGapFinder(
       max_tokens: options.maxTokens,
       response_format: { type: "json_object" }
     },
-    { signal: options.abortSignal }
+    {
+      signal: options.abortSignal,
+      timeoutMs: STUDIO_GENERATION_CHAT_TIMEOUT_MS
+    }
   )
 
   const { content: rawContent, usage } =
@@ -2019,7 +2058,10 @@ async function generateEvidenceBoundHypotheses(
       max_tokens: options.maxTokens,
       response_format: { type: "json_object" }
     },
-    { signal: options.abortSignal }
+    {
+      signal: options.abortSignal,
+      timeoutMs: STUDIO_GENERATION_CHAT_TIMEOUT_MS
+    }
   )
 
   const { content: rawContent, usage } =
@@ -2122,7 +2164,10 @@ async function generateResearchProposalPack(
       top_p: options.topP,
       max_tokens: options.maxTokens
     },
-    { signal: options.abortSignal }
+    {
+      signal: options.abortSignal,
+      timeoutMs: STUDIO_GENERATION_CHAT_TIMEOUT_MS
+    }
   )
 
   const { content: rawContent, usage } =
@@ -2177,6 +2222,9 @@ ${sourceContexts
     temperature: options.temperature,
     top_p: options.topP,
     max_tokens: options.maxTokens
+  }, {
+    signal: options.abortSignal,
+    timeoutMs: STUDIO_GENERATION_CHAT_TIMEOUT_MS
   })
 
   const content = (await readChatCompletionResponseText(response)).trim()
@@ -2545,29 +2593,42 @@ export function useArtifactGeneration(deps: UseArtifactGenerationDeps) {
       typeof value === "string" && value.trim().length > 0
         ? normalizeStudioApiProviderForRequest(value)
         : undefined
+    const providerCandidatesForModel = (model: ModelInfo | undefined) =>
+      [
+        normalizeProviderValue(model?.chatProvider),
+        normalizeProviderValue(model?.provider)
+      ].filter((provider): provider is string => Boolean(provider))
+    const providerForModel = (model: ModelInfo | undefined) =>
+      providerCandidatesForModel(model)[0]
+    const normalizedProviderOverride =
+      normalizedApiProvider !== "__auto__"
+        ? normalizeStudioApiProviderForRequest(normalizedApiProvider)
+        : undefined
 
     const pickRuntime = (models: ModelInfo[]) => {
-      const selectedModelId = normalizeStudioChatModelId(selectedModel) || undefined
+      const selectedModelSelection = resolveStudioModelSelection(selectedModel)
+      const selectedModelId = selectedModelSelection.modelId || undefined
       const providerFiltered =
-        normalizedApiProvider === "__auto__"
+        !normalizedProviderOverride
           ? models
           : models.filter(
               (model) =>
-                String(model.provider || "").trim().toLowerCase() ===
-                normalizedApiProvider
+                providerCandidatesForModel(model).includes(normalizedProviderOverride)
             )
       if (selectedModelId) {
         const matchedModel = models.find(
           (model) =>
             typeof model.id === "string" &&
-            normalizeStudioChatModelId(model.id) === selectedModelId
+            [selectedModelId, selectedModelSelection.rawModelId].includes(
+              normalizeStudioChatModelId(model.id)
+            )
         )
         return {
           model: selectedModelId,
           provider:
-            normalizedApiProvider !== "__auto__"
-              ? normalizeStudioApiProviderForRequest(normalizedApiProvider)
-              : normalizeProviderValue(matchedModel?.provider)
+            normalizedProviderOverride ||
+            normalizeProviderValue(selectedModelSelection.provider) ||
+            providerForModel(matchedModel)
         }
       }
 
@@ -2581,10 +2642,8 @@ export function useArtifactGeneration(deps: UseArtifactGenerationDeps) {
       return {
         model: fallbackModel?.id?.trim() || undefined,
         provider:
-          normalizeProviderValue(fallbackModel?.provider) ||
-          (normalizedApiProvider !== "__auto__"
-            ? normalizeStudioApiProviderForRequest(normalizedApiProvider)
-            : undefined)
+          providerForModel(fallbackModel) ||
+          normalizedProviderOverride
       }
     }
 

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/index.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/index.tsx
@@ -241,7 +241,13 @@ const OUTPUT_GROUPS: Array<{
 ]
 
 // Primary output types shown by default; remaining are collapsed behind an expander
-const PRIMARY_OUTPUT_TYPES = new Set<ArtifactType>(["summary", "flashcards", "quiz", "report"])
+const PRIMARY_OUTPUT_TYPES = new Set<ArtifactType>([
+  "summary",
+  "flashcards",
+  "quiz",
+  "report",
+  "compare_sources"
+])
 
 const getStudioWorkspaceSourceStatus = (source: WorkspaceSource) =>
   source.status || "ready"

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage1.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage1.test.tsx
@@ -1505,6 +1505,40 @@ describe("StudioPane Stage 1 generation lifecycle control", () => {
     })
   })
 
+  it("uses chatProvider and raw model id for provider-qualified llama.cpp selections", async () => {
+    messageOptionStoreState.selectedModel =
+      "llama.cpp:gemma-4-26B-A4B-it-ultra-uncensored-heretic-Q4_K_M.gguf"
+    mockGetChatModels.mockResolvedValue([
+      {
+        id: "gemma-4-26B-A4B-it-ultra-uncensored-heretic-Q4_K_M.gguf",
+        name: "Gemma 4 26B",
+        provider: "llama",
+        chatProvider: "llama.cpp",
+        type: "chat"
+      }
+    ])
+
+    renderStudioPane()
+
+    await waitFor(() => {
+      expect(mockGetChatModels).toHaveBeenCalled()
+    })
+
+    const summaryButton = screen.getByRole("button", { name: "Summary" })
+    expect(summaryButton).not.toBeDisabled()
+
+    fireEvent.click(summaryButton)
+
+    await waitFor(() => {
+      expect(mockCreateChatCompletion).toHaveBeenCalled()
+    })
+
+    expect(mockCreateChatCompletion.mock.calls[0]?.[0]).toMatchObject({
+      model: "gemma-4-26B-A4B-it-ultra-uncensored-heretic-Q4_K_M.gguf",
+      api_provider: "llama.cpp"
+    })
+  })
+
   it("normalizes configured tldw-prefixed model selections before summary generation", async () => {
     messageOptionStoreState.selectedModel = "tldw:ollama/gemma3:1b"
     mockGetChatModels.mockResolvedValue([

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx
@@ -1319,7 +1319,6 @@ describe("StudioPane Stage 2 workflows", () => {
     workspaceStoreState.getSelectedMediaIds = () => [101]
 
     renderStudioPane()
-    expandMoreOutputsSection()
 
     const compareButton = screen.getByRole("button", { name: "Compare Sources" })
     expect(compareButton).toBeDisabled()

--- a/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx
+++ b/apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx
@@ -652,7 +652,12 @@ describe("StudioPane Stage 2 workflows", () => {
         model: "gpt-4o-mini",
         response_format: { type: "json_object" }
       }),
-      expect.any(Object)
+      expect.objectContaining({
+        timeoutMs: expect.any(Number)
+      })
+    )
+    expect(mockCreateChatCompletion.mock.calls[0]?.[1]?.timeoutMs).toBeGreaterThanOrEqual(
+      120_000
     )
 
     expect(mockUpsertWorkspace).toHaveBeenCalledWith("workspace-a", {
@@ -1130,6 +1135,7 @@ describe("StudioPane Stage 2 workflows", () => {
     expect(mockGenerateFlashcardsService).toHaveBeenCalledWith(
       expect.objectContaining({
         text: expect.stringContaining("DSPy Prompting Talk"),
+        num_cards: 6,
         model: "gpt-4o-mini",
         provider: "openai"
       })
@@ -1673,7 +1679,7 @@ describe("StudioPane Stage 2 workflows", () => {
       expect(mockGetMediaDetails).toHaveBeenCalledTimes(2)
     })
 
-    expect(mockCreateChatCompletion).toHaveBeenCalledWith(
+    expect(mockCreateChatCompletion.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
         model: "gpt-4o-mini",
         temperature: 0.7,

--- a/apps/packages/ui/src/components/Quiz/QuizPlayground.tsx
+++ b/apps/packages/ui/src/components/Quiz/QuizPlayground.tsx
@@ -199,6 +199,7 @@ export const QuizPlayground: React.FC = () => {
 
   const handleTabChange = React.useCallback((nextTabRaw: string) => {
     const nextTab = nextTabRaw as QuizTabKey
+    defaultTabResolved.current = true
     if (activeTab === "create" && nextTab !== "create" && createTabDirty) {
       const shouldLeave = window.confirm(
         t("option:quiz.unsavedCreateConfirm", {

--- a/apps/packages/ui/src/components/Quiz/__tests__/QuizPlayground.navigation.test.tsx
+++ b/apps/packages/ui/src/components/Quiz/__tests__/QuizPlayground.navigation.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
 import { QuizPlayground } from "../QuizPlayground"
@@ -277,6 +277,29 @@ describe("QuizPlayground navigation intents", () => {
     render(<QuizPlayground />)
 
     expect(screen.getByTestId("quiz-reset-current-tab")).toBeInTheDocument()
+  })
+
+  it("does not let the late FTUX default override an explicit Manage tab click", async () => {
+    vi.mocked(useQuizzesQuery)
+      .mockReturnValueOnce({
+        data: undefined,
+        isLoading: true
+      } as any)
+      .mockReturnValueOnce({
+        data: { items: [], count: 0 },
+        isLoading: false
+      } as any)
+
+    const { rerender } = render(<QuizPlayground />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Manage" }))
+    expect(screen.getByTestId("active-tab")).toHaveTextContent("manage")
+
+    rerender(<QuizPlayground />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("active-tab")).toHaveTextContent("manage")
+    })
   })
 
   it("keeps inactive tab panes mounted for per-tab state preservation", () => {

--- a/apps/packages/ui/src/hooks/chat-modes/__tests__/ragMode.sanitization.test.ts
+++ b/apps/packages/ui/src/hooks/chat-modes/__tests__/ragMode.sanitization.test.ts
@@ -78,7 +78,24 @@ vi.mock("@/utils/actor", () => ({
 
 vi.mock("@/utils/resolve-api-provider", () => ({
   resolveApiProviderForModel: (...args: unknown[]) =>
-    mocks.resolveApiProviderForModel(...args)
+    mocks.resolveApiProviderForModel(...args),
+  parseProviderQualifiedModelSelection: (value: unknown) => {
+    const raw = String(value || "").trim()
+    if (!raw.startsWith("llama.cpp:")) {
+      return {
+        raw,
+        modelId: raw,
+        provider: undefined,
+        isProviderQualified: false
+      }
+    }
+    return {
+      raw,
+      modelId: raw.slice("llama.cpp:".length),
+      provider: "llama.cpp",
+      isProviderQualified: true
+    }
+  }
 }))
 
 vi.mock("../chatModePipeline", () => ({
@@ -219,6 +236,41 @@ describe("ragMode sanitizer", () => {
             text: expect.stringContaining("PASTE-EVIDENCE-ORION")
           })
         ]
+      })
+    )
+  })
+
+  it("sends raw generation_model when the selected RAG model is provider-qualified", async () => {
+    mocks.ragSearch.mockResolvedValue({
+      documents: [
+        {
+          content: "The llama.cpp provider accepted the raw GGUF model id.",
+          metadata: {
+            source: "media_db",
+            title: "llama.cpp runtime source",
+            type: "text"
+          }
+        }
+      ]
+    })
+    mocks.resolveApiProviderForModel.mockResolvedValue("llama.cpp")
+
+    await expect(
+      __testing__.ragModeDefinition.preflight?.(
+        createRagContext({
+          selectedModel:
+            "llama.cpp:gemma-4-26B-A4B-it-ultra-uncensored-heretic-Q4_K_M.gguf",
+          currentChatModelSettings: { apiProvider: undefined }
+        })
+      )
+    ).resolves.toBeNull()
+
+    expect(mocks.ragSearch).toHaveBeenCalledWith(
+      "What phrase proves the selected source was used?",
+      expect.objectContaining({
+        generation_model:
+          "gemma-4-26B-A4B-it-ultra-uncensored-heretic-Q4_K_M.gguf",
+        generation_provider: "llama.cpp"
       })
     )
   })

--- a/apps/packages/ui/src/hooks/chat-modes/__tests__/ragMode.sanitization.test.ts
+++ b/apps/packages/ui/src/hooks/chat-modes/__tests__/ragMode.sanitization.test.ts
@@ -288,7 +288,7 @@ describe("ragMode sanitizer", () => {
     )
   })
 
-  it("uses backend generated answers directly for selected workspace media RAG", async () => {
+  it("continues through chat completion when selected workspace media RAG returns evidence and a generated answer", async () => {
     mocks.ragSearch.mockResolvedValue({
       documents: [
         {
@@ -302,24 +302,40 @@ describe("ragMode sanitizer", () => {
       generated_answer:
         "The exact phrase is PASTE-EVIDENCE-ORION. It proves pasted workspace sources are indexed and used in grounded Research Workspace answers with visible evidence."
     })
+    const context = createRagContext()
 
-    const response = await __testing__.ragModeDefinition.preflight?.(
-      createRagContext()
-    )
+    await expect(
+      __testing__.ragModeDefinition.preflight?.(context)
+    ).resolves.toBeNull()
 
-    expect(response).toMatchObject({
-      handled: true,
-      fullText: expect.stringContaining("PASTE-EVIDENCE-ORION"),
-      sources: [
-        expect.objectContaining({
-          name: "TASK-478.5 Paste Evidence Source",
-          mode: "rag"
-        })
-      ],
-      generationInfo: expect.objectContaining({
-        grounded: true,
-        reason: "selected_source_generated_answer"
+    const prompt = await __testing__.ragModeDefinition.preparePrompt(context)
+
+    expect(mocks.ragSearch).toHaveBeenCalledTimes(1)
+    expect(prompt.sources).toEqual([
+      expect.objectContaining({
+        name: "TASK-478.5 Paste Evidence Source",
+        mode: "rag"
       })
-    })
+    ])
+    expect(mocks.humanMessageFormatter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: [
+          expect.objectContaining({
+            text: expect.stringContaining("PASTE-EVIDENCE-ORION")
+          })
+        ]
+      })
+    )
+    expect(mocks.humanMessageFormatter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: [
+          expect.objectContaining({
+            text: expect.stringContaining(
+              "What phrase proves the selected source was used?"
+            )
+          })
+        ]
+      })
+    )
   })
 })

--- a/apps/packages/ui/src/hooks/chat-modes/ragMode.ts
+++ b/apps/packages/ui/src/hooks/chat-modes/ragMode.ts
@@ -310,25 +310,6 @@ const buildSelectedSourceGroundingResponse = (
   saveToDb: false
 })
 
-const buildSelectedSourceGeneratedAnswerResponse = (
-  retrieval: PreparedRagRetrieval,
-  fullText: string
-) => ({
-  handled: true as const,
-  fullText,
-  sources: retrieval.source,
-  generationInfo: {
-    mode: "rag",
-    grounded: true,
-    reason: "selected_source_generated_answer",
-    retrievalMetadata: retrieval.rawResponse?.metadata,
-    citations: retrieval.rawResponse?.citations,
-    academicCitations: retrieval.rawResponse?.academic_citations,
-    chunkCitations: retrieval.rawResponse?.chunk_citations
-  },
-  saveToDb: false
-})
-
 const resolveRagQuery = async (
   ctx: ChatModeContext<RagModeParams>,
   questionPrompt: string
@@ -520,13 +501,6 @@ const ragModeDefinition: ChatModeDefinition<RagModeParams> = {
     try {
       const retrieval = await prepareRagRetrieval(ctx, questionPrompt)
       if (retrieval.source.length > 0) {
-        const generatedAnswer = getGeneratedRagAnswer(retrieval.rawResponse)
-        if (generatedAnswer) {
-          return buildSelectedSourceGeneratedAnswerResponse(
-            retrieval,
-            generatedAnswer
-          )
-        }
         selectedSourceRetrievalCache.set(ctx, retrieval)
         return null
       }

--- a/apps/packages/ui/src/hooks/chat-modes/ragMode.ts
+++ b/apps/packages/ui/src/hooks/chat-modes/ragMode.ts
@@ -16,7 +16,10 @@ import { coerceBooleanOrNull } from "@/services/settings/registry"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 import type { ActorSettings } from "@/types/actor"
 import { maybeInjectActorMessage } from "@/utils/actor"
-import { resolveApiProviderForModel } from "@/utils/resolve-api-provider"
+import {
+  parseProviderQualifiedModelSelection,
+  resolveApiProviderForModel
+} from "@/utils/resolve-api-provider"
 import type { ChatModelSettings } from "@/store/model"
 import type { SaveMessageData, SaveMessageErrorData } from "@/types/chat-modes"
 import {
@@ -389,12 +392,18 @@ const buildRagOptions = async (
   // Delete false flags so the backend can apply its default behavior.
   if (ctx.ragEnableGeneration) {
     ragOptions.enable_generation = true
-    const selectedGenerationModel = ctx.selectedModel?.trim()
+    const rawSelectedGenerationModel = ctx.selectedModel?.trim()
+    const selectedModelSelection = parseProviderQualifiedModelSelection(
+      rawSelectedGenerationModel
+    )
+    const selectedGenerationModel = (
+      selectedModelSelection.modelId || rawSelectedGenerationModel
+    )?.trim()
     if (selectedGenerationModel) {
       ragOptions.generation_model = selectedGenerationModel
     }
     const selectedGenerationProvider = await resolveApiProviderForModel({
-      modelId: selectedGenerationModel,
+      modelId: rawSelectedGenerationModel,
       explicitProvider: ctx.currentChatModelSettings?.apiProvider
     })
     if (selectedGenerationProvider) {

--- a/apps/packages/ui/src/services/__tests__/tldw-api-client.chat-mutations.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-api-client.chat-mutations.test.ts
@@ -146,6 +146,29 @@ describe("TldwApiClient chat mutations", () => {
     })
   })
 
+  it("forwards explicit chat completion timeouts to the request transport", async () => {
+    mocks.bgRequest.mockResolvedValue({ id: "resp-1", object: "chat.completion" })
+
+    const client = new TldwApiClient()
+    await client.createChatCompletion(
+      {
+        model: "auto",
+        messages: [{ role: "user", content: "hello" }]
+      },
+      { timeoutMs: 180_000 }
+    )
+
+    const request = mocks.bgRequest.mock.calls.at(-1)?.[0] as {
+      path?: string
+      method?: string
+      timeoutMs?: number
+    }
+
+    expect(request.path).toBe("/api/v1/chat/completions")
+    expect(request.method).toBe("POST")
+    expect(request.timeoutMs).toBe(180_000)
+  })
+
   it("sanitizes leaky background payload fields when creating a chat completion", async () => {
     mocks.bgRequest.mockResolvedValue({
       id: "resp-1",

--- a/apps/packages/ui/src/services/flashcards.ts
+++ b/apps/packages/ui/src/services/flashcards.ts
@@ -21,7 +21,7 @@ const flashcardTagsClient = createResourceClient({
   basePath: "/api/v1/flashcards/tags" as AllowedPath
 })
 
-export const FLASHCARD_GENERATION_TIMEOUT_MS = 120000
+export const FLASHCARD_GENERATION_TIMEOUT_MS = 180000
 
 export type DeckSchedulerSettings = {
   new_steps_minutes: number[]

--- a/apps/packages/ui/src/services/tldw/TldwApiClient.ts
+++ b/apps/packages/ui/src/services/tldw/TldwApiClient.ts
@@ -759,6 +759,7 @@ export interface ChatCompletionRequest {
 
 export type ChatCompletionRequestOptions = {
   signal?: AbortSignal
+  timeoutMs?: number
   debugMetadata?: ChatRequestDebugMetadata
 }
 
@@ -2572,6 +2573,7 @@ export class TldwApiClientBase {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: request,
+      timeoutMs: options?.timeoutMs,
       abortSignal: options?.signal
     })
     // bgRequest returns parsed data; for non-streaming chat we expect a JSON structure or text. To keep existing consumers happy, wrap as Response-like

--- a/apps/packages/ui/src/services/tldw/domains/chat-rag.ts
+++ b/apps/packages/ui/src/services/tldw/domains/chat-rag.ts
@@ -299,6 +299,7 @@ export const chatRagMethods = {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: request,
+      timeoutMs: options?.timeoutMs,
       abortSignal: options?.signal
     })
     // bgRequest returns parsed data; for non-streaming chat we expect a JSON structure or text. To keep existing consumers happy, wrap as Response-like

--- a/apps/tldw-frontend/__tests__/e2e-fixture-models.test.ts
+++ b/apps/tldw-frontend/__tests__/e2e-fixture-models.test.ts
@@ -66,6 +66,28 @@ describe("e2e model preflight helpers", () => {
     ).toEqual(["ollama:gemma3:1b"])
   })
 
+  it("prefers backend chat_provider when metadata provider is only a catalog family", () => {
+    expect(
+      extractUsableModelIds({
+        models: [
+          {
+            provider: "llama",
+            chat_provider: "llama.cpp",
+            id: "gemma-4-26B-A4B-it-ultra-uncensored-heretic-Q4_K_M.gguf",
+            is_configured: true,
+            provider_is_configured: true,
+            provider_enabled: true,
+            availability: "enabled",
+            type: "chat",
+            output_modality: "text",
+          },
+        ],
+      })
+    ).toEqual([
+      "llama.cpp:gemma-4-26B-A4B-it-ultra-uncensored-heretic-Q4_K_M.gguf",
+    ])
+  })
+
   it("filters and normalizes provider fallback entries", () => {
     expect(
       extractModelIds({

--- a/apps/tldw-frontend/__tests__/research-workspace-uat-runner.test.ts
+++ b/apps/tldw-frontend/__tests__/research-workspace-uat-runner.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock("node:child_process", () => ({
+  default: { spawn: mocks.spawn },
   spawn: mocks.spawn
 }))
 
@@ -109,6 +110,74 @@ describe("research-workspace-uat-runner", () => {
     expect(skipped.reasons).toContain("skipped_tests_present")
     expect(empty.status).toBe("environment_blocked")
     expect(empty.reasons).toContain("no_tests_executed")
+  })
+
+  it("classifies known environment-only skips as environment blocked", () => {
+    const classification = classifyPlaywrightRun({
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      report: {
+        stats: {
+          expected: 19,
+          skipped: 2,
+          unexpected: 0,
+          flaky: 0,
+        },
+        suites: [
+          {
+            suites: [
+              {
+                specs: [
+                  {
+                    title:
+                      "grounds live chat requests on the selected source",
+                    tests: [
+                      {
+                        status: "skipped",
+                        expectedStatus: "skipped",
+                        annotations: [
+                          {
+                            type: "skip",
+                            description:
+                              "Skipping live generation workflow: server did not advertise a runnable chat model"
+                          }
+                        ],
+                        results: []
+                      }
+                    ]
+                  },
+                  {
+                    title:
+                      "shows workspace-linked sandbox run in diagnostics when sandbox run API is available",
+                    tests: [
+                      {
+                        status: "skipped",
+                        expectedStatus: "skipped",
+                        annotations: [
+                          {
+                            type: "skip",
+                            description:
+                              "POST /api/v1/sandbox/runs returned HTTP 404: {\"detail\":\"Not Found\"}"
+                          }
+                        ],
+                        results: []
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+    })
+
+    expect(classification.status).toBe("environment_blocked")
+    expect(classification.failureScope).toBe("environment")
+    expect(classification.reasons).toContain("environment_skips_present")
+    expect(classification.reasons).toContain("no_runnable_chat_model")
+    expect(classification.reasons).toContain("sandbox_run_api_unavailable")
   })
 
   it("writes evidence that separates environment failures from product results", () => {

--- a/apps/tldw-frontend/e2e/utils/fixtures.ts
+++ b/apps/tldw-frontend/e2e/utils/fixtures.ts
@@ -186,9 +186,7 @@ export function extractUsableModelIds(payload: any): string[] {
       models.push(model)
       continue
     }
-    const provider = normalizeModelField(
-      model?.provider ?? model?.provider_key ?? model?.api_provider
-    )
+    const provider = normalizeModelProvider(model)
     const id = normalizeModelField(model?.id ?? model?.model ?? model?.name)
     if (!id) continue
     models.push(formatModelId(id, provider))
@@ -213,9 +211,9 @@ export function extractModelIds(payload: any): string[] {
   for (const provider of providers) {
     if (Array.isArray(provider?.models)) {
       const providerUsable = isRunnableModelDescriptor(provider)
-      const providerName = normalizeModelField(
-        provider?.name ?? provider?.id ?? provider?.provider
-      )
+      const providerName =
+        normalizeModelProvider(provider) ??
+        normalizeModelField(provider?.name ?? provider?.id ?? provider?.provider)
       for (const model of provider.models) {
         if (
           !providerUsable ||
@@ -226,9 +224,7 @@ export function extractModelIds(payload: any): string[] {
         if (typeof model === "string") {
           models.push(formatModelId(model, providerName))
         } else {
-          const providerOverride = normalizeModelField(
-            model?.provider ?? model?.provider_key ?? model?.api_provider
-          )
+          const providerOverride = normalizeModelProvider(model)
           const id = normalizeModelField(model?.id ?? model?.model ?? model?.name)
           if (id) models.push(formatModelId(id, providerOverride ?? providerName))
         }
@@ -243,9 +239,7 @@ export function extractModelIds(payload: any): string[] {
       if (typeof model === "string") {
         models.push(model)
       } else {
-        const provider = normalizeModelField(
-          model?.provider ?? model?.provider_key ?? model?.api_provider
-        )
+        const provider = normalizeModelProvider(model)
         const id = normalizeModelField(model?.id ?? model?.model ?? model?.name)
         if (id) models.push(formatModelId(id, provider))
       }
@@ -352,6 +346,18 @@ function normalizeModelField(value: unknown): string | null {
   if (typeof value !== "string" && typeof value !== "number") return null
   const trimmed = String(value).trim()
   return trimmed.length > 0 ? trimmed : null
+}
+
+function normalizeModelProvider(value: any): string | null {
+  return normalizeModelField(
+    value?.chat_provider ??
+      value?.chatProvider ??
+      value?.api_provider ??
+      value?.apiProvider ??
+      value?.provider_key ??
+      value?.providerKey ??
+      value?.provider
+  )
 }
 
 function formatModelId(id: string, provider: string | null): string {

--- a/apps/tldw-frontend/e2e/utils/fixtures.ts
+++ b/apps/tldw-frontend/e2e/utils/fixtures.ts
@@ -272,6 +272,35 @@ function isRunnableModelDescriptor(
     "providerConfigured"
   ])
   if (providerConfigured === false) return false
+  const providerEnabled = firstBoolean(value, [
+    "provider_enabled",
+    "providerEnabled",
+    "enabled"
+  ])
+  if (providerEnabled === false) return false
+  const availability = normalizeModelField(
+    value?.availability ?? value?.status ?? value?.readiness
+  )
+  if (
+    availability === "unavailable" ||
+    availability === "not-configured" ||
+    availability === "not_configured"
+  ) {
+    return false
+  }
+  const readinessReasonCode = normalizeModelField(
+    value?.readiness_reason_code ?? value?.readinessReasonCode
+  )
+  if (
+    [
+      "egress_blocked",
+      "missing_credentials",
+      "provider_not_configured",
+      "unsupported_chat_provider"
+    ].includes(readinessReasonCode || "")
+  ) {
+    return false
+  }
   const deprecated = firstBoolean(value, ["deprecated", "is_deprecated", "isDeprecated"])
   if (deprecated === true) return false
   return true

--- a/apps/tldw-frontend/e2e/utils/page-objects/QuizPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/QuizPage.ts
@@ -101,27 +101,37 @@ export class QuizPage extends BasePage {
 
   /** Take Quiz tab */
   get takeTab(): Locator {
-    return this.page.getByRole("tab", { name: /take/i })
+    return this.page
+      .locator('[data-testid="quiz-tab-take"]')
+      .locator("xpath=ancestor::*[@role='tab'][1]")
   }
 
   /** Generate tab */
   get generateTab(): Locator {
-    return this.page.getByRole("tab", { name: /generate/i })
+    return this.page
+      .locator('[data-testid="quiz-tab-generate"]')
+      .locator("xpath=ancestor::*[@role='tab'][1]")
   }
 
   /** Create tab */
   get createTab(): Locator {
-    return this.page.getByRole("tab", { name: /create|build/i })
+    return this.page
+      .locator('[data-testid="quiz-tab-create"]')
+      .locator("xpath=ancestor::*[@role='tab'][1]")
   }
 
   /** Manage tab */
   get manageTab(): Locator {
-    return this.page.getByRole("tab", { name: /manage/i })
+    return this.page
+      .locator('[data-testid="quiz-tab-manage"]')
+      .locator("xpath=ancestor::*[@role='tab'][1]")
   }
 
   /** Results tab */
   get resultsTab(): Locator {
-    return this.page.getByRole("tab", { name: /results|stats/i })
+    return this.page
+      .locator('[data-testid="quiz-tab-results"]')
+      .locator("xpath=ancestor::*[@role='tab'][1]")
   }
 
   /** Global search input */
@@ -140,7 +150,9 @@ export class QuizPage extends BasePage {
   }
 
   get manageShowWorkspaceQuizzesToggle(): Locator {
-    return this.page.locator('[data-testid="quiz-manage-show-workspace-quizzes"]')
+    return this.page
+      .locator('[data-testid="quiz-manage-show-workspace-quizzes"]')
+      .locator("xpath=ancestor::label[1]")
   }
 
   get manageWorkspaceFilter(): Locator {

--- a/apps/tldw-frontend/e2e/workflows/research-workspace.real-backend.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/research-workspace.real-backend.spec.ts
@@ -14,7 +14,8 @@ import {
   test,
   expect,
   skipIfServerUnavailable,
-  assertNoCriticalErrors
+  assertNoCriticalErrors,
+  type ServerInfo
 } from "../utils/fixtures"
 import {
   seedAuth,
@@ -36,6 +37,35 @@ const REQUIRE_SANDBOX_WORKSPACE_RUN =
   process.env.TLDW_E2E_REQUIRE_SANDBOX_WORKSPACE_RUN === "1"
 const EXPECTED_SANDBOX_RUN_PHASE =
   process.env.TLDW_E2E_EXPECT_SANDBOX_RUN_PHASE?.trim() || ""
+
+const requireRealBackendChatModel = (
+  serverInfo: ServerInfo
+): string => {
+  const modelId = serverInfo.models?.[0]?.trim() || ""
+  test.skip(
+    modelId.length === 0,
+    "Skipping live generation workflow: server did not advertise a runnable chat model"
+  )
+  return modelId
+}
+
+const selectRealBackendChatModel = async (
+  page: Page,
+  modelId: string
+): Promise<void> => {
+  await page.evaluate((selectedModel) => {
+    const store = (window as { __tldw_useStoreMessageOption?: unknown })
+      .__tldw_useStoreMessageOption as
+      | {
+          setState?: (nextState: Record<string, unknown>) => void
+        }
+      | undefined
+    if (!store?.setState) {
+      throw new Error("Message option store is unavailable on window")
+    }
+    store.setState({ selectedModel })
+  }, modelId)
+}
 
 type BootstrapResponse = {
   url: string
@@ -597,9 +627,24 @@ test.describe("Research Workspace Workflow (Real Backend)", () => {
         expect(beginnerEvidence.persona).toBe("beginner-no-key")
         expect(beginnerEvidence.routeTiming.durationMs).toBeGreaterThanOrEqual(0)
         expect(beginnerEvidence.url).toContain("/research-workspace")
-        expect(
-          await beginnerPage.evaluate(() => localStorage.getItem("tldwConfig"))
-        ).toBeNull()
+        const beginnerStoredConfig = await beginnerPage.evaluate(() => {
+          const raw = localStorage.getItem("tldwConfig")
+          if (!raw) {
+            return { raw: null, apiKey: null }
+          }
+          try {
+            const parsed = JSON.parse(raw)
+            return {
+              raw,
+              apiKey:
+                typeof parsed?.apiKey === "string" ? parsed.apiKey : null
+            }
+          } catch {
+            return { raw, apiKey: null }
+          }
+        })
+        expect(beginnerStoredConfig.apiKey).toBeNull()
+        expect(beginnerStoredConfig.raw || "").not.toContain(TEST_CONFIG.apiKey)
       } finally {
         beginnerDiagnostics.dispose()
       }
@@ -950,6 +995,7 @@ test.describe("Research Workspace Workflow (Real Backend)", () => {
       chatBootstrapPreflight.reason ||
         "Skipping real-backend workspace test: chat bootstrap endpoint unavailable"
     )
+    const chatModelId = requireRealBackendChatModel(serverInfo)
 
     const fixtureId = generateTestId("workspace-chat-grounding")
     const probeToken = `${fixtureId}-beacon-fox`
@@ -969,6 +1015,7 @@ test.describe("Research Workspace Workflow (Real Backend)", () => {
     try {
       await workspacePage.goto()
       await workspacePage.waitForReady()
+      await selectRealBackendChatModel(authedPage, chatModelId)
       await assertChatBootstrapHealthy(tracker.responses, tracker.failures)
 
       await workspacePage.seedSources([selectedSource, unselectedSource])
@@ -1022,6 +1069,7 @@ test.describe("Research Workspace Workflow (Real Backend)", () => {
       chatBootstrapPreflight.reason ||
         "Skipping real-backend workspace test: chat bootstrap endpoint unavailable"
     )
+    const chatModelId = requireRealBackendChatModel(serverInfo)
 
     const fixtureId = generateTestId("research-workspace-scope")
     const leftSource = await seedLiveWorkspaceDocument(
@@ -1039,6 +1087,7 @@ test.describe("Research Workspace Workflow (Real Backend)", () => {
     try {
       await workspacePage.goto()
       await workspacePage.waitForReady()
+      await selectRealBackendChatModel(authedPage, chatModelId)
       await assertChatBootstrapHealthy(tracker.responses, tracker.failures)
 
       await workspacePage.seedSources([leftSource, rightSource])
@@ -1110,6 +1159,7 @@ test.describe("Research Workspace Workflow (Real Backend)", () => {
       chatBootstrapPreflight.reason ||
         "Skipping real-backend workspace test: chat bootstrap endpoint unavailable"
     )
+    const chatModelId = requireRealBackendChatModel(serverInfo)
 
     const fixtureId = generateTestId("workspace-global-search")
     const probeToken = `${fixtureId}-search-token`
@@ -1125,6 +1175,7 @@ test.describe("Research Workspace Workflow (Real Backend)", () => {
     try {
       await workspacePage.goto()
       await workspacePage.waitForReady()
+      await selectRealBackendChatModel(authedPage, chatModelId)
       await assertChatBootstrapHealthy(tracker.responses, tracker.failures)
 
       await workspacePage.seedSources([selectedSource])
@@ -1173,6 +1224,7 @@ test.describe("Research Workspace Workflow (Real Backend)", () => {
       chatBootstrapPreflight.reason ||
         "Skipping real-backend workspace test: chat bootstrap endpoint unavailable"
     )
+    const chatModelId = requireRealBackendChatModel(serverInfo)
 
     const fixtureId = generateTestId("workspace-study-quiz")
     const probeToken = `${fixtureId}-quiz-token`
@@ -1192,6 +1244,7 @@ test.describe("Research Workspace Workflow (Real Backend)", () => {
     try {
       await workspacePage.goto()
       await workspacePage.waitForReady()
+      await selectRealBackendChatModel(authedPage, chatModelId)
       await assertChatBootstrapHealthy(tracker.responses, tracker.failures)
 
       await workspacePage.resetWorkspace(`Workspace ${fixtureId}`)
@@ -1336,6 +1389,7 @@ test.describe("Research Workspace Workflow (Real Backend)", () => {
       chatBootstrapPreflight.reason ||
         "Skipping real-backend workspace test: chat bootstrap endpoint unavailable"
     )
+    const chatModelId = requireRealBackendChatModel(serverInfo)
 
     const fixtureId = generateTestId("workspace-study-flashcards")
     const probeToken = `${fixtureId}-flashcards-token`
@@ -1355,6 +1409,7 @@ test.describe("Research Workspace Workflow (Real Backend)", () => {
     try {
       await workspacePage.goto()
       await workspacePage.waitForReady()
+      await selectRealBackendChatModel(authedPage, chatModelId)
       await assertChatBootstrapHealthy(tracker.responses, tracker.failures)
 
       await workspacePage.resetWorkspace(`Workspace ${fixtureId}`)

--- a/apps/tldw-frontend/e2e/workflows/research-workspace.real-backend.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/research-workspace.real-backend.spec.ts
@@ -53,7 +53,12 @@ const selectRealBackendChatModel = async (
   page: Page,
   modelId: string
 ): Promise<void> => {
-  await page.evaluate((selectedModel) => {
+  const separatorIndex = modelId.indexOf(":")
+  const provider = separatorIndex > 0 ? modelId.slice(0, separatorIndex) : ""
+  const selectedModel =
+    provider === "llama.cpp" ? modelId.slice(separatorIndex + 1) : modelId
+
+  await page.evaluate(({ selectedModel, provider }) => {
     const store = (window as { __tldw_useStoreMessageOption?: unknown })
       .__tldw_useStoreMessageOption as
       | {
@@ -64,7 +69,18 @@ const selectRealBackendChatModel = async (
       throw new Error("Message option store is unavailable on window")
     }
     store.setState({ selectedModel })
-  }, modelId)
+
+    if (provider) {
+      const modelSettingsStore = (window as {
+        __tldw_useStoreChatModelSettings?: unknown
+      }).__tldw_useStoreChatModelSettings as
+        | {
+            setState?: (nextState: Record<string, unknown>) => void
+          }
+        | undefined
+      modelSettingsStore?.setState?.({ apiProvider: provider })
+    }
+  }, { selectedModel, provider })
 }
 
 type BootstrapResponse = {
@@ -335,7 +351,7 @@ const seedLiveWorkspaceDocument = async (
   body.append("media_type", "document")
   body.append("title", title)
   body.append("perform_analysis", "false")
-  body.append("perform_chunking", "false")
+  body.append("perform_chunking", "true")
   body.append("files", new Blob([content], { type: "text/plain" }), fileName)
 
   const response = await fetchWithApiKey(

--- a/apps/tldw-frontend/e2e/workflows/research-workspace.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/research-workspace.spec.ts
@@ -148,6 +148,138 @@ test.describe("Research Workspace Workflow", () => {
         body: JSON.stringify({ items: [], total: 0 })
       })
     })
+
+    await page.route(/\/api\/v1\/workspaces\/[^/]+(?:\/.*)?$/i, async (route) => {
+      const request = route.request()
+      const url = new URL(request.url())
+      const workspaceId = decodeURIComponent(
+        url.pathname.match(/\/api\/v1\/workspaces\/([^/]+)/i)?.[1] || "workspace-e2e"
+      )
+      const method = request.method().toUpperCase()
+      const path = url.pathname
+
+      if (path.endsWith("/context")) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            workspace_id: workspaceId,
+            sources: {
+              items: [],
+              summary: {
+                total: 0,
+                selected: 0,
+                queryable: 0,
+                partially_queryable: 0,
+                processing: 0,
+                failed: 0,
+                missing: 0
+              }
+            },
+            capabilities: {
+              workspace_id: workspaceId,
+              capabilities: {}
+            },
+            partial_errors: []
+          })
+        })
+        return
+      }
+
+      if (path.endsWith("/sources/status")) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            workspace_id: workspaceId,
+            sources: [],
+            summary: {
+              total: 0,
+              selected: 0,
+              queryable: 0,
+              partially_queryable: 0,
+              processing: 0,
+              failed: 0,
+              missing: 0
+            }
+          })
+        })
+        return
+      }
+
+      if (path.endsWith("/capabilities")) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            workspace_id: workspaceId,
+            capabilities: {}
+          })
+        })
+        return
+      }
+
+      if (path.endsWith("/sources")) {
+        if (method === "GET") {
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([])
+          })
+          return
+        }
+
+        const body = request.postDataJSON() as
+          | {
+              source_id?: string
+              media_id?: number
+              title?: string
+              selected?: boolean
+            }
+          | undefined
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            id: body?.source_id || `source-${body?.media_id || "mock"}`,
+            workspace_id: workspaceId,
+            media_id: body?.media_id || null,
+            title: body?.title || "Mock source",
+            selected: Boolean(body?.selected),
+            state: "queryable",
+            readiness: {
+              metadata_ready: true,
+              text_extracted: true,
+              fts_ready: true,
+              vector_ready: true,
+              citation_ready: true,
+              summary_ready: true,
+              tool_accessible: true
+            }
+          })
+        })
+        return
+      }
+
+      if (path.endsWith("/sources/selection")) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ workspace_id: workspaceId, selected_source_ids: [] })
+        })
+        return
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: workspaceId,
+          workspace_id: workspaceId,
+          name: "Workspace E2E"
+        })
+      })
+    })
   })
 
   test("loads research workspace and renders core panes", async ({
@@ -776,43 +908,55 @@ test.describe("Research Workspace Workflow", () => {
     }
     const comparisonToken = "workspace-compare-sources-token"
     const comparisonOutput = `## Agreements\n- Both sources reference ${comparisonToken}.\n\n## Disagreements\n- Source B adds extra caveats.\n\n## Evidence Strength\n- Evidence is moderate.\n\n## Open Questions\n- Verify the missing caveat.`
-    const compareRequests: Array<Record<string, unknown>> = []
+    const chatCompletionRequests: Array<Record<string, unknown>> = []
 
-    await authedPage.route("**/api/v1/rag/search", async (route) => {
-      compareRequests.push((route.request().postDataJSON() as Record<string, unknown>) || {})
+    await authedPage.route(/\/api\/v1\/media\/\d+\?.*include_content=true/i, async (route) => {
+      const url = new URL(route.request().url())
+      const mediaId = Number(url.pathname.match(/\/media\/(\d+)$/)?.[1] || 0)
+      const source =
+        mediaId === sourceA.mediaId
+          ? sourceA
+          : mediaId === sourceB.mediaId
+            ? sourceB
+            : null
+      await route.fulfill({
+        status: source ? 200 : 404,
+        contentType: "application/json",
+        body: JSON.stringify(
+          source
+            ? {
+                source: { title: source.title, media_id: source.mediaId },
+                content: {
+                  text:
+                    source.mediaId === sourceA.mediaId
+                      ? "Source A states both documents reference the shared comparison token."
+                      : "Source B references the shared comparison token and adds caveats."
+                }
+              }
+            : { detail: "not found" }
+        )
+      })
+    })
+
+    await authedPage.route("**/api/v1/chat/completions", async (route) => {
+      chatCompletionRequests.push(
+        (route.request().postDataJSON() as Record<string, unknown>) || {}
+      )
       await route.fulfill({
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({
-          generation: comparisonOutput,
+          choices: [
+            {
+              message: {
+                content: comparisonOutput
+              }
+            }
+          ],
           usage: {
             total_tokens: 321,
             total_cost_usd: 0.12
-          },
-          citations: [
-            { source: sourceA.title, media_id: sourceA.mediaId },
-            { source: sourceB.title, media_id: sourceB.mediaId }
-          ],
-          results: [
-            {
-              id: "compare-source-a",
-              content: "Source A evidence",
-              metadata: {
-                title: sourceA.title,
-                media_id: sourceA.mediaId
-              },
-              score: 0.91
-            },
-            {
-              id: "compare-source-b",
-              content: "Source B evidence",
-              metadata: {
-                title: sourceB.title,
-                media_id: sourceB.mediaId
-              },
-              score: 0.88
-            }
-          ]
+          }
         })
       })
     })
@@ -820,6 +964,7 @@ test.describe("Research Workspace Workflow", () => {
     const workspacePage = new ResearchWorkspacePage(authedPage)
     await workspacePage.goto()
     await workspacePage.waitForReady()
+    await setWorkspaceSelectedModel(authedPage)
 
     await workspacePage.seedSources([sourceA, sourceB])
 
@@ -846,18 +991,19 @@ test.describe("Research Workspace Workflow", () => {
     await compareButton.click()
 
     await expect
-      .poll(() => compareRequests.length, { timeout: 10_000 })
+      .poll(() => chatCompletionRequests.length, { timeout: 10_000 })
       .toBe(1)
-    expect(compareRequests[0]?.query).toBe("agreements disagreements claims evidence")
-    expect(compareRequests[0]?.include_media_ids).toEqual([
-      sourceA.mediaId,
-      sourceB.mediaId
-    ])
-    expect(compareRequests[0]?.top_k).toBe(30)
-    expect(compareRequests[0]?.enable_generation).toBe(true)
-    expect(compareRequests[0]?.enable_citations).toBe(true)
-    expect(String(compareRequests[0]?.generation_prompt || "")).toContain(
-      "Compare the selected sources"
+    expect(chatCompletionRequests[0]?.model).toBe(SUMMARY_TEST_MODEL)
+    const comparisonMessages = chatCompletionRequests[0]?.messages as
+      | Array<{ role?: string; content?: string }>
+      | undefined
+    expect(comparisonMessages?.[0]?.content).toContain(
+      "source-grounded comparison analyst"
+    )
+    expect(comparisonMessages?.[1]?.content).toContain(sourceA.title)
+    expect(comparisonMessages?.[1]?.content).toContain(sourceB.title)
+    expect(comparisonMessages?.[1]?.content).toContain(
+      "Source B references the shared comparison token"
     )
 
     const artifactCard = workspacePage.studioPanel

--- a/apps/tldw-frontend/scripts/research-workspace-uat-runner.mjs
+++ b/apps/tldw-frontend/scripts/research-workspace-uat-runner.mjs
@@ -29,6 +29,23 @@ const ENVIRONMENT_FAILURE_PATTERNS = [
   },
 ]
 
+const ENVIRONMENT_SKIP_PATTERNS = [
+  {
+    code: "no_runnable_chat_model",
+    pattern:
+      /server did not advertise a runnable chat model|No LLM models available/i,
+  },
+  {
+    code: "sandbox_run_api_unavailable",
+    pattern:
+      /sandbox run API unavailable|POST\s+\/api\/v1\/sandbox\/runs\s+returned\s+HTTP\s+404/i,
+  },
+  {
+    code: "server_unavailable",
+    pattern: /Server is not available/i,
+  },
+]
+
 const readJsonIfPresent = (filePath) => {
   if (!filePath || !fs.existsSync(filePath)) return null
   return JSON.parse(fs.readFileSync(filePath, "utf8"))
@@ -192,6 +209,67 @@ const getReportStats = (report) => {
   }
 }
 
+const collectSkippedTests = (report) => {
+  const skippedTests = []
+
+  const visitSuite = (suite) => {
+    for (const spec of suite?.specs || []) {
+      for (const test of spec.tests || []) {
+        const isSkipped =
+          test?.status === "skipped" ||
+          test?.expectedStatus === "skipped" ||
+          (test?.results || []).some((result) => result?.status === "skipped")
+        if (!isSkipped) continue
+
+        const annotations = [
+          ...(test.annotations || []),
+          ...(test.results || []).flatMap((result) => result?.annotations || []),
+        ]
+        skippedTests.push({
+          annotations,
+          title: spec.title || "",
+        })
+      }
+    }
+
+    for (const childSuite of suite?.suites || []) {
+      visitSuite(childSuite)
+    }
+  }
+
+  for (const suite of report?.suites || []) {
+    visitSuite(suite)
+  }
+
+  return skippedTests
+}
+
+const getEnvironmentSkipReasons = ({ report, stats }) => {
+  const skippedTests = collectSkippedTests(report)
+  if (skippedTests.length === 0 || skippedTests.length !== stats.skipped) {
+    return null
+  }
+
+  const reasonCodes = new Set()
+  for (const skippedTest of skippedTests) {
+    const description = skippedTest.annotations
+      .map((annotation) => annotation?.description || "")
+      .filter(Boolean)
+      .join("\n")
+    const matchingReasons = ENVIRONMENT_SKIP_PATTERNS.filter(({ pattern }) =>
+      pattern.test(description)
+    )
+    if (matchingReasons.length === 0) {
+      return null
+    }
+    for (const reason of matchingReasons) {
+      reasonCodes.add(reason.code)
+    }
+  }
+
+  return ["environment_skips_present", ...reasonCodes]
+}
+
 export const classifyPlaywrightRun = ({ exitCode, stdout = "", stderr = "", report }) => {
   const combinedOutput = `${stdout}\n${stderr}`
   const environmentReasons = ENVIRONMENT_FAILURE_PATTERNS.filter(({ pattern }) =>
@@ -219,6 +297,21 @@ export const classifyPlaywrightRun = ({ exitCode, stdout = "", stderr = "", repo
         failureScope: "environment",
         reasons,
         status: "environment_blocked",
+      }
+    }
+    if (
+      stats.skipped > 0 &&
+      stats.unexpected === 0 &&
+      stats.flaky === 0 &&
+      exitCode === 0
+    ) {
+      const environmentSkipReasons = getEnvironmentSkipReasons({ report, stats })
+      if (environmentSkipReasons) {
+        return {
+          failureScope: "environment",
+          reasons: environmentSkipReasons,
+          status: "environment_blocked",
+        }
       }
     }
     if (reasons.length > 0 || exitCode !== 0) {

--- a/backlog/tasks/task-12020.35 - Track-remaining-Research-Workspace-UAT-certification-after-PR-2533-merge.md
+++ b/backlog/tasks/task-12020.35 - Track-remaining-Research-Workspace-UAT-certification-after-PR-2533-merge.md
@@ -1,0 +1,59 @@
+---
+id: TASK-12020.35
+title: Track remaining Research Workspace UAT certification after PR 2533 merge
+status: In Progress
+created_date: 2026-06-27 06:07
+labels:
+- research-workspace
+- uat
+- qa
+- follow-up
+priority: High
+milestone: Research Workspace UAT Remediation
+parent_task_id: TASK-12020
+references:
+- https://github.com/rmusser01/tldw_server/pull/2533
+- TASK-12020.11
+- TASK-12020.24
+- TASK-12020.26
+- TASK-12020.28
+- Docs/Reviews/RESEARCH_WORKSPACE_LIVE_UAT_MATRIX_2026_05_25.md
+documentation:
+- Docs/Reviews/RESEARCH_WORKSPACE_LIVE_UAT_MATRIX_2026_05_25.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+PR #2533 was merged before the remaining Research Workspace UAT certification work could continue in an open review thread. This task tracks the follow-up PR that carries the remaining certification work forward from the merged PR without duplicating already-merged implementation commits.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 New draft PR is opened against dev from a fresh branch that does not duplicate already-merged PR #2533 commits.
+- [ ] #2 Remaining work from PR #2533 is documented clearly: clean full beginner/power-user persona matrix, configured-provider Studio generation, broader team/org sharing, standalone runner/browser permission recheck, and residual optional bootstrap warning review.
+- [ ] #3 Follow-up PR body lists current blockers and references the durable UAT matrix plus relevant Backlog tasks.
+- [ ] #4 Future implementation or certification commits update this task with touched files, verification evidence, and final summary before merge.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Remaining work carried forward from merged PR #2533: re-run the clean full beginner and power-user Research Workspace UAT matrix in an unblocked browser/CDP environment; recheck RW-UAT-030 live for imported-chat preservation and selected-source batch remove/undo; certify Studio generation with a reachable configured provider; complete broader team/organization share-permission workflow certification; re-run the standalone final UAT browser runner after Chromium/CDP launch permissions are available; review residual status-0 optional bootstrap warnings for possible product work beyond the scoped global-unreachable-modal fixes.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-12020.35 - Track-remaining-Research-Workspace-UAT-certification-after-PR-2533-merge.md
+++ b/backlog/tasks/task-12020.35 - Track-remaining-Research-Workspace-UAT-certification-after-PR-2533-merge.md
@@ -21,7 +21,7 @@ references:
 - https://github.com/rmusser01/tldw_server/pull/2535
 documentation:
 - Docs/Reviews/RESEARCH_WORKSPACE_LIVE_UAT_MATRIX_2026_05_25.md
-updated_date: 2026-06-27 06:10
+updated_date: 2026-06-27 15:14
 ---
 
 ## Description
@@ -43,6 +43,31 @@ PR #2533 was merged before the remaining Research Workspace UAT certification wo
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Remaining work carried forward from merged PR #2533: re-run the clean full beginner and power-user Research Workspace UAT matrix in an unblocked browser/CDP environment; recheck RW-UAT-030 live for imported-chat preservation and selected-source batch remove/undo; certify Studio generation with a reachable configured provider; complete broader team/organization share-permission workflow certification; re-run the standalone final UAT browser runner after Chromium/CDP launch permissions are available; review residual status-0 optional bootstrap warnings for possible product work beyond the scoped global-unreachable-modal fixes.
 Opened draft PR #2535 against dev from fresh branch codex/research-workspace-remaining-uat. Branch was created from origin/dev after confirming PR #2533 head is already an ancestor of dev, so this follow-up PR starts with tracking-only remaining certification work instead of duplicating merged implementation commits. PR body documents current blockers and remaining work.
+
+2026-06-27 verification pass:
+- GitHub PR checks for head `601a0a16f9` were all cancelled, with no failed job steps found in the Actions job metadata inspected through `gh`; no CI assertion failure was available to fix.
+- Gemini's inline suggestion to rename this Backlog task file was reviewed and not applied. The repository convention in `backlog/tasks/` is `task-id - Title.md`, and this file already follows the established Backlog.md naming pattern.
+- Local backend startup with `AUTH_MODE=single_user`, `SINGLE_USER_API_KEY`, and `DATABASE_URL=sqlite:///./Databases/users.db` initially failed inside the sandbox with `EPERM` binding `127.0.0.1:8000`; rerunning with approved local bind permission succeeded.
+- Local WebUI startup initially failed inside the sandbox with `EPERM` binding `127.0.0.1:8080`; rerunning with approved local bind permission succeeded using `NEXT_PUBLIC_API_URL=http://127.0.0.1:8000` and `NEXT_PUBLIC_X_API_KEY`.
+- In-app browser evidence against `http://127.0.0.1:8080/research-workspace`: after reload, the Research Workspace rendered with `Server context ready` and `Connected`; no new console errors were observed after reload. The Sources panel `Add Sources` control opened the modal, and the modal's `URL` ARIA tab selected correctly with URL input and disabled `Add URL` action visible. Screenshots were saved outside the repo at `/tmp/pr2535-research-workspace-reloaded.png`, `/tmp/pr2535-research-workspace-add-sources-open.png`, and `/tmp/pr2535-research-workspace-add-url-tab.png`.
+- The first in-app browser wait for `networkidle` timed out because the page keeps an SSE connection open. The initial load also showed a transient Next dev overlay for `Failed to fetch (GET /api/v1/llm/models/metadata)`, but direct backend probing returned `200 OK` for that endpoint and a subsequent reload had no new console errors.
+- Standalone UAT runner, sandboxed command:
+  `TLDW_E2E_API_KEY=... NEXT_PUBLIC_X_API_KEY=... bun run e2e:research-workspace:uat -- --no-autostart --web-url http://127.0.0.1:8080 --api-url http://127.0.0.1:8000 --project chromium --workers 1 --report /tmp/pr2535-research-workspace-final-uat-report.json --evidence /tmp/pr2535-research-workspace-final-uat-evidence.json`
+  exited `75` with `status=environment_blocked`, `scope=environment`, reasons `macos_mach_port_denied,browser_launch_failed`.
+- Standalone UAT runner, escalated browser-launch retry:
+  `TLDW_E2E_API_KEY=... NEXT_PUBLIC_X_API_KEY=... bun run e2e:research-workspace:uat -- --no-autostart --web-url http://127.0.0.1:8080 --api-url http://127.0.0.1:8000 --project chromium --workers 1 --report /tmp/pr2535-research-workspace-final-uat-report-escalated.json --evidence /tmp/pr2535-research-workspace-final-uat-evidence-escalated.json`
+  exited `1` with `status=product_failed`, `scope=product`, reasons `skipped_tests_present,unexpected_failures`. Stats: 25 executed, 13 passed/expected, 11 unexpected failures, 1 skipped.
+- Standalone UAT runner, repaired clean-env retry after restoring local dependency resolution:
+  `TLDW_E2E_API_KEY=... bun run e2e:research-workspace:uat -- --no-autostart --web-url http://127.0.0.1:8080 --api-url http://127.0.0.1:8000 --project chromium --workers 1 --report /tmp/pr2535-research-workspace-final-uat-report-clean-env2.json --evidence /tmp/pr2535-research-workspace-final-uat-evidence-clean-env2.json`
+  also exited `1` with `status=product_failed`, `scope=product`, reasons `skipped_tests_present,unexpected_failures`. Stats remained 25 executed, 13 passed/expected, 11 unexpected failures, 1 skipped. Treat this clean-env run as the preferred standalone evidence because it did not expose `NEXT_PUBLIC_X_API_KEY` to the WebUI.
+- Bandit was not run for this verification-only update because the only intended repository change is this Backlog task record; no Python/source code was changed.
+- Escalated runner failure clusters to investigate next:
+  1. Beginner UAT entry expected `localStorage.tldwConfig` to be absent, but the clean-env run still recorded `{"authMode":"single-user","serverUrl":"http://127.0.0.1:8000"}`. The earlier public-key run also included the API key, but the clean-env rerun confirms that runtime config persistence alone violates the current no-key beginner expectation.
+  2. Live-backend grounded chat/search flows timed out waiting for `/api/v1/rag/search`; one mocked grounded-chat spec also observed zero chat completion calls after RAG.
+  3. Studio work-product controls were missing or disabled in several flows: `Compare Sources` not found, `Quiz` disabled, and `Flashcards` disabled.
+  4. Source-pane workflows regressed or test fixtures no longer match UI state: advanced source filters rendered no source titles, and the My Media source checkbox remained disabled/unchecked.
+  5. Keyboard-only source selection could not reach the expected target after 40 Tab presses and stopped on the sidebar Flashcards shortcut.
+  6. `shows workspace-linked sandbox run in diagnostics when sandbox run API is available` remained skipped.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
@@ -54,9 +79,9 @@ Opened draft PR #2535 against dev from fresh branch codex/research-workspace-rem
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
+- [x] #2 Tests or verification recorded
 - [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
 - [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12020.35 - Track-remaining-Research-Workspace-UAT-certification-after-PR-2533-merge.md
+++ b/backlog/tasks/task-12020.35 - Track-remaining-Research-Workspace-UAT-certification-after-PR-2533-merge.md
@@ -21,17 +21,28 @@ references:
 - https://github.com/rmusser01/tldw_server/pull/2535
 documentation:
 - Docs/Reviews/RESEARCH_WORKSPACE_LIVE_UAT_MATRIX_2026_05_25.md
-updated_date: 2026-06-27 15:14
+updated_date: 2026-06-27 12:13
 modified_files:
 - apps/packages/ui/src/hooks/chat-modes/ragMode.ts
 - apps/packages/ui/src/hooks/chat-modes/__tests__/ragMode.sanitization.test.ts
 - apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/index.tsx
+- apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/hooks/useArtifactGeneration.tsx
+- apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage1.test.tsx
 - apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx
+- apps/packages/ui/src/components/Quiz/QuizPlayground.tsx
+- apps/packages/ui/src/components/Quiz/__tests__/QuizPlayground.navigation.test.tsx
+- apps/packages/ui/src/services/__tests__/tldw-api-client.chat-mutations.test.ts
+- apps/packages/ui/src/services/flashcards.ts
+- apps/packages/ui/src/services/tldw/TldwApiClient.ts
+- apps/packages/ui/src/services/tldw/domains/chat-rag.ts
 - apps/tldw-frontend/e2e/workflows/research-workspace.spec.ts
 - apps/tldw-frontend/e2e/workflows/research-workspace.real-backend.spec.ts
+- apps/tldw-frontend/e2e/utils/page-objects/QuizPage.ts
 - apps/tldw-frontend/e2e/utils/fixtures.ts
 - apps/tldw-frontend/scripts/research-workspace-uat-runner.mjs
 - apps/tldw-frontend/__tests__/research-workspace-uat-runner.test.ts
+- apps/tldw-frontend/__tests__/e2e-fixture-models.test.ts
+- Docs/Plans/IMPLEMENTATION_PLAN_research_workspace_llamacpp_uat_retry_TASK_12020_35.md
 ---
 
 ## Description
@@ -45,7 +56,7 @@ PR #2533 was merged before the remaining Research Workspace UAT certification wo
 - [x] #1 New draft PR is opened against dev from a fresh branch that does not duplicate already-merged PR #2533 commits.
 - [x] #2 Remaining work from PR #2533 is documented clearly: clean full beginner/power-user persona matrix, configured-provider Studio generation, broader team/org sharing, standalone runner/browser permission recheck, and residual optional bootstrap warning review.
 - [x] #3 Follow-up PR body lists current blockers and references the durable UAT matrix plus relevant Backlog tasks.
-- [ ] #4 Future implementation or certification commits update this task with touched files, verification evidence, and final summary before merge.
+- [x] #4 Future implementation or certification commits update this task with touched files, verification evidence, and final summary before merge.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -78,20 +89,39 @@ Opened draft PR #2535 against dev from fresh branch codex/research-workspace-rem
   4. Source-pane workflows regressed or test fixtures no longer match UI state: advanced source filters rendered no source titles, and the My Media source checkbox remained disabled/unchecked.
   5. Keyboard-only source selection could not reach the expected target after 40 Tab presses and stopped on the sidebar Flashcards shortcut.
   6. `shows workspace-linked sandbox run in diagnostics when sandbox run API is available` remained skipped.
+2026-06-27 llama.cpp retry follow-up:
+- Local llama.cpp at `127.0.0.1:9099` is reachable through the backend with temp config `/tmp/pr2535-llamacpp-config.txt`; direct `/api/v1/chat/completions` smoke using `api_provider=llama.cpp` returned `RW_LLAMA_OK`.
+- Full standalone Research Workspace UAT with the configured llama.cpp model no longer exits for `no_runnable_chat_model`; it exits `1` with `status=product_failed`, stats 25 executed / 19 passed / 1 skipped / 5 unexpected failures.
+- Current root causes under investigation before edits: real-backend UAT seeds documents with `perform_chunking=false`, leaving selected sources in `Processing`/non-queryable state and preventing `/api/v1/rag/search`; Studio generation resolves the metadata provider `llama` instead of the chat provider `llama.cpp` for llama.cpp-backed models.
+- Intended touched files for the next remediation pass: `apps/tldw-frontend/e2e/workflows/research-workspace.real-backend.spec.ts`, `apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/hooks/useArtifactGeneration.tsx`, and focused Studio tests under `apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/`.
+
+2026-06-27 llama.cpp blocker remediation:
+- Fixed llama.cpp model handling in Research Workspace UAT fixtures, RAG generation options, and Studio artifact generation so backend-advertised `chat_provider` metadata is preferred while `/rag/search` and `/chat/completions` receive the raw GGUF model id with `api_provider=llama.cpp`.
+- Enabled chunking for real-backend seeded UAT documents so live selected-source RAG and Studio source scoping operate on queryable media records.
+- Extended Studio non-streaming chat-completion requests to pass an explicit 180s timeout, reduced bundled flashcard generation requests to a source-scaled count, and raised flashcard generation timeout to 180s so reachable local providers are not classified as failed after the default short frontend request timeout.
+- Fixed the live quiz Manage-tab race by marking the default tab resolution complete on explicit user tab changes and tightened the Playwright quiz page object locators to stable tab/test-id targets.
+- Rechecked RW-UAT-030 focused regressions: `ChatPane.stage1.test.tsx` verifies imported workspace chat loads before empty local autosave, and `SourcesPane.stage3.folders.test.tsx` verifies selected-source batch Remove applies `removeSources(["s1", "s2"])` and Undo restores direct selection plus folder memberships.
+- Broader team/org share-permission frontend behavior remains covered by `ShareDialog.test.tsx` for empty team/org validation, share-link generation, active-share metadata, revoke success cleanup, and revoke error handling. A full live multi-user org/team permission pass was not run because this local certification backend is single-user mode; no new product regression was found in the frontend share workflow.
+- Fresh focused verification: `bun run test:run __tests__/e2e-fixture-models.test.ts ../packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage1.test.tsx ../packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx ../packages/ui/src/hooks/chat-modes/__tests__/ragMode.sanitization.test.ts ../packages/ui/src/components/Quiz/__tests__/QuizPlayground.navigation.test.tsx ../packages/ui/src/services/__tests__/tldw-api-client.chat-mutations.test.ts ../packages/ui/src/services/__tests__/flashcards.test.ts ../packages/ui/src/components/Option/ResearchWorkspace/__tests__/ChatPane.stage1.test.tsx ../packages/ui/src/components/Option/ResearchWorkspace/__tests__/SourcesPane.stage3.folders.test.tsx ../packages/ui/src/components/Option/ResearchWorkspace/__tests__/ShareDialog.test.tsx` passed 10 files / 160 tests. The expected stderr came from existing slides fallback and bulk-flashcard fallback coverage; the CSS parse warnings are test-environment noise from Ant Design styles.
+- Fresh standalone UAT verification against local llama.cpp: `bun run e2e:research-workspace:uat -- --web-url http://127.0.0.1:8080 --api-url http://127.0.0.1:8000 --project chromium --workers 1 --report /tmp/pr2535-research-workspace-uat-report-llamacpp-final3.json --evidence /tmp/pr2535-research-workspace-uat-evidence-llamacpp-final3.json` reached Chromium, ran 25 tests, passed 24, skipped 1, and had 0 unexpected failures. Runner exit was 75 with `status=environment_blocked`, `scope=environment`, reasons `environment_skips_present,sandbox_run_api_unavailable`; the remaining skip is the expected `/api/v1/sandbox/runs` unavailable path, not a llama.cpp or Research Workspace product failure.
+- Residual status-0 optional bootstrap warnings do not need additional scoped product work from this pass. The fresh standalone UAT had no unexpected optional-bootstrap failures and the prior global-unreachable-modal scoping fixes remain sufficient for the observed runner/browser behavior.
+- Bandit was not run for this remediation because no Python files were changed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 2026-06-27 PR #2535 blocker remediation: fixed selected-source RAG so retrieved evidence proceeds through chat completion instead of short-circuiting on backend generated_answer, promoted Compare Sources into the primary Studio actions, updated mocked Research Workspace UAT fixtures for current workspace/media behavior, hardened real-backend model discovery so disabled/unavailable providers are not treated as runnable, and changed the standalone UAT classifier so known environment-only skips are environment_blocked while generic skips remain product failures. Verification: focused red tests reproduced the RAG and Compare Sources blockers; focused Vitest passed; broader Research Workspace Vitest passed 4 files/98 tests; UAT runner unit tests passed 7 tests; mocked Playwright blocker slice passed 5 tests; full standalone Research Workspace UAT reported 19 passed, 6 expected environment skips, 0 unexpected failures, status=environment_blocked, reasons=environment_skips_present,sandbox_run_api_unavailable,no_runnable_chat_model. Bandit was not run because no Python files were changed.
+
+2026-06-27 llama.cpp retry: fixed provider-qualified llama.cpp model mapping for UAT fixtures, RAG, and Studio requests; enabled chunked seeded live documents; added explicit long Studio chat timeouts; reduced bundled flashcard request size; stabilized live quiz Manage-tab selection; and re-ran the full standalone Research Workspace UAT matrix against the local llama.cpp provider. Verification: focused Vitest passed 10 files / 160 tests; full standalone UAT passed 24/24 expected tests with 0 unexpected failures and 1 expected environment skip for unavailable `/api/v1/sandbox/runs`, producing `status=environment_blocked` for `environment_skips_present,sandbox_run_api_unavailable`. Bandit was not run because no Python files were changed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
+- [x] #1 Acceptance criteria completed
 - [x] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
+- [x] #3 Documentation updated when relevant
 - [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
+- [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-12020.35 - Track-remaining-Research-Workspace-UAT-certification-after-PR-2533-merge.md
+++ b/backlog/tasks/task-12020.35 - Track-remaining-Research-Workspace-UAT-certification-after-PR-2533-merge.md
@@ -18,8 +18,10 @@ references:
 - TASK-12020.26
 - TASK-12020.28
 - Docs/Reviews/RESEARCH_WORKSPACE_LIVE_UAT_MATRIX_2026_05_25.md
+- https://github.com/rmusser01/tldw_server/pull/2535
 documentation:
 - Docs/Reviews/RESEARCH_WORKSPACE_LIVE_UAT_MATRIX_2026_05_25.md
+updated_date: 2026-06-27 06:10
 ---
 
 ## Description
@@ -30,9 +32,9 @@ PR #2533 was merged before the remaining Research Workspace UAT certification wo
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 New draft PR is opened against dev from a fresh branch that does not duplicate already-merged PR #2533 commits.
-- [ ] #2 Remaining work from PR #2533 is documented clearly: clean full beginner/power-user persona matrix, configured-provider Studio generation, broader team/org sharing, standalone runner/browser permission recheck, and residual optional bootstrap warning review.
-- [ ] #3 Follow-up PR body lists current blockers and references the durable UAT matrix plus relevant Backlog tasks.
+- [x] #1 New draft PR is opened against dev from a fresh branch that does not duplicate already-merged PR #2533 commits.
+- [x] #2 Remaining work from PR #2533 is documented clearly: clean full beginner/power-user persona matrix, configured-provider Studio generation, broader team/org sharing, standalone runner/browser permission recheck, and residual optional bootstrap warning review.
+- [x] #3 Follow-up PR body lists current blockers and references the durable UAT matrix plus relevant Backlog tasks.
 - [ ] #4 Future implementation or certification commits update this task with touched files, verification evidence, and final summary before merge.
 <!-- AC:END -->
 
@@ -40,6 +42,7 @@ PR #2533 was merged before the remaining Research Workspace UAT certification wo
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Remaining work carried forward from merged PR #2533: re-run the clean full beginner and power-user Research Workspace UAT matrix in an unblocked browser/CDP environment; recheck RW-UAT-030 live for imported-chat preservation and selected-source batch remove/undo; certify Studio generation with a reachable configured provider; complete broader team/organization share-permission workflow certification; re-run the standalone final UAT browser runner after Chromium/CDP launch permissions are available; review residual status-0 optional bootstrap warnings for possible product work beyond the scoped global-unreachable-modal fixes.
+Opened draft PR #2535 against dev from fresh branch codex/research-workspace-remaining-uat. Branch was created from origin/dev after confirming PR #2533 head is already an ancestor of dev, so this follow-up PR starts with tracking-only remaining certification work instead of duplicating merged implementation commits. PR body documents current blockers and remaining work.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-12020.35 - Track-remaining-Research-Workspace-UAT-certification-after-PR-2533-merge.md
+++ b/backlog/tasks/task-12020.35 - Track-remaining-Research-Workspace-UAT-certification-after-PR-2533-merge.md
@@ -22,6 +22,16 @@ references:
 documentation:
 - Docs/Reviews/RESEARCH_WORKSPACE_LIVE_UAT_MATRIX_2026_05_25.md
 updated_date: 2026-06-27 15:14
+modified_files:
+- apps/packages/ui/src/hooks/chat-modes/ragMode.ts
+- apps/packages/ui/src/hooks/chat-modes/__tests__/ragMode.sanitization.test.ts
+- apps/packages/ui/src/components/Option/ResearchWorkspace/StudioPane/index.tsx
+- apps/packages/ui/src/components/Option/ResearchWorkspace/__tests__/StudioPane.stage2.test.tsx
+- apps/tldw-frontend/e2e/workflows/research-workspace.spec.ts
+- apps/tldw-frontend/e2e/workflows/research-workspace.real-backend.spec.ts
+- apps/tldw-frontend/e2e/utils/fixtures.ts
+- apps/tldw-frontend/scripts/research-workspace-uat-runner.mjs
+- apps/tldw-frontend/__tests__/research-workspace-uat-runner.test.ts
 ---
 
 ## Description
@@ -73,7 +83,7 @@ Opened draft PR #2535 against dev from fresh branch codex/research-workspace-rem
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+2026-06-27 PR #2535 blocker remediation: fixed selected-source RAG so retrieved evidence proceeds through chat completion instead of short-circuiting on backend generated_answer, promoted Compare Sources into the primary Studio actions, updated mocked Research Workspace UAT fixtures for current workspace/media behavior, hardened real-backend model discovery so disabled/unavailable providers are not treated as runnable, and changed the standalone UAT classifier so known environment-only skips are environment_blocked while generic skips remain product failures. Verification: focused red tests reproduced the RAG and Compare Sources blockers; focused Vitest passed; broader Research Workspace Vitest passed 4 files/98 tests; UAT runner unit tests passed 7 tests; mocked Playwright blocker slice passed 5 tests; full standalone Research Workspace UAT reported 19 passed, 6 expected environment skips, 0 unexpected failures, status=environment_blocked, reasons=environment_skips_present,sandbox_run_api_unavailable,no_runnable_chat_model. Bandit was not run because no Python files were changed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Opens a fresh follow-up branch after #2533 was merged; #2533 head is already in `dev`, so this PR does not duplicate already-merged implementation commits.
- Tracks the remaining Research Workspace UAT certification work in `TASK-12020.35`.
- Carries forward the remaining work from #2533: clean full beginner/power-user matrix, configured-provider Studio generation, broader team/org sharing, standalone runner/browser permissions, and optional bootstrap warning review.

## Current Blockers
- Local Chromium/CDP launch was previously blocked by host-level browser permission limits, including Mach service permission failures in sandboxed runs.
- Studio generation still needs a reachable configured provider; prior Ollama/provider paths were blocked by reachability or missing configuration.
- Broader team/org share-permission certification needs realistic multi-user/team fixtures or an environment where those permissions can be exercised end to end.

## Remaining Work
- Run the clean full beginner and power-user Research Workspace UAT matrix in an unblocked browser/CDP environment.
- Recheck `RW-UAT-030` live for imported-chat preservation and selected-source batch remove/undo.
- Certify Studio generation with a reachable configured provider.
- Certify broader team/org share-permission workflows.
- Re-run the standalone final UAT browser runner after browser launch permissions are available.
- Decide whether residual status-0 optional bootstrap warnings need product work beyond the scoped global-unreachable-modal fixes.

## Verification
- `git diff --check`
- Product tests not run for this opening commit; this PR currently adds the follow-up tracking task only. Existing #2533 implementation is already merged into `dev`.

## References
- Follow-up from #2533
- `TASK-12020.35`
- `TASK-12020.11`, `TASK-12020.24`, `TASK-12020.26`, `TASK-12020.28`
- `Docs/Reviews/RESEARCH_WORKSPACE_LIVE_UAT_MATRIX_2026_05_25.md`

## Change summary
This PR intentionally starts as a tracking-only draft because #2533 was accidentally merged before the remaining UAT certification work was complete. The branch was created from current `origin/dev` after confirming #2533 is already merged, so future commits can focus only on the still-open certification and remediation work without replaying merged changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advances `TASK-12020.35` with provider-qualified `llama.cpp` support, queryable live UAT sources, and longer Studio/RAG timeouts for more reliable runs. Compare Sources remains a primary chat-completion action; selected-source RAG continues through chat with retrieved evidence.

- **Bug Fixes**
  - `llama.cpp` routing: accept `llama.cpp:<gguf>` selections, send the raw GGUF id as `model` with `api_provider=llama.cpp`, and prefer backend `chat_provider`; filter out disabled/unavailable models.
  - Real backend UAT: seed documents with chunking enabled so selected sources are queryable; tests select a runnable server model or skip when none is advertised.
  - Timeouts and sizing: add a 180s chat-completion timeout across Studio and RAG client calls; raise flashcard generation timeout to 180s and scale `num_cards` by selected sources.
  - Quiz: fix Manage-tab race so a user click isn’t overridden by late FTUX; stabilize Playwright tab and toggle selectors.
  - E2E/mocks: Compare Sources assertions target chat messages and source content; workspace API mocks updated to current endpoints.

<sup>Written for commit 073429d3cd2a40a0d122bd9ab93200eb753ece64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

