### PR TITLE
Fix MCP snapshot schema warning

### DIFF
--- a/apps/mcp-unified/src/mcp_unified/gateway/snapshots.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/snapshots.py
@@ -86,8 +86,7 @@ class GatewayConfigSnapshot(BaseModel):
 
     snapshot_schema: Literal["mcp_unified.gateway.config_snapshot"] = Field(
         default=SNAPSHOT_SCHEMA,
-        validation_alias="schema",
-        serialization_alias="schema",
+        alias="schema",
     )
     version: Literal[1] = SNAPSHOT_VERSION
     profiles: list[MCPProfile] = Field(default_factory=list)

--- a/apps/mcp-unified/src/mcp_unified/gateway/snapshots.py
+++ b/apps/mcp-unified/src/mcp_unified/gateway/snapshots.py
@@ -78,9 +78,17 @@ class GatewayConfigSnapshotManagementError(RuntimeError):
 class GatewayConfigSnapshot(BaseModel):
     """Versioned gateway config snapshot without embedded secret values."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+        serialize_by_alias=True,
+    )
 
-    schema: Literal["mcp_unified.gateway.config_snapshot"] = SNAPSHOT_SCHEMA
+    snapshot_schema: Literal["mcp_unified.gateway.config_snapshot"] = Field(
+        default=SNAPSHOT_SCHEMA,
+        validation_alias="schema",
+        serialization_alias="schema",
+    )
     version: Literal[1] = SNAPSHOT_VERSION
     profiles: list[MCPProfile] = Field(default_factory=list)
     default_assignment: ProfileAssignment | None = None

--- a/backlog/tasks/task-12053 - Clean-up-MCP-Unified-GatewayConfigSnapshot-schema-warning.md
+++ b/backlog/tasks/task-12053 - Clean-up-MCP-Unified-GatewayConfigSnapshot-schema-warning.md
@@ -51,3 +51,9 @@ Cleaned up the MCP Unified standalone GatewayConfigSnapshot Pydantic warning fro
 - [x] #5 Final summary added
 - [x] #6 Known skips or blockers documented
 <!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+PR #2537 review follow-up after rebasing on origin/dev: replaced the GatewayConfigSnapshot field configuration with the single Pydantic alias="schema" form requested by review; marked the warning-clean regression with pytest.mark.unit; made the subprocess regression derive package_src from the imported module, fail explicitly if that path is missing, run with cwd=package_src, and use an isolated PYTHONPATH/PYTHONNOUSERSITE environment. Added explicit nosec justification comments for the subprocess import/call. Fresh verification after the review fixes: focused snapshot+CLI pytest passed 39 tests; standalone warning-clean import check passed under -W error::UserWarning; Ruff F/I/UP passed; py_compile passed; git diff --check passed; production Bandit reported zero findings; test-file Bandit reported only existing B101 pytest assert baseline with the intentional subprocess findings skipped.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/backlog/tasks/task-12053 - Clean-up-MCP-Unified-GatewayConfigSnapshot-schema-warning.md
+++ b/backlog/tasks/task-12053 - Clean-up-MCP-Unified-GatewayConfigSnapshot-schema-warning.md
@@ -1,0 +1,53 @@
+---
+id: TASK-12053
+title: Clean up MCP Unified GatewayConfigSnapshot schema warning
+status: Done
+assignee: []
+created_date: '2026-06-27 17:39'
+updated_date: '2026-06-27 17:44'
+labels:
+  - mcp
+  - packaging
+  - cleanup
+dependencies: []
+references:
+  - >-
+    backlog/tasks/task-2402 -
+    Fix-MCP-Unified-TestPyPI-wheel-missing-policy-grants-package.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the known TASK-2402 follow-up: installed MCP Unified CLI commands emit a non-fatal Pydantic warning because GatewayConfigSnapshot defines a schema field that shadows a BaseModel attribute. Keep snapshot compatibility while making CLI output warning-clean.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Regression coverage fails when importing or running the gateway snapshot model emits the Pydantic shadow warning.
+- [x] #2 GatewayConfigSnapshot no longer triggers the schema-field shadow warning while preserving serialized snapshot compatibility.
+- [x] #3 Focused MCP Unified package/gateway tests, Bandit touched-scope scan, and diff checks pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented warning cleanup with TDD. Red regression: test_snapshot_model_import_is_warning_clean_and_preserves_schema_key failed under -W error::UserWarning because GatewayConfigSnapshot defined a Pydantic field named schema, shadowing BaseModel.schema. Fix: renamed the internal field to snapshot_schema and used validation/serialization aliases plus serialize_by_alias so public snapshots still read/write the schema JSON key. Verification so far: focused snapshot+CLI pytest passed 39 tests; package CLI package-info passed under -W error::UserWarning; py_compile passed for touched module/test; Ruff F/I/UP passed; git diff --check passed; Bandit on production snapshots.py reported zero findings; Bandit on the test file reports only existing low-severity pytest assert baseline after marking the intentional subprocess import/call.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Cleaned up the MCP Unified standalone GatewayConfigSnapshot Pydantic warning from TASK-2402. The internal model field is now snapshot_schema with validation/serialization aliases for the public schema JSON key, so snapshot import/export compatibility is preserved while imports and CLI commands are warning-clean. Verification: red regression failed under -W error::UserWarning before the fix; focused snapshot+CLI pytest passed 39 tests; package-info CLI passed under -W error::UserWarning; py_compile passed for touched files; Ruff F/I/UP passed; git diff --check passed; production Bandit on snapshots.py reported errors=[] and results=[]. Test-file Bandit reports only existing low-severity pytest assert baseline after intentional subprocess use was nosec-marked.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-import os
+
+# Subprocess verifies a fresh interpreter import with warnings promoted to errors.
 import subprocess  # nosec B404
 import sys
 from collections.abc import Mapping
@@ -28,11 +29,13 @@ from mcp_unified.storage.models import (
 from mcp_unified.storage.sqlite import SQLiteMCPStore
 
 
+@pytest.mark.unit
 def test_snapshot_model_import_is_warning_clean_and_preserves_schema_key() -> None:
     """Gateway config snapshot imports warning-clean and still serializes schema."""
 
-    repo_root = Path(__file__).resolve().parents[5]
-    package_src = repo_root / "apps" / "mcp-unified" / "src"
+    package_src = Path(snapshot_module.__file__).resolve().parents[2]
+    if not package_src.is_dir():
+        pytest.fail(f"Package source path not found: {package_src}")
     script = """
 from mcp_unified.gateway.snapshots import GatewayConfigSnapshot
 
@@ -41,19 +44,22 @@ assert payload["schema"] == "mcp_unified.gateway.config_snapshot"
 assert "snapshot_schema" not in payload
 """
     env = {
-        **os.environ,
         "PYTHONPATH": str(package_src),
+        "PYTHONNOUSERSITE": "1",
     }
 
+    # Safe subprocess: sys.executable, constant script, explicit PYTHONPATH, no shell.
     result = subprocess.run(  # nosec B603
         [sys.executable, "-W", "error::UserWarning", "-c", script],
         check=False,
         capture_output=True,
+        cwd=package_src,
         env=env,
         text=True,
     )
 
-    assert result.returncode == 0, result.stderr  # nosec B101
+    if result.returncode != 0:
+        pytest.fail(result.stderr)
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess  # nosec B404
+import sys
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-import pytest
-
 import mcp_unified.gateway.snapshots as snapshot_module
+import pytest
 from mcp_unified.gateway.snapshots import (
     GatewayConfigSnapshot,
     GatewayConfigSnapshotManagementError,
@@ -24,6 +26,34 @@ from mcp_unified.storage.models import (
     ProfileAssignment,
 )
 from mcp_unified.storage.sqlite import SQLiteMCPStore
+
+
+def test_snapshot_model_import_is_warning_clean_and_preserves_schema_key() -> None:
+    """Gateway config snapshot imports warning-clean and still serializes schema."""
+
+    repo_root = Path(__file__).resolve().parents[5]
+    package_src = repo_root / "apps" / "mcp-unified" / "src"
+    script = """
+from mcp_unified.gateway.snapshots import GatewayConfigSnapshot
+
+payload = GatewayConfigSnapshot().model_dump(mode="json")
+assert payload["schema"] == "mcp_unified.gateway.config_snapshot"
+assert "snapshot_schema" not in payload
+"""
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(package_src),
+    }
+
+    result = subprocess.run(  # nosec B603
+        [sys.executable, "-W", "error::UserWarning", "-c", script],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr  # nosec B101
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Change summary
- Renamed the internal GatewayConfigSnapshot Pydantic field from schema to snapshot_schema while keeping the public snapshot JSON key as schema through validation/serialization aliases.
- Added a warning-as-error regression so importing the snapshot model stays clean and exported snapshots do not expose snapshot_schema.
- Recorded TASK-12053 as the focused follow-up to the TASK-2402 known cleanup.

## Why
The standalone MCP CLI imported GatewayConfigSnapshot and emitted a Pydantic warning because schema shadows BaseModel.schema. The alias-based model field removes that warning without changing the persisted/imported snapshot contract.

## Verification
- python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py::test_gateway_cli_export_config_writes_snapshot_to_stdout tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py::test_gateway_cli_export_config_writes_snapshot_file tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py::test_gateway_cli_import_config_dry_run_reports_plan_without_mutation tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py::test_gateway_cli_import_config_applies_snapshot_upserts tldw_Server_API/app/core/MCP_unified/tests/test_gateway_cli_package.py::test_gateway_cli_import_config_reports_sanitized_partial_failure -v
- PYTHONPATH=apps/mcp-unified/src python -W error::UserWarning -m mcp_unified.gateway.cli package-info
- python -m ruff check apps/mcp-unified/src/mcp_unified/gateway/snapshots.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py --select F,I,UP
- python -m py_compile apps/mcp-unified/src/mcp_unified/gateway/snapshots.py tldw_Server_API/app/core/MCP_unified/tests/test_gateway_config_snapshots.py
- python -m bandit -r apps/mcp-unified/src/mcp_unified/gateway/snapshots.py -f json -o /tmp/bandit_mcp_snapshot_schema_warning_pr.json
- git diff --check HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Pydantic shadowing warning in the MCP gateway snapshot by renaming the internal field while keeping the external JSON key "schema"; imports and CLI are now warning-clean with no change to the snapshot format. Addresses TASK-12053 (follow-up to TASK-2402).

- Bug Fixes
  - In `mcp_unified.gateway.snapshots`, renamed the internal field to `snapshot_schema` with `alias="schema"` and enabled `populate_by_name` and `serialize_by_alias`.
  - Added a subprocess-based regression: runs via `sys.executable` with `-W error::UserWarning`, no shell, explicit `PYTHONPATH` and `PYTHONNOUSERSITE`, fixed `cwd`, marked as unit, and asserts JSON includes "schema" and not "snapshot_schema".

<sup>Written for commit a132935b011dba69afbf71da7549a44c486e825c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_server/pull/2537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

